### PR TITLE
fix(cron): harden pacing and automation lifecycle

### DIFF
--- a/src/agents/tools/cron-tool.pacing.test.ts
+++ b/src/agents/tools/cron-tool.pacing.test.ts
@@ -41,6 +41,19 @@ describe("cron next_check action", () => {
     expect(consumeCronNextCheckProposal(RUN_ID, JOB_ID)).toBeUndefined();
   });
 
+  it("accepts an explicit matching job id", async () => {
+    registerRun(true);
+
+    const result = await createScopedTool().execute("call-next-check-explicit", {
+      action: "next_check",
+      jobId: JOB_ID,
+      in: "45m",
+    });
+
+    expect(result.details).toEqual({ ok: true, delayMs: 45 * 60_000 });
+    expect(consumeCronNextCheckProposal(RUN_ID, JOB_ID)).toBe(45 * 60_000);
+  });
+
   it("rejects a proposal when the current job has no pacing", async () => {
     registerRun(false);
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -557,8 +557,11 @@ function assertCronSelfRemoveScope(
   if (!selfRemoveOnlyJobId || isCronSelfIntrospectionAction(action)) {
     return;
   }
-  if (action === "next_check" && params.jobId === undefined && params.id === undefined) {
-    return;
+  if (action === "next_check") {
+    const id = readCronJobIdParam(params);
+    if (!id || id === selfRemoveOnlyJobId) {
+      return;
+    }
   }
   if (action === "get" || action === "remove" || action === "runs") {
     const id = readCronJobIdParam(params);

--- a/src/gateway/cron-exit-watchers.test.ts
+++ b/src/gateway/cron-exit-watchers.test.ts
@@ -141,7 +141,7 @@ describe("createCronExitWatchers", () => {
       stderr: "",
     });
     // One-shot terminal state is persisted BEFORE firing (restart-safe).
-    expect(persistCompletion).toHaveBeenCalledWith("job-a");
+    expect(persistCompletion).toHaveBeenCalledWith(expect.objectContaining({ id: "job-a" }));
     expect(order).toEqual(["persist", "fire"]);
   });
 
@@ -385,10 +385,11 @@ describe("createCronExitWatchers", () => {
 
   it("retains a blocker and suppresses stale fire when removed during terminal persistence", async () => {
     const { supervisor, runs } = makeFakeSupervisor();
-    let releasePersist = () => {};
+    let releasePersist: (release: () => void) => void = () => {};
+    const releaseCompletion = vi.fn();
     const persistCompletion = vi.fn(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise<() => void>((resolve) => {
           releasePersist = resolve;
         }),
     );
@@ -410,9 +411,10 @@ describe("createCronExitWatchers", () => {
     w.reconcile([]);
     expect(w.activeJobIds()).toEqual(["job-a"]);
 
-    releasePersist();
+    releasePersist(releaseCompletion);
     await vi.waitFor(() => expect(w.activeJobIds()).toEqual([]));
     expect(fireOnExit).not.toHaveBeenCalled();
+    expect(releaseCompletion).toHaveBeenCalledOnce();
   });
 
   it("is one-shot: a fired job is not re-armed on a later reconcile", async () => {

--- a/src/gateway/cron-exit-watchers.ts
+++ b/src/gateway/cron-exit-watchers.ts
@@ -46,7 +46,7 @@ function isWatchableExitJob(job: CronJob): job is OnExitCronJob {
 
 export function createCronExitWatchers(params: {
   getProcessSupervisor: () => ProcessSupervisor;
-  persistCompletion: (jobId: string) => Promise<void>;
+  persistCompletion: (job: OnExitCronJob) => Promise<(() => void) | void>;
   fireOnExit: (job: CronJob, exit: CronExitResult) => void | Promise<void>;
   logger: Logger;
   shell?: { command: string; argsFor: (command: string) => string[] };
@@ -183,8 +183,9 @@ export function createCronExitWatchers(params: {
       // Persist the terminal one-shot state BEFORE firing. FAIL CLOSED: if the
       // store write fails we do NOT wake — waking without a persisted terminal
       // state would let a gateway restart re-arm and re-run the command.
+      let releaseCompletion: (() => void) | void;
       try {
-        await params.persistCompletion(job.id);
+        releaseCompletion = await params.persistCompletion(slot.job);
       } catch (err) {
         if (owns()) {
           active.delete(job.id);
@@ -196,27 +197,31 @@ export function createCronExitWatchers(params: {
         return;
       }
       slot.terminalPersisting = false;
-      if (!owns() || slot.cancelled) {
-        if (active.get(job.id) === slot) {
-          active.delete(job.id);
-        }
-        return;
-      }
-      slot.fired = true;
       try {
-        await params.fireOnExit(slot.job, {
-          exitCode: exit.exitCode,
-          reason: exit.reason,
-          stdout: exit.stdout,
-          stderr: exit.stderr,
-          timedOut: exit.timedOut,
-          noOutputTimedOut: exit.noOutputTimedOut,
-        });
-      } catch (err) {
-        params.logger.warn(
-          { err: String(err), jobId: job.id },
-          "cron-exit: fireOnExit after exit failed",
-        );
+        if (!owns() || slot.cancelled) {
+          if (active.get(job.id) === slot) {
+            active.delete(job.id);
+          }
+          return;
+        }
+        slot.fired = true;
+        try {
+          await params.fireOnExit(slot.job, {
+            exitCode: exit.exitCode,
+            reason: exit.reason,
+            stdout: exit.stdout,
+            stderr: exit.stderr,
+            timedOut: exit.timedOut,
+            noOutputTimedOut: exit.noOutputTimedOut,
+          });
+        } catch (err) {
+          params.logger.warn(
+            { err: String(err), jobId: job.id },
+            "cron-exit: fireOnExit after exit failed",
+          );
+        }
+      } finally {
+        releaseCompletion?.();
       }
     })().finally(() => {
       slot.lifecycleSettled = true;

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -223,6 +223,11 @@ vi.mock("../cron/trigger-script.js", () => ({
   createCronScriptRuntime: createCronScriptRuntimeMock,
 }));
 
+import {
+  registerActiveCronTaskRun,
+  trackActiveCronTaskRunSettlement,
+} from "../cron/service/active-run-cancellation.js";
+import { resetActiveCronTaskRunsForTests } from "../cron/service/active-run-cancellation.test-support.js";
 import type { CronJob } from "../cron/types.js";
 import {
   buildGatewayCronService as buildGatewayCronServiceRuntime,
@@ -328,6 +333,7 @@ function expectCleanupForSessionKeys(sessionKeys: string[]) {
 
 describe("buildGatewayCronService", () => {
   beforeEach(() => {
+    resetActiveCronTaskRunsForTests();
     enqueueSystemEventMock.mockClear();
     consumeSelectedSystemEventEntriesMock.mockClear();
     requestHeartbeatMock.mockClear();
@@ -444,6 +450,90 @@ describe("buildGatewayCronService", () => {
     } finally {
       state.cron.stop();
       vi.unstubAllEnvs();
+    }
+  });
+
+  it("fires an on-exit payload after persisting its terminal disable", async () => {
+    let resolveWait!: (result: {
+      reason: "exit";
+      exitCode: number;
+      exitSignal: null;
+      durationMs: number;
+      stdout: string;
+      stderr: string;
+      timedOut: false;
+      noOutputTimedOut: false;
+    }) => void;
+    const wait = new Promise<Parameters<typeof resolveWait>[0]>((resolve) => {
+      resolveWait = resolve;
+    });
+    const spawn = vi.fn(async () => ({
+      runId: "run-on-exit-fire",
+      startedAtMs: Date.now(),
+      cancel: vi.fn(),
+      wait: () => wait,
+    }));
+    getProcessSupervisorMock.mockReturnValue({ spawn, cancelScope: vi.fn() });
+    const cfg = createCronConfig("server-cron-on-exit-fire");
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+
+    try {
+      const job = await state.cron.add({
+        name: "watch and fire",
+        enabled: true,
+        schedule: { kind: "on-exit", command: "true" },
+        payload: { kind: "systemEvent", text: "done" },
+        sessionTarget: "main",
+        wakeMode: "now",
+      });
+      await state.reconcileExitWatchers?.();
+      resolveWait({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 1,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+
+      await vi.waitFor(() => expect(runHeartbeatOnceMock).toHaveBeenCalledOnce());
+      expect(state.cron.getJob(job.id)?.enabled).toBe(false);
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("aborts and drains active cron runs during shutdown", async () => {
+    const controller = new AbortController();
+    const coreRun = new Promise<void>((resolve) => {
+      controller.signal.addEventListener("abort", () => resolve(), { once: true });
+    });
+    const release = registerActiveCronTaskRun({ runId: "run-shutdown", controller });
+    const trackedRun = coreRun.finally(() => release?.());
+    trackActiveCronTaskRunSettlement(trackedRun);
+
+    const cfg = createCronConfig("server-cron-active-run-shutdown");
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+
+    try {
+      await state.cron.stopAndDrain?.();
+      expect(controller.signal.aborted).toBe(true);
+      await expect(trackedRun).resolves.toBeUndefined();
+    } finally {
+      state.cron.stop();
+      resetActiveCronTaskRunsForTests();
     }
   });
 

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -27,6 +27,10 @@ import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { resolveCronJobBoundSessionKeys } from "../cron/job-session-bindings.js";
 import { toPublicCronJob } from "../cron/public-job.js";
 import { CronService, type CronEvent } from "../cron/service.js";
+import {
+  abortActiveCronTaskRuns,
+  waitForActiveCronTaskRuns,
+} from "../cron/service/active-run-cancellation.js";
 import { applyJobPatch } from "../cron/service/jobs.js";
 import {
   resolveCronDeliverySessionKey,
@@ -257,6 +261,8 @@ function isCommandCronJob(job: CronJob | null | undefined): boolean {
   return job?.payload?.kind === "command";
 }
 
+const CRON_ACTIVE_RUN_SHUTDOWN_DRAIN_MS = 10_000;
+
 /** Build the cron service state used by Gateway startup and lazy cron loading. */
 export function buildGatewayCronService(params: {
   cfg: OpenClawConfig;
@@ -440,6 +446,7 @@ export function buildGatewayCronService(params: {
   } = { current: undefined };
   let exitWatcherReconciliations = 0;
   let streamWatcherReconciliations = 0;
+  const terminalExitCompletionTokens = new Map<string, object>();
   let exitWatcherGeneration = 0;
   let streamWatcherGeneration = 0;
   // Bumped when a direct watcher route begins; fences reconcile's async list
@@ -458,10 +465,18 @@ export function buildGatewayCronService(params: {
         return;
       }
       const jobs: CronJob[] = Array.isArray(result) ? result : (result as { jobs: CronJob[] }).jobs;
+      const watcherJobs: CronJob[] = [];
+      for (const job of jobs) {
+        watcherJobs.push(
+          terminalExitCompletionTokens.has(job.id) && job.schedule.kind === "on-exit"
+            ? { ...job, enabled: true }
+            : job,
+        );
+      }
       reconcileCronExitWatchers({
         cronEnabled,
         exitWatchers: exitWatchersRef.current,
-        jobs,
+        jobs: watcherJobs,
       });
     } catch (err) {
       cronLogger.warn({ err: String(err) }, "cron-exit: reconcile failed");
@@ -1052,16 +1067,38 @@ export function buildGatewayCronService(params: {
 
   exitWatchersRef.current = createCronExitWatchers({
     getProcessSupervisor,
-    persistCompletion: async (jobId) =>
-      await runWithGatewayIndependentRootWorkAdmission(async () => {
-        await cron.update(jobId, { enabled: false });
-      }),
-    fireOnExit: (job, exit) =>
-      runWithGatewayIndependentRootWorkAdmission(async () =>
+    persistCompletion: async (job) => {
+      const completionToken = {};
+      terminalExitCompletionTokens.set(job.id, completionToken);
+      const releaseCompletionToken = () => {
+        if (terminalExitCompletionTokens.get(job.id) === completionToken) {
+          terminalExitCompletionTokens.delete(job.id);
+        }
+      };
+      try {
+        await runWithGatewayIndependentRootWorkAdmission(async () => {
+          await cron.updateWithPrecondition(job.id, { enabled: false }, (current) => {
+            if (!current.enabled || current.updatedAtMs !== job.updatedAtMs) {
+              throw new Error("cron on-exit job changed before completion");
+            }
+          });
+        });
+        return () => {
+          releaseCompletionToken();
+          void reconcileExitWatchers();
+        };
+      } catch (err) {
+        releaseCompletionToken();
+        throw err;
+      }
+    },
+    fireOnExit: async (job, exit) => {
+      await runWithGatewayIndependentRootWorkAdmission(async () =>
         fireOnExitJob(job, exit, {
           run: (jobId, payload) => cron.run(jobId, "force", payload ? { payload } : undefined),
         }),
-      ),
+      );
+    },
     logger: cronLogger,
   });
   const updateCron = cron.update.bind(cron);
@@ -1290,7 +1327,24 @@ export function buildGatewayCronService(params: {
     stopCron();
     stopExitWatchers();
     stopHeartbeatReconcileRetry();
-    await stopStreamWatchers();
+    const streamWatchersStop = stopStreamWatchers().then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    const abortedRuns = abortActiveCronTaskRuns("Gateway shutting down.");
+    const [activeRunDrain, streamWatchersResult] = await Promise.all([
+      waitForActiveCronTaskRuns(CRON_ACTIVE_RUN_SHUTDOWN_DRAIN_MS),
+      streamWatchersStop,
+    ]);
+    if (!activeRunDrain.drained) {
+      cronLogger.warn(
+        { abortedRuns, activeRuns: activeRunDrain.active },
+        "cron: active runs did not drain before shutdown timeout",
+      );
+    }
+    if (!streamWatchersResult.ok) {
+      throw streamWatchersResult.error;
+    }
     unregisterSessionAutomationSource(automationSource);
   };
   // Reconciliations serialize on one tail and only the latest requested epoch


### PR DESCRIPTION
## What Problem This Solves

Fixes three cron automation failures reproduced on a live isolated Gateway with a real OpenAI-backed agent:

- A paced cron agent could fail its whole run after calling `next_check` with its own explicit job ID, even though omitting that same ID succeeded.
- An `on-exit` job could persist its terminal disabled state, then cancel its own watcher before the payload entered the normal run pipeline, leaving no history row.
- Gateway shutdown could return while an active cron command process tree continued running and later completed side effects.

## Why This Change Was Made

Restricted `next_check` now accepts either an omitted ID or the exact current job ID while retaining cross-job rejection. On-exit completion now uses an ownership-safe per-transition fence and an optimistic job precondition so terminal persistence cannot cancel its own fire or mask concurrent edits. Gateway shutdown aborts registered active cron runs and drains them alongside stream teardown before completing its bounded shutdown path.

This change was AI-assisted and was validated against a disposable live Gateway rather than the operator's configured Gateway.

## User Impact

Cron automation behaves consistently under live model pacing, event-driven `on-exit` jobs reliably produce exactly one run after the watched command exits, and Gateway shutdown no longer leaves cooperative cron command processes running after the service exits.

## Evidence

- Live OpenAI pacing: `openai/gpt-5.6-luna` completed `CRON_NATURAL_PACING_OK`; persisted next run was exactly 120,000 ms after completion.
- Live on-exit: terminal job was disabled and recorded exactly one successful run with exit code 0 and reason `exit`.
- Live shutdown: the command child received SIGTERM, died 389 ms before Gateway return, wrote no normal-completion marker, and restart showed exactly one `Gateway shutting down.` terminal error with no replay.
- Source-blind behavior validation: 3 passed, 0 failed, 0 blocked.
- Focused tests on latest `main`: 251 assertions passed.
- Blacksmith Testbox broad cron proof: three QA scenarios plus 678 cron/gateway tests passed: https://github.com/openclaw/openclaw/actions/runs/29893825190
- Blacksmith Testbox changed gates passed: https://github.com/openclaw/openclaw/actions/runs/29919147066
- Formatting, Oxlint, core/test typechecks, plugin boundaries, import cycles, database/schema guards, and `git diff --check` passed.
