### PR TITLE
fix(onboarding): reuse active Codex API-key authentication

### DIFF
--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -8,6 +8,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 const execSyncMock = vi.fn();
 const CLI_CREDENTIALS_CACHE_TTL_MS = 15 * 60 * 1000;
 let readClaudeCliCredentialsCached: typeof import("./cli-credentials.js").readClaudeCliCredentialsCached;
+let readCodexCliApiKey: typeof import("./cli-credentials.js").readCodexCliApiKey;
 let readCodexCliCredentialsCached: typeof import("./cli-credentials.js").readCodexCliCredentialsCached;
 let readGeminiCliCredentialsCached: typeof import("./cli-credentials.js").readGeminiCliCredentialsCached;
 let readMiniMaxCliCredentialsCached: typeof import("./cli-credentials.js").readMiniMaxCliCredentialsCached;
@@ -62,6 +63,7 @@ describe("cli credentials", () => {
   beforeAll(async () => {
     ({
       readClaudeCliCredentialsCached,
+      readCodexCliApiKey,
       readCodexCliCredentialsCached,
       readGeminiCliCredentialsCached,
       readMiniMaxCliCredentialsCached,
@@ -597,6 +599,22 @@ describe("cli credentials", () => {
     );
 
     expect(readCodexAuth({ platform: "linux", execSync: execSyncMock })).toBeNull();
+    expect(readCodexCliApiKey({ codexHome: tempHome })).toEqual({
+      type: "api_key",
+      provider: "openai",
+      key: "sk-codex-api-key",
+    });
+  });
+
+  it("does not import a stale Codex API key when auth.json resolves to OAuth mode", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-oauth-mode-"));
+    fs.writeFileSync(
+      path.join(tempHome, "auth.json"),
+      JSON.stringify({ auth_mode: "chatgpt", OPENAI_API_KEY: "stale-api-key" }),
+      "utf8",
+    );
+
+    expect(readCodexCliApiKey({ codexHome: tempHome })).toBeNull();
   });
 
   it("treats an empty Codex auth.json API-key field as API-key mode", () => {

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -9,7 +9,6 @@ const execSyncMock = vi.fn();
 const CLI_CREDENTIALS_CACHE_TTL_MS = 15 * 60 * 1000;
 let readClaudeCliCredentialsCached: typeof import("./cli-credentials.js").readClaudeCliCredentialsCached;
 let readCodexCliActiveApiKey: typeof import("./cli-credentials.js").readCodexCliActiveApiKey;
-let readCodexCliApiKey: typeof import("./cli-credentials.js").readCodexCliApiKey;
 let readCodexCliCredentialsCached: typeof import("./cli-credentials.js").readCodexCliCredentialsCached;
 let readGeminiCliCredentialsCached: typeof import("./cli-credentials.js").readGeminiCliCredentialsCached;
 let readMiniMaxCliCredentialsCached: typeof import("./cli-credentials.js").readMiniMaxCliCredentialsCached;
@@ -65,7 +64,6 @@ describe("cli credentials", () => {
     ({
       readClaudeCliCredentialsCached,
       readCodexCliActiveApiKey,
-      readCodexCliApiKey,
       readCodexCliCredentialsCached,
       readGeminiCliCredentialsCached,
       readMiniMaxCliCredentialsCached,
@@ -601,22 +599,6 @@ describe("cli credentials", () => {
     );
 
     expect(readCodexAuth({ platform: "linux", execSync: execSyncMock })).toBeNull();
-    expect(readCodexCliApiKey({ codexHome: tempHome })).toEqual({
-      type: "api_key",
-      provider: "openai",
-      key: "sk-codex-api-key",
-    });
-  });
-
-  it("does not import a stale Codex API key when auth.json resolves to OAuth mode", () => {
-    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-oauth-mode-"));
-    fs.writeFileSync(
-      path.join(tempHome, "auth.json"),
-      JSON.stringify({ auth_mode: "chatgpt", OPENAI_API_KEY: "stale-api-key" }),
-      "utf8",
-    );
-
-    expect(readCodexCliApiKey({ codexHome: tempHome })).toBeNull();
   });
 
   it("reads API-key auth from the active Codex Keychain store", () => {

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -8,6 +8,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 const execSyncMock = vi.fn();
 const CLI_CREDENTIALS_CACHE_TTL_MS = 15 * 60 * 1000;
 let readClaudeCliCredentialsCached: typeof import("./cli-credentials.js").readClaudeCliCredentialsCached;
+let readCodexCliActiveApiKey: typeof import("./cli-credentials.js").readCodexCliActiveApiKey;
 let readCodexCliApiKey: typeof import("./cli-credentials.js").readCodexCliApiKey;
 let readCodexCliCredentialsCached: typeof import("./cli-credentials.js").readCodexCliCredentialsCached;
 let readGeminiCliCredentialsCached: typeof import("./cli-credentials.js").readGeminiCliCredentialsCached;
@@ -63,6 +64,7 @@ describe("cli credentials", () => {
   beforeAll(async () => {
     ({
       readClaudeCliCredentialsCached,
+      readCodexCliActiveApiKey,
       readCodexCliApiKey,
       readCodexCliCredentialsCached,
       readGeminiCliCredentialsCached,
@@ -615,6 +617,83 @@ describe("cli credentials", () => {
     );
 
     expect(readCodexCliApiKey({ codexHome: tempHome })).toBeNull();
+  });
+
+  it("reads API-key auth from the active Codex Keychain store", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-keychain-api-key-"));
+    execSyncMock.mockImplementation((command: unknown) =>
+      String(command).includes("codex login status")
+        ? "Logged in using an API key - keychain***i-key"
+        : JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: "keychain-api-key" }),
+    );
+
+    expect(
+      readCodexCliActiveApiKey({
+        codexHome: tempHome,
+        platform: "darwin",
+        execSync: execSyncMock,
+      }),
+    ).toEqual({ type: "api_key", provider: "openai", key: "keychain-api-key" });
+  });
+
+  it("prefers active Codex OAuth over a stale file API key", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-keychain-oauth-"));
+    fs.writeFileSync(
+      path.join(tempHome, "auth.json"),
+      JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: "stale-file-api-key" }),
+      "utf8",
+    );
+    execSyncMock.mockReturnValue("Logged in using ChatGPT");
+
+    expect(
+      readCodexCliActiveApiKey({
+        codexHome: tempHome,
+        platform: "darwin",
+        execSync: execSyncMock,
+      }),
+    ).toBeNull();
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the API key that Codex reports active instead of a stale Keychain record", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-default-file-"));
+    fs.writeFileSync(
+      path.join(tempHome, "auth.json"),
+      JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: "active-file-api-key" }),
+      "utf8",
+    );
+    execSyncMock.mockImplementation((command: unknown) =>
+      String(command).includes("codex login status")
+        ? "Logged in using an API key - active-f***i-key"
+        : JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: "stale-keychain-api-key" }),
+    );
+
+    expect(
+      readCodexCliActiveApiKey({
+        codexHome: tempHome,
+        platform: "darwin",
+        execSync: execSyncMock,
+      }),
+    ).toEqual({ type: "api_key", provider: "openai", key: "active-file-api-key" });
+    expect(execSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts legacy Codex API-key status only with one readable candidate", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-legacy-status-"));
+    fs.writeFileSync(
+      path.join(tempHome, "auth.json"),
+      JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: "legacy-file-api-key" }),
+      "utf8",
+    );
+    execSyncMock.mockReturnValue("Logged in using an API key");
+
+    expect(
+      readCodexCliActiveApiKey({
+        codexHome: tempHome,
+        platform: "linux",
+        execSync: execSyncMock,
+      }),
+    ).toEqual({ type: "api_key", provider: "openai", key: "legacy-file-api-key" });
   });
 
   it("treats an empty Codex auth.json API-key field as API-key mode", () => {

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -697,18 +697,6 @@ function readCodexCliCredentials(options?: {
   return parseCodexOauthCredential(raw as Record<string, unknown>, fallbackExpiry);
 }
 
-/** Reads the API key only when Codex auth.json resolves to API-key mode. */
-export function readCodexCliApiKey(options?: {
-  codexHome?: string;
-}): CodexCliApiKeyCredential | null {
-  const authPath = path.join(resolveCodexHomePath(options?.codexHome), CODEX_CLI_AUTH_FILENAME);
-  const raw = loadJsonFile(authPath);
-  if (!raw || typeof raw !== "object") {
-    return null;
-  }
-  return parseCodexApiKeyCredential(raw as Record<string, unknown>);
-}
-
 /** Reads Codex CLI credentials with optional short-lived cache and file fingerprinting. */
 export function readCodexCliCredentialsCached(options?: {
   codexHome?: string;

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -9,7 +9,6 @@ import path from "node:path";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
-  timestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
 import { loadJsonFile } from "../infra/json-file.js";
@@ -350,59 +349,46 @@ function resolveCodexFallbackExpiryMs(nowMs?: number): number | undefined {
   return resolveExpiresAtMsFromDurationMs(CODEX_CLI_FALLBACK_EXPIRY_MS, { nowMs: baseMs });
 }
 
-function readCodexKeychainCredentials(options?: {
-  codexHome?: string;
-  platform?: NodeJS.Platform;
-  execSync?: ExecSyncFn;
-  allowKeychainPrompt?: boolean;
-}): CodexCliCredential | null {
-  const parsed = readCodexKeychainAuthRecord(options);
-  if (!parsed) {
+function parseCodexOauthCredential(
+  data: Record<string, unknown>,
+  fallbackExpiry: number | undefined,
+): CodexCliCredential | null {
+  if (!codexAuthJsonUsesChatGptTokens(data)) {
     return null;
   }
-  const tokens = parsed.tokens as Record<string, unknown> | undefined;
-  try {
-    const accessToken = tokens?.access_token;
-    const refreshToken = tokens?.refresh_token;
-    if (typeof accessToken !== "string" || !accessToken) {
-      return null;
-    }
-    if (typeof refreshToken !== "string" || !refreshToken) {
-      return null;
-    }
-
-    // No explicit expiry stored; treat as fresh for an hour from last_refresh or now.
-    const lastRefreshRaw = parsed.last_refresh;
-    const lastRefresh =
-      typeof lastRefreshRaw === "string" || typeof lastRefreshRaw === "number"
-        ? new Date(lastRefreshRaw).getTime()
-        : Date.now();
-    const fallbackExpiry =
-      resolveCodexFallbackExpiryMs(lastRefresh) ?? resolveCodexFallbackExpiryMs();
-    const expires = decodeJwtExpiryMs(accessToken) ?? fallbackExpiry;
-    if (expires === undefined) {
-      return null;
-    }
-    const accountId = typeof tokens?.account_id === "string" ? tokens.account_id : undefined;
-    const idToken = typeof tokens?.id_token === "string" ? tokens.id_token : undefined;
-
-    log.info("read codex credentials from keychain", {
-      source: "keychain",
-      expires: timestampMsToIsoString(expires),
-    });
-
-    return {
-      type: "oauth",
-      provider: "openai" as OAuthProvider,
-      access: accessToken,
-      refresh: refreshToken,
-      expires,
-      accountId,
-      idToken,
-    };
-  } catch {
+  const tokens = data.tokens as Record<string, unknown> | undefined;
+  const accessToken = tokens?.access_token;
+  const refreshToken = tokens?.refresh_token;
+  if (typeof accessToken !== "string" || !accessToken) {
     return null;
   }
+  if (typeof refreshToken !== "string" || !refreshToken) {
+    return null;
+  }
+
+  const expires = decodeJwtExpiryMs(accessToken) ?? fallbackExpiry;
+  if (expires === undefined) {
+    return null;
+  }
+  return {
+    type: "oauth",
+    provider: "openai" as OAuthProvider,
+    access: accessToken,
+    refresh: refreshToken,
+    expires,
+    accountId: typeof tokens?.account_id === "string" ? tokens.account_id : undefined,
+    idToken: typeof tokens?.id_token === "string" ? tokens.id_token : undefined,
+  };
+}
+
+function parseCodexApiKeyCredential(
+  data: Record<string, unknown>,
+): CodexCliApiKeyCredential | null {
+  if (!codexAuthJsonUsesApiKey(data)) {
+    return null;
+  }
+  const key = typeof data.OPENAI_API_KEY === "string" ? data.OPENAI_API_KEY.trim() : "";
+  return key ? { type: "api_key", provider: "openai", key } : null;
 }
 
 function readCliOauthTokenFields(
@@ -606,6 +592,74 @@ export function readClaudeCliCredentialsCached(options?: {
   });
 }
 
+function formatCodexApiKeyForLoginStatus(key: string): string {
+  return key.length <= 13 ? "***" : `${key.slice(0, 8)}***${key.slice(-5)}`;
+}
+
+/** Reads an API key only when Codex confirms that exact credential is active. */
+export function readCodexCliActiveApiKey(options?: {
+  codexHome?: string;
+  allowKeychainPrompt?: boolean;
+  platform?: NodeJS.Platform;
+  execSync?: ExecSyncFn;
+}): CodexCliApiKeyCredential | null {
+  const { execSyncImpl, codexHome } = resolveCodexKeychainParams(options);
+  let status: string;
+  try {
+    status = execSyncImpl("codex login status 2>&1", {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, CODEX_HOME: codexHome },
+    }).trim();
+  } catch {
+    return null;
+  }
+  const statusMatch = /^Logged in using an API key - (.+)$/mu.exec(status);
+  const activeFingerprint = statusMatch?.[1]?.trim();
+  const legacyApiKeyStatus = status.trim() === "Logged in using an API key";
+  if (!activeFingerprint && !legacyApiKeyStatus) {
+    return null;
+  }
+
+  const candidates: CodexCliApiKeyCredential[] = [];
+  const authPath = path.join(codexHome, CODEX_CLI_AUTH_FILENAME);
+  const raw = loadJsonFile(authPath);
+  if (raw && typeof raw === "object") {
+    const fileCredential = parseCodexApiKeyCredential(raw as Record<string, unknown>);
+    if (fileCredential) {
+      candidates.push(fileCredential);
+    }
+  }
+  const keychainRecord = readCodexKeychainAuthRecord({
+    codexHome,
+    allowKeychainPrompt: options?.allowKeychainPrompt,
+    platform: options?.platform,
+    execSync: options?.execSync,
+  });
+  if (keychainRecord) {
+    const keychainCredential = parseCodexApiKeyCredential(keychainRecord);
+    if (keychainCredential) {
+      candidates.push(keychainCredential);
+    }
+  }
+
+  const matchingKeys = new Set(
+    candidates
+      .filter(
+        (candidate) =>
+          legacyApiKeyStatus ||
+          formatCodexApiKeyForLoginStatus(candidate.key) === activeFingerprint,
+      )
+      .map((candidate) => candidate.key),
+  );
+  if (matchingKeys.size !== 1) {
+    return null;
+  }
+  const key = [...matchingKeys][0];
+  return key ? { type: "api_key", provider: "openai", key } : null;
+}
+
 /** Reads Codex CLI OAuth credentials from Keychain or CODEX_HOME auth.json. */
 function readCodexCliCredentials(options?: {
   codexHome?: string;
@@ -613,14 +667,20 @@ function readCodexCliCredentials(options?: {
   platform?: NodeJS.Platform;
   execSync?: ExecSyncFn;
 }): CodexCliCredential | null {
-  const keychain = readCodexKeychainCredentials({
-    codexHome: options?.codexHome,
-    allowKeychainPrompt: options?.allowKeychainPrompt,
-    platform: options?.platform,
-    execSync: options?.execSync,
-  });
-  if (keychain) {
-    return keychain;
+  const keychainRecord = readCodexKeychainAuthRecord(options);
+  if (keychainRecord) {
+    const lastRefreshRaw = keychainRecord.last_refresh;
+    const lastRefresh =
+      typeof lastRefreshRaw === "string" || typeof lastRefreshRaw === "number"
+        ? new Date(lastRefreshRaw).getTime()
+        : Date.now();
+    const keychainCredential = parseCodexOauthCredential(
+      keychainRecord,
+      resolveCodexFallbackExpiryMs(lastRefresh) ?? resolveCodexFallbackExpiryMs(),
+    );
+    if (keychainCredential) {
+      return keychainCredential;
+    }
   }
 
   const authPath = path.join(resolveCodexHomePath(options?.codexHome), CODEX_CLI_AUTH_FILENAME);
@@ -628,47 +688,13 @@ function readCodexCliCredentials(options?: {
   if (!raw || typeof raw !== "object") {
     return null;
   }
-
-  const data = raw as Record<string, unknown>;
-  if (!codexAuthJsonUsesChatGptTokens(data)) {
-    return null;
-  }
-  const tokens = data.tokens as Record<string, unknown> | undefined;
-  if (!tokens || typeof tokens !== "object") {
-    return null;
-  }
-
-  const accessToken = tokens.access_token;
-  const refreshToken = tokens.refresh_token;
-
-  if (typeof accessToken !== "string" || !accessToken) {
-    return null;
-  }
-  if (typeof refreshToken !== "string" || !refreshToken) {
-    return null;
-  }
-
   let fallbackExpiry: number | undefined;
   try {
-    const stat = fs.statSync(authPath);
-    fallbackExpiry = resolveCodexFallbackExpiryMs(stat.mtimeMs);
+    fallbackExpiry = resolveCodexFallbackExpiryMs(fs.statSync(authPath).mtimeMs);
   } catch {
     fallbackExpiry = resolveCodexFallbackExpiryMs();
   }
-  const expires = decodeJwtExpiryMs(accessToken) ?? fallbackExpiry;
-  if (expires === undefined) {
-    return null;
-  }
-
-  return {
-    type: "oauth",
-    provider: "openai" as OAuthProvider,
-    access: accessToken,
-    refresh: refreshToken,
-    expires,
-    accountId: typeof tokens.account_id === "string" ? tokens.account_id : undefined,
-    idToken: typeof tokens.id_token === "string" ? tokens.id_token : undefined,
-  };
+  return parseCodexOauthCredential(raw as Record<string, unknown>, fallbackExpiry);
 }
 
 /** Reads the API key only when Codex auth.json resolves to API-key mode. */
@@ -680,12 +706,7 @@ export function readCodexCliApiKey(options?: {
   if (!raw || typeof raw !== "object") {
     return null;
   }
-  const data = raw as Record<string, unknown>;
-  if (!codexAuthJsonUsesApiKey(data)) {
-    return null;
-  }
-  const key = typeof data.OPENAI_API_KEY === "string" ? data.OPENAI_API_KEY.trim() : "";
-  return key ? { type: "api_key", provider: "openai", key } : null;
+  return parseCodexApiKeyCredential(raw as Record<string, unknown>);
 }
 
 /** Reads Codex CLI credentials with optional short-lived cache and file fingerprinting. */

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -84,6 +84,13 @@ export type CodexCliCredential = {
   idToken?: string;
 };
 
+/** API-key credential parsed from the active Codex CLI auth mode. */
+export type CodexCliApiKeyCredential = {
+  type: "api_key";
+  provider: "openai";
+  key: string;
+};
+
 /** Credential shape parsed from MiniMax portal CLI storage. */
 type MiniMaxCliCredential = {
   type: "oauth";
@@ -184,6 +191,14 @@ function codexAuthJsonUsesChatGptTokens(data: Record<string, unknown>): boolean 
     return authMode === "chatgpt" || authMode === "chatgptauthtokens";
   }
   return typeof data.OPENAI_API_KEY !== "string";
+}
+
+function codexAuthJsonUsesApiKey(data: Record<string, unknown>): boolean {
+  const authMode = typeof data.auth_mode === "string" ? data.auth_mode.toLowerCase() : undefined;
+  if (authMode) {
+    return authMode === "apikey" || authMode === "api_key";
+  }
+  return typeof data.OPENAI_API_KEY === "string";
 }
 
 function resolveMiniMaxCliCredentialsPath(homeDir?: string) {
@@ -654,6 +669,23 @@ function readCodexCliCredentials(options?: {
     accountId: typeof tokens.account_id === "string" ? tokens.account_id : undefined,
     idToken: typeof tokens.id_token === "string" ? tokens.id_token : undefined,
   };
+}
+
+/** Reads the API key only when Codex auth.json resolves to API-key mode. */
+export function readCodexCliApiKey(options?: {
+  codexHome?: string;
+}): CodexCliApiKeyCredential | null {
+  const authPath = path.join(resolveCodexHomePath(options?.codexHome), CODEX_CLI_AUTH_FILENAME);
+  const raw = loadJsonFile(authPath);
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const data = raw as Record<string, unknown>;
+  if (!codexAuthJsonUsesApiKey(data)) {
+    return null;
+  }
+  const key = typeof data.OPENAI_API_KEY === "string" ? data.OPENAI_API_KEY.trim() : "";
+  return key ? { type: "api_key", provider: "openai", key } : null;
 }
 
 /** Reads Codex CLI credentials with optional short-lived cache and file fingerprinting. */

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -173,11 +173,8 @@ function withSuiteTempDirs<
   if (deps.createTempDir === makeTempDir && !deps.removeTempDir) {
     deps.removeTempDir = deferSuiteTempDirCleanup;
   }
-  if (!deps.readCodexCliCredentialsCached) {
-    deps.readCodexCliCredentialsCached = () => null;
-  }
-  if (!deps.readCodexCliApiKey) {
-    deps.readCodexCliApiKey = () => null;
+  if (!deps.readCodexCliActiveApiKey) {
+    deps.readCodexCliActiveApiKey = () => null;
   }
   return deps;
 }
@@ -3672,8 +3669,7 @@ describe("activateSetupInference", () => {
             sourceConfig: initialConfig,
             runtimeConfig: initialConfig,
           })) as never,
-          readCodexCliCredentialsCached: () => null,
-          readCodexCliApiKey: () => ({
+          readCodexCliActiveApiKey: () => ({
             type: "api_key",
             provider: "openai",
             key: "codex-api-key",
@@ -3715,11 +3711,7 @@ describe("activateSetupInference", () => {
   });
 
   it("prefers usable Codex OAuth without registering a discovered API key", async () => {
-    const readCodexCliApiKey = vi.fn(() => ({
-      type: "api_key" as const,
-      provider: "openai" as const,
-      key: "unused-codex-api-key",
-    }));
+    const readCodexCliActiveApiKey = vi.fn(() => null);
     const configHarness = createConfigTransformHarness();
     const runEmbeddedAgent = vi.fn(successfulRunner("openai", "gpt-5.6-sol"));
 
@@ -3728,14 +3720,7 @@ describe("activateSetupInference", () => {
       surface: "gateway",
       runtime,
       deps: {
-        readCodexCliCredentialsCached: () => ({
-          type: "oauth",
-          provider: "openai",
-          access: "oauth-access",
-          refresh: "oauth-refresh",
-          expires: Date.now() + 60_000,
-        }),
-        readCodexCliApiKey,
+        readCodexCliActiveApiKey,
         ensureCodexRuntimePlugin: vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => ({
           cfg,
           required: true,
@@ -3750,7 +3735,7 @@ describe("activateSetupInference", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(readCodexCliApiKey).not.toHaveBeenCalled();
+    expect(readCodexCliActiveApiKey).toHaveBeenCalledWith({ allowKeychainPrompt: true });
     expect(runEmbeddedAgent.mock.calls[0]?.[0].authProfileId).toBeUndefined();
     expect(configHarness.current().auth).toBeUndefined();
   });
@@ -3777,8 +3762,7 @@ describe("activateSetupInference", () => {
             sourceConfig: initialConfig,
             runtimeConfig: initialConfig,
           })) as never,
-          readCodexCliCredentialsCached: () => null,
-          readCodexCliApiKey: () => ({
+          readCodexCliActiveApiKey: () => ({
             type: "api_key",
             provider: "openai",
             key: "rejected-codex-key",

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -173,6 +173,12 @@ function withSuiteTempDirs<
   if (deps.createTempDir === makeTempDir && !deps.removeTempDir) {
     deps.removeTempDir = deferSuiteTempDirCleanup;
   }
+  if (!deps.readCodexCliCredentialsCached) {
+    deps.readCodexCliCredentialsCached = () => null;
+  }
+  if (!deps.readCodexCliApiKey) {
+    deps.readCodexCliApiKey = () => null;
+  }
   return deps;
 }
 
@@ -3628,6 +3634,176 @@ describe("activateSetupInference", () => {
         expect(result.error).not.toContain("bad-groq-key");
       }
       expect(readAuthProfileStoreForTest(agentDir).profiles["groq:default"]).toBeUndefined();
+    } finally {
+      await removeOAuthTestTempRoot(stateDir);
+    }
+  });
+
+  it("registers an active Codex API key only after its isolated live test succeeds", async () => {
+    const stateDir = await makeTempDir();
+    const agentDir = path.join(stateDir, "agent");
+    const initialConfig = {
+      agents: { list: [{ id: "main", default: true, agentDir }] },
+    } satisfies OpenClawConfig;
+    const configHarness = createConfigTransformHarness(initialConfig);
+    const runEmbeddedAgent = vi.fn(async (params: SuccessfulRunParams & { agentDir?: string }) => {
+      const profileId = params.authProfileId;
+      expect(profileId).toMatch(/^openai:setup-/);
+      expect(readAuthProfileStoreForTest(params.agentDir!).profiles[profileId!]).toMatchObject({
+        type: "api_key",
+        provider: "openai",
+        key: "codex-api-key",
+      });
+      return successfulRun("openai", "gpt-5.6-sol", params);
+    });
+
+    try {
+      const result = await activateSetupInference({
+        kind: "codex-cli",
+        surface: "gateway",
+        runtime,
+        deps: {
+          readConfigFileSnapshot: vi.fn(async () => ({
+            exists: true,
+            valid: true,
+            path: "/tmp/openclaw.json",
+            issues: [],
+            config: initialConfig,
+            sourceConfig: initialConfig,
+            runtimeConfig: initialConfig,
+          })) as never,
+          readCodexCliCredentialsCached: () => null,
+          readCodexCliApiKey: () => ({
+            type: "api_key",
+            provider: "openai",
+            key: "codex-api-key",
+          }),
+          ensureCodexRuntimePlugin: vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => ({
+            cfg,
+            required: true,
+            installed: true,
+            status: "installed" as const,
+          })) as never,
+          runEmbeddedAgent: runEmbeddedAgent as never,
+          transformConfigWithPendingPluginInstalls: configHarness.transform as never,
+          refreshPluginRegistryAfterConfigMutation: vi.fn(async () => {}) as never,
+          createTempDir: makeTempDir,
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true, modelRef: "openai/gpt-5.6-sol" });
+      const profileId = runEmbeddedAgent.mock.calls[0]?.[0].authProfileId;
+      expect(profileId).toMatch(/^openai:setup-/);
+      expect(readAuthProfileStoreForTest(agentDir).profiles[profileId!]).toMatchObject({
+        type: "api_key",
+        provider: "openai",
+        key: "codex-api-key",
+      });
+      expect(configHarness.current()).toMatchObject({
+        auth: {
+          profiles: {
+            [profileId!]: { provider: "openai", mode: "api_key" },
+          },
+        },
+        agents: {
+          defaults: { model: `openai/gpt-5.6-sol@${profileId}` },
+        },
+      });
+    } finally {
+      await removeOAuthTestTempRoot(stateDir);
+    }
+  });
+
+  it("prefers usable Codex OAuth without registering a discovered API key", async () => {
+    const readCodexCliApiKey = vi.fn(() => ({
+      type: "api_key" as const,
+      provider: "openai" as const,
+      key: "unused-codex-api-key",
+    }));
+    const configHarness = createConfigTransformHarness();
+    const runEmbeddedAgent = vi.fn(successfulRunner("openai", "gpt-5.6-sol"));
+
+    const result = await activateSetupInference({
+      kind: "codex-cli",
+      surface: "gateway",
+      runtime,
+      deps: {
+        readCodexCliCredentialsCached: () => ({
+          type: "oauth",
+          provider: "openai",
+          access: "oauth-access",
+          refresh: "oauth-refresh",
+          expires: Date.now() + 60_000,
+        }),
+        readCodexCliApiKey,
+        ensureCodexRuntimePlugin: vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => ({
+          cfg,
+          required: true,
+          installed: true,
+          status: "installed" as const,
+        })) as never,
+        runEmbeddedAgent: runEmbeddedAgent as never,
+        transformConfigWithPendingPluginInstalls: configHarness.transform as never,
+        refreshPluginRegistryAfterConfigMutation: vi.fn(async () => {}) as never,
+        createTempDir: makeTempDir,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readCodexCliApiKey).not.toHaveBeenCalled();
+    expect(runEmbeddedAgent.mock.calls[0]?.[0].authProfileId).toBeUndefined();
+    expect(configHarness.current().auth).toBeUndefined();
+  });
+
+  it("redacts and does not register a Codex API key after a failed live test", async () => {
+    const stateDir = await makeTempDir();
+    const agentDir = path.join(stateDir, "agent");
+    const initialConfig = {
+      agents: { list: [{ id: "main", default: true, agentDir }] },
+    } satisfies OpenClawConfig;
+
+    try {
+      const result = await activateSetupInference({
+        kind: "codex-cli",
+        surface: "gateway",
+        runtime,
+        deps: {
+          readConfigFileSnapshot: vi.fn(async () => ({
+            exists: true,
+            valid: true,
+            path: "/tmp/openclaw.json",
+            issues: [],
+            config: initialConfig,
+            sourceConfig: initialConfig,
+            runtimeConfig: initialConfig,
+          })) as never,
+          readCodexCliCredentialsCached: () => null,
+          readCodexCliApiKey: () => ({
+            type: "api_key",
+            provider: "openai",
+            key: "rejected-codex-key",
+          }),
+          ensureCodexRuntimePlugin: vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => ({
+            cfg,
+            required: true,
+            installed: true,
+            status: "installed" as const,
+          })) as never,
+          runEmbeddedAgent: vi.fn(async () => {
+            throw new Error("401 rejected rejected-codex-key");
+          }) as never,
+          transformConfigWithPendingPluginInstalls: vi.fn() as never,
+          refreshPluginRegistryAfterConfigMutation: vi.fn(async () => {}) as never,
+          createTempDir: makeTempDir,
+        },
+      });
+
+      expect(result).toMatchObject({ ok: false, status: "auth" });
+      if (!result.ok) {
+        expect(result.error).toContain("401 rejected [redacted]");
+        expect(result.error).not.toContain("rejected-codex-key");
+      }
+      expect(readAuthProfileStoreForTest(agentDir).profiles).toEqual({});
     } finally {
       await removeOAuthTestTempRoot(stateDir);
     }

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -18,8 +18,7 @@ import {
 } from "../agents/auth-profiles/store.js";
 import { resolveCliBackendConfig } from "../agents/cli-backends.js";
 import {
-  readCodexCliApiKey,
-  readCodexCliCredentialsCached,
+  readCodexCliActiveApiKey,
   type CodexCliApiKeyCredential,
 } from "../agents/cli-credentials.js";
 import { CliExecutionAuthProfileError } from "../agents/cli-execution-auth.js";
@@ -324,8 +323,7 @@ export type ActivateSetupInferenceDeps = {
   resolveCliRuntimeArtifactFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeArtifactFingerprint;
   resolveCliRuntimeOwnerFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeOwnerFingerprint;
   resolveApiKeyForProvider?: typeof import("../agents/model-auth.js").resolveApiKeyForProvider;
-  readCodexCliApiKey?: typeof readCodexCliApiKey;
-  readCodexCliCredentialsCached?: typeof readCodexCliCredentialsCached;
+  readCodexCliActiveApiKey?: typeof readCodexCliActiveApiKey;
   loadPluginRegistrySnapshot?: SystemAgentVerifiedInferenceDeps["loadPluginRegistrySnapshot"];
   fingerprintPluginRuntimeArtifact?: SystemAgentVerifiedInferenceDeps["fingerprintPluginRuntimeArtifact"];
   captureSystemAgentOwnerPluginArtifacts?: typeof captureSystemAgentOwnerPluginArtifacts;
@@ -2456,12 +2454,8 @@ function resolveCodexCliSetupApiKey(
   if (params.kind !== "codex-cli") {
     return null;
   }
-  const oauthReader = params.deps?.readCodexCliCredentialsCached ?? readCodexCliCredentialsCached;
-  const oauth = oauthReader({ allowKeychainPrompt: false, ttlMs: 0 });
-  if (oauth) {
-    return null;
-  }
-  return (params.deps?.readCodexCliApiKey ?? readCodexCliApiKey)();
+  const reader = params.deps?.readCodexCliActiveApiKey ?? readCodexCliActiveApiKey;
+  return reader({ allowKeychainPrompt: true });
 }
 
 async function redactSetupInferenceError(

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -17,6 +17,11 @@ import {
   updateAuthProfileStoreWithLock,
 } from "../agents/auth-profiles/store.js";
 import { resolveCliBackendConfig } from "../agents/cli-backends.js";
+import {
+  readCodexCliApiKey,
+  readCodexCliCredentialsCached,
+  type CodexCliApiKeyCredential,
+} from "../agents/cli-credentials.js";
 import { CliExecutionAuthProfileError } from "../agents/cli-execution-auth.js";
 import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
 import { describeFailoverError } from "../agents/failover-error.js";
@@ -319,6 +324,8 @@ export type ActivateSetupInferenceDeps = {
   resolveCliRuntimeArtifactFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeArtifactFingerprint;
   resolveCliRuntimeOwnerFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeOwnerFingerprint;
   resolveApiKeyForProvider?: typeof import("../agents/model-auth.js").resolveApiKeyForProvider;
+  readCodexCliApiKey?: typeof readCodexCliApiKey;
+  readCodexCliCredentialsCached?: typeof readCodexCliCredentialsCached;
   loadPluginRegistrySnapshot?: SystemAgentVerifiedInferenceDeps["loadPluginRegistrySnapshot"];
   fingerprintPluginRuntimeArtifact?: SystemAgentVerifiedInferenceDeps["fingerprintPluginRuntimeArtifact"];
   captureSystemAgentOwnerPluginArtifacts?: typeof captureSystemAgentOwnerPluginArtifacts;
@@ -1063,6 +1070,7 @@ async function buildTestPlan(params: {
   isCancelled?: () => boolean;
   isRemoteProviderAuth?: boolean;
   routeAgentId?: string;
+  codexCliApiKey?: CodexCliApiKeyCredential;
   deps: ActivateSetupInferenceDeps;
 }): Promise<SetupInferenceTestPlan | { error: string; status?: SetupInferenceFailureStatus }> {
   const { kind, cfg, workspaceDir } = params;
@@ -1289,6 +1297,40 @@ async function buildTestPlan(params: {
         return modelRef;
       }
       const ref = parseRef(modelRef);
+      if (params.codexCliApiKey) {
+        const preparedAuth = prepareManualAuthForActivation({
+          baseConfig: cfg,
+          preparedConfig: cfg,
+          profiles: [
+            {
+              profileId: "openai:codex-cli-api-key",
+              credential: params.codexCliApiKey,
+            },
+          ],
+          selectedProfileId: "openai:codex-cli-api-key",
+          modelRef,
+          providerId: ref.provider,
+        });
+        return {
+          runner: "embedded",
+          ...ref,
+          modelRef,
+          agentHarnessRuntimeOverride: "codex",
+          config: preparedAuth.config,
+          agentId: "openclaw",
+          routeAgentId: resolveDefaultAgentId(preparedAuth.config),
+          agentDir: params.agentDir,
+          cleanupBundleMcpOnRunEnd: true,
+          authProfileId: preparedAuth.selectedProfileId,
+          persistModelRef: modelRef,
+          manualAuth: {
+            profiles: preparedAuth.profiles,
+            runtimeConfigBase: cfg,
+            sourceConfigBase: params.sourceCfg,
+            configPatch: createMergePatch(cfg, preparedAuth.config),
+          },
+        };
+      }
       return {
         runner: "embedded",
         ...ref,
@@ -1609,23 +1651,26 @@ async function runProviderManualSecretMethod(params: {
 export async function activateSetupInference(
   params: ActivateSetupInferenceParams,
 ): Promise<ActivateSetupInferenceResult> {
+  const codexCliApiKey = resolveCodexCliSetupApiKey(params);
   try {
-    const result = await activateSetupInferenceUnredacted(params);
+    const result = await activateSetupInferenceUnredacted(params, codexCliApiKey ?? undefined);
     if (result.ok) {
       return {
         ...result,
         lines: await Promise.all(
-          result.lines.map((line) => redactSetupInferenceError(line, params.apiKey)),
+          result.lines.map((line) =>
+            redactSetupInferenceError(line, params.apiKey, codexCliApiKey?.key),
+          ),
         ),
       };
     }
     return {
       ...result,
-      error: await redactSetupInferenceError(result.error, params.apiKey),
+      error: await redactSetupInferenceError(result.error, params.apiKey, codexCliApiKey?.key),
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const redacted = await redactSetupInferenceError(message, params.apiKey);
+    const redacted = await redactSetupInferenceError(message, params.apiKey, codexCliApiKey?.key);
     if (error instanceof SetupInferenceCancelledError || params.signal?.aborted) {
       return { ok: false, status: "unavailable", error: "Provider login was cancelled." };
     }
@@ -1645,6 +1690,7 @@ export async function activateSetupInference(
 
 async function activateSetupInferenceUnredacted(
   params: ActivateSetupInferenceParams,
+  codexCliApiKey?: CodexCliApiKeyCredential,
 ): Promise<ActivateSetupInferenceResult> {
   const deps = params.deps ?? {};
   const readSnapshot =
@@ -1692,6 +1738,7 @@ async function activateSetupInferenceUnredacted(
       ...(params.kind === "provider-auth"
         ? { isRemoteProviderAuth: params.surface === "gateway" }
         : {}),
+      ...(codexCliApiKey ? { codexCliApiKey } : {}),
       deps,
     });
     if ("error" in plan) {
@@ -2403,9 +2450,28 @@ async function activateSetupInferenceUnredacted(
   }
 }
 
-async function redactSetupInferenceError(message: string, apiKey?: string): Promise<string> {
+function resolveCodexCliSetupApiKey(
+  params: ActivateSetupInferenceParams,
+): CodexCliApiKeyCredential | null {
+  if (params.kind !== "codex-cli") {
+    return null;
+  }
+  const oauthReader = params.deps?.readCodexCliCredentialsCached ?? readCodexCliCredentialsCached;
+  const oauth = oauthReader({ allowKeychainPrompt: false, ttlMs: 0 });
+  if (oauth) {
+    return null;
+  }
+  return (params.deps?.readCodexCliApiKey ?? readCodexCliApiKey)();
+}
+
+async function redactSetupInferenceError(
+  message: string,
+  ...apiKeys: Array<string | undefined>
+): Promise<string> {
   const secrets = new Set(
-    [apiKey, apiKey?.trim()].filter((value): value is string => Boolean(value)),
+    apiKeys
+      .flatMap((apiKey) => [apiKey, apiKey?.trim()])
+      .filter((value): value is string => Boolean(value)),
   );
   let redacted = message;
   for (const secret of Array.from(secrets).toSorted((a, b) => b.length - a.length)) {


### PR DESCRIPTION
Closes #112750

AI-assisted: Codex implemented and reviewed this change under maintainer direction.

## What Problem This Solves

Fixes an issue where users starting assisted onboarding with API-key-only Codex authentication would see Codex detected as logged in, followed by an authentication failure during the real AI check.

## Why This Change Was Made

Codex login status accepts both OAuth and API-key authentication, while OpenClaw previously imported only OAuth. Assisted setup now asks Codex which API-key credential is active, stages only a uniquely matching key for the isolated real-completion check, and persists it transactionally only after that check succeeds. OAuth remains preferred, rejected keys are removed, and operator-visible failures redact the candidate key.

## User Impact

Users with an active Codex API key can complete the new assisted onboarding flow without signing in again with OAuth. Stale file or Keychain credentials are not registered when Codex reports a different active credential.

## Evidence

- Red: fresh OCM environment detected `Codex — logged in`, then reported `AI check failed` and `Authentication failed` before the fix.
- Green: fresh OCM environment on the proposed source detected the same API-key-only Codex login, completed a real `openai/gpt-5.6-sol` request, and displayed `AI check passed`.
- Negative control: a fresh environment with a unique rejected API key displayed a redacted authentication failure and left both auth-profile tables empty.
- Focused tests: 144 passed (27 credential tests and 117 setup-inference tests).
- The first exact-head CI run exposed an unused test-only export; it was removed, focused proof reran green, and fresh autoreview found no findings.
- `git diff --check` — passed.
- Autoreview — clean; no accepted/actionable findings.
