### PR TITLE
refactor(agents): consolidate model normalization

### DIFF
--- a/src/agents/command/model-ref.ts
+++ b/src/agents/command/model-ref.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../../plugins/config-state.js";
 import { normalizeConfiguredProviderCatalogModelId } from "../model-ref-shared.js";
-import type { ModelManifestNormalizationContext } from "../model-selection-normalize.js";
+import type { ModelManifestNormalizationContext } from "../model-ref-shared.js";
 import {
   buildModelAliasIndex,
   normalizeModelRef,

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -32,7 +32,7 @@ import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
 import { resolveAvailableAgentHarnessPolicy } from "../harness/selection.js";
 import { loadManifestModelCatalog } from "../model-catalog.js";
 import { splitTrailingAuthProfile } from "../model-ref-profile.js";
-import type { ModelManifestNormalizationContext } from "../model-selection-normalize.js";
+import type { ModelManifestNormalizationContext } from "../model-ref-shared.js";
 import {
   modelKey,
   resolveDefaultModelForAgent,

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -35,7 +35,7 @@ import {
 } from "../agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { AGENT_LANE_SUBAGENT } from "../lanes.js";
-import type { ModelManifestNormalizationContext } from "../model-selection-normalize.js";
+import type { ModelManifestNormalizationContext } from "../model-ref-shared.js";
 import { buildConfiguredModelCatalog, resolveConfiguredModelRef } from "../model-selection.js";
 import { normalizeSpawnedRunMetadata } from "../spawned-context.js";
 import { resolveEffectiveAgentRuntime } from "../thinking-runtime.js";

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -4,7 +4,7 @@ import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
 import type { ModelFallbackStepFields } from "../model-fallback-observation.js";
 import { runWithModelFallback, type ModelFallbackResultClassification } from "../model-fallback.js";
 import type { FallbackAttempt } from "../model-fallback.types.js";
-import type { ModelManifestNormalizationContext } from "../model-selection-normalize.js";
+import type { ModelManifestNormalizationContext } from "../model-ref-shared.js";
 import { resolveAgentRunAbortLifecycleFields } from "../run-termination.js";
 import {
   classifyEmbeddedAgentRunResultForModelFallback,

--- a/src/agents/fallback-skip-cache.ts
+++ b/src/agents/fallback-skip-cache.ts
@@ -15,7 +15,7 @@
  */
 
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
-import { modelKey } from "./model-selection-normalize.js";
+import { modelKey } from "./model-ref-shared.js";
 
 /**
  * Default time-to-live for a skip marker. Disabled by default so existing

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -66,14 +66,14 @@ import {
   type ModelFallbackStepFields,
 } from "./model-fallback-observation.js";
 import type { FallbackAttempt, ModelCandidate } from "./model-fallback.types.js";
-import { isCliRuntimeAlias } from "./model-runtime-aliases.js";
-import { isCliProvider } from "./model-selection-cli.js";
 import {
   type ModelManifestNormalizationContext,
   modelKey,
   normalizeModelRef,
   normalizeProviderId,
-} from "./model-selection-normalize.js";
+} from "./model-ref-shared.js";
+import { isCliRuntimeAlias } from "./model-runtime-aliases.js";
+import { isCliProvider } from "./model-selection-cli.js";
 import {
   buildConfiguredAllowlistKeys,
   buildModelAliasIndex,

--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -3,22 +3,33 @@
  * allowlists, and display paths. Manifest policies are optional so tests can
  * isolate built-in normalization behavior.
  */
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import {
+  findNormalizedProviderKey as findNormalizedProviderKeyCore,
+  normalizeProviderId as normalizeProviderIdCore,
+  normalizeProviderIdForAuth as normalizeProviderIdForAuthCore,
+} from "@openclaw/model-catalog-core/provider-id";
 import {
   collectManifestModelIdNormalizationPolicies,
   normalizeBuiltInProviderModelId,
   normalizeConfiguredProviderCatalogModelRef,
   normalizeConfiguredProviderCatalogModelId as normalizeConfiguredProviderCatalogModelIdShared,
   normalizeStaticProviderModelIdWithPolicies,
+  stripSelfProviderModelPrefix,
 } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeProviderModelIdWithManifest } from "../plugins/manifest-model-id-normalization.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { modelKey } from "../shared/model-key.js";
+import { normalizeProviderModelIdWithRuntime } from "./provider-model-normalization.runtime.js";
 export { modelKey } from "../shared/model-key.js";
 
-type StaticModelRef = {
+export type ModelRef = {
   provider: string;
   model: string;
+};
+
+export type ModelManifestNormalizationContext = {
+  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
 };
 
 export type ProviderModelIdNormalizationOptions = {
@@ -41,6 +52,24 @@ type ManifestModelIdNormalizationRecord = {
     providers?: Record<string, ManifestModelIdNormalizationProvider>;
   };
 };
+
+/** Normalize a provider ID using the shared catalog rules. */
+export function normalizeProviderId(provider: string): string {
+  return normalizeProviderIdCore(provider);
+}
+
+/** Normalize a provider ID for auth lookup. */
+export function normalizeProviderIdForAuth(provider: string): string {
+  return normalizeProviderIdForAuthCore(provider);
+}
+
+/** Find the original provider key matching a normalized provider ID. */
+export function findNormalizedProviderKey(
+  entries: Record<string, unknown> | undefined,
+  provider: string,
+): string | undefined {
+  return findNormalizedProviderKeyCore(entries, provider);
+}
 
 /** Normalize a static provider model ID with built-in and optional manifest policy. */
 export function normalizeStaticProviderModelId(
@@ -91,7 +120,57 @@ export function normalizeConfiguredProviderCatalogModelId(
   );
 }
 
-function parseStaticModelRef(raw: string, defaultProvider: string): StaticModelRef | null {
+type ModelRefNormalizeOptions = ModelManifestNormalizationContext & {
+  allowManifestNormalization?: boolean;
+  allowPluginNormalization?: boolean;
+};
+
+function normalizeProviderModelId(
+  provider: string,
+  model: string,
+  options?: ModelRefNormalizeOptions,
+): string {
+  const providerModel = stripSelfProviderModelPrefix(provider, model);
+  const staticModelId = normalizeStaticProviderModelId(provider, providerModel, options);
+  if (options?.allowPluginNormalization === false) {
+    return staticModelId;
+  }
+  return (
+    normalizeProviderModelIdWithRuntime({
+      provider,
+      ...(options?.manifestPlugins ? { plugins: options.manifestPlugins } : {}),
+      context: {
+        provider,
+        modelId: staticModelId,
+      },
+    }) ?? staticModelId
+  );
+}
+
+/** Normalize a provider/model pair into a canonical model reference. */
+export function normalizeModelRef(
+  provider: string,
+  model: string,
+  options?: ModelRefNormalizeOptions,
+): ModelRef {
+  const normalizedProvider = normalizeProviderId(provider);
+  const normalizedModel = normalizeProviderModelId(normalizedProvider, model.trim(), options);
+  return { provider: normalizedProvider, model: normalizedModel };
+}
+
+/** Return the legacy raw key when it differs from the canonical key. */
+export function legacyModelKey(provider: string, model: string): string | null {
+  const providerId = provider.trim();
+  const modelId = model.trim();
+  if (!providerId || !modelId) {
+    return null;
+  }
+  const rawKey = `${providerId}/${modelId}`;
+  const canonicalKey = modelKey(providerId, modelId);
+  return rawKey === canonicalKey ? null : rawKey;
+}
+
+function parseStaticModelRef(raw: string, defaultProvider: string): ModelRef | null {
   const trimmed = raw.trim();
   if (!trimmed) {
     return null;

--- a/src/agents/model-selection-cli.ts
+++ b/src/agents/model-selection-cli.ts
@@ -4,7 +4,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveRuntimeCliBackends } from "../plugins/cli-backends.runtime.js";
 import { resolvePluginSetupCliBackendDescriptor } from "../plugins/setup-registry.runtime.js";
-import { normalizeProviderId } from "./model-selection-normalize.js";
+import { normalizeProviderId } from "./model-ref-shared.js";
 
 /** Return true when a provider id resolves to a configured or plugin CLI backend. */
 export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {

--- a/src/agents/model-selection-config.ts
+++ b/src/agents/model-selection-config.ts
@@ -3,7 +3,7 @@ import { toAgentModelListLike } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentConfig, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
-import type { ModelManifestNormalizationContext, ModelRef } from "./model-selection-normalize.js";
+import type { ModelManifestNormalizationContext, ModelRef } from "./model-ref-shared.js";
 import { normalizeModelSelection, resolveConfiguredModelRef } from "./model-selection-shared.js";
 
 export function resolveDefaultModelForAgent(

--- a/src/agents/model-selection-normalize.ts
+++ b/src/agents/model-selection-normalize.ts
@@ -1,55 +1,21 @@
 /**
- * Normalizes provider/model references and configured model ids.
+ * Public model-reference parser retained at its shipped Plugin SDK declaration
+ * path. Provider/model normalization itself lives in model-ref-shared.
  */
-import {
-  findNormalizedProviderKey as findNormalizedProviderKeyCore,
-  findNormalizedProviderValue as findNormalizedProviderValueCore,
-  normalizeProviderId as normalizeProviderIdCore,
-  normalizeProviderIdForAuth as normalizeProviderIdForAuthCore,
-} from "@openclaw/model-catalog-core/provider-id";
-import { stripSelfProviderModelPrefix } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import { findNormalizedProviderValue as findNormalizedProviderValueCore } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
-import { modelKey as sharedModelKey, normalizeStaticProviderModelId } from "./model-ref-shared.js";
-import { normalizeProviderModelIdWithRuntime } from "./provider-model-normalization.runtime.js";
+import {
+  type ModelManifestNormalizationContext,
+  type ModelRef,
+  normalizeModelRef,
+} from "./model-ref-shared.js";
 
-// Shared provider/model normalization facade for agent model selection. It
-// combines catalog-core provider IDs, static aliases, and optional plugin hooks.
-export type ModelRef = {
-  provider: string;
-  model: string;
+type ModelRefNormalizeOptions = ModelManifestNormalizationContext & {
+  allowManifestNormalization?: boolean;
+  allowPluginNormalization?: boolean;
 };
 
-export type ModelManifestNormalizationContext = {
-  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
-};
-
-/** Build the canonical provider/model key for model selection. */
-export function modelKey(provider: string, model: string) {
-  return sharedModelKey(provider, model);
-}
-
-/** Return the legacy raw key when it differs from the canonical key. */
-export function legacyModelKey(provider: string, model: string): string | null {
-  const providerId = provider.trim();
-  const modelId = model.trim();
-  if (!providerId || !modelId) {
-    return null;
-  }
-  const rawKey = `${providerId}/${modelId}`;
-  const canonicalKey = modelKey(providerId, modelId);
-  return rawKey === canonicalKey ? null : rawKey;
-}
-
-/** Normalize a provider ID using the shared catalog rules. */
-export function normalizeProviderId(provider: string): string {
-  return normalizeProviderIdCore(provider);
-}
-
-/** Normalize a provider ID for auth lookup. */
-export function normalizeProviderIdForAuth(provider: string): string {
-  return normalizeProviderIdForAuthCore(provider);
-}
+const OPENROUTER_AUTO_COMPAT_ALIAS = "openrouter:auto";
 
 /** Find a provider value by normalized provider ID. */
 export function findNormalizedProviderValue<T>(
@@ -58,60 +24,6 @@ export function findNormalizedProviderValue<T>(
 ): T | undefined {
   return findNormalizedProviderValueCore(entries, provider);
 }
-
-/** Find the original provider key matching a normalized provider ID. */
-export function findNormalizedProviderKey(
-  entries: Record<string, unknown> | undefined,
-  provider: string,
-): string | undefined {
-  return findNormalizedProviderKeyCore(entries, provider);
-}
-
-function normalizeProviderModelId(
-  provider: string,
-  model: string,
-  options?: ModelManifestNormalizationContext & {
-    allowManifestNormalization?: boolean;
-    allowPluginNormalization?: boolean;
-  },
-): string {
-  const providerModel = stripSelfProviderModelPrefix(provider, model);
-  const staticModelId = normalizeStaticProviderModelId(provider, providerModel, {
-    allowManifestNormalization: options?.allowManifestNormalization,
-    manifestPlugins: options?.manifestPlugins,
-  });
-  if (options?.allowPluginNormalization === false) {
-    return staticModelId;
-  }
-  return (
-    normalizeProviderModelIdWithRuntime({
-      provider,
-      ...(options?.manifestPlugins ? { plugins: options.manifestPlugins } : {}),
-      context: {
-        provider,
-        modelId: staticModelId,
-      },
-    }) ?? staticModelId
-  );
-}
-
-type ModelRefNormalizeOptions = ModelManifestNormalizationContext & {
-  allowManifestNormalization?: boolean;
-  allowPluginNormalization?: boolean;
-};
-
-/** Normalize a provider/model pair into a canonical model reference. */
-export function normalizeModelRef(
-  provider: string,
-  model: string,
-  options?: ModelRefNormalizeOptions,
-): ModelRef {
-  const normalizedProvider = normalizeProviderId(provider);
-  const normalizedModel = normalizeProviderModelId(normalizedProvider, model.trim(), options);
-  return { provider: normalizedProvider, model: normalizedModel };
-}
-
-const OPENROUTER_AUTO_COMPAT_ALIAS = "openrouter:auto";
 
 /** Parse `provider/model` or bare model text using a default provider. */
 export function parseModelRef(

--- a/src/agents/model-selection-normalize.ts
+++ b/src/agents/model-selection-normalize.ts
@@ -1,6 +1,6 @@
 /**
- * Public model-reference parser retained at its shipped Plugin SDK declaration
- * path. Provider/model normalization itself lives in model-ref-shared.
+ * Internal declaration anchor for parser and lookup exports consumed by the
+ * public Plugin SDK barrel. Provider/model normalization lives in model-ref-shared.
  */
 import { findNormalizedProviderValue as findNormalizedProviderValueCore } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";

--- a/src/agents/model-selection-resolve.ts
+++ b/src/agents/model-selection-resolve.ts
@@ -8,7 +8,7 @@ import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentModelFallbacksOverride } from "./agent-scope.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
-import type { ModelManifestNormalizationContext, ModelRef } from "./model-selection-normalize.js";
+import type { ModelManifestNormalizationContext, ModelRef } from "./model-ref-shared.js";
 import {
   buildModelAliasIndex,
   getModelRefStatusWithFallbackModels,

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -31,12 +31,11 @@ import {
 import {
   type ModelManifestNormalizationContext,
   type ModelRef,
-  findNormalizedProviderValue,
   modelKey,
   normalizeModelRef,
   normalizeProviderId,
-  parseModelRef,
-} from "./model-selection-normalize.js";
+} from "./model-ref-shared.js";
+import { findNormalizedProviderValue, parseModelRef } from "./model-selection-normalize.js";
 
 // Shared model-selection helpers for config aliases, allowlists, provider
 // inference, and configured catalog rows used by CLI and runtime selectors.

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -242,7 +242,7 @@ describe("model-selection plugin runtime normalization", () => {
         },
       },
     ];
-    const { normalizeModelRef } = await import("./model-selection-normalize.js");
+    const { normalizeModelRef } = await import("./model-ref-shared.js");
     normalizeModelRef("custom", "my-model", { manifestPlugins: preparedPlugins });
     expect(normalizeProviderModelIdWithPluginMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -254,7 +254,7 @@ describe("model-selection plugin runtime normalization", () => {
 
   it("omits plugins from the runtime call when no manifestPlugins are prepared (preserves current behavior)", async () => {
     normalizeProviderModelIdWithPluginMock.mockReturnValue(undefined);
-    const { normalizeModelRef } = await import("./model-selection-normalize.js");
+    const { normalizeModelRef } = await import("./model-ref-shared.js");
     normalizeModelRef("custom", "my-model");
     const callArgs = normalizeProviderModelIdWithPluginMock.mock.calls[0]?.[0] as
       | { plugins?: unknown }

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -27,14 +27,13 @@ import {
   type ModelManifestNormalizationContext,
   type ModelRef,
   findNormalizedProviderKey,
-  findNormalizedProviderValue,
   legacyModelKey,
   modelKey,
   normalizeModelRef,
   normalizeProviderId,
   normalizeProviderIdForAuth,
-  parseModelRef,
-} from "./model-selection-normalize.js";
+} from "./model-ref-shared.js";
+import { findNormalizedProviderValue, parseModelRef } from "./model-selection-normalize.js";
 import {
   buildAllowedModelSetWithFallbacks,
   buildConfiguredAllowlistKeys,

--- a/src/agents/model-thinking-default.ts
+++ b/src/agents/model-thinking-default.ts
@@ -11,7 +11,7 @@ import { resolveThinkingDefaultForModel } from "../auto-reply/thinking.js";
 import type { ThinkLevel } from "../auto-reply/thinking.shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
-import { legacyModelKey, modelKey, normalizeProviderId } from "./model-selection-normalize.js";
+import { legacyModelKey, modelKey, normalizeProviderId } from "./model-ref-shared.js";
 import { normalizeModelSelection } from "./model-selection-resolve.js";
 import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
 

--- a/src/agents/model-visibility-policy.ts
+++ b/src/agents/model-visibility-policy.ts
@@ -5,7 +5,7 @@ import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentConfig, resolveAgentModelFallbacksOverride } from "./agent-scope.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
-import type { ModelManifestNormalizationContext } from "./model-selection-normalize.js";
+import type { ModelManifestNormalizationContext } from "./model-ref-shared.js";
 import {
   createModelVisibilityPolicyWithFallbacks,
   type ModelVisibilityPolicy,

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,7 +1,7 @@
 // Builds memory flush prompts when conversation context exceeds model budget.
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-import { legacyModelKey, modelKey } from "../../agents/model-selection-normalize.js";
+import { legacyModelKey, modelKey } from "../../agents/model-ref-shared.js";
 import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -33,7 +33,7 @@ import {
 import { loadAuthProfileStoreForRuntime } from "../../agents/auth-profiles/store.js";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { clearAuthProfileCooldown } from "../../agents/auth-profiles/usage.js";
-import { normalizeProviderId } from "../../agents/model-selection-normalize.js";
+import { normalizeProviderId } from "../../agents/model-ref-shared.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";

--- a/src/commands/models/list.promotions.ts
+++ b/src/commands/models/list.promotions.ts
@@ -1,6 +1,6 @@
 /** Promotion decorations for `models list`: claim tags + passive discovery. */
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
-import { modelKey } from "../../agents/model-selection-normalize.js";
+import { modelKey } from "../../agents/model-ref-shared.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import type { ClawHubPromotionsFeedEntry } from "../../infra/clawhub.js";
 import {

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -7,7 +7,7 @@ import { resolveDefaultAgentId, resolveAgentConfig } from "../agents/agent-scope
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { formatFastModeValue, resolveFastModeState } from "../agents/fast-mode.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
-import { legacyModelKey, modelKey } from "../agents/model-selection-normalize.js";
+import { legacyModelKey, modelKey } from "../agents/model-ref-shared.js";
 import {
   buildConfiguredModelCatalog,
   resolveConfiguredModelRef,

--- a/src/plugin-activation-boundary.test.ts
+++ b/src/plugin-activation-boundary.test.ts
@@ -1,6 +1,6 @@
 // Tests plugin activation boundaries during root package startup.
 import { describe, expect, it, vi } from "vitest";
-import { normalizeModelRef } from "./agents/model-selection-normalize.js";
+import { normalizeModelRef } from "./agents/model-ref-shared.js";
 import { isStaticallyChannelConfigured } from "./config/channel-configured-shared.js";
 import { parseBrowserMajorVersion } from "./plugin-sdk/browser-host-inspection.js";
 

--- a/src/security/audit-model-refs.ts
+++ b/src/security/audit-model-refs.ts
@@ -1,6 +1,6 @@
 // Audits configured model references for risky provider or model choices.
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
-import { modelKey } from "../agents/model-selection-normalize.js";
+import { modelKey } from "../agents/model-ref-shared.js";
 import {
   buildModelAliasIndex,
   resolveModelRefFromString,


### PR DESCRIPTION
## What Problem This Solves

`src/agents` split provider/model reference normalization across `model-ref-shared.ts` and `model-selection-normalize.ts`, forcing callers to choose between overlapping owners and making the normalization order harder to audit.

## Why This Change Was Made

This maintainer-commissioned, AI-assisted refactor makes `model-ref-shared.ts` the canonical owner for provider IDs, static and configured model IDs, model refs, keys, manifest policy, and runtime plugin normalization. The shipped Plugin SDK declarations for `parseModelRef` and `findNormalizedProviderValue` remain at `model-selection-normalize.ts`, preserving the public `agent-runtime` API hash. The lazy `provider-model-normalization.runtime.ts` boundary is unchanged, and unrelated provider-config, model-compatibility, and tool-call normalization paths remain separate.

## User Impact

No user-visible behavior changes. Provider/model inputs retain the same trimming, casing, aliases, manifest policies, runtime plugin hooks, and OpenRouter compatibility behavior, with one fewer internal normalization owner.

## Evidence

- LOC from `git diff --numstat`: production `+116/-127` (net `-11`), tests `+3/-3` (net `0`), total `+119/-130` (net `-11`).
- `node scripts/run-vitest.mjs src/agents/model-ref-shared.test.ts src/agents/model-selection.test.ts src/agents/model-selection.plugin-runtime.test.ts` — passed 3 files / 142 tests.
- `node scripts/run-vitest.mjs src/agents/model*.test.ts` — passed 60 files / 931 tests across 4 routed shards.
- `node scripts/run-vitest.mjs src/gateway/chat-tool-titles.test.ts src/security/audit-extra.sync.test.ts src/security/audit-small-model-risk.test.ts src/security/audit-summary.test.ts` — passed 4 files / 31 tests.
- `node scripts/run-vitest.mjs src/agents/model` — router treated the argument as a directory and reported no test files; the explicit root glob above is the equivalent complete model-root proof.
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox `tbx_01ky5tg0pj8ek9mr7e2pa4bpvp`: formatting, Plugin SDK API contract hash, boundary guards, production and test typechecks, core lint, database/runtime guards, and runtime import-cycle check. Run: https://github.com/openclaw/openclaw/actions/runs/29957989206
- `autoreview --mode uncommitted --stream-engine-output` — Codex review clean; no accepted/actionable findings.
- ClawSweeper infrastructure note: the exact-head review lease expired without editing its placeholder, and the single documented re-review retry exhausted both capacity-router attempts as cancelled runs (https://github.com/openclaw/clawsweeper/actions/runs/29962980272 and https://github.com/openclaw/clawsweeper/actions/runs/29962989086). No `Rank-up moves` were published to apply or skip.
