### PR TITLE
feat(claws): separate portable and OpenClaw profiles

### DIFF
--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -76,8 +76,9 @@ available in `CLAW.md` frontmatter.
 
 Portable agent policy may select any built-in tool profile registered by the
 running OpenClaw version, then refine it with `alsoAllow`, `deny`, and
-`tools.fs.workspaceOnly`. `tools.allow` remains available as an explicit
-allowlist but cannot be combined with `alsoAllow`. A Claw may also set
+`tools.fs.workspaceOnly: true`. A Claw cannot set that field to `false` and
+weaken host filesystem confinement. `tools.allow` remains available as an
+explicit allowlist but cannot be combined with `alsoAllow`. A Claw may also set
 `memory.search.enabled`, choose the portable `memory` and `sessions` sources,
 and opt into cross-conversation memory with `rememberAcrossConversations`.
 Declaring the `sessions` source requires that opt-in.

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -48,7 +48,15 @@ agent:
   id: incident-triage
   name: Incident triage
   tools:
+    profile: coding
+    alsoAllow: [cron]
     deny: [exec]
+    fs:
+      workspaceOnly: true
+  memorySearch:
+    enabled: true
+    rememberAcrossConversations: true
+    sources: [memory, sessions]
 workspace:
   bootstrapFiles: {}
 packages: []
@@ -64,6 +72,16 @@ Creates one agent for reviewing and routing incidents.
 The same strict version 1 schema continues to accept grouped JSON manifests.
 The remaining schema fragments on this page use JSON, with equivalent keys
 available in `CLAW.md` frontmatter.
+
+Portable agent policy may select any built-in tool profile registered by the
+running OpenClaw version, then refine it with `alsoAllow`, `deny`, and
+`tools.fs.workspaceOnly`. `tools.allow` remains available as an explicit
+allowlist but cannot be combined with `alsoAllow`. A Claw may also set
+`memorySearch.enabled`, choose the portable `memory` and `sessions` sources,
+and opt into cross-conversation memory with `rememberAcrossConversations`.
+Declaring the `sessions` source requires that opt-in.
+Host policy still constrains these settings, and Claws do not carry custom
+profile definitions, providers, credentials, bindings, or local memory paths.
 
 Package and workspace paths must remain inside the package root. Manifests are
 limited to 1 MiB, package metadata to 256 KiB, and workspace sources enforce

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -53,10 +53,11 @@ agent:
     deny: [exec]
     fs:
       workspaceOnly: true
-  memorySearch:
-    enabled: true
-    rememberAcrossConversations: true
-    sources: [memory, sessions]
+  memory:
+    search:
+      enabled: true
+      rememberAcrossConversations: true
+      sources: [memory, sessions]
 workspace:
   bootstrapFiles: {}
 packages: []
@@ -77,7 +78,7 @@ Portable agent policy may select any built-in tool profile registered by the
 running OpenClaw version, then refine it with `alsoAllow`, `deny`, and
 `tools.fs.workspaceOnly`. `tools.allow` remains available as an explicit
 allowlist but cannot be combined with `alsoAllow`. A Claw may also set
-`memorySearch.enabled`, choose the portable `memory` and `sessions` sources,
+`memory.search.enabled`, choose the portable `memory` and `sessions` sources,
 and opt into cross-conversation memory with `rememberAcrossConversations`.
 Declaring the `sessions` source requires that opt-in.
 Host policy still constrains these settings, and Claws do not carry custom

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -10,8 +10,9 @@ title: "Claws"
 # `openclaw claws`
 
 A Claw is a versioned setup for one new OpenClaw agent. It can describe the
-agent configuration, workspace files, skills, plugins, MCP servers, and cron
-jobs that agent needs. A Claw does not replace or modify an existing agent.
+agent's portable identity, workspace files, skills, plugins, MCP servers, and
+cron jobs. Harness-specific agent settings may be carried in a referenced
+package profile. A Claw does not replace or modify an existing agent.
 
 Claws are experimental. Their schema, command output, and lifecycle may change.
 Enable the command surface explicitly:
@@ -26,8 +27,8 @@ separate registry track and are not part of this command surface yet.
 
 ## Create a Claw package
 
-A package contains `package.json`, a `CLAW.md` manifest, and any workspace
-sidecars referenced by the manifest:
+A package contains `package.json`, a `CLAW.md` manifest, and any profiles or
+workspace sidecars referenced by that manifest:
 
 ```json
 {
@@ -47,17 +48,8 @@ schemaVersion: 1
 agent:
   id: incident-triage
   name: Incident triage
-  tools:
-    profile: coding
-    alsoAllow: [cron]
-    deny: [exec]
-    fs:
-      workspaceOnly: true
-  memory:
-    search:
-      enabled: true
-      rememberAcrossConversations: true
-      sources: [memory, sessions]
+metadata:
+  openclaw.config: profiles/openclaw.yml
 workspace:
   bootstrapFiles: {}
 packages: []
@@ -70,12 +62,39 @@ cronJobs: []
 Creates one agent for reviewing and routing incidents.
 ```
 
-The same strict version 1 schema continues to accept grouped JSON manifests.
-The remaining schema fragments on this page use JSON, with equivalent keys
-available in `CLAW.md` frontmatter.
+`metadata` is a string-to-string map for portable consumer hints. OpenClaw's
+`openclaw.config` key points to an optional, package-relative YAML profile. The
+exported default is `profiles/openclaw.yml`; the pointer is normative, so a
+package may choose another safe relative `.yml` or `.yaml` path.
 
-Portable agent policy may select any built-in tool profile registered by the
-running OpenClaw version, then refine it with `alsoAllow`, `deny`, and
+```yaml
+schemaVersion: 1
+agent:
+  tools:
+    profile: coding
+    alsoAllow: [cron]
+    deny: [exec]
+    fs:
+      workspaceOnly: true
+  memory:
+    search:
+      enabled: true
+      rememberAcrossConversations: true
+      sources: [memory, sessions]
+```
+
+This profile exists only inside the Claw package. OpenClaw validates and uses it
+while inspecting, adding, updating, and exporting that Claw; it is not copied
+to the user's normal OpenClaw configuration path. Other harnesses can ignore
+the namespaced metadata key and consume the portable manifest fields.
+
+The same strict version 1 schema continues to accept grouped JSON manifests.
+Grouped JSON uses the same `metadata.openclaw.config` pointer rather than
+embedding a second copy of the OpenClaw profile. The remaining schema fragments
+on this page use JSON, with equivalent keys available in `CLAW.md` frontmatter.
+
+The OpenClaw package profile may select any built-in tool profile registered by
+the running OpenClaw version, then refine it with `alsoAllow`, `deny`, and
 `tools.fs.workspaceOnly: true`. A Claw cannot set that field to `false` and
 weaken host filesystem confinement. `tools.allow` remains available as an
 explicit allowlist but cannot be combined with `alsoAllow`. A Claw may also set
@@ -84,6 +103,9 @@ and opt into cross-conversation memory with `rememberAcrossConversations`.
 Declaring the `sessions` source requires that opt-in.
 Host policy still constrains these settings, and Claws do not carry custom
 profile definitions, providers, credentials, bindings, or local memory paths.
+The referenced profile is limited to 256 KiB, must be JSON-compatible YAML, may
+not use aliases, anchors, tags, or merge keys, and must be a regular,
+non-symlinked, non-hardlinked file inside the package.
 
 Package and workspace paths must remain inside the package root. Manifests are
 limited to 1 MiB, package metadata to 256 KiB, and workspace sources enforce

--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -48,10 +48,12 @@ async function installedFixture(
         deny: ["exec"],
         fs: { workspaceOnly: true },
       },
-      memorySearch: {
-        enabled: true,
-        rememberAcrossConversations: true,
-        sources: ["memory", "sessions"],
+      memory: {
+        search: {
+          enabled: true,
+          rememberAcrossConversations: true,
+          sources: ["memory", "sessions"],
+        },
       },
     },
     workspace: {
@@ -158,6 +160,17 @@ async function installedFixture(
 describe("exportClawAgent", () => {
   it("writes a grouped package from one installed agent", async () => {
     const fixture = await installedFixture({ withPackage: true });
+    expect(fixture.plan.agent.config.memory?.search).toEqual({
+      enabled: true,
+      rememberAcrossConversations: true,
+      sources: ["memory", "sessions"],
+    });
+    expect(fixture.config.agents?.entries?.worker?.memory?.search).toEqual({
+      enabled: true,
+      rememberAcrossConversations: true,
+      sources: ["memory", "sessions"],
+    });
+    expect(fixture.config.agents?.entries?.worker).not.toHaveProperty("memorySearch");
     fixture.config.mcp!.servers!.docs!.env = {
       DOCS_TOKEN: "resolved-secret-must-not-be-exported",
     };
@@ -185,10 +198,12 @@ describe("exportClawAgent", () => {
             deny: ["exec"],
             fs: { workspaceOnly: true },
           },
-          memorySearch: {
-            enabled: true,
-            rememberAcrossConversations: true,
-            sources: ["memory", "sessions"],
+          memory: {
+            search: {
+              enabled: true,
+              rememberAcrossConversations: true,
+              sources: ["memory", "sessions"],
+            },
           },
         },
         workspace: {

--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -42,7 +42,17 @@ async function installedFixture(
       id: "worker",
       name: "Worker",
       ...(options.avatar ? { identity: { avatar: options.avatar } } : {}),
-      tools: { deny: ["exec"] },
+      tools: {
+        profile: "coding",
+        alsoAllow: ["cron"],
+        deny: ["exec"],
+        fs: { workspaceOnly: true },
+      },
+      memorySearch: {
+        enabled: true,
+        rememberAcrossConversations: true,
+        sources: ["memory", "sessions"],
+      },
     },
     workspace: {
       bootstrapFiles: { "SOUL.md": { source: "source/SOUL.md" } },
@@ -166,7 +176,21 @@ describe("exportClawAgent", () => {
       agentId: "worker",
       manifest: {
         schemaVersion: 1,
-        agent: { id: "worker", name: "Worker", tools: { deny: ["exec"] } },
+        agent: {
+          id: "worker",
+          name: "Worker",
+          tools: {
+            profile: "coding",
+            alsoAllow: ["cron"],
+            deny: ["exec"],
+            fs: { workspaceOnly: true },
+          },
+          memorySearch: {
+            enabled: true,
+            rememberAcrossConversations: true,
+            sources: ["memory", "sessions"],
+          },
+        },
         workspace: {
           bootstrapFiles: { "SOUL.md": { source: "workspace/SOUL.md" } },
           files: [{ source: "workspace/reference/policy.md", path: "reference/policy.md" }],

--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -11,7 +11,7 @@ import { buildClawAddPlan } from "./lifecycle.js";
 import { installClawMcpServers } from "./mcp.js";
 import { persistClawPackageRef, updateClawInstallRecordStatus } from "./provenance.js";
 import { parseClawManifest } from "./schema.js";
-import type { ClawSourceIdentity } from "./types.js";
+import type { ClawOpenClawProfile, ClawSourceIdentity } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -42,20 +42,8 @@ async function installedFixture(
       id: "worker",
       name: "Worker",
       ...(options.avatar ? { identity: { avatar: options.avatar } } : {}),
-      tools: {
-        profile: "coding",
-        alsoAllow: ["cron"],
-        deny: ["exec"],
-        fs: { workspaceOnly: true },
-      },
-      memory: {
-        search: {
-          enabled: true,
-          rememberAcrossConversations: true,
-          sources: ["memory", "sessions"],
-        },
-      },
     },
+    metadata: { "openclaw.config": "profiles/openclaw.yml" },
     workspace: {
       bootstrapFiles: { "SOUL.md": { source: "source/SOUL.md" } },
       files: [
@@ -87,6 +75,24 @@ async function installedFixture(
   if (!parsed.ok) {
     throw new Error(JSON.stringify(parsed.diagnostics));
   }
+  const openClawProfile: ClawOpenClawProfile = {
+    schemaVersion: 1,
+    agent: {
+      tools: {
+        profile: "coding",
+        alsoAllow: ["cron"],
+        deny: ["exec"],
+        fs: { workspaceOnly: true },
+      },
+      memory: {
+        search: {
+          enabled: true,
+          rememberAcrossConversations: true,
+          sources: ["memory", "sessions"],
+        },
+      },
+    },
+  };
   const source: ClawSourceIdentity = {
     kind: "package",
     name: "@acme/worker",
@@ -100,6 +106,7 @@ async function installedFixture(
   const plan = await buildClawAddPlan({
     manifest: parsed.manifest,
     source,
+    openClawProfile,
     context: { workspace: join(root, "workspace-worker") },
   });
   let config: OpenClawConfig = {};
@@ -189,23 +196,8 @@ describe("exportClawAgent", () => {
       agentId: "worker",
       manifest: {
         schemaVersion: 1,
-        agent: {
-          id: "worker",
-          name: "Worker",
-          tools: {
-            profile: "coding",
-            alsoAllow: ["cron"],
-            deny: ["exec"],
-            fs: { workspaceOnly: true },
-          },
-          memory: {
-            search: {
-              enabled: true,
-              rememberAcrossConversations: true,
-              sources: ["memory", "sessions"],
-            },
-          },
-        },
+        agent: { id: "worker", name: "Worker" },
+        metadata: { "openclaw.config": "profiles/openclaw.yml" },
         workspace: {
           bootstrapFiles: { "SOUL.md": { source: "workspace/SOUL.md" } },
           files: [{ source: "workspace/reference/policy.md", path: "reference/policy.md" }],
@@ -239,6 +231,24 @@ describe("exportClawAgent", () => {
           },
         ],
       },
+      openClawProfile: {
+        schemaVersion: 1,
+        agent: {
+          tools: {
+            profile: "coding",
+            alsoAllow: ["cron"],
+            deny: ["exec"],
+            fs: { workspaceOnly: true },
+          },
+          memory: {
+            search: {
+              enabled: true,
+              rememberAcrossConversations: true,
+              sources: ["memory", "sessions"],
+            },
+          },
+        },
+      },
     });
     const packageJson = JSON.parse(await readFile(join(out, "package.json"), "utf8"));
     expect(packageJson).toMatchObject({
@@ -248,6 +258,9 @@ describe("exportClawAgent", () => {
     expect(packageJson.version).toMatch(/^0\.0\.0-export\.[0-9a-f]{64}$/);
     await expect(readFile(join(out, "CLAW.md"), "utf8")).resolves.not.toContain(
       "resolved-secret-must-not-be-exported",
+    );
+    await expect(readFile(join(out, "profiles", "openclaw.yml"), "utf8")).resolves.toContain(
+      "profile: coding",
     );
     await expect(readFile(join(out, "workspace", "SOUL.md"), "utf8")).resolves.toBe(
       "managed soul\n",

--- a/src/claws/export.ts
+++ b/src/claws/export.ts
@@ -58,8 +58,13 @@ function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawMani
     ...(avatar ? { avatar } : {}),
   };
   const tools = {
+    ...(agent.tools?.profile ? { profile: agent.tools.profile } : {}),
     ...(agent.tools?.allow?.length ? { allow: agent.tools.allow } : {}),
+    ...(agent.tools?.alsoAllow?.length ? { alsoAllow: agent.tools.alsoAllow } : {}),
     ...(agent.tools?.deny?.length ? { deny: agent.tools.deny } : {}),
+    ...(agent.tools?.fs?.workspaceOnly !== undefined
+      ? { fs: { workspaceOnly: agent.tools.fs.workspaceOnly } }
+      : {}),
   };
   return {
     id: agent.id,
@@ -81,6 +86,21 @@ function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawMani
         }
       : {}),
     ...(Object.keys(tools).length > 0 ? { tools } : {}),
+    ...(agent.memorySearch
+      ? {
+          memorySearch: {
+            ...(agent.memorySearch.enabled !== undefined
+              ? { enabled: agent.memorySearch.enabled }
+              : {}),
+            ...(agent.memorySearch.rememberAcrossConversations !== undefined
+              ? {
+                  rememberAcrossConversations: agent.memorySearch.rememberAcrossConversations,
+                }
+              : {}),
+            ...(agent.memorySearch.sources?.length ? { sources: agent.memorySearch.sources } : {}),
+          },
+        }
+      : {}),
     ...(agent.heartbeat
       ? {
           heartbeat: {

--- a/src/claws/export.ts
+++ b/src/claws/export.ts
@@ -86,18 +86,22 @@ function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawMani
         }
       : {}),
     ...(Object.keys(tools).length > 0 ? { tools } : {}),
-    ...(agent.memorySearch
+    ...(agent.memory?.search
       ? {
-          memorySearch: {
-            ...(agent.memorySearch.enabled !== undefined
-              ? { enabled: agent.memorySearch.enabled }
-              : {}),
-            ...(agent.memorySearch.rememberAcrossConversations !== undefined
-              ? {
-                  rememberAcrossConversations: agent.memorySearch.rememberAcrossConversations,
-                }
-              : {}),
-            ...(agent.memorySearch.sources?.length ? { sources: agent.memorySearch.sources } : {}),
+          memory: {
+            search: {
+              ...(agent.memory.search.enabled !== undefined
+                ? { enabled: agent.memory.search.enabled }
+                : {}),
+              ...(agent.memory.search.rememberAcrossConversations !== undefined
+                ? {
+                    rememberAcrossConversations: agent.memory.search.rememberAcrossConversations,
+                  }
+                : {}),
+              ...(agent.memory.search.sources?.length
+                ? { sources: agent.memory.search.sources }
+                : {}),
+            },
           },
         }
       : {}),

--- a/src/claws/export.ts
+++ b/src/claws/export.ts
@@ -15,7 +15,7 @@ import { resolveUserPath } from "../utils.js";
 import { readClawStatus } from "./lifecycle-state.js";
 import type { PackageRemovalDeps } from "./package-remove.js";
 import { isPortableClawAvatar } from "./schema-portability.js";
-import { parseClawManifest } from "./schema.js";
+import { parseClawManifest, parseClawOpenClawProfile } from "./schema.js";
 import { MAX_MANAGED_WORKSPACE_BYTES } from "./source-limits.js";
 import {
   CLAW_BOOTSTRAP_FILE_NAMES,
@@ -23,6 +23,7 @@ import {
   CLAW_SCHEMA_VERSION,
   type ClawManifest,
   type ClawMcpServer,
+  type ClawOpenClawProfile,
 } from "./types.js";
 
 export const CLAW_EXPORT_RESULT_SCHEMA_VERSION = "openclaw.clawExportResult.v1" as const;
@@ -37,6 +38,7 @@ type ClawExportResult = {
   agentId: string;
   outputDirectory: string;
   manifest: ClawManifest;
+  openClawProfile?: ClawOpenClawProfile;
   filesWritten: string[];
 };
 
@@ -57,6 +59,15 @@ function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawMani
     ...(agent.identity?.emoji ? { emoji: agent.identity.emoji } : {}),
     ...(avatar ? { avatar } : {}),
   };
+  return {
+    id: agent.id,
+    ...(agent.name ? { name: agent.name } : {}),
+    ...(agent.description ? { description: agent.description } : {}),
+    ...(Object.keys(identity).length > 0 ? { identity } : {}),
+  };
+}
+
+function portableOpenClawProfile(agent: AgentConfig): ClawOpenClawProfile | undefined {
   const tools = {
     ...(agent.tools?.profile ? { profile: agent.tools.profile } : {}),
     ...(agent.tools?.allow?.length ? { allow: agent.tools.allow } : {}),
@@ -64,11 +75,7 @@ function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawMani
     ...(agent.tools?.deny?.length ? { deny: agent.tools.deny } : {}),
     ...(agent.tools?.fs?.workspaceOnly === true ? { fs: { workspaceOnly: true as const } } : {}),
   };
-  return {
-    id: agent.id,
-    ...(agent.name ? { name: agent.name } : {}),
-    ...(agent.description ? { description: agent.description } : {}),
-    ...(Object.keys(identity).length > 0 ? { identity } : {}),
+  const settings = {
     ...(agent.groupChat?.mentionPatterns?.length
       ? { groupChat: { mentionPatterns: agent.groupChat.mentionPatterns } }
       : {}),
@@ -144,6 +151,7 @@ function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawMani
         }
       : {}),
   };
+  return Object.keys(settings).length > 0 ? { schemaVersion: 1, agent: settings } : undefined;
 }
 
 function normalizedRelativePath(value: string): string {
@@ -356,9 +364,15 @@ export async function exportClawAgent(
   const configuredMcpServers = normalizeConfiguredMcpServers(
     options.sourceMcpServers ?? options.config.mcp?.servers,
   );
+  const openClawProfile = portableOpenClawProfile(agent);
+  const openClawProfilePath = "profiles/openclaw.yml";
+  const openClawProfileRaw = openClawProfile
+    ? Buffer.from(stringifyYaml(openClawProfile))
+    : undefined;
   const manifest: ClawManifest = {
     schemaVersion: CLAW_SCHEMA_VERSION,
     agent: portableAgent(agent, avatar.source),
+    ...(openClawProfile ? { metadata: { "openclaw.config": openClawProfilePath } } : {}),
     workspace: { bootstrapFiles, files },
     packages: record.packages
       .map((pkg) => ({
@@ -389,6 +403,15 @@ export async function exportClawAgent(
       parsed.diagnostics.map((diagnostic) => diagnostic.message).join("; "),
     );
   }
+  if (openClawProfile) {
+    const parsedProfile = parseClawOpenClawProfile(openClawProfile);
+    if (!parsedProfile.ok) {
+      throw new ClawExportError(
+        "export_openclaw_profile_invalid",
+        parsedProfile.diagnostics.map((diagnostic) => diagnostic.message).join("; "),
+      );
+    }
+  }
 
   const target = resolve(resolveUserPath(outputDirectory));
   await mkdir(dirname(target), { recursive: true });
@@ -412,9 +435,19 @@ export async function exportClawAgent(
       await output.write(path, file.content, { mkdir: true, overwrite: false });
       filesWritten.push(path);
     }
+    if (openClawProfileRaw) {
+      await output.write(openClawProfilePath, openClawProfileRaw, {
+        mkdir: true,
+        overwrite: false,
+      });
+      filesWritten.push(openClawProfilePath);
+    }
     const packageJson = {
       name: `openclaw-claw-${record.install.agentId}`,
-      version: derivativePackageVersion(manifest, contents),
+      version: derivativePackageVersion(manifest, [
+        ...contents,
+        ...(openClawProfileRaw ? [{ path: openClawProfilePath, content: openClawProfileRaw }] : []),
+      ]),
       type: "module",
       openclaw: { claw: "CLAW.md" },
     };
@@ -444,6 +477,7 @@ export async function exportClawAgent(
     agentId,
     outputDirectory: target,
     manifest,
+    ...(openClawProfile ? { openClawProfile } : {}),
     filesWritten,
   };
 }

--- a/src/claws/export.ts
+++ b/src/claws/export.ts
@@ -62,9 +62,7 @@ function portableAgent(agent: AgentConfig, avatar: string | undefined): ClawMani
     ...(agent.tools?.allow?.length ? { allow: agent.tools.allow } : {}),
     ...(agent.tools?.alsoAllow?.length ? { alsoAllow: agent.tools.alsoAllow } : {}),
     ...(agent.tools?.deny?.length ? { deny: agent.tools.deny } : {}),
-    ...(agent.tools?.fs?.workspaceOnly !== undefined
-      ? { fs: { workspaceOnly: agent.tools.fs.workspaceOnly } }
-      : {}),
+    ...(agent.tools?.fs?.workspaceOnly === true ? { fs: { workspaceOnly: true as const } } : {}),
   };
   return {
     id: agent.id,

--- a/src/claws/fixtures/incident-response.claw.json
+++ b/src/claws/fixtures/incident-response.claw.json
@@ -7,35 +7,10 @@
     "identity": {
       "name": "Incident Response",
       "emoji": "siren"
-    },
-    "groupChat": {
-      "mentionPatterns": [
-        "@incident-response"
-      ]
-    },
-    "sandbox": {
-      "mode": "all",
-      "scope": "agent",
-      "workspaceAccess": "rw"
-    },
-    "tools": {
-      "allow": [
-        "read",
-        "write",
-        "web_fetch"
-      ],
-      "deny": [
-        "exec",
-        "browser"
-      ]
-    },
-    "heartbeat": {
-      "every": "30m",
-      "lightContext": true,
-      "isolatedSession": true,
-      "skipWhenBusy": true,
-      "timeoutSeconds": 120
     }
+  },
+  "metadata": {
+    "openclaw.config": "profiles/incident-response.openclaw.yml"
   },
   "workspace": {
     "bootstrapFiles": {

--- a/src/claws/fixtures/minimal-agent.claw.json
+++ b/src/claws/fixtures/minimal-agent.claw.json
@@ -6,15 +6,9 @@
     "description": "Triages internal work without changing operator runtime settings.",
     "identity": {
       "name": "Triage"
-    },
-    "tools": {
-      "deny": [
-        "exec",
-        "browser"
-      ]
-    },
-    "humanDelay": {
-      "mode": "natural"
     }
+  },
+  "metadata": {
+    "openclaw.config": "profiles/minimal-agent.openclaw.yml"
   }
 }

--- a/src/claws/fixtures/profiles/incident-response.openclaw.yml
+++ b/src/claws/fixtures/profiles/incident-response.openclaw.yml
@@ -1,0 +1,22 @@
+schemaVersion: 1
+agent:
+  groupChat:
+    mentionPatterns:
+      - "@incident-response"
+  sandbox:
+    mode: all
+    scope: agent
+    workspaceAccess: rw
+  tools:
+    allow:
+      - read
+      - write
+      - web_fetch
+    deny:
+      - exec
+      - browser
+  heartbeat:
+    every: 30m
+    lightContext: true
+    isolatedSession: true
+    timeoutSeconds: 120

--- a/src/claws/fixtures/profiles/minimal-agent.openclaw.yml
+++ b/src/claws/fixtures/profiles/minimal-agent.openclaw.yml
@@ -1,0 +1,8 @@
+schemaVersion: 1
+agent:
+  tools:
+    deny:
+      - exec
+      - browser
+  humanDelay:
+    mode: natural

--- a/src/claws/lifecycle.e2e.test.ts
+++ b/src/claws/lifecycle.e2e.test.ts
@@ -80,6 +80,13 @@ describe("claws lifecycle cli e2e", () => {
         agent: { id: "incident-response" },
         packages: expect.any(Array),
       },
+      openClawProfile: {
+        schemaVersion: 1,
+        agent: {
+          tools: { allow: ["read", "write", "web_fetch"], deny: ["exec", "browser"] },
+          heartbeat: { every: "30m", isolatedSession: true, timeoutSeconds: 120 },
+        },
+      },
     });
   });
 
@@ -150,6 +157,8 @@ describe("claws lifecycle cli e2e", () => {
       main: { default: true },
       "internal-triage": expect.objectContaining({
         name: "Internal Triage",
+        tools: { deny: ["exec", "browser"] },
+        humanDelay: { mode: "natural" },
         workspace: join(canonicalStateDir, ".openclaw", "workspace-internal-triage"),
       }),
     });

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -239,6 +239,9 @@ export async function buildClawAddPlan(params: {
   const agentCapabilityEffect = {
     ...(params.manifest.agent.sandbox ? { sandbox: params.manifest.agent.sandbox } : {}),
     ...(params.manifest.agent.tools ? { tools: params.manifest.agent.tools } : {}),
+    ...(params.manifest.agent.memorySearch
+      ? { memorySearch: params.manifest.agent.memorySearch }
+      : {}),
     ...(params.manifest.agent.heartbeat ? { heartbeat: params.manifest.agent.heartbeat } : {}),
   };
   if (Object.keys(agentCapabilityEffect).length > 0) {
@@ -248,7 +251,8 @@ export async function buildClawAddPlan(params: {
         id: finalId,
         path: "agent",
         action: "create",
-        reason: "The new agent declares sandbox, tool, or recurring heartbeat capabilities.",
+        reason:
+          "The new agent declares sandbox, tool, memory-search, or recurring heartbeat capabilities.",
         effect: agentCapabilityEffect,
       }),
     );

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -20,6 +20,7 @@ import {
   type ClawDiagnostic,
   type ClawManifest,
   type ClawLocalPrerequisite,
+  type ClawOpenClawProfile,
   type ClawPackage,
   type ClawSourceIdentity,
 } from "./types.js";
@@ -189,6 +190,7 @@ async function inspectWorkspaceFileAction(params: {
 
 export async function buildClawAddPlan(params: {
   manifest: ClawManifest;
+  openClawProfile?: ClawOpenClawProfile;
   source: ClawSourceIdentity;
   diagnostics?: ClawDiagnostic[];
   context?: ClawAddPlanContext;
@@ -219,6 +221,13 @@ export async function buildClawAddPlan(params: {
   }
   const existingAgentIds = new Set(context.existingAgentIds ?? []);
   const agentBlocked = existingAgentIds.has(finalId);
+  const openClawAgentSettings = params.openClawProfile?.agent ?? {};
+  const agentConfig: ClawAddPlan["agent"]["config"] = {
+    ...params.manifest.agent,
+    ...openClawAgentSettings,
+    id: finalId,
+    workspace,
+  };
   if (agentBlocked) {
     blockers.push(
       blocker(
@@ -233,14 +242,14 @@ export async function buildClawAddPlan(params: {
     id: finalId,
     action: "create",
     target: `agents.entries[${JSON.stringify(finalId)}]`,
-    details: { ...params.manifest.agent, id: finalId, workspace, expectedState: "absent" },
+    details: { ...agentConfig, expectedState: "absent" },
     blocked: agentBlocked || !AGENT_ID_PATTERN.test(finalId),
   });
   const agentCapabilityEffect = {
-    ...(params.manifest.agent.sandbox ? { sandbox: params.manifest.agent.sandbox } : {}),
-    ...(params.manifest.agent.tools ? { tools: params.manifest.agent.tools } : {}),
-    ...(params.manifest.agent.memory ? { memory: params.manifest.agent.memory } : {}),
-    ...(params.manifest.agent.heartbeat ? { heartbeat: params.manifest.agent.heartbeat } : {}),
+    ...(openClawAgentSettings.sandbox ? { sandbox: openClawAgentSettings.sandbox } : {}),
+    ...(openClawAgentSettings.tools ? { tools: openClawAgentSettings.tools } : {}),
+    ...(openClawAgentSettings.memory ? { memory: openClawAgentSettings.memory } : {}),
+    ...(openClawAgentSettings.heartbeat ? { heartbeat: openClawAgentSettings.heartbeat } : {}),
   };
   if (Object.keys(agentCapabilityEffect).length > 0) {
     capabilityChanges.push(
@@ -561,7 +570,7 @@ export async function buildClawAddPlan(params: {
       requestedId: params.manifest.agent.id,
       finalId,
       workspace,
-      config: { ...params.manifest.agent, id: finalId, workspace },
+      config: agentConfig,
     },
     summary: {
       totalActions: actions.length,

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -239,9 +239,7 @@ export async function buildClawAddPlan(params: {
   const agentCapabilityEffect = {
     ...(params.manifest.agent.sandbox ? { sandbox: params.manifest.agent.sandbox } : {}),
     ...(params.manifest.agent.tools ? { tools: params.manifest.agent.tools } : {}),
-    ...(params.manifest.agent.memorySearch
-      ? { memorySearch: params.manifest.agent.memorySearch }
-      : {}),
+    ...(params.manifest.agent.memory ? { memory: params.manifest.agent.memory } : {}),
     ...(params.manifest.agent.heartbeat ? { heartbeat: params.manifest.agent.heartbeat } : {}),
   };
   if (Object.keys(agentCapabilityEffect).length > 0) {

--- a/src/claws/openclaw-profile.test.ts
+++ b/src/claws/openclaw-profile.test.ts
@@ -1,0 +1,216 @@
+import { link, mkdir, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { readClawManifestFile } from "./reader.js";
+import { parseClawOpenClawProfile } from "./schema.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("OpenClaw profile schema", () => {
+  it("accepts typed settings", () => {
+    const result = parseClawOpenClawProfile({
+      schemaVersion: 1,
+      agent: {
+        tools: {
+          profile: "coding",
+          alsoAllow: ["cron"],
+          deny: ["exec"],
+          fs: { workspaceOnly: true },
+        },
+        memory: {
+          search: {
+            enabled: true,
+            rememberAcrossConversations: true,
+            sources: ["memory", "sessions"],
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects disabled host filesystem confinement", () => {
+    const result = parseClawOpenClawProfile({
+      schemaVersion: 1,
+      agent: { tools: { fs: { workspaceOnly: false } } },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects invalid profile policy", () => {
+    for (const agent of [
+      { tools: { profile: "future-profile" } },
+      { tools: { allow: ["read"], alsoAllow: ["write"] } },
+      { memory: { search: { provider: "openai" } } },
+      { memory: { search: { sources: ["sessions"] } } },
+    ]) {
+      expect(parseClawOpenClawProfile({ schemaVersion: 1, agent }).ok).toBe(false);
+    }
+  });
+});
+
+describe("OpenClaw profile reader", () => {
+  it("loads and integrity-binds a metadata-referenced profile", async () => {
+    const root = tempDirs.make("openclaw-claw-profile-");
+    await mkdir(join(root, "profiles"));
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({
+        name: "@acme/github-triage",
+        version: "3.2.1",
+        openclaw: { claw: "CLAW.md" },
+      }),
+      "utf8",
+    );
+    await writeFile(
+      join(root, "CLAW.md"),
+      [
+        "---",
+        "schemaVersion: 1",
+        "agent:",
+        "  id: triage",
+        "metadata:",
+        "  openclaw.config: profiles/openclaw.yml",
+        "---",
+        "",
+        "# GitHub Triage",
+      ].join("\n"),
+      "utf8",
+    );
+    const profilePath = join(root, "profiles", "openclaw.yml");
+    await writeFile(
+      profilePath,
+      [
+        "schemaVersion: 1",
+        "agent:",
+        "  tools:",
+        "    profile: coding",
+        "    deny: [exec]",
+        "    fs:",
+        "      workspaceOnly: true",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const first = await readClawManifestFile(root);
+    expect(first).toMatchObject({
+      ok: true,
+      manifest: {
+        metadata: { "openclaw.config": "profiles/openclaw.yml" },
+      },
+      openClawProfile: {
+        schemaVersion: 1,
+        agent: {
+          tools: { profile: "coding", deny: ["exec"], fs: { workspaceOnly: true } },
+        },
+      },
+    });
+    if (!first.ok) {
+      throw new Error("expected OpenClaw profile to parse");
+    }
+
+    await writeFile(
+      profilePath,
+      "schemaVersion: 1\nagent:\n  tools:\n    profile: messaging\n",
+      "utf8",
+    );
+    const second = await readClawManifestFile(root);
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      throw new Error("expected changed OpenClaw profile to parse");
+    }
+    expect(second.source.integrity).not.toBe(first.source.integrity);
+  });
+
+  it("rejects a hardlinked profile", async () => {
+    const root = tempDirs.make("openclaw-claw-profile-hardlink-");
+    await mkdir(join(root, "profiles"));
+    await writeFile(
+      join(root, "openclaw.claw.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        agent: { id: "triage" },
+        metadata: { "openclaw.config": "profiles/openclaw.yml" },
+      }),
+      "utf8",
+    );
+    const source = join(root, "source.yml");
+    await writeFile(source, "schemaVersion: 1\nagent: {}\n", "utf8");
+    await link(source, join(root, "profiles", "openclaw.yml"));
+
+    const result = await readClawManifestFile(join(root, "openclaw.claw.json"));
+
+    expect(result).toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "openclaw_profile_unsafe" })],
+    });
+  });
+  it("rejects a symlinked profile at the read boundary", async () => {
+    const root = tempDirs.make("openclaw-claw-profile-symlink-");
+    await mkdir(join(root, "profiles"));
+    const path = join(root, "openclaw.claw.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        agent: { id: "triage" },
+        metadata: { "openclaw.config": "profiles/openclaw.yml" },
+      }),
+      "utf8",
+    );
+    await writeFile(join(root, "source.yml"), "schemaVersion: 1\nagent: {}\n", "utf8");
+    await symlink("../source.yml", join(root, "profiles", "openclaw.yml"));
+
+    const result = await readClawManifestFile(path);
+
+    expect(result).toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "openclaw_profile_unsafe" })],
+    });
+  });
+
+  it("rejects an escaping profile path", async () => {
+    const root = tempDirs.make("openclaw-claw-profile-path-");
+    const path = join(root, "openclaw.claw.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        agent: { id: "triage" },
+        metadata: { "openclaw.config": "../openclaw.yml" },
+      }),
+      "utf8",
+    );
+
+    const result = await readClawManifestFile(path);
+
+    expect(result).toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "invalid_openclaw_profile_path" })],
+    });
+  });
+
+  it("rejects an empty declared profile path", async () => {
+    const root = tempDirs.make("openclaw-claw-profile-empty-path-");
+    const path = join(root, "openclaw.claw.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        agent: { id: "triage" },
+        metadata: { "openclaw.config": "" },
+      }),
+      "utf8",
+    );
+
+    const result = await readClawManifestFile(path);
+
+    expect(result).toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "invalid_openclaw_profile_path" })],
+    });
+  });
+});

--- a/src/claws/openclaw-profile.test.ts
+++ b/src/claws/openclaw-profile.test.ts
@@ -42,6 +42,7 @@ describe("OpenClaw profile schema", () => {
 
   it("rejects invalid profile policy", () => {
     for (const agent of [
+      { heartbeat: { skipWhenBusy: true } },
       { tools: { profile: "future-profile" } },
       { tools: { allow: ["read"], alsoAllow: ["write"] } },
       { memory: { search: { provider: "openai" } } },
@@ -181,6 +182,27 @@ describe("OpenClaw profile reader", () => {
         schemaVersion: 1,
         agent: { id: "triage" },
         metadata: { "openclaw.config": "../openclaw.yml" },
+      }),
+      "utf8",
+    );
+
+    const result = await readClawManifestFile(path);
+
+    expect(result).toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "invalid_openclaw_profile_path" })],
+    });
+  });
+
+  it("rejects a backslash profile path", async () => {
+    const root = tempDirs.make("openclaw-claw-profile-backslash-path-");
+    const path = join(root, "openclaw.claw.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        agent: { id: "triage" },
+        metadata: { "openclaw.config": "profiles\\openclaw.yml" },
       }),
       "utf8",
     );

--- a/src/claws/openclaw-profile.ts
+++ b/src/claws/openclaw-profile.ts
@@ -1,0 +1,152 @@
+// Safe loader for package-local OpenClaw profiles referenced by Claw metadata.
+import { isScalar, parseDocument, visit } from "yaml";
+import { FsSafeError, root as fsSafeRoot } from "../infra/fs-safe.js";
+import { isSafeClawRelativePath } from "./schema-portability.js";
+import { parseClawOpenClawProfile } from "./schema.js";
+import type { ClawDiagnostic, ClawManifest, ClawOpenClawProfile } from "./types.js";
+
+const MAX_OPENCLAW_PROFILE_BYTES = 256 * 1024;
+
+function diagnostic(code: string, message: string, path = "$"): ClawDiagnostic {
+  return { level: "error", code, phase: "parse", path, message };
+}
+
+function parseProfileYaml(
+  raw: string,
+  path: string,
+): { ok: true; value: unknown } | { ok: false; diagnostics: ClawDiagnostic[] } {
+  const document = parseDocument(raw.startsWith("\uFEFF") ? raw.slice(1) : raw, {
+    prettyErrors: false,
+    uniqueKeys: true,
+  });
+  if (document.errors.length > 0) {
+    return {
+      ok: false,
+      diagnostics: document.errors.map((error) =>
+        diagnostic("invalid_openclaw_profile", `Could not parse ${path}: ${error.message}`),
+      ),
+    };
+  }
+  let unsupportedFeature: string | undefined;
+  visit(document, {
+    Alias() {
+      unsupportedFeature ??= "aliases";
+    },
+    Node(_key, node) {
+      if (node.anchor) {
+        unsupportedFeature ??= "anchors";
+      } else if (node.tag) {
+        unsupportedFeature ??= "explicit tags";
+      }
+    },
+    Pair(_key, pair) {
+      if (isScalar(pair.key) && pair.key.value === "<<") {
+        unsupportedFeature ??= "merge keys";
+      }
+    },
+  });
+  if (unsupportedFeature) {
+    return {
+      ok: false,
+      diagnostics: [
+        diagnostic(
+          "unsupported_openclaw_profile_yaml_feature",
+          `${path} uses ${unsupportedFeature}; OpenClaw profile YAML must map directly to JSON data.`,
+        ),
+      ],
+    };
+  }
+  try {
+    return { ok: true, value: document.toJSON() };
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostics: [
+        diagnostic(
+          "invalid_openclaw_profile",
+          `Could not parse ${path}: ${(error as Error).message}`,
+        ),
+      ],
+    };
+  }
+}
+
+async function readProfileFile(packageRoot: string, path: string): Promise<Buffer> {
+  const packageFiles = await fsSafeRoot(packageRoot);
+  const read = await packageFiles.read(path, {
+    hardlinks: "reject",
+    maxBytes: MAX_OPENCLAW_PROFILE_BYTES,
+    nonBlockingRead: true,
+    symlinks: "reject",
+  });
+  return read.buffer;
+}
+
+export async function readClawOpenClawProfile(params: {
+  packageRoot: string;
+  manifest: ClawManifest;
+}): Promise<
+  | { ok: true; profile?: ClawOpenClawProfile; raw?: Buffer; path?: string }
+  | { ok: false; diagnostics: ClawDiagnostic[] }
+> {
+  const declaredPath = params.manifest.metadata?.["openclaw.config"];
+  if (declaredPath === undefined) {
+    return { ok: true };
+  }
+  if (!isSafeClawRelativePath(declaredPath) || !/\.ya?ml$/i.test(declaredPath)) {
+    return {
+      ok: false,
+      diagnostics: [
+        diagnostic(
+          "invalid_openclaw_profile_path",
+          "metadata.openclaw.config must reference a package-relative .yml or .yaml file.",
+          "$.metadata.openclaw.config",
+        ),
+      ],
+    };
+  }
+
+  let raw: Buffer;
+  try {
+    raw = await readProfileFile(params.packageRoot, declaredPath);
+  } catch (error) {
+    const unsafe =
+      error instanceof FsSafeError &&
+      (error.code === "hardlink" || error.code === "symlink" || error.code === "path-mismatch");
+    const tooLarge = error instanceof FsSafeError && error.code === "too-large";
+    return {
+      ok: false,
+      diagnostics: [
+        diagnostic(
+          unsafe
+            ? "openclaw_profile_unsafe"
+            : tooLarge
+              ? "openclaw_profile_too_large"
+              : "openclaw_profile_read_failed",
+          unsafe
+            ? "The OpenClaw profile must be a regular, non-symlinked, non-hardlinked file."
+            : tooLarge
+              ? `The OpenClaw profile exceeds ${MAX_OPENCLAW_PROFILE_BYTES} bytes.`
+              : `Could not read ${declaredPath}: ${(error as Error).message}`,
+          "$.metadata.openclaw.config",
+        ),
+      ],
+    };
+  }
+
+  const yaml = parseProfileYaml(raw.toString("utf8"), declaredPath);
+  if (!yaml.ok) {
+    return yaml;
+  }
+  const parsed = parseClawOpenClawProfile(yaml.value);
+  if (!parsed.ok) {
+    return {
+      ok: false,
+      diagnostics: parsed.diagnostics.map((entry) => ({
+        ...entry,
+        path: `$.metadata.openclaw.config${entry.path.slice(1)}`,
+      })),
+    };
+  }
+  return { ok: true, profile: parsed.profile, raw, path: declaredPath };
+}

--- a/src/claws/openclaw-profile.ts
+++ b/src/claws/openclaw-profile.ts
@@ -93,13 +93,17 @@ export async function readClawOpenClawProfile(params: {
   if (declaredPath === undefined) {
     return { ok: true };
   }
-  if (!isSafeClawRelativePath(declaredPath) || !/\.ya?ml$/i.test(declaredPath)) {
+  if (
+    declaredPath.includes("\\") ||
+    !isSafeClawRelativePath(declaredPath) ||
+    !/\.ya?ml$/i.test(declaredPath)
+  ) {
     return {
       ok: false,
       diagnostics: [
         diagnostic(
           "invalid_openclaw_profile_path",
-          "metadata.openclaw.config must reference a package-relative .yml or .yaml file.",
+          "metadata.openclaw.config must reference a forward-slash package-relative .yml or .yaml file.",
           "$.metadata.openclaw.config",
         ),
       ],

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -22,7 +22,7 @@ import {
   updateClawPackageRefStatus,
 } from "./provenance.js";
 import { parseClawManifest } from "./schema.js";
-import type { ClawSourceIdentity } from "./types.js";
+import type { ClawOpenClawProfile, ClawSourceIdentity } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -32,7 +32,7 @@ afterEach(() => {
 
 async function makePlan(
   manifestValue: unknown = { schemaVersion: 1, agent: { id: "worker" } },
-  options: { workspace?: string } = {},
+  options: { workspace?: string; openClawProfile?: ClawOpenClawProfile } = {},
 ) {
   const root = tempDirs.make("openclaw-claw-add-");
   const parsed = parseClawManifest(manifestValue);
@@ -51,6 +51,7 @@ async function makePlan(
   };
   const plan = await buildClawAddPlan({
     manifest: parsed.manifest,
+    openClawProfile: options.openClawProfile,
     source,
     context: { workspace: options.workspace ?? join(root, "workspace-worker") },
   });
@@ -349,15 +350,22 @@ describe("Claw root install provenance", () => {
 
 describe("applyClawAddPlan", () => {
   it("appends one agent, preserves defaults and existing agents, and creates a new workspace", async () => {
-    const { root, plan } = await makePlan({
-      schemaVersion: 1,
-      agent: {
-        id: "worker",
-        name: "Worker",
-        identity: { name: "Work" },
-        tools: { deny: ["exec"] },
+    const { root, plan } = await makePlan(
+      {
+        schemaVersion: 1,
+        agent: {
+          id: "worker",
+          name: "Worker",
+          identity: { name: "Work" },
+        },
       },
-    });
+      {
+        openClawProfile: {
+          schemaVersion: 1,
+          agent: { tools: { deny: ["exec"] } },
+        },
+      },
+    );
     let config: OpenClawConfig = {
       agents: {
         defaults: { workspace: "/operator/default" },

--- a/src/claws/reader.ts
+++ b/src/claws/reader.ts
@@ -5,6 +5,7 @@ import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path
 import { isScalar, parseDocument, visit } from "yaml";
 import { assertNoSymlinkParents } from "../infra/fs-safe-advanced.js";
 import { FsSafeError, root as fsSafeRoot, type OpenResult } from "../infra/fs-safe.js";
+import { readClawOpenClawProfile } from "./openclaw-profile.js";
 import { isCanonicalClawHubPackageName, isExactSemVer } from "./schema-portability.js";
 import { parseClawManifest } from "./schema.js";
 import { MAX_MANAGED_FILE_BYTES, MAX_MANAGED_WORKSPACE_BYTES } from "./source-limits.js";
@@ -91,6 +92,7 @@ async function buildDevelopmentSnapshot(params: {
   source: ResolvedClawSource;
   manifest: ClawManifest;
   manifestRaw: Buffer;
+  openClawProfile?: { path: string; raw: Buffer };
 }): Promise<
   | {
       ok: true;
@@ -108,6 +110,9 @@ async function buildDevelopmentSnapshot(params: {
   };
   add("canonical-source", Buffer.from(params.source.manifestPath, "utf8"));
   add("manifest", params.manifestRaw);
+  if (params.openClawProfile) {
+    add(`profile:${params.openClawProfile.path.replaceAll("\\", "/")}`, params.openClawProfile.raw);
+  }
 
   if (params.source.kind === "package") {
     const packageJson = params.source.packageJsonRaw;
@@ -519,10 +524,20 @@ export async function readClawManifestFile(path: string): Promise<ClawReadResult
   if (!parsed.ok) {
     return parsed;
   }
+  const profile = await readClawOpenClawProfile({
+    packageRoot: sourceResult.source.packageRoot,
+    manifest: parsed.manifest,
+  });
+  if (!profile.ok) {
+    return profile;
+  }
   const snapshot = await buildDevelopmentSnapshot({
     source: sourceResult.source,
     manifest: parsed.manifest,
     manifestRaw: manifestResult.raw,
+    ...(profile.raw && profile.path
+      ? { openClawProfile: { path: profile.path, raw: profile.raw } }
+      : {}),
   });
   if (!snapshot.ok) {
     return snapshot;
@@ -541,6 +556,7 @@ export async function readClawManifestFile(path: string): Promise<ClawReadResult
   return {
     ok: true,
     manifest: parsed.manifest,
+    ...(profile.profile ? { openClawProfile: profile.profile } : {}),
     source,
     snapshot: { workspaceSources: snapshot.workspaceSources },
     diagnostics: parsed.diagnostics,

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -6,7 +6,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { readClawManifestFile } from "./reader.js";
 import { parseClawManifest, parseClawOpenClawProfile } from "./schema.js";
-import type { ClawManifest, ClawSourceIdentity } from "./types.js";
+import type { ClawManifest, ClawOpenClawProfile, ClawSourceIdentity } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -60,7 +60,7 @@ const baseManifest = {
   ],
 } as const;
 
-const baseOpenClawProfile = {
+const baseOpenClawProfile: ClawOpenClawProfile = {
   schemaVersion: 1,
   agent: {
     groupChat: { mentionPatterns: ["@triage"] },
@@ -69,7 +69,7 @@ const baseOpenClawProfile = {
     heartbeat: { every: "30m", lightContext: true, skipWhenBusy: true },
     humanDelay: { mode: "natural" },
   },
-} as const;
+};
 
 function requireManifest(value: unknown = baseManifest): ClawManifest {
   const result = parseClawManifest(value);

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -66,7 +66,7 @@ const baseOpenClawProfile: ClawOpenClawProfile = {
     groupChat: { mentionPatterns: ["@triage"] },
     sandbox: { mode: "all", scope: "agent", workspaceAccess: "rw" },
     tools: { allow: ["read", "write"], deny: ["exec"] },
-    heartbeat: { every: "30m", lightContext: true, skipWhenBusy: true },
+    heartbeat: { every: "30m", lightContext: true },
     humanDelay: { mode: "natural" },
   },
 };

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { readClawManifestFile } from "./reader.js";
-import { parseClawManifest } from "./schema.js";
+import { parseClawManifest, parseClawOpenClawProfile } from "./schema.js";
 import type { ClawManifest, ClawSourceIdentity } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -17,12 +17,8 @@ const baseManifest = {
     name: "GitHub Triage",
     description: "Reviews incoming issues.",
     identity: { name: "Triage", emoji: "search" },
-    groupChat: { mentionPatterns: ["@triage"] },
-    sandbox: { mode: "all", scope: "agent", workspaceAccess: "rw" },
-    tools: { allow: ["read", "write"], deny: ["exec"] },
-    heartbeat: { every: "30m", lightContext: true, skipWhenBusy: true },
-    humanDelay: { mode: "natural" },
   },
+  metadata: { "openclaw.config": "profiles/openclaw.yml" },
   workspace: {
     bootstrapFiles: {
       "AGENTS.md": { source: "workspace/AGENTS.md" },
@@ -62,6 +58,17 @@ const baseManifest = {
       delivery: { mode: "announce", channel: "last" },
     },
   ],
+} as const;
+
+const baseOpenClawProfile = {
+  schemaVersion: 1,
+  agent: {
+    groupChat: { mentionPatterns: ["@triage"] },
+    sandbox: { mode: "all", scope: "agent", workspaceAccess: "rw" },
+    tools: { allow: ["read", "write"], deny: ["exec"] },
+    heartbeat: { every: "30m", lightContext: true, skipWhenBusy: true },
+    humanDelay: { mode: "natural" },
+  },
 } as const;
 
 function requireManifest(value: unknown = baseManifest): ClawManifest {
@@ -109,6 +116,7 @@ describe("parseClawManifest", () => {
     expect(manifest).toEqual({
       schemaVersion: 1,
       agent: { id: "minimal-agent" },
+      metadata: {},
       workspace: { bootstrapFiles: {}, files: [] },
       packages: [],
       mcpServers: {},
@@ -141,47 +149,14 @@ describe("parseClawManifest", () => {
     },
   );
 
-  it("accepts portable agent tool and memory-search settings", () => {
-    const result = parseClawManifest({
-      ...baseManifest,
-      agent: {
-        ...baseManifest.agent,
-        tools: {
-          profile: "coding",
-          alsoAllow: ["cron"],
-          deny: ["exec"],
-          fs: { workspaceOnly: true },
-        },
-        memory: {
-          search: {
-            enabled: true,
-            rememberAcrossConversations: true,
-            sources: ["memory", "sessions"],
-          },
-        },
-      },
-    });
-
-    expect(result.ok).toBe(true);
-  });
-
-  it("rejects portable policy that disables host filesystem confinement", () => {
-    const result = parseClawManifest({
-      schemaVersion: 1,
-      agent: { id: "worker", tools: { fs: { workspaceOnly: false } } },
-    });
-
-    expect(result.ok).toBe(false);
-  });
-
-  it("rejects unknown profiles, conflicting allowlists, and non-portable memory settings", () => {
-    for (const agent of [
-      { id: "worker", tools: { profile: "future-profile" } },
-      { id: "worker", tools: { allow: ["read"], alsoAllow: ["write"] } },
-      { id: "worker", memory: { search: { provider: "openai" } } },
-      { id: "worker", memory: { search: { sources: ["sessions"] } } },
-    ]) {
-      expect(parseClawManifest({ schemaVersion: 1, agent }).ok).toBe(false);
+  it("keeps harness-specific settings out of the portable agent object", () => {
+    for (const field of ["groupChat", "sandbox", "tools", "memory", "heartbeat", "humanDelay"]) {
+      expect(
+        parseClawManifest({
+          schemaVersion: 1,
+          agent: { id: "worker", [field]: {} },
+        }).ok,
+      ).toBe(false);
     }
   });
 
@@ -317,9 +292,9 @@ describe("parseClawManifest", () => {
   });
 
   it("rejects invalid heartbeat durations and cron expressions", () => {
-    const heartbeat = parseClawManifest({
-      ...baseManifest,
-      agent: { ...baseManifest.agent, heartbeat: { every: "eventually" } },
+    const heartbeat = parseClawOpenClawProfile({
+      schemaVersion: 1,
+      agent: { heartbeat: { every: "eventually" } },
     });
     expect(heartbeat.ok).toBe(false);
     expect(heartbeat.diagnostics).toContainEqual(
@@ -768,6 +743,7 @@ describe("buildClawAddPlan", () => {
     const { source, workspace } = await createPlanSource();
     const plan = await buildClawAddPlan({
       manifest: requireManifest(),
+      openClawProfile: baseOpenClawProfile,
       source,
       context: { workspace },
     });
@@ -985,24 +961,31 @@ describe("buildClawAddPlan", () => {
     const { source, workspace } = await createPlanSource();
     const first = await buildClawAddPlan({
       manifest: requireManifest(),
+      openClawProfile: baseOpenClawProfile,
       source,
       context: { workspace },
     });
     const repeated = await buildClawAddPlan({
       manifest: requireManifest(),
+      openClawProfile: baseOpenClawProfile,
       source,
       context: { workspace },
     });
     const changed = await buildClawAddPlan({
       manifest: requireManifest(),
+      openClawProfile: baseOpenClawProfile,
       source: { ...source, integrity: "sha256:changed" },
       context: { workspace },
     });
     const changedCapability = await buildClawAddPlan({
-      manifest: requireManifest({
-        ...baseManifest,
-        agent: { ...baseManifest.agent, tools: { allow: ["read", "exec"] } },
-      }),
+      manifest: requireManifest(),
+      openClawProfile: {
+        ...baseOpenClawProfile,
+        agent: {
+          ...baseOpenClawProfile.agent,
+          tools: { allow: ["read", "exec"] },
+        },
+      },
       source,
       context: { workspace },
     });

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -152,10 +152,12 @@ describe("parseClawManifest", () => {
           deny: ["exec"],
           fs: { workspaceOnly: true },
         },
-        memorySearch: {
-          enabled: true,
-          rememberAcrossConversations: true,
-          sources: ["memory", "sessions"],
+        memory: {
+          search: {
+            enabled: true,
+            rememberAcrossConversations: true,
+            sources: ["memory", "sessions"],
+          },
         },
       },
     });
@@ -167,8 +169,8 @@ describe("parseClawManifest", () => {
     for (const agent of [
       { id: "worker", tools: { profile: "future-profile" } },
       { id: "worker", tools: { allow: ["read"], alsoAllow: ["write"] } },
-      { id: "worker", memorySearch: { provider: "openai" } },
-      { id: "worker", memorySearch: { sources: ["sessions"] } },
+      { id: "worker", memory: { search: { provider: "openai" } } },
+      { id: "worker", memory: { search: { sources: ["sessions"] } } },
     ]) {
       expect(parseClawManifest({ schemaVersion: 1, agent }).ok).toBe(false);
     }

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -141,6 +141,39 @@ describe("parseClawManifest", () => {
     },
   );
 
+  it("accepts portable agent tool and memory-search settings", () => {
+    const result = parseClawManifest({
+      ...baseManifest,
+      agent: {
+        ...baseManifest.agent,
+        tools: {
+          profile: "coding",
+          alsoAllow: ["cron"],
+          deny: ["exec"],
+          fs: { workspaceOnly: true },
+        },
+        memorySearch: {
+          enabled: true,
+          rememberAcrossConversations: true,
+          sources: ["memory", "sessions"],
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects unknown profiles, conflicting allowlists, and non-portable memory settings", () => {
+    for (const agent of [
+      { id: "worker", tools: { profile: "future-profile" } },
+      { id: "worker", tools: { allow: ["read"], alsoAllow: ["write"] } },
+      { id: "worker", memorySearch: { provider: "openai" } },
+      { id: "worker", memorySearch: { sources: ["sessions"] } },
+    ]) {
+      expect(parseClawManifest({ schemaVersion: 1, agent }).ok).toBe(false);
+    }
+  });
+
   it("rejects non-v1 package fields and connector packages", () => {
     const connector = parseClawManifest({
       ...baseManifest,

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -165,6 +165,15 @@ describe("parseClawManifest", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("rejects portable policy that disables host filesystem confinement", () => {
+    const result = parseClawManifest({
+      schemaVersion: 1,
+      agent: { id: "worker", tools: { fs: { workspaceOnly: false } } },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
   it("rejects unknown profiles, conflicting allowlists, and non-portable memory settings", () => {
     for (const agent of [
       { id: "worker", tools: { profile: "future-profile" } },

--- a/src/claws/schema.ts
+++ b/src/claws/schema.ts
@@ -91,7 +91,10 @@ const agentSchema = z
         allow: z.array(nonEmptyString).min(1).optional(),
         alsoAllow: z.array(nonEmptyString).min(1).optional(),
         deny: z.array(nonEmptyString).min(1).optional(),
-        fs: z.object({ workspaceOnly: z.boolean().optional() }).strict().optional(),
+        fs: z
+          .object({ workspaceOnly: z.literal(true).optional() })
+          .strict()
+          .optional(),
       })
       .strict()
       .superRefine((tools, ctx) => {

--- a/src/claws/schema.ts
+++ b/src/claws/schema.ts
@@ -1,5 +1,6 @@
 // Strict parser for grouped Claw schema version 1 manifests.
 import { z } from "zod";
+import { resolveToolProfilePolicy } from "../agents/tool-policy-shared.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import { computeNextRunAtMs } from "../cron/schedule.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
@@ -81,10 +82,52 @@ const agentSchema = z
       .optional(),
     tools: z
       .object({
+        profile: nonEmptyString
+          .refine(
+            (value) => resolveToolProfilePolicy(value) !== undefined,
+            "Tool profile must name a registered OpenClaw built-in profile.",
+          )
+          .optional(),
         allow: z.array(nonEmptyString).min(1).optional(),
+        alsoAllow: z.array(nonEmptyString).min(1).optional(),
         deny: z.array(nonEmptyString).min(1).optional(),
+        fs: z.object({ workspaceOnly: z.boolean().optional() }).strict().optional(),
       })
       .strict()
+      .superRefine((tools, ctx) => {
+        if (tools.allow && tools.alsoAllow) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["alsoAllow"],
+            message:
+              "Agent tools cannot set both allow and alsoAllow; use allow alone or profile with alsoAllow.",
+          });
+        }
+      })
+      .optional(),
+    memorySearch: z
+      .object({
+        enabled: z.boolean().optional(),
+        rememberAcrossConversations: z.boolean().optional(),
+        sources: z
+          .array(z.enum(["memory", "sessions"]))
+          .min(1)
+          .optional(),
+      })
+      .strict()
+      .superRefine((memorySearch, ctx) => {
+        if (
+          memorySearch.sources?.includes("sessions") &&
+          memorySearch.rememberAcrossConversations !== true
+        ) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["rememberAcrossConversations"],
+            message:
+              "The sessions source requires rememberAcrossConversations: true in a portable Claw.",
+          });
+        }
+      })
       .optional(),
     heartbeat: z
       .object({

--- a/src/claws/schema.ts
+++ b/src/claws/schema.ts
@@ -105,29 +105,34 @@ const agentSchema = z
         }
       })
       .optional(),
-    memorySearch: z
+    memory: z
       .object({
-        enabled: z.boolean().optional(),
-        rememberAcrossConversations: z.boolean().optional(),
-        sources: z
-          .array(z.enum(["memory", "sessions"]))
-          .min(1)
+        search: z
+          .object({
+            enabled: z.boolean().optional(),
+            rememberAcrossConversations: z.boolean().optional(),
+            sources: z
+              .array(z.enum(["memory", "sessions"]))
+              .min(1)
+              .optional(),
+          })
+          .strict()
+          .superRefine((search, ctx) => {
+            if (
+              search.sources?.includes("sessions") &&
+              search.rememberAcrossConversations !== true
+            ) {
+              ctx.addIssue({
+                code: "custom",
+                path: ["rememberAcrossConversations"],
+                message:
+                  "The sessions source requires rememberAcrossConversations: true in a portable Claw.",
+              });
+            }
+          })
           .optional(),
       })
       .strict()
-      .superRefine((memorySearch, ctx) => {
-        if (
-          memorySearch.sources?.includes("sessions") &&
-          memorySearch.rememberAcrossConversations !== true
-        ) {
-          ctx.addIssue({
-            code: "custom",
-            path: ["rememberAcrossConversations"],
-            message:
-              "The sessions source requires rememberAcrossConversations: true in a portable Claw.",
-          });
-        }
-      })
       .optional(),
     heartbeat: z
       .object({

--- a/src/claws/schema.ts
+++ b/src/claws/schema.ts
@@ -20,6 +20,7 @@ import {
   CLAW_SCHEMA_VERSION,
   type ClawDiagnostic,
   type ClawManifest,
+  type ClawOpenClawProfile,
 } from "./types.js";
 
 const nonEmptyString = z
@@ -68,112 +69,122 @@ const agentSchema = z
     name: optionalString,
     description: optionalString,
     identity: identitySchema.optional(),
-    groupChat: z
-      .object({ mentionPatterns: z.array(nonEmptyString).min(1).optional() })
-      .strict()
-      .optional(),
-    sandbox: z
+  })
+  .strict();
+
+const openClawProfileSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    agent: z
       .object({
-        mode: z.enum(["off", "non-main", "all"]).optional(),
-        scope: z.enum(["session", "agent", "shared"]).optional(),
-        workspaceAccess: z.enum(["none", "ro", "rw"]).optional(),
-      })
-      .strict()
-      .optional(),
-    tools: z
-      .object({
-        profile: nonEmptyString
-          .refine(
-            (value) => resolveToolProfilePolicy(value) !== undefined,
-            "Tool profile must name a registered OpenClaw built-in profile.",
-          )
-          .optional(),
-        allow: z.array(nonEmptyString).min(1).optional(),
-        alsoAllow: z.array(nonEmptyString).min(1).optional(),
-        deny: z.array(nonEmptyString).min(1).optional(),
-        fs: z
-          .object({ workspaceOnly: z.literal(true).optional() })
+        groupChat: z
+          .object({ mentionPatterns: z.array(nonEmptyString).min(1).optional() })
           .strict()
           .optional(),
-      })
-      .strict()
-      .superRefine((tools, ctx) => {
-        if (tools.allow && tools.alsoAllow) {
-          ctx.addIssue({
-            code: "custom",
-            path: ["alsoAllow"],
-            message:
-              "Agent tools cannot set both allow and alsoAllow; use allow alone or profile with alsoAllow.",
-          });
-        }
-      })
-      .optional(),
-    memory: z
-      .object({
-        search: z
+        sandbox: z
           .object({
-            enabled: z.boolean().optional(),
-            rememberAcrossConversations: z.boolean().optional(),
-            sources: z
-              .array(z.enum(["memory", "sessions"]))
-              .min(1)
+            mode: z.enum(["off", "non-main", "all"]).optional(),
+            scope: z.enum(["session", "agent", "shared"]).optional(),
+            workspaceAccess: z.enum(["none", "ro", "rw"]).optional(),
+          })
+          .strict()
+          .optional(),
+        tools: z
+          .object({
+            profile: nonEmptyString
+              .refine(
+                (value) => resolveToolProfilePolicy(value) !== undefined,
+                "Tool profile must name a registered OpenClaw built-in profile.",
+              )
+              .optional(),
+            allow: z.array(nonEmptyString).min(1).optional(),
+            alsoAllow: z.array(nonEmptyString).min(1).optional(),
+            deny: z.array(nonEmptyString).min(1).optional(),
+            fs: z
+              .object({ workspaceOnly: z.literal(true).optional() })
+              .strict()
               .optional(),
           })
           .strict()
-          .superRefine((search, ctx) => {
-            if (
-              search.sources?.includes("sessions") &&
-              search.rememberAcrossConversations !== true
-            ) {
+          .superRefine((tools, ctx) => {
+            if (tools.allow && tools.alsoAllow) {
               ctx.addIssue({
                 code: "custom",
-                path: ["rememberAcrossConversations"],
+                path: ["alsoAllow"],
                 message:
-                  "The sessions source requires rememberAcrossConversations: true in a portable Claw.",
+                  "Agent tools cannot set both allow and alsoAllow; use allow alone or profile with alsoAllow.",
               });
             }
           })
           .optional(),
-      })
-      .strict()
-      .optional(),
-    heartbeat: z
-      .object({
-        every: nonEmptyString
-          .refine((value) => {
-            try {
-              parseDurationMs(value, { defaultUnit: "m" });
-              return true;
-            } catch {
-              return false;
-            }
-          }, "Invalid heartbeat duration.")
-          .optional(),
-        activeHours: z
+        memory: z
           .object({
-            start: nonEmptyString.regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/).optional(),
-            end: nonEmptyString.regex(/^(?:(?:[01]\d|2[0-3]):[0-5]\d|24:00)$/).optional(),
-            timezone: nonEmptyString
-              .refine(isValidClawTimezone, "Invalid IANA timezone.")
+            search: z
+              .object({
+                enabled: z.boolean().optional(),
+                rememberAcrossConversations: z.boolean().optional(),
+                sources: z
+                  .array(z.enum(["memory", "sessions"]))
+                  .min(1)
+                  .optional(),
+              })
+              .strict()
+              .superRefine((search, ctx) => {
+                if (
+                  search.sources?.includes("sessions") &&
+                  search.rememberAcrossConversations !== true
+                ) {
+                  ctx.addIssue({
+                    code: "custom",
+                    path: ["rememberAcrossConversations"],
+                    message:
+                      "The sessions source requires rememberAcrossConversations: true in the OpenClaw profile.",
+                  });
+                }
+              })
               .optional(),
           })
           .strict()
           .optional(),
-        lightContext: z.boolean().optional(),
-        isolatedSession: z.boolean().optional(),
-        skipWhenBusy: z.boolean().optional(),
-        timeoutSeconds: z.number().int().positive().optional(),
+        heartbeat: z
+          .object({
+            every: nonEmptyString
+              .refine((value) => {
+                try {
+                  parseDurationMs(value, { defaultUnit: "m" });
+                  return true;
+                } catch {
+                  return false;
+                }
+              }, "Invalid heartbeat duration.")
+              .optional(),
+            activeHours: z
+              .object({
+                start: nonEmptyString.regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/).optional(),
+                end: nonEmptyString.regex(/^(?:(?:[01]\d|2[0-3]):[0-5]\d|24:00)$/).optional(),
+                timezone: nonEmptyString
+                  .refine(isValidClawTimezone, "Invalid IANA timezone.")
+                  .optional(),
+              })
+              .strict()
+              .optional(),
+            lightContext: z.boolean().optional(),
+            isolatedSession: z.boolean().optional(),
+            skipWhenBusy: z.boolean().optional(),
+            timeoutSeconds: z.number().int().positive().optional(),
+          })
+          .strict()
+          .optional(),
+        humanDelay: z
+          .object({
+            mode: z.enum(["off", "natural", "custom"]).optional(),
+            minMs: z.number().int().nonnegative().optional(),
+            maxMs: z.number().int().nonnegative().optional(),
+          })
+          .strict()
+          .optional(),
       })
-      .strict()
-      .optional(),
-    humanDelay: z
-      .object({
-        mode: z.enum(["off", "natural", "custom"]).optional(),
-        minMs: z.number().int().nonnegative().optional(),
-        maxMs: z.number().int().nonnegative().optional(),
-      })
-      .strict()
-      .optional(),
+      .strict(),
   })
   .strict();
 
@@ -365,6 +376,7 @@ const manifestSchema = z
   .object({
     schemaVersion: z.literal(CLAW_SCHEMA_VERSION),
     agent: agentSchema,
+    metadata: z.record(nonEmptyString, z.string()).optional().default({}),
     workspace: workspaceSchema.optional().default({ bootstrapFiles: {}, files: [] }),
     packages: z.array(packageSchema).optional().default([]),
     mcpServers: z
@@ -467,4 +479,22 @@ export function parseClawManifest(
     return { ok: false, diagnostics: diagnosticsFromZodError(parsed.error) };
   }
   return { ok: true, manifest: parsed.data as ClawManifest, diagnostics: [] };
+}
+
+export function parseClawOpenClawProfile(value: unknown):
+  | {
+      ok: true;
+      profile: ClawOpenClawProfile;
+      diagnostics: ClawDiagnostic[];
+    }
+  | { ok: false; diagnostics: ClawDiagnostic[] } {
+  const parsed = openClawProfileSchema.safeParse(value);
+  if (!parsed.success) {
+    return { ok: false, diagnostics: diagnosticsFromZodError(parsed.error) };
+  }
+  return {
+    ok: true,
+    profile: parsed.data as ClawOpenClawProfile,
+    diagnostics: [],
+  };
 }

--- a/src/claws/schema.ts
+++ b/src/claws/schema.ts
@@ -170,7 +170,6 @@ const openClawProfileSchema = z
               .optional(),
             lightContext: z.boolean().optional(),
             isolatedSession: z.boolean().optional(),
-            skipWhenBusy: z.boolean().optional(),
             timeoutSeconds: z.number().int().positive().optional(),
           })
           .strict()

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -27,46 +27,52 @@ type ClawAgent = {
     emoji?: string;
     avatar?: string;
   };
-  groupChat?: {
-    mentionPatterns?: string[];
-  };
-  sandbox?: {
-    mode?: "off" | "non-main" | "all";
-    scope?: "session" | "agent" | "shared";
-    workspaceAccess?: "none" | "ro" | "rw";
-  };
-  tools?: {
-    profile?: ToolProfileId;
-    allow?: string[];
-    alsoAllow?: string[];
-    deny?: string[];
-    fs?: {
-      workspaceOnly?: true;
+};
+
+export type ClawOpenClawProfile = {
+  schemaVersion: 1;
+  agent: {
+    groupChat?: {
+      mentionPatterns?: string[];
     };
-  };
-  memory?: {
-    search?: {
-      enabled?: boolean;
-      rememberAcrossConversations?: boolean;
-      sources?: Array<"memory" | "sessions">;
+    sandbox?: {
+      mode?: "off" | "non-main" | "all";
+      scope?: "session" | "agent" | "shared";
+      workspaceAccess?: "none" | "ro" | "rw";
     };
-  };
-  heartbeat?: {
-    every?: string;
-    activeHours?: {
-      start?: string;
-      end?: string;
-      timezone?: string;
+    tools?: {
+      profile?: ToolProfileId;
+      allow?: string[];
+      alsoAllow?: string[];
+      deny?: string[];
+      fs?: {
+        workspaceOnly?: true;
+      };
     };
-    lightContext?: boolean;
-    isolatedSession?: boolean;
-    skipWhenBusy?: boolean;
-    timeoutSeconds?: number;
-  };
-  humanDelay?: {
-    mode?: "off" | "natural" | "custom";
-    minMs?: number;
-    maxMs?: number;
+    memory?: {
+      search?: {
+        enabled?: boolean;
+        rememberAcrossConversations?: boolean;
+        sources?: Array<"memory" | "sessions">;
+      };
+    };
+    heartbeat?: {
+      every?: string;
+      activeHours?: {
+        start?: string;
+        end?: string;
+        timezone?: string;
+      };
+      lightContext?: boolean;
+      isolatedSession?: boolean;
+      skipWhenBusy?: boolean;
+      timeoutSeconds?: number;
+    };
+    humanDelay?: {
+      mode?: "off" | "natural" | "custom";
+      minMs?: number;
+      maxMs?: number;
+    };
   };
 };
 
@@ -141,6 +147,7 @@ export type ClawCronJob = {
 export type ClawManifest = {
   schemaVersion: typeof CLAW_SCHEMA_VERSION;
   agent: ClawAgent;
+  metadata?: Record<string, string>;
   workspace: ClawWorkspace;
   packages: ClawPackage[];
   mcpServers: Record<string, ClawMcpServer>;
@@ -173,6 +180,7 @@ export type ClawReadResult =
   | {
       ok: true;
       manifest: ClawManifest;
+      openClawProfile?: ClawOpenClawProfile;
       source: ClawSourceIdentity;
       snapshot: ClawSourceSnapshot;
       diagnostics: ClawDiagnostic[];

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -65,7 +65,6 @@ export type ClawOpenClawProfile = {
       };
       lightContext?: boolean;
       isolatedSession?: boolean;
-      skipWhenBusy?: boolean;
       timeoutSeconds?: number;
     };
     humanDelay?: {

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -41,7 +41,7 @@ type ClawAgent = {
     alsoAllow?: string[];
     deny?: string[];
     fs?: {
-      workspaceOnly?: boolean;
+      workspaceOnly?: true;
     };
   };
   memory?: {

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -1,4 +1,5 @@
 // Shared types for grouped OpenClaw Claw manifests and read-only add plans.
+import type { ToolProfileId } from "../agents/tool-policy-shared.js";
 
 export const CLAW_SCHEMA_VERSION = 1 as const;
 export const CLAW_ADD_PLAN_SCHEMA_VERSION = "openclaw.clawAddPlan.v1" as const;
@@ -34,8 +35,18 @@ type ClawAgent = {
     workspaceAccess?: "none" | "ro" | "rw";
   };
   tools?: {
+    profile?: ToolProfileId;
     allow?: string[];
+    alsoAllow?: string[];
     deny?: string[];
+    fs?: {
+      workspaceOnly?: boolean;
+    };
+  };
+  memorySearch?: {
+    enabled?: boolean;
+    rememberAcrossConversations?: boolean;
+    sources?: Array<"memory" | "sessions">;
   };
   heartbeat?: {
     every?: string;

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -1,5 +1,6 @@
 // Shared types for grouped OpenClaw Claw manifests and read-only add plans.
 import type { ToolProfileId } from "../agents/tool-policy-shared.js";
+import type { AgentConfig } from "../config/types.agents.js";
 
 export const CLAW_SCHEMA_VERSION = 1 as const;
 export const CLAW_ADD_PLAN_SCHEMA_VERSION = "openclaw.clawAddPlan.v1" as const;
@@ -43,10 +44,12 @@ type ClawAgent = {
       workspaceOnly?: boolean;
     };
   };
-  memorySearch?: {
-    enabled?: boolean;
-    rememberAcrossConversations?: boolean;
-    sources?: Array<"memory" | "sessions">;
+  memory?: {
+    search?: {
+      enabled?: boolean;
+      rememberAcrossConversations?: boolean;
+      sources?: Array<"memory" | "sessions">;
+    };
   };
   heartbeat?: {
     every?: string;
@@ -219,7 +222,7 @@ export type ClawAddPlan = {
     requestedId: string;
     finalId: string;
     workspace: string;
-    config: ClawAgent & { workspace: string };
+    config: AgentConfig & { workspace: string };
   };
   summary: {
     totalActions: number;

--- a/src/claws/update-apply.ts
+++ b/src/claws/update-apply.ts
@@ -31,6 +31,7 @@ import {
 import {
   CLAW_OUTPUT_STABILITY,
   type ClawManifest,
+  type ClawOpenClawProfile,
   type ClawPackage,
   type ClawSourceIdentity,
 } from "./types.js";
@@ -88,6 +89,7 @@ export async function applyClawUpdatePlan(
   plan: ClawUpdatePlan,
   params: {
     targetManifest: ClawManifest;
+    targetOpenClawProfile?: ClawOpenClawProfile;
     targetSource: ClawSourceIdentity;
   },
   options: OpenClawStateDatabaseOptions & {
@@ -124,6 +126,7 @@ export async function applyClawUpdatePlan(
   const fresh = await rebuildPlan({
     agentId: plan.agentId,
     targetManifest: params.targetManifest,
+    targetOpenClawProfile: params.targetOpenClawProfile,
     targetSource: params.targetSource,
     config: options.config,
     sourceMcpServers: options.sourceMcpServers,
@@ -175,6 +178,7 @@ export async function applyClawUpdatePlan(
   };
   const targetAddPlan = await buildAddPlan({
     manifest: params.targetManifest,
+    openClawProfile: params.targetOpenClawProfile,
     source: params.targetSource,
     context: {
       agentId: fresh.agentId,

--- a/src/claws/update-capability-changes.test.ts
+++ b/src/claws/update-capability-changes.test.ts
@@ -426,6 +426,31 @@ describe("pushResolvedAgentCapabilityChanges", () => {
     );
   });
 
+  it("uses contextual memory defaults when classifying cross-conversation recall", () => {
+    const changes = collectChanges({
+      currentAgent: {
+        id: "worker",
+        memory: { search: { rememberAcrossConversations: false } },
+      },
+      desiredAgent: { id: "worker" },
+    });
+
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "agent.memory.search.rememberAcrossConversations",
+          classification: "escalation",
+          requiresDistinctConsent: true,
+        }),
+        expect.objectContaining({
+          path: "agent.memory.search.sources",
+          classification: "escalation",
+          requiresDistinctConsent: true,
+        }),
+      ]),
+    );
+  });
+
   it("treats tool policies on a restored missing agent as escalations", () => {
     for (const field of ["allow", "deny"] as const) {
       const changes: Changes = [];

--- a/src/claws/update-capability-changes.test.ts
+++ b/src/claws/update-capability-changes.test.ts
@@ -13,12 +13,16 @@ function collectChanges(params: {
   defaults?: NonNullable<
     Parameters<typeof pushResolvedAgentCapabilityChanges>[0]["config"]["agents"]
   >["defaults"];
+  tools?: Parameters<typeof pushResolvedAgentCapabilityChanges>[0]["config"]["tools"];
+  memory?: Parameters<typeof pushResolvedAgentCapabilityChanges>[0]["config"]["memory"];
 }): Changes {
   const changes: Changes = [];
   pushResolvedAgentCapabilityChanges({
     changes,
     agentId: params.currentAgent.id,
     config: {
+      tools: params.tools,
+      memory: params.memory,
       agents: {
         defaults: params.defaults,
         list: [params.currentAgent],
@@ -227,15 +231,95 @@ describe("pushResolvedAgentCapabilityChanges", () => {
     }
   });
 
+  it("classifies additive tool grants as escalations and removals as reductions", () => {
+    const added = collectChanges({
+      currentAgent: { id: "worker", tools: { profile: "coding" } },
+      desiredAgent: {
+        id: "worker",
+        tools: { profile: "coding", alsoAllow: ["browser"] },
+      },
+    });
+
+    expect(added).toContainEqual(
+      expect.objectContaining({
+        path: "agent.tools.alsoAllow",
+        classification: "escalation",
+        requiresDistinctConsent: true,
+      }),
+    );
+    expect(added).not.toContainEqual(expect.objectContaining({ path: "agent.tools.profile" }));
+
+    const removed = collectChanges({
+      currentAgent: {
+        id: "worker",
+        tools: { profile: "coding", alsoAllow: ["browser"] },
+      },
+      desiredAgent: { id: "worker", tools: { profile: "coding" } },
+    });
+    expect(removed).toContainEqual(
+      expect.objectContaining({
+        path: "agent.tools.alsoAllow",
+        classification: "reduction",
+        requiresDistinctConsent: false,
+      }),
+    );
+    expect(removed).not.toContainEqual(expect.objectContaining({ path: "agent.tools.profile" }));
+  });
+
+  it("classifies inherited profiles and wildcard reductions by effective capabilities", () => {
+    const inheritedExpansion = collectChanges({
+      currentAgent: { id: "worker" },
+      desiredAgent: { id: "worker", tools: { profile: "coding" } },
+      tools: { profile: "minimal" },
+    });
+    expect(inheritedExpansion).toContainEqual(
+      expect.objectContaining({
+        path: "agent.tools.profile",
+        classification: "escalation",
+        requiresDistinctConsent: true,
+      }),
+    );
+
+    const wildcardReduction = collectChanges({
+      currentAgent: { id: "worker", tools: { profile: "full" } },
+      desiredAgent: { id: "worker", tools: { profile: "coding" } },
+    });
+    expect(wildcardReduction).toContainEqual(
+      expect.objectContaining({
+        path: "agent.tools.profile",
+        classification: "reduction",
+        requiresDistinctConsent: false,
+      }),
+    );
+  });
+
+  it("classifies removal of workspace-only confinement against host defaults", () => {
+    const changes = collectChanges({
+      currentAgent: { id: "worker", tools: { fs: { workspaceOnly: true } } },
+      desiredAgent: { id: "worker" },
+      tools: { fs: { workspaceOnly: false } },
+    });
+
+    expect(changes).toContainEqual(
+      expect.objectContaining({
+        path: "agent.tools.fs.workspaceOnly",
+        classification: "escalation",
+        requiresDistinctConsent: true,
+      }),
+    );
+  });
+
   it("resolves built-in profile capabilities and portable policy changes", () => {
     const changes = collectChanges({
       currentAgent: {
         id: "worker",
         tools: { profile: "coding", fs: { workspaceOnly: false } },
-        memorySearch: {
-          enabled: false,
-          rememberAcrossConversations: false,
-          sources: ["memory"],
+        memory: {
+          search: {
+            enabled: false,
+            rememberAcrossConversations: false,
+            sources: ["memory"],
+          },
         },
       },
       desiredAgent: {
@@ -245,10 +329,12 @@ describe("pushResolvedAgentCapabilityChanges", () => {
           alsoAllow: ["cron"],
           fs: { workspaceOnly: true },
         },
-        memorySearch: {
-          enabled: true,
-          rememberAcrossConversations: true,
-          sources: ["memory", "sessions"],
+        memory: {
+          search: {
+            enabled: true,
+            rememberAcrossConversations: true,
+            sources: ["memory", "sessions"],
+          },
         },
       },
     });
@@ -263,7 +349,7 @@ describe("pushResolvedAgentCapabilityChanges", () => {
             current: "coding",
             desired: "full",
             currentCapabilities: expect.arrayContaining(["read", "write"]),
-            desiredCapabilities: ["*"],
+            desiredCapabilities: expect.arrayContaining(["*"]),
           }),
         }),
         expect.objectContaining({
@@ -272,17 +358,17 @@ describe("pushResolvedAgentCapabilityChanges", () => {
           requiresDistinctConsent: false,
         }),
         expect.objectContaining({
-          path: "agent.memorySearch.enabled",
+          path: "agent.memory.search.enabled",
           classification: "escalation",
           requiresDistinctConsent: true,
         }),
         expect.objectContaining({
-          path: "agent.memorySearch.rememberAcrossConversations",
+          path: "agent.memory.search.rememberAcrossConversations",
           classification: "escalation",
           requiresDistinctConsent: true,
         }),
         expect.objectContaining({
-          path: "agent.memorySearch.sources",
+          path: "agent.memory.search.sources",
           classification: "escalation",
           requiresDistinctConsent: true,
         }),
@@ -292,16 +378,50 @@ describe("pushResolvedAgentCapabilityChanges", () => {
 
   it("resolves inherited memory defaults before classifying updates", () => {
     const changes = collectChanges({
-      currentAgent: { id: "worker", memorySearch: { enabled: false } },
+      currentAgent: { id: "worker", memory: { search: { enabled: false } } },
       desiredAgent: { id: "worker" },
     });
 
     expect(changes).toContainEqual(
       expect.objectContaining({
-        path: "agent.memorySearch.enabled",
+        path: "agent.memory.search.enabled",
         classification: "escalation",
         current: expect.objectContaining({ summary: "false" }),
         desired: expect.objectContaining({ summary: "true" }),
+      }),
+    );
+  });
+
+  it("reads canonical top-level and per-agent memory search settings", () => {
+    const inherited = collectChanges({
+      currentAgent: { id: "worker" },
+      desiredAgent: { id: "worker" },
+      memory: {
+        search: {
+          enabled: true,
+          rememberAcrossConversations: true,
+          sources: ["memory", "sessions"],
+        },
+      },
+    });
+    expect(inherited.filter((change) => change.path.startsWith("agent.memory.search."))).toEqual(
+      [],
+    );
+
+    const overridden = collectChanges({
+      currentAgent: {
+        id: "worker",
+        memory: { search: { enabled: false } },
+      },
+      desiredAgent: {
+        id: "worker",
+        memory: { search: { enabled: true } },
+      },
+    });
+    expect(overridden).toContainEqual(
+      expect.objectContaining({
+        path: "agent.memory.search.enabled",
+        classification: "escalation",
       }),
     );
   });

--- a/src/claws/update-capability-changes.test.ts
+++ b/src/claws/update-capability-changes.test.ts
@@ -227,6 +227,85 @@ describe("pushResolvedAgentCapabilityChanges", () => {
     }
   });
 
+  it("resolves built-in profile capabilities and portable policy changes", () => {
+    const changes = collectChanges({
+      currentAgent: {
+        id: "worker",
+        tools: { profile: "coding", fs: { workspaceOnly: false } },
+        memorySearch: {
+          enabled: false,
+          rememberAcrossConversations: false,
+          sources: ["memory"],
+        },
+      },
+      desiredAgent: {
+        id: "worker",
+        tools: {
+          profile: "full",
+          alsoAllow: ["cron"],
+          fs: { workspaceOnly: true },
+        },
+        memorySearch: {
+          enabled: true,
+          rememberAcrossConversations: true,
+          sources: ["memory", "sessions"],
+        },
+      },
+    });
+
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "agent.tools.profile",
+          classification: "escalation",
+          requiresDistinctConsent: true,
+          effect: expect.objectContaining({
+            current: "coding",
+            desired: "full",
+            currentCapabilities: expect.arrayContaining(["read", "write"]),
+            desiredCapabilities: ["*"],
+          }),
+        }),
+        expect.objectContaining({
+          path: "agent.tools.fs.workspaceOnly",
+          classification: "reduction",
+          requiresDistinctConsent: false,
+        }),
+        expect.objectContaining({
+          path: "agent.memorySearch.enabled",
+          classification: "escalation",
+          requiresDistinctConsent: true,
+        }),
+        expect.objectContaining({
+          path: "agent.memorySearch.rememberAcrossConversations",
+          classification: "escalation",
+          requiresDistinctConsent: true,
+        }),
+        expect.objectContaining({
+          path: "agent.memorySearch.sources",
+          classification: "escalation",
+          requiresDistinctConsent: true,
+        }),
+      ]),
+    );
+  });
+
+  it("resolves inherited memory defaults before classifying updates", () => {
+    const changes = collectChanges({
+      currentAgent: { id: "worker", memorySearch: { enabled: false } },
+      desiredAgent: { id: "worker" },
+    });
+
+    expect(changes).toContainEqual(
+      expect.objectContaining({
+        path: "agent.memorySearch.enabled",
+        classification: "escalation",
+        current: expect.objectContaining({ summary: "false" }),
+        desired: expect.objectContaining({ summary: "true" }),
+      }),
+    );
+  });
+
   it("treats tool policies on a restored missing agent as escalations", () => {
     for (const field of ["allow", "deny"] as const) {
       const changes: Changes = [];

--- a/src/claws/update-capability-changes.ts
+++ b/src/claws/update-capability-changes.ts
@@ -180,7 +180,7 @@ function classifyAgentCapability(
   if (path === "heartbeat.every") {
     return classifyHeartbeatEvery(current, desired);
   }
-  if (path === "heartbeat.isolatedSession" || path === "heartbeat.skipWhenBusy") {
+  if (path === "heartbeat.isolatedSession") {
     return desired === true ? "reduction" : "escalation";
   }
   if (path === "heartbeat.timeoutSeconds") {
@@ -273,7 +273,6 @@ function pushAgentCapabilityChanges(params: {
     ["heartbeat", "every"],
     ["heartbeat", "activeHours"],
     ["heartbeat", "isolatedSession"],
-    ["heartbeat", "skipWhenBusy"],
     ["heartbeat", "timeoutSeconds"],
   ] as const;
   for (const field of fields) {

--- a/src/claws/update-capability-changes.ts
+++ b/src/claws/update-capability-changes.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
 import { stableStringify } from "../agents/stable-stringify.js";
+import { expandToolGroups, resolveToolProfilePolicy } from "../agents/tool-policy-shared.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
@@ -110,7 +111,12 @@ function classifyAgentCapability(
   desired: unknown,
   currentAgentExists: boolean,
 ): ClawUpdateCapabilityChange["classification"] {
-  if (path === "tools.allow" || path === "tools.deny") {
+  if (
+    path === "tools.profile" ||
+    path === "tools.allow" ||
+    path === "tools.alsoAllow" ||
+    path === "tools.deny"
+  ) {
     if (!currentAgentExists && desired !== undefined) {
       return "escalation";
     }
@@ -150,6 +156,22 @@ function classifyAgentCapability(
       ? "reduction"
       : "escalation";
   }
+  if (path === "tools.fs.workspaceOnly") {
+    return desired === true ? "reduction" : "escalation";
+  }
+  if (path === "memorySearch.enabled") {
+    return desired === false ? "reduction" : "escalation";
+  }
+  if (path === "memorySearch.rememberAcrossConversations") {
+    return desired === true ? "escalation" : "reduction";
+  }
+  if (path === "memorySearch.sources") {
+    if (!Array.isArray(current) || !Array.isArray(desired)) {
+      return desired === undefined ? "reduction" : "escalation";
+    }
+    const currentSources = new Set(current);
+    return desired.some((source) => !currentSources.has(source)) ? "escalation" : "reduction";
+  }
   if (path === "tools.deny") {
     if (!Array.isArray(current) || !Array.isArray(desired)) {
       return "escalation";
@@ -167,7 +189,11 @@ function classifyAgentCapability(
       ? "reduction"
       : "neutral";
   }
-  if (path === "tools.allow" && Array.isArray(current) && Array.isArray(desired)) {
+  if (
+    (path === "tools.profile" || path === "tools.allow" || path === "tools.alsoAllow") &&
+    Array.isArray(current) &&
+    Array.isArray(desired)
+  ) {
     const currentTools = new Set(
       current.filter((value): value is string => typeof value === "string"),
     );
@@ -175,9 +201,20 @@ function classifyAgentCapability(
       ? "escalation"
       : "reduction";
   }
-  return path.startsWith("sandbox.") || path === "tools.allow" || path.startsWith("heartbeat.")
+  return path.startsWith("sandbox.") ||
+    path.startsWith("tools.") ||
+    path.startsWith("heartbeat.") ||
+    path.startsWith("memorySearch.")
     ? "escalation"
     : "neutral";
+}
+
+function resolveProfileCapabilities(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const policy = resolveToolProfilePolicy(value);
+  return policy?.allow ? expandToolGroups(policy.allow).toSorted() : value;
 }
 
 function pushAgentCapabilityChanges(params: {
@@ -189,13 +226,21 @@ function pushAgentCapabilityChanges(params: {
   desiredSandbox?: unknown;
   currentHeartbeat?: unknown;
   desiredHeartbeat?: unknown;
+  currentMemorySearch?: unknown;
+  desiredMemorySearch?: unknown;
 }): void {
   const fields = [
     ["sandbox", "mode"],
     ["sandbox", "scope"],
     ["sandbox", "workspaceAccess"],
+    ["tools", "profile"],
     ["tools", "allow"],
+    ["tools", "alsoAllow"],
     ["tools", "deny"],
+    ["tools", "fs", "workspaceOnly"],
+    ["memorySearch", "enabled"],
+    ["memorySearch", "rememberAcrossConversations"],
+    ["memorySearch", "sources"],
     ["heartbeat", "every"],
     ["heartbeat", "activeHours"],
     ["heartbeat", "isolatedSession"],
@@ -205,16 +250,24 @@ function pushAgentCapabilityChanges(params: {
   for (const field of fields) {
     const sandboxField = field[0] === "sandbox" ? field.slice(1) : undefined;
     const heartbeatField = field[0] === "heartbeat" ? field.slice(1) : undefined;
-    const current = sandboxField
+    const memorySearchField = field[0] === "memorySearch" ? field.slice(1) : undefined;
+    const currentValue = sandboxField
       ? getPath(params.currentSandbox, sandboxField)
       : heartbeatField
         ? getPath(params.currentHeartbeat, heartbeatField)
-        : getPath(params.currentAgent, field);
-    const desired = sandboxField
+        : memorySearchField
+          ? getPath(params.currentMemorySearch, memorySearchField)
+          : getPath(params.currentAgent, field);
+    const desiredValue = sandboxField
       ? getPath(params.desiredSandbox, sandboxField)
       : heartbeatField
         ? getPath(params.desiredHeartbeat, heartbeatField)
-        : getPath(params.desiredAgent, field);
+        : memorySearchField
+          ? getPath(params.desiredMemorySearch, memorySearchField)
+          : getPath(params.desiredAgent, field);
+    const profileField = field[0] === "tools" && field[1] === "profile";
+    const current = profileField ? resolveProfileCapabilities(currentValue) : currentValue;
+    const desired = profileField ? resolveProfileCapabilities(desiredValue) : desiredValue;
     if (sameValue(current, desired)) {
       continue;
     }
@@ -233,13 +286,31 @@ function pushAgentCapabilityChanges(params: {
       classification,
       requiresDistinctConsent: classification === "escalation",
       reason: `Agent capability field ${path} changes in the target manifest.`,
-      effect: { path, current, desired },
-      ...(current === undefined
+      effect: profileField
+        ? {
+            path,
+            current: currentValue,
+            desired: desiredValue,
+            currentCapabilities: current,
+            desiredCapabilities: desired,
+          }
+        : { path, current, desired },
+      ...(currentValue === undefined
         ? {}
-        : { current: capabilityValue(summarizeAgentCapability(current)) }),
-      ...(desired === undefined
+        : {
+            current: capabilityValue(
+              summarizeAgentCapability(currentValue),
+              profileField ? { value: currentValue, resolvedCapabilities: current } : current,
+            ),
+          }),
+      ...(desiredValue === undefined
         ? {}
-        : { desired: capabilityValue(summarizeAgentCapability(desired)) }),
+        : {
+            desired: capabilityValue(
+              summarizeAgentCapability(desiredValue),
+              profileField ? { value: desiredValue, resolvedCapabilities: desired } : desired,
+            ),
+          }),
     });
   }
 }
@@ -254,6 +325,31 @@ function resolveHeartbeat(config: OpenClawConfig, agentId: string): unknown {
     ...overrides,
     every: resolveHeartbeatSummaryForAgent(config, agentId).every,
   };
+}
+
+function resolvePortableMemorySearch(config: OpenClawConfig, agentId: string): unknown {
+  const defaults = config.agents?.defaults?.memorySearch;
+  const overrides = config.agents?.list?.find((agent) => agent.id === agentId)?.memorySearch;
+  const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
+  const rememberAcrossConversations =
+    overrides?.rememberAcrossConversations ?? defaults?.rememberAcrossConversations ?? false;
+  const sessionMemory =
+    rememberAcrossConversations ||
+    (overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false);
+  const configuredSources = overrides?.sources ?? defaults?.sources ?? ["memory"];
+  const sources = new Set<"memory" | "sessions">();
+  for (const source of configuredSources) {
+    if (source === "memory" || (source === "sessions" && sessionMemory)) {
+      sources.add(source);
+    }
+  }
+  if (rememberAcrossConversations) {
+    sources.add("sessions");
+  }
+  if (sources.size === 0) {
+    sources.add("memory");
+  }
+  return { enabled, rememberAcrossConversations, sources: [...sources].toSorted() };
 }
 
 export function pushResolvedAgentCapabilityChanges(params: {
@@ -289,6 +385,10 @@ export function pushResolvedAgentCapabilityChanges(params: {
     desiredSandbox: resolveSandboxConfigForAgent(desiredConfig, params.agentId),
     currentHeartbeat: currentAgent ? resolveHeartbeat(params.config, params.agentId) : undefined,
     desiredHeartbeat: resolveHeartbeat(desiredConfig, params.agentId),
+    currentMemorySearch: currentAgent
+      ? resolvePortableMemorySearch(params.config, params.agentId)
+      : undefined,
+    desiredMemorySearch: resolvePortableMemorySearch(desiredConfig, params.agentId),
   });
 }
 

--- a/src/claws/update-capability-changes.ts
+++ b/src/claws/update-capability-changes.ts
@@ -6,6 +6,7 @@ import { expandToolGroups, resolveToolProfilePolicy } from "../agents/tool-polic
 import { parseDurationMs } from "../cli/parse-duration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
+import { resolveRememberAcrossConversations } from "../memory-host-sdk/host/config-utils.js";
 
 type ClawUpdateCapabilityValue = {
   summary: string;
@@ -381,8 +382,7 @@ function resolvePortableMemorySearch(config: OpenClawConfig, agentId: string): u
   const defaults = config.memory?.search;
   const overrides = config.agents?.list?.find((agent) => agent.id === agentId)?.memory?.search;
   const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
-  const rememberAcrossConversations =
-    overrides?.rememberAcrossConversations ?? defaults?.rememberAcrossConversations ?? false;
+  const rememberAcrossConversations = resolveRememberAcrossConversations(config, agentId);
   const sessionMemory =
     rememberAcrossConversations ||
     (overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false);

--- a/src/claws/update-capability-changes.ts
+++ b/src/claws/update-capability-changes.ts
@@ -74,6 +74,31 @@ function compareRankedCapability(
       : "neutral";
 }
 
+function classifyToolSet(
+  current: unknown,
+  desired: unknown,
+): ClawUpdateCapabilityChange["classification"] {
+  if (!Array.isArray(current) || !Array.isArray(desired)) {
+    return "neutral";
+  }
+  const currentTools = new Set(
+    current.filter((value): value is string => typeof value === "string"),
+  );
+  const desiredTools = new Set(
+    desired.filter((value): value is string => typeof value === "string"),
+  );
+  if (currentTools.has("*") !== desiredTools.has("*")) {
+    return desiredTools.has("*") ? "escalation" : "reduction";
+  }
+  if (desiredTools.has("*")) {
+    return "neutral";
+  }
+  if ([...desiredTools].some((tool) => !currentTools.has(tool))) {
+    return "escalation";
+  }
+  return [...currentTools].some((tool) => !desiredTools.has(tool)) ? "reduction" : "neutral";
+}
+
 function classifyHeartbeatEvery(
   current: unknown,
   desired: unknown,
@@ -111,12 +136,7 @@ function classifyAgentCapability(
   desired: unknown,
   currentAgentExists: boolean,
 ): ClawUpdateCapabilityChange["classification"] {
-  if (
-    path === "tools.profile" ||
-    path === "tools.allow" ||
-    path === "tools.alsoAllow" ||
-    path === "tools.deny"
-  ) {
+  if (path === "tools.profile" || path === "tools.allow" || path === "tools.deny") {
     if (!currentAgentExists && desired !== undefined) {
       return "escalation";
     }
@@ -125,6 +145,17 @@ function classifyAgentCapability(
     }
     if (current === undefined) {
       return "reduction";
+    }
+  }
+  if (path === "tools.alsoAllow") {
+    if (!currentAgentExists && desired !== undefined) {
+      return "escalation";
+    }
+    if (desired === undefined) {
+      return "reduction";
+    }
+    if (current === undefined) {
+      return "escalation";
     }
   }
   if (desired === undefined) {
@@ -159,13 +190,13 @@ function classifyAgentCapability(
   if (path === "tools.fs.workspaceOnly") {
     return desired === true ? "reduction" : "escalation";
   }
-  if (path === "memorySearch.enabled") {
+  if (path === "memory.search.enabled") {
     return desired === false ? "reduction" : "escalation";
   }
-  if (path === "memorySearch.rememberAcrossConversations") {
+  if (path === "memory.search.rememberAcrossConversations") {
     return desired === true ? "escalation" : "reduction";
   }
-  if (path === "memorySearch.sources") {
+  if (path === "memory.search.sources") {
     if (!Array.isArray(current) || !Array.isArray(desired)) {
       return desired === undefined ? "reduction" : "escalation";
     }
@@ -194,17 +225,12 @@ function classifyAgentCapability(
     Array.isArray(current) &&
     Array.isArray(desired)
   ) {
-    const currentTools = new Set(
-      current.filter((value): value is string => typeof value === "string"),
-    );
-    return desired.some((value) => typeof value === "string" && !currentTools.has(value))
-      ? "escalation"
-      : "reduction";
+    return classifyToolSet(current, desired);
   }
   return path.startsWith("sandbox.") ||
     path.startsWith("tools.") ||
     path.startsWith("heartbeat.") ||
-    path.startsWith("memorySearch.")
+    path.startsWith("memory.search.")
     ? "escalation"
     : "neutral";
 }
@@ -228,6 +254,8 @@ function pushAgentCapabilityChanges(params: {
   desiredHeartbeat?: unknown;
   currentMemorySearch?: unknown;
   desiredMemorySearch?: unknown;
+  currentTools?: unknown;
+  desiredTools?: unknown;
 }): void {
   const fields = [
     ["sandbox", "mode"],
@@ -238,9 +266,9 @@ function pushAgentCapabilityChanges(params: {
     ["tools", "alsoAllow"],
     ["tools", "deny"],
     ["tools", "fs", "workspaceOnly"],
-    ["memorySearch", "enabled"],
-    ["memorySearch", "rememberAcrossConversations"],
-    ["memorySearch", "sources"],
+    ["memory", "search", "enabled"],
+    ["memory", "search", "rememberAcrossConversations"],
+    ["memory", "search", "sources"],
     ["heartbeat", "every"],
     ["heartbeat", "activeHours"],
     ["heartbeat", "isolatedSession"],
@@ -250,21 +278,31 @@ function pushAgentCapabilityChanges(params: {
   for (const field of fields) {
     const sandboxField = field[0] === "sandbox" ? field.slice(1) : undefined;
     const heartbeatField = field[0] === "heartbeat" ? field.slice(1) : undefined;
-    const memorySearchField = field[0] === "memorySearch" ? field.slice(1) : undefined;
+    const memorySearchField =
+      field[0] === "memory" && field[1] === "search" ? field.slice(2) : undefined;
+    const effectiveToolField =
+      field[0] === "tools" &&
+      (field[1] === "profile" || field[1] === "alsoAllow" || field[1] === "fs")
+        ? field.slice(1)
+        : undefined;
     const currentValue = sandboxField
       ? getPath(params.currentSandbox, sandboxField)
       : heartbeatField
         ? getPath(params.currentHeartbeat, heartbeatField)
         : memorySearchField
           ? getPath(params.currentMemorySearch, memorySearchField)
-          : getPath(params.currentAgent, field);
+          : effectiveToolField
+            ? getPath(params.currentTools, effectiveToolField)
+            : getPath(params.currentAgent, field);
     const desiredValue = sandboxField
       ? getPath(params.desiredSandbox, sandboxField)
       : heartbeatField
         ? getPath(params.desiredHeartbeat, heartbeatField)
         : memorySearchField
           ? getPath(params.desiredMemorySearch, memorySearchField)
-          : getPath(params.desiredAgent, field);
+          : effectiveToolField
+            ? getPath(params.desiredTools, effectiveToolField)
+            : getPath(params.desiredAgent, field);
     const profileField = field[0] === "tools" && field[1] === "profile";
     const current = profileField ? resolveProfileCapabilities(currentValue) : currentValue;
     const desired = profileField ? resolveProfileCapabilities(desiredValue) : desiredValue;
@@ -327,9 +365,21 @@ function resolveHeartbeat(config: OpenClawConfig, agentId: string): unknown {
   };
 }
 
+function resolvePortableTools(config: OpenClawConfig, agentId: string): unknown {
+  const globalTools = config.tools;
+  const agentTools = config.agents?.list?.find((agent) => agent.id === agentId)?.tools;
+  return {
+    profile: agentTools?.profile ?? globalTools?.profile,
+    alsoAllow: agentTools?.alsoAllow ?? globalTools?.alsoAllow,
+    fs: {
+      workspaceOnly: agentTools?.fs?.workspaceOnly ?? globalTools?.fs?.workspaceOnly ?? false,
+    },
+  };
+}
+
 function resolvePortableMemorySearch(config: OpenClawConfig, agentId: string): unknown {
-  const defaults = config.agents?.defaults?.memorySearch;
-  const overrides = config.agents?.list?.find((agent) => agent.id === agentId)?.memorySearch;
+  const defaults = config.memory?.search;
+  const overrides = config.agents?.list?.find((agent) => agent.id === agentId)?.memory?.search;
   const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
   const rememberAcrossConversations =
     overrides?.rememberAcrossConversations ?? defaults?.rememberAcrossConversations ?? false;
@@ -389,6 +439,8 @@ export function pushResolvedAgentCapabilityChanges(params: {
       ? resolvePortableMemorySearch(params.config, params.agentId)
       : undefined,
     desiredMemorySearch: resolvePortableMemorySearch(desiredConfig, params.agentId),
+    currentTools: currentAgent ? resolvePortableTools(params.config, params.agentId) : undefined,
+    desiredTools: resolvePortableTools(desiredConfig, params.agentId),
   });
 }
 

--- a/src/claws/update-plan.test.ts
+++ b/src/claws/update-plan.test.ts
@@ -241,8 +241,6 @@ describe("buildClawUpdatePlan", () => {
       agent: {
         id: "requested-id",
         name: "Worker v2",
-        sandbox: { mode: "all", scope: "agent", workspaceAccess: "rw" },
-        tools: { allow: ["web.fetch"] },
       },
       workspace: {
         bootstrapFiles: { "SOUL.md": { source: "SOUL-v2.md" } },
@@ -293,6 +291,13 @@ describe("buildClawUpdatePlan", () => {
     const plan = await buildClawUpdatePlan({
       agentId: "worker",
       targetManifest: parsed.manifest,
+      targetOpenClawProfile: {
+        schemaVersion: 1,
+        agent: {
+          sandbox: { mode: "all", scope: "agent", workspaceAccess: "rw" },
+          tools: { allow: ["web.fetch"] },
+        },
+      },
       targetSource: targetSource(current.root, "2.0.0", "sha256:target"),
       config: current.config,
       sourceMcpServers: current.config.mcp?.servers ?? {},

--- a/src/claws/update-plan.ts
+++ b/src/claws/update-plan.ts
@@ -19,6 +19,7 @@ import {
   CLAW_OUTPUT_STABILITY,
   type ClawDiagnostic,
   type ClawManifest,
+  type ClawOpenClawProfile,
   type ClawPackage,
   type ClawSourceIdentity,
 } from "./types.js";
@@ -58,6 +59,7 @@ function manualState(state: string): boolean {
 export async function buildClawUpdatePlan(params: {
   agentId: string;
   targetManifest: ClawManifest;
+  targetOpenClawProfile?: ClawOpenClawProfile;
   targetSource: ClawSourceIdentity;
   config: OpenClawConfig;
   sourceMcpServers: Record<string, Record<string, unknown>>;
@@ -201,6 +203,7 @@ export async function buildClawUpdatePlan(params: {
     >();
     const targetPlan = await buildClawAddPlan({
       manifest: params.targetManifest,
+      openClawProfile: params.targetOpenClawProfile,
       source: params.targetSource,
       diagnostics: params.diagnostics,
       context: {

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -200,6 +200,7 @@ export async function runClawsInspectCommand(
     valid: true,
     source: result.source,
     manifest: result.manifest,
+    ...(result.openClawProfile ? { openClawProfile: result.openClawProfile } : {}),
     diagnostics: result.diagnostics,
   };
   if (opts.json) {
@@ -262,6 +263,7 @@ export async function runClawsAddCommand(
   };
   let plan = await buildClawAddPlan({
     manifest: result.manifest,
+    openClawProfile: result.openClawProfile,
     source: result.source,
     diagnostics: result.diagnostics,
     context: basePlanContext,
@@ -278,6 +280,7 @@ export async function runClawsAddCommand(
       (resumeRecord.status === "workspace_ready" && committedAgent !== undefined);
     plan = await buildClawAddPlan({
       manifest: result.manifest,
+      openClawProfile: result.openClawProfile,
       source: result.source,
       diagnostics: result.diagnostics,
       context: {

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -428,17 +428,30 @@ describe("claws cli", () => {
   });
 
   it("discloses capability escalations in the human dry-run", async () => {
-    const path = await writeManifest({
-      schemaVersion: 1,
-      agent: { id: "demo-agent", tools: { allow: ["read"] } },
-      mcpServers: {
-        docs: {
-          command: "node",
-          env: { API_TOKEN: "${GITHUB_TOKEN}" },
-          toolFilter: { include: ["search_*"] },
+    const root = tempDirs.make("openclaw-claws-cli-profile-");
+    await mkdir(join(root, "profiles"));
+    await writeFile(
+      join(root, "profiles", "openclaw.yml"),
+      "schemaVersion: 1\nagent:\n  tools:\n    allow: [read]\n",
+      "utf8",
+    );
+    const path = join(root, "openclaw.claw.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        agent: { id: "demo-agent" },
+        metadata: { "openclaw.config": "profiles/openclaw.yml" },
+        mcpServers: {
+          docs: {
+            command: "node",
+            env: { API_TOKEN: "${GITHUB_TOKEN}" },
+            toolFilter: { include: ["search_*"] },
+          },
         },
-      },
-    });
+      }),
+      "utf8",
+    );
 
     await runCli(["claws", "add", path, "--dry-run"]);
 

--- a/src/cli/claws-update-cli.runtime.ts
+++ b/src/cli/claws-update-cli.runtime.ts
@@ -169,6 +169,7 @@ export async function runClawsUpdateCommand(
   const plan = await buildClawUpdatePlan({
     agentId: target,
     targetManifest: loaded.manifest,
+    targetOpenClawProfile: loaded.openClawProfile,
     targetSource: loaded.source,
     config,
     sourceMcpServers: listedMcpServers.mcpServers,
@@ -195,7 +196,11 @@ export async function runClawsUpdateCommand(
   try {
     const result = await applyClawUpdatePlan(
       plan,
-      { targetManifest: loaded.manifest, targetSource: loaded.source },
+      {
+        targetManifest: loaded.manifest,
+        targetOpenClawProfile: loaded.openClawProfile,
+        targetSource: loaded.source,
+      },
       {
         config,
         sourceMcpServers: listedMcpServers.mcpServers,


### PR DESCRIPTION
## Summary

- Keep `CLAW.md` and grouped JSON portable: the agent object contains only id, name, description, and identity presentation.
- Define `metadata` as a string-to-string map, following the Agent Skills portability precedent.
- Move OpenClaw-specific per-agent policy into a strict package-local YAML profile referenced by `metadata.openclaw.config`.
- Export the conventional `profiles/openclaw.yml` path while treating the metadata pointer, not the filename, as normative.
- Validate the sidecar as bounded JSON-compatible YAML with forward-slash package-relative pointers and no links, aliases, merge keys, tags, duplicate keys, unknown fields, or unsupported schema versions.
- Bind the exact sidecar path and bytes into local-development integrity, and preserve it through inspect, add, update, provenance, and export.

The profile exists only inside the Claw package. It is consumed while planning the new agent and is never copied to OpenClaw's ordinary configuration path.

This is the final implementation slice after [#111391](https://github.com/openclaw/openclaw/pull/111391). It implements the portability boundary in [RFC PR #48](https://github.com/openclaw/rfcs/pull/48), building on [Claws RFC #27](https://github.com/openclaw/rfcs/pull/27).

## Policy boundary

The portable core remains harness-agnostic. OpenClaw recognizes `openclaw.config`; other harnesses may ignore it or define their own namespaced metadata pointer. Host policy remains authoritative. The OpenClaw profile cannot carry custom profile definitions, providers, credentials, bindings, local paths, arbitrary executable configuration, or settings that relax host confinement.

## Real behavior proof

- Missing, empty, escaping, symlinked, hardlinked, oversized, malformed, schema-invalid, and non-portable profile pointers fail before planning.
- A profile byte change changes local-development integrity.
- Add and update consume the same validated profile snapshot.
- Export writes core identity to `CLAW.md`, writes OpenClaw policy to `profiles/openclaw.yml`, and includes the sidecar in derivative version hashing.
- Inspect JSON reports the validated OpenClaw profile without mutating lifecycle state.
- Lifecycle fixtures prove the referenced profile is consumed by inspect and add.
- Existing built-in profile, capability-consent, memory, and host-policy behavior remains enforced.

## Validation

- 82 focused schema, profile, capability-change, and export tests pass.
- 8/8 lifecycle E2E tests pass.
- Full `pnpm check:test-types` passes.
- Oxlint reports 0 warnings and 0 errors on changed files.
- Formatting and `git diff --check` pass.
- Final Codex review reports no actionable findings.
- Signed head: `d255a128a23`.