### PR TITLE
fix(logging): give non-default profiles their own gateway log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Profile-isolated gateway logs:** write non-default profiles to `openclaw-<profile>-YYYY-MM-DD.log` and keep CLI, RPC, and Control UI tails on the same profile-specific file while preserving the default profile path.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.
 - **Control UI terminal error messages:** preserve message-only assistant output beginning with `Error:` or a warning marker instead of treating text prefixes as synthetic failures. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Profile-isolated gateway logs:** write non-default profiles to `openclaw-<profile>-YYYY-MM-DD.log` and keep CLI, RPC, and Control UI tails on the same profile-specific file while preserving the default profile path.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.
 - **Control UI terminal error messages:** preserve message-only assistant output beginning with `Error:` or a warning marker instead of treating text prefixes as synthetic failures. Thanks @shakkernerd.

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -429,7 +429,7 @@ Extra checks:
 ```bash
 openclaw pairing list signal
 pgrep -af signal-cli
-grep -i "signal" "/tmp/openclaw/openclaw-$(date +%Y-%m-%d).log" | tail -20
+openclaw logs --plain --limit 500 | grep -i "signal" | tail -20
 ```
 
 For triage flow: [Channels Troubleshooting](/channels/troubleshooting).

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -36,6 +36,8 @@ Passing `--url` skips auto-applied config credentials; include `--token` explici
 ```bash
 openclaw logs
 openclaw logs --follow
+openclaw --dev logs --follow
+openclaw --profile work logs --follow
 openclaw logs --follow --interval 2000
 openclaw logs --limit 500 --max-bytes 500000
 openclaw logs --json
@@ -45,6 +47,11 @@ openclaw logs --utc
 openclaw logs --follow --local-time
 openclaw logs --url ws://127.0.0.1:18789 --token "$OPENCLAW_GATEWAY_TOKEN"
 ```
+
+The selected root profile matches the Gateway's rolling file: the default
+profile uses `openclaw-YYYY-MM-DD.log`, while named profiles use
+`openclaw-<profile>-YYYY-MM-DD.log` (for example,
+`openclaw-dev-YYYY-MM-DD.log`).
 
 ## Fallback and recovery behavior
 

--- a/docs/diagnostics/flags.md
+++ b/docs/diagnostics/flags.md
@@ -158,6 +158,9 @@ Flags emit logs into the standard diagnostics log file. By default:
 /tmp/openclaw/openclaw-YYYY-MM-DD.log
 ```
 
+Named profiles use `/tmp/openclaw/openclaw-<profile>-YYYY-MM-DD.log`; for
+example, `--dev` uses `openclaw-dev-YYYY-MM-DD.log`.
+
 If you set `logging.file`, use that path instead. Logs are JSONL (one JSON
 object per line). Redaction still applies based on `logging.redactSensitive`.
 See [Logging](/logging) for the full log-path resolution, rotation, and
@@ -165,28 +168,30 @@ redaction model.
 
 ## Extract logs
 
-Pick the latest log file:
+Read the active profile's latest log file:
 
 ```bash
-ls -t /tmp/openclaw/openclaw-*.log | head -n 1
+openclaw logs --plain
+# Named profile example:
+openclaw --profile work logs --plain
 ```
 
 Filter for Telegram HTTP diagnostics:
 
 ```bash
-rg "telegram http error" /tmp/openclaw/openclaw-*.log
+openclaw logs --plain --limit 5000 | rg "telegram http error"
 ```
 
 Filter for Brave Search HTTP diagnostics:
 
 ```bash
-rg "brave http" /tmp/openclaw/openclaw-*.log
+openclaw logs --plain --limit 5000 | rg "brave http"
 ```
 
 Or tail while reproducing:
 
 ```bash
-tail -f /tmp/openclaw/openclaw-$(date +%F).log | rg "telegram http error"
+openclaw logs --follow --plain | rg "telegram http error"
 ```
 
 For remote gateways, use `openclaw logs --follow` instead (see

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1242,7 +1242,7 @@ writer is best-effort, not a lossless compliance archive.
 }
 ```
 
-- Default log file: `/tmp/openclaw/openclaw-YYYY-MM-DD.log`.
+- Default log file: `/tmp/openclaw/openclaw-YYYY-MM-DD.log`; named profiles use `/tmp/openclaw/openclaw-<profile>-YYYY-MM-DD.log`.
 - Set `logging.file` for a stable path.
 - `consoleLevel` bumps to `debug` when `--verbose`.
 - `maxFileBytes`: maximum active log file size in bytes before rotation (positive integer; default: `104857600` = 100 MB). OpenClaw keeps up to five numbered archives beside the active file.

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -18,7 +18,7 @@ Short guide to verify channel connectivity without guessing.
 - `openclaw health --verbose` (alias `--debug`) - forces a live health probe and prints gateway connection details.
 - `openclaw health --json` - machine-readable health snapshot output.
 - Send `/status` as a standalone chat command in any channel to get a status reply without invoking the agent.
-- Logs: tail `/tmp/openclaw/openclaw-*.log` and filter for `web-heartbeat`, `web-reconnect`, `web-auto-reply`, `web-inbound`.
+- Logs: run `openclaw logs --follow` (or `openclaw --profile <profile> logs --follow`) and filter for `web-heartbeat`, `web-reconnect`, `web-auto-reply`, `web-inbound`.
 
 For Discord and other chat providers, session rows are not socket liveness.
 `openclaw sessions`, Gateway `sessions.list`, and the agent `sessions_list` tool

--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -25,7 +25,7 @@ agent model: openai/gpt-5.6-sol (thinking=medium, fast=on)
 
 ## File-based logger
 
-- Default rolling log file is under `/tmp/openclaw/` (one file per day): `openclaw-YYYY-MM-DD.log`, dated by the gateway host's local timezone. If that directory is unsafe or unwritable (wrong owner, world-writable, a symlink), OpenClaw falls back to a user-scoped `os.tmpdir()/openclaw-<uid>` path instead; on Windows it always uses that OS-tmpdir fallback.
+- Default rolling log files are under `/tmp/openclaw/` (one file per day), dated by the gateway host's local timezone. The default profile uses `openclaw-YYYY-MM-DD.log`; named profiles use `openclaw-<profile>-YYYY-MM-DD.log` (for example, `openclaw-dev-YYYY-MM-DD.log`). If that directory is unsafe or unwritable (wrong owner, world-writable, a symlink), OpenClaw falls back to a user-scoped `os.tmpdir()/openclaw-<uid>` path instead; on Windows it always uses that OS-tmpdir fallback.
 - Active log files rotate at `logging.maxFileBytes` (default: 100 MB), keeping up to five numbered archives (`.1` through `.5`) and continuing to write a fresh active file.
 - Configure the log file path and level via `~/.openclaw/openclaw.json`: `logging.file`, `logging.level`.
 - The file format is one JSON object per line.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -822,7 +822,7 @@ For phone-number-based channels, consider running the assistant on a separate nu
 
 ### Audit
 
-1. Check Gateway logs: `/tmp/openclaw/openclaw-YYYY-MM-DD.log` (or `logging.file`).
+1. Check Gateway logs with `openclaw logs` (or `openclaw --profile <profile> logs` for a named profile). The default path is `/tmp/openclaw/openclaw-YYYY-MM-DD.log`; named profiles use `/tmp/openclaw/openclaw-<profile>-YYYY-MM-DD.log`, unless `logging.file` overrides it.
 2. Review the relevant transcript(s): `~/.openclaw/agents/<agentId>/sessions/*.jsonl`.
 3. Review recent config changes that could have widened access: `gateway.bind`, `gateway.auth`, DM/group policies, `tools.elevated`, plugin changes.
 4. Re-run `openclaw security audit --deep` and confirm critical findings are resolved.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -41,7 +41,9 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
     ```
     If RPC is down, fall back to:
     ```bash
-    tail -f "$(ls -t /tmp/openclaw/openclaw-*.log | head -1)"
+    tail -f "/tmp/openclaw/openclaw-$(date +%F).log"
+    # Named profile example:
+    tail -f "/tmp/openclaw/openclaw-dev-$(date +%F).log"
     ```
     File logs are separate from service logs; see [Logging](/logging) and [Troubleshooting](/gateway/troubleshooting).
   </Step>
@@ -1240,7 +1242,7 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
 
 <AccordionGroup>
   <Accordion title="Where are logs?">
-    File logs (structured): `/tmp/openclaw/openclaw-YYYY-MM-DD.log`. Set a stable path via `logging.file`; file log level via `logging.level`; console verbosity via `--verbose` and `logging.consoleLevel`.
+    File logs (structured): `/tmp/openclaw/openclaw-YYYY-MM-DD.log` for the default profile, or `/tmp/openclaw/openclaw-<profile>-YYYY-MM-DD.log` for a named profile. Set a stable path via `logging.file`; file log level via `logging.level`; console verbosity via `--verbose` and `logging.consoleLevel`.
 
     Fastest tail:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -17,9 +17,22 @@ logs live, how to read them, and how to configure log levels and formats.
 
 ## Where logs live
 
-By default, the Gateway writes a rolling log file per day:
+By default, the Gateway writes a rolling log file per day. The default profile
+keeps the historical path:
 
 `/tmp/openclaw/openclaw-YYYY-MM-DD.log`
+
+Named profiles use a profile-qualified filename in the same directory:
+
+`/tmp/openclaw/openclaw-<profile>-YYYY-MM-DD.log`
+
+The filename profile segment is lowercase and limited to letters, numbers, and
+dashes. Simple lowercase names stay readable, so the `--dev` shorthand writes
+`openclaw-dev-YYYY-MM-DD.log`. Case, underscores, and literal dashes use a
+reversible dash escape so distinct profile names never share a log file.
+Oversized values set directly through the environment use a bounded hash suffix
+to stay within filesystem filename limits. An explicit `logging.file` overrides
+these defaults.
 
 The date uses the gateway host's local timezone. When `/tmp/openclaw` is unsafe
 or unavailable (and always on Windows), OpenClaw uses a user-scoped
@@ -28,8 +41,9 @@ pruned after 24 hours.
 
 Each file rotates when the next write would exceed `logging.maxFileBytes`
 (default: 100 MB). OpenClaw keeps up to five numbered archives beside the
-active file, such as `openclaw-YYYY-MM-DD.1.log`, and keeps writing to a fresh
-active log instead of suppressing diagnostics.
+active file, such as `openclaw-YYYY-MM-DD.1.log` or
+`openclaw-dev-YYYY-MM-DD.1.log`, and keeps writing to a fresh active log instead
+of suppressing diagnostics.
 
 You can override the path in `~/.openclaw/openclaw.json`:
 
@@ -49,7 +63,12 @@ Tail the gateway log file via RPC:
 
 ```bash
 openclaw logs --follow
+openclaw --dev logs --follow
+openclaw --profile work logs --follow
 ```
+
+The root profile selector resolves the same profile-specific file used by the
+Gateway, including CLI fallback reads when local RPC is unavailable.
 
 Options:
 
@@ -174,7 +193,7 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
 {
   "logging": {
     "level": "info",
-    "file": "/tmp/openclaw/openclaw-YYYY-MM-DD.log",
+    "file": "/path/to/openclaw.log",
     "consoleLevel": "info",
     "consoleStyle": "pretty",
     "redactSensitive": "tools",

--- a/docs/platforms/mac/health.md
+++ b/docs/platforms/mac/health.md
@@ -39,8 +39,8 @@ does not flicker while offline.
 ## When in doubt
 
 Use the CLI flow in [Gateway health](/gateway/health) (`openclaw status`,
-`openclaw status --deep`, `openclaw health --json`) and tail
-`/tmp/openclaw/openclaw-*.log`, filtering for `web-heartbeat` / `web-reconnect`.
+`openclaw status --deep`, `openclaw health --json`) and run
+`openclaw logs --follow`, filtering for `web-heartbeat` / `web-reconnect`.
 
 ## Related
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -224,7 +224,8 @@ openclaw status --deep   # probe channels (WhatsApp Web + Telegram + Discord + S
 openclaw health --json   # gateway health snapshot over the WS connection
 ```
 
-Logs live under `/tmp/openclaw/` (default: `openclaw-YYYY-MM-DD.log`).
+Logs live under `/tmp/openclaw/`: `openclaw-YYYY-MM-DD.log` for the default
+profile and `openclaw-<profile>-YYYY-MM-DD.log` for named profiles.
 
 ## Next steps
 

--- a/src/logging/log-file-path.test.ts
+++ b/src/logging/log-file-path.test.ts
@@ -1,0 +1,122 @@
+// Log file path tests cover profile-aware rolling filename resolution.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  isLegacyRollingLogFilePath,
+  isSameRollingLogFileFamily,
+  resolveConfiguredLogFilePath,
+  resolveRollingLogFilePathForDate,
+} from "./log-file-path.js";
+
+const date = new Date(2026, 6, 22, 12, 0, 0);
+
+describe("resolveConfiguredLogFilePath", () => {
+  it.each([
+    { name: "unset", env: {}, expected: "openclaw-2026-07-22.log" },
+    {
+      name: "explicit default",
+      env: { OPENCLAW_PROFILE: "Default" },
+      expected: "openclaw-2026-07-22.log",
+    },
+    {
+      name: "named",
+      env: { OPENCLAW_PROFILE: "dev" },
+      expected: "openclaw-dev-2026-07-22.log",
+    },
+    {
+      name: "sanitized",
+      env: { OPENCLAW_PROFILE: "QA_Profile" },
+      expected: "openclaw--1q-1a-0-1profile-2026-07-22.log",
+    },
+  ])("uses the $name profile filename", ({ env, expected }) => {
+    const resolved = resolveConfiguredLogFilePath(undefined, { date, env });
+
+    expect(path.basename(resolved)).toBe(expected);
+  });
+
+  it("keeps profiles distinct when sanitization would otherwise collide", () => {
+    const underscored = resolveConfiguredLogFilePath(undefined, {
+      date,
+      env: { OPENCLAW_PROFILE: "QA_Profile" },
+    });
+    const dashed = resolveConfiguredLogFilePath(undefined, {
+      date,
+      env: { OPENCLAW_PROFILE: "qa-profile" },
+    });
+
+    expect(underscored).not.toBe(dashed);
+    expect(path.basename(dashed)).toBe("openclaw-qa--profile-2026-07-22.log");
+  });
+
+  it("keeps escaped output distinct from a profile that resembles the encoding", () => {
+    const transformed = resolveConfiguredLogFilePath(undefined, {
+      date,
+      env: { OPENCLAW_PROFILE: "QA_Profile" },
+    });
+    const lookalike = resolveConfiguredLogFilePath(undefined, {
+      date,
+      env: { OPENCLAW_PROFILE: "-1q-1a-0-1profile" },
+    });
+
+    expect(transformed).not.toBe(lookalike);
+  });
+
+  it("bounds direct environment profiles that exceed the CLI length contract", () => {
+    const first = resolveConfiguredLogFilePath(undefined, {
+      date,
+      env: { OPENCLAW_PROFILE: "A".repeat(80) },
+    });
+    const second = resolveConfiguredLogFilePath(undefined, {
+      date,
+      env: { OPENCLAW_PROFILE: "B".repeat(80) },
+    });
+
+    expect(path.basename(first)).toMatch(/^openclaw--3[a-f0-9]{64}-2026-07-22\.log$/u);
+    expect(path.basename(first).length).toBeLessThanOrEqual(255);
+    expect(first).not.toBe(second);
+  });
+
+  it("preserves an explicit logging.file override", () => {
+    expect(
+      resolveConfiguredLogFilePath(
+        { logging: { file: "/var/log/openclaw/custom.log" } },
+        { date, env: { OPENCLAW_PROFILE: "dev" } },
+      ),
+    ).toBe("/var/log/openclaw/custom.log");
+  });
+});
+
+describe("profile rolling log families", () => {
+  it("preserves the profile segment across date rollover", () => {
+    expect(
+      resolveRollingLogFilePathForDate(
+        "/tmp/openclaw/openclaw-dev-2026-07-22.log",
+        new Date(2026, 6, 23, 12, 0, 0),
+      ),
+    ).toBe("/tmp/openclaw/openclaw-dev-2026-07-23.log");
+  });
+
+  it("expands the legacy YYYY-MM-DD placeholder", () => {
+    expect(
+      resolveRollingLogFilePathForDate(
+        "/tmp/openclaw/openclaw-YYYY-MM-DD.log",
+        new Date(2026, 6, 23, 12, 0, 0),
+      ),
+    ).toBe("/tmp/openclaw/openclaw-2026-07-23.log");
+  });
+
+  it("keeps default and named profile fallback families separate", () => {
+    expect(
+      isSameRollingLogFileFamily("openclaw-dev-2026-07-22.log", "openclaw-dev-2026-07-21.log"),
+    ).toBe(true);
+    expect(
+      isSameRollingLogFileFamily("openclaw-dev-2026-07-22.log", "openclaw-2026-07-22.log"),
+    ).toBe(false);
+  });
+
+  it("keeps legacy explicit dated paths rolling without broadening the override contract", () => {
+    expect(isLegacyRollingLogFilePath("openclaw-2026-07-22.log")).toBe(true);
+    expect(isLegacyRollingLogFilePath("openclaw-YYYY-MM-DD.log")).toBe(true);
+    expect(isLegacyRollingLogFilePath("openclaw-dev-2026-07-22.log")).toBe(false);
+  });
+});

--- a/src/logging/log-file-path.ts
+++ b/src/logging/log-file-path.ts
@@ -1,4 +1,5 @@
 // Log file path helpers resolve log output paths for local runtime logs.
+import { createHash } from "node:crypto";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.js";
 import {
@@ -7,12 +8,91 @@ import {
 } from "../infra/tmp-openclaw-dir.js";
 import { canUseNodeFs, formatLocalDate, LOG_PREFIX, LOG_SUFFIX } from "./log-file-shared.js";
 
-function resolveDefaultRollingLogFile(date = new Date()): string {
-  const logDir = canUseNodeFs() ? resolvePreferredOpenClawTmpDir() : DEFAULT_POSIX_TMP_ROOT;
-  return path.join(logDir, `${LOG_PREFIX}-${formatLocalDate(date)}${LOG_SUFFIX}`);
+const ROLLING_LOG_FILE_RE = /^(openclaw(?:-[a-z0-9-]+)?)-(\d{4}-\d{2}-\d{2})\.log$/u;
+const MAX_LOG_PROFILE_SEGMENT_LENGTH = 220;
+
+function encodeLogProfileSegment(profile: string): string {
+  let encoded = "";
+  for (const char of profile) {
+    if (/^[a-z0-9]$/u.test(char)) {
+      encoded += char;
+    } else if (char === "-") {
+      encoded += "--";
+    } else if (char === "_") {
+      encoded += "-0";
+    } else if (/^[A-Z]$/u.test(char)) {
+      encoded += `-1${char.toLowerCase()}`;
+    } else {
+      encoded += `-2${char.codePointAt(0)?.toString(16) ?? "0"}-`;
+    }
+  }
+  return encoded;
+}
+
+function resolveLogProfileSegment(env: NodeJS.ProcessEnv): string | null {
+  const profile = env.OPENCLAW_PROFILE?.trim();
+  if (!profile || profile.toLowerCase() === "default") {
+    return null;
+  }
+  const encoded = encodeLogProfileSegment(profile);
+  if (encoded.length <= MAX_LOG_PROFILE_SEGMENT_LENGTH) {
+    return encoded;
+  }
+  return `-3${createHash("sha256").update(profile).digest("hex")}`;
+}
+
+/** Resolves today's default rolling log path for the active CLI profile. */
+export function resolveDefaultRollingLogFile(options?: {
+  date?: Date;
+  env?: NodeJS.ProcessEnv;
+  logDir?: string;
+}): string {
+  const date = options?.date ?? new Date();
+  const env = options?.env ?? process.env;
+  const logDir =
+    options?.logDir ?? (canUseNodeFs() ? resolvePreferredOpenClawTmpDir() : DEFAULT_POSIX_TMP_ROOT);
+  const profileSegment = resolveLogProfileSegment(env);
+  const profileSuffix = profileSegment ? `-${profileSegment}` : "";
+  return path.join(logDir, `${LOG_PREFIX}${profileSuffix}-${formatLocalDate(date)}${LOG_SUFFIX}`);
 }
 
 /** Resolves the configured log file or today's rolling default log path. */
-export function resolveConfiguredLogFilePath(config?: OpenClawConfig | null): string {
-  return config?.logging?.file ?? resolveDefaultRollingLogFile();
+export function resolveConfiguredLogFilePath(
+  config?: OpenClawConfig | null,
+  options?: { date?: Date; env?: NodeJS.ProcessEnv; logDir?: string },
+): string {
+  return config?.logging?.file ?? resolveDefaultRollingLogFile(options);
+}
+
+/** Returns whether a path is one of OpenClaw's dated rolling log files. */
+export function isRollingLogFilePath(file: string): boolean {
+  return ROLLING_LOG_FILE_RE.test(path.basename(file));
+}
+
+/** Returns whether a configured path had the legacy default rolling filename shape. */
+export function isLegacyRollingLogFilePath(file: string): boolean {
+  const base = path.basename(file);
+  return (
+    base.startsWith(`${LOG_PREFIX}-`) &&
+    base.endsWith(LOG_SUFFIX) &&
+    base.length === `${LOG_PREFIX}-YYYY-MM-DD${LOG_SUFFIX}`.length
+  );
+}
+
+/** Advances a rolling log path to the requested date while preserving its profile family. */
+export function resolveRollingLogFilePathForDate(file: string, date: Date): string {
+  const match = ROLLING_LOG_FILE_RE.exec(path.basename(file));
+  if (!match) {
+    return isLegacyRollingLogFilePath(file)
+      ? path.join(path.dirname(file), `${LOG_PREFIX}-${formatLocalDate(date)}${LOG_SUFFIX}`)
+      : file;
+  }
+  return path.join(path.dirname(file), `${match[1]}-${formatLocalDate(date)}${LOG_SUFFIX}`);
+}
+
+/** Returns whether two dated rolling paths belong to the same profile family. */
+export function isSameRollingLogFileFamily(left: string, right: string): boolean {
+  const leftMatch = ROLLING_LOG_FILE_RE.exec(path.basename(left));
+  const rightMatch = ROLLING_LOG_FILE_RE.exec(path.basename(right));
+  return Boolean(leftMatch && rightMatch && leftMatch[1] === rightMatch[1]);
 }

--- a/src/logging/log-file-size-cap.test.ts
+++ b/src/logging/log-file-size-cap.test.ts
@@ -96,4 +96,22 @@ describe("log file size cap", () => {
     expect(fs.readFileSync(secondDay, "utf8")).toContain("second day");
     expect(fs.readFileSync(firstDay, "utf8")).not.toContain("second day");
   });
+
+  it("keeps an explicit profile-shaped log path stable across date changes", () => {
+    const logDir = path.dirname(logPath);
+    const configured = path.join(logDir, "openclaw-dev-2026-01-01.log");
+    const inferredNextDay = path.join(logDir, "openclaw-dev-2026-01-02.log");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T08:00:00Z"));
+    setLoggerOverride({ level: "info", file: configured });
+    const logger = getLogger();
+
+    logger.info({ message: "first day" });
+    vi.setSystemTime(new Date("2026-01-02T08:00:00Z"));
+    logger.info({ message: "second day" });
+
+    expect(fs.readFileSync(configured, "utf8")).toContain("first day");
+    expect(fs.readFileSync(configured, "utf8")).toContain("second day");
+    expect(fs.existsSync(inferredNextDay)).toBe(false);
+  });
 });

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -84,4 +84,33 @@ describe("readConfiguredLogTail", () => {
 
     expect(result.lines).toEqual(["old line", "recent one", "recent two"]);
   });
+
+  it("falls back only within the active profile's rolling log family", async () => {
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const missing = path.join(tempDir, "openclaw-dev-2026-01-22.log");
+    const devLog = path.join(tempDir, "openclaw-dev-2026-01-21.log");
+    const defaultLog = path.join(tempDir, "openclaw-2026-01-21.log");
+    await fs.writeFile(devLog, "dev profile\n");
+    await fs.writeFile(defaultLog, "default profile\n");
+    await fs.utimes(devLog, new Date(0), new Date(0));
+    await fs.utimes(defaultLog, new Date(), new Date());
+    const { resolveLogFile } = await import("./log-tail.js");
+    const result = await resolveLogFile(missing, { rolling: true });
+
+    expect(result).toBe(devLog);
+  });
+
+  it("does not reinterpret an explicit profile-shaped logging.file as rolling", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const configured = path.join(tempDir, "openclaw-dev-2026-01-22.log");
+    const sibling = path.join(tempDir, "openclaw-dev-2026-01-21.log");
+    await fs.writeFile(sibling, "sibling profile log\n");
+    setLoggerOverride({ file: configured });
+
+    const result = await readConfiguredLogTail();
+
+    expect(result.file).toBe(configured);
+    expect(result.lines).toEqual([]);
+  });
 });

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -2,8 +2,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { readFileWindowFully } from "../infra/file-read.js";
-import { getResolvedLoggerSettings } from "../logging.js";
 import { clamp } from "../utils.js";
+import { isRollingLogFilePath, isSameRollingLogFileFamily } from "./log-file-path.js";
+import "./logger.js";
+import { getResolvedLoggerFileTarget } from "./logger-settings-internal.js";
 import { redactSensitiveLines, resolveRedactOptions } from "./redact.js";
 
 // Tail reader for the active log file, with cursor reset and line redaction.
@@ -11,7 +13,6 @@ const DEFAULT_LIMIT = 500;
 const DEFAULT_MAX_BYTES = 250_000;
 const MAX_LIMIT = 5000;
 const MAX_BYTES = 1_000_000;
-const ROLLING_LOG_RE = /^openclaw-\d{4}-\d{2}-\d{2}\.log$/;
 
 /** Payload returned to log-tail callers with cursor and truncation metadata. */
 export type LogTailPayload = {
@@ -23,17 +24,16 @@ export type LogTailPayload = {
   reset: boolean;
 };
 
-function isRollingLogFile(file: string): boolean {
-  return ROLLING_LOG_RE.test(path.basename(file));
-}
-
 /** Resolves a rolling daily log path to the newest existing rolling log when needed. */
-export async function resolveLogFile(file: string): Promise<string> {
+export async function resolveLogFile(
+  file: string,
+  options?: { rolling?: boolean },
+): Promise<string> {
   const stat = await fs.stat(file).catch(() => null);
   if (stat) {
     return file;
   }
-  if (!isRollingLogFile(file)) {
+  if (!(options?.rolling ?? isRollingLogFilePath(file))) {
     return file;
   }
 
@@ -45,7 +45,7 @@ export async function resolveLogFile(file: string): Promise<string> {
 
   const candidates = await Promise.all(
     entries
-      .filter((entry) => entry.isFile() && ROLLING_LOG_RE.test(entry.name))
+      .filter((entry) => entry.isFile() && isSameRollingLogFileFamily(file, entry.name))
       .map(async (entry) => {
         const fullPath = path.join(dir, entry.name);
         const fileStat = await fs.stat(fullPath).catch(() => null);
@@ -161,7 +161,8 @@ export async function readConfiguredLogTail(params?: {
   limit?: number;
   maxBytes?: number;
 }): Promise<LogTailPayload> {
-  const file = await resolveLogFile(getResolvedLoggerSettings().file);
+  const target = getResolvedLoggerFileTarget();
+  const file = await resolveLogFile(target.file, { rolling: target.rolling });
   const result = await readLogSlice({
     file,
     cursor: params?.cursor,

--- a/src/logging/logger-settings-internal.ts
+++ b/src/logging/logger-settings-internal.ts
@@ -1,0 +1,16 @@
+// Internal bridge shares the logger's resolved file target without widening its public API.
+type LoggerFileTarget = { file: string; rolling: boolean };
+type LoggerFileTargetResolver = () => LoggerFileTarget;
+
+let resolveLoggerFileTarget: LoggerFileTargetResolver | undefined;
+
+export function setLoggerFileTargetResolver(resolver: LoggerFileTargetResolver): void {
+  resolveLoggerFileTarget = resolver;
+}
+
+export function getResolvedLoggerFileTarget(): LoggerFileTarget {
+  if (!resolveLoggerFileTarget) {
+    throw new Error("Logger file target resolver is not initialized");
+  }
+  return resolveLoggerFileTarget();
+}

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -27,7 +27,10 @@ import {
 import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
+import { isLegacyRollingLogFilePath, resolveRollingLogFilePathForDate } from "./log-file-path.js";
+import { resolveDefaultRollingLogFile } from "./log-file-path.js";
 import { canUseNodeFs, formatLocalDate, LOG_PREFIX, LOG_SUFFIX } from "./log-file-shared.js";
+import { setLoggerFileTargetResolver } from "./logger-settings-internal.js";
 import { redactSecrets, redactSensitiveText } from "./redact.js";
 import { loggingState } from "./state.js";
 import { formatTimestamp } from "./timestamps.js";
@@ -58,6 +61,7 @@ type ResolvedSettings = {
   file: string;
   maxFileBytes: number;
 };
+type ResolvedRuntimeSettings = ResolvedSettings & { rolling: boolean };
 export type LoggerResolvedSettings = ResolvedSettings;
 type TsLogRecord = Record<string, unknown>;
 type LoggerConfigLoader = () => OpenClawConfig["logging"] | undefined;
@@ -508,15 +512,16 @@ function resolveDefaultActiveLogFile(): string {
       `${LOG_PREFIX}-vitest-${process.pid}-${formatLocalDate(new Date())}${LOG_SUFFIX}`,
     );
   }
-  return defaultRollingPathForToday();
+  return resolveDefaultRollingLogFile({ logDir: DEFAULT_LOG_DIR });
 }
 
-function resolveSettings(): ResolvedSettings {
+function resolveSettings(): ResolvedRuntimeSettings {
   if (!canUseNodeFs()) {
     return {
       level: "silent",
       file: DEFAULT_LOG_FILE,
       maxFileBytes: DEFAULT_MAX_LOG_FILE_BYTES,
+      rolling: false,
     };
   }
 
@@ -526,8 +531,9 @@ function resolveSettings(): ResolvedSettings {
   if (canUseSilentVitestFileLogFastPath(envLevel)) {
     return {
       level: "silent",
-      file: defaultRollingPathForToday(),
+      file: resolveDefaultRollingLogFile({ logDir: DEFAULT_LOG_DIR }),
       maxFileBytes: DEFAULT_MAX_LOG_FILE_BYTES,
+      rolling: true,
     };
   }
 
@@ -539,18 +545,30 @@ function resolveSettings(): ResolvedSettings {
   const level = envLevel ?? fromConfig;
   const file = cfg?.file ?? resolveDefaultActiveLogFile();
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
-  return { level, file, maxFileBytes };
+  const rolling = cfg?.file ? isLegacyRollingLogFilePath(cfg.file) : true;
+  return { level, file, maxFileBytes, rolling };
 }
 
-function settingsChanged(a: ResolvedSettings | null, b: ResolvedSettings) {
+setLoggerFileTargetResolver(() => {
+  const { file, rolling } = resolveSettings();
+  return { file, rolling };
+});
+
+function settingsChanged(a: ResolvedRuntimeSettings | null, b: ResolvedRuntimeSettings) {
   if (!a) {
     return true;
   }
-  return a.level !== b.level || a.file !== b.file || a.maxFileBytes !== b.maxFileBytes;
+  return (
+    a.level !== b.level ||
+    a.file !== b.file ||
+    a.maxFileBytes !== b.maxFileBytes ||
+    a.rolling !== b.rolling
+  );
 }
 
 export function isFileLogLevelEnabled(level: LogLevel): boolean {
-  const settings = (loggingState.cachedSettings as ResolvedSettings | null) ?? resolveSettings();
+  const settings =
+    (loggingState.cachedSettings as ResolvedRuntimeSettings | null) ?? resolveSettings();
   if (!loggingState.cachedSettings) {
     loggingState.cachedSettings = settings;
   }
@@ -563,7 +581,7 @@ export function isFileLogLevelEnabled(level: LogLevel): boolean {
   return levelToMinLevel(level) >= levelToMinLevel(settings.level);
 }
 
-function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
+function buildLogger(settings: ResolvedRuntimeSettings): TsLogger<LogObj> {
   const logger = new TsLogger<LogObj>({
     name: "openclaw",
     // Custom structured redaction runs at each transport boundary; avoid tslog pre-masking divergent records.
@@ -578,8 +596,8 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
     return logger;
   }
 
-  const rollingFile = isRollingPath(settings.file);
-  let activeFile = resolveActiveLogFile(settings.file);
+  const rollingFile = settings.rolling;
+  let activeFile = resolveActiveLogFileWithMode(settings.file, rollingFile);
   fs.mkdirSync(path.dirname(activeFile), { recursive: true });
   // Clean up stale rolling logs when using a dated log filename.
   if (rollingFile) {
@@ -590,7 +608,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
 
   logger.attachTransport((logObj: LogObj) => {
     try {
-      const nextActiveFile = resolveActiveLogFile(settings.file);
+      const nextActiveFile = resolveActiveLogFileWithMode(settings.file, rollingFile);
       if (nextActiveFile !== activeFile) {
         activeFile = nextActiveFile;
         fs.mkdirSync(path.dirname(activeFile), { recursive: true });
@@ -666,7 +684,7 @@ function appendLogLine(file: string, line: string): boolean {
 export function getLogger(): TsLogger<LogObj> {
   const settings = resolveSettings();
   const cachedLogger = loggingState.cachedLogger as TsLogger<LogObj> | null;
-  const cachedSettings = loggingState.cachedSettings as ResolvedSettings | null;
+  const cachedSettings = loggingState.cachedSettings as ResolvedRuntimeSettings | null;
   if (!cachedLogger || settingsChanged(cachedSettings, settings)) {
     loggingState.cachedLogger = buildLogger(settings);
     loggingState.cachedSettings = settings;
@@ -723,7 +741,8 @@ export type PinoLikeLogger = {
 };
 
 export function getResolvedLoggerSettings(): LoggerResolvedSettings {
-  return resolveSettings();
+  const { rolling: _rolling, ...settings } = resolveSettings();
+  return settings;
 }
 
 // Test helpers
@@ -754,30 +773,13 @@ export const testApi = {
 };
 export { testApi as __test__ };
 
-function defaultRollingPathForToday(): string {
-  return rollingPathForDate(DEFAULT_LOG_DIR, new Date());
-}
-
-function rollingPathForDate(dir: string, date: Date): string {
-  const today = formatLocalDate(date);
-  return path.join(dir, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
-}
-
 function resolveActiveLogFile(file: string): string {
-  const expandedFile = expandHomePrefix(file);
-  if (!isRollingPath(expandedFile)) {
-    return expandedFile;
-  }
-  return rollingPathForDate(path.dirname(expandedFile), new Date());
+  return resolveActiveLogFileWithMode(file, isLegacyRollingLogFilePath(file));
 }
 
-function isRollingPath(file: string): boolean {
-  const base = path.basename(file);
-  return (
-    base.startsWith(`${LOG_PREFIX}-`) &&
-    base.endsWith(LOG_SUFFIX) &&
-    base.length === `${LOG_PREFIX}-YYYY-MM-DD${LOG_SUFFIX}`.length
-  );
+function resolveActiveLogFileWithMode(file: string, rolling: boolean): string {
+  const expandedFile = expandHomePrefix(file);
+  return rolling ? resolveRollingLogFilePathForDate(expandedFile, new Date()) : expandedFile;
 }
 
 function pruneOldRollingLogs(dir: string): void {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running the default Gateway alongside a named profile, especially `--dev`, would get both processes interleaved in the same daily file log. That made CLI, RPC, and Control UI log forensics ambiguous.

## Why This Change Was Made

The canonical log-path resolver now derives a filename-safe, collision-resistant segment from `OPENCLAW_PROFILE`, while preserving the historical unqualified filename for the default profile. The logger and log-tail fallback share the same resolved target and rolling-mode decision, so explicit `logging.file` overrides keep their prior semantics and a missing profile log cannot fall back to another profile's family.

## User Impact

The default profile still writes `openclaw-YYYY-MM-DD.log`. Named profiles write their own `openclaw-<profile>-YYYY-MM-DD.log` family, including `openclaw-dev-YYYY-MM-DD.log`, and `openclaw --profile <profile> logs` plus Control UI Settings > Logs follow that same file.

## Evidence

- `node scripts/run-vitest.mjs src/logging/log-file-path.test.ts src/logging/log-tail.test.ts src/logging/log-file-size-cap.test.ts src/logging/logger-settings.test.ts src/logging/logger.browser-import.test.ts` — 26 tests passed across 2 routed shards.
- `node scripts/check-changed.mjs -- <18 touched files>` — core and core-test TypeScript, changed-file lint, formatting, Plugin SDK API baseline, import-cycle checks, and all selected guards passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
