### PR TITLE
refactor: hoist channel doctor migration helpers

### DIFF
--- a/extensions/discord/src/doctor-contract.ts
+++ b/extensions/discord/src/doctor-contract.ts
@@ -8,7 +8,13 @@ import {
   isSupportedRealtimeVoiceActivationName,
   normalizeRealtimeVoiceActivationNamePrefix,
 } from "openclaw/plugin-sdk/realtime-voice";
-import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  asObjectRecord,
+  defineChannelAliasMigration,
+  hasLegacyAccountStreamingAliases,
+  normalizeChannelAccounts,
+  stripRetiredChannelKeys,
+} from "openclaw/plugin-sdk/runtime-doctor";
 
 const LEGACY_TTS_PROVIDER_KEYS = ["openai", "elevenlabs", "microsoft", "edge"] as const;
 const RETIRED_TUNING_KEYS = new Set([
@@ -19,48 +25,6 @@ const RETIRED_TUNING_KEYS = new Set([
   "retry",
 ]);
 type AgentBindingConfig = NonNullable<OpenClawConfig["bindings"]>[number];
-
-function stripRetiredTuningKnobs(value: unknown): { value: unknown; changed: boolean } {
-  const record = asObjectRecord(value);
-  if (!record) {
-    return { value, changed: false };
-  }
-  const next = { ...record };
-  let changed = false;
-  for (const key of RETIRED_TUNING_KEYS) {
-    if (Object.hasOwn(next, key)) {
-      delete next[key];
-      changed = true;
-    }
-  }
-  return { value: changed ? next : record, changed };
-}
-
-function stripRetiredDiscordTuningKnobs(value: unknown): {
-  value: Record<string, unknown>;
-  changed: boolean;
-} {
-  const root = asObjectRecord(value) ?? {};
-  const rootResult = stripRetiredTuningKnobs(root);
-  const nextRoot = rootResult.value as Record<string, unknown>;
-  const accounts = asObjectRecord(nextRoot.accounts);
-  if (!accounts) {
-    return { value: nextRoot, changed: rootResult.changed };
-  }
-  let accountsChanged = false;
-  const nextAccounts = { ...accounts };
-  for (const [accountId, account] of Object.entries(accounts)) {
-    const accountResult = stripRetiredTuningKnobs(account);
-    if (accountResult.changed) {
-      nextAccounts[accountId] = accountResult.value;
-      accountsChanged = true;
-    }
-  }
-  return {
-    value: accountsChanged ? { ...nextRoot, accounts: nextAccounts } : nextRoot,
-    changed: rootResult.changed || accountsChanged,
-  };
-}
 
 const streamingAliasMigration = defineChannelAliasMigration({
   channelId: "discord",
@@ -106,18 +70,6 @@ function hasLegacyTtsProviderKeys(value: unknown): boolean {
   return LEGACY_TTS_PROVIDER_KEYS.some((key) => Object.hasOwn(tts, key));
 }
 
-function hasLegacyDiscordAccountTtsProviderKeys(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((accountValue) => {
-    const account = asObjectRecord(accountValue);
-    const voice = asObjectRecord(account?.voice);
-    return hasLegacyTtsProviderKeys(voice?.tts);
-  });
-}
-
 function hasLegacyDiscordGuildChannelAllowAlias(value: unknown): boolean {
   const guilds = asObjectRecord(asObjectRecord(value)?.guilds);
   if (!guilds) {
@@ -150,22 +102,6 @@ function hasLegacyDiscordGuildChannelAgentId(value: unknown): boolean {
   });
 }
 
-function hasLegacyDiscordAccountGuildChannelAllowAlias(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => hasLegacyDiscordGuildChannelAllowAlias(account));
-}
-
-function hasLegacyDiscordAccountGuildChannelAgentId(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => hasLegacyDiscordGuildChannelAgentId(account));
-}
-
 function hasUnsupportedRealtimeWakeNamesInVoice(value: unknown): boolean {
   const voice = asObjectRecord(value);
   const realtime = asObjectRecord(voice?.realtime);
@@ -185,14 +121,6 @@ function hasUnsupportedDiscordRealtimeWakeNames(value: unknown): boolean {
     return false;
   }
   return hasUnsupportedRealtimeWakeNamesInVoice(entry.voice);
-}
-
-function hasUnsupportedDiscordAccountRealtimeWakeNames(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => hasUnsupportedDiscordRealtimeWakeNames(account));
 }
 
 function mergeMissing(target: Record<string, unknown>, source: Record<string, unknown>) {
@@ -512,7 +440,11 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "discord", "accounts"],
     message:
       'channels.discord.accounts.<id>.voice.tts.<provider> keys (openai/elevenlabs/microsoft/edge) are legacy; use channels.discord.accounts.<id>.voice.tts.providers.<provider>. Run "openclaw doctor --fix".',
-    match: hasLegacyDiscordAccountTtsProviderKeys,
+    match: (value) =>
+      hasLegacyAccountStreamingAliases(value, (accountValue) => {
+        const account = asObjectRecord(accountValue);
+        return hasLegacyTtsProviderKeys(asObjectRecord(account?.voice)?.tts);
+      }),
   },
   {
     path: ["channels", "discord"],
@@ -524,7 +456,8 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "discord", "accounts"],
     message:
       'channels.discord.accounts.<id>.guilds.<id>.channels.<id>.allow is legacy; use channels.discord.accounts.<id>.guilds.<id>.channels.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: hasLegacyDiscordAccountGuildChannelAllowAlias,
+    match: (value) =>
+      hasLegacyAccountStreamingAliases(value, hasLegacyDiscordGuildChannelAllowAlias),
   },
   {
     path: ["channels", "discord"],
@@ -536,7 +469,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "discord", "accounts"],
     message:
       'channels.discord.accounts.<id>.guilds.<id>.channels.<id>.agentId is legacy; use top-level bindings[] with match.accountId for per-channel Discord agent routing. Run "openclaw doctor --fix".',
-    match: hasLegacyDiscordAccountGuildChannelAgentId,
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacyDiscordGuildChannelAgentId),
   },
   {
     path: ["channels", "discord"],
@@ -548,7 +481,8 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "discord", "accounts"],
     message:
       'channels.discord.accounts.<id>.voice.realtime.wakeNames entries longer than two words are unsupported; use one- or two-word activation names. Run "openclaw doctor --fix".',
-    match: hasUnsupportedDiscordAccountRealtimeWakeNames,
+    match: (value) =>
+      hasLegacyAccountStreamingAliases(value, hasUnsupportedDiscordRealtimeWakeNames),
   },
   ...streamingAliasMigration.legacyConfigRules,
 ];
@@ -562,19 +496,22 @@ export function normalizeCompatibilityConfig({
   const bindingsToAdd: AgentBindingConfig[] = [];
 
   const aliases = streamingAliasMigration.normalizeChannelConfig({ cfg, changes });
+  const tuningKnobs = stripRetiredChannelKeys({
+    cfg: aliases.config,
+    channelId: "discord",
+    keys: RETIRED_TUNING_KEYS,
+    scope: "root-and-accounts",
+  });
   const rawEntry = asObjectRecord(
-    (aliases.config.channels as Record<string, unknown> | undefined)?.discord,
+    (tuningKnobs.config.channels as Record<string, unknown> | undefined)?.discord,
   );
   if (!rawEntry) {
     return { config: cfg, changes: [] };
   }
   let updated = rawEntry;
-  let changed = aliases.config !== cfg;
-  const tuningKnobs = stripRetiredDiscordTuningKnobs(updated);
+  let changed = tuningKnobs.config !== cfg;
   if (tuningKnobs.changed) {
-    updated = tuningKnobs.value as Record<string, unknown>;
     changes.push("Removed retired Discord tuning knobs.");
-    changed = true;
   }
 
   const guildAliases = normalizeDiscordGuildChannelAllowAliases({
@@ -595,50 +532,37 @@ export function normalizeCompatibilityConfig({
   updated = channelAgentIds.entry;
   changed = changed || channelAgentIds.changed;
 
-  const accounts = asObjectRecord(updated.accounts);
-  if (accounts) {
-    let accountsChanged = false;
-    const nextAccounts = { ...accounts };
-    for (const [accountId, accountValue] of Object.entries(accounts)) {
-      const account = asObjectRecord(accountValue);
-      if (!account) {
-        continue;
-      }
-      const normalized = normalizeDiscordGuildChannelAllowAliases({
+  const accounts = normalizeChannelAccounts({
+    entry: updated,
+    pathPrefix: "channels.discord",
+    changes,
+    normalizeAccount: ({ account, accountId, pathPrefix, changes: accountChanges }) => {
+      const guilds = normalizeDiscordGuildChannelAllowAliases({
         entry: account,
-        pathPrefix: `channels.discord.accounts.${accountId}`,
-        changes,
+        pathPrefix,
+        changes: accountChanges,
       });
-      let nextAccount = normalized.entry;
-      let accountChanged = normalized.changed;
-      const normalizedAgentIds = normalizeDiscordGuildChannelAgentIds({
+      const agentIds = normalizeDiscordGuildChannelAgentIds({
         cfg,
-        entry: nextAccount,
-        pathPrefix: `channels.discord.accounts.${accountId}`,
+        entry: guilds.entry,
+        pathPrefix,
         accountId,
-        changes,
+        changes: accountChanges,
         bindingsToAdd,
       });
-      nextAccount = normalizedAgentIds.entry;
-      accountChanged = accountChanged || normalizedAgentIds.changed;
-      const normalizedWakeNames = normalizeUnsupportedRealtimeWakeNames(
-        nextAccount,
-        `channels.discord.accounts.${accountId}`,
-        changes,
+      const wakeNames = normalizeUnsupportedRealtimeWakeNames(
+        agentIds.entry,
+        pathPrefix,
+        accountChanges,
       );
-      nextAccount = normalizedWakeNames.entry;
-      accountChanged = accountChanged || normalizedWakeNames.changed;
-      if (!accountChanged) {
-        continue;
-      }
-      nextAccounts[accountId] = nextAccount;
-      accountsChanged = true;
-    }
-    if (accountsChanged) {
-      updated = { ...updated, accounts: nextAccounts };
-      changed = true;
-    }
-  }
+      return {
+        entry: wakeNames.entry,
+        changed: guilds.changed || agentIds.changed || wakeNames.changed,
+      };
+    },
+  });
+  updated = accounts.entry;
+  changed = changed || accounts.changed;
 
   const voice = asObjectRecord(updated.voice);
   if (
@@ -661,9 +585,9 @@ export function normalizeCompatibilityConfig({
   }
   return {
     config: {
-      ...aliases.config,
+      ...tuningKnobs.config,
       channels: {
-        ...aliases.config.channels,
+        ...tuningKnobs.config.channels,
         discord: updated,
       } as OpenClawConfig["channels"],
       bindings:

--- a/extensions/feishu/src/doctor-contract.ts
+++ b/extensions/feishu/src/doctor-contract.ts
@@ -4,7 +4,11 @@ import type {
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  asObjectRecord,
+  defineChannelAliasMigration,
+  normalizeChannelConfigEntries,
+} from "openclaw/plugin-sdk/runtime-doctor";
 
 // Feishu's legacy boolean `streaming` gated streaming-card replies with an
 // enabled default, so it migrates through the mode path (true → "partial",
@@ -80,61 +84,19 @@ function sanitizeLegacyCoalesceFields(params: {
 }
 
 function sanitizeFeishuCoalesce(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
-  const channels = cfg.channels as Record<string, unknown> | undefined;
-  const entry = asObjectRecord(channels?.feishu);
-  if (!entry) {
-    return cfg;
-  }
-  const root = sanitizeLegacyCoalesceFields({
-    entry,
-    pathPrefix: "channels.feishu",
+  return normalizeChannelConfigEntries({
+    cfg,
+    channelId: "feishu",
     changes,
-  });
-  const rootHeartbeat = sanitizeLegacyHeartbeatFields({
-    entry: root.entry,
-    pathPrefix: "channels.feishu",
-    changes,
-  });
-  let updated = rootHeartbeat.entry;
-  let changed = root.changed || rootHeartbeat.changed;
-
-  const accounts = asObjectRecord(updated.accounts);
-  if (accounts) {
-    let accountsChanged = false;
-    const nextAccounts = { ...accounts };
-    for (const [accountId, rawAccount] of Object.entries(accounts)) {
-      const account = asObjectRecord(rawAccount);
-      if (!account) {
-        continue;
-      }
-      const sanitized = sanitizeLegacyCoalesceFields({
-        entry: account,
-        pathPrefix: `channels.feishu.accounts.${accountId}`,
-        changes,
-      });
-      const sanitizedHeartbeat = sanitizeLegacyHeartbeatFields({
-        entry: sanitized.entry,
-        pathPrefix: `channels.feishu.accounts.${accountId}`,
-        changes,
-      });
-      if (sanitized.changed || sanitizedHeartbeat.changed) {
-        nextAccounts[accountId] = sanitizedHeartbeat.entry;
-        accountsChanged = true;
-      }
-    }
-    if (accountsChanged) {
-      updated = { ...updated, accounts: nextAccounts };
-      changed = true;
-    }
-  }
-
-  if (!changed) {
-    return cfg;
-  }
-  return {
-    ...cfg,
-    channels: { ...channels, feishu: updated },
-  } as OpenClawConfig;
+    normalizeEntry: (params) => {
+      const coalesce = sanitizeLegacyCoalesceFields(params);
+      const heartbeat = sanitizeLegacyHeartbeatFields({ ...params, entry: coalesce.entry });
+      return {
+        entry: heartbeat.entry,
+        changed: coalesce.changed || heartbeat.changed,
+      };
+    },
+  }).config;
 }
 
 export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] =

--- a/extensions/googlechat/src/doctor-contract.ts
+++ b/extensions/googlechat/src/doctor-contract.ts
@@ -1,14 +1,15 @@
 // Googlechat plugin module implements doctor contract behavior.
-import { isDeepStrictEqual } from "node:util";
 import type {
   ChannelDoctorConfigMutation,
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { mergeDeep } from "openclaw/plugin-sdk/plugin-config-runtime";
-import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
-
-type GoogleChatChannelsConfig = NonNullable<OpenClawConfig["channels"]>;
+import {
+  asObjectRecord,
+  defineChannelAliasMigration,
+  hasLegacyAccountStreamingAliases,
+  normalizeChannelConfigEntries,
+} from "openclaw/plugin-sdk/runtime-doctor";
 
 // Google Chat's nested streaming schema is delivery-only ({chunkMode, block});
 // it has no preview mode (legacy streamMode is removed outright above), so
@@ -17,6 +18,7 @@ type GoogleChatChannelsConfig = NonNullable<OpenClawConfig["channels"]>;
 const streamingAliasMigration = defineChannelAliasMigration({
   channelId: "googlechat",
   streaming: { defaultMode: "partial", deliveryOnly: true },
+  accountStreamingInheritsDefaultAccount: true,
   dm: { root: true, accounts: true },
 });
 
@@ -34,14 +36,6 @@ function hasLegacyGoogleChatGroupAllowAlias(value: unknown): boolean {
     return false;
   }
   return Object.values(groups).some((group) => Object.hasOwn(asObjectRecord(group) ?? {}, "allow"));
-}
-
-function hasLegacyAccountAliases(value: unknown, match: (entry: unknown) => boolean): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => match(account));
 }
 
 function normalizeGoogleChatGroups(params: {
@@ -131,7 +125,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "googlechat", "accounts"],
     message:
       'channels.googlechat.accounts.<id>.actions.reactions is retired and ignored. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyAccountAliases(value, hasRetiredReactions),
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasRetiredReactions),
   },
   {
     path: ["channels", "googlechat"],
@@ -142,7 +136,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "googlechat", "accounts"],
     message:
       "channels.googlechat.accounts.<id>.streamMode is legacy and no longer used; it is removed on load.",
-    match: (value) => hasLegacyAccountAliases(value, hasLegacyGoogleChatStreamMode),
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacyGoogleChatStreamMode),
   },
   {
     path: ["channels", "googlechat"],
@@ -154,138 +148,17 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "googlechat", "accounts"],
     message:
       'channels.googlechat.accounts.<id>.groups.<id>.allow is legacy; use channels.googlechat.accounts.<id>.groups.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyAccountAliases(value, hasLegacyGoogleChatGroupAllowAlias),
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacyGoogleChatGroupAllowAlias),
   },
   ...streamingAliasMigration.legacyConfigRules,
 ];
 
 function normalizeRetiredGoogleChatKeys(cfg: OpenClawConfig): ChannelDoctorConfigMutation {
-  const rawEntry = asObjectRecord(
-    (cfg.channels as Record<string, unknown> | undefined)?.googlechat,
-  );
-  if (!rawEntry) {
-    return { config: cfg, changes: [] };
-  }
-
-  const changes: string[] = [];
-  let updated = rawEntry;
-  let changed;
-
-  const root = normalizeGoogleChatEntry({
-    entry: updated,
-    pathPrefix: "channels.googlechat",
-    changes,
+  return normalizeChannelConfigEntries({
+    cfg,
+    channelId: "googlechat",
+    normalizeEntry: normalizeGoogleChatEntry,
   });
-  updated = root.entry;
-  changed = root.changed;
-
-  const accounts = asObjectRecord(updated.accounts);
-  if (accounts) {
-    let accountsChanged = false;
-    const nextAccounts = { ...accounts };
-    for (const [accountId, accountValue] of Object.entries(accounts)) {
-      const account = asObjectRecord(accountValue);
-      if (!account) {
-        continue;
-      }
-      const normalized = normalizeGoogleChatEntry({
-        entry: account,
-        pathPrefix: `channels.googlechat.accounts.${accountId}`,
-        changes,
-      });
-      if (!normalized.changed) {
-        continue;
-      }
-      nextAccounts[accountId] = normalized.entry;
-      accountsChanged = true;
-    }
-    if (accountsChanged) {
-      updated = { ...updated, accounts: nextAccounts };
-      changed = true;
-    }
-  }
-
-  if (!changed) {
-    return { config: cfg, changes: [] };
-  }
-  return {
-    config: {
-      ...cfg,
-      channels: {
-        ...cfg.channels,
-        googlechat: updated as GoogleChatChannelsConfig["googlechat"],
-      },
-    },
-    changes,
-  };
-}
-
-// Runtime replaces streaming at each layer. When doctor creates an object from
-// flat aliases, materialize the effective root < accounts.default < named value
-// so the canonical runtime path preserves the pre-migration behavior.
-function materializeMigratedAccountStreaming(params: {
-  cfg: OpenClawConfig;
-  accountsBefore: Record<string, unknown> | null;
-  changes: string[];
-}): OpenClawConfig {
-  const channels = params.cfg.channels as Record<string, unknown> | undefined;
-  const entry = asObjectRecord(channels?.googlechat);
-  const accounts = asObjectRecord(entry?.accounts);
-  if (!entry || !accounts) {
-    return params.cfg;
-  }
-  const rootStreaming = asObjectRecord(entry.streaming);
-  const defaultKey = Object.hasOwn(accounts, "default")
-    ? "default"
-    : Object.keys(accounts).find((key) => key.trim().toLowerCase() === "default");
-
-  let accountsChanged = false;
-  const nextAccounts = { ...accounts };
-  const accountIds = Object.keys(accounts).toSorted((left, right) =>
-    left === defaultKey ? -1 : right === defaultKey ? 1 : left.localeCompare(right),
-  );
-  for (const accountId of accountIds) {
-    const accountBefore = asObjectRecord(params.accountsBefore?.[accountId]);
-    if (accountBefore?.streaming !== undefined) {
-      continue;
-    }
-    const account = asObjectRecord(nextAccounts[accountId]);
-    const created = asObjectRecord(account?.streaming);
-    if (!account || !created) {
-      continue;
-    }
-    const defaultStreaming = defaultKey
-      ? asObjectRecord(asObjectRecord(nextAccounts[defaultKey])?.streaming)
-      : null;
-    const inherited =
-      accountId === defaultKey ? rootStreaming : (defaultStreaming ?? rootStreaming);
-    if (!inherited) {
-      continue;
-    }
-    const materialized = asObjectRecord(mergeDeep(inherited, created));
-    if (!materialized || isDeepStrictEqual(materialized, created)) {
-      continue;
-    }
-    nextAccounts[accountId] = { ...account, streaming: materialized };
-    accountsChanged = true;
-    const sourcePath =
-      accountId !== defaultKey && defaultKey && defaultStreaming
-        ? `channels.googlechat.accounts.${defaultKey}.streaming`
-        : "channels.googlechat.streaming";
-    params.changes.push(
-      `Copied ${sourcePath} into channels.googlechat.accounts.${accountId}.streaming to keep inherited settings while migrating flat streaming keys.`,
-    );
-  }
-  if (!accountsChanged) {
-    return params.cfg;
-  }
-  return {
-    ...params.cfg,
-    channels: {
-      ...channels,
-      googlechat: { ...entry, accounts: nextAccounts },
-    },
-  } as OpenClawConfig;
 }
 
 export function normalizeCompatibilityConfig({
@@ -294,20 +167,8 @@ export function normalizeCompatibilityConfig({
   cfg: OpenClawConfig;
 }): ChannelDoctorConfigMutation {
   const retired = normalizeRetiredGoogleChatKeys(cfg);
-  const accountsBefore = asObjectRecord(
-    asObjectRecord((retired.config.channels as Record<string, unknown> | undefined)?.googlechat)
-      ?.accounts,
-  );
-  const aliases = streamingAliasMigration.normalizeChannelConfig({
+  return streamingAliasMigration.normalizeChannelConfig({
     cfg: retired.config,
     changes: retired.changes,
   });
-  return {
-    config: materializeMigratedAccountStreaming({
-      cfg: aliases.config,
-      accountsBefore,
-      changes: aliases.changes,
-    }),
-    changes: aliases.changes,
-  };
 }

--- a/extensions/matrix/src/doctor-contract.ts
+++ b/extensions/matrix/src/doctor-contract.ts
@@ -4,7 +4,12 @@ import type {
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  defineChannelAliasMigration,
+  hasLegacyAccountStreamingAliases,
+  normalizeChannelConfigEntries,
+  stripRetiredChannelKeys,
+} from "openclaw/plugin-sdk/runtime-doctor";
 import {
   hasLegacyFlatAllowPrivateNetworkAlias,
   migrateLegacyFlatAllowPrivateNetworkAlias,
@@ -50,53 +55,6 @@ const streamingAliasMigration = defineChannelAliasMigration<MatrixStreamingMode>
   accountStreamingReplacesRoot: true,
 });
 
-// Runs before the alias migration: leaving `streamMode` in place would make
-// the generic migration materialize a streaming.mode from a key Matrix never
-// honored, silently changing the effective (inherited) mode.
-function stripMatrixJunkStreamMode(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
-  const channels = isRecord(cfg.channels) ? cfg.channels : null;
-  const matrix = isRecord(channels?.matrix) ? channels.matrix : null;
-  if (!matrix) {
-    return cfg;
-  }
-  let updated = matrix;
-  let changed = false;
-  if (updated.streamMode !== undefined) {
-    const { streamMode: _streamMode, ...rest } = updated;
-    updated = rest;
-    changes.push("Removed channels.matrix.streamMode (never read by the Matrix runtime).");
-    changed = true;
-  }
-  const accounts = isRecord(updated.accounts) ? updated.accounts : null;
-  if (accounts) {
-    let accountsChanged = false;
-    const nextAccounts: Record<string, unknown> = { ...accounts };
-    for (const [accountId, accountValue] of Object.entries(accounts)) {
-      const account = isRecord(accountValue) ? accountValue : null;
-      if (!account || account.streamMode === undefined) {
-        continue;
-      }
-      const { streamMode: _streamMode, ...rest } = account;
-      nextAccounts[accountId] = rest;
-      changes.push(
-        `Removed channels.matrix.accounts.${accountId}.streamMode (never read by the Matrix runtime).`,
-      );
-      accountsChanged = true;
-    }
-    if (accountsChanged) {
-      updated = { ...updated, accounts: nextAccounts };
-      changed = true;
-    }
-  }
-  if (!changed) {
-    return cfg;
-  }
-  return {
-    ...cfg,
-    channels: { ...channels, matrix: updated },
-  } as OpenClawConfig;
-}
-
 function hasLegacyMatrixRoomAllowAlias(value: unknown): boolean {
   const room = isRecord(value) ? value : null;
   return Boolean(room && typeof room.allow === "boolean");
@@ -107,32 +65,6 @@ function hasLegacyMatrixRoomMapAllowAliases(value: unknown): boolean {
   return Boolean(rooms && Object.values(rooms).some((room) => hasLegacyMatrixRoomAllowAlias(room)));
 }
 
-function hasLegacyMatrixAccountRoomAllowAliases(value: unknown): boolean {
-  const accounts = isRecord(value) ? value : null;
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => {
-    if (!isRecord(account)) {
-      return false;
-    }
-    return (
-      hasLegacyMatrixRoomMapAllowAliases(account.groups) ||
-      hasLegacyMatrixRoomMapAllowAliases(account.rooms)
-    );
-  });
-}
-
-function hasLegacyMatrixAccountPrivateNetworkAliases(value: unknown): boolean {
-  const accounts = isRecord(value) ? value : null;
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) =>
-    hasLegacyFlatAllowPrivateNetworkAlias(isRecord(account) ? account : {}),
-  );
-}
-
 function hasLegacyTrustedDmPolicy(value: unknown): boolean {
   const root = isRecord(value) ? value : null;
   if (!root) {
@@ -140,14 +72,6 @@ function hasLegacyTrustedDmPolicy(value: unknown): boolean {
   }
   const dm = isRecord(root.dm) ? root.dm : null;
   return dm?.policy === "trusted";
-}
-
-function hasLegacyMatrixAccountTrustedDmPolicies(value: unknown): boolean {
-  const accounts = isRecord(value) ? value : null;
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => hasLegacyTrustedDmPolicy(account));
 }
 
 function migrateLegacyTrustedDmPolicy(params: {
@@ -218,7 +142,10 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "matrix", "accounts"],
     message:
       'channels.matrix.accounts.<id>.allowPrivateNetwork is legacy; use channels.matrix.accounts.<id>.network.dangerouslyAllowPrivateNetwork instead. Run "openclaw doctor --fix".',
-    match: hasLegacyMatrixAccountPrivateNetworkAliases,
+    match: (value) =>
+      hasLegacyAccountStreamingAliases(value, (account) =>
+        hasLegacyFlatAllowPrivateNetworkAlias(isRecord(account) ? account : {}),
+      ),
   },
   {
     path: ["channels", "matrix", "groups"],
@@ -236,7 +163,16 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "matrix", "accounts"],
     message:
       'channels.matrix.accounts.<id>.{groups,rooms}.<room>.allow is legacy; use channels.matrix.accounts.<id>.{groups,rooms}.<room>.enabled instead. Run "openclaw doctor --fix".',
-    match: hasLegacyMatrixAccountRoomAllowAliases,
+    match: (value) =>
+      hasLegacyAccountStreamingAliases(value, (account) => {
+        if (!isRecord(account)) {
+          return false;
+        }
+        return (
+          hasLegacyMatrixRoomMapAllowAliases(account.groups) ||
+          hasLegacyMatrixRoomMapAllowAliases(account.rooms)
+        );
+      }),
   },
   {
     path: ["channels", "matrix"],
@@ -248,9 +184,36 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "matrix", "accounts"],
     message:
       'channels.matrix.accounts.<id>.dm.policy "trusted" is legacy; use "allowlist" (with allowFrom entries) or "pairing" instead. Run "openclaw doctor --fix".',
-    match: hasLegacyMatrixAccountTrustedDmPolicies,
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacyTrustedDmPolicy),
   },
 ];
+
+function normalizeMatrixEntry(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+}): { entry: Record<string, unknown>; changed: boolean } {
+  const network = migrateLegacyFlatAllowPrivateNetworkAlias(params);
+  const dmPolicy = migrateLegacyTrustedDmPolicy({ ...params, entry: network.entry });
+  let entry = dmPolicy.entry;
+  let changed = network.changed || dmPolicy.changed;
+  for (const key of ["groups", "rooms"] as const) {
+    const rooms = isRecord(entry[key]) ? entry[key] : null;
+    if (!rooms) {
+      continue;
+    }
+    const normalized = normalizeMatrixRoomAllowAliases({
+      rooms,
+      pathPrefix: `${params.pathPrefix}.${key}`,
+      changes: params.changes,
+    });
+    if (normalized.changed) {
+      entry = Object.assign({}, entry, { [key]: normalized.rooms });
+      changed = true;
+    }
+  }
+  return { entry, changed };
+}
 
 export function normalizeCompatibilityConfig({
   cfg,
@@ -258,124 +221,24 @@ export function normalizeCompatibilityConfig({
   cfg: OpenClawConfig;
 }): ChannelDoctorConfigMutation {
   const changes: string[] = [];
-  const withoutJunkStreamMode = stripMatrixJunkStreamMode(cfg, changes);
+  // `streamMode` was never honored by Matrix, so remove it before the generic
+  // alias migration can mistake it for mode intent.
+  const withoutJunkStreamMode = stripRetiredChannelKeys({
+    cfg,
+    channelId: "matrix",
+    keys: new Set(["streamMode"]),
+    scope: "root-and-accounts",
+    onRemove: ({ key, pathPrefix }) =>
+      changes.push(`Removed ${pathPrefix}.${key} (never read by the Matrix runtime).`),
+  }).config;
   const aliases = streamingAliasMigration.normalizeChannelConfig({
     cfg: withoutJunkStreamMode,
     changes,
   });
-  const channels = isRecord(aliases.config.channels) ? aliases.config.channels : null;
-  const matrix = isRecord(channels?.matrix) ? channels.matrix : null;
-  if (!matrix) {
-    return { config: cfg, changes: [] };
-  }
-
-  let updatedMatrix: Record<string, unknown> = matrix;
-  let changed = aliases.config !== cfg;
-
-  const topLevelPrivateNetwork = migrateLegacyFlatAllowPrivateNetworkAlias({
-    entry: updatedMatrix,
-    pathPrefix: "channels.matrix",
+  return normalizeChannelConfigEntries({
+    cfg: aliases.config,
+    channelId: "matrix",
     changes,
+    normalizeEntry: normalizeMatrixEntry,
   });
-  updatedMatrix = topLevelPrivateNetwork.entry;
-  changed = changed || topLevelPrivateNetwork.changed;
-
-  const topLevelTrustedDmPolicy = migrateLegacyTrustedDmPolicy({
-    entry: updatedMatrix,
-    pathPrefix: "channels.matrix",
-    changes,
-  });
-  updatedMatrix = topLevelTrustedDmPolicy.entry;
-  changed = changed || topLevelTrustedDmPolicy.changed;
-
-  const normalizeTopLevelRoomScope = (key: "groups" | "rooms") => {
-    const rooms = isRecord(updatedMatrix[key]) ? updatedMatrix[key] : null;
-    if (!rooms) {
-      return;
-    }
-    const normalized = normalizeMatrixRoomAllowAliases({
-      rooms,
-      pathPrefix: `channels.matrix.${key}`,
-      changes,
-    });
-    if (normalized.changed) {
-      updatedMatrix = { ...updatedMatrix, [key]: normalized.rooms };
-      changed = true;
-    }
-  };
-
-  normalizeTopLevelRoomScope("groups");
-  normalizeTopLevelRoomScope("rooms");
-
-  const accounts = isRecord(updatedMatrix.accounts) ? updatedMatrix.accounts : null;
-  if (accounts) {
-    let accountsChanged = false;
-    const nextAccounts: Record<string, unknown> = { ...accounts };
-    for (const [accountId, accountValue] of Object.entries(accounts)) {
-      const account = isRecord(accountValue) ? accountValue : null;
-      if (!account) {
-        continue;
-      }
-      let nextAccount: Record<string, unknown> = account;
-      let accountChanged = false;
-
-      const privateNetworkMigration = migrateLegacyFlatAllowPrivateNetworkAlias({
-        entry: nextAccount,
-        pathPrefix: `channels.matrix.accounts.${accountId}`,
-        changes,
-      });
-      if (privateNetworkMigration.changed) {
-        nextAccount = privateNetworkMigration.entry;
-        accountChanged = true;
-      }
-
-      const accountTrustedDmPolicy = migrateLegacyTrustedDmPolicy({
-        entry: nextAccount,
-        pathPrefix: `channels.matrix.accounts.${accountId}`,
-        changes,
-      });
-      if (accountTrustedDmPolicy.changed) {
-        nextAccount = accountTrustedDmPolicy.entry;
-        accountChanged = true;
-      }
-
-      for (const key of ["groups", "rooms"] as const) {
-        const rooms = isRecord(nextAccount[key]) ? nextAccount[key] : null;
-        if (!rooms) {
-          continue;
-        }
-        const normalized = normalizeMatrixRoomAllowAliases({
-          rooms,
-          pathPrefix: `channels.matrix.accounts.${accountId}.${key}`,
-          changes,
-        });
-        if (normalized.changed) {
-          nextAccount = { ...nextAccount, [key]: normalized.rooms };
-          accountChanged = true;
-        }
-      }
-      if (accountChanged) {
-        nextAccounts[accountId] = nextAccount;
-        accountsChanged = true;
-      }
-    }
-    if (accountsChanged) {
-      updatedMatrix = { ...updatedMatrix, accounts: nextAccounts };
-      changed = true;
-    }
-  }
-
-  if (!changed) {
-    return { config: cfg, changes: [] };
-  }
-  return {
-    config: {
-      ...aliases.config,
-      channels: {
-        ...aliases.config.channels,
-        matrix: updatedMatrix as NonNullable<OpenClawConfig["channels"]>["matrix"],
-      },
-    },
-    changes,
-  };
 }

--- a/extensions/qqbot/src/doctor-contract.ts
+++ b/extensions/qqbot/src/doctor-contract.ts
@@ -5,7 +5,11 @@ import type {
 } from "openclaw/plugin-sdk/channel-contract";
 import type { GroupToolPolicyConfig } from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  asObjectRecord,
+  hasLegacyAccountStreamingAliases,
+  normalizeChannelConfigEntries,
+} from "openclaw/plugin-sdk/runtime-doctor";
 
 const RESTRICTED_GROUP_TOOLS: GroupToolPolicyConfig = {
   deny: ["exec", "read", "write"],
@@ -28,14 +32,6 @@ function hasLegacyStreamingValue(value: unknown): boolean {
     typeof entry.streaming === "boolean" ||
     asObjectRecord(entry.streaming)?.c2cStreamApi !== undefined
   );
-}
-
-function hasLegacyAccountStreamingValues(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => hasLegacyStreamingValue(account));
 }
 
 function migrateStreamingValue(params: {
@@ -77,16 +73,6 @@ function hasLegacyGroupToolPolicy(value: unknown): boolean {
     return false;
   }
   return Object.values(groups).some((group) => asObjectRecord(group)?.toolPolicy !== undefined);
-}
-
-function hasLegacyAccountGroupToolPolicy(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) =>
-    hasLegacyGroupToolPolicy(asObjectRecord(account)?.groups),
-  );
 }
 
 function migrateToolPolicy(value: unknown): GroupToolPolicyConfig | undefined {
@@ -151,7 +137,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "qqbot", "accounts"],
     message:
       'channels.qqbot.accounts.<id>.streaming (boolean) and streaming.c2cStreamApi are legacy; use channels.qqbot.accounts.<id>.streaming.{mode,nativeTransport}. Run "openclaw doctor --fix".',
-    match: hasLegacyAccountStreamingValues,
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacyStreamingValue),
   },
   {
     path: ["channels", "qqbot", "groups"],
@@ -163,97 +149,41 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "qqbot", "accounts"],
     message:
       'channels.qqbot.accounts.<id>.groups.<groupId>.toolPolicy is legacy and was ignored by QQBot group tool enforcement; use channels.qqbot.accounts.<id>.groups.<groupId>.tools instead. Run "openclaw doctor --fix".',
-    match: hasLegacyAccountGroupToolPolicy,
+    match: (value) =>
+      hasLegacyAccountStreamingAliases(value, (account) =>
+        hasLegacyGroupToolPolicy(asObjectRecord(account)?.groups),
+      ),
   },
 ];
+
+function normalizeQqbotEntry(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+}): { entry: Record<string, unknown>; changed: boolean } {
+  const streaming = migrateStreamingValue(params);
+  const groups = asObjectRecord(streaming.entry.groups);
+  if (!groups) {
+    return streaming;
+  }
+  const migrated = migrateGroups({
+    groups,
+    pathPrefix: `${params.pathPrefix}.groups`,
+    changes: params.changes,
+  });
+  return migrated.changed
+    ? { entry: { ...streaming.entry, groups: migrated.groups }, changed: true }
+    : streaming;
+}
 
 export function normalizeCompatibilityConfig({
   cfg,
 }: {
   cfg: OpenClawConfig;
 }): ChannelDoctorConfigMutation {
-  const rawEntry = asObjectRecord((cfg.channels as Record<string, unknown> | undefined)?.qqbot);
-  if (!rawEntry) {
-    return { config: cfg, changes: [] };
-  }
-
-  const changes: string[] = [];
-  let updated = rawEntry;
-  let changed = false;
-
-  const rootStreaming = migrateStreamingValue({
-    entry: updated,
-    pathPrefix: "channels.qqbot",
-    changes,
+  return normalizeChannelConfigEntries({
+    cfg,
+    channelId: "qqbot",
+    normalizeEntry: normalizeQqbotEntry,
   });
-  updated = rootStreaming.entry;
-  changed = changed || rootStreaming.changed;
-
-  const groups = asObjectRecord(updated.groups);
-  if (groups) {
-    const migrated = migrateGroups({
-      groups,
-      pathPrefix: "channels.qqbot.groups",
-      changes,
-    });
-    if (migrated.changed) {
-      updated = { ...updated, groups: migrated.groups };
-      changed = true;
-    }
-  }
-
-  const accounts = asObjectRecord(updated.accounts);
-  if (accounts) {
-    let accountsChanged = false;
-    const nextAccounts = { ...accounts };
-    for (const [accountId, rawAccount] of Object.entries(accounts)) {
-      const account = asObjectRecord(rawAccount);
-      if (!account) {
-        continue;
-      }
-      const accountStreaming = migrateStreamingValue({
-        entry: account,
-        pathPrefix: `channels.qqbot.accounts.${accountId}`,
-        changes,
-      });
-      let nextAccount = accountStreaming.entry;
-      let accountChanged = accountStreaming.changed;
-
-      const accountGroups = asObjectRecord(nextAccount.groups);
-      if (accountGroups) {
-        const migrated = migrateGroups({
-          groups: accountGroups,
-          pathPrefix: `channels.qqbot.accounts.${accountId}.groups`,
-          changes,
-        });
-        if (migrated.changed) {
-          nextAccount = { ...nextAccount, groups: migrated.groups };
-          accountChanged = true;
-        }
-      }
-
-      if (accountChanged) {
-        nextAccounts[accountId] = nextAccount;
-        accountsChanged = true;
-      }
-    }
-    if (accountsChanged) {
-      updated = { ...updated, accounts: nextAccounts };
-      changed = true;
-    }
-  }
-
-  if (!changed) {
-    return { config: cfg, changes: [] };
-  }
-  return {
-    config: {
-      ...cfg,
-      channels: {
-        ...cfg.channels,
-        qqbot: updated as unknown as NonNullable<OpenClawConfig["channels"]>["qqbot"],
-      } as OpenClawConfig["channels"],
-    },
-    changes,
-  };
 }

--- a/extensions/slack/src/doctor-contract.ts
+++ b/extensions/slack/src/doctor-contract.ts
@@ -4,7 +4,12 @@ import type {
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  asObjectRecord,
+  defineChannelAliasMigration,
+  hasLegacyAccountStreamingAliases,
+  normalizeChannelConfigEntries,
+} from "openclaw/plugin-sdk/runtime-doctor";
 import { resolveSlackNativeStreaming, resolveSlackStreamingMode } from "./streaming-compat.js";
 
 const streamingAliasMigration = defineChannelAliasMigration({
@@ -145,8 +150,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "slack", "accounts"],
     message:
       'channels.slack.accounts.<id>.dm.replyToMode moved to replyToModeByChatType.direct. Run "openclaw doctor --fix".',
-    match: (value) =>
-      Object.values(asObjectRecord(value) ?? {}).some((account) => hasLegacyDmReplyMode(account)),
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacyDmReplyMode),
   },
   {
     path: ["channels", "slack"],
@@ -158,13 +162,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "slack", "accounts"],
     message:
       'channels.slack.accounts.<id>.thread.requireExplicitMention is legacy; use channels.slack.accounts.<id>.implicitMentions.threadParticipation instead. Run "openclaw doctor --fix".',
-    match: (value) => {
-      const accounts = asObjectRecord(value);
-      return Boolean(
-        accounts &&
-        Object.values(accounts).some((account) => hasLegacySlackThreadMentionPolicy(account)),
-      );
-    },
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacySlackThreadMentionPolicy),
   },
   {
     path: ["channels", "slack"],
@@ -176,15 +174,38 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "slack", "accounts"],
     message:
       'channels.slack.accounts.<id>.channels.<id>.allow is legacy; use channels.slack.accounts.<id>.channels.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: (value) => {
-      const accounts = asObjectRecord(value);
-      if (!accounts) {
-        return false;
-      }
-      return Object.values(accounts).some((account) => hasLegacySlackChannelAllowAlias(account));
-    },
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacySlackChannelAllowAlias),
   },
 ];
+
+function normalizeSlackEntry(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+}): { entry: Record<string, unknown>; changed: boolean } {
+  let entry = params.entry;
+  let changed = migrateDmReplyMode(entry, params.pathPrefix, params.changes);
+  const threadPolicy = normalizeSlackThreadMentionPolicy({
+    value: entry,
+    pathPrefix: params.pathPrefix,
+    changes: params.changes,
+  });
+  entry = threadPolicy.value;
+  changed = changed || threadPolicy.changed;
+  const channels = asObjectRecord(entry.channels);
+  if (channels) {
+    const normalized = normalizeSlackChannelAllowAliases({
+      channels,
+      pathPrefix: `${params.pathPrefix}.channels`,
+      changes: params.changes,
+    });
+    if (normalized.changed) {
+      entry = { ...entry, channels: normalized.channels };
+      changed = true;
+    }
+  }
+  return { entry, changed };
+}
 
 export function normalizeCompatibilityConfig({
   cfg,
@@ -193,92 +214,10 @@ export function normalizeCompatibilityConfig({
 }): ChannelDoctorConfigMutation {
   const changes: string[] = [];
   const aliases = streamingAliasMigration.normalizeChannelConfig({ cfg, changes });
-  const rawEntry = asObjectRecord(
-    (aliases.config.channels as Record<string, unknown> | undefined)?.slack,
-  );
-  if (!rawEntry) {
-    return { config: cfg, changes: [] };
-  }
-  let updated = rawEntry;
-  let changed = aliases.config !== cfg;
-  changed = migrateDmReplyMode(updated, "channels.slack", changes) || changed;
-
-  const normalizedThreadPolicy = normalizeSlackThreadMentionPolicy({
-    value: updated,
-    pathPrefix: "channels.slack",
+  return normalizeChannelConfigEntries({
+    cfg: aliases.config,
+    channelId: "slack",
     changes,
+    normalizeEntry: normalizeSlackEntry,
   });
-  if (normalizedThreadPolicy.changed) {
-    updated = normalizedThreadPolicy.value;
-    changed = true;
-  }
-
-  const channels = asObjectRecord(updated.channels);
-  if (channels) {
-    const normalized = normalizeSlackChannelAllowAliases({
-      channels,
-      pathPrefix: "channels.slack.channels",
-      changes,
-    });
-    if (normalized.changed) {
-      updated = { ...updated, channels: normalized.channels };
-      changed = true;
-    }
-  }
-
-  const accounts = asObjectRecord(updated.accounts);
-  if (accounts) {
-    let accountsChanged = false;
-    const nextAccounts = { ...accounts };
-    for (const [accountId, accountValue] of Object.entries(accounts)) {
-      let account = asObjectRecord(accountValue);
-      if (!account) {
-        continue;
-      }
-      if (migrateDmReplyMode(account, `channels.slack.accounts.${accountId}`, changes)) {
-        nextAccounts[accountId] = account;
-        accountsChanged = true;
-      }
-      const normalizedAccountThreadPolicy = normalizeSlackThreadMentionPolicy({
-        value: account,
-        pathPrefix: `channels.slack.accounts.${accountId}`,
-        changes,
-      });
-      if (normalizedAccountThreadPolicy.changed) {
-        account = normalizedAccountThreadPolicy.value;
-        nextAccounts[accountId] = account;
-        accountsChanged = true;
-      }
-      const channelEntries = asObjectRecord(account.channels);
-      if (channelEntries) {
-        const normalized = normalizeSlackChannelAllowAliases({
-          channels: channelEntries,
-          pathPrefix: `channels.slack.accounts.${accountId}.channels`,
-          changes,
-        });
-        if (normalized.changed) {
-          nextAccounts[accountId] = { ...account, channels: normalized.channels };
-          accountsChanged = true;
-        }
-      }
-    }
-    if (accountsChanged) {
-      updated = { ...updated, accounts: nextAccounts };
-      changed = true;
-    }
-  }
-
-  if (!changed) {
-    return { config: cfg, changes: [] };
-  }
-  return {
-    config: {
-      ...aliases.config,
-      channels: {
-        ...aliases.config.channels,
-        slack: updated as unknown as NonNullable<OpenClawConfig["channels"]>["slack"],
-      } as OpenClawConfig["channels"],
-    },
-    changes,
-  };
 }

--- a/extensions/telegram/src/doctor-contract.ts
+++ b/extensions/telegram/src/doctor-contract.ts
@@ -5,7 +5,13 @@ import type {
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
-import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  asObjectRecord,
+  defineChannelAliasMigration,
+  hasLegacyAccountStreamingAliases,
+  normalizeChannelAccounts,
+  stripRetiredChannelKeys,
+} from "openclaw/plugin-sdk/runtime-doctor";
 
 const streamingAliasMigration = defineChannelAliasMigration({
   channelId: "telegram",
@@ -22,34 +28,6 @@ const RETIRED_TUNING_KEYS = new Set([
   "errorCooldownMs",
 ]);
 
-function stripRetiredTuningKnobs(value: unknown): { value: unknown; changed: boolean } {
-  if (Array.isArray(value)) {
-    let changed = false;
-    const next = value.map((item) => {
-      const stripped = stripRetiredTuningKnobs(item);
-      changed = changed || stripped.changed;
-      return stripped.value;
-    });
-    return { value: changed ? next : value, changed };
-  }
-  const record = asObjectRecord(value);
-  if (!record) {
-    return { value, changed: false };
-  }
-  let changed = false;
-  const next: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(record)) {
-    if (RETIRED_TUNING_KEYS.has(key)) {
-      changed = true;
-      continue;
-    }
-    const stripped = stripRetiredTuningKnobs(child);
-    changed = changed || stripped.changed;
-    next[key] = stripped.value;
-  }
-  return { value: changed ? next : value, changed };
-}
-
 function hasRetiredTelegramDmConfig(value: unknown): boolean {
   const entry = asObjectRecord(value);
   if (!entry) {
@@ -63,14 +41,6 @@ function hasRetiredTelegramDmConfig(value: unknown): boolean {
   );
 }
 
-function hasRetiredTelegramAccountDmConfig(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => hasRetiredTelegramDmConfig(account));
-}
-
 function hasRetiredTelegramNativeDraftConfig(value: unknown): boolean {
   const entry = asObjectRecord(value);
   const streaming = asObjectRecord(entry?.streaming);
@@ -82,24 +52,6 @@ function hasRetiredTelegramNativeDraftConfig(value: unknown): boolean {
 
 function hasRetiredTelegramGroupHistoryContextConfig(value: unknown): boolean {
   return asObjectRecord(value)?.includeGroupHistoryContext !== undefined;
-}
-
-function hasRetiredTelegramAccountNativeDraftConfig(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => hasRetiredTelegramNativeDraftConfig(account));
-}
-
-function hasRetiredTelegramAccountGroupHistoryContextConfig(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) =>
-    hasRetiredTelegramGroupHistoryContextConfig(account),
-  );
 }
 
 function removeRetiredTelegramDmConfig(params: {
@@ -248,7 +200,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "telegram", "accounts"],
     message:
       'channels.telegram.accounts.<id>.dm and direct.<chatId>.threadReplies were removed; DM topic sessions now follow Telegram getMe.has_topics_enabled, so topics-enabled bots may use thread-scoped DM sessions. Run "openclaw doctor --fix".',
-    match: hasRetiredTelegramAccountDmConfig,
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasRetiredTelegramDmConfig),
   },
   {
     path: ["channels", "telegram"],
@@ -260,7 +212,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "telegram", "accounts"],
     message:
       'channels.telegram.accounts.<id>.streaming.preview.nativeToolProgress and nativeToolProgressAllowFrom were removed; Telegram previews now use rich send/edit messages. Run "openclaw doctor --fix".',
-    match: hasRetiredTelegramAccountNativeDraftConfig,
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasRetiredTelegramNativeDraftConfig),
   },
   {
     path: ["channels", "telegram"],
@@ -272,7 +224,8 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "telegram", "accounts"],
     message:
       'channels.telegram.accounts.<id>.includeGroupHistoryContext was removed; Telegram group history is always on for groups and bounded by historyLimit. Run "openclaw doctor --fix".',
-    match: hasRetiredTelegramAccountGroupHistoryContextConfig,
+    match: (value) =>
+      hasLegacyAccountStreamingAliases(value, hasRetiredTelegramGroupHistoryContextConfig),
   },
   ...streamingAliasMigration.legacyConfigRules,
 ];
@@ -284,20 +237,23 @@ export function normalizeCompatibilityConfig({
 }): ChannelDoctorConfigMutation {
   const changes: string[] = [];
   const aliases = streamingAliasMigration.normalizeChannelConfig({ cfg, changes });
+  const tuningKnobs = stripRetiredChannelKeys({
+    cfg: aliases.config,
+    channelId: "telegram",
+    keys: RETIRED_TUNING_KEYS,
+    scope: "recursive",
+  });
   const rawEntry = asObjectRecord(
-    (aliases.config.channels as Record<string, unknown> | undefined)?.telegram,
+    (tuningKnobs.config.channels as Record<string, unknown> | undefined)?.telegram,
   );
   if (!rawEntry) {
     return { config: cfg, changes: [] };
   }
 
   let updated = rawEntry;
-  let changed = aliases.config !== cfg;
-  const tuningKnobs = stripRetiredTuningKnobs(updated);
+  let changed = tuningKnobs.config !== cfg;
   if (tuningKnobs.changed) {
-    updated = tuningKnobs.value as Record<string, unknown>;
     changes.push("Removed retired Telegram tuning knobs.");
-    changed = true;
   }
   const rootGroupHistoryContextMode = updated.includeGroupHistoryContext;
   const rootGroupHistoryLimitBeforeMigration =
@@ -355,60 +311,46 @@ export function normalizeCompatibilityConfig({
     }
   }
 
-  const accounts = asObjectRecord(updated.accounts);
-  if (accounts) {
-    let accountsChanged = false;
-    const nextAccounts = { ...accounts };
-    for (const [accountId, rawAccount] of Object.entries(accounts)) {
-      const account = asObjectRecord(rawAccount);
-      if (!account) {
-        continue;
-      }
-      const accountRemovedThreadReplies = removeRetiredTelegramDmConfig({
+  const accounts = normalizeChannelAccounts({
+    entry: updated,
+    pathPrefix: "channels.telegram",
+    changes,
+    normalizeAccount: ({ account, pathPrefix, changes: accountChanges }) => {
+      const dm = removeRetiredTelegramDmConfig({
         entry: account,
-        pathPrefix: `channels.telegram.accounts.${accountId}`,
-        changes,
+        pathPrefix,
+        changes: accountChanges,
       });
-      if (accountRemovedThreadReplies.changed) {
-        nextAccounts[accountId] = accountRemovedThreadReplies.entry;
-        accountsChanged = true;
-      }
-      const accountRemovedNativeDraft = removeRetiredTelegramNativeDraftConfig({
-        entry: nextAccounts[accountId] as Record<string, unknown>,
-        pathPrefix: `channels.telegram.accounts.${accountId}`,
-        changes,
+      const nativeDraft = removeRetiredTelegramNativeDraftConfig({
+        entry: dm.entry,
+        pathPrefix,
+        changes: accountChanges,
       });
-      if (accountRemovedNativeDraft.changed) {
-        nextAccounts[accountId] = accountRemovedNativeDraft.entry;
-        accountsChanged = true;
-      }
-      const accountRemovedGroupHistoryContext = removeRetiredTelegramGroupHistoryContextConfig({
-        entry: nextAccounts[accountId] as Record<string, unknown>,
-        pathPrefix: `channels.telegram.accounts.${accountId}`,
-        changes,
+      const history = removeRetiredTelegramGroupHistoryContextConfig({
+        entry: nativeDraft.entry,
+        pathPrefix,
+        changes: accountChanges,
         ...(rootGroupHistoryContextMode === "none"
           ? { preserveRecentHistoryLimit: rootGroupHistoryLimitBeforeMigration }
           : {}),
       });
-      if (accountRemovedGroupHistoryContext.changed) {
-        nextAccounts[accountId] = accountRemovedGroupHistoryContext.entry;
-        accountsChanged = true;
-      }
-    }
-    if (accountsChanged) {
-      updated = { ...updated, accounts: nextAccounts };
-      changed = true;
-    }
-  }
+      return {
+        entry: history.entry,
+        changed: dm.changed || nativeDraft.changed || history.changed,
+      };
+    },
+  });
+  updated = accounts.entry;
+  changed = changed || accounts.changed;
 
   if (!changed && changes.length === 0) {
     return { config: cfg, changes: [] };
   }
   return {
     config: {
-      ...aliases.config,
+      ...tuningKnobs.config,
       channels: {
-        ...aliases.config.channels,
+        ...tuningKnobs.config.channels,
         telegram: updated as unknown as NonNullable<OpenClawConfig["channels"]>["telegram"],
       } as OpenClawConfig["channels"],
     },

--- a/extensions/whatsapp/src/doctor-contract.ts
+++ b/extensions/whatsapp/src/doctor-contract.ts
@@ -1,23 +1,26 @@
 // Whatsapp plugin module implements doctor contract behavior.
-import { isDeepStrictEqual } from "node:util";
 import type {
   ChannelDoctorConfigMutation,
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { mergeDeep } from "openclaw/plugin-sdk/plugin-config-runtime";
-import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  asObjectRecord,
+  defineChannelAliasMigration,
+  hasLegacyAccountStreamingAliases,
+  stripRetiredChannelKeys,
+} from "openclaw/plugin-sdk/runtime-doctor";
 import { normalizeCompatibilityConfig as normalizeAckReactionConfig } from "./doctor.js";
 
 // WhatsApp's nested streaming schema is delivery-only ({chunkMode, block});
 // it has no preview mode, so only the delivery flat aliases are legal legacy
-// input. Seeding is handled below instead of via accountStreamingReplacesRoot
-// because WhatsApp resolution layers accounts.default shared config between
-// the channel root and named accounts (account-config.ts), so a materialized
-// named-account object must inherit default-account settings over root ones.
+// input. WhatsApp resolution layers accounts.default shared config between the
+// channel root and named accounts, so the shared migration materializes that
+// inheritance when it creates a named-account streaming object.
 const streamingAliasMigration = defineChannelAliasMigration({
   channelId: "whatsapp",
   streaming: { defaultMode: "partial", deliveryOnly: true },
+  accountStreamingInheritsDefaultAccount: true,
 });
 
 const hasExposeErrorText = (value: unknown): boolean =>
@@ -34,114 +37,18 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "whatsapp", "accounts"],
     message:
       'channels.whatsapp.accounts.<id>.exposeErrorText is retired and ignored. Run "openclaw doctor --fix".',
-    match: (value) => Object.values(asObjectRecord(value) ?? {}).some(hasExposeErrorText),
+    match: (value) => hasLegacyAccountStreamingAliases(value, hasExposeErrorText),
   },
 ];
 
 function removeExposeErrorText(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
-  const channels = cfg.channels as Record<string, unknown> | undefined;
-  const entry = asObjectRecord(channels?.whatsapp);
-  if (!entry) {
-    return cfg;
-  }
-  let changed = false;
-  const next = { ...entry };
-  if (Object.hasOwn(next, "exposeErrorText")) {
-    delete next.exposeErrorText;
-    changes.push("Removed retired channels.whatsapp.exposeErrorText.");
-    changed = true;
-  }
-  const accounts = asObjectRecord(next.accounts);
-  if (accounts) {
-    const nextAccounts = { ...accounts };
-    for (const [id, value] of Object.entries(accounts)) {
-      const account = asObjectRecord(value);
-      if (!account || !Object.hasOwn(account, "exposeErrorText")) {
-        continue;
-      }
-      const cleaned = { ...account };
-      delete cleaned.exposeErrorText;
-      nextAccounts[id] = cleaned;
-      changes.push(`Removed retired channels.whatsapp.accounts.${id}.exposeErrorText.`);
-      changed = true;
-    }
-    next.accounts = nextAccounts;
-  }
-  return changed ? ({ ...cfg, channels: { ...channels, whatsapp: next } } as OpenClawConfig) : cfg;
-}
-
-// The runtime merge replaces `streaming` wholesale per layer (named account >
-// accounts.default > root), while the retired flat keys resolved per key
-// across those layers. Account objects that migration materializes must carry
-// the settings the account previously inherited, or `doctor --fix` silently
-// changes effective delivery behavior for that account.
-function materializeMigratedAccountStreaming(params: {
-  cfg: OpenClawConfig;
-  accountsBefore: Record<string, unknown> | null;
-  changes: string[];
-}): OpenClawConfig {
-  const channels = params.cfg.channels as Record<string, unknown> | undefined;
-  const entry = asObjectRecord(channels?.whatsapp);
-  const accounts = asObjectRecord(entry?.accounts);
-  if (!entry || !accounts) {
-    return params.cfg;
-  }
-  const rootStreaming = asObjectRecord(entry.streaming);
-  // Account lookup treats keys case-insensitively (resolveAccountEntry), so
-  // `accounts.Default` is the default account too.
-  const defaultKey = Object.hasOwn(accounts, "default")
-    ? "default"
-    : Object.keys(accounts).find((key) => key.trim().toLowerCase() === "default");
-
-  let accountsChanged = false;
-  const nextAccounts = { ...accounts };
-  // Seed the default account first: its final object is the inheritance
-  // source for named accounts (default replaces root wholesale when set).
-  const accountIds = Object.keys(accounts).toSorted((left, right) =>
-    left === defaultKey ? -1 : right === defaultKey ? 1 : left.localeCompare(right),
-  );
-  for (const accountId of accountIds) {
-    const accountBefore = asObjectRecord(params.accountsBefore?.[accountId]);
-    if (accountBefore?.streaming !== undefined) {
-      continue;
-    }
-    const account = asObjectRecord(nextAccounts[accountId]);
-    const created = asObjectRecord(account?.streaming);
-    if (!account || !created) {
-      continue;
-    }
-    const defaultStreaming = defaultKey
-      ? asObjectRecord(asObjectRecord(nextAccounts[defaultKey])?.streaming)
-      : null;
-    const inheritedSource =
-      accountId === defaultKey ? rootStreaming : (defaultStreaming ?? rootStreaming);
-    if (!inheritedSource) {
-      continue;
-    }
-    const materialized = asObjectRecord(mergeDeep(inheritedSource, created));
-    if (!materialized || isDeepStrictEqual(materialized, created)) {
-      continue;
-    }
-    nextAccounts[accountId] = { ...account, streaming: materialized };
-    accountsChanged = true;
-    const sourcePath =
-      accountId !== defaultKey && defaultKey && defaultStreaming
-        ? `channels.whatsapp.accounts.${defaultKey}.streaming`
-        : "channels.whatsapp.streaming";
-    params.changes.push(
-      `Copied ${sourcePath} into channels.whatsapp.accounts.${accountId}.streaming to keep inherited settings while migrating flat streaming keys.`,
-    );
-  }
-  if (!accountsChanged) {
-    return params.cfg;
-  }
-  return {
-    ...params.cfg,
-    channels: {
-      ...channels,
-      whatsapp: { ...entry, accounts: nextAccounts },
-    },
-  } as OpenClawConfig;
+  return stripRetiredChannelKeys({
+    cfg,
+    channelId: "whatsapp",
+    keys: new Set(["exposeErrorText"]),
+    scope: "root-and-accounts",
+    onRemove: ({ key, pathPrefix }) => changes.push(`Removed retired ${pathPrefix}.${key}.`),
+  }).config;
 }
 
 export function normalizeCompatibilityConfig({
@@ -151,20 +58,8 @@ export function normalizeCompatibilityConfig({
 }): ChannelDoctorConfigMutation {
   const ackReaction = normalizeAckReactionConfig({ cfg });
   const retiredConfig = removeExposeErrorText(ackReaction.config, ackReaction.changes);
-  const accountsBefore = asObjectRecord(
-    asObjectRecord((retiredConfig.channels as Record<string, unknown> | undefined)?.whatsapp)
-      ?.accounts,
-  );
-  const aliases = streamingAliasMigration.normalizeChannelConfig({
+  return streamingAliasMigration.normalizeChannelConfig({
     cfg: retiredConfig,
     changes: ackReaction.changes,
   });
-  return {
-    config: materializeMigratedAccountStreaming({
-      cfg: aliases.config,
-      accountsBefore,
-      changes: aliases.changes,
-    }),
-    changes: aliases.changes,
-  };
 }

--- a/extensions/zalouser/src/doctor-contract.ts
+++ b/extensions/zalouser/src/doctor-contract.ts
@@ -4,14 +4,11 @@ import type {
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-
-type ZalouserChannelsConfig = NonNullable<OpenClawConfig["channels"]>;
-
-function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
+import {
+  asObjectRecord,
+  hasLegacyAccountStreamingAliases,
+  normalizeChannelConfigEntries,
+} from "openclaw/plugin-sdk/runtime-doctor";
 
 function hasLegacyZalouserGroupAllowAlias(value: unknown): boolean {
   const group = asObjectRecord(value);
@@ -23,17 +20,6 @@ function hasLegacyZalouserGroupAllowAliases(value: unknown): boolean {
   return Boolean(
     groups && Object.values(groups).some((group) => hasLegacyZalouserGroupAllowAlias(group)),
   );
-}
-
-function hasLegacyZalouserAccountGroupAllowAliases(value: unknown): boolean {
-  const accounts = asObjectRecord(value);
-  if (!accounts) {
-    return false;
-  }
-  return Object.values(accounts).some((account) => {
-    const accountRecord = asObjectRecord(account);
-    return Boolean(accountRecord && hasLegacyZalouserGroupAllowAliases(accountRecord.groups));
-  });
 }
 
 function normalizeZalouserGroupAllowAliases(params: {
@@ -62,77 +48,23 @@ function normalizeZalouserGroupAllowAliases(params: {
   return { groups: nextGroups, changed };
 }
 
-function normalizeZalouserCompatibilityConfig(cfg: OpenClawConfig): ChannelDoctorConfigMutation {
-  const channels = asObjectRecord(cfg.channels);
-  const zalouser = asObjectRecord(channels?.zalouser);
-  if (!zalouser) {
-    return { config: cfg, changes: [] };
+function normalizeZalouserEntry(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+}): { entry: Record<string, unknown>; changed: boolean } {
+  const groups = asObjectRecord(params.entry.groups);
+  if (!groups) {
+    return { entry: params.entry, changed: false };
   }
-
-  const changes: string[] = [];
-  let updatedZalouser: Record<string, unknown> = zalouser;
-  let changed = false;
-
-  const groups = asObjectRecord(updatedZalouser.groups);
-  if (groups) {
-    const normalized = normalizeZalouserGroupAllowAliases({
-      groups,
-      pathPrefix: "channels.zalouser.groups",
-      changes,
-    });
-    if (normalized.changed) {
-      updatedZalouser = { ...updatedZalouser, groups: normalized.groups };
-      changed = true;
-    }
-  }
-
-  const accounts = asObjectRecord(updatedZalouser.accounts);
-  if (accounts) {
-    let accountsChanged = false;
-    const nextAccounts: Record<string, unknown> = { ...accounts };
-    for (const [accountId, accountValue] of Object.entries(accounts)) {
-      const account = asObjectRecord(accountValue);
-      if (!account) {
-        continue;
-      }
-      const accountGroups = asObjectRecord(account.groups);
-      if (!accountGroups) {
-        continue;
-      }
-      const normalized = normalizeZalouserGroupAllowAliases({
-        groups: accountGroups,
-        pathPrefix: `channels.zalouser.accounts.${accountId}.groups`,
-        changes,
-      });
-      if (!normalized.changed) {
-        continue;
-      }
-      nextAccounts[accountId] = {
-        ...account,
-        groups: normalized.groups,
-      };
-      accountsChanged = true;
-    }
-    if (accountsChanged) {
-      updatedZalouser = { ...updatedZalouser, accounts: nextAccounts };
-      changed = true;
-    }
-  }
-
-  if (!changed) {
-    return { config: cfg, changes: [] };
-  }
-
-  return {
-    config: {
-      ...cfg,
-      channels: {
-        ...cfg.channels,
-        zalouser: updatedZalouser as ZalouserChannelsConfig["zalouser"],
-      },
-    },
-    changes,
-  };
+  const normalized = normalizeZalouserGroupAllowAliases({
+    groups,
+    pathPrefix: `${params.pathPrefix}.groups`,
+    changes: params.changes,
+  });
+  return normalized.changed
+    ? { entry: { ...params.entry, groups: normalized.groups }, changed: true }
+    : { entry: params.entry, changed: false };
 }
 
 export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
@@ -146,12 +78,19 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "zalouser", "accounts"],
     message:
       'channels.zalouser.accounts.<id>.groups.<id>.allow is legacy; use channels.zalouser.accounts.<id>.groups.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: hasLegacyZalouserAccountGroupAllowAliases,
+    match: (value) =>
+      hasLegacyAccountStreamingAliases(value, (account) =>
+        hasLegacyZalouserGroupAllowAliases(asObjectRecord(account)?.groups),
+      ),
   },
 ];
 
 export function normalizeCompatibilityConfig(params: {
   cfg: OpenClawConfig;
 }): ChannelDoctorConfigMutation {
-  return normalizeZalouserCompatibilityConfig(params.cfg);
+  return normalizeChannelConfigEntries({
+    cfg: params.cfg,
+    channelId: "zalouser",
+    normalizeEntry: normalizeZalouserEntry,
+  });
 }

--- a/src/config/channel-alias-migration.test.ts
+++ b/src/config/channel-alias-migration.test.ts
@@ -230,4 +230,38 @@ describe("defineChannelAliasMigration normalizeChannelConfig", () => {
       accounts: { work: { dmPolicy: "open", allowFrom: ["*"] } },
     });
   });
+
+  it("materializes root and default-account streaming inheritance", () => {
+    const migration = defineChannelAliasMigration({
+      channelId: "layered",
+      streaming: { defaultMode: "partial", deliveryOnly: true },
+      accountStreamingInheritsDefaultAccount: true,
+    });
+    const result = migration.normalizeChannelConfig({
+      cfg: cfgWith("layered", {
+        streaming: { block: { enabled: true } },
+        accounts: {
+          Default: { chunkMode: "newline" },
+          work: { blockStreamingCoalesce: { minChars: 20 } },
+        },
+      }),
+    });
+
+    expect((result.config.channels as Record<string, unknown>).layered).toEqual({
+      streaming: { block: { enabled: true } },
+      accounts: {
+        Default: { streaming: { block: { enabled: true }, chunkMode: "newline" } },
+        work: {
+          streaming: {
+            block: { enabled: true, coalesce: { minChars: 20 } },
+            chunkMode: "newline",
+          },
+        },
+      },
+    });
+    expect(result.changes.slice(-2)).toEqual([
+      "Copied channels.layered.streaming into channels.layered.accounts.Default.streaming to keep inherited settings while migrating flat streaming keys.",
+      "Copied channels.layered.accounts.Default.streaming into channels.layered.accounts.work.streaming to keep inherited settings while migrating flat streaming keys.",
+    ]);
+  });
 });

--- a/src/config/channel-alias-migration.ts
+++ b/src/config/channel-alias-migration.ts
@@ -9,6 +9,7 @@ import {
   type LegacyStreamingAliasOptions,
   type NormalizeLegacyChannelAccountParams,
 } from "./channel-compat-normalization.js";
+import { materializeInheritedAccountStreaming } from "./channel-doctor-helpers.js";
 import type { LegacyConfigRule } from "./legacy.shared.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
@@ -58,6 +59,8 @@ export type ChannelAliasMigrationSpec<TMode extends string = StreamingAliasMode>
    * would freeze inheritance into the account config.
    */
   accountStreamingReplacesRoot?: boolean;
+  /** Account resolution layers accounts.default between root and named accounts. */
+  accountStreamingInheritsDefaultAccount?: boolean;
   dm?: {
     root?: boolean;
     accounts?: boolean;
@@ -156,6 +159,9 @@ export function defineChannelAliasMigration<TMode extends string = StreamingAlia
     if (!entry) {
       return { config: params.cfg, changes };
     }
+    const accountsBefore = spec.accountStreamingInheritsDefaultAccount
+      ? asObjectRecord(entry.accounts)
+      : null;
     if (
       streaming.deliveryOnly === true &&
       !hasLegacyAliases(entry) &&
@@ -179,11 +185,19 @@ export function defineChannelAliasMigration<TMode extends string = StreamingAlia
     if (!result.changed) {
       return { config: params.cfg, changes };
     }
+    const config = {
+      ...params.cfg,
+      channels: { ...channels, [spec.channelId]: result.entry },
+    } as OpenClawConfig;
     return {
-      config: {
-        ...params.cfg,
-        channels: { ...channels, [spec.channelId]: result.entry },
-      } as OpenClawConfig,
+      config: spec.accountStreamingInheritsDefaultAccount
+        ? materializeInheritedAccountStreaming({
+            cfg: config,
+            channelId: spec.channelId,
+            accountsBefore,
+            changes,
+          })
+        : config,
       changes,
     };
   };

--- a/src/config/channel-compat-normalization.ts
+++ b/src/config/channel-compat-normalization.ts
@@ -29,6 +29,18 @@ export type NormalizeLegacyChannelAccountParams = {
   changes: string[];
 };
 
+export type NormalizeChannelConfigEntryParams = {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+  accountId?: string;
+};
+
+export type RetiredChannelKeyRemoval = {
+  key: string;
+  pathPrefix: string;
+};
+
 /** Narrows unknown config JSON values to mutable object records. */
 export function asObjectRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)

--- a/src/config/channel-doctor-helpers.ts
+++ b/src/config/channel-doctor-helpers.ts
@@ -1,0 +1,243 @@
+import { isDeepStrictEqual } from "node:util";
+import { mergeDeep } from "../infra/deep-merge.js";
+import {
+  asObjectRecord,
+  type CompatMutationResult,
+  type NormalizeChannelConfigEntryParams,
+  type NormalizeLegacyChannelAccountParams,
+  type RetiredChannelKeyRemoval,
+} from "./channel-compat-normalization.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+/** Applies one channel-specific doctor migration to every object-shaped account. */
+export function normalizeChannelAccounts(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+  normalizeAccount: (params: NormalizeLegacyChannelAccountParams) => CompatMutationResult;
+}): CompatMutationResult {
+  const rawAccounts = asObjectRecord(params.entry.accounts);
+  if (!rawAccounts) {
+    return { entry: params.entry, changed: false };
+  }
+  let changed = false;
+  const accounts = { ...rawAccounts };
+  for (const [accountId, value] of Object.entries(rawAccounts)) {
+    const account = asObjectRecord(value);
+    if (!account) {
+      continue;
+    }
+    const normalized = params.normalizeAccount({
+      account,
+      accountId,
+      pathPrefix: `${params.pathPrefix}.accounts.${accountId}`,
+      changes: params.changes,
+    });
+    if (normalized.changed) {
+      accounts[accountId] = normalized.entry;
+      changed = true;
+    }
+  }
+  return changed
+    ? { entry: { ...params.entry, accounts }, changed: true }
+    : { entry: params.entry, changed: false };
+}
+
+/** Applies the same channel-specific doctor migration at root and account scope. */
+export function normalizeChannelConfigEntries(params: {
+  cfg: OpenClawConfig;
+  channelId: string;
+  changes?: string[];
+  normalizeEntry: (params: NormalizeChannelConfigEntryParams) => CompatMutationResult;
+}): { config: OpenClawConfig; changes: string[] } {
+  const changes = params.changes ?? [];
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const entry = asObjectRecord(channels?.[params.channelId]);
+  if (!entry) {
+    return { config: params.cfg, changes };
+  }
+  const channelPath = `channels.${params.channelId}`;
+  const root = params.normalizeEntry({ entry, pathPrefix: channelPath, changes });
+  const accounts = normalizeChannelAccounts({
+    entry: root.entry,
+    pathPrefix: channelPath,
+    changes,
+    normalizeAccount: (accountParams) =>
+      params.normalizeEntry({
+        entry: accountParams.account,
+        accountId: accountParams.accountId,
+        pathPrefix: accountParams.pathPrefix,
+        changes: accountParams.changes,
+      }),
+  });
+  if (!root.changed && !accounts.changed) {
+    return { config: params.cfg, changes };
+  }
+  return {
+    config: {
+      ...params.cfg,
+      channels: { ...channels, [params.channelId]: accounts.entry },
+    } as OpenClawConfig,
+    changes,
+  };
+}
+
+function stripRetiredKeys(params: {
+  value: unknown;
+  keys: ReadonlySet<string>;
+  pathPrefix: string;
+  recursive: boolean;
+  onRemove?: (removed: RetiredChannelKeyRemoval) => void;
+}): { value: unknown; changed: boolean } {
+  if (params.recursive && Array.isArray(params.value)) {
+    let changed = false;
+    const value = params.value.map((item, index) => {
+      const stripped = stripRetiredKeys({
+        ...params,
+        value: item,
+        pathPrefix: `${params.pathPrefix}[${index}]`,
+      });
+      changed = changed || stripped.changed;
+      return stripped.value;
+    });
+    return { value: changed ? value : params.value, changed };
+  }
+  const record = asObjectRecord(params.value);
+  if (!record) {
+    return { value: params.value, changed: false };
+  }
+  let changed = false;
+  const value: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(record)) {
+    if (params.keys.has(key)) {
+      params.onRemove?.({ key, pathPrefix: params.pathPrefix });
+      changed = true;
+      continue;
+    }
+    if (!params.recursive) {
+      value[key] = child;
+      continue;
+    }
+    const stripped = stripRetiredKeys({
+      ...params,
+      value: child,
+      pathPrefix: `${params.pathPrefix}.${key}`,
+    });
+    changed = changed || stripped.changed;
+    value[key] = stripped.value;
+  }
+  return { value: changed ? value : params.value, changed };
+}
+
+/** Removes retired keys recursively or from a channel root and its accounts. */
+export function stripRetiredChannelKeys(params: {
+  cfg: OpenClawConfig;
+  channelId: string;
+  keys: ReadonlySet<string>;
+  scope: "recursive" | "root-and-accounts";
+  onRemove?: (removed: RetiredChannelKeyRemoval) => void;
+}): { config: OpenClawConfig; changed: boolean } {
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const entry = asObjectRecord(channels?.[params.channelId]);
+  if (!entry) {
+    return { config: params.cfg, changed: false };
+  }
+  const channelPath = `channels.${params.channelId}`;
+  if (params.scope === "recursive") {
+    const stripped = stripRetiredKeys({
+      value: entry,
+      keys: params.keys,
+      pathPrefix: channelPath,
+      recursive: true,
+      onRemove: params.onRemove,
+    });
+    return stripped.changed
+      ? {
+          config: {
+            ...params.cfg,
+            channels: { ...channels, [params.channelId]: stripped.value },
+          } as OpenClawConfig,
+          changed: true,
+        }
+      : { config: params.cfg, changed: false };
+  }
+  const normalized = normalizeChannelConfigEntries({
+    cfg: params.cfg,
+    channelId: params.channelId,
+    normalizeEntry: (entryParams) => {
+      const stripped = stripRetiredKeys({
+        value: entryParams.entry,
+        keys: params.keys,
+        pathPrefix: entryParams.pathPrefix,
+        recursive: false,
+        onRemove: params.onRemove,
+      });
+      return { entry: stripped.value as Record<string, unknown>, changed: stripped.changed };
+    },
+  });
+  return { config: normalized.config, changed: normalized.config !== params.cfg };
+}
+
+/** Materializes root/default-account inheritance after aliases create streaming. */
+export function materializeInheritedAccountStreaming(params: {
+  cfg: OpenClawConfig;
+  channelId: string;
+  accountsBefore: Record<string, unknown> | null;
+  changes: string[];
+}): OpenClawConfig {
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const entry = asObjectRecord(channels?.[params.channelId]);
+  const accounts = asObjectRecord(entry?.accounts);
+  if (!entry || !accounts) {
+    return params.cfg;
+  }
+  const rootStreaming = asObjectRecord(entry.streaming);
+  const defaultKey = Object.hasOwn(accounts, "default")
+    ? "default"
+    : Object.keys(accounts).find((key) => key.trim().toLowerCase() === "default");
+  let changed = false;
+  const nextAccounts = { ...accounts };
+  const accountIds = Object.keys(accounts).toSorted((left, right) =>
+    left === defaultKey ? -1 : right === defaultKey ? 1 : left.localeCompare(right),
+  );
+  for (const accountId of accountIds) {
+    if (asObjectRecord(params.accountsBefore?.[accountId])?.streaming !== undefined) {
+      continue;
+    }
+    const account = asObjectRecord(nextAccounts[accountId]);
+    const created = asObjectRecord(account?.streaming);
+    if (!account || !created) {
+      continue;
+    }
+    const defaultStreaming = defaultKey
+      ? asObjectRecord(asObjectRecord(nextAccounts[defaultKey])?.streaming)
+      : null;
+    const inherited =
+      accountId === defaultKey ? rootStreaming : (defaultStreaming ?? rootStreaming);
+    if (!inherited) {
+      continue;
+    }
+    const materialized = asObjectRecord(mergeDeep(inherited, created));
+    if (!materialized || isDeepStrictEqual(materialized, created)) {
+      continue;
+    }
+    nextAccounts[accountId] = { ...account, streaming: materialized };
+    changed = true;
+    const sourcePath =
+      accountId !== defaultKey && defaultKey && defaultStreaming
+        ? `channels.${params.channelId}.accounts.${defaultKey}.streaming`
+        : `channels.${params.channelId}.streaming`;
+    params.changes.push(
+      `Copied ${sourcePath} into channels.${params.channelId}.accounts.${accountId}.streaming to keep inherited settings while migrating flat streaming keys.`,
+    );
+  }
+  return changed
+    ? ({
+        ...params.cfg,
+        channels: {
+          ...channels,
+          [params.channelId]: { ...entry, accounts: nextAccounts },
+        },
+      } as OpenClawConfig)
+    : params.cfg;
+}

--- a/src/plugin-sdk/runtime-doctor.test.ts
+++ b/src/plugin-sdk/runtime-doctor.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./config-contracts.js";
+import { normalizeChannelConfigEntries, stripRetiredChannelKeys } from "./runtime-doctor.js";
+
+function cfgWith(entry: Record<string, unknown>): OpenClawConfig {
+  return { channels: { sample: entry } } as never;
+}
+
+describe("runtime-doctor channel helpers", () => {
+  it("normalizes the root and every object-shaped account in order", () => {
+    const changeLog: string[] = [];
+    const result = normalizeChannelConfigEntries({
+      cfg: cfgWith({ legacy: true, accounts: { work: { legacy: false }, invalid: "skip" } }),
+      channelId: "sample",
+      changes: changeLog,
+      normalizeEntry: ({ entry, pathPrefix, changes }) => {
+        if (!Object.hasOwn(entry, "legacy")) {
+          return { entry, changed: false };
+        }
+        const { legacy: _legacy, ...rest } = entry;
+        changes.push(`Removed ${pathPrefix}.legacy.`);
+        return { entry: rest, changed: true };
+      },
+    });
+
+    expect(result.changes).toBe(changeLog);
+    expect(result.changes).toEqual([
+      "Removed channels.sample.legacy.",
+      "Removed channels.sample.accounts.work.legacy.",
+    ]);
+    expect((result.config.channels as Record<string, unknown>).sample).toEqual({
+      accounts: { work: {}, invalid: "skip" },
+    });
+  });
+
+  it("supports recursive and root-account-only retired key scopes", () => {
+    const source = cfgWith({
+      retired: 1,
+      nested: { retired: 2 },
+      accounts: { work: { retired: 3, nested: { retired: 4 } } },
+    });
+    const keys = new Set(["retired"]);
+
+    const scoped = stripRetiredChannelKeys({
+      cfg: source,
+      channelId: "sample",
+      keys,
+      scope: "root-and-accounts",
+    });
+    expect((scoped.config.channels as Record<string, unknown>).sample).toEqual({
+      nested: { retired: 2 },
+      accounts: { work: { nested: { retired: 4 } } },
+    });
+
+    const recursive = stripRetiredChannelKeys({
+      cfg: source,
+      channelId: "sample",
+      keys,
+      scope: "recursive",
+    });
+    expect((recursive.config.channels as Record<string, unknown>).sample).toEqual({
+      nested: {},
+      accounts: { work: { nested: {} } },
+    });
+  });
+});

--- a/src/plugin-sdk/runtime-doctor.ts
+++ b/src/plugin-sdk/runtime-doctor.ts
@@ -16,10 +16,18 @@ export {
   normalizeLegacyStreamingAliases,
   resolveLegacyAliasStreamingMode,
 } from "../config/channel-compat-normalization.js";
+export {
+  materializeInheritedAccountStreaming,
+  normalizeChannelAccounts,
+  normalizeChannelConfigEntries,
+  stripRetiredChannelKeys,
+} from "../config/channel-doctor-helpers.js";
 export type {
   CompatMutationResult,
   LegacyStreamingAliasOptions,
+  NormalizeChannelConfigEntryParams,
   NormalizeLegacyChannelAccountParams,
+  RetiredChannelKeyRemoval,
 } from "../config/channel-compat-normalization.js";
 export {
   detectPluginInstallPathIssue,


### PR DESCRIPTION
## What Problem This Solves

Nine bundled channel plugins repeated the same doctor-contract mechanics: walking root and account entries, stripping retired keys, and materializing inherited streaming config when flat aliases create account-level objects. The duplicated walkers made compatibility migrations harder to compare and maintain.

## Why This Change Was Made

This moves the generic mechanics into the existing `openclaw/plugin-sdk/runtime-doctor` surface and keeps only channel-specific migration rules and message wording in each plugin. Google Chat and WhatsApp now declare their root → default account → named account streaming inheritance through the shared alias-migration spec. Telegram and Discord use the shared retired-key stripper with their existing recursive versus root/account scopes. The remaining migrated plugins use the shared root/account entry walker.

The tiny Mattermost, Nextcloud Talk, and Tlon contracts already delegate entirely to shared contracts, so they required no source changes.

Maintainer decision: confirmed. Peter explicitly commissioned this batch to hoist the generic mechanics into `openclaw/plugin-sdk/runtime-doctor`; the four additive helpers, two helper types, and `accountStreamingInheritsDefaultAccount` are intended as the supported plugin doctor-migration contract.

## User Impact

None. This is a behavior-neutral refactor: normalized config bytes and doctor change messages remain covered by the unchanged per-plugin tests. There are no config, environment, schema, protocol, or fallback changes.

## Evidence

- LOC: production +594/-1062 (net -468); tests +100/-0; total +694/-1062 (net -368) across 15 files.
- `node scripts/run-vitest.mjs src/plugin-sdk/runtime-doctor.test.ts src/config/channel-alias-migration.test.ts extensions/discord/src/doctor.test.ts extensions/feishu/src/doctor-contract.test.ts extensions/googlechat/src/doctor-contract.test.ts extensions/matrix/src/doctor.test.ts extensions/mattermost/src/doctor-contract.test.ts extensions/mattermost/src/doctor.test.ts extensions/nextcloud-talk/src/doctor-contract.test.ts extensions/nextcloud-talk/src/doctor.test.ts extensions/qqbot/src/doctor-contract.test.ts extensions/slack/src/doctor-contract.test.ts extensions/slack/src/doctor.test.ts extensions/telegram/src/doctor.test.ts extensions/whatsapp/src/doctor-contract.test.ts extensions/whatsapp/src/doctor.test.ts extensions/zalouser/src/doctor.test.ts` — passed 11 Vitest shards, 141 tests.
- `node scripts/check-changed.mjs -- <15 changed files>` on Blacksmith Testbox — formatting, max-lines, SDK API manifest, package exports, SDK surface budget, plugin boundaries, core/extension production and test typechecks, and full core lint passed. The final extension-lint step reported three lint-shape findings; all were fixed.
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json <9 changed doctor-contract files> --deny-warnings` — passed after those fixes.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings (0.94 confidence).
- Real `doctor --fix` proof: Blacksmith Testbox `tbx_01ky6488ha7894mzdpe0d78h23`, [run 29967722509](https://github.com/openclaw/openclaw/actions/runs/29967722509), isolated synthetic state with no credentials. Before: WhatsApp root `chunkMode: "length"`, `accounts.default.blockStreaming: true`, and `accounts.work.chunkMode: "newline"`. Doctor reported the three moves plus both inheritance copies. After: root `streaming.chunkMode="length"`; default account `streaming={chunkMode:"length",block:{enabled:true}}`; work account `streaming={chunkMode:"newline",block:{enabled:true}}`. Command exited 0 and the one-shot Testbox was stopped.
