### PR TITLE
feat(android): add OpenClaw settings chat

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -2,6 +2,22 @@
   "version": 1,
   "entries": [
     {
+      "kind": "conditional-branch",
+      "line": 123,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt",
+      "source": "I can check Gateway status, repair configuration, change models, or connect channels.",
+      "surface": "android",
+      "id": "native.android.8a2fec00ed1d71b5"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 125,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt",
+      "source": "I’ll keep this conversation separate from ordinary agent chat.",
+      "surface": "android",
+      "id": "native.android.53ec61863e575d82"
+    },
+    {
       "kind": "ui-call",
       "line": 95,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/AppLanguage.kt",
@@ -563,7 +579,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 470,
+      "line": 471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -571,7 +587,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 604,
+      "line": 607,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -579,7 +595,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 618,
+      "line": 621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -715,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 177,
+      "line": 180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -723,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 179,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -731,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 181,
+      "line": 184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -739,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -747,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 185,
+      "line": 188,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -755,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 282,
+      "line": 285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Device approved.",
       "surface": "android",
@@ -763,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 283,
+      "line": 286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pairing request rejected.",
       "surface": "android",
@@ -771,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 284,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Paired device removed.",
       "surface": "android",
@@ -779,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 345,
+      "line": 348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -787,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 345,
+      "line": 348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -795,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 346,
+      "line": 349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -803,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 346,
+      "line": 349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -811,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 347,
+      "line": 350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -819,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 347,
+      "line": 350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -827,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 354,
+      "line": 357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -835,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 355,
+      "line": 358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -843,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 363,
+      "line": 366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -851,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 545,
+      "line": 548,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -859,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 546,
+      "line": 549,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -867,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 548,
+      "line": 551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -875,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 556,
+      "line": 559,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -883,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2231,
+      "line": 2270,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -891,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2261,
+      "line": 2300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -899,7 +915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2261,
+      "line": 2300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -907,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2274,
+      "line": 2313,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -915,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2305,
+      "line": 2344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -923,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2305,
+      "line": 2344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -931,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2327,
+      "line": 2366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -939,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2333,
+      "line": 2372,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -947,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2348,
+      "line": 2387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -955,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2598,
+      "line": 2637,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -963,7 +979,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2609,
+      "line": 2648,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -971,7 +987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2630,
+      "line": 2669,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -979,7 +995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2641,
+      "line": 2680,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -987,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3725,
+      "line": 3766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -995,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3753,
+      "line": 3794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -1003,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3762,
+      "line": 3803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -1011,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4473,
+      "line": 4514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -1019,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4477,
+      "line": 4518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -1027,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4481,
+      "line": 4522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1035,7 +1051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4531,
+      "line": 4572,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1043,7 +1059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4741,
+      "line": 4782,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1051,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5483,
+      "line": 5557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1059,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5514,
+      "line": 5588,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1067,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5516,
+      "line": 5590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1075,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5532,
+      "line": 5606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1083,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5619,
+      "line": 5693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1091,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5705,
+      "line": 5779,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1099,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5715,
+      "line": 5789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1107,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5719,
+      "line": 5793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1115,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5731,
+      "line": 5805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1123,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5762,
+      "line": 5836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1131,7 +1147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5779,
+      "line": 5853,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1139,7 +1155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5788,
+      "line": 5862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1147,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5800,
+      "line": 5874,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1155,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5847,
+      "line": 5921,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1163,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5974,
+      "line": 6048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1171,7 +1187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6009,
+      "line": 6083,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1179,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6022,
+      "line": 6096,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1187,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6026,
+      "line": 6100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1195,7 +1211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6041,
+      "line": 6115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1203,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6041,
+      "line": 6115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1211,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6059,
+      "line": 6133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6105,
+      "line": 6179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1227,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6118,
+      "line": 6192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1235,7 +1251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6151,
+      "line": 6225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1243,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6167,
+      "line": 6241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1251,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6183,
+      "line": 6257,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1259,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6199,
+      "line": 6273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1267,7 +1283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6289,
+      "line": 6363,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1275,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6296,
+      "line": 6370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1283,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6336,
+      "line": 6410,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1291,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6376,
+      "line": 6450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1299,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6396,
+      "line": 6470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1307,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6448,
+      "line": 6522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1315,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6468,
+      "line": 6542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1323,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6473,
+      "line": 6547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1331,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6663,
+      "line": 6737,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not verify the device pairing change. Refresh and try again.",
       "surface": "android",
@@ -1339,7 +1355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6745,
+      "line": 6819,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1347,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6775,
+      "line": 6849,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1355,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7433,
+      "line": 7508,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1363,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7463,
+      "line": 7538,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1371,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7500,
+      "line": 7575,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1379,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7969,
+      "line": 8044,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1387,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7978,
+      "line": 8053,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1395,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7979,
+      "line": 8054,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1403,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7987,
+      "line": 8062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1411,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7988,
+      "line": 8063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1419,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7989,
+      "line": 8064,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1427,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7990,
+      "line": 8065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1435,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8006,
+      "line": 8081,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1443,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8023,
+      "line": 8098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1451,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8031,
+      "line": 8106,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1459,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8032,
+      "line": 8107,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1467,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8034,
+      "line": 8109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1475,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8038,
+      "line": 8113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1483,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8041,
+      "line": 8116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1491,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8046,
+      "line": 8121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1499,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8047,
+      "line": 8122,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1507,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8049,
+      "line": 8124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1515,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8053,
+      "line": 8128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1523,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8056,
+      "line": 8131,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1531,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8061,
+      "line": 8136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1539,7 +1555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8062,
+      "line": 8137,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1547,7 +1563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8064,
+      "line": 8139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1555,7 +1571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8068,
+      "line": 8143,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1563,7 +1579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8071,
+      "line": 8146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1571,7 +1587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8103,
+      "line": 8178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1579,7 +1595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8118,
+      "line": 8193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1587,7 +1603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8119,
+      "line": 8194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1595,7 +1611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8120,
+      "line": 8195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1603,7 +1619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8775,
+      "line": 8850,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1952,6 +1968,38 @@
       "source": "OpenClaw Active",
       "surface": "android",
       "id": "native.android.a79d6ccab877c9ca"
+    },
+    {
+      "kind": "ui-call",
+      "line": 203,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/systemagent/SystemAgentChatController.kt",
+      "source": "Skip for now",
+      "surface": "android",
+      "id": "native.android.2aa3ad1a12683954"
+    },
+    {
+      "kind": "ui-call",
+      "line": 250,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/systemagent/SystemAgentChatController.kt",
+      "source": "<redacted secret>",
+      "surface": "android",
+      "id": "native.android.9fa262fa4e057a3b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 326,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/systemagent/SystemAgentChatController.kt",
+      "source": "OpenClaw request failed.",
+      "surface": "android",
+      "id": "native.android.e1a8681198e91766"
+    },
+    {
+      "kind": "ui-call",
+      "line": 453,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/systemagent/SystemAgentChatController.kt",
+      "source": "The Gateway connection changed. Restart OpenClaw to reconnect.",
+      "surface": "android",
+      "id": "native.android.a71a93ec69cee4d9"
     },
     {
       "kind": "conditional-branch",
@@ -6475,7 +6523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 257,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
@@ -6483,7 +6531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 257,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -6491,7 +6539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 259,
+      "line": 261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Providers",
       "surface": "android",
@@ -6499,7 +6547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 277,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -6507,7 +6555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 280,
+      "line": 282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -6515,7 +6563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -6523,7 +6571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 320,
+      "line": 322,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
@@ -6531,7 +6579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 325,
+      "line": 327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automations",
       "surface": "android",
@@ -6539,7 +6587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 333,
+      "line": 335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search automations",
       "surface": "android",
@@ -6547,7 +6595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 336,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search",
       "surface": "android",
@@ -6555,7 +6603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 350,
+      "line": 352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open an automation to inspect its configuration and run history. Admin-scoped connections can also run, edit, enable, disable, or delete it.",
       "surface": "android",
@@ -6563,7 +6611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 360,
+      "line": 362,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load automations.",
       "surface": "android",
@@ -6571,7 +6619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 365,
+      "line": 367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No automations yet.",
       "surface": "android",
@@ -6579,7 +6627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 366,
+      "line": 368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled work created on the gateway will appear here.",
       "surface": "android",
@@ -6587,7 +6635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 371,
+      "line": 373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching automations.",
       "surface": "android",
@@ -6595,7 +6643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 470,
+      "line": 472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation",
       "surface": "android",
@@ -6603,7 +6651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 471,
+      "line": 473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect and manage scheduled gateway work.",
       "surface": "android",
@@ -6611,7 +6659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 492,
+      "line": 494,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -6619,7 +6667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 500,
+      "line": 502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation not loaded.",
       "surface": "android",
@@ -6627,7 +6675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 500,
+      "line": 502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading automation…",
       "surface": "android",
@@ -6635,7 +6683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 551,
+      "line": 553,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
@@ -6643,7 +6691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Available",
       "surface": "android",
@@ -6651,7 +6699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 562,
+      "line": 564,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -6659,7 +6707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 566,
+      "line": 568,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -6667,7 +6715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 595,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -6675,7 +6723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 595,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
@@ -6683,7 +6731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 597,
+      "line": 599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway Pending",
       "surface": "android",
@@ -6691,7 +6739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 598,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Thread Activity",
       "surface": "android",
@@ -6699,7 +6747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 599,
+      "line": 601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issues",
       "surface": "android",
@@ -6707,7 +6755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 600,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active Runs",
       "surface": "android",
@@ -6715,7 +6763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 604,
+      "line": 606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -6723,7 +6771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 604,
+      "line": 606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -6731,7 +6779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 622,
+      "line": 624,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -6739,7 +6787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 623,
+      "line": 625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -6747,7 +6795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 629,
+      "line": 631,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -6755,7 +6803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 630,
+      "line": 632,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -6763,7 +6811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 640,
+      "line": 642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Thread activity",
       "surface": "android",
@@ -6771,7 +6819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 641,
+      "line": 643,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active thread remain visible here.",
       "surface": "android",
@@ -6779,7 +6827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 655,
+      "line": 657,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
@@ -6787,7 +6835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 655,
+      "line": 657,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -6795,7 +6843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 658,
+      "line": 660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -6803,7 +6851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 659,
+      "line": 661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -6811,7 +6859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure wake words, talk, and playback.",
       "surface": "android",
@@ -6819,7 +6867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice",
       "surface": "android",
@@ -6827,7 +6875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 720,
+      "line": 722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice Wake",
       "surface": "android",
@@ -6835,7 +6883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 725,
+      "line": 727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Listen for wake words",
       "surface": "android",
@@ -6843,7 +6891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 728,
+      "line": 730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runs on-device while OpenClaw is visible.",
       "surface": "android",
@@ -6851,7 +6899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 730,
+      "line": 732,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On-device speech recognition is unavailable.",
       "surface": "android",
@@ -6859,7 +6907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 740,
+      "line": 742,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake listener",
       "surface": "android",
@@ -6867,7 +6915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 742,
+      "line": 744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last command: $command",
       "surface": "android",
@@ -6875,7 +6923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 743,
+      "line": 745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pauses during other voice activity.",
       "surface": "android",
@@ -6883,7 +6931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 750,
+      "line": 752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake words",
       "surface": "android",
@@ -6891,7 +6939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 752,
+      "line": 754,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add one wake word or phrase per field. Then say one before your command.",
       "surface": "android",
@@ -6899,7 +6947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 767,
+      "line": 769,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake word or phrase",
       "surface": "android",
@@ -6907,7 +6955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 776,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove wake phrase",
       "surface": "android",
@@ -6915,7 +6963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 783,
+      "line": 785,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add wake phrase",
       "surface": "android",
@@ -6923,7 +6971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save wake words",
       "surface": "android",
@@ -6931,7 +6979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving…",
       "surface": "android",
@@ -6939,7 +6987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 795,
+      "line": 797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -6947,7 +6995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 800,
+      "line": 802,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -6955,7 +7003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 802,
+      "line": 804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Microphone",
       "surface": "android",
@@ -6963,7 +7011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 809,
+      "line": 811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -6971,7 +7019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 810,
+      "line": 812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -6979,7 +7027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 813,
+      "line": 815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -6987,7 +7035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 813,
+      "line": 815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -6995,7 +7043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 814,
+      "line": 816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -7003,7 +7051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 814,
+      "line": 816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -7011,7 +7059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 816,
+      "line": 818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -7019,7 +7067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 816,
+      "line": 818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -7027,7 +7075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 820,
+      "line": 822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -7035,7 +7083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 838,
+      "line": 840,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automatic",
       "surface": "android",
@@ -7043,7 +7091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 841,
+      "line": 843,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Preferred microphone unavailable; using automatic routing.",
       "surface": "android",
@@ -7051,7 +7099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 843,
+      "line": 845,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Prioritizes connected Bluetooth microphones.",
       "surface": "android",
@@ -7059,7 +7107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 852,
+      "line": 854,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Preferred microphone",
       "surface": "android",
@@ -7067,7 +7115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 853,
+      "line": 855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unavailable",
       "surface": "android",
@@ -7075,7 +7123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 885,
+      "line": 887,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Next session",
       "surface": "android",
@@ -7083,7 +7131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 907,
+      "line": 909,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Built-in microphone",
       "surface": "android",
@@ -7091,7 +7139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 908,
+      "line": 910,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bluetooth microphone",
       "surface": "android",
@@ -7099,7 +7147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 909,
+      "line": 911,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bluetooth LE microphone",
       "surface": "android",
@@ -7107,7 +7155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 910,
+      "line": 912,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wired headset microphone",
       "surface": "android",
@@ -7115,7 +7163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 914,
+      "line": 916,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "USB microphone",
       "surface": "android",
@@ -7123,7 +7171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 915,
+      "line": 917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "External microphone",
       "surface": "android",
@@ -7131,7 +7179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 923,
+      "line": 925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -7139,7 +7187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 924,
+      "line": 926,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -7147,7 +7195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1094,
+      "line": 1096,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -7155,7 +7203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1094,
+      "line": 1096,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -7163,7 +7211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 1100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -7171,7 +7219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 1100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forward Notifications",
       "surface": "android",
@@ -7179,7 +7227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 1100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -7187,7 +7235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1100,
+      "line": 1102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Quiet Hours",
       "surface": "android",
@@ -7195,7 +7243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1101,
+      "line": 1103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$quietStart to $quietEnd",
       "surface": "android",
@@ -7203,7 +7251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1113,
+      "line": 1115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Policy",
       "surface": "android",
@@ -7211,7 +7259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1114,
+      "line": 1116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected Apps",
       "surface": "android",
@@ -7219,7 +7267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1115,
+      "line": 1117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Rate Limit",
       "surface": "android",
@@ -7227,7 +7275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1116,
+      "line": 1118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -7235,7 +7283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1116,
+      "line": 1118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -7243,7 +7291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1121,
+      "line": 1123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -7251,7 +7299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1121,
+      "line": 1123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -7259,7 +7307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1130,
+      "line": 1132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -7267,7 +7315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1132,
+      "line": 1134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -7275,7 +7323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1136,
+      "line": 1138,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -7283,7 +7331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1185,
+      "line": 1187,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -7291,7 +7339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1192,
+      "line": 1194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -7299,7 +7347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1192,
+      "line": 1194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -7307,7 +7355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1197,
+      "line": 1199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -7315,7 +7363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1200,
+      "line": 1202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -7323,7 +7371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1201,
+      "line": 1203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -7331,7 +7379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1208,
+      "line": 1210,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -7339,7 +7387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1219,
+      "line": 1221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -7347,7 +7395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1466,
+      "line": 1468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -7355,7 +7403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1466,
+      "line": 1468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -7363,7 +7411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1470,
+      "line": 1472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow camera tools when requested.",
       "surface": "android",
@@ -7371,7 +7419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1470,
+      "line": 1472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Camera",
       "surface": "android",
@@ -7379,7 +7427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1471,
+      "line": 1473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Precise Location",
       "surface": "android",
@@ -7387,7 +7435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1471,
+      "line": 1473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share precise location while location is enabled.",
       "surface": "android",
@@ -7395,7 +7443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1474,
+      "line": 1476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Photos",
       "surface": "android",
@@ -7403,7 +7451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1475,
+      "line": 1477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -7411,7 +7459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1475,
+      "line": 1477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -7419,7 +7467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1484,
+      "line": 1486,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Installed Apps",
       "surface": "android",
@@ -7427,7 +7475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1485,
+      "line": 1487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -7435,7 +7483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1485,
+      "line": 1487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -7443,7 +7491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1490,
+      "line": 1492,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep Awake",
       "surface": "android",
@@ -7451,7 +7499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1490,
+      "line": 1492,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep the node available during active work.",
       "surface": "android",
@@ -7459,7 +7507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1491,
+      "line": 1493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Canvas Status",
       "surface": "android",
@@ -7467,7 +7515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1491,
+      "line": 1493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show screen-sharing debug state.",
       "surface": "android",
@@ -7475,7 +7523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1499,
+      "line": 1501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -7483,7 +7531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1507,
+      "line": 1509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -7491,7 +7539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1542,
+      "line": 1544,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -7499,7 +7547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1545,
+      "line": 1547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
       "surface": "android",
@@ -7507,7 +7555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1559,
+      "line": 1561,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -7515,7 +7563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1578,
+      "line": 1580,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share installed app information?",
       "surface": "android",
@@ -7523,7 +7571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1582,
+      "line": 1584,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
       "surface": "android",
@@ -7531,7 +7579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1585,
+      "line": 1587,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
       "surface": "android",
@@ -7539,7 +7587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1591,
+      "line": 1593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agree and Enable",
       "surface": "android",
@@ -7547,7 +7595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1596,
+      "line": 1598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -7555,7 +7603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1650,
+      "line": 1652,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -7563,7 +7611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1665,
+      "line": 1667,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -7571,7 +7619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1679,
+      "line": 1681,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "this gateway",
       "surface": "android",
@@ -7579,7 +7627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1682,
+      "line": 1684,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
@@ -7587,7 +7635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1685,
+      "line": 1687,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove $gatewayName and its saved credentials from this phone?",
       "surface": "android",
@@ -7595,7 +7643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1702,
+      "line": 1704,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -7603,7 +7651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1740,
+      "line": 1742,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -7611,7 +7659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1754,
+      "line": 1756,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -7619,7 +7667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1754,
+      "line": 1756,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection",
       "surface": "android",
@@ -7627,7 +7675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1754,
+      "line": 1756,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -7635,7 +7683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1755,
+      "line": 1757,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -7643,7 +7691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1755,
+      "line": 1757,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -7651,7 +7699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1757,
+      "line": 1759,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Access",
       "surface": "android",
@@ -7659,7 +7707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1764,
+      "line": 1766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Address",
       "surface": "android",
@@ -7667,7 +7715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1769,
+      "line": 1771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Discovered",
       "surface": "android",
@@ -7675,7 +7723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1770,
+      "line": 1772,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default Agent",
       "surface": "android",
@@ -7683,7 +7731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1771,
+      "line": 1773,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -7691,7 +7739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1772,
+      "line": 1774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Instance ID",
       "surface": "android",
@@ -7699,7 +7747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1778,
+      "line": 1780,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR to Pair",
       "surface": "android",
@@ -7707,7 +7755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1788,
+      "line": 1790,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited Gateway access",
       "surface": "android",
@@ -7715,7 +7763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1801,
+      "line": 1803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -7723,7 +7771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1802,
+      "line": 1804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -7731,7 +7779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1805,
+      "line": 1807,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Diagnose",
       "surface": "android",
@@ -7739,7 +7787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1818,
+      "line": 1820,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add Gateway",
       "surface": "android",
@@ -7747,7 +7795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1820,
+      "line": 1822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
@@ -7755,7 +7803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1826,
+      "line": 1828,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR",
       "surface": "android",
@@ -7763,7 +7811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1827,
+      "line": 1829,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -7771,7 +7819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1830,
+      "line": 1832,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Where do I get a setup code?",
       "surface": "android",
@@ -7779,7 +7827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1834,
+      "line": 1836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -7787,7 +7835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1841,
+      "line": 1843,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateways found yet. Use manual setup if discovery is blocked.",
       "surface": "android",
@@ -7795,7 +7843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1854,
+      "line": 1856,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect",
       "surface": "android",
@@ -7803,7 +7851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1865,
+      "line": 1867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
@@ -7811,7 +7859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1867,
+      "line": 1869,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
@@ -7819,7 +7867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1895,
+      "line": 1897,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
@@ -7827,7 +7875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1912,
+      "line": 1914,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Manual Gateway",
       "surface": "android",
@@ -7835,7 +7883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1914,
+      "line": 1916,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -7843,7 +7891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1915,
+      "line": 1917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -7851,7 +7899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1917,
+      "line": 1919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
@@ -7859,7 +7907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1921,
+      "line": 1923,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -7867,7 +7915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1925,
+      "line": 1927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -7875,7 +7923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1938,
+      "line": 1940,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -7883,7 +7931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1939,
+      "line": 1941,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -7891,7 +7939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1941,
+      "line": 1943,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -7899,7 +7947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1946,
+      "line": 1948,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -7907,7 +7955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1963,
+      "line": 1965,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -7915,7 +7963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1984,
+      "line": 1986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not available",
       "surface": "android",
@@ -7923,7 +7971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1985,
+      "line": 1987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Full",
       "surface": "android",
@@ -7931,7 +7979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1986,
+      "line": 1988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited",
       "surface": "android",
@@ -7939,7 +7987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1990,
+      "line": 1992,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Use a secure wss:// or Tailscale Serve Gateway, generate a full-access setup code in the Control UI or with openclaw qr, then scan or paste it below and reconnect to enable settings and upgrades.",
       "surface": "android",
@@ -7947,7 +7995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2004,
+      "line": 2006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -7955,7 +8003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2004,
+      "line": 2006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme and translated Android text.",
       "surface": "android",
@@ -7963,7 +8011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2009,
+      "line": 2011,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Language",
       "surface": "android",
@@ -7971,7 +8019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2010,
+      "line": 2012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Contrast",
       "surface": "android",
@@ -7979,7 +8027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2010,
+      "line": 2012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "High",
       "surface": "android",
@@ -7987,7 +8035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2011,
+      "line": 2013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Readable",
       "surface": "android",
@@ -7995,7 +8043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2011,
+      "line": 2013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Typography",
       "surface": "android",
@@ -8003,7 +8051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2016,
+      "line": 2018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -8011,7 +8059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2026,
+      "line": 2028,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App language",
       "surface": "android",
@@ -8019,7 +8067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2060,
+      "line": 2062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected",
       "surface": "android",
@@ -8027,7 +8075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2072,
+      "line": 2074,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System",
       "surface": "android",
@@ -8035,7 +8083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2100,
+      "line": 2102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "While Using",
       "surface": "android",
@@ -8043,7 +8091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2101,
+      "line": 2103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -8051,7 +8099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2113,
+      "line": 2115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connecting...",
       "surface": "android",
@@ -8059,7 +8107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2114,
+      "line": 2116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pairing needed",
       "surface": "android",
@@ -8067,7 +8115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2115,
+      "line": 2117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Authentication needed",
       "surface": "android",
@@ -8075,7 +8123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2116,
+      "line": 2118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "TLS timed out",
       "surface": "android",
@@ -8083,7 +8131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2117,
+      "line": 2119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No TLS endpoint",
       "surface": "android",
@@ -8091,7 +8139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2118,
+      "line": 2120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Certificate review needed",
       "surface": "android",
@@ -8099,7 +8147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2119,
+      "line": 2121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cannot reach gateway",
       "surface": "android",
@@ -8107,7 +8155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2140,
+      "line": 2142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -8115,7 +8163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2140,
+      "line": 2142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -8123,7 +8171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2152,
+      "line": 2154,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Channel",
       "surface": "android",
@@ -8131,7 +8179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2153,
+      "line": 2155,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not connected",
       "surface": "android",
@@ -8139,7 +8187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2158,
+      "line": 2160,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Home Gateway",
       "surface": "android",
@@ -8147,7 +8195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2160,
+      "line": 2162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -8155,7 +8203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2160,
+      "line": 2162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting",
       "surface": "android",
@@ -8163,7 +8211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2163,
+      "line": 2165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -8171,7 +8219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2164,
+      "line": 2166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Up to date",
       "surface": "android",
@@ -8179,7 +8227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2164,
+      "line": 2166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "v$it available",
       "surface": "android",
@@ -8187,7 +8235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2174,
+      "line": 2176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
@@ -8195,7 +8243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2191,
+      "line": 2193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -8203,7 +8251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2193,
+      "line": 2195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -8211,7 +8259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2194,
+      "line": 2196,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
@@ -8219,7 +8267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2253,
+      "line": 2255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -8227,7 +8275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2254,
+      "line": 2256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -8235,7 +8283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2263,
+      "line": 2265,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -8243,7 +8291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2289,
+      "line": 2291,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -8251,7 +8299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2300,
+      "line": 2302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Third-party",
       "surface": "android",
@@ -8259,7 +8307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2301,
+      "line": 2303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unknown",
       "surface": "android",
@@ -8267,7 +8315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2307,
+      "line": 2309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Website",
       "surface": "android",
@@ -8275,7 +8323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2308,
+      "line": 2310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Docs",
       "surface": "android",
@@ -8283,7 +8331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2312,
+      "line": 2314,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow all the time",
       "surface": "android",
@@ -8291,7 +8339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2315,
+      "line": 2317,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
       "surface": "android",
@@ -8299,7 +8347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2334,
+      "line": 2336,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -8307,7 +8355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2341,
+      "line": 2343,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
       "surface": "android",
@@ -8315,7 +8363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2343,
+      "line": 2345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
       "surface": "android",
@@ -8323,7 +8371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2368,
+      "line": 2370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -8331,7 +8379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2442,
+      "line": 2444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command approval",
       "surface": "android",
@@ -8339,7 +8387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2447,
+      "line": 2449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -8347,7 +8395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2507,
+      "line": 2509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -8355,7 +8403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2508,
+      "line": 2510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Always",
       "surface": "android",
@@ -8363,7 +8411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2509,
+      "line": 2511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -8371,7 +8419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2530,
+      "line": 2532,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approval ${notice.approvalId}",
       "surface": "android",
@@ -8379,7 +8427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2537,
+      "line": 2539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dismiss approval notice",
       "surface": "android",
@@ -8387,7 +8435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2556,
+      "line": 2558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -8395,7 +8443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2596,
+      "line": 2598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open automation detail",
       "surface": "android",
@@ -8403,7 +8451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2639,
+      "line": 2641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -8411,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2639,
+      "line": 2641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Status",
       "surface": "android",
@@ -8419,7 +8467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2640,
+      "line": 2642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule",
       "surface": "android",
@@ -8427,7 +8475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2641,
+      "line": 2643,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Next Wake",
       "surface": "android",
@@ -8435,7 +8483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2642,
+      "line": 2644,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Run",
       "surface": "android",
@@ -8443,7 +8491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2649,
+      "line": 2651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Description",
       "surface": "android",
@@ -8451,7 +8499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2650,
+      "line": 2652,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule Detail",
       "surface": "android",
@@ -8459,7 +8507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2651,
+      "line": 2653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session Target",
       "surface": "android",
@@ -8467,7 +8515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2652,
+      "line": 2654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake Mode",
       "surface": "android",
@@ -8475,7 +8523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2653,
+      "line": 2655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delete After Run",
       "surface": "android",
@@ -8483,7 +8531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2653,
+      "line": 2655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -8491,7 +8539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2653,
+      "line": 2655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -8499,7 +8547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2654,
+      "line": 2656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload",
       "surface": "android",
@@ -8507,7 +8555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2655,
+      "line": 2657,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery",
       "surface": "android",
@@ -8515,7 +8563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2656,
+      "line": 2658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Failure Alert",
       "surface": "android",
@@ -8523,7 +8571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2657,
+      "line": 2659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Created",
       "surface": "android",
@@ -8531,7 +8579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2658,
+      "line": 2660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Updated",
       "surface": "android",
@@ -8539,7 +8587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2659,
+      "line": 2661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Running Since",
       "surface": "android",
@@ -8547,7 +8595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2660,
+      "line": 2662,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Status",
       "surface": "android",
@@ -8555,7 +8603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2662,
+      "line": 2664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Duration",
       "surface": "android",
@@ -8563,7 +8611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2663,
+      "line": 2665,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${durationMs}ms",
       "surface": "android",
@@ -8571,7 +8619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2665,
+      "line": 2667,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Errors",
       "surface": "android",
@@ -8579,7 +8627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2666,
+      "line": 2668,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Skips",
       "surface": "android",
@@ -8587,7 +8635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2667,
+      "line": 2669,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Status",
       "surface": "android",
@@ -8595,7 +8643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2674,
+      "line": 2676,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -8603,7 +8651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2677,
+      "line": 2679,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -8611,7 +8659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2693,
+      "line": 2695,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Copy ${row.title}",
       "surface": "android",
@@ -8619,7 +8667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2718,
+      "line": 2720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -8627,7 +8675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2733,
+      "line": 2735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -8635,7 +8683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2771,
+      "line": 2773,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -8643,7 +8691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2777,
+      "line": 2779,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -8651,7 +8699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2785,
+      "line": 2787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${endpoint.host}:${endpoint.port}",
       "surface": "android",
@@ -8659,7 +8707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2831,
+      "line": 2833,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Action Request",
       "surface": "android",
@@ -8667,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2839,
+      "line": 2841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -8675,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2842,
+      "line": 2844,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -8683,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2842,
+      "line": 2844,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -8691,7 +8739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2853,
+      "line": 2855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node ${nodeId}",
       "surface": "android",
@@ -8699,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2855,
+      "line": 2857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node",
       "surface": "android",
@@ -8707,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2858,
+      "line": 2860,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -8715,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2863,
+      "line": 2865,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent ${agentId}",
       "surface": "android",
@@ -8723,7 +8771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2868,
+      "line": 2870,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${duration}",
       "surface": "android",
@@ -8731,7 +8779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2873,
+      "line": 2875,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Expires ${duration}",
       "surface": "android",
@@ -8739,7 +8787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2883,
+      "line": 2885,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "soon",
       "surface": "android",
@@ -8747,7 +8795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2891,
+      "line": 2893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Main",
       "surface": "android",
@@ -8755,7 +8803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2892,
+      "line": 2894,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Isolated",
       "surface": "android",
@@ -8763,7 +8811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2893,
+      "line": 2895,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Current",
       "surface": "android",
@@ -8771,7 +8819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2899,
+      "line": 2901,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -8779,7 +8827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2915,
+      "line": 2917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "All",
       "surface": "android",
@@ -8787,7 +8835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2916,
+      "line": 2918,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active",
       "surface": "android",
@@ -8795,7 +8843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2917,
+      "line": 2919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Paused",
       "surface": "android",
@@ -8803,7 +8851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2950,
+      "line": 2952,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${remaining}% left ${label}",
       "surface": "android",
@@ -8811,7 +8859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2953,
+      "line": 2955,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -8819,7 +8867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2964,
+      "line": 2966,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Never",
       "surface": "android",
@@ -8827,7 +8875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2969,
+      "line": 2971,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Now",
       "surface": "android",
@@ -8835,7 +8883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2991,
+      "line": 2993,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -8843,7 +8891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2993,
+      "line": 2995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -8851,7 +8899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2995,
+      "line": 2997,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Skipped",
       "surface": "android",
@@ -8859,7 +8907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2996,
+      "line": 2998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -8867,7 +8915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3012,
+      "line": 3014,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -8875,7 +8923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3013,
+      "line": 3015,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -8883,7 +8931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3014,
+      "line": 3016,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -8891,7 +8939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3015,
+      "line": 3017,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Script",
       "surface": "android",
@@ -8899,7 +8947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3016,
+      "line": 3018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
@@ -8907,7 +8955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3046,
+      "line": 3048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps selected. Nothing forwards until you add apps.",
       "surface": "android",
@@ -8915,7 +8963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3048,
+      "line": 3050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app allowed to forward.",
       "surface": "android",
@@ -8923,7 +8971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3050,
+      "line": 3052,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps allowed to forward.",
       "surface": "android",
@@ -8931,7 +8979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3054,
+      "line": 3056,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps blocked. Apps can forward unless you add blocks.",
       "surface": "android",
@@ -8939,7 +8987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3056,
+      "line": 3058,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app blocked from forwarding.",
       "surface": "android",
@@ -8947,7 +8995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3058,
+      "line": 3060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps blocked from forwarding.",
       "surface": "android",
@@ -8955,7 +9003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3084,
+      "line": 3086,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Due",
       "surface": "android",
@@ -8963,7 +9011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3089,
+      "line": 3091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${days}d",
       "surface": "android",
@@ -8971,7 +9019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3090,
+      "line": 3092,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -8979,7 +9027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3091,
+      "line": 3093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -8987,7 +9035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3092,
+      "line": 3094,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Soon",
       "surface": "android",
@@ -8995,7 +9043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3097,
+      "line": 3099,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "None",
       "surface": "android",
@@ -9003,7 +9051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 135,
+      "line": 137,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Home",
       "surface": "android",
@@ -9011,7 +9059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 142,
+      "line": 144,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Dashboard",
       "surface": "android",
@@ -9019,7 +9067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 373,
+      "line": 375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Close Canvas",
       "surface": "android",
@@ -9027,7 +9075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 403,
+      "line": 405,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "The gateway certificate could not be read automatically. Paste the SHA-256 fingerprint obtained on the gateway host.",
       "surface": "android",
@@ -9035,7 +9083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 431,
+      "line": 433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "This gateway now presents a certificate trusted by this device.",
       "surface": "android",
@@ -9043,7 +9091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 441,
+      "line": 443,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "SHA-256 fingerprint",
       "surface": "android",
@@ -9051,7 +9099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 461,
+      "line": 463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Use system trust",
       "surface": "android",
@@ -9059,7 +9107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 566,
+      "line": 568,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -9067,7 +9115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 613,
+      "line": 615,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
@@ -9075,7 +9123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 614,
+      "line": 616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -9083,7 +9131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 668,
+      "line": 670,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -9091,7 +9139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 721,
+      "line": 723,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
@@ -9099,7 +9147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 726,
+      "line": 728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$agentName is working",
       "surface": "android",
@@ -9107,7 +9155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 730,
+      "line": 732,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
@@ -9115,7 +9163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 733,
+      "line": 735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
@@ -9123,7 +9171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 733,
+      "line": 735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
@@ -9131,7 +9179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 733,
+      "line": 735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
@@ -9139,7 +9187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 734,
+      "line": 736,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
@@ -9147,7 +9195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 735,
+      "line": 737,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
@@ -9155,7 +9203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 738,
+      "line": 740,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -9163,7 +9211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 742,
+      "line": 744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
@@ -9171,7 +9219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 893,
+      "line": 895,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
@@ -9179,7 +9227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 973,
+      "line": 975,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -9187,7 +9235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 974,
+      "line": 976,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
@@ -9195,7 +9243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 976,
+      "line": 978,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -9203,7 +9251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 984,
+      "line": 986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Threads",
       "surface": "android",
@@ -9211,7 +9259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 994,
+      "line": 996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -9219,7 +9267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1112,
+      "line": 1114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Online",
       "surface": "android",
@@ -9227,7 +9275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1113,
+      "line": 1115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Healthy",
       "surface": "android",
@@ -9235,7 +9283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1117,
+      "line": 1119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect to continue",
       "surface": "android",
@@ -9243,7 +9291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1118,
+      "line": 1120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review highlighted items",
       "surface": "android",
@@ -9251,7 +9299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1119,
+      "line": 1121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems nominal",
       "surface": "android",
@@ -9259,7 +9307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1132,
+      "line": 1134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Nodes",
       "surface": "android",
@@ -9267,7 +9315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1133,
+      "line": 1135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -9275,7 +9323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1133,
+      "line": 1135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -9283,7 +9331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1136,
+      "line": 1138,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review node access",
       "surface": "android",
@@ -9291,7 +9339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1138,
+      "line": 1140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
       "surface": "android",
@@ -9299,7 +9347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1166,
+      "line": 1168,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Threads",
       "surface": "android",
@@ -9307,7 +9355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1168,
+      "line": 1170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent threads",
       "surface": "android",
@@ -9315,7 +9363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1168,
+      "line": 1170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -9323,7 +9371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1174,
+      "line": 1176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Files",
       "surface": "android",
@@ -9331,7 +9379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1175,
+      "line": 1177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Browse",
       "surface": "android",
@@ -9339,7 +9387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1175,
+      "line": 1177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -9347,7 +9395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1176,
+      "line": 1178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Agent workspace files",
       "surface": "android",
@@ -9355,7 +9403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1234,
+      "line": 1236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · 1 active run",
       "surface": "android",
@@ -9363,7 +9411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1236,
+      "line": 1238,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active runs",
       "surface": "android",
@@ -9371,7 +9419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1240,
+      "line": 1242,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · 1 thread",
       "surface": "android",
@@ -9379,7 +9427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1241,
+      "line": 1243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · $sessionCount threads",
       "surface": "android",
@@ -9387,7 +9435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1242,
+      "line": 1244,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · 1 scheduled job",
       "surface": "android",
@@ -9395,7 +9443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1243,
+      "line": 1245,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · $cronJobCount scheduled jobs",
       "surface": "android",
@@ -9403,15 +9451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1293,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "OpenClaw",
-      "surface": "android",
-      "id": "native.android.4f369a09c8731092"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1325,
+      "line": 1327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Connect before chat, voice, and live status.",
       "surface": "android",
@@ -9419,7 +9459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1349,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No ready providers",
       "surface": "android",
@@ -9427,7 +9467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1349,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Providers",
       "surface": "android",
@@ -9435,7 +9475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1544,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open thread",
       "surface": "android",
@@ -9443,7 +9483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1642,
+      "line": 1645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -9451,7 +9491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1645,
+      "line": 1648,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -9459,7 +9499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1648,
+      "line": 1651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -9467,7 +9507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1661,
+      "line": 1664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway",
       "surface": "android",
@@ -9475,7 +9515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1667,
+      "line": 1670,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Nodes & Devices",
       "surface": "android",
@@ -9483,7 +9523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1668,
+      "line": 1671,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Channels",
       "surface": "android",
@@ -9491,7 +9531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1669,
+      "line": 1672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${agents.size} available",
       "surface": "android",
@@ -9499,7 +9539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1669,
+      "line": 1672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Agents",
       "surface": "android",
@@ -9507,7 +9547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1669,
+      "line": 1672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Load from gateway",
       "surface": "android",
@@ -9515,7 +9555,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 1671,
+      "line": 1674,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "OpenClaw",
+      "surface": "android",
+      "id": "native.android.4f369a09c8731092"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1675,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "Setup, status, and repair",
+      "surface": "android",
+      "id": "native.android.4878165188c0310c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1686,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Providers & Models",
       "surface": "android",
@@ -9523,7 +9579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1673,
+      "line": 1688,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$readyProviderCount ready",
       "surface": "android",
@@ -9531,7 +9587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1674,
+      "line": 1689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Availability unknown",
       "surface": "android",
@@ -9539,7 +9595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1675,
+      "line": 1690,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review readiness",
       "surface": "android",
@@ -9547,7 +9603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1687,
+      "line": 1702,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Approvals",
       "surface": "android",
@@ -9555,7 +9611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1688,
+      "line": 1703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Automations",
       "surface": "android",
@@ -9563,7 +9619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1689,
+      "line": 1704,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Usage",
       "surface": "android",
@@ -9571,7 +9627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1690,
+      "line": 1705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Skills",
       "surface": "android",
@@ -9579,7 +9635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1692,
+      "line": 1707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Skill Workshop",
       "surface": "android",
@@ -9587,7 +9643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1698,
+      "line": 1713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Dreaming",
       "surface": "android",
@@ -9595,7 +9651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1699,
+      "line": 1714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Shell in the agent workspace",
       "surface": "android",
@@ -9603,7 +9659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1699,
+      "line": 1714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Terminal",
       "surface": "android",
@@ -9611,7 +9667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1700,
+      "line": 1715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -9619,7 +9675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1700,
+      "line": 1715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -9627,7 +9683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1700,
+      "line": 1715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -9635,7 +9691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1701,
+      "line": 1716,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Canvas",
       "surface": "android",
@@ -9643,7 +9699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1701,
+      "line": 1716,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Screen surface",
       "surface": "android",
@@ -9651,7 +9707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1702,
+      "line": 1717,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Notifications",
       "surface": "android",
@@ -9659,7 +9715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1702,
+      "line": 1717,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -9667,7 +9723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1703,
+      "line": 1718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -9675,7 +9731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1703,
+      "line": 1718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -9683,7 +9739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1703,
+      "line": 1718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -9691,7 +9747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1705,
+      "line": 1720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Appearance",
       "surface": "android",
@@ -9699,7 +9755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1713,
+      "line": 1728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "About",
       "surface": "android",
@@ -9707,7 +9763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1713,
+      "line": 1728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Version and update",
       "surface": "android",
@@ -9715,7 +9771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1714,
+      "line": 1729,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Health",
       "surface": "android",
@@ -9723,7 +9779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1727,
+      "line": 1742,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Account",
       "surface": "android",
@@ -9731,7 +9787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1731,
+      "line": 1746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Return to setup",
       "surface": "android",
@@ -9739,7 +9795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1731,
+      "line": 1746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sign Out",
       "surface": "android",
@@ -9747,7 +9803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1742,
+      "line": 1757,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Licenses",
       "surface": "android",
@@ -9755,7 +9811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1753,
+      "line": 1768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -9763,7 +9819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1756,
+      "line": 1771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -9771,7 +9827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1756,
+      "line": 1771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -9779,7 +9835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1770,
+      "line": 1785,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No pending approvals",
       "surface": "android",
@@ -9787,7 +9843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1772,
+      "line": 1787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count pending",
       "surface": "android",
@@ -9795,7 +9851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1780,
+      "line": 1795,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No scheduled jobs",
       "surface": "android",
@@ -9803,7 +9859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1781,
+      "line": 1796,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 scheduled",
       "surface": "android",
@@ -9811,7 +9867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1782,
+      "line": 1797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count scheduled",
       "surface": "android",
@@ -9819,7 +9875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1788,
+      "line": 1803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -9827,7 +9883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1789,
+      "line": 1804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -9835,7 +9891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1790,
+      "line": 1805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -9843,7 +9899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1800,
+      "line": 1815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -9851,7 +9907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1802,
+      "line": 1817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -9859,7 +9915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1821,
+      "line": 1836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pending pending",
       "surface": "android",
@@ -9867,7 +9923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1821,
+      "line": 1836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 pending",
       "surface": "android",
@@ -9875,7 +9931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1825,
+      "line": 1840,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No proposals",
       "surface": "android",
@@ -9883,7 +9939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1826,
+      "line": 1841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$held held",
       "surface": "android",
@@ -9891,7 +9947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1826,
+      "line": 1841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 held",
       "surface": "android",
@@ -9899,7 +9955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1827,
+      "line": 1842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$applied applied",
       "surface": "android",
@@ -9907,7 +9963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1827,
+      "line": 1842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 applied",
       "surface": "android",
@@ -9915,7 +9971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1828,
+      "line": 1843,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${summary.proposals.size} proposals",
       "surface": "android",
@@ -9923,7 +9979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1845,
+      "line": 1860,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${summary.pendingDevices.size} pending",
       "surface": "android",
@@ -9931,7 +9987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1846,
+      "line": 1861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Node approval pending",
       "surface": "android",
@@ -9939,7 +9995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1847,
+      "line": 1862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$online/${summary.nodes.size} online",
       "surface": "android",
@@ -9947,7 +10003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1848,
+      "line": 1863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$devices paired",
       "surface": "android",
@@ -9955,7 +10011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1849,
+      "line": 1864,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No devices",
       "surface": "android",
@@ -9963,7 +10019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1875,
+      "line": 1890,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 issue",
       "surface": "android",
@@ -9971,7 +10027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1876,
+      "line": 1891,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$issueCount issues",
       "surface": "android",
@@ -9979,7 +10035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1877,
+      "line": 1892,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$connected/${summary.channels.size} connected",
       "surface": "android",
@@ -9987,7 +10043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1878,
+      "line": 1893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No channels",
       "surface": "android",
@@ -9995,7 +10051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1894,
+      "line": 1909,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -10003,7 +10059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1895,
+      "line": 1910,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${summary.shortTermCount} waiting",
       "surface": "android",
@@ -10011,7 +10067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1896,
+      "line": 1911,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -10019,7 +10075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1940,
+      "line": 1955,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Connection",
       "surface": "android",
@@ -10027,7 +10083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1951,
+      "line": 1967,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Agents & automation",
       "surface": "android",
@@ -10035,7 +10091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1957,
+      "line": 1973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Phone context & privacy",
       "surface": "android",
@@ -10043,7 +10099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1963,
+      "line": 1979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Profile & device",
       "surface": "android",
@@ -10051,7 +10107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1966,
+      "line": 1982,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Diagnostics",
       "surface": "android",
@@ -10059,7 +10115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2012,
+      "line": 2028,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -10067,7 +10123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2016,
+      "line": 2032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -10075,7 +10131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2096,
+      "line": 2112,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -10083,7 +10139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2104,
+      "line": 2120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "now",
       "surface": "android",
@@ -10091,7 +10147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2105,
+      "line": 2121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -10099,7 +10155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2107,
+      "line": 2123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -10107,7 +10163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2109,
+      "line": 2125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${days}d",
       "surface": "android",
@@ -10115,7 +10171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2112,
+      "line": 2128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main thread",
       "surface": "android",
@@ -10123,7 +10179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2119,
+      "line": 2135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Online and ready",
       "surface": "android",
@@ -10131,7 +10187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2122,
+      "line": 2138,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Connecting...",
       "surface": "android",
@@ -10139,7 +10195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2123,
+      "line": 2139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Waiting for pairing",
       "surface": "android",
@@ -10147,7 +10203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2124,
+      "line": 2140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Authentication needed",
       "surface": "android",
@@ -10155,7 +10211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2125,
+      "line": 2141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "TLS timed out",
       "surface": "android",
@@ -10163,7 +10219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2126,
+      "line": 2142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No TLS endpoint",
       "surface": "android",
@@ -10171,7 +10227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2127,
+      "line": 2143,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Certificate review needed",
       "surface": "android",
@@ -10179,7 +10235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2128,
+      "line": 2144,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Not connected",
       "surface": "android",
@@ -11040,6 +11096,166 @@
       "source": "Skill",
       "surface": "android",
       "id": "native.android.14d7845e9790eaab"
+    },
+    {
+      "kind": "ui-call",
+      "line": 82,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Back",
+      "surface": "android",
+      "id": "native.android.9ee4764599e5979c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 86,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "OpenClaw",
+      "surface": "android",
+      "id": "native.android.4b2c29c94377f235"
+    },
+    {
+      "kind": "ui-call",
+      "line": 120,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Gateway Required",
+      "surface": "android",
+      "id": "native.android.7a7da7d8f8613d33"
+    },
+    {
+      "kind": "ui-call",
+      "line": 121,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Full Access Required",
+      "surface": "android",
+      "id": "native.android.aebc338b09b0a24d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 122,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Checking Gateway",
+      "surface": "android",
+      "id": "native.android.69e0b2ce76a5ff7a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 123,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Gateway Update Required",
+      "surface": "android",
+      "id": "native.android.93c293872c6deb49"
+    },
+    {
+      "kind": "ui-call",
+      "line": 128,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Connect this phone to a Gateway before opening OpenClaw.",
+      "surface": "android",
+      "id": "native.android.06e5bfbad4b42e3b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 129,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Reconnect with operator.admin access to review and change Gateway settings.",
+      "surface": "android",
+      "id": "native.android.44cca3625b125c19"
+    },
+    {
+      "kind": "ui-call",
+      "line": 130,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Checking whether this Gateway supports the OpenClaw settings assistant.",
+      "surface": "android",
+      "id": "native.android.6089cc78ebd95573"
+    },
+    {
+      "kind": "ui-call",
+      "line": 131,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Update this Gateway to use the OpenClaw settings assistant.",
+      "surface": "android",
+      "id": "native.android.3c3a35369bc2f1f9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 184,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "OpenClaw is working…",
+      "surface": "android",
+      "id": "native.android.41b7b9cd883e3e81"
+    },
+    {
+      "kind": "ui-call",
+      "line": 196,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Restart",
+      "surface": "android",
+      "id": "native.android.072481856dd25c89"
+    },
+    {
+      "kind": "ui-call",
+      "line": 204,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "OpenClaw is ready to continue in your ordinary chat.",
+      "surface": "android",
+      "id": "native.android.25fcaa5f2ef2546e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 205,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Open Chat",
+      "surface": "android",
+      "id": "native.android.88377fbc76395226"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 252,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "${option.label} · ${nativeString(\"Recommended\")}",
+      "surface": "android",
+      "id": "native.android.1e3b32696a4c4487"
+    },
+    {
+      "kind": "ui-call",
+      "line": 252,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Recommended",
+      "surface": "android",
+      "id": "native.android.3ca44882cf461305"
+    },
+    {
+      "kind": "ui-call",
+      "line": 258,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Skip for now",
+      "surface": "android",
+      "id": "native.android.56968d3bbeb687f9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 290,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Enter secret…",
+      "surface": "android",
+      "id": "native.android.6b255d7620170498"
+    },
+    {
+      "kind": "ui-call",
+      "line": 292,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Reply to OpenClaw…",
+      "surface": "android",
+      "id": "native.android.4753194a1f8c6c6b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 305,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt",
+      "source": "Send",
+      "surface": "android",
+      "id": "native.android.07d2609a561a43b0"
     },
     {
       "kind": "ui-call",

--- a/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
@@ -1,11 +1,16 @@
 package ai.openclaw.app
 
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 internal object AndroidScreenshotFixture {
+  const val gatewayId = "android-screenshot-gateway"
   const val mainSessionKey = "agent:main:node-screenshot"
   const val primarySessionTitle = "Android release planning"
   const val cronJobId = "android-release-digest"
@@ -99,8 +104,61 @@ internal object AndroidScreenshotFixture {
       "cron.list" -> cronList()
       "cron.get" -> cronJob().toString()
       "cron.runs" -> cronRuns()
+      "openclaw.chat" -> systemAgentChat(paramsJson)
       else -> error("Screenshot fixture does not implement gateway method $method with params $paramsJson")
     }
+
+  private fun systemAgentChat(paramsJson: String?): String {
+    val message =
+      paramsJson
+        ?.let { Json.parseToJsonElement(it).jsonObject["message"] }
+        ?.jsonPrimitive
+        ?.contentOrNull
+    return buildJsonObject {
+      put("sessionId", JsonPrimitive("android-screenshot-openclaw"))
+      put(
+        "reply",
+        JsonPrimitive(
+          if (message == null) {
+            "I can check Gateway status, repair configuration, change models, or connect channels."
+          } else {
+            "I’ll keep this conversation separate from ordinary agent chat."
+          },
+        ),
+      )
+      put("action", JsonPrimitive("none"))
+      if (message == null) {
+        put(
+          "question",
+          buildJsonObject {
+            put("id", JsonPrimitive("help"))
+            put("header", JsonPrimitive("OpenClaw"))
+            put("question", JsonPrimitive("What should we look at first?"))
+            put(
+              "options",
+              buildJsonArray {
+                add(
+                  buildJsonObject {
+                    put("label", JsonPrimitive("Check status"))
+                    put("description", JsonPrimitive("Review the Gateway and active services."))
+                    put("recommended", JsonPrimitive(true))
+                    put("reply", JsonPrimitive("Check Gateway status"))
+                  },
+                )
+                add(
+                  buildJsonObject {
+                    put("label", JsonPrimitive("Review setup"))
+                    put("description", JsonPrimitive("Inspect models, channels, and configuration."))
+                    put("reply", JsonPrimitive("Review setup"))
+                  },
+                )
+              },
+            )
+          },
+        )
+      }
+    }.toString()
+  }
 
   private fun cronList(): String =
     buildJsonObject {

--- a/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotMode.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotMode.kt
@@ -15,6 +15,7 @@ enum class AndroidScreenshotScene(
   Chat("chat", HomeDestination.Chat),
   Settings("settings", HomeDestination.Settings),
   Gateway("gateway", HomeDestination.Settings, SettingsRoute.Gateway),
+  OpenClaw("openclaw", HomeDestination.Settings, SettingsRoute.SystemAgent),
   VoiceWake("voice-wake", HomeDestination.Settings, SettingsRoute.Voice),
   ;
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -26,6 +26,7 @@ import ai.openclaw.app.gateway.GatewayUpdateAvailableSummary
 import ai.openclaw.app.node.CameraCaptureManager
 import ai.openclaw.app.node.CanvasController
 import ai.openclaw.app.node.SmsManager
+import ai.openclaw.app.systemagent.SystemAgentChatState
 import ai.openclaw.app.ui.GatewayConnectPlan
 import ai.openclaw.app.ui.GatewaySavedAuthAction
 import ai.openclaw.app.ui.SettingsRoute
@@ -491,6 +492,8 @@ class MainViewModel private constructor(
   val gatewayConnectionDisplay: StateFlow<GatewayConnectionDisplay> =
     runtimeState(initial = GatewayConnectionDisplay(false, "Offline", null)) { it.gatewayConnectionDisplay }
   val operatorAdminScopeAvailable: StateFlow<Boolean> = runtimeState(initial = false) { it.operatorAdminScopeAvailable }
+  internal val systemAgentChatState: StateFlow<SystemAgentChatState> =
+    runtimeState(initial = SystemAgentChatState()) { it.systemAgentChatState }
   val serverName: StateFlow<String?> = runtimeState(initial = null) { it.serverName }
   val remoteAddress: StateFlow<String?> = runtimeState(initial = null) { it.remoteAddress }
   val gatewayVersion: StateFlow<String?> = runtimeState(initial = null) { it.gatewayVersion }
@@ -1715,6 +1718,46 @@ class MainViewModel private constructor(
         throw err
       }
     }
+  }
+
+  internal fun refreshSystemAgentChat() {
+    ensureRuntime().refreshSystemAgentChat()
+  }
+
+  internal fun clearSystemAgentChatInput() {
+    ensureRuntime().clearSystemAgentChatInput()
+  }
+
+  internal fun setSystemAgentChatInput(value: String) {
+    ensureRuntime().setSystemAgentChatInput(value)
+  }
+
+  internal fun sendSystemAgentChatInput() {
+    ensureRuntime().sendSystemAgentChatInput()
+  }
+
+  internal fun answerSystemAgentQuestion(
+    messageId: String,
+    optionLabel: String,
+  ) {
+    ensureRuntime().answerSystemAgentQuestion(messageId, optionLabel)
+  }
+
+  internal fun skipSystemAgentQuestion(messageId: String) {
+    ensureRuntime().skipSystemAgentQuestion(messageId)
+  }
+
+  internal fun restartSystemAgentChat() {
+    ensureRuntime().restartSystemAgentChat()
+  }
+
+  internal fun openSystemAgentChatHandoff() {
+    val handoff = ensureRuntime().consumeSystemAgentChatHandoff() ?: return
+    handoff.agentId
+      ?.trim()
+      ?.takeIf { it.isNotEmpty() }
+      ?.let(::selectChatAgent)
+    handleAssistantLaunch(AssistantLaunchRequest(source = "system-agent", prompt = null, autoSend = false))
   }
 
   fun selectChatAgent(agentId: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -93,6 +93,9 @@ import ai.openclaw.app.node.asStringOrNull
 import ai.openclaw.app.node.invokeErrorFromThrowable
 import ai.openclaw.app.node.parseHexColorArgb
 import ai.openclaw.app.protocol.OpenClawCanvasA2UIAction
+import ai.openclaw.app.systemagent.SystemAgentChatController
+import ai.openclaw.app.systemagent.SystemAgentChatState
+import ai.openclaw.app.systemagent.SystemAgentGatewayAccess
 import ai.openclaw.app.voice.AndroidOnDeviceVoiceWakeRecognizer
 import ai.openclaw.app.voice.GatewayTranscriptionSession
 import ai.openclaw.app.voice.MicCaptureManager
@@ -1169,6 +1172,7 @@ class NodeRuntime private constructor(
   val skillsErrorText: StateFlow<String?> = _skillsErrorText.resolveOptionalNativeText()
   private val _clawHubSkillMethodsAvailable = MutableStateFlow(false)
   val clawHubSkillMethodsAvailable: StateFlow<Boolean> = _clawHubSkillMethodsAvailable.asStateFlow()
+  private val systemAgentChatSupported = MutableStateFlow<Boolean?>(null)
   private val _skillMutationKeys = MutableStateFlow<Set<String>>(emptySet())
   val skillMutationKeys: StateFlow<Set<String>> = _skillMutationKeys.asStateFlow()
   private val _clawHubSkillSearchState = MutableStateFlow(GatewayClawHubSkillSearchState())
@@ -1297,7 +1301,7 @@ class NodeRuntime private constructor(
   private var nodeConnectionProblem: GatewayConnectionProblem? = null
   private val gatewayStatusLock = Any()
 
-  private val operatorSession =
+  private val operatorSession: GatewaySession =
     GatewaySession(
       scope = scope,
       identityStore = identityStore,
@@ -1325,6 +1329,9 @@ class NodeRuntime private constructor(
           operatorConnected = true
           operatorStatusText = "Connected"
         }
+        // Method and scope snapshots are synchronous above; refresh only after both so
+        // this route cannot inherit readiness from the connection it replaced.
+        systemAgentChatController.refresh(startIfNeeded = false)
         micCapture.onGatewayConnectionChanged(true)
         wearProxyBridge()?.publishConnection(connected = true, status = "Connected")
         scope.launch {
@@ -1348,6 +1355,7 @@ class NodeRuntime private constructor(
           operatorStatusText = message
           operatorConnectionProblem = gatewayProblemAfterDisconnect(operatorConnectionProblem, message)
         }
+        systemAgentChatController.refresh(startIfNeeded = false)
         micCapture.onGatewayConnectionChanged(false)
         wearProxyBridge()?.publishConnection(
           connected = false,
@@ -1363,6 +1371,7 @@ class NodeRuntime private constructor(
           operatorStatusText = problem.message
           operatorConnectionProblem = problem
         }
+        systemAgentChatController.refresh(startIfNeeded = false)
         micCapture.onGatewayConnectionChanged(false)
         wearProxyBridge()?.publishConnection(
           connected = false,
@@ -1375,6 +1384,36 @@ class NodeRuntime private constructor(
       },
       customHeadersProvider = prefs::loadGatewayCustomHeaders,
     )
+
+  private val systemAgentChatController by lazy {
+    SystemAgentChatController(
+      scope = scope,
+      access = {
+        SystemAgentGatewayAccess(
+          connected = operatorConnected,
+          hasAdminScope = _operatorScopes.value.any { it == OperatorAdminScope },
+          supportsMethod = systemAgentChatSupported.value,
+          gatewayId =
+            when (mode) {
+              NodeRuntimeMode.Live -> operatorSession.currentEndpointStableId()
+              NodeRuntimeMode.ScreenshotFixture -> AndroidScreenshotFixture.gatewayId
+            },
+        )
+      },
+      captureLease = { gatewayId ->
+        when (mode) {
+          NodeRuntimeMode.Live -> operatorSession.captureRequestLease(gatewayId)
+          NodeRuntimeMode.ScreenshotFixture ->
+            GatewaySession.RequestLease(endpointStableId = AndroidScreenshotFixture.gatewayId) { method, paramsJson, _ ->
+              AndroidScreenshotFixture.request(method, paramsJson)
+            }
+        }
+      },
+      json = json,
+    )
+  }
+  internal val systemAgentChatState: StateFlow<SystemAgentChatState>
+    get() = systemAgentChatController.state
 
   private data class SecondaryOperatorRuntime(
     val endpoint: GatewayEndpoint,
@@ -2801,6 +2840,7 @@ class NodeRuntime private constructor(
       )
     _cronJobs.value = parseScreenshotCronJobs()
     _operatorScopes.value = listOf(OperatorAdminScope)
+    systemAgentChatSupported.value = true
     _nodesDevicesSummary.value = AndroidScreenshotFixture.nodes
     _channelsSummary.value = AndroidScreenshotFixture.channels
     _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Approved
@@ -2814,6 +2854,7 @@ class NodeRuntime private constructor(
       operatorConnectionProblem = null
       nodeConnectionProblem = null
     }
+    systemAgentChatController.refresh(startIfNeeded = false)
     chat.refreshSessions(limit = 20)
   }
 
@@ -4968,6 +5009,39 @@ class NodeRuntime private constructor(
     stopMessageSpeech()
     chat.switchSession(sessionKey, ownerAgentId)
   }
+
+  internal fun refreshSystemAgentChat() {
+    systemAgentChatController.refresh()
+  }
+
+  internal fun clearSystemAgentChatInput() {
+    systemAgentChatController.clearInputForBackground()
+  }
+
+  internal fun sendSystemAgentChatInput() {
+    systemAgentChatController.sendInput()
+  }
+
+  internal fun setSystemAgentChatInput(value: String) {
+    systemAgentChatController.setInput(value)
+  }
+
+  internal fun answerSystemAgentQuestion(
+    messageId: String,
+    optionLabel: String,
+  ) {
+    systemAgentChatController.answerQuestion(messageId, optionLabel)
+  }
+
+  internal fun skipSystemAgentQuestion(messageId: String) {
+    systemAgentChatController.skipQuestion(messageId)
+  }
+
+  internal fun restartSystemAgentChat() {
+    systemAgentChatController.restart()
+  }
+
+  internal fun consumeSystemAgentChatHandoff() = systemAgentChatController.openHandoff()
 
   fun selectChatAgent(agentId: String) {
     val normalizedAgentId = agentId.trim()
@@ -7282,6 +7356,7 @@ class NodeRuntime private constructor(
     synchronized(gatewayMethodsLock) {
       gatewayApprovalRpcFamily = selectGatewayApprovalRpcFamily(methods)
       _clawHubSkillMethodsAvailable.value = supportsClawHubSkillManagement(methods)
+      systemAgentChatSupported.value = GatewayMethod.OpenclawChat.rawValue in methods
       gatewayMethodsEpoch += 1
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/systemagent/SystemAgentChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/systemagent/SystemAgentChatController.kt
@@ -1,0 +1,453 @@
+package ai.openclaw.app.systemagent
+
+import ai.openclaw.app.gateway.GatewayMethod
+import ai.openclaw.app.gateway.GatewayRequestNotEnqueued
+import ai.openclaw.app.gateway.GatewayRequestRejected
+import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.i18n.nativeString
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+
+internal data class SystemAgentGatewayAccess(
+  val connected: Boolean,
+  val hasAdminScope: Boolean,
+  val supportsMethod: Boolean?,
+  val gatewayId: String?,
+)
+
+enum class SystemAgentChatAccess {
+  Disconnected,
+  MissingAdminScope,
+  CheckingGateway,
+  GatewayUpdateRequired,
+  Ready,
+}
+
+data class SystemAgentChatQuestionOption(
+  val label: String,
+  val description: String?,
+  val reply: String?,
+  val recommended: Boolean,
+)
+
+data class SystemAgentChatQuestion(
+  val header: String,
+  val question: String,
+  val options: List<SystemAgentChatQuestionOption>,
+)
+
+data class SystemAgentChatMessage(
+  val id: String = UUID.randomUUID().toString(),
+  val role: Role,
+  val text: String,
+  val question: SystemAgentChatQuestion? = null,
+) {
+  enum class Role {
+    Assistant,
+    User,
+  }
+}
+
+data class SystemAgentChatHandoff(
+  val agentId: String?,
+)
+
+data class SystemAgentChatState(
+  val access: SystemAgentChatAccess = SystemAgentChatAccess.Disconnected,
+  val sessionId: String = newSystemAgentSessionId(),
+  val messages: List<SystemAgentChatMessage> = emptyList(),
+  val input: String = "",
+  val sending: Boolean = false,
+  val expectsSensitiveReply: Boolean = false,
+  val errorText: String? = null,
+  val dismissedQuestionIds: Set<String> = emptySet(),
+  val retiredQuestionIds: Set<String> = emptySet(),
+  val handoff: SystemAgentChatHandoff? = null,
+)
+
+private fun newSystemAgentSessionId(): String = "android-settings-openclaw-${UUID.randomUUID()}"
+
+/**
+ * Keeps the settings-only OpenClaw conversation outside ordinary chat/session state.
+ * Every request captures a physical Gateway lease, so it cannot retarget a replacement connection.
+ */
+internal class SystemAgentChatController(
+  private val scope: CoroutineScope,
+  private val access: () -> SystemAgentGatewayAccess,
+  private val captureLease: (gatewayId: String?) -> GatewaySession.RequestLease?,
+  private val json: Json,
+) {
+  private val generation = AtomicLong(0)
+  private var activeGatewayId: String? = null
+  private var requestJob: Job? = null
+  private val _state = MutableStateFlow(SystemAgentChatState())
+  val state: StateFlow<SystemAgentChatState> = _state.asStateFlow()
+
+  fun refresh(startIfNeeded: Boolean = true) {
+    val next = access()
+    val nextAccess = next.toChatAccess()
+    val current = state.value
+    val gatewayChanged = activeGatewayId != next.gatewayId
+    if (gatewayChanged) {
+      invalidateRequest()
+      activeGatewayId = next.gatewayId
+      _state.value = SystemAgentChatState(access = nextAccess)
+    } else if (nextAccess == SystemAgentChatAccess.Ready) {
+      _state.update { it.copy(access = nextAccess) }
+    } else {
+      val conversationStarted = current.messages.isNotEmpty() || current.sending || current.errorText != null
+      if (current.sending) invalidateRequest()
+      _state.update {
+        it.copy(
+          access = nextAccess,
+          input = "",
+          sending = false,
+          expectsSensitiveReply =
+            if (nextAccess == SystemAgentChatAccess.CheckingGateway) {
+              it.expectsSensitiveReply
+            } else {
+              false
+            },
+          errorText =
+            when {
+              nextAccess == SystemAgentChatAccess.CheckingGateway -> it.errorText
+              conversationStarted -> routeChangedMessage()
+              else -> null
+            },
+          handoff = if (nextAccess == SystemAgentChatAccess.CheckingGateway) it.handoff else null,
+        )
+      }
+    }
+
+    val refreshed = state.value
+    if (
+      refreshed.access == SystemAgentChatAccess.Ready &&
+      refreshed.messages.isEmpty() &&
+      !refreshed.sending &&
+      startIfNeeded &&
+      refreshed.errorText == null &&
+      refreshed.handoff == null
+    ) {
+      request(message = null)
+    }
+  }
+
+  fun restart() {
+    val next = access()
+    if (next.toChatAccess() != SystemAgentChatAccess.Ready) {
+      refresh()
+      return
+    }
+    invalidateRequest()
+    activeGatewayId = next.gatewayId
+    _state.value = SystemAgentChatState(access = SystemAgentChatAccess.Ready)
+    request(message = null)
+  }
+
+  fun setInput(value: String) {
+    _state.update { current ->
+      if (current.access == SystemAgentChatAccess.Ready && current.handoff == null) {
+        current.copy(input = value)
+      } else {
+        current
+      }
+    }
+  }
+
+  fun clearInputForBackground() {
+    _state.update { it.copy(input = "") }
+  }
+
+  fun sendInput() {
+    val current = state.value
+    if (current.input.trim().isEmpty()) return
+    request(message = if (current.expectsSensitiveReply) current.input else current.input.trim())
+  }
+
+  fun answerQuestion(
+    messageId: String,
+    optionLabel: String,
+  ) {
+    val current = state.value
+    val message = current.messages.firstOrNull { it.id == messageId } ?: return
+    if (!current.canAnswer(message)) return
+    val option = message.question?.options?.firstOrNull { it.label == optionLabel } ?: return
+    request(message = option.reply ?: option.label, displayText = option.label)
+  }
+
+  fun skipQuestion(messageId: String) {
+    val current = state.value
+    val message = current.messages.firstOrNull { it.id == messageId } ?: return
+    if (!current.canAnswer(message)) return
+    request(
+      message = "Skip for now",
+      displayText = nativeString("Skip for now"),
+      dismissedQuestionId = messageId,
+    )
+  }
+
+  fun openHandoff(): SystemAgentChatHandoff? {
+    val handoff = state.value.handoff ?: return null
+    _state.update { it.copy(handoff = null) }
+    return handoff
+  }
+
+  private fun request(
+    message: String?,
+    displayText: String? = null,
+    dismissedQuestionId: String? = null,
+  ) {
+    val current = state.value
+    if (
+      current.access != SystemAgentChatAccess.Ready ||
+      current.sending ||
+      current.errorText != null ||
+      current.handoff != null
+    ) {
+      return
+    }
+    val gateway = access()
+    if (gateway.toChatAccess() != SystemAgentChatAccess.Ready || gateway.gatewayId != activeGatewayId) {
+      refresh()
+      return
+    }
+    val requestGeneration = generation.incrementAndGet()
+    val lease = captureLease(gateway.gatewayId)
+    if (lease == null) {
+      markRouteChanged(requestGeneration)
+      return
+    }
+
+    val retired =
+      if (message == null) {
+        current.retiredQuestionIds
+      } else {
+        current.retiredQuestionIds + current.messages.filter { it.question != null }.map { it.id }
+      }
+    val localMessage =
+      message?.let {
+        SystemAgentChatMessage(
+          role = SystemAgentChatMessage.Role.User,
+          text = displayText ?: if (current.expectsSensitiveReply) nativeString("<redacted secret>") else it,
+        )
+      }
+    val admitted =
+      lease.commitIfCurrent {
+        if (!isCurrent(requestGeneration)) return@commitIfCurrent
+        _state.update {
+          it.copy(
+            messages = if (localMessage == null) it.messages else it.messages + localMessage,
+            input = "",
+            sending = true,
+            dismissedQuestionIds = it.dismissedQuestionIds + listOfNotNull(dismissedQuestionId),
+            retiredQuestionIds = retired,
+          )
+        }
+      }
+    if (!admitted) {
+      markRouteChanged(requestGeneration)
+      return
+    }
+    if (!isCurrent(requestGeneration)) return
+
+    requestJob =
+      scope.launch {
+        try {
+          if (!isCurrent(requestGeneration) || !lease.isCurrent()) return@launch
+          val payload =
+            buildJsonObject {
+              put("sessionId", JsonPrimitive(current.sessionId))
+              message?.let { put("message", JsonPrimitive(it)) }
+            }
+          val response = lease.request(GatewayMethod.OpenclawChat.rawValue, payload.toString(), 190_000)
+          if (!isCurrent(requestGeneration)) return@launch
+          if (!lease.isCurrent()) {
+            markRouteChanged(requestGeneration)
+            return@launch
+          }
+          val result = parseResult(json.parseToJsonElement(response).jsonObject)
+          if (!isCurrent(requestGeneration)) return@launch
+          if (!lease.isCurrent()) {
+            markRouteChanged(requestGeneration)
+            return@launch
+          }
+          val committed =
+            lease.commitIfCurrent {
+              if (!isCurrent(requestGeneration)) return@commitIfCurrent
+              _state.update {
+                it.copy(
+                  messages =
+                    it.messages +
+                      SystemAgentChatMessage(
+                        role = SystemAgentChatMessage.Role.Assistant,
+                        text = result.reply,
+                        question = parseQuestion(result.question),
+                      ),
+                  sending = false,
+                  expectsSensitiveReply = result.sensitive == true,
+                  errorText = null,
+                  handoff = if (result.action == "open-agent") SystemAgentChatHandoff(result.agentId) else null,
+                )
+              }
+            }
+          if (!committed) markRouteChanged(requestGeneration)
+        } catch (err: CancellationException) {
+          throw err
+        } catch (_: GatewayRequestNotEnqueued) {
+          markRouteChanged(requestGeneration)
+        } catch (err: GatewayRequestRejected) {
+          if (!isCurrent(requestGeneration)) return@launch
+          val message =
+            err.gatewayError.message
+              .trim()
+              .ifEmpty { nativeString("OpenClaw request failed.") }
+          commitRequestError(requestGeneration, lease, message)
+        } catch (_: Throwable) {
+          if (!isCurrent(requestGeneration)) return@launch
+          commitRequestError(requestGeneration, lease, nativeString("OpenClaw request failed."))
+        }
+      }
+  }
+
+  private fun commitRequestError(
+    requestGeneration: Long,
+    lease: GatewaySession.RequestLease,
+    message: String,
+  ) {
+    val committed =
+      lease.commitIfCurrent {
+        if (!isCurrent(requestGeneration)) return@commitIfCurrent
+        _state.update { it.copy(sending = false, errorText = message) }
+      }
+    if (!committed) markRouteChanged(requestGeneration)
+  }
+
+  private fun invalidateRequest() {
+    generation.incrementAndGet()
+    requestJob?.cancel()
+    requestJob = null
+  }
+
+  private fun isCurrent(requestGeneration: Long): Boolean = generation.get() == requestGeneration
+
+  private fun markRouteChanged(requestGeneration: Long? = null) {
+    if (requestGeneration == null) {
+      invalidateRequest()
+    } else if (!generation.compareAndSet(requestGeneration, requestGeneration + 1)) {
+      return
+    }
+    _state.update {
+      it.copy(
+        input = "",
+        sending = false,
+        expectsSensitiveReply = false,
+        errorText = routeChangedMessage(),
+        handoff = null,
+      )
+    }
+  }
+
+  private data class Result(
+    val reply: String,
+    val action: String,
+    val sensitive: Boolean?,
+    val agentId: String?,
+    val question: JsonElement?,
+  )
+
+  private fun parseResult(root: JsonObject): Result =
+    Result(
+      reply = root["reply"]?.jsonPrimitive?.contentOrNull ?: "",
+      action = root["action"]?.jsonPrimitive?.contentOrNull ?: "none",
+      sensitive = root["sensitive"]?.jsonPrimitive?.booleanOrNull,
+      agentId = root["agentId"]?.jsonPrimitive?.contentOrNull,
+      question = root["question"],
+    )
+
+  private fun parseQuestion(value: JsonElement?): SystemAgentChatQuestion? {
+    val root = value as? JsonObject ?: return null
+    val header =
+      root["header"]
+        ?.jsonPrimitive
+        ?.contentOrNull
+        ?.trim()
+        .orEmpty()
+    val question =
+      root["question"]
+        ?.jsonPrimitive
+        ?.contentOrNull
+        ?.trim()
+        .orEmpty()
+    val options = root["options"] as? JsonArray ?: return null
+    if (header.isEmpty() || question.isEmpty() || options.size !in 2..4) return null
+    val parsed =
+      options.mapNotNull { element ->
+        val option = element as? JsonObject ?: return null
+        val label =
+          option["label"]
+            ?.jsonPrimitive
+            ?.contentOrNull
+            ?.trim()
+            .orEmpty()
+        if (label.isEmpty()) return null
+        SystemAgentChatQuestionOption(
+          label = label,
+          description =
+            option["description"]
+              ?.jsonPrimitive
+              ?.contentOrNull
+              ?.trim()
+              ?.ifEmpty { null },
+          reply =
+            option["reply"]
+              ?.jsonPrimitive
+              ?.contentOrNull
+              ?.trim()
+              ?.ifEmpty { null },
+          recommended = option["recommended"]?.jsonPrimitive?.booleanOrNull == true,
+        )
+      }
+    if (parsed.size != options.size || parsed.map { it.label.lowercase() }.toSet().size != parsed.size) return null
+    if (parsed.count { it.recommended } > 1) return null
+    return SystemAgentChatQuestion(header = header, question = question, options = parsed)
+  }
+}
+
+private fun SystemAgentChatState.canAnswer(message: SystemAgentChatMessage): Boolean =
+  access == SystemAgentChatAccess.Ready &&
+    !sending &&
+    errorText == null &&
+    handoff == null &&
+    message.question != null &&
+    message.id !in dismissedQuestionIds &&
+    message.id !in retiredQuestionIds
+
+private fun SystemAgentGatewayAccess.toChatAccess(): SystemAgentChatAccess =
+  when {
+    !connected -> SystemAgentChatAccess.Disconnected
+    !hasAdminScope -> SystemAgentChatAccess.MissingAdminScope
+    supportsMethod == null -> SystemAgentChatAccess.CheckingGateway
+    !supportsMethod -> SystemAgentChatAccess.GatewayUpdateRequired
+    else -> SystemAgentChatAccess.Ready
+  }
+
+private fun routeChangedMessage(): String = nativeString("The Gateway connection changed. Restart OpenClaw to reconnect.")

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -185,6 +185,7 @@ internal enum class SettingsRoute {
   Usage,
   Skills,
   SkillWorkshop,
+  SystemAgent,
   NodesDevices,
   Channels,
   Dreaming,
@@ -219,6 +220,7 @@ internal fun SettingsDetailScreen(
     SettingsRoute.Usage -> UsageSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Skills -> SkillsSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.SkillWorkshop -> SkillWorkshopSettingsScreen(viewModel = viewModel, onBack = onBack)
+    SettingsRoute.SystemAgent -> SystemAgentSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.NodesDevices -> NodesDevicesSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Channels -> ChannelsSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Dreaming -> DreamingSettingsScreen(viewModel = viewModel, onBack = onBack)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -25,6 +25,7 @@ import ai.openclaw.app.i18n.nativeText
 import ai.openclaw.app.i18n.resolveNativeTextResource
 import ai.openclaw.app.i18n.verbatimText
 import ai.openclaw.app.node.CanvasController
+import ai.openclaw.app.systemagent.SystemAgentChatAccess
 import ai.openclaw.app.ui.design.AgentAvatarSource
 import ai.openclaw.app.ui.design.ClawAgentAvatar
 import ai.openclaw.app.ui.design.ClawBottomNav
@@ -74,6 +75,7 @@ import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.ScreenShare
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Favorite
@@ -1580,6 +1582,7 @@ private fun SettingsShellScreen(
   val displayName by viewModel.displayName.collectAsState()
   val gatewayConnectionDisplay by viewModel.gatewayConnectionDisplay.collectAsState()
   val isConnected = gatewayConnectionDisplay.isConnected
+  val systemAgentChatState by viewModel.systemAgentChatState.collectAsState()
   val models by viewModel.providerModelCatalog.collectAsState()
   val providers by viewModel.modelAuthProviders.collectAsState()
   val cameraEnabled by viewModel.cameraEnabled.collectAsState()
@@ -1667,6 +1670,18 @@ private fun SettingsShellScreen(
           SettingsRow(nativeText("Nodes & Devices"), verbatimText(nodesDevicesSummaryText(nodesDevicesSummary)), Icons.Default.Cloud, status = nodesDevicesStatus(nodesDevicesSummary), route = SettingsRoute.NodesDevices),
           SettingsRow(nativeText("Channels"), verbatimText(channelsSummaryText(channelsSummary)), Icons.Default.Notifications, status = channelsStatus(channelsSummary), route = SettingsRoute.Channels),
           SettingsRow(nativeText("Agents"), if (agents.isEmpty()) nativeText("Load from gateway") else nativeText("\${agents.size} available", agents.size), Icons.Default.Person, status = agents.isNotEmpty(), route = SettingsRoute.Agents),
+          SettingsRow(
+            nativeText("OpenClaw"),
+            nativeText("Setup, status, and repair"),
+            Icons.Default.Bolt,
+            status =
+              when (systemAgentChatState.access) {
+                SystemAgentChatAccess.Ready -> true
+                SystemAgentChatAccess.CheckingGateway -> null
+                else -> false
+              },
+            route = SettingsRoute.SystemAgent,
+          ),
           SettingsRow(
             nativeText("Providers & Models"),
             when {
@@ -1940,6 +1955,7 @@ internal fun settingsSectionTitleForRoute(route: SettingsRoute): NativeText =
     -> nativeText("Connection")
 
     SettingsRoute.Agents,
+    SettingsRoute.SystemAgent,
     SettingsRoute.ProvidersModels,
     SettingsRoute.Approvals,
     SettingsRoute.CronJobs,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt
@@ -1,0 +1,310 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.i18n.nativeString
+import ai.openclaw.app.systemagent.SystemAgentChatAccess
+import ai.openclaw.app.systemagent.SystemAgentChatMessage
+import ai.openclaw.app.systemagent.SystemAgentChatQuestionOption
+import ai.openclaw.app.systemagent.SystemAgentChatState
+import ai.openclaw.app.ui.design.ClawPanel
+import ai.openclaw.app.ui.design.ClawPlainIconButton
+import ai.openclaw.app.ui.design.ClawPrimaryButton
+import ai.openclaw.app.ui.design.ClawScaffold
+import ai.openclaw.app.ui.design.ClawSecondaryButton
+import ai.openclaw.app.ui.design.ClawTheme
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+internal fun SystemAgentSettingsScreen(
+  viewModel: MainViewModel,
+  onBack: () -> Unit,
+) {
+  val state by viewModel.systemAgentChatState.collectAsState()
+  val lifecycleOwner = LocalLifecycleOwner.current
+  LaunchedEffect(state.access, state.sessionId) { viewModel.refreshSystemAgentChat() }
+  DisposableEffect(lifecycleOwner) {
+    val observer =
+      LifecycleEventObserver { _, event ->
+        if (event == Lifecycle.Event.ON_STOP) viewModel.clearSystemAgentChatInput()
+      }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose {
+      lifecycleOwner.lifecycle.removeObserver(observer)
+      viewModel.clearSystemAgentChatInput()
+    }
+  }
+
+  ClawScaffold {
+    Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        ClawPlainIconButton(
+          icon = Icons.AutoMirrored.Filled.ArrowBack,
+          contentDescription = nativeString("Back"),
+          onClick = onBack,
+        )
+        Text(
+          text = nativeString("OpenClaw"),
+          style = ClawTheme.type.display,
+          color = ClawTheme.colors.text,
+          modifier = Modifier.weight(1f),
+        )
+        Icon(
+          imageVector = Icons.Default.Bolt,
+          contentDescription = null,
+          tint = ClawTheme.colors.primary,
+          modifier = Modifier.size(24.dp),
+        )
+      }
+
+      when (state.access) {
+        SystemAgentChatAccess.Ready ->
+          SystemAgentConversation(
+            state = state,
+            onInputChange = viewModel::setSystemAgentChatInput,
+            onSend = viewModel::sendSystemAgentChatInput,
+            onAnswer = viewModel::answerSystemAgentQuestion,
+            onSkip = viewModel::skipSystemAgentQuestion,
+            onRestart = viewModel::restartSystemAgentChat,
+            onOpenChat = viewModel::openSystemAgentChatHandoff,
+          )
+        else -> SystemAgentAccessGate(state = state)
+      }
+    }
+  }
+}
+
+@Composable
+private fun SystemAgentAccessGate(state: SystemAgentChatState) {
+  val title =
+    when (state.access) {
+      SystemAgentChatAccess.Disconnected -> nativeString("Gateway Required")
+      SystemAgentChatAccess.MissingAdminScope -> nativeString("Full Access Required")
+      SystemAgentChatAccess.CheckingGateway -> nativeString("Checking Gateway")
+      SystemAgentChatAccess.GatewayUpdateRequired -> nativeString("Gateway Update Required")
+      SystemAgentChatAccess.Ready -> ""
+    }
+  val detail =
+    when (state.access) {
+      SystemAgentChatAccess.Disconnected -> nativeString("Connect this phone to a Gateway before opening OpenClaw.")
+      SystemAgentChatAccess.MissingAdminScope -> nativeString("Reconnect with operator.admin access to review and change Gateway settings.")
+      SystemAgentChatAccess.CheckingGateway -> nativeString("Checking whether this Gateway supports the OpenClaw settings assistant.")
+      SystemAgentChatAccess.GatewayUpdateRequired -> nativeString("Update this Gateway to use the OpenClaw settings assistant.")
+      SystemAgentChatAccess.Ready -> ""
+    }
+  ClawPanel(modifier = Modifier.fillMaxWidth()) {
+    Column(
+      modifier = Modifier.fillMaxWidth().padding(24.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Icon(
+        imageVector = if (state.access == SystemAgentChatAccess.Disconnected) Icons.Default.Lock else Icons.Default.Bolt,
+        contentDescription = null,
+        tint = ClawTheme.colors.warning,
+        modifier = Modifier.size(42.dp),
+      )
+      Text(text = title, style = ClawTheme.type.title, color = ClawTheme.colors.text)
+      Text(
+        text = detail,
+        style = ClawTheme.type.body,
+        color = ClawTheme.colors.textMuted,
+        textAlign = TextAlign.Center,
+      )
+    }
+  }
+}
+
+@Composable
+private fun SystemAgentConversation(
+  state: SystemAgentChatState,
+  onInputChange: (String) -> Unit,
+  onSend: () -> Unit,
+  onAnswer: (String, String) -> Unit,
+  onSkip: (String) -> Unit,
+  onRestart: () -> Unit,
+  onOpenChat: () -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+    LazyColumn(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      items(state.messages, key = { it.id }) { message ->
+        SystemAgentMessage(message = message)
+        message.question?.takeIf { message.id !in state.dismissedQuestionIds && message.id !in state.retiredQuestionIds }?.let { question ->
+          SystemAgentQuestionCard(
+            question = question,
+            enabled = !state.sending && state.errorText == null,
+            onAnswer = { option -> onAnswer(message.id, option.label) },
+            onSkip = { onSkip(message.id) },
+          )
+        }
+      }
+      if (state.sending) {
+        item { Text(nativeString("OpenClaw is working…"), style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted) }
+      }
+    }
+
+    state.errorText?.let { error ->
+      ClawPanel(modifier = Modifier.fillMaxWidth()) {
+        Row(
+          modifier = Modifier.fillMaxWidth().padding(12.dp),
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+          Text(error, style = ClawTheme.type.caption, color = ClawTheme.colors.warning, modifier = Modifier.weight(1f))
+          ClawSecondaryButton(text = nativeString("Restart"), onClick = onRestart, icon = Icons.Default.Refresh)
+        }
+      }
+    }
+
+    state.handoff?.let {
+      ClawPanel(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          Text(nativeString("OpenClaw is ready to continue in your ordinary chat."), style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+          ClawPrimaryButton(text = nativeString("Open Chat"), onClick = onOpenChat)
+        }
+      }
+    }
+
+    if (state.handoff == null) {
+      SystemAgentComposer(
+        state = state,
+        onInputChange = onInputChange,
+        onSend = onSend,
+      )
+    }
+  }
+}
+
+@Composable
+private fun SystemAgentMessage(message: SystemAgentChatMessage) {
+  val user = message.role == SystemAgentChatMessage.Role.User
+  Row(modifier = Modifier.fillMaxWidth()) {
+    if (user) Spacer(modifier = Modifier.weight(1f))
+    Text(
+      text = message.text,
+      style = ClawTheme.type.body,
+      color = ClawTheme.colors.text,
+      modifier =
+        Modifier
+          .weight(if (user) 0.8f else 0.9f, fill = false)
+          .background(if (user) ClawTheme.colors.primary.copy(alpha = 0.14f) else ClawTheme.colors.surfaceRaised, RoundedCornerShape(14.dp))
+          .padding(horizontal = 12.dp, vertical = 9.dp),
+    )
+    if (!user) Spacer(modifier = Modifier.weight(1f))
+  }
+}
+
+@Composable
+private fun SystemAgentQuestionCard(
+  question: ai.openclaw.app.systemagent.SystemAgentChatQuestion,
+  enabled: Boolean,
+  onAnswer: (SystemAgentChatQuestionOption) -> Unit,
+  onSkip: () -> Unit,
+) {
+  ClawPanel(modifier = Modifier.fillMaxWidth()) {
+    Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(9.dp)) {
+      Text(question.header.uppercase(), style = ClawTheme.type.caption, color = ClawTheme.colors.primary)
+      Text(question.question, style = ClawTheme.type.body, color = ClawTheme.colors.text)
+      question.options.forEach { option ->
+        ClawSecondaryButton(
+          text = if (option.recommended) "${option.label} · ${nativeString("Recommended")}" else option.label,
+          onClick = { onAnswer(option) },
+          enabled = enabled,
+        )
+        option.description?.let { Text(it, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted) }
+      }
+      ClawSecondaryButton(text = nativeString("Skip for now"), onClick = onSkip, enabled = enabled)
+    }
+  }
+}
+
+@Composable
+private fun SystemAgentComposer(
+  state: SystemAgentChatState,
+  onInputChange: (String) -> Unit,
+  onSend: () -> Unit,
+) {
+  Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    BasicTextField(
+      value = state.input,
+      onValueChange = onInputChange,
+      modifier =
+        Modifier
+          .fillMaxWidth()
+          .border(1.dp, ClawTheme.colors.border, RoundedCornerShape(ClawTheme.radii.control))
+          .background(ClawTheme.colors.surfaceRaised, RoundedCornerShape(ClawTheme.radii.control))
+          .padding(12.dp),
+      textStyle = ClawTheme.type.body.copy(color = ClawTheme.colors.text),
+      keyboardOptions = KeyboardOptions(keyboardType = if (state.expectsSensitiveReply) KeyboardType.Password else KeyboardType.Text),
+      visualTransformation = if (state.expectsSensitiveReply) PasswordVisualTransformation() else VisualTransformation.None,
+      minLines = 1,
+      maxLines = 5,
+      enabled = !state.sending && state.errorText == null,
+      decorationBox = { inner ->
+        Box {
+          if (state.input.isEmpty()) {
+            val placeholder =
+              if (state.expectsSensitiveReply) {
+                nativeString("Enter secret…")
+              } else {
+                nativeString("Reply to OpenClaw…")
+              }
+            Text(
+              placeholder,
+              style = ClawTheme.type.body,
+              color = ClawTheme.colors.textSubtle,
+            )
+          }
+          inner()
+        }
+      },
+    )
+    ClawPrimaryButton(
+      text = nativeString("Send"),
+      onClick = onSend,
+      enabled = state.input.isNotBlank() && !state.sending && state.errorText == null,
+    )
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureTest.kt
@@ -112,6 +112,40 @@ class AndroidScreenshotFixtureTest {
   }
 
   @Test
+  fun providesDeterministicSystemAgentConversation() {
+    val greeting =
+      json
+        .parseToJsonElement(
+          AndroidScreenshotFixture.request(
+            "openclaw.chat",
+            """{"sessionId":"android-settings-openclaw-test"}""",
+          ),
+        ).jsonObject
+    val response =
+      json
+        .parseToJsonElement(
+          AndroidScreenshotFixture.request(
+            "openclaw.chat",
+            """{"sessionId":"android-settings-openclaw-test","message":"Check status"}""",
+          ),
+        ).jsonObject
+
+    assertEquals("android-screenshot-openclaw", greeting["sessionId"]?.jsonPrimitive?.content)
+    assertEquals(
+      "What should we look at first?",
+      greeting["question"]
+        ?.jsonObject
+        ?.get("question")
+        ?.jsonPrimitive
+        ?.content,
+    )
+    assertEquals(
+      "I’ll keep this conversation separate from ordinary agent chat.",
+      response["reply"]?.jsonPrimitive?.content,
+    )
+  }
+
+  @Test
   fun rejectsUnexpectedGatewayCalls() {
     val error =
       assertThrows(IllegalStateException::class.java) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotModeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotModeTest.kt
@@ -65,6 +65,15 @@ class AndroidScreenshotModeTest {
   }
 
   @Test
+  fun openClawSceneTargetsSystemAgentSettings() {
+    val scene = AndroidScreenshotScene.fromRawValue("openclaw")
+
+    assertEquals(AndroidScreenshotScene.OpenClaw, scene)
+    assertEquals(HomeDestination.Settings, scene.homeDestination)
+    assertEquals(SettingsRoute.SystemAgent, scene.settingsRoute)
+  }
+
+  @Test
   fun voiceWakeSceneTargetsVoiceSettings() {
     val scene = AndroidScreenshotScene.fromRawValue("voice-wake")
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/systemagent/SystemAgentChatControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/systemagent/SystemAgentChatControllerTest.kt
@@ -1,0 +1,501 @@
+package ai.openclaw.app.systemagent
+
+import ai.openclaw.app.gateway.GatewayRequestRejected
+import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SystemAgentChatControllerTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun chatIsGatedAndGreetingUsesOnlySettingsSessionParams() =
+    runTest {
+      val harness = Harness(this)
+      harness.responses += reply("Ready")
+
+      harness.controller.refresh()
+      harness.access = harness.access.copy(connected = true, gatewayId = "gateway-a")
+      harness.controller.refresh()
+      harness.access = harness.access.copy(hasAdminScope = true)
+      harness.controller.refresh()
+      assertTrue(harness.requests.isEmpty())
+
+      harness.access = harness.access.copy(supportsMethod = true)
+      harness.controller.refresh()
+      advanceUntilIdle()
+
+      val request = harness.requests.single()
+      assertEquals("openclaw.chat", request.method)
+      assertEquals(190_000, request.timeoutMs)
+      val params = json.parseToJsonElement(request.paramsJson).jsonObject
+      assertTrue(
+        params
+          .getValue("sessionId")
+          .jsonPrimitive.content
+          .startsWith("android-settings-openclaw-"),
+      )
+      assertFalse("message" in params)
+      assertFalse("welcomeVariant" in params)
+      assertFalse("delegation" in params)
+    }
+
+  @Test
+  fun gatewayAccessRefreshDoesNotStartConversationUntilScreenRequestsIt() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.responses += reply("Ready")
+
+      harness.controller.refresh(startIfNeeded = false)
+      advanceUntilIdle()
+      assertEquals(SystemAgentChatAccess.Ready, harness.controller.state.value.access)
+      assertTrue(harness.requests.isEmpty())
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+      assertEquals(1, harness.requests.size)
+    }
+
+  @Test
+  fun sensitiveReplyIsSentVerbatimAndRedactedLocally() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.responses += reply("Enter the token", sensitive = true)
+      harness.responses += reply("Saved")
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+      assertTrue(harness.controller.state.value.expectsSensitiveReply)
+
+      harness.controller.setInput(" nonpublic test text ")
+      harness.controller.sendInput()
+      advanceUntilIdle()
+
+      val params = json.parseToJsonElement(harness.requests[1].paramsJson).jsonObject
+      assertEquals(" nonpublic test text ", params.getValue("message").jsonPrimitive.content)
+      assertTrue(
+        harness.controller.state.value.messages.any {
+          it.role == SystemAgentChatMessage.Role.User && it.text == "<redacted secret>"
+        },
+      )
+      assertFalse(
+        harness.controller.state.value.messages
+          .any { "nonpublic test text" in it.text },
+      )
+    }
+
+  @Test
+  fun typedOptionSendsCanonicalReplyAndRetiresQuestion() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.responses += questionReply()
+      harness.responses += reply("Applied")
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+      val questionMessage =
+        harness.controller.state.value.messages
+          .single()
+
+      harness.controller.answerQuestion(questionMessage.id, "Use Tailscale")
+      advanceUntilIdle()
+
+      val params = json.parseToJsonElement(harness.requests[1].paramsJson).jsonObject
+      assertEquals("tailscale", params.getValue("message").jsonPrimitive.content)
+      assertTrue(
+        harness.controller.state.value.messages
+          .any { it.text == "Use Tailscale" },
+      )
+      assertTrue(questionMessage.id in harness.controller.state.value.retiredQuestionIds)
+    }
+
+  @Test
+  fun skipSendsExplicitReplyAndDismissesQuestion() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.responses += questionReply()
+      harness.responses += reply("Skipped")
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+      val questionMessage =
+        harness.controller.state.value.messages
+          .single()
+
+      harness.controller.skipQuestion(questionMessage.id)
+      advanceUntilIdle()
+
+      val params = json.parseToJsonElement(harness.requests[1].paramsJson).jsonObject
+      assertEquals("Skip for now", params.getValue("message").jsonPrimitive.content)
+      assertTrue(questionMessage.id in harness.controller.state.value.dismissedQuestionIds)
+    }
+
+  @Test
+  fun staleRouteReplyIsRejectedAndRequiresRestart() =
+    runTest {
+      val requestStarted = CompletableDeferred<Unit>()
+      val response = CompletableDeferred<String>()
+      val harness = readyHarness(this)
+      harness.handler = {
+        requestStarted.complete(Unit)
+        response.await()
+      }
+
+      harness.controller.refresh()
+      runCurrent()
+      requestStarted.await()
+      harness.routeCurrent = false
+      response.complete(reply("stale reply"))
+      advanceUntilIdle()
+
+      assertTrue(
+        harness.controller.state.value.messages
+          .isEmpty(),
+      )
+      assertEquals(
+        "The Gateway connection changed. Restart OpenClaw to reconnect.",
+        harness.controller.state.value.errorText,
+      )
+    }
+
+  @Test
+  fun gatewaySwitchDuringAdmissionCannotPolluteReplacementConversation() =
+    runTest {
+      var access =
+        SystemAgentGatewayAccess(
+          connected = true,
+          hasAdminScope = true,
+          supportsMethod = true,
+          gatewayId = "gateway-a",
+        )
+      var currentRoute = "gateway-a"
+      var switchDuringCapture = false
+      var requestCount = 0
+      lateinit var controller: SystemAgentChatController
+      controller =
+        SystemAgentChatController(
+          scope = this,
+          access = { access },
+          captureLease = { gatewayId ->
+            val capturedRoute = gatewayId.orEmpty()
+            val lease =
+              GatewaySession.RequestLease(capturedRoute, { currentRoute == capturedRoute }, null) { _, _, _ ->
+                requestCount += 1
+                reply("Welcome")
+              }
+            if (switchDuringCapture) {
+              currentRoute = "gateway-b"
+              access = access.copy(gatewayId = currentRoute)
+              controller.refresh(startIfNeeded = false)
+            }
+            lease
+          },
+          json = json,
+        )
+
+      controller.refresh()
+      advanceUntilIdle()
+      assertEquals(
+        listOf("Welcome"),
+        controller.state.value.messages
+          .map { it.text },
+      )
+
+      switchDuringCapture = true
+      controller.setInput("stale message")
+      controller.sendInput()
+      advanceUntilIdle()
+
+      assertEquals(SystemAgentChatAccess.Ready, controller.state.value.access)
+      assertTrue(
+        controller.state.value.messages
+          .isEmpty(),
+      )
+      assertFalse(controller.state.value.sending)
+      assertNull(controller.state.value.errorText)
+      assertEquals(1, requestCount)
+    }
+
+  @Test
+  fun staleFailureCannotCommitOutsideCapturedRoute() =
+    runTest {
+      val harness = readyHarness(this)
+      var commitCount = 0
+      harness.commitIfCurrent = { block ->
+        commitCount += 1
+        if (commitCount == 1) {
+          block()
+          true
+        } else {
+          false
+        }
+      }
+      harness.handler = {
+        throw GatewayRequestRejected(GatewaySession.ErrorShape("FAILED", "old route failure"))
+      }
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+
+      assertEquals(
+        "The Gateway connection changed. Restart OpenClaw to reconnect.",
+        harness.controller.state.value.errorText,
+      )
+      assertFalse(
+        harness.controller.state.value.errorText
+          ?.contains("old route failure") == true,
+      )
+    }
+
+  @Test
+  fun gatewayIdentityChangeRotatesConversationAndSession() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.responses += questionReply()
+      harness.responses += reply("New gateway")
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+      val originalSessionId = harness.controller.state.value.sessionId
+      harness.controller.setInput("discard-me")
+
+      harness.access = harness.access.copy(gatewayId = "gateway-b")
+      harness.controller.refresh(startIfNeeded = false)
+      assertNotEquals(originalSessionId, harness.controller.state.value.sessionId)
+      assertTrue(
+        harness.controller.state.value.messages
+          .isEmpty(),
+      )
+      assertEquals("", harness.controller.state.value.input)
+      assertEquals(1, harness.requests.size)
+      harness.controller.refresh()
+      advanceUntilIdle()
+      assertEquals(
+        listOf("New gateway"),
+        harness.controller.state.value.messages
+          .map { it.text },
+      )
+    }
+
+  @Test
+  fun reconnectOnSameGatewayRetainsTranscriptButRequiresFreshSession() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.responses += reply("Welcome")
+      harness.responses += reply("Recovered")
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+      val originalSessionId = harness.controller.state.value.sessionId
+
+      harness.access = harness.access.copy(connected = false, supportsMethod = false)
+      harness.controller.refresh()
+      assertEquals(SystemAgentChatAccess.Disconnected, harness.controller.state.value.access)
+      assertEquals(
+        listOf("Welcome"),
+        harness.controller.state.value.messages
+          .map { it.text },
+      )
+
+      harness.access = harness.access.copy(connected = true, supportsMethod = true)
+      harness.controller.refresh()
+      assertEquals(SystemAgentChatAccess.Ready, harness.controller.state.value.access)
+      assertTrue(harness.controller.state.value.errorText != null)
+      assertEquals(1, harness.requests.size)
+
+      harness.controller.restart()
+      advanceUntilIdle()
+      assertNotEquals(originalSessionId, harness.controller.state.value.sessionId)
+      assertEquals(
+        listOf("Recovered"),
+        harness.controller.state.value.messages
+          .map { it.text },
+      )
+    }
+
+  @Test
+  fun pendingSupportCheckClearsDraftButKeepsSecureConversationState() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.responses += reply("Enter a secret", sensitive = true)
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+      harness.controller.setInput("discard-me")
+      harness.access = harness.access.copy(supportsMethod = null)
+      harness.controller.refresh()
+
+      assertEquals(SystemAgentChatAccess.CheckingGateway, harness.controller.state.value.access)
+      assertEquals("", harness.controller.state.value.input)
+      assertTrue(harness.controller.state.value.expectsSensitiveReply)
+      assertNull(harness.controller.state.value.errorText)
+
+      harness.access = harness.access.copy(supportsMethod = true)
+      harness.controller.refresh()
+      assertEquals(1, harness.requests.size)
+      assertEquals(
+        listOf("Enter a secret"),
+        harness.controller.state.value.messages
+          .map { it.text },
+      )
+    }
+
+  @Test
+  fun backgroundCleanupClearsDraftWithoutCancelingInFlightGreeting() =
+    runTest {
+      val requestStarted = CompletableDeferred<Unit>()
+      val response = CompletableDeferred<String>()
+      val harness = readyHarness(this)
+      harness.handler = {
+        requestStarted.complete(Unit)
+        response.await()
+      }
+
+      harness.controller.refresh()
+      runCurrent()
+      requestStarted.await()
+      harness.controller.setInput("discard-me")
+      harness.controller.clearInputForBackground()
+      response.complete(reply("Welcome"))
+      advanceUntilIdle()
+
+      assertEquals("", harness.controller.state.value.input)
+      assertEquals(
+        listOf("Welcome"),
+        harness.controller.state.value.messages
+          .map { it.text },
+      )
+      assertNull(harness.controller.state.value.errorText)
+    }
+
+  @Test
+  fun handoffWaitsForExplicitActionAndBlocksFurtherMessages() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.responses += reply("Continue in chat", action = "open-agent", agentId = " reviewer ")
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+      harness.controller.setInput("must-not-send")
+      harness.controller.sendInput()
+      advanceUntilIdle()
+
+      assertEquals(1, harness.requests.size)
+      assertEquals(
+        " reviewer ",
+        harness.controller.state.value.handoff
+          ?.agentId,
+      )
+      assertEquals(" reviewer ", harness.controller.openHandoff()?.agentId)
+      assertNull(harness.controller.state.value.handoff)
+    }
+
+  private fun readyHarness(scope: CoroutineScope): Harness =
+    Harness(scope).also {
+      it.access =
+        SystemAgentGatewayAccess(
+          connected = true,
+          hasAdminScope = true,
+          supportsMethod = true,
+          gatewayId = "gateway-a",
+        )
+    }
+
+  private fun reply(
+    text: String,
+    action: String = "none",
+    sensitive: Boolean? = null,
+    agentId: String? = null,
+  ): String =
+    buildJsonObject {
+      put("sessionId", JsonPrimitive("system-session"))
+      put("reply", JsonPrimitive(text))
+      put("action", JsonPrimitive(action))
+      sensitive?.let { put("sensitive", JsonPrimitive(it)) }
+      agentId?.let { put("agentId", JsonPrimitive(it)) }
+    }.toString()
+
+  private fun questionReply(): String =
+    """
+    {
+      "sessionId": "system-session",
+      "reply": "Choose a connection",
+      "action": "none",
+      "question": {
+        "id": "connection",
+        "header": "Connection",
+        "question": "How should OpenClaw connect?",
+        "options": [
+          {
+            "label": "Use Tailscale",
+            "description": "Private network",
+            "recommended": true,
+            "reply": "tailscale"
+          },
+          {
+            "label": "Use LAN",
+            "description": "Local network",
+            "reply": "lan"
+          }
+        ]
+      }
+    }
+    """.trimIndent()
+
+  private data class RecordedRequest(
+    val method: String,
+    val paramsJson: String,
+    val timeoutMs: Long,
+  )
+
+  private class Harness(
+    scope: CoroutineScope,
+  ) {
+    var access =
+      SystemAgentGatewayAccess(
+        connected = false,
+        hasAdminScope = false,
+        supportsMethod = null,
+        gatewayId = null,
+      )
+    var routeCurrent = true
+    var commitIfCurrent: ((block: () -> Unit) -> Boolean)? = null
+    val requests = mutableListOf<RecordedRequest>()
+    val responses = ArrayDeque<String>()
+    var handler: suspend (RecordedRequest) -> String = { responses.removeFirst() }
+    val controller =
+      SystemAgentChatController(
+        scope = scope,
+        access = { access },
+        captureLease = { gatewayId ->
+          if (!access.connected) {
+            null
+          } else {
+            GatewaySession.RequestLease(gatewayId.orEmpty(), { routeCurrent }, commitIfCurrent) { method, paramsJson, timeoutMs ->
+              val request = RecordedRequest(method, paramsJson.orEmpty(), timeoutMs)
+              requests += request
+              handler(request)
+            }
+          }
+        },
+        json = Json { ignoreUnknownKeys = true },
+      )
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -781,6 +781,7 @@ class ShellScreenLogicTest {
   fun settingsSectionTitlesGroupPowerSettingsByMeaning() {
     assertEquals("Connection", settingsSectionTitleForRoute(SettingsRoute.Gateway).resolveNativeText())
     assertEquals("Connection", settingsSectionTitleForRoute(SettingsRoute.NodesDevices).resolveNativeText())
+    assertEquals("Agents & automation", settingsSectionTitleForRoute(SettingsRoute.SystemAgent).resolveNativeText())
     assertEquals("Agents & automation", settingsSectionTitleForRoute(SettingsRoute.ProvidersModels).resolveNativeText())
     assertEquals("Agents & automation", settingsSectionTitleForRoute(SettingsRoute.Approvals).resolveNativeText())
     assertEquals("Agents & automation", settingsSectionTitleForRoute(SettingsRoute.CronJobs).resolveNativeText())

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -1,5 +1,5 @@
 ---
-summary: "Android app (node): connection runbook + Connect/Chat/Voice/Canvas command surface"
+summary: "Android app (node): connection runbook + Connect/Chat/OpenClaw/Voice/Canvas command surface"
 read_when:
   - Pairing or reconnecting the Android node
   - Debugging Android gateway discovery or auth
@@ -19,6 +19,7 @@ The official Android app is available on [Google Play](https://play.google.com/s
 - Install: [Google Play](https://play.google.com/store/apps/details?id=ai.openclaw.app&hl=en_IN) or `OpenClaw-Android.apk` from a supported [GitHub Release](https://github.com/openclaw/openclaw/releases), [Getting Started](/start/getting-started) for the Gateway, then [Pairing](/channels/pairing).
 - Gateway: [Runbook](/gateway) + [Configuration](/gateway/configuration).
   - Protocols: [Gateway protocol](/gateway/protocol) (nodes + control plane).
+- **Settings → OpenClaw** opens a dedicated Gateway settings assistant when the operator connection has `operator.admin` and the Gateway supports `openclaw.chat`. Its setup conversation stays separate from ordinary Chat, redacts secret replies locally, and moves to Chat only after you tap **Open Chat**.
 
 System control (launchd/systemd) lives on the Gateway host — see [Gateway](/gateway).
 


### PR DESCRIPTION
Related: #112002

## What Problem This Solves

Android operators currently have no native way to talk to the OpenClaw setup and repair assistant from Settings. Ordinary mobile Chat intentionally excludes system agents, so operators must switch to macOS, iOS, or Control UI for Gateway-level setup and repair help.

## Why This Change Was Made

Adds a dedicated **Settings → OpenClaw** destination backed solely by `openclaw.chat`, not ordinary agent or session routing. The retained conversation requires a connected `operator.admin` session, checks Gateway method support, binds every state commit to one captured physical Gateway route, redacts sensitive replies locally, renders typed choice cards, and moves to ordinary Chat only after an explicit server-directed handoff.

The conversation is retained while navigating within Settings, rotates when the Gateway identity changes, requires an explicit restart after a same-Gateway reconnect, and does not start inference until the screen is actually opened. A deterministic screenshot fixture covers the production route without introducing a second runtime path.

This change was AI-assisted and reviewed with the repository's structured autoreview workflow.

## User Impact

Android operators can now open OpenClaw from Settings to inspect Gateway status, repair configuration, review setup, change models, or connect channels without exposing the system agent in ordinary Chat. Limited-access connections and older Gateways show clear unavailable states.

## Visual proof

| Before | After |
| --- | --- |
| ![Android Settings before OpenClaw](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/android-openclaw-settings-chat/before-settings.png) | ![Android Settings with OpenClaw](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/android-openclaw-settings-chat/after-settings.png) |

![Android OpenClaw settings conversation with recommended typed choice](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/android-openclaw-settings-chat/openclaw-chat.png)

## Evidence

- Blacksmith Testbox [run 29962101034](https://github.com/openclaw/openclaw/actions/runs/29962101034): native source inventory stable, app ktlint passed, `compilePlayDebugKotlin` passed, and focused controller/screenshot/navigation unit tests passed.
- Source-blind Android 16 emulator validation: navigated through the Settings row, observed the dedicated typed conversation, pasted ten lines while **Send** remained visible above the keyboard, submitted successfully, and remained on the Settings-owned conversation rather than ordinary Chat.
- Deterministic before/after screenshots were captured from the unmodified base and this branch on the same AVD, theme, fixture data, and viewport.
- `autoreview --mode uncommitted --engine codex --model gpt-5.6-sol --thinking high` — clean; no accepted or actionable findings.
