### PR TITLE
fix(telegram): keep message mutations in forum topics

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -6,7 +6,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { captureEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleTelegramAction, telegramActionRuntime } from "./action-runtime.js";
+import {
+  handleTelegramAction as handleTelegramActionRuntime,
+  telegramActionRuntime,
+} from "./action-runtime.js";
 import { beginTelegramInboundEventDeliveryCorrelation } from "./inbound-event-delivery.js";
 import { setTelegramRuntime } from "./runtime.js";
 import {
@@ -17,6 +20,17 @@ import type { TelegramRuntime } from "./runtime.types.js";
 import { getTopicName, resolveTopicNameCacheScope } from "./topic-name-cache.js";
 
 const originalTelegramActionRuntime = { ...telegramActionRuntime };
+
+function handleTelegramAction(
+  params: Parameters<typeof handleTelegramActionRuntime>[0],
+  cfg: Parameters<typeof handleTelegramActionRuntime>[1],
+  options?: Parameters<typeof handleTelegramActionRuntime>[2],
+) {
+  return handleTelegramActionRuntime(params, cfg, {
+    conversationReadOrigin: "direct-operator",
+    ...options,
+  });
+}
 const reactMessageTelegram = vi.fn(async () => ({ ok: true }));
 const sendMessageTelegram = vi.fn(
   async (_to: string, _text: string, _opts?: Record<string, unknown>) => ({
@@ -473,6 +487,72 @@ describe("handleTelegramAction", () => {
           currentThreadTs: "77",
         },
       },
+    );
+
+    expect(resultDetails(result)).toMatchObject({ ok: false, reason: "error" });
+    expect(reactMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("rejects threadless cross-chat mutations before provider execution", async () => {
+    const context = {
+      conversationReadOrigin: "delegated" as const,
+      requesterAccountId: "default",
+      toolContext: {
+        currentChannelProvider: "telegram" as const,
+        currentChannelId: "telegram:-1001",
+        currentMessageId: "456",
+      },
+    };
+
+    const reaction = await handleTelegramAction(
+      {
+        action: "react",
+        chatId: "-1002",
+        messageId: 456,
+        emoji: "✅",
+      },
+      reactionConfig("minimal"),
+      context,
+    );
+    expect(resultDetails(reaction)).toMatchObject({ ok: false, reason: "error" });
+    await expect(
+      handleTelegramAction(
+        {
+          action: "editMessage",
+          chatId: "-1002",
+          messageId: 456,
+          content: "updated",
+        },
+        telegramConfig(),
+        context,
+      ),
+    ).rejects.toThrow("provider-observed binding");
+    await expect(
+      handleTelegramAction(
+        {
+          action: "deleteMessage",
+          chatId: "-1002",
+          messageId: 456,
+        },
+        telegramConfig(),
+        context,
+      ),
+    ).rejects.toThrow("provider-observed binding");
+
+    expect(reactMessageTelegram).not.toHaveBeenCalled();
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deleteMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("treats missing invocation origin as delegated for threadless mutations", async () => {
+    const result = await handleTelegramActionRuntime(
+      {
+        action: "react",
+        chatId: "-1001",
+        messageId: 456,
+        emoji: "✅",
+      },
+      reactionConfig("minimal"),
     );
 
     expect(resultDetails(result)).toMatchObject({ ok: false, reason: "error" });

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -357,6 +357,77 @@ describe("handleTelegramAction", () => {
     await expectReactionAdded("minimal");
   });
 
+  it("strips a topic target only after binding the delegated current message", async () => {
+    await handleTelegramAction(
+      {
+        action: "react",
+        chatId: "telegram:-1001:topic:77",
+        messageId: 456,
+        emoji: "✅",
+      },
+      reactionConfig("minimal"),
+      {
+        conversationReadOrigin: "delegated",
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "telegram:-1001:topic:77",
+          currentMessageId: "456",
+        },
+      },
+    );
+
+    expect(mockCall(reactMessageTelegram, 0, "topic reaction")[0]).toBe("-1001");
+  });
+
+  it("soft-fails an unbound delegated topic reaction before provider execution", async () => {
+    const result = await handleTelegramAction(
+      {
+        action: "react",
+        chatId: "telegram:-1001:topic:77",
+        messageId: 456,
+        emoji: "✅",
+      },
+      reactionConfig("minimal"),
+      {
+        conversationReadOrigin: "delegated",
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "telegram:-1001:topic:77",
+          currentMessageId: "999",
+        },
+      },
+    );
+
+    expect(resultDetails(result)).toMatchObject({ ok: false, reason: "error" });
+    expect(reactMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("soft-fails a topicless delegated reaction during a trusted topic turn", async () => {
+    const result = await handleTelegramAction(
+      {
+        action: "react",
+        chatId: "-1001",
+        messageId: 456,
+        emoji: "✅",
+      },
+      reactionConfig("minimal"),
+      {
+        conversationReadOrigin: "delegated",
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "telegram:-1001:topic:77",
+          currentMessageId: "456",
+        },
+      },
+    );
+
+    expect(resultDetails(result)).toMatchObject({ ok: false, reason: "error" });
+    expect(reactMessageTelegram).not.toHaveBeenCalled();
+  });
+
   it("routes omitted-account action tokens through the configured defaultAccount (#61012)", async () => {
     const cfg = {
       channels: {
@@ -1755,6 +1826,93 @@ describe("handleTelegramAction", () => {
     expect(call[0]).toBe("123");
     expect(call[1]).toBe(456);
     expect(requireRecord(call[2], "delete message options").token).toBe("tok");
+  });
+
+  it("binds delegated topic edit and delete actions before provider execution", async () => {
+    const actionContext = {
+      conversationReadOrigin: "delegated" as const,
+      requesterAccountId: "default",
+      toolContext: {
+        currentChannelProvider: "telegram" as const,
+        currentChannelId: "telegram:-1001:topic:77",
+        currentMessageId: "456",
+      },
+    };
+
+    await handleTelegramAction(
+      {
+        action: "editMessage",
+        chatId: "telegram:-1001:topic:77",
+        messageId: 456,
+        content: "updated",
+      },
+      telegramConfig(),
+      actionContext,
+    );
+    expect(mockCall(editMessageTelegram, 0, "topic edit")[0]).toBe("-1001");
+
+    await handleTelegramAction(
+      {
+        action: "deleteMessage",
+        chatId: "telegram:-1001:topic:77",
+        messageId: 456,
+      },
+      telegramConfig(),
+      actionContext,
+    );
+    expect(mockCall(deleteMessageTelegram, 0, "topic delete")[0]).toBe("-1001");
+  });
+
+  it("rejects unbound delegated topic edit and delete actions before provider execution", async () => {
+    const actionContext = {
+      conversationReadOrigin: "delegated" as const,
+      requesterAccountId: "default",
+      toolContext: {
+        currentChannelProvider: "telegram" as const,
+        currentChannelId: "telegram:-1001:topic:77",
+        currentMessageId: "999",
+      },
+    };
+
+    await expect(
+      handleTelegramAction(
+        {
+          action: "editMessage",
+          chatId: "telegram:-1001:topic:77",
+          messageId: 456,
+          content: "updated",
+        },
+        telegramConfig(),
+        actionContext,
+      ),
+    ).rejects.toThrow("provider-observed binding");
+    await expect(
+      handleTelegramAction(
+        {
+          action: "deleteMessage",
+          chatId: "telegram:-1001:topic:77",
+          messageId: 456,
+        },
+        telegramConfig(),
+        actionContext,
+      ),
+    ).rejects.toThrow("provider-observed binding");
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deleteMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("keeps direct-operator topic mutations available", async () => {
+    await handleTelegramAction(
+      {
+        action: "deleteMessage",
+        chatId: "telegram:-1001:topic:77",
+        messageId: 456,
+      },
+      telegramConfig(),
+      { conversationReadOrigin: "direct-operator" },
+    );
+
+    expect(mockCall(deleteMessageTelegram, 0, "direct topic delete")[0]).toBe("-1001");
   });
 
   it("rejects fractional message ids before mutating messages", async () => {

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -404,7 +404,7 @@ describe("handleTelegramAction", () => {
     expect(reactMessageTelegram).not.toHaveBeenCalled();
   });
 
-  it("soft-fails a topicless delegated reaction during a trusted topic turn", async () => {
+  it("binds a topicless delegated reaction to the trusted current topic", async () => {
     const result = await handleTelegramAction(
       {
         action: "react",
@@ -420,6 +420,57 @@ describe("handleTelegramAction", () => {
           currentChannelProvider: "telegram",
           currentChannelId: "telegram:-1001:topic:77",
           currentMessageId: "456",
+          currentThreadTs: "77",
+        },
+      },
+    );
+
+    expect(resultDetails(result)).toMatchObject({ ok: true });
+    expect(mockCall(reactMessageTelegram, 0, "topicless reaction")[0]).toBe("-1001");
+  });
+
+  it("binds a General-topic reaction using trusted thread context", async () => {
+    const result = await handleTelegramAction(
+      {
+        action: "react",
+        chatId: "-1001",
+        messageId: 456,
+        emoji: "✅",
+      },
+      reactionConfig("minimal"),
+      {
+        conversationReadOrigin: "delegated",
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "telegram:-1001",
+          currentMessageId: "456",
+          currentThreadTs: "1",
+        },
+      },
+    );
+
+    expect(resultDetails(result)).toMatchObject({ ok: true });
+    expect(mockCall(reactMessageTelegram, 0, "General-topic reaction")[0]).toBe("-1001");
+  });
+
+  it("soft-fails a topicless different-chat reaction during a trusted topic turn", async () => {
+    const result = await handleTelegramAction(
+      {
+        action: "react",
+        chatId: "-1002",
+        messageId: 456,
+        emoji: "✅",
+      },
+      reactionConfig("minimal"),
+      {
+        conversationReadOrigin: "delegated",
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "telegram:-1001:topic:77",
+          currentMessageId: "456",
+          currentThreadTs: "77",
         },
       },
     );

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -11,6 +11,7 @@ import {
   resolvePollMaxSelections,
   resolveReactionMessageId,
 } from "openclaw/plugin-sdk/channel-actions";
+import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import { normalizeOutboundLocation } from "openclaw/plugin-sdk/channel-inbound";
 import {
   buildOutboundSessionContext,
@@ -37,6 +38,10 @@ import {
   resolveTelegramTargetChatType,
 } from "./inline-buttons.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
+import {
+  resolveTelegramMessageMutationChatId,
+  type TelegramMessageMutationContext,
+} from "./message-topic-binding.js";
 import { resolveTelegramPollVisibility } from "./poll-visibility.js";
 import { resolveTelegramReactionLevel } from "./reaction-level.js";
 import {
@@ -96,6 +101,9 @@ const TELEGRAM_ACTION_ALIASES = {
 } as const;
 
 type TelegramActionName = (typeof TELEGRAM_ACTION_ALIASES)[keyof typeof TELEGRAM_ACTION_ALIASES];
+type ConversationReadInvocationOrigin = NonNullable<
+  ChannelMessageActionContext["conversationReadOrigin"]
+>;
 type TelegramForumTopicIconColor = (typeof TELEGRAM_FORUM_TOPIC_ICON_COLORS)[number];
 
 function readTelegramForumTopicIconColor(
@@ -343,6 +351,9 @@ export async function handleTelegramAction(
     sessionKey?: string | null;
     inboundEventKind?: string;
     gatewayClientScopes?: readonly string[];
+    conversationReadOrigin?: ConversationReadInvocationOrigin;
+    requesterAccountId?: string | null;
+    toolContext?: TelegramMessageMutationContext["toolContext"];
   },
 ): Promise<AgentToolResult<unknown>> {
   const { action, accountId } = {
@@ -418,8 +429,15 @@ export async function handleTelegramAction(
     }
     let reactionResult: Awaited<ReturnType<typeof telegramActionRuntime.reactMessageTelegram>>;
     try {
+      const authorizedChatId = await resolveTelegramMessageMutationChatId({
+        chatId: chatId ?? "",
+        messageId,
+        cfg,
+        accountId,
+        context: options,
+      });
       reactionResult = await telegramActionRuntime.reactMessageTelegram(
-        chatId ?? "",
+        authorizedChatId,
         messageId ?? 0,
         emoji ?? "",
         {
@@ -671,18 +689,29 @@ export async function handleTelegramAction(
     if (messageId === undefined) {
       throw new Error("messageId required");
     }
+    const authorizedChatId = await resolveTelegramMessageMutationChatId({
+      chatId: chatId ?? "",
+      messageId,
+      cfg,
+      accountId,
+      context: options,
+    });
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
       );
     }
-    const result = await telegramActionRuntime.deleteMessageTelegram(chatId ?? "", messageId ?? 0, {
-      cfg,
-      token,
-      accountId: accountId ?? undefined,
-      gatewayClientScopes: options?.gatewayClientScopes,
-    });
+    const result = await telegramActionRuntime.deleteMessageTelegram(
+      authorizedChatId,
+      messageId ?? 0,
+      {
+        cfg,
+        token,
+        accountId: accountId ?? undefined,
+        gatewayClientScopes: options?.gatewayClientScopes,
+      },
+    );
     if (!result.ok) {
       return jsonResult({ ok: false, deleted: false, warning: result.warning });
     }
@@ -700,6 +729,13 @@ export async function handleTelegramAction(
     if (messageId === undefined) {
       throw new Error("messageId required");
     }
+    const authorizedChatId = await resolveTelegramMessageMutationChatId({
+      chatId: chatId ?? "",
+      messageId,
+      cfg,
+      accountId,
+      context: options,
+    });
     const content =
       readStringParam(params, "content", { allowEmpty: false }) ??
       readStringParam(params, "message", { allowEmpty: false });
@@ -729,7 +765,7 @@ export async function handleTelegramAction(
     }
     if (content == null && caption == null && buttons !== undefined) {
       const result = await telegramActionRuntime.editMessageReplyMarkupTelegram(
-        chatId ?? "",
+        authorizedChatId,
         messageId ?? 0,
         buttons,
         {
@@ -746,7 +782,7 @@ export async function handleTelegramAction(
       });
     }
     const result = await telegramActionRuntime.editMessageTelegram(
-      chatId ?? "",
+      authorizedChatId,
       messageId ?? 0,
       caption ?? content ?? "",
       {

--- a/extensions/telegram/src/bot-handlers.message-context.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.runtime.ts
@@ -82,6 +82,7 @@ export function createTelegramMessageContextRuntime({
       chatId: msg.chat.id,
       msg,
       ...(botUserId !== undefined ? { botUserId } : {}),
+      ...(threadId != null ? { providerObservedThreadId: threadId } : {}),
       ...(threadId != null ? { threadId } : {}),
     });
 
@@ -96,6 +97,7 @@ export function createTelegramMessageContextRuntime({
     const {
       sourceMessage: _sourceMessage,
       promptContextProjectionMarker: _promptContextProjectionMarker,
+      threadBinding: _threadBinding,
       ...entry
     } = node;
     const projectedEntry = { ...entry, sender: resolvePromptSender(node, ctx) };

--- a/extensions/telegram/src/bot-message-dispatch-delivery.ts
+++ b/extensions/telegram/src/bot-message-dispatch-delivery.ts
@@ -150,6 +150,7 @@ export function createTelegramDeliveryController(params: {
       ...(record.text ? { text: record.text } : {}),
       ...(record.projection ? { promptContextProjection: record.projection } : {}),
       ...(params.threadSpec.id !== undefined ? { messageThreadId: params.threadSpec.id } : {}),
+      successfulSendThread: params.threadSpec,
     });
   const createPromptContextSequence = (source?: TelegramPromptContextSource) =>
     createTelegramPromptContextProjectionSequence({

--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -22,6 +22,7 @@ import { createTelegramDraftStream, type TelegramDraftPreview } from "./draft-st
 import { renderTelegramHtmlText } from "./format.js";
 import type { DraftLaneState, LaneName } from "./lane-delivery.js";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
+import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import { splitTelegramReasoningText } from "./reasoning-lane-coordinator.js";
 import { buildTelegramRichMarkdown, TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
 
@@ -133,6 +134,21 @@ export function createTelegramDraftController(params: {
             lanes[laneName].retainedPromptContextPages.push({
               messageId: page.messageId,
               text: page.textSnapshot,
+            });
+          },
+          onProviderMessage: async (message) => {
+            await (
+              params.telegramDeps.recordOutboundMessageForPromptContext ??
+              recordOutboundMessageForPromptContext
+            )({
+              cfg: params.cfg,
+              account: {
+                accountId: params.accountId,
+                ...(params.telegramCfg.name !== undefined ? { name: params.telegramCfg.name } : {}),
+              },
+              chatId: params.chatId,
+              message,
+              messageId: message.message_id,
             });
           },
           log: logVerbose,

--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -149,6 +149,10 @@ export function createTelegramDraftController(params: {
               chatId: params.chatId,
               message,
               messageId: message.message_id,
+              ...(params.threadSpec.id !== undefined
+                ? { messageThreadId: params.threadSpec.id }
+                : {}),
+              successfulSendThread: params.threadSpec,
             });
           },
           log: logVerbose,

--- a/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
@@ -168,6 +168,51 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("carries General-topic context through stream-off fallback recording", async () => {
+    deliverReplies.mockImplementation(async (params: Record<string, unknown>) => {
+      const sequence = params.promptContextSequence as
+        | {
+            accept(message: {
+              messageId: number;
+              message?: Record<string, unknown>;
+              text?: string;
+            }): Promise<void>;
+          }
+        | undefined;
+      await sequence?.accept({
+        messageId: 1004,
+        message: {
+          message_id: 1004,
+          chat: { id: -1001234, type: "supergroup" },
+          date: 1_779_394_741,
+          text: "Reply in General",
+        },
+        text: "Reply in General",
+      });
+      return { delivered: true };
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Reply in General" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        chatId: -1001234,
+        isGroup: true,
+        threadSpec: { id: 1, scope: "forum" },
+      }),
+      streamMode: "off",
+      telegramDeps: telegramDepsForTest,
+    });
+
+    expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext), {
+      messageId: 1004,
+      messageThreadId: 1,
+      successfulSendThread: { id: 1, scope: "forum" },
+    });
+  });
+
   it("queues media-only final Telegram replies through outbound delivery when available", async () => {
     deliverInboundReplyWithMessageSendContext.mockResolvedValue({
       status: "handled_visible",

--- a/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
@@ -209,8 +209,20 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
       text: "Done already: timeoutSeconds is now 7200s.",
       timestamp: transcriptTimestamp,
     });
+    const recordResults: boolean[] = [];
     setupDraftStreams({ answerMessageId: 1497 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      const streamParams = mockCallArg(createTelegramDraftStream) as Parameters<
+        NonNullable<TelegramBotDeps["createTelegramDraftStream"]>
+      >[0];
+      await streamParams.onProviderMessage?.({
+        chat: { id: 123, type: "private", first_name: "Keshav" },
+        message_thread_id: 777,
+        message_id: 1497,
+        date: 1_779_425_461,
+        text: "Initial streamed text",
+        from: { id: 999, is_bot: true, first_name: "Telegram Bot Name" },
+      });
       await dispatcherOptions.deliver(
         { text: "Done already: timeoutSeconds is now 7200s." },
         { kind: "final" },
@@ -224,9 +236,15 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
       telegramCfg: { name: "Configured Agent" },
       telegramDeps: {
         ...telegramDepsForTest,
-        recordOutboundMessageForPromptContext: recordOutboundMessageForPromptContextActual,
+        recordOutboundMessageForPromptContext: async (params) => {
+          const recorded = await recordOutboundMessageForPromptContextActual(params);
+          recordResults.push(recorded);
+          return recorded;
+        },
       },
     });
+
+    expect(recordResults).toEqual([true, true]);
 
     const cache = createTelegramMessageCache({
       scope: resolveTelegramMessageCacheScope(storePath),
@@ -277,6 +295,10 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
         partIndex: 0,
         finalPart: true,
       },
+    });
+    expect(streamedReply?.node.threadBinding).toEqual({
+      kind: "provider-observed-v1",
+      threadId: "777",
     });
   });
 

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -62,7 +62,7 @@ export {
   resolveTelegramPrimaryMedia,
 };
 
-const TELEGRAM_GENERAL_TOPIC_ID = 1;
+export const TELEGRAM_GENERAL_TOPIC_ID = 1;
 const TELEGRAM_FORUM_FLAG_CACHE_MAX_CHATS = 1024;
 const TELEGRAM_FORUM_FLAG_CACHE_TTL_MS = 10 * 60_000;
 const telegramForumFlagByChatId = new Map<string, { expiresAtMs: number; isForum: boolean }>();

--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -23,6 +23,15 @@ describe("telegram actions contract", () => {
     ],
   });
 
+  it("exposes message resource aliases through the registered adapter", () => {
+    for (const action of ["react", "edit", "delete"] as const) {
+      expect(telegramPlugin.actions?.messageActionTargetAliases?.[action]).toEqual({
+        aliases: ["messageId"],
+        deliveryTargetAliases: [],
+      });
+    }
+  });
+
   it.each([
     {
       richMessages: undefined as boolean | undefined,

--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -34,6 +34,50 @@ describe("telegramMessageActions", () => {
     }
   });
 
+  it("classifies Telegram message ids as resources rather than delivery targets", () => {
+    for (const action of ["react", "edit", "delete"] as const) {
+      expect(telegramMessageActions.messageActionTargetAliases?.[action]).toEqual({
+        aliases: ["messageId"],
+        deliveryTargetAliases: [],
+      });
+    }
+  });
+
+  it("forwards only host-owned mutation context to the runtime", async () => {
+    await telegramMessageActions.handleAction?.({
+      channel: "telegram",
+      action: "delete",
+      params: {
+        messageId: "9001",
+        to: "-1001:topic:77",
+        conversationReadOrigin: "direct-operator",
+      },
+      cfg: { channels: { telegram: { botToken: "tok" } } } as OpenClawConfig,
+      accountId: "work",
+      requesterAccountId: "work",
+      conversationReadOrigin: "delegated",
+      toolContext: {
+        currentChannelProvider: "telegram",
+        currentChannelId: "telegram:-1001:topic:77",
+        currentMessageId: "9001",
+      },
+    } as never);
+
+    expect(handleTelegramActionMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ conversationReadOrigin: "direct-operator" }),
+      expect.anything(),
+      expect.objectContaining({
+        conversationReadOrigin: "delegated",
+        requesterAccountId: "work",
+        toolContext: expect.objectContaining({ currentMessageId: "9001" }),
+      }),
+    );
+    expect(handleTelegramActionMock.mock.calls[0]?.[0]).toMatchObject({
+      action: "deleteMessage",
+      messageId: "9001",
+    });
+  });
+
   it("allows interactive-only sends", async () => {
     await telegramMessageActions.handleAction!({
       action: "send",

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -216,6 +216,11 @@ function describeTelegramMessageTool({
 export const telegramMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: describeTelegramMessageTool,
   resolveExecutionMode: () => "gateway",
+  messageActionTargetAliases: {
+    react: { aliases: ["messageId"], deliveryTargetAliases: [] },
+    edit: { aliases: ["messageId"], deliveryTargetAliases: [] },
+    delete: { aliases: ["messageId"], deliveryTargetAliases: [] },
+  },
   prepareSendPayload: prepareTelegramSendPayload,
   resolveCliActionRequest: ({ action, args }) => {
     if (action !== "thread-create") {
@@ -245,25 +250,44 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     sessionKey,
     inboundEventKind,
     toolContext,
+    conversationReadOrigin,
+    requesterAccountId,
     gatewayClientScopes,
   }) => {
     const telegramAction = resolveTelegramMessageActionName(action);
     if (!telegramAction) {
       throw new Error(`Unsupported Telegram action: ${action}`);
     }
+    const {
+      conversationReadOrigin: _modelConversationReadOrigin,
+      requesterAccountId: _modelRequesterAccountId,
+      toolContext: _modelToolContext,
+      ...runtimeParams
+    } = params;
     return await telegramMessageActionRuntime.handleTelegramAction(
       {
-        ...params,
+        // Authority stays in the host-owned options object below. Model tool
+        // arguments with these names must never reach the runtime as context.
+        ...runtimeParams,
         action: telegramAction,
         accountId: accountId ?? undefined,
         ...(action === "react"
           ? {
-              messageId: resolveReactionMessageId({ args: params, toolContext }),
+              messageId: resolveReactionMessageId({ args: runtimeParams, toolContext }),
             }
           : {}),
       },
       cfg,
-      { mediaLocalRoots, mediaReadFile, sessionKey, inboundEventKind, gatewayClientScopes },
+      {
+        mediaLocalRoots,
+        mediaReadFile,
+        sessionKey,
+        inboundEventKind,
+        gatewayClientScopes,
+        ...(conversationReadOrigin ? { conversationReadOrigin } : {}),
+        ...(requesterAccountId ? { requesterAccountId } : {}),
+        ...(toolContext ? { toolContext } : {}),
+      },
     );
   },
 };

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -267,6 +267,7 @@ const telegramMessageAdapter = createChannelMessageAdapterFromOutbound<OpenClawC
 });
 
 const telegramMessageActions: ChannelMessageActionAdapter = {
+  messageActionTargetAliases: telegramMessageActionsImpl.messageActionTargetAliases,
   resolveExecutionMode: (ctx) =>
     getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.resolveExecutionMode?.(ctx) ??
     telegramMessageActionsImpl.resolveExecutionMode?.(ctx) ??

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -122,7 +122,7 @@ function createForceNewMessageHarness(params: { throttleMs?: number } = {}) {
 }
 
 describe("createTelegramDraftStream", () => {
-  it("reports the provider response after the first persistent preview lands", async () => {
+  it("reports the provider response after the first preview becomes durable", async () => {
     const api = createMockDraftApi(async () => ({ message_id: 101, message_thread_id: 99 }));
     const onProviderMessage = vi.fn();
     const observedStream = createDraftStream(api, {
@@ -133,10 +133,36 @@ describe("createTelegramDraftStream", () => {
     observedStream.update("A provider-observed preview response");
     await observedStream.flush();
 
+    expect(onProviderMessage).not.toHaveBeenCalled();
+    await observedStream.stop();
+
     expect(onProviderMessage).toHaveBeenCalledTimes(1);
     expect(onProviderMessage).toHaveBeenCalledWith(
       expect.objectContaining({ message_id: 101, message_thread_id: 99 }),
     );
+  });
+
+  it("stops accepting updates before awaiting durable provider observation", async () => {
+    let resolveObservation: (() => void) | undefined;
+    const observation = new Promise<void>((resolve) => {
+      resolveObservation = resolve;
+    });
+    const api = createMockDraftApi();
+    const onProviderMessage = vi.fn(() => observation);
+    const stream = createDraftStream(api, { onProviderMessage });
+
+    stream.update("Durable preview");
+    await stream.flush();
+    const stopPromise = stream.stop();
+    await vi.waitFor(() => expect(onProviderMessage).toHaveBeenCalledTimes(1));
+
+    stream.update("Late update");
+    resolveObservation?.();
+    await stopPromise;
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.editMessageText).not.toHaveBeenCalled();
   });
 
   it("sends stream preview message with message_thread_id when provided", async () => {
@@ -612,6 +638,8 @@ describe("createTelegramDraftStream", () => {
 
         // The raced first send is NOT retained as a durable chunk...
         expect(onSupersededPreview).not.toHaveBeenCalled();
+        expect(onProviderMessage).not.toHaveBeenCalled();
+        await stream.stop();
         expect(onProviderMessage).toHaveBeenCalledTimes(1);
         expect(onProviderMessage).toHaveBeenCalledWith(expect.objectContaining({ message_id: 42 }));
         expect(api.deleteMessage).not.toHaveBeenCalled();
@@ -628,6 +656,35 @@ describe("createTelegramDraftStream", () => {
       }
     },
   );
+
+  it("does not report a first preview cleared while its send is in flight", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveSend: ((value: { message_id: number }) => void) | undefined;
+      const send = new Promise<{ message_id: number }>((resolve) => {
+        resolveSend = resolve;
+      });
+      const api = createMockDraftApi();
+      api.sendMessage.mockReturnValueOnce(send);
+      const onProviderMessage = vi.fn();
+      const stream = createDraftStream(api, { onProviderMessage });
+
+      stream.update("Temporary preview");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(api.sendMessage).toHaveBeenCalledTimes(1);
+
+      const clearPromise = stream.clear();
+      resolveSend?.({ message_id: 17 });
+      await vi.advanceTimersByTimeAsync(0);
+      await clearPromise;
+
+      expect(onProviderMessage).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it.each(["first", "batched"] as const)(
     "keeps an in-flight %s reply target owned when reposition cleanup fails",

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -10,16 +10,17 @@ import {
 import { buildTelegramRichMarkdown, type TelegramInputRichMessage } from "./rich-message.js";
 
 type TelegramDraftStreamParams = Parameters<typeof createTelegramDraftStream>[0];
+type MockSentMessage = { message_id: number; message_thread_id?: number };
 type MockSendMessage = (
   chatId: string | number,
   text: string,
   params?: Record<string, unknown>,
-) => Promise<{ message_id: number }>;
+) => Promise<MockSentMessage>;
 type MockSendRichMessage = (params: {
   rich_message?: TelegramInputRichMessage;
-}) => Promise<{ message_id: number }>;
+}) => Promise<MockSentMessage>;
 
-function createMockDraftApi(sendMessageImpl?: () => Promise<{ message_id: number }>) {
+function createMockDraftApi(sendMessageImpl?: () => Promise<MockSentMessage>) {
   const resolveSend = sendMessageImpl ?? (async () => ({ message_id: 17 }));
   const sendRichMessage = vi.fn<MockSendRichMessage>(async () => await resolveSend());
   const editRichMessageText = vi.fn().mockResolvedValue(true);
@@ -121,6 +122,23 @@ function createForceNewMessageHarness(params: { throttleMs?: number } = {}) {
 }
 
 describe("createTelegramDraftStream", () => {
+  it("reports the provider response after the first persistent preview lands", async () => {
+    const api = createMockDraftApi(async () => ({ message_id: 101, message_thread_id: 99 }));
+    const onProviderMessage = vi.fn();
+    const observedStream = createDraftStream(api, {
+      thread: { id: 99, scope: "forum" },
+      onProviderMessage,
+    });
+
+    observedStream.update("A provider-observed preview response");
+    await observedStream.flush();
+
+    expect(onProviderMessage).toHaveBeenCalledTimes(1);
+    expect(onProviderMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ message_id: 101, message_thread_id: 99 }),
+    );
+  });
+
   it("sends stream preview message with message_thread_id when provided", async () => {
     const api = createMockDraftApi();
     const stream = createForumDraftStream(api);

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -582,8 +582,10 @@ describe("createTelegramDraftStream", () => {
         const api = createMockDraftApi();
         api.sendMessage.mockReturnValueOnce(firstSend).mockResolvedValueOnce({ message_id: 42 });
         const onSupersededPreview = vi.fn();
+        const onProviderMessage = vi.fn();
         const stream = createDraftStream(api, {
           onRetainedPage: onSupersededPreview,
+          onProviderMessage,
           replyToMessageId: 411,
           replyToMode,
           thread: { id: 42, scope: "dm" },
@@ -610,6 +612,8 @@ describe("createTelegramDraftStream", () => {
 
         // The raced first send is NOT retained as a durable chunk...
         expect(onSupersededPreview).not.toHaveBeenCalled();
+        expect(onProviderMessage).toHaveBeenCalledTimes(1);
+        expect(onProviderMessage).toHaveBeenCalledWith(expect.objectContaining({ message_id: 42 }));
         expect(api.deleteMessage).not.toHaveBeenCalled();
         // ...it is deleted deferred, so no orphaned stale bubble is left behind.
         await vi.advanceTimersByTimeAsync(4_000);

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -1,5 +1,6 @@
 // Telegram plugin module implements draft stream behavior.
 import type { Bot } from "grammy";
+import type { Message } from "grammy/types";
 import {
   createFinalizableDraftStreamControlsForState,
   takeMessageIdAfterStop,
@@ -240,6 +241,8 @@ export function createTelegramDraftStream(params: {
   renderText?: (text: string) => TelegramDraftPreview;
   /** Called when a completed page remains visible after the stream advances. */
   onRetainedPage?: (page: RetainedTelegramDraftPage) => void;
+  /** Called with Telegram's response after a new persistent preview message lands. */
+  onProviderMessage?: (message: Message) => Promise<void> | void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
 }): TelegramDraftStream {
@@ -453,6 +456,13 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     retainReplyTarget(sendGeneration, normalizedMessageId);
+    try {
+      await params.onProviderMessage?.(sent.message);
+    } catch (err) {
+      // Observation runs after Telegram accepted the send. Never turn a cache
+      // failure into a transport retry that could duplicate the message.
+      params.warn?.(`telegram stream preview observation failed: ${formatErrorMessage(err)}`);
+    }
     if (sendGeneration !== generation) {
       const visibleSinceMs = Date.now();
       if (repositionedSendGenerations.delete(sendGeneration)) {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -456,13 +456,15 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     retainReplyTarget(sendGeneration, normalizedMessageId);
-    try {
-      await params.onProviderMessage?.(sent.message);
-    } catch (err) {
-      // Observation runs after Telegram accepted the send. Never turn a cache
-      // failure into a transport retry that could duplicate the message.
-      params.warn?.(`telegram stream preview observation failed: ${formatErrorMessage(err)}`);
-    }
+    const observeProviderMessage = async () => {
+      try {
+        await params.onProviderMessage?.(sent.message);
+      } catch (err) {
+        // Observation runs after Telegram accepted the send. Never turn a cache
+        // failure into a transport retry that could duplicate the message.
+        params.warn?.(`telegram stream preview observation failed: ${formatErrorMessage(err)}`);
+      }
+    };
     if (sendGeneration !== generation) {
       const visibleSinceMs = Date.now();
       if (repositionedSendGenerations.delete(sendGeneration)) {
@@ -476,12 +478,14 @@ export function createTelegramDraftStream(params: {
         textSnapshot: sent.snapshot.text,
         visibleSinceMs,
       });
+      await observeProviderMessage();
       return true;
     }
     const visibleSinceMs = Date.now();
     streamMessageId = normalizedMessageId;
     streamMessageSnapshot = sent.snapshot;
     streamVisibleSinceMs = visibleSinceMs;
+    await observeProviderMessage();
     return true;
   };
   const sendOrEditPlannedPage = async (page: PlannedTelegramDraftPage): Promise<boolean> => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -241,7 +241,7 @@ export function createTelegramDraftStream(params: {
   renderText?: (text: string) => TelegramDraftPreview;
   /** Called when a completed page remains visible after the stream advances. */
   onRetainedPage?: (page: RetainedTelegramDraftPage) => void;
-  /** Called with Telegram's response after a new persistent preview message lands. */
+  /** Called with Telegram's response after a new preview message becomes durable. */
   onProviderMessage?: (message: Message) => Promise<void> | void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
@@ -298,6 +298,8 @@ export function createTelegramDraftStream(params: {
   let consecutivePreviewFailures = 0;
   let streamMessageId: number | undefined;
   let streamMessageSnapshot: TelegramDraftMessageSnapshot | undefined;
+  let streamProviderMessage: Message | undefined;
+  const pendingProviderObservations = new Set<Promise<void>>();
   let streamVisibleSinceMs: number | undefined;
   let lastSentPreviewKey = "";
   let lastDeliveredText = "";
@@ -315,6 +317,36 @@ export function createTelegramDraftStream(params: {
     sourceText: escapeTelegramHtml(plainText),
     sourceTextMode: "html",
   });
+  const scheduleProviderMessageObservation = (message: Message | undefined) => {
+    if (!message) {
+      return;
+    }
+    const observation = (async () => {
+      try {
+        await params.onProviderMessage?.(message);
+      } catch (err) {
+        // Observation follows an accepted Telegram send. Never turn a cache
+        // failure into a transport retry that could duplicate the message.
+        try {
+          params.warn?.(`telegram stream preview observation failed: ${formatErrorMessage(err)}`);
+        } catch {
+          // Diagnostics must not make the observation task reject.
+        }
+      }
+    })();
+    pendingProviderObservations.add(observation);
+    void observation.then(() => {
+      pendingProviderObservations.delete(observation);
+    });
+  };
+  const observeCurrentProviderMessage = () => {
+    const message = streamProviderMessage;
+    streamProviderMessage = undefined;
+    scheduleProviderMessageObservation(message);
+  };
+  const drainProviderMessageObservations = async () => {
+    await Promise.all(pendingProviderObservations);
+  };
   const sendPlannedMessage = async (
     page: PlannedTelegramDraftPage,
     sendMessageParams: ReturnType<typeof reserveReplyTargetForSend>,
@@ -456,15 +488,6 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     retainReplyTarget(sendGeneration, normalizedMessageId);
-    const observeProviderMessage = async () => {
-      try {
-        await params.onProviderMessage?.(sent.message);
-      } catch (err) {
-        // Observation runs after Telegram accepted the send. Never turn a cache
-        // failure into a transport retry that could duplicate the message.
-        params.warn?.(`telegram stream preview observation failed: ${formatErrorMessage(err)}`);
-      }
-    };
     if (sendGeneration !== generation) {
       const visibleSinceMs = Date.now();
       if (repositionedSendGenerations.delete(sendGeneration)) {
@@ -478,14 +501,14 @@ export function createTelegramDraftStream(params: {
         textSnapshot: sent.snapshot.text,
         visibleSinceMs,
       });
-      await observeProviderMessage();
+      scheduleProviderMessageObservation(sent.message);
       return true;
     }
     const visibleSinceMs = Date.now();
     streamMessageId = normalizedMessageId;
     streamMessageSnapshot = sent.snapshot;
+    streamProviderMessage = sent.message;
     streamVisibleSinceMs = visibleSinceMs;
-    await observeProviderMessage();
     return true;
   };
   const sendOrEditPlannedPage = async (page: PlannedTelegramDraftPage): Promise<boolean> => {
@@ -564,6 +587,7 @@ export function createTelegramDraftStream(params: {
       textSnapshot: streamMessageSnapshot.text,
       visibleSinceMs: streamVisibleSinceMs,
     });
+    observeCurrentProviderMessage();
   };
 
   const resolveExactRemainingPage = (plan: {
@@ -728,6 +752,8 @@ export function createTelegramDraftStream(params: {
       }
     }
     streamState.final = true;
+    observeCurrentProviderMessage();
+    await drainProviderMessageObservations();
   };
 
   const remainingFinalContent = (): TelegramDraftMessageSnapshot | undefined => {
@@ -754,7 +780,13 @@ export function createTelegramDraftStream(params: {
     };
   };
 
-  const resetStreamToNewMessage = (continueFinalPagination = false) => {
+  const resetStreamToNewMessage = (
+    continueFinalPagination = false,
+    retainCurrentProviderMessage = false,
+  ) => {
+    if (retainCurrentProviderMessage) {
+      observeCurrentProviderMessage();
+    }
     streamState.stopped = false;
     streamState.final = continueFinalPagination;
     if (!continueFinalPagination) {
@@ -763,6 +795,7 @@ export function createTelegramDraftStream(params: {
     messageSendAttempted = false;
     streamMessageId = undefined;
     streamMessageSnapshot = undefined;
+    streamProviderMessage = undefined;
     streamVisibleSinceMs = undefined;
     lastSentPreviewKey = "";
     if (!continueFinalPagination) {
@@ -823,6 +856,7 @@ export function createTelegramDraftStream(params: {
       clearMessageId: () => {
         streamMessageId = undefined;
         streamMessageSnapshot = undefined;
+        streamProviderMessage = undefined;
       },
     });
     if (typeof messageId === "number" && Number.isFinite(messageId)) {
@@ -830,6 +864,7 @@ export function createTelegramDraftStream(params: {
       // first appeared, then delete.
       scheduleDetachedDelete(messageId, visibleSince);
     }
+    await drainProviderMessageObservations();
   };
 
   // Reposition the window: rewind so the NEXT update creates a fresh message
@@ -911,6 +946,8 @@ export function createTelegramDraftStream(params: {
       return undefined;
     }
     streamState.stopped = true;
+    observeCurrentProviderMessage();
+    await drainProviderMessageObservations();
     return edited ? streamMessageId : undefined;
   };
 
@@ -925,11 +962,15 @@ export function createTelegramDraftStream(params: {
     currentMessageSnapshot: () => streamMessageSnapshot,
     clear,
     stop,
-    discard: stopForClear,
+    discard: async () => {
+      await stopForClear();
+      observeCurrentProviderMessage();
+      await drainProviderMessageObservations();
+    },
     remainingFinalContent,
     hasConsumedReplyTarget: () => replyTargetState.kind !== "available",
     finalizeToPreview,
-    forceNewMessage: () => resetStreamToNewMessage(),
+    forceNewMessage: () => resetStreamToNewMessage(false, true),
     rotateToNewMessageDeferringDelete,
     sendMayHaveLanded: () => messageSendAttempted && typeof streamMessageId !== "number",
   };

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -5,6 +5,7 @@ import {
   buildTelegramConversationContext,
   buildTelegramReplyChain,
   createTelegramMessageCache,
+  hasProviderObservedTelegramThreadBinding,
   resolveTelegramMessageCachePersistentScopeKey,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
 } from "./message-cache.js";
@@ -19,6 +20,7 @@ type PersistedCacheValue = {
   sourceMessage: Message;
   botUserId?: number;
   promptContextProjection?: unknown;
+  threadBinding?: { kind: "provider-observed-v1"; threadId: string };
   threadId?: string;
 };
 
@@ -60,6 +62,49 @@ function createMemoryPersistentStore(maxEntries = TELEGRAM_MESSAGE_CACHE_PERSIST
 }
 
 describe("telegram message cache", () => {
+  it("persists provider-observed topic bindings for messages and same-topic replies", async () => {
+    const { bucketKey, entries, store } = createMemoryPersistentStore();
+    const cache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    await cache.record({
+      accountId: "default",
+      chatId: -1001,
+      threadId: 77,
+      providerObservedThreadId: 77,
+      msg: {
+        chat: { id: -1001, type: "supergroup", title: "QA", is_forum: true },
+        message_id: 902,
+        message_thread_id: 77,
+        is_topic_message: true,
+        date: 1_736_380_702,
+        text: "Reply",
+        from: { id: 2, is_bot: false, first_name: "Grace" },
+        reply_to_message: {
+          chat: { id: -1001, type: "supergroup", title: "QA", is_forum: true },
+          message_id: 901,
+          date: 1_736_380_701,
+          text: "Parent",
+          from: { id: 1, is_bot: false, first_name: "Ada" },
+        } as Message["reply_to_message"],
+      } as Message,
+    });
+
+    expect(entries.size).toBe(2);
+    expect(
+      Array.from(entries.values()).every(
+        (value) =>
+          value.threadBinding?.kind === "provider-observed-v1" &&
+          value.threadBinding.threadId === "77",
+      ),
+    ).toBe(true);
+
+    resetTelegramMessageCacheBucketsForTest();
+    const reloaded = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    for (const messageId of ["901", "902"]) {
+      const node = await reloaded.get({ accountId: "default", chatId: -1001, messageId });
+      expect(hasProviderObservedTelegramThreadBinding(node, 77)).toBe(true);
+    }
+  });
+
   it("hydrates reply chains from persisted cached messages", async () => {
     const { bucketKey, store } = createMemoryPersistentStore();
     const firstCache = createTelegramMessageCache({ bucketKey, persistentStore: store });
@@ -740,7 +785,8 @@ describe("telegram message cache", () => {
         partIndex: 0,
         finalPart: true,
       },
-      ...(persistedValue.threadId ? { threadId: persistedValue.threadId } : {}),
+      threadBinding: { kind: "provider-observed-v1", threadId: "77" },
+      threadId: "77",
     };
     const legacyStore: TelegramMessageCachePersistentStore = {
       register: (key, value) => store.register(key, value),
@@ -762,6 +808,7 @@ describe("telegram message cache", () => {
       messageId: "9126",
     });
     expect(reloaded?.promptContextProjectionMarker).toBeUndefined();
+    expect(hasProviderObservedTelegramThreadBinding(reloaded, 77)).toBe(false);
   });
 
   it("rejects unknown future persisted cache versions", async () => {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -39,7 +39,7 @@ export type TelegramCachedMessageNode = Omit<TelegramReplyChainEntry, "messageId
 
 // This marker is a provider fact, never an inference from invocation origin or
 // a legacy threadId. Delegated mutations may rely on it after cache hydration.
-export type TelegramMessageThreadBinding = {
+type TelegramMessageThreadBinding = {
   kind: "provider-observed-v1";
   threadId: string;
 };

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -34,6 +34,14 @@ export type TelegramCachedMessageNode = Omit<TelegramReplyChainEntry, "messageId
   messageId: string;
   sourceMessage: Message;
   promptContextProjectionMarker?: TelegramPromptContextProjectionMarker;
+  threadBinding?: TelegramMessageThreadBinding;
+};
+
+// This marker is a provider fact, never an inference from invocation origin or
+// a legacy threadId. Delegated mutations may rely on it after cache hydration.
+export type TelegramMessageThreadBinding = {
+  kind: "provider-observed-v1";
+  threadId: string;
 };
 
 type TelegramConversationContextNode = {
@@ -48,6 +56,8 @@ type TelegramMessageCache = {
     msg: Message;
     botUserId?: number;
     promptContextProjection?: TelegramPromptContextProjection;
+    /** Set only while recording an authenticated provider event or response. */
+    providerObservedThreadId?: number;
     threadId?: number;
   }) => Promise<TelegramCachedMessageNode>;
   get: (params: {
@@ -127,6 +137,7 @@ export type PersistedTelegramMessageCacheValue = {
   sourceMessage: Message;
   botUserId?: number;
   promptContextProjection?: TelegramPromptContextProjection | TelegramPromptContextSource;
+  threadBinding?: TelegramMessageThreadBinding;
   threadId?: string;
 };
 
@@ -206,6 +217,7 @@ function normalizeMessageNode(
   params: {
     threadId?: number;
     promptContextProjectionMarker?: TelegramPromptContextProjectionMarker;
+    threadBinding?: TelegramMessageThreadBinding;
   },
 ): TelegramCachedMessageNode {
   const media = resolveTelegramPrimaryMedia(msg);
@@ -214,6 +226,7 @@ function normalizeMessageNode(
   const replyMessage = resolveReplyMessage(msg);
   const body = resolveMessageBody(msg, params.promptContextProjectionMarker !== undefined);
   const threadId = parseTelegramMessageThreadId(params.threadId);
+  const threadBinding = normalizeTelegramMessageThreadBinding(params.threadBinding, threadId);
   const timestamp = resolveMessageTimestamp(msg);
   return {
     sourceMessage: msg,
@@ -234,7 +247,39 @@ function normalizeMessageNode(
     ...(params.promptContextProjectionMarker
       ? { promptContextProjectionMarker: params.promptContextProjectionMarker }
       : {}),
+    ...(threadBinding ? { threadBinding } : {}),
   };
+}
+
+function normalizeTelegramMessageThreadBinding(
+  value: unknown,
+  threadId: unknown,
+): TelegramMessageThreadBinding | undefined {
+  if (!isRecord(value) || value.kind !== "provider-observed-v1") {
+    return undefined;
+  }
+  const normalizedThreadId = parseTelegramMessageThreadId(threadId);
+  const observedThreadId = parseTelegramMessageThreadId(value.threadId);
+  if (normalizedThreadId === undefined || observedThreadId !== normalizedThreadId) {
+    return undefined;
+  }
+  return { kind: "provider-observed-v1", threadId: String(normalizedThreadId) };
+}
+
+function createTelegramMessageThreadBinding(
+  threadId: unknown,
+): TelegramMessageThreadBinding | undefined {
+  const normalizedThreadId = parseTelegramMessageThreadId(threadId);
+  return normalizedThreadId === undefined
+    ? undefined
+    : { kind: "provider-observed-v1", threadId: String(normalizedThreadId) };
+}
+
+export function hasProviderObservedTelegramThreadBinding(
+  node: TelegramCachedMessageNode | null | undefined,
+  threadId: unknown,
+): boolean {
+  return normalizeTelegramMessageThreadBinding(node?.threadBinding, threadId) !== undefined;
 }
 
 function normalizeMessageNodes(
@@ -242,6 +287,7 @@ function normalizeMessageNodes(
   params: {
     threadId?: number;
     promptContextProjectionMarker?: TelegramPromptContextProjectionMarker;
+    threadBinding?: TelegramMessageThreadBinding;
   },
 ): TelegramCachedMessageObservation[] {
   const observations: TelegramCachedMessageObservation[] = [];
@@ -253,6 +299,7 @@ function normalizeMessageNodes(
     inheritedThreadId: number | undefined,
     mode: TelegramMessageObservationMode,
     promptContextProjectionMarker?: TelegramPromptContextProjectionMarker,
+    threadBinding?: TelegramMessageThreadBinding,
   ) => {
     const node = normalizeMessageNode(message, {
       threadId:
@@ -260,6 +307,7 @@ function normalizeMessageNodes(
           (message as { message_thread_id?: unknown }).message_thread_id,
         ) ?? inheritedThreadId,
       ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
+      ...(threadBinding ? { threadBinding } : {}),
     });
     if (visited.has(node.messageId)) {
       return;
@@ -267,11 +315,23 @@ function normalizeMessageNodes(
     visited.add(node.messageId);
     const replyMessage = resolveEmbeddedReplyMessage(message);
     if (replyMessage?.message_id != null) {
-      visit(replyMessage, nodeThreadId(node) ?? inheritedThreadId, "partial");
+      visit(
+        replyMessage,
+        nodeThreadId(node) ?? inheritedThreadId,
+        "partial",
+        undefined,
+        node.threadBinding,
+      );
     }
     observations.push({ node, mode });
   };
-  visit(msg, params.threadId, "authoritative", params.promptContextProjectionMarker);
+  visit(
+    msg,
+    params.threadId,
+    "authoritative",
+    params.promptContextProjectionMarker,
+    params.threadBinding,
+  );
   return observations;
 }
 
@@ -307,9 +367,14 @@ function parsePersistedCacheValue(key: string, value: unknown) {
     isTelegramMessageFromCurrentBot(value.sourceMessage, botUserId)
       ? parseTelegramPromptContextProjection(value.promptContextProjection)
       : undefined;
+  const threadBinding =
+    value.version === TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION
+      ? normalizeTelegramMessageThreadBinding(value.threadBinding, threadId)
+      : undefined;
   return normalizeMessageNodes(value.sourceMessage, {
     ...(threadId !== undefined ? { threadId } : {}),
     ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
+    ...(threadBinding ? { threadBinding } : {}),
   }).map(({ node, mode }) => ({
     key: `${key.slice(0, separatorIndex + 1)}${node.messageId}`,
     node,
@@ -375,9 +440,13 @@ function mergeCachedMessageNode(
     : mergedSourceMessage;
   const promptContextProjectionMarker =
     incoming.promptContextProjectionMarker ?? existing.promptContextProjectionMarker;
+  const threadBinding =
+    normalizeTelegramMessageThreadBinding(incoming.threadBinding, threadId) ??
+    normalizeTelegramMessageThreadBinding(existing.threadBinding, threadId);
   return normalizeMessageNode(sourceMessage, {
     ...(threadId !== undefined ? { threadId } : {}),
     ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
+    ...(threadBinding ? { threadBinding } : {}),
   });
 }
 
@@ -504,6 +573,7 @@ async function persistCachedNode(params: {
       sourceMessage: params.node.sourceMessage,
       ...(params.botUserId !== undefined ? { botUserId: params.botUserId } : {}),
       ...(promptContextProjection ? { promptContextProjection } : {}),
+      ...(params.node.threadBinding ? { threadBinding: params.node.threadBinding } : {}),
       ...(params.node.threadId ? { threadId: params.node.threadId } : {}),
     });
   } catch (error) {
@@ -582,8 +652,17 @@ export function createTelegramMessageCache(params?: {
   };
 
   return {
-    record: async ({ accountId, botUserId, chatId, msg, promptContextProjection, threadId }) => {
+    record: async ({
+      accountId,
+      botUserId,
+      chatId,
+      msg,
+      promptContextProjection,
+      providerObservedThreadId,
+      threadId,
+    }) => {
       await hydrateMessageCacheBucket(bucket, maxMessages, scopeKey);
+      const threadBinding = createTelegramMessageThreadBinding(providerObservedThreadId);
       const observations = normalizeMessageNodes(msg, {
         threadId,
         ...(promptContextProjection && isTelegramMessageFromCurrentBot(msg, botUserId)
@@ -594,6 +673,7 @@ export function createTelegramMessageCache(params?: {
               },
             }
           : {}),
+        ...(threadBinding ? { threadBinding } : {}),
       });
       const currentObservation = observations.at(-1)!;
       let recordedEntry = currentObservation.node;

--- a/extensions/telegram/src/message-topic-binding.test.ts
+++ b/extensions/telegram/src/message-topic-binding.test.ts
@@ -1,0 +1,268 @@
+// Telegram tests cover provider-observed forum-topic message bindings.
+import type { Message } from "grammy/types";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
+import { resolveTelegramMessageMutationChatId } from "./message-topic-binding.js";
+import { setTelegramRuntime } from "./runtime.js";
+import {
+  clearTelegramRuntimeForTest,
+  resetTelegramMessageCacheForTest,
+} from "./runtime.test-support.js";
+import type { TelegramRuntime } from "./runtime.types.js";
+
+const cfg = {
+  channels: { telegram: { botToken: "tok" } },
+  session: { store: "/tmp/openclaw-telegram-topic-binding-test.json" },
+} as OpenClawConfig;
+
+function installRuntimeStore() {
+  setTelegramRuntime({
+    state: {
+      openKeyedStore: ((options) =>
+        createPluginStateKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openKeyedStore"],
+    },
+    channel: {},
+  } as TelegramRuntime);
+}
+
+function delegatedContext(overrides?: Record<string, unknown>) {
+  return {
+    conversationReadOrigin: "delegated" as const,
+    requesterAccountId: "default",
+    toolContext: {
+      currentChannelProvider: "telegram" as const,
+      currentChannelId: "telegram:-1001:topic:77",
+      currentMessageId: "901",
+    },
+    ...overrides,
+  };
+}
+
+function topicMessage(messageId: number, threadId: number): Message {
+  return {
+    chat: { id: -1001, type: "supergroup", title: "QA", is_forum: true },
+    message_id: messageId,
+    message_thread_id: threadId,
+    is_topic_message: true,
+    date: 1_736_380_700,
+    text: `message-${messageId}`,
+    from: { id: 1, is_bot: false, first_name: "QA" },
+  } as Message;
+}
+
+async function recordMessage(params: {
+  messageId: number;
+  threadId: number;
+  providerObserved: boolean;
+  accountId?: string;
+}) {
+  const cache = createTelegramMessageCache({
+    scope: resolveTelegramMessageCacheScope(resolveStorePath(cfg.session?.store)),
+  });
+  await cache.record({
+    accountId: params.accountId ?? "default",
+    chatId: -1001,
+    msg: topicMessage(params.messageId, params.threadId),
+    threadId: params.threadId,
+    ...(params.providerObserved ? { providerObservedThreadId: params.threadId } : {}),
+  });
+}
+
+describe("Telegram message topic binding", () => {
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    resetTelegramMessageCacheForTest();
+    installRuntimeStore();
+  });
+
+  afterEach(() => {
+    clearTelegramRuntimeForTest();
+    resetTelegramMessageCacheForTest();
+    resetPluginStateStoreForTests();
+  });
+
+  it("allows the trusted current message without a cache lookup", async () => {
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "telegram:-1001:topic:77",
+        messageId: 901,
+        cfg,
+        accountId: "default",
+        context: delegatedContext(),
+      }),
+    ).resolves.toBe("-1001");
+  });
+
+  it("rejects a delegated base-chat spelling during a trusted topic turn", async () => {
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001",
+        messageId: 901,
+        cfg,
+        accountId: "default",
+        context: delegatedContext(),
+      }),
+    ).rejects.toThrow("provider-observed binding");
+  });
+
+  it("allows an earlier provider-observed same-topic message after restart", async () => {
+    await recordMessage({ messageId: 900, threadId: 77, providerObserved: true });
+    resetTelegramMessageCacheForTest();
+
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001:topic:77",
+        messageId: 900,
+        cfg,
+        accountId: "default",
+        context: delegatedContext(),
+      }),
+    ).resolves.toBe("-1001");
+  });
+
+  it("rejects legacy and wrong-topic cache entries", async () => {
+    await recordMessage({ messageId: 899, threadId: 77, providerObserved: false });
+    await recordMessage({ messageId: 900, threadId: 88, providerObserved: true });
+    resetTelegramMessageCacheForTest();
+
+    for (const messageId of [899, 900]) {
+      await expect(
+        resolveTelegramMessageMutationChatId({
+          chatId: "-1001:topic:77",
+          messageId,
+          cfg,
+          accountId: "default",
+          context: delegatedContext(),
+        }),
+      ).rejects.toThrow("provider-observed binding");
+    }
+  });
+
+  it("does not borrow a binding from another account", async () => {
+    await recordMessage({ messageId: 900, threadId: 77, providerObserved: true });
+
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001:topic:77",
+        messageId: 900,
+        cfg,
+        accountId: "work",
+        context: delegatedContext({ requesterAccountId: "work" }),
+      }),
+    ).rejects.toThrow("provider-observed binding");
+
+    await recordMessage({
+      messageId: 900,
+      threadId: 77,
+      providerObserved: true,
+      accountId: "work",
+    });
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001:topic:77",
+        messageId: 900,
+        cfg,
+        accountId: "work",
+        context: delegatedContext({ requesterAccountId: "work" }),
+      }),
+    ).resolves.toBe("-1001");
+  });
+
+  it.each([
+    {
+      name: "missing origin",
+      messageId: 800,
+      context: {
+        requesterAccountId: "default",
+        toolContext: delegatedContext().toolContext,
+      },
+    },
+    {
+      name: "unknown origin",
+      messageId: 800,
+      context: delegatedContext({ conversationReadOrigin: "forged-direct-operator" }),
+    },
+    {
+      name: "wrong account",
+      context: delegatedContext({ requesterAccountId: "work" }),
+    },
+    {
+      name: "invalid account",
+      accountId: " !!! ",
+      context: delegatedContext({ requesterAccountId: " !!! " }),
+    },
+    {
+      name: "wrong provider",
+      context: delegatedContext({
+        toolContext: {
+          ...delegatedContext().toolContext,
+          currentChannelProvider: "slack",
+        },
+      }),
+    },
+    {
+      name: "stale topic",
+      context: delegatedContext({
+        toolContext: {
+          ...delegatedContext().toolContext,
+          currentChannelId: "telegram:-1001:topic:88",
+        },
+      }),
+    },
+    {
+      name: "conflicting target forms",
+      context: delegatedContext({
+        toolContext: {
+          ...delegatedContext().toolContext,
+          currentMessagingTarget: "telegram:-1002:topic:77",
+        },
+      }),
+    },
+  ])("rejects $name before provider execution", async ({ accountId, context, messageId }) => {
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001:topic:77",
+        messageId: messageId ?? 901,
+        cfg,
+        accountId: accountId ?? "default",
+        context: context as never,
+      }),
+    ).rejects.toThrow("provider-observed binding");
+  });
+
+  it("keeps direct and delegated authority operation-local under mixed ordering", async () => {
+    const direct = () =>
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001:topic:77",
+        messageId: 800,
+        cfg,
+        accountId: "default",
+        context: { conversationReadOrigin: "direct-operator" },
+      });
+    const delegated = () =>
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001:topic:77",
+        messageId: 800,
+        cfg,
+        accountId: "default",
+        context: delegatedContext(),
+      });
+
+    await expect(direct()).resolves.toBe("-1001");
+    await expect(delegated()).rejects.toThrow("provider-observed binding");
+    await expect(delegated()).rejects.toThrow("provider-observed binding");
+    await expect(direct()).resolves.toBe("-1001");
+
+    const concurrent = await Promise.allSettled([direct(), delegated()]);
+    expect(concurrent.map((result) => result.status)).toEqual(["fulfilled", "rejected"]);
+  });
+});

--- a/extensions/telegram/src/message-topic-binding.test.ts
+++ b/extensions/telegram/src/message-topic-binding.test.ts
@@ -167,6 +167,71 @@ describe("Telegram message topic binding", () => {
     ).rejects.toThrow("provider-observed binding");
   });
 
+  it.each([
+    {
+      name: "different chat",
+      chatId: "-1002",
+      context: delegatedContext({
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "telegram:-1001",
+          currentMessageId: "901",
+        },
+      }),
+    },
+    {
+      name: "different provider",
+      chatId: "-1001",
+      context: delegatedContext({
+        toolContext: {
+          currentChannelProvider: "slack",
+          currentChannelId: "telegram:-1001",
+          currentMessageId: "901",
+        },
+      }),
+    },
+    {
+      name: "different account",
+      chatId: "-1001",
+      context: delegatedContext({
+        requesterAccountId: "work",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "telegram:-1001",
+          currentMessageId: "901",
+        },
+      }),
+    },
+  ])("rejects a threadless $name mutation", async ({ chatId, context }) => {
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId,
+        messageId: 901,
+        cfg,
+        accountId: "default",
+        context,
+      }),
+    ).rejects.toThrow("provider-observed binding");
+  });
+
+  it("allows a threadless exact-current mutation with a matching account", async () => {
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001",
+        messageId: 901,
+        cfg,
+        accountId: "default",
+        context: delegatedContext({
+          toolContext: {
+            currentChannelProvider: "telegram",
+            currentChannelId: "telegram:-1001",
+            currentMessageId: "901",
+          },
+        }),
+      }),
+    ).resolves.toBe("-1001");
+  });
+
   it("allows an earlier provider-observed same-topic message after restart", async () => {
     await recordMessage({ messageId: 900, threadId: 77, providerObserved: true });
     resetTelegramMessageCacheForTest();

--- a/extensions/telegram/src/message-topic-binding.test.ts
+++ b/extensions/telegram/src/message-topic-binding.test.ts
@@ -102,10 +102,63 @@ describe("Telegram message topic binding", () => {
     ).resolves.toBe("-1001");
   });
 
-  it("rejects a delegated base-chat spelling during a trusted topic turn", async () => {
+  it("binds a delegated base-chat spelling to the trusted current topic", async () => {
     await expect(
       resolveTelegramMessageMutationChatId({
         chatId: "-1001",
+        messageId: 901,
+        cfg,
+        accountId: "default",
+        context: delegatedContext(),
+      }),
+    ).resolves.toBe("-1001");
+  });
+
+  it("binds General-topic mutations using trusted thread context", async () => {
+    await recordMessage({ messageId: 900, threadId: 1, providerObserved: true });
+    await recordMessage({ messageId: 899, threadId: 2, providerObserved: true });
+    const context = delegatedContext({
+      toolContext: {
+        currentChannelProvider: "telegram",
+        currentChannelId: "telegram:-1001",
+        currentMessageId: "901",
+        currentThreadTs: "1",
+      },
+    });
+
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001",
+        messageId: 901,
+        cfg,
+        accountId: "default",
+        context,
+      }),
+    ).resolves.toBe("-1001");
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001",
+        messageId: 900,
+        cfg,
+        accountId: "default",
+        context,
+      }),
+    ).resolves.toBe("-1001");
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001",
+        messageId: 899,
+        cfg,
+        accountId: "default",
+        context,
+      }),
+    ).rejects.toThrow("provider-observed binding");
+  });
+
+  it("rejects a topicless different-chat target during a trusted topic turn", async () => {
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1002",
         messageId: 901,
         cfg,
         accountId: "default",
@@ -215,6 +268,15 @@ describe("Telegram message topic binding", () => {
         toolContext: {
           ...delegatedContext().toolContext,
           currentChannelId: "telegram:-1001:topic:88",
+        },
+      }),
+    },
+    {
+      name: "conflicting trusted thread context",
+      context: delegatedContext({
+        toolContext: {
+          ...delegatedContext().toolContext,
+          currentThreadTs: "88",
         },
       }),
     },

--- a/extensions/telegram/src/message-topic-binding.ts
+++ b/extensions/telegram/src/message-topic-binding.ts
@@ -1,0 +1,122 @@
+// Telegram provider-owned authorization for message mutations in forum topics.
+import { normalizeAccountId, normalizeOptionalAccountId } from "openclaw/plugin-sdk/account-core";
+import type {
+  ChannelMessageActionContext,
+  ChannelThreadingToolContext,
+} from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { resolveDefaultTelegramAccountId } from "./accounts.js";
+import {
+  createTelegramMessageCache,
+  hasProviderObservedTelegramThreadBinding,
+  resolveTelegramMessageCacheScope,
+} from "./message-cache.js";
+import { parseTelegramTarget } from "./targets.js";
+
+type ConversationReadInvocationOrigin = NonNullable<
+  ChannelMessageActionContext["conversationReadOrigin"]
+>;
+
+export type TelegramMessageMutationContext = {
+  conversationReadOrigin?: ConversationReadInvocationOrigin;
+  requesterAccountId?: string | null;
+  toolContext?: ChannelThreadingToolContext;
+};
+
+const TOPIC_BINDING_ERROR =
+  "Delegated Telegram message mutation requires a provider-observed binding to the exact current topic and account.";
+
+function rejectUnboundTopicMutation(): never {
+  throw new Error(TOPIC_BINDING_ERROR);
+}
+
+function matchesCurrentTopic(
+  toolContext: ChannelThreadingToolContext | undefined,
+  chatId: string,
+  threadId: number,
+): boolean {
+  if (toolContext?.currentChannelProvider?.trim().toLowerCase() !== "telegram") {
+    return false;
+  }
+  const targets = [toolContext.currentChannelId, toolContext.currentMessagingTarget].filter(
+    (value): value is string => typeof value === "string" && Boolean(value.trim()),
+  );
+  return (
+    targets.length > 0 &&
+    targets.every((value) => {
+      const current = parseTelegramTarget(value);
+      return current.chatId === chatId && current.messageThreadId === threadId;
+    })
+  );
+}
+
+function hasCurrentTelegramTopic(toolContext: ChannelThreadingToolContext | undefined): boolean {
+  if (toolContext?.currentChannelProvider?.trim().toLowerCase() !== "telegram") {
+    return false;
+  }
+  return [toolContext.currentChannelId, toolContext.currentMessagingTarget].some(
+    (value) =>
+      typeof value === "string" && parseTelegramTarget(value).messageThreadId !== undefined,
+  );
+}
+
+export async function resolveTelegramMessageMutationChatId(params: {
+  chatId: string | number;
+  messageId: number;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  context?: TelegramMessageMutationContext;
+}): Promise<string | number> {
+  const target = parseTelegramTarget(String(params.chatId));
+  if (target.messageThreadId === undefined) {
+    // A topicless spelling must not bypass the provider check if this operation
+    // escaped shared normalization while still carrying trusted topic context.
+    if (
+      params.context?.conversationReadOrigin !== "direct-operator" &&
+      hasCurrentTelegramTopic(params.context?.toolContext)
+    ) {
+      return rejectUnboundTopicMutation();
+    }
+    return params.chatId;
+  }
+  if (params.context?.conversationReadOrigin === "direct-operator") {
+    return target.chatId;
+  }
+
+  const selectedAccountId = normalizeOptionalAccountId(
+    params.accountId ?? resolveDefaultTelegramAccountId(params.cfg),
+  );
+  const requesterAccountId = normalizeOptionalAccountId(params.context?.requesterAccountId);
+  if (
+    !selectedAccountId ||
+    !requesterAccountId ||
+    normalizeAccountId(selectedAccountId) !== normalizeAccountId(requesterAccountId) ||
+    !matchesCurrentTopic(params.context?.toolContext, target.chatId, target.messageThreadId)
+  ) {
+    return rejectUnboundTopicMutation();
+  }
+
+  const currentMessageId = parseStrictPositiveInteger(
+    params.context?.toolContext?.currentMessageId,
+  );
+  // Current-message context is server-owned. Earlier messages need the
+  // persisted provider observation so a sibling topic cannot borrow the ID.
+  if (currentMessageId === params.messageId) {
+    return target.chatId;
+  }
+
+  const cache = createTelegramMessageCache({
+    scope: resolveTelegramMessageCacheScope(resolveStorePath(params.cfg.session?.store)),
+  });
+  const cached = await cache.get({
+    accountId: selectedAccountId,
+    chatId: target.chatId,
+    messageId: String(params.messageId),
+  });
+  if (!hasProviderObservedTelegramThreadBinding(cached, target.messageThreadId)) {
+    return rejectUnboundTopicMutation();
+  }
+  return target.chatId;
+}

--- a/extensions/telegram/src/message-topic-binding.ts
+++ b/extensions/telegram/src/message-topic-binding.ts
@@ -81,14 +81,6 @@ export async function resolveTelegramMessageMutationChatId(params: {
     params.context?.toolContext,
     target.chatId,
   );
-  const threadId = target.messageThreadId ?? currentConversation.threadId;
-  if (threadId === undefined && !currentConversation.hasThreadContext) {
-    return params.chatId;
-  }
-  if (threadId === undefined) {
-    return rejectUnboundTopicMutation();
-  }
-
   const selectedAccountId = normalizeOptionalAccountId(
     params.accountId ?? resolveDefaultTelegramAccountId(params.cfg),
   );
@@ -97,9 +89,16 @@ export async function resolveTelegramMessageMutationChatId(params: {
     !selectedAccountId ||
     !requesterAccountId ||
     normalizeAccountId(selectedAccountId) !== normalizeAccountId(requesterAccountId) ||
-    !currentConversation.matchesChat ||
-    currentConversation.threadId !== threadId
+    !currentConversation.matchesChat
   ) {
+    return rejectUnboundTopicMutation();
+  }
+
+  const threadId = target.messageThreadId ?? currentConversation.threadId;
+  if (threadId === undefined && !currentConversation.hasThreadContext) {
+    return target.chatId;
+  }
+  if (threadId === undefined || currentConversation.threadId !== threadId) {
     return rejectUnboundTopicMutation();
   }
 

--- a/extensions/telegram/src/message-topic-binding.ts
+++ b/extensions/telegram/src/message-topic-binding.ts
@@ -32,34 +32,37 @@ function rejectUnboundTopicMutation(): never {
   throw new Error(TOPIC_BINDING_ERROR);
 }
 
-function matchesCurrentTopic(
+type CurrentTelegramConversation = {
+  hasThreadContext: boolean;
+  matchesChat: boolean;
+  threadId?: number;
+};
+
+function resolveCurrentTelegramConversation(
   toolContext: ChannelThreadingToolContext | undefined,
   chatId: string,
-  threadId: number,
-): boolean {
+): CurrentTelegramConversation {
   if (toolContext?.currentChannelProvider?.trim().toLowerCase() !== "telegram") {
-    return false;
+    return { hasThreadContext: false, matchesChat: false };
   }
   const targets = [toolContext.currentChannelId, toolContext.currentMessagingTarget].filter(
     (value): value is string => typeof value === "string" && Boolean(value.trim()),
   );
-  return (
+  const parsedTargets = targets.map((value) => parseTelegramTarget(value));
+  const threadIds = [
+    ...parsedTargets.map((target) => target.messageThreadId),
+    parseStrictPositiveInteger(toolContext.currentThreadTs),
+  ].filter((value): value is number => value !== undefined);
+  const threadId = threadIds[0];
+  const matchesChat =
     targets.length > 0 &&
-    targets.every((value) => {
-      const current = parseTelegramTarget(value);
-      return current.chatId === chatId && current.messageThreadId === threadId;
-    })
-  );
-}
-
-function hasCurrentTelegramTopic(toolContext: ChannelThreadingToolContext | undefined): boolean {
-  if (toolContext?.currentChannelProvider?.trim().toLowerCase() !== "telegram") {
-    return false;
-  }
-  return [toolContext.currentChannelId, toolContext.currentMessagingTarget].some(
-    (value) =>
-      typeof value === "string" && parseTelegramTarget(value).messageThreadId !== undefined,
-  );
+    parsedTargets.every((target) => target.chatId === chatId) &&
+    (threadId === undefined || threadIds.every((value) => value === threadId));
+  return {
+    hasThreadContext: threadIds.length > 0,
+    matchesChat,
+    ...(threadId !== undefined ? { threadId } : {}),
+  };
 }
 
 export async function resolveTelegramMessageMutationChatId(params: {
@@ -70,19 +73,20 @@ export async function resolveTelegramMessageMutationChatId(params: {
   context?: TelegramMessageMutationContext;
 }): Promise<string | number> {
   const target = parseTelegramTarget(String(params.chatId));
-  if (target.messageThreadId === undefined) {
-    // A topicless spelling must not bypass the provider check if this operation
-    // escaped shared normalization while still carrying trusted topic context.
-    if (
-      params.context?.conversationReadOrigin !== "direct-operator" &&
-      hasCurrentTelegramTopic(params.context?.toolContext)
-    ) {
-      return rejectUnboundTopicMutation();
-    }
+  if (params.context?.conversationReadOrigin === "direct-operator") {
+    return target.messageThreadId === undefined ? params.chatId : target.chatId;
+  }
+
+  const currentConversation = resolveCurrentTelegramConversation(
+    params.context?.toolContext,
+    target.chatId,
+  );
+  const threadId = target.messageThreadId ?? currentConversation.threadId;
+  if (threadId === undefined && !currentConversation.hasThreadContext) {
     return params.chatId;
   }
-  if (params.context?.conversationReadOrigin === "direct-operator") {
-    return target.chatId;
+  if (threadId === undefined) {
+    return rejectUnboundTopicMutation();
   }
 
   const selectedAccountId = normalizeOptionalAccountId(
@@ -93,7 +97,8 @@ export async function resolveTelegramMessageMutationChatId(params: {
     !selectedAccountId ||
     !requesterAccountId ||
     normalizeAccountId(selectedAccountId) !== normalizeAccountId(requesterAccountId) ||
-    !matchesCurrentTopic(params.context?.toolContext, target.chatId, target.messageThreadId)
+    !currentConversation.matchesChat ||
+    currentConversation.threadId !== threadId
   ) {
     return rejectUnboundTopicMutation();
   }
@@ -115,7 +120,7 @@ export async function resolveTelegramMessageMutationChatId(params: {
     chatId: target.chatId,
     messageId: String(params.messageId),
   });
-  if (!hasProviderObservedTelegramThreadBinding(cached, target.messageThreadId)) {
+  if (!hasProviderObservedTelegramThreadBinding(cached, threadId)) {
     return rejectUnboundTopicMutation();
   }
   return target.chatId;

--- a/extensions/telegram/src/outbound-message-context.test.ts
+++ b/extensions/telegram/src/outbound-message-context.test.ts
@@ -119,6 +119,7 @@ describe("recordOutboundMessageForPromptContext", () => {
     } as const;
     const callerOnlyThread = await recordAndRead({
       ...common,
+      successfulSendThread: { id: 77, scope: "forum" },
       message: {
         chat: { id: -1001, type: "supergroup", title: "QA" },
         date: 1_736_380_700,
@@ -142,6 +143,44 @@ describe("recordOutboundMessageForPromptContext", () => {
       },
     });
     expect(hasProviderObservedTelegramThreadBinding(providerThread, 77)).toBe(true);
+  });
+
+  it("binds a successful General-topic response from trusted send context", async () => {
+    const cached = await recordAndRead({
+      account: { accountId: "default", name: "Configured Agent" },
+      chatId: -1001,
+      message: {
+        chat: { id: -1001, type: "supergroup", title: "QA" },
+        date: 1_736_380_700,
+        from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+        message_id: 702,
+        text: "Bot replied in General",
+      },
+      messageId: 702,
+      messageThreadId: 1,
+      successfulSendThread: { id: 1, scope: "forum" },
+    });
+
+    expect(hasProviderObservedTelegramThreadBinding(cached, 1)).toBe(true);
+  });
+
+  it("does not infer a General-topic binding for DM thread context", async () => {
+    const cached = await recordAndRead({
+      account: { accountId: "default", name: "Configured Agent" },
+      chatId: 42,
+      message: {
+        chat: { id: 42, type: "private" },
+        date: 1_736_380_700,
+        from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+        message_id: 703,
+        text: "Bot replied in a DM topic",
+      },
+      messageId: 703,
+      messageThreadId: 1,
+      successfulSendThread: { id: 1, scope: "dm" },
+    });
+
+    expect(hasProviderObservedTelegramThreadBinding(cached, 1)).toBe(false);
   });
 
   it("falls back to the Telegram bot name when no configured name exists", async () => {

--- a/extensions/telegram/src/outbound-message-context.test.ts
+++ b/extensions/telegram/src/outbound-message-context.test.ts
@@ -6,7 +6,11 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
+import {
+  createTelegramMessageCache,
+  hasProviderObservedTelegramThreadBinding,
+  resolveTelegramMessageCacheScope,
+} from "./message-cache.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import { setTelegramRuntime } from "./runtime.js";
 import {
@@ -103,6 +107,41 @@ describe("recordOutboundMessageForPromptContext", () => {
       },
     });
     expect(cached?.sourceMessage.from).not.toHaveProperty("last_name");
+  });
+
+  it("binds topics only when the successful provider response identifies the thread", async () => {
+    const common = {
+      account: { accountId: "default", name: "Configured Agent" },
+      chatId: -1001,
+      messageId: 700,
+      text: "Bot just replied",
+      messageThreadId: 77,
+    } as const;
+    const callerOnlyThread = await recordAndRead({
+      ...common,
+      message: {
+        chat: { id: -1001, type: "supergroup", title: "QA" },
+        date: 1_736_380_700,
+        from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+        message_id: 700,
+        text: "Bot just replied",
+      },
+    });
+    expect(hasProviderObservedTelegramThreadBinding(callerOnlyThread, 77)).toBe(false);
+
+    const providerThread = await recordAndRead({
+      ...common,
+      messageId: 701,
+      message: {
+        chat: { id: -1001, type: "supergroup", title: "QA" },
+        date: 1_736_380_701,
+        from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+        message_id: 701,
+        message_thread_id: 77,
+        text: "Bot replied in the topic",
+      },
+    });
+    expect(hasProviderObservedTelegramThreadBinding(providerThread, 77)).toBe(true);
   });
 
   it("falls back to the Telegram bot name when no configured name exists", async () => {

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -3,6 +3,7 @@ import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { TELEGRAM_GENERAL_TOPIC_ID, type TelegramThreadSpec } from "./bot/helpers.js";
 import { buildTelegramSelfSenderName } from "./group-history-window.js";
 import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
 import type { TelegramPromptContextProjection } from "./prompt-context-projection.js";
@@ -130,11 +131,25 @@ export async function recordOutboundMessageForPromptContext(params: {
   botUserId?: number;
   text?: string;
   messageThreadId?: number;
+  /** Effective server-owned thread for the successful provider send. */
+  successfulSendThread?: TelegramThreadSpec;
   promptContextTimestampMs?: number;
   promptContextProjection?: TelegramPromptContextProjection;
 }): Promise<boolean> {
   try {
-    const cacheMessage = buildOutboundCacheMessage(params);
+    const providerGeneralTopicId =
+      params.message.message_thread_id === undefined &&
+      params.message.chat?.type === "supergroup" &&
+      params.successfulSendThread?.scope === "forum" &&
+      params.successfulSendThread.id === TELEGRAM_GENERAL_TOPIC_ID
+        ? TELEGRAM_GENERAL_TOPIC_ID
+        : undefined;
+    const providerObservedThreadId = params.message.message_thread_id ?? providerGeneralTopicId;
+    const messageThreadId = params.messageThreadId ?? providerGeneralTopicId;
+    const cacheMessage = buildOutboundCacheMessage({
+      ...params,
+      ...(messageThreadId !== undefined ? { messageThreadId } : {}),
+    });
     const cache = createTelegramMessageCache({
       scope: resolveTelegramMessageCacheScope(resolveStorePath(params.cfg.session?.store)),
     });
@@ -146,17 +161,15 @@ export async function recordOutboundMessageForPromptContext(params: {
       ...(params.promptContextProjection
         ? { promptContextProjection: params.promptContextProjection }
         : {}),
-      ...(params.message.message_thread_id !== undefined
-        ? { providerObservedThreadId: params.message.message_thread_id }
-        : {}),
-      ...(params.messageThreadId !== undefined ? { threadId: params.messageThreadId } : {}),
+      ...(providerObservedThreadId !== undefined ? { providerObservedThreadId } : {}),
+      ...(messageThreadId !== undefined ? { threadId: messageThreadId } : {}),
     });
     const timestamp = resolveOutboundCacheMessageTimestamp(cacheMessage);
     outboundGroupHistoryRecorders.get(params.account.accountId)?.({
       chatId: params.chatId,
       messageId: params.messageId,
       text: params.text ?? cacheMessage.text ?? cacheMessage.caption,
-      ...(params.messageThreadId !== undefined ? { messageThreadId: params.messageThreadId } : {}),
+      ...(messageThreadId !== undefined ? { messageThreadId } : {}),
       ...(timestamp !== undefined ? { timestamp } : {}),
     });
     return true;

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -146,6 +146,9 @@ export async function recordOutboundMessageForPromptContext(params: {
       ...(params.promptContextProjection
         ? { promptContextProjection: params.promptContextProjection }
         : {}),
+      ...(params.message.message_thread_id !== undefined
+        ? { providerObservedThreadId: params.message.message_thread_id }
+        : {}),
       ...(params.messageThreadId !== undefined ? { threadId: params.messageThreadId } : {}),
     });
     const timestamp = resolveOutboundCacheMessageTimestamp(cacheMessage);

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -13,6 +13,7 @@ import { markdownToTelegramHtml, telegramHtmlToPlainTextFallback } from "./forma
 import {
   buildTelegramConversationContext,
   createTelegramMessageCache,
+  hasProviderObservedTelegramThreadBinding,
   resolveTelegramMessageCacheScope,
 } from "./message-cache.js";
 import { createTelegramPromptContextProjectionCursor } from "./prompt-context-projection.js";
@@ -980,6 +981,35 @@ describe("sendMessageTelegram", () => {
     expect(context.map((entry) => entry.node.body)).toContain(
       "Done already: timeoutSeconds is now 7200s.",
     );
+  });
+
+  it("records a successful General-topic send when the response omits the thread id", async () => {
+    const storePath = `/tmp/openclaw-telegram-general-context-${process.pid}-${Date.now()}.json`;
+    const chatId = "-1003966283270";
+    botApi.sendMessage.mockResolvedValueOnce({
+      message_id: 1498,
+      date: 1_779_394_741,
+      chat: { id: chatId, type: "supergroup", title: "QA forum" },
+      from: { id: 42, is_bot: true, first_name: "OpenClaw" },
+      text: "Reply in General",
+    });
+
+    await sendMessageTelegram(`${chatId}:topic:1`, "Reply in General", {
+      cfg: { session: { store: storePath } },
+      token: "tok",
+    });
+
+    expect(firstMockCall(botApi.sendMessage, "General-topic send")[2]).not.toHaveProperty(
+      "message_thread_id",
+    );
+    const cached = await createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    }).get({
+      accountId: "default",
+      chatId,
+      messageId: "1498",
+    });
+    expect(hasProviderObservedTelegramThreadBinding(cached, 1)).toBe(true);
   });
 
   it("records transcript projection metadata without replacing Telegram time", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -3914,6 +3914,33 @@ describe("sendStickerTelegram", () => {
     });
   }
 
+  it("records a successful topic sticker for later message mutations", async () => {
+    const storePath = `/tmp/openclaw-telegram-sticker-context-${process.pid}-${Date.now()}.json`;
+    const chatId = "-100123";
+    const sendSticker = vi.fn().mockResolvedValue({
+      message_id: 107,
+      chat: { id: chatId, type: "supergroup" },
+      message_thread_id: 77,
+      sticker: { file_id: "fileId123", file_unique_id: "unique", type: "regular" },
+    });
+    const api = { sendSticker } as unknown as { sendSticker: typeof sendSticker };
+
+    await sendStickerTelegram(`${chatId}:topic:77`, "fileId123", {
+      cfg: { session: { store: storePath } },
+      token: "tok",
+      api,
+    });
+
+    const cached = await createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    }).get({
+      accountId: "default",
+      chatId,
+      messageId: "107",
+    });
+    expect(hasProviderObservedTelegramThreadBinding(cached, 77)).toBe(true);
+  });
+
   it("rejects a blank fileId before creating a Telegram client", async () => {
     botCtorSpy.mockClear();
 
@@ -4559,6 +4586,32 @@ describe("sendPollTelegram", () => {
     );
 
     expect(firstMockCall(api.sendPoll, "send poll call")[2]).toEqual(options);
+  });
+
+  it("records a successful General-topic poll for later message mutations", async () => {
+    const storePath = `/tmp/openclaw-telegram-poll-context-${process.pid}-${Date.now()}.json`;
+    const chatId = "-100123";
+    const sendPoll = vi.fn().mockResolvedValue({
+      message_id: 124,
+      chat: { id: chatId, type: "supergroup" },
+      poll: { id: "p2", question: "Q", options: [] },
+    });
+    const api = { sendPoll } as unknown as Bot["api"];
+
+    await sendPollTelegram(
+      `${chatId}:topic:1`,
+      { question: "Q", options: ["A", "B"] },
+      { cfg: { session: { store: storePath } }, token: "t", api },
+    );
+
+    const cached = await createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    }).get({
+      accountId: "default",
+      chatId,
+      messageId: "124",
+    });
+    expect(hasProviderObservedTelegramThreadBinding(cached, 1)).toBe(true);
   });
 
   it("propagates gateway client scopes when resolving legacy poll targets", async () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -840,6 +840,11 @@ async function sendMessageTelegramWithContext(
     verbose: opts.verbose,
     gatewayClientScopes: opts.gatewayClientScopes,
   });
+  const threadSpec = resolveTelegramSendThreadSpec({
+    targetMessageThreadId: target.messageThreadId,
+    messageThreadId: opts.messageThreadId,
+    chatType: target.chatType,
+  });
   const reportDelivery = async (
     messageId: string | number,
     deliveredChatId: string | number,
@@ -865,6 +870,8 @@ async function sendMessageTelegramWithContext(
       account,
       ...(botUserId !== undefined ? { botUserId } : {}),
       chatId,
+      ...(threadSpec?.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
+      ...(threadSpec ? { successfulSendThread: threadSpec } : {}),
       ...params,
       promptContextProjection: projection,
     });
@@ -880,11 +887,6 @@ async function sendMessageTelegramWithContext(
     (typeof account.config.mediaMaxMb === "number" ? account.config.mediaMaxMb : 100) * 1024 * 1024;
   const replyMarkup = buildInlineKeyboard(opts.buttons);
 
-  const threadSpec = resolveTelegramSendThreadSpec({
-    targetMessageThreadId: target.messageThreadId,
-    messageThreadId: opts.messageThreadId,
-    chatType: target.chatType,
-  });
   const singleUseReplyTo =
     opts.replyToIdSource === "implicit" &&
     opts.replyToMode !== undefined &&
@@ -1659,12 +1661,13 @@ async function sendLocationTelegramWithContext(
     verbose: opts.verbose,
     gatewayClientScopes: opts.gatewayClientScopes,
   });
+  const threadSpec = resolveTelegramSendThreadSpec({
+    targetMessageThreadId: target.messageThreadId,
+    messageThreadId: opts.messageThreadId,
+    chatType: target.chatType,
+  });
   const threadParams = buildTelegramThreadReplyParams({
-    thread: resolveTelegramSendThreadSpec({
-      targetMessageThreadId: target.messageThreadId,
-      messageThreadId: opts.messageThreadId,
-      chatType: target.chatType,
-    }),
+    thread: threadSpec,
     replyToMessageId: opts.replyToMessageId,
     replyQuoteText: opts.quoteText,
     useReplyIdAsQuoteSource: true,
@@ -1726,6 +1729,8 @@ async function sendLocationTelegramWithContext(
     message: result,
     messageId,
     text: formatLocationText(location),
+    ...(threadSpec?.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
+    ...(threadSpec ? { successfulSendThread: threadSpec } : {}),
     ...(acceptedParams?.message_thread_id !== undefined
       ? { messageThreadId: acceptedParams.message_thread_id }
       : {}),

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -2484,13 +2484,13 @@ async function sendStickerTelegramWithContext(
     verbose: opts.verbose,
     gatewayClientScopes: opts.gatewayClientScopes,
   });
-
+  const threadSpec = resolveTelegramSendThreadSpec({
+    targetMessageThreadId: target.messageThreadId,
+    messageThreadId: opts.messageThreadId,
+    chatType: target.chatType,
+  });
   const threadParams = buildTelegramThreadReplyParams({
-    thread: resolveTelegramSendThreadSpec({
-      targetMessageThreadId: target.messageThreadId,
-      messageThreadId: opts.messageThreadId,
-      chatType: target.chatType,
-    }),
+    thread: threadSpec,
     replyToMessageId: opts.replyToMessageId,
   });
   const hasThreadParams = Object.keys(threadParams).length > 0;
@@ -2518,6 +2518,15 @@ async function sendStickerTelegramWithContext(
   const messageId = resolveTelegramMessageIdOrThrow(result, "sticker send");
   const resolvedChatId = String(result?.chat?.id ?? chatId);
   recordSentMessage(chatId, messageId, opts.cfg);
+  await recordOutboundMessageForPromptContext({
+    cfg,
+    account,
+    chatId,
+    message: result,
+    messageId,
+    ...(threadSpec?.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
+    ...(threadSpec ? { successfulSendThread: threadSpec } : {}),
+  });
   recordChannelActivity({
     channel: "telegram",
     accountId: account.accountId,
@@ -2579,13 +2588,13 @@ async function sendPollTelegramWithContext(
 
   // Normalize the poll input (validates question, options, maxSelections)
   const normalizedPoll = normalizePollInput(poll, { maxOptions: 12 });
-
+  const threadSpec = resolveTelegramSendThreadSpec({
+    targetMessageThreadId: target.messageThreadId,
+    messageThreadId: opts.messageThreadId,
+    chatType: target.chatType,
+  });
   const threadParams = buildTelegramThreadReplyParams({
-    thread: resolveTelegramSendThreadSpec({
-      targetMessageThreadId: target.messageThreadId,
-      messageThreadId: opts.messageThreadId,
-      chatType: target.chatType,
-    }),
+    thread: threadSpec,
     replyToMessageId: opts.replyToMessageId,
   });
 
@@ -2633,6 +2642,15 @@ async function sendPollTelegramWithContext(
   const resolvedChatId = String(result?.chat?.id ?? chatId);
   const pollId = result?.poll?.id;
   recordSentMessage(chatId, messageId, opts.cfg);
+  await recordOutboundMessageForPromptContext({
+    cfg,
+    account,
+    chatId,
+    message: result,
+    messageId,
+    ...(threadSpec?.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
+    ...(threadSpec ? { successfulSendThread: threadSpec } : {}),
+  });
 
   recordChannelActivity({
     channel: "telegram",

--- a/src/channels/plugins/message-action-dispatch.ts
+++ b/src/channels/plugins/message-action-dispatch.ts
@@ -24,6 +24,13 @@ const BUNDLED_CHANNELS_WITH_PROVIDER_READ_GATES: ReadonlySet<string> = new Set([
   "slack",
 ]);
 
+// Telegram owns exact topic/account binding for message mutations only. Other
+// Telegram reads retain the host gate, including targetless sticker cache reads.
+const BUNDLED_PROVIDER_READ_GATE_ACTIONS: ReadonlyMap<
+  string,
+  ReadonlySet<ChannelMessageActionName>
+> = new Map([["telegram", new Set<ChannelMessageActionName>(["react", "edit", "delete"])]]);
+
 declare const serverOwnedConversationReadOrigin: unique symbol;
 
 type ServerOwnedConversationReadOrigin = ReturnType<
@@ -137,12 +144,14 @@ type MessageActionReadEnforcement =
     };
 
 function resolveMessageActionReadEnforcement(params: {
+  action: ChannelMessageActionName;
   channel: string;
   pluginOrigin: string | undefined;
 }): MessageActionReadEnforcement {
   if (
     params.pluginOrigin === "bundled" &&
-    BUNDLED_CHANNELS_WITH_PROVIDER_READ_GATES.has(params.channel)
+    (BUNDLED_CHANNELS_WITH_PROVIDER_READ_GATES.has(params.channel) ||
+      BUNDLED_PROVIDER_READ_GATE_ACTIONS.get(params.channel)?.has(params.action) === true)
   ) {
     return { kind: "provider-owned" };
   }
@@ -551,6 +560,7 @@ export async function dispatchChannelMessageAction(
     origin,
     actionPolicy,
     enforcement: resolveMessageActionReadEnforcement({
+      action: actionContext.action,
       channel: actionContext.channel,
       pluginOrigin: registration.origin,
     }),

--- a/src/channels/plugins/message-actions.security.test.ts
+++ b/src/channels/plugins/message-actions.security.test.ts
@@ -530,6 +530,52 @@ describe("dispatchChannelMessageAction conversation-read provenance", () => {
     expect(handleAction).not.toHaveBeenCalled();
   });
 
+  it.each(["react", "edit", "delete"] as const)(
+    "delegates Telegram %s topic binding to the bundled provider",
+    async (action) => {
+      setReadPlugin({ channel: "telegram", origin: "bundled" });
+
+      await dispatchChannelMessageAction({
+        channel: "telegram",
+        action,
+        cfg: {} as OpenClawConfig,
+        params: { chatId: "-1001" },
+        accountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "telegram:-1001:topic:77",
+          currentThreadTs: "77",
+        },
+      });
+
+      expect(handleAction).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not grant Telegram mutation enforcement to an external override", async () => {
+    setReadPlugin({ channel: "telegram", origin: "workspace" });
+
+    await expect(
+      dispatchChannelMessageAction({
+        channel: "telegram",
+        action: "react",
+        cfg: {} as OpenClawConfig,
+        params: { chatId: "-1001" },
+        accountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "telegram:-1001:topic:77",
+          currentThreadTs: "77",
+        },
+      }),
+    ).rejects.toThrow("requires the exact current conversation and account");
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+
   it("uses bundled provider target normalization for equivalent exact-current forms", async () => {
     const normalizeTarget = vi.fn((raw: string) => {
       const room = raw

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -319,6 +319,31 @@ describe("normalizeMessageActionInput", () => {
     ).toThrow(/requires a target/);
   });
 
+  it.each(["react", "edit", "delete"] as const)(
+    "infers the exact current conversation for a provider-owned %s message resource",
+    (action) => {
+      expect(
+        normalizeMessageActionInput({
+          action,
+          args: { channel: "forum", messageId: "901" },
+          toolContext: {
+            currentChannelProvider: "forum",
+            currentChannelId: "-1001:topic:77",
+          },
+          targetAliasSpec: {
+            aliases: ["messageId"],
+            deliveryTargetAliases: [],
+          },
+        }),
+      ).toMatchObject({
+        channel: "forum",
+        messageId: "901",
+        target: "-1001:topic:77",
+        to: "-1001:topic:77",
+      });
+    },
+  );
+
   it.each([
     { action: "react" as const, args: { channel: "imessage", messageId: "msg_123" } },
     { action: "poll-vote" as const, args: { channel: "imessage", pollId: "poll_123" } },


### PR DESCRIPTION
Closes #112795

## What Problem This Solves

Fixes an issue where Telegram forum-topic users could not reliably ask an agent to react to, edit, or delete an earlier message in the current topic. Topic-qualified targets stopped before Telegram execution, while the provider API requires the base chat plus message ID.

## Why This Change Was Made

Telegram now records provider-observed topic bindings in its existing message cache for authenticated inbound updates and successful outbound sends, including durable streamed replies, polls, and stickers. Delegated mutations require an exact account, chat, and topic match before the provider call; legacy or unbound entries remain unavailable. Direct operator behavior is unchanged.

## User Impact

Agents can mutate the current message and earlier observed messages in the same Telegram forum topic after a restart. Attempts aimed at a sibling topic remain rejected without changing that topic.

## Evidence

- 571 focused remote tests passed on `6a8d77372f2` across shared normalization/security and Telegram message actions, caching, delivery, streaming, polls, and stickers.
- Remote changed checks, build, and self-contained package verification passed on that exact head.
- Its immutable package was exercised against the real Telegram API and a real model in two disposable forum topics.
- Two durable provider-observed bindings survived a Gateway restart.
- Transcript verification found exactly seven model-selected `message` tool calls: current reaction; same-topic reaction, edit, and delete; sibling-topic reaction, edit, and delete.
- All four allowed operations were verified in Telegram. All three sibling-topic operations were rejected, and the sibling message remained present and unchanged.
- Mandatory fresh autoreview completed with no accepted actionable findings.
- Current rebased HEAD `f10f59876f0` is patch-equivalent across all eight commits by `git range-diff`; live proof was not rerun after the rebase by maintainer direction.

AI-assisted: yes.
