### PR TITLE
fix(doctor): warn when legacy device auth store still needs migration

### DIFF
--- a/src/commands/doctor-device-pairing.test.ts
+++ b/src/commands/doctor-device-pairing.test.ts
@@ -197,6 +197,52 @@ describe("noteDevicePairingHealth", () => {
     });
   });
 
+  it("warns when the legacy device auth store has not been migrated", async () => {
+    await withTempDir("openclaw-doctor-device-pairing-", async (stateDir) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_TEST_FAST: "1",
+        },
+        async () => {
+          const legacyPath = path.join(stateDir, "identity", "device-auth.json");
+          await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+          const legacyStore = JSON.stringify({
+            version: 1,
+            deviceId: "device-legacy",
+            tokens: { operator: { token: "legacy-token" } },
+          });
+          await fs.writeFile(legacyPath, legacyStore, "utf8");
+
+          await noteDevicePairingHealth({
+            cfg: { gateway: { mode: "local" } },
+            healthOk: false,
+          });
+
+          expect(noteMock).toHaveBeenCalledTimes(1);
+          const message = requireNoteMessage();
+          expect(requireNoteTitle()).toBe("Device pairing");
+          expect(message).toContain("device-auth.json");
+          expect(message).toContain("doctor --fix");
+
+          const findings = await collectDevicePairingHealthFindings({
+            cfg: { gateway: { mode: "local" } },
+          });
+          expect(findings).toEqual([
+            expect.objectContaining({
+              checkId: "core/doctor/device-pairing",
+              severity: "warning",
+              path: "identity.device-auth",
+              requirement: "device-auth-store-legacy-file",
+              message: expect.stringContaining("has not been imported"),
+            }),
+          ]);
+          expect(await fs.readFile(legacyPath, "utf8")).toBe(legacyStore);
+        },
+      );
+    });
+  });
+
   it("warns when the local cached device token predates the gateway rotation", async () => {
     await withApprovedOperatorPairing(async ({ identity }) => {
       const now = vi.spyOn(Date, "now").mockReturnValue(1);

--- a/src/commands/doctor-device-pairing.ts
+++ b/src/commands/doctor-device-pairing.ts
@@ -7,7 +7,7 @@ import { quoteCliArg } from "../cli/quote-cli-arg.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding } from "../flows/health-checks.js";
 import { callGateway } from "../gateway/call.js";
-import { loadDeviceAuthTokens } from "../infra/device-auth-store.js";
+import { legacyDeviceAuthStorePath, loadDeviceAuthTokens } from "../infra/device-auth-store.js";
 import { loadDeviceIdentityIfPresent } from "../infra/device-identity.js";
 import {
   listApprovedPairedDeviceRoles,
@@ -486,6 +486,16 @@ async function collectLegacyPairingStoreIssues(cfg: OpenClawConfig): Promise<str
   return (await listLegacyDevicePairingStoreFiles()).map(formatLegacyPairingStoreIssue);
 }
 
+function formatLegacyDeviceAuthStoreIssue(filePath: string): string {
+  const fixCommand = formatCliArgs(["openclaw", "doctor", "--fix"]);
+  return `- Legacy device auth store ${filePath} has not been imported into the SQLite state store yet, so doctor cannot inspect locally cached device tokens. Stop the gateway and run ${fixCommand} to import it.`;
+}
+
+function collectLegacyDeviceAuthStoreIssues(): string[] {
+  const filePath = legacyDeviceAuthStorePath();
+  return filePath ? [formatLegacyDeviceAuthStoreIssue(filePath)] : [];
+}
+
 function stripListMarker(message: string): string {
   return message.startsWith("- ") ? message.slice(2) : message;
 }
@@ -542,13 +552,28 @@ function legacyPairingStoreIssueToHealthFinding(message: string): HealthFinding 
   };
 }
 
+function legacyDeviceAuthStoreIssueToHealthFinding(message: string): HealthFinding {
+  const fixCommand = formatCliArgs(["openclaw", "doctor", "--fix"]);
+  return {
+    checkId: DEVICE_PAIRING_CHECK_ID,
+    severity: "warning",
+    message: stripListMarker(message),
+    path: "identity.device-auth",
+    requirement: "device-auth-store-legacy-file",
+    fixHint: `Stop the gateway and run ${fixCommand} to import the legacy device auth store.`,
+  };
+}
+
 export async function collectDevicePairingHealthFindings(params: {
   cfg: OpenClawConfig;
   healthOk?: boolean;
 }): Promise<HealthFinding[]> {
-  const legacyStoreFindings = (await collectLegacyPairingStoreIssues(params.cfg)).map(
-    legacyPairingStoreIssueToHealthFinding,
-  );
+  const legacyStoreFindings = [
+    ...(await collectLegacyPairingStoreIssues(params.cfg)).map(
+      legacyPairingStoreIssueToHealthFinding,
+    ),
+    ...collectLegacyDeviceAuthStoreIssues().map(legacyDeviceAuthStoreIssueToHealthFinding),
+  ];
   const snapshot = await loadDoctorPairingSnapshot({
     cfg: params.cfg,
     healthOk: params.healthOk ?? false,
@@ -574,7 +599,10 @@ export async function noteDevicePairingHealth(params: {
   cfg: OpenClawConfig;
   healthOk: boolean;
 }): Promise<void> {
-  const legacyStoreLines = await collectLegacyPairingStoreIssues(params.cfg);
+  const legacyStoreLines = [
+    ...(await collectLegacyPairingStoreIssues(params.cfg)),
+    ...collectLegacyDeviceAuthStoreIssues(),
+  ];
   const snapshot = await loadDoctorPairingSnapshot(params);
   const lines = [
     ...legacyStoreLines,

--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -24,14 +24,19 @@ type DeviceAuthDatabase = Pick<OpenClawStateKyselyDatabase, "device_auth_tokens"
 // the entry after its exclusive legacy import removes the retired file.
 const legacyPresenceCache = new Map<string, boolean>();
 
-function assertNoLegacyDeviceAuth(env: NodeJS.ProcessEnv | undefined): void {
+export function legacyDeviceAuthStorePath(env?: NodeJS.ProcessEnv): string | null {
   const stateDir = resolveStateDir(env);
+  const filePath = path.join(stateDir, "identity", "device-auth.json");
   let hasLegacy = legacyPresenceCache.get(stateDir);
   if (hasLegacy === undefined) {
-    hasLegacy = fs.existsSync(path.join(stateDir, "identity", "device-auth.json"));
+    hasLegacy = fs.existsSync(filePath);
     legacyPresenceCache.set(stateDir, hasLegacy);
   }
-  if (hasLegacy) {
+  return hasLegacy ? filePath : null;
+}
+
+function assertNoLegacyDeviceAuth(env: NodeJS.ProcessEnv | undefined): void {
+  if (legacyDeviceAuthStorePath(env) !== null) {
     throw new Error(
       "Legacy device auth requires migration; stop the Gateway and run `openclaw doctor --fix`.",
     );


### PR DESCRIPTION
## What Problem This Solves

After upgrading to a build that stores device auth tokens in SQLite (#112663), any install that still has the retired `identity/device-auth.json` file gets a doctor that is silently blind on the device auth surface: `openclaw doctor` reports no local device auth findings at all and never tells the user that the legacy store needs migration.

Root cause chain on current main:

- `loadDeviceAuthTokens` throws whenever the legacy file exists (`src/infra/device-auth-store.ts`, `assertNoLegacyDeviceAuth`).
- Doctor's `readLocalDeviceAuthTokens` wrapper catches every error and returns an empty token list (`src/commands/doctor-device-pairing.ts`), so all local token findings (stale token, scope mismatch, role no longer approved) are suppressed with no hint anything was skipped.
- Plain `openclaw doctor` does not surface the pending migration either: `detectLegacyDeviceAuth` reports the file only when `doctorOnlyStateMigrations` is set, which requires `--fix` or `--yes` (`src/flows/doctor-health-contributions.ts`).

So the one command that should tell the user "run `openclaw doctor --fix`" is the command that stays silent.

## Why This Change Was Made

Doctor already owns a pattern for exactly this condition: `collectLegacyPairingStoreIssues` warns when a legacy `devices/*.json` pairing store has not been imported into SQLite. This change mirrors that pattern for the client-side legacy device auth store:

- `src/infra/device-auth-store.ts` exports `legacyDeviceAuthStorePath`, which returns the retired file path when it is still present, reusing the existing presence cache. `assertNoLegacyDeviceAuth` now derives its answer from it, so there is still exactly one probe.
- `src/commands/doctor-device-pairing.ts` emits a warning (`path: identity.device-auth`, `requirement: device-auth-store-legacy-file`) naming the file and the exact fix command, in both the interactive note flow (`noteDevicePairingHealth`) and the structured findings flow (`collectDevicePairingHealthFindings`).

Boundary notes: runtime consumers of the store (`src/gateway/call.ts`, `src/gateway/probe.ts`) intentionally degrade to "no cached device token" when the loader throws, so connections keep working; doctor is the diagnostic owner, and this fix is bounded to it. The new check is not gated on `gateway.mode` because `identity/device-auth.json` is client-local state used when connecting to either a local or a remote gateway; the existing `devices/*.json` check stays gateway-local as before.

## User Impact

`openclaw doctor` on an upgraded install with a pending legacy device auth store now prints a Device pairing warning that names the un-imported file and tells the user to stop the gateway and run `openclaw doctor --fix`. Local device auth drift findings come back after the import. Installs without the legacy file see no behavior change.

## Evidence

Regression provenance: #112663 (merged 2026-07-22) replaced doctor's direct JSON store read with the throwing SQLite loader plus a catch-all wrapper.

Live CLI before/after: real `openclaw doctor --non-interactive` run from source, no mocks, against a state dir whose only content is a legacy `identity/device-auth.json` (version 1, one operator token). Identical inputs for both runs.

Before (pristine main `0f3855aa81`): doctor renders 12 sections and finishes with no Device pairing section and no mention of the legacy store anywhere in the output.

```
◇  UI ... Startup optimization ... Doctor warnings ... Gateway ... Gateway auth ...
   Command owner ... Plugin registry ... State integrity ... Skills ... Memory search ...

└  Doctor complete.
```

After (this patch, identical inputs): the Device pairing section appears with the new warning.

```
◇  Device pairing ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                      │
│  - Legacy device auth store                                                                                          │
│    /tmp/claude-0/-root/a487594e-bfa9-4a53-8ad2-c41a0d1e0da0/scratchpad/doctor-proof/state/identity/device-auth.json  │
│    has not been imported into the SQLite state store yet, so doctor                                                  │
│    cannot inspect locally cached device tokens. Stop the gateway and                                                 │
│    run openclaw doctor --fix to import it.                                                                           │
│                                                                                                                      │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

└  Doctor complete.
```

- New colocated regression test (`src/commands/doctor-device-pairing.test.ts`, "warns when the legacy device auth store has not been migrated") drives both doctor entry points against a real on-disk legacy store, asserts the warning in the note flow and the structured findings, and asserts the file is left untouched. It fails on pristine main and passes with the patch.
- Scoped gates on the changed files, all clean: `node scripts/run-vitest.mjs src/commands/doctor-device-pairing.test.ts src/infra/device-auth-store.test.ts`, `node scripts/run-oxlint.mjs` on the three changed files, `oxfmt --check`, and `tsgo` core plus core-test lanes.
