### PR TITLE
fix(outbound): ignore a blank reply-payload location

### DIFF
--- a/src/infra/outbound/reply-payload-normalize.ts
+++ b/src/infra/outbound/reply-payload-normalize.ts
@@ -1,6 +1,9 @@
 // Reply-payload normalization projects loose tool/agent objects onto the
 // outbound-supported reply payload fields.
-import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalString,
+  readStringValue,
+} from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload as InternalReplyPayload } from "../../auto-reply/reply-payload.js";
 import { normalizeOutboundLocation } from "../../channels/location.js";
 
@@ -47,7 +50,13 @@ export function normalizeOutboundReplyPayload(
   const channelData = readObjectValue(payload.channelData) as OutboundReplyPayload["channelData"];
   const sensitiveMedia = payload.sensitiveMedia === true ? true : undefined;
   const replyToId = readStringValue(payload.replyToId);
-  const location = normalizeOutboundLocation(payload.location);
+  const rawLocation = payload.location;
+  // Some producers pad the unused optional `location` slot with a blank string;
+  // treat blank as absent but keep real locations strict (mirrors message-action-runner, #112013).
+  const location =
+    typeof rawLocation === "string" && normalizeOptionalString(rawLocation) === undefined
+      ? undefined
+      : normalizeOutboundLocation(rawLocation);
   const videoAsNote = payload.videoAsNote === true ? true : undefined;
   return {
     text,

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -509,6 +509,23 @@ describe("normalizeOutboundReplyPayload", () => {
     });
   });
 
+  it("treats a blank-string location as absent", () => {
+    // Some producers pad the unused optional location slot with a blank string.
+    const empty = normalizeOutboundReplyPayload({ text: "hi", location: "" });
+    expect(empty.location).toBeUndefined();
+    expect(empty.text).toBe("hi");
+    expect(normalizeOutboundReplyPayload({ text: "hi", location: "   " }).location).toBeUndefined();
+  });
+
+  it("keeps a non-blank invalid location strict", () => {
+    expect(() => normalizeOutboundReplyPayload({ location: "Main stage" })).toThrow(
+      "location must be an object",
+    );
+    expect(() => normalizeOutboundReplyPayload({ location: [1, 2] })).toThrow(
+      "location must be an object",
+    );
+  });
+
   it.each(["source", "isLive", "caption"])(
     "rejects unsupported outbound location %s semantics from loose payloads",
     (field) => {


### PR DESCRIPTION
## What Problem This Solves

`normalizeOutboundReplyPayload` (`src/infra/outbound/reply-payload-normalize.ts`) calls `normalizeOutboundLocation(payload.location)` with no blank-string guard. A producer that leaves the optional `location` slot as a blank string (`""` or whitespace) hits `normalizeOutboundLocation`'s `must be an object` throw, which fails the entire reply send.

`fix: message sends fail when optional location is blank` (#112013) applied analogous handling on the `message-action-runner` send path. The reply-payload producer path — reached by `inbound-reply-dispatch` and `direct-dm` delivery — was left unfixed.

## Why This Change Was Made

Mirror #112013's rule: a **blank string** `location` is treated as absent; everything else stays strict.

```ts
const rawLocation = payload.location;
const location =
  typeof rawLocation === "string" && normalizeOptionalString(rawLocation) === undefined
    ? undefined
    : normalizeOutboundLocation(rawLocation);
```

Only blank strings become absent. A non-blank string (`"Main stage"`) or a non-object (array) still throws, so genuinely malformed locations are not silently swallowed. Keeping the exception at this loose reply-payload boundary preserves strictness in the shared `channels/location.ts` normalizer.

## User Impact

An agent or producer emitting a reply payload with an empty `location` slot currently fails the whole reply send. After this change, the blank location is ignored and the reply is delivered — matching the behavior #112013 shipped for the message-action path.

## Evidence

- Exact head: `0fb5801884`, rebased onto current `main` (zero commits behind)
- Changed: `src/infra/outbound/reply-payload-normalize.ts` (+11/-2), `src/plugin-sdk/reply-payload.test.ts` (+17)

### Focused tests

Red before the change, with only `reply-payload-normalize.ts` reverted to `upstream/main`:

```
 × src/plugin-sdk/reply-payload.test.ts > normalizeOutboundReplyPayload > treats a blank-string location as absent
   → location must be an object.
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
Error: location must be an object.
     41|     throw new Error(`${label} must be an object.`);
 Test Files  1 failed (1)
      Tests  1 failed | 70 passed (71)
```

Green with the fix in place:

```
 Test Files  1 passed (1)
      Tests  71 passed (71)
```

The suite also pins the strict side: `location: "Main stage"` and `location: [1, 2]` still throw `location must be an object`, so only blank strings become absent.

oxlint and oxfmt are clean on the changed files, and `git diff --check` is clean.

### Why there is no live delivery transcript here

A previous review asked for an after-fix real reply delivery — a transcript or runtime log of a blank-location inbound reply or direct DM going out. I did not produce one, and it is worth saying why rather than substituting something weaker.

The payload reaching `normalizeOutboundReplyPayload` on this path comes from the agent's reply dispatcher, at two call sites:

```
src/channels/direct-dm.ts:151
src/channels/message/inbound-reply-dispatch.ts:255
```

For a blank `location` to arrive there, some producer has to put one in. Searching for producers that populate a reply-payload `location`:

```
$ grep -rn "location:" src/ extensions/ --include=*.ts | grep -v "\.test\." | ...
src/infra/outbound/payloads.ts:354:  ...(payload.location ? { location: payload.location } : {}),
src/infra/outbound/payloads.ts:379:  ...(payload.location ? { location: payload.location } : {}),
src/infra/outbound/payloads.ts:418:  ...(payload.location ? { location: payload.location } : {}),
```

Every producer that search surfaced guards on truthiness, so none of them forwards `""`. I am not claiming that search is exhaustive — it is one query over `src/` and `extensions/`, and a caller reaching the normalizer some other way could exist. What it does establish is that I found no shipped path in this tree that would let me trigger the branch by driving a real channel.

The input shape this guards against — an optional string slot arriving blank rather than absent — is the one #112013 was opened for on the send path; I have not observed it on this path myself, and I do not have a client on hand that produces it, so I could not reproduce the input in my environment. Writing a producer that emits it would be a harness, and a harness is not a live delivery — presenting one as such is the thing worth avoiding here.

So the evidence this PR rests on is the boundary test above: reproducible, red on the unmodified normalizer with the exact `location must be an object.` failure, green after, with the strict cases pinned alongside it.

For context on the shape rather than on this path's evidence: `fix: message sends fail when optional location is blank` (#112013) applied analogous handling on the message-action send path and merged on 2026-07-22. This PR is the same rule at the reply-payload boundary that one did not cover.


### Direct before/after run of the normalizer

The section above explains why there is no live delivery transcript, and that
stands: what follows is not one. It is the changed function itself, driven
directly at two pinned SHAs outside the test runner, so the behavior can be
inspected without reading a test file.

## Real behavior proof

Behavior addressed: a reply payload whose optional `location` slot arrives as a
blank string throws `location must be an object.` inside
`normalizeOutboundReplyPayload`, so the reply is not normalized and cannot go
out — the same input shape #112013 fixed on the message-action send path.
Real environment tested: Linux, Node 24.18.0, patch at `0fb580188457`, pre-fix
baseline pinned at `2b19ae1f00ee` (current `main`). Both production versions of
`src/infra/outbound/reply-payload-normalize.ts` are imported and called directly,
outside Vitest. Nothing is mocked or stubbed — in particular
`normalizeOutboundLocation`, the collaborator that raises the error, runs for
real. This is not a live channel delivery, for the reason given in the section
above; it is the changed function under its real dependencies. Those
dependencies are the module's whole import graph (`src/channels/location.ts`,
`src/auto-reply/reply-payload.ts` type-only, and
`@openclaw/normalization-core/string-coerce`) and all three are byte-identical
between the two SHAs. Their blob ids are identical at both, which pins the
listed direct dependencies; it does not speak for their transitive imports or
for the built package the runtime resolves:

```
git rev-parse <sha>:<path>       2b19ae1f00ee   0fb580188457
src/channels/location.ts                    3eb25725b01d   3eb25725b01d
src/auto-reply/reply-payload.ts             8635d543fd5e   8635d543fd5e
packages/normalization-core/.../string-coerce.ts  22f8e00bc793   22f8e00bc793
```

Exact steps or command run after this patch:

```sh
B=2b19ae1f00ee; A=0fb580188457; D=src/infra/outbound
# Both versions must sit in that directory: the module resolves its siblings
# (../../channels/location.js) relative to itself.
trap 'rm -f "$D"/reply-payload-normalize.__before__.ts "$D"/reply-payload-normalize.__after__.ts' EXIT
git show "$B:$D/reply-payload-normalize.ts" > "$D/reply-payload-normalize.__before__.ts"
git show "$A:$D/reply-payload-normalize.ts" > "$D/reply-payload-normalize.__after__.ts"
PROOF_LABEL=before PROOF_MODULE="$PWD/$D/reply-payload-normalize.__before__.ts" node --import tsx harness.mjs
PROOF_LABEL=after  PROOF_MODULE="$PWD/$D/reply-payload-normalize.__after__.ts"  node --import tsx harness.mjs
```

<details>
<summary>harness.mjs in full — its only import is the module under test</summary>

```js
// Standalone before/after harness for openclaw/openclaw#112804.
//
// Drives the REAL exported normalizeOutboundReplyPayload. The function is pure,
// so nothing here is mocked or stubbed — including normalizeOutboundLocation,
// which is what actually throws on a blank-string location.
//
// Contract with repro.sh: PROOF_LABEL is "before" or "after", PROOF_MODULE is
// the materialized production module to import. One JSON object goes to stdout;
// diagnostics go to stderr, which repro.sh does not capture.

const label = process.env.PROOF_LABEL ?? "unknown";
const modulePath = process.env.PROOF_MODULE;
const note = (msg) => process.stderr.write(`[harness: ${msg}]\n`);

if (!modulePath) {
  throw new Error("PROOF_MODULE is required");
}

const REAL_LOCATION = { latitude: 35.681236, longitude: 139.767125 };

const CASES = [
  {
    case: "blank-location-string",
    why: "a producer padding the unused optional slot with an empty string",
    payload: { text: "hi", location: "" },
    mustSucceedAfterFix: true,
  },
  {
    case: "whitespace-location-string",
    why: "the same padding with whitespace only",
    payload: { text: "hi", location: "   " },
    mustSucceedAfterFix: true,
  },
  {
    case: "control-real-location",
    why: "a genuine location must still normalize identically",
    payload: { text: "hi", location: REAL_LOCATION },
    mustSucceedAfterFix: true,
  },
  {
    case: "control-absent-location",
    why: "an omitted location must stay absent",
    payload: { text: "hi" },
    mustSucceedAfterFix: true,
  },
  {
    case: "control-nonblank-garbage-string",
    why: "strictness must be preserved: a non-blank non-object location is still a caller error",
    payload: { text: "hi", location: "35.68,139.76" },
    mustSucceedAfterFix: false,
  },
  {
    case: "control-invalid-latitude",
    why: "an object with an out-of-range latitude must still be rejected",
    payload: { text: "hi", location: { latitude: 999, longitude: 0 } },
    mustSucceedAfterFix: false,
  },
];

note(`importing ${modulePath}`);
const mod = await import(modulePath);
if (typeof mod.normalizeOutboundReplyPayload !== "function") {
  throw new Error("normalizeOutboundReplyPayload not exported by the module under test");
}

const results = [];
for (const scenario of CASES) {
  note(`running ${scenario.case}: ${scenario.why}`);
  let outcome;
  try {
    const normalized = mod.normalizeOutboundReplyPayload(scenario.payload);
    outcome = {
      threw: false,
      errorMessage: null,
      // What the caller actually receives for the field under test.
      locationInResult:
        normalized.location === undefined ? "undefined" : JSON.stringify(normalized.location),
      textSurvived: normalized.text === scenario.payload.text,
    };
  } catch (err) {
    outcome = {
      threw: true,
      errorMessage: err instanceof Error ? err.message : String(err),
      locationInResult: null,
      textSurvived: false,
    };
  }
  results.push({
    case: scenario.case,
    label,
    locationInput: JSON.stringify(scenario.payload.location ?? null),
    ...outcome,
    mustSucceedAfterFix: scenario.mustSucceedAfterFix,
  });
}

process.stdout.write(
  `${JSON.stringify(
    { label, moduleUnderTest: modulePath.split("/").pop(), results },
    null,
    2,
  )}\n`,
);
```

</details>

Before (pre-fix):

```text
===== BEFORE (pinned 2b19ae1f00eec0f72f41375589b100ae298bb4d3, defect present) =====
{
  "label": "before",
  "moduleUnderTest": "reply-payload-normalize.__before__.ts",
  "results": [
    {
      "case": "blank-location-string",
      "label": "before",
      "locationInput": "\"\"",
      "threw": true,
      "errorMessage": "location must be an object.",
      "locationInResult": null,
      "textSurvived": false,
      "mustSucceedAfterFix": true
    },
    {
      "case": "whitespace-location-string",
      "label": "before",
      "locationInput": "\"   \"",
      "threw": true,
      "errorMessage": "location must be an object.",
      "locationInResult": null,
      "textSurvived": false,
      "mustSucceedAfterFix": true
    },
    {
      "case": "control-real-location",
      "label": "before",
      "locationInput": "{\"latitude\":35.681236,\"longitude\":139.767125}",
      "threw": false,
      "errorMessage": null,
      "locationInResult": "{\"latitude\":35.681236,\"longitude\":139.767125}",
      "textSurvived": true,
      "mustSucceedAfterFix": true
    },
    {
      "case": "control-absent-location",
      "label": "before",
      "locationInput": "null",
      "threw": false,
      "errorMessage": null,
      "locationInResult": "undefined",
      "textSurvived": true,
      "mustSucceedAfterFix": true
    },
    {
      "case": "control-nonblank-garbage-string",
      "label": "before",
      "locationInput": "\"35.68,139.76\"",
      "threw": true,
      "errorMessage": "location must be an object.",
      "locationInResult": null,
      "textSurvived": false,
      "mustSucceedAfterFix": false
    },
    {
      "case": "control-invalid-latitude",
      "label": "before",
      "locationInput": "{\"latitude\":999,\"longitude\":0}",
      "threw": true,
      "errorMessage": "location.latitude must be a finite number between -90 and 90.",
      "locationInResult": null,
      "textSurvived": false,
      "mustSucceedAfterFix": false
    }
  ]
}

```

Evidence after fix:

```text
===== AFTER (fix applied) =====
{
  "label": "after",
  "moduleUnderTest": "reply-payload-normalize.__after__.ts",
  "results": [
    {
      "case": "blank-location-string",
      "label": "after",
      "locationInput": "\"\"",
      "threw": false,
      "errorMessage": null,
      "locationInResult": "undefined",
      "textSurvived": true,
      "mustSucceedAfterFix": true
    },
    {
      "case": "whitespace-location-string",
      "label": "after",
      "locationInput": "\"   \"",
      "threw": false,
      "errorMessage": null,
      "locationInResult": "undefined",
      "textSurvived": true,
      "mustSucceedAfterFix": true
    },
    {
      "case": "control-real-location",
      "label": "after",
      "locationInput": "{\"latitude\":35.681236,\"longitude\":139.767125}",
      "threw": false,
      "errorMessage": null,
      "locationInResult": "{\"latitude\":35.681236,\"longitude\":139.767125}",
      "textSurvived": true,
      "mustSucceedAfterFix": true
    },
    {
      "case": "control-absent-location",
      "label": "after",
      "locationInput": "null",
      "threw": false,
      "errorMessage": null,
      "locationInResult": "undefined",
      "textSurvived": true,
      "mustSucceedAfterFix": true
    },
    {
      "case": "control-nonblank-garbage-string",
      "label": "after",
      "locationInput": "\"35.68,139.76\"",
      "threw": true,
      "errorMessage": "location must be an object.",
      "locationInResult": null,
      "textSurvived": false,
      "mustSucceedAfterFix": false
    },
    {
      "case": "control-invalid-latitude",
      "label": "after",
      "locationInput": "{\"latitude\":999,\"longitude\":0}",
      "threw": true,
      "errorMessage": "location.latitude must be a finite number between -90 and 90.",
      "locationInResult": null,
      "textSurvived": false,
      "mustSucceedAfterFix": false
    }
  ]
}
```

Observed result after fix: the two blank-string cases go from throwing
`location must be an object.` to being accepted with `location` absent, and the
reply text survives normalization. Four controls are unchanged across the two
runs: a real location object normalizes identically, an omitted location stays
absent, and — the ones that matter for scope — `location: "35.68,139.76"` and
`location: { latitude: 999 }` still throw after the fix. Blank is treated as
absent without loosening the strictness that makes a genuine caller error
visible.
What was not tested: no live channel delivery, for the reason set out above — no
shipped producer in this tree forwards a blank `location` on this path, so the
branch cannot be reached by driving a real channel. The other outbound payload
fields (media, channelData, replyToId) were not exercised, and #112013's
message-action path was not re-run.
