### PR TITLE
fix(feishu): keep Drive comments working through identity outages

### DIFF
--- a/extensions/feishu/src/bot-identity-cache.test.ts
+++ b/extensions/feishu/src/bot-identity-cache.test.ts
@@ -1,0 +1,90 @@
+// Feishu tests cover provider-verified bot identity cache behavior.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readCachedFeishuBotIdentity, writeCachedFeishuBotIdentity } from "./bot-identity-cache.js";
+
+const cacheHarness = vi.hoisted(() => ({
+  entries: new Map<string, unknown>(),
+  openKeyedStore: vi.fn(),
+}));
+
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    state: {
+      openKeyedStore: cacheHarness.openKeyedStore,
+    },
+  }),
+}));
+
+beforeEach(() => {
+  cacheHarness.entries.clear();
+  cacheHarness.openKeyedStore.mockReset().mockReturnValue({
+    lookup: vi.fn(async (key: string) => cacheHarness.entries.get(key)),
+    register: vi.fn(async (key: string, value: unknown) => {
+      cacheHarness.entries.set(key, value);
+    }),
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Feishu bot identity cache", () => {
+  it("persists provider-verified identity in a bounded plugin-state namespace", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-22T23:00:00.000Z"));
+
+    await writeCachedFeishuBotIdentity({
+      accountId: "person-2",
+      appId: "cli_person_2",
+      botOpenId: "ou_bot_person_2",
+      botName: "OpenClaw QA",
+    });
+
+    await expect(
+      readCachedFeishuBotIdentity({ accountId: "person-2", appId: "cli_person_2" }),
+    ).resolves.toEqual({
+      botOpenId: "ou_bot_person_2",
+      botName: "OpenClaw QA",
+      fetchedAt: "2026-07-22T23:00:00.000Z",
+    });
+    expect(cacheHarness.openKeyedStore).toHaveBeenCalledWith({
+      namespace: "feishu.bot-identity-cache",
+      maxEntries: 128,
+    });
+  });
+
+  it("keeps identity across secret rotation but rejects a different app id", async () => {
+    await writeCachedFeishuBotIdentity({
+      accountId: "person-2",
+      appId: "cli_person_2",
+      botOpenId: "ou_bot_person_2",
+    });
+
+    await expect(
+      readCachedFeishuBotIdentity({ accountId: "person-2", appId: "cli_person_2" }),
+    ).resolves.toMatchObject({ botOpenId: "ou_bot_person_2" });
+    await expect(
+      readCachedFeishuBotIdentity({ accountId: "person-2", appId: "cli_replacement" }),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects malformed or incomplete persisted values", async () => {
+    cacheHarness.entries.set("person-2", {
+      appId: "cli_person_2",
+      botOpenId: "ou_bot_person_2",
+      fetchedAt: "not-a-date",
+    });
+
+    await expect(
+      readCachedFeishuBotIdentity({ accountId: "person-2", appId: "cli_person_2" }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not persist an identity without both app and bot ids", async () => {
+    await writeCachedFeishuBotIdentity({ accountId: "person-2", botOpenId: "ou_bot_person_2" });
+    await writeCachedFeishuBotIdentity({ accountId: "person-2", appId: "cli_person_2" });
+
+    expect(cacheHarness.entries.size).toBe(0);
+  });
+});

--- a/extensions/feishu/src/bot-identity-cache.ts
+++ b/extensions/feishu/src/bot-identity-cache.ts
@@ -1,0 +1,85 @@
+// Feishu plugin module implements provider-verified bot identity cache behavior.
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-resolution";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { getFeishuRuntime } from "./runtime.js";
+
+const FEISHU_BOT_IDENTITY_CACHE_NAMESPACE = "feishu.bot-identity-cache";
+const FEISHU_BOT_IDENTITY_CACHE_MAX_ENTRIES = 128;
+
+type FeishuBotIdentityCacheState = {
+  appId: string;
+  botOpenId: string;
+  botName?: string;
+  fetchedAt: string;
+};
+
+export type CachedFeishuBotIdentity = {
+  botOpenId: string;
+  botName?: string;
+  fetchedAt: string;
+};
+
+function openFeishuBotIdentityCache() {
+  return getFeishuRuntime().state.openKeyedStore<FeishuBotIdentityCacheState>({
+    namespace: FEISHU_BOT_IDENTITY_CACHE_NAMESPACE,
+    maxEntries: FEISHU_BOT_IDENTITY_CACHE_MAX_ENTRIES,
+  });
+}
+
+function parseCachedFeishuBotIdentity(value: unknown): FeishuBotIdentityCacheState | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const state = value as Partial<FeishuBotIdentityCacheState>;
+  const appId = normalizeOptionalString(state.appId);
+  const botOpenId = normalizeOptionalString(state.botOpenId);
+  const botName = normalizeOptionalString(state.botName);
+  const fetchedAt = normalizeOptionalString(state.fetchedAt);
+  if (!appId || !botOpenId || !fetchedAt || Number.isNaN(Date.parse(fetchedAt))) {
+    return null;
+  }
+  return { appId, botOpenId, botName, fetchedAt };
+}
+
+export async function readCachedFeishuBotIdentity(params: {
+  accountId: string;
+  appId?: string;
+}): Promise<CachedFeishuBotIdentity | null> {
+  const appId = normalizeOptionalString(params.appId);
+  if (!appId) {
+    return null;
+  }
+  const cached = parseCachedFeishuBotIdentity(
+    await openFeishuBotIdentityCache().lookup(normalizeAccountId(params.accountId)),
+  );
+  // The app id is the stable provider identity boundary. Secret rotation keeps
+  // this cache valid; changing apps must never reuse another bot's identity.
+  if (!cached || cached.appId !== appId) {
+    return null;
+  }
+  return {
+    botOpenId: cached.botOpenId,
+    botName: cached.botName,
+    fetchedAt: cached.fetchedAt,
+  };
+}
+
+export async function writeCachedFeishuBotIdentity(params: {
+  accountId: string;
+  appId?: string;
+  botOpenId?: string;
+  botName?: string;
+}): Promise<void> {
+  const appId = normalizeOptionalString(params.appId);
+  const botOpenId = normalizeOptionalString(params.botOpenId);
+  if (!appId || !botOpenId) {
+    return;
+  }
+  const botName = normalizeOptionalString(params.botName);
+  await openFeishuBotIdentityCache().register(normalizeAccountId(params.accountId), {
+    appId,
+    botOpenId,
+    botName,
+    fetchedAt: new Date().toISOString(),
+  });
+}

--- a/extensions/feishu/src/bot-identity-cache.ts
+++ b/extensions/feishu/src/bot-identity-cache.ts
@@ -13,7 +13,7 @@ type FeishuBotIdentityCacheState = {
   fetchedAt: string;
 };
 
-export type CachedFeishuBotIdentity = {
+type CachedFeishuBotIdentity = {
   botOpenId: string;
   botName?: string;
   fetchedAt: string;

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -459,7 +459,12 @@ function registerEventHandlers(
 }
 
 type BotOpenIdSource =
-  | { kind: "prefetched"; botOpenId?: string; botName?: string }
+  | {
+      kind: "prefetched";
+      botOpenId?: string;
+      botName?: string;
+      source?: "provider" | "cache";
+    }
   | { kind: "fetch" };
 
 type MonitorSingleAccountParams = {
@@ -486,13 +491,23 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   const botOpenIdSource = params.botOpenIdSource ?? { kind: "fetch" };
   const botIdentity =
     botOpenIdSource.kind === "prefetched"
-      ? { botOpenId: botOpenIdSource.botOpenId, botName: botOpenIdSource.botName }
+      ? {
+          botOpenId: botOpenIdSource.botOpenId,
+          botName: botOpenIdSource.botName,
+          source: botOpenIdSource.source,
+        }
       : await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
   const { botOpenId } = applyBotIdentityState(accountId, botIdentity);
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
 
-  if (!botOpenId && !abortSignal?.aborted) {
-    startBotIdentityRecovery({ account, accountId, runtime, abortSignal });
+  if ((!botOpenId || botIdentity.source === "cache") && !abortSignal?.aborted) {
+    startBotIdentityRecovery({
+      account,
+      accountId,
+      runtime,
+      abortSignal,
+      currentSource: botIdentity.source,
+    });
   }
 
   const connectionMode = account.config.connectionMode ?? "websocket";

--- a/extensions/feishu/src/monitor.bot-identity.test.ts
+++ b/extensions/feishu/src/monitor.bot-identity.test.ts
@@ -1,0 +1,74 @@
+// Feishu tests cover background bot identity recovery behavior.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime-api.js";
+import { startBotIdentityRecovery } from "./monitor.bot-identity.js";
+
+const fetchBotIdentityForMonitorMock = vi.hoisted(() => vi.fn());
+const setFeishuBotIdentityStateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./monitor.startup.js", () => ({
+  fetchBotIdentityForMonitor: fetchBotIdentityForMonitorMock,
+}));
+
+vi.mock("./monitor.state.js", () => ({
+  setFeishuBotIdentityState: setFeishuBotIdentityStateMock,
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchBotIdentityForMonitorMock.mockReset();
+  setFeishuBotIdentityStateMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Feishu bot identity recovery", () => {
+  it("bypasses cache and stops only after a provider-verified refresh", async () => {
+    fetchBotIdentityForMonitorMock
+      .mockResolvedValueOnce({ botOpenId: "ou_cached", source: "cache" })
+      .mockResolvedValueOnce({
+        botOpenId: "ou_provider",
+        botName: "OpenClaw QA",
+        source: "provider",
+      });
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+    } as unknown as RuntimeEnv;
+
+    startBotIdentityRecovery({
+      account: {
+        accountId: "person-2",
+        appId: "cli_person_2",
+        appSecret: "secret_person_2", // pragma: allowlist secret
+      } as never,
+      accountId: "person-2",
+      runtime,
+      currentSource: "cache",
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchBotIdentityForMonitorMock).toHaveBeenCalledTimes(1);
+    expect(fetchBotIdentityForMonitorMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ allowCachedFallback: false }),
+    );
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("recovered via background retry"),
+    );
+    expect(setFeishuBotIdentityStateMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetchBotIdentityForMonitorMock).toHaveBeenCalledTimes(2);
+    expect(runtime.log).toHaveBeenCalledWith(
+      "feishu[person-2]: bot open_id recovered via background retry: ou_provider",
+    );
+    expect(setFeishuBotIdentityStateMock).toHaveBeenCalledTimes(1);
+    expect(setFeishuBotIdentityStateMock).toHaveBeenLastCalledWith("person-2", {
+      botOpenId: "ou_provider",
+      botName: "OpenClaw QA",
+    });
+  });
+});

--- a/extensions/feishu/src/monitor.bot-identity.ts
+++ b/extensions/feishu/src/monitor.bot-identity.ts
@@ -13,13 +13,13 @@ const BOT_IDENTITY_RETRY_DELAYS_MS = [60_000, 120_000, 300_000, 600_000, 900_000
 export function applyBotIdentityState(
   accountId: string,
   identity: FeishuMonitorBotIdentity,
-): { botOpenId?: string; botName?: string } {
+): FeishuMonitorBotIdentity {
   const botOpenId = normalizeOptionalString(identity.botOpenId);
   const botName = normalizeOptionalString(identity.botName);
 
   setFeishuBotIdentityState(accountId, { botOpenId: botOpenId ?? "", botName });
 
-  return { botOpenId, botName };
+  return { botOpenId, botName, source: botOpenId ? identity.source : undefined };
 }
 
 async function retryBotIdentityProbe(
@@ -42,9 +42,13 @@ async function retryBotIdentityProbe(
       return;
     }
 
-    const identity = await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
-    const resolved = applyBotIdentityState(accountId, identity);
-    if (resolved.botOpenId) {
+    const identity = await fetchBotIdentityForMonitor(account, {
+      runtime,
+      abortSignal,
+      allowCachedFallback: false,
+    });
+    if (normalizeOptionalString(identity.botOpenId) && identity.source === "provider") {
+      const resolved = applyBotIdentityState(accountId, identity);
       log(
         `feishu[${accountId}]: bot open_id recovered via background retry: ${resolved.botOpenId}`,
       );
@@ -69,16 +73,20 @@ export function startBotIdentityRecovery(params: {
   accountId: string;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
+  currentSource?: FeishuMonitorBotIdentity["source"];
 }): void {
-  const { account, accountId, runtime, abortSignal } = params;
+  const { account, accountId, runtime, abortSignal, currentSource } = params;
   const log = runtime?.log ?? console.log;
 
+  const identityState = currentSource === "cache" ? "loaded from cache" : "unknown";
   log(
-    `feishu[${accountId}]: bot open_id unknown; starting background retry (delays: ${BOT_IDENTITY_RETRY_DELAYS_MS.map((delay) => `${delay / 1000}s`).join(", ")})`,
+    `feishu[${accountId}]: bot open_id ${identityState}; starting background provider refresh (delays: ${BOT_IDENTITY_RETRY_DELAYS_MS.map((delay) => `${delay / 1000}s`).join(", ")})`,
   );
-  log(
-    `feishu[${accountId}]: requireMention group messages stay gated until bot identity recovery succeeds`,
-  );
+  if (currentSource !== "cache") {
+    log(
+      `feishu[${accountId}]: requireMention group messages stay gated until bot identity recovery succeeds`,
+    );
+  }
 
   void retryBotIdentityProbe(account, accountId, runtime, abortSignal);
 }

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -858,11 +858,72 @@ describe("resolveDriveCommentEventTurn", () => {
     expect(turn).toBeNull();
   });
 
-  it("skips comment notices when bot open_id is unavailable", async () => {
+  it("uses a mentioned event recipient when startup bot identity is unavailable", async () => {
     const turn = await resolveDriveCommentEventTurn({
       cfg: buildMonitorConfig(),
       accountId: "default",
       event: makeDriveCommentEvent(),
+      botOpenId: undefined,
+      createClient: () => makeOpenApiClient({}) as never,
+    });
+
+    expect(turn?.senderId).toBe("ou_509d4d7ace4a9addec2312676ffcba9b");
+  });
+
+  it("uses the event recipient to reject self-authored cold-start notices", async () => {
+    const turn = await resolveDriveCommentEventTurn({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          from_user_id: { open_id: "ou_bot" },
+        },
+      }),
+      botOpenId: undefined,
+      createClient: () => makeOpenApiClient({}) as never,
+    });
+
+    expect(turn).toBeNull();
+  });
+
+  it("prefers startup bot identity over a mismatched event recipient", async () => {
+    const turn = await resolveDriveCommentEventTurn({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          from_user_id: { open_id: "ou_configured_bot" },
+          to_user_id: { open_id: "ou_other_bot" },
+        },
+      }),
+      botOpenId: "ou_configured_bot",
+      createClient: () => makeOpenApiClient({}) as never,
+    });
+
+    expect(turn).toBeNull();
+  });
+
+  it.each([
+    {
+      name: "not explicitly mentioned",
+      event: makeDriveCommentEvent({ is_mentioned: false }),
+    },
+    {
+      name: "missing recipient identity",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          to_user_id: undefined,
+        },
+      }),
+    },
+  ])("skips a cold-start comment notice when $name", async ({ event }) => {
+    const turn = await resolveDriveCommentEventTurn({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event,
       botOpenId: undefined,
       createClient: () => makeOpenApiClient({}) as never,
     });

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -1255,14 +1255,21 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     logger?.(`feishu[${accountId}]: unsupported drive comment notice type ${noticeType}`);
     return null;
   }
-  if (!botOpenId) {
+  const configuredBotOpenId = botOpenId?.trim();
+  const eventRecipientBotOpenId = event.notice_meta?.to_user_id?.open_id?.trim();
+  // Mentioned comment notices identify their recipient even when the startup
+  // identity probe is unavailable. Keep this fallback event-local so an
+  // unverified envelope can never seed process or persisted bot identity.
+  const effectiveBotOpenId =
+    configuredBotOpenId || (event.is_mentioned === true ? eventRecipientBotOpenId : undefined);
+  if (!effectiveBotOpenId) {
     logger?.(
       `feishu[${accountId}]: skipping drive comment notice because bot open_id is unavailable ` +
         `event=${eventId}`,
     );
     return null;
   }
-  if (senderId === botOpenId) {
+  if (senderId === effectiveBotOpenId) {
     logger?.(
       `feishu[${accountId}]: ignoring self-authored drive comment notice event=${eventId} sender=${senderId}`,
     );
@@ -1280,7 +1287,7 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     fileType,
     commentId,
     replyId,
-    botOpenIds: [botOpenId, event.notice_meta?.to_user_id?.open_id],
+    botOpenIds: [effectiveBotOpenId, event.notice_meta?.to_user_id?.open_id],
     timeoutMs: verificationTimeoutMs,
     logger,
     accountId,

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -9,10 +9,17 @@ import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
 const registerFeishuAiAgentMock = vi.hoisted(() => vi.fn());
+const readCachedFeishuBotIdentityMock = vi.hoisted(() => vi.fn());
+const writeCachedFeishuBotIdentityMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
   registerFeishuAiAgent: registerFeishuAiAgentMock,
+}));
+
+vi.mock("./bot-identity-cache.js", () => ({
+  readCachedFeishuBotIdentity: readCachedFeishuBotIdentityMock,
+  writeCachedFeishuBotIdentity: writeCachedFeishuBotIdentityMock,
 }));
 
 vi.mock("./client.js", async () => {
@@ -30,6 +37,8 @@ beforeAll(async () => {
 
 beforeEach(() => {
   registerFeishuAiAgentMock.mockResolvedValue({ ok: true });
+  readCachedFeishuBotIdentityMock.mockReset().mockResolvedValue(null);
+  writeCachedFeishuBotIdentityMock.mockReset().mockResolvedValue(undefined);
 });
 
 function buildMultiAccountWebsocketConfig(accountIds: string[]): ClawdbotConfig {
@@ -218,7 +227,13 @@ describe("Feishu monitor startup preflight", () => {
         appId: "cli_alpha",
         appSecret: "secret_alpha", // pragma: allowlist secret
       } as never),
-    ).resolves.toEqual({ botOpenId: "bot_alpha", botName: "Alpha" });
+    ).resolves.toEqual({ botOpenId: "bot_alpha", botName: "Alpha", source: "provider" });
+    expect(writeCachedFeishuBotIdentityMock).toHaveBeenCalledWith({
+      accountId: "alpha",
+      appId: "cli_alpha",
+      botOpenId: "bot_alpha",
+      botName: "Alpha",
+    });
   });
 
   it("keeps standard bot identity when AI-agent registration is unavailable", async () => {
@@ -239,12 +254,116 @@ describe("Feishu monitor startup preflight", () => {
         } as never,
         { runtime },
       ),
-    ).resolves.toEqual({ botOpenId: "bot_alpha", botName: "Alpha" });
+    ).resolves.toEqual({ botOpenId: "bot_alpha", botName: "Alpha", source: "provider" });
     await vi.waitFor(() => {
       expect(runtime.log).toHaveBeenCalledWith(
         "feishu[alpha]: AI-agent registration unavailable (api-error); continuing with standard bot identity",
       );
     });
+  });
+
+  it("falls back to cached identity without treating it as a fresh provider result", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: false, error: "rate limited" });
+    readCachedFeishuBotIdentityMock.mockResolvedValue({
+      botOpenId: "bot_alpha",
+      botName: "Alpha",
+      fetchedAt: "2026-07-22T23:00:00.000Z",
+    });
+    const runtime = createNonExitingRuntimeEnv();
+
+    await expect(
+      fetchBotIdentityForMonitor(
+        {
+          accountId: "alpha",
+          appId: "cli_alpha",
+          appSecret: "rotated_secret_alpha", // pragma: allowlist secret
+        } as never,
+        { runtime },
+      ),
+    ).resolves.toEqual({ botOpenId: "bot_alpha", botName: "Alpha", source: "cache" });
+    expect(writeCachedFeishuBotIdentityMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      "feishu[alpha]: using cached provider-verified bot identity while the fresh probe is unavailable",
+    );
+  });
+
+  it("bypasses cached identity during background provider refresh", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: false, error: "rate limited" });
+
+    await expect(
+      fetchBotIdentityForMonitor(
+        {
+          accountId: "alpha",
+          appId: "cli_alpha",
+          appSecret: "secret_alpha", // pragma: allowlist secret
+        } as never,
+        { allowCachedFallback: false },
+      ),
+    ).resolves.toEqual({});
+    expect(readCachedFeishuBotIdentityMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps cache read and write failures best-effort", async () => {
+    const runtime = createNonExitingRuntimeEnv();
+    probeFeishuMock.mockResolvedValueOnce({
+      ok: true,
+      botOpenId: "bot_alpha",
+      botName: "Alpha",
+    });
+    writeCachedFeishuBotIdentityMock.mockRejectedValueOnce(new Error("state unavailable"));
+
+    await expect(
+      fetchBotIdentityForMonitor(
+        {
+          accountId: "alpha",
+          appId: "cli_alpha",
+          appSecret: "secret_alpha", // pragma: allowlist secret
+        } as never,
+        { runtime },
+      ),
+    ).resolves.toEqual({ botOpenId: "bot_alpha", botName: "Alpha", source: "provider" });
+
+    probeFeishuMock.mockResolvedValueOnce({ ok: false, error: "rate limited" });
+    readCachedFeishuBotIdentityMock.mockRejectedValueOnce(new Error("state unavailable"));
+    await expect(
+      fetchBotIdentityForMonitor(
+        {
+          accountId: "alpha",
+          appId: "cli_alpha",
+          appSecret: "secret_alpha", // pragma: allowlist secret
+        } as never,
+        { runtime },
+      ),
+    ).resolves.toEqual({});
+  });
+
+  it("starts a provider refresh while a cached identity keeps ingress available", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: false, error: "rate limited" });
+    readCachedFeishuBotIdentityMock.mockResolvedValue({
+      botOpenId: "bot_alpha",
+      botName: "Alpha",
+      fetchedAt: "2026-07-22T23:00:00.000Z",
+    });
+    const abortController = new AbortController();
+    const runtime = createNonExitingRuntimeEnv();
+    const monitorPromise = monitorFeishuProvider({
+      config: buildMultiAccountWebsocketConfig(["alpha"]),
+      runtime,
+      abortSignal: abortController.signal,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(runtime.log).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "feishu[alpha]: bot open_id loaded from cache; starting background provider refresh",
+          ),
+        );
+      });
+    } finally {
+      abortController.abort();
+      await monitorPromise;
+    }
   });
 
   it("stops sequential preflight when aborted during probe", async () => {

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -1,15 +1,18 @@
 // Feishu tests cover monitor.startup plugin behavior.
 import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveStartupProbeTimeoutMs } from "./monitor-startup-timeout.js";
 import { cleanupFeishuMonitorStateForTests } from "./monitor.cleanup.test-helpers.js";
 import { monitorFeishuProvider } from "./monitor.js";
+import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
+const registerFeishuAiAgentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
+  registerFeishuAiAgent: registerFeishuAiAgentMock,
 }));
 
 vi.mock("./client.js", async () => {
@@ -23,6 +26,10 @@ vi.mock("./runtime.js", async () => {
 
 beforeAll(async () => {
   await import("./monitor.account.js");
+});
+
+beforeEach(() => {
+  registerFeishuAiAgentMock.mockResolvedValue({ ok: true });
 });
 
 function buildMultiAccountWebsocketConfig(accountIds: string[]): ClawdbotConfig {
@@ -195,6 +202,49 @@ describe("Feishu monitor startup preflight", () => {
       abortController.abort();
       await monitorPromise;
     }
+  });
+
+  it("returns standard bot identity without waiting for AI-agent registration", async () => {
+    probeFeishuMock.mockResolvedValue({
+      ok: true,
+      botOpenId: "bot_alpha",
+      botName: "Alpha",
+    });
+    registerFeishuAiAgentMock.mockReturnValue(new Promise(() => {}));
+
+    await expect(
+      fetchBotIdentityForMonitor({
+        accountId: "alpha",
+        appId: "cli_alpha",
+        appSecret: "secret_alpha", // pragma: allowlist secret
+      } as never),
+    ).resolves.toEqual({ botOpenId: "bot_alpha", botName: "Alpha" });
+  });
+
+  it("keeps standard bot identity when AI-agent registration is unavailable", async () => {
+    probeFeishuMock.mockResolvedValue({
+      ok: true,
+      botOpenId: "bot_alpha",
+      botName: "Alpha",
+    });
+    registerFeishuAiAgentMock.mockResolvedValue({ ok: false, reason: "api-error" });
+    const runtime = createNonExitingRuntimeEnv();
+
+    await expect(
+      fetchBotIdentityForMonitor(
+        {
+          accountId: "alpha",
+          appId: "cli_alpha",
+          appSecret: "secret_alpha", // pragma: allowlist secret
+        } as never,
+        { runtime },
+      ),
+    ).resolves.toEqual({ botOpenId: "bot_alpha", botName: "Alpha" });
+    await vi.waitFor(() => {
+      expect(runtime.log).toHaveBeenCalledWith(
+        "feishu[alpha]: AI-agent registration unavailable (api-error); continuing with standard bot identity",
+      );
+    });
   });
 
   it("stops sequential preflight when aborted during probe", async () => {

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -36,7 +36,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  registerFeishuAiAgentMock.mockResolvedValue({ ok: true });
+  registerFeishuAiAgentMock.mockReset().mockResolvedValue({ ok: true });
   readCachedFeishuBotIdentityMock.mockReset().mockResolvedValue(null);
   writeCachedFeishuBotIdentityMock.mockReset().mockResolvedValue(undefined);
 });
@@ -108,13 +108,13 @@ describe("Feishu monitor startup preflight", () => {
       throw new Error("Expected probe release callback to be initialized");
     }
     const releaseStartedProbes = releaseProbes;
-    probeFeishuMock.mockImplementation(async (account: { accountId: string }) => {
+    probeFeishuMock.mockImplementation(async (account: { accountId: string; appId: string }) => {
       started.push(account.accountId);
       inFlight += 1;
       maxInFlight = Math.max(maxInFlight, inFlight);
       await probesReleased;
       inFlight -= 1;
-      return { ok: true, botOpenId: `bot_${account.accountId}` };
+      return { ok: true, appId: account.appId, botOpenId: `bot_${account.accountId}` };
     });
 
     const abortController = new AbortController();
@@ -145,13 +145,13 @@ describe("Feishu monitor startup preflight", () => {
     }
     const releaseStartedBetaProbe = releaseBetaProbe;
 
-    probeFeishuMock.mockImplementation(async (account: { accountId: string }) => {
+    probeFeishuMock.mockImplementation(async (account: { accountId: string; appId: string }) => {
       started.push(account.accountId);
       if (account.accountId === "alpha") {
         return { ok: false };
       }
       await betaProbeReleased;
-      return { ok: true, botOpenId: `bot_${account.accountId}` };
+      return { ok: true, appId: account.appId, botOpenId: `bot_${account.accountId}` };
     });
 
     const abortController = new AbortController();
@@ -184,12 +184,16 @@ describe("Feishu monitor startup preflight", () => {
     }
     const releaseStartedBetaProbe = releaseBetaProbe;
 
-    probeFeishuMock.mockImplementation((account: { accountId: string }) => {
+    probeFeishuMock.mockImplementation((account: { accountId: string; appId: string }) => {
       started.push(account.accountId);
       if (account.accountId === "alpha") {
         return Promise.resolve({ ok: false, error: "probe timed out after 10000ms" });
       }
-      return betaProbeReleased.then(() => ({ ok: true, botOpenId: `bot_${account.accountId}` }));
+      return betaProbeReleased.then(() => ({
+        ok: true,
+        appId: account.appId,
+        botOpenId: `bot_${account.accountId}`,
+      }));
     });
 
     const abortController = new AbortController();
@@ -216,6 +220,7 @@ describe("Feishu monitor startup preflight", () => {
   it("returns standard bot identity without waiting for AI-agent registration", async () => {
     probeFeishuMock.mockResolvedValue({
       ok: true,
+      appId: "cli_alpha",
       botOpenId: "bot_alpha",
       botName: "Alpha",
     });
@@ -239,6 +244,7 @@ describe("Feishu monitor startup preflight", () => {
   it("keeps standard bot identity when AI-agent registration is unavailable", async () => {
     probeFeishuMock.mockResolvedValue({
       ok: true,
+      appId: "cli_alpha",
       botOpenId: "bot_alpha",
       botName: "Alpha",
     });
@@ -287,6 +293,33 @@ describe("Feishu monitor startup preflight", () => {
     );
   });
 
+  it("rejects a provider result from another app before persistence", async () => {
+    probeFeishuMock.mockResolvedValue({
+      ok: true,
+      appId: "cli_old",
+      botOpenId: "bot_old",
+      botName: "Old",
+    });
+    readCachedFeishuBotIdentityMock.mockResolvedValue(null);
+    const runtime = createNonExitingRuntimeEnv();
+
+    await expect(
+      fetchBotIdentityForMonitor(
+        {
+          accountId: "alpha",
+          appId: "cli_alpha",
+          appSecret: "secret_alpha", // pragma: allowlist secret
+        } as never,
+        { runtime },
+      ),
+    ).resolves.toEqual({});
+    expect(writeCachedFeishuBotIdentityMock).not.toHaveBeenCalled();
+    expect(registerFeishuAiAgentMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      "feishu[alpha]: bot info probe returned identity for a different app; ignoring stale result",
+    );
+  });
+
   it("bypasses cached identity during background provider refresh", async () => {
     probeFeishuMock.mockResolvedValue({ ok: false, error: "rate limited" });
 
@@ -307,6 +340,7 @@ describe("Feishu monitor startup preflight", () => {
     const runtime = createNonExitingRuntimeEnv();
     probeFeishuMock.mockResolvedValueOnce({
       ok: true,
+      appId: "cli_alpha",
       botOpenId: "bot_alpha",
       botName: "Alpha",
     });

--- a/extensions/feishu/src/monitor.startup.ts
+++ b/extensions/feishu/src/monitor.startup.ts
@@ -1,6 +1,10 @@
 // Feishu plugin module implements monitor.startup behavior.
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { RuntimeEnv } from "../runtime-api.js";
+import { readCachedFeishuBotIdentity, writeCachedFeishuBotIdentity } from "./bot-identity-cache.js";
 import { resolveStartupProbeTimeoutMs } from "./monitor-startup-timeout.js";
 import { probeFeishu, registerFeishuAiAgent } from "./probe.js";
 import type { ResolvedFeishuAccount } from "./types.js";
@@ -11,11 +15,13 @@ type FetchBotOpenIdOptions = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   timeoutMs?: number;
+  allowCachedFallback?: boolean;
 };
 
 export type FeishuMonitorBotIdentity = {
   botOpenId?: string;
   botName?: string;
+  source?: "provider" | "cache";
 };
 
 function isTimeoutErrorMessage(message: string | undefined): boolean {
@@ -25,6 +31,50 @@ function isTimeoutErrorMessage(message: string | undefined): boolean {
 
 function isAbortErrorMessage(message: string | undefined): boolean {
   return normalizeLowercaseStringOrEmpty(message).includes("aborted");
+}
+
+async function writeProviderBotIdentityCache(params: {
+  account: ResolvedFeishuAccount;
+  botOpenId?: string;
+  botName?: string;
+  runtime?: RuntimeEnv;
+}): Promise<void> {
+  try {
+    await writeCachedFeishuBotIdentity({
+      accountId: params.account.accountId,
+      appId: params.account.appId,
+      botOpenId: params.botOpenId,
+      botName: params.botName,
+    });
+  } catch {
+    params.runtime?.log?.(
+      `feishu[${params.account.accountId}]: bot identity cache write failed; continuing startup`,
+    );
+  }
+}
+
+async function readProviderBotIdentityCache(params: {
+  account: ResolvedFeishuAccount;
+  runtime?: RuntimeEnv;
+}): Promise<FeishuMonitorBotIdentity> {
+  try {
+    const cached = await readCachedFeishuBotIdentity({
+      accountId: params.account.accountId,
+      appId: params.account.appId,
+    });
+    if (!cached) {
+      return {};
+    }
+    params.runtime?.log?.(
+      `feishu[${params.account.accountId}]: using cached provider-verified bot identity while the fresh probe is unavailable`,
+    );
+    return { botOpenId: cached.botOpenId, botName: cached.botName, source: "cache" };
+  } catch {
+    params.runtime?.log?.(
+      `feishu[${params.account.accountId}]: bot identity cache read failed; continuing without cached identity`,
+    );
+    return {};
+  }
 }
 
 export async function fetchBotIdentityForMonitor(
@@ -58,7 +108,17 @@ export async function fetchBotIdentityForMonitor(
           `feishu[${account.accountId}]: AI-agent registration failed unexpectedly; continuing with standard bot identity`,
         );
       });
-    return { botOpenId: result.botOpenId, botName: result.botName };
+    await writeProviderBotIdentityCache({
+      account,
+      botOpenId: result.botOpenId,
+      botName: result.botName,
+      runtime: options.runtime,
+    });
+    return {
+      botOpenId: normalizeOptionalString(result.botOpenId),
+      botName: normalizeOptionalString(result.botName),
+      source: "provider",
+    };
   }
 
   const probeError = result.error ?? undefined;
@@ -72,5 +132,8 @@ export async function fetchBotIdentityForMonitor(
       `feishu[${account.accountId}]: bot info probe timed out after ${timeoutMs}ms; continuing startup`,
     );
   }
-  return {};
+  if (options.allowCachedFallback === false) {
+    return {};
+  }
+  return readProviderBotIdentityCache({ account, runtime: options.runtime });
 }

--- a/extensions/feishu/src/monitor.startup.ts
+++ b/extensions/feishu/src/monitor.startup.ts
@@ -90,7 +90,8 @@ export async function fetchBotIdentityForMonitor(
     timeoutMs,
     abortSignal: options.abortSignal,
   });
-  if (result.ok) {
+  const resultAppId = normalizeOptionalString(result.appId);
+  if (result.ok && resultAppId === account.appId) {
     // AI-agent registration is provider metadata, not channel identity. Keep it
     // best-effort so its quota or availability cannot suppress message ingress.
     void registerFeishuAiAgent(account, { abortSignal: options.abortSignal })
@@ -119,6 +120,13 @@ export async function fetchBotIdentityForMonitor(
       botName: normalizeOptionalString(result.botName),
       source: "provider",
     };
+  }
+
+  if (result.ok) {
+    const log = options.runtime?.log ?? console.log;
+    log(
+      `feishu[${account.accountId}]: bot info probe returned identity for a different app; ignoring stale result`,
+    );
   }
 
   const probeError = result.error ?? undefined;

--- a/extensions/feishu/src/monitor.startup.ts
+++ b/extensions/feishu/src/monitor.startup.ts
@@ -2,7 +2,7 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { RuntimeEnv } from "../runtime-api.js";
 import { resolveStartupProbeTimeoutMs } from "./monitor-startup-timeout.js";
-import { probeFeishu } from "./probe.js";
+import { probeFeishu, registerFeishuAiAgent } from "./probe.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 const FEISHU_STARTUP_BOT_INFO_TIMEOUT_MS = resolveStartupProbeTimeoutMs();
@@ -41,6 +41,23 @@ export async function fetchBotIdentityForMonitor(
     abortSignal: options.abortSignal,
   });
   if (result.ok) {
+    // AI-agent registration is provider metadata, not channel identity. Keep it
+    // best-effort so its quota or availability cannot suppress message ingress.
+    void registerFeishuAiAgent(account, { abortSignal: options.abortSignal })
+      .then((registration) => {
+        if (!registration.ok && registration.reason !== "aborted") {
+          const log = options.runtime?.log ?? console.log;
+          log(
+            `feishu[${account.accountId}]: AI-agent registration unavailable (${registration.reason}); continuing with standard bot identity`,
+          );
+        }
+      })
+      .catch(() => {
+        const log = options.runtime?.log ?? console.log;
+        log(
+          `feishu[${account.accountId}]: AI-agent registration failed unexpectedly; continuing with standard bot identity`,
+        );
+      });
     return { botOpenId: result.botOpenId, botName: result.botName };
   }
 

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -82,7 +82,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     }
 
     // Probe sequentially so large multi-account startups do not burst Feishu's bot-info endpoint.
-    const { botOpenId, botName } = await fetchBotIdentityForMonitor(account, {
+    const { botOpenId, botName, source } = await fetchBotIdentityForMonitor(account, {
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
     });
@@ -99,7 +99,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         channelRuntime: opts.channelRuntime,
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
-        botOpenIdSource: { kind: "prefetched", botOpenId, botName },
+        botOpenIdSource: { kind: "prefetched", botOpenId, botName, source },
         ...(opts.statusSink ? { statusSink: opts.statusSink } : {}),
       }),
     );

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -15,6 +15,7 @@ const probeFeishuMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
+  registerFeishuAiAgent: vi.fn().mockResolvedValue({ ok: true }),
 }));
 
 vi.mock("./client.js", async () => {

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -16,6 +16,7 @@ const probeFeishuMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
+  registerFeishuAiAgent: vi.fn().mockResolvedValue({ ok: true }),
 }));
 
 vi.mock("./client.js", () => createFeishuClientMockModule());

--- a/extensions/feishu/src/probe.test.ts
+++ b/extensions/feishu/src/probe.test.ts
@@ -1,6 +1,6 @@
 // Feishu tests cover probe plugin behavior.
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { probeFeishu } from "./probe.js";
+import { probeFeishu, registerFeishuAiAgent } from "./probe.js";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 
@@ -13,7 +13,7 @@ const DEFAULT_CREDS = { accountId: "probe-0", appId: "cli_123", appSecret: "secr
 let defaultAccountSequence = 0;
 const DEFAULT_SUCCESS_RESPONSE = {
   code: 0,
-  data: { pingBotInfo: { botName: "TestBot", botID: "ou_abc123" } },
+  bot: { app_name: "TestBot", open_id: "ou_abc123" },
 } as const;
 const DEFAULT_SUCCESS_RESULT = {
   ok: true,
@@ -23,7 +23,7 @@ const DEFAULT_SUCCESS_RESULT = {
 } as const;
 const BOT1_RESPONSE = {
   code: 0,
-  data: { pingBotInfo: { botName: "Bot1", botID: "ou_1" } },
+  bot: { app_name: "Bot1", open_id: "ou_1" },
 } as const;
 
 afterAll(() => {
@@ -140,9 +140,8 @@ describe("probeFeishu", () => {
     await probeFeishu(DEFAULT_CREDS);
 
     expect(requestFn).toHaveBeenCalledWith({
-      method: "POST",
-      url: "/open-apis/bot/v1/openclaw_bot/ping",
-      data: { needBotInfo: true },
+      method: "GET",
+      url: "/open-apis/bot/v3/info",
       timeout: FEISHU_PROBE_REQUEST_TIMEOUT_MS,
     });
   });
@@ -233,6 +232,16 @@ describe("probeFeishu", () => {
     });
   });
 
+  it("rejects a successful standard response without bot identity", async () => {
+    setupClient({ code: 0, bot: { app_name: "MissingId" } });
+
+    await expect(probeFeishu(DEFAULT_CREDS)).resolves.toEqual({
+      ok: false,
+      appId: DEFAULT_CREDS.appId,
+      error: "API response missing bot open_id",
+    });
+  });
+
   it("caches thrown request errors for the error TTL", async () => {
     await withFakeTimers(async () => {
       await expectErrorResultCached({
@@ -286,10 +295,10 @@ describe("probeFeishu", () => {
     expect(requestFn).toHaveBeenCalledTimes(2);
   });
 
-  it("handles response with pingBotInfo in data", async () => {
+  it("handles standard bot info nested under data", async () => {
     setupClient({
       code: 0,
-      data: { pingBotInfo: { botName: "DataBot", botID: "ou_data" } },
+      data: { bot: { app_name: "DataBot", open_id: "ou_data" } },
     });
 
     await expectDefaultSuccessResult(DEFAULT_CREDS, {
@@ -297,5 +306,61 @@ describe("probeFeishu", () => {
       botName: "DataBot",
       botOpenId: "ou_data",
     });
+  });
+
+  it("registers the app as an AI agent through a separate best-effort request", async () => {
+    const requestFn = setupClient({ code: 0 });
+
+    await expect(registerFeishuAiAgent(DEFAULT_CREDS)).resolves.toEqual({ ok: true });
+    expect(requestFn).toHaveBeenCalledWith({
+      method: "POST",
+      url: "/open-apis/bot/v1/openclaw_bot/ping",
+      data: { needBotInfo: true },
+      timeout: FEISHU_PROBE_REQUEST_TIMEOUT_MS,
+    });
+  });
+
+  it("contains AI-agent registration API failures", async () => {
+    setupClient({ code: 99991403, msg: "quota exhausted" });
+
+    await expect(registerFeishuAiAgent(DEFAULT_CREDS)).resolves.toEqual({
+      ok: false,
+      reason: "api-error",
+    });
+  });
+
+  it("contains AI-agent registration request failures", async () => {
+    createFeishuClientMock.mockReturnValue({
+      request: vi.fn().mockRejectedValue(new Error("network error")),
+    });
+
+    await expect(registerFeishuAiAgent(DEFAULT_CREDS)).resolves.toEqual({
+      ok: false,
+      reason: "request-error",
+    });
+  });
+
+  it("bounds AI-agent registration timeouts", async () => {
+    await withFakeTimers(async () => {
+      createFeishuClientMock.mockReturnValue({
+        request: vi.fn().mockImplementation(() => new Promise(() => {})),
+      });
+
+      const promise = registerFeishuAiAgent(DEFAULT_CREDS, { timeoutMs: 1_000 });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(promise).resolves.toEqual({ ok: false, reason: "timeout" });
+    });
+  });
+
+  it("does not start AI-agent registration after abort", async () => {
+    createFeishuClientMock.mockClear();
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      registerFeishuAiAgent(DEFAULT_CREDS, { abortSignal: abortController.signal }),
+    ).resolves.toEqual({ ok: false, reason: "aborted" });
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/probe.test.ts
+++ b/extensions/feishu/src/probe.test.ts
@@ -295,6 +295,28 @@ describe("probeFeishu", () => {
     expect(requestFn).toHaveBeenCalledTimes(2);
   });
 
+  it("does not reuse cached identity when an account is reassigned to another app", async () => {
+    const requestFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        code: 0,
+        bot: { app_name: "OldBot", open_id: "ou_old" },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        bot: { app_name: "NewBot", open_id: "ou_new" },
+      });
+    createFeishuClientMock.mockReturnValue({ request: requestFn });
+
+    await expect(
+      probeFeishu({ accountId: "acct-switch", appId: "cli_old", appSecret: "secret_old" }), // pragma: allowlist secret
+    ).resolves.toMatchObject({ ok: true, appId: "cli_old", botOpenId: "ou_old" });
+    await expect(
+      probeFeishu({ accountId: "acct-switch", appId: "cli_new", appSecret: "secret_new" }), // pragma: allowlist secret
+    ).resolves.toMatchObject({ ok: true, appId: "cli_new", botOpenId: "ou_new" });
+    expect(requestFn).toHaveBeenCalledTimes(2);
+  });
+
   it("handles standard bot info nested under data", async () => {
     setupClient({
       code: 0,

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -43,7 +43,7 @@ type FeishuRequestClient = ReturnType<typeof createFeishuClient> & {
   }): Promise<FeishuBotInfoResponse | FeishuAiAgentRegistrationResponse>;
 };
 
-export type FeishuAiAgentRegistrationResult =
+type FeishuAiAgentRegistrationResult =
   | { ok: true }
   | {
       ok: false;

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -1,4 +1,5 @@
 // Feishu plugin module implements probe behavior.
+import { createHash } from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   asDateTimestampMs,
@@ -50,6 +51,13 @@ type FeishuAiAgentRegistrationResult =
       reason: "missing-credentials" | "aborted" | "timeout" | "api-error" | "request-error";
     };
 
+function buildProbeCacheKey(creds: FeishuClientCredentials): string {
+  // Account ids survive config reloads. Bind cached health and identity to the
+  // complete credentials so a reconfigured account must perform a fresh probe.
+  const identity = [creds.accountId ?? null, creds.appId, creds.appSecret, creds.domain ?? null];
+  return createHash("sha256").update(JSON.stringify(identity)).digest("hex");
+}
+
 function setCachedProbeResult(
   cacheKey: string,
   result: FeishuProbeResult,
@@ -90,11 +98,8 @@ export async function probeFeishu(
 
   const timeoutMs = options.timeoutMs ?? FEISHU_PROBE_REQUEST_TIMEOUT_MS;
 
-  // Return cached result if still valid.
-  // Use accountId when available; otherwise include appSecret prefix so two
-  // accounts sharing the same appId (e.g. after secret rotation) don't
-  // pollute each other's cache entry.
-  const cacheKey = creds.accountId ?? `${creds.appId}:${creds.appSecret.slice(0, 8)}`;
+  // Return cached result if still valid for this exact configured identity.
+  const cacheKey = buildProbeCacheKey(creds);
   const cached = probeCache.get(cacheKey);
   if (cached) {
     const now = asDateTimestampMs(Date.now());

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -23,20 +23,32 @@ type ProbeFeishuOptions = {
   abortSignal?: AbortSignal;
 };
 
-type FeishuPingResponse = {
+type FeishuBotInfoResponse = {
   code: number;
   msg?: string;
-  data?: { pingBotInfo?: { botID?: string; botName?: string } };
+  bot?: { app_name?: string; open_id?: string };
+  data?: { bot?: { app_name?: string; open_id?: string } };
+};
+
+type FeishuAiAgentRegistrationResponse = {
+  code: number;
 };
 
 type FeishuRequestClient = ReturnType<typeof createFeishuClient> & {
   request(params: {
-    method: "POST";
+    method: "GET" | "POST";
     url: string;
-    data: Record<string, unknown>;
+    data?: Record<string, unknown>;
     timeout: number;
-  }): Promise<FeishuPingResponse>;
+  }): Promise<FeishuBotInfoResponse | FeishuAiAgentRegistrationResponse>;
 };
+
+export type FeishuAiAgentRegistrationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "missing-credentials" | "aborted" | "timeout" | "api-error" | "request-error";
+    };
 
 function setCachedProbeResult(
   cacheKey: string,
@@ -95,16 +107,14 @@ export async function probeFeishu(
 
   try {
     const client = createFeishuClient(creds) as FeishuRequestClient;
-    // Feishu-provided endpoint for OpenClaw, supported on both Feishu (CN)
-    // and Lark (international). No OAuth scopes required. Validates
-    // credentials and registers the app as an AI agent (智能体).
-    const responseResult = await raceWithTimeoutAndAbort<FeishuPingResponse>(
+    // Bot identity is required for mention and self-message filtering. Keep it on the
+    // standard bot-info API so optional AI-agent registration cannot gate the channel.
+    const responseResult = await raceWithTimeoutAndAbort<FeishuBotInfoResponse>(
       client.request({
-        method: "POST",
-        url: "/open-apis/bot/v1/openclaw_bot/ping",
-        data: { needBotInfo: true },
+        method: "GET",
+        url: "/open-apis/bot/v3/info",
         timeout: timeoutMs,
-      }),
+      }) as Promise<FeishuBotInfoResponse>,
       {
         timeoutMs,
         abortSignal: options.abortSignal,
@@ -151,14 +161,25 @@ export async function probeFeishu(
       );
     }
 
-    const botInfo = response.data?.pingBotInfo;
+    const botInfo = response.bot ?? response.data?.bot;
+    if (!botInfo?.open_id) {
+      return setCachedProbeResult(
+        cacheKey,
+        {
+          ok: false,
+          appId: creds.appId,
+          error: "API response missing bot open_id",
+        },
+        PROBE_ERROR_TTL_MS,
+      );
+    }
     return setCachedProbeResult(
       cacheKey,
       {
         ok: true,
         appId: creds.appId,
-        botName: botInfo?.botName,
-        botOpenId: botInfo?.botID,
+        botName: botInfo.app_name,
+        botOpenId: botInfo.open_id,
       },
       PROBE_SUCCESS_TTL_MS,
     );
@@ -172,5 +193,44 @@ export async function probeFeishu(
       },
       PROBE_ERROR_TTL_MS,
     );
+  }
+}
+
+/**
+ * Preserve Feishu's optional AI-agent registration without coupling it to health or
+ * identity. Monitor startup calls this once per account and never awaits it.
+ */
+export async function registerFeishuAiAgent(
+  creds?: FeishuClientCredentials,
+  options: ProbeFeishuOptions = {},
+): Promise<FeishuAiAgentRegistrationResult> {
+  if (!creds?.appId || !creds?.appSecret) {
+    return { ok: false, reason: "missing-credentials" };
+  }
+  if (options.abortSignal?.aborted) {
+    return { ok: false, reason: "aborted" };
+  }
+
+  const timeoutMs = options.timeoutMs ?? FEISHU_PROBE_REQUEST_TIMEOUT_MS;
+  try {
+    const client = createFeishuClient(creds) as FeishuRequestClient;
+    const responseResult = await raceWithTimeoutAndAbort<FeishuAiAgentRegistrationResponse>(
+      client.request({
+        method: "POST",
+        url: "/open-apis/bot/v1/openclaw_bot/ping",
+        data: { needBotInfo: true },
+        timeout: timeoutMs,
+      }) as Promise<FeishuAiAgentRegistrationResponse>,
+      { timeoutMs, abortSignal: options.abortSignal },
+    );
+    if (responseResult.status === "aborted" || options.abortSignal?.aborted) {
+      return { ok: false, reason: "aborted" };
+    }
+    if (responseResult.status === "timeout") {
+      return { ok: false, reason: "timeout" };
+    }
+    return responseResult.value.code === 0 ? { ok: true } : { ok: false, reason: "api-error" };
+  } catch {
+    return { ok: false, reason: "request-error" };
   }
 }


### PR DESCRIPTION
Closes #112806

AI-assisted: Yes — implemented and reviewed with Codex; the design, live-validation plan, and final result were approved through maintainer-guided development.

## What Problem This Solves

Fixes an issue where users who explicitly mention OpenClaw in a Lark Drive comment could receive no reply when a transient startup bot-info failure left the bundled Feishu plugin without the bot Open ID.

## Why This Change Was Made

The plugin now keeps standard Lark bot info authoritative for health and identity while decoupling best-effort AI-agent registration from startup availability. It retains the last provider-verified identity in bounded plugin-owned SQLite state and allows an explicitly mentioned Drive-comment event to use its recipient Open ID only for that event when startup identity is unavailable; event-derived identity is never persisted or promoted globally.

This remains entirely inside the Feishu plugin. It adds no config, environment variable, core contract, protocol change, or public Plugin SDK surface.

## User Impact

Lark Drive comment mentions continue through the normal comment workflow during transient bot-info outages instead of being silently dropped. Self-authored events remain filtered, fresh provider failures remain visible as failures, and background refresh continues until a provider-verified identity is available.

## Evidence

- Live Lark proof: https://crabbox.openclaw.ai/portal/runs/run_c7a6738a2a07
  - Production bundled plugin and Gateway with real Lark WebSocket ingress.
  - The provider condition was reproduced naturally: tenant token succeeded while standard bot info returned HTTP 429 / API code `99991403`, leaving startup identity unknown.
  - One UI-selected bot mention in an isolated Drive comment produced exactly one visible bot reply in Lark.
- Focused regression proof: 60/60 tests passed across bot identity caching, monitor identity/startup/comment behavior, provider probing, and same-account app reassignment.
- Changed-surface checks, Feishu production/test typechecks, plugin boundary guards, touched-file lint, `git diff --check`, and the full build passed.
- Remote validation passed on the exact candidate: https://github.com/openclaw/openclaw/actions/runs/29966698667
- Fresh branch autoreview completed with no findings.
- Rebased onto `origin/main` at `4a2a6008091d60d7a543c2ea53a3306d2ea2c1ec`; `git range-diff` reports the original two commits patch-identical, and all 60 focused tests pass on current head `fccc97453301cea468d3032f254bc275f07678fa`.
- The CI deadcode gates pass on the current tree after keeping two implementation-only return types module-private: https://github.com/openclaw/openclaw/actions/runs/29968501689
- The full changed-surface gate and both deadcode gates pass after binding transient probe results to complete configured credentials: https://github.com/openclaw/openclaw/actions/runs/29969388030

No credentials, private comment content, file tokens, or raw provider identifiers are included in the evidence.
