### PR TITLE
refactor(ui): replace minified sidebar render snapshot with host interface

### DIFF
--- a/ui/src/app/user-profile.ts
+++ b/ui/src/app/user-profile.ts
@@ -1,6 +1,7 @@
 import type { PresenceEntry } from "../api/types.ts";
 
 export type AuthenticatedUser = NonNullable<PresenceEntry["user"]>;
+export type PresencePayload = { presence: readonly PresenceEntry[] };
 
 export function readPresenceEntries(value: unknown): PresenceEntry[] | undefined {
   if (!value || typeof value !== "object") {

--- a/ui/src/components/app-sidebar-menus.ts
+++ b/ui/src/components/app-sidebar-menus.ts
@@ -45,10 +45,10 @@ import type { SessionMenuAction, SessionMenuWork } from "./session-menu.ts";
 export abstract class AppSidebarMenusElement extends AppSidebarSessionGroupsElement {
   @state() protected customizeMenuPosition: { x: number; y: number } | null = null;
   @state() protected moreMenuPosition: { x: number; y: number } | null = null;
-  @state() protected sessionMenu: SidebarSessionMenuState | null = null;
+  @state() sessionMenu: SidebarSessionMenuState | null = null;
   @state() protected sessionMenuWork: SessionMenuWork | null = null;
-  @state() protected sessionGroupMenu: SidebarSessionGroupMenuState | null = null;
-  @state() protected sessionSortMenuPosition: { x: number; y: number } | null = null;
+  @state() sessionGroupMenu: SidebarSessionGroupMenuState | null = null;
+  @state() sessionSortMenuPosition: { x: number; y: number } | null = null;
   // Anchored by its bottom edge so the footer menu grows upward regardless of height.
   @state() protected agentMenuPosition: { x: number; bottom: number } | null = null;
   @state() protected agentMenuFilter = "";
@@ -172,7 +172,7 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionGroupsElem
   }
 
   /** A row outside the current selection retargets before the menu opens. */
-  protected openSessionMenuForRow(
+  openSessionMenu(
     session: SidebarRecentSession,
     x: number,
     y: number,
@@ -181,10 +181,10 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionGroupsElem
     if (!this.selectedSessionKeys.has(session.key)) {
       this.clearSessionSelection();
     }
-    this.openSessionMenu(session, x, y, trigger);
+    this.showSessionMenu(session, x, y, trigger);
   }
 
-  private openSessionMenu(
+  private showSessionMenu(
     session: SidebarRecentSession,
     x: number,
     y: number,
@@ -232,7 +232,7 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionGroupsElem
     });
   }
 
-  protected openSessionGroupMenu(group: string, x: number, y: number, trigger: HTMLElement | null) {
+  openSessionGroupMenu(group: string, x: number, y: number, trigger: HTMLElement | null) {
     const menuWidth = 224;
     const menuMaxHeight = 160;
     this.dismissTransientMenus();
@@ -253,7 +253,7 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionGroupsElem
     }
   }
 
-  protected toggleSessionSortMenu(trigger: HTMLElement) {
+  toggleSessionSortMenu(trigger: HTMLElement) {
     if (this.sessionSortMenuPosition) {
       this.closeSessionSortMenu();
       return;

--- a/ui/src/components/app-sidebar-session-catalog-data.ts
+++ b/ui/src/components/app-sidebar-session-catalog-data.ts
@@ -214,7 +214,7 @@ export abstract class AppSidebarSessionCatalogDataElement extends AppSidebarBase
     });
   }
 
-  protected async loadMoreSessionCatalog(catalogId: string) {
+  async loadMoreSessionCatalog(catalogId: string) {
     if (this.loadingMoreSessionCatalogIds.has(catalogId)) {
       return;
     }

--- a/ui/src/components/app-sidebar-session-data.ts
+++ b/ui/src/components/app-sidebar-session-data.ts
@@ -7,6 +7,7 @@ import {
   type ApprovalBadgeSnapshot,
 } from "../app/approval-presentation.ts";
 import type { ApplicationContext } from "../app/context.ts";
+import { readPresenceEntries, type PresencePayload } from "../app/user-profile.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
@@ -38,9 +39,9 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarSessionCata
   @state() protected loadingChildSessionKeys: ReadonlySet<string> = new Set();
   @state() protected activeSessionLineageRoot: GatewaySessionRow | null = null;
   @state() protected sessionsScrollState: SidebarSessionsScrollState = "none";
-  @state() protected sessionMutationError: string | null = null;
-  @state() protected presencePayload: unknown;
-  @state() protected presenceInstanceId?: string;
+  @state() sessionMutationError: string | null = null;
+  @state() presencePayload: PresencePayload | undefined;
+  @state() presenceInstanceId?: string;
 
   protected sessionRowsByAgent: Record<string, SessionsListResult["sessions"]> = {};
   protected sessionCreatedOrder = new Map<string, number>();
@@ -97,7 +98,8 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarSessionCata
               return;
             }
             if (event.event === "presence") {
-              this.presencePayload = event.payload;
+              const presence = readPresenceEntries(event.payload);
+              this.presencePayload = presence ? { presence } : undefined;
               this.handleSessionCatalogPresence(event.payload);
             }
           }),
@@ -116,7 +118,7 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarSessionCata
       );
   }
 
-  protected approvalBadgeSnapshot(): ApprovalBadgeSnapshot {
+  approvalBadgeSnapshot(): ApprovalBadgeSnapshot {
     const queue = this.context?.overlays?.snapshot.approvalQueue ?? [];
     if (queue !== this.approvalBadgeQueue) {
       this.approvalBadgeQueue = queue;
@@ -300,7 +302,8 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarSessionCata
     if (!connected) {
       this.presencePayload = undefined;
     } else if (clientChanged || connectedStarted) {
-      this.presencePayload = gateway.snapshot.hello?.snapshot;
+      const presence = readPresenceEntries(gateway.snapshot.hello?.snapshot);
+      this.presencePayload = presence ? { presence } : undefined;
     }
     if (!sourceOrClientChanged) {
       return;

--- a/ui/src/components/app-sidebar-session-groups.ts
+++ b/ui/src/components/app-sidebar-session-groups.ts
@@ -35,17 +35,17 @@ import {
 
 /** Custom session groups, collapse state, and drag-and-drop assignment. */
 export abstract class AppSidebarSessionGroupsElement extends AppSidebarSessionMutationsElement {
-  @state() protected collapsedSessionSections = loadStoredCollapsedSessionSections();
-  @state() protected draggingSessionKey: string | null = null;
-  @state() protected draggingSessionGroup: string | null = null;
-  @state() protected sessionDropTarget: string | null = null;
-  @state() protected sessionGroupDropTarget: SidebarSessionGroupDropTarget | null = null;
+  @state() collapsedSessionSections = loadStoredCollapsedSessionSections();
+  @state() draggingSessionKey: string | null = null;
+  @state() draggingSessionGroup: string | null = null;
+  @state() sessionDropTarget: string | null = null;
+  @state() sessionGroupDropTarget: SidebarSessionGroupDropTarget | null = null;
   @state() protected draggingSidebarEntry: string | null = null;
   @state() protected sidebarZoneDropTarget: {
     entry: string;
     position: "before" | "after";
   } | null = null;
-  @state() protected sessionListRemovalDrop = false;
+  @state() sessionListRemovalDrop = false;
 
   protected startSidebarRouteDrag(event: DragEvent, route: SidebarNavRoute) {
     if (!event.dataTransfer) {
@@ -167,7 +167,7 @@ export abstract class AppSidebarSessionGroupsElement extends AppSidebarSessionMu
     this.onUpdateSidebarEntries?.(next);
   }
 
-  protected handleSessionListDragOver(event: DragEvent) {
+  handleSessionListDragOver(event: DragEvent) {
     const routeDrag = sidebarRouteDragActive(event.dataTransfer);
     const sessionKey = readSessionDragData(event.dataTransfer);
     const session = sessionKey ? this.findSidebarSessionByKey(sessionKey) : undefined;
@@ -181,14 +181,14 @@ export abstract class AppSidebarSessionGroupsElement extends AppSidebarSessionMu
     this.sessionListRemovalDrop = true;
   }
 
-  protected handleSessionListDragLeave(event: DragEvent) {
+  handleSessionListDragLeave(event: DragEvent) {
     const current = event.currentTarget as HTMLElement;
     if (!(event.relatedTarget instanceof Node && current.contains(event.relatedTarget))) {
       this.sessionListRemovalDrop = false;
     }
   }
 
-  protected handleSessionListDrop(event: DragEvent) {
+  handleSessionListDrop(event: DragEvent) {
     const draggedNavigation = readSidebarRouteDragData(event.dataTransfer);
     const dynamicEntry = parseSidebarEntry(draggedNavigation);
     const entry =
@@ -327,7 +327,7 @@ export abstract class AppSidebarSessionGroupsElement extends AppSidebarSessionMu
     }
   }
 
-  protected toggleSessionSection(sectionId: string) {
+  toggleSection(sectionId: string) {
     const collapsed = new Set(this.collapsedSessionSections);
     if (collapsed.has(sectionId)) {
       collapsed.delete(sectionId);
@@ -372,7 +372,7 @@ export abstract class AppSidebarSessionGroupsElement extends AppSidebarSessionMu
     })();
   }
 
-  protected handleSessionSectionDragOver(event: DragEvent, sectionId: string, category?: string) {
+  sectionDragOver(event: DragEvent, sectionId: string, category?: string) {
     const dataTransfer = event.dataTransfer;
     if (
       category &&
@@ -401,7 +401,7 @@ export abstract class AppSidebarSessionGroupsElement extends AppSidebarSessionMu
     this.sessionGroupDropTarget = null;
   }
 
-  protected handleSessionSectionDragLeave(event: DragEvent, sectionId: string, category?: string) {
+  sectionDragLeave(event: DragEvent, sectionId: string, category?: string) {
     const current = event.currentTarget as HTMLElement;
     if (event.relatedTarget instanceof Node && current.contains(event.relatedTarget)) {
       return;
@@ -431,7 +431,7 @@ export abstract class AppSidebarSessionGroupsElement extends AppSidebarSessionMu
     return undefined;
   }
 
-  protected handleSessionSectionDrop(event: DragEvent, sectionId: string, category?: string) {
+  sectionDrop(event: DragEvent, sectionId: string, category?: string) {
     const sourceGroup = readSessionGroupDragData(event.dataTransfer);
     const sessionKey = readSessionDragData(event.dataTransfer);
     if (!sourceGroup && !sessionKey) {

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -12,7 +12,7 @@ import { renderSessionCatalogGroups } from "./app-sidebar-session-catalogs.ts";
 import {
   renderRecentSession,
   renderSessionTree,
-  type SessionListRenderContext,
+  type SessionListHost,
 } from "./app-sidebar-session-row-render.ts";
 import {
   limitSidebarSessionRows,
@@ -43,20 +43,19 @@ type SessionCatalogRenderSnapshot = {
 };
 
 function renderSessionSection(params: {
-  context: SessionListRenderContext;
+  host: SessionListHost;
   section: RenderableSessionSection;
   trailing?: TemplateResult | typeof nothing;
   showDraft?: boolean;
 }) {
-  const { context, section } = params;
-  const { data, cb } = context;
+  const { host, section } = params;
   const trailing = params.trailing ?? nothing;
   const showDraft = params.showDraft ?? false;
   const totalRowCount = section.totalRowCount;
   const group = section.category;
   // zonedVisibleSections removes pinned rows; AppSidebar renders them through
   // renderPinnedSidebarSession, so every section here has a header.
-  const collapsed = data.c.has(section.id);
+  const collapsed = host.collapsedSessionSections.has(section.id);
   const label = section.groups
     ? t("chat.sidebar.groups")
     : section.work
@@ -73,15 +72,16 @@ function renderSessionSection(params: {
   const collapsedAttentionDot =
     collapsed &&
     section.rows.some((row) => rowDemandsVisibility(row, RowVisibilityReason.Attention));
-  const acceptsSessions = data.g === "category" && (section.id === "ungrouped" || Boolean(group));
+  const acceptsSessions =
+    host.sessionsGrouping === "category" && (section.id === "ungrouped" || Boolean(group));
   const sectionClass = [
     "sidebar-recent-sessions__group",
     `sidebar-recent-sessions__group--zone-${zone}`,
     collapsed ? "sidebar-recent-sessions__group--collapsed" : "",
-    group && data.dg === group ? "sidebar-recent-sessions__group--dragging" : "",
-    data.q === section.id ? "sidebar-recent-sessions__group--session-drop" : "",
-    group && data.gd?.group === group
-      ? `sidebar-recent-sessions__group--group-drop-${data.gd.position}`
+    group && host.draggingSessionGroup === group ? "sidebar-recent-sessions__group--dragging" : "",
+    host.sessionDropTarget === section.id ? "sidebar-recent-sessions__group--session-drop" : "",
+    group && host.sessionGroupDropTarget?.group === group
+      ? `sidebar-recent-sessions__group--group-drop-${host.sessionGroupDropTarget.position}`
       : "",
   ]
     .filter(Boolean)
@@ -91,13 +91,13 @@ function renderSessionSection(params: {
       class=${sectionClass}
       data-session-section=${section.id}
       @dragover=${acceptsSessions || group
-        ? (event: DragEvent) => cb.ov(event, section.id, group)
+        ? (event: DragEvent) => host.sectionDragOver(event, section.id, group)
         : nothing}
       @dragleave=${acceptsSessions || group
-        ? (event: DragEvent) => cb.lv(event, section.id, group)
+        ? (event: DragEvent) => host.sectionDragLeave(event, section.id, group)
         : nothing}
       @drop=${acceptsSessions || group
-        ? (event: DragEvent) => cb.sp(event, section.id, group)
+        ? (event: DragEvent) => host.sectionDrop(event, section.id, group)
         : nothing}
     >
       ${html`
@@ -110,19 +110,19 @@ function renderSessionSection(params: {
             ? (event: DragEvent) => {
                 if (event.dataTransfer) {
                   writeSessionGroupDragData(event.dataTransfer, group);
-                  cb.gs(group);
+                  host.startSessionGroupDrag(group);
                 }
               }
             : nothing}
           @dragend=${group
             ? () => {
-                cb.ge();
+                host.finishSessionGroupDrag();
               }
             : nothing}
           @contextmenu=${group
             ? (event: MouseEvent) => {
                 event.preventDefault();
-                cb.gm(group, event.clientX, event.clientY, null);
+                host.openSessionGroupMenu(group, event.clientX, event.clientY, null);
               }
             : nothing}
         >
@@ -134,7 +134,7 @@ function renderSessionSection(params: {
             class="sidebar-session-group-toggle"
             aria-expanded=${String(!collapsed)}
             aria-label=${label}
-            @click=${() => cb.section(section.id)}
+            @click=${() => host.toggleSection(section.id)}
           >
             <span class="sidebar-recent-sessions__label-text">${label}</span>
             <span class="sidebar-session-group-toggle__icon" aria-hidden="true"
@@ -168,10 +168,10 @@ function renderSessionSection(params: {
                   title=${t("chat.sidebar.sortSessions")}
                   aria-label=${t("chat.sidebar.sortSessions")}
                   aria-haspopup="menu"
-                  aria-expanded=${String(data.z)}
+                  aria-expanded=${String(host.sessionSortMenuPosition !== null)}
                   @click=${(event: MouseEvent) => {
                     event.stopPropagation();
-                    cb.z(event.currentTarget as HTMLElement);
+                    host.toggleSessionSortMenu(event.currentTarget as HTMLElement);
                   }}
                 >
                   ${icons.listFilter}
@@ -179,14 +179,14 @@ function renderSessionSection(params: {
                 <button
                   type="button"
                   class="sidebar-session-group-actions sidebar-new-session"
-                  title=${data.o
+                  title=${host.connected
                     ? t("chat.runControls.newSession")
                     : t("chat.runControls.newSessionDisconnected")}
                   aria-label=${t("chat.runControls.newSession")}
-                  ?disabled=${!data.o}
+                  ?disabled=${!host.connected}
                   @click=${(event: MouseEvent) => {
                     event.stopPropagation();
-                    cb.ns();
+                    host.openNewSession();
                   }}
                 >
                   ${icons.plus}
@@ -201,12 +201,12 @@ function renderSessionSection(params: {
                   title=${t("sessionsView.groupMenu", { group })}
                   aria-label=${t("sessionsView.groupMenu", { group })}
                   aria-haspopup="menu"
-                  aria-expanded=${String(data.gm === group)}
+                  aria-expanded=${String(host.sessionGroupMenu?.group === group)}
                   @click=${(event: MouseEvent) => {
                     event.stopPropagation();
                     const trigger = event.currentTarget as HTMLElement;
                     const rect = trigger.getBoundingClientRect();
-                    cb.gm(group, rect.right, rect.bottom + 4, trigger);
+                    host.openSessionGroupMenu(group, rect.right, rect.bottom + 4, trigger);
                   }}
                 >
                   ${icons.moreHorizontal}
@@ -221,7 +221,7 @@ function renderSessionSection(params: {
             ${section.rows.length > 0 || showDraft
               ? html`<div class="sidebar-recent-sessions__list" role="list" aria-label=${label}>
                   ${showDraft ? renderDraftSessionRow() : nothing}
-                  ${section.rows.map((session) => renderSessionTree({ context, session }))}
+                  ${section.rows.map((session) => renderSessionTree({ host, session }))}
                 </div>`
               : nothing}
             ${trailing}
@@ -246,12 +246,11 @@ function renderDraftSessionRow() {
 }
 
 function renderSessionPagination(params: {
-  context: SessionListRenderContext;
+  host: SessionListHost;
   rows: SidebarRecentSession[];
   visible: number;
 }) {
-  const { context, rows, visible } = params;
-  const { cb } = context;
+  const { host, rows, visible } = params;
   const canShowMore = visible < rows.length;
   const collapsedVisible = limitSidebarSessionRows(rows, SIDEBAR_SESSION_PAGE_SIZE).length;
   const canShowLess = visible > SIDEBAR_SESSION_SEE_LESS_THRESHOLD && visible > collapsedVisible;
@@ -266,7 +265,7 @@ function renderSessionPagination(params: {
             class="sidebar-session-pagination__button"
             aria-label=${t("chat.selectors.loadMoreSessions")}
             @click=${() => {
-              cb.sl(visible + SIDEBAR_SESSION_PAGE_SIZE);
+              host.setVisibleSessionLimit(visible + SIDEBAR_SESSION_PAGE_SIZE);
             }}
           >
             ${t("chat.selectors.loadMoreSessions")}
@@ -278,8 +277,8 @@ function renderSessionPagination(params: {
             class="sidebar-session-pagination__button"
             aria-label=${t("usage.details.collapse")}
             @click=${() => {
-              cb.cl();
-              cb.sl(SIDEBAR_SESSION_PAGE_SIZE);
+              host.clearSessionSelection();
+              host.setVisibleSessionLimit(SIDEBAR_SESSION_PAGE_SIZE);
             }}
           >
             ${t("usage.details.collapse")}
@@ -290,42 +289,41 @@ function renderSessionPagination(params: {
 }
 
 function renderSessionCatalogs(params: {
-  context: SessionListRenderContext;
+  host: SessionListHost;
   snapshot: SessionCatalogRenderSnapshot;
 }) {
-  const { context, snapshot } = params;
-  const { cb } = context;
+  const { host, snapshot } = params;
   return renderSessionCatalogGroups({
     catalogs: snapshot.catalogs,
-    connected: context.data.o,
+    connected: host.connected,
     basePath: snapshot.basePath,
     routeSessionKey: snapshot.routeSessionKey,
     newSessionAgentId: snapshot.newSessionAgentId,
-    collapsedSections: context.data.c,
+    collapsedSections: host.collapsedSessionSections,
     loadingMoreCatalogIds: snapshot.loadingMoreCatalogIds,
     projectGrouping: snapshot.projectGrouping,
     liveRows: snapshot.liveRows,
     creatorId: snapshot.creatorId,
     renderLiveRow: (row, display) =>
       renderRecentSession({
-        context,
+        host,
         session: snapshot.sidebarRowsByKey.get(row.key)!,
         display,
       }),
-    onToggleSection: (sectionId) => cb.section(sectionId),
-    onToggleProjectGrouping: () => cb.cg(),
-    onLoadMore: (catalogId) => void cb.mo(catalogId),
-    onOpenNewSession: cb.tg,
-    onNavigate: cb.nv,
+    onToggleSection: (sectionId) => host.toggleSection(sectionId),
+    onToggleProjectGrouping: () => host.toggleCatalogProjectGrouping(),
+    onLoadMore: (catalogId) => void host.loadMoreSessionCatalog(catalogId),
+    onOpenNewSession: host.onOpenNewSession,
+    onNavigate: host.onNavigate,
     catalogOpenTarget: snapshot.catalogOpenTarget,
     terminalAvailable: snapshot.terminalAvailable,
     onOpenTerminal: openCatalogSessionInTerminal,
-    onOpenMenu: (request, x, y, trigger) => cb.ct(request, x, y, trigger),
+    onOpenMenu: (request, x, y, trigger) => host.openCatalogMenu(request, x, y, trigger),
   });
 }
 
 function renderSessionListBody(params: {
-  context: SessionListRenderContext;
+  host: SessionListHost;
   sections: RenderableSessionSection[];
   expandedRows: SidebarRecentSession[];
   visibleRowCount: number;
@@ -333,8 +331,7 @@ function renderSessionListBody(params: {
   codingTrailing?: TemplateResult | typeof nothing;
   codingTrailingPresent?: boolean;
 }) {
-  const { context } = params;
-  const { data } = context;
+  const { host } = params;
   return html`
     ${params.sections.map((section) => {
       const showDraft = section.id === "ungrouped" && params.showDraft;
@@ -345,7 +342,7 @@ function renderSessionListBody(params: {
           return nothing;
         }
         return renderSessionSection({
-          context,
+          host,
           section,
           trailing: params.codingTrailing ?? nothing,
         });
@@ -356,15 +353,15 @@ function renderSessionListBody(params: {
         section.id === "ungrouped" &&
         section.totalRowCount === 0 &&
         !showDraft &&
-        data.t === "active" &&
-        data.d === null
+        host.sessionsStatusFilter === "active" &&
+        host.draggingSessionKey === null
       ) {
         return nothing;
       }
-      return renderSessionSection({ context, section, showDraft });
+      return renderSessionSection({ host, section, showDraft });
     })}
     ${renderSessionPagination({
-      context,
+      host,
       rows: params.expandedRows,
       visible: params.visibleRowCount,
     })}
@@ -372,7 +369,7 @@ function renderSessionListBody(params: {
 }
 
 export function renderSessionList(params: {
-  context: SessionListRenderContext;
+  host: SessionListHost;
   empty: boolean;
   sections: RenderableSessionSection[];
   expandedRows: SidebarRecentSession[];
@@ -381,28 +378,29 @@ export function renderSessionList(params: {
   creatorFilter: TemplateResult | typeof nothing;
   catalogs: SessionCatalogRenderSnapshot;
 }) {
-  const { context } = params;
-  const { data, cb } = context;
+  const { host } = params;
   return html`
     <section
-      class="sidebar-sessions ${data.r ? "sidebar-sessions--removal-drop" : ""}"
-      @dragover=${(event: DragEvent) => cb.lo(event)}
-      @dragleave=${(event: DragEvent) => cb.ll(event)}
-      @drop=${(event: DragEvent) => cb.ld(event)}
+      class="sidebar-sessions ${host.sessionListRemovalDrop
+        ? "sidebar-sessions--removal-drop"
+        : ""}"
+      @dragover=${(event: DragEvent) => host.handleSessionListDragOver(event)}
+      @dragleave=${(event: DragEvent) => host.handleSessionListDragLeave(event)}
+      @drop=${(event: DragEvent) => host.handleSessionListDrop(event)}
     >
-      ${data.e
+      ${host.sessionMutationError
         ? html`
             <div
               class="sidebar-session-error callout danger callout--dismissible"
               role="alert"
               data-sidebar-session-error
             >
-              <span class="callout__content">${data.e}</span>
+              <span class="callout__content">${host.sessionMutationError}</span>
               <openclaw-tooltip .content=${t("chat.actions.dismissError")}>
                 <button
                   class="callout__dismiss"
                   type="button"
-                  @click=${() => cb.di()}
+                  @click=${() => host.dismissSessionMutationError()}
                   aria-label=${t("chat.actions.dismissError")}
                 >
                   ${icons.x}
@@ -414,18 +412,19 @@ export function renderSessionList(params: {
       <div class="sidebar-recent-sessions" aria-label=${titleForRoute("sessions")}>
         ${params.creatorFilter}
         ${renderSessionListBody({
-          context,
+          host,
           sections: params.sections,
           expandedRows: params.expandedRows,
           visibleRowCount: params.visibleRowCount,
           showDraft: params.showDraft,
           codingTrailing:
-            data.t === "archived"
+            host.sessionsStatusFilter === "archived"
               ? nothing
-              : html`${renderSessionCatalogs({ context, snapshot: params.catalogs })}`,
-          codingTrailingPresent: data.t !== "archived" && params.catalogs.catalogs.length > 0,
+              : html`${renderSessionCatalogs({ host, snapshot: params.catalogs })}`,
+          codingTrailingPresent:
+            host.sessionsStatusFilter !== "archived" && params.catalogs.catalogs.length > 0,
         })}
-        ${data.t === "archived" && params.empty
+        ${host.sessionsStatusFilter === "archived" && params.empty
           ? html`<span class="sidebar-session-empty-hint"
               >${t("sessionsView.noArchivedSessions")}</span
             >`

--- a/ui/src/components/app-sidebar-session-list.ts
+++ b/ui/src/components/app-sidebar-session-list.ts
@@ -1,27 +1,27 @@
 import type { PropertyValues, TemplateResult } from "lit";
 import { state } from "lit/decorators.js";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
+import type { CatalogSessionMenuRequest } from "./app-sidebar-session-catalogs.ts";
 import { renderSessionList } from "./app-sidebar-session-list-render.ts";
 import { AppSidebarSessionNarrationElement } from "./app-sidebar-session-narration-element.ts";
-import {
-  renderSessionTree,
-  type SessionListRenderContext,
-} from "./app-sidebar-session-row-render.ts";
+import { renderSessionTree, type SessionListHost } from "./app-sidebar-session-row-render.ts";
 import {
   loadStoredSidebarCatalogGrouping,
   storeSidebarCatalogGrouping,
   type SidebarRecentSession,
 } from "./app-sidebar-session-types.ts";
-import type { SessionPullRequestIndicatorState } from "./session-menu-work.ts";
 import { renderSessionCreatorFilter } from "./session-owner-chip.ts";
 
 /** Session-list presentation and catalog renderer wiring. */
-export abstract class AppSidebarSessionListElement extends AppSidebarSessionNarrationElement {
+export abstract class AppSidebarSessionListElement
+  extends AppSidebarSessionNarrationElement
+  implements SessionListHost
+{
   @state() protected catalogProjectGrouping = loadStoredSidebarCatalogGrouping();
 
   protected override willUpdate(changed: PropertyValues<this>) {
     super.willUpdate(changed);
-    // A fresh draft must be visible where it will l: genuinely expand a
+    // A fresh draft must be visible where it will live: genuinely expand a
     // collapsed Threads section (persisted) instead of overriding at render
     // time, so the header toggle keeps matching the visible state.
     if (
@@ -29,120 +29,76 @@ export abstract class AppSidebarSessionListElement extends AppSidebarSessionNarr
       this.draftSessionAgentId &&
       this.collapsedSessionSections.has("ungrouped")
     ) {
-      this.toggleSessionSection("ungrouped");
+      this.toggleSection("ungrouped");
     }
   }
 
-  private createSessionListRenderContext(
-    rows: readonly SidebarRecentSession[],
-  ): SessionListRenderContext {
-    const pullRequestStates = new Map<string, SessionPullRequestIndicatorState>();
-    const expandedSessionKeys = new Set<string>();
-    const append = (row: SidebarRecentSession) => {
-      if (row.worktreeId) {
-        pullRequestStates.set(
-          row.key,
-          this.sessionPullRequestIndicatorState(row.key, row.worktreeId),
-        );
-      }
-      if (this.isSessionChildrenExpanded(row)) {
-        expandedSessionKeys.add(row.key);
-      }
-      row.children.forEach(append);
-    };
-    rows.forEach(append);
+  startSessionDrag(session: SidebarRecentSession): void {
+    this.draggingSessionKey = session.key;
+    this.draggingSidebarEntry = session.pinned ? `session:${session.key}` : null;
+  }
 
-    return {
-      data: {
-        l: this.sidebarLiveActivity,
-        n: this.sidebarNarrationLines,
-        h: this.sidebarObserverDigests,
-        p: pullRequestStates,
-        a: this.approvalBadgeSnapshot(),
-        s: this.selectedSessionKeys,
-        d: this.draggingSessionKey,
-        o: this.connected,
-        v: this.presencePayload,
-        i: this.presenceInstanceId,
-        x: expandedSessionKeys,
-        f: this.fullyShownChildSessionKeys,
-        g: this.sessionsGrouping,
-        c: this.collapsedSessionSections,
-        dg: this.draggingSessionGroup,
-        q: this.sessionDropTarget,
-        gd: this.sessionGroupDropTarget,
-        z: this.sessionSortMenuPosition !== null,
-        m: this.sessionMenu?.session.key ?? null,
-        gm: this.sessionGroupMenu?.group ?? null,
-        t: this.sessionsStatusFilter,
-        r: this.sessionListRemovalDrop,
-        e: this.sessionMutationError,
-        w: this.sessionOwnershipVisible,
-      },
-      cb: {
-        sd: (session) => {
-          this.draggingSessionKey = session.key;
-          this.draggingSidebarEntry = session.pinned ? `session:${session.key}` : null;
-        },
-        ed: () => {
-          this.finishSidebarEntryDrag();
-          this.sessionDropTarget = null;
-        },
-        om: this.openSessionMenuForRow.bind(this),
-        rc: this.handleSessionRowClick.bind(this),
-        ch: this.toggleSessionChildren.bind(this),
-        pin: (session) => void this.patchSession(session, { pinned: !session.pinned }),
-        mc: (session, menuSession, trigger) => {
-          if (this.sessionMenu?.session.key === session.key) {
-            this.closeSessionMenu();
-            return;
-          }
-          const rect = trigger.getBoundingClientRect();
-          this.openSessionMenuForRow(menuSession, rect.right, rect.bottom + 4, trigger);
-        },
-        sh: this.showAllSessionChildren.bind(this),
-        ov: this.handleSessionSectionDragOver.bind(this),
-        lv: this.handleSessionSectionDragLeave.bind(this),
-        sp: this.handleSessionSectionDrop.bind(this),
-        gs: (group) => {
-          this.draggingSessionGroup = group;
-        },
-        ge: () => {
-          this.draggingSessionGroup = null;
-          this.sessionGroupDropTarget = null;
-        },
-        gm: this.openSessionGroupMenu.bind(this),
-        section: this.toggleSessionSection.bind(this),
-        z: this.toggleSessionSortMenu.bind(this),
-        ns: () => {
-          this.onOpenNewSession?.(this.expandedAgentId());
-        },
-        sl: (limit) => {
-          this.visibleSessionLimit = limit;
-        },
-        cl: this.clearSessionSelection.bind(this),
-        lo: this.handleSessionListDragOver.bind(this),
-        ll: this.handleSessionListDragLeave.bind(this),
-        ld: this.handleSessionListDrop.bind(this),
-        di: () => {
-          this.sessionMutationError = null;
-        },
-        cg: () => {
-          const next = this.catalogProjectGrouping === "project" ? "none" : "project";
-          storeSidebarCatalogGrouping(next);
-          this.catalogProjectGrouping = next;
-        },
-        mo: this.loadMoreSessionCatalog.bind(this),
-        tg: this.onOpenNewSession,
-        nv: this.onNavigate,
-        ct: this.catalogMenu.open.bind(this.catalogMenu),
-      },
-    };
+  finishSessionDrag(): void {
+    this.finishSidebarEntryDrag();
+    this.sessionDropTarget = null;
+  }
+
+  toggleSessionPin(session: SidebarRecentSession): void {
+    void this.patchSession(session, { pinned: !session.pinned });
+  }
+
+  toggleSessionMenu(
+    session: SidebarRecentSession,
+    menuSession: SidebarRecentSession,
+    trigger: HTMLElement,
+  ): void {
+    if (this.sessionMenu?.session.key === session.key) {
+      this.closeSessionMenu();
+      return;
+    }
+    const rect = trigger.getBoundingClientRect();
+    this.openSessionMenu(menuSession, rect.right, rect.bottom + 4, trigger);
+  }
+
+  startSessionGroupDrag(group: string): void {
+    this.draggingSessionGroup = group;
+  }
+
+  finishSessionGroupDrag(): void {
+    this.draggingSessionGroup = null;
+    this.sessionGroupDropTarget = null;
+  }
+
+  openNewSession(): void {
+    this.onOpenNewSession?.(this.expandedAgentId());
+  }
+
+  setVisibleSessionLimit(limit: number): void {
+    this.visibleSessionLimit = limit;
+  }
+
+  dismissSessionMutationError(): void {
+    this.sessionMutationError = null;
+  }
+
+  toggleCatalogProjectGrouping(): void {
+    const next = this.catalogProjectGrouping === "project" ? "none" : "project";
+    storeSidebarCatalogGrouping(next);
+    this.catalogProjectGrouping = next;
+  }
+
+  openCatalogMenu(
+    request: CatalogSessionMenuRequest,
+    x: number,
+    y: number,
+    trigger?: HTMLElement,
+  ): void {
+    this.catalogMenu.open(request, x, y, trigger);
   }
 
   protected renderPinnedSidebarSession(session: SidebarRecentSession): TemplateResult {
     return renderSessionTree({
-      context: this.createSessionListRenderContext([session]),
+      host: this,
       session,
     });
   }
@@ -162,13 +118,8 @@ export abstract class AppSidebarSessionListElement extends AppSidebarSessionNarr
       }
     }
     const { sections, expandedRows, visibleRows } = this.zonedVisibleSections(visibleSessions);
-    const context = this.createSessionListRenderContext([
-      ...visibleSessions,
-      ...sidebarRowsByKey.values(),
-    ]);
-
     return renderSessionList({
-      context,
+      host: this,
       empty: visibleSessions.length === 0,
       sections,
       expandedRows,

--- a/ui/src/components/app-sidebar-session-narration-element.ts
+++ b/ui/src/components/app-sidebar-session-narration-element.ts
@@ -11,8 +11,8 @@ import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 
 /** Gateway subscription and reactive narration state for the session-list renderer. */
 export abstract class AppSidebarSessionNarrationElement extends AppSidebarMenusElement {
-  @state() protected sidebarNarrationLines: ReadonlyMap<string, string> = new Map();
-  @state() protected sidebarObserverDigests: ReadonlyMap<string, SessionObserverDigest> = new Map();
+  @state() sidebarNarrationLines: ReadonlyMap<string, string> = new Map();
+  @state() sidebarObserverDigests: ReadonlyMap<string, SessionObserverDigest> = new Map();
 
   // Lazy: the controller pulls core token-suppression modules that must stay
   // out of the startup chunk (QA smoke startup-JS budget). It loads on the

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -56,14 +56,13 @@ import { isStoppableCloudWorkerPlacement } from "./session-row-badges.ts";
 
 /** Session-row projection, selection, sorting, and agent scope navigation. */
 export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessionOwnershipElement {
-  @state() protected selectedSessionKeys: ReadonlySet<string> = new Set();
+  @state() selectedSessionKeys: ReadonlySet<string> = new Set();
   @state() protected expandedChildSessionKeys: ReadonlySet<string> = new Set();
   @state() protected collapsedActiveChildSessionKeys: ReadonlySet<string> = new Set();
-  @state() protected fullyShownChildSessionKeys: ReadonlySet<string> = new Set();
-  @state() protected sessionsGrouping: SidebarSessionsGrouping =
-    loadStoredSidebarSessionsGrouping();
+  @state() fullyShownChildSessionKeys: ReadonlySet<string> = new Set();
+  @state() sessionsGrouping: SidebarSessionsGrouping = loadStoredSidebarSessionsGrouping();
   @state() protected sessionsShowCron = loadStoredSidebarSessionsShowCron();
-  @state() protected sessionsStatusFilter: SidebarSessionStatusFilter =
+  @state() sessionsStatusFilter: SidebarSessionStatusFilter =
     loadStoredSidebarSessionStatusFilter();
 
   private sessionSelectionAnchor: string | null = null;
@@ -340,7 +339,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
     return this.visibleSessionRowsInOrder().filter((row) => this.selectedSessionKeys.has(row.key));
   }
 
-  protected handleSessionRowClick(event: MouseEvent, session: SidebarRecentSession) {
+  handleSessionRowClick(event: MouseEvent, session: SidebarRecentSession) {
     if (event.defaultPrevented || event.button !== 0) {
       return;
     }
@@ -403,7 +402,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
     this.selectedSessionKeys = new Set(rows.slice(start, end + 1).map((row) => row.key));
   }
 
-  protected clearSessionSelection() {
+  clearSessionSelection() {
     this.sessionSelectionAnchor = null;
     if (this.selectedSessionKeys.size > 0) {
       this.selectedSessionKeys = new Set();
@@ -673,14 +672,14 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
     this.selectSession(this.selectedAgentMainSessionKey(normalizeAgentId(agentId)));
   };
 
-  protected isSessionChildrenExpanded(session: SidebarRecentSession): boolean {
+  isSessionChildrenExpanded(session: SidebarRecentSession): boolean {
     return (
       this.expandedChildSessionKeys.has(session.key) ||
       (session.containsActiveDescendant && !this.collapsedActiveChildSessionKeys.has(session.key))
     );
   }
 
-  protected toggleSessionChildren(session: SidebarRecentSession) {
+  toggleSessionChildren(session: SidebarRecentSession) {
     const next = new Set(this.expandedChildSessionKeys);
     const collapsedActive = new Set(this.collapsedActiveChildSessionKeys);
     const fullyShown = new Set(this.fullyShownChildSessionKeys);
@@ -713,7 +712,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
     this.fullyShownChildSessionKeys = fullyShown;
   }
 
-  protected showAllSessionChildren(sessionKey: string) {
+  showMoreChildren(sessionKey: string) {
     this.fullyShownChildSessionKeys = new Set(this.fullyShownChildSessionKeys).add(sessionKey);
   }
 
@@ -723,5 +722,5 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
   }
 
   protected abstract closeAgentMenu(options?: { restoreFocus?: boolean }): void;
-  protected abstract readonly collapsedSessionSections: ReadonlySet<string>;
+  abstract readonly collapsedSessionSections: ReadonlySet<string>;
 }

--- a/ui/src/components/app-sidebar-session-ownership.ts
+++ b/ui/src/components/app-sidebar-session-ownership.ts
@@ -10,7 +10,7 @@ export abstract class AppSidebarSessionOwnershipElement extends AppSidebarSessio
   protected sessionCreatorOptions: readonly SessionCreatedBy[] = [];
   protected activeSessionCreatorId: string | null = null;
   protected sessionCreatorFilterActive = false;
-  protected sessionOwnershipVisible = false;
+  sessionOwnershipVisible = false;
 
   override updated() {
     super.updated();

--- a/ui/src/components/app-sidebar-session-projection.ts
+++ b/ui/src/components/app-sidebar-session-projection.ts
@@ -44,7 +44,7 @@ export abstract class AppSidebarSessionProjectionElement extends AppSidebarSessi
     this.requestUpdate();
   }
 
-  protected sessionPullRequestIndicatorState(sessionKey: string, worktreeId: string) {
+  sessionPullRequestIndicatorState(sessionKey: string, worktreeId: string) {
     return this.sessionPullRequestIndicators.state(sessionKey, worktreeId);
   }
 

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -5,6 +5,7 @@ import type { NavigationRouteId } from "../app-navigation.ts";
 import type { ApprovalBadgeSnapshot } from "../app/approval-presentation.ts";
 import { sessionHasPendingApproval } from "../app/approval-presentation.ts";
 import type { ApplicationNavigationOptions } from "../app/context.ts";
+import type { PresencePayload } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
 import { sessionHasBoard } from "../lib/board/provider.ts";
 import { formatDurationCompact } from "../lib/format.ts";
@@ -36,68 +37,76 @@ import "./elapsed-time.ts";
 
 const SIDEBAR_VISIBLE_CHILD_SESSION_LIMIT = 4;
 
-export type SessionListRenderContext = {
-  data: {
-    l: boolean;
-    n: ReadonlyMap<string, string>;
-    h: ReadonlyMap<string, SessionObserverDigest>;
-    p: ReadonlyMap<string, SessionPullRequestIndicatorState>;
-    a: ApprovalBadgeSnapshot;
-    s: ReadonlySet<string>;
-    d: string | null;
-    o: boolean;
-    v: unknown;
-    i: string | undefined;
-    x: ReadonlySet<string>;
-    f: ReadonlySet<string>;
-    g: SidebarSessionsGrouping;
-    c: ReadonlySet<string>;
-    dg: string | null;
-    q: string | null;
-    gd: SidebarSessionGroupDropTarget | null;
-    z: boolean;
-    m: string | null;
-    gm: string | null;
-    t: SidebarSessionStatusFilter;
-    r: boolean;
-    e: string | null;
-    w: boolean;
-  };
-  cb: {
-    sd: (session: SidebarRecentSession) => void;
-    ed: () => void;
-    om: (session: SidebarRecentSession, x: number, y: number, trigger?: HTMLElement) => void;
-    rc: (event: MouseEvent, session: SidebarRecentSession) => void;
-    ch: (session: SidebarRecentSession) => void;
-    pin: (session: SidebarRecentSession) => void;
-    mc: (
-      session: SidebarRecentSession,
-      menuSession: SidebarRecentSession,
-      trigger: HTMLElement,
-    ) => void;
-    sh: (sessionKey: string) => void;
-    ov: (event: DragEvent, sectionId: string, group?: string) => void;
-    lv: (event: DragEvent, sectionId: string, group?: string) => void;
-    sp: (event: DragEvent, sectionId: string, group?: string) => void;
-    gs: (group: string) => void;
-    ge: () => void;
-    gm: (group: string, x: number, y: number, trigger: HTMLElement | null) => void;
-    section: (sectionId: string) => void;
-    z: (trigger: HTMLElement) => void;
-    ns: () => void;
-    sl: (limit: number) => void;
-    cl: () => void;
-    lo: (event: DragEvent) => void;
-    ll: (event: DragEvent) => void;
-    ld: (event: DragEvent) => void;
-    di: () => void;
-    cg: () => void;
-    mo: (catalogId: string) => Promise<void>;
-    tg?: (agentId: string, target?: NewSessionTarget) => void;
-    nv?: (routeId: NavigationRouteId, options?: ApplicationNavigationOptions) => void;
-    ct: (request: CatalogSessionMenuRequest, x: number, y: number, trigger?: HTMLElement) => void;
-  };
-};
+export interface SessionListHost {
+  readonly sidebarLiveActivity: boolean;
+  readonly sidebarNarrationLines: ReadonlyMap<string, string>;
+  readonly sidebarObserverDigests: ReadonlyMap<string, SessionObserverDigest>;
+  readonly selectedSessionKeys: ReadonlySet<string>;
+  readonly draggingSessionKey: string | null;
+  readonly connected: boolean;
+  readonly presencePayload: PresencePayload | undefined;
+  readonly presenceInstanceId?: string;
+  readonly fullyShownChildSessionKeys: ReadonlySet<string>;
+  readonly sessionsGrouping: SidebarSessionsGrouping;
+  readonly collapsedSessionSections: ReadonlySet<string>;
+  readonly draggingSessionGroup: string | null;
+  readonly sessionDropTarget: string | null;
+  readonly sessionGroupDropTarget: SidebarSessionGroupDropTarget | null;
+  readonly sessionSortMenuPosition: { readonly x: number; readonly y: number } | null;
+  readonly sessionMenu: { readonly session: SidebarRecentSession } | null;
+  readonly sessionGroupMenu: { readonly group: string } | null;
+  readonly sessionsStatusFilter: SidebarSessionStatusFilter;
+  readonly sessionListRemovalDrop: boolean;
+  readonly sessionMutationError: string | null;
+  readonly sessionOwnershipVisible: boolean;
+  readonly onOpenNewSession?: (agentId: string, target?: NewSessionTarget) => void;
+  readonly onNavigate?: (
+    routeId: NavigationRouteId,
+    options?: ApplicationNavigationOptions,
+  ) => void;
+
+  sessionPullRequestIndicatorState(
+    sessionKey: string,
+    worktreeId: string,
+  ): SessionPullRequestIndicatorState;
+  approvalBadgeSnapshot(): ApprovalBadgeSnapshot;
+  isSessionChildrenExpanded(session: SidebarRecentSession): boolean;
+  startSessionDrag(session: SidebarRecentSession): void;
+  finishSessionDrag(): void;
+  openSessionMenu(session: SidebarRecentSession, x: number, y: number, trigger?: HTMLElement): void;
+  handleSessionRowClick(event: MouseEvent, session: SidebarRecentSession): void;
+  toggleSessionChildren(session: SidebarRecentSession): void;
+  toggleSessionPin(session: SidebarRecentSession): void;
+  toggleSessionMenu(
+    session: SidebarRecentSession,
+    menuSession: SidebarRecentSession,
+    trigger: HTMLElement,
+  ): void;
+  showMoreChildren(sessionKey: string): void;
+  sectionDragOver(event: DragEvent, sectionId: string, group?: string): void;
+  sectionDragLeave(event: DragEvent, sectionId: string, group?: string): void;
+  sectionDrop(event: DragEvent, sectionId: string, group?: string): void;
+  startSessionGroupDrag(group: string): void;
+  finishSessionGroupDrag(): void;
+  openSessionGroupMenu(group: string, x: number, y: number, trigger: HTMLElement | null): void;
+  toggleSection(sectionId: string): void;
+  toggleSessionSortMenu(trigger: HTMLElement): void;
+  openNewSession(): void;
+  setVisibleSessionLimit(limit: number): void;
+  clearSessionSelection(): void;
+  handleSessionListDragOver(event: DragEvent): void;
+  handleSessionListDragLeave(event: DragEvent): void;
+  handleSessionListDrop(event: DragEvent): void;
+  dismissSessionMutationError(): void;
+  toggleCatalogProjectGrouping(): void;
+  loadMoreSessionCatalog(catalogId: string): Promise<void>;
+  openCatalogMenu(
+    request: CatalogSessionMenuRequest,
+    x: number,
+    y: number,
+    trigger?: HTMLElement,
+  ): void;
+}
 
 export function visibleSessionChildren(params: {
   session: SidebarRecentSession;
@@ -114,24 +123,26 @@ export function visibleSessionChildren(params: {
 }
 
 export function renderRecentSession(params: {
-  context: SessionListRenderContext;
+  host: SessionListHost;
   session: SidebarRecentSession;
   display?: CatalogBackingSessionDisplay;
 }) {
-  const { context, session, display } = params;
-  const { data, cb } = context;
+  const { host, session, display } = params;
   const label = display?.label ?? session.label;
   const { subtitle, narration } = resolveSidebarSessionSubtitle({
     session,
     hasDisplay: display !== undefined,
     displaySubtitle: display?.subtitle,
-    sidebarLiveActivity: data.l,
-    narrationLine: data.n.get(session.key),
-    observerDigest: data.h.get(session.key) ?? null,
+    sidebarLiveActivity: host.sidebarLiveActivity,
+    narrationLine: host.sidebarNarrationLines.get(session.key),
+    observerDigest: host.sidebarObserverDigests.get(session.key) ?? null,
   });
+  const pullRequestState = session.worktreeId
+    ? host.sessionPullRequestIndicatorState(session.key, session.worktreeId)
+    : "none";
   const { running, pinnedState, leadingIndicator } = renderSessionLeadingState(
     session,
-    data.p.get(session.key) ?? "none",
+    pullRequestState,
   );
   const meta = display?.meta ?? session.meta;
   const rowMeta = session.pinned ? "" : meta;
@@ -145,7 +156,7 @@ export function renderRecentSession(params: {
     session.isChild ? "sidebar-recent-session--child" : "",
     session.archived ? "sidebar-session--archived" : "",
     session.visuallyActive ? "sidebar-recent-session--active" : "",
-    data.s.has(session.key) ? "sidebar-recent-session--selected" : "",
+    host.selectedSessionKeys.has(session.key) ? "sidebar-recent-session--selected" : "",
     session.pinned ? "session-row-host--pinned" : "",
     running ? "session-row-host--running" : "",
     session.attention.kind === "error"
@@ -153,11 +164,11 @@ export function renderRecentSession(params: {
       : session.attention.kind !== "none"
         ? "sidebar-recent-session--attention-amber"
         : "",
-    data.d === session.key ? "sidebar-recent-session--dragging" : "",
+    host.draggingSessionKey === session.key ? "sidebar-recent-session--dragging" : "",
   ]
     .filter(Boolean)
     .join(" ");
-  const childrenExpanded = data.x.has(session.key);
+  const childrenExpanded = host.isSessionChildrenExpanded(session);
   const row = html`
     <div
       class=${rowClass}
@@ -169,19 +180,19 @@ export function renderRecentSession(params: {
         : (event: DragEvent) => {
             if (event.dataTransfer) {
               writeSessionDragData(event.dataTransfer, session.key);
-              cb.sd(session);
+              host.startSessionDrag(session);
             }
           }}
       @dragend=${session.isChild
         ? nothing
         : () => {
-            cb.ed();
+            host.finishSessionDrag();
           }}
       @contextmenu=${session.isChild
         ? nothing
         : (event: MouseEvent) => {
             event.preventDefault();
-            cb.om(menuSession, event.clientX, event.clientY);
+            host.openSessionMenu(menuSession, event.clientX, event.clientY);
           }}
       @mouseenter=${(event: MouseEvent) => startHoverMarquee(event.currentTarget as HTMLElement)}
       @mouseleave=${(event: MouseEvent) => stopHoverMarquee(event.currentTarget as HTMLElement)}
@@ -193,10 +204,10 @@ export function renderRecentSession(params: {
         title=${title}
         aria-current=${session.visuallyActive ? "page" : nothing}
         aria-describedby=${metaId ?? nothing}
-        @click=${(event: MouseEvent) => cb.rc(event, session)}
+        @click=${(event: MouseEvent) => host.handleSessionRowClick(event, session)}
       >
         <span class="sidebar-session-indicator">${leadingIndicator}</span>${renderSessionOwnerChip(
-          data.w ? session.createdBy : undefined,
+          host.sessionOwnershipVisible ? session.createdBy : undefined,
           "row",
         )}
         <span class="sidebar-recent-session__text">
@@ -222,8 +233,8 @@ export function renderRecentSession(params: {
             >`
           : nothing}
         <openclaw-viewer-facepile
-          .presencePayload=${data.v}
-          .selfInstanceId=${data.i}
+          .presencePayload=${host.presencePayload}
+          .selfInstanceId=${host.presenceInstanceId}
           .sessionKey=${session.key}
           .maxVisible=${3}
           variant="session"
@@ -231,7 +242,7 @@ export function renderRecentSession(params: {
         ${renderSessionRowBadges({
           ...session,
           pullRequest: session.pullRequest ?? display?.pullRequest,
-          hasApproval: sessionHasPendingApproval(data.a, session.key),
+          hasApproval: sessionHasPendingApproval(host.approvalBadgeSnapshot(), session.key),
         })}
         ${pinnedState}
       </a>
@@ -251,7 +262,7 @@ export function renderRecentSession(params: {
                 : "sessionsView.showChildSessions",
               { count: String(session.childSessionKeys.length), session: label },
             )}
-            @click=${() => cb.ch(session)}
+            @click=${() => host.toggleSessionChildren(session)}
           >
             <span class="sidebar-child-session-toggle__icon" aria-hidden="true"
               >${childrenExpanded ? icons.chevronDown : icons.chevronRight}</span
@@ -291,8 +302,8 @@ export function renderRecentSession(params: {
                 aria-label=${session.pinned
                   ? t("sessionsView.unpinSession")
                   : t("sessionsView.pinSession")}
-                ?disabled=${!data.o}
-                @click=${() => cb.pin(session)}
+                ?disabled=${!host.connected}
+                @click=${() => host.toggleSessionPin(session)}
               >
                 ${icons.pin}
               </button>
@@ -303,11 +314,11 @@ export function renderRecentSession(params: {
                 title=${t("chat.sidebar.openSessionMenu")}
                 aria-label=${t("chat.sidebar.openSessionMenu")}
                 aria-haspopup="menu"
-                aria-expanded=${String(data.m === session.key)}
+                aria-expanded=${String(host.sessionMenu?.session.key === session.key)}
                 @click=${(event: MouseEvent) => {
                   event.stopPropagation();
                   const trigger = event.currentTarget as HTMLElement;
-                  cb.mc(session, menuSession, trigger);
+                  host.toggleSessionMenu(session, menuSession, trigger);
                 }}
               >
                 ${icons.moreHorizontal}
@@ -321,25 +332,24 @@ export function renderRecentSession(params: {
 }
 
 export function renderSessionTree(params: {
-  context: SessionListRenderContext;
+  host: SessionListHost;
   session: SidebarRecentSession;
 }): TemplateResult {
-  const { context, session } = params;
-  const { data, cb } = context;
-  const expanded = data.x.has(session.key);
+  const { host, session } = params;
+  const expanded = host.isSessionChildrenExpanded(session);
   const visibleChildren = visibleSessionChildren({
     session,
-    fullyShownChildSessionKeys: data.f,
+    fullyShownChildSessionKeys: host.fullyShownChildSessionKeys,
   });
   const hiddenChildCount = session.children.length - visibleChildren.length;
   return html`<div class="sidebar-session-tree" data-session-tree=${session.key}>
-    ${renderRecentSession({ context, session })}
+    ${renderRecentSession({ host, session })}
     ${expanded
       ? html`<div
           class="sidebar-session-tree__children"
           aria-label=${t("sessionsView.childSessions")}
         >
-          ${visibleChildren.map((child) => renderSessionTree({ context, session: child }))}
+          ${visibleChildren.map((child) => renderSessionTree({ host, session: child }))}
           ${hiddenChildCount > 0
             ? html`<button
                 class="sidebar-session-tree__show-more"
@@ -348,7 +358,7 @@ export function renderSessionTree(params: {
                 aria-label=${t("sessionsView.showMoreChildren", {
                   count: String(hiddenChildCount),
                 })}
-                @click=${() => cb.sh(session.key)}
+                @click=${() => host.showMoreChildren(session.key)}
               >
                 ${t("sessionsView.showMoreChildren", { count: String(hiddenChildCount) })}
               </button>`


### PR DESCRIPTION
Related: #112753

## What Problem This Solves

PR #112753 left the Control UI sidebar session-list renderer with hand-minified source names such as `data.l`, `data.v`, and `cb.om`. That made a maintainability refactor materially harder to read and weakened the presence payload to `unknown` solely to stay under the startup-JS budget.

## Why This Change Was Made

The render functions now accept one narrow `SessionListHost` implemented structurally by the sidebar element. They read the element's descriptively named state and call its methods directly, removing the duplicated snapshot builder and callback-binding table rather than abbreviating the interface. The host shape is byte-neutral in production because its TypeScript interface erases and the generated call sites are the same `host.property` reads the class renderers originally used.

The presence payload is normalized at the gateway boundary to a typed `{ presence }` shape. DOM structure, CSS, keyed rendering, and event behavior are unchanged.

## User Impact

No user-visible behavior changes. The sidebar rendering boundary is maintainable again without giving up the startup size guard.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts`: 160 passed
- `node scripts/run-vitest.mjs ui/src/app/user-profile.test.ts ui/src/pages/profile/profile-page.test.ts`: 8 passed across 2 files
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json`: passed on Blacksmith Testbox
- `node scripts/check-changed.mjs -- <12 touched files>`: passed (`coreTests, ui`) on Blacksmith Testbox
- `pnpm ui:build`: passed on Blacksmith Testbox; startup JS gzip fell from 322,494 B to 322,281 B (-213 B), below the 322,560 B budget
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings
- `git diff --numstat origin/main`: +284/-321 across 12 files (net -37)

AI-assisted change; implementation and proof were reviewed with the repository autoreview workflow.
