### PR TITLE
fix(release): accept complete core tarball manifests

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -456,6 +456,14 @@ jobs:
           const path = require("node:path");
           const [manifestPath, packageDir] = process.argv.slice(2);
           const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+          const dependencyTarballs = Array.isArray(manifest.corePackageTarballs)
+            ? manifest.corePackageTarballs
+            : manifest.corePackageTarballs === undefined && Array.isArray(manifest.dependencyTarballs)
+              ? manifest.dependencyTarballs
+              : null;
+          if (!dependencyTarballs) {
+            throw new Error("package artifact manifest is missing dependency tarball metadata");
+          }
           const entries = [
             {
               packageName: "openclaw",
@@ -463,7 +471,7 @@ jobs:
               tarballName: manifest.tarballName,
               tarballSha256: manifest.tarballSha256,
             },
-            ...(Array.isArray(manifest.dependencyTarballs) ? manifest.dependencyTarballs : []),
+            ...dependencyTarballs,
           ];
           const packageNames = new Set();
           const tarballNames = new Set();

--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -185,6 +185,15 @@ export function requireRunIdFromDispatchOutput(output: unknown, workflowFile: un
  */
 export function buildPublishCommand(options: unknown): string;
 export function validatePreflightManifest(manifest: unknown, params: unknown): void;
+export function preflightCorePackageTarballs(manifest: {
+  corePackageTarballs?: unknown;
+  dependencyTarballs?: unknown;
+}): Array<{
+  packageName: string;
+  packageVersion: string;
+  tarballName: string;
+  tarballSha256: string;
+}>;
 export function validateFullManifest(manifest: unknown, params: unknown): void;
 export function validateTrustedToolingPin({
   toolingSha,

--- a/scripts/release-candidate-checklist.mjs
+++ b/scripts/release-candidate-checklist.mjs
@@ -1200,10 +1200,7 @@ export function validatePreflightManifest(manifest, params) {
   if (!manifest.tarballName || !manifest.tarballSha256) {
     throw new Error("npm preflight manifest missing tarball metadata");
   }
-  if (!Array.isArray(manifest.dependencyTarballs)) {
-    throw new Error("npm preflight manifest missing dependency tarball metadata");
-  }
-  for (const dependency of manifest.dependencyTarballs) {
+  for (const dependency of preflightCorePackageTarballs(manifest)) {
     if (
       !dependency?.packageName ||
       !dependency.packageVersion ||
@@ -1214,6 +1211,17 @@ export function validatePreflightManifest(manifest, params) {
       throw new Error("npm preflight manifest contains invalid dependency tarball metadata");
     }
   }
+}
+
+export function preflightCorePackageTarballs(manifest) {
+  const hasCorePackageTarballs = Object.hasOwn(manifest, "corePackageTarballs");
+  const tarballs = hasCorePackageTarballs
+    ? manifest.corePackageTarballs
+    : manifest.dependencyTarballs;
+  if (!Array.isArray(tarballs)) {
+    throw new Error("npm preflight manifest missing dependency tarball metadata");
+  }
+  return tarballs;
 }
 
 export function validateFullManifest(manifest, params) {
@@ -1534,7 +1542,7 @@ async function main() {
       `prepared tarball digest mismatch: expected ${npmManifest.tarballSha256}, got ${actualTarballSha}`,
     );
   }
-  const dependencyTarballPaths = npmManifest.dependencyTarballs.map((dependency) => {
+  const dependencyTarballPaths = preflightCorePackageTarballs(npmManifest).map((dependency) => {
     const dependencyPath = join(npmDir, dependency.tarballName);
     if (!existsSync(dependencyPath)) {
       throw new Error(`prepared dependency tarball missing: ${dependencyPath}`);

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3187,6 +3187,8 @@ describe("package artifact reuse", () => {
       'candidate_manifest="${package_dir}/package-candidate.json"',
       'find "${package_dir}" -type f -name "*.tgz"',
       "package artifact manifest contains duplicate package metadata",
+      "Array.isArray(manifest.corePackageTarballs)",
+      "manifest.corePackageTarballs === undefined",
       "package artifact tarball set does not match preflight manifest",
       "package candidate manifest does not match the OpenClaw tarball",
       "Package Telegram artifact SHA-256 differs from package_sha256.",

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -14,6 +14,7 @@ import {
   isDirectReleaseCandidateExecution,
   parseArgs,
   parseRunIdFromDispatchOutput,
+  preflightCorePackageTarballs,
   reconcileReleaseCandidateState,
   releaseBranchForTag,
   resolveArtifactName,
@@ -587,6 +588,37 @@ describe("release candidate checklist", () => {
         params,
       ),
     ).toThrow("invalid dependency tarball metadata");
+  });
+
+  it("prefers the complete core package tarball set with legacy manifest fallback", () => {
+    const legacyTarball = {
+      packageName: "@openclaw/ai",
+      packageVersion: "2026.7.1-beta.3",
+      tarballName: "openclaw-ai-2026.7.1-beta.3.tgz",
+      tarballSha256: "ai-sha",
+    };
+    const gatewayProtocolTarball = {
+      packageName: "@openclaw/gateway-protocol",
+      packageVersion: "2026.7.1-beta.3",
+      tarballName: "openclaw-gateway-protocol-2026.7.1-beta.3.tgz",
+      tarballSha256: "protocol-sha",
+    };
+
+    expect(
+      preflightCorePackageTarballs({
+        corePackageTarballs: [legacyTarball, gatewayProtocolTarball],
+        dependencyTarballs: [legacyTarball],
+      }),
+    ).toEqual([legacyTarball, gatewayProtocolTarball]);
+    expect(preflightCorePackageTarballs({ dependencyTarballs: [legacyTarball] })).toEqual([
+      legacyTarball,
+    ]);
+    expect(() =>
+      preflightCorePackageTarballs({
+        corePackageTarballs: null,
+        dependencyTarballs: [legacyTarball],
+      }),
+    ).toThrow("missing dependency tarball metadata");
   });
 
   it("trusts the npm workflow SHA while binding the candidate through its manifest", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release candidate Telegram and Parallels validation rejected a valid npm preflight artifact after Gateway Protocol and Gateway Client became separately packed core dependencies. The artifact contained all declared tarballs, but those consumers compared it against the older AI-only compatibility field.

Observed in [NPM Telegram Beta E2E run 29968257967](https://github.com/openclaw/openclaw/actions/runs/29968257967), which failed before Telegram setup with `package artifact tarball set does not match preflight manifest`.

## Why This Change Was Made

Both candidate consumers now treat `corePackageTarballs` as the authoritative complete dependency set and fall back to `dependencyTarballs` only when reading an older manifest that lacks the canonical field. A present but malformed canonical field still fails closed.

## User Impact

No product runtime behavior changes. Release operators can validate and publish candidates whose prepared package includes the separately packed Gateway Protocol and Gateway Client dependencies.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts` — 56 passed
- exact npm Telegram workflow-structure regression — 1 passed
- `node scripts/check-workflows.mjs` — passed
- `actionlint .github/workflows/npm-telegram-beta-e2e.yml` — passed
- `git diff --check` — passed
- structured Codex autoreview — no findings

The combined local workflow test run passed 146/147; its unrelated existing protected-ref test requires GNU `timeout`, which is absent from the macOS PATH. Hosted CI remains the authoritative workflow proof.
