### PR TITLE
fix(qa): apply Matrix thread override during flow setup

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
@@ -99,6 +99,20 @@ describe("Matrix QA Lab scenario flows", () => {
     }
   });
 
+  it("applies the portable thread override through Matrix flow preparation", () => {
+    expect(readQaScenarioById("thread-reply-override").execution).toMatchObject({
+      kind: "flow",
+      channel: "matrix",
+      timeoutMs: 60_000,
+      retryCount: 0,
+      config: {
+        matrixConfigOverrides: {
+          threadReplies: "always",
+        },
+      },
+    });
+  });
+
   it("runs the allowlist scenario through its config-file reload owner", () => {
     const scenario = catalog.scenarios.find((entry) => entry.id === "matrix-allowlist-hot-reload");
     expect(scenario?.execution.kind).toBe("flow");

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -599,14 +599,14 @@ describe("qa suite planning helpers", () => {
   });
 
   it("targets the selected adapter account in scenario startup config patches", () => {
-    const scenarios = [readQaScenarioById("thread-reply-override")];
+    const scenarios = [readQaScenarioById("whatsapp-access-control-dm-open")];
 
-    expect(collectQaSuiteGatewayConfigPatch(scenarios, "matrix-alt")).toEqual({
+    expect(collectQaSuiteGatewayConfigPatch(scenarios, "whatsapp-alt")).toEqual({
       channels: {
-        matrix: {
+        whatsapp: {
           accounts: {
-            "matrix-alt": {
-              threadReplies: "always",
+            "whatsapp-alt": {
+              dmPolicy: "open",
             },
           },
         },

--- a/qa/scenarios/channels/thread-reply-override.yaml
+++ b/qa/scenarios/channels/thread-reply-override.yaml
@@ -7,12 +7,6 @@ scenario:
     primary:
       - channels.native-threads
   objective: Verify Matrix threadReplies=always converts a top-level inbound message into a native threaded reply.
-  gatewayConfigPatch:
-    channels:
-      matrix:
-        accounts:
-          $selectedAccount:
-            threadReplies: always
   successCriteria:
     - A top-level Matrix inbound message receives the requested marker.
     - The outbound message carries the triggering inbound message as its normalized thread id.
@@ -26,10 +20,14 @@ scenario:
     profiles: { "matrix:adapter": 10, "matrix:all": 6, "matrix:transport": 5 }
     kind: flow
     channel: matrix
+    timeoutMs: 60000
+    retryCount: 0
     summary: Require the canonical Matrix adapter to surface the native m.thread relation through threadId.
     config:
       conversationId: main
       marker: QA-MATRIX-THREAD-OVERRIDE-OK
+      matrixConfigOverrides:
+        threadReplies: always
 
 flow:
   steps:
@@ -56,7 +54,7 @@ flow:
             threadId:
               expr: inbound.id
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 45000)
+              ref: scenario.execution.timeoutMs
           saveAs: outbound
         - assert:
             expr: outbound.threadId === inbound.id


### PR DESCRIPTION
Related: #112569

## What Problem This Solves

Fixes an issue where the full QA release profile could spend six minutes waiting on `thread-reply-override`, retry for another six minutes, and exhaust the maturity workflow timeout. The Matrix reply text was emitted promptly, but without the required native thread relation.

## Why This Change Was Made

Moves `threadReplies: always` from the generic startup patch into the Matrix flow-preparation contract, which owns the final account configuration used by the scenario. The scenario now uses one explicit 60-second timeout and no duplicate retry, so a real regression remains a hard failure without blocking later release-profile partitions for up to twelve minutes.

The account-placeholder planning test now uses an existing WhatsApp startup-patch scenario because this Matrix scenario no longer uses that mechanism.

AI-assisted: yes. The implementation and failure artifacts were reviewed directly, and the repository autoreview completed with no actionable findings.

## User Impact

No product runtime behavior changes. Maintainers get correct native-thread evidence and a bounded failure time when generating maturity scorecards.

## Evidence

- Before: [maturity workflow 29902354451](https://github.com/openclaw/openclaw/actions/runs/29902354451) timed out after the first six-minute attempt and the start of its retry. The preserved Matrix harness data shows the marker reply arrived in about six seconds without `m.thread`.
- Focused tests: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts extensions/qa-lab/src/suite-planning.test.ts` — 44 passed.
- Changed-file gate: [Blacksmith run 29969143554](https://github.com/openclaw/openclaw/actions/runs/29969143554) — full typecheck, lint, formatting, import-cycle, and policy gates passed.
- Autoreview: clean; no accepted/actionable findings.
