### PR TITLE
fix(slack): publish Socket Mode transport liveness (#77249)

### DIFF
--- a/extensions/slack/src/monitor/provider-support.ts
+++ b/extensions/slack/src/monitor/provider-support.ts
@@ -1,9 +1,14 @@
 // Slack provider module implements model/runtime integration.
+import { createTransportActivityStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { asOptionalRecord as asRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SlackChannelResolution } from "../resolve-channels.js";
 import type { SlackUserResolution } from "../resolve-users.js";
 import type { SlackIdentityHealth } from "./enterprise-install.js";
-import { formatUnknownError, waitForSlackSocketDisconnect } from "./reconnect-policy.js";
+import {
+  formatUnknownError,
+  SLACK_SOCKET_DISCONNECT_IDLE_TIMEOUT_MS,
+  waitForSlackSocketDisconnect,
+} from "./reconnect-policy.js";
 
 type SlackAppConstructor = typeof import("@slack/bolt").App;
 type SlackHttpReceiverConstructor = typeof import("@slack/bolt").HTTPReceiver;
@@ -190,9 +195,12 @@ export function publishSlackConnectedStatus(
   if (!setStatus) {
     return;
   }
+  const at = Date.now();
   setStatus({
     connected: true,
-    lastConnectedAt: Date.now(),
+    lastConnectedAt: at,
+    // Seed transport liveness on connect. App inbound timestamps stay separate.
+    ...createTransportActivityStatusPatch(at),
     ...identityHealth,
   });
 }
@@ -362,12 +370,18 @@ export function createSlackBoltApp(params: {
   return { app, receiver, socketModeLogger };
 }
 
-function createSlackSocketDisconnectWaiter(app: unknown, abortSignal?: AbortSignal) {
+function createSlackSocketDisconnectWaiter(
+  app: unknown,
+  abortSignal?: AbortSignal,
+  idleTimeoutMs: number = SLACK_SOCKET_DISCONNECT_IDLE_TIMEOUT_MS,
+) {
   const waiterAbortController = new AbortController();
   const relayAbort = () => waiterAbortController.abort();
   let latest: SlackSocketDisconnect | undefined;
   abortSignal?.addEventListener("abort", relayAbort, { once: true });
-  const promise = waitForSlackSocketDisconnect(app, waiterAbortController.signal).then((value) => {
+  const promise = waitForSlackSocketDisconnect(app, waiterAbortController.signal, {
+    idleTimeoutMs,
+  }).then((value) => {
     latest = value;
     return value;
   });
@@ -388,8 +402,13 @@ export async function startSlackSocketAndWaitForDisconnect(params: {
   app: { start: () => unknown };
   abortSignal?: AbortSignal;
   onStarted?: () => void;
+  idleTimeoutMs?: number;
 }) {
-  const disconnectWaiter = createSlackSocketDisconnectWaiter(params.app, params.abortSignal);
+  const disconnectWaiter = createSlackSocketDisconnectWaiter(
+    params.app,
+    params.abortSignal,
+    params.idleTimeoutMs,
+  );
   try {
     await Promise.resolve(params.app.start());
     if (params.abortSignal?.aborted) {

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -614,6 +614,7 @@ describe("connected identity health", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
+      lastTransportActivityAt: expect.any(Number),
       ...expected,
     });
   });
@@ -628,6 +629,7 @@ describe("connected identity health", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
+      lastTransportActivityAt: expect.any(Number),
       healthState: "degraded",
       lastError: "request_timeout",
     });

--- a/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
@@ -150,6 +150,7 @@ describe("slack socket reconnect loop", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
+      lastTransportActivityAt: expect.any(Number),
       healthState: "degraded",
       lastError: expect.stringContaining("without bot_id"),
     });

--- a/extensions/slack/src/monitor/provider.reconnect.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect.test.ts
@@ -10,6 +10,7 @@ import {
   formatSlackSocketModeSharedConnectionWarning,
   formatUnknownError,
   registerSlackSocketModeConnectionDiagnostics,
+  registerSlackSocketModeTransportActivity,
   waitForSlackSocketDisconnect,
 } from "./reconnect-policy.js";
 
@@ -51,10 +52,11 @@ function statusCallAt(setStatus: ReturnType<typeof vi.fn>, index: number): Recor
 
 describe("slack socket reconnect helpers", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("marks socket mode healthy without seeding event liveness on connect", () => {
+  it("marks socket mode healthy and seeds transport liveness without app event stamps", () => {
     const setStatus = vi.fn();
     vi.spyOn(Date, "now").mockReturnValue(1_711_406_400_000);
 
@@ -64,9 +66,11 @@ describe("slack socket reconnect helpers", () => {
     const status = statusCallAt(setStatus, 0);
     expect(status?.connected).toBe(true);
     expect(status?.lastConnectedAt).toBe(1_711_406_400_000);
+    expect(status?.lastTransportActivityAt).toBe(1_711_406_400_000);
     expect(status?.healthState).toBe("healthy");
     expect(status?.lastError).toBeNull();
     expect(status).not.toHaveProperty("lastEventAt");
+    expect(status).not.toHaveProperty("lastInboundAt");
   });
 
   it("marks socket mode degraded when boot identity is unavailable", () => {
@@ -82,6 +86,7 @@ describe("slack socket reconnect helpers", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: 1_711_406_400_500,
+      lastTransportActivityAt: 1_711_406_400_500,
       healthState: "degraded",
       lastError: "auth.test returned no user_id",
     });
@@ -314,5 +319,103 @@ describe("slack socket reconnect helpers", () => {
 
     expect(app.stop).toHaveBeenCalledTimes(1);
     expect(app.receiver.client.shuttingDown).toBe(true);
+  });
+
+  it("publishes transport activity from connect/hello frames without app inbound stamps", () => {
+    const client = new FakeEmitter();
+    const onTransportActivity = vi.fn();
+    const unregister = registerSlackSocketModeTransportActivity({
+      app: { receiver: { client } },
+      onTransportActivity,
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(1_711_406_500_000);
+    client.emit("connected");
+    client.emit(
+      "ws_message",
+      Buffer.from(JSON.stringify({ type: "hello", num_connections: 1 })),
+      false,
+    );
+    client.emit(
+      "ws_message",
+      Buffer.from(JSON.stringify({ type: "events_api", payload: { event: { type: "message" } } })),
+      false,
+    );
+
+    expect(onTransportActivity).toHaveBeenCalledTimes(3);
+    expect(onTransportActivity).toHaveBeenCalledWith(1_711_406_500_000);
+
+    unregister();
+    client.emit("connected");
+    expect(onTransportActivity).toHaveBeenCalledTimes(3);
+    expect(client.listenerCount("ws_message")).toBe(0);
+    expect(client.listenerCount("connected")).toBe(0);
+  });
+
+  it("ignores binary websocket frames for transport activity", () => {
+    const client = new FakeEmitter();
+    const onTransportActivity = vi.fn();
+    const unregister = registerSlackSocketModeTransportActivity({
+      app: { receiver: { client } },
+      onTransportActivity,
+    });
+
+    client.emit("ws_message", Buffer.from("binary"), true);
+    expect(onTransportActivity).not.toHaveBeenCalled();
+    unregister();
+  });
+
+  it("resolves disconnect waiter on transport idle when no disconnect event fires", async () => {
+    vi.useFakeTimers();
+    const client = new FakeEmitter();
+    const app = { receiver: { client } };
+    const waiter = waitForSlackSocketDisconnect(app as never, undefined, {
+      idleTimeoutMs: 1_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(999);
+    await Promise.resolve();
+    let settled = false;
+    void waiter.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(waiter).resolves.toMatchObject({
+      event: "transport_idle",
+    });
+    expect(client.listenerCount("disconnected")).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it("keeps disconnect waiter open while keepalive transport frames continue", async () => {
+    vi.useFakeTimers();
+    const client = new FakeEmitter();
+    const app = { receiver: { client } };
+    const waiter = waitForSlackSocketDisconnect(app as never, undefined, {
+      idleTimeoutMs: 1_000,
+    });
+
+    let settled = false;
+    void waiter.then(() => {
+      settled = true;
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      await vi.advanceTimersByTimeAsync(900);
+      client.emit(
+        "ws_message",
+        Buffer.from(JSON.stringify({ type: "hello", num_connections: 1 })),
+        false,
+      );
+      await Promise.resolve();
+      expect(settled).toBe(false);
+    }
+
+    client.emit("disconnected");
+    await expect(waiter).resolves.toEqual({ event: "disconnect" });
+    vi.useRealTimers();
   });
 });

--- a/extensions/slack/src/monitor/provider.reconnect.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect.test.ts
@@ -366,8 +366,57 @@ describe("slack socket reconnect helpers", () => {
     unregister();
   });
 
+  it("marks transport activity from owned WebSocket ping/pong keepalives", () => {
+    const ownedWs = new FakeEmitter();
+    const client = Object.assign(new FakeEmitter(), {
+      websocket: { websocket: ownedWs },
+    });
+    const onTransportActivity = vi.fn();
+    const unregister = registerSlackSocketModeTransportActivity({
+      app: { receiver: { client } },
+      onTransportActivity,
+    });
+
+    ownedWs.emit("ping", Buffer.from("ping"));
+    ownedWs.emit("pong", Buffer.from("pong"));
+    expect(onTransportActivity).toHaveBeenCalledTimes(2);
+
+    unregister();
+    ownedWs.emit("pong", Buffer.from("pong"));
+    expect(onTransportActivity).toHaveBeenCalledTimes(2);
+    expect(ownedWs.listenerCount("ping")).toBe(0);
+    expect(ownedWs.listenerCount("pong")).toBe(0);
+  });
+
+  it("rebinds owned WebSocket keepalives on reconnect", () => {
+    const firstWs = new FakeEmitter();
+    const secondWs = new FakeEmitter();
+    const slackWebSocket = { websocket: firstWs as FakeEmitter | null };
+    const client = Object.assign(new FakeEmitter(), {
+      websocket: slackWebSocket,
+    });
+    const onTransportActivity = vi.fn();
+    const unregister = registerSlackSocketModeTransportActivity({
+      app: { receiver: { client } },
+      onTransportActivity,
+    });
+
+    firstWs.emit("pong", Buffer.from("pong"));
+    expect(onTransportActivity).toHaveBeenCalledTimes(1);
+
+    slackWebSocket.websocket = secondWs;
+    client.emit("connected");
+    expect(onTransportActivity).toHaveBeenCalledTimes(2);
+    expect(firstWs.listenerCount("pong")).toBe(0);
+
+    secondWs.emit("pong", Buffer.from("pong"));
+    expect(onTransportActivity).toHaveBeenCalledTimes(3);
+
+    unregister();
+  });
+
   it("ignores undici ping/pong from foreign WebSockets and unscoped handles", () => {
-    const ownedUndici = { id: "owned-slack-ws" };
+    const ownedUndici = Object.assign(new FakeEmitter(), { id: "owned-slack-ws" });
     const foreignUndici = { id: "other-process-ws" };
     const client = Object.assign(new FakeEmitter(), {
       websocket: { websocket: ownedUndici },

--- a/extensions/slack/src/monitor/provider.reconnect.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect.test.ts
@@ -1,4 +1,5 @@
 // Slack tests cover provider.reconnect plugin behavior.
+import { channel } from "node:diagnostics_channel";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   gracefulStopSlackApp,
@@ -363,6 +364,38 @@ describe("slack socket reconnect helpers", () => {
     client.emit("ws_message", Buffer.from("binary"), true);
     expect(onTransportActivity).not.toHaveBeenCalled();
     unregister();
+  });
+
+  it("ignores undici ping/pong from foreign WebSockets and unscoped handles", () => {
+    const ownedUndici = { id: "owned-slack-ws" };
+    const foreignUndici = { id: "other-process-ws" };
+    const client = Object.assign(new FakeEmitter(), {
+      websocket: { websocket: ownedUndici },
+    });
+    const onTransportActivity = vi.fn();
+    const unregister = registerSlackSocketModeTransportActivity({
+      app: { receiver: { client } },
+      onTransportActivity,
+    });
+
+    const pong = channel("undici:websocket:pong");
+    pong.publish({ websocket: foreignUndici, payload: Buffer.from("pong") });
+    expect(onTransportActivity).not.toHaveBeenCalled();
+
+    pong.publish({ websocket: ownedUndici, payload: Buffer.from("pong") });
+    expect(onTransportActivity).toHaveBeenCalledTimes(1);
+
+    const unscopedClient = new FakeEmitter();
+    const unscopedActivity = vi.fn();
+    const unregisterUnscoped = registerSlackSocketModeTransportActivity({
+      app: { receiver: { client: unscopedClient } },
+      onTransportActivity: unscopedActivity,
+    });
+    pong.publish({ websocket: ownedUndici, payload: Buffer.from("pong") });
+    expect(unscopedActivity).not.toHaveBeenCalled();
+
+    unregister();
+    unregisterUnscoped();
   });
 
   it("resolves disconnect waiter on transport idle when no disconnect event fires", async () => {

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -10,6 +10,7 @@ import {
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import type { SessionScope } from "openclaw/plugin-sdk/config-contracts";
+import { createTransportActivityStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
@@ -83,7 +84,9 @@ import {
   formatUnknownError,
   isNonRecoverableSlackAuthError,
   registerSlackSocketModeConnectionDiagnostics,
+  registerSlackSocketModeTransportActivity,
   SLACK_SOCKET_RECONNECT_POLICY,
+  SLACK_SOCKET_TRANSPORT_ACTIVITY_STATUS_MIN_INTERVAL_MS,
 } from "./reconnect-policy.js";
 import { setSlackDefaultSendIdentity } from "./send.runtime.js";
 import { registerSlackMonitorSlashCommands } from "./slash.js";
@@ -403,6 +406,24 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           },
         })
       : () => {};
+  let lastTransportActivityStatusAt: number | undefined;
+  const unregisterSocketModeTransportActivity =
+    slackMode === "socket" && opts.setStatus
+      ? registerSlackSocketModeTransportActivity({
+          app,
+          onTransportActivity: (at) => {
+            if (
+              lastTransportActivityStatusAt !== undefined &&
+              at - lastTransportActivityStatusAt <
+                SLACK_SOCKET_TRANSPORT_ACTIVITY_STATUS_MIN_INTERVAL_MS
+            ) {
+              return;
+            }
+            lastTransportActivityStatusAt = at;
+            opts.setStatus?.(createTransportActivityStatusPatch(at));
+          },
+        })
+      : () => {};
 
   let botUserId = "";
   let botId = "";
@@ -509,8 +530,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     mediaMaxBytes,
   });
 
-  // Slack's socket-mode client keeps ping/pong health private and closes on
-  // missed pongs. App events are useful status activity, but not transport proof.
+  // App inbound activity only. Socket Mode transport/keepalive updates
+  // lastTransportActivityAt via registerSlackSocketModeTransportActivity.
   const trackEvent = opts.setStatus
     ? () => {
         opts.setStatus!({ lastEventAt: Date.now(), lastInboundAt: Date.now() });
@@ -852,6 +873,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     }
     opts.abortSignal?.removeEventListener("abort", stopOnAbort);
     unregisterSocketModeConnectionDiagnostics();
+    unregisterSocketModeTransportActivity();
     unregisterHttpHandler?.();
     await durableIngress.stop();
     await gracefulStop();

--- a/extensions/slack/src/monitor/reconnect-policy.ts
+++ b/extensions/slack/src/monitor/reconnect-policy.ts
@@ -1,4 +1,5 @@
 // Slack plugin module implements reconnect policy behavior.
+import { channel } from "node:diagnostics_channel";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatSlackError } from "../errors.js";
 
@@ -13,18 +14,39 @@ export const SLACK_SOCKET_RECONNECT_POLICY = {
   jitter: 0.25,
 } as const;
 
-type SlackSocketDisconnectEvent = "disconnect" | "unable_to_socket_mode_start" | "error";
+/** Throttle status-store writes for transport keepalive frames. */
+export const SLACK_SOCKET_TRANSPORT_ACTIVITY_STATUS_MIN_INTERVAL_MS = 30_000;
+
+/**
+ * Upper bound for the reconnect supervisor's disconnect waiter when Socket Mode
+ * stops emitting disconnect/error events (zombie WSS). Keepalive frames reset
+ * this idle window so quiet-but-alive workspaces do not false-reconnect.
+ */
+export const SLACK_SOCKET_DISCONNECT_IDLE_TIMEOUT_MS = 120_000;
+
+type SlackSocketDisconnectEvent =
+  | "disconnect"
+  | "unable_to_socket_mode_start"
+  | "error"
+  | "transport_idle";
 
 type EmitterLike = {
   on: (event: string, listener: (...args: unknown[]) => void) => unknown;
   off: (event: string, listener: (...args: unknown[]) => void) => unknown;
 };
 
+type DiagnosticsChannelLike = {
+  subscribe: (listener: (message: unknown) => void) => void;
+  unsubscribe: (listener: (message: unknown) => void) => void;
+};
+
 const SLACK_SOCKET_SHARED_CONNECTION_DOCS_URL =
   "https://docs.slack.dev/apis/events-api/using-socket-mode#using-multiple-connections";
 const SLACK_SOCKET_HELLO_MARKER = Buffer.from('"hello"');
+const UNDICI_WEBSOCKET_PING_CHANNEL = "undici:websocket:ping";
+const UNDICI_WEBSOCKET_PONG_CHANNEL = "undici:websocket:pong";
 
-function getSocketEmitter(app: unknown): EmitterLike | null {
+function getSocketClient(app: unknown): object | null {
   const receiver = (app as { receiver?: unknown }).receiver;
   const client =
     receiver && typeof receiver === "object"
@@ -33,8 +55,16 @@ function getSocketEmitter(app: unknown): EmitterLike | null {
   if (!client || typeof client !== "object") {
     return null;
   }
-  const on = (client as { on?: unknown }).on;
-  const off = (client as { off?: unknown }).off;
+  return client;
+}
+
+function getSocketEmitter(app: unknown): EmitterLike | null {
+  const client = getSocketClient(app);
+  if (!client) {
+    return null;
+  }
+  const on = Reflect.get(client, "on");
+  const off = Reflect.get(client, "off");
   if (typeof on !== "function" || typeof off !== "function") {
     return null;
   }
@@ -48,6 +78,45 @@ function getSocketEmitter(app: unknown): EmitterLike | null {
         off as (this: unknown, event: string, listener: (...args: unknown[]) => void) => unknown
       ).call(client, event, listener),
   };
+}
+
+function resolveUndiciWebSocket(app: unknown): object | null {
+  const client = getSocketClient(app);
+  if (!client) {
+    return null;
+  }
+  const slackWebSocket = Reflect.get(client, "websocket");
+  if (!slackWebSocket || typeof slackWebSocket !== "object") {
+    return null;
+  }
+  const undiciWebSocket = Reflect.get(slackWebSocket, "websocket");
+  return undiciWebSocket && typeof undiciWebSocket === "object" ? undiciWebSocket : null;
+}
+
+function isUndiciPingPongMessage(
+  message: unknown,
+): message is { websocket: object; payload: Buffer } {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const websocket = Reflect.get(message, "websocket");
+  const payload = Reflect.get(message, "payload");
+  return Boolean(websocket && typeof websocket === "object" && Buffer.isBuffer(payload));
+}
+
+function getDiagnosticsChannel(name: string): DiagnosticsChannelLike | null {
+  try {
+    const diagnosticsChannel = channel(name) as DiagnosticsChannelLike;
+    if (
+      typeof diagnosticsChannel.subscribe !== "function" ||
+      typeof diagnosticsChannel.unsubscribe !== "function"
+    ) {
+      return null;
+    }
+    return diagnosticsChannel;
+  } catch {
+    return null;
+  }
 }
 
 function isBufferArray(value: unknown): value is Buffer[] {
@@ -87,6 +156,61 @@ export function formatSlackSocketModeSharedConnectionWarning(activeConnections: 
   ].join("; ");
 }
 
+/**
+ * Observe Socket Mode transport liveness (connect/hello/ws frames + undici ping/pong).
+ * App inbound events are intentionally excluded — those update lastEventAt/lastInboundAt.
+ */
+export function registerSlackSocketModeTransportActivity(params: {
+  app: unknown;
+  onTransportActivity: (at: number) => void;
+}): () => void {
+  const emitter = getSocketEmitter(params.app);
+  if (!emitter) {
+    return () => {};
+  }
+
+  const noteActivity = () => {
+    params.onTransportActivity(Date.now());
+  };
+
+  const wsMessageListener = (_message: unknown, isBinary?: unknown) => {
+    if (isBinary === true) {
+      return;
+    }
+    noteActivity();
+  };
+  const connectedListener = () => {
+    noteActivity();
+  };
+
+  const pingChannel = getDiagnosticsChannel(UNDICI_WEBSOCKET_PING_CHANNEL);
+  const pongChannel = getDiagnosticsChannel(UNDICI_WEBSOCKET_PONG_CHANNEL);
+  const pingPongListener = (message: unknown) => {
+    if (!isUndiciPingPongMessage(message)) {
+      return;
+    }
+    const ownedWebSocket = resolveUndiciWebSocket(params.app);
+    if (ownedWebSocket && message.websocket !== ownedWebSocket) {
+      return;
+    }
+    // When the undici socket handle is not yet exposed, still accept ping/pong
+    // while this Socket Mode client exists (single-socket and test harnesses).
+    noteActivity();
+  };
+
+  emitter.on("ws_message", wsMessageListener);
+  emitter.on("connected", connectedListener);
+  pingChannel?.subscribe(pingPongListener);
+  pongChannel?.subscribe(pingPongListener);
+
+  return () => {
+    emitter.off("ws_message", wsMessageListener);
+    emitter.off("connected", connectedListener);
+    pingChannel?.unsubscribe(pingPongListener);
+    pongChannel?.unsubscribe(pingPongListener);
+  };
+}
+
 export function registerSlackSocketModeConnectionDiagnostics(params: {
   app: unknown;
   onSharedConnection: (activeConnections: number) => void;
@@ -116,10 +240,14 @@ export function registerSlackSocketModeConnectionDiagnostics(params: {
 export function waitForSlackSocketDisconnect(
   app: unknown,
   abortSignal?: AbortSignal,
+  options?: {
+    idleTimeoutMs?: number;
+  },
 ): Promise<{
   event: SlackSocketDisconnectEvent;
   error?: unknown;
 }> {
+  const idleTimeoutMs = options?.idleTimeoutMs ?? SLACK_SOCKET_DISCONNECT_IDLE_TIMEOUT_MS;
   return new Promise((resolve) => {
     const emitter = getSocketEmitter(app);
     if (!emitter) {
@@ -129,13 +257,42 @@ export function waitForSlackSocketDisconnect(
       return;
     }
 
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let unregisterTransportActivity: (() => void) | undefined;
+
     const disconnectListener = () => resolveOnce({ event: "disconnect" });
     const startFailListener = (error?: unknown) =>
       resolveOnce({ event: "unable_to_socket_mode_start", error });
     const errorListener = (error: unknown) => resolveOnce({ event: "error", error });
     const abortListener = () => resolveOnce({ event: "disconnect" });
 
+    const clearIdleTimer = () => {
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
+    };
+
+    const armIdleTimer = () => {
+      clearIdleTimer();
+      if (!(idleTimeoutMs > 0) || abortSignal?.aborted) {
+        return;
+      }
+      idleTimer = setTimeout(() => {
+        resolveOnce({
+          event: "transport_idle",
+          error: new Error(
+            `Slack Socket Mode transport idle for ${idleTimeoutMs}ms without disconnect event`,
+          ),
+        });
+      }, idleTimeoutMs);
+      idleTimer.unref?.();
+    };
+
     const cleanup = () => {
+      clearIdleTimer();
+      unregisterTransportActivity?.();
+      unregisterTransportActivity = undefined;
       emitter.off("disconnected", disconnectListener);
       emitter.off("unable_to_socket_mode_start", startFailListener);
       emitter.off("error", errorListener);
@@ -147,10 +304,18 @@ export function waitForSlackSocketDisconnect(
       resolve(value);
     };
 
+    unregisterTransportActivity = registerSlackSocketModeTransportActivity({
+      app,
+      onTransportActivity: () => {
+        armIdleTimer();
+      },
+    });
+
     emitter.on("disconnected", disconnectListener);
     emitter.on("unable_to_socket_mode_start", startFailListener);
     emitter.on("error", errorListener);
     abortSignal?.addEventListener("abort", abortListener, { once: true });
+    armIdleTimer();
   });
 }
 

--- a/extensions/slack/src/monitor/reconnect-policy.ts
+++ b/extensions/slack/src/monitor/reconnect-policy.ts
@@ -80,7 +80,12 @@ function getSocketEmitter(app: unknown): EmitterLike | null {
   };
 }
 
-function resolveUndiciWebSocket(app: unknown): object | null {
+/**
+ * Resolve the process-level WebSocket owned by this Socket Mode client.
+ * `@slack/socket-mode` wraps it as `client.websocket.websocket` (`ws` today;
+ * Undici-compatible shapes use the same nested handle).
+ */
+function resolveOwnedWebSocket(app: unknown): object | null {
   const client = getSocketClient(app);
   if (!client) {
     return null;
@@ -89,8 +94,8 @@ function resolveUndiciWebSocket(app: unknown): object | null {
   if (!slackWebSocket || typeof slackWebSocket !== "object") {
     return null;
   }
-  const undiciWebSocket = Reflect.get(slackWebSocket, "websocket");
-  return undiciWebSocket && typeof undiciWebSocket === "object" ? undiciWebSocket : null;
+  const ownedWebSocket = Reflect.get(slackWebSocket, "websocket");
+  return ownedWebSocket && typeof ownedWebSocket === "object" ? ownedWebSocket : null;
 }
 
 function isUndiciPingPongMessage(
@@ -102,6 +107,54 @@ function isUndiciPingPongMessage(
   const websocket = Reflect.get(message, "websocket");
   const payload = Reflect.get(message, "payload");
   return Boolean(websocket && typeof websocket === "object" && Buffer.isBuffer(payload));
+}
+
+type EventTargetLike = {
+  on: (event: string, listener: (...args: unknown[]) => void) => unknown;
+  off: (event: string, listener: (...args: unknown[]) => void) => unknown;
+};
+
+function asEventTarget(value: object): EventTargetLike | null {
+  const on = Reflect.get(value, "on");
+  const off = Reflect.get(value, "off") ?? Reflect.get(value, "removeListener");
+  if (typeof on !== "function" || typeof off !== "function") {
+    return null;
+  }
+  return {
+    on: (event, listener) =>
+      (
+        on as (this: unknown, event: string, listener: (...args: unknown[]) => void) => unknown
+      ).call(value, event, listener),
+    off: (event, listener) =>
+      (
+        off as (this: unknown, event: string, listener: (...args: unknown[]) => void) => unknown
+      ).call(value, event, listener),
+  };
+}
+
+/**
+ * Bind WebSocket protocol ping/pong on the owned socket only.
+ * Slack Socket Mode keepalives are protocol frames (`ws` `ping`/`pong`), not
+ * `ws_message` payloads — so idle recovery must observe these directly.
+ */
+function bindOwnedWebSocketKeepalive(app: unknown, onTransportActivity: () => void): () => void {
+  const ownedWebSocket = resolveOwnedWebSocket(app);
+  if (!ownedWebSocket) {
+    return () => {};
+  }
+  const target = asEventTarget(ownedWebSocket);
+  if (!target) {
+    return () => {};
+  }
+  const listener = () => {
+    onTransportActivity();
+  };
+  target.on("ping", listener);
+  target.on("pong", listener);
+  return () => {
+    target.off("ping", listener);
+    target.off("pong", listener);
+  };
 }
 
 function getDiagnosticsChannel(name: string): DiagnosticsChannelLike | null {
@@ -157,7 +210,8 @@ export function formatSlackSocketModeSharedConnectionWarning(activeConnections: 
 }
 
 /**
- * Observe Socket Mode transport liveness (connect/hello/ws frames + undici ping/pong).
+ * Observe Socket Mode transport liveness:
+ * connect/hello/`ws_message` plus owned-socket WebSocket ping/pong keepalives.
  * App inbound events are intentionally excluded — those update lastEventAt/lastInboundAt.
  */
 export function registerSlackSocketModeTransportActivity(params: {
@@ -173,6 +227,12 @@ export function registerSlackSocketModeTransportActivity(params: {
     params.onTransportActivity(Date.now());
   };
 
+  let unbindOwnedKeepalive: (() => void) | undefined;
+  const rebindOwnedKeepalive = () => {
+    unbindOwnedKeepalive?.();
+    unbindOwnedKeepalive = bindOwnedWebSocketKeepalive(params.app, noteActivity);
+  };
+
   const wsMessageListener = (_message: unknown, isBinary?: unknown) => {
     if (isBinary === true) {
       return;
@@ -180,20 +240,23 @@ export function registerSlackSocketModeTransportActivity(params: {
     noteActivity();
   };
   const connectedListener = () => {
+    // Slack recreates the underlying WebSocket on each connect — rebind keepalives.
+    rebindOwnedKeepalive();
     noteActivity();
   };
 
   const pingChannel = getDiagnosticsChannel(UNDICI_WEBSOCKET_PING_CHANNEL);
   const pongChannel = getDiagnosticsChannel(UNDICI_WEBSOCKET_PONG_CHANNEL);
-  // Undici ping/pong is process-wide via diagnostics_channel. Only count frames
-  // for this Socket Mode client's WebSocket. If the handle is not resolvable yet,
-  // ignore undici diagnostics and rely on Slack client `connected`/`ws_message`
-  // (already scoped to this emitter) so foreign WebSockets cannot mask a dead socket.
+  // Undici ping/pong (if present) is process-wide via diagnostics_channel. Only
+  // count frames for this Socket Mode client's WebSocket. If the handle is not
+  // resolvable yet, ignore undici diagnostics so foreign WebSockets cannot mask
+  // a dead socket. Primary keepalive for `@slack/socket-mode` is the owned
+  // `ws` ping/pong binding above.
   const pingPongListener = (message: unknown) => {
     if (!isUndiciPingPongMessage(message)) {
       return;
     }
-    const ownedWebSocket = resolveUndiciWebSocket(params.app);
+    const ownedWebSocket = resolveOwnedWebSocket(params.app);
     if (!ownedWebSocket || message.websocket !== ownedWebSocket) {
       return;
     }
@@ -204,8 +267,12 @@ export function registerSlackSocketModeTransportActivity(params: {
   emitter.on("connected", connectedListener);
   pingChannel?.subscribe(pingPongListener);
   pongChannel?.subscribe(pingPongListener);
+  // Already-connected monitors still need keepalive binding.
+  rebindOwnedKeepalive();
 
   return () => {
+    unbindOwnedKeepalive?.();
+    unbindOwnedKeepalive = undefined;
     emitter.off("ws_message", wsMessageListener);
     emitter.off("connected", connectedListener);
     pingChannel?.unsubscribe(pingPongListener);

--- a/extensions/slack/src/monitor/reconnect-policy.ts
+++ b/extensions/slack/src/monitor/reconnect-policy.ts
@@ -185,16 +185,18 @@ export function registerSlackSocketModeTransportActivity(params: {
 
   const pingChannel = getDiagnosticsChannel(UNDICI_WEBSOCKET_PING_CHANNEL);
   const pongChannel = getDiagnosticsChannel(UNDICI_WEBSOCKET_PONG_CHANNEL);
+  // Undici ping/pong is process-wide via diagnostics_channel. Only count frames
+  // for this Socket Mode client's WebSocket. If the handle is not resolvable yet,
+  // ignore undici diagnostics and rely on Slack client `connected`/`ws_message`
+  // (already scoped to this emitter) so foreign WebSockets cannot mask a dead socket.
   const pingPongListener = (message: unknown) => {
     if (!isUndiciPingPongMessage(message)) {
       return;
     }
     const ownedWebSocket = resolveUndiciWebSocket(params.app);
-    if (ownedWebSocket && message.websocket !== ownedWebSocket) {
+    if (!ownedWebSocket || message.websocket !== ownedWebSocket) {
       return;
     }
-    // When the undici socket handle is not yet exposed, still accept ping/pong
-    // while this Socket Mode client exists (single-socket and test harnesses).
     noteActivity();
   };
 

--- a/scripts/live-slack-transport-proof.mjs
+++ b/scripts/live-slack-transport-proof.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Live Slack Socket Mode transport-liveness proof (redacted output).
+ *
+ * Env:
+ *   SLACK_BOT_TOKEN=xoxb-...
+ *   SLACK_APP_TOKEN=xapp-...
+ *   PROOF_QUIET_MS=45000   (default)
+ *   PROOF_IDLE_MS=15000    (default; must be < quiet window)
+ *
+ * Run:
+ *   node --import tsx scripts/live-slack-transport-proof.mjs
+ *
+ * Proof:
+ *   A) Quiet keepalive produces transport activity marks (owned ws ping/pong)
+ *   B) Disconnect waiter armed with idleTimeoutMs does NOT fire during quiet
+ *      because live Slack keepalive resets the idle window
+ *   C) Same waiter fires transport_idle when no transport frames arrive
+ */
+const bot = process.env.SLACK_BOT_TOKEN || "";
+const appToken = process.env.SLACK_APP_TOKEN || "";
+if (!bot.startsWith("xoxb-") || !appToken.startsWith("xapp-")) {
+  console.error("Need SLACK_BOT_TOKEN (xoxb-) and SLACK_APP_TOKEN (xapp-) in env");
+  process.exit(2);
+}
+
+function redactToken(t) {
+  return `${t.slice(0, 8)}… len=${t.length}`;
+}
+
+const quietMs = Number(process.env.PROOF_QUIET_MS || 45_000);
+const idleMs = Number(process.env.PROOF_IDLE_MS || 15_000);
+if (!(idleMs > 0) || !(quietMs > idleMs * 2)) {
+  console.error("PROOF_QUIET_MS must be > 2 * PROOF_IDLE_MS");
+  process.exit(2);
+}
+
+console.log("=== Slack Socket Mode transport proof (redacted) ===");
+console.log("bot", redactToken(bot));
+console.log("app", redactToken(appToken));
+console.log("quietMs", quietMs, "idleMs", idleMs);
+
+const reconnect = await import(
+  new URL("../extensions/slack/src/monitor/reconnect-policy.ts", import.meta.url).href
+);
+const { registerSlackSocketModeTransportActivity, waitForSlackSocketDisconnect } = reconnect;
+
+const { App } = await import("@slack/bolt");
+const app = new App({
+  token: bot,
+  appToken,
+  socketMode: true,
+});
+
+const transportMarks = [];
+let lastAt = 0;
+const unregister = registerSlackSocketModeTransportActivity({
+  app,
+  onTransportActivity: (at) => {
+    const delta = lastAt ? at - lastAt : 0;
+    lastAt = at;
+    transportMarks.push({ at, deltaMs: delta });
+    if (transportMarks.length <= 8 || transportMarks.length % 10 === 0) {
+      console.log(
+        `[transport] mark#${transportMarks.length} at=${new Date(at).toISOString()} deltaMs=${delta}`,
+      );
+    }
+  },
+});
+
+console.log("starting socket mode…");
+await app.start();
+console.log(
+  "started; owned websocket readyState=",
+  app.receiver?.client?.websocket?.websocket?.readyState,
+);
+
+const abort = new AbortController();
+let idleEarly = null;
+const liveWaiter = waitForSlackSocketDisconnect(app, abort.signal, { idleTimeoutMs: idleMs }).then(
+  (result) => {
+    idleEarly = result;
+    return result;
+  },
+);
+
+console.log(
+  `observing quiet keepalive for ${quietMs}ms with idleTimeoutMs=${idleMs} (must NOT fire)…`,
+);
+await new Promise((r) => setTimeout(r, quietMs));
+
+const quietMarks = transportMarks.length;
+console.log(`[quiet] transport marks during quiet window: ${quietMarks}`);
+if (quietMarks < 5) {
+  console.error("FAIL A: expected repeated transport activity during quiet keepalive window");
+  abort.abort();
+  unregister();
+  await app.stop().catch(() => {});
+  process.exit(1);
+}
+console.log("PASS A: quiet keepalive produced repeated transport activity without app inbound");
+
+if (idleEarly) {
+  console.error("FAIL B: idle waiter fired early during live keepalive:", idleEarly.event);
+  unregister();
+  await app.stop().catch(() => {});
+  process.exit(1);
+}
+console.log(
+  "PASS B: idle waiter did not fire during quiet window (keepalive reset the bounded idle timer)",
+);
+abort.abort();
+await liveWaiter.catch(() => {});
+
+unregister();
+class SilentEmitter {
+  constructor() {
+    this.m = new Map();
+  }
+  on(e, l) {
+    const s = this.m.get(e) ?? new Set();
+    s.add(l);
+    this.m.set(e, s);
+  }
+  off(e, l) {
+    this.m.get(e)?.delete(l);
+  }
+}
+const silentApp = { receiver: { client: new SilentEmitter() } };
+console.log(`arming waiter on silent client with idleTimeoutMs=${Math.min(idleMs, 3000)}…`);
+const silentIdle = await waitForSlackSocketDisconnect(silentApp, undefined, {
+  idleTimeoutMs: Math.min(idleMs, 3000),
+});
+console.log("[idle] silent waiter result:", silentIdle.event);
+if (silentIdle.event !== "transport_idle") {
+  console.error("FAIL C: expected transport_idle on silent client");
+  await app.stop().catch(() => {});
+  process.exit(1);
+}
+console.log("PASS C: bounded idle waiter fires transport_idle when no transport frames arrive");
+
+await app.stop().catch(() => {});
+console.log("=== proof complete ===");
+console.log(
+  JSON.stringify(
+    {
+      quietWindowMs: quietMs,
+      idleTimeoutMs: idleMs,
+      transportMarksInQuietWindow: quietMarks,
+      firstMarkIso: new Date(transportMarks[0].at).toISOString(),
+      lastMarkIso: new Date(transportMarks.at(-1).at).toISOString(),
+      liveIdleFiredDuringQuiet: false,
+      silentIdleResult: silentIdle.event,
+      keepaliveSource: "owned ws ping/pong (+ connect/ws_message)",
+    },
+    null,
+    2,
+  ),
+);
+process.exit(0);

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -163,6 +163,39 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 
+  it("keeps slack healthy when transport keepalive is fresh even if app events are stale", () => {
+    const now = 100_000;
+    const evaluation = evaluateHealth(
+      connectedAccount({
+        lastStartAt: 0,
+        lastEventAt: 0,
+        lastInboundAt: 0,
+        lastTransportActivityAt: now - 5_000,
+      }),
+      { now, channelId: "slack" },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("flags slack stale-socket when transport activity ages past threshold", () => {
+    const evaluation = evaluateHealth(staleTransportAccount(), {
+      channelId: "slack",
+    });
+    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+
+  it("does not treat null slack transport stamps as stale-socket", () => {
+    const evaluation = evaluateHealth(
+      connectedAccount({
+        lastStartAt: 0,
+        lastEventAt: 0,
+        lastTransportActivityAt: null,
+      }),
+      { channelId: "slack" },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
   it("flags stale sockets for telegram polling channels with transport activity", () => {
     const evaluation = evaluateHealth(staleTransportAccount({ mode: "polling" }), {
       channelId: "example",


### PR DESCRIPTION
## What Problem This Solves

Slack Socket Mode can report `connected` + `health:healthy` while delivering **zero inbound events**. Root causes tracked in #77249:

1. Slack never publishes `lastTransportActivityAt`, and `evaluateChannelHealth` only evaluates `stale-socket` when that field is non-null — so a zombie socket stays \"healthy\" forever.
2. The reconnect supervisor disconnect waiter is event-only; if no `disconnected`/`error` fires, it can park indefinitely with no recovery.

Quiet workspaces with a live keepalive must remain healthy (app silence is not a dead socket; per 2026.4.20 / 4.22 policy).

## Evidence

### After-fix live Slack Socket Mode proof (redacted)

Ran against a real Slack app token pair with `scripts/live-slack-transport-proof.mjs` on this PR head. No app inbound traffic during the quiet window.

```text
=== Slack Socket Mode transport proof (redacted) ===
bot xoxb-971… len=58
app xapp-1-A… len=98
quietMs 45000 idleMs 15000
starting socket mode…
[transport] mark#1 at=2026-07-24T23:26:20.308Z deltaMs=0
[transport] mark#2 at=2026-07-24T23:26:20.308Z deltaMs=0
started; owned websocket readyState= 1
observing quiet keepalive for 45000ms with idleTimeoutMs=15000 (must NOT fire)…
[transport] mark#3 at=2026-07-24T23:26:22.378Z deltaMs=2070
[transport] mark#4 at=2026-07-24T23:26:23.416Z deltaMs=1038
[transport] mark#5 at=2026-07-24T23:26:23.954Z deltaMs=538
[transport] mark#6 at=2026-07-24T23:26:26.022Z deltaMs=2068
[transport] mark#7 at=2026-07-24T23:26:27.090Z deltaMs=1068
[transport] mark#8 at=2026-07-24T23:26:28.753Z deltaMs=1663
[transport] mark#10 at=2026-07-24T23:26:32.134Z deltaMs=1577
[transport] mark#20 at=2026-07-24T23:26:45.797Z deltaMs=1870
[transport] mark#30 at=2026-07-24T23:27:00.753Z deltaMs=1887
[quiet] transport marks during quiet window: 33
PASS A: quiet keepalive produced repeated transport activity without app inbound
PASS B: idle waiter did not fire during quiet window (keepalive reset the bounded idle timer)
arming waiter on silent client with idleTimeoutMs=3000…
[idle] silent waiter result: transport_idle
PASS C: bounded idle waiter fires transport_idle when no transport frames arrive
=== proof complete ===
{
  "quietWindowMs": 45000,
  "idleTimeoutMs": 15000,
  "transportMarksInQuietWindow": 33,
  "firstMarkIso": "2026-07-24T23:26:20.308Z",
  "lastMarkIso": "2026-07-24T23:27:04.202Z",
  "liveIdleFiredDuringQuiet": false,
  "silentIdleResult": "transport_idle",
  "keepaliveSource": "owned ws ping/pong (+ connect/ws_message)"
}
```

Interpretation:
- **PASS A** — owned-socket WebSocket `ping`/`pong` keepalives produced repeated `lastTransportActivityAt` marks with zero app inbound.
- **PASS B** — disconnect waiter armed with `idleTimeoutMs=15000` stayed open for a 45s quiet window because keepalive reset the idle timer (prevents false reconnect).
- **PASS C** — same waiter returns `transport_idle` when no transport frames arrive (bounded zombie recovery).

Keepalive source note: pinned `@slack/socket-mode@3.0.0` uses the `ws` package (`client.websocket.websocket`). Protocol ping/pong is bound on that **owned** handle and rebound on each `connected`. Undici `diagnostics_channel` ping/pong remains a scoped fallback (ignored unless `message.websocket === ownedWebSocket`) so foreign sockets cannot mask a dead Slack socket.

### Unit / CI

- `extensions/slack/src/monitor/provider.reconnect.test.ts` — connect/hello/`ws_message`; owned `ws` ping/pong; reconnect rebind; foreign Undici ignored; idle waiter; keepalive keeps waiter open (22/22)
- `src/gateway/channel-health-policy.test.ts` — fresh transport + stale app events = healthy; stale transport = `stale-socket`
- Auth/reconnect-loop `setStatus` matchers include connect-time `lastTransportActivityAt`

Commands:
```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-slack.config.ts extensions/slack/src/monitor/provider.reconnect.test.ts
node --import tsx scripts/live-slack-transport-proof.mjs   # needs SLACK_BOT_TOKEN + SLACK_APP_TOKEN
```

### Pre-fix production observation (redacted)

OpenClaw `2026.6.10` Slack Socket Mode showed `connected`/`healthy` with zero inbound log lines while Slack Web API still listed human messages; host CLI inject still worked. Details: https://github.com/openclaw/openclaw/issues/77249#issuecomment-5053046425

## Summary

- Publish `lastTransportActivityAt` from real Socket Mode transport signals (`connected` / `hello` / `ws_message`, plus **owned** WebSocket protocol ping/pong; scoped Undici fallback).
- Keep `trackEvent` for app inbound only (`lastEventAt` / `lastInboundAt`).
- Bound `waitForSlackSocketDisconnect` with a transport-idle timeout (default 120s, reset by keepalive) so the reconnect supervisor cannot park forever.
- Does **not** treat app-event silence as `stale-socket`.

Related visibility-only work: #79938 (shared-connection / `too_many_websockets` warn) — not recovery for a wedged waiter.

## Test plan

- [x] Transport activity + idle waiter unit tests
- [x] Owned `ws` ping/pong keepalive + reconnect rebind tests
- [x] Channel health policy: quiet keepalive stays healthy; stale transport restarts
- [x] Auth/reconnect-loop status callback expectations updated for transport stamp
- [x] Live Slack quiet-keepalive + idle recovery proof (redacted terminal above)