### PR TITLE
refactor(ui): move sidebar attention ownership into a reactive controller

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -52,6 +52,7 @@ import {
   type SidebarRecentSession,
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
+import { SessionAttentionController } from "./session-attention-controller.ts";
 import { isStoppableCloudWorkerPlacement } from "./session-row-badges.ts";
 
 /** Session-row projection, selection, sorting, and agent scope navigation. */
@@ -68,6 +69,11 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
   private sessionSelectionAnchor: string | null = null;
   private collapsedActiveRouteKey: string | null = null;
   private readonly runtimeSampledAtByRow = new WeakMap<GatewaySessionRow, number>();
+  private readonly attention = new SessionAttentionController(this);
+
+  get sessionAttentionContext() {
+    return this.context;
+  }
 
   override updated() {
     super.updated();
@@ -190,8 +196,10 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
         unread: row.archived !== true && row.unread === true,
         lastReadAt: row.lastReadAt,
         attention:
-          row.archived === true ? SIDEBAR_SESSION_NO_ATTENTION : this.resolveSessionAttention(row),
-        agentStatusNote: this.resolveSessionAgentStatus(row)?.note,
+          row.archived === true
+            ? SIDEBAR_SESSION_NO_ATTENTION
+            : this.attention.resolveSessionAttention(row),
+        agentStatusNote: this.attention.resolveSessionAgentStatus(row)?.note,
         observerDigest: row.observerDigest,
         spawnedBy: row.spawnedBy,
         status: row.status,
@@ -626,7 +634,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
       agentRows: rows,
       childRowsByParent: this.childSessionRowsByParent,
       loadingChildKeys: this.loadingChildSessionKeys,
-      knownSessionAttention: this.knownSessionAttention(),
+      knownSessionAttention: this.attention.knownSessionAttention(),
       toSidebarSession: navigationState.toSidebarSession,
     });
     const creatorFacet =

--- a/ui/src/components/app-sidebar-session-projection.ts
+++ b/ui/src/components/app-sidebar-session-projection.ts
@@ -1,13 +1,13 @@
 import { state } from "lit/decorators.js";
 import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
 import { compareSessionRowsByUpdatedAt } from "../lib/sessions/index.ts";
-import { AppSidebarSessionAttentionElement } from "./app-sidebar-session-attention.ts";
 import { adoptedCatalogSessionKeys } from "./app-sidebar-session-catalogs.ts";
+import { AppSidebarSessionDataElement } from "./app-sidebar-session-data.ts";
 import { SessionPullRequestIndicatorsController } from "./app-sidebar-session-pr-indicators.ts";
 import type { SidebarRecentSession, SidebarSessionSortMode } from "./app-sidebar-session-types.ts";
 
 /** Shared ordering and PR-state projection used by sidebar navigation. */
-export abstract class AppSidebarSessionProjectionElement extends AppSidebarSessionAttentionElement {
+export abstract class AppSidebarSessionProjectionElement extends AppSidebarSessionDataElement {
   @state() protected sessionSortMode: SidebarSessionSortMode = "created";
 
   private readonly sessionPullRequestIndicators = new SessionPullRequestIndicatorsController(this, {

--- a/ui/src/components/session-attention-controller.ts
+++ b/ui/src/components/session-attention-controller.ts
@@ -1,3 +1,4 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { SessionAgentStatus } from "../../../packages/gateway-protocol/src/session-icon.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { GatewaySessionRow } from "../api/types.ts";
@@ -15,45 +16,51 @@ import { t } from "../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { areUiSessionKeysEquivalent } from "../lib/sessions/session-key.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
-import { AppSidebarSessionDataElement } from "./app-sidebar-session-data.ts";
 import {
   SIDEBAR_SESSION_NO_ATTENTION,
   type SidebarKnownSessionAttention,
   type SidebarSessionAttention,
 } from "./app-sidebar-session-types.ts";
 
+interface SessionAttentionControllerHost extends ReactiveControllerHost {
+  readonly isConnected: boolean;
+  readonly sessionAttentionContext: ApplicationContext<RouteId> | undefined;
+}
+
 /** Session-scoped question, approval, and failed-run attention ownership. */
-export abstract class AppSidebarSessionAttentionElement extends AppSidebarSessionDataElement {
-  private readonly attentionSubscriptions = new SubscriptionsController(this);
-  private readonly questionPromptState = createQuestionPromptState(() => this.requestUpdate());
+export class SessionAttentionController implements ReactiveController {
+  private readonly attentionSubscriptions: SubscriptionsController;
+  private readonly questionPromptState: ReturnType<typeof createQuestionPromptState>;
   private attentionGateway: ApplicationContext<RouteId>["gateway"] | null = null;
   private attentionGatewayClient: GatewayBrowserClient | null = null;
   private attentionGatewayConnected = false;
   private agentStatusExpiryTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private agentStatusExpiryAt: number | null = null;
 
-  constructor() {
-    super();
+  constructor(private readonly host: SessionAttentionControllerHost) {
+    host.addController(this);
+    this.attentionSubscriptions = new SubscriptionsController(host);
+    this.questionPromptState = createQuestionPromptState(() => host.requestUpdate());
     this.attentionSubscriptions
       .watch(
-        () => this.context?.gateway,
+        () => host.sessionAttentionContext?.gateway,
         (gateway, notify) => gateway.subscribe(notify),
         (gateway) => this.synchronizeAttentionGateway(gateway),
       )
       .effect(
-        () => this.context?.gateway,
+        () => host.sessionAttentionContext?.gateway,
         (gateway) =>
           gateway.subscribeEvents((event) => {
             handleQuestionPromptEvent(this.questionPromptState, event);
           }),
       )
       .watch(
-        () => this.context?.overlays,
+        () => host.sessionAttentionContext?.overlays,
         (overlays, notify) => overlays.subscribe(notify),
       );
   }
 
-  override disconnectedCallback() {
+  hostDisconnected(): void {
     this.attentionGateway = null;
     this.attentionGatewayClient = null;
     this.attentionGatewayConnected = false;
@@ -63,7 +70,6 @@ export abstract class AppSidebarSessionAttentionElement extends AppSidebarSessio
       this.agentStatusExpiryAt = null;
     }
     disposeQuestionPromptState(this.questionPromptState);
-    super.disconnectedCallback();
   }
 
   private synchronizeAttentionGateway(gateway: ApplicationContext<RouteId>["gateway"]) {
@@ -90,15 +96,15 @@ export abstract class AppSidebarSessionAttentionElement extends AppSidebarSessio
         this.questionPromptState,
         client,
         () =>
-          this.isConnected &&
-          this.context?.gateway === gateway &&
+          this.host.isConnected &&
+          this.host.sessionAttentionContext?.gateway === gateway &&
           gateway.snapshot.connected &&
           gateway.snapshot.client === client,
       );
     }
   }
 
-  protected resolveSessionAttention(row: GatewaySessionRow): SidebarSessionAttention {
+  resolveSessionAttention(row: GatewaySessionRow): SidebarSessionAttention {
     const knownAttention = this.knownSessionAttention().find((entry) =>
       areUiSessionKeysEquivalent(entry.sessionKey, row.key),
     );
@@ -124,7 +130,7 @@ export abstract class AppSidebarSessionAttentionElement extends AppSidebarSessio
     return { kind: "error", reason };
   }
 
-  protected resolveSessionAgentStatus(row: GatewaySessionRow): SessionAgentStatus | undefined {
+  resolveSessionAgentStatus(row: GatewaySessionRow): SessionAgentStatus | undefined {
     const status = row.agentStatus;
     if (!status || status.expiresAt <= Date.now() || !status.note.trim()) {
       return undefined;
@@ -147,19 +153,21 @@ export abstract class AppSidebarSessionAttentionElement extends AppSidebarSessio
       () => {
         this.agentStatusExpiryTimer = null;
         this.agentStatusExpiryAt = null;
-        this.requestUpdate();
+        this.host.requestUpdate();
       },
       Math.max(0, expiresAt - Date.now() + 1),
     );
   }
 
-  protected knownSessionAttention(): readonly SidebarKnownSessionAttention[] {
+  knownSessionAttention(): readonly SidebarKnownSessionAttention[] {
     const questions = listQuestionPrompts(this.questionPromptState).flatMap((prompt) =>
       prompt.status === "pending" && prompt.sessionKey !== undefined
         ? [{ sessionKey: prompt.sessionKey, attention: { kind: "question" } as const }]
         : [],
     );
-    const approvals = (this.context?.overlays?.snapshot.approvalQueue ?? []).flatMap((approval) =>
+    const approvals = (
+      this.host.sessionAttentionContext?.overlays?.snapshot.approvalQueue ?? []
+    ).flatMap((approval) =>
       typeof approval.request.sessionKey === "string"
         ? [{ sessionKey: approval.request.sessionKey, attention: { kind: "approval" } as const }]
         : [],


### PR DESCRIPTION
Related: #112753
Related: #112809

## What Problem This Solves

PRs #112753 and #112809 extracted the Control UI sidebar session-list renderers behind a narrow host interface, but session attention still occupied a 169-line inheritance layer between session data and projection even though only Navigation consumes its behavior.

## Why This Change Was Made

This is PR 2 of the sidebar-flattening series. Session attention now lives in a `SessionAttentionController` owned directly by Navigation, its only consumer. Projection extends Data directly, while the controller preserves the existing gateway and overlay subscriptions, question-prompt refresh liveness checks, agent-status expiry invalidation, and disconnect cleanup.

The controller host is intentionally narrow: Lit controller lifecycle/update support, `isConnected`, and one descriptively named context accessor. The deleted element has no compatibility alias or re-export.

## User Impact

None. Session attention badges, subtitles, bubbling, timers, and update scheduling are behaviorally unchanged.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts`: 160 passed in 1 suite; existing attention cases unchanged
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json`: passed
- `node scripts/check-changed.mjs -- <4 touched paths>`: passed (`coreTests, ui`) on Blacksmith Testbox, run 29969166326
- `pnpm ui:build`: passed on Blacksmith Testbox, run 29969991429; startup JS 9 requests / 314.8 KiB gzip against the 315.0 KiB budget
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings
- `git diff --numstat origin/main...HEAD`: +39/-23 across 3 logical files (Git records the deleted attention element and new controller as a rename)

AI-assisted change; implementation and proof were reviewed with the repository autoreview workflow.
