### PR TITLE
fix(claws): preserve MCP timeout units across export and install

### DIFF
--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -65,6 +65,7 @@ async function installedFixture(
     packageBootstrapContent?: Buffer;
     soulContent?: string | Buffer;
     withPackage?: boolean;
+    mcpDocsTimeoutSeconds?: number;
   } = {},
 ) {
   const root = tempDirs.make("openclaw-claw-export-");
@@ -95,6 +96,9 @@ async function installedFixture(
         command: "uvx",
         args: ["docs-mcp"],
         env: { DOCS_TOKEN: "${DOCS_TOKEN}" },
+        ...(options.mcpDocsTimeoutSeconds !== undefined
+          ? { timeout: options.mcpDocsTimeoutSeconds }
+          : {}),
       },
       linear: {
         url: "https://mcp.linear.app/mcp",
@@ -395,6 +399,21 @@ describe("exportClawAgent", () => {
       "profile: full",
     );
     await expect(readFile(join(out, "workspace", "SOUL.md"), "utf8")).rejects.toThrow();
+  });
+
+  it("exports canonical MCP timeouts as portable seconds", async () => {
+    const fixture = await installedFixture({ mcpDocsTimeoutSeconds: 30 });
+    const out = join(fixture.root, "exported-timeout");
+
+    const result = await exportClawAgent("worker", out, {
+      env: fixture.env,
+      config: fixture.config,
+      packageDeps: fixture.packageDeps,
+      sourceMcpServers: fixture.sourceMcpServers,
+    });
+
+    expect(fixture.sourceMcpServers.docs).toMatchObject({ requestTimeoutMs: 30_000 });
+    expect(result.manifest.mcpServers.docs).toMatchObject({ timeout: 30 });
   });
 
   it("exports extension plugins into profile v1 without duplicating manifest packages", async () => {

--- a/src/claws/export.ts
+++ b/src/claws/export.ts
@@ -280,8 +280,12 @@ function portableMcpServer(server: Record<string, unknown>): ClawMcpServer {
     ...(server.toolFilter && typeof server.toolFilter === "object"
       ? { toolFilter: server.toolFilter as ClawMcpServer["toolFilter"] }
       : {}),
-    ...(typeof server.timeout === "number" ? { timeout: server.timeout } : {}),
-    ...(typeof server.connectTimeout === "number" ? { connectTimeout: server.connectTimeout } : {}),
+    ...(typeof server.requestTimeoutMs === "number"
+      ? { timeout: server.requestTimeoutMs / 1000 }
+      : {}),
+    ...(typeof server.connectionTimeoutMs === "number"
+      ? { connectTimeout: server.connectionTimeoutMs / 1000 }
+      : {}),
   };
   if (typeof server.url === "string") {
     if (server.transport !== "sse" && server.transport !== "streamable-http") {

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -9,7 +9,7 @@ import { assertNoSymlinkParents } from "../infra/fs-safe-advanced.js";
 import { FsSafeError, root as fsSafeRoot, type Root } from "../infra/fs-safe.js";
 import { resolveUserPath } from "../utils.js";
 import { findClawExtensionPackageCollisions, planClawExtensions } from "./application-plan.js";
-import { digestClawMcpServer } from "./mcp.js";
+import { digestClawMcpServer, portableMcpServerToConfig } from "./mcp.js";
 import { clawManifestWorkspaceConflictsWithPath } from "./schema.js";
 import { MAX_MANAGED_FILE_BYTES, MAX_MANAGED_WORKSPACE_BYTES } from "./source-limits.js";
 import { materializeClawToolProfile } from "./tool-profile-consent.js";
@@ -578,10 +578,11 @@ export async function buildClawAddPlan(params: {
 
   const existingMcpServerNames = new Set(context.existingMcpServerNames ?? []);
   for (const [name, server] of Object.entries(params.manifest.mcpServers)) {
+    const configServer = portableMcpServerToConfig(server);
     const existingServer = context.existingMcpServers?.[name];
     const exactExisting =
       existingServer !== undefined &&
-      digestClawMcpServer(existingServer) === digestClawMcpServer(server);
+      digestClawMcpServer(existingServer) === digestClawMcpServer(configServer);
     const blocked =
       !exactExisting && (existingMcpServerNames.has(name) || existingServer !== undefined);
     if (blocked) {
@@ -611,7 +612,7 @@ export async function buildClawAddPlan(params: {
       action: "configure",
       target: `mcp.servers.${name}`,
       details: {
-        ...server,
+        ...configServer,
         expectedState: exactExisting ? "present-exact" : "absent",
         prerequisites: readinessRequirements.filter(
           (requirement) => requirement.kind !== "plugin-setup" && requirement.mcpServer === name,

--- a/src/claws/mcp-update.test.ts
+++ b/src/claws/mcp-update.test.ts
@@ -94,6 +94,60 @@ function manifest(): ClawManifest {
 }
 
 describe("applyClawMcpUpdate", () => {
+  it("writes portable timeout seconds in canonical config units", async () => {
+    const declared: ClawMcpServer = {
+      command: "uvx",
+      args: ["docs@2"],
+      timeout: 30,
+      connectTimeout: 5,
+    };
+    const canonical = {
+      command: "uvx",
+      args: ["docs@2"],
+      requestTimeoutMs: 30_000,
+      connectionTimeoutMs: 5_000,
+    };
+    const setServer = vi.fn(async () => ({
+      ok: true as const,
+      path: "config",
+      config: {},
+      mcpServers: {},
+    }));
+    const upsertRef = vi.fn();
+
+    await applyClawMcpUpdate(
+      plan([
+        {
+          kind: "mcpServer",
+          id: "docs",
+          action: "add",
+          target: "mcp.servers.docs",
+          blocked: false,
+          reason: "added",
+        },
+      ]),
+      { ...manifest(), mcpServers: { docs: declared } },
+      {
+        config: { mcp: { servers: {} } },
+        sourceMcpServers: {},
+        readRefs: () => [],
+        setServer,
+        upsertRef,
+      },
+    );
+
+    expect(setServer).toHaveBeenCalledWith({
+      name: "docs",
+      server: canonical,
+      createOnly: true,
+      recordIndependentOwner: false,
+    });
+    expect(upsertRef).toHaveBeenCalledWith(
+      expect.objectContaining({ configDigest: digestClawMcpServer(canonical) }),
+      expect.any(Object),
+    );
+  });
+
   it("applies add, change, and remove with CAS writes and reversible ownership", async () => {
     const currentRefs = [ref("docs", oldDocs), ref("legacy", legacy)];
     const setServer = vi.fn(async () => ({

--- a/src/claws/mcp-update.ts
+++ b/src/claws/mcp-update.ts
@@ -9,6 +9,7 @@ import {
   deleteClawMcpServerRef,
   digestClawMcpServer,
   planClawMcpServerRemoval,
+  portableMcpServerToConfig,
   readClawMcpServerRefs,
   readClawMcpServerRefsByName,
   upsertClawMcpServerRef,
@@ -167,12 +168,13 @@ export async function applyClawMcpUpdate(
           return;
         }
 
-        const targetServer = targetManifest.mcpServers[name];
-        if (!targetServer) {
+        const declaredServer = targetManifest.mcpServers[name];
+        if (!declaredServer) {
           throw new ClawMcpUpdateError(
             `Target MCP declaration ${JSON.stringify(name)} is missing.`,
           );
         }
+        const targetServer = portableMcpServerToConfig(declaredServer);
         const targetRef: PersistedClawMcpServerRef = {
           schemaVersion: CLAW_MCP_REF_SCHEMA_VERSION,
           agentId: updatePlan.agentId,

--- a/src/claws/mcp.test.ts
+++ b/src/claws/mcp.test.ts
@@ -1,10 +1,16 @@
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { validateConfigObjectRaw } from "../config/validation.js";
 import { markClawMcpServerIndependentlyOwned } from "../state/claw-mcp-adoption.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { buildClawAddPlan } from "./lifecycle.js";
-import { deleteClawMcpServerRef, installClawMcpServers, planClawMcpServerRemoval } from "./mcp.js";
+import {
+  deleteClawMcpServerRef,
+  digestClawMcpServer,
+  installClawMcpServers,
+  planClawMcpServerRemoval,
+} from "./mcp.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawSourceIdentity } from "./types.js";
 
@@ -55,6 +61,73 @@ function listedMcpServers(mcpServers: Record<string, Record<string, unknown>> = 
 }
 
 describe("installClawMcpServers", () => {
+  it("converts portable timeout seconds to canonical config milliseconds", async () => {
+    const root = tempDirs.make("openclaw-claw-mcp-timeout-");
+    const parsed = parseClawManifest({
+      schemaVersion: 1,
+      agent: { id: "worker" },
+      mcpServers: {
+        docs: { command: "uvx", args: ["docs-mcp"], timeout: 30, connectTimeout: 5 },
+      },
+    });
+    if (!parsed.ok) {
+      throw new Error(JSON.stringify(parsed.diagnostics));
+    }
+    const canonical = {
+      command: "uvx",
+      args: ["docs-mcp"],
+      requestTimeoutMs: 30_000,
+      connectionTimeoutMs: 5_000,
+    };
+    const source: ClawSourceIdentity = {
+      kind: "package",
+      name: "@acme/worker",
+      version: "1.0.0",
+      packageRoot: root,
+      manifestPath: join(root, "openclaw.claw.json"),
+      integrityKind: "artifact",
+      integrity: "sha256:manifest",
+      byteLength: 100,
+    };
+    const plan = await buildClawAddPlan({
+      manifest: parsed.manifest,
+      source,
+      context: {
+        workspace: join(root, "workspace"),
+        existingMcpServers: { docs: canonical },
+      },
+    });
+    const action = plan.actions.find((entry) => entry.kind === "mcpServer" && entry.id === "docs");
+    const {
+      expectedState: _expectedState,
+      prerequisites: _prerequisites,
+      ...plannedServer
+    } = action?.details ?? {};
+
+    expect(action).toMatchObject({ blocked: false, details: { expectedState: "present-exact" } });
+    expect(plannedServer).toEqual(canonical);
+    expect(validateConfigObjectRaw({ mcp: { servers: { docs: plannedServer } } }).ok).toBe(true);
+    expect(digestClawMcpServer(parsed.manifest.mcpServers.docs!)).toBe(
+      digestClawMcpServer(canonical),
+    );
+
+    const setMcpServer = vi
+      .fn()
+      .mockResolvedValue({ ok: true, path: "config", config: {}, mcpServers: {} });
+    await installClawMcpServers(plan, {
+      env: { OPENCLAW_STATE_DIR: join(root, "state") },
+      setMcpServer,
+      listMcpServers: vi.fn().mockResolvedValue(listedMcpServers()),
+    });
+
+    expect(setMcpServer).toHaveBeenCalledWith({
+      name: "docs",
+      server: canonical,
+      createOnly: true,
+      recordIndependentOwner: false,
+    });
+  });
+
   it("uses create-only config writes and stores digest-only ownership", async () => {
     const current = await fixture();
     const setMcpServer = vi

--- a/src/claws/mcp.ts
+++ b/src/claws/mcp.ts
@@ -58,6 +58,28 @@ function mcpServerFromActionDetails(details: Record<string, unknown>): ClawMcpSe
   return "command" in server || "url" in server ? (server as ClawMcpServer) : undefined;
 }
 
+export function portableMcpServerToConfig(
+  server: Record<string, unknown>,
+): Record<string, unknown> {
+  const next = { ...server };
+  for (const [secondsKey, millisecondsKey] of [
+    ["timeout", "requestTimeoutMs"],
+    ["connectTimeout", "connectionTimeoutMs"],
+  ] as const) {
+    const seconds = next[secondsKey];
+    const milliseconds = typeof seconds === "number" ? seconds * 1000 : undefined;
+    if (
+      milliseconds !== undefined &&
+      Number.isFinite(milliseconds) &&
+      next[millisecondsKey] === undefined
+    ) {
+      next[millisecondsKey] = milliseconds;
+      delete next[secondsKey];
+    }
+  }
+  return next;
+}
+
 function rowToRef(row: McpRefRow): PersistedClawMcpServerRef {
   return {
     schemaVersion: CLAW_MCP_REF_SCHEMA_VERSION,
@@ -75,7 +97,9 @@ function rowToRef(row: McpRefRow): PersistedClawMcpServerRef {
 }
 
 export function digestClawMcpServer(server: Record<string, unknown>): string {
-  const canonical = canonicalizeConfiguredMcpServer(server);
+  // Claw manifests use seconds while config/runtime use milliseconds; digest
+  // the canonical projection so portable and installed representations match.
+  const canonical = canonicalizeConfiguredMcpServer(portableMcpServerToConfig(server));
   return `sha256:${createHash("sha256").update(stableStringify(canonical)).digest("hex")}`;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where installing or updating a Claw with MCP timeouts could write portable seconds into canonical config fields that use milliseconds, while export omitted those canonical values. The result was rejected or ineffective configuration and a broken export/reinstall round trip.

## Why This Change Was Made

Claw manifests remain portable and express `timeout` / `connectTimeout` in seconds. OpenClaw config and the MCP runtime remain canonical and use `requestTimeoutMs` / `connectionTimeoutMs` in milliseconds.

The Claw owner now performs one shared portable-to-canonical projection when building install plans, applying updates, and computing ownership digests. Export performs the inverse projection. The shared config writer is unchanged, avoiding double conversion for non-Claw callers.

This is a maintainer rewrite of @masatohoshino's original fix. The replacement commit is authored by Masato Hoshino to preserve contributor credit.

No config, schema, help, docs, doctor, database, dependency, default, alias, compatibility reader, or migration surface changed.

## User Impact

Operators can install, update, export, and reinstall timeout-bearing Claws without losing either MCP timeout. Equivalent portable and canonical representations also produce the same ownership digest, so an already-matching server is not reported as drift.

## Evidence

Exact reviewed head: `343449124e3` (rebased onto `a8722e74ec947335de61f2009fef8073c2bd9848`).
The patch is semantically unchanged from the pre-rebase submission. Six of the seven files reapplied
without conflict; in `mcp-update.ts` the single changed hunk is the same two edits (import
`portableMcpServerToConfig`, convert the declared server before it is written) indented one level
deeper, because upstream has since wrapped that loop body in `withClawMcpLifecycleLease`. The lease
wrapper is base context, not a change this PR makes.

Root cause and owner:

- Portable Claw manifest: seconds.
- Canonical MCP config/runtime: milliseconds.
- Owner boundary: `src/claws/*` manifest/config projection, not the shared config writer.

Dependency contract:

- Inspected `@modelcontextprotocol/sdk@1.30.0` directly.
- `dist/esm/shared/protocol.d.ts` defines request timeouts in milliseconds and `DEFAULT_REQUEST_TIMEOUT_MSEC = 60000`.
- `dist/esm/shared/protocol.js` passes that value directly to `setTimeout`.

Red controls — each of these was observed **before the fix**, on unmodified `main`:

- The focused added tests failed on install planning, update writing, and export.
- Raw `timeout: 30` / `connectTimeout: 5` failed canonical config validation.
- The portable-seconds and canonical-milliseconds digests differed.

Green proof:

- `node scripts/run-vitest.mjs src/claws/mcp.test.ts src/claws/mcp-update.test.ts src/claws/export.test.ts src/claws/lifecycle-state-mcp.test.ts`
  - 4 files, 61 tests passed on the rebased head.
- Isolated real CLI round trip, re-captured on this head through `scripts/run-node.mjs` (the entry
  point `openclaw` itself invokes), with each leg built from source and the build verified before it
  is read — the BEFORE leg asserts `dist` does not contain `portableMcpServerToConfig`, so a stale
  bundle cannot pass for the unfixed behaviour:
The manifest under test declares portable seconds — `timeout: 45`, `connectTimeout: 12` — and config
stores canonical milliseconds, so a correct round trip is `45 → 45000 → 45` and `12 → 12000 → 12`.

**Before the fix**, with the four production files reverted to their `upstream/main` content on this
same head, the plan writes the manifest's seconds into config verbatim, under keys config does not
consume:

```console
$ OPENCLAW_EXPERIMENTAL_CLAWS=1 OPENCLAW_STATE_DIR=$TMP/BEFORE/state \
    node scripts/run-node.mjs claws add $TMP/BEFORE/pkg \
    --workspace $TMP/BEFORE/workspace --dry-run --json
      "action": "configure",
      "target": "mcp.servers.slow-tool",
      "details": {
        "command": "npx",
        "args": [
          "--yes",
          "@acme/slow-mcp@1.0.0"
        ],
        "timeout": 45,
        "connectTimeout": 12,
        "expectedState": "absent",
        "prerequisites": []
      },
```

**After the fix**, the same command against the same manifest plans the canonical keys instead:

```console
$ OPENCLAW_EXPERIMENTAL_CLAWS=1 OPENCLAW_STATE_DIR=$TMP/AFTER/state \
    node scripts/run-node.mjs claws add $TMP/AFTER/pkg \
    --workspace $TMP/AFTER/workspace --dry-run --json
      "action": "configure",
      "target": "mcp.servers.slow-tool",
      "details": {
        "command": "npx",
        "args": [
          "--yes",
          "@acme/slow-mcp@1.0.0"
        ],
        "requestTimeoutMs": 45000,
        "connectionTimeoutMs": 12000,
        "expectedState": "absent",
        "prerequisites": []
      },
```

Export closes the round trip, reading the canonical config back out as portable seconds:

```console
$ OPENCLAW_EXPERIMENTAL_CLAWS=1 OPENCLAW_STATE_DIR=$TMP/AFTER/state \
    node scripts/run-node.mjs claws export timeout-probe --out $TMP/AFTER/exported
Experimental: Claws contracts may change while RFC 0016 is under review.
Exported agent: timeout-probe
Package directory: /tmp/.../AFTER/exported
Workspace files: 0
Packages: 0
Bootstrap: none

### AFTER — exported CLAW.md front matter
mcpServers:
  slow-tool:
    command: npx
    args:
      - --yes
      - "@acme/slow-mcp@1.0.0"
    timeout: 45
    connectTimeout: 12
```

Reinstalling that export produces a byte-equivalent canonical MCP config.
- `git diff --check`: clean.
- Targeted `oxfmt`: clean.
- Repository CI on this head: **206 successful checks, 0 failures** (51 skipped, 1 neutral), as
  reported for `343449124e3` on this PR's Checks tab.
- `pnpm check:changed --base a8722e74ec947335de61f2009fef8073c2bd9848` run locally: exit 0. The base is
  spelled as a SHA rather than `upstream/main` so the command reproduces the same range later.
- Supplementary review: `codex` (`gpt-5.6-luna`, high reasoning) over this head's diff returned no
  actionable findings. Listed as supplementary, not as a gate.

Diff:

- Production: `+39/-8`
- Tests: `+147/-1`
- Production growth is the shared manifest/config ownership boundary and its four flows: install, digest, update, and export.

Stale provenance — issued for the pre-rebase head `62bc1c6f7b8`, listed so the record is complete, and
**not** offered as coverage of `343449124e3`:

- Blacksmith Testbox changed gate: passed. provider `blacksmith-testbox`, lease
  `tbx_01kzqcx5d31znedsp552hbsz8n`,
  run https://github.com/openclaw/openclaw/actions/runs/31454707735. I cannot re-lease Testbox for a
  rebased head from outside the repository; the current head is covered by the repository CI figure
  above instead.
- Max-P1 autoreview: no accepted or actionable findings, confidence `0.92`.
- Local clawpatch exact-patch review — **not** re-run after the rebase, so its conclusions describe the
  pre-rebase patch. The patch is semantically unchanged across the rebase (see *Exact reviewed head*),
  but that is an argument, not a re-run.
- `Punchcard-Session: quiet-harbor-lantern-f7`
- Commit attestation: `att_01KZQE4KD8K675QQYM9XFDJPBC`
- PR attestation: `att_01KZQE4X5Y34FR4193ZNHFNNX2`

