### PR TITLE
fix(release): isolate extended-stable Docker aliases

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -29,3 +29,10 @@ paths:
       - 'constant expression "false" in condition'
       # actionlint's built-in runner label allowlist lags Blacksmith additions.
       - 'label "blacksmith-16vcpu-[^"]+" is unknown\.'
+  # GitHub Actions supports concurrency.queue, but actionlint does not yet model it.
+  .github/workflows/docker-release.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/docker-channel-promote.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/docker-channel-promote.yml
+++ b/.github/workflows/docker-channel-promote.yml
@@ -81,6 +81,8 @@ jobs:
   approve:
     name: Approve ${{ inputs.tag }} to ${{ needs.resolve.outputs.channel }} (${{ needs.resolve.outputs.default_aliases }})
     needs: resolve
+    # Keep human approval outside the queued writer so waiting for approval
+    # cannot block a tag-driven Docker release in docker-release-publish.
     # WARNING: KEEP CHANNEL PROMOTION GATED BY THE docker-release ENVIRONMENT.
     runs-on: ubuntu-24.04
     environment: docker-release
@@ -159,6 +161,26 @@ jobs:
           registry: ${{ env.DOCKERHUB_REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Verify immutable source attestations
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+          source_refs=(
+            "${GHCR_IMAGE}:${VERSION}"
+            "${GHCR_IMAGE}:${VERSION}-slim"
+            "${GHCR_IMAGE}:${VERSION}-browser"
+            "${DOCKERHUB_IMAGE}:${VERSION}"
+            "${DOCKERHUB_IMAGE}:${VERSION}-slim"
+            "${DOCKERHUB_IMAGE}:${VERSION}-browser"
+          )
+          node scripts/verify-docker-attestations.mjs \
+            --platform linux/amd64 \
+            --platform linux/arm64 \
+            "${source_refs[@]}"
 
       - name: Promote and verify channel aliases
         env:

--- a/.github/workflows/docker-channel-promote.yml
+++ b/.github/workflows/docker-channel-promote.yml
@@ -104,6 +104,7 @@ jobs:
     concurrency:
       group: docker-release-publish
       cancel-in-progress: false
+      queue: max
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-channel-promote.yml
+++ b/.github/workflows/docker-channel-promote.yml
@@ -162,26 +162,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Verify immutable source attestations
-        env:
-          VERSION: ${{ needs.resolve.outputs.version }}
-          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
-        run: |
-          set -euo pipefail
-          source_refs=(
-            "${GHCR_IMAGE}:${VERSION}"
-            "${GHCR_IMAGE}:${VERSION}-slim"
-            "${GHCR_IMAGE}:${VERSION}-browser"
-            "${DOCKERHUB_IMAGE}:${VERSION}"
-            "${DOCKERHUB_IMAGE}:${VERSION}-slim"
-            "${DOCKERHUB_IMAGE}:${VERSION}-browser"
-          )
-          node scripts/verify-docker-attestations.mjs \
-            --platform linux/amd64 \
-            --platform linux/arm64 \
-            "${source_refs[@]}"
-
       - name: Promote and verify channel aliases
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
@@ -192,9 +172,11 @@ jobs:
           node scripts/docker-channel-promote.mjs \
             --version "${VERSION}" \
             --image "${GHCR_IMAGE}" \
-            --image "${DOCKERHUB_IMAGE}"
+            --image "${DOCKERHUB_IMAGE}" \
+            --allow-rollback
           {
             echo "## Docker channel promotion"
             echo "- Version: ${VERSION}"
             echo "- Registries: ${GHCR_IMAGE}, ${DOCKERHUB_IMAGE}"
+            echo "- Rollback: explicitly approved"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-channel-promote.yml
+++ b/.github/workflows/docker-channel-promote.yml
@@ -1,0 +1,177 @@
+name: Docker Channel Promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing stable or extended-stable release tag
+        required: true
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  DOCKERHUB_REGISTRY: docker.io
+  DOCKERHUB_IMAGE_NAME: openclaw/openclaw
+
+jobs:
+  resolve:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.policy.outputs.version }}
+      channel: ${{ steps.policy.outputs.channel }}
+      default_aliases: ${{ steps.policy.outputs.default_aliases }}
+      slim_aliases: ${{ steps.policy.outputs.slim_aliases }}
+      browser_aliases: ${{ steps.policy.outputs.browser_aliases }}
+    steps:
+      - name: Require a main-branch dispatch
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Docker channel promotion must be dispatched from main; got ${WORKFLOW_REF}."
+            exit 1
+          fi
+
+      - name: Checkout trusted promotion tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve release channel policy
+        id: policy
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$ ]]; then
+            echo "::error::Expected a final stable or extended-stable release tag; got ${RELEASE_TAG}."
+            exit 1
+          fi
+          git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}" >/dev/null
+          version="${RELEASE_TAG#v}"
+          policy="$(node scripts/lib/docker-release-policy.mjs "${version}")"
+          channel="$(jq -r '.channel' <<< "${policy}")"
+          default_aliases="$(jq -r '.movingAliases.default | join(" ")' <<< "${policy}")"
+          slim_aliases="$(jq -r '.movingAliases.slim | join(" ")' <<< "${policy}")"
+          browser_aliases="$(jq -r '.movingAliases.browser | join(" ")' <<< "${policy}")"
+          {
+            echo "version=${version}"
+            echo "channel=${channel}"
+            echo "default_aliases=${default_aliases}"
+            echo "slim_aliases=${slim_aliases}"
+            echo "browser_aliases=${browser_aliases}"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Docker channel promotion plan"
+            echo "- Version: ${version}"
+            echo "- Channel: ${channel}"
+            echo "- Default aliases: ${default_aliases}"
+            echo "- Slim aliases: ${slim_aliases}"
+            echo "- Browser aliases: ${browser_aliases}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  approve:
+    name: Approve ${{ inputs.tag }} to ${{ needs.resolve.outputs.channel }} (${{ needs.resolve.outputs.default_aliases }})
+    needs: resolve
+    # WARNING: KEEP CHANNEL PROMOTION GATED BY THE docker-release ENVIRONMENT.
+    runs-on: ubuntu-24.04
+    environment: docker-release
+    permissions: {}
+    steps:
+      - name: Record approval
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          DEFAULT_ALIASES: ${{ needs.resolve.outputs.default_aliases }}
+          SLIM_ALIASES: ${{ needs.resolve.outputs.slim_aliases }}
+          BROWSER_ALIASES: ${{ needs.resolve.outputs.browser_aliases }}
+        run: |
+          echo "Approved Docker channel promotion for ${RELEASE_TAG}"
+          echo "Default aliases: ${DEFAULT_ALIASES}"
+          echo "Slim aliases: ${SLIM_ALIASES}"
+          echo "Browser aliases: ${BROWSER_ALIASES}"
+
+  promote:
+    needs: [resolve, approve]
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: docker-release-publish
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Validate Docker Hub publish credentials
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
+            echo "::error::Docker Hub publishing requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets."
+            exit 1
+          fi
+
+      - name: Checkout trusted promotion tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Pre-pull BuildKit image
+        shell: bash
+        env:
+          BUILDKIT_IMAGE: moby/buildkit:buildx-stable-1
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4; do
+            if docker pull "${BUILDKIT_IMAGE}"; then
+              exit 0
+            fi
+            if [[ "${attempt}" -eq 4 ]]; then
+              echo "::error::Failed to pull ${BUILDKIT_IMAGE} after ${attempt} attempts."
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
+
+      - name: Set up Docker Builder
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Promote and verify channel aliases
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+          node scripts/docker-channel-promote.mjs \
+            --version "${VERSION}" \
+            --image "${GHCR_IMAGE}" \
+            --image "${DOCKERHUB_IMAGE}"
+          {
+            echo "## Docker channel promotion"
+            echo "- Version: ${VERSION}"
+            echo "- Registries: ${GHCR_IMAGE}, ${DOCKERHUB_IMAGE}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,7 +27,7 @@ on:
           - promote-channel
 
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && format('docker-release-manual-{0}', inputs.tag) || format('docker-release-push-{0}', github.run_id) }}
+  group: ${{ github.event_name == 'workflow_dispatch' && inputs.operation == 'backfill' && format('docker-release-manual-{0}', inputs.tag) || 'docker-release-publish' }}
   cancel-in-progress: false
 
 env:
@@ -90,10 +90,15 @@ jobs:
         env:
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
           RELEASE_OPERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.operation || 'release' }}
+          WORKFLOW_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
           if [[ "${SOURCE_REF}" != refs/tags/v* ]]; then
             echo "::error::Docker releases require a v-prefixed release tag; got ${SOURCE_REF}."
+            exit 1
+          fi
+          if [[ "${RELEASE_OPERATION}" == "promote-channel" && "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Docker channel promotion must be dispatched from main; got ${WORKFLOW_REF}."
             exit 1
           fi
           version="${SOURCE_REF#refs/tags/v}"
@@ -126,7 +131,14 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           RELEASE_OPERATION: ${{ inputs.operation }}
-        run: echo "Approved Docker ${RELEASE_OPERATION} for ${RELEASE_TAG}"
+          DEFAULT_ALIASES: ${{ needs.resolve_release_policy.outputs.default_aliases }}
+          SLIM_ALIASES: ${{ needs.resolve_release_policy.outputs.slim_aliases }}
+          BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}
+        run: |
+          echo "Approved Docker ${RELEASE_OPERATION} for ${RELEASE_TAG}"
+          echo "Default aliases: ${DEFAULT_ALIASES:-none}"
+          echo "Slim aliases: ${SLIM_ALIASES:-none}"
+          echo "Browser aliases: ${BROWSER_ALIASES:-none}"
 
   validate_publish_config:
     runs-on: ubuntu-24.04
@@ -779,15 +791,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       packages: write
-      contents: read
     steps:
-      - name: Checkout selected tag
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: refs/tags/${{ inputs.tag }}
-          fetch-depth: 1
-          persist-credentials: false
-
       - *buildkit_prepull_step
       - name: Set up Docker Builder
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
@@ -864,27 +868,18 @@ jobs:
             done
           }
 
-          browser_supported=0
-          if grep -q '^ARG OPENCLAW_INSTALL_BROWSER' Dockerfile; then
-            browser_supported=1
-          fi
-
           # Resolve every immutable source before moving any alias so missing
           # release images fail without leaving a partially promoted channel.
           for image in "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"; do
             require_group_source "${image}" "" "${DEFAULT_ALIASES}"
             require_group_source "${image}" "-slim" "${SLIM_ALIASES}"
-            if [[ "${browser_supported}" == "1" ]]; then
-              require_group_source "${image}" "-browser" "${BROWSER_ALIASES}"
-            fi
+            require_group_source "${image}" "-browser" "${BROWSER_ALIASES}"
           done
 
           for image in "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"; do
             promote_group "${image}" "" "${DEFAULT_ALIASES}"
             promote_group "${image}" "-slim" "${SLIM_ALIASES}"
-            if [[ "${browser_supported}" == "1" ]]; then
-              promote_group "${image}" "-browser" "${BROWSER_ALIASES}"
-            fi
+            promote_group "${image}" "-browser" "${BROWSER_ALIASES}"
           done
 
           {

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -21,6 +21,7 @@ on:
 concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && format('docker-release-manual-{0}', inputs.tag) || 'docker-release-publish' }}
   cancel-in-progress: false
+  queue: max
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -14,9 +14,17 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing stable or beta release tag to backfill (for example v2026.3.22 or v2026.3.22-beta.1)
+        description: Existing stable, extended-stable, or beta release tag
         required: true
         type: string
+      operation:
+        description: Build immutable images, or promote an existing immutable version to its moving channel aliases
+        required: true
+        type: choice
+        default: backfill
+        options:
+          - backfill
+          - promote-channel
 
 concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && format('docker-release-manual-{0}', inputs.tag) || format('docker-release-push-{0}', github.run_id) }}
@@ -45,7 +53,7 @@ jobs:
             echo "Docker alpha image publishing is disabled."
             exit 1
           fi
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-beta\.[1-9][0-9]*)?$ ]]; then
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-(beta\.)?[1-9][0-9]*)?$ ]]; then
             echo "Invalid release tag: ${RELEASE_TAG}"
             exit 1
           fi
@@ -56,18 +64,69 @@ jobs:
           ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 0
 
+  resolve_release_policy:
+    needs: validate_manual_backfill
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.validate_manual_backfill.result == 'success') }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.policy.outputs.version }}
+      channel: ${{ steps.policy.outputs.channel }}
+      default_aliases: ${{ steps.policy.outputs.default_aliases }}
+      slim_aliases: ${{ steps.policy.outputs.slim_aliases }}
+      browser_aliases: ${{ steps.policy.outputs.browser_aliases }}
+    steps:
+      - name: Checkout trusted workflow helpers
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.sha }}
+          path: workflow-source
+          persist-credentials: false
+
+      - name: Resolve release channel policy
+        id: policy
+        shell: bash
+        env:
+          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          RELEASE_OPERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.operation || 'release' }}
+        run: |
+          set -euo pipefail
+          if [[ "${SOURCE_REF}" != refs/tags/v* ]]; then
+            echo "::error::Docker releases require a v-prefixed release tag; got ${SOURCE_REF}."
+            exit 1
+          fi
+          version="${SOURCE_REF#refs/tags/v}"
+          policy="$(node workflow-source/scripts/lib/docker-release-policy.mjs "${version}")"
+          channel="$(jq -r '.channel' <<< "${policy}")"
+          if [[ "${RELEASE_OPERATION}" == "promote-channel" && "${channel}" == "beta" ]]; then
+            echo "::error::Beta releases have no moving Docker channel aliases to promote."
+            exit 1
+          fi
+          default_aliases="$(jq -r '.movingAliases.default | join(" ")' <<< "${policy}")"
+          slim_aliases="$(jq -r '.movingAliases.slim | join(" ")' <<< "${policy}")"
+          browser_aliases="$(jq -r '.movingAliases.browser | join(" ")' <<< "${policy}")"
+          {
+            echo "version=${version}"
+            echo "channel=${channel}"
+            echo "default_aliases=${default_aliases}"
+            echo "slim_aliases=${slim_aliases}"
+            echo "browser_aliases=${browser_aliases}"
+          } >> "$GITHUB_OUTPUT"
+
   approve_manual_backfill:
     if: github.event_name == 'workflow_dispatch'
-    needs: validate_manual_backfill
+    needs: [validate_manual_backfill, resolve_release_policy]
     # WARNING: KEEP MANUAL BACKFILLS GATED BY THE docker-release ENVIRONMENT.
     runs-on: ubuntu-24.04
     environment: docker-release
     permissions: {}
     steps:
-      - name: Approve Docker backfill
+      - name: Approve Docker operation
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-        run: echo "Approved Docker backfill for $RELEASE_TAG"
+          RELEASE_OPERATION: ${{ inputs.operation }}
+        run: echo "Approved Docker ${RELEASE_OPERATION} for ${RELEASE_TAG}"
 
   validate_publish_config:
     runs-on: ubuntu-24.04
@@ -86,6 +145,30 @@ jobs:
             exit 1
           fi
           echo "Docker Hub publishing configured for ${DOCKERHUB_IMAGE}."
+
+  resolve_build_provenance:
+    needs: [approve_manual_backfill, resolve_release_policy, validate_publish_config]
+    if: ${{ always() && needs.resolve_release_policy.result == 'success' && needs.validate_publish_config.result == 'success' && (github.event_name != 'workflow_dispatch' || (needs.approve_manual_backfill.result == 'success' && inputs.operation == 'backfill')) }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      built_at: ${{ steps.build_provenance.outputs.built_at }}
+      source_sha: ${{ steps.build_provenance.outputs.source_sha }}
+    steps:
+      - name: Checkout selected source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.sha }}
+          fetch-depth: 0
+
+      - name: Resolve shared build provenance
+        id: build_provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "built_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
   # KEEP THIS WORKFLOW ON GITHUB-HOSTED RUNNERS.
   # DO NOT MOVE IT BACK TO BLACKSMITH WITHOUT RE-VALIDATING TAG BUILDS AND BACKFILLS.
@@ -533,7 +616,15 @@ jobs:
 
   # Create multi-platform manifests
   create-manifest:
-    needs: [approve_manual_backfill, validate_publish_config, build-amd64, build-arm64]
+    needs:
+      [
+        approve_manual_backfill,
+        resolve_release_policy,
+        validate_publish_config,
+        resolve_build_provenance,
+        build-amd64,
+        build-arm64,
+      ]
     if: ${{ always() && needs.validate_publish_config.result == 'success' && needs.build-amd64.result == 'success' && needs.build-arm64.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
     # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04
@@ -569,6 +660,9 @@ jobs:
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
           IS_MANUAL_BACKFILL: ${{ github.event_name == 'workflow_dispatch' && '1' || '0' }}
+          DEFAULT_ALIASES: ${{ needs.resolve_release_policy.outputs.default_aliases }}
+          SLIM_ALIASES: ${{ needs.resolve_release_policy.outputs.slim_aliases }}
+          BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}
         run: |
           set -euo pipefail
           tags=()
@@ -591,16 +685,25 @@ jobs:
               browser_tags+=("${GHCR_IMAGE}:${version}-browser")
               dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${version}-browser")
             fi
-            # Beta releases and manual backfills publish only immutable version tags;
-            # do not advance latest/main aliases from those flows.
-            if [[ "${IS_MANUAL_BACKFILL}" != "1" && "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$ ]]; then
-              tags+=("${GHCR_IMAGE}:latest" "${GHCR_IMAGE}:main")
-              slim_tags+=("${GHCR_IMAGE}:slim" "${GHCR_IMAGE}:main-slim")
-              dockerhub_tags+=("${DOCKERHUB_IMAGE}:latest" "${DOCKERHUB_IMAGE}:main")
-              dockerhub_slim_tags+=("${DOCKERHUB_IMAGE}:slim" "${DOCKERHUB_IMAGE}:main-slim")
+            # Manual backfills publish immutable tags only. Tag pushes advance
+            # only the moving aliases assigned by the release-version policy.
+            if [[ "${IS_MANUAL_BACKFILL}" != "1" ]]; then
+              read -r -a default_aliases <<< "${DEFAULT_ALIASES}"
+              read -r -a slim_aliases <<< "${SLIM_ALIASES}"
+              read -r -a browser_aliases <<< "${BROWSER_ALIASES}"
+              for alias in "${default_aliases[@]}"; do
+                tags+=("${GHCR_IMAGE}:${alias}")
+                dockerhub_tags+=("${DOCKERHUB_IMAGE}:${alias}")
+              done
+              for alias in "${slim_aliases[@]}"; do
+                slim_tags+=("${GHCR_IMAGE}:${alias}")
+                dockerhub_slim_tags+=("${DOCKERHUB_IMAGE}:${alias}")
+              done
               if [[ "${browser_supported}" == "1" ]]; then
-                browser_tags+=("${GHCR_IMAGE}:latest-browser" "${GHCR_IMAGE}:main-browser")
-                dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:latest-browser" "${DOCKERHUB_IMAGE}:main-browser")
+                for alias in "${browser_aliases[@]}"; do
+                  browser_tags+=("${GHCR_IMAGE}:${alias}")
+                  dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${alias}")
+                done
               fi
             fi
           fi
@@ -670,8 +773,129 @@ jobs:
               "${dockerhub_browser_tags[@]}"
           fi
 
+  promote-channel-aliases:
+    needs: [approve_manual_backfill, resolve_release_policy, validate_publish_config]
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.operation == 'promote-channel' && needs.approve_manual_backfill.result == 'success' && needs.resolve_release_policy.result == 'success' && needs.validate_publish_config.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout selected tag
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - *buildkit_prepull_step
+      - name: Set up Docker Builder
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Promote and verify channel aliases
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve_release_policy.outputs.version }}
+          RELEASE_CHANNEL: ${{ needs.resolve_release_policy.outputs.channel }}
+          DEFAULT_ALIASES: ${{ needs.resolve_release_policy.outputs.default_aliases }}
+          SLIM_ALIASES: ${{ needs.resolve_release_policy.outputs.slim_aliases }}
+          BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+
+          manifest_digest() {
+            local ref="$1"
+            docker buildx imagetools inspect "${ref}" --format '{{json .Manifest}}' |
+              jq -er '.digest | select(startswith("sha256:"))'
+          }
+
+          require_group_source() {
+            local image="$1"
+            local suffix="$2"
+            local aliases_text="$3"
+            if [[ -n "${aliases_text}" ]]; then
+              manifest_digest "${image}:${VERSION}${suffix}" >/dev/null
+            fi
+          }
+
+          promote_group() {
+            local image="$1"
+            local suffix="$2"
+            local aliases_text="$3"
+            if [[ -z "${aliases_text}" ]]; then
+              return
+            fi
+            local source_ref="${image}:${VERSION}${suffix}"
+            local source_digest
+            source_digest="$(manifest_digest "${source_ref}")"
+            local aliases=()
+            local create_args=()
+            read -r -a aliases <<< "${aliases_text}"
+            for alias in "${aliases[@]}"; do
+              create_args+=(--tag "${image}:${alias}")
+            done
+            docker buildx imagetools create --prefer-index=false \
+              "${create_args[@]}" "${image}@${source_digest}"
+            for alias in "${aliases[@]}"; do
+              local target_ref="${image}:${alias}"
+              local target_digest
+              target_digest="$(manifest_digest "${target_ref}")"
+              if [[ "${target_digest}" != "${source_digest}" ]]; then
+                echo "::error::${target_ref} resolved to ${target_digest}, expected ${source_digest}."
+                exit 1
+              fi
+              echo "Verified ${target_ref} -> ${source_digest}."
+            done
+          }
+
+          browser_supported=0
+          if grep -q '^ARG OPENCLAW_INSTALL_BROWSER' Dockerfile; then
+            browser_supported=1
+          fi
+
+          # Resolve every immutable source before moving any alias so missing
+          # release images fail without leaving a partially promoted channel.
+          for image in "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"; do
+            require_group_source "${image}" "" "${DEFAULT_ALIASES}"
+            require_group_source "${image}" "-slim" "${SLIM_ALIASES}"
+            if [[ "${browser_supported}" == "1" ]]; then
+              require_group_source "${image}" "-browser" "${BROWSER_ALIASES}"
+            fi
+          done
+
+          for image in "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"; do
+            promote_group "${image}" "" "${DEFAULT_ALIASES}"
+            promote_group "${image}" "-slim" "${SLIM_ALIASES}"
+            if [[ "${browser_supported}" == "1" ]]; then
+              promote_group "${image}" "-browser" "${BROWSER_ALIASES}"
+            fi
+          done
+
+          {
+            echo "## Docker channel promotion"
+            echo "- Version: ${VERSION}"
+            echo "- Channel: ${RELEASE_CHANNEL}"
+            echo "- Registries: ${GHCR_IMAGE}, ${DOCKERHUB_IMAGE}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   verify-attestations:
-    needs: [create-manifest]
+    needs: [resolve_release_policy, resolve_build_provenance, create-manifest]
     if: ${{ always() && needs.create-manifest.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
@@ -727,6 +951,9 @@ jobs:
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
           IS_MANUAL_BACKFILL: ${{ github.event_name == 'workflow_dispatch' && '1' || '0' }}
+          DEFAULT_ALIASES: ${{ needs.resolve_release_policy.outputs.default_aliases }}
+          SLIM_ALIASES: ${{ needs.resolve_release_policy.outputs.slim_aliases }}
+          BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}
         run: |
           set -euo pipefail
           multi_refs=()
@@ -777,16 +1004,25 @@ jobs:
               arm64_refs+=("${GHCR_IMAGE}:${version}-browser-arm64")
               dockerhub_arm64_refs+=("${DOCKERHUB_IMAGE}:${version}-browser-arm64")
             fi
-            # Beta releases and manual backfills publish only immutable version tags;
-            # do not advance latest/main aliases from those flows.
-            if [[ "${IS_MANUAL_BACKFILL}" != "1" && "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$ ]]; then
-              multi_refs+=("${GHCR_IMAGE}:latest" "${GHCR_IMAGE}:main")
-              slim_multi_refs+=("${GHCR_IMAGE}:slim" "${GHCR_IMAGE}:main-slim")
-              dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:latest" "${DOCKERHUB_IMAGE}:main")
-              dockerhub_slim_multi_refs+=("${DOCKERHUB_IMAGE}:slim" "${DOCKERHUB_IMAGE}:main-slim")
+            # Manual backfills verify immutable tags only. Tag pushes also
+            # verify the moving aliases selected by the release policy.
+            if [[ "${IS_MANUAL_BACKFILL}" != "1" ]]; then
+              read -r -a default_aliases <<< "${DEFAULT_ALIASES}"
+              read -r -a slim_aliases <<< "${SLIM_ALIASES}"
+              read -r -a browser_aliases <<< "${BROWSER_ALIASES}"
+              for alias in "${default_aliases[@]}"; do
+                multi_refs+=("${GHCR_IMAGE}:${alias}")
+                dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${alias}")
+              done
+              for alias in "${slim_aliases[@]}"; do
+                slim_multi_refs+=("${GHCR_IMAGE}:${alias}")
+                dockerhub_slim_multi_refs+=("${DOCKERHUB_IMAGE}:${alias}")
+              done
               if [[ "${browser_supported}" == "1" ]]; then
-                multi_refs+=("${GHCR_IMAGE}:latest-browser" "${GHCR_IMAGE}:main-browser")
-                dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:latest-browser" "${DOCKERHUB_IMAGE}:main-browser")
+                for alias in "${browser_aliases[@]}"; do
+                  multi_refs+=("${GHCR_IMAGE}:${alias}")
+                  dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${alias}")
+                done
               fi
             fi
           fi

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -66,9 +66,6 @@ jobs:
     outputs:
       version: ${{ steps.policy.outputs.version }}
       channel: ${{ steps.policy.outputs.channel }}
-      default_aliases: ${{ steps.policy.outputs.default_aliases }}
-      slim_aliases: ${{ steps.policy.outputs.slim_aliases }}
-      browser_aliases: ${{ steps.policy.outputs.browser_aliases }}
     steps:
       - name: Checkout trusted workflow helpers
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -91,23 +88,14 @@ jobs:
           version="${SOURCE_REF#refs/tags/v}"
           policy="$(node workflow-source/scripts/lib/docker-release-policy.mjs "${version}")"
           channel="$(jq -r '.channel' <<< "${policy}")"
-          default_aliases="$(jq -r '.movingAliases.default | join(" ")' <<< "${policy}")"
-          slim_aliases="$(jq -r '.movingAliases.slim | join(" ")' <<< "${policy}")"
-          browser_aliases="$(jq -r '.movingAliases.browser | join(" ")' <<< "${policy}")"
           {
             echo "version=${version}"
             echo "channel=${channel}"
-            echo "default_aliases=${default_aliases}"
-            echo "slim_aliases=${slim_aliases}"
-            echo "browser_aliases=${browser_aliases}"
           } >> "$GITHUB_OUTPUT"
           {
             echo "## Docker release policy"
             echo "- Version: ${version}"
             echo "- Channel: ${channel}"
-            echo "- Default aliases: ${default_aliases:-none}"
-            echo "- Slim aliases: ${slim_aliases:-none}"
-            echo "- Browser aliases: ${browser_aliases:-none}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   approve_manual_backfill:
@@ -656,10 +644,6 @@ jobs:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
-          IS_MANUAL_BACKFILL: ${{ github.event_name == 'workflow_dispatch' && '1' || '0' }}
-          DEFAULT_ALIASES: ${{ needs.resolve_release_policy.outputs.default_aliases }}
-          SLIM_ALIASES: ${{ needs.resolve_release_policy.outputs.slim_aliases }}
-          BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}
         run: |
           set -euo pipefail
           tags=()
@@ -681,27 +665,6 @@ jobs:
             if [[ "${browser_supported}" == "1" ]]; then
               browser_tags+=("${GHCR_IMAGE}:${version}-browser")
               dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${version}-browser")
-            fi
-            # Manual backfills publish immutable tags only. Tag pushes advance
-            # only the moving aliases assigned by the release-version policy.
-            if [[ "${IS_MANUAL_BACKFILL}" != "1" ]]; then
-              read -r -a default_aliases <<< "${DEFAULT_ALIASES}"
-              read -r -a slim_aliases <<< "${SLIM_ALIASES}"
-              read -r -a browser_aliases <<< "${BROWSER_ALIASES}"
-              for alias in "${default_aliases[@]}"; do
-                tags+=("${GHCR_IMAGE}:${alias}")
-                dockerhub_tags+=("${DOCKERHUB_IMAGE}:${alias}")
-              done
-              for alias in "${slim_aliases[@]}"; do
-                slim_tags+=("${GHCR_IMAGE}:${alias}")
-                dockerhub_slim_tags+=("${DOCKERHUB_IMAGE}:${alias}")
-              done
-              if [[ "${browser_supported}" == "1" ]]; then
-                for alias in "${browser_aliases[@]}"; do
-                  browser_tags+=("${GHCR_IMAGE}:${alias}")
-                  dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${alias}")
-                done
-              fi
             fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
@@ -771,12 +734,13 @@ jobs:
           fi
 
   verify-attestations:
+    name: Verify attestations and promote channel
     needs: [resolve_release_policy, resolve_build_provenance, create-manifest]
     if: ${{ always() && needs.create-manifest.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      packages: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -826,10 +790,6 @@ jobs:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
-          IS_MANUAL_BACKFILL: ${{ github.event_name == 'workflow_dispatch' && '1' || '0' }}
-          DEFAULT_ALIASES: ${{ needs.resolve_release_policy.outputs.default_aliases }}
-          SLIM_ALIASES: ${{ needs.resolve_release_policy.outputs.slim_aliases }}
-          BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}
         run: |
           set -euo pipefail
           multi_refs=()
@@ -879,27 +839,6 @@ jobs:
               dockerhub_amd64_refs+=("${DOCKERHUB_IMAGE}:${version}-browser-amd64")
               arm64_refs+=("${GHCR_IMAGE}:${version}-browser-arm64")
               dockerhub_arm64_refs+=("${DOCKERHUB_IMAGE}:${version}-browser-arm64")
-            fi
-            # Manual backfills verify immutable tags only. Tag pushes also
-            # verify the moving aliases selected by the release policy.
-            if [[ "${IS_MANUAL_BACKFILL}" != "1" ]]; then
-              read -r -a default_aliases <<< "${DEFAULT_ALIASES}"
-              read -r -a slim_aliases <<< "${SLIM_ALIASES}"
-              read -r -a browser_aliases <<< "${BROWSER_ALIASES}"
-              for alias in "${default_aliases[@]}"; do
-                multi_refs+=("${GHCR_IMAGE}:${alias}")
-                dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${alias}")
-              done
-              for alias in "${slim_aliases[@]}"; do
-                slim_multi_refs+=("${GHCR_IMAGE}:${alias}")
-                dockerhub_slim_multi_refs+=("${DOCKERHUB_IMAGE}:${alias}")
-              done
-              if [[ "${browser_supported}" == "1" ]]; then
-                for alias in "${browser_aliases[@]}"; do
-                  multi_refs+=("${GHCR_IMAGE}:${alias}")
-                  dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${alias}")
-                done
-              fi
             fi
           fi
           if [[ ${#multi_refs[@]} -eq 0 || ${#amd64_refs[@]} -eq 0 || ${#arm64_refs[@]} -eq 0 || ${#dockerhub_multi_refs[@]} -eq 0 || ${#dockerhub_amd64_refs[@]} -eq 0 || ${#dockerhub_arm64_refs[@]} -eq 0 ]]; then
@@ -965,3 +904,15 @@ jobs:
           node scripts/verify-docker-attestations.mjs \
             --platform linux/arm64 \
             "${dockerhub_arm64_refs[@]}"
+
+      - name: Promote and verify channel aliases
+        if: ${{ github.event_name != 'workflow_dispatch' && needs.resolve_release_policy.outputs.channel != 'beta' }}
+        env:
+          VERSION: ${{ needs.resolve_release_policy.outputs.version }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+        run: |
+          node scripts/docker-channel-promote.mjs \
+            --version "${VERSION}" \
+            --image "${GHCR_IMAGE}" \
+            --image "${DOCKERHUB_IMAGE}"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -17,17 +17,9 @@ on:
         description: Existing stable, extended-stable, or beta release tag
         required: true
         type: string
-      operation:
-        description: Build immutable images, or promote an existing immutable version to its moving channel aliases
-        required: true
-        type: choice
-        default: backfill
-        options:
-          - backfill
-          - promote-channel
 
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && inputs.operation == 'backfill' && format('docker-release-manual-{0}', inputs.tag) || 'docker-release-publish' }}
+  group: ${{ github.event_name == 'workflow_dispatch' && format('docker-release-manual-{0}', inputs.tag) || 'docker-release-publish' }}
   cancel-in-progress: false
 
 env:
@@ -89,25 +81,15 @@ jobs:
         shell: bash
         env:
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
-          RELEASE_OPERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.operation || 'release' }}
-          WORKFLOW_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
           if [[ "${SOURCE_REF}" != refs/tags/v* ]]; then
             echo "::error::Docker releases require a v-prefixed release tag; got ${SOURCE_REF}."
             exit 1
           fi
-          if [[ "${RELEASE_OPERATION}" == "promote-channel" && "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
-            echo "::error::Docker channel promotion must be dispatched from main; got ${WORKFLOW_REF}."
-            exit 1
-          fi
           version="${SOURCE_REF#refs/tags/v}"
           policy="$(node workflow-source/scripts/lib/docker-release-policy.mjs "${version}")"
           channel="$(jq -r '.channel' <<< "${policy}")"
-          if [[ "${RELEASE_OPERATION}" == "promote-channel" && "${channel}" == "beta" ]]; then
-            echo "::error::Beta releases have no moving Docker channel aliases to promote."
-            exit 1
-          fi
           default_aliases="$(jq -r '.movingAliases.default | join(" ")' <<< "${policy}")"
           slim_aliases="$(jq -r '.movingAliases.slim | join(" ")' <<< "${policy}")"
           browser_aliases="$(jq -r '.movingAliases.browser | join(" ")' <<< "${policy}")"
@@ -121,7 +103,6 @@ jobs:
           {
             echo "## Docker release policy"
             echo "- Version: ${version}"
-            echo "- Operation: ${RELEASE_OPERATION}"
             echo "- Channel: ${channel}"
             echo "- Default aliases: ${default_aliases:-none}"
             echo "- Slim aliases: ${slim_aliases:-none}"
@@ -129,7 +110,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   approve_manual_backfill:
-    name: Approve Docker ${{ inputs.operation }} ${{ inputs.tag }} → ${{ needs.resolve_release_policy.outputs.channel }} (${{ needs.resolve_release_policy.outputs.default_aliases }})
+    name: Approve Docker backfill ${{ inputs.tag }}
     if: github.event_name == 'workflow_dispatch'
     needs: [validate_manual_backfill, resolve_release_policy]
     # WARNING: KEEP MANUAL BACKFILLS GATED BY THE docker-release ENVIRONMENT.
@@ -137,18 +118,11 @@ jobs:
     environment: docker-release
     permissions: {}
     steps:
-      - name: Approve Docker operation
+      - name: Approve Docker backfill
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-          RELEASE_OPERATION: ${{ inputs.operation }}
-          DEFAULT_ALIASES: ${{ needs.resolve_release_policy.outputs.default_aliases }}
-          SLIM_ALIASES: ${{ needs.resolve_release_policy.outputs.slim_aliases }}
-          BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}
         run: |
-          echo "Approved Docker ${RELEASE_OPERATION} for ${RELEASE_TAG}"
-          echo "Default aliases: ${DEFAULT_ALIASES:-none}"
-          echo "Slim aliases: ${SLIM_ALIASES:-none}"
-          echo "Browser aliases: ${BROWSER_ALIASES:-none}"
+          echo "Approved immutable Docker image backfill for ${RELEASE_TAG}"
 
   validate_publish_config:
     runs-on: ubuntu-24.04
@@ -170,7 +144,7 @@ jobs:
 
   resolve_build_provenance:
     needs: [approve_manual_backfill, resolve_release_policy, validate_publish_config]
-    if: ${{ always() && needs.resolve_release_policy.result == 'success' && needs.validate_publish_config.result == 'success' && (github.event_name != 'workflow_dispatch' || (needs.approve_manual_backfill.result == 'success' && inputs.operation == 'backfill')) }}
+    if: ${{ always() && needs.resolve_release_policy.result == 'success' && needs.validate_publish_config.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -794,110 +768,6 @@ jobs:
               "${DOCKERHUB_IMAGE}:${version}-browser-arm64" \
               "${dockerhub_browser_tags[@]}"
           fi
-
-  promote-channel-aliases:
-    needs: [approve_manual_backfill, resolve_release_policy, validate_publish_config]
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.operation == 'promote-channel' && needs.approve_manual_backfill.result == 'success' && needs.resolve_release_policy.result == 'success' && needs.validate_publish_config.result == 'success' }}
-    runs-on: ubuntu-24.04
-    permissions:
-      packages: write
-    steps:
-      - *buildkit_prepull_step
-      - name: Set up Docker Builder
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
-        with:
-          registry: ${{ env.DOCKERHUB_REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Promote and verify channel aliases
-        shell: bash
-        env:
-          VERSION: ${{ needs.resolve_release_policy.outputs.version }}
-          RELEASE_CHANNEL: ${{ needs.resolve_release_policy.outputs.channel }}
-          DEFAULT_ALIASES: ${{ needs.resolve_release_policy.outputs.default_aliases }}
-          SLIM_ALIASES: ${{ needs.resolve_release_policy.outputs.slim_aliases }}
-          BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}
-          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
-        run: |
-          set -euo pipefail
-
-          manifest_digest() {
-            local ref="$1"
-            docker buildx imagetools inspect "${ref}" --format '{{json .Manifest}}' |
-              jq -er '.digest | select(startswith("sha256:"))'
-          }
-
-          require_group_source() {
-            local image="$1"
-            local suffix="$2"
-            local aliases_text="$3"
-            if [[ -n "${aliases_text}" ]]; then
-              manifest_digest "${image}:${VERSION}${suffix}" >/dev/null
-            fi
-          }
-
-          promote_group() {
-            local image="$1"
-            local suffix="$2"
-            local aliases_text="$3"
-            if [[ -z "${aliases_text}" ]]; then
-              return
-            fi
-            local source_ref="${image}:${VERSION}${suffix}"
-            local source_digest
-            source_digest="$(manifest_digest "${source_ref}")"
-            local aliases=()
-            local create_args=()
-            read -r -a aliases <<< "${aliases_text}"
-            for alias in "${aliases[@]}"; do
-              create_args+=(--tag "${image}:${alias}")
-            done
-            docker buildx imagetools create --prefer-index=false \
-              "${create_args[@]}" "${image}@${source_digest}"
-            for alias in "${aliases[@]}"; do
-              local target_ref="${image}:${alias}"
-              local target_digest
-              target_digest="$(manifest_digest "${target_ref}")"
-              if [[ "${target_digest}" != "${source_digest}" ]]; then
-                echo "::error::${target_ref} resolved to ${target_digest}, expected ${source_digest}."
-                exit 1
-              fi
-              echo "Verified ${target_ref} -> ${source_digest}."
-            done
-          }
-
-          # Resolve every immutable source before moving any alias so missing
-          # release images fail without leaving a partially promoted channel.
-          for image in "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"; do
-            require_group_source "${image}" "" "${DEFAULT_ALIASES}"
-            require_group_source "${image}" "-slim" "${SLIM_ALIASES}"
-            require_group_source "${image}" "-browser" "${BROWSER_ALIASES}"
-          done
-
-          for image in "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"; do
-            promote_group "${image}" "" "${DEFAULT_ALIASES}"
-            promote_group "${image}" "-slim" "${SLIM_ALIASES}"
-            promote_group "${image}" "-browser" "${BROWSER_ALIASES}"
-          done
-
-          {
-            echo "## Docker channel promotion"
-            echo "- Version: ${VERSION}"
-            echo "- Channel: ${RELEASE_CHANNEL}"
-            echo "- Registries: ${GHCR_IMAGE}, ${DOCKERHUB_IMAGE}"
-          } >> "$GITHUB_STEP_SUMMARY"
 
   verify-attestations:
     needs: [resolve_release_policy, resolve_build_provenance, create-manifest]

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -118,8 +118,18 @@ jobs:
             echo "slim_aliases=${slim_aliases}"
             echo "browser_aliases=${browser_aliases}"
           } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Docker release policy"
+            echo "- Version: ${version}"
+            echo "- Operation: ${RELEASE_OPERATION}"
+            echo "- Channel: ${channel}"
+            echo "- Default aliases: ${default_aliases:-none}"
+            echo "- Slim aliases: ${slim_aliases:-none}"
+            echo "- Browser aliases: ${browser_aliases:-none}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   approve_manual_backfill:
+    name: Approve Docker ${{ inputs.operation }} ${{ inputs.tag }} → ${{ needs.resolve_release_policy.outputs.channel }} (${{ needs.resolve_release_policy.outputs.default_aliases }})
     if: github.event_name == 'workflow_dispatch'
     needs: [validate_manual_backfill, resolve_release_policy]
     # WARNING: KEEP MANUAL BACKFILLS GATED BY THE docker-release ENVIRONMENT.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -57,6 +57,10 @@ Docker is **optional**. Use it only if you want a containerized gateway or to va
     `<version>` (e.g. `2026.2.26`), and beta versions such as
     `2026.2.26-beta.1`. Beta tags do not move `latest` or `main`.
 
+    Extended-stable releases use dedicated aliases: `extended-stable`,
+    `extended-stable-slim`, and `extended-stable-browser`. They never advance
+    the regular `latest`, `main`, or browser aliases.
+
   </Step>
 
   <Step title="Airgapped rerun">

--- a/scripts/docker-channel-promote.d.mts
+++ b/scripts/docker-channel-promote.d.mts
@@ -12,12 +12,6 @@ export type DockerChannelPromotionPlan = {
   version: string;
 };
 
-export type DockerChannelPromotionArgs = {
-  help: boolean;
-  images: string[];
-  version?: string;
-};
-
 export function createDockerChannelPromotionPlan(params: {
   version: string;
   images: string[];
@@ -30,5 +24,3 @@ export function promoteDockerChannel(
     log?: (message: string) => void;
   },
 ): DockerChannelPromotionPlan;
-
-export function parseDockerChannelPromotionArgs(argv: string[]): DockerChannelPromotionArgs;

--- a/scripts/docker-channel-promote.d.mts
+++ b/scripts/docker-channel-promote.d.mts
@@ -20,7 +20,18 @@ export function createDockerChannelPromotionPlan(params: {
 export function promoteDockerChannel(
   params: { version: string; images: string[] },
   options?: {
+    allowRollback?: boolean;
     execFileSyncImpl?: (command: string, args: string[], options: object) => string;
     log?: (message: string) => void;
+    verifyAttestationsImpl?: (params: {
+      imageRefs: string[];
+      requiredPlatforms: Array<{
+        architecture: string;
+        os: string;
+        variant?: string;
+      }>;
+      execFileSyncImpl: (command: string, args: string[], options: object) => string;
+      log: (message: string) => void;
+    }) => void;
   },
 ): DockerChannelPromotionPlan;

--- a/scripts/docker-channel-promote.d.mts
+++ b/scripts/docker-channel-promote.d.mts
@@ -1,0 +1,34 @@
+import type { DockerReleaseChannel } from "./lib/docker-release-policy.mjs";
+
+export type DockerChannelPromotion = {
+  image: string;
+  sourceRef: string;
+  targetRefs: string[];
+};
+
+export type DockerChannelPromotionPlan = {
+  channel: DockerReleaseChannel;
+  promotions: DockerChannelPromotion[];
+  version: string;
+};
+
+export type DockerChannelPromotionArgs = {
+  help: boolean;
+  images: string[];
+  version?: string;
+};
+
+export function createDockerChannelPromotionPlan(params: {
+  version: string;
+  images: string[];
+}): DockerChannelPromotionPlan;
+
+export function promoteDockerChannel(
+  params: { version: string; images: string[] },
+  options?: {
+    execFileSyncImpl?: (command: string, args: string[], options: object) => string;
+    log?: (message: string) => void;
+  },
+): DockerChannelPromotionPlan;
+
+export function parseDockerChannelPromotionArgs(argv: string[]): DockerChannelPromotionArgs;

--- a/scripts/docker-channel-promote.mjs
+++ b/scripts/docker-channel-promote.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
+import { resolveDockerReleasePolicy } from "./lib/docker-release-policy.mjs";
+
+const DOCKER_TIMEOUT_MS = 120_000;
+const VARIANTS = Object.freeze([
+  { aliasKey: "default", suffix: "" },
+  { aliasKey: "slim", suffix: "-slim" },
+  { aliasKey: "browser", suffix: "-browser" },
+]);
+
+/** Build the immutable-source to moving-alias promotion plan. */
+export function createDockerChannelPromotionPlan({ version, images }) {
+  if (images.length === 0) {
+    throw new Error("At least one --image is required.");
+  }
+  const policy = resolveDockerReleasePolicy(version);
+  const promotions = [];
+  for (const image of images) {
+    for (const { aliasKey, suffix } of VARIANTS) {
+      const aliases = policy.movingAliases[aliasKey];
+      if (aliases.length === 0) {
+        continue;
+      }
+      promotions.push({
+        image,
+        sourceRef: `${image}:${version}${suffix}`,
+        targetRefs: aliases.map((alias) => `${image}:${alias}`),
+      });
+    }
+  }
+  if (promotions.length === 0) {
+    throw new Error(`Docker ${policy.channel} releases have no moving aliases to promote.`);
+  }
+  return { channel: policy.channel, promotions, version: policy.version };
+}
+
+function runDocker(args, execFileSyncImpl) {
+  return execFileSyncImpl("docker", args, {
+    encoding: "utf8",
+    killSignal: "SIGKILL",
+    maxBuffer: 20 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: DOCKER_TIMEOUT_MS,
+  });
+}
+
+function inspectManifestDigest(imageRef, execFileSyncImpl) {
+  const raw = runDocker(
+    ["buildx", "imagetools", "inspect", imageRef, "--format", "{{json .Manifest}}"],
+    execFileSyncImpl,
+  );
+  let digest;
+  try {
+    digest = JSON.parse(raw).digest;
+  } catch (error) {
+    throw new Error(`Could not parse the manifest for ${imageRef}.`, { cause: error });
+  }
+  if (typeof digest !== "string" || !/^sha256:[a-f0-9]{64}$/.test(digest)) {
+    throw new Error(`The manifest for ${imageRef} did not contain a valid sha256 digest.`);
+  }
+  return digest;
+}
+
+/** Promote every planned alias and verify the registry result. */
+export function promoteDockerChannel({ version, images }, options = {}) {
+  const execFileSyncImpl = options.execFileSyncImpl ?? execFileSync;
+  const log = options.log ?? console.log;
+  const plan = createDockerChannelPromotionPlan({ version, images });
+
+  // Resolve every immutable source before the first alias write. A missing
+  // release variant must not leave the channel partially promoted.
+  const resolved = plan.promotions.map((promotion) => ({
+    ...promotion,
+    sourceDigest: inspectManifestDigest(promotion.sourceRef, execFileSyncImpl),
+  }));
+
+  for (const promotion of resolved) {
+    const targetArgs = promotion.targetRefs.flatMap((targetRef) => ["--tag", targetRef]);
+    runDocker(
+      [
+        "buildx",
+        "imagetools",
+        "create",
+        "--prefer-index=false",
+        ...targetArgs,
+        `${promotion.image}@${promotion.sourceDigest}`,
+      ],
+      execFileSyncImpl,
+    );
+    for (const targetRef of promotion.targetRefs) {
+      const targetDigest = inspectManifestDigest(targetRef, execFileSyncImpl);
+      if (targetDigest !== promotion.sourceDigest) {
+        throw new Error(
+          `${targetRef} resolved to ${targetDigest}, expected ${promotion.sourceDigest}.`,
+        );
+      }
+      log(`Verified ${targetRef} -> ${promotion.sourceDigest}.`);
+    }
+  }
+  return plan;
+}
+
+export function parseDockerChannelPromotionArgs(argv) {
+  let version;
+  const images = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const option = argv[index];
+    if (option === "--help" || option === "-h") {
+      return { help: true, images, version };
+    }
+    if (option !== "--version" && option !== "--image") {
+      throw new Error(`Unknown option: ${option}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("-")) {
+      throw new Error(`${option} requires a value.`);
+    }
+    if (option === "--version") {
+      version = value;
+    } else {
+      images.push(value);
+    }
+    index += 1;
+  }
+  if (!version) {
+    throw new Error("--version is required.");
+  }
+  if (images.length === 0) {
+    throw new Error("At least one --image is required.");
+  }
+  return { help: false, images, version };
+}
+
+function printHelp() {
+  console.log(
+    "Usage: node scripts/docker-channel-promote.mjs --version YYYY.M.P --image REGISTRY/IMAGE [--image REGISTRY/IMAGE]",
+  );
+}
+
+function main() {
+  const parsed = parseDockerChannelPromotionArgs(process.argv.slice(2));
+  if (parsed.help) {
+    printHelp();
+    return;
+  }
+  const plan = promoteDockerChannel(parsed);
+  console.log(`Promoted Docker ${plan.channel} aliases for ${plan.version}.`);
+}
+
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `docker-channel-promote: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/docker-channel-promote.mjs
+++ b/scripts/docker-channel-promote.mjs
@@ -5,15 +5,21 @@ import process from "node:process";
 import { parseArgs } from "node:util";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { resolveDockerReleasePolicy } from "./lib/docker-release-policy.mjs";
+import { compareReleaseVersions } from "./lib/release-version.mjs";
+import { parsePlatform, verifyDockerAttestations } from "./verify-docker-attestations.mjs";
 
 const DOCKER_TIMEOUT_MS = 120_000;
+const REQUIRED_PLATFORMS = Object.freeze([
+  parsePlatform("linux/amd64"),
+  parsePlatform("linux/arm64"),
+]);
 const VARIANTS = Object.freeze([
   { aliasKey: "default", suffix: "" },
   { aliasKey: "slim", suffix: "-slim" },
   { aliasKey: "browser", suffix: "-browser" },
 ]);
 
-/** Build the immutable-source to moving-alias promotion plan. */
+/** Build the version-specific source to moving-alias promotion plan. */
 export function createDockerChannelPromotionPlan({ version, images }) {
   if (images.length === 0) {
     throw new Error("At least one --image is required.");
@@ -66,18 +72,147 @@ function inspectManifestDigest(imageRef, execFileSyncImpl) {
   return digest;
 }
 
+function formatCommandError(error) {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+  const output = [error.message];
+  for (const field of ["stderr", "stdout"]) {
+    const value = error[field];
+    if (typeof value === "string") {
+      output.push(value);
+    } else if (Buffer.isBuffer(value)) {
+      output.push(value.toString("utf8"));
+    }
+  }
+  return output.join("\n");
+}
+
+function isMissingManifestError(error) {
+  const message = formatCommandError(error);
+  return /(?:manifest unknown|no such manifest|:\s*not found(?:\s|$))/i.test(message);
+}
+
+function formatPlatform(platform) {
+  const suffix = platform.variant ? `/${platform.variant}` : "";
+  return `${platform.os}/${platform.architecture}${suffix}`;
+}
+
+function inspectImageVersion(imageRef, execFileSyncImpl, { allowMissing = false } = {}) {
+  const versions = new Map();
+  for (const [index, platform] of REQUIRED_PLATFORMS.entries()) {
+    const platformName = formatPlatform(platform);
+    let raw;
+    try {
+      // In formatted multi-platform inspection, Buildx keys .Image by os/arch.
+      // Read every promoted platform rather than trusting one config label.
+      raw = runDocker(
+        [
+          "buildx",
+          "imagetools",
+          "inspect",
+          imageRef,
+          "--format",
+          `{{json (index .Image "${platformName}")}}`,
+        ],
+        execFileSyncImpl,
+      );
+    } catch (error) {
+      if (allowMissing && index === 0 && isMissingManifestError(error)) {
+        return null;
+      }
+      throw error;
+    }
+
+    let version;
+    try {
+      version = JSON.parse(raw)?.config?.Labels?.["org.opencontainers.image.version"];
+    } catch (error) {
+      throw new Error(`Could not parse the ${platformName} image config for ${imageRef}.`, {
+        cause: error,
+      });
+    }
+    if (typeof version !== "string" || version.trim().length === 0) {
+      throw new Error(
+        `${imageRef} does not have an org.opencontainers.image.version label for ${platformName}.`,
+      );
+    }
+    versions.set(platformName, version.trim());
+  }
+  const uniqueVersions = new Set(versions.values());
+  if (uniqueVersions.size !== 1) {
+    const details = [...versions].map(([platform, version]) => `${platform}=${version}`).join(", ");
+    throw new Error(`${imageRef} has inconsistent platform versions: ${details}.`);
+  }
+  return uniqueVersions.values().next().value;
+}
+
+function verifySourceVersions(resolved, version, execFileSyncImpl) {
+  for (const promotion of resolved) {
+    const sourceVersion = inspectImageVersion(promotion.sourceDigestRef, execFileSyncImpl);
+    if (sourceVersion !== version) {
+      throw new Error(
+        `${promotion.sourceDigestRef} reports version ${sourceVersion}, expected ${version}.`,
+      );
+    }
+  }
+}
+
+function preventChannelRollback(resolved, version, execFileSyncImpl) {
+  for (const promotion of resolved) {
+    for (const targetRef of promotion.targetRefs) {
+      const currentVersion = inspectImageVersion(targetRef, execFileSyncImpl, {
+        allowMissing: true,
+      });
+      if (currentVersion === null) {
+        continue;
+      }
+      const comparison = compareReleaseVersions(version, currentVersion);
+      if (comparison === null) {
+        throw new Error(
+          `Cannot compare candidate version ${version} with ${targetRef} version ${currentVersion}.`,
+        );
+      }
+      if (comparison < 0) {
+        throw new Error(
+          `Refusing to move ${targetRef} backward from ${currentVersion} to ${version}. ` +
+            "An approved repair may rerun with --allow-rollback.",
+        );
+      }
+    }
+  }
+}
+
 /** Promote every planned alias and verify the registry result. */
 export function promoteDockerChannel({ version, images }, options = {}) {
   const execFileSyncImpl = options.execFileSyncImpl ?? execFileSync;
   const log = options.log ?? console.log;
+  const verifyAttestationsImpl = options.verifyAttestationsImpl ?? verifyDockerAttestations;
   const plan = createDockerChannelPromotionPlan({ version, images });
 
-  // Resolve every immutable source before the first alias write. A missing
+  // Resolve every version-specific source before the first alias write. A missing
   // release variant must not leave the channel partially promoted.
-  const resolved = plan.promotions.map((promotion) => ({
-    ...promotion,
-    sourceDigest: inspectManifestDigest(promotion.sourceRef, execFileSyncImpl),
-  }));
+  const resolved = plan.promotions.map((promotion) => {
+    const sourceDigest = inspectManifestDigest(promotion.sourceRef, execFileSyncImpl);
+    return {
+      ...promotion,
+      sourceDigest,
+      sourceDigestRef: `${promotion.image}@${sourceDigest}`,
+    };
+  });
+
+  // Attestation checks and writes share these digest refs so a concurrent tag
+  // rewrite cannot swap the content between verification and promotion.
+  verifyAttestationsImpl({
+    imageRefs: resolved.map((promotion) => promotion.sourceDigestRef),
+    requiredPlatforms: REQUIRED_PLATFORMS,
+    execFileSyncImpl,
+    log,
+  });
+  verifySourceVersions(resolved, plan.version, execFileSyncImpl);
+  if (!options.allowRollback) {
+    preventChannelRollback(resolved, plan.version, execFileSyncImpl);
+  }
 
   for (const promotion of resolved) {
     const targetArgs = promotion.targetRefs.flatMap((targetRef) => ["--tag", targetRef]);
@@ -88,7 +223,7 @@ export function promoteDockerChannel({ version, images }, options = {}) {
         "create",
         "--prefer-index=false",
         ...targetArgs,
-        `${promotion.image}@${promotion.sourceDigest}`,
+        promotion.sourceDigestRef,
       ],
       execFileSyncImpl,
     );
@@ -107,7 +242,7 @@ export function promoteDockerChannel({ version, images }, options = {}) {
 
 function printHelp() {
   console.log(
-    "Usage: node scripts/docker-channel-promote.mjs --version YYYY.M.P --image REGISTRY/IMAGE [--image REGISTRY/IMAGE]",
+    "Usage: node scripts/docker-channel-promote.mjs --version YYYY.M.P --image REGISTRY/IMAGE [--image REGISTRY/IMAGE] [--allow-rollback]",
   );
 }
 
@@ -115,6 +250,7 @@ function main() {
   const { values } = parseArgs({
     args: process.argv.slice(2),
     options: {
+      "allow-rollback": { type: "boolean" },
       help: { type: "boolean", short: "h" },
       image: { type: "string", multiple: true },
       version: { type: "string" },
@@ -133,7 +269,10 @@ function main() {
   if (images.length === 0 || images.some((image) => image.length === 0)) {
     throw new Error("At least one non-empty --image is required.");
   }
-  const plan = promoteDockerChannel({ version, images });
+  const plan = promoteDockerChannel(
+    { version, images },
+    { allowRollback: values["allow-rollback"] },
+  );
   console.log(`Promoted Docker ${plan.channel} aliases for ${plan.version}.`);
 }
 

--- a/scripts/docker-channel-promote.mjs
+++ b/scripts/docker-channel-promote.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import process from "node:process";
+import { parseArgs } from "node:util";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { resolveDockerReleasePolicy } from "./lib/docker-release-policy.mjs";
 
@@ -104,37 +105,6 @@ export function promoteDockerChannel({ version, images }, options = {}) {
   return plan;
 }
 
-export function parseDockerChannelPromotionArgs(argv) {
-  let version;
-  const images = [];
-  for (let index = 0; index < argv.length; index += 1) {
-    const option = argv[index];
-    if (option === "--help" || option === "-h") {
-      return { help: true, images, version };
-    }
-    if (option !== "--version" && option !== "--image") {
-      throw new Error(`Unknown option: ${option}`);
-    }
-    const value = argv[index + 1];
-    if (!value || value.startsWith("-")) {
-      throw new Error(`${option} requires a value.`);
-    }
-    if (option === "--version") {
-      version = value;
-    } else {
-      images.push(value);
-    }
-    index += 1;
-  }
-  if (!version) {
-    throw new Error("--version is required.");
-  }
-  if (images.length === 0) {
-    throw new Error("At least one --image is required.");
-  }
-  return { help: false, images, version };
-}
-
 function printHelp() {
   console.log(
     "Usage: node scripts/docker-channel-promote.mjs --version YYYY.M.P --image REGISTRY/IMAGE [--image REGISTRY/IMAGE]",
@@ -142,12 +112,28 @@ function printHelp() {
 }
 
 function main() {
-  const parsed = parseDockerChannelPromotionArgs(process.argv.slice(2));
-  if (parsed.help) {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      help: { type: "boolean", short: "h" },
+      image: { type: "string", multiple: true },
+      version: { type: "string" },
+    },
+    strict: true,
+  });
+  if (values.help) {
     printHelp();
     return;
   }
-  const plan = promoteDockerChannel(parsed);
+  const version = values.version?.trim();
+  if (!version) {
+    throw new Error("--version is required.");
+  }
+  const images = (values.image ?? []).map((image) => image.trim());
+  if (images.length === 0 || images.some((image) => image.length === 0)) {
+    throw new Error("At least one non-empty --image is required.");
+  }
+  const plan = promoteDockerChannel({ version, images });
   console.log(`Promoted Docker ${plan.channel} aliases for ${plan.version}.`);
 }
 

--- a/scripts/docker-channel-promote.mjs
+++ b/scripts/docker-channel-promote.mjs
@@ -5,7 +5,7 @@ import process from "node:process";
 import { parseArgs } from "node:util";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { resolveDockerReleasePolicy } from "./lib/docker-release-policy.mjs";
-import { compareReleaseVersions } from "./lib/release-version.mjs";
+import { compareReleaseVersions } from "./lib/npm-publish-plan.mjs";
 import { parsePlatform, verifyDockerAttestations } from "./verify-docker-attestations.mjs";
 
 const DOCKER_TIMEOUT_MS = 120_000;

--- a/scripts/lib/docker-release-policy.d.mts
+++ b/scripts/lib/docker-release-policy.d.mts
@@ -1,0 +1,15 @@
+export type DockerReleaseChannel = "stable" | "extended-stable" | "beta";
+
+export type DockerReleaseAliases = {
+  default: readonly string[];
+  slim: readonly string[];
+  browser: readonly string[];
+};
+
+export type DockerReleasePolicy = {
+  version: string;
+  channel: DockerReleaseChannel;
+  movingAliases: DockerReleaseAliases;
+};
+
+export function resolveDockerReleasePolicy(version: string): DockerReleasePolicy;

--- a/scripts/lib/docker-release-policy.mjs
+++ b/scripts/lib/docker-release-policy.mjs
@@ -1,6 +1,5 @@
-import path from "node:path";
-import { pathToFileURL } from "node:url";
-import { parseReleaseVersion } from "./npm-publish-plan.mjs";
+import { isDirectRunUrl } from "./direct-run.mjs";
+import { classifyReleaseTrain, parseReleaseVersion } from "./npm-publish-plan.mjs";
 
 const STABLE_ALIASES = Object.freeze({
   default: Object.freeze(["latest", "main"]),
@@ -40,23 +39,24 @@ export function resolveDockerReleasePolicy(version) {
   if (parsed === null) {
     throw new Error(`Unsupported Docker release version "${version}".`);
   }
-  if (parsed.channel === "alpha") {
+  const releaseTrain = classifyReleaseTrain(parsed);
+  if (releaseTrain === "alpha") {
     throw new Error("Docker alpha image publishing is disabled.");
   }
-  if (parsed.channel === "beta") {
+  if (releaseTrain === "beta") {
     return { version: parsed.version, channel: "beta", movingAliases: NO_MOVING_ALIASES };
   }
-  if (parsed.patch >= 33) {
-    if (parsed.correctionNumber !== undefined) {
-      throw new Error(
-        `Extended-stable Docker publication requires a final YYYY.M.PATCH version; found "${version}".`,
-      );
-    }
+  if (releaseTrain === "extended-stable") {
     return {
       version: parsed.version,
       channel: "extended-stable",
       movingAliases: EXTENDED_STABLE_ALIASES,
     };
+  }
+  if (releaseTrain === "unsupported-extended-stable-correction") {
+    throw new Error(
+      `Extended-stable Docker publication requires a final YYYY.M.PATCH version; found "${version}".`,
+    );
   }
   return { version: parsed.version, channel: "stable", movingAliases: STABLE_ALIASES };
 }
@@ -69,7 +69,7 @@ function main() {
   process.stdout.write(`${JSON.stringify(resolveDockerReleasePolicy(version))}\n`);
 }
 
-if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   try {
     main();
   } catch (error) {

--- a/scripts/lib/docker-release-policy.mjs
+++ b/scripts/lib/docker-release-policy.mjs
@@ -1,0 +1,80 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseReleaseVersion } from "./npm-publish-plan.mjs";
+
+const STABLE_ALIASES = Object.freeze({
+  default: Object.freeze(["latest", "main"]),
+  slim: Object.freeze(["slim", "main-slim"]),
+  browser: Object.freeze(["latest-browser", "main-browser"]),
+});
+
+const EXTENDED_STABLE_ALIASES = Object.freeze({
+  default: Object.freeze(["extended-stable"]),
+  slim: Object.freeze(["extended-stable-slim"]),
+  browser: Object.freeze(["extended-stable-browser"]),
+});
+
+const NO_MOVING_ALIASES = Object.freeze({
+  default: Object.freeze([]),
+  slim: Object.freeze([]),
+  browser: Object.freeze([]),
+});
+
+/**
+ * @typedef {object} DockerReleasePolicy
+ * @property {string} version
+ * @property {"stable" | "extended-stable" | "beta"} channel
+ * @property {{default: readonly string[], slim: readonly string[], browser: readonly string[]}} movingAliases
+ */
+
+/**
+ * Keep Docker's moving channels aligned with the release-version contract.
+ * Patch 33+ finals belong to the trailing-month extended-stable line; they
+ * must never move the regular latest/main aliases.
+ *
+ * @param {string} version
+ * @returns {DockerReleasePolicy}
+ */
+export function resolveDockerReleasePolicy(version) {
+  const parsed = parseReleaseVersion(version);
+  if (parsed === null) {
+    throw new Error(`Unsupported Docker release version "${version}".`);
+  }
+  if (parsed.channel === "alpha") {
+    throw new Error("Docker alpha image publishing is disabled.");
+  }
+  if (parsed.channel === "beta") {
+    return { version: parsed.version, channel: "beta", movingAliases: NO_MOVING_ALIASES };
+  }
+  if (parsed.patch >= 33) {
+    if (parsed.correctionNumber !== undefined) {
+      throw new Error(
+        `Extended-stable Docker publication requires a final YYYY.M.PATCH version; found "${version}".`,
+      );
+    }
+    return {
+      version: parsed.version,
+      channel: "extended-stable",
+      movingAliases: EXTENDED_STABLE_ALIASES,
+    };
+  }
+  return { version: parsed.version, channel: "stable", movingAliases: STABLE_ALIASES };
+}
+
+function main() {
+  const version = process.argv[2]?.trim();
+  if (!version) {
+    throw new Error("Usage: node scripts/lib/docker-release-policy.mjs <version>");
+  }
+  process.stdout.write(`${JSON.stringify(resolveDockerReleasePolicy(version))}\n`);
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`docker-release-policy: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/lib/npm-publish-plan.mjs
+++ b/scripts/lib/npm-publish-plan.mjs
@@ -1,4 +1,4 @@
-// Parses OpenClaw monthly patch release versions and npm dist-tag publish plans.
+// Parses OpenClaw monthly release versions, classifies release trains, and plans npm tags.
 const STABLE_VERSION_REGEX = /^(?<year>\d{4})\.(?<month>[1-9]\d?)\.(?<patch>[1-9]\d*)$/;
 const ALPHA_VERSION_REGEX =
   /^(?<year>\d{4})\.(?<month>[1-9]\d?)\.(?<patch>[1-9]\d*)-alpha\.(?<alpha>[1-9]\d*)$/;
@@ -7,6 +7,7 @@ const BETA_VERSION_REGEX =
 const CORRECTION_VERSION_REGEX =
   /^(?<year>\d{4})\.(?<month>[1-9]\d?)\.(?<patch>[1-9]\d*)-(?<correction>[1-9]\d*)$/;
 export const JUNE_2026_PATCH_FLOOR = 5;
+const EXTENDED_STABLE_PATCH_FLOOR = 33;
 
 /**
  * @typedef {object} ParsedReleaseVersion
@@ -244,6 +245,23 @@ export function parseReleaseVersion(version) {
 }
 
 /**
+ * Classifies a parsed version once for every release publisher. Patch 33 and
+ * later final releases belong to the trailing-month extended-stable line;
+ * correction suffixes are not valid on that line.
+ */
+export function classifyReleaseTrain(parsedVersion) {
+  if (parsedVersion.channel !== "stable") {
+    return parsedVersion.channel;
+  }
+  if (parsedVersion.patch < EXTENDED_STABLE_PATCH_FLOOR) {
+    return "stable";
+  }
+  return parsedVersion.correctionNumber === undefined
+    ? "extended-stable"
+    : "unsupported-extended-stable-correction";
+}
+
+/**
  * @param {string | ParsedReleaseVersion | null} version
  * @returns {string[]}
  */
@@ -316,6 +334,7 @@ export function resolveNpmPublishPlan(version, currentBetaVersion, publishTagOve
     throw new Error(`Unsupported release version "${version}".`);
   }
 
+  const releaseTrain = classifyReleaseTrain(parsedVersion);
   const normalizedOverride = publishTagOverride?.trim();
   if (normalizedOverride && normalizedOverride !== "extended-stable") {
     throw new Error(
@@ -323,11 +342,7 @@ export function resolveNpmPublishPlan(version, currentBetaVersion, publishTagOve
     );
   }
   if (normalizedOverride === "extended-stable") {
-    if (
-      parsedVersion.channel !== "stable" ||
-      parsedVersion.correctionNumber !== undefined ||
-      parsedVersion.patch < 33
-    ) {
+    if (releaseTrain !== "extended-stable") {
       throw new Error(
         `Extended-stable npm publication requires a final YYYY.M.PATCH version with PATCH >= 33; found "${version}".`,
       );

--- a/scripts/openclaw-npm-extended-stable-release.mjs
+++ b/scripts/openclaw-npm-extended-stable-release.mjs
@@ -3,7 +3,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { appendFileSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import { parseReleaseVersion } from "./lib/npm-publish-plan.mjs";
+import { classifyReleaseTrain, parseReleaseVersion } from "./lib/npm-publish-plan.mjs";
 
 const SUPPORTED_DIST_TAGS = new Set(["alpha", "beta", "latest", "extended-stable"]);
 
@@ -38,14 +38,15 @@ export function validateNpmPublishBoundary(
   if (parsed === null) {
     throw new Error(`Unsupported release version "${packageVersion}".`);
   }
+  const releaseTrain = classifyReleaseTrain(parsed);
 
-  if (parsed.channel === "alpha") {
+  if (releaseTrain === "alpha") {
     if (npmDistTag !== "alpha") {
       throw new Error("Alpha prereleases must publish to the alpha npm dist-tag.");
     }
     return parsed;
   }
-  if (parsed.channel === "beta") {
+  if (releaseTrain === "beta") {
     if (npmDistTag !== "beta") {
       throw new Error("Beta prereleases must publish to the beta npm dist-tag.");
     }
@@ -56,12 +57,15 @@ export function validateNpmPublishBoundary(
     if (parsed.correctionNumber !== undefined) {
       throw new Error("Extended-stable npm publication does not allow correction suffixes.");
     }
-    if (!bypassExtendedStableGuard && parsed.patch < 33) {
+    if (!bypassExtendedStableGuard && releaseTrain !== "extended-stable") {
       throw new Error("Extended-stable npm publication requires release patch 33 or above.");
     }
     return parsed;
   }
-  if (parsed.patch >= 33) {
+  if (
+    releaseTrain === "extended-stable" ||
+    releaseTrain === "unsupported-extended-stable-correction"
+  ) {
     throw new Error(
       `Final or correction release patch 33 and above must publish to the extended-stable npm dist-tag; got ${npmDistTag}.`,
     );
@@ -159,7 +163,7 @@ export function validateExtendedStableNpmReleaseRequest(request) {
       `Protected main must be in a later calendar month than ${taggedVersion.year}.${taggedVersion.month}; got ${request.mainPackageVersion}.`,
     );
   }
-  if (mainVersion.patch >= 33) {
+  if (classifyReleaseTrain(mainVersion) !== "stable") {
     throw new Error("Protected main must remain on a daily patch below 33.");
   }
   return { extendedStable: true, releaseVersion, extendedStableBranch };

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -28,6 +28,7 @@ import { formatErrorMessage } from "../src/infra/errors.ts";
 import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../src/plugins/runtime-sidecar-paths.ts";
 import { readBoundedResponseText } from "./lib/bounded-response.ts";
 import { listBundledPluginPackArtifacts } from "./lib/bundled-plugin-build-entries.mjs";
+import { classifyReleaseTrain } from "./lib/npm-publish-plan.mjs";
 import { runNpmVerifyCommand } from "./lib/npm-verify-exec.ts";
 import {
   collectRuntimeDependencySpecs,
@@ -283,9 +284,13 @@ function resolveNpmProvenanceVerificationPolicy(
   const workflow = statement.predicate?.buildDefinition?.externalParameters?.workflow;
   const workflowRef = workflow?.ref;
   const expectedReleaseRef = `refs/heads/release/${parsedVersion.baseVersion}`;
+  const isExpectedExtendedStableRef =
+    classifyReleaseTrain(parsedVersion) === "extended-stable" &&
+    workflowRef === `refs/heads/extended-stable/${parsedVersion.year}.${parsedVersion.month}.33`;
   const isTrustedRef =
     workflowRef === "refs/heads/main" ||
     workflowRef === expectedReleaseRef ||
+    isExpectedExtendedStableRef ||
     (parsedVersion.channel === "alpha" &&
       /^refs\/heads\/tideclaw\/alpha\/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$/u.test(
         workflowRef ?? "",

--- a/scripts/verify-docker-attestations.mjs
+++ b/scripts/verify-docker-attestations.mjs
@@ -39,6 +39,43 @@ function formatPlatform(platform) {
     : `${platform.os}/${platform.architecture}`;
 }
 
+/** Verify required Docker attestations for every image reference. */
+export function verifyDockerAttestations(params) {
+  const {
+    imageRefs,
+    requiredPlatforms,
+    execFileSyncImpl = execFileSync,
+    log = console.log,
+  } = params;
+  const allErrors = [];
+  for (const imageRef of imageRefs) {
+    const index = parseJson(inspectRaw(imageRef, { execFileSyncImpl }), `${imageRef} index`);
+    const errors = collectDockerAttestationErrors({
+      imageRef,
+      index,
+      requiredPlatforms,
+      inspectAttestation(digest) {
+        return parseJson(
+          inspectRaw(imageRefForDigest(imageRef, digest), { execFileSyncImpl }),
+          `${imageRef} attestation ${digest}`,
+        );
+      },
+    });
+    if (errors.length === 0) {
+      log(
+        `Verified Docker attestations for ${imageRef}: ${requiredPlatforms
+          .map(formatPlatform)
+          .join(", ")}`,
+      );
+    }
+    allErrors.push(...errors);
+  }
+
+  if (allErrors.length > 0) {
+    throw new Error(allErrors.map((error) => `[docker-attestations] ${error}`).join("\n"));
+  }
+}
+
 function platformMatches(actual, expected) {
   return (
     actual?.os === expected.os &&
@@ -180,36 +217,10 @@ async function main() {
     throw new Error("At least one --platform is required.");
   }
 
-  const allErrors = [];
-  for (const imageRef of parsed.imageRefs) {
-    const index = parseJson(inspectRaw(imageRef), `${imageRef} index`);
-    const errors = collectDockerAttestationErrors({
-      imageRef,
-      index,
-      requiredPlatforms: parsed.requiredPlatforms,
-      inspectAttestation(digest) {
-        return parseJson(
-          inspectRaw(imageRefForDigest(imageRef, digest)),
-          `${imageRef} attestation ${digest}`,
-        );
-      },
-    });
-    if (errors.length === 0) {
-      console.log(
-        `Verified Docker attestations for ${imageRef}: ${parsed.requiredPlatforms
-          .map(formatPlatform)
-          .join(", ")}`,
-      );
-    }
-    allErrors.push(...errors);
-  }
-
-  if (allErrors.length > 0) {
-    for (const error of allErrors) {
-      console.error(`[docker-attestations] ${error}`);
-    }
-    process.exit(1);
-  }
+  verifyDockerAttestations({
+    imageRefs: parsed.imageRefs,
+    requiredPlatforms: parsed.requiredPlatforms,
+  });
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -9,10 +9,6 @@ import YAML from "yaml";
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
 const dockerReleaseWorkflowPath = join(repoRoot, ".github/workflows/docker-release.yml");
-const dockerChannelPromoteWorkflowPath = join(
-  repoRoot,
-  ".github/workflows/docker-channel-promote.yml",
-);
 const fullReleaseValidationWorkflowPath = join(
   repoRoot,
   ".github/workflows/full-release-validation.yml",
@@ -390,21 +386,6 @@ describe("Dockerfile", () => {
     expect(
       workflow.split("needs.resolve_release_policy.outputs.browser_aliases").length,
     ).toBeGreaterThanOrEqual(3);
-  });
-
-  it("promotes existing immutable Docker images without rebuilding them", async () => {
-    const releaseWorkflow = await readFile(dockerReleaseWorkflowPath, "utf8");
-    const promoteWorkflow = await readFile(dockerChannelPromoteWorkflowPath, "utf8");
-
-    expect(releaseWorkflow).not.toContain("promote-channel");
-    expect(releaseWorkflow).toContain("queue: max");
-    expect(promoteWorkflow).toContain("Docker channel promotion must be dispatched from main");
-    expect(promoteWorkflow).toContain("group: docker-release-publish");
-    expect(promoteWorkflow).toContain("queue: max");
-    expect(promoteWorkflow).toContain("environment: docker-release");
-    expect(promoteWorkflow).toContain("node scripts/docker-channel-promote.mjs");
-    expect(promoteWorkflow).toContain('--image "${GHCR_IMAGE}"');
-    expect(promoteWorkflow).toContain('--image "${DOCKERHUB_IMAGE}"');
   });
 
   it("smokes runtime workspace templates before Docker release manifests publish", async () => {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -377,9 +377,9 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-slim");
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-browser");
     expect(workflow).toContain("node workflow-source/scripts/lib/docker-release-policy.mjs");
-    expect(workflow.split("needs.resolve_release_policy.outputs.default_aliases")).toHaveLength(4);
-    expect(workflow.split("needs.resolve_release_policy.outputs.slim_aliases")).toHaveLength(4);
-    expect(workflow.split("needs.resolve_release_policy.outputs.browser_aliases")).toHaveLength(4);
+    expect(workflow.split("needs.resolve_release_policy.outputs.default_aliases")).toHaveLength(5);
+    expect(workflow.split("needs.resolve_release_policy.outputs.slim_aliases")).toHaveLength(5);
+    expect(workflow.split("needs.resolve_release_policy.outputs.browser_aliases")).toHaveLength(5);
   });
 
   it("promotes existing immutable Docker images without rebuilding them", async () => {
@@ -387,10 +387,13 @@ describe("Dockerfile", () => {
 
     expect(workflow).toContain("promote-channel-aliases:");
     expect(workflow).toContain("inputs.operation == 'promote-channel'");
+    expect(workflow).toContain("Docker channel promotion must be dispatched from main");
+    expect(workflow).toContain("'docker-release-publish'");
     expect(workflow).toContain("docker buildx imagetools create --prefer-index=false");
     expect(workflow).toContain('"${image}@${source_digest}"');
     expect(workflow).toContain('if [[ "${target_digest}" != "${source_digest}" ]]; then');
     expect(workflow).toContain('require_group_source "${image}" "-slim" "${SLIM_ALIASES}"');
+    expect(workflow).toContain('require_group_source "${image}" "-browser" "${BROWSER_ALIASES}"');
   });
 
   it("smokes runtime workspace templates before Docker release manifests publish", async () => {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -334,11 +334,6 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("OPENCLAW_INSTALL_BROWSER=1");
     expect(workflow).toContain('${GHCR_IMAGE}:${version}-browser"');
     expect(workflow).toContain('${DOCKERHUB_IMAGE}:${version}-browser"');
-    expect(workflow).toContain(
-      "BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}",
-    );
-    expect(workflow).toContain('browser_tags+=("${GHCR_IMAGE}:${alias}")');
-    expect(workflow).toContain('dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${alias}")');
     expect(workflow).not.toContain("main-browser-amd64");
     expect(workflow).not.toContain("main-browser-arm64");
     expect(workflow).toContain("Smoke test amd64 browser image");
@@ -367,7 +362,7 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("DOCKERHUB_MULTI_REFS: ${{ steps.refs.outputs.dockerhub_multi }}");
   });
 
-  it("keeps moving Docker aliases behind the release-version policy", async () => {
+  it("validates release tags before immutable Docker publication", async () => {
     const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
 
     expect(workflow).toContain("Existing stable, extended-stable, or beta release tag");
@@ -377,15 +372,9 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-slim");
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-browser");
     expect(workflow).toContain("node workflow-source/scripts/lib/docker-release-policy.mjs");
-    expect(
-      workflow.split("needs.resolve_release_policy.outputs.default_aliases").length,
-    ).toBeGreaterThanOrEqual(3);
-    expect(
-      workflow.split("needs.resolve_release_policy.outputs.slim_aliases").length,
-    ).toBeGreaterThanOrEqual(3);
-    expect(
-      workflow.split("needs.resolve_release_policy.outputs.browser_aliases").length,
-    ).toBeGreaterThanOrEqual(3);
+    expect(workflow).not.toContain("needs.resolve_release_policy.outputs.default_aliases");
+    expect(workflow).not.toContain("needs.resolve_release_policy.outputs.slim_aliases");
+    expect(workflow).not.toContain("needs.resolve_release_policy.outputs.browser_aliases");
   });
 
   it("smokes runtime workspace templates before Docker release manifests publish", async () => {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -334,10 +334,11 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("OPENCLAW_INSTALL_BROWSER=1");
     expect(workflow).toContain('${GHCR_IMAGE}:${version}-browser"');
     expect(workflow).toContain('${DOCKERHUB_IMAGE}:${version}-browser"');
-    expect(workflow).toContain('${GHCR_IMAGE}:latest-browser"');
-    expect(workflow).toContain('${DOCKERHUB_IMAGE}:latest-browser"');
-    expect(workflow).toContain('${GHCR_IMAGE}:main-browser"');
-    expect(workflow).toContain('${DOCKERHUB_IMAGE}:main-browser"');
+    expect(workflow).toContain(
+      "BROWSER_ALIASES: ${{ needs.resolve_release_policy.outputs.browser_aliases }}",
+    );
+    expect(workflow).toContain('browser_tags+=("${GHCR_IMAGE}:${alias}")');
+    expect(workflow).toContain('dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${alias}")');
     expect(workflow).not.toContain("main-browser-amd64");
     expect(workflow).not.toContain("main-browser-arm64");
     expect(workflow).toContain("Smoke test amd64 browser image");
@@ -366,17 +367,30 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("DOCKERHUB_MULTI_REFS: ${{ steps.refs.outputs.dockerhub_multi }}");
   });
 
-  it("publishes beta Docker tags without advancing latest aliases", async () => {
+  it("keeps moving Docker aliases behind the release-version policy", async () => {
     const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
 
-    expect(workflow).toContain("Existing stable or beta release tag to backfill");
+    expect(workflow).toContain("Existing stable, extended-stable, or beta release tag");
     expect(workflow).toContain('! "${RELEASE_TAG}" =~ ^v[0-9]{4}');
-    expect(workflow).toContain("(-beta\\.[1-9][0-9]*)?");
+    expect(workflow).toContain("(-(beta\\.)?[1-9][0-9]*)?");
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}");
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-slim");
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-browser");
-    expect(workflow.split("do not advance latest/main aliases from those flows")).toHaveLength(3);
-    expect(workflow.split('"$version" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+)?$')).toHaveLength(3);
+    expect(workflow).toContain("node workflow-source/scripts/lib/docker-release-policy.mjs");
+    expect(workflow.split("needs.resolve_release_policy.outputs.default_aliases")).toHaveLength(4);
+    expect(workflow.split("needs.resolve_release_policy.outputs.slim_aliases")).toHaveLength(4);
+    expect(workflow.split("needs.resolve_release_policy.outputs.browser_aliases")).toHaveLength(4);
+  });
+
+  it("promotes existing immutable Docker images without rebuilding them", async () => {
+    const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
+
+    expect(workflow).toContain("promote-channel-aliases:");
+    expect(workflow).toContain("inputs.operation == 'promote-channel'");
+    expect(workflow).toContain("docker buildx imagetools create --prefer-index=false");
+    expect(workflow).toContain('"${image}@${source_digest}"');
+    expect(workflow).toContain('if [[ "${target_digest}" != "${source_digest}" ]]; then');
+    expect(workflow).toContain('require_group_source "${image}" "-slim" "${SLIM_ALIASES}"');
   });
 
   it("smokes runtime workspace templates before Docker release manifests publish", async () => {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -9,6 +9,10 @@ import YAML from "yaml";
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
 const dockerReleaseWorkflowPath = join(repoRoot, ".github/workflows/docker-release.yml");
+const dockerChannelPromoteWorkflowPath = join(
+  repoRoot,
+  ".github/workflows/docker-channel-promote.yml",
+);
 const fullReleaseValidationWorkflowPath = join(
   repoRoot,
   ".github/workflows/full-release-validation.yml",
@@ -379,29 +383,26 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("node workflow-source/scripts/lib/docker-release-policy.mjs");
     expect(
       workflow.split("needs.resolve_release_policy.outputs.default_aliases").length,
-    ).toBeGreaterThanOrEqual(5);
+    ).toBeGreaterThanOrEqual(3);
     expect(
       workflow.split("needs.resolve_release_policy.outputs.slim_aliases").length,
-    ).toBeGreaterThanOrEqual(5);
+    ).toBeGreaterThanOrEqual(3);
     expect(
       workflow.split("needs.resolve_release_policy.outputs.browser_aliases").length,
-    ).toBeGreaterThanOrEqual(5);
+    ).toBeGreaterThanOrEqual(3);
   });
 
   it("promotes existing immutable Docker images without rebuilding them", async () => {
-    const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
+    const releaseWorkflow = await readFile(dockerReleaseWorkflowPath, "utf8");
+    const promoteWorkflow = await readFile(dockerChannelPromoteWorkflowPath, "utf8");
 
-    expect(workflow).toContain("promote-channel-aliases:");
-    expect(workflow).toContain("inputs.operation == 'promote-channel'");
-    expect(workflow).toContain("Docker channel promotion must be dispatched from main");
-    expect(workflow).toContain("'docker-release-publish'");
-    expect(workflow).toContain('echo "## Docker release policy"');
-    expect(workflow).toContain("name: Approve Docker ${{ inputs.operation }} ${{ inputs.tag }}");
-    expect(workflow).toContain("docker buildx imagetools create --prefer-index=false");
-    expect(workflow).toContain('"${image}@${source_digest}"');
-    expect(workflow).toContain('if [[ "${target_digest}" != "${source_digest}" ]]; then');
-    expect(workflow).toContain('require_group_source "${image}" "-slim" "${SLIM_ALIASES}"');
-    expect(workflow).toContain('require_group_source "${image}" "-browser" "${BROWSER_ALIASES}"');
+    expect(releaseWorkflow).not.toContain("promote-channel");
+    expect(promoteWorkflow).toContain("Docker channel promotion must be dispatched from main");
+    expect(promoteWorkflow).toContain("group: docker-release-publish");
+    expect(promoteWorkflow).toContain("environment: docker-release");
+    expect(promoteWorkflow).toContain("node scripts/docker-channel-promote.mjs");
+    expect(promoteWorkflow).toContain('--image "${GHCR_IMAGE}"');
+    expect(promoteWorkflow).toContain('--image "${DOCKERHUB_IMAGE}"');
   });
 
   it("smokes runtime workspace templates before Docker release manifests publish", async () => {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -397,8 +397,10 @@ describe("Dockerfile", () => {
     const promoteWorkflow = await readFile(dockerChannelPromoteWorkflowPath, "utf8");
 
     expect(releaseWorkflow).not.toContain("promote-channel");
+    expect(releaseWorkflow).toContain("queue: max");
     expect(promoteWorkflow).toContain("Docker channel promotion must be dispatched from main");
     expect(promoteWorkflow).toContain("group: docker-release-publish");
+    expect(promoteWorkflow).toContain("queue: max");
     expect(promoteWorkflow).toContain("environment: docker-release");
     expect(promoteWorkflow).toContain("node scripts/docker-channel-promote.mjs");
     expect(promoteWorkflow).toContain('--image "${GHCR_IMAGE}"');

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -377,9 +377,15 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-slim");
     expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-browser");
     expect(workflow).toContain("node workflow-source/scripts/lib/docker-release-policy.mjs");
-    expect(workflow.split("needs.resolve_release_policy.outputs.default_aliases")).toHaveLength(5);
-    expect(workflow.split("needs.resolve_release_policy.outputs.slim_aliases")).toHaveLength(5);
-    expect(workflow.split("needs.resolve_release_policy.outputs.browser_aliases")).toHaveLength(5);
+    expect(
+      workflow.split("needs.resolve_release_policy.outputs.default_aliases").length,
+    ).toBeGreaterThanOrEqual(5);
+    expect(
+      workflow.split("needs.resolve_release_policy.outputs.slim_aliases").length,
+    ).toBeGreaterThanOrEqual(5);
+    expect(
+      workflow.split("needs.resolve_release_policy.outputs.browser_aliases").length,
+    ).toBeGreaterThanOrEqual(5);
   });
 
   it("promotes existing immutable Docker images without rebuilding them", async () => {
@@ -389,6 +395,8 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("inputs.operation == 'promote-channel'");
     expect(workflow).toContain("Docker channel promotion must be dispatched from main");
     expect(workflow).toContain("'docker-release-publish'");
+    expect(workflow).toContain('echo "## Docker release policy"');
+    expect(workflow).toContain("name: Approve Docker ${{ inputs.operation }} ${{ inputs.tag }}");
     expect(workflow).toContain("docker buildx imagetools create --prefer-index=false");
     expect(workflow).toContain('"${image}@${source_digest}"');
     expect(workflow).toContain('if [[ "${target_digest}" != "${source_digest}" ]]; then');

--- a/test/npm-publish-plan.test.ts
+++ b/test/npm-publish-plan.test.ts
@@ -1,13 +1,32 @@
 // npm publish plan tests validate package publish planning rules.
 import { describe, expect, it } from "vitest";
 import {
+  classifyReleaseTrain,
   collectReleaseVersionFloorErrors,
   fetchNpmRegistryPackumentWithRetry,
+  parseReleaseVersion,
   resolveNpmDistTagMirrorAuth,
   resolveNpmPublishPlan,
   resolvePublishedNpmVersionRoute,
   shouldRequireNpmDistTagMirrorAuth,
 } from "../scripts/lib/npm-publish-plan.mjs";
+
+describe("release train classification", () => {
+  it.each([
+    ["2026.7.2-alpha.1", "alpha"],
+    ["2026.7.2-beta.1", "beta"],
+    ["2026.7.32", "stable"],
+    ["2026.6.33", "extended-stable"],
+    ["2026.6.34", "extended-stable"],
+    ["2026.6.33-1", "unsupported-extended-stable-correction"],
+  ] as const)("classifies %s as %s", (version, expected) => {
+    const parsed = parseReleaseVersion(version);
+    if (!parsed) {
+      throw new Error(`test version did not parse: ${version}`);
+    }
+    expect(classifyReleaseTrain(parsed)).toBe(expected);
+  });
+});
 
 function registryResponse(params: {
   status?: number;

--- a/test/scripts/docker-channel-promote.test.ts
+++ b/test/scripts/docker-channel-promote.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDockerChannelPromotionPlan,
+  parseDockerChannelPromotionArgs,
+  promoteDockerChannel,
+} from "../../scripts/docker-channel-promote.mjs";
+
+const images = ["ghcr.io/openclaw/openclaw", "docker.io/openclaw/openclaw"];
+const digest = `sha256:${"1".repeat(64)}`;
+
+describe("Docker channel promotion", () => {
+  it("plans every extended-stable image variant in both registries", () => {
+    expect(createDockerChannelPromotionPlan({ version: "2026.6.33", images })).toEqual({
+      channel: "extended-stable",
+      promotions: images.flatMap((image) => [
+        {
+          image,
+          sourceRef: `${image}:2026.6.33`,
+          targetRefs: [`${image}:extended-stable`],
+        },
+        {
+          image,
+          sourceRef: `${image}:2026.6.33-slim`,
+          targetRefs: [`${image}:extended-stable-slim`],
+        },
+        {
+          image,
+          sourceRef: `${image}:2026.6.33-browser`,
+          targetRefs: [`${image}:extended-stable-browser`],
+        },
+      ]),
+      version: "2026.6.33",
+    });
+  });
+
+  it("preflights every source before moving and verifying aliases", () => {
+    const calls: string[][] = [];
+    const targetDigests = new Map<string, string>();
+    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
+      calls.push(args);
+      if (args[2] === "inspect") {
+        return JSON.stringify({ digest: targetDigests.get(args[3]!) ?? digest });
+      }
+      const sourceDigest = args.at(-1)!.split("@")[1]!;
+      for (let index = 0; index < args.length; index += 1) {
+        if (args[index] === "--tag") {
+          targetDigests.set(args[index + 1]!, sourceDigest);
+        }
+      }
+      return "";
+    });
+
+    promoteDockerChannel({ version: "2026.6.33", images }, { execFileSyncImpl });
+
+    const firstCreate = calls.findIndex((args) => args[2] === "create");
+    expect(firstCreate).toBe(6);
+    expect(calls.slice(0, firstCreate).every((args) => args[2] === "inspect")).toBe(true);
+    expect(calls.filter((args) => args[2] === "create")).toHaveLength(6);
+    expect(execFileSyncImpl).toHaveBeenCalledWith(
+      "docker",
+      [
+        "buildx",
+        "imagetools",
+        "create",
+        "--prefer-index=false",
+        "--tag",
+        "ghcr.io/openclaw/openclaw:extended-stable",
+        `ghcr.io/openclaw/openclaw@${digest}`,
+      ],
+      expect.objectContaining({ timeout: 120_000 }),
+    );
+  });
+
+  it("fails without mutating when any immutable source is missing", () => {
+    const calls: string[][] = [];
+    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
+      calls.push(args);
+      if (calls.length === 3) {
+        throw new Error("missing manifest");
+      }
+      return JSON.stringify({ digest });
+    });
+
+    expect(() =>
+      promoteDockerChannel({ version: "2026.6.33", images }, { execFileSyncImpl }),
+    ).toThrow("missing manifest");
+    expect(calls.some((args) => args[2] === "create")).toBe(false);
+  });
+
+  it("fails when a promoted alias does not match its immutable source", () => {
+    const wrongDigest = `sha256:${"2".repeat(64)}`;
+    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
+      if (args[2] === "inspect" && args[3]?.endsWith(":extended-stable")) {
+        return JSON.stringify({ digest: wrongDigest });
+      }
+      return args[2] === "inspect" ? JSON.stringify({ digest }) : "";
+    });
+
+    expect(() =>
+      promoteDockerChannel({ version: "2026.6.33", images }, { execFileSyncImpl }),
+    ).toThrow(`resolved to ${wrongDigest}, expected ${digest}`);
+  });
+
+  it("rejects channels without moving aliases", () => {
+    expect(() => createDockerChannelPromotionPlan({ version: "2026.7.2-beta.3", images })).toThrow(
+      "no moving aliases",
+    );
+  });
+
+  it("parses repeated image arguments", () => {
+    expect(
+      parseDockerChannelPromotionArgs([
+        "--version",
+        "2026.6.33",
+        "--image",
+        images[0]!,
+        "--image",
+        images[1]!,
+      ]),
+    ).toEqual({ help: false, images, version: "2026.6.33" });
+  });
+});

--- a/test/scripts/docker-channel-promote.test.ts
+++ b/test/scripts/docker-channel-promote.test.ts
@@ -1,12 +1,46 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
 import {
   createDockerChannelPromotionPlan,
-  parseDockerChannelPromotionArgs,
   promoteDockerChannel,
 } from "../../scripts/docker-channel-promote.mjs";
 
 const images = ["ghcr.io/openclaw/openclaw", "docker.io/openclaw/openclaw"];
 const digest = `sha256:${"1".repeat(64)}`;
+
+type WorkflowStep = {
+  env?: Record<string, string>;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, boolean | string>;
+};
+
+type WorkflowJob = {
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean; queue?: string };
+  environment?: string;
+  needs?: string | string[];
+  permissions?: Record<string, string>;
+  steps?: WorkflowStep[];
+};
+
+type Workflow = {
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean; queue?: string };
+  jobs?: Record<string, WorkflowJob>;
+};
+
+function readWorkflow(path: string): Workflow {
+  return parse(readFileSync(path, "utf8")) as Workflow;
+}
+
+function requireJob(workflow: Workflow, name: string): WorkflowJob {
+  const job = workflow.jobs?.[name];
+  if (!job) {
+    throw new Error(`Missing workflow job: ${name}`);
+  }
+  return job;
+}
 
 describe("Docker channel promotion", () => {
   it("plans every extended-stable image variant in both registries", () => {
@@ -107,16 +141,67 @@ describe("Docker channel promotion", () => {
     );
   });
 
-  it("parses repeated image arguments", () => {
-    expect(
-      parseDockerChannelPromotionArgs([
-        "--version",
-        "2026.6.33",
-        "--image",
-        images[0]!,
-        "--image",
-        images[1]!,
-      ]),
-    ).toEqual({ help: false, images, version: "2026.6.33" });
+  it("gates every registry mutation behind approval and attestation verification", () => {
+    const workflow = readWorkflow(".github/workflows/docker-channel-promote.yml");
+    const releaseWorkflow = readWorkflow(".github/workflows/docker-release.yml");
+    const resolve = requireJob(workflow, "resolve");
+    const approve = requireJob(workflow, "approve");
+    const promote = requireJob(workflow, "promote");
+
+    expect(releaseWorkflow.concurrency).toEqual({
+      group:
+        "${{ github.event_name == 'workflow_dispatch' && format('docker-release-manual-{0}', inputs.tag) || 'docker-release-publish' }}",
+      "cancel-in-progress": false,
+      queue: "max",
+    });
+    expect(resolve.permissions).toEqual({ contents: "read" });
+    expect(resolve.steps?.find((step) => step.uses?.startsWith("actions/checkout@"))?.with).toEqual(
+      expect.objectContaining({ ref: "${{ github.sha }}", "persist-credentials": false }),
+    );
+    expect(approve.needs).toBe("resolve");
+    expect(approve.environment).toBe("docker-release");
+    expect(approve.permissions).toEqual({});
+    expect(promote.needs).toEqual(["resolve", "approve"]);
+    expect(promote.permissions).toEqual({ contents: "read", packages: "write" });
+    expect(promote.concurrency).toEqual({
+      group: "docker-release-publish",
+      "cancel-in-progress": false,
+      queue: "max",
+    });
+    expect(promote.steps?.find((step) => step.uses?.startsWith("actions/checkout@"))?.with).toEqual(
+      expect.objectContaining({ ref: "${{ github.sha }}", "persist-credentials": false }),
+    );
+
+    const steps = promote.steps ?? [];
+    const attestationIndex = steps.findIndex(
+      (step) => step.name === "Verify immutable source attestations",
+    );
+    const promotionIndex = steps.findIndex(
+      (step) => step.name === "Promote and verify channel aliases",
+    );
+    expect(attestationIndex).toBeGreaterThan(-1);
+    expect(promotionIndex).toBeGreaterThan(attestationIndex);
+
+    const attestationRun = steps[attestationIndex]?.run ?? "";
+    for (const ref of [
+      "${GHCR_IMAGE}:${VERSION}",
+      "${GHCR_IMAGE}:${VERSION}-slim",
+      "${GHCR_IMAGE}:${VERSION}-browser",
+      "${DOCKERHUB_IMAGE}:${VERSION}",
+      "${DOCKERHUB_IMAGE}:${VERSION}-slim",
+      "${DOCKERHUB_IMAGE}:${VERSION}-browser",
+    ]) {
+      expect(attestationRun).toContain(ref);
+    }
+    expect(attestationRun).toContain("node scripts/verify-docker-attestations.mjs");
+    expect(attestationRun).toContain("--platform linux/amd64");
+    expect(attestationRun).toContain("--platform linux/arm64");
+    expect(steps[promotionIndex]?.run).toContain("node scripts/docker-channel-promote.mjs");
+
+    const packageWriters = Object.entries(workflow.jobs ?? {}).filter(
+      ([, job]) => job.permissions?.packages === "write",
+    );
+    expect(packageWriters.map(([name]) => name)).toEqual(["promote"]);
+    expect(packageWriters[0]?.[1].needs).toContain("approve");
   });
 });

--- a/test/scripts/docker-channel-promote.test.ts
+++ b/test/scripts/docker-channel-promote.test.ts
@@ -11,6 +11,7 @@ const digest = `sha256:${"1".repeat(64)}`;
 
 type WorkflowStep = {
   env?: Record<string, string>;
+  if?: string;
   name?: string;
   run?: string;
   uses?: string;
@@ -141,9 +142,11 @@ describe("Docker channel promotion", () => {
     );
   });
 
-  it("gates every registry mutation behind approval and attestation verification", () => {
+  it("uses the same attestation-gated promotion path for releases and repairs", () => {
     const workflow = readWorkflow(".github/workflows/docker-channel-promote.yml");
     const releaseWorkflow = readWorkflow(".github/workflows/docker-release.yml");
+    const createManifest = requireJob(releaseWorkflow, "create-manifest");
+    const verifyAttestations = requireJob(releaseWorkflow, "verify-attestations");
     const resolve = requireJob(workflow, "resolve");
     const approve = requireJob(workflow, "approve");
     const promote = requireJob(workflow, "promote");
@@ -154,6 +157,38 @@ describe("Docker channel promotion", () => {
       "cancel-in-progress": false,
       queue: "max",
     });
+    expect(verifyAttestations.permissions).toEqual({ contents: "read", packages: "write" });
+
+    const manifestTagStep = createManifest.steps?.find(
+      (step) => step.name === "Resolve manifest tags",
+    );
+    expect(manifestTagStep?.run).not.toContain("alias");
+    expect(manifestTagStep?.env).not.toHaveProperty("DEFAULT_ALIASES");
+
+    const releaseSteps = verifyAttestations.steps ?? [];
+    const resolveRefsStep = releaseSteps.find((step) => step.name === "Resolve image refs");
+    expect(resolveRefsStep?.run).not.toContain("alias");
+    expect(resolveRefsStep?.env).not.toHaveProperty("DEFAULT_ALIASES");
+    const releaseAttestationIndex = releaseSteps.findIndex(
+      (step) => step.name === "Verify Docker attestations",
+    );
+    const releasePromotionIndex = releaseSteps.findIndex(
+      (step) => step.name === "Promote and verify channel aliases",
+    );
+    expect(releaseAttestationIndex).toBeGreaterThan(-1);
+    expect(releasePromotionIndex).toBeGreaterThan(releaseAttestationIndex);
+    expect(releaseSteps[releasePromotionIndex]?.if).toBe(
+      "${{ github.event_name != 'workflow_dispatch' && needs.resolve_release_policy.outputs.channel != 'beta' }}",
+    );
+    expect(releaseSteps[releasePromotionIndex]?.run).toContain(
+      "node scripts/docker-channel-promote.mjs",
+    );
+    expect(
+      Object.values(releaseWorkflow.jobs ?? {}).flatMap((job) =>
+        (job.steps ?? []).filter((step) => step.run?.includes("docker-channel-promote.mjs")),
+      ),
+    ).toHaveLength(1);
+
     expect(resolve.permissions).toEqual({ contents: "read" });
     expect(resolve.steps?.find((step) => step.uses?.startsWith("actions/checkout@"))?.with).toEqual(
       expect.objectContaining({ ref: "${{ github.sha }}", "persist-credentials": false }),

--- a/test/scripts/docker-channel-promote.test.ts
+++ b/test/scripts/docker-channel-promote.test.ts
@@ -8,6 +8,42 @@ import {
 
 const images = ["ghcr.io/openclaw/openclaw", "docker.io/openclaw/openclaw"];
 const digest = `sha256:${"1".repeat(64)}`;
+const changedDigest = `sha256:${"2".repeat(64)}`;
+
+function imageConfig(version: string): string {
+  return JSON.stringify({
+    config: { Labels: { "org.opencontainers.image.version": version } },
+  });
+}
+
+function createDockerMock(params: {
+  candidateVersion: string;
+  currentVersion?: string;
+  wrongTargetDigest?: string;
+}) {
+  const targetDigests = new Map<string, string>();
+  return vi.fn((_command: string, args: string[]) => {
+    if (args[2] === "inspect") {
+      const ref = args[3]!;
+      if (args.at(-1)?.includes(".Image")) {
+        return imageConfig(ref.includes("@") ? params.candidateVersion : params.currentVersion!);
+      }
+      if (params.wrongTargetDigest && ref.includes(":extended-stable")) {
+        return JSON.stringify({ digest: params.wrongTargetDigest });
+      }
+      return JSON.stringify({ digest: targetDigests.get(ref) ?? digest });
+    }
+    const sourceDigest = args.at(-1)!.split("@")[1]!;
+    for (let index = 0; index < args.length; index += 1) {
+      if (args[index] === "--tag") {
+        targetDigests.set(args[index + 1]!, sourceDigest);
+      }
+    }
+    return "";
+  });
+}
+
+const skipAttestationVerification = () => {};
 
 type WorkflowStep = {
   env?: Record<string, string>;
@@ -70,27 +106,41 @@ describe("Docker channel promotion", () => {
 
   it("preflights every source before moving and verifying aliases", () => {
     const calls: string[][] = [];
-    const targetDigests = new Map<string, string>();
-    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
-      calls.push(args);
-      if (args[2] === "inspect") {
-        return JSON.stringify({ digest: targetDigests.get(args[3]!) ?? digest });
-      }
-      const sourceDigest = args.at(-1)!.split("@")[1]!;
-      for (let index = 0; index < args.length; index += 1) {
-        if (args[index] === "--tag") {
-          targetDigests.set(args[index + 1]!, sourceDigest);
-        }
-      }
-      return "";
+    const docker = createDockerMock({
+      candidateVersion: "2026.6.33",
+      currentVersion: "2026.6.33",
     });
+    const execFileSyncImpl = vi.fn((command: string, args: string[]) => {
+      calls.push(args);
+      return docker(command, args);
+    });
+    const verifyAttestationsImpl = vi.fn();
 
-    promoteDockerChannel({ version: "2026.6.33", images }, { execFileSyncImpl });
+    promoteDockerChannel(
+      { version: "2026.6.33", images },
+      { execFileSyncImpl, verifyAttestationsImpl },
+    );
 
     const firstCreate = calls.findIndex((args) => args[2] === "create");
-    expect(firstCreate).toBe(6);
+    expect(firstCreate).toBe(30);
     expect(calls.slice(0, firstCreate).every((args) => args[2] === "inspect")).toBe(true);
     expect(calls.filter((args) => args[2] === "create")).toHaveLength(6);
+    expect(verifyAttestationsImpl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageRefs: [
+          `ghcr.io/openclaw/openclaw@${digest}`,
+          `ghcr.io/openclaw/openclaw@${digest}`,
+          `ghcr.io/openclaw/openclaw@${digest}`,
+          `docker.io/openclaw/openclaw@${digest}`,
+          `docker.io/openclaw/openclaw@${digest}`,
+          `docker.io/openclaw/openclaw@${digest}`,
+        ],
+        requiredPlatforms: [
+          { architecture: "amd64", os: "linux", variant: undefined },
+          { architecture: "arm64", os: "linux", variant: undefined },
+        ],
+      }),
+    );
     expect(execFileSyncImpl).toHaveBeenCalledWith(
       "docker",
       [
@@ -106,7 +156,7 @@ describe("Docker channel promotion", () => {
     );
   });
 
-  it("fails without mutating when any immutable source is missing", () => {
+  it("fails without mutating when any version-specific source is missing", () => {
     const calls: string[][] = [];
     const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
       calls.push(args);
@@ -117,23 +167,196 @@ describe("Docker channel promotion", () => {
     });
 
     expect(() =>
-      promoteDockerChannel({ version: "2026.6.33", images }, { execFileSyncImpl }),
+      promoteDockerChannel(
+        { version: "2026.6.33", images },
+        { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
+      ),
     ).toThrow("missing manifest");
     expect(calls.some((args) => args[2] === "create")).toBe(false);
   });
 
-  it("fails when a promoted alias does not match its immutable source", () => {
-    const wrongDigest = `sha256:${"2".repeat(64)}`;
-    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
-      if (args[2] === "inspect" && args[3]?.endsWith(":extended-stable")) {
-        return JSON.stringify({ digest: wrongDigest });
-      }
-      return args[2] === "inspect" ? JSON.stringify({ digest }) : "";
+  it("fails when a promoted alias does not match its version-specific source", () => {
+    const execFileSyncImpl = createDockerMock({
+      candidateVersion: "2026.6.33",
+      currentVersion: "2026.6.33",
+      wrongTargetDigest: changedDigest,
     });
 
     expect(() =>
-      promoteDockerChannel({ version: "2026.6.33", images }, { execFileSyncImpl }),
-    ).toThrow(`resolved to ${wrongDigest}, expected ${digest}`);
+      promoteDockerChannel(
+        { version: "2026.6.33", images },
+        { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
+      ),
+    ).toThrow(`resolved to ${changedDigest}, expected ${digest}`);
+  });
+
+  it("refuses automatic channel rollback before writing aliases", () => {
+    const execFileSyncImpl = createDockerMock({
+      candidateVersion: "2026.6.33",
+      currentVersion: "2026.6.34",
+    });
+
+    expect(() =>
+      promoteDockerChannel(
+        { version: "2026.6.33", images: images.slice(0, 1) },
+        { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
+      ),
+    ).toThrow(
+      "Refusing to move ghcr.io/openclaw/openclaw:extended-stable backward from 2026.6.34 to 2026.6.33",
+    );
+    expect(execFileSyncImpl.mock.calls.some(([, args]) => args[2] === "create")).toBe(false);
+  });
+
+  it.each([
+    ["same", "2026.6.33", "2026.6.33"],
+    ["newer", "2026.6.34", "2026.6.33"],
+  ])("allows an automatic %s-version promotion", (_label, candidateVersion, currentVersion) => {
+    const execFileSyncImpl = createDockerMock({ candidateVersion, currentVersion });
+
+    promoteDockerChannel(
+      { version: candidateVersion, images: images.slice(0, 1) },
+      { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
+    );
+
+    expect(execFileSyncImpl.mock.calls.some(([, args]) => args[2] === "create")).toBe(true);
+  });
+
+  it("allows an explicitly approved rollback", () => {
+    const execFileSyncImpl = createDockerMock({
+      candidateVersion: "2026.6.33",
+      currentVersion: "2026.6.34",
+    });
+
+    promoteDockerChannel(
+      { version: "2026.6.33", images: images.slice(0, 1) },
+      {
+        allowRollback: true,
+        execFileSyncImpl,
+        verifyAttestationsImpl: skipAttestationVerification,
+      },
+    );
+
+    expect(execFileSyncImpl.mock.calls.some(([, args]) => args[2] === "create")).toBe(true);
+  });
+
+  it("allows a first promotion when the target alias does not exist", () => {
+    let created = false;
+    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
+      if (args[2] === "create") {
+        created = true;
+        return "";
+      }
+      if (args.at(-1)?.includes(".Image")) {
+        if (!args[3]!.includes("@") && !created) {
+          const error = new Error("docker inspect failed");
+          Object.assign(error, { stderr: `ERROR: ${args[3]}: not found` });
+          throw error;
+        }
+        return imageConfig("2026.6.33");
+      }
+      return JSON.stringify({ digest });
+    });
+
+    promoteDockerChannel(
+      { version: "2026.6.33", images: images.slice(0, 1) },
+      { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
+    );
+
+    expect(created).toBe(true);
+  });
+
+  it("fails closed when an existing alias cannot be inspected", () => {
+    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
+      if (args.at(-1)?.includes(".Image") && !args[3]!.includes("@")) {
+        const error = new Error("unauthorized: authentication required");
+        Object.assign(error, { stderr: "denied: requested access to the resource is denied" });
+        throw error;
+      }
+      if (args.at(-1)?.includes(".Image")) {
+        return imageConfig("2026.6.33");
+      }
+      return JSON.stringify({ digest });
+    });
+
+    expect(() =>
+      promoteDockerChannel(
+        { version: "2026.6.33", images: images.slice(0, 1) },
+        { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
+      ),
+    ).toThrow("unauthorized");
+    expect(execFileSyncImpl.mock.calls.some(([, args]) => args[2] === "create")).toBe(false);
+  });
+
+  it("promotes the same digests whose attestations were verified", () => {
+    let sourceDigest = digest;
+    const targetDigests = new Map<string, string>();
+    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
+      if (args[2] === "create") {
+        const promotedDigest = args.at(-1)!.split("@")[1]!;
+        for (let index = 0; index < args.length; index += 1) {
+          if (args[index] === "--tag") {
+            targetDigests.set(args[index + 1]!, promotedDigest);
+          }
+        }
+        return "";
+      }
+      if (args.at(-1)?.includes(".Image")) {
+        return imageConfig("2026.6.33");
+      }
+      const ref = args[3]!;
+      return JSON.stringify({ digest: targetDigests.get(ref) ?? sourceDigest });
+    });
+    const verifiedRefs: string[] = [];
+
+    promoteDockerChannel(
+      { version: "2026.6.33", images: images.slice(0, 1) },
+      {
+        execFileSyncImpl,
+        verifyAttestationsImpl({ imageRefs }) {
+          verifiedRefs.push(...imageRefs);
+          sourceDigest = changedDigest;
+        },
+      },
+    );
+
+    expect(verifiedRefs).toEqual(Array(3).fill(`ghcr.io/openclaw/openclaw@${digest}`));
+    expect(
+      execFileSyncImpl.mock.calls
+        .filter(([, args]) => args[2] === "create")
+        .map(([, args]) => args.at(-1)),
+    ).toEqual(Array(3).fill(`ghcr.io/openclaw/openclaw@${digest}`));
+  });
+
+  it("rejects a source whose version label does not match the requested release", () => {
+    const execFileSyncImpl = createDockerMock({
+      candidateVersion: "2026.6.34",
+      currentVersion: "2026.6.33",
+    });
+
+    expect(() =>
+      promoteDockerChannel(
+        { version: "2026.6.33", images: images.slice(0, 1) },
+        { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
+      ),
+    ).toThrow(`ghcr.io/openclaw/openclaw@${digest} reports version 2026.6.34, expected 2026.6.33`);
+  });
+
+  it("rejects a source whose platform version labels disagree", () => {
+    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
+      if (args.at(-1)?.includes(".Image")) {
+        const version = args.at(-1)?.includes("linux/arm64") ? "2026.6.34" : "2026.6.33";
+        return imageConfig(version);
+      }
+      return JSON.stringify({ digest });
+    });
+
+    expect(() =>
+      promoteDockerChannel(
+        { version: "2026.6.33", images: images.slice(0, 1) },
+        { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
+      ),
+    ).toThrow("inconsistent platform versions: linux/amd64=2026.6.33, linux/arm64=2026.6.34");
+    expect(execFileSyncImpl.mock.calls.some(([, args]) => args[2] === "create")).toBe(false);
   });
 
   it("rejects channels without moving aliases", () => {
@@ -142,7 +365,7 @@ describe("Docker channel promotion", () => {
     );
   });
 
-  it("uses the same attestation-gated promotion path for releases and repairs", () => {
+  it("uses the digest-bound promotion path for releases and approved repairs", () => {
     const workflow = readWorkflow(".github/workflows/docker-channel-promote.yml");
     const releaseWorkflow = readWorkflow(".github/workflows/docker-release.yml");
     const createManifest = requireJob(releaseWorkflow, "create-manifest");
@@ -183,6 +406,7 @@ describe("Docker channel promotion", () => {
     expect(releaseSteps[releasePromotionIndex]?.run).toContain(
       "node scripts/docker-channel-promote.mjs",
     );
+    expect(releaseSteps[releasePromotionIndex]?.run).not.toContain("--allow-rollback");
     expect(
       Object.values(releaseWorkflow.jobs ?? {}).flatMap((job) =>
         (job.steps ?? []).filter((step) => step.run?.includes("docker-channel-promote.mjs")),
@@ -208,30 +432,13 @@ describe("Docker channel promotion", () => {
     );
 
     const steps = promote.steps ?? [];
-    const attestationIndex = steps.findIndex(
-      (step) => step.name === "Verify immutable source attestations",
-    );
     const promotionIndex = steps.findIndex(
       (step) => step.name === "Promote and verify channel aliases",
     );
-    expect(attestationIndex).toBeGreaterThan(-1);
-    expect(promotionIndex).toBeGreaterThan(attestationIndex);
-
-    const attestationRun = steps[attestationIndex]?.run ?? "";
-    for (const ref of [
-      "${GHCR_IMAGE}:${VERSION}",
-      "${GHCR_IMAGE}:${VERSION}-slim",
-      "${GHCR_IMAGE}:${VERSION}-browser",
-      "${DOCKERHUB_IMAGE}:${VERSION}",
-      "${DOCKERHUB_IMAGE}:${VERSION}-slim",
-      "${DOCKERHUB_IMAGE}:${VERSION}-browser",
-    ]) {
-      expect(attestationRun).toContain(ref);
-    }
-    expect(attestationRun).toContain("node scripts/verify-docker-attestations.mjs");
-    expect(attestationRun).toContain("--platform linux/amd64");
-    expect(attestationRun).toContain("--platform linux/arm64");
+    expect(steps.some((step) => step.run?.includes("verify-docker-attestations.mjs"))).toBe(false);
+    expect(promotionIndex).toBeGreaterThan(-1);
     expect(steps[promotionIndex]?.run).toContain("node scripts/docker-channel-promote.mjs");
+    expect(steps[promotionIndex]?.run).toContain("--allow-rollback");
 
     const packageWriters = Object.entries(workflow.jobs ?? {}).filter(
       ([, job]) => job.permissions?.packages === "write",

--- a/test/scripts/docker-release-policy.test.ts
+++ b/test/scripts/docker-release-policy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveDockerReleasePolicy } from "../../scripts/lib/docker-release-policy.mjs";
+
+describe("Docker release policy", () => {
+  it("advances regular stable aliases only for final and correction patches below 33", () => {
+    for (const version of ["2026.7.1", "2026.7.1-2"]) {
+      expect(resolveDockerReleasePolicy(version)).toEqual({
+        version,
+        channel: "stable",
+        movingAliases: {
+          default: ["latest", "main"],
+          slim: ["slim", "main-slim"],
+          browser: ["latest-browser", "main-browser"],
+        },
+      });
+    }
+  });
+
+  it("keeps extended-stable releases on dedicated moving aliases", () => {
+    for (const version of ["2026.6.33", "2026.6.34", "2026.6.99"]) {
+      expect(resolveDockerReleasePolicy(version)).toEqual({
+        version,
+        channel: "extended-stable",
+        movingAliases: {
+          default: ["extended-stable"],
+          slim: ["extended-stable-slim"],
+          browser: ["extended-stable-browser"],
+        },
+      });
+    }
+  });
+
+  it("publishes beta versions without moving a channel alias", () => {
+    expect(resolveDockerReleasePolicy("2026.7.2-beta.3")).toEqual({
+      version: "2026.7.2-beta.3",
+      channel: "beta",
+      movingAliases: { default: [], slim: [], browser: [] },
+    });
+  });
+
+  it.each(["2026.6.33-1", "2026.6.33-alpha.1", "2026.0.33", "not-a-version"])(
+    "rejects unsupported release version %s",
+    (version) => {
+      expect(() => resolveDockerReleasePolicy(version)).toThrow();
+    },
+  );
+});

--- a/test/scripts/openclaw-npm-extended-stable-release.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-release.test.ts
@@ -85,6 +85,11 @@ describe("npm extended-stable publication boundary", () => {
     expect(() => validateNpmPublishBoundary("2026.6.11", "extended-stable")).toThrow(
       /patch 33 or above/u,
     );
+    expect(() =>
+      validateNpmPublishBoundary("2026.6.11-1", "extended-stable", {
+        bypassExtendedStableGuard: true,
+      }),
+    ).toThrow(/does not allow correction suffixes/u);
   });
 
   it.each(["alpha", "beta", "latest"])(


### PR DESCRIPTION
## Problem

The 2026.6.34 release must never advance the regular Docker `latest`, `main`, or browser aliases.

## Change

Backports the release-critical Docker machinery from #112494, adapted to the 6.6 release tooling. A final extended-stable patch now promotes only `extended-stable`, `extended-stable-slim`, and `extended-stable-browser`; beta releases move no alias. Promotion resolves immutable digest sources, verifies attestations and both platform labels, blocks alias rollback, and verifies the resulting aliases.

## Adaptation

This branch keeps version parsing in `scripts/lib/npm-publish-plan.mjs`, so it preserves #112494's policy behavior and tests without importing the newer unrelated `release-version` refactor.

## Validation

- `node scripts/run-vitest.mjs test/scripts/docker-channel-promote.test.ts test/scripts/docker-release-policy.test.ts test/npm-publish-plan.test.ts test/scripts/openclaw-npm-extended-stable-release.test.ts` (144 tests)
- `node scripts/lib/docker-release-policy.mjs 2026.6.34` confirms extended-stable aliases only
- `git diff --check`
- fresh autoreview: no actionable findings