### PR TITLE
fix(plugins): keep versioned installs off source checkout paths

### DIFF
--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -1,4 +1,7 @@
 // Plugin install plan tests cover install planning for local, registry, and bundled plugins.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { installedPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
@@ -11,6 +14,21 @@ import {
   resolveBundledInstallPlanBeforeNpm,
   resolveBundledInstallPlanForNpmFailure,
 } from "./plugin-install-plan.js";
+
+function createSourceCheckoutPlugin(pluginId: string): {
+  packageRoot: string;
+  pluginRoot: string;
+} {
+  const packageRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-plan-"));
+  fs.mkdirSync(path.join(packageRoot, ".git"));
+  fs.mkdirSync(path.join(packageRoot, "src"));
+  fs.mkdirSync(path.join(packageRoot, "extensions"));
+  const pluginRoot = path.join(packageRoot, "dist", "extensions", pluginId);
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: "openclaw" }));
+  fs.writeFileSync(path.join(packageRoot, "pnpm-workspace.yaml"), "packages: []\n");
+  return { packageRoot, pluginRoot };
+}
 
 describe("plugin install plan helpers", () => {
   it("prefers bundled plugin for bare plugin-id specs", () => {
@@ -59,6 +77,46 @@ describe("plugin install plan helpers", () => {
     expect(result?.bundledSource.pluginId).toBe("voice-call");
     expect(result?.warning).toContain('npm install spec "@openclaw/voice-call@2026.5.20"');
     expect(result?.warning).toContain("npm:@openclaw/voice-call@2026.5.20");
+  });
+
+  it("keeps scoped npm specs on the registry path for source checkout bundles", () => {
+    const { packageRoot, pluginRoot } = createSourceCheckoutPlugin("codex");
+    try {
+      const findBundledSource = vi.fn().mockReturnValue({
+        pluginId: "codex",
+        localPath: pluginRoot,
+        npmSpec: "@openclaw/codex",
+      });
+
+      const result = resolveBundledInstallPlanBeforeNpm({
+        rawSpec: "@openclaw/codex@2026.7.2-beta.3",
+        findBundledSource,
+      });
+
+      expect(result).toBeNull();
+    } finally {
+      fs.rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps bare plugin ids on source checkout bundles", () => {
+    const { packageRoot, pluginRoot } = createSourceCheckoutPlugin("codex");
+    try {
+      const findBundledSource = vi.fn().mockReturnValue({
+        pluginId: "codex",
+        localPath: pluginRoot,
+        npmSpec: "@openclaw/codex",
+      });
+
+      const result = resolveBundledInstallPlanBeforeNpm({
+        rawSpec: "codex",
+        findBundledSource,
+      });
+
+      expect(result?.bundledSource.pluginId).toBe("codex");
+    } finally {
+      fs.rmSync(packageRoot, { recursive: true, force: true });
+    }
   });
 
   it("skips bundled pre-plan for npm specs that do not match bundled packages", () => {
@@ -195,6 +253,48 @@ describe("plugin install plan helpers", () => {
       value: "@openclaw/voice-call",
     });
     expect(result?.warning).toContain("npm package unavailable");
+  });
+
+  it("does not fall back to source checkout bundles after npm package-not-found", () => {
+    const { packageRoot, pluginRoot } = createSourceCheckoutPlugin("codex");
+    try {
+      const findBundledSource = vi.fn().mockReturnValue({
+        pluginId: "codex",
+        localPath: pluginRoot,
+        npmSpec: "@openclaw/codex",
+      });
+
+      const result = resolveBundledInstallPlanForNpmFailure({
+        rawSpec: "@openclaw/codex",
+        code: PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND,
+        findBundledSource,
+      });
+
+      expect(result).toBeNull();
+    } finally {
+      fs.rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("allows bare plugin ids to fall back to source checkout bundles", () => {
+    const { packageRoot, pluginRoot } = createSourceCheckoutPlugin("codex");
+    try {
+      const findBundledSource = vi.fn().mockReturnValue({
+        pluginId: "codex",
+        localPath: pluginRoot,
+        npmSpec: "@openclaw/codex",
+      });
+
+      const result = resolveBundledInstallPlanForNpmFailure({
+        rawSpec: "codex",
+        code: PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND,
+        findBundledSource,
+      });
+
+      expect(result?.bundledSource.pluginId).toBe("codex");
+    } finally {
+      fs.rmSync(packageRoot, { recursive: true, force: true });
+    }
   });
 
   it("skips fallback for non-not-found npm failures", () => {

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -1,4 +1,6 @@
 // Plugin install planning helpers for bundled, official external, and npm fallback paths.
+import fs from "node:fs";
+import path from "node:path";
 import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import type { BundledPluginSource } from "../plugins/bundled-sources.js";
 import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
@@ -12,6 +14,31 @@ type BundledLookup = (params: {
 function isBareNpmPackageName(spec: string): boolean {
   const trimmed = spec.trim();
   return /^[a-z0-9][a-z0-9-._~]*$/.test(trimmed);
+}
+
+function isSourceCheckoutBundledPath(localPath: string): boolean {
+  const extensionsDir = path.dirname(path.resolve(localPath));
+  if (path.basename(extensionsDir) !== "extensions") {
+    return false;
+  }
+  const extensionsParent = path.dirname(extensionsDir);
+  const packageRoot = ["dist", "dist-runtime"].includes(path.basename(extensionsParent))
+    ? path.dirname(extensionsParent)
+    : extensionsParent;
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+    ) as { name?: unknown };
+    return (
+      packageJson.name === "openclaw" &&
+      fs.existsSync(path.join(packageRoot, ".git")) &&
+      fs.existsSync(path.join(packageRoot, "pnpm-workspace.yaml")) &&
+      fs.existsSync(path.join(packageRoot, "src")) &&
+      fs.existsSync(path.join(packageRoot, "extensions"))
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function resolveBundledInstallPlanForCatalogEntry(params: {
@@ -86,6 +113,15 @@ export function resolveBundledInstallPlanBeforeNpm(params: {
   if (!bundledSource) {
     return null;
   }
+  // An explicit npm request from a Git source checkout is package intent, not a
+  // request to persist disposable build output from that checkout. Packaged
+  // bundles remain image-owned, and bare plugin ids still select local source.
+  if (
+    !isBareNpmPackageName(params.rawSpec) &&
+    isSourceCheckoutBundledPath(bundledSource.localPath)
+  ) {
+    return null;
+  }
   return {
     bundledSource,
     warning: `Using bundled plugin "${bundledSource.pluginId}" from ${shortenHomePath(bundledSource.localPath)} for npm install spec "${rawSpec}" because this plugin ships with the current OpenClaw build. To force an external npm override, use npm:${rawSpec}.`,
@@ -105,6 +141,12 @@ export function resolveBundledInstallPlanForNpmFailure(params: {
     value: params.rawSpec,
   });
   if (!bundledSource) {
+    return null;
+  }
+  if (
+    !isBareNpmPackageName(params.rawSpec) &&
+    isSourceCheckoutBundledPath(bundledSource.localPath)
+  ) {
     return null;
   }
   return {


### PR DESCRIPTION
Closes #112827

## What Problem This Solves

Fixes an issue where users installing a versioned official plugin from an OpenClaw Git checkout could get a disposable checkout path recorded instead of the requested npm package. After changing runtimes or removing the worktree, the affected agent could fail before replying because that path install was not a trusted official npm install.

## Why This Change Was Made

Explicit npm package selectors now stay registry-backed when a matching bundle comes from an OpenClaw source checkout. Intentional bare plugin-ID installs still select local source, and bundles shipped inside packaged runtime images keep their existing image-owned behavior; the trusted-plugin security gate is unchanged.

## User Impact

Operators can install a versioned official plugin while developing from source without coupling persistent plugin state to that checkout. Runtime swaps and worktree cleanup no longer turn that apparently successful install into a pre-reply trust failure.

AI-assisted: yes. I reviewed the implementation, reproduction, security boundary, and test evidence.

## Evidence

- Red/base: unmodified `main` at `eccf02f04ac11d205c0025d781f5c76b98943498` selected `<checkout>/dist/extensions/codex` for `@openclaw/codex@2026.7.2-beta.3` instead of returning the registry plan.
- Green/head: 190 focused tests pass across `plugin-install-plan.test.ts` and `plugins-cli.install.test.ts`, including explicit selector, package-not-found fallback, bare-ID, and packaged-bundle controls.
- Exact-head formatting and focused oxlint pass.
- Remote Testbox `tbx_01ky686vvxn24aj3qn2g3hbqkc`: format, focused oxlint, `tsgo:core`, `tsgo:core:test`, build artifacts, and isolated-home black-box CLI proof passed. Run: https://github.com/openclaw/openclaw/actions/runs/29970975745
- Source-blind behavior proof: an explicit Codex version installed under the managed npm project path, while bare `codex` continued to load the checkout bundle.
- Live recovery control: replacing the stale path record with the same published Codex package restored a successful `gpt-5.6-sol` reply without weakening the plugin trust check.
- Autoreview: clean, no accepted/actionable findings.
- Known unrelated baseline failure: an earlier Testbox `pnpm check:changed` run hit the fresh-`main` max-lines ratchet for `src/config/zod-schema.providers-core.ts`; the focused and type/build lanes above passed.
