### PR TITLE
fix(auto-reply): read group sender fields from ctx before sessionCtx

### DIFF
--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -273,9 +273,9 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
           // Direct transcripts keep their existing identity-storage boundary.
           sender: persistGroupSender
             ? {
-                id: normalizeOptionalString(sessionCtx.SenderId),
-                name: normalizeOptionalString(sessionCtx.SenderName),
-                username: normalizeOptionalString(sessionCtx.SenderUsername),
+                id: normalizeOptionalString(ctx.SenderId ?? sessionCtx.SenderId),
+                name: normalizeOptionalString(ctx.SenderName ?? sessionCtx.SenderName),
+                username: normalizeOptionalString(ctx.SenderUsername ?? sessionCtx.SenderUsername),
               }
             : undefined,
         }

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1580,6 +1580,52 @@ describe("runPreparedReply media-only handling", () => {
     }
   });
 
+  it("persists the live ctx sender, not a stale sessionCtx sender from a different group member", async () => {
+    // Two distinct members of the same group session: sessionCtx still reflects the
+    // first member's identity (carried over from session-level context), while ctx
+    // carries the second, current message's live sender. Before the fix, the
+    // sessionCtx-only read silently attributed the second member's message to the
+    // first member.
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          ...createInboundBody("hello"),
+          OriginatingChannel: "telegram",
+          OriginatingTo: "chat-1",
+          ChatType: "group",
+          SenderId: "user-bob",
+          SenderName: "Bob",
+          SenderUsername: "bob",
+        },
+        sessionCtx: {
+          ...createSessionBody("hello"),
+          Provider: "telegram",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "chat-1",
+          ChatType: "group",
+          SenderId: "user-alice",
+          SenderName: "Alice",
+          SenderUsername: "alice",
+        },
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: 1,
+          chatType: "group",
+          channel: "telegram",
+        } as SessionEntry,
+      }),
+    );
+
+    const message = requireRunReplyAgentCall().followupRun.userTurnTranscriptRecorder?.message;
+    expect(message).toMatchObject({
+      __openclaw: {
+        senderId: "user-bob",
+        senderName: "Bob",
+        senderUsername: "bob",
+      },
+    });
+  });
+
   it("normalizes second-based inbound timestamps before preparing user turns", async () => {
     await runPrepared({
       ctx: {


### PR DESCRIPTION
## Summary

- Group/channel messages persist sender attribution (`sender.{id,name,username}`) for the transcript. The block built it from `sessionCtx.SenderId/SenderName/SenderUsername` only, unlike every sibling field in the same object (`ChatType`, `InputProvenance`, timestamp), which already reads `ctx.X ?? sessionCtx.X`.
- Fix: read `ctx.SenderId/SenderName/SenderUsername` first, falling back to `sessionCtx`, matching the pattern the neighboring fields already use.
- **Rebased onto current `main`.** The original branch predated the reply-run split, so the owner function moved: transcript construction now lives in `src/auto-reply/reply/get-reply-run-execute.ts`, not in the old monolithic `get-reply-run.ts`. The head is now a single commit against current `main` and the merge state is clean. The previous head is preserved at `abacha/openclaw@backup/112833-old-base-20260804` for reference.

## What Problem This Solves

In a group/channel with two or more distinct senders, a message from the second member was persisted in the transcript under the **first** member's identity — a wrong-attribution bug, not a missing-name fallback to "Them".

Root cause: the `sender` block read only `sessionCtx.{SenderId,SenderName,SenderUsername}`. `sessionCtx` carries session-level identity, which can still be a previous member, while `ctx` carries the live sender of the current turn. Reading `sessionCtx` alone persisted the wrong member — silently, into the transcript that every later turn reads as history.

## Evidence

Regression test `persists the live ctx sender, not a stale sessionCtx sender from a different group member` in `src/auto-reply/reply/get-reply-run.media-only.test.ts`. It drives the real `runPreparedReply` executor with two distinct members — `ctx` = Bob (live sender of this turn), `sessionCtx` = Alice (stale session identity) — and asserts the persisted transcript identity is Bob.

**On current `main`, without the fix**, the same test run against `609ee6cb7e^` — the transcript records Alice as the author of Bob's message:

```
$ npx vitest run src/auto-reply/reply/get-reply-run.media-only.test.ts -t "persists the live ctx sender"

- Expected
+ Received

  {
    "__openclaw": {
-     "senderId": "user-bob",
-     "senderName": "Bob",
-     "senderUsername": "bob",
+     "senderId": "user-alice",
+     "senderName": "Alice",
+     "senderUsername": "alice",
    },
  }

 ❯ src/auto-reply/reply/get-reply-run.media-only.test.ts:1318:21
 Test Files  1 failed (1)
      Tests  1 failed | 104 skipped (105)
```

**At this head**, same command, same test:

```
 Test Files  1 passed (1)
      Tests  1 passed | 104 skipped (105)
```

Full file, no filter:

```
$ npx vitest run src/auto-reply/reply/get-reply-run.media-only.test.ts
 Test Files  1 passed (1)
      Tests  105 passed (105)
```

Both runs are reproducible from this branch with no fixtures beyond the repo — revert only the source file, keep the test:

```
git checkout HEAD^ -- src/auto-reply/reply/get-reply-run-execute.ts   # fails, persists Alice
git checkout HEAD  -- src/auto-reply/reply/get-reply-run-execute.ts   # passes, persists Bob
```

The assertion reads the persisted `userTurnTranscript` message the executor actually hands to the agent run, not an intermediate value.

## Test plan

- [x] Failing-first regression test, verified failing on the unfixed parent commit (output above) and passing at this head.
- [x] `npx vitest run src/auto-reply/reply/get-reply-run.media-only.test.ts` — 105/105 passed.
- [x] `npx tsc -p tsconfig.core.json --noEmit` — no errors in the touched files. One pre-existing error remains in `packages/terminal-core/src/ansi.ts` (TS2554), unrelated to this change and untouched by it.
