### PR TITLE
fix: report exact WhatsApp access coverage owners

### DIFF
--- a/qa/scenarios/channels/whatsapp-access-control-dm-disabled.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-dm-disabled.yaml
@@ -5,7 +5,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - whatsapp.direct-message-dmpolicy
   objective: Verify dmPolicy disabled rejects direct messages.
   gatewayConfigPatch:
     channels:

--- a/qa/scenarios/channels/whatsapp-access-control-dm-open.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-dm-open.yaml
@@ -5,7 +5,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - whatsapp.direct-message-dmpolicy
   objective: Verify dmPolicy open accepts a direct message.
   gatewayConfigPatch:
     channels:

--- a/qa/scenarios/channels/whatsapp-access-control-group-disabled.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-group-disabled.yaml
@@ -5,7 +5,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - whatsapp.group-allowlists
   objective: Verify groupPolicy disabled rejects group messages.
   gatewayConfigPatch:
     channels:

--- a/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
@@ -5,7 +5,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - whatsapp.group-allowlists
   objective: Verify groupPolicy open accepts a mentioned group message.
   gatewayConfigPatch:
     channels:

--- a/qa/scenarios/channels/whatsapp-pairing-block.yaml
+++ b/qa/scenarios/channels/whatsapp-pairing-block.yaml
@@ -5,7 +5,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.dm-pairing-pairing-gate
+      - whatsapp.dm-pairing-challenge
   objective: Verify an unpaired WhatsApp DM receives the pairing gate instead of reaching the agent.
   gatewayConfigPatch:
     channels:


### PR DESCRIPTION
Closes #112826

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a QA reporting problem where five WhatsApp access-control and pairing scenarios credited generic channel capabilities instead of the WhatsApp taxonomy owners they directly exercise.

## Why This Change Was Made

Retargets only the five drifted scenario mappings. The existing generic catalog contract validates coverage IDs against taxonomy without duplicating scenario IDs in another test; the other 47 WhatsApp scenarios retain their existing owners after a full disposition audit. No production channel behavior or shared QA control-plane surface changes.

## User Impact

No end-user runtime behavior changes. Maintainers get accurate WhatsApp coverage accounting for direct-message policy, group allowlists, and the DM pairing challenge.

## Evidence

- Blacksmith Testbox `tbx_01ky6be9yjj92sy58msgx2skjm`: generic `scenario-catalog.test.ts` passed 35/35, including catalog-wide validation that scenario coverage IDs exist in taxonomy. Run: https://github.com/openclaw/openclaw/actions/runs/29973427749
- Blacksmith Testbox `pnpm check:changed` passed its fail-safe all-lanes plan for the five YAML mappings, including changed-file formatting, repository typecheck, all lint shards, runtime import-cycle validation, and repository guards.
- Local `git diff --check` passed.
- Fresh pre-commit Codex autoreview (`gpt-5.6-sol`, high) returned no findings and judged the patch correct (0.91).
