### PR TITLE
fix(ui): keep user footer controls in reading order

### DIFF
--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -19,8 +19,12 @@ const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? descri
 let browser: Browser;
 let server: ControlUiE2eServer;
 
+function resolveArtifactDir(): string | undefined {
+  return process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim() || undefined;
+}
+
 async function captureProof(page: Page, name: string) {
-  const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+  const artifactDir = resolveArtifactDir();
   if (!artifactDir) {
     return;
   }
@@ -43,7 +47,16 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
   });
 
   it("uses one avatar placement and keeps shared-thread authors readable", async () => {
-    const context = await browser.newContext({ viewport: { height: 760, width: 1180 } });
+    const artifactDir = resolveArtifactDir();
+    if (artifactDir) {
+      await fs.mkdir(artifactDir, { recursive: true });
+    }
+    const context = await browser.newContext({
+      viewport: { height: 760, width: 1180 },
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 760, width: 1180 } } }
+        : {}),
+    });
     const page = await context.newPage();
     const now = Date.now();
     await installMockGateway(page, {
@@ -61,7 +74,12 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
           role: "user",
           content: "Can we keep one clear avatar and show who wrote each message?",
           timestamp: now - 120_000,
-          __openclaw: { senderId: "profile-riley", senderName: "Riley" },
+          __openclaw: {
+            id: "riley-message",
+            senderId: "profile-riley",
+            senderName: "Riley",
+            seq: 2,
+          },
         },
         {
           role: "assistant",
@@ -72,7 +90,12 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
           role: "user",
           content: "This is much easier to scan in a team conversation.",
           timestamp: now - 30_000,
-          __openclaw: { senderId: "profile-colin", senderName: "Colin" },
+          __openclaw: {
+            id: "colin-message",
+            senderId: "profile-colin",
+            senderName: "Colin",
+            seq: 4,
+          },
         },
       ],
     });
@@ -96,6 +119,23 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
     await expect(hoverDetails).toHaveCSS("opacity", "1");
     await expect(page.locator(".chat-author-avatar")).toHaveCount(0);
     await captureProof(page, "after-hover.png");
+
+    const footerOrder = await userGroups
+      .last()
+      .locator(".chat-group-footer")
+      .locator("button, .chat-sender-name, .chat-group-timestamp")
+      .evaluateAll((elements) =>
+        elements.map((element) => {
+          if (element.classList.contains("chat-sender-name")) {
+            return "name";
+          }
+          if (element.classList.contains("chat-group-timestamp")) {
+            return "time";
+          }
+          return element.getAttribute("aria-label");
+        }),
+      );
+    expect(footerOrder).toEqual(["Reply to message", "Hide message", "Rewind", "name", "time"]);
 
     await context.close();
   });

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -712,6 +712,40 @@ describe("grouped chat rendering", () => {
     });
   });
 
+  it("orders user footer actions before the sender name and timestamp", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: "User footer order.",
+        timestamp: Date.now(),
+      },
+      "user",
+      {
+        onDelete: vi.fn(),
+        onReply: vi.fn(),
+        onRewind: vi.fn(),
+        userName: "Jason",
+      },
+    );
+
+    const footer = expectElement(container, ".chat-group.user .chat-group-footer", HTMLElement);
+    const order = [
+      ...footer.querySelectorAll<HTMLElement>("button, .chat-sender-name, .chat-group-timestamp"),
+    ].map((element) => {
+      if (element.classList.contains("chat-sender-name")) {
+        return "name";
+      }
+      if (element.classList.contains("chat-group-timestamp")) {
+        return "time";
+      }
+      return element.getAttribute("aria-label");
+    });
+
+    expect(order).toEqual(["Reply to message", "Hide message", "Rewind", "name", "time"]);
+  });
+
   it("keeps hidden assistant thinking out of inline reply context", () => {
     const container = document.createElement("div");
     const onReply = vi.fn();

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -1102,6 +1102,9 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
   );
   const lastMessageIndex = group.messages.length - 1;
   const footerActionDetails = messageActionDetails[lastMessageIndex] ?? null;
+  const hasUserFooterActions =
+    normalizedRole === "user" &&
+    Boolean((footerActionDetails?.replyTarget && opts.onReply) || opts.onDelete || opts.onRewind);
 
   // Attributed (logged-in) senders tint their bubbles with the same stable
   // identity hue as their avatar initials; CSS owns per-theme lightness so
@@ -1160,11 +1163,21 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
           : ""}"
       >
         <div class="chat-group-footer__meta">
-          ${opts.onRewind && normalizedRole === "user"
-            ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled), "left")
-            : nothing}
-          ${opts.onDelete && normalizedRole === "user"
-            ? renderDeleteButton(opts.onDelete, "left")
+          ${hasUserFooterActions
+            ? html`
+                <div
+                  class="chat-group-footer-actions"
+                  data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
+                >
+                  ${footerActionDetails?.replyTarget && opts.onReply
+                    ? renderReplyButton(footerActionDetails.replyTarget, opts.onReply)
+                    : nothing}
+                  ${opts.onDelete ? renderDeleteButton(opts.onDelete, "left") : nothing}
+                  ${opts.onRewind
+                    ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled), "left")
+                    : nothing}
+                </div>
+              `
             : nothing}
           ${normalizedRole === "user" && !showAvatarGutter
             ? renderChatAuthorAvatar(group.sender)
@@ -1172,7 +1185,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
           <span class="chat-sender-name">${who}</span>
           ${renderMessageMeta(group.timestamp, meta)}
         </div>
-        ${footerActionDetails || (opts.onDelete && normalizedRole !== "user")
+        ${normalizedRole !== "user" && (footerActionDetails || opts.onDelete)
           ? html`
               <div
                 class="chat-group-footer-actions"
@@ -1185,7 +1198,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                       opts.onOpenSidebar,
                       normalizedRole !== "user" ? opts.onDelete : undefined,
                     )
-                  : opts.onDelete && normalizedRole !== "user"
+                  : opts.onDelete
                     ? renderDeleteButton(opts.onDelete, "right")
                     : nothing}
               </div>

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -135,7 +135,7 @@
 .chat-group-footer--persistent-identity .chat-delete-wrap,
 .chat-group-footer--persistent-identity .chat-group-timestamp,
 .chat-group-footer--persistent-identity .msg-meta,
-.chat-group-footer--persistent-identity > .chat-group-footer-actions {
+.chat-group-footer--persistent-identity .chat-group-footer-actions {
   position: absolute;
   opacity: 0;
   pointer-events: none;
@@ -156,9 +156,9 @@
 .chat-group-footer--persistent-identity:has(details.msg-meta[open]) .chat-delete-wrap,
 .chat-group-footer--persistent-identity:has(details.msg-meta[open]) .chat-group-timestamp,
 .chat-group-footer--persistent-identity:has(details.msg-meta[open]) .msg-meta,
-.chat-group:hover .chat-group-footer--persistent-identity > .chat-group-footer-actions,
-.chat-group:focus-within .chat-group-footer--persistent-identity > .chat-group-footer-actions,
-.chat-group-footer--persistent-identity:has(details.msg-meta[open]) > .chat-group-footer-actions {
+.chat-group:hover .chat-group-footer--persistent-identity .chat-group-footer-actions,
+.chat-group:focus-within .chat-group-footer--persistent-identity .chat-group-footer-actions,
+.chat-group-footer--persistent-identity:has(details.msg-meta[open]) .chat-group-footer-actions {
   position: static;
   opacity: 1;
   pointer-events: auto;
@@ -185,6 +185,7 @@
   flex: 0 0 auto;
 }
 
+.chat-group.user .chat-group-footer-actions,
 .chat-group.assistant .chat-group-footer-actions,
 .chat-group.assistant .chat-message-actions-row {
   justify-content: flex-start;
@@ -597,7 +598,7 @@ img.chat-avatar {
   .chat-group-footer--persistent-identity .chat-delete-wrap,
   .chat-group-footer--persistent-identity .chat-group-timestamp,
   .chat-group-footer--persistent-identity .msg-meta,
-  .chat-group-footer--persistent-identity > .chat-group-footer-actions {
+  .chat-group-footer--persistent-identity .chat-group-footer-actions {
     position: static;
     opacity: 1;
     pointer-events: auto;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users hovering a user message would see Reply separated at the far edge of the footer while Hide, Rewind, the sender name, and timestamp remained grouped on the opposite side. The split also made the DOM and keyboard order disagree with the intended reading order.

## Why This Change Was Made

Render available user-message actions as one sequence before identity metadata, preserving the stable order Reply, Hide, Rewind, sender name, timestamp. Assistant-message actions stay on their existing rendering path, and shared-thread reveal styling now handles the nested user action group.

This change was AI-assisted and reviewed with the repository's isolated autoreview workflow.

## User Impact

User-message footers now read and focus left-to-right as Reply, Hide, Rewind, sender name, timestamp. Missing actions retain the relative order of the remaining items.

## Evidence

- Source-blind live validation: deployed to Rosita; Jason confirmed the result looks correct.
- Before/after Chromium screenshots and short recordings were captured with a synthetic shared-chat fixture and retained in the private maintainer-proof workspace.
- Exact-head focused proof on `ac204bdf8fa57f89169aba49b4f0e6591b9c3d28`:
  - `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts ui/src/e2e/chat-attributed-identity.e2e.test.ts`
  - 123 UI unit tests passed.
  - 1 attributed-chat Chromium E2E passed, including the exact DOM order assertion.
- `git diff --check` passed.
- Autoreview: clean; no accepted/actionable findings (0.91 confidence).
