### PR TITLE
fix(qa): align Matrix scenario coverage with executed behavior

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
@@ -5,6 +5,17 @@ import {
   readQaScenarioExecutionConfig,
 } from "../../scenario-catalog.js";
 
+const MATRIX_MENTION_GATE_PRIMARY_SCENARIOS = [
+  "matrix-allowbots-default-block",
+  "matrix-allowbots-mentions-mentioned-room",
+  "matrix-allowbots-mentions-unmentioned-open-room-block",
+  "matrix-allowbots-room-override-blocks-account-true",
+  "matrix-allowbots-room-override-enables-account-off",
+  "matrix-allowbots-self-sender-ignored",
+  "matrix-allowbots-true-unmentioned-open-room",
+  "matrix-mention-metadata-spoof-block",
+] as const;
+
 function readModuleBinding(
   scenario: ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"][number],
 ) {
@@ -125,6 +136,21 @@ describe("Matrix QA Lab scenario flows", () => {
       call: "scenarioModule.runMatrixQaAllowlistHotReloadScenario",
       args: [{ expr: "scenarioContext" }],
       saveAs: "result",
+    });
+  });
+
+  it("attributes Matrix admission and media evidence to behavior the flows execute", () => {
+    for (const scenarioId of MATRIX_MENTION_GATE_PRIMARY_SCENARIOS) {
+      expect(readQaScenarioById(scenarioId).coverage, scenarioId).toEqual({
+        primary: ["matrix.mention-gates"],
+      });
+    }
+    expect(readQaScenarioById("matrix-mxid-prefixed-command-block").coverage).toEqual({
+      primary: ["matrix.mention-gates"],
+      secondary: ["channels.channel-native-commands"],
+    });
+    expect(readQaScenarioById("matrix-unsupported-media-safe").coverage).toEqual({
+      primary: ["channels.inbound-media-normalization"],
     });
   });
 

--- a/qa/scenarios/channels/matrix-allowbots-default-block.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-default-block.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - matrix.mention-gates
   execution:
     profiles: { "matrix:all": 36, "matrix:fast": 8, "matrix:transport": 35 }
     kind: flow

--- a/qa/scenarios/channels/matrix-allowbots-mentions-mentioned-room.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-mentions-mentioned-room.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - matrix.mention-gates
   execution:
     profiles: { "matrix:all": 38, "matrix:fast": 9, "matrix:transport": 37 }
     kind: flow

--- a/qa/scenarios/channels/matrix-allowbots-mentions-unmentioned-open-room-block.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-mentions-unmentioned-open-room-block.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - matrix.mention-gates
   execution:
     profiles: { "matrix:all": 39, "matrix:transport": 38 }
     kind: flow

--- a/qa/scenarios/channels/matrix-allowbots-room-override-blocks-account-true.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-room-override-blocks-account-true.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - matrix.mention-gates
   execution:
     profiles: { "matrix:all": 41, "matrix:transport": 40 }
     kind: flow

--- a/qa/scenarios/channels/matrix-allowbots-room-override-enables-account-off.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-room-override-enables-account-off.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - matrix.mention-gates
   execution:
     profiles: { "matrix:all": 42, "matrix:transport": 41 }
     kind: flow

--- a/qa/scenarios/channels/matrix-allowbots-self-sender-ignored.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-self-sender-ignored.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - matrix.mention-gates
   execution:
     profiles: { "matrix:all": 43, "matrix:transport": 42 }
     kind: flow

--- a/qa/scenarios/channels/matrix-allowbots-true-unmentioned-open-room.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-true-unmentioned-open-room.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - matrix.mention-gates
   execution:
     profiles: { "matrix:all": 37, "matrix:transport": 36 }
     kind: flow

--- a/qa/scenarios/channels/matrix-mention-metadata-spoof-block.yaml
+++ b/qa/scenarios/channels/matrix-mention-metadata-spoof-block.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.room-allowlist-access-policy
+      - matrix.mention-gates
   execution:
     profiles: { "matrix:all": 45, "matrix:transport": 44 }
     kind: flow

--- a/qa/scenarios/channels/matrix-mxid-prefixed-command-block.yaml
+++ b/qa/scenarios/channels/matrix-mxid-prefixed-command-block.yaml
@@ -4,9 +4,9 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - channels.channel-native-commands
-    secondary:
       - matrix.mention-gates
+    secondary:
+      - channels.channel-native-commands
   execution:
     profiles: { "matrix:all": 44, "matrix:transport": 43 }
     kind: flow

--- a/qa/scenarios/channels/matrix-unsupported-media-safe.yaml
+++ b/qa/scenarios/channels/matrix-unsupported-media-safe.yaml
@@ -5,8 +5,6 @@ scenario:
   coverage:
     primary:
       - channels.inbound-media-normalization
-    secondary:
-      - matrix.inbound-media-failure-handling
   execution:
     profiles: { "matrix:all": 56, "matrix:media": 5 }
     kind: flow


### PR DESCRIPTION
Closes #112830

## What Problem This Solves

Resolves a problem where ten Matrix QA scenarios attributed passing evidence to generic or unexercised taxonomy owners. That could fulfill the wrong scorecard feature or imply Matrix download-failure coverage that the executable never ran.

## Why This Change Was Made

The patch audits all 85 Matrix scenarios against their flow implementations, retargets eight bot-loop/mention-admission scenarios to `matrix.mention-gates`, makes that Matrix owner primary for the MXID-prefixed command gate while retaining generic command authorization as advisory evidence, and removes an unsupported Matrix media-failure claim. A Matrix-owned catalog test locks those exact dispositions.

The remaining 75 scenarios retain their existing coverage roles. This changes no production Matrix code, QA Lab control-plane surface, WhatsApp file, taxonomy policy, or cross-channel shared runtime.

## User Impact

No user-visible runtime behavior changes. Maintainers and QA scorecard consumers get Matrix evidence that matches the behavior each scenario actually executes, and the real inbound media download-failure gap remains visible instead of being credited by an unsupported-media success path.

## Evidence

- Full disposition audit: 85 Matrix scenarios; 8 primary retargets, 1 primary/advisory role swap, 1 false secondary deletion, 75 retained unchanged.
- Final-head focused proof: `matrix-scenario-flows.test.ts` passed 6/6 on `eedcc9b7fcfa756221c986126a1b3a36af6c7e21`.
- Changed gate on the identical patch before unrelated main-only rebases: Blacksmith Testbox `tbx_01ky6a3warevnn7w6rh0jh8tdp` passed formatting, repository guards, full-project tsgo, full lint, and runtime cycle checks (exit 0): https://github.com/openclaw/openclaw/actions/runs/29972426462
- Earlier changed-gate confirmation: Testbox `tbx_01ky69az1ct2grqx1af2yt24e9` passed the same lanes (exit 0): https://github.com/openclaw/openclaw/actions/runs/29971833286
- Fresh Codex autoreview (`gpt-5.6-sol`, high reasoning, uncommitted mode) returned no accepted/actionable findings and `patch is correct` (0.92); TruffleHog clean.
- `git diff --check` passed. Final diff is 36 insertions and 12 deletions across ten Matrix scenario YAML files and one Matrix-specific test.

The broader local catalog/report probe also exposed unrelated current-main failures from untouched cron/Telegram coverage IDs plus an environment-sensitive `update.run` assertion. This PR does not cross those owner boundaries; exact-head CI remains the merge-gate source of truth.
