### PR TITLE
fix(qa): stop retrying unavailable credentials per channel partition

### DIFF
--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1178,7 +1178,7 @@ describe("qa suite runtime launcher", () => {
     expect(rejected).toBe(true);
   });
 
-  it("records unavailable channel credentials as blocked evidence", async () => {
+  it("reuses unavailable channel credential evidence across serial partitions", async () => {
     const repoRoot = await makeTempRepo("qa-suite-credential-unavailable-");
     const poolError = Object.assign(new Error("no WhatsApp credential is available"), {
       code: "POOL_EXHAUSTED",
@@ -1195,17 +1195,22 @@ describe("qa suite runtime launcher", () => {
       providerMode: "mock-openai",
       channelDriver: "live",
       adapterFactories: [{ id: "whatsapp", matches: () => true, create: vi.fn() }],
-      scenarioIds: ["whatsapp-status-command", "control-ui-chat-flow-playwright"],
+      scenarioIds: [
+        "whatsapp-status-command",
+        "whatsapp-access-control-dm-open",
+        "control-ui-chat-flow-playwright",
+      ],
     });
 
     expect(result.executionKind).toBe("suite");
     if (result.executionKind !== "suite") {
       throw new Error("expected unified suite result");
     }
-    expect(result.result.scenarios[0]).toMatchObject({
-      status: "fail",
-      details: expect.stringContaining("channel credential unavailable"),
-    });
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(result.result.scenarios.slice(0, 2)).toMatchObject([
+      { status: "fail", details: expect.stringContaining("channel credential unavailable") },
+      { status: "fail", details: expect.stringContaining("channel credential unavailable") },
+    ]);
     const evidence = JSON.parse(await fs.readFile(result.result.evidencePath, "utf8")) as {
       entries?: Array<{
         execution?: { channel?: { id?: string } };
@@ -1213,11 +1218,13 @@ describe("qa suite runtime launcher", () => {
         test?: { id?: string };
       }>;
     };
-    const blocked = evidence.entries?.find((entry) => entry.test?.id === "whatsapp-status-command");
-    expect(blocked).toMatchObject({
-      execution: { channel: { id: "whatsapp" } },
-      result: { status: "blocked" },
-    });
+    for (const scenarioId of ["whatsapp-status-command", "whatsapp-access-control-dm-open"]) {
+      const blocked = evidence.entries?.find((entry) => entry.test?.id === scenarioId);
+      expect(blocked).toMatchObject({
+        execution: { channel: { id: "whatsapp" } },
+        result: { status: "blocked" },
+      });
+    }
   });
 
   it("shares ordinary flow scenarios and isolates flow scenarios with config patches", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -627,6 +627,7 @@ async function runUnifiedQaSuite(params: {
   const isolatedFlowPartitionTasks: QaUnifiedPartitionTask[] = [];
   const testFilePartitionTasks: QaUnifiedPartitionTask[] = [];
   const scriptPartitionTasks: QaUnifiedPartitionTask[] = [];
+  const unavailableChannelCredentialDetails = new Map<string, string>();
   if (params.plan.flowScenarios.length > 0) {
     const channelGroups = (
       await resolveQaFlowChannelGroups(params.runParams, params.plan.flowScenarios)
@@ -713,6 +714,41 @@ async function runUnifiedQaSuite(params: {
         ]
           .filter((part): part is string => Boolean(part))
           .join("-");
+        const buildCredentialUnavailableResult = (details: string): QaUnifiedPartitionResult => {
+          const blockedResults = partition.scenarios.map((scenario) => ({
+            name: scenario.title,
+            status: "blocked" as const,
+            details,
+          }));
+          return {
+            evidenceSummaries: [
+              buildQaSuiteEvidenceSummary({
+                artifactPaths: [],
+                evidenceMode: params.runParams?.evidenceMode,
+                channelId: channelGroup.channelId ?? transportId,
+                channelDriver:
+                  params.runParams?.channelDriver ??
+                  channelGroup.channelDriverSelection?.channelDriver,
+                env: process.env,
+                generatedAt: new Date().toISOString(),
+                primaryModel,
+                providerMode,
+                repoRoot,
+                scenarioDefinitions: partition.scenarios,
+                scenarioResults: blockedResults,
+              }),
+            ],
+            scenarioResults: partition.scenarios.map((scenario) => ({
+              scenarioId: scenario.id,
+              result: {
+                name: scenario.title,
+                status: "fail",
+                details,
+                steps: [{ name: "Acquire channel credential", status: "fail", details }],
+              },
+            })),
+          };
+        };
         const task = {
           // One channel's credential and Gateway state stay serial unless each adapter create()
           // owns an isolated runtime. Distinct channels may always run together.
@@ -721,6 +757,12 @@ async function runUnifiedQaSuite(params: {
             : undefined,
           weight: partition.concurrency,
           run: async () => {
+            const unavailableDetails = channelGroup.channelId
+              ? unavailableChannelCredentialDetails.get(channelGroup.channelId)
+              : undefined;
+            if (unavailableDetails) {
+              return buildCredentialUnavailableResult(unavailableDetails);
+            }
             const result = await runFlowSuite({
               ...params.runParams,
               outputDir: partitionName
@@ -755,39 +797,10 @@ async function runUnifiedQaSuite(params: {
               // Preserve other channels' evidence, but keep the suite failed: maturity
               // docs must not publish until every required channel can run.
               const details = `channel credential unavailable: ${formatErrorMessage(error)}`;
-              const blockedResults = partition.scenarios.map((scenario) => ({
-                name: scenario.title,
-                status: "blocked" as const,
-                details,
-              }));
-              return {
-                evidenceSummaries: [
-                  buildQaSuiteEvidenceSummary({
-                    artifactPaths: [],
-                    evidenceMode: params.runParams?.evidenceMode,
-                    channelId: channelGroup.channelId ?? transportId,
-                    channelDriver:
-                      params.runParams?.channelDriver ??
-                      channelGroup.channelDriverSelection?.channelDriver,
-                    env: process.env,
-                    generatedAt: new Date().toISOString(),
-                    primaryModel,
-                    providerMode,
-                    repoRoot,
-                    scenarioDefinitions: partition.scenarios,
-                    scenarioResults: blockedResults,
-                  }),
-                ],
-                scenarioResults: partition.scenarios.map((scenario) => ({
-                  scenarioId: scenario.id,
-                  result: {
-                    name: scenario.title,
-                    status: "fail",
-                    details,
-                    steps: [{ name: "Acquire channel credential", status: "fail", details }],
-                  },
-                })),
-              } satisfies QaUnifiedPartitionResult;
+              if (channelDriverFlowRequiresExclusiveWorkers && channelGroup.channelId) {
+                unavailableChannelCredentialDetails.set(channelGroup.channelId, details);
+              }
+              return buildCredentialUnavailableResult(details);
             });
             if ("evidenceSummaries" in result) {
               return result;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full QA release profiles could exceed the one-hour workflow limit when a channel credential pool was unavailable. The failed maturity run waited two minutes for WhatsApp credentials once per serialized partition; the full profile contains 45 WhatsApp partitions.

Related: #112569
Related: #112815

## Why This Change Was Made

After a serialized channel partition establishes that its credential pool is unavailable, later partitions for that channel reuse the same blocked evidence instead of repeating credential acquisition. This is scoped to exclusive same-channel workers; independently isolated channel workers retain their existing behavior.

## User Impact

Full QA profiles still fail and prevent scorecard publication when required credentials are unavailable, but they finish promptly enough to expose complete failure evidence instead of timing out after redundant waits.

## Evidence

- Timed-out source run: https://github.com/openclaw/openclaw/actions/runs/29970096150
- Before: Matrix isolated completed 7/7, then WhatsApp began a new two-minute credential wait for every serialized partition.
- Worst-case saving for this profile when the WhatsApp pool is unavailable: about 88 minutes (one two-minute wait instead of 45).
- Focused regression suite: `extensions/qa-lab/src/suite-launch.runtime.test.ts` — 29/29 passed.
- Changed-file gate: https://github.com/openclaw/openclaw/actions/runs/29973249826 — passed.
- Autoreview: clean, no actionable findings.

AI-assisted: yes. I understand and verified the change.
