### PR TITLE
fix(release): validate frozen extended-stable candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1112,7 +1112,22 @@ jobs:
       # packages/-only PRs cannot land stale committed plugin bundles; the
       # extension byte-equality suites do not run for those diffs.
       - name: Check bundled plugin generated assets
-        run: pnpm plugins:assets:check
+        run: |
+          set -euo pipefail
+
+          if node --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+
+          const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+          process.exit(packageJson.scripts?.["plugins:assets:check"] ? 0 : 1);
+          NODE
+          then
+            pnpm plugins:assets:check
+          else
+            # Frozen release candidates predate this generated-asset contract.
+            # Their own build remains the available asset validation surface.
+            echo "Selected release candidate predates plugins:assets:check; skipping unavailable check."
+          fi
 
       - name: Pack built runtime artifacts
         run: tar --posix -cf dist-runtime-build.tar.zst --use-compress-program zstdmt dist dist-runtime packages/*/dist

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1246,15 +1246,29 @@ jobs:
           set -euo pipefail
 
           output_dir="runtime-pair-${RUNTIME_PAIR_LANE}"
-
-          pnpm openclaw qa suite \
-            --provider-mode mock-openai \
-            --runtime-pair-lane "$RUNTIME_PAIR_LANE" \
-            --concurrency "${QA_PARITY_CONCURRENCY}" \
-            --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model "openai/gpt-5.6-luna-alt" \
-            --runtime-pair openclaw,codex \
+          runtime_pair_args=(
+            --provider-mode mock-openai
+            --concurrency "${QA_PARITY_CONCURRENCY}"
+            --model "${OPENCLAW_CI_OPENAI_MODEL}"
+            --alt-model "openai/gpt-5.6-luna-alt"
+            --runtime-pair openclaw,codex
             --output-dir ".artifacts/qa-e2e/${output_dir}"
+          )
+
+          if pnpm openclaw qa suite --help | grep -Fq -- "--runtime-pair-lane"; then
+            runtime_pair_args+=(--runtime-pair-lane "$RUNTIME_PAIR_LANE")
+          elif [[ "$RUNTIME_PAIR_LANE" == "core" ]]; then
+            # Before runtime-pair lanes, the frozen candidate's standard and
+            # live-only tiers together defined the current core lane.
+            runtime_pair_args+=(--runtime-parity-tier standard,live-only)
+          elif [[ "$RUNTIME_PAIR_LANE" == "soak" ]]; then
+            runtime_pair_args+=(--runtime-parity-tier soak)
+          else
+            echo "Frozen candidate cannot select runtime-pair lane: $RUNTIME_PAIR_LANE" >&2
+            exit 1
+          fi
+
+          pnpm openclaw qa suite "${runtime_pair_args[@]}"
 
       - name: Generate runtime-pair lane report
         id: generate_runtime_parity_report

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -2232,7 +2232,7 @@ jobs:
             trap 'printf "::%s::\n" "$workflow_command_token"' EXIT
             set +e
             TMPDIR="${SUT_RUNTIME_ROOT}/tmp" \
-              pnpm openclaw qa telegram \
+              pnpm --dir "$CANDIDATE_ROOT" openclaw qa telegram \
                 --repo-root "$CANDIDATE_ROOT" \
                 --output-dir "${EVIDENCE_RELATIVE}/${output_name}" \
                 --provider-mode mock-openai \
@@ -2260,7 +2260,7 @@ jobs:
             fi
           done < <(
             TMPDIR="${SUT_RUNTIME_ROOT}/tmp" \
-              pnpm openclaw qa telegram \
+              pnpm --dir "$CANDIDATE_ROOT" openclaw qa telegram \
                 --repo-root "$CANDIDATE_ROOT" \
                 --provider-mode mock-openai \
                 --list-scenarios

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5196,6 +5196,18 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
   });
 
+  it("skips generated-asset validation only when a frozen candidate lacks the contract", () => {
+    const workflow = readCiWorkflow();
+    const buildArtifactsJob = workflow.jobs["build-artifacts"];
+    const assetCheckStep = buildArtifactsJob.steps.find(
+      (step: WorkflowStep) => step.name === "Check bundled plugin generated assets",
+    );
+
+    expect(assetCheckStep.run).toContain('packageJson.scripts?.["plugins:assets:check"]');
+    expect(assetCheckStep.run).toContain("pnpm plugins:assets:check");
+    expect(assetCheckStep.run).toContain("predates plugins:assets:check");
+  });
+
   it("keeps network CodeQL off unrelated source-only refactors", () => {
     const workflow = readCriticalQualityWorkflow();
     const networkConfig = readFileSync(

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -578,6 +578,7 @@ describe("release Telegram QA workflow", () => {
     expect(runStep?.run).toContain("! grep -Fq '\"openai/gpt-5.6-luna\": {'");
     expect(runStep?.run).toContain('qa_model="mock-openai/gpt-5.5"');
     expect(runStep?.run).toContain('--model "$qa_model"');
+    expect(runStep?.run).toContain('pnpm --dir "$CANDIDATE_ROOT" openclaw qa telegram');
     expect(runStep?.run).toContain(
       "Telegram channel canary failed; skipping the remaining scenarios.",
     );

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2775,9 +2775,11 @@ describe("package artifact reuse", () => {
     expect(laneJob.strategy?.["fail-fast"]).toBe(false);
     expect(laneJob.strategy?.matrix?.lane).toContain('["core","soak"]');
     expect(laneJob.strategy?.matrix?.lane).toContain('["core"]');
-    expect(workflowStep(laneJob, "Run runtime-pair lane").run).toContain(
-      '--runtime-pair-lane "$RUNTIME_PAIR_LANE"',
-    );
+    const runtimePairRun = workflowStep(laneJob, "Run runtime-pair lane").run;
+    expect(runtimePairRun).toContain('--runtime-pair-lane "$RUNTIME_PAIR_LANE"');
+    expect(runtimePairRun).toContain("--runtime-parity-tier standard,live-only");
+    expect(runtimePairRun).toContain("--runtime-parity-tier soak");
+    expect(runtimePairRun).toContain("Frozen candidate cannot select runtime-pair lane");
     expect(workflowStep(laneJob, "Upload runtime-pair lane artifacts").with?.name).toContain(
       "${{ matrix.lane }}",
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes a release-validation failure where the frozen `2026.6.34` extended-stable candidate could not be validated after current `main` workflows began assuming newer CI scripts, QA flags, and QA config contracts.

## Why This Change Was Made

The trusted harness now detects the selected candidate capability before invoking generated-asset and runtime-pair checks. Telegram QA runs its CLI from the candidate root, so candidate-native configuration is passed to the candidate runtime. This retains the current checks for current candidates and does not change the frozen release source.

## User Impact

Release operators can validate supported extended-stable candidates without weakening current-main validation or mutating the release branch to match newer harness APIs.

## Evidence

- Reproduced the candidate mismatches in Full Release Validation run `29972066617`: unavailable `plugins:assets:check`, unavailable `--runtime-pair-lane`, and incompatible current-harness `agents.entries` config.
- Verified the frozen candidate accepts `pnpm --dir "$CANDIDATE_ROOT" openclaw qa telegram --help` and exposes legacy `--runtime-parity-tier` selectors.
- Focused workflow contract tests pass:
  - `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t "skips generated-asset validation"`
  - `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts -t "runs canonical runtime-pair lanes"`
  - `node scripts/run-vitest.mjs test/scripts/openclaw-release-telegram-qa-workflow.test.ts -t "keeps the isolated SUT lifetime"`
- `git diff --check` passes; fresh autoreview found no actionable findings.
- The broader package-acceptance file has seven existing failures on both this branch and clean `origin/main`; they concern mocked Telegram-child/release-publish fixtures and are unrelated to this diff.