### PR TITLE
fix(kilocode): discover models when HTTP proxy is required

### DIFF
--- a/extensions/kilocode/provider-models.proxy.test.ts
+++ b/extensions/kilocode/provider-models.proxy.test.ts
@@ -1,0 +1,51 @@
+// Kilocode proxy tests cover the live model discovery transport policy.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+import { discoverKilocodeModels } from "./provider-models.js";
+
+const ORIGINAL_VITEST = process.env.VITEST;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function restoreEnv(key: "VITEST" | "NODE_ENV", value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv("VITEST", ORIGINAL_VITEST);
+  restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
+  fetchWithSsrFGuardMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("Kilocode model discovery proxy policy", () => {
+  it("allows the guarded official catalog request to use an eligible HTTP proxy", async () => {
+    delete process.env.VITEST;
+    process.env.NODE_ENV = "development";
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("unavailable", { status: 503 }),
+      release,
+    });
+
+    await discoverKilocodeModels();
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "trusted_env_proxy",
+        url: "https://api.kilo.ai/api/gateway/models",
+      }),
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/kilocode/provider-models.ts
+++ b/extensions/kilocode/provider-models.ts
@@ -1,4 +1,5 @@
 // Kilocode provider module implements model/runtime integration.
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { readProviderJsonArrayFieldResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -166,15 +167,17 @@ export async function discoverKilocodeModels(): Promise<ModelDefinitionConfig[]>
   }
 
   try {
-    const { response, release } = await fetchWithSsrFGuard({
-      url: KILOCODE_MODELS_URL,
-      init: {
-        headers: { Accept: "application/json" },
-      },
-      timeoutMs: DISCOVERY_TIMEOUT_MS,
-      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(KILOCODE_BASE_URL),
-      auditContext: "kilocode.model_discovery",
-    });
+    const { response, release } = await fetchWithSsrFGuard(
+      withTrustedEnvProxyGuardedFetchMode({
+        url: KILOCODE_MODELS_URL,
+        init: {
+          headers: { Accept: "application/json" },
+        },
+        timeoutMs: DISCOVERY_TIMEOUT_MS,
+        policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(KILOCODE_BASE_URL),
+        auditContext: "kilocode.model_discovery",
+      }),
+    );
     try {
       if (!response.ok) {
         await response.body?.cancel().catch(() => undefined);


### PR DESCRIPTION
## Summary

Kilocode live model discovery now honors `HTTPS_PROXY`/`HTTP_PROXY`, so proxy-required networks get the live Kilo Gateway catalog instead of silently falling back to the single static model.

## What Problem This Solves

In environments where outbound HTTPS is only possible through an HTTP(S) proxy (typical corporate egress), `openclaw models list --all --provider kilocode` waits out the 5-second discovery window and then lists only the one bundled fallback model (`kilocode/kilo-auto/balanced`). The same request through the same proxy succeeds (the endpoint is public and needs no API key), so users on proxy-required networks lose the entire live catalog.

**Code evidence**: in `extensions/kilocode/provider-models.ts`, `discoverKilocodeModels()` calls `fetchWithSsrFGuard` with the default STRICT mode, which by design never reads `HTTPS_PROXY`/`HTTP_PROXY`. The discovery request therefore attempts direct egress, times out, and the catch-all silently returns the static catalog.

## Root Cause

- Introduced by commit `a379ac05626` ("fix: guard plugin HTTP calls in CI", 2026-05-01), which routed the discovery request through `fetchWithSsrFGuard` without selecting a fetch mode. The guard defaults to STRICT, and STRICT intentionally ignores env proxy configuration.
- Violated invariant: discovery requests to a first-party, pinned-hostname endpoint are trusted targets and should opt into the existing `trusted_env_proxy` guarded-fetch preset — the same preset already used by huggingface (#110924), deepinfra (#111428), chutes (#111266), vercel-ai-gateway (#111209), and this repo's `extensions/google/oauth.http.ts`.
- Trigger condition: `HTTPS_PROXY` (or `HTTP_PROXY`) configured + direct egress blocked.

## Why This Fix

- Wrap the existing guarded request in `withTrustedEnvProxyGuardedFetchMode(...)`: one import + one wrapper, the exact pattern established by the four merged sibling fixes above.
- The SSRF hostname policy (`api.kilo.ai` only), the 5s timeout, bounded JSON parsing, NO_PROXY/direct behavior, static fallback, and response release semantics are all unchanged.
- Alternatives considered: changing the shared default `fetchGuard` in `provider-catalog-live-runtime.ts` to env-proxy (rejected: STRICT is the deliberate safe default for user-influenced URLs); passing an explicit proxy per call (rejected: duplicates the existing preset for no benefit).

## User Impact

- Before: users behind a required HTTP proxy see only `kilocode/kilo-auto/balanced` in `openclaw models list --all --provider kilocode`.
- After: the same command returns the live Kilo Gateway catalog (339 models at verification time), matching the official `https://api.kilo.ai/api/gateway/models` response.

## Evidence

- Live before (Linux, Node v22, isolated state dir, throwaway `KILOCODE_API_KEY`, required HTTPS proxy): `pnpm openclaw models list --all --provider kilocode --plain` logged `Discovery failed: TimeoutError` after the 5000ms window and listed only `kilocode/kilo-auto/balanced`.
- Third-party control: a direct `curl` through the same proxy to `https://api.kilo.ai/api/gateway/models` returned HTTP 200 in ~0.75s; the same request without the proxy failed to connect — confirming this network reaches the endpoint only via the proxy.
- Live after (same command, same environment, fixed code): the CLI listed 339 live kilocode models.
- Mechanism check with a local CONNECT-counting proxy harness (`node --import tsx`): before, the proxy saw 0 CONNECTs while discovery attempted direct egress (FAIL); after, the proxy received `CONNECT api.kilo.ai:443` (PASS).
- Regression coverage: new `provider-models.proxy.test.ts` asserts the guarded discovery request selects `mode: "trusted_env_proxy"` for the official catalog URL.
- Focused green: `node scripts/test-projects.mjs extensions/kilocode` — 5 test files, 34 tests passed.
- Extension lane: `pnpm test:extension kilocode` — 5 test files, 34 tests passed.
- `oxfmt --check` on the changed files passed; `git diff --check` clean.

## Real Behavior Proof

### Before (on main)

```bash
$ export HTTPS_PROXY=http://<required-corp-proxy> KILOCODE_API_KEY=proof-token
$ pnpm openclaw models list --all --provider kilocode --plain
[fetch-timeout] fetch timeout after 5000ms (elapsed 5002ms) operation=fetchWithSsrFGuard url=https://api.kilo.ai/api/gateway/models
[kilocode-models] Discovery failed: TimeoutError: request timed out, using static catalog
kilocode/kilo-auto/balanced
```

Control through the same proxy (the endpoint itself is healthy):

```bash
$ curl -s -o /dev/null -w "%{http_code}\n" -x "$HTTPS_PROXY" https://api.kilo.ai/api/gateway/models
200
```

### After (with fix)

```bash
$ export HTTPS_PROXY=http://<required-corp-proxy> KILOCODE_API_KEY=proof-token
$ pnpm openclaw models list --all --provider kilocode --plain
kilocode/kilo-auto/frontier
kilocode/kilo-auto/balanced
kilocode/kilo-auto/efficient
kilocode/kilo-auto/free
kilocode/stepfun/step-3.7-flash:free
kilocode/anthropic/claude-sonnet-5
kilocode/anthropic/claude-opus-4.8
kilocode/openai/gpt-5.6-sol
... (339 live models total)
```

Local CONNECT-counting proxy harness (deterministic, no external network):

```bash
$ node --import tsx proof.mjs   # HTTPS_PROXY pointed at a local counting proxy
# before: proxy CONNECT count: 0 -> FAIL: discovery ignored HTTPS_PROXY
# after:  proxy received CONNECT: api.kilo.ai:443 -> PASS
```

## Tests and Validation

- `node scripts/test-projects.mjs extensions/kilocode` — 5 files, 34 tests passed (includes the new proxy regression test).
- `pnpm test:extension kilocode` — 5 files, 34 tests passed.
- `oxfmt --check extensions/kilocode/provider-models.ts extensions/kilocode/provider-models.proxy.test.ts` passed.
- Manual verification: live CLI before/after output above on a network where direct egress is blocked and the corporate proxy is required.
