### PR TITLE
fix(release): restore saved validation attempt guidance

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -256,7 +256,8 @@ on pinned current `main` as the exact command and validation contract.
    `npm_dist_tag=extended-stable`. Require complete exact-version and selector
    readback, then save the successful plugin run ID.
 7. Publish core from the same branch with the tag, `npm_dist_tag=extended-stable`,
-   all three run IDs, and the saved validation attempt. Require the prepared
+   all three run IDs, and
+   `full_release_validation_run_attempt=<saved-attempt>`. Require the prepared
    tarball and every run to match the branch and release SHA.
 8. From a clean current-`main` checkout, run
    `node --import tsx scripts/openclaw-npm-postpublish-verify.ts YYYY.M.P`.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the extended-stable release instructions described the saved Full Release Validation attempt only generically. This made the package acceptance contract fail on `main` and left the exact publish input unclear.

## Why This Change Was Made

Names `full_release_validation_run_attempt=<saved-attempt>` directly in the existing core publish step. The assertion remains unchanged because it protects the exact immutable-attempt handoff required by the release workflow.

## User Impact

Release operators get the precise workflow input needed to bind publication to the validated run attempt. There is no product runtime impact.

## Evidence

- Failing main run: https://github.com/openclaw/openclaw/actions/runs/29973427156
- Failing job: https://github.com/openclaw/openclaw/actions/runs/29973427156/job/89100201863
- `pnpm test test/scripts/package-acceptance-workflow.test.ts`: 91/91 passed on Blacksmith Testbox
- `pnpm check:changed`: passed the docs-only changed-file gate
- Testbox proof: https://github.com/openclaw/openclaw/actions/runs/29974038890
- `git diff --check origin/main...HEAD`: passed

No QA Lab files or tests were changed.
