### PR TITLE
fix(release): document validation attempt input

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -1057,7 +1057,8 @@ node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
     `latest` only when you intentionally want direct stable publish), keep it
     the same as the preflight run, and pass the successful npm
     `preflight_run_id` plus the successful `full_release_validation_run_id` and
-    its exact `full_release_validation_run_attempt`.
+    its exact `full_release_validation_run_attempt`
+    (`full_release_validation_run_attempt=<saved-attempt>`).
     For stable publish, also pass the exact non-prerelease
     `openclaw/openclaw-windows-node` tag as `windows_node_tag` and its
     candidate-approved installer digest map as `windows_node_installer_digests`.


### PR DESCRIPTION
## What Problem This Solves

Upstream `main` is failing `test/scripts/package-acceptance-workflow.test.ts` because the release maintainer skill describes passing the full release validation attempt but does not include the exact workflow-dispatch key form asserted by the package acceptance workflow.

## Summary

- add the exact `full_release_validation_run_attempt=<saved-attempt>` dispatch key to the release maintainer workflow instructions
- restore the package acceptance workflow contract checked by CI

## Evidence

- Focused regression: `PATH=/mnt/openclaw/workspace/.cache/node/node-v24.18.0-linux-x64/bin:$PATH corepack pnpm exec vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/package-acceptance-workflow.test.ts -t "keeps release publish creation compatible with gh api and prerelease notes"`
- Whitespace validation: `git diff --check`
- Hosted CI gate passed on the refreshed branch head; the only failing hosted check before this body update was `Real behavior proof`, which requested these PR body sections.

Full file note: local full-file run reached unrelated host prerequisites (`zip`, an `origin` remote, and GitHub auth inside spawned scripts), while the focused regression passed.