### PR TITLE
fix(venice): discover models when HTTP proxy is required

### DIFF
--- a/extensions/venice/models.proxy.test.ts
+++ b/extensions/venice/models.proxy.test.ts
@@ -1,0 +1,54 @@
+// Venice proxy tests cover the live model discovery transport policy.
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+import { discoverVeniceModels, VENICE_BASE_URL } from "./models.js";
+
+const ORIGINAL_VITEST = process.env.VITEST;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function restoreEnv(key: "VITEST" | "NODE_ENV", value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv("VITEST", ORIGINAL_VITEST);
+  restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
+  clearLiveCatalogCacheForTests();
+  fetchWithSsrFGuardMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("Venice model discovery proxy policy", () => {
+  it("allows the guarded official catalog request to use an eligible HTTP proxy", async () => {
+    delete process.env.VITEST;
+    process.env.NODE_ENV = "development";
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("unavailable", { status: 400 }),
+      release,
+      finalUrl: `${VENICE_BASE_URL}/models`,
+    });
+
+    await discoverVeniceModels({ retryDelayMs: 0 });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "trusted_env_proxy",
+        url: `${VENICE_BASE_URL}/models`,
+      }),
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/venice/models.ts
+++ b/extensions/venice/models.ts
@@ -1,4 +1,5 @@
 // Venice plugin module implements models behavior.
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import {
   getCachedLiveProviderModelRows,
   LiveModelCatalogHttpError,
@@ -6,6 +7,7 @@ import {
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { createSubsystemLogger, retryAsync } from "openclaw/plugin-sdk/runtime-env";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
@@ -189,6 +191,7 @@ export async function discoverVeniceModels(
           ttlMs: VENICE_DISCOVERY_CACHE_TTL_MS,
           policy: { allowedHostnames: VENICE_ALLOWED_HOSTNAMES },
           auditContext: "venice-model-discovery",
+          fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params)),
         }),
       {
         attempts: 3,


### PR DESCRIPTION
## Summary

Venice live model discovery now honors `HTTPS_PROXY`/`HTTP_PROXY`, so proxy-required networks get the live Venice catalog instead of silently falling back to the bundled static catalog.

## What Problem This Solves

In environments where outbound HTTPS is only possible through an HTTP(S) proxy (typical corporate egress), `openclaw models list --all --provider venice` waits out the 10-second discovery window and then lists only the 30 bundled fallback models. The same request through the same proxy succeeds (the endpoint is public and needs no API key), so users on proxy-required networks lose most of the live catalog.

**Code evidence**: in `extensions/venice/models.ts`, `discoverVeniceModels()` calls `getCachedLiveProviderModelRows` without a `fetchGuard` argument. The shared helper then defaults to plain `fetchWithSsrFGuard` in STRICT mode, which by design never reads `HTTPS_PROXY`/`HTTP_PROXY`. The discovery request therefore attempts direct egress, times out, and the catch-all silently returns the static catalog.

## Root Cause

- Introduced by commit `57e0bdaabe0` ("feat: add live provider model catalog helper", 2026-06-07), which migrated Venice discovery to the shared `getCachedLiveProviderModelRows` helper without selecting a fetch mode; the helper's default guard is STRICT and intentionally ignores env proxy configuration.
- Violated invariant: discovery requests to a first-party, pinned-hostname endpoint are trusted targets and should opt into the existing `trusted_env_proxy` guarded-fetch preset — the same preset already used by huggingface (#110924), deepinfra (#111428), chutes (#111266), vercel-ai-gateway (#111209), and this repo's `extensions/google/oauth.http.ts`.
- Trigger condition: `HTTPS_PROXY` (or `HTTP_PROXY`) configured + direct egress blocked.

## Why This Fix

- Pass `fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params))` at the call site: two imports + one argument, the exact pattern established by the four merged sibling fixes above.
- The SSRF hostname policy (`api.venice.ai` only), the 10s timeout, the 3-attempt retry policy, the 60s catalog cache, NO_PROXY/direct behavior, static fallback, and response release semantics are all unchanged.
- Alternatives considered: changing the shared helper's default guard to env-proxy (rejected: STRICT is the deliberate safe default for user-influenced URLs); passing an explicit proxy per call (rejected: duplicates the existing preset for no benefit).

## User Impact

- Before: users behind a required HTTP proxy see only the 30 bundled models in `openclaw models list --all --provider venice`.
- After: the same command returns the live Venice catalog (104 models at verification time), matching the official `https://api.venice.ai/api/v1/models` response.

## Evidence

- Live before (Linux, Node v22, isolated state dir, throwaway `VENICE_API_KEY`, required HTTPS proxy): `pnpm openclaw models list --all --provider venice --plain` logged `Discovery failed: TimeoutError` after the 10000ms window and listed only the 30 static models (`venice/llama-3.3-70b`, ...).
- Third-party control: a direct `curl` through the same proxy to `https://api.venice.ai/api/v1/models` returned HTTP 200 in ~0.42s; the same request without the proxy failed to connect — confirming this network reaches the endpoint only via the proxy.
- Live after (same command, same environment, fixed code): the CLI listed 104 live venice models.
- Mechanism check with a local CONNECT-counting proxy harness (`node --import tsx`): before, the proxy saw 0 CONNECTs while discovery attempted direct egress (FAIL); after, the proxy received `CONNECT api.venice.ai:443` on each of the 3 retry attempts (PASS).
- Regression coverage: new `models.proxy.test.ts` asserts the guarded discovery request selects `mode: "trusted_env_proxy"` for the official catalog URL.
- Focused green: `node scripts/test-projects.mjs extensions/venice` — 5 test files, 21 tests passed.
- `oxfmt --check` on the changed files passed; `git diff --check` clean.

## Real Behavior Proof

### Before (on main)

```bash
$ export HTTPS_PROXY=http://<required-corp-proxy> VENICE_API_KEY=proof-token
$ pnpm openclaw models list --all --provider venice --plain
[fetch-timeout] fetch timeout after 10000ms (elapsed 10002ms) operation=fetchWithSsrFGuard url=https://api.venice.ai/api/v1/models
[venice-models] Discovery failed: TimeoutError: request timed out, using static catalog
venice/llama-3.3-70b
venice/llama-3.2-3b
venice/hermes-3-llama-3.1-405b
... (30 static fallback models total)
```

Control through the same proxy (the endpoint itself is healthy):

```bash
$ curl -s -o /dev/null -w "%{http_code}\n" -x "$HTTPS_PROXY" https://api.venice.ai/api/v1/models
200
```

### After (with fix)

```bash
$ export HTTPS_PROXY=http://<required-corp-proxy> VENICE_API_KEY=proof-token
$ pnpm openclaw models list --all --provider venice --plain
venice/gemini-3-6-flash
venice/gemini-3-5-flash-lite
venice/zai-org-glm-5-2
venice/zai-org-glm-5-1
... (104 live models total)
```

Local CONNECT-counting proxy harness (deterministic, no external network):

```bash
$ node --import tsx proof.mjs   # HTTPS_PROXY pointed at a local counting proxy
# before: proxy CONNECT count: 0 -> FAIL: discovery ignored HTTPS_PROXY
# after:  proxy received CONNECT: api.venice.ai:443 (x3 retries) -> PASS
```

## Tests and Validation

- `node scripts/test-projects.mjs extensions/venice` — 5 files, 21 tests passed (includes the new proxy regression test).
- `oxfmt --check extensions/venice/models.ts extensions/venice/models.proxy.test.ts` passed.
- Manual verification: live CLI before/after output above on a network where direct egress is blocked and the corporate proxy is required.
