### PR TITLE
fix(ui): sync agent selection when sidebar selects a session (#112516)

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -236,6 +236,13 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
 
   protected readonly selectSession = (sessionKey: string) => {
     this.context?.gateway.setSessionKey(sessionKey);
+    // Sync the agent selection immediately so the sidebar chip label reflects
+    // the session's owning agent without waiting for chat-pane's async render
+    // cycle.  Fixes #112516.
+    const parsed = parseAgentSessionKey(sessionKey);
+    if (parsed?.agentId) {
+      this.context?.agentSelection.set(parsed.agentId);
+    }
     this.onNavigate?.("chat", {
       search: searchForSession(sessionKey),
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes #112516

In multi-agent setups, the sidebar agent chip label shows the wrong agent name after selecting a session belonging to a different agent. For example, if `custom` agent is currently active and the user clicks a session owned by `main`, the chip still displays "custom" until the chat pane's async render cycle catches up.

## Why This Change Was Made

`selectSession()` in `app-sidebar-session-navigation.ts` called `gateway.setSessionKey()` and navigated to the chat route, but never updated `agentSelection`. The chat pane does eventually sync via `applyActiveSessionBindings()`, but that runs in a later reactive update — leaving a visible window where the label is stale.

## What Was Changed

Added an immediate `agentSelection.set()` call inside `selectSession()`, parsing the agent ID from the session key (same pattern chat-pane already uses). This eliminates the stale-label window.

**File:** `ui/src/components/app-sidebar-session-navigation.ts` (+7 lines)

## User Impact

The sidebar agent chip now immediately reflects the correct agent when selecting any session, regardless of which agent was previously active.

## How to Test

1. Configure two agents (e.g. `main` and `custom`)
2. Start a session under `custom`, then click a session belonging to `main` in the sidebar
3. Observe the agent chip label updates to "main" immediately (previously stayed on "custom")

## Evidence

### Problem statement
In multi-agent setups, the sidebar agent chip label shows the wrong agent name
after clicking a session belonging to a different agent. The `selectSession()`
method updates the gateway session key but never syncs `agentSelection`, leaving
the chip stale until chat-pane's deferred reactive cycle catches up.

### Validation

**Code path analysis:**
- `chat-pane.ts:920-922` already uses the exact same pattern
  (`parseAgentSessionKey` → `agentSelection.set`) and works correctly
- This fix mirrors that proven pattern into the sidebar's `selectSession()`

**CI results:**
- `checks-ui`: ✅ passed — confirms no UI test regression
- `checks-fast-core`: ✅ passed
- `check-shard`: ✅ passed
- The only failure (`tui-backend.test.ts` timel
  integration test with no connection to sideb

**Test compatibility:**
- Existing test helper (`test-helpers/app-side
  `agentSelection.set` as a no-op — all existing sidebar tests remain green    ## Evidence

### Problem statement
In multi-agent setups, the sidebar agent chip label shows the wrong agent name
after clicking a session belonging to a different agent. The `selectSession()`
method updates the gateway session key but never syncs `agentSelection`, leaving
the chip stale until chat-pane's deferred reactive cycle catches up.

### Validation

**Code path analysis:**
- `chat-pane.ts:920-922` already uses the exact same pattern
  (`parseAgentSessionKey` → `agentSelection.set`) and works correctly
- This fix mirrors that proven pattern into the sidebar's `selectSession()`

**CI results:**
- `checks-ui`: ✅ passed — confirms no UI test regression
- `checks-fast-core`: ✅ passed
- `check-shard`: ✅ passed
- The only failure (`tui-backend.test.ts` timel
  integration test with no connection to sideb

**Test compatibility:**
- Existing test helper (`test-helpers/app-side
  `agentSelection.set` as a no-op — all existing sidebar tests remain green    