### PR TITLE
fix: doctor preserves locks owned by exact gateway process title

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -1075,6 +1075,47 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
+  it("recognizes the exact openclaw-gateway process title as an OpenClaw owner", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const nowMs = Date.now();
+    const gatewayLock = path.join(sessionsDir, "gateway.jsonl.lock");
+
+    try {
+      await fs.writeFile(
+        gatewayLock,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date(nowMs).toISOString(),
+        }),
+        "utf8",
+      );
+
+      const result = await cleanStaleLockFiles({
+        sessionsDir,
+        staleMs: 30_000,
+        nowMs,
+        removeStale: true,
+        readOwnerProcessArgs: () => ["openclaw-gateway"],
+      });
+
+      expect(lockCleanupRecords(result.locks)).toEqual([
+        {
+          name: "gateway.jsonl.lock",
+          removed: false,
+          stale: false,
+          staleReasons: [],
+        },
+      ]);
+      expect(result.cleaned).toEqual([]);
+      await expect(fs.access(gatewayLock)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("memoizes readOwnerProcessArgs across locks with the same pid in one sweep (#86509)", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     const sessionsDir = path.join(root, "sessions");

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -461,7 +461,12 @@ function isOpenClawSessionOwnerArgv(args: string[]): boolean {
     return false;
   }
   const exe = (normalized[0] ?? "").replace(/\.(bat|cmd|exe)$/i, "");
-  if (exe === "openclaw" || exe.endsWith("/openclaw") || exe.endsWith("/openclaw-gateway")) {
+  if (
+    exe === "openclaw" ||
+    exe === "openclaw-gateway" ||
+    exe.endsWith("/openclaw") ||
+    exe.endsWith("/openclaw-gateway")
+  ) {
     return true;
   }
   if (

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -11,6 +11,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import { parseSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createFileLockManager } from "../infra/file-lock-manager.js";
+import { isGatewayArgv } from "../infra/gateway-process-argv.js";
 import { readGatewayProcessArgsSync as readProcessArgsSync } from "../infra/gateway-processes.js";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import {
@@ -456,17 +457,15 @@ function normalizeOwnerProcessArg(arg: string): string {
 }
 
 function isOpenClawSessionOwnerArgv(args: string[]): boolean {
+  if (isGatewayArgv(args, { allowGatewayBinary: true })) {
+    return true;
+  }
   const normalized = args.map(normalizeOwnerProcessArg).filter(Boolean);
   if (normalized.length === 0) {
     return false;
   }
   const exe = (normalized[0] ?? "").replace(/\.(bat|cmd|exe)$/i, "");
-  if (
-    exe === "openclaw" ||
-    exe === "openclaw-gateway" ||
-    exe.endsWith("/openclaw") ||
-    exe.endsWith("/openclaw-gateway")
-  ) {
+  if (exe === "openclaw" || exe.endsWith("/openclaw")) {
     return true;
   }
   if (
@@ -488,9 +487,9 @@ function isOpenClawSessionOwnerArgv(args: string[]): boolean {
     "src/entry.ts",
     "src/index.ts",
   ];
-  const hasOpenClawCommandToken = normalized.some((arg) => arg === "gateway" || arg === "agent");
+  const hasAgentCommandToken = normalized.includes("agent");
   return normalized.some(
-    (arg) => entryCandidates.some((entry) => arg.endsWith(entry)) && hasOpenClawCommandToken,
+    (arg) => entryCandidates.some((entry) => arg.endsWith(entry)) && hasAgentCommandToken,
   );
 }
 


### PR DESCRIPTION
Closes #112854

## What Problem This Solves

Fixes an issue where operators running OpenClaw in Linux containers could see fresh, live Gateway session locks reported by `openclaw doctor` as `stale=yes (non-openclaw-owner)` when the owner process title was exactly `openclaw-gateway`.

## Why This Change Was Made

The Gateway deliberately retitles its long-running process to `openclaw-gateway`. Session-lock cleanup now delegates Gateway ownership checks to the shared Gateway argv recognizer used by gateway locking, signaling, listener discovery, and stale-process cleanup, instead of maintaining a second literal matcher. A regression test exercises the full cleanup decision and verifies the live lock is retained.

## User Impact

Operators no longer receive misleading stale-lock cleanup guidance for a healthy Gateway whose Linux process title is `openclaw-gateway`. Active locks remain present and report as non-stale.

## Evidence

Current-main negative control:

```text
node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts
FAIL: expected no cleaned locks; received one removed lock with staleReasons=["non-openclaw-owner"]
```

Focused final tests:

```text
node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts src/infra/gateway-process-argv.test.ts
Test Files  2 passed (2)
Tests       62 passed (62)
```

Real Linux Doctor-path proof on Blacksmith Testbox `tbx_01kycc5at5h38rc5hh5987mhzx` ([run](https://github.com/openclaw/openclaw/actions/runs/30154057861)):

```text
Session locks
- Found 1 session lock file.
- /tmp/.../agents/main/sessions/live-gateway.jsonl.lock pid=4688 (alive) age=0s stale=no
{"ownerArgs":["openclaw-gateway"],"lockPreserved":true,"result":"PASS"}
```

The proof launched a real Node process with `process.title = "openclaw-gateway"`, read its actual Linux `/proc/<pid>/cmdline` through the production process reader, and ran the real Doctor session-lock health path in repair mode. Doctor preserved the fresh lock.

Final changed-file gate:

```text
node scripts/check-changed.mjs -- src/agents/session-write-lock.ts src/agents/session-write-lock.test.ts
PASS on Blacksmith Testbox tbx_01kycc7075a4fn18x12t6szfg0
```

The branch was rebased onto current `main` at `1d43d602c56ed08242d0c92a311189bf28233688`; exact-head CI is validating `4bfb911f1c1a8655e60c8ffc91c0d0a0d61a9087`.
