### PR TITLE
fix: steer active Codex tasks from the Control UI

### DIFF
--- a/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
@@ -21,6 +21,7 @@ import {
   adaptCodexTestClientFactory,
   createCodexTestModel,
   type CodexTestAppServerClientFactory,
+  withPersistentCodexTestToolPolicy,
 } from "./test-support.js";
 
 let codexAppServerClientFactoryForTest: CodexTestAppServerClientFactory | undefined;
@@ -47,7 +48,7 @@ function runCodexAppServerAttempt(
     (codexAppServerClientFactoryForTest
       ? adaptCodexTestClientFactory(codexAppServerClientFactoryForTest)
       : undefined);
-  return runCodexAppServerAttemptImpl(params, {
+  return runCodexAppServerAttemptImpl(withPersistentCodexTestToolPolicy(params), {
     ...options,
     bindingStore: testCodexAppServerBindingStore,
     ...(clientFactory ? { clientFactory } : {}),
@@ -71,7 +72,6 @@ function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAtt
     modelId: "gpt-5.4-codex",
     model: createCodexTestModel(AUTH_PROFILE_RUNTIME_CONTRACT.codexHarnessProvider),
     thinkLevel: "medium",
-    disableTools: true,
     timeoutMs: 5_000,
     authStorage: {} as never,
     authProfileStore: { version: 1, profiles: {} },

--- a/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
@@ -21,7 +21,6 @@ import {
   adaptCodexTestClientFactory,
   createCodexTestModel,
   type CodexTestAppServerClientFactory,
-  withPersistentCodexTestToolPolicy,
 } from "./test-support.js";
 
 let codexAppServerClientFactoryForTest: CodexTestAppServerClientFactory | undefined;
@@ -37,6 +36,36 @@ function setCodexAppServerClientFactoryForTest(factory: CodexTestAppServerClient
 
 function resetCodexAppServerClientFactoryForTest(): void {
   codexAppServerClientFactoryForTest = undefined;
+}
+
+/** Keeps native Codex bindings reusable while omitting OpenClaw tools and search. */
+function withPersistentCodexTestToolPolicy(
+  params: EmbeddedRunAttemptParams,
+): EmbeddedRunAttemptParams {
+  const modelCompat =
+    params.model.compat && typeof params.model.compat === "object" ? params.model.compat : {};
+  const model = {
+    ...params.model,
+    compat: { ...modelCompat, supportsTools: false },
+  } as EmbeddedRunAttemptParams["model"] & { compat: { supportsTools: boolean } };
+  return {
+    ...params,
+    disableTools: false,
+    model,
+    config: {
+      ...params.config,
+      tools: {
+        ...params.config?.tools,
+        web: {
+          ...params.config?.tools?.web,
+          search: {
+            ...params.config?.tools?.web?.search,
+            enabled: false,
+          },
+        },
+      },
+    },
+  };
 }
 
 function runCodexAppServerAttempt(

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -181,6 +181,9 @@ export async function activateCodexAttemptTurn(
     isAbortable: () =>
       !terminalState.terminalOutcomeFrozen || terminalState.sharedAbortAllowedAfterTerminalOutcome,
     isCompacting: () => projectorRef.current?.isCompacting() ?? false,
+    // queueMessage resolves only after Codex echoes the steered userMessage completion.
+    // Gateway-owned turns rely on that boundary before finalizing adoption.
+    supportsTranscriptCommitWait: true,
     supportsQueueMessageImages: true,
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     cancel: () => abortExplicitly("cancelled"),

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -188,6 +188,7 @@ async function drainActiveAppServerAttemptsForTest(): Promise<void> {
 }
 
 export function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAttemptParams {
+  const model = createCodexTestModel("codex");
   return {
     prompt: "hello",
     sessionId: "session-1",
@@ -197,7 +198,10 @@ export function createParams(sessionFile: string, workspaceDir: string): Embedde
     runId: "run-1",
     provider: "codex",
     modelId: "gpt-5.4-codex",
-    model: createCodexTestModel("codex"),
+    model: {
+      ...model,
+      compat: { ...model.compat, supportsTools: false },
+    } as EmbeddedRunAttemptParams["model"] & { compat: { supportsTools: boolean } },
     contextTokenBudget: 150_000,
     contextWindowInfo: {
       tokens: 150_000,
@@ -205,13 +209,24 @@ export function createParams(sessionFile: string, workspaceDir: string): Embedde
       source: "agentContextTokens",
     },
     thinkLevel: "medium",
-    disableTools: true,
+    disableTools: false,
+    config: { tools: { web: { search: { enabled: false } } } },
     timeoutMs: 5_000,
     authStorage: {} as never,
     authProfileStore: { version: 1, profiles: {} },
     modelRegistry: {} as never,
     observeToolTerminal: createCodexTestToolTerminalObserver(),
   } as EmbeddedRunAttemptParams;
+}
+
+export function setCodexTestModelSupportsTools(
+  params: EmbeddedRunAttemptParams,
+  supportsTools: boolean,
+): void {
+  params.model = {
+    ...params.model,
+    compat: { ...params.model.compat, supportsTools },
+  } as EmbeddedRunAttemptParams["model"] & { compat: { supportsTools: boolean } };
 }
 
 export function createCodexRuntimePlanFixture(): NonNullable<

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -6,6 +6,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
 import {
   embeddedAgentLog,
+  supportsModelTools,
   type HarnessContextEngine as ContextEngine,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
@@ -18,6 +19,7 @@ import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtim
 import { registerSandboxBackend } from "openclaw/plugin-sdk/sandbox";
 import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { shouldEnableCodexAppServerNativeToolSurface } from "./dynamic-tool-build.js";
 import type { CodexServerNotification } from "./protocol.js";
 import { runCodexAppServerAttempt as runCodexAppServerAttemptImpl } from "./run-attempt.js";
 import {
@@ -31,6 +33,7 @@ import {
   adaptCodexTestClientFactory,
   createCodexTestModel,
   type CodexTestAppServerClientFactory,
+  withPersistentCodexTestToolPolicy,
 } from "./test-support.js";
 
 const CODEX_TURN_START_TEXT_INPUT_MAX_CHARS = 1 << 20;
@@ -60,7 +63,7 @@ function runCodexAppServerAttempt(
     (codexAppServerClientFactoryForTest
       ? adaptCodexTestClientFactory(codexAppServerClientFactoryForTest)
       : undefined);
-  return runCodexAppServerAttemptImpl(params, {
+  return runCodexAppServerAttemptImpl(withPersistentCodexTestToolPolicy(params), {
     ...options,
     bindingStore: testCodexAppServerBindingStore,
     ...(clientFactory ? { clientFactory } : {}),
@@ -80,7 +83,6 @@ function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAtt
     modelId: "gpt-5.4-codex",
     model: createCodexTestModel("codex"),
     thinkLevel: "medium",
-    disableTools: true,
     timeoutMs: 5_000,
     authStorage: {} as never,
     authProfileStore: { version: 1, profiles: {} },
@@ -409,6 +411,17 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     resetGlobalHookRunner();
     vi.restoreAllMocks();
     await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("keeps the fixture thread persistent while denying web search", () => {
+    const params = withPersistentCodexTestToolPolicy(
+      createParams(path.join(tempDir, "policy.jsonl"), path.join(tempDir, "workspace")),
+    );
+
+    expect(params.disableTools).toBe(false);
+    expect(supportsModelTools(params.model)).toBe(false);
+    expect(params.config?.tools?.web?.search?.enabled).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
   });
 
   it("bootstraps and assembles non-legacy context before the Codex turn starts", async () => {

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -33,7 +33,6 @@ import {
   adaptCodexTestClientFactory,
   createCodexTestModel,
   type CodexTestAppServerClientFactory,
-  withPersistentCodexTestToolPolicy,
 } from "./test-support.js";
 
 const CODEX_TURN_START_TEXT_INPUT_MAX_CHARS = 1 << 20;
@@ -52,6 +51,36 @@ function setCodexAppServerClientFactoryForTest(factory: CodexTestAppServerClient
 
 function resetCodexAppServerClientFactoryForTest(): void {
   codexAppServerClientFactoryForTest = undefined;
+}
+
+/** Keeps native Codex bindings reusable while omitting OpenClaw tools and search. */
+function withPersistentCodexTestToolPolicy(
+  params: EmbeddedRunAttemptParams,
+): EmbeddedRunAttemptParams {
+  const modelCompat =
+    params.model.compat && typeof params.model.compat === "object" ? params.model.compat : {};
+  const model = {
+    ...params.model,
+    compat: { ...modelCompat, supportsTools: false },
+  } as EmbeddedRunAttemptParams["model"] & { compat: { supportsTools: boolean } };
+  return {
+    ...params,
+    disableTools: false,
+    model,
+    config: {
+      ...params.config,
+      tools: {
+        ...params.config?.tools,
+        web: {
+          ...params.config?.tools?.web,
+          search: {
+            ...params.config?.tools?.web?.search,
+            enabled: false,
+          },
+        },
+      },
+    },
+  };
 }
 
 function runCodexAppServerAttempt(

--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -107,6 +107,51 @@ async function waitAndQueueActiveRunMessage(
 }
 
 describe("runCodexAppServerAttempt steering", () => {
+  it("accepts Gateway transcript-backed steering for the active Codex turn", async () => {
+    const { requests, waitForMethod, completeTurn, notify } = createStartedThreadHarness();
+    const params = createSteeringParams();
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await waitForMethod("turn/start");
+
+    // This public queue returns immediate eligibility; the handle's delivery
+    // promise stays pending until the matching item/completed notification below.
+    await waitAndQueueActiveRunMessage(params.sessionId, "steer this active turn", {
+      debounceMs: 0,
+      isInboundUserMessage: true,
+      waitForTranscriptCommit: true,
+    });
+    await vi.waitFor(
+      () => expect(requests.map((entry) => entry.method)).toContain("turn/steer"),
+      fastWait,
+    );
+    const steer = requests.find((entry) => entry.method === "turn/steer");
+    const clientUserMessageId = (steer?.params as { clientUserMessageId?: string } | undefined)
+      ?.clientUserMessageId;
+    if (!clientUserMessageId) {
+      throw new Error("turn/steer clientUserMessageId missing");
+    }
+
+    await notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "steered-user-message", type: "userMessage", clientId: clientUserMessageId },
+      },
+    });
+    await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    expect(steer?.params).toMatchObject({
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "steer this active turn" }],
+    });
+  });
+
   it("forwards queued text and images to the active app-server turn", async () => {
     const { requests, waitForMethod, completeTurn, notify } = createStartedThreadHarness();
     const params = createSteeringParams();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -74,6 +74,7 @@ import {
   mockClientRuntimeMethods,
   queueActiveRunMessageForTest,
   runCodexAppServerAttempt,
+  setCodexTestModelSupportsTools,
   setCodexAppServerClientFactoryForTest,
   setupRunAttemptTestHooks,
   tempDir,
@@ -657,6 +658,7 @@ describe("runCodexAppServerAttempt", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
+    setCodexTestModelSupportsTools(params, true);
     params.runtimePlan = createCodexRuntimePlanFixture();
     const sandbox = {
       enabled: true,
@@ -752,6 +754,7 @@ describe("runCodexAppServerAttempt", () => {
       const workspaceDir = path.join(tempDir, "workspace");
       const params = createParams(sessionFile, workspaceDir);
       params.disableTools = false;
+      setCodexTestModelSupportsTools(params, true);
       params.runtimePlan = createCodexRuntimePlanFixture();
       params.config = {
         agents: {
@@ -2839,6 +2842,7 @@ describe("runCodexAppServerAttempt", () => {
     ]);
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
+    setCodexTestModelSupportsTools(params, true);
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, workspaceDir);
     const {
@@ -2948,6 +2952,7 @@ describe("runCodexAppServerAttempt", () => {
     ]);
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
+    setCodexTestModelSupportsTools(params, true);
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, workspaceDir);
 
@@ -2978,6 +2983,7 @@ describe("runCodexAppServerAttempt", () => {
     ]);
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
+    setCodexTestModelSupportsTools(params, true);
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, workspaceDir);
 
@@ -3106,6 +3112,7 @@ describe("runCodexAppServerAttempt", () => {
     testing.setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("memory_get")]);
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
+    setCodexTestModelSupportsTools(params, true);
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, workspaceDir);
 
@@ -3192,6 +3199,7 @@ describe("runCodexAppServerAttempt", () => {
     });
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
+    setCodexTestModelSupportsTools(params, true);
     params.runtimePlan = createCodexRuntimePlanFixture();
     params.config = {
       agents: {
@@ -3259,6 +3267,7 @@ describe("runCodexAppServerAttempt", () => {
     ]);
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
+    setCodexTestModelSupportsTools(params, true);
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, workspaceDir);
 
@@ -4059,6 +4068,7 @@ describe("runCodexAppServerAttempt", () => {
     const pngBase64 =
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
     params.model = createCodexTestModel("codex", ["text", "image"]);
+    setCodexTestModelSupportsTools(params, false);
     params.images = [
       {
         type: "image",
@@ -5535,6 +5545,7 @@ describe("runCodexAppServerAttempt", () => {
     delete params.authProfileId;
     params.agentDir = agentDir;
     params.config = {
+      ...params.config,
       agents: {
         defaults: {
           compaction: {
@@ -6131,13 +6142,16 @@ describe("runCodexAppServerAttempt", () => {
       return {};
     });
     const clientFactory = vi.fn(async () => harness.client);
-    const params = {
-      ...createParams(sessionFile, workspaceDir),
-      provider: "anthropic",
-      modelId: "claude-opus-4-6",
-      model: createCodexTestModel("anthropic"),
-      config: { tools: { exec: { mode: "auto" } } },
-    } as EmbeddedRunAttemptParams;
+    testing.setOpenClawCodingToolsFactoryForTests(() => []);
+    const params = createParams(sessionFile, workspaceDir);
+    params.provider = "anthropic";
+    params.modelId = "claude-opus-4-6";
+    params.model = createCodexTestModel("anthropic");
+    setCodexTestModelSupportsTools(params, false);
+    params.config = {
+      ...params.config,
+      tools: { ...params.config?.tools, exec: { mode: "auto" } },
+    } as EmbeddedRunAttemptParams["config"];
 
     const run = runCodexAppServerAttempt(params, {
       pluginConfig: {

--- a/extensions/codex/src/app-server/test-support.ts
+++ b/extensions/codex/src/app-server/test-support.ts
@@ -135,6 +135,35 @@ export function createCodexTestModel(provider = "openai", input = ["text"]): Mod
   } as Model;
 }
 
+/** Keeps native Codex thread bindings reusable while omitting OpenClaw tools and search. */
+export function withPersistentCodexTestToolPolicy(
+  params: EmbeddedRunAttemptParams,
+): EmbeddedRunAttemptParams {
+  const modelCompat =
+    params.model.compat && typeof params.model.compat === "object" ? params.model.compat : {};
+  return {
+    ...params,
+    disableTools: false,
+    model: {
+      ...params.model,
+      compat: { ...modelCompat, supportsTools: false },
+    },
+    config: {
+      ...params.config,
+      tools: {
+        ...params.config?.tools,
+        web: {
+          ...params.config?.tools?.web,
+          search: {
+            ...params.config?.tools?.web?.search,
+            enabled: false,
+          },
+        },
+      },
+    },
+  };
+}
+
 /** Creates an in-memory Codex app-server client harness with writable stdout frames. */
 export function createClientHarness() {
   const stdout = new PassThrough();

--- a/extensions/codex/src/app-server/test-support.ts
+++ b/extensions/codex/src/app-server/test-support.ts
@@ -135,36 +135,6 @@ export function createCodexTestModel(provider = "openai", input = ["text"]): Mod
   } as Model;
 }
 
-/** Keeps native Codex thread bindings reusable while omitting OpenClaw tools and search. */
-export function withPersistentCodexTestToolPolicy(
-  params: EmbeddedRunAttemptParams,
-): EmbeddedRunAttemptParams {
-  const modelCompat =
-    params.model.compat && typeof params.model.compat === "object" ? params.model.compat : {};
-  const model = {
-    ...params.model,
-    compat: { ...modelCompat, supportsTools: false },
-  } as EmbeddedRunAttemptParams["model"] & { compat: { supportsTools: boolean } };
-  return {
-    ...params,
-    disableTools: false,
-    model,
-    config: {
-      ...params.config,
-      tools: {
-        ...params.config?.tools,
-        web: {
-          ...params.config?.tools?.web,
-          search: {
-            ...params.config?.tools?.web?.search,
-            enabled: false,
-          },
-        },
-      },
-    },
-  };
-}
-
 /** Creates an in-memory Codex app-server client harness with writable stdout frames. */
 export function createClientHarness() {
   const stdout = new PassThrough();

--- a/extensions/codex/src/app-server/test-support.ts
+++ b/extensions/codex/src/app-server/test-support.ts
@@ -141,13 +141,14 @@ export function withPersistentCodexTestToolPolicy(
 ): EmbeddedRunAttemptParams {
   const modelCompat =
     params.model.compat && typeof params.model.compat === "object" ? params.model.compat : {};
+  const model = {
+    ...params.model,
+    compat: { ...modelCompat, supportsTools: false },
+  } as EmbeddedRunAttemptParams["model"] & { compat: { supportsTools: boolean } };
   return {
     ...params,
     disableTools: false,
-    model: {
-      ...params.model,
-      compat: { ...modelCompat, supportsTools: false },
-    },
+    model,
     config: {
       ...params.config,
       tools: {

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -88,6 +88,7 @@ function createNetworkProxyThreadLifecycleAppServerOptions() {
 function createParams(sessionFile: string, workspaceDir: string) {
   const params = createRunAttemptParams(sessionFile, workspaceDir);
   params.disableTools = false;
+  params.config = undefined;
   return params;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users steering an active Codex task from the Control UI would see the message accepted, but Codex would not receive it during the active turn. The message could instead become a later follow-up turn after the original run finished.

## Why This Change Was Made

Codex already confirms a steer only after its user-message item completes, which satisfies the gateway-owned transcript-commit contract. This change advertises that capability on the active run handle so the shared queue path can deliver the steer immediately instead of rejecting it before `turn/steer`.

## User Impact

Users can steer an active Codex task from the Control UI and have the instruction affect that same running turn.

## Evidence

- Canonical-base red reproduction at `f7d61b4352952aae852454f7571cf59d42b695ff`: a test-only probe through the public gateway-style queue returned `accepted=false` before any `turn/steer`; the other 8 Codex steering tests passed.
- Exact-head Blacksmith Testbox proof at `4938d9637eb2966cfa4d6aa660039d1730d4fea0`: 49/49 shared active-run tests and 9/9 Codex steering tests passed. https://github.com/openclaw/openclaw/actions/runs/29977421481
- Independent Control UI entry-point proof: the selected real-Chromium E2E passed and emitted `chat.send` with steer mode (1 selected, 53 skipped).
- The regression exercises `waitForTranscriptCommit: true`, verifies the generated `clientUserMessageId` on `turn/steer`, retains the unrelated-completion negative control, and resolves only on the matching Codex user-message completion.
- Fresh branch autoreview: no accepted/actionable findings, confidence 0.93.

No live Rosita session was touched: doing so would mutate a private operator session without separate deployment/proof authorization. A mocked UI video would look the same on base and head and would overstate the evidence, so the raw base/head protocol behavior and independent Chromium entry-point check are the retained proof.

AI-assisted: yes.
