### PR TITLE
fix: commentary no longer repeats after steering a task

### DIFF
--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -967,6 +967,123 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatStreamSegments).toEqual([]);
   });
 
+  it("does not replay persisted keyed commentary after retiring a same-run steer", () => {
+    const originalUser = {
+      role: "user",
+      content: [{ type: "text", text: "Ask" }],
+      timestamp: 1,
+    };
+    const persistedCommentary = {
+      role: "assistant",
+      content: [{ type: "text", text: "Looking into it." }],
+      timestamp: 2,
+      openclawStreamFallback: {
+        itemId: "preamble-1",
+        replacementText: "Looking into it.",
+        source: "segment",
+      },
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [originalUser, persistedCommentary],
+      chatQueue: [
+        {
+          id: "steer-1",
+          text: "Focus on the deployment too",
+          createdAt: 3,
+          kind: "steered",
+          pendingRunId: "run-1",
+          sendRunId: "steer-send-1",
+          sessionKey: "main",
+        },
+      ],
+      chatStream: null,
+      chatStreamStartedAt: null,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
+    };
+    state.chatStreamSegments = [{ text: "Looking into it.", ts: 2, itemId: "preamble-1" }];
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Final answer." }],
+          timestamp: 5,
+        },
+      }),
+    ).toBe("final");
+
+    expect(state.chatQueue).toEqual([]);
+    expect(state.chatMessages).toHaveLength(4);
+    expectTextChatMessage(state.chatMessages[0], "user", "Ask");
+    expectTextChatMessage(state.chatMessages[1], "assistant", "Looking into it.");
+    expectTextChatMessage(state.chatMessages[2], "user", "Focus on the deployment too");
+    expectTextChatMessage(state.chatMessages[3], "assistant", "Final answer.");
+  });
+
+  it("uses an already-persisted steer to recover the active stream boundary", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [
+        { role: "user", content: [{ type: "text", text: "Ask" }], timestamp: 1 },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Looking into it." }],
+          timestamp: 2,
+          openclawStreamFallback: {
+            itemId: "preamble-1",
+            replacementText: "Looking into it.",
+            source: "segment",
+          },
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Focus on deployment" }],
+          timestamp: 3,
+          __openclaw: { idempotencyKey: "steer-send-1:user" },
+        },
+      ],
+      chatQueue: [
+        {
+          id: "steer-1",
+          text: "Focus on deployment",
+          createdAt: 3,
+          kind: "steered",
+          pendingRunId: "run-1",
+          sendRunId: "steer-send-1",
+          sessionKey: "main",
+        },
+      ],
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
+    };
+    state.chatStreamSegments = [{ text: "Looking into it.", ts: 2, itemId: "preamble-1" }];
+
+    handleChatGatewayEvent(state, {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Final answer." }],
+        timestamp: 5,
+      },
+    });
+
+    expect(state.chatQueue).toEqual([]);
+    expect(state.chatMessages).toHaveLength(4);
+    expectTextChatMessage(state.chatMessages[0], "user", "Ask");
+    expectTextChatMessage(state.chatMessages[1], "assistant", "Looking into it.");
+    expectTextChatMessage(state.chatMessages[2], "user", "Focus on deployment");
+    expectTextChatMessage(state.chatMessages[3], "assistant", "Final answer.");
+  });
+
   it("clears keyed commentary when chatPersistCommentary is false", () => {
     const user = { role: "user", content: [{ type: "text", text: "Ask" }], timestamp: 1 };
     const state = createState({

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -20,6 +20,7 @@ import {
   appendTerminalAssistantMessage,
   clearToolStreamSegments,
   hasVisibleStreamParts,
+  streamReconciliationStartIndex,
   terminalMessageReplacesVisibleStream,
 } from "./stream-reconciliation.ts";
 import {
@@ -181,7 +182,11 @@ function appendCachedChatMessage(
   appendChatMessageToCache(state.chatMessagesBySession, state, { sessionKey, agentId }, message);
 }
 
-function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
+function handleChatEvent(
+  state: ChatState,
+  payload?: ChatEventPayload,
+  opts?: { keyedStreamStartIndex?: number },
+) {
   if (!payload) {
     return null;
   }
@@ -235,6 +240,13 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   }
 
   const terminalRunId = payload.runId ?? state.chatRunId;
+  const materializeVisibleStream = (
+    materializeOpts: Parameters<typeof materializeVisibleAssistantStreamMessages>[2] = {},
+  ) =>
+    materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
+      ...materializeOpts,
+      keyedStartIndex: opts?.keyedStreamStartIndex,
+    });
   const reconcileTerminalRun = (
     outcome: "done" | "interrupted",
     sessionStatus: "done" | "failed" | "killed",
@@ -288,9 +300,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
           isHiddenStreamText: isHiddenAssistantStreamText,
         })
       ) {
-        state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
-          includeCurrent: false,
-        });
+        state.chatMessages = materializeVisibleStream({ includeCurrent: false });
         clearToolStreamSegments(state);
       }
       state.chatMessages = appendTerminalAssistantMessage(
@@ -298,7 +308,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         rememberLiveTerminalRun(finalMessage, terminalRunId),
       );
     } else {
-      state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state);
+      state.chatMessages = materializeVisibleStream();
     }
     if (payload.yielded === true && payload.stopReason === "end_turn") {
       reconcileChatRunLifecycle(
@@ -318,13 +328,13 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !shouldHideAssistantChatMessage(normalizedMessage)) {
-      state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
+      state.chatMessages = materializeVisibleStream({
         replacementMessages: [normalizedMessage],
         includeCurrent: false,
       });
       state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, normalizedMessage);
     } else {
-      state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state);
+      state.chatMessages = materializeVisibleStream();
     }
     reconcileTerminalRun("interrupted", "killed");
   } else if (payload.state === "error") {
@@ -351,11 +361,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
               isHiddenStreamText: isHiddenAssistantStreamText,
             })
           ) {
-            state.chatMessages = materializeVisibleAssistantStreamMessages(
-              state.chatMessages,
-              state,
-              { includeCurrent: false },
-            );
+            state.chatMessages = materializeVisibleStream({ includeCurrent: false });
             clearToolStreamSegments(state);
           }
           state.chatMessages = appendTerminalAssistantMessage(
@@ -363,18 +369,12 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
             visiblePayloadMessage,
           );
         } else {
-          state.chatMessages = materializeVisibleAssistantStreamMessages(
-            state.chatMessages,
-            state,
-            { includeCurrent: true },
-          );
+          state.chatMessages = materializeVisibleStream({ includeCurrent: true });
           clearToolStreamSegments(state);
           state.chatMessages = [...state.chatMessages, visiblePayloadMessage];
         }
       } else {
-        state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
-          includeCurrent: true,
-        });
+        state.chatMessages = materializeVisibleStream({ includeCurrent: true });
       }
     }
     reconcileTerminalRun("interrupted", "failed");
@@ -419,17 +419,27 @@ export function handleChatGatewayEvent(state: ChatState, payload?: ChatEventPayl
     return null;
   }
   const activeRunIdBeforeEvent = state.chatRunId;
+  let terminalKeyedStreamStartIndex: number | undefined;
   if (
     isTerminalChatState(payload?.state) &&
     payload !== undefined &&
     (chatEventSessionMatches(state, payload) || payload.runId === activeRunIdBeforeEvent) &&
     !isEventForDifferentActiveRun(payload, activeRunIdBeforeEvent)
   ) {
+    // The active stream belongs to the user boundary that preceded any steer
+    // chip retired below. Preserve that boundary through terminal materialization.
+    const localOnlySteerBoundary = streamReconciliationStartIndex(state.chatMessages);
     // A steered chip can be the only local copy while transcript persistence lags.
     // Materialize it before the terminal assistant so user/assistant order stays stable.
-    retireSteeredChipsForTerminalRun(state, payload?.runId);
+    const firstPersistedSteerIndex = retireSteeredChipsForTerminalRun(state, payload?.runId);
+    terminalKeyedStreamStartIndex =
+      firstPersistedSteerIndex === undefined
+        ? localOnlySteerBoundary
+        : streamReconciliationStartIndex(state.chatMessages, firstPersistedSteerIndex);
   }
-  const result = handleChatEvent(state, payload);
+  const result = handleChatEvent(state, payload, {
+    keyedStreamStartIndex: terminalKeyedStreamStartIndex,
+  });
   return result;
 }
 

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -258,6 +258,7 @@ export function materializeVisibleAssistantStreamMessages(
     requirePersistedTool?: boolean;
     replacementMessages?: unknown[];
     persistCommentary?: boolean;
+    keyedStartIndex?: number;
   } = {},
 ): unknown[] {
   return materializeVisibleStreamState(messages, state, {

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -81,10 +81,18 @@ export function chatMessagesContainQueuedSend(
   item: ChatQueueItem,
   userRoleOnly = false,
 ): boolean {
+  return findQueuedSendMessageIndex(messages, item, userRoleOnly) >= 0;
+}
+
+function findQueuedSendMessageIndex(
+  messages: unknown,
+  item: ChatQueueItem,
+  userRoleOnly = false,
+): number {
   if (!item.sendRunId) {
-    return false;
+    return -1;
   }
-  return (Array.isArray(messages) ? messages : []).some((message) => {
+  return (Array.isArray(messages) ? messages : []).findIndex((message) => {
     if (!message || typeof message !== "object" || Array.isArray(message)) {
       return false;
     }
@@ -159,16 +167,25 @@ export function preserveQueuedUserTurn(state: SteerLifecycleHost, item: ChatQueu
 export function retireSteeredChipsForTerminalRun(
   state: SteerLifecycleHost,
   runId: string | undefined,
-): void {
+): number | undefined {
   if (!runId) {
-    return;
+    return undefined;
   }
+  let firstPersistedSteerIndex: number | undefined;
   for (const item of state.chatQueue) {
     if (isAckedSteeredChip(item) && item.pendingRunId === runId) {
+      const persistedIndex = findQueuedSendMessageIndex(state.chatMessages, item, true);
+      if (
+        persistedIndex >= 0 &&
+        (firstPersistedSteerIndex === undefined || persistedIndex < firstPersistedSteerIndex)
+      ) {
+        firstPersistedSteerIndex = persistedIndex;
+      }
       preserveQueuedUserTurn(state, item);
     }
   }
   clearPendingQueueItemsForRun(state, runId);
+  return firstPersistedSteerIndex;
 }
 
 export function retireHistoryProvenSteeredChips(state: SteerLifecycleHost): void {

--- a/ui/src/pages/chat/stream-reconciliation.test.ts
+++ b/ui/src/pages/chat/stream-reconciliation.test.ts
@@ -80,6 +80,47 @@ describe("stream reconciliation", () => {
     ]);
   });
 
+  it("does not replay a keyed preamble across a same-run steer boundary", () => {
+    const state = {
+      chatStream: null,
+      chatStreamStartedAt: null,
+      chatStreamSegments: [
+        { text: "already visible", ts: 2, itemId: "preamble-1" },
+        { text: "distinct item", ts: 4, itemId: "preamble-2" },
+        { text: "already visible", ts: 5 },
+      ],
+    } satisfies StreamReconciliationState & {
+      chatStreamSegments: Array<{ text: string; ts: number; itemId?: string }>;
+    };
+    const messages = [
+      { role: "user", content: "original ask", timestamp: 1 },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "already visible" }],
+        timestamp: 2,
+        openclawStreamFallback: {
+          itemId: "preamble-1",
+          replacementText: "already visible",
+          source: "segment",
+        },
+      },
+      { role: "user", content: "steer this run", timestamp: 3 },
+    ];
+
+    const next = materializeVisibleStreamState(messages, state, {
+      ...visibleStreamOptions,
+      keyedStartIndex: 1,
+    });
+
+    expect(next.map(messageText)).toEqual([
+      "original ask",
+      "already visible",
+      "steer this run",
+      "distinct item",
+      "already visible",
+    ]);
+  });
+
   it("does not prune keyed preambles by live tool index", () => {
     const state = {
       chatStream: null,

--- a/ui/src/pages/chat/stream-reconciliation.test.ts
+++ b/ui/src/pages/chat/stream-reconciliation.test.ts
@@ -121,6 +121,37 @@ describe("stream reconciliation", () => {
     ]);
   });
 
+  it("recomputes the unkeyed boundary after keyed insertions before a steer", () => {
+    const state = {
+      chatStream: null,
+      chatStreamStartedAt: null,
+      chatStreamSegments: [
+        { text: "first keyed", ts: 2, itemId: "preamble-1" },
+        { text: "repeatable", ts: 3, itemId: "preamble-2" },
+        { text: "repeatable", ts: 5 },
+      ],
+    } satisfies StreamReconciliationState & {
+      chatStreamSegments: Array<{ text: string; ts: number; itemId?: string }>;
+    };
+    const messages = [
+      { role: "user", content: "original ask", timestamp: 1 },
+      { role: "user", content: "steer this run", timestamp: 4 },
+    ];
+
+    const next = materializeVisibleStreamState(messages, state, {
+      ...visibleStreamOptions,
+      keyedStartIndex: 1,
+    });
+
+    expect(next.map(messageText)).toEqual([
+      "original ask",
+      "first keyed",
+      "repeatable",
+      "steer this run",
+      "repeatable",
+    ]);
+  });
+
   it("does not prune keyed preambles by live tool index", () => {
     const state = {
       chatStream: null,

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -598,12 +598,12 @@ export function materializeVisibleStreamState(
 ): unknown[] {
   let nextMessages = messages;
   const persistCommentary = opts.persistCommentary === true;
-  const defaultStartIndex = streamReconciliationStartIndex(messages);
   for (const part of visibleAssistantStreamParts(state, opts)) {
     if (!persistCommentary && part.itemId) {
       continue;
     }
     const replacementMessages = opts.replacementMessages ?? [];
+    const defaultStartIndex = streamReconciliationStartIndex(nextMessages);
     const startIndex = part.itemId
       ? (opts.keyedStartIndex ?? defaultStartIndex)
       : defaultStartIndex;

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -113,6 +113,7 @@ type MaterializeVisibleStreamOptions = {
   requirePersistedTool?: boolean;
   replacementMessages?: unknown[];
   persistCommentary?: boolean;
+  keyedStartIndex?: number;
   isHiddenAssistantMessage: AssistantMessageVisibility;
   isHiddenStreamText: StreamVisibility;
 };
@@ -138,6 +139,13 @@ function lastUserMessageIndex(messages: unknown[]): number {
     }
   }
   return -1;
+}
+
+export function streamReconciliationStartIndex(
+  messages: unknown[],
+  beforeIndex = messages.length,
+): number {
+  return lastUserMessageIndex(messages.slice(0, beforeIndex)) + 1;
 }
 
 export function maybeResetToolStream(
@@ -273,12 +281,12 @@ function hasAssistantStreamReplacement(
   messages: unknown[],
   stream: string,
   isHiddenAssistantMessage: AssistantMessageVisibility,
+  startIndex: number,
 ): boolean {
   const expected = stream.trim();
   if (!expected) {
     return false;
   }
-  const startIndex = lastUserMessageIndex(messages) + 1;
   return messages.slice(startIndex).some((message) => {
     if (!message || typeof message !== "object") {
       return false;
@@ -307,8 +315,11 @@ function streamFallbackItemId(message: unknown): string | null {
   return typeof itemId === "string" && itemId.trim() ? itemId.trim() : null;
 }
 
-function hasKeyedAssistantStreamReplacement(messages: unknown[], itemId: string): boolean {
-  const startIndex = lastUserMessageIndex(messages) + 1;
+function hasKeyedAssistantStreamReplacement(
+  messages: unknown[],
+  itemId: string,
+  startIndex: number,
+): boolean {
   return messages.slice(startIndex).some((message) => streamFallbackItemId(message) === itemId);
 }
 
@@ -407,13 +418,18 @@ function hasAssistantStreamPartReplacement(
   messages: unknown[],
   part: VisibleAssistantStreamPart,
   isHiddenAssistantMessage: AssistantMessageVisibility,
+  startIndex: number,
 ): boolean {
   if (part.itemId) {
-    return hasKeyedAssistantStreamReplacement(messages, part.itemId);
+    return hasKeyedAssistantStreamReplacement(messages, part.itemId, startIndex);
   }
   return (
-    hasAssistantStreamReplacement(messages, part.replacementText, isHiddenAssistantMessage) ||
-    hasAssistantStreamReplacement(messages, part.text, isHiddenAssistantMessage)
+    hasAssistantStreamReplacement(
+      messages,
+      part.replacementText,
+      isHiddenAssistantMessage,
+      startIndex,
+    ) || hasAssistantStreamReplacement(messages, part.text, isHiddenAssistantMessage, startIndex)
   );
 }
 
@@ -450,7 +466,12 @@ export function historyReplacedVisibleStream(
     (requiredParts.length > 0 ||
       hasVisibleAssistantMessageAfterUser(messages, opts.isHiddenAssistantMessage)) &&
     requiredParts.every((part) =>
-      hasAssistantStreamPartReplacement(messages, part, opts.isHiddenAssistantMessage),
+      hasAssistantStreamPartReplacement(
+        messages,
+        part,
+        opts.isHiddenAssistantMessage,
+        streamReconciliationStartIndex(messages),
+      ),
     )
   );
 }
@@ -496,13 +517,13 @@ export function terminalMessageReplacesVisibleStream(
 function currentToolStreamMessageIndex(
   messages: unknown[],
   state: StreamReconciliationState,
+  startIndex: number,
   toolCallId?: string,
 ): number {
   const liveToolIds = toolCallId ? new Set([toolCallId]) : new Set(currentLiveToolCallIds(state));
   if (liveToolIds.size === 0) {
     return -1;
   }
-  const startIndex = lastUserMessageIndex(messages) + 1;
   for (let index = startIndex; index < messages.length; index++) {
     if (extractToolMessageRefs(messages[index]).some((ref) => liveToolIds.has(ref.id))) {
       return index;
@@ -515,8 +536,11 @@ function insertMessageAtIndex(messages: unknown[], message: unknown, index: numb
   return [...messages.slice(0, index), message, ...messages.slice(index)];
 }
 
-function timestampOrderedInsertIndex(messages: unknown[], desiredTimestamp: number): number {
-  const startIndex = lastUserMessageIndex(messages) + 1;
+function timestampOrderedInsertIndex(
+  messages: unknown[],
+  desiredTimestamp: number,
+  startIndex: number,
+): number {
   for (let index = startIndex; index < messages.length; index++) {
     const timestamp = messageTimestampMs(messages[index]);
     if (timestamp != null && timestamp > desiredTimestamp) {
@@ -574,23 +598,28 @@ export function materializeVisibleStreamState(
 ): unknown[] {
   let nextMessages = messages;
   const persistCommentary = opts.persistCommentary === true;
+  const defaultStartIndex = streamReconciliationStartIndex(messages);
   for (const part of visibleAssistantStreamParts(state, opts)) {
     if (!persistCommentary && part.itemId) {
       continue;
     }
     const replacementMessages = opts.replacementMessages ?? [];
+    const startIndex = part.itemId
+      ? (opts.keyedStartIndex ?? defaultStartIndex)
+      : defaultStartIndex;
     if (
       hasAssistantStreamPartReplacement(
         [...nextMessages, ...replacementMessages],
         part,
         opts.isHiddenAssistantMessage,
+        startIndex,
       )
     ) {
       continue;
     }
     const toolIndex =
       part.source === "segment" && part.toolCallId
-        ? currentToolStreamMessageIndex(nextMessages, state, part.toolCallId)
+        ? currentToolStreamMessageIndex(nextMessages, state, startIndex, part.toolCallId)
         : -1;
     if (opts.requirePersistedTool && toolIndex < 0) {
       continue;
@@ -599,7 +628,7 @@ export function materializeVisibleStreamState(
       toolIndex >= 0
         ? toolIndex
         : part.source === "segment"
-          ? timestampOrderedInsertIndex(nextMessages, part.timestamp)
+          ? timestampOrderedInsertIndex(nextMessages, part.timestamp, startIndex)
           : nextMessages.length;
     const streamMessage = buildAssistantStreamMessage(
       part.text,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where commentary already shown during a running task could appear a second time after the user steered the task and the run reached a terminal state.

## Why This Change Was Made

Terminal reconciliation now preserves the active stream's pre-steer boundary for keyed stream items, including when the steer is already persisted. Unkeyed assistant text continues to use the normal latest-user boundary so distinct post-steer output is not accidentally collapsed.

The reconciliation boundary is recomputed as keyed items are inserted, so later unkeyed parts cannot inherit a stale numeric index.

## User Impact

Users can steer a running task without earlier commentary being repeated around the steer message when the task finishes.

## Evidence

- Red observation: the model emitted each commentary item once, but the Control UI rendered earlier keyed commentary again after inserting the steer message at terminal reconciliation. Private session identifiers and transcript content are intentionally omitted.
- Exact-head Blacksmith Testbox proof: stream-reconciliation, chat-gateway, and chat-send passed, 385 tests total, at head 9a2f5be074ad9a385eb148e22312c7a19920c5b1. https://github.com/openclaw/openclaw/actions/runs/29978007700
- Regression coverage includes locally materialized and already-persisted steer ordering, the unkeyed-text negative control, and keyed insertions that shift the steer boundary.
- Fresh autoreview found one stale-index defect; it was repaired and the follow-up autoreview is clean with 0.98 confidence.
- Browser proof limitation: repeated mocked Control UI attempts hit the same setup/timing failure class. One attempt never entered steer mode; later attempts entered queueMode steer through a command path but rendered command acknowledgement instead of the queued user turn; settings/history-refresh attempts timed out or remained loading before the required lifecycle fixture existed. These captures are invalid for the ordering claim and are not presented as passing proof. Per maintainer direction, the repeated harness was stopped and the deterministic regression proof plus the original observation are the canonical evidence.

AI-assisted: yes.
