### PR TITLE
feat(signal): add chat-based setup and account linking

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/systemagent/SystemAgentChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/systemagent/SystemAgentChatController.kt
@@ -53,6 +53,7 @@ data class SystemAgentChatQuestion(
   val header: String,
   val question: String,
   val options: List<SystemAgentChatQuestionOption>,
+  val allowSkip: Boolean,
 )
 
 data class SystemAgentChatMessage(
@@ -60,6 +61,7 @@ data class SystemAgentChatMessage(
   val role: Role,
   val text: String,
   val question: SystemAgentChatQuestion? = null,
+  val qrCodePngBase64: String? = null,
 ) {
   enum class Role {
     Assistant,
@@ -85,6 +87,30 @@ data class SystemAgentChatState(
 )
 
 private fun newSystemAgentSessionId(): String = "android-settings-openclaw-${UUID.randomUUID()}"
+
+private fun buildSystemAgentChatPayload(
+  sessionId: String,
+  message: String?,
+  includeCapabilities: Boolean,
+): JsonObject =
+  buildJsonObject {
+    put("sessionId", JsonPrimitive(sessionId))
+    if (includeCapabilities) {
+      put(
+        "capabilities",
+        buildJsonObject {
+          put("qrCodePng", JsonPrimitive(true))
+        },
+      )
+    }
+    message?.let { put("message", JsonPrimitive(it)) }
+  }
+
+private fun isLegacySystemAgentChatParamsRejection(error: GatewayRequestRejected): Boolean =
+  error.gatewayError.code == "INVALID_REQUEST" &&
+    error.gatewayError.message
+      .lowercase()
+      .contains("invalid openclaw.chat params")
 
 /**
  * Keeps the settings-only OpenClaw conversation outside ordinary chat/session state.
@@ -197,7 +223,7 @@ internal class SystemAgentChatController(
   fun skipQuestion(messageId: String) {
     val current = state.value
     val message = current.messages.firstOrNull { it.id == messageId } ?: return
-    if (!current.canAnswer(message)) return
+    if (!current.canAnswer(message) || message.question?.allowSkip != true) return
     request(
       message = "Skip for now",
       displayText = nativeString("Skip for now"),
@@ -274,11 +300,24 @@ internal class SystemAgentChatController(
         try {
           if (!isCurrent(requestGeneration) || !lease.isCurrent()) return@launch
           val payload =
-            buildJsonObject {
-              put("sessionId", JsonPrimitive(current.sessionId))
-              message?.let { put("message", JsonPrimitive(it)) }
+            buildSystemAgentChatPayload(
+              sessionId = current.sessionId,
+              message = message,
+              includeCapabilities = true,
+            )
+          val response =
+            try {
+              lease.request(GatewayMethod.OpenclawChat.rawValue, payload.toString(), 190_000)
+            } catch (err: GatewayRequestRejected) {
+              if (!isLegacySystemAgentChatParamsRejection(err)) throw err
+              val legacyPayload =
+                buildSystemAgentChatPayload(
+                  sessionId = current.sessionId,
+                  message = message,
+                  includeCapabilities = false,
+                )
+              lease.request(GatewayMethod.OpenclawChat.rawValue, legacyPayload.toString(), 190_000)
             }
-          val response = lease.request(GatewayMethod.OpenclawChat.rawValue, payload.toString(), 190_000)
           if (!isCurrent(requestGeneration)) return@launch
           if (!lease.isCurrent()) {
             markRouteChanged(requestGeneration)
@@ -301,6 +340,7 @@ internal class SystemAgentChatController(
                         role = SystemAgentChatMessage.Role.Assistant,
                         text = result.reply,
                         question = parseQuestion(result.question),
+                        qrCodePngBase64 = result.qrCodePngBase64,
                       ),
                   sending = false,
                   expectsSensitiveReply = result.sensitive == true,
@@ -372,6 +412,7 @@ internal class SystemAgentChatController(
     val sensitive: Boolean?,
     val agentId: String?,
     val question: JsonElement?,
+    val qrCodePngBase64: String?,
   )
 
   private fun parseResult(root: JsonObject): Result =
@@ -381,6 +422,7 @@ internal class SystemAgentChatController(
       sensitive = root["sensitive"]?.jsonPrimitive?.booleanOrNull,
       agentId = root["agentId"]?.jsonPrimitive?.contentOrNull,
       question = root["question"],
+      qrCodePngBase64 = root["qrCodePngBase64"]?.jsonPrimitive?.contentOrNull,
     )
 
   private fun parseQuestion(value: JsonElement?): SystemAgentChatQuestion? {
@@ -398,7 +440,7 @@ internal class SystemAgentChatController(
         ?.trim()
         .orEmpty()
     val options = root["options"] as? JsonArray ?: return null
-    if (header.isEmpty() || question.isEmpty() || options.size !in 2..4) return null
+    if (header.isEmpty() || question.isEmpty() || options.size !in 1..4) return null
     val parsed =
       options.mapNotNull { element ->
         val option = element as? JsonObject ?: return null
@@ -428,7 +470,12 @@ internal class SystemAgentChatController(
       }
     if (parsed.size != options.size || parsed.map { it.label.lowercase() }.toSet().size != parsed.size) return null
     if (parsed.count { it.recommended } > 1) return null
-    return SystemAgentChatQuestion(header = header, question = question, options = parsed)
+    return SystemAgentChatQuestion(
+      header = header,
+      question = question,
+      options = parsed,
+      allowSkip = root["allowSkip"]?.jsonPrimitive?.booleanOrNull != false,
+    )
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt
@@ -12,6 +12,9 @@ import ai.openclaw.app.ui.design.ClawPrimaryButton
 import ai.openclaw.app.ui.design.ClawScaffold
 import ai.openclaw.app.ui.design.ClawSecondaryButton
 import ai.openclaw.app.ui.design.ClawTheme
+import android.graphics.BitmapFactory
+import android.util.Base64
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -23,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -40,8 +44,11 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -220,18 +227,37 @@ private fun SystemAgentConversation(
 @Composable
 private fun SystemAgentMessage(message: SystemAgentChatMessage) {
   val user = message.role == SystemAgentChatMessage.Role.User
+  val qrImage =
+    remember(message.qrCodePngBase64) {
+      message.qrCodePngBase64
+        ?.let { runCatching { Base64.decode(it, Base64.DEFAULT) }.getOrNull() }
+        ?.let { bytes -> BitmapFactory.decodeByteArray(bytes, 0, bytes.size) }
+        ?.asImageBitmap()
+    }
   Row(modifier = Modifier.fillMaxWidth()) {
     if (user) Spacer(modifier = Modifier.weight(1f))
-    Text(
-      text = message.text,
-      style = ClawTheme.type.body,
-      color = ClawTheme.colors.text,
+    Column(
       modifier =
         Modifier
           .weight(if (user) 0.8f else 0.9f, fill = false)
           .background(if (user) ClawTheme.colors.primary.copy(alpha = 0.14f) else ClawTheme.colors.surfaceRaised, RoundedCornerShape(14.dp))
           .padding(horizontal = 12.dp, vertical = 9.dp),
-    )
+      verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      Text(
+        text = message.text,
+        style = ClawTheme.type.body,
+        color = ClawTheme.colors.text,
+      )
+      if (qrImage != null) {
+        Image(
+          bitmap = qrImage,
+          contentDescription = nativeString("QR code"),
+          modifier = Modifier.sizeIn(maxWidth = 280.dp, maxHeight = 280.dp),
+          filterQuality = FilterQuality.None,
+        )
+      }
+    }
     if (!user) Spacer(modifier = Modifier.weight(1f))
   }
 }
@@ -264,7 +290,9 @@ private fun SystemAgentQuestionCard(
         )
         option.description?.let { Text(it, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted) }
       }
-      ClawSecondaryButton(text = nativeString("Skip for now"), onClick = onSkip, enabled = enabled)
+      if (question.allowSkip) {
+        ClawSecondaryButton(text = nativeString("Skip for now"), onClick = onSkip, enabled = enabled)
+      }
     }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/systemagent/SystemAgentChatControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/systemagent/SystemAgentChatControllerTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -55,6 +56,14 @@ class SystemAgentChatControllerTest {
       assertFalse("message" in params)
       assertFalse("welcomeVariant" in params)
       assertFalse("delegation" in params)
+      assertTrue(
+        params
+          .getValue("capabilities")
+          .jsonObject
+          .getValue("qrCodePng")
+          .jsonPrimitive
+          .booleanOrNull == true,
+      )
     }
 
   @Test
@@ -91,6 +100,14 @@ class SystemAgentChatControllerTest {
       val params = json.parseToJsonElement(harness.requests[1].paramsJson).jsonObject
       assertEquals(" nonpublic test text ", params.getValue("message").jsonPrimitive.content)
       assertTrue(
+        params
+          .getValue("capabilities")
+          .jsonObject
+          .getValue("qrCodePng")
+          .jsonPrimitive
+          .booleanOrNull == true,
+      )
+      assertTrue(
         harness.controller.state.value.messages.any {
           it.role == SystemAgentChatMessage.Role.User && it.text == "<redacted secret>"
         },
@@ -98,6 +115,90 @@ class SystemAgentChatControllerTest {
       assertFalse(
         harness.controller.state.value.messages
           .any { "nonpublic test text" in it.text },
+      )
+    }
+
+  @Test
+  fun qrImageIsRetainedOnTheAssistantMessage() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.responses +=
+        """
+        {
+          "sessionId": "system-session",
+          "reply": "Scan this code",
+          "action": "none",
+          "qrCodePngBase64": "cG5n",
+          "question": {
+            "id": "signal-link",
+            "header": "Signal account linking",
+            "question": "Scan the QR code, then continue.",
+            "options": [{"label": "Continue"}],
+            "allowSkip": false
+          }
+        }
+        """.trimIndent()
+      harness.responses += reply("Signal linked")
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+
+      assertEquals(
+        "cG5n",
+        harness.controller.state.value.messages
+          .single()
+          .qrCodePngBase64,
+      )
+      assertEquals(
+        listOf("Continue"),
+        harness.controller.state.value.messages
+          .single()
+          .question
+          ?.options
+          ?.map { it.label },
+      )
+      val message =
+        harness.controller.state.value.messages
+          .single()
+      assertFalse(message.question?.allowSkip ?: true)
+      harness.controller.skipQuestion(message.id)
+      advanceUntilIdle()
+      assertEquals(1, harness.requests.size)
+
+      harness.controller.answerQuestion(message.id, "Continue")
+      advanceUntilIdle()
+      val params = json.parseToJsonElement(harness.requests[1].paramsJson).jsonObject
+      assertEquals("Continue", params.getValue("message").jsonPrimitive.content)
+    }
+
+  @Test
+  fun olderGatewayRetriesGreetingWithoutQrCapability() =
+    runTest {
+      val harness = readyHarness(this)
+      var attempt = 0
+      harness.handler = {
+        attempt += 1
+        if (attempt == 1) {
+          throw GatewayRequestRejected(
+            GatewaySession.ErrorShape("INVALID_REQUEST", "invalid openclaw.chat params"),
+          )
+        }
+        reply("Legacy gateway welcome")
+      }
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+
+      assertEquals(2, harness.requests.size)
+      val firstParams = json.parseToJsonElement(harness.requests[0].paramsJson).jsonObject
+      val secondParams = json.parseToJsonElement(harness.requests[1].paramsJson).jsonObject
+      assertTrue("capabilities" in firstParams)
+      assertFalse("capabilities" in secondParams)
+      assertEquals(
+        "Legacy gateway welcome",
+        harness.controller.state.value.messages
+          .single()
+          .text,
       )
     }
 
@@ -386,6 +487,39 @@ class SystemAgentChatControllerTest {
     }
 
   @Test
+  fun olderGatewayRetryPreservesUserMessage() =
+    runTest {
+      val harness = readyHarness(this)
+      harness.handler = { request ->
+        val params = json.parseToJsonElement(request.paramsJson).jsonObject
+        when {
+          "message" !in params -> reply("Ready")
+          "capabilities" in params ->
+            throw GatewayRequestRejected(
+              GatewaySession.ErrorShape("INVALID_REQUEST", "invalid openclaw.chat params"),
+            )
+          else -> {
+            assertEquals("keep this answer", params.getValue("message").jsonPrimitive.content)
+            reply("Saved")
+          }
+        }
+      }
+
+      harness.controller.refresh()
+      advanceUntilIdle()
+      harness.controller.setInput("keep this answer")
+      harness.controller.sendInput()
+      advanceUntilIdle()
+
+      assertEquals(3, harness.requests.size)
+      assertEquals(
+        listOf("Ready", "keep this answer", "Saved"),
+        harness.controller.state.value.messages
+          .map { it.text },
+      )
+    }
+
+  @Test
   fun handoffWaitsForExplicitActionAndBlocksFurtherMessages() =
     runTest {
       val harness = readyHarness(this)
@@ -423,6 +557,7 @@ class SystemAgentChatControllerTest {
     action: String = "none",
     sensitive: Boolean? = null,
     agentId: String? = null,
+    qrCodePngBase64: String? = null,
   ): String =
     buildJsonObject {
       put("sessionId", JsonPrimitive("system-session"))
@@ -430,6 +565,7 @@ class SystemAgentChatControllerTest {
       put("action", JsonPrimitive(action))
       sensitive?.let { put("sensitive", JsonPrimitive(it)) }
       agentId?.let { put("agentId", JsonPrimitive(it)) }
+      qrCodePngBase64?.let { put("qrCodePngBase64", JsonPrimitive(it)) }
     }.toString()
 
   private fun questionReply(): String =

--- a/apps/ios/Sources/Design/SettingsSystemAgentChat.swift
+++ b/apps/ios/Sources/Design/SettingsSystemAgentChat.swift
@@ -2,6 +2,7 @@ import Foundation
 import Observation
 import OpenClawKit
 import SwiftUI
+import UIKit
 
 struct IOSSystemAgentChatRouteLease: Sendable {
     let route: GatewayNodeSessionRoute?
@@ -47,17 +48,20 @@ final class IOSSystemAgentChatModel {
         let role: Role
         let text: String
         let question: SystemAgentChatQuestion?
+        let qrCodePngBase64: String?
 
         init(
             id: UUID = UUID(),
             role: Role,
             text: String,
-            question: SystemAgentChatQuestion? = nil)
+            question: SystemAgentChatQuestion? = nil,
+            qrCodePngBase64: String? = nil)
         {
             self.id = id
             self.role = role
             self.text = text
             self.question = question
+            self.qrCodePngBase64 = qrCodePngBase64
         }
     }
 
@@ -73,6 +77,7 @@ final class IOSSystemAgentChatModel {
         let sensitive: Bool?
         let agentId: String?
         let question: AnyCodable?
+        let qrCodePngBase64: String?
     }
 
     private(set) var messages: [Message] = []
@@ -296,6 +301,7 @@ final class IOSSystemAgentChatModel {
     @discardableResult
     func skipQuestion(messageID: UUID) -> Task<Void, Never>? {
         guard let message = self.messages.first(where: { $0.id == messageID }),
+              message.question?.allowSkip == true,
               self.canAnswerQuestion(message),
               let task = self.send(
                   message: "Skip for now",
@@ -423,13 +429,16 @@ final class IOSSystemAgentChatModel {
         do {
             var params: [String: AnyCodable] = [
                 "sessionId": AnyCodable(self.sessionID),
+                "capabilities": AnyCodable([
+                    "qrCodePng": AnyCodable(true),
+                ]),
             ]
             if let message {
                 params["message"] = AnyCodable(message)
             }
             let routeLease = try await self.sessionRoute(for: generation)
             guard self.isCurrentRequest(generation) else { return }
-            let data = try await routeLease.request("openclaw.chat", params, 190_000)
+            let data = try await self.requestChat(params: params, routeLease: routeLease)
             guard self.isCurrentRequest(generation) else { return }
             guard await routeLease.isCurrent() else { throw CancellationError() }
             let result = try JSONDecoder().decode(ChatResult.self, from: data)
@@ -438,7 +447,8 @@ final class IOSSystemAgentChatModel {
             self.messages.append(Message(
                 role: .assistant,
                 text: result.reply,
-                question: SystemAgentChatQuestion.parse(result.question?.dictionaryValue)))
+                question: SystemAgentChatQuestion.parse(result.question?.dictionaryValue),
+                qrCodePngBase64: result.qrCodePngBase64))
             if result.action == "open-agent" {
                 self.pendingHandoff = Handoff(agentID: result.agentId)
             }
@@ -458,6 +468,23 @@ final class IOSSystemAgentChatModel {
                 return
             }
             self.errorMessage = error.localizedDescription
+        }
+    }
+
+    private func requestChat(
+        params: [String: AnyCodable],
+        routeLease: IOSSystemAgentChatRouteLease) async throws -> Data
+    {
+        do {
+            return try await routeLease.request("openclaw.chat", params, 190_000)
+        } catch let error as GatewayResponseError
+            where params["capabilities"] != nil &&
+            error.code == "INVALID_REQUEST" &&
+            error.message.lowercased().contains("invalid openclaw.chat params")
+        {
+            var legacyParams = params
+            legacyParams.removeValue(forKey: "capabilities")
+            return try await routeLease.request("openclaw.chat", legacyParams, 190_000)
         }
     }
 }
@@ -858,13 +885,15 @@ private struct IOSSystemAgentQuestionCard: View {
             ForEach(self.question.options, id: \.label) { option in
                 self.optionButton(option)
             }
-            Button(action: self.onSkip) {
-                Text("Skip for now")
-                    .font(OpenClawType.captionSemiBold)
+            if self.question.allowSkip {
+                Button(action: self.onSkip) {
+                    Text("Skip for now")
+                        .font(OpenClawType.captionSemiBold)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .disabled(!self.isEnabled)
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
-            .disabled(!self.isEnabled)
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -928,9 +957,19 @@ private struct IOSSystemAgentChatBubble: View {
             if self.message.role == .user {
                 Spacer(minLength: 44)
             }
-            Text(self.message.text)
-                .font(OpenClawType.body)
-                .textSelection(.enabled)
+            VStack(alignment: .leading, spacing: 10) {
+                Text(self.message.text)
+                    .font(OpenClawType.body)
+                    .textSelection(.enabled)
+                if let qrImage = self.qrImage {
+                    Image(uiImage: qrImage)
+                        .resizable()
+                        .interpolation(.none)
+                        .scaledToFit()
+                        .frame(maxWidth: 280, maxHeight: 280)
+                        .accessibilityLabel(Text("QR code"))
+                }
+            }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 9)
                 .background(
@@ -942,5 +981,12 @@ private struct IOSSystemAgentChatBubble: View {
                 Spacer(minLength: 44)
             }
         }
+    }
+
+    private var qrImage: UIImage? {
+        guard let pngBase64 = self.message.qrCodePngBase64,
+              let data = Data(base64Encoded: pngBase64)
+        else { return nil }
+        return UIImage(data: data)
     }
 }

--- a/apps/ios/Tests/IOSSystemAgentChatTests.swift
+++ b/apps/ios/Tests/IOSSystemAgentChatTests.swift
@@ -18,9 +18,14 @@ struct IOSSystemAgentChatTests {
     private actor RequestRecorder {
         private var requests: [RecordedRequest] = []
         private var responses: [Result<Data, HarnessError>]
+        private var legacyParamsRejections: Int
 
-        init(responses: [Result<Data, HarnessError>]) {
+        init(
+            responses: [Result<Data, HarnessError>],
+            legacyParamsRejections: Int = 0)
+        {
             self.responses = responses
+            self.legacyParamsRejections = legacyParamsRejections
         }
 
         func perform(
@@ -29,6 +34,14 @@ struct IOSSystemAgentChatTests {
             timeoutMs: Double) throws -> Data
         {
             self.requests.append(RecordedRequest(method: method, params: params, timeoutMs: timeoutMs))
+            if self.legacyParamsRejections > 0 {
+                self.legacyParamsRejections -= 1
+                throw GatewayResponseError(
+                    method: method,
+                    code: "INVALID_REQUEST",
+                    message: "invalid openclaw.chat params",
+                    details: nil)
+            }
             guard !self.responses.isEmpty else { throw HarnessError.failed }
             return try self.responses.removeFirst().get()
         }
@@ -95,6 +108,23 @@ struct IOSSystemAgentChatTests {
         #expect(request.params["message"] == nil)
         #expect(request.params["welcomeVariant"] == nil)
         #expect(request.params["delegation"] == nil)
+        let capabilities = try #require(request.params["capabilities"]?.value as? [String: AnyCodable])
+        #expect(capabilities["qrCodePng"]?.value as? Bool == true)
+    }
+
+    @Test func `older gateway retries greeting without QR capability`() async throws {
+        let recorder = RequestRecorder(
+            responses: [.success(Self.reply("Legacy gateway welcome"))],
+            legacyParamsRejections: 1)
+        let model = self.makeModel(recorder: recorder)
+
+        await Self.start(model)
+
+        let requests = await recorder.allRequests()
+        #expect(requests.count == 2)
+        #expect(requests[0].params["capabilities"] != nil)
+        #expect(requests[1].params["capabilities"] == nil)
+        #expect(try #require(model.messages.first).text == "Legacy gateway welcome")
     }
 
     @Test func `missing advertised system-agent method blocks the chat`() {
@@ -201,6 +231,36 @@ struct IOSSystemAgentChatTests {
         #expect(!model.messages.contains { $0.text.contains("super-secret-value") })
     }
 
+    @Test func `PNG QR image is retained on the assistant message`() async throws {
+        let recorder = RequestRecorder(responses: [
+            .success(Self.reply(
+                "Scan this code",
+                qrCodePngBase64: "cG5n",
+                question: [
+                    "id": "signal-link",
+                    "header": "Signal account linking",
+                    "question": "Scan the QR code, then continue.",
+                    "options": [["label": "Continue"]],
+                    "allowSkip": false,
+                ])),
+            .success(Self.reply("Signal linked")),
+        ])
+        let model = self.makeModel(recorder: recorder)
+
+        await Self.start(model)
+
+        let message = try #require(model.messages.first)
+        #expect(message.qrCodePngBase64 == "cG5n")
+        #expect(message.question?.allowSkip == false)
+        #expect(model.skipQuestion(messageID: message.id) == nil)
+
+        let answer = try #require(
+            model.answerQuestion(messageID: message.id, optionLabel: "Continue"))
+        await answer.value
+        let requests = await recorder.allRequests()
+        #expect(requests[1].params["message"]?.value as? String == "Continue")
+    }
+
     @Test func `option reply uses canonical value while transcript keeps label`() async throws {
         let recorder = RequestRecorder(responses: [
             .success(Self.questionReply()),
@@ -215,6 +275,9 @@ struct IOSSystemAgentChatTests {
 
         let requests = await recorder.allRequests()
         #expect(requests[1].params["message"]?.value as? String == "tailscale")
+        let capabilities = try #require(
+            requests[1].params["capabilities"]?.value as? [String: AnyCodable])
+        #expect(capabilities["qrCodePng"]?.value as? Bool == true)
         #expect(model.messages.contains { $0.role == .user && $0.text == "Use Tailscale" })
         #expect(model.retiredQuestionMessageIDs.contains(questionMessage.id))
     }
@@ -483,7 +546,9 @@ struct IOSSystemAgentChatTests {
         _ reply: String,
         action: String = "reply",
         sensitive: Bool? = nil,
-        agentID: String? = nil) -> Data
+        agentID: String? = nil,
+        qrCodePngBase64: String? = nil,
+        question: [String: Any]? = nil) -> Data
     {
         var result: [String: Any] = [
             "sessionId": "system-session",
@@ -495,6 +560,12 @@ struct IOSSystemAgentChatTests {
         }
         if let agentID {
             result["agentId"] = agentID
+        }
+        if let qrCodePngBase64 {
+            result["qrCodePngBase64"] = qrCodePngBase64
+        }
+        if let question {
+            result["question"] = question
         }
         guard let data = try? JSONSerialization.data(withJSONObject: result) else {
             preconditionFailure("System-agent reply fixture must encode")

--- a/apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 import OpenClawKit
@@ -62,11 +63,18 @@ final class SystemAgentOnboardingChatModel {
         let role: Role
         let text: String
         let question: SystemAgentChatQuestion?
+        let qrCodePngBase64: String?
 
-        init(role: Role, text: String, question: SystemAgentChatQuestion? = nil) {
+        init(
+            role: Role,
+            text: String,
+            question: SystemAgentChatQuestion? = nil,
+            qrCodePngBase64: String? = nil)
+        {
             self.role = role
             self.text = text
             self.question = question
+            self.qrCodePngBase64 = qrCodePngBase64
         }
     }
 
@@ -111,6 +119,7 @@ final class SystemAgentOnboardingChatModel {
         let sensitive: Bool?
         let agentDraft: SystemAgentDraft?
         let question: AnyCodable?
+        let qrCodePngBase64: String?
     }
 
     func startIfNeeded() async {
@@ -147,6 +156,7 @@ final class SystemAgentOnboardingChatModel {
     @discardableResult
     func skipQuestion(messageID: UUID) -> Task<Void, Never>? {
         guard let message = self.messages.first(where: { $0.id == messageID }),
+              message.question?.allowSkip == true,
               self.canAnswerQuestion(message),
               let task = self.send(message: "Skip for now", displayText: "Skip for now")
         else { return nil }
@@ -253,6 +263,9 @@ final class SystemAgentOnboardingChatModel {
         do {
             var params: [String: AnyCodable] = [
                 "sessionId": AnyCodable(self.sessionId),
+                "capabilities": AnyCodable([
+                    "qrCodePng": AnyCodable(true),
+                ]),
             ]
             if let welcomeVariant = self.welcomeVariant {
                 params["welcomeVariant"] = AnyCodable(welcomeVariant)
@@ -262,11 +275,7 @@ final class SystemAgentOnboardingChatModel {
             }
             let route = try await self.sessionRoute(for: generation)
             guard self.isCurrentRequest(generation) else { return }
-            let data = try await self.gateway.request(
-                method: "openclaw.chat",
-                params: params,
-                timeoutMs: 190_000,
-                ifCurrentRoute: route)
+            let data = try await self.requestChat(params: params, route: route)
             guard self.isCurrentRequest(generation) else { return }
             guard await self.gateway.isCurrentRoute(route) else { throw CancellationError() }
             let result = try JSONDecoder().decode(ChatResult.self, from: data)
@@ -275,7 +284,8 @@ final class SystemAgentOnboardingChatModel {
             self.messages.append(Message(
                 role: .assistant,
                 text: result.reply,
-                question: SystemAgentChatQuestion.parse(result.question?.dictionaryValue)))
+                question: SystemAgentChatQuestion.parse(result.question?.dictionaryValue),
+                qrCodePngBase64: result.qrCodePngBase64))
             self.onReplyReceived?()
             if result.action == "open-agent" {
                 self.onAgentHandoff?(result.agentDraft)
@@ -290,6 +300,31 @@ final class SystemAgentOnboardingChatModel {
                 return
             }
             self.errorMessage = error.localizedDescription
+        }
+    }
+
+    private func requestChat(
+        params: [String: AnyCodable],
+        route: GatewayConnection.Route) async throws -> Data
+    {
+        do {
+            return try await self.gateway.request(
+                method: "openclaw.chat",
+                params: params,
+                timeoutMs: 190_000,
+                ifCurrentRoute: route)
+        } catch let error as GatewayResponseError
+            where params["capabilities"] != nil &&
+            error.code == "INVALID_REQUEST" &&
+            error.message.lowercased().contains("invalid openclaw.chat params")
+        {
+            var legacyParams = params
+            legacyParams.removeValue(forKey: "capabilities")
+            return try await self.gateway.request(
+                method: "openclaw.chat",
+                params: legacyParams,
+                timeoutMs: 190_000,
+                ifCurrentRoute: route)
         }
     }
 }
@@ -406,11 +441,13 @@ private struct SystemAgentChatQuestionCard: View {
             ForEach(self.question.options, id: \.label) { option in
                 self.optionButton(option)
             }
-            Button("Skip for now", action: self.onSkip)
-                .buttonStyle(.plain)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .disabled(!self.isEnabled)
+            if self.question.allowSkip {
+                Button("Skip for now", action: self.onSkip)
+                    .buttonStyle(.plain)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .disabled(!self.isEnabled)
+            }
         }
         .padding(12)
         .frame(maxWidth: 460, alignment: .leading)
@@ -474,9 +511,19 @@ private struct SystemAgentChatBubble: View {
             if self.message.role == .user {
                 Spacer(minLength: 40)
             }
-            Text(self.attributedText)
-                .font(.callout)
-                .textSelection(.enabled)
+            VStack(alignment: .leading, spacing: 10) {
+                Text(self.attributedText)
+                    .font(.callout)
+                    .textSelection(.enabled)
+                if let qrImage = self.qrImage {
+                    Image(nsImage: qrImage)
+                        .resizable()
+                        .interpolation(.none)
+                        .scaledToFit()
+                        .frame(maxWidth: 280, maxHeight: 280)
+                        .accessibilityLabel("QR code")
+                }
+            }
                 .padding(.horizontal, 10)
                 .padding(.vertical, 7)
                 .background(
@@ -488,6 +535,13 @@ private struct SystemAgentChatBubble: View {
                 Spacer(minLength: 40)
             }
         }
+    }
+
+    private var qrImage: NSImage? {
+        guard let pngBase64 = self.message.qrCodePngBase64,
+              let data = Data(base64Encoded: pngBase64)
+        else { return nil }
+        return NSImage(data: data)
     }
 
     private var attributedText: AttributedString {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingSystemAgentChatTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingSystemAgentChatTests.swift
@@ -114,6 +114,21 @@ private func systemAgentChatMessage(from message: URLSessionWebSocketTask.Messag
     return params["message"] as? String
 }
 
+private func systemAgentSupportsQrCode(from message: URLSessionWebSocketTask.Message) -> Bool {
+    let data: Data? = switch message {
+    case let .data(data): data
+    case let .string(string): string.data(using: .utf8)
+    @unknown default: nil
+    }
+    guard let data,
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          object["method"] as? String == "openclaw.chat",
+          let params = object["params"] as? [String: Any],
+          let capabilities = params["capabilities"] as? [String: Any]
+    else { return false }
+    return capabilities["qrCodePng"] as? Bool == true
+}
+
 private func respondToSystemAgentHealth(
     task: GatewayTestWebSocketTask,
     id: String,
@@ -128,10 +143,12 @@ private func systemAgentResponse(
     id: String,
     action: String = "none",
     agentDraft: String? = nil,
-    questionJSON: String? = nil) -> Data
+    questionJSON: String? = nil,
+    qrCodePngBase64: String? = nil) -> Data
 {
     let agentDraftField = agentDraft.map { ",\n            \"agentDraft\": \"\($0)\"" } ?? ""
     let questionField = questionJSON.map { ",\n            \"question\": \($0)" } ?? ""
+    let qrCodeField = qrCodePngBase64.map { ",\n            \"qrCodePngBase64\": \"\($0)\"" } ?? ""
     return Data(
         """
         {
@@ -142,8 +159,20 @@ private func systemAgentResponse(
             "sessionId": "test-session",
             "reply": "ready",
             "action": "\(action)",
-            "sensitive": false\(agentDraftField)\(questionField)
+            "sensitive": false\(agentDraftField)\(questionField)\(qrCodeField)
           }
+        }
+        """.utf8)
+}
+
+private func systemAgentErrorResponse(id: String, code: String, message: String) -> Data {
+    Data(
+        """
+        {
+          "type": "res",
+          "id": "\(id)",
+          "ok": false,
+          "error": { "code": "\(code)", "message": "\(message)" }
         }
         """.utf8)
 }
@@ -524,8 +553,9 @@ struct OnboardingSystemAgentChatTests {
                 guard sendIndex > 0,
                       let id = GatewayWebSocketTestSupport.requestID(from: message)
                 else { return }
-                if let message = systemAgentChatMessage(from: message) {
-                    await recordedMessages.record(message)
+                #expect(systemAgentSupportsQrCode(from: message))
+                if let chatMessage = systemAgentChatMessage(from: message) {
+                    await recordedMessages.record(chatMessage)
                     task.emitReceiveSuccess(.data(systemAgentResponse(id: id)))
                 } else {
                     task.emitReceiveSuccess(.data(systemAgentResponse(
@@ -553,6 +583,89 @@ struct OnboardingSystemAgentChatTests {
         #expect(await recordedMessages.snapshot() == ["connect whatsapp"])
         #expect(chat.messages.map(\.text) == ["ready", "Connect WhatsApp", "ready"])
         #expect(!chat.canAnswerQuestion(assistant))
+    }
+
+    @Test func `PNG QR image is retained on the assistant message`() async throws {
+        let recordedMessages = SystemAgentMessageRecorder()
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
+                guard sendIndex > 0,
+                      let id = GatewayWebSocketTestSupport.requestID(from: message)
+                else { return }
+                #expect(systemAgentSupportsQrCode(from: message))
+                if let chatMessage = systemAgentChatMessage(from: message) {
+                    await recordedMessages.record(chatMessage)
+                    task.emitReceiveSuccess(.data(systemAgentResponse(id: id)))
+                    return
+                }
+                task.emitReceiveSuccess(.data(systemAgentResponse(
+                    id: id,
+                    questionJSON:
+                        """
+                        {
+                          "id":"signal-link",
+                          "header":"Signal account linking",
+                          "question":"Scan the QR code, then continue.",
+                          "options":[{"label":"Continue"}],
+                          "allowSkip":false
+                        }
+                        """,
+                    qrCodePngBase64: "cG5n")))
+            })
+        })
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let gateway = GatewayConnection(
+            configProvider: { (url: url, token: nil, password: nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+        let chat = SystemAgentOnboardingChatModel(gateway: gateway)
+
+        await chat.startIfNeeded()
+
+        let message = try #require(chat.messages.first)
+        #expect(message.qrCodePngBase64 == "cG5n")
+        #expect(message.question?.allowSkip == false)
+        #expect(chat.skipQuestion(messageID: message.id) == nil)
+
+        let answer = try #require(chat.answerQuestion(
+            messageID: message.id,
+            optionLabel: "Continue"))
+        await answer.value
+        #expect(await recordedMessages.snapshot() == ["Continue"])
+    }
+
+    @Test func `older gateway retries greeting without QR capability`() async throws {
+        let requests = SystemAgentMethodRecorder()
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
+                guard sendIndex > 0,
+                      let id = GatewayWebSocketTestSupport.requestID(from: message)
+                else { return }
+                let method = systemAgentRequestMethod(from: message)
+                if respondToSystemAgentHealth(task: task, id: id, method: method) {
+                    return
+                }
+                if systemAgentSupportsQrCode(from: message) {
+                    await requests.record("qr-capability")
+                    task.emitReceiveSuccess(.data(systemAgentErrorResponse(
+                        id: id,
+                        code: "INVALID_REQUEST",
+                        message: "invalid openclaw.chat params")))
+                } else {
+                    await requests.record("legacy")
+                    task.emitReceiveSuccess(.data(systemAgentResponse(id: id)))
+                }
+            })
+        })
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let gateway = GatewayConnection(
+            configProvider: { (url: url, token: nil, password: nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+        let chat = SystemAgentOnboardingChatModel(gateway: gateway)
+
+        await chat.startIfNeeded()
+
+        #expect(await requests.snapshot() == ["qr-capability", "legacy"])
+        #expect(chat.messages.map(\.text) == ["ready"])
     }
 
     @Test func `typed question skip sends fixed reply and dismisses cards`() async throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemAgentChatQuestion.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemAgentChatQuestion.swift
@@ -13,6 +13,7 @@ public struct SystemAgentChatQuestion: Equatable, Sendable {
     public let question: String
     public let options: [Option]
     public let isOther: Bool
+    public let allowSkip: Bool
 
     /// Card-capable clients validate the open payload before turning values into actions.
     /// Invalid questions stay prose-only instead of exposing partial or ambiguous choices.
@@ -22,7 +23,7 @@ public struct SystemAgentChatQuestion: Equatable, Sendable {
               let header = nonEmptyString(value["header"]),
               let question = nonEmptyString(value["question"]),
               let rawOptions = value["options"]?.arrayValue,
-              (2...4).contains(rawOptions.count)
+              (1...4).contains(rawOptions.count)
         else { return nil }
 
         var labels = Set<String>()
@@ -51,7 +52,8 @@ public struct SystemAgentChatQuestion: Equatable, Sendable {
             header: header,
             question: question,
             options: options,
-            isOther: value["isOther"]?.boolValue == true)
+            isOther: value["isOther"]?.boolValue == true,
+            allowSkip: value["allowSkip"]?.boolValue != false)
     }
 
     private static func nonEmptyString(_ value: AnyCodable?) -> String? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -9095,6 +9095,7 @@ public struct ConfigSchemaLookupResult: Codable, Sendable {
 public struct SystemAgentChatParams: Codable, Sendable {
     public let sessionid: String
     public let message: String?
+    public let capabilities: [String: AnyCodable]?
     public let welcomevariant: AnyCodable?
     public let reset: Bool?
     public let delegation: [String: AnyCodable]?
@@ -9102,12 +9103,14 @@ public struct SystemAgentChatParams: Codable, Sendable {
     public init(
         sessionid: String,
         message: String? = nil,
+        capabilities: [String: AnyCodable]? = nil,
         welcomevariant: AnyCodable? = nil,
         reset: Bool? = nil,
         delegation: [String: AnyCodable]? = nil)
     {
         self.sessionid = sessionid
         self.message = message
+        self.capabilities = capabilities
         self.welcomevariant = welcomevariant
         self.reset = reset
         self.delegation = delegation
@@ -9116,6 +9119,7 @@ public struct SystemAgentChatParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case sessionid = "sessionId"
         case message
+        case capabilities
         case welcomevariant = "welcomeVariant"
         case reset
         case delegation
@@ -9127,6 +9131,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
     public let reply: String
     public let sensitive: Bool?
     public let wizardinputpending: Bool?
+    public let qrcodepngbase64: String?
     public let action: AnyCodable
     public let agentdraft: String?
     public let agentid: String?
@@ -9139,6 +9144,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
         reply: String,
         sensitive: Bool? = nil,
         wizardinputpending: Bool? = nil,
+        qrcodepngbase64: String? = nil,
         action: AnyCodable,
         agentdraft: String? = nil,
         agentid: String? = nil,
@@ -9150,6 +9156,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
         self.reply = reply
         self.sensitive = sensitive
         self.wizardinputpending = wizardinputpending
+        self.qrcodepngbase64 = qrcodepngbase64
         self.action = action
         self.agentdraft = agentdraft
         self.agentid = agentid
@@ -9163,6 +9170,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
         case reply
         case sensitive
         case wizardinputpending = "wizardInputPending"
+        case qrcodepngbase64 = "qrCodePngBase64"
         case action
         case agentdraft = "agentDraft"
         case agentid = "agentId"

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SystemAgentChatQuestionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/SystemAgentChatQuestionTests.swift
@@ -65,9 +65,26 @@ struct SystemAgentChatQuestionTests {
     }
 
     @Test
+    func `single acknowledgement action is valid`() throws {
+        let decoded = try Self.parse(
+            """
+            {
+              "id": "signal-link",
+              "header": "Signal account linking",
+              "question": "Scan the QR code, then continue.",
+              "options": [{"label": "Continue"}],
+              "allowSkip": false
+            }
+            """)
+        let parsed = try #require(decoded)
+
+        #expect(parsed.options.map(\.label) == ["Continue"])
+        #expect(!parsed.allowSkip)
+    }
+
+    @Test
     func `malformed gateway questions degrade to nil`() throws {
         let malformedQuestions = [
-            #"{"id":"one","header":"H","question":"Q","options":[{"label":"Only"}]}"#,
             """
             {"id":"five","header":"H","question":"Q","options":\
             [{"label":"A"},{"label":"B"},{"label":"C"},{"label":"D"},{"label":"E"}]}

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -33,27 +33,27 @@ Bare plugin specs try ClawHub first, then npm fallback. Force a source with `ope
     openclaw plugins install @openclaw/signal
     ```
   </Step>
-  <Step title="Link or register the local account">
-    Skip this step when you are connecting to an existing Signal server that already owns the account.
-
-    - **QR link (fastest):** `signal-cli link -n "OpenClaw"`, then scan with Signal. See [Path A](#setup-path-a-link-existing-signal-account-qr).
-    - **SMS registration:** dedicated number with captcha + SMS verification. See [Path B](#setup-path-b-register-dedicated-bot-number-sms-linux).
-
-    If you want the wizard to install `signal-cli`, continue to the next step first. After installation, the wizard prints the exact link command for the selected CLI and config directory. Run it in another terminal, scan the QR code, then choose **Retry this setup**.
-
-  </Step>
   <Step title="Run the guided setup">
     ```bash
     openclaw channels add
     ```
     Signal uses a real Signal account/device, not a bot token. The wizard asks whether OpenClaw should manage a local `signal-cli` or connect to an existing Signal server.
 
-    - **Local `signal-cli`:** the wizard can install or reuse `signal-cli`, accepts an optional custom config directory, and requires the Signal phone number. It checks that the number is linked in that config directory, starts a temporary daemon, validates it, stops it, and only then saves the transport.
+    - **Local `signal-cli`:** the wizard can install or reuse `signal-cli` and accepts an optional custom config directory. It discovers linked accounts automatically. If none exist, choose **Link a Signal account now**, then scan the QR code shown in the wizard from Signal **Settings > Linked devices**. The wizard adopts the linked phone number, starts a temporary daemon, validates it, stops it, and only then saves the transport.
     - **Existing server:** enter the server URL. The wizard detects the native or container protocol, asks for a Signal phone number when the server requires one, and probes the concrete transport before saving it. An external native server may remain accountless only when the probe confirms the server is unambiguous.
 
     If detection or validation fails, the wizard can retry, change the account or URL, or stop without persisting the candidate transport.
 
     For non-interactive setup, `openclaw channels add --channel signal` also accepts `--signal-number <e164>` for the bot phone number, plus `--http-host <host>` and `--http-port <port>` for the Signal daemon endpoint (default `127.0.0.1:8080`).
+
+  </Step>
+  <Step title="Or link or register manually">
+    You can prepare the local `signal-cli` account before running the wizard:
+
+    - **QR link (fastest):** `signal-cli link -n "OpenClaw"`, then scan with Signal. See [Path A](#setup-path-a-link-existing-signal-account-qr).
+    - **SMS registration:** dedicated number with captcha + SMS verification. See [Path B](#setup-path-b-register-dedicated-bot-number-sms-linux).
+
+    Skip this step when the wizard links the account for you or when you connect to an existing Signal server that already owns the account.
 
   </Step>
   <Step title="Verify and pair">

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -33,23 +33,27 @@ Bare plugin specs try ClawHub first, then npm fallback. Force a source with `ope
     openclaw plugins install @openclaw/signal
     ```
   </Step>
+  <Step title="Link or register the local account">
+    Skip this step when you are connecting to an existing Signal server that already owns the account.
+
+    - **QR link (fastest):** `signal-cli link -n "OpenClaw"`, then scan with Signal. See [Path A](#setup-path-a-link-existing-signal-account-qr).
+    - **SMS registration:** dedicated number with captcha + SMS verification. See [Path B](#setup-path-b-register-dedicated-bot-number-sms-linux).
+
+    If you want the wizard to install `signal-cli`, continue to the next step first. After installation, the wizard prints the exact link command for the selected CLI and config directory. Run it in another terminal, scan the QR code, then choose **Retry this setup**.
+
+  </Step>
   <Step title="Run the guided setup">
     ```bash
     openclaw channels add
     ```
     Signal uses a real Signal account/device, not a bot token. The wizard asks whether OpenClaw should manage a local `signal-cli` or connect to an existing Signal server.
 
-    - **Local `signal-cli`:** the wizard can install or reuse `signal-cli`, accepts an optional custom config directory, requires the Signal phone number, and validates the prepared daemon before saving it.
+    - **Local `signal-cli`:** the wizard can install or reuse `signal-cli`, accepts an optional custom config directory, and requires the Signal phone number. It checks that the number is linked in that config directory, starts a temporary daemon, validates it, stops it, and only then saves the transport.
     - **Existing server:** enter the server URL. The wizard detects the native or container protocol, asks for a Signal phone number when the server requires one, and probes the concrete transport before saving it. An external native server may remain accountless only when the probe confirms the server is unambiguous.
 
     If detection or validation fails, the wizard can retry, change the account or URL, or stop without persisting the candidate transport.
 
     For non-interactive setup, `openclaw channels add --channel signal` also accepts `--signal-number <e164>` for the bot phone number, plus `--http-host <host>` and `--http-port <port>` for the Signal daemon endpoint (default `127.0.0.1:8080`).
-
-  </Step>
-  <Step title="Link or register the account">
-    - **QR link (fastest):** `signal-cli link -n "OpenClaw"`, then scan with Signal. See [Path A](#setup-path-a-link-existing-signal-account-qr).
-    - **SMS registration:** dedicated number with captcha + SMS verification. See [Path B](#setup-path-b-register-dedicated-bot-number-sms-linux).
 
   </Step>
   <Step title="Verify and pair">

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -37,7 +37,12 @@ Bare plugin specs try ClawHub first, then npm fallback. Force a source with `ope
     ```bash
     openclaw channels add
     ```
-    The wizard detects whether `signal-cli` is on `PATH` and, when missing, offers to install it: downloads the official native GraalVM build on Linux x86-64, or installs via Homebrew on macOS and other architectures. It then prompts for the bot number and `signal-cli` path.
+    Signal uses a real Signal account/device, not a bot token. The wizard asks whether OpenClaw should manage a local `signal-cli` or connect to an existing Signal server.
+
+    - **Local `signal-cli`:** the wizard can install or reuse `signal-cli`, accepts an optional custom config directory, requires the Signal phone number, and validates the prepared daemon before saving it.
+    - **Existing server:** enter the server URL. The wizard detects the native or container protocol, asks for a Signal phone number when the server requires one, and probes the concrete transport before saving it. An external native server may remain accountless only when the probe confirms the server is unambiguous.
+
+    If detection or validation fails, the wizard can retry, change the account or URL, or stop without persisting the candidate transport.
 
     For non-interactive setup, `openclaw channels add --channel signal` also accepts `--signal-number <e164>` for the bot phone number, plus `--http-host <host>` and `--http-port <port>` for the Signal daemon endpoint (default `127.0.0.1:8080`).
 

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -40,7 +40,7 @@ Bare plugin specs try ClawHub first, then npm fallback. Force a source with `ope
     Signal uses a real Signal account/device, not a bot token. The wizard asks whether OpenClaw should manage a local `signal-cli` or connect to an existing Signal server.
 
     - **Local `signal-cli`:** the wizard can install or reuse `signal-cli` and accepts an optional custom config directory. It discovers linked accounts automatically. If none exist, choose **Link a Signal account now**, then scan the QR code shown in the wizard from Signal **Settings > Linked devices**. The wizard adopts the linked phone number, starts a temporary daemon, validates it, stops it, and only then saves the transport.
-    - **Existing server:** enter the server URL. The wizard detects the native or container protocol, asks for a Signal phone number when the server requires one, and probes the concrete transport before saving it. An external native server may remain accountless only when the probe confirms the server is unambiguous.
+    - **Existing server:** enter the server URL and the Signal phone number that OpenClaw should use. The wizard detects the native or container protocol and probes that concrete transport before saving it.
 
     If detection or validation fails, the wizard can retry, change the account or URL, or stop without persisting the candidate transport.
 

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -34,7 +34,6 @@ import {
 } from "./reply-authors.js";
 import {
   buildSignalSetupPatch,
-  createSignalCliPathTextInput,
   normalizeSignalAccountInput,
   signalDmPolicy,
 } from "./setup-core.js";
@@ -309,13 +308,6 @@ describe("probeSignal", () => {
     });
 
     expect(status.configured).toBe(true);
-  });
-
-  it("does not show a second missing-binary note before the cliPath prompt", () => {
-    const input = createSignalCliPathTextInput(async () => true);
-
-    expect(input.helpLines).toBeUndefined();
-    expect(input.helpTitle).toBeUndefined();
   });
 });
 

--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -1,10 +1,11 @@
 // Signal tests cover daemon plugin behavior.
 import { EventEmitter, once } from "node:events";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { spawnSignalDaemon } from "./daemon.js";
+import { assertSignalDaemonBindAvailable, spawnSignalDaemon } from "./daemon.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -42,6 +43,30 @@ afterEach(() => {
 });
 
 describe("spawnSignalDaemon", () => {
+  it("rejects a bind already owned by another process", async () => {
+    const owner = createServer();
+    await new Promise<void>((resolve, reject) => {
+      owner.once("error", reject);
+      owner.listen({ host: "127.0.0.1", port: 0, exclusive: true }, resolve);
+    });
+    const address = owner.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected TCP test address");
+    }
+    try {
+      await expect(
+        assertSignalDaemonBindAvailable({
+          httpHost: "127.0.0.1",
+          httpPort: address.port,
+        }),
+      ).rejects.toThrow("address is already in use");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        owner.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("expands home-relative configPath before passing it to signal-cli", () => {
     spawnSignalDaemon({
       cliPath: "signal-cli",

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -1,9 +1,8 @@
 // Signal plugin module implements daemon behavior.
 import { spawn } from "node:child_process";
-import os from "node:os";
-import path from "node:path";
 import { createInterface } from "node:readline";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { resolveSignalCliConfigPath } from "./signal-cli-config-path.js";
 
 type SignalDaemonOpts = {
   cliPath: string;
@@ -80,17 +79,6 @@ function bindSignalCliOutput(params: {
       params.error(`signal-cli: ${line.trim()}`);
     }
   });
-}
-
-function resolveSignalCliConfigPath(raw: string): string {
-  const value = raw.trim();
-  if (value === "~") {
-    return os.homedir();
-  }
-  if (value.startsWith("~/") || value.startsWith("~\\")) {
-    return path.join(os.homedir(), value.slice(2));
-  }
-  return value;
 }
 
 function buildDaemonArgs(opts: SignalDaemonOpts): string[] {

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -1,5 +1,6 @@
 // Signal plugin module implements daemon behavior.
 import { spawn } from "node:child_process";
+import { createServer } from "node:net";
 import { createInterface } from "node:readline";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { resolveSignalCliConfigPath } from "./signal-cli-config-path.js";
@@ -31,6 +32,30 @@ type SignalDaemonExitEvent = {
   code: number | null;
   signal: NodeJS.Signals | null;
 };
+
+export async function assertSignalDaemonBindAvailable(params: {
+  httpHost: string;
+  httpPort: number;
+}): Promise<void> {
+  const server = createServer();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen({ host: params.httpHost, port: params.httpPort, exclusive: true }, resolve);
+    });
+  } catch (error) {
+    throw new Error(
+      `Signal cannot start a managed daemon on ${params.httpHost}:${String(params.httpPort)} because that address is already in use. Stop the existing server or choose “Connect to an existing Signal server”, then retry.`,
+      { cause: error },
+    );
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }
+}
 
 export function formatSignalDaemonExit(exit: SignalDaemonExitEvent): string {
   return `signal daemon exited (source=${exit.source} code=${exit.code ?? "null"} signal=${exit.signal ?? "null"})`;

--- a/extensions/signal/src/setup-core.test.ts
+++ b/extensions/signal/src/setup-core.test.ts
@@ -523,14 +523,6 @@ describe("signalSetupAdapter", () => {
     expect(
       await input.currentValue?.({ cfg, accountId: "default", credentialValues: {} }),
     ).toBeUndefined();
-    const wizardInput = signalSetupWizard.textInputs?.find((entry) => entry.inputKey === "cliPath");
-    expect(
-      await wizardInput?.shouldPrompt?.({
-        cfg,
-        accountId: "default",
-        credentialValues: {},
-      }),
-    ).toBe(false);
   });
 
   it("reports an external transport as configured without checking signal-cli", async () => {

--- a/extensions/signal/src/setup-core.test.ts
+++ b/extensions/signal/src/setup-core.test.ts
@@ -1,7 +1,11 @@
 // Signal tests cover setup adapter integration with account-owned transport policy.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createSignalCliPathTextInput, signalSetupAdapter } from "./setup-core.js";
+import {
+  createSignalSetupWizardProxy,
+  signalNumberTextInputs,
+  signalSetupAdapter,
+} from "./setup-core.js";
 import { signalSetupWizard } from "./setup-surface.js";
 
 const detectSignalTransportMock = vi.hoisted(() => vi.fn());
@@ -113,7 +117,10 @@ describe("signalSetupAdapter", () => {
           signal: {
             transport: { kind: "managed-native", httpPort: 8080 },
             accounts: {
-              default: { account: "+15555550123" },
+              default: {
+                account: "+15555550123",
+                accountUuid: "123e4567-e89b-12d3-a456-426614174000",
+              },
             },
           },
         },
@@ -127,7 +134,11 @@ describe("signalSetupAdapter", () => {
       kind: "managed-native",
       httpPort: 8080,
     });
-    expect(next?.channels?.signal?.accounts?.default).toBeUndefined();
+    expect(next?.channels?.signal?.accountUuid).toBeUndefined();
+    expect(next?.channels?.signal?.accounts?.default).toEqual({
+      accountUuid: "123e4567-e89b-12d3-a456-426614174000",
+    });
+    expect(next?.channels?.signal?.accounts?.work?.accountUuid).toBeUndefined();
     expect(next?.channels?.signal?.accounts?.work?.transport).toEqual({
       kind: "managed-native",
       httpHost: "127.0.0.1",
@@ -460,7 +471,7 @@ describe("signalSetupAdapter", () => {
     ).toBe("Signal --signal-transport requires --http-url.");
   });
 
-  it("rejects a fresh container transport without a Signal account", () => {
+  it("requires an account for containers but preserves accountless native servers", () => {
     expect(
       signalSetupAdapter.validateInput?.({
         cfg: {},
@@ -470,7 +481,17 @@ describe("signalSetupAdapter", () => {
           signalTransport: "container",
         },
       }),
-    ).toBe("Signal container transport requires --signal-number or an existing account.");
+    ).toBe("Signal server transport requires --signal-number or an existing account.");
+    expect(
+      signalSetupAdapter.validateInput?.({
+        cfg: {},
+        accountId: "work",
+        input: {
+          httpUrl: "http://signal-native:8080",
+          signalTransport: "external-native",
+        },
+      }),
+    ).toBeNull();
   });
 
   it("allows a container transport to reuse the configured Signal account", () => {
@@ -509,22 +530,6 @@ describe("signalSetupAdapter", () => {
     ).toBeNull();
   });
 
-  it("does not materialize a CLI path for an external transport", async () => {
-    const input = createSignalCliPathTextInput(async () => false);
-    const cfg: OpenClawConfig = {
-      channels: {
-        signal: {
-          account: "+15555550124",
-          transport: { kind: "container", url: "http://signal:8080" },
-        },
-      },
-    };
-
-    expect(
-      await input.currentValue?.({ cfg, accountId: "default", credentialValues: {} }),
-    ).toBeUndefined();
-  });
-
   it("reports an external transport as configured without checking signal-cli", async () => {
     const cfg: OpenClawConfig = {
       channels: {
@@ -547,5 +552,34 @@ describe("signalSetupAdapter", () => {
       "configured",
     );
     await expect(signalSetupWizard.status.resolveQuickstartScore?.(params)).resolves.toBe(1);
+  });
+
+  it("collects account numbers only where the selected transport requires them", async () => {
+    const requiredAccountInput = signalNumberTextInputs.find((input) => input.required !== false);
+    const proxy = createSignalSetupWizardProxy(async () => signalSetupWizard);
+
+    expect(
+      requiredAccountInput?.shouldPrompt?.({
+        cfg: {},
+        accountId: "default",
+        credentialValues: { signalTransportKind: "managed-native" },
+      }),
+    ).toBe(false);
+    expect(
+      requiredAccountInput?.shouldPrompt?.({
+        cfg: {},
+        accountId: "default",
+        credentialValues: { signalTransportKind: "container" },
+      }),
+    ).toBe(true);
+    expect(
+      requiredAccountInput?.shouldPrompt?.({
+        cfg: {},
+        accountId: "default",
+        credentialValues: { signalTransportKind: "external-native" },
+      }),
+    ).toBe(true);
+    expect(proxy.introNote).toEqual(signalSetupWizard.introNote);
+    expect(proxy.finalize).toBeTypeOf("function");
   });
 });

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -8,6 +8,7 @@ import {
   createPatchedAccountSetupAdapter,
   createSetupInputPresenceValidator,
   DEFAULT_ACCOUNT_ID,
+  patchChannelConfigForAccount,
   promptParsedAllowFromForAccount,
   setAccountAllowFromForChannel,
   setSetupChannelEnabled,

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -329,8 +329,9 @@ export const signalNumberTextInputs: ChannelSetupWizardTextInput[] = [
 export const signalCompletionNote = {
   title: t("wizard.signal.nextStepsTitle"),
   lines: [
-    "Signal setup is validated and ready for the gateway.",
-    `Then run: ${formatCliCommand("openclaw gateway call channels.status --params '{\"probe\":true}'")}`,
+    "Signal setup is validated.",
+    "OpenClaw will use this Signal connection when the gateway runs.",
+    `Check it later: ${formatCliCommand("openclaw channels status --probe")}`,
     `Docs: ${formatDocsLink("/signal", "signal")}`,
   ],
 };

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -4,7 +4,6 @@ import { parseAllowFromEntries } from "openclaw/plugin-sdk/allow-from";
 import { createChannelDmPolicy } from "openclaw/plugin-sdk/channel-dm-policy";
 import { defineChannelSetupContract } from "openclaw/plugin-sdk/channel-setup";
 import {
-  createCliPathTextInput,
   createDelegatedSetupWizardProxy,
   createPatchedAccountSetupAdapter,
   createSetupInputPresenceValidator,
@@ -48,6 +47,8 @@ export const signalSetupStateKeys = {
   cliConfigPath: "signalCliConfigPath",
   installRequested: "signalInstallRequested",
   serverUrl: "signalServerUrl",
+  originalAccount: "signalOriginalAccount",
+  linkDeferred: "signalLinkDeferred",
 } as const;
 
 const signalSetupFields = {
@@ -266,35 +267,6 @@ export const signalDmPolicy = createChannelDmPolicy({
   promptAllowFrom: promptSignalAllowFrom,
 });
 
-function resolveSignalCliPath(params: {
-  cfg: OpenClawConfig;
-  accountId: string;
-  credentialValues: Record<string, unknown>;
-}) {
-  const transport = resolveSignalAccount({
-    cfg: params.cfg,
-    accountId: params.accountId,
-  }).transport;
-  if (transport.kind !== "managed-native") {
-    return undefined;
-  }
-  return typeof params.credentialValues.cliPath === "string"
-    ? params.credentialValues.cliPath
-    : transport.cliPath;
-}
-
-export function createSignalCliPathTextInput(
-  shouldPrompt: NonNullable<ChannelSetupWizardTextInput["shouldPrompt"]>,
-): ChannelSetupWizardTextInput {
-  return createCliPathTextInput({
-    inputKey: "cliPath",
-    message: "signal-cli path",
-    resolvePath: ({ cfg, accountId, credentialValues }) =>
-      resolveSignalCliPath({ cfg, accountId, credentialValues }),
-    shouldPrompt,
-  });
-}
-
 export const signalNumberTextInput: ChannelSetupWizardTextInput = {
   inputKey: "signalNumber",
   message: t("wizard.signal.botNumberPrompt"),
@@ -311,30 +283,30 @@ export const signalNumberTextInputs: ChannelSetupWizardTextInput[] = [
   {
     ...signalNumberTextInput,
     shouldPrompt: ({ credentialValues }) =>
-      credentialValues[signalSetupStateKeys.transportKind] === "container",
-  },
-  {
-    ...signalNumberTextInput,
-    message: "Signal phone number (optional)",
-    required: false,
-    shouldPrompt: ({ credentialValues }) =>
+      credentialValues[signalSetupStateKeys.transportKind] === "container" ||
       credentialValues[signalSetupStateKeys.transportKind] === "external-native",
-    validate: ({ value }) =>
-      normalizeOptionalString(value) && !normalizeSignalAccountInput(value)
-        ? INVALID_SIGNAL_ACCOUNT_ERROR
-        : undefined,
   },
 ];
+
+export const signalIntroNote = {
+  title: "Signal",
+  lines: [
+    "Signal uses a real Signal account/device, not a bot token.",
+    "A dedicated Signal number is recommended for bot-like operation.",
+  ],
+};
 
 export const signalCompletionNote = {
   title: t("wizard.signal.nextStepsTitle"),
   lines: [
-    "Signal setup is validated.",
-    "OpenClaw will use this Signal connection when the gateway runs.",
+    "Signal setup validation passed.",
+    "OpenClaw will save this connection when channel setup finishes.",
     `Check it later: ${formatCliCommand("openclaw channels status --probe")}`,
     `Docs: ${formatDocsLink("/signal", "signal")}`,
   ],
-};
+  shouldShow: ({ credentialValues }) =>
+    credentialValues[signalSetupStateKeys.linkDeferred] !== "true",
+} satisfies NonNullable<ChannelSetupWizard["completionNote"]>;
 
 const signalSetupAdapterBase = createPatchedAccountSetupAdapter<SignalSetupInput>({
   channelKey: channel,
@@ -365,7 +337,7 @@ const signalSetupAdapterBase = createPatchedAccountSetupAdapter<SignalSetupInput
         !normalizeSignalAccountInput(input.signalNumber) &&
         !normalizeSignalAccountInput(resolveSignalSetupAccount({ cfg, accountId }))
       ) {
-        return "Signal container transport requires --signal-number or an existing account.";
+        return "Signal server transport requires --signal-number or an existing account.";
       }
       if (
         !input.signalNumber &&
@@ -406,6 +378,20 @@ function restorePromotedSignalDefaultAccount(cfg: OpenClawConfig): OpenClawConfi
       },
     },
   };
+}
+
+export function patchSignalSetupAccount(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  patch: Record<string, unknown>;
+}): OpenClawConfig {
+  return patchChannelConfigForAccount({
+    cfg: restorePromotedSignalDefaultAccount(params.cfg),
+    channel,
+    accountId: params.accountId,
+    patch: params.patch,
+    setupSurface: signalSetupAdapter,
+  });
 }
 
 export const signalSetupAdapter: ChannelSetupAdapter<SignalSetupInput> = {
@@ -460,23 +446,26 @@ export const signalSetupContract = defineChannelSetupContract({
 });
 
 export function createSignalSetupWizardProxy(loadWizard: () => Promise<ChannelSetupWizard>) {
-  return createDelegatedSetupWizardProxy({
-    channel,
-    loadWizard,
-    status: {
-      configuredLabel: t("wizard.channels.statusConfigured"),
-      unconfiguredLabel: t("wizard.channels.statusNeedsSetup"),
-      configuredHint: t("wizard.channels.statusSignalCliFound"),
-      unconfiguredHint: t("wizard.channels.statusSignalCliMissing"),
-      configuredScore: 1,
-      unconfiguredScore: 0,
-    },
-    delegatePrepare: true,
-    delegateFinalize: true,
-    credentials: [],
-    textInputs: signalNumberTextInputs,
-    completionNote: signalCompletionNote,
-    dmPolicy: signalDmPolicy,
-    disable: (cfg: OpenClawConfig) => setSetupChannelEnabled(cfg, channel, false),
-  });
+  return {
+    ...createDelegatedSetupWizardProxy({
+      channel,
+      loadWizard,
+      status: {
+        configuredLabel: t("wizard.channels.statusConfigured"),
+        unconfiguredLabel: t("wizard.channels.statusNeedsSetup"),
+        configuredHint: t("wizard.channels.statusSignalCliFound"),
+        unconfiguredHint: t("wizard.channels.statusSignalCliMissing"),
+        configuredScore: 1,
+        unconfiguredScore: 0,
+      },
+      delegatePrepare: true,
+      delegateFinalize: true,
+      credentials: [],
+      textInputs: signalNumberTextInputs,
+      completionNote: signalCompletionNote,
+      dmPolicy: signalDmPolicy,
+      disable: (cfg: OpenClawConfig) => setSetupChannelEnabled(cfg, channel, false),
+    }),
+    introNote: signalIntroNote,
+  };
 }

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -40,6 +40,15 @@ const t = createSetupTranslator();
 
 const channel = "signal" as const;
 
+// Prepare emits this transient state before generic text inputs run; finalize consumes it
+// to rebuild and probe the account-owned transport before any transport write.
+export const signalSetupStateKeys = {
+  transportKind: "signalTransportKind",
+  cliPath: "signalCliPath",
+  cliConfigPath: "signalCliConfigPath",
+  serverUrl: "signalServerUrl",
+} as const;
+
 const signalSetupFields = {
   signalNumber: {
     kind: "string",
@@ -301,14 +310,14 @@ export const signalNumberTextInputs: ChannelSetupWizardTextInput[] = [
   {
     ...signalNumberTextInput,
     shouldPrompt: ({ credentialValues }) =>
-      credentialValues.signalTransportKind !== "external-native",
+      credentialValues[signalSetupStateKeys.transportKind] !== "external-native",
   },
   {
     ...signalNumberTextInput,
     message: "Signal phone number (optional)",
     required: false,
     shouldPrompt: ({ credentialValues }) =>
-      credentialValues.signalTransportKind === "external-native",
+      credentialValues[signalSetupStateKeys.transportKind] === "external-native",
     validate: ({ value }) =>
       normalizeOptionalString(value) && !normalizeSignalAccountInput(value)
         ? INVALID_SIGNAL_ACCOUNT_ERROR

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -46,6 +46,7 @@ export const signalSetupStateKeys = {
   transportKind: "signalTransportKind",
   cliPath: "signalCliPath",
   cliConfigPath: "signalCliConfigPath",
+  installRequested: "signalInstallRequested",
   serverUrl: "signalServerUrl",
 } as const;
 

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -6,7 +6,6 @@ import { defineChannelSetupContract } from "openclaw/plugin-sdk/channel-setup";
 import {
   createCliPathTextInput,
   createDelegatedSetupWizardProxy,
-  createDelegatedTextInputShouldPrompt,
   createPatchedAccountSetupAdapter,
   createSetupInputPresenceValidator,
   DEFAULT_ACCOUNT_ID,
@@ -298,6 +297,25 @@ export const signalNumberTextInput: ChannelSetupWizardTextInput = {
   normalizeValue: ({ value }) => normalizeSignalAccountInput(value) ?? value,
 };
 
+export const signalNumberTextInputs: ChannelSetupWizardTextInput[] = [
+  {
+    ...signalNumberTextInput,
+    shouldPrompt: ({ credentialValues }) =>
+      credentialValues.signalTransportKind !== "external-native",
+  },
+  {
+    ...signalNumberTextInput,
+    message: "Signal phone number (optional)",
+    required: false,
+    shouldPrompt: ({ credentialValues }) =>
+      credentialValues.signalTransportKind === "external-native",
+    validate: ({ value }) =>
+      normalizeOptionalString(value) && !normalizeSignalAccountInput(value)
+        ? INVALID_SIGNAL_ACCOUNT_ERROR
+        : undefined,
+  },
+];
+
 export const signalCompletionNote = {
   title: t("wizard.signal.nextStepsTitle"),
   lines: [
@@ -444,16 +462,9 @@ export function createSignalSetupWizardProxy(loadWizard: () => Promise<ChannelSe
       unconfiguredScore: 0,
     },
     delegatePrepare: true,
+    delegateFinalize: true,
     credentials: [],
-    textInputs: [
-      createSignalCliPathTextInput(
-        createDelegatedTextInputShouldPrompt({
-          loadWizard,
-          inputKey: "cliPath",
-        }),
-      ),
-      signalNumberTextInput,
-    ],
+    textInputs: signalNumberTextInputs,
     completionNote: signalCompletionNote,
     dmPolicy: signalDmPolicy,
     disable: (cfg: OpenClawConfig) => setSetupChannelEnabled(cfg, channel, false),

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -311,7 +311,7 @@ export const signalNumberTextInputs: ChannelSetupWizardTextInput[] = [
   {
     ...signalNumberTextInput,
     shouldPrompt: ({ credentialValues }) =>
-      credentialValues[signalSetupStateKeys.transportKind] !== "external-native",
+      credentialValues[signalSetupStateKeys.transportKind] === "container",
   },
   {
     ...signalNumberTextInput,
@@ -329,8 +329,7 @@ export const signalNumberTextInputs: ChannelSetupWizardTextInput[] = [
 export const signalCompletionNote = {
   title: t("wizard.signal.nextStepsTitle"),
   lines: [
-    t("wizard.signal.nextLinkDevice"),
-    t("wizard.signal.nextScanQr"),
+    "Signal setup is validated and ready for the gateway.",
     `Then run: ${formatCliCommand("openclaw gateway call channels.status --params '{\"probe\":true}'")}`,
     `Docs: ${formatDocsLink("/signal", "signal")}`,
   ],

--- a/extensions/signal/src/setup-endpoint-identity.ts
+++ b/extensions/signal/src/setup-endpoint-identity.ts
@@ -1,0 +1,186 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import { hostname, networkInterfaces } from "node:os";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { listSignalAccountIds, resolveSignalAccount } from "./accounts.js";
+import { normalizeSignalEndpointAddress } from "./transport-policy.js";
+
+type ManagedSignalEndpoint = {
+  url: string;
+  source: "connection" | "bind";
+};
+
+function normalizeEndpointHostname(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^\[(.*)\]$/, "$1")
+    .replace(/\.$/, "")
+    .replace(/%.+$/, "");
+}
+
+function endpointPort(url: URL): number {
+  return url.port ? Number.parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
+}
+
+function endpointBasePath(url: URL): string {
+  return url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
+}
+
+function localInterfaceAddresses(): Set<string> {
+  const addresses = new Set(["127.0.0.1", "::1"]);
+  try {
+    for (const entries of Object.values(networkInterfaces())) {
+      for (const entry of entries ?? []) {
+        addresses.add(normalizeSignalEndpointAddress(entry.address));
+      }
+    }
+  } catch {
+    // Some restricted environments deny interface enumeration; loopback aliases still work.
+  }
+  return addresses;
+}
+
+async function resolveEndpointAddresses(endpointHostname: string): Promise<Set<string>> {
+  const normalized = normalizeEndpointHostname(endpointHostname);
+  const localAddresses = localInterfaceAddresses();
+  if (normalized === "0.0.0.0" || normalized === "::") {
+    return new Set([normalized]);
+  }
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) {
+    return new Set(["127.0.0.1", "::1"]);
+  }
+  const localHostname = normalizeEndpointHostname(hostname());
+  if (normalized === localHostname || normalized === `${localHostname}.local`) {
+    return localAddresses;
+  }
+  if (isIP(normalized)) {
+    return new Set([normalizeSignalEndpointAddress(normalized)]);
+  }
+  try {
+    const records = await lookup(normalized, { all: true });
+    return new Set(records.map((record) => normalizeSignalEndpointAddress(record.address)));
+  } catch {
+    return new Set();
+  }
+}
+
+function wildcardBindMatchesEndpoint(
+  bindHostname: string,
+  candidateHostname: string,
+  candidateAddresses: ReadonlySet<string>,
+): boolean {
+  const bind = normalizeEndpointHostname(bindHostname);
+  if (bind !== "0.0.0.0" && bind !== "::") {
+    return false;
+  }
+  const candidate = normalizeSignalEndpointAddress(candidateHostname);
+  if (candidate === "localhost" || candidate.endsWith(".localhost")) {
+    return true;
+  }
+  const localHostname = normalizeEndpointHostname(hostname());
+  if (candidate === localHostname || candidate === `${localHostname}.local`) {
+    return true;
+  }
+  // Wildcard binds own every local address in their family. In particular, 127/8
+  // loopback aliases are valid sockets even when interface enumeration omits them.
+  if (bind === "0.0.0.0") {
+    const localAddresses = localInterfaceAddresses();
+    return [...candidateAddresses].some(
+      (address) =>
+        (isIP(address) === 4 && address.startsWith("127.")) ||
+        (isIP(address) === 4 && localAddresses.has(address)),
+    );
+  }
+  const localAddresses = localInterfaceAddresses();
+  return [...candidateAddresses].some(
+    (address) =>
+      address === "::1" ||
+      (isIP(address) === 4 && address.startsWith("127.")) ||
+      localAddresses.has(address),
+  );
+}
+
+async function matchesManagedSignalEndpoint(
+  managedEndpoint: ManagedSignalEndpoint,
+  candidateEndpoint: string,
+): Promise<boolean> {
+  try {
+    const managed = new URL(managedEndpoint.url);
+    const candidate = new URL(candidateEndpoint);
+    if (endpointBasePath(managed) !== endpointBasePath(candidate)) {
+      return false;
+    }
+    if (managed.origin === candidate.origin) {
+      return true;
+    }
+    if (
+      managed.protocol !== candidate.protocol ||
+      endpointPort(managed) !== endpointPort(candidate)
+    ) {
+      return false;
+    }
+    const candidateAddresses = await resolveEndpointAddresses(candidate.hostname);
+    if (wildcardBindMatchesEndpoint(managed.hostname, candidate.hostname, candidateAddresses)) {
+      return true;
+    }
+    const managedHostname = normalizeEndpointHostname(managed.hostname);
+    const candidateHostname = normalizeEndpointHostname(candidate.hostname);
+    if (managedHostname === candidateHostname) {
+      return true;
+    }
+    if (
+      managedEndpoint.source === "connection" &&
+      !isIP(managedHostname) &&
+      !isIP(candidateHostname)
+    ) {
+      // Shared proxy addresses do not make distinct virtual-host names equivalent.
+      return false;
+    }
+    const managedAddresses = await resolveEndpointAddresses(managed.hostname);
+    return [...managedAddresses].some((address) => candidateAddresses.has(address));
+  } catch {
+    return false;
+  }
+}
+
+function formatSignalEndpointHost(host: string): string {
+  const normalized = normalizeEndpointHostname(host);
+  return normalized.includes(":") ? `[${normalized}]` : normalized;
+}
+
+function listConfiguredManagedSignalEndpoints(cfg: OpenClawConfig): ManagedSignalEndpoint[] {
+  const managedEndpoints: ManagedSignalEndpoint[] = [];
+  for (const accountId of listSignalAccountIds(cfg)) {
+    const account = resolveSignalAccount({ cfg, accountId });
+    if (!account.enabled || !account.configured || account.transport.kind !== "managed-native") {
+      continue;
+    }
+    const configuredTransport = account.config.transport;
+    const endpoints = new Map<string, ManagedSignalEndpoint>();
+    if (configuredTransport?.kind === "managed-native" && configuredTransport.url) {
+      endpoints.set(configuredTransport.url, {
+        url: configuredTransport.url,
+        source: "connection",
+      });
+    }
+    const bindUrl = `http://${formatSignalEndpointHost(account.transport.httpHost)}:${account.transport.httpPort}`;
+    // Bind ownership is stronger than connection URL identity when both normalize
+    // to the same endpoint: DNS aliases would still reach the daemon OpenClaw stops.
+    endpoints.set(bindUrl, { url: bindUrl, source: "bind" });
+    managedEndpoints.push(...endpoints.values());
+  }
+  return managedEndpoints;
+}
+
+export async function aliasesManagedSignalEndpoint(
+  cfg: OpenClawConfig,
+  candidateUrl: string,
+): Promise<boolean> {
+  for (const managedEndpoint of listConfiguredManagedSignalEndpoints(cfg)) {
+    if (await matchesManagedSignalEndpoint(managedEndpoint, candidateUrl)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/extensions/signal/src/setup-existing-server.test.ts
+++ b/extensions/signal/src/setup-existing-server.test.ts
@@ -1,0 +1,836 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createQueuedWizardPrompter,
+  createRuntimeEnv,
+  runSetupWizardFinalize,
+  runSetupWizardPrepare,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { WizardCancelledError } from "openclaw/plugin-sdk/setup";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSignalAccount } from "./accounts.js";
+import {
+  configuredManagedSignalConfig,
+  toCredentialValues,
+} from "./setup-surface.test-fixtures.js";
+import type { SignalTransportProbeResult } from "./setup-transport.js";
+
+const mocks = vi.hoisted(() => ({
+  lookup: vi.fn(
+    async (_hostname: string, _options: { all: true }) =>
+      [] as Array<{ address: string; family: number }>,
+  ),
+  detectSignalTransport: vi.fn(
+    async (params: {
+      url: string;
+    }): Promise<{ kind: "external-native" | "container"; url: string }> => ({
+      kind: "external-native",
+      url: params.url,
+    }),
+  ),
+  probeSignalTransport: vi.fn(
+    async (): Promise<SignalTransportProbeResult> => ({ ok: true, status: 200 }),
+  ),
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: mocks.lookup,
+}));
+
+vi.mock("./setup-transport.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./setup-transport.js")>("./setup-transport.js");
+  return {
+    ...actual,
+    detectSignalTransport: mocks.detectSignalTransport,
+    probeSignalTransport: mocks.probeSignalTransport,
+  };
+});
+
+import { signalSetupWizard } from "./setup-surface.js";
+
+describe("Signal existing-server setup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.detectSignalTransport.mockImplementation(async ({ url }: { url: string }) => ({
+      kind: "external-native",
+      url,
+    }));
+    mocks.probeSignalTransport.mockResolvedValue({ ok: true, status: 200 });
+    mocks.lookup.mockResolvedValue([]);
+  });
+
+  it("changes and re-detects the server URL after a failed probe", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "receive probe failed" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["url"],
+      textValues: ["+15555550123", "http://signal-helper-new:8080"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "default",
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper-old:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.detectSignalTransport).toHaveBeenCalledWith({
+      url: "http://signal-helper-new:8080",
+    });
+    expect(finalized?.cfg?.channels?.signal?.transport).toEqual({
+      kind: "external-native",
+      url: "http://signal-helper-new:8080",
+    });
+  });
+
+  it("prompts for an account when URL recovery changes to a container", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "receive probe failed" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    mocks.detectSignalTransport.mockResolvedValueOnce({
+      kind: "container",
+      url: "http://signal-helper-new:8080",
+    });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["url"],
+      textValues: ["+15555550123", "http://signal-helper-new:8080"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "default",
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper-old:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ message: "Signal phone number" }),
+    );
+    expect(queued.text).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ message: "Signal server URL" }),
+    );
+    expect(mocks.probeSignalTransport).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        transport: { kind: "container", url: "http://signal-helper-new:8080" },
+        account: "+15555550123",
+      }),
+    );
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "default" }).config.account,
+    ).toBe("+15555550123");
+  });
+
+  it("retries the same candidate without re-detecting it", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "not ready" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["retry"],
+      textValues: ["+15555550123"],
+    });
+
+    await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
+    expect(mocks.detectSignalTransport).not.toHaveBeenCalled();
+  });
+
+  it("retries failed server detection without prompting for the URL again", async () => {
+    mocks.detectSignalTransport
+      .mockRejectedValueOnce(new Error("server starting"))
+      .mockResolvedValueOnce({
+        kind: "external-native",
+        url: "http://signal-helper:8080",
+      });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "retry"],
+      textValues: ["http://signal-helper:8080", "+15555550123"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {},
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).toHaveBeenCalledOnce();
+    expect(mocks.detectSignalTransport).toHaveBeenCalledTimes(2);
+    expect(mocks.detectSignalTransport).toHaveBeenNthCalledWith(1, {
+      url: "http://signal-helper:8080",
+    });
+    expect(mocks.detectSignalTransport).toHaveBeenNthCalledWith(2, {
+      url: "http://signal-helper:8080",
+    });
+    expect(prepared?.credentialValues).toMatchObject({
+      signalTransportKind: "external-native",
+    });
+  });
+
+  it("changes the URL after server detection fails", async () => {
+    mocks.detectSignalTransport
+      .mockRejectedValueOnce(new Error("connection refused"))
+      .mockResolvedValueOnce({
+        kind: "external-native",
+        url: "http://signal-helper-new:8080",
+      });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "url"],
+      textValues: [
+        "http://signal-helper-old:8080",
+        "http://signal-helper-new:8080",
+        "+15555550123",
+      ],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {},
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenNthCalledWith(1, {
+      url: "http://signal-helper-old:8080",
+    });
+    expect(mocks.detectSignalTransport).toHaveBeenNthCalledWith(2, {
+      url: "http://signal-helper-new:8080",
+    });
+    expect(prepared?.credentialValues).toMatchObject({
+      signalTransportKind: "external-native",
+      signalServerUrl: "http://signal-helper-new:8080",
+    });
+  });
+
+  it("requires an explicit account for an external-native server", async () => {
+    const queued = createQueuedWizardPrompter({ textValues: ["+15555550123"] });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Signal phone number" }),
+    );
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      accountId: "default",
+      transport: { kind: "external-native", url: "http://signal-helper:8080" },
+      account: "+15555550123",
+    });
+    expect(finalized?.cfg?.channels?.signal?.transport).toEqual({
+      kind: "external-native",
+      url: "http://signal-helper:8080",
+    });
+  });
+
+  it("stops failed setup with the generic wizard cancellation", async () => {
+    mocks.probeSignalTransport.mockResolvedValue({ ok: false, error: "not ready" });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["stop"],
+      textValues: ["+15555550123"],
+    });
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {},
+        credentialValues: {
+          signalTransportKind: "external-native",
+          signalServerUrl: "http://signal-helper:8080",
+        },
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+  });
+
+  it("rejects a URL that aliases an OpenClaw-managed daemon", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "url"],
+      textValues: ["http://localhost:8080", "http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "127.0.0.1",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledTimes(2);
+    expect(prepared?.credentialValues).toMatchObject({
+      signalTransportKind: "external-native",
+      signalServerUrl: "http://signal-helper:8080",
+    });
+  });
+
+  it("allows a URL formerly owned by a disabled managed account", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server"],
+      textValues: ["http://localhost:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            enabled: false,
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "127.0.0.1",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
+    expect(queued.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("OpenClaw-managed Signal daemon"),
+      "Signal server URL",
+    );
+    expect(prepared?.credentialValues).toMatchObject({
+      signalTransportKind: "external-native",
+      signalServerUrl: "http://localhost:8080",
+    });
+  });
+
+  it("rejects an IPv4-mapped IPv6 alias of an OpenClaw-managed daemon", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "url"],
+      textValues: ["http://[::ffff:127.0.0.1]:8080", "http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "127.0.0.1",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("OpenClaw-managed Signal daemon"),
+      "Signal server URL",
+    );
+    expect(prepared?.credentialValues).toMatchObject({
+      signalServerUrl: "http://signal-helper:8080",
+    });
+  });
+
+  it("rejects an equivalent fully qualified hostname for a managed daemon", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "url"],
+      textValues: ["http://localhost.:8080", "http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "localhost",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("OpenClaw-managed Signal daemon"),
+      "Signal server URL",
+    );
+    expect(prepared?.credentialValues).toMatchObject({
+      signalServerUrl: "http://signal-helper:8080",
+    });
+  });
+
+  it("rejects a DNS alias of a hostname-based managed daemon bind", async () => {
+    mocks.lookup.mockImplementation(async (host: string) =>
+      host === "gateway.local" || host === "signal-alias.local"
+        ? [{ address: "192.0.2.10", family: 4 }]
+        : [],
+    );
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "url"],
+      textValues: ["http://signal-alias.local:8080", "http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "gateway.local",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.lookup).toHaveBeenCalledWith("signal-alias.local", { all: true });
+    expect(mocks.lookup).toHaveBeenCalledWith("gateway.local", { all: true });
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("OpenClaw-managed Signal daemon"),
+      "Signal server URL",
+    );
+    expect(prepared?.credentialValues).toMatchObject({
+      signalServerUrl: "http://signal-helper:8080",
+    });
+  });
+
+  it("allows a different base path on the same reverse-proxy origin", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server"],
+      textValues: ["http://signal-proxy:8080/signal-b"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              url: "http://signal-proxy:8080/signal-a",
+              httpHost: "127.0.0.1",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
+    expect(prepared?.credentialValues).toMatchObject({
+      signalServerUrl: "http://signal-proxy:8080/signal-b",
+    });
+  });
+
+  it("allows distinct virtual hosts that share a reverse-proxy address", async () => {
+    mocks.lookup.mockResolvedValue([{ address: "192.0.2.10", family: 4 }]);
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server"],
+      textValues: ["https://signal-b.example/signal"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              url: "https://signal-a.example/signal",
+              httpHost: "127.0.0.1",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
+    expect(prepared?.credentialValues).toMatchObject({
+      signalServerUrl: "https://signal-b.example/signal",
+    });
+  });
+
+  it("allows a distinct IPv4 loopback bind on the same port", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server"],
+      textValues: ["http://127.0.0.3:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "127.0.0.2",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
+    expect(prepared?.credentialValues).toMatchObject({
+      signalServerUrl: "http://127.0.0.3:8080",
+    });
+  });
+
+  it("rejects any IPv4 loopback alias of an IPv4 wildcard managed bind", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "url"],
+      textValues: ["http://127.0.0.2:8080", "http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "0.0.0.0",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledTimes(2);
+    expect(prepared?.credentialValues).toMatchObject({
+      signalServerUrl: "http://signal-helper:8080",
+    });
+  });
+
+  it("rejects an IPv4 loopback alias of an IPv6 wildcard managed bind", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "url"],
+      textValues: ["http://127.0.0.1:8080", "http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "::",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledTimes(2);
+    expect(prepared?.credentialValues).toMatchObject({
+      signalServerUrl: "http://signal-helper:8080",
+    });
+  });
+
+  it("rejects a DNS alias of an IPv4 wildcard managed bind", async () => {
+    mocks.lookup.mockImplementation(async (host: string) =>
+      host === "managed-signal.local" ? [{ address: "127.0.0.2", family: 4 }] : [],
+    );
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "url"],
+      textValues: ["http://managed-signal.local:8080", "http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "0.0.0.0",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.lookup).toHaveBeenCalledWith("managed-signal.local", { all: true });
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("OpenClaw-managed Signal daemon"),
+      "Signal server URL",
+    );
+    expect(prepared?.credentialValues).toMatchObject({
+      signalServerUrl: "http://signal-helper:8080",
+    });
+  });
+
+  it("detects, probes, and writes a concrete existing container transport", async () => {
+    mocks.detectSignalTransport.mockResolvedValue({
+      kind: "container",
+      url: "http://signal-helper:8080",
+    });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server"],
+      textValues: ["http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {},
+      accountId: "work",
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: { work: { account: "+15555550123" } },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      credentialValues: toCredentialValues(prepared?.credentialValues),
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.detectSignalTransport).toHaveBeenCalledWith({
+      url: "http://signal-helper:8080",
+    });
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      accountId: "work",
+      transport: { kind: "container", url: "http://signal-helper:8080" },
+      account: "+15555550123",
+    });
+    expect(finalized?.cfg?.channels?.signal?.accounts?.work?.transport).toEqual({
+      kind: "container",
+      url: "http://signal-helper:8080",
+    });
+  });
+
+  it("requires a Signal account before probing a container", async () => {
+    const queued = createQueuedWizardPrompter({ textValues: ["+15555550123"] });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "container",
+        signalServerUrl: "http://signal-helper:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Signal phone number" }),
+    );
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      accountId: "work",
+      transport: { kind: "container", url: "http://signal-helper:8080" },
+      account: "+15555550123",
+    });
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550123");
+  });
+
+  it("clears the previous account UUID when a later setup step changes the account", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: {
+              work: {
+                account: "+15555550124",
+                accountUuid: "123e4567-e89b-12d3-a456-426614174000",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper:8080",
+        signalOriginalAccount: "+15555550123",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550124");
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["malformed", "not-a-phone-number"],
+  ])("clears a stale account UUID when replacing a %s account", async (_label, previousAccount) => {
+    const queued = createQueuedWizardPrompter({ textValues: ["+15555550123"] });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: {
+              work: {
+                ...(previousAccount ? { account: previousAccount } : {}),
+                accountUuid: "123e4567-e89b-12d3-a456-426614174000",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    const account = resolveSignalAccount({
+      cfg: finalized?.cfg ?? {},
+      accountId: "work",
+    }).config;
+    expect(account.account).toBe("+15555550123");
+    expect(account.accountUuid).toBeUndefined();
+  });
+
+  it("changes the Signal account and retries after a failed probe", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "account not registered" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["account"],
+      textValues: ["+15555550124"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: configuredManagedSignalConfig({ withTransport: false }),
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
+    expect(mocks.probeSignalTransport).toHaveBeenLastCalledWith(
+      expect.objectContaining({ account: "+15555550124" }),
+    );
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550124");
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
+    ).toBeUndefined();
+  });
+
+  it("propagates generic Back navigation without Signal-specific catches", async () => {
+    const back = new Error("wizard back");
+    const queued = createQueuedWizardPrompter();
+    queued.select.mockRejectedValueOnce(back);
+
+    await expect(
+      runSetupWizardPrepare({
+        prepare: signalSetupWizard.prepare,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toBe(back);
+  });
+});

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -16,18 +16,13 @@ import {
   type ResolvedSignalTransport,
 } from "./accounts.js";
 import { installSignalCli } from "./install-signal-cli.js";
-import { normalizeSignalAccountInput } from "./setup-core.js";
+import { normalizeSignalAccountInput, signalSetupStateKeys } from "./setup-core.js";
 import {
   detectSignalTransport,
   prepareSignalManagedNativeTransport,
   probeSignalTransport,
   writeSignalAccountTransport,
 } from "./setup-transport.js";
-
-const SIGNAL_TRANSPORT_KIND_KEY = "signalTransportKind";
-const SIGNAL_CLI_PATH_KEY = "signalCliPath";
-const SIGNAL_CLI_CONFIG_PATH_KEY = "signalCliConfigPath";
-const SIGNAL_SERVER_URL_KEY = "signalServerUrl";
 
 type SignalSetupMode = "local" | "existing-server";
 type SignalPrepareParams = Parameters<NonNullable<ChannelSetupWizard["prepare"]>>[0];
@@ -38,10 +33,320 @@ type SignalExistingTransport = Extract<
 >;
 type ExistingServerPromptParams = {
   cfg: OpenClawConfig;
-  accountId: string;
   prompter: WizardPrompter;
   initialValue?: string;
 };
+
+export async function prepareSignalInteractiveSetup(params: SignalPrepareParams) {
+  const resolvedAccount = resolveSignalAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const initialMode: SignalSetupMode =
+    resolvedAccount.configured && resolvedAccount.transport.kind !== "managed-native"
+      ? "existing-server"
+      : "local";
+
+  const mode = await params.prompter.select<SignalSetupMode>({
+    message: "How do you want to set up Signal for OpenClaw?",
+    initialValue: initialMode,
+    options: [
+      {
+        value: "local",
+        label: "Use local signal-cli",
+        hint: "OpenClaw starts the local signal-cli daemon for this account.",
+      },
+      {
+        value: "existing-server",
+        label: "Connect to an existing Signal server",
+        hint: "OpenClaw detects and stores the server protocol for this account.",
+      },
+    ],
+  });
+
+  if (mode === "local") {
+    return await prepareManagedNativeSetup(params, resolvedAccount.transport);
+  }
+  return await prepareExistingServerSetup(params, resolvedAccount.transport);
+}
+
+export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParams) {
+  const kind = params.credentialValues[signalSetupStateKeys.transportKind];
+  let cfg = params.cfg;
+  const resolvedAccount = resolveSignalAccount({
+    cfg,
+    accountId: params.accountId,
+  });
+  let account = normalizeSignalAccountInput(resolvedAccount.config.account) ?? undefined;
+  let transport: SignalTransportConfig;
+  if (kind === "managed-native") {
+    const configPath = params.credentialValues[signalSetupStateKeys.cliConfigPath];
+    transport = prepareSignalManagedNativeTransport({
+      cfg,
+      accountId: params.accountId,
+      overrides: {
+        cliPath: params.credentialValues[signalSetupStateKeys.cliPath] ?? "signal-cli",
+        ...(configPath ? { configPath } : {}),
+      },
+    });
+  } else if (kind === "external-native" || kind === "container") {
+    const url = params.credentialValues[signalSetupStateKeys.serverUrl];
+    if (!url) {
+      throw new Error("Signal setup is missing its prepared transport candidate.");
+    }
+    transport = { kind, url };
+  } else {
+    throw new Error("Signal setup is missing its prepared transport candidate.");
+  }
+
+  let shouldPromptAccount = !account && transport.kind !== "external-native";
+
+  while (true) {
+    // Account or URL recovery re-enters here so every probe sees matching candidate state.
+    if (shouldPromptAccount) {
+      account = await promptSignalAccount(params.prompter);
+      cfg = patchChannelConfigForAccount({
+        cfg,
+        channel: "signal",
+        accountId: params.accountId,
+        patch: { account, accountUuid: undefined },
+      });
+      shouldPromptAccount = false;
+    }
+
+    const probe = await probeSignalTransport({
+      cfg,
+      accountId: params.accountId,
+      transport,
+      account,
+    }).catch((error: unknown) => ({ ok: false, error: String(error) }));
+    if (probe.ok) {
+      break;
+    }
+
+    await params.prompter.note(
+      `OpenClaw could not validate this Signal setup.\nError: ${probe.error ?? "Signal transport probe failed."}`,
+      "Signal setup",
+    );
+    const recovery = await params.prompter.select<"retry" | "account" | "url" | "stop">({
+      message: "How should Signal setup continue?",
+      options: [
+        { value: "retry", label: "Retry this setup" },
+        { value: "account", label: "Try another Signal account" },
+        ...(transport.kind === "managed-native"
+          ? []
+          : [{ value: "url" as const, label: "Try another Signal server URL" }]),
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "retry",
+    });
+    if (recovery === "stop") {
+      throw new WizardCancelledError("Signal setup stopped");
+    }
+    if (recovery === "account") {
+      shouldPromptAccount = true;
+      continue;
+    }
+    if (recovery === "url" && transport.kind !== "managed-native") {
+      transport = await promptExistingSignalTransport({
+        cfg,
+        prompter: params.prompter,
+        initialValue: transport.url,
+      });
+      shouldPromptAccount = !account && transport.kind !== "external-native";
+    }
+  }
+
+  return {
+    cfg: writeSignalAccountTransport({
+      cfg,
+      accountId: params.accountId,
+      transport,
+    }),
+  };
+}
+
+async function promptSignalAccount(prompter: WizardPrompter) {
+  const raw = await prompter.text({
+    message: "Signal phone number",
+    placeholder: "+15555550123",
+    validate: (value) =>
+      normalizeSignalAccountInput(value)
+        ? undefined
+        : "Enter a Signal phone number in international format, for example +15555550123.",
+  });
+  const account = normalizeSignalAccountInput(raw);
+  if (!account) {
+    throw new Error("Signal phone number is required.");
+  }
+  return account;
+}
+
+async function prepareManagedNativeSetup(
+  params: SignalPrepareParams,
+  resolvedTransport: ResolvedSignalTransport,
+) {
+  let cliPath =
+    resolvedTransport.kind === "managed-native" ? resolvedTransport.cliPath : "signal-cli";
+  let cliDetected = await detectBinary(cliPath);
+
+  if (params.options?.allowSignalInstall) {
+    const wantsInstall = await params.prompter.confirm({
+      message: cliDetected ? "Reinstall signal-cli?" : "Install signal-cli?",
+      initialValue: !cliDetected,
+    });
+    if (wantsInstall) {
+      await params.options.beforePersistentEffect?.();
+      try {
+        const result = await installSignalCli(params.runtime);
+        if (result.ok && result.cliPath) {
+          cliPath = result.cliPath;
+          await params.prompter.note(`Installed signal-cli at ${result.cliPath}`, "Signal");
+        } else {
+          await params.prompter.note(result.error ?? "signal-cli install failed.", "Signal");
+        }
+      } catch (error) {
+        await params.prompter.note(`signal-cli install failed: ${String(error)}`, "Signal");
+      }
+      cliDetected = await detectBinary(cliPath);
+    }
+  }
+
+  if (!cliDetected) {
+    cliPath =
+      normalizeOptionalString(
+        await params.prompter.text({
+          message: "signal-cli path",
+          initialValue: cliPath,
+          validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
+        }),
+      ) ?? cliPath;
+  }
+
+  const existingConfigPath =
+    resolvedTransport.kind === "managed-native" ? resolvedTransport.configPath : undefined;
+  const configPath = normalizeOptionalString(
+    await params.prompter.text({
+      message: "signal-cli config path (optional)",
+      initialValue: existingConfigPath,
+      placeholder: "~/.local/share/signal-cli",
+    }),
+  );
+
+  // Validate account-owned port allocation now, while keeping the candidate ephemeral until probe.
+  prepareSignalManagedNativeTransport({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    overrides: { cliPath, ...(configPath ? { configPath } : {}) },
+  });
+
+  return {
+    credentialValues: {
+      [signalSetupStateKeys.transportKind]: "managed-native",
+      [signalSetupStateKeys.cliPath]: cliPath,
+      ...(configPath ? { [signalSetupStateKeys.cliConfigPath]: configPath } : {}),
+    },
+  };
+}
+
+async function promptSignalServerUrl(prompter: WizardPrompter, initialValue: string) {
+  return (
+    normalizeOptionalString(
+      await prompter.text({
+        message: "Signal server URL",
+        initialValue,
+        placeholder: "http://127.0.0.1:8080",
+        validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
+      }),
+    ) ?? initialValue
+  );
+}
+
+async function promptExistingSignalTransport(
+  params: ExistingServerPromptParams,
+): Promise<SignalExistingTransport> {
+  let url = await promptSignalServerUrl(
+    params.prompter,
+    params.initialValue ?? "http://127.0.0.1:8080",
+  );
+  while (true) {
+    const detection = await detectSignalTransport({ url }).then(
+      (transport) => ({ ok: true as const, transport }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    if (!detection.ok) {
+      await params.prompter.note(
+        `OpenClaw could not detect a working Signal server at ${url}.\nError: ${String(detection.error)}`,
+        "Signal server URL",
+      );
+      const recovery = await params.prompter.select<"retry" | "url" | "stop">({
+        message: "How should Signal server setup continue?",
+        options: [
+          { value: "retry", label: "Retry this Signal server URL" },
+          { value: "url", label: "Try another Signal server URL" },
+          { value: "stop", label: "Stop Signal setup" },
+        ],
+        initialValue: "retry",
+      });
+      if (recovery === "stop") {
+        throw new WizardCancelledError("Signal setup stopped");
+      }
+      if (recovery === "url") {
+        url = await promptSignalServerUrl(params.prompter, url);
+      }
+      continue;
+    }
+
+    const transport = detection.transport;
+    if (transport.kind === "managed-native") {
+      throw new Error("Signal transport detection returned a managed-native transport");
+    }
+    if (!aliasesManagedSignalEndpoint(params.cfg, transport.url)) {
+      return transport;
+    }
+
+    await params.prompter.note(
+      [
+        "That URL is an OpenClaw-managed Signal daemon.",
+        "It stops when its account switches away from local signal-cli.",
+        "Enter the URL of an independently operated Signal server instead.",
+      ].join("\n"),
+      "Signal server URL",
+    );
+    const recovery = await params.prompter.select<"url" | "stop">({
+      message: "How should Signal server setup continue?",
+      options: [
+        { value: "url", label: "Try another Signal server URL" },
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "url",
+    });
+    if (recovery === "stop") {
+      throw new WizardCancelledError("Signal setup stopped");
+    }
+    url = await promptSignalServerUrl(params.prompter, url);
+  }
+}
+
+async function prepareExistingServerSetup(
+  params: SignalPrepareParams,
+  resolvedTransport: ResolvedSignalTransport,
+) {
+  const transport = await promptExistingSignalTransport({
+    cfg: params.cfg,
+    prompter: params.prompter,
+    initialValue:
+      resolvedTransport.kind === "external-native" || resolvedTransport.kind === "container"
+        ? resolvedTransport.baseUrl
+        : "http://127.0.0.1:8080",
+  });
+  return {
+    credentialValues: {
+      [signalSetupStateKeys.transportKind]: transport.kind,
+      [signalSetupStateKeys.serverUrl]: transport.url,
+    },
+  };
+}
 
 function normalizeEndpointHostname(value: string): string {
   return value
@@ -136,325 +441,4 @@ function aliasesManagedSignalEndpoint(cfg: OpenClawConfig, candidateUrl: string)
   return listConfiguredManagedSignalEndpoints(cfg).some((managedUrl) =>
     matchesManagedSignalEndpoint(managedUrl, candidateUrl),
   );
-}
-
-async function promptSignalAccount(params: SignalFinalizeParams) {
-  const raw = await params.prompter.text({
-    message: "Signal phone number",
-    placeholder: "+15555550123",
-    validate: (value) =>
-      normalizeSignalAccountInput(value)
-        ? undefined
-        : "Enter a Signal phone number in international format, for example +15555550123.",
-  });
-  const account = normalizeSignalAccountInput(raw);
-  if (!account) {
-    throw new Error("Signal phone number is required.");
-  }
-  return account;
-}
-
-async function prepareManagedNativeSetup(
-  params: SignalPrepareParams,
-  resolvedTransport: ResolvedSignalTransport,
-) {
-  let cliPath =
-    resolvedTransport.kind === "managed-native" ? resolvedTransport.cliPath : "signal-cli";
-  const cliDetected = await detectBinary(cliPath);
-
-  if (params.options?.allowSignalInstall) {
-    const wantsInstall = await params.prompter.confirm({
-      message: cliDetected ? "Reinstall signal-cli?" : "Install signal-cli?",
-      initialValue: !cliDetected,
-    });
-    if (wantsInstall) {
-      await params.options.beforePersistentEffect?.();
-      try {
-        const result = await installSignalCli(params.runtime);
-        if (result.ok && result.cliPath) {
-          cliPath = result.cliPath;
-          await params.prompter.note(`Installed signal-cli at ${result.cliPath}`, "Signal");
-        } else {
-          await params.prompter.note(result.error ?? "signal-cli install failed.", "Signal");
-        }
-      } catch (error) {
-        await params.prompter.note(`signal-cli install failed: ${String(error)}`, "Signal");
-      }
-    }
-  }
-
-  if (!(await detectBinary(cliPath))) {
-    cliPath =
-      normalizeOptionalString(
-        await params.prompter.text({
-          message: "signal-cli path",
-          initialValue: cliPath,
-          validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
-        }),
-      ) ?? cliPath;
-  }
-
-  const existingConfigPath =
-    resolvedTransport.kind === "managed-native" ? resolvedTransport.configPath : undefined;
-  const configPath = normalizeOptionalString(
-    await params.prompter.text({
-      message: "signal-cli config path (optional)",
-      initialValue: existingConfigPath,
-      placeholder: "~/.local/share/signal-cli",
-    }),
-  );
-
-  // Validate account-owned port allocation now, while keeping the candidate ephemeral until probe.
-  prepareSignalManagedNativeTransport({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    overrides: { cliPath, ...(configPath ? { configPath } : {}) },
-  });
-
-  return {
-    credentialValues: {
-      [SIGNAL_TRANSPORT_KIND_KEY]: "managed-native",
-      [SIGNAL_CLI_PATH_KEY]: cliPath,
-      ...(configPath ? { [SIGNAL_CLI_CONFIG_PATH_KEY]: configPath } : {}),
-    },
-  };
-}
-
-async function promptExistingSignalTransport(
-  params: ExistingServerPromptParams,
-): Promise<SignalExistingTransport> {
-  let initialValue = params.initialValue ?? "http://127.0.0.1:8080";
-  let url = initialValue;
-  let promptForUrl = true;
-
-  while (true) {
-    if (promptForUrl) {
-      url =
-        normalizeOptionalString(
-          await params.prompter.text({
-            message: "Signal server URL",
-            initialValue,
-            placeholder: "http://127.0.0.1:8080",
-            validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
-          }),
-        ) ?? initialValue;
-    }
-
-    const detection = await detectSignalTransport({ url }).then(
-      (transport) => ({ ok: true as const, transport }),
-      (error: unknown) => ({ ok: false as const, error }),
-    );
-    if (!detection.ok) {
-      await params.prompter.note(
-        `OpenClaw could not detect a working Signal server at ${url}.\nError: ${String(detection.error)}`,
-        "Signal server URL",
-      );
-      const recovery = await params.prompter.select<"retry" | "url" | "stop">({
-        message: "How should Signal server setup continue?",
-        options: [
-          { value: "retry", label: "Retry this Signal server URL" },
-          { value: "url", label: "Try another Signal server URL" },
-          { value: "stop", label: "Stop Signal setup" },
-        ],
-        initialValue: "retry",
-      });
-      if (recovery === "stop") {
-        throw new WizardCancelledError("Signal setup stopped");
-      }
-      promptForUrl = recovery === "url";
-      initialValue = url;
-      continue;
-    }
-
-    const transport = detection.transport;
-    if (transport.kind === "managed-native") {
-      throw new Error("Signal transport detection returned a managed-native transport");
-    }
-    if (!aliasesManagedSignalEndpoint(params.cfg, transport.url)) {
-      return transport;
-    }
-
-    await params.prompter.note(
-      [
-        "That URL is an OpenClaw-managed Signal daemon.",
-        "It stops when its account switches away from local signal-cli.",
-        "Enter the URL of an independently operated Signal server instead.",
-      ].join("\n"),
-      "Signal server URL",
-    );
-    const recovery = await params.prompter.select<"url" | "stop">({
-      message: "How should Signal server setup continue?",
-      options: [
-        { value: "url", label: "Try another Signal server URL" },
-        { value: "stop", label: "Stop Signal setup" },
-      ],
-      initialValue: "url",
-    });
-    if (recovery === "stop") {
-      throw new WizardCancelledError("Signal setup stopped");
-    }
-    initialValue = url;
-    promptForUrl = true;
-  }
-}
-
-async function prepareExistingServerSetup(
-  params: SignalPrepareParams,
-  resolvedTransport: ResolvedSignalTransport,
-) {
-  const transport = await promptExistingSignalTransport({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    prompter: params.prompter,
-    initialValue:
-      resolvedTransport.kind === "external-native" || resolvedTransport.kind === "container"
-        ? resolvedTransport.baseUrl
-        : "http://127.0.0.1:8080",
-  });
-  return {
-    credentialValues: {
-      [SIGNAL_TRANSPORT_KIND_KEY]: transport.kind,
-      [SIGNAL_SERVER_URL_KEY]: transport.url,
-    },
-  };
-}
-
-export async function prepareSignalInteractiveSetup(params: SignalPrepareParams) {
-  const resolvedAccount = resolveSignalAccount({
-    cfg: params.cfg,
-    accountId: params.accountId,
-  });
-  const initialMode: SignalSetupMode =
-    resolvedAccount.configured && resolvedAccount.transport.kind !== "managed-native"
-      ? "existing-server"
-      : "local";
-
-  const mode = await params.prompter.select<SignalSetupMode>({
-    message: "How do you want to set up Signal for OpenClaw?",
-    initialValue: initialMode,
-    options: [
-      {
-        value: "local",
-        label: "Use local signal-cli",
-        hint: "OpenClaw starts the local signal-cli daemon for this account.",
-      },
-      {
-        value: "existing-server",
-        label: "Connect to an existing Signal server",
-        hint: "OpenClaw detects and stores the server protocol for this account.",
-      },
-    ],
-  });
-
-  if (mode === "local") {
-    return await prepareManagedNativeSetup(params, resolvedAccount.transport);
-  }
-  return await prepareExistingServerSetup(params, resolvedAccount.transport);
-}
-
-export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParams) {
-  const kind = params.credentialValues[SIGNAL_TRANSPORT_KIND_KEY];
-  let cfg = params.cfg;
-  const resolvedAccount = resolveSignalAccount({
-    cfg,
-    accountId: params.accountId,
-  });
-  let account = normalizeSignalAccountInput(resolvedAccount.config.account) ?? undefined;
-  let transport: SignalTransportConfig | undefined =
-    kind === "managed-native"
-      ? prepareSignalManagedNativeTransport({
-          cfg,
-          accountId: params.accountId,
-          overrides: {
-            cliPath: params.credentialValues[SIGNAL_CLI_PATH_KEY] ?? "signal-cli",
-            ...(params.credentialValues[SIGNAL_CLI_CONFIG_PATH_KEY]
-              ? { configPath: params.credentialValues[SIGNAL_CLI_CONFIG_PATH_KEY] }
-              : {}),
-          },
-        })
-      : kind === "external-native" || kind === "container"
-        ? {
-            kind,
-            url: params.credentialValues[SIGNAL_SERVER_URL_KEY] ?? "",
-          }
-        : undefined;
-  if (!transport || (transport.kind !== "managed-native" && !transport.url)) {
-    throw new Error("Signal setup is missing its prepared transport candidate.");
-  }
-  if ((transport.kind === "managed-native" || transport.kind === "container") && !account) {
-    account = await promptSignalAccount(params);
-    cfg = patchChannelConfigForAccount({
-      cfg,
-      channel: "signal",
-      accountId: params.accountId,
-      patch: { account, accountUuid: undefined },
-    });
-  }
-
-  while (true) {
-    const probe = await probeSignalTransport({
-      cfg,
-      accountId: params.accountId,
-      transport,
-      account,
-    }).catch((error: unknown) => ({ ok: false, error: String(error) }));
-    if (probe.ok) {
-      break;
-    }
-
-    await params.prompter.note(
-      `OpenClaw could not validate this Signal setup.\nError: ${probe.error ?? "Signal transport probe failed."}`,
-      "Signal setup",
-    );
-    const recovery = await params.prompter.select<"retry" | "account" | "url" | "stop">({
-      message: "How should Signal setup continue?",
-      options: [
-        { value: "retry", label: "Retry this setup" },
-        { value: "account", label: "Try another Signal account" },
-        ...(transport.kind === "managed-native"
-          ? []
-          : [{ value: "url" as const, label: "Try another Signal server URL" }]),
-        { value: "stop", label: "Stop Signal setup" },
-      ],
-      initialValue: "retry",
-    });
-    if (recovery === "stop") {
-      throw new WizardCancelledError("Signal setup stopped");
-    }
-    if (recovery === "account") {
-      account = await promptSignalAccount(params);
-      cfg = patchChannelConfigForAccount({
-        cfg,
-        channel: "signal",
-        accountId: params.accountId,
-        patch: { account, accountUuid: undefined },
-      });
-      continue;
-    }
-    if (recovery === "url" && transport.kind !== "managed-native") {
-      transport = await promptExistingSignalTransport({
-        cfg,
-        accountId: params.accountId,
-        prompter: params.prompter,
-        initialValue: transport.url,
-      });
-      if (transport.kind === "container" && !account) {
-        account = await promptSignalAccount(params);
-        cfg = patchChannelConfigForAccount({
-          cfg,
-          channel: "signal",
-          accountId: params.accountId,
-          patch: { account, accountUuid: undefined },
-        });
-      }
-    }
-  }
-
-  return {
-    cfg: writeSignalAccountTransport({
-      cfg,
-      accountId: params.accountId,
-      transport,
-    }),
-  };
 }

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -1,6 +1,5 @@
 import { isIP } from "node:net";
 import { hostname, networkInterfaces } from "node:os";
-import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import {
   patchChannelConfigForAccount,
   WizardCancelledError,
@@ -10,7 +9,6 @@ import {
 } from "openclaw/plugin-sdk/setup";
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import type { SignalTransportConfig } from "./account-types.js";
 import {
@@ -22,6 +20,7 @@ import {
 import { spawnSignalDaemon } from "./daemon.js";
 import { installSignalCli } from "./install-signal-cli.js";
 import { normalizeSignalAccountInput, signalSetupStateKeys } from "./setup-core.js";
+import { resolveManagedSignalAccount } from "./setup-managed-account.js";
 import {
   detectSignalTransport,
   prepareSignalManagedNativeTransport,
@@ -44,8 +43,6 @@ type ExistingServerPromptParams = {
 };
 type ManagedSignalTransport = Extract<SignalTransportConfig, { kind: "managed-native" }>;
 type ResolvedManagedSignalTransport = Extract<ResolvedSignalTransport, { kind: "managed-native" }>;
-
-const SIGNAL_CLI_ACCOUNT_CHECK_TIMEOUT_MS = 10_000;
 
 export async function prepareSignalInteractiveSetup(params: SignalPrepareParams) {
   const resolvedAccount = resolveSignalAccount({
@@ -89,6 +86,7 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
   });
   let account = normalizeSignalAccountInput(resolvedAccount.config.account) ?? undefined;
   let transport: SignalTransportConfig;
+  let resolvedManagedTransport: ResolvedManagedSignalTransport | undefined;
   if (kind === "managed-native") {
     let cliPath = params.credentialValues[signalSetupStateKeys.cliPath] ?? "signal-cli";
     if (
@@ -116,6 +114,27 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
     throw new Error("Signal setup is missing its prepared transport candidate.");
   }
 
+  if (transport.kind === "managed-native") {
+    const resolvedTransport = resolveSignalTransport(transport);
+    if (resolvedTransport.kind !== "managed-native") {
+      throw new Error("Signal setup did not resolve a managed signal-cli transport.");
+    }
+    resolvedManagedTransport = resolvedTransport;
+    account = await resolveManagedSignalAccount({
+      transport: resolvedTransport,
+      configuredAccount: account,
+      selectionMode: "reuse-configured-or-only",
+      prompter: params.prompter,
+      beforePersistentEffect: params.options?.beforePersistentEffect,
+    });
+    cfg = patchChannelConfigForAccount({
+      cfg,
+      channel: "signal",
+      accountId: params.accountId,
+      patch: { account, accountUuid: undefined },
+    });
+  }
+
   let shouldPromptAccount = !account && transport.kind !== "external-native";
 
   while (true) {
@@ -132,11 +151,12 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
     }
 
     const probe =
-      transport.kind === "managed-native" && account
+      transport.kind === "managed-native" && resolvedManagedTransport && account
         ? await probeManagedSignalSetup({
             cfg,
             accountId: params.accountId,
             transport,
+            resolvedTransport: resolvedManagedTransport,
             account,
             runtime: params.runtime,
           })
@@ -170,7 +190,22 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
       throw new WizardCancelledError("Signal setup stopped");
     }
     if (recovery === "account") {
-      shouldPromptAccount = true;
+      if (transport.kind === "managed-native" && resolvedManagedTransport) {
+        account = await resolveManagedSignalAccount({
+          transport: resolvedManagedTransport,
+          selectionMode: "choose",
+          prompter: params.prompter,
+          beforePersistentEffect: params.options?.beforePersistentEffect,
+        });
+        cfg = patchChannelConfigForAccount({
+          cfg,
+          channel: "signal",
+          accountId: params.accountId,
+          patch: { account, accountUuid: undefined },
+        });
+      } else {
+        shouldPromptAccount = true;
+      }
       continue;
     }
     if (recovery === "url" && transport.kind !== "managed-native") {
@@ -196,32 +231,26 @@ async function probeManagedSignalSetup(params: {
   cfg: OpenClawConfig;
   accountId: string;
   transport: ManagedSignalTransport;
+  resolvedTransport: ResolvedManagedSignalTransport;
   account: string;
   runtime: SignalFinalizeParams["runtime"];
 }): Promise<SignalTransportProbeResult> {
-  const resolvedTransport = resolveSignalTransport(params.transport);
-  if (resolvedTransport.kind !== "managed-native") {
-    return { ok: false, error: "Signal setup did not resolve a managed signal-cli transport." };
-  }
-  const linkedAccount = await checkSignalCliAccount({
-    transport: resolvedTransport,
-    account: params.account,
-  });
-  if (!linkedAccount.ok) {
-    return linkedAccount;
-  }
-
   const daemon = spawnSignalDaemon({
-    cliPath: resolvedTransport.cliPath,
-    ...(resolvedTransport.configPath ? { configPath: resolvedTransport.configPath } : {}),
+    cliPath: params.resolvedTransport.cliPath,
+    ...(params.resolvedTransport.configPath
+      ? { configPath: params.resolvedTransport.configPath }
+      : {}),
     account: params.account,
-    httpHost: resolvedTransport.httpHost,
-    httpPort: resolvedTransport.httpPort,
+    httpHost: params.resolvedTransport.httpHost,
+    httpPort: params.resolvedTransport.httpPort,
     runtime: params.runtime,
   });
   let successfulProbe: SignalTransportProbeResult | undefined;
   try {
-    const startupTimeoutMs = Math.min(120_000, Math.max(1_000, resolvedTransport.startupTimeoutMs));
+    const startupTimeoutMs = Math.min(
+      120_000,
+      Math.max(1_000, params.resolvedTransport.startupTimeoutMs),
+    );
     await waitForTransportReady({
       label: "signal-cli setup daemon",
       timeoutMs: startupTimeoutMs,
@@ -252,96 +281,6 @@ async function probeManagedSignalSetup(params: {
   } finally {
     await daemon.stop();
   }
-}
-
-async function checkSignalCliAccount(params: {
-  transport: ResolvedManagedSignalTransport;
-  account: string;
-}): Promise<{ ok: true } | { ok: false; error: string }> {
-  const configPath = params.transport.configPath?.trim();
-  const result = await runPluginCommandWithTimeout({
-    argv: [
-      params.transport.cliPath,
-      ...(configPath ? ["--config", resolveUserPath(configPath)] : []),
-      "--output",
-      "json",
-      "listAccounts",
-    ],
-    timeoutMs: SIGNAL_CLI_ACCOUNT_CHECK_TIMEOUT_MS,
-  });
-  if (result.code !== 0) {
-    return {
-      ok: false,
-      error:
-        `signal-cli could not list its linked accounts (exit ${result.code}). ` +
-        "Check the signal-cli path and config path, then retry.",
-    };
-  }
-
-  const linkedAccounts = parseSignalCliAccounts(result.stdout);
-  if (!linkedAccounts) {
-    return {
-      ok: false,
-      error:
-        "signal-cli returned an unexpected account list. Check the signal-cli version and config path, then retry.",
-    };
-  }
-  if (linkedAccounts.has(params.account)) {
-    return { ok: true };
-  }
-
-  return {
-    ok: false,
-    error: [
-      "This signal-cli data directory does not contain the Signal account selected for OpenClaw.",
-      "Entering a phone number does not link signal-cli.",
-      `Run: ${formatSignalCliLinkCommand(params.transport)}`,
-      "Then, on your phone, open Signal > Settings > Linked devices, add a device, and scan the QR code.",
-      "Return here and choose Retry this setup.",
-    ].join("\n"),
-  };
-}
-
-function parseSignalCliAccounts(stdout: string): Set<string> | undefined {
-  try {
-    const value: unknown = JSON.parse(stdout);
-    if (!Array.isArray(value)) {
-      return undefined;
-    }
-    const accounts = new Set<string>();
-    for (const entry of value) {
-      if (
-        typeof entry !== "object" ||
-        entry === null ||
-        !("number" in entry) ||
-        typeof entry.number !== "string"
-      ) {
-        return undefined;
-      }
-      const account = normalizeSignalAccountInput(entry.number);
-      if (account) {
-        accounts.add(account);
-      }
-    }
-    return accounts;
-  } catch {
-    return undefined;
-  }
-}
-
-function formatSignalCliLinkCommand(transport: ResolvedManagedSignalTransport): string {
-  const configPath = transport.configPath?.trim();
-  return [
-    quoteShellArg(transport.cliPath),
-    ...(configPath ? ["--config", quoteShellArg(resolveUserPath(configPath))] : []),
-    "link",
-    "-n",
-    '"OpenClaw"',
-  ].join(" ");
-}
-
-function quoteShellArg(value: string): string {
-  return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 async function promptSignalAccount(prompter: WizardPrompter) {

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -25,7 +25,7 @@ const SIGNAL_CLI_PATH_KEY = "signalCliPath";
 const SIGNAL_CLI_CONFIG_PATH_KEY = "signalCliConfigPath";
 const SIGNAL_SERVER_URL_KEY = "signalServerUrl";
 
-type SignalSetupChoice = "managed-native" | "existing-server";
+type SignalSetupMode = "local" | "existing-server";
 type SignalPrepareParams = Parameters<NonNullable<ChannelSetupWizard["prepare"]>>[0];
 type SignalFinalizeParams = Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0];
 type SignalExistingTransport = Extract<
@@ -150,15 +150,13 @@ async function promptSignalAccount(params: SignalFinalizeParams) {
   return account;
 }
 
-function resolveSetupChoice(params: Pick<SignalPrepareParams, "cfg" | "accountId">) {
-  return resolveSignalAccount(params).transport.kind === "managed-native"
-    ? "managed-native"
-    : "existing-server";
-}
-
 async function prepareManagedNativeSetup(params: SignalPrepareParams) {
-  const existing = resolveSignalAccount({ cfg: params.cfg, accountId: params.accountId }).transport;
-  let cliPath = existing.kind === "managed-native" ? existing.cliPath : "signal-cli";
+  const resolvedTransport = resolveSignalAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  }).transport;
+  let cliPath =
+    resolvedTransport.kind === "managed-native" ? resolvedTransport.cliPath : "signal-cli";
   const cliDetected = await detectBinary(cliPath);
 
   if (params.options?.allowSignalInstall) {
@@ -193,7 +191,8 @@ async function prepareManagedNativeSetup(params: SignalPrepareParams) {
       ) ?? cliPath;
   }
 
-  const existingConfigPath = existing.kind === "managed-native" ? existing.configPath : undefined;
+  const existingConfigPath =
+    resolvedTransport.kind === "managed-native" ? resolvedTransport.configPath : undefined;
   const configPath = normalizeOptionalString(
     await params.prompter.text({
       message: "signal-cli config path (optional)",
@@ -297,14 +296,17 @@ async function promptExistingSignalTransport(
 }
 
 async function prepareExistingServerSetup(params: SignalPrepareParams) {
-  const existing = resolveSignalAccount({ cfg: params.cfg, accountId: params.accountId }).transport;
+  const resolvedTransport = resolveSignalAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  }).transport;
   const transport = await promptExistingSignalTransport({
     cfg: params.cfg,
     accountId: params.accountId,
     prompter: params.prompter,
     initialValue:
-      existing.kind === "external-native" || existing.kind === "container"
-        ? existing.baseUrl
+      resolvedTransport.kind === "external-native" || resolvedTransport.kind === "container"
+        ? resolvedTransport.baseUrl
         : "http://127.0.0.1:8080",
   });
   return {
@@ -316,12 +318,21 @@ async function prepareExistingServerSetup(params: SignalPrepareParams) {
 }
 
 export async function prepareSignalInteractiveSetup(params: SignalPrepareParams) {
-  const choice = await params.prompter.select<SignalSetupChoice>({
+  const resolvedAccount = resolveSignalAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const initialMode: SignalSetupMode =
+    resolvedAccount.configured && resolvedAccount.transport.kind !== "managed-native"
+      ? "existing-server"
+      : "local";
+
+  const mode = await params.prompter.select<SignalSetupMode>({
     message: "How do you want to set up Signal for OpenClaw?",
-    initialValue: resolveSetupChoice(params),
+    initialValue: initialMode,
     options: [
       {
-        value: "managed-native",
+        value: "local",
         label: "Use local signal-cli",
         hint: "OpenClaw starts the local signal-cli daemon for this account.",
       },
@@ -333,7 +344,7 @@ export async function prepareSignalInteractiveSetup(params: SignalPrepareParams)
     ],
   });
 
-  if (choice === "managed-native") {
+  if (mode === "local") {
     return await prepareManagedNativeSetup(params);
   }
   return await prepareExistingServerSetup(params);

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -1,5 +1,6 @@
 import { isIP } from "node:net";
 import { hostname, networkInterfaces } from "node:os";
+import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import {
   patchChannelConfigForAccount,
   WizardCancelledError,
@@ -9,18 +10,23 @@ import {
 } from "openclaw/plugin-sdk/setup";
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
+import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import type { SignalTransportConfig } from "./account-types.js";
 import {
   listSignalAccountIds,
   resolveSignalAccount,
+  resolveSignalTransport,
   type ResolvedSignalTransport,
 } from "./accounts.js";
+import { spawnSignalDaemon } from "./daemon.js";
 import { installSignalCli } from "./install-signal-cli.js";
 import { normalizeSignalAccountInput, signalSetupStateKeys } from "./setup-core.js";
 import {
   detectSignalTransport,
   prepareSignalManagedNativeTransport,
   probeSignalTransport,
+  type SignalTransportProbeResult,
   writeSignalAccountTransport,
 } from "./setup-transport.js";
 
@@ -36,6 +42,10 @@ type ExistingServerPromptParams = {
   prompter: WizardPrompter;
   initialValue?: string;
 };
+type ManagedSignalTransport = Extract<SignalTransportConfig, { kind: "managed-native" }>;
+type ResolvedManagedSignalTransport = Extract<ResolvedSignalTransport, { kind: "managed-native" }>;
+
+const SIGNAL_CLI_ACCOUNT_CHECK_TIMEOUT_MS = 10_000;
 
 export async function prepareSignalInteractiveSetup(params: SignalPrepareParams) {
   const resolvedAccount = resolveSignalAccount({
@@ -121,18 +131,27 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
       shouldPromptAccount = false;
     }
 
-    const probe = await probeSignalTransport({
-      cfg,
-      accountId: params.accountId,
-      transport,
-      account,
-    }).catch((error: unknown) => ({ ok: false, error: String(error) }));
+    const probe =
+      transport.kind === "managed-native" && account
+        ? await probeManagedSignalSetup({
+            cfg,
+            accountId: params.accountId,
+            transport,
+            account,
+            runtime: params.runtime,
+          })
+        : await probeSignalTransport({
+            cfg,
+            accountId: params.accountId,
+            transport,
+            account,
+          }).catch((error: unknown) => ({ ok: false, error: String(error) }));
     if (probe.ok) {
       break;
     }
 
     await params.prompter.note(
-      `OpenClaw could not validate this Signal setup.\nError: ${probe.error ?? "Signal transport probe failed."}`,
+      `OpenClaw could not validate this Signal setup.\n\n${probe.error ?? "Signal transport probe failed."}`,
       "Signal setup",
     );
     const recovery = await params.prompter.select<"retry" | "account" | "url" | "stop">({
@@ -171,6 +190,158 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
       transport,
     }),
   };
+}
+
+async function probeManagedSignalSetup(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  transport: ManagedSignalTransport;
+  account: string;
+  runtime: SignalFinalizeParams["runtime"];
+}): Promise<SignalTransportProbeResult> {
+  const resolvedTransport = resolveSignalTransport(params.transport);
+  if (resolvedTransport.kind !== "managed-native") {
+    return { ok: false, error: "Signal setup did not resolve a managed signal-cli transport." };
+  }
+  const linkedAccount = await checkSignalCliAccount({
+    transport: resolvedTransport,
+    account: params.account,
+  });
+  if (!linkedAccount.ok) {
+    return linkedAccount;
+  }
+
+  const daemon = spawnSignalDaemon({
+    cliPath: resolvedTransport.cliPath,
+    ...(resolvedTransport.configPath ? { configPath: resolvedTransport.configPath } : {}),
+    account: params.account,
+    httpHost: resolvedTransport.httpHost,
+    httpPort: resolvedTransport.httpPort,
+    runtime: params.runtime,
+  });
+  let successfulProbe: SignalTransportProbeResult | undefined;
+  try {
+    const startupTimeoutMs = Math.min(120_000, Math.max(1_000, resolvedTransport.startupTimeoutMs));
+    await waitForTransportReady({
+      label: "signal-cli setup daemon",
+      timeoutMs: startupTimeoutMs,
+      logAfterMs: 10_000,
+      logIntervalMs: 10_000,
+      pollIntervalMs: 150,
+      runtime: params.runtime,
+      check: async () => {
+        if (daemon.isExited()) {
+          throw new Error("signal-cli exited before its HTTP server became ready.");
+        }
+        const probe = await probeSignalTransport({
+          cfg: params.cfg,
+          accountId: params.accountId,
+          transport: params.transport,
+          account: params.account,
+          timeoutMs: 1_000,
+        }).catch((error: unknown) => ({ ok: false, error: String(error) }));
+        if (probe.ok) {
+          successfulProbe = probe;
+        }
+        return probe;
+      },
+    });
+    return successfulProbe ?? { ok: false, error: "Signal transport probe failed." };
+  } catch (error) {
+    return { ok: false, error: String(error) };
+  } finally {
+    await daemon.stop();
+  }
+}
+
+async function checkSignalCliAccount(params: {
+  transport: ResolvedManagedSignalTransport;
+  account: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const configPath = params.transport.configPath?.trim();
+  const result = await runPluginCommandWithTimeout({
+    argv: [
+      params.transport.cliPath,
+      ...(configPath ? ["--config", resolveUserPath(configPath)] : []),
+      "--output",
+      "json",
+      "listAccounts",
+    ],
+    timeoutMs: SIGNAL_CLI_ACCOUNT_CHECK_TIMEOUT_MS,
+  });
+  if (result.code !== 0) {
+    return {
+      ok: false,
+      error:
+        `signal-cli could not list its linked accounts (exit ${result.code}). ` +
+        "Check the signal-cli path and config path, then retry.",
+    };
+  }
+
+  const linkedAccounts = parseSignalCliAccounts(result.stdout);
+  if (!linkedAccounts) {
+    return {
+      ok: false,
+      error:
+        "signal-cli returned an unexpected account list. Check the signal-cli version and config path, then retry.",
+    };
+  }
+  if (linkedAccounts.has(params.account)) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    error: [
+      "This signal-cli data directory does not contain the Signal account selected for OpenClaw.",
+      "Entering a phone number does not link signal-cli.",
+      `Run: ${formatSignalCliLinkCommand(params.transport)}`,
+      "Then, on your phone, open Signal > Settings > Linked devices, add a device, and scan the QR code.",
+      "Return here and choose Retry this setup.",
+    ].join("\n"),
+  };
+}
+
+function parseSignalCliAccounts(stdout: string): Set<string> | undefined {
+  try {
+    const value: unknown = JSON.parse(stdout);
+    if (!Array.isArray(value)) {
+      return undefined;
+    }
+    const accounts = new Set<string>();
+    for (const entry of value) {
+      if (
+        typeof entry !== "object" ||
+        entry === null ||
+        !("number" in entry) ||
+        typeof entry.number !== "string"
+      ) {
+        return undefined;
+      }
+      const account = normalizeSignalAccountInput(entry.number);
+      if (account) {
+        accounts.add(account);
+      }
+    }
+    return accounts;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatSignalCliLinkCommand(transport: ResolvedManagedSignalTransport): string {
+  const configPath = transport.configPath?.trim();
+  return [
+    quoteShellArg(transport.cliPath),
+    ...(configPath ? ["--config", quoteShellArg(resolveUserPath(configPath))] : []),
+    "link",
+    "-n",
+    '"OpenClaw"',
+  ].join(" ");
+}
+
+function quoteShellArg(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 async function promptSignalAccount(prompter: WizardPrompter) {

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -159,6 +159,7 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
             resolvedTransport: resolvedManagedTransport,
             account,
             runtime: params.runtime,
+            prompter: params.prompter,
           })
         : await probeSignalTransport({
             cfg,
@@ -234,7 +235,9 @@ async function probeManagedSignalSetup(params: {
   resolvedTransport: ResolvedManagedSignalTransport;
   account: string;
   runtime: SignalFinalizeParams["runtime"];
+  prompter: WizardPrompter;
 }): Promise<SignalTransportProbeResult> {
+  const progress = params.prompter.progress("Validating Signal setup...");
   const daemon = spawnSignalDaemon({
     cliPath: params.resolvedTransport.cliPath,
     ...(params.resolvedTransport.configPath
@@ -243,9 +246,9 @@ async function probeManagedSignalSetup(params: {
     account: params.account,
     httpHost: params.resolvedTransport.httpHost,
     httpPort: params.resolvedTransport.httpPort,
-    runtime: params.runtime,
   });
   let successfulProbe: SignalTransportProbeResult | undefined;
+  let result: SignalTransportProbeResult;
   try {
     const startupTimeoutMs = Math.min(
       120_000,
@@ -275,12 +278,14 @@ async function probeManagedSignalSetup(params: {
         return probe;
       },
     });
-    return successfulProbe ?? { ok: false, error: "Signal transport probe failed." };
+    result = successfulProbe ?? { ok: false, error: "Signal transport probe failed." };
   } catch (error) {
-    return { ok: false, error: String(error) };
+    result = { ok: false, error: String(error) };
   } finally {
     await daemon.stop();
   }
+  progress.stop(result.ok ? "Signal setup validated." : "Signal setup validation failed.");
+  return result;
 }
 
 async function promptSignalAccount(prompter: WizardPrompter) {
@@ -340,7 +345,7 @@ async function prepareManagedNativeSetup(
 
   if (params.options?.allowSignalInstall) {
     installRequested = await params.prompter.confirm({
-      message: cliDetected ? "Reinstall signal-cli?" : "Install signal-cli?",
+      message: cliDetected ? "Reinstall signal-cli? (not normally needed)" : "Install signal-cli?",
       initialValue: !cliDetected,
     });
   }
@@ -360,7 +365,7 @@ async function prepareManagedNativeSetup(
     resolvedTransport.kind === "managed-native" ? resolvedTransport.configPath : undefined;
   const configPath = normalizeOptionalString(
     await params.prompter.text({
-      message: "signal-cli config path (optional)",
+      message: "signal-cli config directory (leave blank for default)",
       initialValue: existingConfigPath,
       placeholder: "~/.local/share/signal-cli",
     }),

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -80,12 +80,19 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
   let account = normalizeSignalAccountInput(resolvedAccount.config.account) ?? undefined;
   let transport: SignalTransportConfig;
   if (kind === "managed-native") {
+    let cliPath = params.credentialValues[signalSetupStateKeys.cliPath] ?? "signal-cli";
+    if (
+      params.options?.allowSignalInstall &&
+      params.credentialValues[signalSetupStateKeys.installRequested] === "true"
+    ) {
+      cliPath = await installRequestedSignalCli(params, cliPath);
+    }
     const configPath = params.credentialValues[signalSetupStateKeys.cliConfigPath];
     transport = prepareSignalManagedNativeTransport({
       cfg,
       accountId: params.accountId,
       overrides: {
-        cliPath: params.credentialValues[signalSetupStateKeys.cliPath] ?? "signal-cli",
+        cliPath,
         ...(configPath ? { configPath } : {}),
       },
     });
@@ -182,37 +189,53 @@ async function promptSignalAccount(prompter: WizardPrompter) {
   return account;
 }
 
+async function installRequestedSignalCli(params: SignalFinalizeParams, initialCliPath: string) {
+  await params.options?.beforePersistentEffect?.();
+
+  let cliPath = initialCliPath;
+  try {
+    const result = await installSignalCli(params.runtime);
+    if (result.ok && result.cliPath) {
+      cliPath = result.cliPath;
+      await params.prompter.note(`Installed signal-cli at ${result.cliPath}`, "Signal");
+    } else {
+      await params.prompter.note(result.error ?? "signal-cli install failed.", "Signal");
+    }
+  } catch (error) {
+    await params.prompter.note(`signal-cli install failed: ${String(error)}`, "Signal");
+  }
+
+  if (await detectBinary(cliPath)) {
+    return cliPath;
+  }
+  return (
+    normalizeOptionalString(
+      await params.prompter.text({
+        message: "signal-cli path",
+        initialValue: cliPath,
+        validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
+      }),
+    ) ?? cliPath
+  );
+}
+
 async function prepareManagedNativeSetup(
   params: SignalPrepareParams,
   resolvedTransport: ResolvedSignalTransport,
 ) {
   let cliPath =
     resolvedTransport.kind === "managed-native" ? resolvedTransport.cliPath : "signal-cli";
-  let cliDetected = await detectBinary(cliPath);
+  const cliDetected = await detectBinary(cliPath);
+  let installRequested = false;
 
   if (params.options?.allowSignalInstall) {
-    const wantsInstall = await params.prompter.confirm({
+    installRequested = await params.prompter.confirm({
       message: cliDetected ? "Reinstall signal-cli?" : "Install signal-cli?",
       initialValue: !cliDetected,
     });
-    if (wantsInstall) {
-      await params.options.beforePersistentEffect?.();
-      try {
-        const result = await installSignalCli(params.runtime);
-        if (result.ok && result.cliPath) {
-          cliPath = result.cliPath;
-          await params.prompter.note(`Installed signal-cli at ${result.cliPath}`, "Signal");
-        } else {
-          await params.prompter.note(result.error ?? "signal-cli install failed.", "Signal");
-        }
-      } catch (error) {
-        await params.prompter.note(`signal-cli install failed: ${String(error)}`, "Signal");
-      }
-      cliDetected = await detectBinary(cliPath);
-    }
   }
 
-  if (!cliDetected) {
+  if (!cliDetected && !installRequested) {
     cliPath =
       normalizeOptionalString(
         await params.prompter.text({
@@ -245,6 +268,7 @@ async function prepareManagedNativeSetup(
       [signalSetupStateKeys.transportKind]: "managed-native",
       [signalSetupStateKeys.cliPath]: cliPath,
       ...(configPath ? { [signalSetupStateKeys.cliConfigPath]: configPath } : {}),
+      ...(installRequested ? { [signalSetupStateKeys.installRequested]: "true" } : {}),
     },
   };
 }

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -1,0 +1,446 @@
+import { isIP } from "node:net";
+import { hostname, networkInterfaces } from "node:os";
+import {
+  patchChannelConfigForAccount,
+  WizardCancelledError,
+  type ChannelSetupWizard,
+  type OpenClawConfig,
+  type WizardPrompter,
+} from "openclaw/plugin-sdk/setup";
+import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { SignalTransportConfig } from "./account-types.js";
+import { listSignalAccountIds, resolveSignalAccount } from "./accounts.js";
+import { installSignalCli } from "./install-signal-cli.js";
+import { normalizeSignalAccountInput } from "./setup-core.js";
+import {
+  detectSignalTransport,
+  prepareSignalManagedNativeTransport,
+  probeSignalTransport,
+  writeSignalAccountTransport,
+} from "./setup-transport.js";
+
+const SIGNAL_TRANSPORT_KIND_KEY = "signalTransportKind";
+const SIGNAL_CLI_PATH_KEY = "signalCliPath";
+const SIGNAL_CLI_CONFIG_PATH_KEY = "signalCliConfigPath";
+const SIGNAL_SERVER_URL_KEY = "signalServerUrl";
+
+type SignalSetupChoice = "managed-native" | "existing-server";
+type SignalPrepareParams = Parameters<NonNullable<ChannelSetupWizard["prepare"]>>[0];
+type SignalFinalizeParams = Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0];
+type SignalExistingTransport = Extract<
+  SignalTransportConfig,
+  { kind: "external-native" | "container" }
+>;
+type ExistingServerPromptParams = {
+  cfg: OpenClawConfig;
+  accountId: string;
+  prompter: WizardPrompter;
+  initialValue?: string;
+};
+
+function normalizeEndpointHostname(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^\[(.*)\]$/, "$1")
+    .replace(/\.$/, "")
+    .replace(/%.+$/, "");
+}
+
+function normalizeEndpointAddress(value: string): string {
+  const normalized = normalizeEndpointHostname(value);
+  return isIP(normalized) === 4 && normalized.startsWith("127.") ? "127.0.0.1" : normalized;
+}
+
+function endpointPort(url: URL): number {
+  return url.port ? Number.parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
+}
+
+function localInterfaceAddresses(): Set<string> {
+  const addresses = new Set(["127.0.0.1", "::1"]);
+  try {
+    for (const entries of Object.values(networkInterfaces())) {
+      for (const entry of entries ?? []) {
+        addresses.add(normalizeEndpointAddress(entry.address));
+      }
+    }
+  } catch {
+    // Some restricted environments deny interface enumeration; loopback aliases still work.
+  }
+  return addresses;
+}
+
+function resolveEndpointAddresses(endpointHostname: string): Set<string> {
+  const normalized = normalizeEndpointHostname(endpointHostname);
+  const localAddresses = localInterfaceAddresses();
+  if (normalized === "0.0.0.0" || normalized === "::") {
+    return localAddresses;
+  }
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) {
+    return new Set(["127.0.0.1", "::1"]);
+  }
+  const localHostname = normalizeEndpointHostname(hostname());
+  if (normalized === localHostname || normalized === `${localHostname}.local`) {
+    return localAddresses;
+  }
+  return isIP(normalized) ? new Set([normalizeEndpointAddress(normalized)]) : new Set();
+}
+
+function matchesManagedSignalEndpoint(managedEndpoint: string, candidateEndpoint: string): boolean {
+  try {
+    const managed = new URL(managedEndpoint);
+    const candidate = new URL(candidateEndpoint);
+    if (managed.origin === candidate.origin) {
+      return true;
+    }
+    if (
+      managed.protocol !== candidate.protocol ||
+      endpointPort(managed) !== endpointPort(candidate)
+    ) {
+      return false;
+    }
+    const managedAddresses = resolveEndpointAddresses(managed.hostname);
+    const candidateAddresses = resolveEndpointAddresses(candidate.hostname);
+    return [...managedAddresses].some((address) => candidateAddresses.has(address));
+  } catch {
+    return false;
+  }
+}
+
+function formatSignalEndpointHost(host: string): string {
+  const normalized = normalizeEndpointHostname(host);
+  return normalized.includes(":") ? `[${normalized}]` : normalized;
+}
+
+function listConfiguredManagedSignalEndpoints(cfg: OpenClawConfig): string[] {
+  return listSignalAccountIds(cfg).flatMap((accountId) => {
+    const account = resolveSignalAccount({ cfg, accountId });
+    if (!account.configured || account.transport.kind !== "managed-native") {
+      return [];
+    }
+    return Array.from(
+      new Set([
+        account.transport.baseUrl,
+        `http://${formatSignalEndpointHost(account.transport.httpHost)}:${account.transport.httpPort}`,
+      ]),
+    );
+  });
+}
+
+function aliasesManagedSignalEndpoint(cfg: OpenClawConfig, candidateUrl: string): boolean {
+  return listConfiguredManagedSignalEndpoints(cfg).some((managedUrl) =>
+    matchesManagedSignalEndpoint(managedUrl, candidateUrl),
+  );
+}
+
+async function promptSignalAccount(params: SignalFinalizeParams) {
+  const raw = await params.prompter.text({
+    message: "Signal phone number",
+    placeholder: "+15555550123",
+    validate: (value) =>
+      normalizeSignalAccountInput(value)
+        ? undefined
+        : "Enter a Signal phone number in international format, for example +15555550123.",
+  });
+  const account = normalizeSignalAccountInput(raw);
+  if (!account) {
+    throw new Error("Signal phone number is required.");
+  }
+  return account;
+}
+
+function resolveSetupChoice(params: Pick<SignalPrepareParams, "cfg" | "accountId">) {
+  return resolveSignalAccount(params).transport.kind === "managed-native"
+    ? "managed-native"
+    : "existing-server";
+}
+
+async function prepareManagedNativeSetup(params: SignalPrepareParams) {
+  const existing = resolveSignalAccount({ cfg: params.cfg, accountId: params.accountId }).transport;
+  let cliPath = existing.kind === "managed-native" ? existing.cliPath : "signal-cli";
+  const cliDetected = await detectBinary(cliPath);
+
+  if (params.options?.allowSignalInstall) {
+    const wantsInstall = await params.prompter.confirm({
+      message: cliDetected ? "Reinstall signal-cli?" : "Install signal-cli?",
+      initialValue: !cliDetected,
+    });
+    if (wantsInstall) {
+      await params.options.beforePersistentEffect?.();
+      try {
+        const result = await installSignalCli(params.runtime);
+        if (result.ok && result.cliPath) {
+          cliPath = result.cliPath;
+          await params.prompter.note(`Installed signal-cli at ${result.cliPath}`, "Signal");
+        } else {
+          await params.prompter.note(result.error ?? "signal-cli install failed.", "Signal");
+        }
+      } catch (error) {
+        await params.prompter.note(`signal-cli install failed: ${String(error)}`, "Signal");
+      }
+    }
+  }
+
+  if (!(await detectBinary(cliPath))) {
+    cliPath =
+      normalizeOptionalString(
+        await params.prompter.text({
+          message: "signal-cli path",
+          initialValue: cliPath,
+          validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
+        }),
+      ) ?? cliPath;
+  }
+
+  const existingConfigPath = existing.kind === "managed-native" ? existing.configPath : undefined;
+  const configPath = normalizeOptionalString(
+    await params.prompter.text({
+      message: "signal-cli config path (optional)",
+      initialValue: existingConfigPath,
+      placeholder: "~/.local/share/signal-cli",
+    }),
+  );
+
+  // Validate account-owned port allocation now, while keeping the candidate ephemeral until probe.
+  prepareSignalManagedNativeTransport({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    overrides: { cliPath, ...(configPath ? { configPath } : {}) },
+  });
+
+  return {
+    credentialValues: {
+      [SIGNAL_TRANSPORT_KIND_KEY]: "managed-native",
+      [SIGNAL_CLI_PATH_KEY]: cliPath,
+      ...(configPath ? { [SIGNAL_CLI_CONFIG_PATH_KEY]: configPath } : {}),
+    },
+  };
+}
+
+async function promptExistingSignalTransport(
+  params: ExistingServerPromptParams,
+): Promise<SignalExistingTransport> {
+  let initialValue = params.initialValue ?? "http://127.0.0.1:8080";
+  let url = initialValue;
+  let promptForUrl = true;
+
+  while (true) {
+    if (promptForUrl) {
+      url =
+        normalizeOptionalString(
+          await params.prompter.text({
+            message: "Signal server URL",
+            initialValue,
+            placeholder: "http://127.0.0.1:8080",
+            validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
+          }),
+        ) ?? initialValue;
+    }
+
+    const detection = await detectSignalTransport({ url }).then(
+      (transport) => ({ ok: true as const, transport }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    if (!detection.ok) {
+      await params.prompter.note(
+        `OpenClaw could not detect a working Signal server at ${url}.\nError: ${String(detection.error)}`,
+        "Signal server URL",
+      );
+      const recovery = await params.prompter.select<"retry" | "url" | "stop">({
+        message: "How should Signal server setup continue?",
+        options: [
+          { value: "retry", label: "Retry this Signal server URL" },
+          { value: "url", label: "Try another Signal server URL" },
+          { value: "stop", label: "Stop Signal setup" },
+        ],
+        initialValue: "retry",
+      });
+      if (recovery === "stop") {
+        throw new WizardCancelledError("Signal setup stopped");
+      }
+      promptForUrl = recovery === "url";
+      initialValue = url;
+      continue;
+    }
+
+    const transport = detection.transport;
+    if (transport.kind === "managed-native") {
+      throw new Error("Signal transport detection returned a managed-native transport");
+    }
+    if (!aliasesManagedSignalEndpoint(params.cfg, transport.url)) {
+      return transport;
+    }
+
+    await params.prompter.note(
+      [
+        "That URL is an OpenClaw-managed Signal daemon.",
+        "It stops when its account switches away from local signal-cli.",
+        "Enter the URL of an independently operated Signal server instead.",
+      ].join("\n"),
+      "Signal server URL",
+    );
+    const recovery = await params.prompter.select<"url" | "stop">({
+      message: "How should Signal server setup continue?",
+      options: [
+        { value: "url", label: "Try another Signal server URL" },
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "url",
+    });
+    if (recovery === "stop") {
+      throw new WizardCancelledError("Signal setup stopped");
+    }
+    initialValue = url;
+    promptForUrl = true;
+  }
+}
+
+async function prepareExistingServerSetup(params: SignalPrepareParams) {
+  const existing = resolveSignalAccount({ cfg: params.cfg, accountId: params.accountId }).transport;
+  const transport = await promptExistingSignalTransport({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    prompter: params.prompter,
+    initialValue:
+      existing.kind === "external-native" || existing.kind === "container"
+        ? existing.baseUrl
+        : "http://127.0.0.1:8080",
+  });
+  return {
+    credentialValues: {
+      [SIGNAL_TRANSPORT_KIND_KEY]: transport.kind,
+      [SIGNAL_SERVER_URL_KEY]: transport.url,
+    },
+  };
+}
+
+export async function prepareSignalInteractiveSetup(params: SignalPrepareParams) {
+  const choice = await params.prompter.select<SignalSetupChoice>({
+    message: "How do you want to set up Signal for OpenClaw?",
+    initialValue: resolveSetupChoice(params),
+    options: [
+      {
+        value: "managed-native",
+        label: "Use local signal-cli",
+        hint: "OpenClaw starts the local signal-cli daemon for this account.",
+      },
+      {
+        value: "existing-server",
+        label: "Connect to an existing Signal server",
+        hint: "OpenClaw detects and stores the server protocol for this account.",
+      },
+    ],
+  });
+
+  if (choice === "managed-native") {
+    return await prepareManagedNativeSetup(params);
+  }
+  return await prepareExistingServerSetup(params);
+}
+
+export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParams) {
+  const kind = params.credentialValues[SIGNAL_TRANSPORT_KIND_KEY];
+  let cfg = params.cfg;
+  let account =
+    normalizeSignalAccountInput(
+      resolveSignalAccount({ cfg, accountId: params.accountId }).config.account,
+    ) ?? undefined;
+  let transport: SignalTransportConfig | undefined =
+    kind === "managed-native"
+      ? prepareSignalManagedNativeTransport({
+          cfg,
+          accountId: params.accountId,
+          overrides: {
+            cliPath: params.credentialValues[SIGNAL_CLI_PATH_KEY] ?? "signal-cli",
+            ...(params.credentialValues[SIGNAL_CLI_CONFIG_PATH_KEY]
+              ? { configPath: params.credentialValues[SIGNAL_CLI_CONFIG_PATH_KEY] }
+              : {}),
+          },
+        })
+      : kind === "external-native" || kind === "container"
+        ? {
+            kind,
+            url: params.credentialValues[SIGNAL_SERVER_URL_KEY] ?? "",
+          }
+        : undefined;
+  if (!transport || (transport.kind !== "managed-native" && !transport.url)) {
+    throw new Error("Signal setup is missing its prepared transport candidate.");
+  }
+  if ((transport.kind === "managed-native" || transport.kind === "container") && !account) {
+    account = await promptSignalAccount(params);
+    cfg = patchChannelConfigForAccount({
+      cfg,
+      channel: "signal",
+      accountId: params.accountId,
+      patch: { account, accountUuid: undefined },
+    });
+  }
+
+  while (true) {
+    const probe = await probeSignalTransport({
+      cfg,
+      accountId: params.accountId,
+      transport,
+      account,
+    }).catch((error: unknown) => ({ ok: false, error: String(error) }));
+    if (probe.ok) {
+      break;
+    }
+
+    await params.prompter.note(
+      `OpenClaw could not validate this Signal setup.\nError: ${probe.error ?? "Signal transport probe failed."}`,
+      "Signal setup",
+    );
+    const recovery = await params.prompter.select<"retry" | "account" | "url" | "stop">({
+      message: "How should Signal setup continue?",
+      options: [
+        { value: "retry", label: "Retry this setup" },
+        { value: "account", label: "Try another Signal account" },
+        ...(transport.kind === "managed-native"
+          ? []
+          : [{ value: "url" as const, label: "Try another Signal server URL" }]),
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "retry",
+    });
+    if (recovery === "stop") {
+      throw new WizardCancelledError("Signal setup stopped");
+    }
+    if (recovery === "account") {
+      account = await promptSignalAccount(params);
+      cfg = patchChannelConfigForAccount({
+        cfg,
+        channel: "signal",
+        accountId: params.accountId,
+        patch: { account, accountUuid: undefined },
+      });
+      continue;
+    }
+    if (recovery === "url" && transport.kind !== "managed-native") {
+      transport = await promptExistingSignalTransport({
+        cfg,
+        accountId: params.accountId,
+        prompter: params.prompter,
+        initialValue: transport.url,
+      });
+      if (transport.kind === "container" && !account) {
+        account = await promptSignalAccount(params);
+        cfg = patchChannelConfigForAccount({
+          cfg,
+          channel: "signal",
+          accountId: params.accountId,
+          patch: { account, accountUuid: undefined },
+        });
+      }
+    }
+  }
+
+  return {
+    cfg: writeSignalAccountTransport({
+      cfg,
+      accountId: params.accountId,
+      transport,
+    }),
+  };
+}

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -10,7 +10,11 @@ import {
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SignalTransportConfig } from "./account-types.js";
-import { listSignalAccountIds, resolveSignalAccount } from "./accounts.js";
+import {
+  listSignalAccountIds,
+  resolveSignalAccount,
+  type ResolvedSignalTransport,
+} from "./accounts.js";
 import { installSignalCli } from "./install-signal-cli.js";
 import { normalizeSignalAccountInput } from "./setup-core.js";
 import {
@@ -150,11 +154,10 @@ async function promptSignalAccount(params: SignalFinalizeParams) {
   return account;
 }
 
-async function prepareManagedNativeSetup(params: SignalPrepareParams) {
-  const resolvedTransport = resolveSignalAccount({
-    cfg: params.cfg,
-    accountId: params.accountId,
-  }).transport;
+async function prepareManagedNativeSetup(
+  params: SignalPrepareParams,
+  resolvedTransport: ResolvedSignalTransport,
+) {
   let cliPath =
     resolvedTransport.kind === "managed-native" ? resolvedTransport.cliPath : "signal-cli";
   const cliDetected = await detectBinary(cliPath);
@@ -295,11 +298,10 @@ async function promptExistingSignalTransport(
   }
 }
 
-async function prepareExistingServerSetup(params: SignalPrepareParams) {
-  const resolvedTransport = resolveSignalAccount({
-    cfg: params.cfg,
-    accountId: params.accountId,
-  }).transport;
+async function prepareExistingServerSetup(
+  params: SignalPrepareParams,
+  resolvedTransport: ResolvedSignalTransport,
+) {
   const transport = await promptExistingSignalTransport({
     cfg: params.cfg,
     accountId: params.accountId,
@@ -345,18 +347,19 @@ export async function prepareSignalInteractiveSetup(params: SignalPrepareParams)
   });
 
   if (mode === "local") {
-    return await prepareManagedNativeSetup(params);
+    return await prepareManagedNativeSetup(params, resolvedAccount.transport);
   }
-  return await prepareExistingServerSetup(params);
+  return await prepareExistingServerSetup(params, resolvedAccount.transport);
 }
 
 export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParams) {
   const kind = params.credentialValues[SIGNAL_TRANSPORT_KIND_KEY];
   let cfg = params.cfg;
-  let account =
-    normalizeSignalAccountInput(
-      resolveSignalAccount({ cfg, accountId: params.accountId }).config.account,
-    ) ?? undefined;
+  const resolvedAccount = resolveSignalAccount({
+    cfg,
+    accountId: params.accountId,
+  });
+  let account = normalizeSignalAccountInput(resolvedAccount.config.account) ?? undefined;
   let transport: SignalTransportConfig | undefined =
     kind === "managed-native"
       ? prepareSignalManagedNativeTransport({

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -1,7 +1,7 @@
-import { isIP } from "node:net";
-import { hostname, networkInterfaces } from "node:os";
+import { realpathSync } from "node:fs";
+import { createServer } from "node:net";
+import path from "node:path";
 import {
-  patchChannelConfigForAccount,
   WizardCancelledError,
   type ChannelSetupWizard,
   type OpenClawConfig,
@@ -9,25 +9,32 @@ import {
 } from "openclaw/plugin-sdk/setup";
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import type { SignalTransportConfig } from "./account-types.js";
 import {
-  listSignalAccountIds,
   resolveSignalAccount,
   resolveSignalTransport,
   type ResolvedSignalTransport,
 } from "./accounts.js";
 import { spawnSignalDaemon } from "./daemon.js";
 import { installSignalCli } from "./install-signal-cli.js";
-import { normalizeSignalAccountInput, signalSetupStateKeys } from "./setup-core.js";
+import {
+  normalizeSignalAccountInput,
+  patchSignalSetupAccount,
+  signalSetupStateKeys,
+} from "./setup-core.js";
+import { aliasesManagedSignalEndpoint } from "./setup-endpoint-identity.js";
 import { resolveManagedSignalAccount } from "./setup-managed-account.js";
 import {
   detectSignalTransport,
   prepareSignalManagedNativeTransport,
   probeSignalTransport,
+  resolveConfiguredSignalTransport,
   type SignalTransportProbeResult,
   writeSignalAccountTransport,
 } from "./setup-transport.js";
+import { buildSignalTransportHttpUrl } from "./transport-url.js";
 
 type SignalSetupMode = "local" | "existing-server";
 type SignalPrepareParams = Parameters<NonNullable<ChannelSetupWizard["prepare"]>>[0];
@@ -44,11 +51,46 @@ type ExistingServerPromptParams = {
 type ManagedSignalTransport = Extract<SignalTransportConfig, { kind: "managed-native" }>;
 type ResolvedManagedSignalTransport = Extract<ResolvedSignalTransport, { kind: "managed-native" }>;
 
+function resolveExplicitSignalCliDataDirectory(configPath: string | undefined): string | undefined {
+  const configured = normalizeOptionalString(configPath);
+  if (!configured) {
+    return undefined;
+  }
+  const absolute = path.resolve(resolveUserPath(configured));
+  try {
+    return realpathSync.native(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+type SignalCliDataDirectoryRelationship = "same" | "different" | "unknown";
+
+function compareSignalCliDataDirectories(
+  active: ResolvedManagedSignalTransport,
+  candidate: ResolvedManagedSignalTransport,
+): SignalCliDataDirectoryRelationship {
+  const activeDirectory = resolveExplicitSignalCliDataDirectory(active.configPath);
+  const candidateDirectory = resolveExplicitSignalCliDataDirectory(candidate.configPath);
+  if (!activeDirectory || !candidateDirectory) {
+    // signal-cli can source its implicit dataDir from system or user config.
+    // Two omitted paths share that resolution; one omitted path cannot be
+    // proven distinct from an explicit store while the daemon owns its lock.
+    return !activeDirectory && !candidateDirectory ? "same" : "unknown";
+  }
+  const same =
+    process.platform === "win32"
+      ? activeDirectory.toLowerCase() === candidateDirectory.toLowerCase()
+      : activeDirectory === candidateDirectory;
+  return same ? "same" : "different";
+}
+
 export async function prepareSignalInteractiveSetup(params: SignalPrepareParams) {
   const resolvedAccount = resolveSignalAccount({
     cfg: params.cfg,
     accountId: params.accountId,
   });
+  const originalAccount = normalizeSignalAccountInput(resolvedAccount.config.account) ?? undefined;
   const initialMode: SignalSetupMode =
     resolvedAccount.configured && resolvedAccount.transport.kind !== "managed-native"
       ? "existing-server"
@@ -71,10 +113,17 @@ export async function prepareSignalInteractiveSetup(params: SignalPrepareParams)
     ],
   });
 
-  if (mode === "local") {
-    return await prepareManagedNativeSetup(params, resolvedAccount.transport);
-  }
-  return await prepareExistingServerSetup(params, resolvedAccount.transport);
+  const prepared =
+    mode === "local"
+      ? await prepareManagedNativeSetup(params, resolvedAccount.transport)
+      : await prepareExistingServerSetup(params, resolvedAccount.transport);
+  return {
+    ...prepared,
+    credentialValues: {
+      ...prepared.credentialValues,
+      ...(originalAccount ? { [signalSetupStateKeys.originalAccount]: originalAccount } : {}),
+    },
+  };
 }
 
 export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParams) {
@@ -84,9 +133,23 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
     cfg,
     accountId: params.accountId,
   });
-  let account = normalizeSignalAccountInput(resolvedAccount.config.account) ?? undefined;
+  const configuredAccount =
+    normalizeSignalAccountInput(resolvedAccount.config.account) ?? undefined;
+  const originalAccount = normalizeSignalAccountInput(
+    params.credentialValues[signalSetupStateKeys.originalAccount],
+  );
+  if (originalAccount && originalAccount !== configuredAccount) {
+    cfg = patchSignalSetupAccount({
+      cfg,
+      accountId: params.accountId,
+      patch: { accountUuid: undefined },
+    });
+  }
+  let account = configuredAccount;
+  let managedAccountLinked = true;
   let transport: SignalTransportConfig;
   let resolvedManagedTransport: ResolvedManagedSignalTransport | undefined;
+  let useTemporaryManagedValidationPort = false;
   if (kind === "managed-native") {
     let cliPath = params.credentialValues[signalSetupStateKeys.cliPath] ?? "signal-cli";
     if (
@@ -95,15 +158,27 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
     ) {
       cliPath = await installRequestedSignalCli(params, cliPath);
     }
-    const configPath = params.credentialValues[signalSetupStateKeys.cliConfigPath];
-    transport = prepareSignalManagedNativeTransport({
+    const hasConfigPathChoice = Object.hasOwn(
+      params.credentialValues,
+      signalSetupStateKeys.cliConfigPath,
+    );
+    const configPath = normalizeOptionalString(
+      params.credentialValues[signalSetupStateKeys.cliConfigPath],
+    );
+    const preparedTransport = prepareSignalManagedNativeTransport({
       cfg,
       accountId: params.accountId,
       overrides: {
         cliPath,
-        ...(configPath ? { configPath } : {}),
+        ...(hasConfigPathChoice ? { configPath: configPath ?? "" } : {}),
       },
     });
+    if (hasConfigPathChoice && !configPath) {
+      const { configPath: _clearedConfigPath, ...defaultConfigTransport } = preparedTransport;
+      transport = defaultConfigTransport;
+    } else {
+      transport = preparedTransport;
+    }
   } else if (kind === "external-native" || kind === "container") {
     const url = params.credentialValues[signalSetupStateKeys.serverUrl];
     if (!url) {
@@ -120,36 +195,89 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
       throw new Error("Signal setup did not resolve a managed signal-cli transport.");
     }
     resolvedManagedTransport = resolvedTransport;
-    account = await resolveManagedSignalAccount({
+    const configuredTransport = resolveConfiguredSignalTransport(cfg, params.accountId);
+    if (
+      resolvedAccount.transport.kind === "managed-native" &&
+      (account || configuredTransport?.kind === "managed-native")
+    ) {
+      const existingTransport = configuredTransport ?? {
+        kind: "managed-native",
+      };
+      const existingProbe = await probeSignalTransport({
+        cfg,
+        accountId: params.accountId,
+        transport: existingTransport,
+        ...(account ? { account } : {}),
+        timeoutMs: 1_000,
+      }).catch((error: unknown) => ({ ok: false, error: String(error) }));
+      if (existingProbe.ok) {
+        const activeManagedTransport = resolvedAccount.transport;
+        if (isSameResolvedManagedTransport(activeManagedTransport, resolvedTransport)) {
+          if (!account) {
+            throw new Error(
+              "The running Signal daemon is using this signal-cli config directory. Stop the OpenClaw gateway before discovering or linking an account, then retry setup.",
+            );
+          }
+          return {
+            cfg: writeSignalAccountTransport({
+              cfg,
+              accountId: params.accountId,
+              transport,
+            }),
+          };
+        }
+        if (
+          compareSignalCliDataDirectories(activeManagedTransport, resolvedTransport) !== "different"
+        ) {
+          throw new Error(
+            "The running Signal daemon may be using this signal-cli config directory. Stop the OpenClaw gateway before changing its signal-cli settings, then retry setup.",
+          );
+        }
+        useTemporaryManagedValidationPort = true;
+      }
+    }
+    const resolution = await resolveManagedSignalAccount({
       transport: resolvedTransport,
       configuredAccount: account,
-      selectionMode: "reuse-configured-or-only",
+      selectionMode: "reuse-only-account",
       prompter: params.prompter,
       beforePersistentEffect: params.options?.beforePersistentEffect,
+      ...(params.options?.abortSignal ? { abortSignal: params.options.abortSignal } : {}),
+      deferDeviceLinkToClient: params.options?.deferDeviceLinkToClient,
+      remoteWizard: params.options?.remoteWizard,
     });
-    cfg = patchChannelConfigForAccount({
+    account = resolution.account;
+    managedAccountLinked = resolution.linked;
+    cfg = patchSignalSetupAccount({
       cfg,
-      channel: "signal",
       accountId: params.accountId,
-      patch: { account, accountUuid: undefined },
+      patch: {
+        account,
+        ...(account === configuredAccount ? {} : { accountUuid: undefined }),
+      },
     });
   }
 
-  let shouldPromptAccount = !account && transport.kind !== "external-native";
+  let shouldPromptAccount = !account && transport.kind !== "managed-native";
 
   while (true) {
     // Account or URL recovery re-enters here so every probe sees matching candidate state.
     if (shouldPromptAccount) {
       account = await promptSignalAccount(params.prompter);
-      cfg = patchChannelConfigForAccount({
+      cfg = patchSignalSetupAccount({
         cfg,
-        channel: "signal",
         accountId: params.accountId,
-        patch: { account, accountUuid: undefined },
+        patch: {
+          account,
+          ...(account === configuredAccount ? {} : { accountUuid: undefined }),
+        },
       });
       shouldPromptAccount = false;
     }
 
+    if (transport.kind === "managed-native" && !managedAccountLinked) {
+      break;
+    }
     const probe =
       transport.kind === "managed-native" && resolvedManagedTransport && account
         ? await probeManagedSignalSetup({
@@ -160,6 +288,8 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
             account,
             runtime: params.runtime,
             prompter: params.prompter,
+            useTemporaryPort: useTemporaryManagedValidationPort,
+            ...(params.options?.abortSignal ? { abortSignal: params.options.abortSignal } : {}),
           })
         : await probeSignalTransport({
             cfg,
@@ -192,17 +322,24 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
     }
     if (recovery === "account") {
       if (transport.kind === "managed-native" && resolvedManagedTransport) {
-        account = await resolveManagedSignalAccount({
+        const resolution = await resolveManagedSignalAccount({
           transport: resolvedManagedTransport,
           selectionMode: "choose",
           prompter: params.prompter,
           beforePersistentEffect: params.options?.beforePersistentEffect,
+          ...(params.options?.abortSignal ? { abortSignal: params.options.abortSignal } : {}),
+          deferDeviceLinkToClient: params.options?.deferDeviceLinkToClient,
+          remoteWizard: params.options?.remoteWizard,
         });
-        cfg = patchChannelConfigForAccount({
+        account = resolution.account;
+        managedAccountLinked = resolution.linked;
+        cfg = patchSignalSetupAccount({
           cfg,
-          channel: "signal",
           accountId: params.accountId,
-          patch: { account, accountUuid: undefined },
+          patch: {
+            account,
+            ...(account === configuredAccount ? {} : { accountUuid: undefined }),
+          },
         });
       } else {
         shouldPromptAccount = true;
@@ -215,16 +352,33 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
         prompter: params.prompter,
         initialValue: transport.url,
       });
-      shouldPromptAccount = !account && transport.kind !== "external-native";
+      shouldPromptAccount = !account;
     }
   }
 
+  if (!managedAccountLinked) {
+    await params.prompter.note(
+      [
+        "Signal is not linked yet.",
+        "After this wizard finishes, run `openclaw configure --section channels` in a terminal to link the account.",
+        "Signal will not be ready until that linking step succeeds.",
+      ].join("\n"),
+      "Signal next steps",
+    );
+  }
   return {
     cfg: writeSignalAccountTransport({
       cfg,
       accountId: params.accountId,
       transport,
     }),
+    ...(!managedAccountLinked
+      ? {
+          credentialValues: {
+            [signalSetupStateKeys.linkDeferred]: "true",
+          },
+        }
+      : {}),
   };
 }
 
@@ -236,39 +390,52 @@ async function probeManagedSignalSetup(params: {
   account: string;
   runtime: SignalFinalizeParams["runtime"];
   prompter: WizardPrompter;
+  useTemporaryPort: boolean;
+  abortSignal?: AbortSignal;
 }): Promise<SignalTransportProbeResult> {
   const progress = params.prompter.progress("Validating Signal setup...");
-  const daemon = spawnSignalDaemon({
-    cliPath: params.resolvedTransport.cliPath,
-    ...(params.resolvedTransport.configPath
-      ? { configPath: params.resolvedTransport.configPath }
-      : {}),
-    account: params.account,
-    httpHost: params.resolvedTransport.httpHost,
-    httpPort: params.resolvedTransport.httpPort,
-  });
+  let transport = params.transport;
+  let resolvedTransport = params.resolvedTransport;
+  let daemon: ReturnType<typeof spawnSignalDaemon> | undefined;
   let successfulProbe: SignalTransportProbeResult | undefined;
   let result: SignalTransportProbeResult;
   try {
-    const startupTimeoutMs = Math.min(
-      120_000,
-      Math.max(1_000, params.resolvedTransport.startupTimeoutMs),
-    );
+    if (params.useTemporaryPort) {
+      const httpPort = await allocateSignalValidationPort(resolvedTransport.httpHost);
+      const baseUrl = buildSignalTransportHttpUrl(resolvedTransport.httpHost, httpPort);
+      transport = { ...transport, httpPort, url: baseUrl };
+      resolvedTransport = { ...resolvedTransport, httpPort, baseUrl };
+    }
+    const spawnedDaemon = spawnSignalDaemon({
+      cliPath: resolvedTransport.cliPath,
+      ...(resolvedTransport.configPath ? { configPath: resolvedTransport.configPath } : {}),
+      account: params.account,
+      httpHost: resolvedTransport.httpHost,
+      httpPort: resolvedTransport.httpPort,
+      // Validation must not drain queued messages before the real monitor installs its handler.
+      receiveMode: "manual",
+      ...(typeof resolvedTransport.ignoreStories === "boolean"
+        ? { ignoreStories: resolvedTransport.ignoreStories }
+        : {}),
+    });
+    daemon = spawnedDaemon;
+    const startupTimeoutMs = Math.min(120_000, Math.max(1_000, resolvedTransport.startupTimeoutMs));
     await waitForTransportReady({
       label: "signal-cli setup daemon",
       timeoutMs: startupTimeoutMs,
       logAfterMs: 10_000,
       logIntervalMs: 10_000,
       pollIntervalMs: 150,
+      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
       runtime: params.runtime,
       check: async () => {
-        if (daemon.isExited()) {
+        if (spawnedDaemon.isExited()) {
           throw new Error("signal-cli exited before its HTTP server became ready.");
         }
         const probe = await probeSignalTransport({
           cfg: params.cfg,
           accountId: params.accountId,
-          transport: params.transport,
+          transport,
           account: params.account,
           timeoutMs: 1_000,
         }).catch((error: unknown) => ({ ok: false, error: String(error) }));
@@ -278,14 +445,68 @@ async function probeManagedSignalSetup(params: {
         return probe;
       },
     });
+    params.abortSignal?.throwIfAborted();
     result = successfulProbe ?? { ok: false, error: "Signal transport probe failed." };
   } catch (error) {
+    if (params.abortSignal?.aborted) {
+      throw params.abortSignal.reason;
+    }
     result = { ok: false, error: String(error) };
   } finally {
-    await daemon.stop();
+    await daemon?.stop();
   }
   progress.stop(result.ok ? "Signal setup validated." : "Signal setup validation failed.");
   return result;
+}
+
+async function allocateSignalValidationPort(host: string): Promise<number> {
+  const server = createServer();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen({ host, port: 0, exclusive: true }, resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Could not allocate a temporary Signal validation port.");
+    }
+    return address.port;
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }
+}
+
+function isSameResolvedManagedBind(
+  existing: ResolvedSignalTransport,
+  candidate: ResolvedManagedSignalTransport,
+): boolean {
+  return (
+    existing.kind === "managed-native" &&
+    existing.httpHost === candidate.httpHost &&
+    existing.httpPort === candidate.httpPort
+  );
+}
+
+function isSameResolvedManagedTransport(
+  existing: ResolvedSignalTransport,
+  candidate: ResolvedManagedSignalTransport,
+): boolean {
+  if (existing.kind !== "managed-native") {
+    return false;
+  }
+  return (
+    isSameResolvedManagedBind(existing, candidate) &&
+    existing.baseUrl === candidate.baseUrl &&
+    existing.cliPath === candidate.cliPath &&
+    compareSignalCliDataDirectories(existing, candidate) === "same" &&
+    existing.startupTimeoutMs === candidate.startupTimeoutMs &&
+    existing.receiveMode === candidate.receiveMode &&
+    existing.ignoreStories === candidate.ignoreStories
+  );
 }
 
 async function promptSignalAccount(prompter: WizardPrompter) {
@@ -382,7 +603,7 @@ async function prepareManagedNativeSetup(
     credentialValues: {
       [signalSetupStateKeys.transportKind]: "managed-native",
       [signalSetupStateKeys.cliPath]: cliPath,
-      ...(configPath ? { [signalSetupStateKeys.cliConfigPath]: configPath } : {}),
+      [signalSetupStateKeys.cliConfigPath]: configPath ?? "",
       ...(installRequested ? { [signalSetupStateKeys.installRequested]: "true" } : {}),
     },
   };
@@ -440,7 +661,7 @@ async function promptExistingSignalTransport(
     if (transport.kind === "managed-native") {
       throw new Error("Signal transport detection returned a managed-native transport");
     }
-    if (!aliasesManagedSignalEndpoint(params.cfg, transport.url)) {
+    if (!(await aliasesManagedSignalEndpoint(params.cfg, transport.url))) {
       return transport;
     }
 
@@ -485,99 +706,4 @@ async function prepareExistingServerSetup(
       [signalSetupStateKeys.serverUrl]: transport.url,
     },
   };
-}
-
-function normalizeEndpointHostname(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/^\[(.*)\]$/, "$1")
-    .replace(/\.$/, "")
-    .replace(/%.+$/, "");
-}
-
-function normalizeEndpointAddress(value: string): string {
-  const normalized = normalizeEndpointHostname(value);
-  return isIP(normalized) === 4 && normalized.startsWith("127.") ? "127.0.0.1" : normalized;
-}
-
-function endpointPort(url: URL): number {
-  return url.port ? Number.parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
-}
-
-function localInterfaceAddresses(): Set<string> {
-  const addresses = new Set(["127.0.0.1", "::1"]);
-  try {
-    for (const entries of Object.values(networkInterfaces())) {
-      for (const entry of entries ?? []) {
-        addresses.add(normalizeEndpointAddress(entry.address));
-      }
-    }
-  } catch {
-    // Some restricted environments deny interface enumeration; loopback aliases still work.
-  }
-  return addresses;
-}
-
-function resolveEndpointAddresses(endpointHostname: string): Set<string> {
-  const normalized = normalizeEndpointHostname(endpointHostname);
-  const localAddresses = localInterfaceAddresses();
-  if (normalized === "0.0.0.0" || normalized === "::") {
-    return localAddresses;
-  }
-  if (normalized === "localhost" || normalized.endsWith(".localhost")) {
-    return new Set(["127.0.0.1", "::1"]);
-  }
-  const localHostname = normalizeEndpointHostname(hostname());
-  if (normalized === localHostname || normalized === `${localHostname}.local`) {
-    return localAddresses;
-  }
-  return isIP(normalized) ? new Set([normalizeEndpointAddress(normalized)]) : new Set();
-}
-
-function matchesManagedSignalEndpoint(managedEndpoint: string, candidateEndpoint: string): boolean {
-  try {
-    const managed = new URL(managedEndpoint);
-    const candidate = new URL(candidateEndpoint);
-    if (managed.origin === candidate.origin) {
-      return true;
-    }
-    if (
-      managed.protocol !== candidate.protocol ||
-      endpointPort(managed) !== endpointPort(candidate)
-    ) {
-      return false;
-    }
-    const managedAddresses = resolveEndpointAddresses(managed.hostname);
-    const candidateAddresses = resolveEndpointAddresses(candidate.hostname);
-    return [...managedAddresses].some((address) => candidateAddresses.has(address));
-  } catch {
-    return false;
-  }
-}
-
-function formatSignalEndpointHost(host: string): string {
-  const normalized = normalizeEndpointHostname(host);
-  return normalized.includes(":") ? `[${normalized}]` : normalized;
-}
-
-function listConfiguredManagedSignalEndpoints(cfg: OpenClawConfig): string[] {
-  return listSignalAccountIds(cfg).flatMap((accountId) => {
-    const account = resolveSignalAccount({ cfg, accountId });
-    if (!account.configured || account.transport.kind !== "managed-native") {
-      return [];
-    }
-    return Array.from(
-      new Set([
-        account.transport.baseUrl,
-        `http://${formatSignalEndpointHost(account.transport.httpHost)}:${account.transport.httpPort}`,
-      ]),
-    );
-  });
-}
-
-function aliasesManagedSignalEndpoint(cfg: OpenClawConfig, candidateUrl: string): boolean {
-  return listConfiguredManagedSignalEndpoints(cfg).some((managedUrl) =>
-    matchesManagedSignalEndpoint(managedUrl, candidateUrl),
-  );
 }

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -1,6 +1,3 @@
-import { realpathSync } from "node:fs";
-import { createServer } from "node:net";
-import path from "node:path";
 import {
   WizardCancelledError,
   type ChannelSetupWizard,
@@ -9,15 +6,12 @@ import {
 } from "openclaw/plugin-sdk/setup";
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
-import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import type { SignalTransportConfig } from "./account-types.js";
 import {
   resolveSignalAccount,
   resolveSignalTransport,
   type ResolvedSignalTransport,
 } from "./accounts.js";
-import { spawnSignalDaemon } from "./daemon.js";
 import { installSignalCli } from "./install-signal-cli.js";
 import {
   normalizeSignalAccountInput,
@@ -27,14 +21,17 @@ import {
 import { aliasesManagedSignalEndpoint } from "./setup-endpoint-identity.js";
 import { resolveManagedSignalAccount } from "./setup-managed-account.js";
 import {
+  evaluateLiveManagedTransport,
+  probeManagedSignalSetup,
+  type ManagedSignalTransport,
+  type ResolvedManagedSignalTransport,
+} from "./setup-managed-validation.js";
+import {
   detectSignalTransport,
   prepareSignalManagedNativeTransport,
   probeSignalTransport,
-  resolveConfiguredSignalTransport,
-  type SignalTransportProbeResult,
   writeSignalAccountTransport,
 } from "./setup-transport.js";
-import { buildSignalTransportHttpUrl } from "./transport-url.js";
 
 type SignalSetupMode = "local" | "existing-server";
 type SignalCliConfigLocation = "default" | "custom";
@@ -49,43 +46,6 @@ type ExistingServerPromptParams = {
   prompter: WizardPrompter;
   initialValue?: string;
 };
-type ManagedSignalTransport = Extract<SignalTransportConfig, { kind: "managed-native" }>;
-type ResolvedManagedSignalTransport = Extract<ResolvedSignalTransport, { kind: "managed-native" }>;
-
-function resolveExplicitSignalCliDataDirectory(configPath: string | undefined): string | undefined {
-  const configured = normalizeOptionalString(configPath);
-  if (!configured) {
-    return undefined;
-  }
-  const absolute = path.resolve(resolveUserPath(configured));
-  try {
-    return realpathSync.native(absolute);
-  } catch {
-    return absolute;
-  }
-}
-
-type SignalCliDataDirectoryRelationship = "same" | "different" | "unknown";
-
-function compareSignalCliDataDirectories(
-  active: ResolvedManagedSignalTransport,
-  candidate: ResolvedManagedSignalTransport,
-): SignalCliDataDirectoryRelationship {
-  const activeDirectory = resolveExplicitSignalCliDataDirectory(active.configPath);
-  const candidateDirectory = resolveExplicitSignalCliDataDirectory(candidate.configPath);
-  if (!activeDirectory || !candidateDirectory) {
-    // signal-cli can source its implicit dataDir from system or user config.
-    // Two omitted paths share that resolution; one omitted path cannot be
-    // proven distinct from an explicit store while the daemon owns its lock.
-    return !activeDirectory && !candidateDirectory ? "same" : "unknown";
-  }
-  const same =
-    process.platform === "win32"
-      ? activeDirectory.toLowerCase() === candidateDirectory.toLowerCase()
-      : activeDirectory === candidateDirectory;
-  return same ? "same" : "different";
-}
-
 export async function prepareSignalInteractiveSetup(params: SignalPrepareParams) {
   const resolvedAccount = resolveSignalAccount({
     cfg: params.cfg,
@@ -191,64 +151,98 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
   }
 
   if (transport.kind === "managed-native") {
-    const resolvedTransport = resolveSignalTransport(transport);
+    let resolvedTransport = resolveSignalTransport(transport);
     if (resolvedTransport.kind !== "managed-native") {
       throw new Error("Signal setup did not resolve a managed signal-cli transport.");
     }
     resolvedManagedTransport = resolvedTransport;
-    const configuredTransport = resolveConfiguredSignalTransport(cfg, params.accountId);
-    if (
-      resolvedAccount.transport.kind === "managed-native" &&
-      (account || configuredTransport?.kind === "managed-native")
-    ) {
-      const existingTransport = configuredTransport ?? {
-        kind: "managed-native",
+    let liveTransportState = await evaluateLiveManagedTransport({
+      cfg,
+      accountId: params.accountId,
+      account,
+      activeTransport: resolvedAccount.transport,
+      candidateTransport: resolvedTransport,
+    });
+    if (liveTransportState === "reuse-active-transport") {
+      return {
+        cfg: writeSignalAccountTransport({
+          cfg,
+          accountId: params.accountId,
+          transport,
+        }),
       };
-      const existingProbe = await probeSignalTransport({
-        cfg,
-        accountId: params.accountId,
-        transport: existingTransport,
-        ...(account ? { account } : {}),
-        timeoutMs: 1_000,
-      }).catch((error: unknown) => ({ ok: false, error: String(error) }));
-      if (existingProbe.ok) {
-        const activeManagedTransport = resolvedAccount.transport;
-        if (isSameResolvedManagedTransport(activeManagedTransport, resolvedTransport)) {
-          if (!account) {
-            throw new Error(
-              "The running Signal daemon is using this signal-cli config directory. Stop the OpenClaw gateway before discovering or linking an account, then retry setup.",
-            );
+    }
+    useTemporaryManagedValidationPort = liveTransportState === "validate-different-store";
+    while (true) {
+      try {
+        const resolution = await resolveManagedSignalAccount({
+          transport: resolvedTransport,
+          configuredAccount: account,
+          selectionMode: "reuse-only-account",
+          prompter: params.prompter,
+          beforePersistentEffect: params.options?.beforePersistentEffect,
+          ...(params.options?.abortSignal ? { abortSignal: params.options.abortSignal } : {}),
+          deferDeviceLinkToClient: params.options?.deferDeviceLinkToClient,
+          remoteWizard: params.options?.remoteWizard,
+        });
+        account = resolution.account;
+        managedAccountLinked = resolution.linked;
+        break;
+      } catch (error) {
+        if (error instanceof WizardCancelledError || params.options?.abortSignal?.aborted) {
+          throw error;
+        }
+        await params.prompter.note(
+          error instanceof Error ? error.message : String(error),
+          "Signal account discovery",
+        );
+        const recovery = await params.prompter.select<"retry" | "settings" | "stop">({
+          message: "How should local signal-cli setup continue?",
+          options: [
+            { value: "retry", label: "Retry account discovery" },
+            { value: "settings", label: "Change signal-cli settings" },
+            { value: "stop", label: "Stop Signal setup" },
+          ],
+          initialValue: "settings",
+        });
+        if (recovery === "stop") {
+          throw new WizardCancelledError("Signal setup stopped");
+        }
+        if (recovery === "settings") {
+          transport = await promptManagedSignalCliSettings({
+            cfg,
+            accountId: params.accountId,
+            transport,
+            prompter: params.prompter,
+          });
+          const correctedTransport = resolveSignalTransport(transport);
+          if (correctedTransport.kind !== "managed-native") {
+            throw new Error("Signal setup did not resolve a managed signal-cli transport.", {
+              cause: error,
+            });
           }
-          return {
-            cfg: writeSignalAccountTransport({
-              cfg,
-              accountId: params.accountId,
-              transport,
-            }),
-          };
+          resolvedTransport = correctedTransport;
+          resolvedManagedTransport = correctedTransport;
+          liveTransportState = await evaluateLiveManagedTransport({
+            cfg,
+            accountId: params.accountId,
+            account,
+            activeTransport: resolvedAccount.transport,
+            candidateTransport: correctedTransport,
+          });
+          if (liveTransportState === "reuse-active-transport") {
+            return {
+              cfg: writeSignalAccountTransport({
+                cfg,
+                accountId: params.accountId,
+                transport,
+              }),
+            };
+          }
+          useTemporaryManagedValidationPort = liveTransportState === "validate-different-store";
         }
-        if (
-          compareSignalCliDataDirectories(activeManagedTransport, resolvedTransport) !== "different"
-        ) {
-          throw new Error(
-            "The running Signal daemon may be using this signal-cli config directory. Stop the OpenClaw gateway before changing its signal-cli settings, then retry setup.",
-          );
-        }
-        useTemporaryManagedValidationPort = true;
       }
     }
-    const resolution = await resolveManagedSignalAccount({
-      transport: resolvedTransport,
-      configuredAccount: account,
-      selectionMode: "reuse-only-account",
-      prompter: params.prompter,
-      beforePersistentEffect: params.options?.beforePersistentEffect,
-      ...(params.options?.abortSignal ? { abortSignal: params.options.abortSignal } : {}),
-      deferDeviceLinkToClient: params.options?.deferDeviceLinkToClient,
-      remoteWizard: params.options?.remoteWizard,
-    });
-    account = resolution.account;
-    managedAccountLinked = resolution.linked;
     cfg = patchSignalSetupAccount({
       cfg,
       accountId: params.accountId,
@@ -383,133 +377,6 @@ export async function finalizeSignalInteractiveSetup(params: SignalFinalizeParam
   };
 }
 
-async function probeManagedSignalSetup(params: {
-  cfg: OpenClawConfig;
-  accountId: string;
-  transport: ManagedSignalTransport;
-  resolvedTransport: ResolvedManagedSignalTransport;
-  account: string;
-  runtime: SignalFinalizeParams["runtime"];
-  prompter: WizardPrompter;
-  useTemporaryPort: boolean;
-  abortSignal?: AbortSignal;
-}): Promise<SignalTransportProbeResult> {
-  const progress = params.prompter.progress("Validating Signal setup...");
-  let transport = params.transport;
-  let resolvedTransport = params.resolvedTransport;
-  let daemon: ReturnType<typeof spawnSignalDaemon> | undefined;
-  let successfulProbe: SignalTransportProbeResult | undefined;
-  let result: SignalTransportProbeResult;
-  try {
-    if (params.useTemporaryPort) {
-      const httpPort = await allocateSignalValidationPort(resolvedTransport.httpHost);
-      const baseUrl = buildSignalTransportHttpUrl(resolvedTransport.httpHost, httpPort);
-      transport = { ...transport, httpPort, url: baseUrl };
-      resolvedTransport = { ...resolvedTransport, httpPort, baseUrl };
-    }
-    const spawnedDaemon = spawnSignalDaemon({
-      cliPath: resolvedTransport.cliPath,
-      ...(resolvedTransport.configPath ? { configPath: resolvedTransport.configPath } : {}),
-      account: params.account,
-      httpHost: resolvedTransport.httpHost,
-      httpPort: resolvedTransport.httpPort,
-      // Validation must not drain queued messages before the real monitor installs its handler.
-      receiveMode: "manual",
-      ...(typeof resolvedTransport.ignoreStories === "boolean"
-        ? { ignoreStories: resolvedTransport.ignoreStories }
-        : {}),
-    });
-    daemon = spawnedDaemon;
-    const startupTimeoutMs = Math.min(120_000, Math.max(1_000, resolvedTransport.startupTimeoutMs));
-    await waitForTransportReady({
-      label: "signal-cli setup daemon",
-      timeoutMs: startupTimeoutMs,
-      logAfterMs: 10_000,
-      logIntervalMs: 10_000,
-      pollIntervalMs: 150,
-      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
-      runtime: params.runtime,
-      check: async () => {
-        if (spawnedDaemon.isExited()) {
-          throw new Error("signal-cli exited before its HTTP server became ready.");
-        }
-        const probe = await probeSignalTransport({
-          cfg: params.cfg,
-          accountId: params.accountId,
-          transport,
-          account: params.account,
-          timeoutMs: 1_000,
-        }).catch((error: unknown) => ({ ok: false, error: String(error) }));
-        if (probe.ok) {
-          successfulProbe = probe;
-        }
-        return probe;
-      },
-    });
-    params.abortSignal?.throwIfAborted();
-    result = successfulProbe ?? { ok: false, error: "Signal transport probe failed." };
-  } catch (error) {
-    if (params.abortSignal?.aborted) {
-      throw params.abortSignal.reason;
-    }
-    result = { ok: false, error: String(error) };
-  } finally {
-    await daemon?.stop();
-  }
-  progress.stop(result.ok ? "Signal setup validated." : "Signal setup validation failed.");
-  return result;
-}
-
-async function allocateSignalValidationPort(host: string): Promise<number> {
-  const server = createServer();
-  try {
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen({ host, port: 0, exclusive: true }, resolve);
-    });
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("Could not allocate a temporary Signal validation port.");
-    }
-    return address.port;
-  } finally {
-    if (server.listening) {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
-  }
-}
-
-function isSameResolvedManagedBind(
-  existing: ResolvedSignalTransport,
-  candidate: ResolvedManagedSignalTransport,
-): boolean {
-  return (
-    existing.kind === "managed-native" &&
-    existing.httpHost === candidate.httpHost &&
-    existing.httpPort === candidate.httpPort
-  );
-}
-
-function isSameResolvedManagedTransport(
-  existing: ResolvedSignalTransport,
-  candidate: ResolvedManagedSignalTransport,
-): boolean {
-  if (existing.kind !== "managed-native") {
-    return false;
-  }
-  return (
-    isSameResolvedManagedBind(existing, candidate) &&
-    existing.baseUrl === candidate.baseUrl &&
-    existing.cliPath === candidate.cliPath &&
-    compareSignalCliDataDirectories(existing, candidate) === "same" &&
-    existing.startupTimeoutMs === candidate.startupTimeoutMs &&
-    existing.receiveMode === candidate.receiveMode &&
-    existing.ignoreStories === candidate.ignoreStories
-  );
-}
-
 async function promptSignalAccount(prompter: WizardPrompter) {
   const raw = await prompter.text({
     message: "Signal phone number",
@@ -524,6 +391,56 @@ async function promptSignalAccount(prompter: WizardPrompter) {
     throw new Error("Signal phone number is required.");
   }
   return account;
+}
+
+async function promptManagedSignalCliSettings(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  transport: ManagedSignalTransport;
+  prompter: WizardPrompter;
+}): Promise<ManagedSignalTransport> {
+  const cliPath =
+    normalizeOptionalString(
+      await params.prompter.text({
+        message: "signal-cli path",
+        initialValue: params.transport.cliPath ?? "signal-cli",
+        validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
+      }),
+    ) ?? "signal-cli";
+  const configLocation = await params.prompter.select<SignalCliConfigLocation>({
+    message: "Where should signal-cli store its configuration?",
+    options: [
+      { value: "default", label: "Use the default location" },
+      { value: "custom", label: "Choose a custom directory" },
+    ],
+    initialValue: params.transport.configPath ? "custom" : "default",
+  });
+  const configPath =
+    configLocation === "custom"
+      ? normalizeOptionalString(
+          await params.prompter.text({
+            message: "signal-cli config directory",
+            initialValue: params.transport.configPath,
+            placeholder: "~/.local/share/signal-cli",
+            validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
+          }),
+        )
+      : undefined;
+  const { kind: _kind, configPath: _configPath, ...currentOptions } = params.transport;
+  const prepared = prepareSignalManagedNativeTransport({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    overrides: {
+      ...currentOptions,
+      cliPath,
+      ...(configPath ? { configPath } : { configPath: "" }),
+    },
+  });
+  if (configPath) {
+    return prepared;
+  }
+  const { configPath: _clearedConfigPath, ...defaultConfigTransport } = prepared;
+  return defaultConfigTransport;
 }
 
 async function installRequestedSignalCli(params: SignalFinalizeParams, initialCliPath: string) {

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -37,6 +37,7 @@ import {
 import { buildSignalTransportHttpUrl } from "./transport-url.js";
 
 type SignalSetupMode = "local" | "existing-server";
+type SignalCliConfigLocation = "default" | "custom";
 type SignalPrepareParams = Parameters<NonNullable<ChannelSetupWizard["prepare"]>>[0];
 type SignalFinalizeParams = Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0];
 type SignalExistingTransport = Extract<
@@ -584,14 +585,25 @@ async function prepareManagedNativeSetup(
 
   const existingConfigPath =
     resolvedTransport.kind === "managed-native" ? resolvedTransport.configPath : undefined;
-  const configPathAnswer = normalizeOptionalString(
-    await params.prompter.text({
-      message: "signal-cli config directory (type `default` for the standard location)",
-      initialValue: existingConfigPath,
-      placeholder: "~/.local/share/signal-cli",
-    }),
-  );
-  const configPath = configPathAnswer?.toLowerCase() === "default" ? undefined : configPathAnswer;
+  const configLocation = await params.prompter.select<SignalCliConfigLocation>({
+    message: "Where should signal-cli store its configuration?",
+    options: [
+      { value: "default", label: "Use the default location" },
+      { value: "custom", label: "Choose a custom directory" },
+    ],
+    initialValue: existingConfigPath ? "custom" : "default",
+  });
+  const configPath =
+    configLocation === "custom"
+      ? normalizeOptionalString(
+          await params.prompter.text({
+            message: "signal-cli config directory",
+            initialValue: existingConfigPath,
+            placeholder: "~/.local/share/signal-cli",
+            validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
+          }),
+        )
+      : undefined;
 
   // Validate account-owned port allocation now, while keeping the candidate ephemeral until probe.
   prepareSignalManagedNativeTransport({

--- a/extensions/signal/src/setup-interactive.ts
+++ b/extensions/signal/src/setup-interactive.ts
@@ -584,13 +584,14 @@ async function prepareManagedNativeSetup(
 
   const existingConfigPath =
     resolvedTransport.kind === "managed-native" ? resolvedTransport.configPath : undefined;
-  const configPath = normalizeOptionalString(
+  const configPathAnswer = normalizeOptionalString(
     await params.prompter.text({
-      message: "signal-cli config directory (leave blank for default)",
+      message: "signal-cli config directory (type `default` for the standard location)",
       initialValue: existingConfigPath,
       placeholder: "~/.local/share/signal-cli",
     }),
   );
+  const configPath = configPathAnswer?.toLowerCase() === "default" ? undefined : configPathAnswer;
 
   // Validate account-owned port allocation now, while keeping the candidate ephemeral until probe.
   prepareSignalManagedNativeTransport({

--- a/extensions/signal/src/setup-managed-account.test.ts
+++ b/extensions/signal/src/setup-managed-account.test.ts
@@ -1,0 +1,230 @@
+import os from "node:os";
+import path from "node:path";
+import { createQueuedWizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  linkSignalCliAccount: vi.fn(
+    async (params: {
+      abortSignal?: AbortSignal;
+      onLinkUri: (uri: string, completion: Promise<{ ok: boolean }>) => Promise<void>;
+    }) => {
+      await params.onLinkUri(
+        "sgnl://linkdevice?uuid=test&pub_key=test",
+        Promise.resolve({ ok: true }),
+      );
+      return { ok: true as const, associatedAccount: "+15555550123" };
+    },
+  ),
+  renderQrPngBase64: vi.fn(async () => "c2lnbmFsLXFy"),
+  renderQrTerminal: vi.fn(async () => "terminal QR"),
+  runPluginCommandWithTimeout: vi
+    .fn()
+    .mockResolvedValueOnce({ code: 0, stdout: "[]", stderr: "" })
+    .mockResolvedValueOnce({
+      code: 0,
+      stdout: '[{"number":"+15555550123"}]',
+      stderr: "",
+    }),
+}));
+
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  renderQrPngBase64: mocks.renderQrPngBase64,
+  renderQrTerminal: mocks.renderQrTerminal,
+}));
+
+vi.mock("openclaw/plugin-sdk/run-command", () => ({
+  runPluginCommandWithTimeout: mocks.runPluginCommandWithTimeout,
+}));
+
+vi.mock("./signal-cli-link.js", () => ({
+  linkSignalCliAccount: mocks.linkSignalCliAccount,
+}));
+
+import { resolveManagedSignalAccount } from "./setup-managed-account.js";
+
+describe("resolveManagedSignalAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runPluginCommandWithTimeout
+      .mockReset()
+      .mockResolvedValueOnce({ code: 0, stdout: "[]", stderr: "" })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '[{"number":"+15555550123"}]',
+        stderr: "",
+      });
+  });
+
+  it("uses a PNG QR image when the wizard client supports it", async () => {
+    const queued = createQueuedWizardPrompter({ selectValues: ["link"] });
+    const abortController = new AbortController();
+    const effectOrder: string[] = [];
+    const qrCode = vi.fn(async () => {
+      effectOrder.push("confirmed");
+      return true;
+    });
+    const beforePersistentEffect = vi.fn(async () => {
+      effectOrder.push("locked");
+    });
+
+    await expect(
+      resolveManagedSignalAccount({
+        transport: {
+          kind: "managed-native",
+          baseUrl: "http://127.0.0.1:8080",
+          cliPath: "/opt/openclaw/signal-cli",
+          configPath: "~/.local/share/signal-cli",
+          httpHost: "127.0.0.1",
+          httpPort: 8080,
+          startupTimeoutMs: 30_000,
+        },
+        selectionMode: "choose",
+        prompter: { ...queued.prompter, qrCode },
+        beforePersistentEffect,
+        abortSignal: abortController.signal,
+      }),
+    ).resolves.toEqual({ account: "+15555550123", linked: true });
+
+    expect(mocks.renderQrPngBase64).toHaveBeenCalledWith(
+      "sgnl://linkdevice?uuid=test&pub_key=test",
+    );
+    expect(mocks.runPluginCommandWithTimeout).toHaveBeenNthCalledWith(1, {
+      argv: [
+        "/opt/openclaw/signal-cli",
+        "--config",
+        path.join(os.homedir(), ".local/share/signal-cli"),
+        "--output",
+        "json",
+        "listAccounts",
+      ],
+      timeoutMs: 10_000,
+    });
+    expect(qrCode).toHaveBeenCalledWith({
+      title: "Signal account linking",
+      message: expect.stringContaining("Signal > Settings > Linked devices"),
+      pngBase64: "c2lnbmFsLXFy",
+      dismissWhen: expect.any(Promise),
+    });
+    expect(effectOrder).toEqual(["locked", "confirmed"]);
+    expect(mocks.linkSignalCliAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    );
+    expect(mocks.renderQrTerminal).not.toHaveBeenCalled();
+  });
+
+  it("lets a configured account switch to another linked local account", async () => {
+    mocks.runPluginCommandWithTimeout.mockReset().mockResolvedValue({
+      code: 0,
+      stdout: '[{"number":"+15555550123"},{"number":"+15555550124"}]',
+      stderr: "",
+    });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["account:+15555550123"],
+    });
+
+    await expect(
+      resolveManagedSignalAccount({
+        transport: {
+          kind: "managed-native",
+          baseUrl: "http://127.0.0.1:8080",
+          cliPath: "/opt/openclaw/signal-cli",
+          configPath: "/var/lib/signal-cli",
+          httpHost: "127.0.0.1",
+          httpPort: 8080,
+          startupTimeoutMs: 30_000,
+        },
+        configuredAccount: "+15555550124",
+        selectionMode: "reuse-only-account",
+        prompter: queued.prompter,
+      }),
+    ).resolves.toEqual({ account: "+15555550123", linked: true });
+
+    expect(queued.select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Choose the linked Signal account for OpenClaw",
+        initialValue: "account:+15555550124",
+      }),
+    );
+  });
+
+  it("stops after a declined remote linking QR", async () => {
+    const queued = createQueuedWizardPrompter({ selectValues: ["link"] });
+    const effectOrder: string[] = [];
+    const beforePersistentEffect = vi.fn(async () => {
+      effectOrder.push("locked");
+    });
+
+    await expect(
+      resolveManagedSignalAccount({
+        transport: {
+          kind: "managed-native",
+          baseUrl: "http://127.0.0.1:8080",
+          cliPath: "/opt/openclaw/signal-cli",
+          configPath: "/var/lib/signal-cli",
+          httpHost: "127.0.0.1",
+          httpPort: 8080,
+          startupTimeoutMs: 30_000,
+        },
+        selectionMode: "choose",
+        prompter: {
+          ...queued.prompter,
+          qrCode: async () => {
+            effectOrder.push("shown");
+            return false;
+          },
+        },
+        beforePersistentEffect,
+      }),
+    ).rejects.toThrow("Signal account linking was not confirmed");
+
+    expect(effectOrder).toEqual(["locked", "shown"]);
+  });
+
+  it("continues when signal-cli finishes before the user acknowledges the QR", async () => {
+    const queued = createQueuedWizardPrompter({ selectValues: ["link"] });
+    const qrCode = vi.fn(async () => await new Promise<boolean>(() => {}));
+
+    await expect(
+      resolveManagedSignalAccount({
+        transport: {
+          kind: "managed-native",
+          baseUrl: "http://127.0.0.1:8080",
+          cliPath: "/opt/openclaw/signal-cli",
+          configPath: "/var/lib/signal-cli",
+          httpHost: "127.0.0.1",
+          httpPort: 8080,
+          startupTimeoutMs: 30_000,
+        },
+        selectionMode: "choose",
+        prompter: { ...queued.prompter, qrCode },
+      }),
+    ).resolves.toEqual({ account: "+15555550123", linked: true });
+
+    expect(qrCode).toHaveBeenCalledOnce();
+  });
+
+  it("stops a remote wizard before starting a link it cannot display", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    await expect(
+      resolveManagedSignalAccount({
+        transport: {
+          kind: "managed-native",
+          baseUrl: "http://127.0.0.1:8080",
+          cliPath: "/opt/openclaw/signal-cli",
+          configPath: "/var/lib/signal-cli",
+          httpHost: "127.0.0.1",
+          httpPort: 8080,
+          startupTimeoutMs: 30_000,
+        },
+        selectionMode: "choose",
+        prompter: queued.prompter,
+        remoteWizard: true,
+      }),
+    ).rejects.toThrow("cannot display the Signal linking QR code");
+
+    expect(mocks.linkSignalCliAccount).not.toHaveBeenCalled();
+    expect(queued.note).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/signal/src/setup-managed-account.test.ts
+++ b/extensions/signal/src/setup-managed-account.test.ts
@@ -181,26 +181,76 @@ describe("resolveManagedSignalAccount", () => {
     expect(effectOrder).toEqual(["locked", "shown"]);
   });
 
-  it("continues when signal-cli finishes before the user acknowledges the QR", async () => {
+  it("does not finish linking when the user continues before signal-cli completes", async () => {
+    let complete!: (result: { ok: boolean }) => void;
+    const completion = new Promise<{ ok: boolean }>((resolve) => {
+      complete = resolve;
+    });
+    mocks.linkSignalCliAccount.mockImplementationOnce(async (params) => {
+      await params.onLinkUri("sgnl://linkdevice?uuid=test&pub_key=test", completion);
+      return { ok: true as const, associatedAccount: "+15555550123" };
+    });
     const queued = createQueuedWizardPrompter({ selectValues: ["link"] });
-    const qrCode = vi.fn(async () => await new Promise<boolean>(() => {}));
+    const qrCode = vi.fn(async () => true);
 
-    await expect(
-      resolveManagedSignalAccount({
-        transport: {
-          kind: "managed-native",
-          baseUrl: "http://127.0.0.1:8080",
-          cliPath: "/opt/openclaw/signal-cli",
-          configPath: "/var/lib/signal-cli",
-          httpHost: "127.0.0.1",
-          httpPort: 8080,
-          startupTimeoutMs: 30_000,
-        },
-        selectionMode: "choose",
-        prompter: { ...queued.prompter, qrCode },
-      }),
-    ).resolves.toEqual({ account: "+15555550123", linked: true });
+    const resolution = resolveManagedSignalAccount({
+      transport: {
+        kind: "managed-native",
+        baseUrl: "http://127.0.0.1:8080",
+        cliPath: "/opt/openclaw/signal-cli",
+        configPath: "/var/lib/signal-cli",
+        httpHost: "127.0.0.1",
+        httpPort: 8080,
+        startupTimeoutMs: 30_000,
+      },
+      selectionMode: "choose",
+      prompter: { ...queued.prompter, qrCode },
+    });
+    let resolved = false;
+    void resolution.then(() => {
+      resolved = true;
+    });
 
+    await vi.waitFor(() => expect(qrCode).toHaveBeenCalledOnce());
+    await Promise.resolve();
+    const resolvedBeforeCompletion = resolved;
+    complete({ ok: true });
+
+    await expect(resolution).resolves.toEqual({ account: "+15555550123", linked: true });
+    expect(resolvedBeforeCompletion).toBe(false);
+  });
+
+  it("waits for user acknowledgement after signal-cli finishes", async () => {
+    const queued = createQueuedWizardPrompter({ selectValues: ["link"] });
+    let confirm!: (confirmed: boolean) => void;
+    const confirmation = new Promise<boolean>((resolve) => {
+      confirm = resolve;
+    });
+    const qrCode = vi.fn(async () => await confirmation);
+
+    const resolution = resolveManagedSignalAccount({
+      transport: {
+        kind: "managed-native",
+        baseUrl: "http://127.0.0.1:8080",
+        cliPath: "/opt/openclaw/signal-cli",
+        configPath: "/var/lib/signal-cli",
+        httpHost: "127.0.0.1",
+        httpPort: 8080,
+        startupTimeoutMs: 30_000,
+      },
+      selectionMode: "choose",
+      prompter: { ...queued.prompter, qrCode },
+    });
+    let resolved = false;
+    void resolution.then(() => {
+      resolved = true;
+    });
+
+    await vi.waitFor(() => expect(qrCode).toHaveBeenCalledOnce());
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    confirm(true);
+    await expect(resolution).resolves.toEqual({ account: "+15555550123", linked: true });
     expect(qrCode).toHaveBeenCalledOnce();
   });
 

--- a/extensions/signal/src/setup-managed-account.ts
+++ b/extensions/signal/src/setup-managed-account.ts
@@ -1,10 +1,10 @@
-import { renderQrTerminal } from "openclaw/plugin-sdk/media-runtime";
 import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
 import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ResolvedSignalTransport } from "./accounts.js";
 import { normalizeSignalAccountInput } from "./setup-core.js";
 import { linkSignalCliAccount } from "./signal-cli-link.js";
+import { renderSignalLinkQr } from "./signal-link-qr.js";
 
 type ResolvedManagedSignalTransport = Extract<ResolvedSignalTransport, { kind: "managed-native" }>;
 type ManagedSignalAccountChoice = "link" | "stop" | `account:${string}`;
@@ -96,9 +96,7 @@ async function linkManagedSignalAccount(params: {
       cliPath: params.transport.cliPath,
       ...(params.transport.configPath ? { configPath: params.transport.configPath } : {}),
       onLinkUri: async (uri) => {
-        // The compact renderer uses foreground black, which some embedded terminals remap.
-        // Full mode uses background colors only, keeping the Signal QR code scannable.
-        const qr = await renderQrTerminal(uri);
+        const qr = await renderSignalLinkQr(uri);
         await params.prompter.plain?.(
           [
             "On your phone, open Signal > Settings > Linked devices and add a device.",

--- a/extensions/signal/src/setup-managed-account.ts
+++ b/extensions/signal/src/setup-managed-account.ts
@@ -96,7 +96,9 @@ async function linkManagedSignalAccount(params: {
       cliPath: params.transport.cliPath,
       ...(params.transport.configPath ? { configPath: params.transport.configPath } : {}),
       onLinkUri: async (uri) => {
-        const qr = await renderQrTerminal(uri, { small: true });
+        // The compact renderer uses foreground black, which some embedded terminals remap.
+        // Full mode uses background colors only, keeping the Signal QR code scannable.
+        const qr = await renderQrTerminal(uri);
         await params.prompter.plain?.(
           [
             "On your phone, open Signal > Settings > Linked devices and add a device.",

--- a/extensions/signal/src/setup-managed-account.ts
+++ b/extensions/signal/src/setup-managed-account.ts
@@ -1,0 +1,208 @@
+import { renderQrTerminal } from "openclaw/plugin-sdk/media-runtime";
+import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
+import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
+import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
+import type { ResolvedSignalTransport } from "./accounts.js";
+import { normalizeSignalAccountInput } from "./setup-core.js";
+import { linkSignalCliAccount } from "./signal-cli-link.js";
+
+type ResolvedManagedSignalTransport = Extract<ResolvedSignalTransport, { kind: "managed-native" }>;
+type ManagedSignalAccountChoice = "link" | "stop" | `account:${string}`;
+type ManagedSignalAccountSelectionMode = "reuse-configured-or-only" | "choose";
+
+const SIGNAL_CLI_ACCOUNT_CHECK_TIMEOUT_MS = 10_000;
+
+export async function resolveManagedSignalAccount(params: {
+  transport: ResolvedManagedSignalTransport;
+  configuredAccount?: string;
+  selectionMode: ManagedSignalAccountSelectionMode;
+  prompter: WizardPrompter;
+  beforePersistentEffect?: () => Promise<void>;
+}): Promise<string> {
+  const listed = await listSignalCliAccounts(params.transport);
+  if (!listed.ok) {
+    throw new Error(listed.error);
+  }
+  if (params.configuredAccount && listed.accounts.has(params.configuredAccount)) {
+    return params.configuredAccount;
+  }
+  if (
+    params.selectionMode === "reuse-configured-or-only" &&
+    !params.configuredAccount &&
+    listed.accounts.size === 1
+  ) {
+    const account = listed.accounts.values().next().value;
+    if (account) {
+      return account;
+    }
+  }
+
+  const choice = await promptManagedSignalAccountChoice({
+    accounts: listed.accounts,
+    prompter: params.prompter,
+  });
+  if (choice === "stop") {
+    throw new WizardCancelledError("Signal setup stopped");
+  }
+  if (choice.startsWith("account:")) {
+    return choice.slice("account:".length);
+  }
+  return await linkManagedSignalAccount({
+    transport: params.transport,
+    accountsBeforeLink: listed.accounts,
+    prompter: params.prompter,
+    beforePersistentEffect: params.beforePersistentEffect,
+  });
+}
+
+async function promptManagedSignalAccountChoice(params: {
+  accounts: Set<string>;
+  prompter: WizardPrompter;
+}): Promise<ManagedSignalAccountChoice> {
+  const accounts = [...params.accounts];
+  if (accounts.length === 0) {
+    return await params.prompter.select<"link" | "stop">({
+      message: "No linked Signal account was found. How should setup continue?",
+      options: [
+        { value: "link", label: "Link a Signal account now" },
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "link",
+    });
+  }
+  return await params.prompter.select<ManagedSignalAccountChoice>({
+    message: "Choose the linked Signal account for OpenClaw",
+    options: [
+      ...accounts.map((account) => ({
+        value: `account:${account}` as const,
+        label: account,
+      })),
+      { value: "link", label: "Link another Signal account" },
+    ],
+    initialValue: `account:${accounts[0]}`,
+  });
+}
+
+async function linkManagedSignalAccount(params: {
+  transport: ResolvedManagedSignalTransport;
+  accountsBeforeLink: Set<string>;
+  prompter: WizardPrompter;
+  beforePersistentEffect?: () => Promise<void>;
+}): Promise<string> {
+  let associatedAccountFromLink: string | undefined;
+  while (true) {
+    await params.beforePersistentEffect?.();
+    const link = await linkSignalCliAccount({
+      cliPath: params.transport.cliPath,
+      ...(params.transport.configPath ? { configPath: params.transport.configPath } : {}),
+      onLinkUri: async (uri) => {
+        const qr = await renderQrTerminal(uri, { small: true });
+        await params.prompter.plain?.(
+          [
+            "On your phone, open Signal > Settings > Linked devices and add a device.",
+            "Scan this QR code:",
+            "OpenClaw will continue automatically after Signal approves the linked device.",
+            "",
+            qr,
+          ].join("\n"),
+        );
+      },
+    });
+    if (link.ok) {
+      associatedAccountFromLink = link.associatedAccount;
+      break;
+    }
+    await params.prompter.note(
+      `signal-cli could not link this device.\n\n${link.error}`,
+      "Signal account linking",
+    );
+    const recovery = await params.prompter.select<"retry" | "stop">({
+      message: "How should Signal account linking continue?",
+      options: [
+        { value: "retry", label: "Retry account linking" },
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "retry",
+    });
+    if (recovery === "stop") {
+      throw new WizardCancelledError("Signal setup stopped");
+    }
+  }
+
+  const listed = await listSignalCliAccounts(params.transport);
+  if (!listed.ok) {
+    throw new Error(listed.error);
+  }
+  const associatedAccount = normalizeSignalAccountInput(associatedAccountFromLink);
+  if (associatedAccount && listed.accounts.has(associatedAccount)) {
+    return associatedAccount;
+  }
+  const newAccounts = [...listed.accounts].filter(
+    (account) => !params.accountsBeforeLink.has(account),
+  );
+  if (newAccounts.length === 1 && newAccounts[0]) {
+    return newAccounts[0];
+  }
+  throw new Error("signal-cli linked a device, but OpenClaw could not identify its account.");
+}
+
+async function listSignalCliAccounts(
+  transport: ResolvedManagedSignalTransport,
+): Promise<{ ok: true; accounts: Set<string> } | { ok: false; error: string }> {
+  const configPath = transport.configPath?.trim();
+  const result = await runPluginCommandWithTimeout({
+    argv: [
+      transport.cliPath,
+      ...(configPath ? ["--config", resolveUserPath(configPath)] : []),
+      "--output",
+      "json",
+      "listAccounts",
+    ],
+    timeoutMs: SIGNAL_CLI_ACCOUNT_CHECK_TIMEOUT_MS,
+  });
+  if (result.code !== 0) {
+    return {
+      ok: false,
+      error:
+        `signal-cli could not list its linked accounts (exit ${result.code}). ` +
+        "Check the signal-cli path and config path, then retry.",
+    };
+  }
+
+  const linkedAccounts = parseSignalCliAccounts(result.stdout);
+  if (!linkedAccounts) {
+    return {
+      ok: false,
+      error:
+        "signal-cli returned an unexpected account list. Check the signal-cli version and config path, then retry.",
+    };
+  }
+  return { ok: true, accounts: linkedAccounts };
+}
+
+function parseSignalCliAccounts(stdout: string): Set<string> | undefined {
+  try {
+    const value: unknown = JSON.parse(stdout);
+    if (!Array.isArray(value)) {
+      return undefined;
+    }
+    const accounts = new Set<string>();
+    for (const entry of value) {
+      if (
+        typeof entry !== "object" ||
+        entry === null ||
+        !("number" in entry) ||
+        typeof entry.number !== "string"
+      ) {
+        return undefined;
+      }
+      const account = normalizeSignalAccountInput(entry.number);
+      if (account) {
+        accounts.add(account);
+      }
+    }
+    return accounts;
+  } catch {
+    return undefined;
+  }
+}

--- a/extensions/signal/src/setup-managed-account.ts
+++ b/extensions/signal/src/setup-managed-account.ts
@@ -1,14 +1,19 @@
+import { renderQrPngBase64 } from "openclaw/plugin-sdk/media-runtime";
 import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
-import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ResolvedSignalTransport } from "./accounts.js";
 import { normalizeSignalAccountInput } from "./setup-core.js";
+import { resolveSignalCliConfigPath } from "./signal-cli-config-path.js";
 import { linkSignalCliAccount } from "./signal-cli-link.js";
 import { renderSignalLinkQr } from "./signal-link-qr.js";
 
 type ResolvedManagedSignalTransport = Extract<ResolvedSignalTransport, { kind: "managed-native" }>;
 type ManagedSignalAccountChoice = "link" | "stop" | `account:${string}`;
-type ManagedSignalAccountSelectionMode = "reuse-configured-or-only" | "choose";
+type ManagedSignalAccountSelectionMode = "reuse-only-account" | "choose";
+export type ManagedSignalAccountResolution = {
+  account: string;
+  linked: boolean;
+};
 
 const SIGNAL_CLI_ACCOUNT_CHECK_TIMEOUT_MS = 10_000;
 
@@ -18,49 +23,97 @@ export async function resolveManagedSignalAccount(params: {
   selectionMode: ManagedSignalAccountSelectionMode;
   prompter: WizardPrompter;
   beforePersistentEffect?: () => Promise<void>;
-}): Promise<string> {
+  abortSignal?: AbortSignal;
+  deferDeviceLinkToClient?: boolean;
+  remoteWizard?: boolean;
+}): Promise<ManagedSignalAccountResolution> {
   const listed = await listSignalCliAccounts(params.transport);
   if (!listed.ok) {
     throw new Error(listed.error);
   }
-  if (params.configuredAccount && listed.accounts.has(params.configuredAccount)) {
-    return params.configuredAccount;
-  }
-  if (
-    params.selectionMode === "reuse-configured-or-only" &&
-    !params.configuredAccount &&
-    listed.accounts.size === 1
-  ) {
+  if (params.selectionMode === "reuse-only-account" && listed.accounts.size === 1) {
     const account = listed.accounts.values().next().value;
-    if (account) {
-      return account;
+    if (account && (!params.configuredAccount || account === params.configuredAccount)) {
+      return { account, linked: true };
     }
+  }
+  if (listed.accounts.size === 0 && params.deferDeviceLinkToClient) {
+    return {
+      account: await promptDeferredSignalAccount(params.prompter, params.configuredAccount),
+      linked: false,
+    };
+  }
+  if (listed.accounts.size === 0 && params.remoteWizard && !params.prompter.qrCode) {
+    throw new Error(
+      "This setup client cannot display the Signal linking QR code. Update OpenClaw and retry, or run `openclaw configure --section channels` in a terminal.",
+    );
   }
 
   const choice = await promptManagedSignalAccountChoice({
     accounts: listed.accounts,
+    configuredAccount: params.configuredAccount,
     prompter: params.prompter,
+    allowLink:
+      !params.deferDeviceLinkToClient && (!params.remoteWizard || Boolean(params.prompter.qrCode)),
   });
   if (choice === "stop") {
     throw new WizardCancelledError("Signal setup stopped");
   }
   if (choice.startsWith("account:")) {
-    return choice.slice("account:".length);
+    return { account: choice.slice("account:".length), linked: true };
   }
-  return await linkManagedSignalAccount({
-    transport: params.transport,
-    accountsBeforeLink: listed.accounts,
-    prompter: params.prompter,
-    beforePersistentEffect: params.beforePersistentEffect,
+  return {
+    account: await linkManagedSignalAccount({
+      transport: params.transport,
+      accountsBeforeLink: listed.accounts,
+      prompter: params.prompter,
+      beforePersistentEffect: params.beforePersistentEffect,
+      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+    }),
+    linked: true,
+  };
+}
+
+async function promptDeferredSignalAccount(
+  prompter: WizardPrompter,
+  configuredAccount?: string,
+): Promise<string> {
+  await prompter.note(
+    [
+      "This setup screen can save the Signal configuration, but it cannot link a Signal device.",
+      "After this wizard finishes, run `openclaw configure --section channels` in a terminal to link the account.",
+    ].join("\n"),
+    "Signal account linking",
+  );
+  const input = await prompter.text({
+    message: "Signal account number (E.164)",
+    ...(configuredAccount ? { initialValue: configuredAccount } : {}),
+    placeholder: "+15555550123",
+    validate: (candidate) =>
+      normalizeSignalAccountInput(candidate)
+        ? undefined
+        : "Enter a valid E.164 phone number, for example +15555550123.",
   });
+  const account = normalizeSignalAccountInput(input);
+  if (!account) {
+    throw new Error("Signal setup requires a valid E.164 account number.");
+  }
+  return account;
 }
 
 async function promptManagedSignalAccountChoice(params: {
   accounts: Set<string>;
+  configuredAccount?: string;
   prompter: WizardPrompter;
+  allowLink: boolean;
 }): Promise<ManagedSignalAccountChoice> {
-  const accounts = [...params.accounts];
+  const accounts = [...params.accounts].toSorted();
   if (accounts.length === 0) {
+    if (!params.allowLink) {
+      throw new Error(
+        "No linked Signal account was found. Link one from a terminal with `openclaw configure --section channels`, then retry.",
+      );
+    }
     return await params.prompter.select<"link" | "stop">({
       message: "No linked Signal account was found. How should setup continue?",
       options: [
@@ -77,9 +130,15 @@ async function promptManagedSignalAccountChoice(params: {
         value: `account:${account}` as const,
         label: account,
       })),
-      { value: "link", label: "Link another Signal account" },
+      ...(params.allowLink
+        ? [{ value: "link" as const, label: "Link another Signal account" }]
+        : []),
     ],
-    initialValue: `account:${accounts[0]}`,
+    initialValue: `account:${
+      params.configuredAccount && params.accounts.has(params.configuredAccount)
+        ? params.configuredAccount
+        : accounts[0]
+    }`,
   });
 }
 
@@ -88,24 +147,56 @@ async function linkManagedSignalAccount(params: {
   accountsBeforeLink: Set<string>;
   prompter: WizardPrompter;
   beforePersistentEffect?: () => Promise<void>;
+  abortSignal?: AbortSignal;
 }): Promise<string> {
   let associatedAccountFromLink: string | undefined;
   while (true) {
-    await params.beforePersistentEffect?.();
+    if (!params.prompter.qrCode) {
+      await params.beforePersistentEffect?.();
+    }
     const link = await linkSignalCliAccount({
       cliPath: params.transport.cliPath,
       ...(params.transport.configPath ? { configPath: params.transport.configPath } : {}),
-      onLinkUri: async (uri) => {
+      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+      onLinkUri: async (uri, completion) => {
+        const instructions =
+          "On your phone, open Signal > Settings > Linked devices and add a device.";
+        if (params.prompter.qrCode) {
+          // Signal may persist the linked device as soon as the phone approves
+          // this QR, so cancellation must lock before the code becomes visible.
+          await params.beforePersistentEffect?.();
+          const outcome = await Promise.race([
+            params.prompter
+              .qrCode({
+                title: "Signal account linking",
+                message: [
+                  instructions,
+                  "Scan this QR code, approve the linked device in Signal, then choose Continue.",
+                ].join("\n"),
+                pngBase64: await renderQrPngBase64(uri),
+                dismissWhen: completion,
+              })
+              .then((confirmed) => ({ source: "user" as const, confirmed })),
+            completion.then((result) => ({ source: "signal-cli" as const, ...result })),
+          ]);
+          if (outcome.source === "user" && !outcome.confirmed) {
+            throw new Error("Signal account linking was not confirmed.");
+          }
+          return;
+        }
         const qr = await renderSignalLinkQr(uri);
-        await params.prompter.plain?.(
-          [
-            "On your phone, open Signal > Settings > Linked devices and add a device.",
-            "Scan this QR code:",
-            "OpenClaw will continue automatically after Signal approves the linked device.",
-            "",
-            qr,
-          ].join("\n"),
-        );
+        const message = [
+          instructions,
+          "Scan this QR code:",
+          "OpenClaw will continue automatically after Signal approves the linked device.",
+          "",
+          qr,
+        ].join("\n");
+        if (params.prompter.plain) {
+          await params.prompter.plain(message);
+        } else {
+          await params.prompter.note(message, "Signal account linking");
+        }
       },
     });
     if (link.ok) {
@@ -153,7 +244,7 @@ async function listSignalCliAccounts(
   const result = await runPluginCommandWithTimeout({
     argv: [
       transport.cliPath,
-      ...(configPath ? ["--config", resolveUserPath(configPath)] : []),
+      ...(configPath ? ["--config", resolveSignalCliConfigPath(configPath)] : []),
       "--output",
       "json",
       "listAccounts",

--- a/extensions/signal/src/setup-managed-account.ts
+++ b/extensions/signal/src/setup-managed-account.ts
@@ -165,23 +165,19 @@ async function linkManagedSignalAccount(params: {
           // Signal may persist the linked device as soon as the phone approves
           // this QR, so cancellation must lock before the code becomes visible.
           await params.beforePersistentEffect?.();
-          const outcome = await Promise.race([
-            params.prompter
-              .qrCode({
-                title: "Signal account linking",
-                message: [
-                  instructions,
-                  "Scan this QR code, approve the linked device in Signal, then choose Continue.",
-                ].join("\n"),
-                pngBase64: await renderQrPngBase64(uri),
-                dismissWhen: completion,
-              })
-              .then((confirmed) => ({ source: "user" as const, confirmed })),
-            completion.then((result) => ({ source: "signal-cli" as const, ...result })),
-          ]);
-          if (outcome.source === "user" && !outcome.confirmed) {
+          const confirmed = await params.prompter.qrCode({
+            title: "Signal account linking",
+            message: [
+              instructions,
+              "Scan this QR code, approve the linked device in Signal, then choose Continue.",
+            ].join("\n"),
+            pngBase64: await renderQrPngBase64(uri),
+            dismissWhen: completion,
+          });
+          if (!confirmed) {
             throw new Error("Signal account linking was not confirmed.");
           }
+          await completion;
           return;
         }
         const qr = await renderSignalLinkQr(uri);

--- a/extensions/signal/src/setup-managed-validation.test.ts
+++ b/extensions/signal/src/setup-managed-validation.test.ts
@@ -1,0 +1,360 @@
+import os from "node:os";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createQueuedWizardPrompter,
+  createRuntimeEnv,
+  runSetupWizardFinalize,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SignalTransportConfig } from "./account-types.js";
+import { resolveSignalAccount } from "./accounts.js";
+import type { SignalDaemonHandle } from "./daemon.js";
+import {
+  configuredManagedSignalConfig,
+  managedSignalCredentialValues,
+} from "./setup-surface.test-fixtures.js";
+import type { SignalTransportProbeResult } from "./setup-transport.js";
+
+type SpawnSignalDaemonParams = Parameters<typeof import("./daemon.js").spawnSignalDaemon>[0];
+
+const mocks = vi.hoisted(() => ({
+  runPluginCommandWithTimeout: vi.fn(async () => ({
+    code: 0,
+    stdout: '[{"number":"+15555550123"}]',
+    stderr: "",
+  })),
+  spawnSignalDaemon: vi.fn(
+    (_params: SpawnSignalDaemonParams): SignalDaemonHandle => ({
+      pid: 1234,
+      stop: vi.fn(async () => undefined),
+      exited: new Promise<never>(() => {}),
+      isExited: () => false,
+    }),
+  ),
+  assertSignalDaemonBindAvailable: vi.fn(async () => undefined),
+  prepareSignalManagedNativeTransport: vi.fn(
+    (): Extract<SignalTransportConfig, { kind: "managed-native" }> => ({
+      kind: "managed-native",
+      cliPath: "/opt/openclaw/signal-cli",
+      configPath: "/var/lib/signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    }),
+  ),
+  probeSignalTransport: vi.fn(
+    async (): Promise<SignalTransportProbeResult> => ({ ok: true, status: 200 }),
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/run-command", () => ({
+  runPluginCommandWithTimeout: mocks.runPluginCommandWithTimeout,
+}));
+
+vi.mock("./daemon.js", () => ({
+  assertSignalDaemonBindAvailable: mocks.assertSignalDaemonBindAvailable,
+  spawnSignalDaemon: mocks.spawnSignalDaemon,
+}));
+
+vi.mock("./setup-transport.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./setup-transport.js")>("./setup-transport.js");
+  return {
+    ...actual,
+    prepareSignalManagedNativeTransport: mocks.prepareSignalManagedNativeTransport,
+    probeSignalTransport: mocks.probeSignalTransport,
+  };
+});
+
+import { signalSetupWizard } from "./setup-surface.js";
+
+describe("managed Signal validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.probeSignalTransport.mockReset().mockResolvedValue({ ok: true, status: 200 });
+    mocks.assertSignalDaemonBindAvailable.mockReset().mockResolvedValue(undefined);
+    mocks.runPluginCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: '[{"number":"+15555550123"}]',
+      stderr: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("probes an unchanged running managed daemon without starting a competing process", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: configuredManagedSignalConfig(),
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(queued.progress).not.toHaveBeenCalled();
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
+    ).toBe("123e4567-e89b-12d3-a456-426614174000");
+  });
+
+  it("does not enumerate accounts locked by an unchanged running daemon", async () => {
+    mocks.runPluginCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: '[{"number":"+15555550124"}]',
+      stderr: "",
+    });
+    const queued = createQueuedWizardPrompter();
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: configuredManagedSignalConfig(),
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550123");
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
+    ).toBe("123e4567-e89b-12d3-a456-426614174000");
+  });
+
+  it("stops before account discovery when an accountless managed daemon is running", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {
+          channels: {
+            signal: {
+              accounts: {
+                work: {
+                  transport: {
+                    kind: "managed-native",
+                    cliPath: "/opt/openclaw/signal-cli",
+                    configPath: "/var/lib/signal-cli",
+                    httpHost: "127.0.0.1",
+                    httpPort: 8080,
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toThrow(
+      "The running Signal daemon is using this signal-cli config directory. Stop the OpenClaw gateway before discovering or linking an account, then retry setup.",
+    );
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+
+  it("reuses an unchanged active transport when both data directories are implicit", async () => {
+    mocks.prepareSignalManagedNativeTransport.mockReturnValueOnce({
+      kind: "managed-native",
+      cliPath: "/opt/openclaw/signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+    const cfg = configuredManagedSignalConfig();
+    const work = cfg.channels?.signal?.accounts?.work;
+    if (work?.transport?.kind !== "managed-native") {
+      throw new Error("expected managed Signal fixture");
+    }
+    delete work.transport.configPath;
+
+    await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg,
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+      },
+      prompter: createQueuedWizardPrompter().prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+
+  it("compares signal-cli data directories against the OS home, not OPENCLAW_HOME", async () => {
+    const previousOpenClawHome = process.env.OPENCLAW_HOME;
+    process.env.OPENCLAW_HOME = "/srv/openclaw-home";
+    vi.spyOn(os, "homedir").mockReturnValue("/Users/signal-owner");
+    mocks.prepareSignalManagedNativeTransport.mockReturnValueOnce({
+      kind: "managed-native",
+      cliPath: "/opt/openclaw/signal-cli",
+      configPath: "/srv/openclaw-home/signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+    try {
+      await runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {
+          channels: {
+            signal: {
+              accounts: {
+                work: {
+                  account: "+15555550123",
+                  transport: {
+                    kind: "managed-native",
+                    cliPath: "/opt/openclaw/signal-cli",
+                    configPath: "~/signal-cli",
+                    httpHost: "127.0.0.1",
+                    httpPort: 8080,
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: createQueuedWizardPrompter().prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      });
+    } finally {
+      if (previousOpenClawHome === undefined) {
+        delete process.env.OPENCLAW_HOME;
+      } else {
+        process.env.OPENCLAW_HOME = previousOpenClawHome;
+      }
+    }
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
+    expect(mocks.runPluginCommandWithTimeout).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon.mock.calls[0]?.[0].httpPort).not.toBe(8080);
+  });
+
+  it("fails closed when an active implicit data directory is compared with an explicit path", async () => {
+    const queued = createQueuedWizardPrompter();
+    const cfg = configuredManagedSignalConfig();
+    const work = cfg.channels?.signal?.accounts?.work;
+    if (work?.transport?.kind !== "managed-native") {
+      throw new Error("expected managed Signal fixture");
+    }
+    delete work.transport.configPath;
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg,
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toThrow("The running Signal daemon may be using this signal-cli config directory");
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+
+  it("preserves account UUID while revalidating the same offline managed account", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "not running" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const queued = createQueuedWizardPrompter();
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: configuredManagedSignalConfig(),
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.runPluginCommandWithTimeout).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon).toHaveBeenCalledOnce();
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
+    ).toBe("123e4567-e89b-12d3-a456-426614174000");
+  });
+
+  it("explains that a live daemon must stop before changing its signal-cli settings", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {
+          channels: {
+            signal: {
+              accounts: {
+                work: {
+                  account: "+15555550123",
+                  transport: {
+                    kind: "managed-native",
+                    cliPath: "signal-cli",
+                    configPath: "/var/lib/signal-cli",
+                    httpHost: "127.0.0.1",
+                    httpPort: 8080,
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toThrow(
+      "The running Signal daemon may be using this signal-cli config directory. Stop the OpenClaw gateway before changing its signal-cli settings, then retry setup.",
+    );
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+
+  it("requires the live daemon to stop before switching from an explicit to implicit store", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: configuredManagedSignalConfig(),
+        accountId: "work",
+        credentialValues: {
+          ...managedSignalCredentialValues,
+          signalCliConfigPath: "",
+        },
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toThrow("The running Signal daemon may be using this signal-cli config directory");
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/signal/src/setup-managed-validation.ts
+++ b/extensions/signal/src/setup-managed-validation.ts
@@ -1,0 +1,260 @@
+import { realpathSync } from "node:fs";
+import { createServer } from "node:net";
+import path from "node:path";
+import type { ChannelSetupWizard, OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk/setup";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
+import type { SignalTransportConfig } from "./account-types.js";
+import type { ResolvedSignalTransport } from "./accounts.js";
+import { assertSignalDaemonBindAvailable, spawnSignalDaemon } from "./daemon.js";
+import {
+  probeSignalTransport,
+  resolveConfiguredSignalTransport,
+  type SignalTransportProbeResult,
+} from "./setup-transport.js";
+import { resolveSignalCliConfigPath } from "./signal-cli-config-path.js";
+import { buildSignalTransportHttpUrl } from "./transport-url.js";
+
+type SignalFinalizeParams = Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0];
+
+export type ManagedSignalTransport = Extract<SignalTransportConfig, { kind: "managed-native" }>;
+export type ResolvedManagedSignalTransport = Extract<
+  ResolvedSignalTransport,
+  { kind: "managed-native" }
+>;
+export type LiveManagedTransportState =
+  | "not-running"
+  | "reuse-active-transport"
+  | "validate-different-store";
+
+function resolveExplicitSignalCliDataDirectory(configPath: string | undefined): string | undefined {
+  const configured = normalizeOptionalString(configPath);
+  if (!configured) {
+    return undefined;
+  }
+  const absolute = path.resolve(resolveSignalCliConfigPath(configured));
+  try {
+    return realpathSync.native(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+type SignalCliDataDirectoryRelationship = "same" | "different" | "unknown";
+
+function compareSignalCliDataDirectories(
+  active: ResolvedManagedSignalTransport,
+  candidate: ResolvedManagedSignalTransport,
+): SignalCliDataDirectoryRelationship {
+  const activeDirectory = resolveExplicitSignalCliDataDirectory(active.configPath);
+  const candidateDirectory = resolveExplicitSignalCliDataDirectory(candidate.configPath);
+  if (!activeDirectory || !candidateDirectory) {
+    // signal-cli can source its implicit dataDir from system or user config.
+    // Two omitted paths share that resolution; one omitted path cannot be
+    // proven distinct from an explicit store while the daemon owns its lock.
+    return !activeDirectory && !candidateDirectory ? "same" : "unknown";
+  }
+  const same =
+    process.platform === "win32"
+      ? activeDirectory.toLowerCase() === candidateDirectory.toLowerCase()
+      : activeDirectory === candidateDirectory;
+  return same ? "same" : "different";
+}
+
+function isSameResolvedManagedBind(
+  existing: ResolvedSignalTransport,
+  candidate: ResolvedManagedSignalTransport,
+): boolean {
+  return (
+    existing.kind === "managed-native" &&
+    existing.httpHost === candidate.httpHost &&
+    existing.httpPort === candidate.httpPort
+  );
+}
+
+function isSameResolvedManagedTransport(
+  existing: ResolvedSignalTransport,
+  candidate: ResolvedManagedSignalTransport,
+): boolean {
+  if (existing.kind !== "managed-native") {
+    return false;
+  }
+  return (
+    isSameResolvedManagedBind(existing, candidate) &&
+    existing.baseUrl === candidate.baseUrl &&
+    existing.cliPath === candidate.cliPath &&
+    compareSignalCliDataDirectories(existing, candidate) === "same" &&
+    existing.startupTimeoutMs === candidate.startupTimeoutMs &&
+    existing.receiveMode === candidate.receiveMode &&
+    existing.ignoreStories === candidate.ignoreStories
+  );
+}
+
+export async function evaluateLiveManagedTransport(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  account: string | undefined;
+  activeTransport: ResolvedSignalTransport;
+  candidateTransport: ResolvedManagedSignalTransport;
+}): Promise<LiveManagedTransportState> {
+  const configuredTransport = resolveConfiguredSignalTransport(params.cfg, params.accountId);
+  if (
+    params.activeTransport.kind !== "managed-native" ||
+    (!params.account && configuredTransport?.kind !== "managed-native")
+  ) {
+    return "not-running";
+  }
+  const existingTransport = configuredTransport ?? { kind: "managed-native" };
+  const existingProbe = await probeSignalTransport({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    transport: existingTransport,
+    ...(params.account ? { account: params.account } : {}),
+    timeoutMs: 1_000,
+  }).catch((error: unknown) => ({ ok: false, error: String(error) }));
+  if (!existingProbe.ok) {
+    return "not-running";
+  }
+  if (isSameResolvedManagedTransport(params.activeTransport, params.candidateTransport)) {
+    if (!params.account) {
+      throw new Error(
+        "The running Signal daemon is using this signal-cli config directory. Stop the OpenClaw gateway before discovering or linking an account, then retry setup.",
+      );
+    }
+    return "reuse-active-transport";
+  }
+  if (
+    compareSignalCliDataDirectories(params.activeTransport, params.candidateTransport) !==
+    "different"
+  ) {
+    throw new Error(
+      "The running Signal daemon may be using this signal-cli config directory. Stop the OpenClaw gateway before changing its signal-cli settings, then retry setup.",
+    );
+  }
+  return "validate-different-store";
+}
+
+export async function probeManagedSignalSetup(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  transport: ManagedSignalTransport;
+  resolvedTransport: ResolvedManagedSignalTransport;
+  account: string;
+  runtime: SignalFinalizeParams["runtime"];
+  prompter: WizardPrompter;
+  useTemporaryPort: boolean;
+  abortSignal?: AbortSignal;
+}): Promise<SignalTransportProbeResult> {
+  const progress = params.prompter.progress("Validating Signal setup...");
+  let transport = params.transport;
+  let resolvedTransport = params.resolvedTransport;
+  let daemon: ReturnType<typeof spawnSignalDaemon> | undefined;
+  let successfulProbe: SignalTransportProbeResult | undefined;
+  let result: SignalTransportProbeResult;
+  try {
+    if (params.useTemporaryPort) {
+      const httpPort = await allocateSignalValidationPort(resolvedTransport.httpHost);
+      const baseUrl = buildSignalTransportHttpUrl(resolvedTransport.httpHost, httpPort);
+      transport = { ...transport, httpPort, url: baseUrl };
+      resolvedTransport = { ...resolvedTransport, httpPort, baseUrl };
+    }
+    const bindUrl = buildSignalTransportHttpUrl(
+      resolvedTransport.httpHost,
+      resolvedTransport.httpPort,
+    );
+    const bindTransport: ManagedSignalTransport = {
+      ...transport,
+      httpHost: resolvedTransport.httpHost,
+      httpPort: resolvedTransport.httpPort,
+      url: bindUrl,
+    };
+    if (!params.useTemporaryPort) {
+      // A response from an existing process on this address must not be
+      // mistaken for readiness of the daemon setup is about to spawn.
+      await assertSignalDaemonBindAvailable({
+        httpHost: resolvedTransport.httpHost,
+        httpPort: resolvedTransport.httpPort,
+      });
+    }
+    const spawnedDaemon = spawnSignalDaemon({
+      cliPath: resolvedTransport.cliPath,
+      ...(resolvedTransport.configPath ? { configPath: resolvedTransport.configPath } : {}),
+      account: params.account,
+      httpHost: resolvedTransport.httpHost,
+      httpPort: resolvedTransport.httpPort,
+      // Validation must not drain queued messages before the real monitor installs its handler.
+      receiveMode: "manual",
+      ...(typeof resolvedTransport.ignoreStories === "boolean"
+        ? { ignoreStories: resolvedTransport.ignoreStories }
+        : {}),
+    });
+    daemon = spawnedDaemon;
+    const startupTimeoutMs = Math.min(120_000, Math.max(1_000, resolvedTransport.startupTimeoutMs));
+    await waitForTransportReady({
+      label: "signal-cli setup daemon",
+      timeoutMs: startupTimeoutMs,
+      logAfterMs: 10_000,
+      logIntervalMs: 10_000,
+      pollIntervalMs: 150,
+      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+      runtime: params.runtime,
+      check: async () => {
+        if (spawnedDaemon.isExited()) {
+          throw new Error("signal-cli exited before its HTTP server became ready.");
+        }
+        const probe = await probeSignalTransport({
+          cfg: params.cfg,
+          accountId: params.accountId,
+          transport: bindTransport,
+          account: params.account,
+          timeoutMs: 1_000,
+        }).catch((error: unknown) => ({ ok: false, error: String(error) }));
+        if (probe.ok) {
+          successfulProbe = probe;
+        }
+        return probe;
+      },
+    });
+    params.abortSignal?.throwIfAborted();
+    result = successfulProbe ?? { ok: false, error: "Signal transport probe failed." };
+    if (result.ok && resolvedTransport.baseUrl !== bindUrl) {
+      result = await probeSignalTransport({
+        cfg: params.cfg,
+        accountId: params.accountId,
+        transport,
+        account: params.account,
+        timeoutMs: 1_000,
+      }).catch((error: unknown) => ({ ok: false, error: String(error) }));
+    }
+  } catch (error) {
+    if (params.abortSignal?.aborted) {
+      throw params.abortSignal.reason;
+    }
+    result = { ok: false, error: String(error) };
+  } finally {
+    await daemon?.stop();
+  }
+  progress.stop(result.ok ? "Signal setup validated." : "Signal setup validation failed.");
+  return result;
+}
+
+async function allocateSignalValidationPort(host: string): Promise<number> {
+  const server = createServer();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen({ host, port: 0, exclusive: true }, resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Could not allocate a temporary Signal validation port.");
+    }
+    return address.port;
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }
+}

--- a/extensions/signal/src/setup-surface.test-fixtures.ts
+++ b/extensions/signal/src/setup-surface.test-fixtures.ts
@@ -1,0 +1,45 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+
+export const managedSignalCredentialValues = {
+  signalTransportKind: "managed-native",
+  signalCliPath: "/opt/openclaw/signal-cli",
+  signalCliConfigPath: "/var/lib/signal-cli",
+};
+
+export function toCredentialValues(
+  values: Partial<Record<string, string>> | undefined,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(values ?? {}).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+export function configuredManagedSignalConfig(options?: {
+  withTransport?: boolean;
+}): OpenClawConfig {
+  return {
+    channels: {
+      signal: {
+        accounts: {
+          work: {
+            account: "+15555550123",
+            accountUuid: "123e4567-e89b-12d3-a456-426614174000",
+            ...(options?.withTransport === false
+              ? {}
+              : {
+                  transport: {
+                    kind: "managed-native",
+                    cliPath: "/opt/openclaw/signal-cli",
+                    configPath: "/var/lib/signal-cli",
+                    httpHost: "127.0.0.1",
+                    httpPort: 8080,
+                  },
+                }),
+          },
+        },
+      },
+    },
+  };
+}

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -74,11 +74,11 @@ describe("signalSetupWizard", () => {
     mocks.probeSignalTransport.mockResolvedValue({ ok: true, status: 200 });
   });
 
-  it("prepares local signal-cli only after the persistent-effect boundary", async () => {
+  it("defaults an unconfigured account to local setup and installs after the boundary", async () => {
     mocks.detectBinary.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     const beforePersistentEffect = vi.fn(async () => undefined);
     const queued = createQueuedWizardPrompter({
-      selectValues: ["managed-native"],
+      selectValues: ["local"],
       confirmValues: [true],
       textValues: ["/var/lib/signal-cli"],
     });
@@ -94,8 +94,9 @@ describe("signalSetupWizard", () => {
 
     expect(queued.select).toHaveBeenCalledWith(
       expect.objectContaining({
+        initialValue: "local",
         options: expect.arrayContaining([
-          expect.objectContaining({ value: "managed-native", label: "Use local signal-cli" }),
+          expect.objectContaining({ value: "local", label: "Use local signal-cli" }),
           expect.objectContaining({
             value: "existing-server",
             label: "Connect to an existing Signal server",
@@ -115,6 +116,41 @@ describe("signalSetupWizard", () => {
         signalCliConfigPath: "/var/lib/signal-cli",
       },
     });
+  });
+
+  it("defaults a configured existing server account to existing server setup", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server"],
+      textValues: ["http://signal-helper:8080"],
+    });
+
+    await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: {
+              work: {
+                transport: {
+                  kind: "external-native",
+                  url: "http://signal-helper:8080",
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.select).toHaveBeenCalledWith(
+      expect.objectContaining({ initialValue: "existing-server" }),
+    );
+    expect(queued.text).toHaveBeenCalledWith(
+      expect.objectContaining({ initialValue: "http://signal-helper:8080" }),
+    );
   });
 
   it("probes and writes a prepared managed transport for the selected account", async () => {

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -337,6 +337,50 @@ describe("signalSetupWizard", () => {
     });
   });
 
+  it("prompts for an account when URL recovery changes to a container", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "receive probe failed" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    mocks.detectSignalTransport.mockResolvedValueOnce({
+      kind: "container",
+      url: "http://signal-helper-new:8080",
+    });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["url"],
+      textValues: ["http://signal-helper-new:8080", "+15555550123"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "default",
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper-old:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ message: "Signal server URL" }),
+    );
+    expect(queued.text).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ message: "Signal phone number" }),
+    );
+    expect(mocks.probeSignalTransport).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        transport: { kind: "container", url: "http://signal-helper-new:8080" },
+        account: "+15555550123",
+      }),
+    );
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "default" }).config.account,
+    ).toBe("+15555550123");
+  });
+
   it("retries the same candidate without re-detecting it", async () => {
     mocks.probeSignalTransport
       .mockResolvedValueOnce({ ok: false, error: "not ready" })

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -325,7 +325,7 @@ describe("signalSetupWizard", () => {
       expect.stringContaining("Signal > Settings > Linked devices"),
     );
     expect(queued.plain).toHaveBeenCalledWith(
-      expect.stringContaining("\x1b[40m\x1b[37m█ ▄▀█\x1b[0m"),
+      expect.stringContaining("\x1b[48;2;0;0;0m\x1b[38;2;255;255;255m"),
     );
     expect(queued.text).not.toHaveBeenCalled();
     expect(mocks.probeSignalTransport).toHaveBeenCalledWith(

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -74,7 +74,7 @@ describe("signalSetupWizard", () => {
     mocks.probeSignalTransport.mockResolvedValue({ ok: true, status: 200 });
   });
 
-  it("defaults an unconfigured account to local setup and installs after the boundary", async () => {
+  it("keeps account entry reversible until immediately before signal-cli installation", async () => {
     mocks.detectBinary.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     const beforePersistentEffect = vi.fn(async () => undefined);
     const queued = createQueuedWizardPrompter({
@@ -92,6 +92,14 @@ describe("signalSetupWizard", () => {
       options: { allowSignalInstall: true, beforePersistentEffect },
     });
 
+    expect(beforePersistentEffect).not.toHaveBeenCalled();
+    expect(mocks.installSignalCli).not.toHaveBeenCalled();
+    expect(prepared?.credentialValues).toEqual({
+      signalTransportKind: "managed-native",
+      signalCliPath: "signal-cli",
+      signalCliConfigPath: "/var/lib/signal-cli",
+      signalInstallRequested: "true",
+    });
     expect(queued.select).toHaveBeenCalledWith(
       expect.objectContaining({
         initialValue: "local",
@@ -104,18 +112,35 @@ describe("signalSetupWizard", () => {
         ]),
       }),
     );
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: {
+              work: {
+                account: "+15555550123",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      credentialValues: prepared?.credentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+      options: { allowSignalInstall: true, beforePersistentEffect },
+    });
+
     expect(beforePersistentEffect).toHaveBeenCalledOnce();
     expect(mocks.installSignalCli).toHaveBeenCalledOnce();
     expect(beforePersistentEffect.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.installSignalCli.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
-    expect(prepared).toEqual({
-      credentialValues: {
-        signalTransportKind: "managed-native",
-        signalCliPath: "/opt/openclaw/signal-cli",
-        signalCliConfigPath: "/var/lib/signal-cli",
-      },
-    });
+    expect(finalized?.cfg?.channels?.signal?.accounts?.work?.transport).toEqual(
+      expect.objectContaining({ kind: "managed-native" }),
+    );
   });
 
   it("defaults a configured existing server account to existing server setup", async () => {

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -103,7 +103,11 @@ vi.mock("./setup-transport.js", async () => {
   };
 });
 
-import { createSignalSetupWizardProxy, signalNumberTextInputs } from "./setup-core.js";
+import {
+  createSignalSetupWizardProxy,
+  signalCompletionNote,
+  signalNumberTextInputs,
+} from "./setup-core.js";
 import { signalSetupWizard } from "./setup-surface.js";
 
 function toCredentialValues(
@@ -324,9 +328,7 @@ describe("signalSetupWizard", () => {
     expect(queued.plain).toHaveBeenCalledWith(
       expect.stringContaining("Signal > Settings > Linked devices"),
     );
-    expect(queued.plain).toHaveBeenCalledWith(
-      expect.stringContaining("\x1b[48;2;0;0;0m\x1b[38;2;255;255;255m"),
-    );
+    expect(queued.plain).toHaveBeenCalledWith(expect.stringContaining("Scan this QR code:"));
     expect(queued.text).not.toHaveBeenCalled();
     expect(mocks.probeSignalTransport).toHaveBeenCalledWith(
       expect.objectContaining({ account: "+15555550123" }),
@@ -507,7 +509,6 @@ describe("signalSetupWizard", () => {
   });
 
   it("starts and stops a temporary signal-cli daemon around a managed probe", async () => {
-    const runtime = createRuntimeEnv({ throwOnExit: false });
     const queued = createQueuedWizardPrompter();
 
     await runSetupWizardFinalize({
@@ -526,7 +527,7 @@ describe("signalSetupWizard", () => {
         signalCliConfigPath: "/var/lib/signal-cli",
       },
       prompter: queued.prompter,
-      runtime,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
     });
 
     expect(mocks.spawnSignalDaemon).toHaveBeenCalledWith({
@@ -535,10 +536,21 @@ describe("signalSetupWizard", () => {
       account: "+15555550123",
       httpHost: "127.0.0.1",
       httpPort: 8080,
-      runtime,
     });
+    expect(queued.progress).toHaveBeenCalledWith("Validating Signal setup...");
+    expect(queued.progress.mock.results[0]?.value.stop).toHaveBeenCalledWith(
+      "Signal setup validated.",
+    );
     expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
     expect(mocks.spawnSignalDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
+  });
+
+  it("shows user-facing completion guidance instead of a raw gateway RPC", () => {
+    const lines = signalCompletionNote.lines.join("\n");
+
+    expect(lines).toContain("Signal setup is validated.");
+    expect(lines).toContain("openclaw channels status --probe");
+    expect(lines).not.toContain("gateway call");
   });
 
   it("stops a temporary daemon that exits before its managed probe", async () => {

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -39,7 +39,7 @@ const mocks = vi.hoisted(() => ({
       return { ok: true as const, associatedAccount: "+15555550123" };
     },
   ),
-  renderQrTerminal: vi.fn(async () => "TERMINAL-QR"),
+  renderQrTerminal: vi.fn(async () => "\x1b[47m\x1b[30m █▀▄ \x1b[0m"),
   runPluginCommandWithTimeout: vi.fn(async () => ({
     code: 0,
     stdout: '[{"number":"+15555550123"}]',
@@ -317,11 +317,16 @@ describe("signalSetupWizard", () => {
       configPath: "/var/lib/signal-cli",
       onLinkUri: expect.any(Function),
     });
-    expect(mocks.renderQrTerminal).toHaveBeenCalledWith("sgnl://linkdevice?uuid=test&pub_key=test");
+    expect(mocks.renderQrTerminal).toHaveBeenCalledWith(
+      "sgnl://linkdevice?uuid=test&pub_key=test",
+      { small: true },
+    );
     expect(queued.plain).toHaveBeenCalledWith(
       expect.stringContaining("Signal > Settings > Linked devices"),
     );
-    expect(queued.plain).toHaveBeenCalledWith(expect.stringContaining("TERMINAL-QR"));
+    expect(queued.plain).toHaveBeenCalledWith(
+      expect.stringContaining("\x1b[40m\x1b[37m█ ▄▀█\x1b[0m"),
+    );
     expect(queued.text).not.toHaveBeenCalled();
     expect(mocks.probeSignalTransport).toHaveBeenCalledWith(
       expect.objectContaining({ account: "+15555550123" }),

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -8,6 +8,7 @@ import {
 import { WizardCancelledError } from "openclaw/plugin-sdk/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveSignalAccount } from "./accounts.js";
+import type { SignalDaemonHandle } from "./daemon.js";
 import type { SignalInstallResult } from "./install-signal-cli.js";
 import type { SignalTransportProbeResult } from "./setup-transport.js";
 
@@ -25,6 +26,19 @@ const mocks = vi.hoisted(() => ({
     async (): Promise<SignalInstallResult> => ({
       ok: true,
       cliPath: "/opt/openclaw/signal-cli",
+    }),
+  ),
+  runPluginCommandWithTimeout: vi.fn(async () => ({
+    code: 0,
+    stdout: '[{"number":"+15555550123"}]',
+    stderr: "",
+  })),
+  spawnSignalDaemon: vi.fn(
+    (): SignalDaemonHandle => ({
+      pid: 1234,
+      stop: vi.fn(async () => undefined),
+      exited: new Promise<never>(() => {}),
+      isExited: () => false,
     }),
   ),
   prepareSignalManagedNativeTransport: vi.fn(() => ({
@@ -46,6 +60,14 @@ vi.mock("openclaw/plugin-sdk/setup-tools", async () => {
   return { ...actual, detectBinary: mocks.detectBinary };
 });
 
+vi.mock("openclaw/plugin-sdk/run-command", () => ({
+  runPluginCommandWithTimeout: mocks.runPluginCommandWithTimeout,
+}));
+
+vi.mock("./daemon.js", () => ({
+  spawnSignalDaemon: mocks.spawnSignalDaemon,
+}));
+
 vi.mock("./install-signal-cli.js", () => ({
   installSignalCli: mocks.installSignalCli,
 }));
@@ -64,6 +86,16 @@ vi.mock("./setup-transport.js", async () => {
 import { createSignalSetupWizardProxy, signalNumberTextInputs } from "./setup-core.js";
 import { signalSetupWizard } from "./setup-surface.js";
 
+function toCredentialValues(
+  values: Partial<Record<string, string>> | undefined,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(values ?? {}).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
 describe("signalSetupWizard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,6 +104,11 @@ describe("signalSetupWizard", () => {
       url,
     }));
     mocks.probeSignalTransport.mockResolvedValue({ ok: true, status: 200 });
+    mocks.runPluginCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: '[{"number":"+15555550123"}]',
+      stderr: "",
+    });
   });
 
   it("keeps account entry reversible until immediately before signal-cli installation", async () => {
@@ -127,7 +164,7 @@ describe("signalSetupWizard", () => {
         },
       } as OpenClawConfig,
       accountId: "work",
-      credentialValues: prepared?.credentialValues,
+      credentialValues: toCredentialValues(prepared?.credentialValues),
       prompter: queued.prompter,
       runtime: createRuntimeEnv({ throwOnExit: false }),
       options: { allowSignalInstall: true, beforePersistentEffect },
@@ -214,6 +251,142 @@ describe("signalSetupWizard", () => {
     );
   });
 
+  it("explains how to link signal-cli before probing an unlinked managed account", async () => {
+    mocks.runPluginCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "[]",
+      stderr: "",
+    });
+    const queued = createQueuedWizardPrompter({ selectValues: ["stop"] });
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {
+          channels: {
+            signal: {
+              accounts: { work: { account: "+15555550123" } },
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "work",
+        credentialValues: {
+          signalTransportKind: "managed-native",
+          signalCliPath: "/opt/openclaw/signal-cli",
+          signalCliConfigPath: "/var/lib/signal-cli",
+        },
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("Entering a phone number does not link signal-cli"),
+      "Signal setup",
+    );
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/opt/openclaw/signal-cli --config /var/lib/signal-cli link -n "OpenClaw"',
+      ),
+      "Signal setup",
+    );
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("Signal > Settings > Linked devices"),
+      "Signal setup",
+    );
+    expect(mocks.runPluginCommandWithTimeout).toHaveBeenCalledWith({
+      argv: [
+        "/opt/openclaw/signal-cli",
+        "--config",
+        "/var/lib/signal-cli",
+        "--output",
+        "json",
+        "listAccounts",
+      ],
+      timeoutMs: 10_000,
+    });
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).not.toHaveBeenCalled();
+  });
+
+  it("starts and stops a temporary signal-cli daemon around a managed probe", async () => {
+    const runtime = createRuntimeEnv({ throwOnExit: false });
+    const queued = createQueuedWizardPrompter();
+
+    await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: { work: { account: "+15555550123" } },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+        signalCliConfigPath: "/var/lib/signal-cli",
+      },
+      prompter: queued.prompter,
+      runtime,
+    });
+
+    expect(mocks.spawnSignalDaemon).toHaveBeenCalledWith({
+      cliPath: "/opt/openclaw/signal-cli",
+      configPath: "/var/lib/signal-cli",
+      account: "+15555550123",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+      runtime,
+    });
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
+  });
+
+  it("stops a temporary daemon that exits before its managed probe", async () => {
+    const stop = vi.fn(async () => undefined);
+    mocks.spawnSignalDaemon.mockReturnValueOnce({
+      pid: 1234,
+      stop,
+      exited: Promise.resolve({
+        source: "process" as const,
+        code: 1,
+        signal: null,
+      }),
+      isExited: () => true,
+    });
+    const queued = createQueuedWizardPrompter({ selectValues: ["stop"] });
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {
+          channels: {
+            signal: {
+              accounts: { work: { account: "+15555550123" } },
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "work",
+        credentialValues: {
+          signalTransportKind: "managed-native",
+          signalCliPath: "/opt/openclaw/signal-cli",
+          signalCliConfigPath: "/var/lib/signal-cli",
+        },
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("signal-cli exited before its HTTP server became ready"),
+      "Signal setup",
+    );
+    expect(mocks.probeSignalTransport).not.toHaveBeenCalled();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("detects, probes, and writes a concrete existing container transport", async () => {
     mocks.detectSignalTransport.mockResolvedValue({
       kind: "container",
@@ -241,11 +414,7 @@ describe("signalSetupWizard", () => {
         },
       } as OpenClawConfig,
       accountId: "work",
-      credentialValues: Object.fromEntries(
-        Object.entries(prepared?.credentialValues ?? {}).filter(
-          (entry): entry is [string, string] => typeof entry[1] === "string",
-        ),
-      ),
+      credentialValues: toCredentialValues(prepared?.credentialValues),
       prompter: queued.prompter,
       runtime: createRuntimeEnv({ throwOnExit: false }),
     });

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -11,6 +11,7 @@ import { resolveSignalAccount } from "./accounts.js";
 import type { SignalDaemonHandle } from "./daemon.js";
 import type { SignalInstallResult } from "./install-signal-cli.js";
 import type { SignalTransportProbeResult } from "./setup-transport.js";
+import type { SignalCliLinkResult } from "./signal-cli-link.js";
 
 const mocks = vi.hoisted(() => ({
   detectBinary: vi.fn(async (_cliPath: string) => false),
@@ -28,6 +29,17 @@ const mocks = vi.hoisted(() => ({
       cliPath: "/opt/openclaw/signal-cli",
     }),
   ),
+  linkSignalCliAccount: vi.fn(
+    async (params: {
+      cliPath: string;
+      configPath?: string;
+      onLinkUri: (uri: string) => Promise<void>;
+    }): Promise<SignalCliLinkResult> => {
+      await params.onLinkUri("sgnl://linkdevice?uuid=test&pub_key=test");
+      return { ok: true as const, associatedAccount: "+15555550123" };
+    },
+  ),
+  renderQrTerminal: vi.fn(async () => "TERMINAL-QR"),
   runPluginCommandWithTimeout: vi.fn(async () => ({
     code: 0,
     stdout: '[{"number":"+15555550123"}]',
@@ -64,12 +76,20 @@ vi.mock("openclaw/plugin-sdk/run-command", () => ({
   runPluginCommandWithTimeout: mocks.runPluginCommandWithTimeout,
 }));
 
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  renderQrTerminal: mocks.renderQrTerminal,
+}));
+
 vi.mock("./daemon.js", () => ({
   spawnSignalDaemon: mocks.spawnSignalDaemon,
 }));
 
 vi.mock("./install-signal-cli.js", () => ({
   installSignalCli: mocks.installSignalCli,
+}));
+
+vi.mock("./signal-cli-link.js", () => ({
+  linkSignalCliAccount: mocks.linkSignalCliAccount,
 }));
 
 vi.mock("./setup-transport.js", async () => {
@@ -251,7 +271,187 @@ describe("signalSetupWizard", () => {
     );
   });
 
-  it("explains how to link signal-cli before probing an unlinked managed account", async () => {
+  it("links an unconfigured local account inside the wizard before probing it", async () => {
+    mocks.runPluginCommandWithTimeout
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: "[]",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '[{"number":"+15555550123"}]',
+        stderr: "",
+      });
+    const beforePersistentEffect = vi.fn(async () => undefined);
+    const queued = createQueuedWizardPrompter({ selectValues: ["link"] });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+        signalCliConfigPath: "/var/lib/signal-cli",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+      options: { beforePersistentEffect },
+    });
+
+    expect(queued.select).toHaveBeenCalledWith({
+      message: "No linked Signal account was found. How should setup continue?",
+      options: [
+        { value: "link", label: "Link a Signal account now" },
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "link",
+    });
+    expect(beforePersistentEffect).toHaveBeenCalledOnce();
+    expect(beforePersistentEffect.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.linkSignalCliAccount.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(mocks.linkSignalCliAccount).toHaveBeenCalledWith({
+      cliPath: "/opt/openclaw/signal-cli",
+      configPath: "/var/lib/signal-cli",
+      onLinkUri: expect.any(Function),
+    });
+    expect(mocks.renderQrTerminal).toHaveBeenCalledWith(
+      "sgnl://linkdevice?uuid=test&pub_key=test",
+      { small: true },
+    );
+    expect(queued.plain).toHaveBeenCalledWith(
+      expect.stringContaining("Signal > Settings > Linked devices"),
+    );
+    expect(queued.plain).toHaveBeenCalledWith(expect.stringContaining("TERMINAL-QR"));
+    expect(queued.text).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ account: "+15555550123" }),
+    );
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550123");
+  });
+
+  it("explains and retries a failed in-TUI signal-cli link", async () => {
+    mocks.runPluginCommandWithTimeout
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: "[]",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '[{"number":"+15555550123"}]',
+        stderr: "",
+      });
+    mocks.linkSignalCliAccount.mockResolvedValueOnce({
+      ok: false,
+      error: "Link request timed out, please try again.",
+    });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["link", "retry"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+        signalCliConfigPath: "/var/lib/signal-cli",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.note).toHaveBeenCalledWith(
+      "signal-cli could not link this device.\n\nLink request timed out, please try again.",
+      "Signal account linking",
+    );
+    expect(queued.select).toHaveBeenLastCalledWith({
+      message: "How should Signal account linking continue?",
+      options: [
+        { value: "retry", label: "Retry account linking" },
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "retry",
+    });
+    expect(mocks.linkSignalCliAccount).toHaveBeenCalledTimes(2);
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550123");
+  });
+
+  it("adopts the only existing local signal-cli account without asking for its number", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+        signalCliConfigPath: "/var/lib/signal-cli",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).not.toHaveBeenCalled();
+    expect(queued.select).not.toHaveBeenCalled();
+    expect(mocks.linkSignalCliAccount).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ account: "+15555550123" }),
+    );
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550123");
+  });
+
+  it("lets the user choose among multiple existing local signal-cli accounts", async () => {
+    mocks.runPluginCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: '[{"number":"+15555550123"},{"number":"+15555550124"}]',
+      stderr: "",
+    });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["account:+15555550124"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+        signalCliConfigPath: "/var/lib/signal-cli",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.select).toHaveBeenCalledWith({
+      message: "Choose the linked Signal account for OpenClaw",
+      options: [
+        { value: "account:+15555550123", label: "+15555550123" },
+        { value: "account:+15555550124", label: "+15555550124" },
+        { value: "link", label: "Link another Signal account" },
+      ],
+      initialValue: "account:+15555550123",
+    });
+    expect(queued.text).not.toHaveBeenCalled();
+    expect(mocks.linkSignalCliAccount).not.toHaveBeenCalled();
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550124");
+  });
+
+  it("stops before linking when the user declines in-TUI account linking", async () => {
     mocks.runPluginCommandWithTimeout.mockResolvedValue({
       code: 0,
       stdout: "[]",
@@ -280,20 +480,14 @@ describe("signalSetupWizard", () => {
       }),
     ).rejects.toBeInstanceOf(WizardCancelledError);
 
-    expect(queued.note).toHaveBeenCalledWith(
-      expect.stringContaining("Entering a phone number does not link signal-cli"),
-      "Signal setup",
-    );
-    expect(queued.note).toHaveBeenCalledWith(
-      expect.stringContaining(
-        '/opt/openclaw/signal-cli --config /var/lib/signal-cli link -n "OpenClaw"',
-      ),
-      "Signal setup",
-    );
-    expect(queued.note).toHaveBeenCalledWith(
-      expect.stringContaining("Signal > Settings > Linked devices"),
-      "Signal setup",
-    );
+    expect(queued.select).toHaveBeenCalledWith({
+      message: "No linked Signal account was found. How should setup continue?",
+      options: [
+        { value: "link", label: "Link a Signal account now" },
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "link",
+    });
     expect(mocks.runPluginCommandWithTimeout).toHaveBeenCalledWith({
       argv: [
         "/opt/openclaw/signal-cli",
@@ -305,6 +499,7 @@ describe("signalSetupWizard", () => {
       ],
       timeoutMs: 10_000,
     });
+    expect(mocks.linkSignalCliAccount).not.toHaveBeenCalled();
     expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
     expect(mocks.probeSignalTransport).not.toHaveBeenCalled();
   });
@@ -492,6 +687,60 @@ describe("signalSetupWizard", () => {
     });
 
     expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
+    expect(mocks.probeSignalTransport).toHaveBeenLastCalledWith(
+      expect.objectContaining({ account: "+15555550124" }),
+    );
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550124");
+  });
+
+  it("selects another linked local account after a managed probe failure", async () => {
+    mocks.runPluginCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: '[{"number":"+15555550123"},{"number":"+15555550124"}]',
+      stderr: "",
+    });
+    mocks.spawnSignalDaemon.mockReturnValueOnce({
+      pid: 1234,
+      stop: vi.fn(async () => undefined),
+      exited: Promise.resolve({
+        source: "process" as const,
+        code: 1,
+        signal: null,
+      }),
+      isExited: () => true,
+    });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["account", "account:+15555550124"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: { work: { account: "+15555550123" } },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+        signalCliConfigPath: "/var/lib/signal-cli",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).not.toHaveBeenCalled();
+    expect(queued.select).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        message: "Choose the linked Signal account for OpenClaw",
+      }),
+    );
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
     expect(mocks.probeSignalTransport).toHaveBeenLastCalledWith(
       expect.objectContaining({ account: "+15555550124" }),
     );
@@ -718,13 +967,35 @@ describe("signalSetupWizard", () => {
     ).rejects.toBe(back);
   });
 
-  it("allows an accountless external-native selection and delegates lazy finalization", () => {
+  it("collects account numbers only where the selected transport requires them", () => {
+    const requiredAccountInput = signalNumberTextInputs.find((input) => input.required !== false);
     const optionalAccountInput = signalNumberTextInputs.find(
       (input) => input.message === "Signal phone number (optional)",
     );
     const proxy = createSignalSetupWizardProxy(async () => signalSetupWizard);
 
+    expect(
+      requiredAccountInput?.shouldPrompt?.({
+        cfg: {},
+        accountId: "default",
+        credentialValues: { signalTransportKind: "managed-native" },
+      }),
+    ).toBe(false);
+    expect(
+      requiredAccountInput?.shouldPrompt?.({
+        cfg: {},
+        accountId: "default",
+        credentialValues: { signalTransportKind: "container" },
+      }),
+    ).toBe(true);
     expect(optionalAccountInput?.required).toBe(false);
+    expect(
+      optionalAccountInput?.shouldPrompt?.({
+        cfg: {},
+        accountId: "default",
+        credentialValues: { signalTransportKind: "external-native" },
+      }),
+    ).toBe(true);
     expect(proxy.finalize).toBeTypeOf("function");
   });
 });

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -317,10 +317,7 @@ describe("signalSetupWizard", () => {
       configPath: "/var/lib/signal-cli",
       onLinkUri: expect.any(Function),
     });
-    expect(mocks.renderQrTerminal).toHaveBeenCalledWith(
-      "sgnl://linkdevice?uuid=test&pub_key=test",
-      { small: true },
-    );
+    expect(mocks.renderQrTerminal).toHaveBeenCalledWith("sgnl://linkdevice?uuid=test&pub_key=test");
     expect(queued.plain).toHaveBeenCalledWith(
       expect.stringContaining("Signal > Settings > Linked devices"),
     );

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -1,0 +1,456 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createQueuedWizardPrompter,
+  createRuntimeEnv,
+  runSetupWizardFinalize,
+  runSetupWizardPrepare,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { WizardCancelledError } from "openclaw/plugin-sdk/setup";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSignalAccount } from "./accounts.js";
+import type { SignalInstallResult } from "./install-signal-cli.js";
+import type { SignalTransportProbeResult } from "./setup-transport.js";
+
+const mocks = vi.hoisted(() => ({
+  detectBinary: vi.fn(async (_cliPath: string) => false),
+  detectSignalTransport: vi.fn(
+    async (params: {
+      url: string;
+    }): Promise<{ kind: "external-native" | "container"; url: string }> => ({
+      kind: "external-native",
+      url: params.url,
+    }),
+  ),
+  installSignalCli: vi.fn(
+    async (): Promise<SignalInstallResult> => ({
+      ok: true,
+      cliPath: "/opt/openclaw/signal-cli",
+    }),
+  ),
+  prepareSignalManagedNativeTransport: vi.fn(() => ({
+    kind: "managed-native" as const,
+    cliPath: "/opt/openclaw/signal-cli",
+    configPath: "/var/lib/signal-cli",
+    httpHost: "127.0.0.1",
+    httpPort: 8080,
+  })),
+  probeSignalTransport: vi.fn(
+    async (): Promise<SignalTransportProbeResult> => ({ ok: true, status: 200 }),
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/setup-tools", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/setup-tools")>(
+    "openclaw/plugin-sdk/setup-tools",
+  );
+  return { ...actual, detectBinary: mocks.detectBinary };
+});
+
+vi.mock("./install-signal-cli.js", () => ({
+  installSignalCli: mocks.installSignalCli,
+}));
+
+vi.mock("./setup-transport.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./setup-transport.js")>("./setup-transport.js");
+  return {
+    ...actual,
+    detectSignalTransport: mocks.detectSignalTransport,
+    prepareSignalManagedNativeTransport: mocks.prepareSignalManagedNativeTransport,
+    probeSignalTransport: mocks.probeSignalTransport,
+  };
+});
+
+import { createSignalSetupWizardProxy, signalNumberTextInputs } from "./setup-core.js";
+import { signalSetupWizard } from "./setup-surface.js";
+
+describe("signalSetupWizard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.detectSignalTransport.mockImplementation(async ({ url }: { url: string }) => ({
+      kind: "external-native",
+      url,
+    }));
+    mocks.probeSignalTransport.mockResolvedValue({ ok: true, status: 200 });
+  });
+
+  it("prepares local signal-cli only after the persistent-effect boundary", async () => {
+    mocks.detectBinary.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const beforePersistentEffect = vi.fn(async () => undefined);
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["managed-native"],
+      confirmValues: [true],
+      textValues: ["/var/lib/signal-cli"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {},
+      accountId: "work",
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+      options: { allowSignalInstall: true, beforePersistentEffect },
+    });
+
+    expect(queued.select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.arrayContaining([
+          expect.objectContaining({ value: "managed-native", label: "Use local signal-cli" }),
+          expect.objectContaining({
+            value: "existing-server",
+            label: "Connect to an existing Signal server",
+          }),
+        ]),
+      }),
+    );
+    expect(beforePersistentEffect).toHaveBeenCalledOnce();
+    expect(mocks.installSignalCli).toHaveBeenCalledOnce();
+    expect(beforePersistentEffect.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.installSignalCli.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(prepared).toEqual({
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+        signalCliConfigPath: "/var/lib/signal-cli",
+      },
+    });
+  });
+
+  it("probes and writes a prepared managed transport for the selected account", async () => {
+    const queued = createQueuedWizardPrompter({ textValues: ["+15555550123"] });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+        signalCliConfigPath: "/var/lib/signal-cli",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.prepareSignalManagedNativeTransport).toHaveBeenCalledWith({
+      cfg: {},
+      accountId: "work",
+      overrides: {
+        cliPath: "/opt/openclaw/signal-cli",
+        configPath: "/var/lib/signal-cli",
+      },
+    });
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "work",
+        transport: expect.objectContaining({ kind: "managed-native" }),
+        account: "+15555550123",
+      }),
+    );
+    expect(finalized?.cfg?.channels?.signal?.accounts?.work?.transport).toEqual(
+      expect.objectContaining({ kind: "managed-native" }),
+    );
+  });
+
+  it("detects, probes, and writes a concrete existing container transport", async () => {
+    mocks.detectSignalTransport.mockResolvedValue({
+      kind: "container",
+      url: "http://signal-helper:8080",
+    });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server"],
+      textValues: ["http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {},
+      accountId: "work",
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: { work: { account: "+15555550123" } },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      credentialValues: Object.fromEntries(
+        Object.entries(prepared?.credentialValues ?? {}).filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string",
+        ),
+      ),
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.detectSignalTransport).toHaveBeenCalledWith({
+      url: "http://signal-helper:8080",
+    });
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      accountId: "work",
+      transport: { kind: "container", url: "http://signal-helper:8080" },
+      account: "+15555550123",
+    });
+    expect(finalized?.cfg?.channels?.signal?.accounts?.work?.transport).toEqual({
+      kind: "container",
+      url: "http://signal-helper:8080",
+    });
+  });
+
+  it("requires a Signal account before probing a container", async () => {
+    const queued = createQueuedWizardPrompter({ textValues: ["+15555550123"] });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "container",
+        signalServerUrl: "http://signal-helper:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Signal phone number" }),
+    );
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      accountId: "work",
+      transport: { kind: "container", url: "http://signal-helper:8080" },
+      account: "+15555550123",
+    });
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550123");
+  });
+
+  it("changes the Signal account and retries after a failed probe", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "account not registered" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["account"],
+      textValues: ["+15555550124"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: { work: { account: "+15555550123" } },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
+    expect(mocks.probeSignalTransport).toHaveBeenLastCalledWith(
+      expect.objectContaining({ account: "+15555550124" }),
+    );
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550124");
+  });
+
+  it("changes and re-detects the server URL after a failed probe", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "receive probe failed" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["url"],
+      textValues: ["http://signal-helper-new:8080"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "default",
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper-old:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.detectSignalTransport).toHaveBeenCalledWith({
+      url: "http://signal-helper-new:8080",
+    });
+    expect(finalized?.cfg?.channels?.signal?.transport).toEqual({
+      kind: "external-native",
+      url: "http://signal-helper-new:8080",
+    });
+  });
+
+  it("retries the same candidate without re-detecting it", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "not ready" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const queued = createQueuedWizardPrompter({ selectValues: ["retry"] });
+
+    await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
+    expect(mocks.detectSignalTransport).not.toHaveBeenCalled();
+  });
+
+  it("retries failed server detection without prompting for the URL again", async () => {
+    mocks.detectSignalTransport
+      .mockRejectedValueOnce(new Error("server starting"))
+      .mockResolvedValueOnce({
+        kind: "external-native",
+        url: "http://signal-helper:8080",
+      });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "retry"],
+      textValues: ["http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {},
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).toHaveBeenCalledOnce();
+    expect(mocks.detectSignalTransport).toHaveBeenCalledTimes(2);
+    expect(mocks.detectSignalTransport).toHaveBeenNthCalledWith(1, {
+      url: "http://signal-helper:8080",
+    });
+    expect(mocks.detectSignalTransport).toHaveBeenNthCalledWith(2, {
+      url: "http://signal-helper:8080",
+    });
+    expect(prepared?.credentialValues).toMatchObject({
+      signalTransportKind: "external-native",
+    });
+  });
+
+  it("allows an unambiguous external-native server without a Signal account", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      credentialValues: {
+        signalTransportKind: "external-native",
+        signalServerUrl: "http://signal-helper:8080",
+      },
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.text).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith({
+      cfg: {},
+      accountId: "default",
+      transport: { kind: "external-native", url: "http://signal-helper:8080" },
+      account: undefined,
+    });
+    expect(finalized?.cfg?.channels?.signal?.transport).toEqual({
+      kind: "external-native",
+      url: "http://signal-helper:8080",
+    });
+  });
+
+  it("stops failed setup with the generic wizard cancellation", async () => {
+    mocks.probeSignalTransport.mockResolvedValue({ ok: false, error: "not ready" });
+    const queued = createQueuedWizardPrompter({ selectValues: ["stop"] });
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {},
+        credentialValues: {
+          signalTransportKind: "external-native",
+          signalServerUrl: "http://signal-helper:8080",
+        },
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+  });
+
+  it("rejects a URL that aliases an OpenClaw-managed daemon", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["existing-server", "url"],
+      textValues: ["http://localhost:8080", "http://signal-helper:8080"],
+    });
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15555550123",
+            transport: {
+              kind: "managed-native",
+              httpHost: "127.0.0.1",
+              httpPort: 8080,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.detectSignalTransport).toHaveBeenCalledTimes(2);
+    expect(prepared?.credentialValues).toMatchObject({
+      signalTransportKind: "external-native",
+      signalServerUrl: "http://signal-helper:8080",
+    });
+  });
+
+  it("propagates generic Back navigation without Signal-specific catches", async () => {
+    const back = new Error("wizard back");
+    const queued = createQueuedWizardPrompter();
+    queued.select.mockRejectedValueOnce(back);
+
+    await expect(
+      runSetupWizardPrepare({
+        prepare: signalSetupWizard.prepare,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toBe(back);
+  });
+
+  it("allows an accountless external-native selection and delegates lazy finalization", () => {
+    const optionalAccountInput = signalNumberTextInputs.find(
+      (input) => input.message === "Signal phone number (optional)",
+    );
+    const proxy = createSignalSetupWizardProxy(async () => signalSetupWizard);
+
+    expect(optionalAccountInput?.required).toBe(false);
+    expect(proxy.finalize).toBeTypeOf("function");
+  });
+});

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -7,11 +7,19 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { WizardCancelledError } from "openclaw/plugin-sdk/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SignalTransportConfig } from "./account-types.js";
 import { resolveSignalAccount } from "./accounts.js";
 import type { SignalDaemonHandle } from "./daemon.js";
 import type { SignalInstallResult } from "./install-signal-cli.js";
+import {
+  configuredManagedSignalConfig,
+  managedSignalCredentialValues,
+  toCredentialValues,
+} from "./setup-surface.test-fixtures.js";
 import type { SignalTransportProbeResult } from "./setup-transport.js";
 import type { SignalCliLinkResult } from "./signal-cli-link.js";
+
+type SpawnSignalDaemonParams = Parameters<typeof import("./daemon.js").spawnSignalDaemon>[0];
 
 const mocks = vi.hoisted(() => ({
   detectBinary: vi.fn(async (_cliPath: string) => false),
@@ -33,9 +41,12 @@ const mocks = vi.hoisted(() => ({
     async (params: {
       cliPath: string;
       configPath?: string;
-      onLinkUri: (uri: string) => Promise<void>;
+      onLinkUri: (uri: string, completion: Promise<{ ok: boolean }>) => Promise<void>;
     }): Promise<SignalCliLinkResult> => {
-      await params.onLinkUri("sgnl://linkdevice?uuid=test&pub_key=test");
+      await params.onLinkUri(
+        "sgnl://linkdevice?uuid=test&pub_key=test",
+        Promise.resolve({ ok: true }),
+      );
       return { ok: true as const, associatedAccount: "+15555550123" };
     },
   ),
@@ -46,20 +57,22 @@ const mocks = vi.hoisted(() => ({
     stderr: "",
   })),
   spawnSignalDaemon: vi.fn(
-    (): SignalDaemonHandle => ({
+    (_params: SpawnSignalDaemonParams): SignalDaemonHandle => ({
       pid: 1234,
       stop: vi.fn(async () => undefined),
       exited: new Promise<never>(() => {}),
       isExited: () => false,
     }),
   ),
-  prepareSignalManagedNativeTransport: vi.fn(() => ({
-    kind: "managed-native" as const,
-    cliPath: "/opt/openclaw/signal-cli",
-    configPath: "/var/lib/signal-cli",
-    httpHost: "127.0.0.1",
-    httpPort: 8080,
-  })),
+  prepareSignalManagedNativeTransport: vi.fn(
+    (): Extract<SignalTransportConfig, { kind: "managed-native" }> => ({
+      kind: "managed-native",
+      cliPath: "/opt/openclaw/signal-cli",
+      configPath: "/var/lib/signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    }),
+  ),
   probeSignalTransport: vi.fn(
     async (): Promise<SignalTransportProbeResult> => ({ ok: true, status: 200 }),
   ),
@@ -103,22 +116,8 @@ vi.mock("./setup-transport.js", async () => {
   };
 });
 
-import {
-  createSignalSetupWizardProxy,
-  signalCompletionNote,
-  signalNumberTextInputs,
-} from "./setup-core.js";
+import { signalCompletionNote } from "./setup-core.js";
 import { signalSetupWizard } from "./setup-surface.js";
-
-function toCredentialValues(
-  values: Partial<Record<string, string>> | undefined,
-): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(values ?? {}).filter(
-      (entry): entry is [string, string] => typeof entry[1] === "string",
-    ),
-  );
-}
 
 describe("signalSetupWizard", () => {
   beforeEach(() => {
@@ -127,7 +126,7 @@ describe("signalSetupWizard", () => {
       kind: "external-native",
       url,
     }));
-    mocks.probeSignalTransport.mockResolvedValue({ ok: true, status: 200 });
+    mocks.probeSignalTransport.mockReset().mockResolvedValue({ ok: true, status: 200 });
     mocks.runPluginCommandWithTimeout.mockResolvedValue({
       code: 0,
       stdout: '[{"number":"+15555550123"}]',
@@ -137,6 +136,9 @@ describe("signalSetupWizard", () => {
 
   it("keeps account entry reversible until immediately before signal-cli installation", async () => {
     mocks.detectBinary.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "not running" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
     const beforePersistentEffect = vi.fn(async () => undefined);
     const queued = createQueuedWizardPrompter({
       selectValues: ["local"],
@@ -246,11 +248,7 @@ describe("signalSetupWizard", () => {
       finalize: signalSetupWizard.finalize,
       cfg: {},
       accountId: "work",
-      credentialValues: {
-        signalTransportKind: "managed-native",
-        signalCliPath: "/opt/openclaw/signal-cli",
-        signalCliConfigPath: "/var/lib/signal-cli",
-      },
+      credentialValues: managedSignalCredentialValues,
       prompter: queued.prompter,
       runtime: createRuntimeEnv({ throwOnExit: false }),
     });
@@ -294,11 +292,7 @@ describe("signalSetupWizard", () => {
       finalize: signalSetupWizard.finalize,
       cfg: {},
       accountId: "work",
-      credentialValues: {
-        signalTransportKind: "managed-native",
-        signalCliPath: "/opt/openclaw/signal-cli",
-        signalCliConfigPath: "/var/lib/signal-cli",
-      },
+      credentialValues: managedSignalCredentialValues,
       prompter: queued.prompter,
       runtime: createRuntimeEnv({ throwOnExit: false }),
       options: { beforePersistentEffect },
@@ -313,9 +307,6 @@ describe("signalSetupWizard", () => {
       initialValue: "link",
     });
     expect(beforePersistentEffect).toHaveBeenCalledOnce();
-    expect(beforePersistentEffect.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.linkSignalCliAccount.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    );
     expect(mocks.linkSignalCliAccount).toHaveBeenCalledWith({
       cliPath: "/opt/openclaw/signal-cli",
       configPath: "/var/lib/signal-cli",
@@ -336,6 +327,36 @@ describe("signalSetupWizard", () => {
     expect(
       resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
     ).toBe("+15555550123");
+  });
+
+  it("falls back to a note when the prompter cannot render plain QR output", async () => {
+    mocks.runPluginCommandWithTimeout
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: "[]",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '[{"number":"+15555550123"}]',
+        stderr: "",
+      });
+    const queued = createQueuedWizardPrompter({ selectValues: ["link"] });
+    const { plain: _plain, ...prompterWithoutPlain } = queued.prompter;
+
+    await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: prompterWithoutPlain,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("Scan this QR code:"),
+      "Signal account linking",
+    );
   });
 
   it("explains and retries a failed in-TUI signal-cli link", async () => {
@@ -362,11 +383,7 @@ describe("signalSetupWizard", () => {
       finalize: signalSetupWizard.finalize,
       cfg: {},
       accountId: "work",
-      credentialValues: {
-        signalTransportKind: "managed-native",
-        signalCliPath: "/opt/openclaw/signal-cli",
-        signalCliConfigPath: "/var/lib/signal-cli",
-      },
+      credentialValues: managedSignalCredentialValues,
       prompter: queued.prompter,
       runtime: createRuntimeEnv({ throwOnExit: false }),
     });
@@ -396,11 +413,7 @@ describe("signalSetupWizard", () => {
       finalize: signalSetupWizard.finalize,
       cfg: {},
       accountId: "work",
-      credentialValues: {
-        signalTransportKind: "managed-native",
-        signalCliPath: "/opt/openclaw/signal-cli",
-        signalCliConfigPath: "/var/lib/signal-cli",
-      },
+      credentialValues: managedSignalCredentialValues,
       prompter: queued.prompter,
       runtime: createRuntimeEnv({ throwOnExit: false }),
     });
@@ -419,7 +432,7 @@ describe("signalSetupWizard", () => {
   it("lets the user choose among multiple existing local signal-cli accounts", async () => {
     mocks.runPluginCommandWithTimeout.mockResolvedValue({
       code: 0,
-      stdout: '[{"number":"+15555550123"},{"number":"+15555550124"}]',
+      stdout: '[{"number":"+15555550124"},{"number":"+15555550123"}]',
       stderr: "",
     });
     const queued = createQueuedWizardPrompter({
@@ -430,11 +443,7 @@ describe("signalSetupWizard", () => {
       finalize: signalSetupWizard.finalize,
       cfg: {},
       accountId: "work",
-      credentialValues: {
-        signalTransportKind: "managed-native",
-        signalCliPath: "/opt/openclaw/signal-cli",
-        signalCliConfigPath: "/var/lib/signal-cli",
-      },
+      credentialValues: managedSignalCredentialValues,
       prompter: queued.prompter,
       runtime: createRuntimeEnv({ throwOnExit: false }),
     });
@@ -456,6 +465,7 @@ describe("signalSetupWizard", () => {
   });
 
   it("stops before linking when the user declines in-TUI account linking", async () => {
+    mocks.probeSignalTransport.mockResolvedValueOnce({ ok: false, error: "not running" });
     mocks.runPluginCommandWithTimeout.mockResolvedValue({
       code: 0,
       stdout: "[]",
@@ -474,11 +484,7 @@ describe("signalSetupWizard", () => {
           },
         } as OpenClawConfig,
         accountId: "work",
-        credentialValues: {
-          signalTransportKind: "managed-native",
-          signalCliPath: "/opt/openclaw/signal-cli",
-          signalCliConfigPath: "/var/lib/signal-cli",
-        },
+        credentialValues: managedSignalCredentialValues,
         prompter: queued.prompter,
         runtime: createRuntimeEnv({ throwOnExit: false }),
       }),
@@ -505,10 +511,56 @@ describe("signalSetupWizard", () => {
     });
     expect(mocks.linkSignalCliAccount).not.toHaveBeenCalled();
     expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
-    expect(mocks.probeSignalTransport).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
   });
 
-  it("starts and stops a temporary signal-cli daemon around a managed probe", async () => {
+  it("saves a manual account for a remote client that cannot own Signal linking", async () => {
+    mocks.runPluginCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "[]",
+      stderr: "",
+    });
+    const queued = createQueuedWizardPrompter({
+      textValues: ["+15555550123"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+      options: { deferDeviceLinkToClient: true, remoteWizard: true },
+    });
+
+    expect(mocks.linkSignalCliAccount).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).not.toHaveBeenCalled();
+    expect(finalized?.cfg?.channels?.signal?.accounts?.work?.account).toBe("+15555550123");
+    expect(finalized?.credentialValues).toEqual({
+      signalLinkDeferred: "true",
+    });
+    expect(queued.note).toHaveBeenLastCalledWith(
+      expect.stringContaining("Signal will not be ready until that linking step succeeds."),
+      "Signal next steps",
+    );
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("After this wizard finishes"),
+      "Signal account linking",
+    );
+  });
+
+  it("uses a temporary port when validating changes to a configured managed daemon", async () => {
+    mocks.prepareSignalManagedNativeTransport.mockReturnValueOnce({
+      kind: "managed-native",
+      cliPath: "/opt/openclaw/signal-cli",
+      configPath: "/var/lib/signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+      receiveMode: "on-start",
+      ignoreStories: true,
+    });
     const queued = createQueuedWizardPrompter();
 
     await runSetupWizardFinalize({
@@ -516,44 +568,392 @@ describe("signalSetupWizard", () => {
       cfg: {
         channels: {
           signal: {
-            accounts: { work: { account: "+15555550123" } },
+            accounts: {
+              work: {
+                account: "+15555550123",
+                transport: {
+                  kind: "managed-native",
+                  cliPath: "/opt/openclaw/signal-cli",
+                  configPath: "/var/lib/signal-cli-old",
+                  httpHost: "127.0.0.1",
+                  httpPort: 8080,
+                },
+              },
+            },
           },
         },
       } as OpenClawConfig,
       accountId: "work",
-      credentialValues: {
-        signalTransportKind: "managed-native",
-        signalCliPath: "/opt/openclaw/signal-cli",
-        signalCliConfigPath: "/var/lib/signal-cli",
-      },
+      credentialValues: managedSignalCredentialValues,
       prompter: queued.prompter,
       runtime: createRuntimeEnv({ throwOnExit: false }),
     });
 
-    expect(mocks.spawnSignalDaemon).toHaveBeenCalledWith({
-      cliPath: "/opt/openclaw/signal-cli",
-      configPath: "/var/lib/signal-cli",
-      account: "+15555550123",
-      httpHost: "127.0.0.1",
-      httpPort: 8080,
-    });
+    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
+    const validationPort = mocks.spawnSignalDaemon.mock.calls[0]?.[0]?.httpPort;
+    expect(validationPort).toEqual(expect.any(Number));
+    expect(validationPort).not.toBe(8080);
+    expect(mocks.spawnSignalDaemon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cliPath: "/opt/openclaw/signal-cli",
+        configPath: "/var/lib/signal-cli",
+        account: "+15555550123",
+        httpHost: "127.0.0.1",
+        httpPort: validationPort,
+        receiveMode: "manual",
+        ignoreStories: true,
+      }),
+    );
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          kind: "managed-native",
+          httpPort: validationPort,
+          url: `http://127.0.0.1:${String(validationPort)}`,
+        }),
+      }),
+    );
     expect(queued.progress).toHaveBeenCalledWith("Validating Signal setup...");
     expect(queued.progress.mock.results[0]?.value.stop).toHaveBeenCalledWith(
       "Signal setup validated.",
     );
-    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
     expect(mocks.spawnSignalDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
+  });
+
+  it("stops managed validation immediately when the remote wizard is cancelled", async () => {
+    const abortController = new AbortController();
+    const cancellation = new WizardCancelledError("Signal setup stopped");
+    const stop = vi.fn(async () => undefined);
+    mocks.spawnSignalDaemon.mockReturnValueOnce({
+      pid: 1234,
+      stop,
+      exited: new Promise<never>(() => {}),
+      isExited: () => false,
+    });
+    mocks.probeSignalTransport.mockImplementationOnce(async () => {
+      abortController.abort(cancellation);
+      return { ok: false, error: "not ready" };
+    });
+    const queued = createQueuedWizardPrompter();
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {
+          channels: {
+            signal: {
+              accounts: { work: { account: "+15555550123" } },
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+        options: { abortSignal: abortController.signal },
+      }),
+    ).rejects.toBe(cancellation);
+
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("probes an unchanged running managed daemon without starting a competing process", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: configuredManagedSignalConfig(),
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(queued.progress).not.toHaveBeenCalled();
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
+    ).toBe("123e4567-e89b-12d3-a456-426614174000");
+  });
+
+  it("does not enumerate accounts locked by an unchanged running daemon", async () => {
+    mocks.runPluginCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: '[{"number":"+15555550124"}]',
+      stderr: "",
+    });
+    const queued = createQueuedWizardPrompter();
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: configuredManagedSignalConfig(),
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
+    ).toBe("+15555550123");
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
+    ).toBe("123e4567-e89b-12d3-a456-426614174000");
+  });
+
+  it("stops before account discovery when an accountless managed daemon is running", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {
+          channels: {
+            signal: {
+              accounts: {
+                work: {
+                  transport: {
+                    kind: "managed-native",
+                    cliPath: "/opt/openclaw/signal-cli",
+                    configPath: "/var/lib/signal-cli",
+                    httpHost: "127.0.0.1",
+                    httpPort: 8080,
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toThrow(
+      "The running Signal daemon is using this signal-cli config directory. Stop the OpenClaw gateway before discovering or linking an account, then retry setup.",
+    );
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+
+  it("reuses an unchanged active transport when both data directories are implicit", async () => {
+    mocks.prepareSignalManagedNativeTransport.mockReturnValueOnce({
+      kind: "managed-native",
+      cliPath: "/opt/openclaw/signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+    const cfg = configuredManagedSignalConfig();
+    const work = cfg.channels?.signal?.accounts?.work;
+    if (work?.transport?.kind !== "managed-native") {
+      throw new Error("expected managed Signal fixture");
+    }
+    delete work.transport.configPath;
+
+    await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg,
+      accountId: "work",
+      credentialValues: {
+        signalTransportKind: "managed-native",
+        signalCliPath: "/opt/openclaw/signal-cli",
+      },
+      prompter: createQueuedWizardPrompter().prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when an active implicit data directory is compared with an explicit path", async () => {
+    const queued = createQueuedWizardPrompter();
+    const cfg = configuredManagedSignalConfig();
+    const work = cfg.channels?.signal?.accounts?.work;
+    if (work?.transport?.kind !== "managed-native") {
+      throw new Error("expected managed Signal fixture");
+    }
+    delete work.transport.configPath;
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg,
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toThrow("The running Signal daemon may be using this signal-cli config directory");
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+
+  it("preserves account UUID while revalidating the same offline managed account", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "not running" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const queued = createQueuedWizardPrompter();
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: configuredManagedSignalConfig(),
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.runPluginCommandWithTimeout).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon).toHaveBeenCalledOnce();
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
+    ).toBe("123e4567-e89b-12d3-a456-426614174000");
+  });
+
+  it("explains that a live daemon must stop before changing its signal-cli settings", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {
+          channels: {
+            signal: {
+              accounts: {
+                work: {
+                  account: "+15555550123",
+                  transport: {
+                    kind: "managed-native",
+                    cliPath: "signal-cli",
+                    configPath: "/var/lib/signal-cli",
+                    httpHost: "127.0.0.1",
+                    httpPort: 8080,
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toThrow(
+      "The running Signal daemon may be using this signal-cli config directory. Stop the OpenClaw gateway before changing its signal-cli settings, then retry setup.",
+    );
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+
+  it("requires the live daemon to stop before switching from an explicit to implicit store", async () => {
+    const queued = createQueuedWizardPrompter();
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: configuredManagedSignalConfig(),
+        accountId: "work",
+        credentialValues: {
+          ...managedSignalCredentialValues,
+          signalCliConfigPath: "",
+        },
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toThrow("The running Signal daemon may be using this signal-cli config directory");
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+  });
+
+  it("clears a configured signal-cli directory when the user chooses the default", async () => {
+    mocks.probeSignalTransport
+      .mockResolvedValueOnce({ ok: false, error: "not running" })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["local"],
+      textValues: [""],
+    });
+    const cfg = {
+      channels: {
+        signal: {
+          accounts: {
+            work: {
+              account: "+15555550123",
+              transport: {
+                kind: "managed-native",
+                cliPath: "/opt/openclaw/signal-cli",
+                configPath: "/var/lib/signal-cli",
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const prepared = await runSetupWizardPrepare({
+      prepare: signalSetupWizard.prepare,
+      cfg,
+      accountId: "work",
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg,
+      accountId: "work",
+      credentialValues: toCredentialValues(prepared?.credentialValues),
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(prepared?.credentialValues).toMatchObject({ signalCliConfigPath: "" });
+    expect(mocks.prepareSignalManagedNativeTransport).toHaveBeenLastCalledWith({
+      cfg,
+      accountId: "work",
+      overrides: {
+        cliPath: "/opt/openclaw/signal-cli",
+        configPath: "",
+      },
+    });
+    expect(
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.transport,
+    ).not.toHaveProperty("configPath");
   });
 
   it("shows user-facing completion guidance instead of a raw gateway RPC", () => {
     const lines = signalCompletionNote.lines.join("\n");
 
-    expect(lines).toContain("Signal setup is validated.");
+    expect(lines).toContain("Signal setup validation passed.");
+    expect(lines).toContain("save this connection when channel setup finishes");
     expect(lines).toContain("openclaw channels status --probe");
     expect(lines).not.toContain("gateway call");
+    expect(
+      signalCompletionNote.shouldShow({
+        cfg: {},
+        accountId: "work",
+        credentialValues: { signalLinkDeferred: "true" },
+      }),
+    ).toBe(false);
   });
 
   it("stops a temporary daemon that exits before its managed probe", async () => {
+    mocks.probeSignalTransport.mockResolvedValueOnce({ ok: false, error: "not running" });
     const stop = vi.fn(async () => undefined);
     mocks.spawnSignalDaemon.mockReturnValueOnce({
       pid: 1234,
@@ -578,11 +978,7 @@ describe("signalSetupWizard", () => {
           },
         } as OpenClawConfig,
         accountId: "work",
-        credentialValues: {
-          signalTransportKind: "managed-native",
-          signalCliPath: "/opt/openclaw/signal-cli",
-          signalCliConfigPath: "/var/lib/signal-cli",
-        },
+        credentialValues: managedSignalCredentialValues,
         prompter: queued.prompter,
         runtime: createRuntimeEnv({ throwOnExit: false }),
       }),
@@ -592,158 +988,26 @@ describe("signalSetupWizard", () => {
       expect.stringContaining("signal-cli exited before its HTTP server became ready"),
       "Signal setup",
     );
-    expect(mocks.probeSignalTransport).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
     expect(stop).toHaveBeenCalledOnce();
   });
 
-  it("detects, probes, and writes a concrete existing container transport", async () => {
-    mocks.detectSignalTransport.mockResolvedValue({
-      kind: "container",
-      url: "http://signal-helper:8080",
-    });
-    const queued = createQueuedWizardPrompter({
-      selectValues: ["existing-server"],
-      textValues: ["http://signal-helper:8080"],
-    });
-
-    const prepared = await runSetupWizardPrepare({
-      prepare: signalSetupWizard.prepare,
-      cfg: {},
-      accountId: "work",
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-    const finalized = await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: {
-        channels: {
-          signal: {
-            accounts: { work: { account: "+15555550123" } },
-          },
-        },
-      } as OpenClawConfig,
-      accountId: "work",
-      credentialValues: toCredentialValues(prepared?.credentialValues),
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
-    expect(mocks.detectSignalTransport).toHaveBeenCalledWith({
-      url: "http://signal-helper:8080",
-    });
-    expect(mocks.probeSignalTransport).toHaveBeenCalledWith({
-      cfg: expect.any(Object),
-      accountId: "work",
-      transport: { kind: "container", url: "http://signal-helper:8080" },
-      account: "+15555550123",
-    });
-    expect(finalized?.cfg?.channels?.signal?.accounts?.work?.transport).toEqual({
-      kind: "container",
-      url: "http://signal-helper:8080",
-    });
-  });
-
-  it("requires a Signal account before probing a container", async () => {
-    const queued = createQueuedWizardPrompter({ textValues: ["+15555550123"] });
-
-    const finalized = await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: {},
-      accountId: "work",
-      credentialValues: {
-        signalTransportKind: "container",
-        signalServerUrl: "http://signal-helper:8080",
-      },
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(queued.text).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Signal phone number" }),
-    );
-    expect(mocks.probeSignalTransport).toHaveBeenCalledWith({
-      cfg: expect.any(Object),
-      accountId: "work",
-      transport: { kind: "container", url: "http://signal-helper:8080" },
-      account: "+15555550123",
-    });
-    expect(
-      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
-    ).toBe("+15555550123");
-  });
-
-  it("changes the Signal account and retries after a failed probe", async () => {
-    mocks.probeSignalTransport
-      .mockResolvedValueOnce({ ok: false, error: "account not registered" })
-      .mockResolvedValueOnce({ ok: true, status: 200 });
-    const queued = createQueuedWizardPrompter({
-      selectValues: ["account"],
-      textValues: ["+15555550124"],
-    });
-
-    const finalized = await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: {
-        channels: {
-          signal: {
-            accounts: { work: { account: "+15555550123" } },
-          },
-        },
-      } as OpenClawConfig,
-      accountId: "work",
-      credentialValues: {
-        signalTransportKind: "external-native",
-        signalServerUrl: "http://signal-helper:8080",
-      },
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
-    expect(mocks.probeSignalTransport).toHaveBeenLastCalledWith(
-      expect.objectContaining({ account: "+15555550124" }),
-    );
-    expect(
-      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
-    ).toBe("+15555550124");
-  });
-
-  it("selects another linked local account after a managed probe failure", async () => {
+  it("selects another linked local account before validating managed setup", async () => {
+    mocks.probeSignalTransport.mockResolvedValueOnce({ ok: false, error: "not running" });
     mocks.runPluginCommandWithTimeout.mockResolvedValue({
       code: 0,
       stdout: '[{"number":"+15555550123"},{"number":"+15555550124"}]',
       stderr: "",
     });
-    mocks.spawnSignalDaemon.mockReturnValueOnce({
-      pid: 1234,
-      stop: vi.fn(async () => undefined),
-      exited: Promise.resolve({
-        source: "process" as const,
-        code: 1,
-        signal: null,
-      }),
-      isExited: () => true,
-    });
     const queued = createQueuedWizardPrompter({
-      selectValues: ["account", "account:+15555550124"],
+      selectValues: ["account:+15555550124"],
     });
 
     const finalized = await runSetupWizardFinalize({
       finalize: signalSetupWizard.finalize,
-      cfg: {
-        channels: {
-          signal: {
-            accounts: { work: { account: "+15555550123" } },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: configuredManagedSignalConfig({ withTransport: false }),
       accountId: "work",
-      credentialValues: {
-        signalTransportKind: "managed-native",
-        signalCliPath: "/opt/openclaw/signal-cli",
-        signalCliConfigPath: "/var/lib/signal-cli",
-      },
+      credentialValues: managedSignalCredentialValues,
       prompter: queued.prompter,
       runtime: createRuntimeEnv({ throwOnExit: false }),
     });
@@ -754,262 +1018,15 @@ describe("signalSetupWizard", () => {
         message: "Choose the linked Signal account for OpenClaw",
       }),
     );
-    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
+    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
     expect(mocks.probeSignalTransport).toHaveBeenLastCalledWith(
       expect.objectContaining({ account: "+15555550124" }),
     );
     expect(
       resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
     ).toBe("+15555550124");
-  });
-
-  it("changes and re-detects the server URL after a failed probe", async () => {
-    mocks.probeSignalTransport
-      .mockResolvedValueOnce({ ok: false, error: "receive probe failed" })
-      .mockResolvedValueOnce({ ok: true, status: 200 });
-    const queued = createQueuedWizardPrompter({
-      selectValues: ["url"],
-      textValues: ["http://signal-helper-new:8080"],
-    });
-
-    const finalized = await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: {},
-      accountId: "default",
-      credentialValues: {
-        signalTransportKind: "external-native",
-        signalServerUrl: "http://signal-helper-old:8080",
-      },
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(mocks.detectSignalTransport).toHaveBeenCalledOnce();
-    expect(mocks.detectSignalTransport).toHaveBeenCalledWith({
-      url: "http://signal-helper-new:8080",
-    });
-    expect(finalized?.cfg?.channels?.signal?.transport).toEqual({
-      kind: "external-native",
-      url: "http://signal-helper-new:8080",
-    });
-  });
-
-  it("prompts for an account when URL recovery changes to a container", async () => {
-    mocks.probeSignalTransport
-      .mockResolvedValueOnce({ ok: false, error: "receive probe failed" })
-      .mockResolvedValueOnce({ ok: true, status: 200 });
-    mocks.detectSignalTransport.mockResolvedValueOnce({
-      kind: "container",
-      url: "http://signal-helper-new:8080",
-    });
-    const queued = createQueuedWizardPrompter({
-      selectValues: ["url"],
-      textValues: ["http://signal-helper-new:8080", "+15555550123"],
-    });
-
-    const finalized = await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: {},
-      accountId: "default",
-      credentialValues: {
-        signalTransportKind: "external-native",
-        signalServerUrl: "http://signal-helper-old:8080",
-      },
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(queued.text).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ message: "Signal server URL" }),
-    );
-    expect(queued.text).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ message: "Signal phone number" }),
-    );
-    expect(mocks.probeSignalTransport).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        transport: { kind: "container", url: "http://signal-helper-new:8080" },
-        account: "+15555550123",
-      }),
-    );
     expect(
-      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "default" }).config.account,
-    ).toBe("+15555550123");
-  });
-
-  it("retries the same candidate without re-detecting it", async () => {
-    mocks.probeSignalTransport
-      .mockResolvedValueOnce({ ok: false, error: "not ready" })
-      .mockResolvedValueOnce({ ok: true, status: 200 });
-    const queued = createQueuedWizardPrompter({ selectValues: ["retry"] });
-
-    await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: {},
-      credentialValues: {
-        signalTransportKind: "external-native",
-        signalServerUrl: "http://signal-helper:8080",
-      },
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
-    expect(mocks.detectSignalTransport).not.toHaveBeenCalled();
-  });
-
-  it("retries failed server detection without prompting for the URL again", async () => {
-    mocks.detectSignalTransport
-      .mockRejectedValueOnce(new Error("server starting"))
-      .mockResolvedValueOnce({
-        kind: "external-native",
-        url: "http://signal-helper:8080",
-      });
-    const queued = createQueuedWizardPrompter({
-      selectValues: ["existing-server", "retry"],
-      textValues: ["http://signal-helper:8080"],
-    });
-
-    const prepared = await runSetupWizardPrepare({
-      prepare: signalSetupWizard.prepare,
-      cfg: {},
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(queued.text).toHaveBeenCalledOnce();
-    expect(mocks.detectSignalTransport).toHaveBeenCalledTimes(2);
-    expect(mocks.detectSignalTransport).toHaveBeenNthCalledWith(1, {
-      url: "http://signal-helper:8080",
-    });
-    expect(mocks.detectSignalTransport).toHaveBeenNthCalledWith(2, {
-      url: "http://signal-helper:8080",
-    });
-    expect(prepared?.credentialValues).toMatchObject({
-      signalTransportKind: "external-native",
-    });
-  });
-
-  it("allows an unambiguous external-native server without a Signal account", async () => {
-    const queued = createQueuedWizardPrompter();
-
-    const finalized = await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: {},
-      credentialValues: {
-        signalTransportKind: "external-native",
-        signalServerUrl: "http://signal-helper:8080",
-      },
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(queued.text).not.toHaveBeenCalled();
-    expect(mocks.probeSignalTransport).toHaveBeenCalledWith({
-      cfg: {},
-      accountId: "default",
-      transport: { kind: "external-native", url: "http://signal-helper:8080" },
-      account: undefined,
-    });
-    expect(finalized?.cfg?.channels?.signal?.transport).toEqual({
-      kind: "external-native",
-      url: "http://signal-helper:8080",
-    });
-  });
-
-  it("stops failed setup with the generic wizard cancellation", async () => {
-    mocks.probeSignalTransport.mockResolvedValue({ ok: false, error: "not ready" });
-    const queued = createQueuedWizardPrompter({ selectValues: ["stop"] });
-
-    await expect(
-      runSetupWizardFinalize({
-        finalize: signalSetupWizard.finalize,
-        cfg: {},
-        credentialValues: {
-          signalTransportKind: "external-native",
-          signalServerUrl: "http://signal-helper:8080",
-        },
-        prompter: queued.prompter,
-        runtime: createRuntimeEnv({ throwOnExit: false }),
-      }),
-    ).rejects.toBeInstanceOf(WizardCancelledError);
-  });
-
-  it("rejects a URL that aliases an OpenClaw-managed daemon", async () => {
-    const queued = createQueuedWizardPrompter({
-      selectValues: ["existing-server", "url"],
-      textValues: ["http://localhost:8080", "http://signal-helper:8080"],
-    });
-
-    const prepared = await runSetupWizardPrepare({
-      prepare: signalSetupWizard.prepare,
-      cfg: {
-        channels: {
-          signal: {
-            account: "+15555550123",
-            transport: {
-              kind: "managed-native",
-              httpHost: "127.0.0.1",
-              httpPort: 8080,
-            },
-          },
-        },
-      } as OpenClawConfig,
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(mocks.detectSignalTransport).toHaveBeenCalledTimes(2);
-    expect(prepared?.credentialValues).toMatchObject({
-      signalTransportKind: "external-native",
-      signalServerUrl: "http://signal-helper:8080",
-    });
-  });
-
-  it("propagates generic Back navigation without Signal-specific catches", async () => {
-    const back = new Error("wizard back");
-    const queued = createQueuedWizardPrompter();
-    queued.select.mockRejectedValueOnce(back);
-
-    await expect(
-      runSetupWizardPrepare({
-        prepare: signalSetupWizard.prepare,
-        prompter: queued.prompter,
-        runtime: createRuntimeEnv({ throwOnExit: false }),
-      }),
-    ).rejects.toBe(back);
-  });
-
-  it("collects account numbers only where the selected transport requires them", () => {
-    const requiredAccountInput = signalNumberTextInputs.find((input) => input.required !== false);
-    const optionalAccountInput = signalNumberTextInputs.find(
-      (input) => input.message === "Signal phone number (optional)",
-    );
-    const proxy = createSignalSetupWizardProxy(async () => signalSetupWizard);
-
-    expect(
-      requiredAccountInput?.shouldPrompt?.({
-        cfg: {},
-        accountId: "default",
-        credentialValues: { signalTransportKind: "managed-native" },
-      }),
-    ).toBe(false);
-    expect(
-      requiredAccountInput?.shouldPrompt?.({
-        cfg: {},
-        accountId: "default",
-        credentialValues: { signalTransportKind: "container" },
-      }),
-    ).toBe(true);
-    expect(optionalAccountInput?.required).toBe(false);
-    expect(
-      optionalAccountInput?.shouldPrompt?.({
-        cfg: {},
-        accountId: "default",
-        credentialValues: { signalTransportKind: "external-native" },
-      }),
-    ).toBe(true);
-    expect(proxy.finalize).toBeTypeOf("function");
+      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
+    ).toBeUndefined();
   });
 });

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -881,13 +881,14 @@ describe("signalSetupWizard", () => {
     expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
   });
 
-  it("clears a configured signal-cli directory when the user chooses the default", async () => {
+  it("accepts the explicit default answer for the signal-cli directory", async () => {
+    mocks.detectBinary.mockResolvedValueOnce(true);
     mocks.probeSignalTransport
       .mockResolvedValueOnce({ ok: false, error: "not running" })
       .mockResolvedValueOnce({ ok: true, status: 200 });
     const queued = createQueuedWizardPrompter({
       selectValues: ["local"],
-      textValues: [""],
+      textValues: ["default"],
     });
     const cfg = {
       channels: {
@@ -923,6 +924,11 @@ describe("signalSetupWizard", () => {
     });
 
     expect(prepared?.credentialValues).toMatchObject({ signalCliConfigPath: "" });
+    expect(queued.text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "signal-cli config directory (type `default` for the standard location)",
+      }),
+    );
     expect(mocks.prepareSignalManagedNativeTransport).toHaveBeenLastCalledWith({
       cfg,
       accountId: "work",

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -141,7 +141,7 @@ describe("signalSetupWizard", () => {
       .mockResolvedValueOnce({ ok: true, status: 200 });
     const beforePersistentEffect = vi.fn(async () => undefined);
     const queued = createQueuedWizardPrompter({
-      selectValues: ["local"],
+      selectValues: ["local", "custom"],
       confirmValues: [true],
       textValues: ["/var/lib/signal-cli"],
     });
@@ -881,14 +881,13 @@ describe("signalSetupWizard", () => {
     expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
   });
 
-  it("accepts the explicit default answer for the signal-cli directory", async () => {
+  it("offers the default signal-cli directory as a choice instead of a text answer", async () => {
     mocks.detectBinary.mockResolvedValueOnce(true);
     mocks.probeSignalTransport
       .mockResolvedValueOnce({ ok: false, error: "not running" })
       .mockResolvedValueOnce({ ok: true, status: 200 });
     const queued = createQueuedWizardPrompter({
-      selectValues: ["local"],
-      textValues: ["default"],
+      selectValues: ["local", "default"],
     });
     const cfg = {
       channels: {
@@ -924,11 +923,15 @@ describe("signalSetupWizard", () => {
     });
 
     expect(prepared?.credentialValues).toMatchObject({ signalCliConfigPath: "" });
-    expect(queued.text).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "signal-cli config directory (type `default` for the standard location)",
-      }),
-    );
+    expect(queued.select).toHaveBeenCalledWith({
+      message: "Where should signal-cli store its configuration?",
+      options: [
+        { value: "default", label: "Use the default location" },
+        { value: "custom", label: "Choose a custom directory" },
+      ],
+      initialValue: "custom",
+    });
+    expect(queued.text).not.toHaveBeenCalled();
     expect(mocks.prepareSignalManagedNativeTransport).toHaveBeenLastCalledWith({
       cfg,
       accountId: "work",

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -20,6 +20,9 @@ import type { SignalTransportProbeResult } from "./setup-transport.js";
 import type { SignalCliLinkResult } from "./signal-cli-link.js";
 
 type SpawnSignalDaemonParams = Parameters<typeof import("./daemon.js").spawnSignalDaemon>[0];
+type ProbeSignalTransportParams = Parameters<
+  typeof import("./setup-transport.js").probeSignalTransport
+>[0];
 
 const mocks = vi.hoisted(() => ({
   detectBinary: vi.fn(async (_cliPath: string) => false),
@@ -75,7 +78,10 @@ const mocks = vi.hoisted(() => ({
     }),
   ),
   probeSignalTransport: vi.fn(
-    async (): Promise<SignalTransportProbeResult> => ({ ok: true, status: 200 }),
+    async (_params: ProbeSignalTransportParams): Promise<SignalTransportProbeResult> => ({
+      ok: true,
+      status: 200,
+    }),
   ),
 }));
 
@@ -771,7 +777,7 @@ describe("signalSetupWizard", () => {
     mocks.spawnSignalDaemon.mockReturnValueOnce({
       pid: 1234,
       stop,
-      exited: Promise.resolve({ code: 1, signal: null }),
+      exited: Promise.resolve({ source: "process", code: 1, signal: null }),
       isExited: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
     });
     mocks.probeSignalTransport.mockImplementation(async ({ transport }) => ({

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -6,7 +6,7 @@ import {
   runSetupWizardPrepare,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { WizardCancelledError } from "openclaw/plugin-sdk/setup";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SignalTransportConfig } from "./account-types.js";
 import { resolveSignalAccount } from "./accounts.js";
 import type { SignalDaemonHandle } from "./daemon.js";
@@ -64,6 +64,7 @@ const mocks = vi.hoisted(() => ({
       isExited: () => false,
     }),
   ),
+  assertSignalDaemonBindAvailable: vi.fn(async () => undefined),
   prepareSignalManagedNativeTransport: vi.fn(
     (): Extract<SignalTransportConfig, { kind: "managed-native" }> => ({
       kind: "managed-native",
@@ -94,6 +95,7 @@ vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
 }));
 
 vi.mock("./daemon.js", () => ({
+  assertSignalDaemonBindAvailable: mocks.assertSignalDaemonBindAvailable,
   spawnSignalDaemon: mocks.spawnSignalDaemon,
 }));
 
@@ -127,11 +129,16 @@ describe("signalSetupWizard", () => {
       url,
     }));
     mocks.probeSignalTransport.mockReset().mockResolvedValue({ ok: true, status: 200 });
+    mocks.assertSignalDaemonBindAvailable.mockReset().mockResolvedValue(undefined);
     mocks.runPluginCommandWithTimeout.mockResolvedValue({
       code: 0,
       stdout: '[{"number":"+15555550123"}]',
       stderr: "",
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("keeps account entry reversible until immediately before signal-cli installation", async () => {
@@ -429,6 +436,137 @@ describe("signalSetupWizard", () => {
     ).toBe("+15555550123");
   });
 
+  it("lets the user correct local signal-cli settings after account discovery fails", async () => {
+    mocks.runPluginCommandWithTimeout
+      .mockResolvedValueOnce({
+        code: 1,
+        stdout: "",
+        stderr: "signal-cli not found",
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '[{"number":"+15555550123"}]',
+        stderr: "",
+      });
+    mocks.prepareSignalManagedNativeTransport
+      .mockReturnValueOnce({
+        kind: "managed-native",
+        cliPath: "/opt/openclaw/signal-cli",
+        configPath: "/var/lib/signal-cli",
+        httpHost: "127.0.0.1",
+        httpPort: 8080,
+      })
+      .mockReturnValueOnce({
+        kind: "managed-native",
+        cliPath: "/usr/local/bin/signal-cli",
+        httpHost: "127.0.0.1",
+        httpPort: 8080,
+      });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["settings", "default"],
+      textValues: ["/usr/local/bin/signal-cli"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {},
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("signal-cli could not list its linked accounts"),
+      "Signal account discovery",
+    );
+    expect(queued.select).toHaveBeenCalledWith({
+      message: "How should local signal-cli setup continue?",
+      options: [
+        { value: "retry", label: "Retry account discovery" },
+        { value: "settings", label: "Change signal-cli settings" },
+        { value: "stop", label: "Stop Signal setup" },
+      ],
+      initialValue: "settings",
+    });
+    expect(mocks.runPluginCommandWithTimeout).toHaveBeenLastCalledWith({
+      argv: ["/usr/local/bin/signal-cli", "--output", "json", "listAccounts"],
+      timeoutMs: 10_000,
+    });
+    expect(finalized?.cfg?.channels?.signal?.accounts?.work?.transport).toEqual(
+      expect.objectContaining({
+        kind: "managed-native",
+        cliPath: "/usr/local/bin/signal-cli",
+      }),
+    );
+    expect(finalized?.cfg?.channels?.signal?.accounts?.work?.transport).not.toHaveProperty(
+      "configPath",
+    );
+  });
+
+  it("rechecks the live signal-cli store after account-discovery settings recovery", async () => {
+    mocks.runPluginCommandWithTimeout.mockResolvedValueOnce({
+      code: 1,
+      stdout: "",
+      stderr: "signal-cli data store unavailable",
+    });
+    mocks.prepareSignalManagedNativeTransport
+      .mockReturnValueOnce({
+        kind: "managed-native",
+        cliPath: "/opt/openclaw/signal-cli",
+        configPath: "/var/lib/signal-cli-candidate",
+        httpHost: "127.0.0.1",
+        httpPort: 8080,
+      })
+      .mockReturnValueOnce({
+        kind: "managed-native",
+        cliPath: "/opt/openclaw/signal-cli",
+        configPath: "/var/lib/signal-cli-active",
+        httpHost: "127.0.0.1",
+        httpPort: 8080,
+      });
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["settings", "custom"],
+      textValues: ["/opt/openclaw/signal-cli", "/var/lib/signal-cli-active"],
+    });
+
+    const finalized = await runSetupWizardFinalize({
+      finalize: signalSetupWizard.finalize,
+      cfg: {
+        channels: {
+          signal: {
+            accounts: {
+              work: {
+                account: "+15555550123",
+                transport: {
+                  kind: "managed-native",
+                  cliPath: "/opt/openclaw/signal-cli",
+                  configPath: "/var/lib/signal-cli-active",
+                  httpHost: "127.0.0.1",
+                  httpPort: 8080,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      credentialValues: managedSignalCredentialValues,
+      prompter: queued.prompter,
+      runtime: createRuntimeEnv({ throwOnExit: false }),
+    });
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledTimes(2);
+    expect(mocks.runPluginCommandWithTimeout).toHaveBeenCalledOnce();
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+    expect(finalized?.cfg?.channels?.signal?.accounts?.work?.transport).toEqual(
+      expect.objectContaining({
+        kind: "managed-native",
+        configPath: "/var/lib/signal-cli-active",
+      }),
+    );
+  });
+
   it("lets the user choose among multiple existing local signal-cli accounts", async () => {
     mocks.runPluginCommandWithTimeout.mockResolvedValue({
       code: 0,
@@ -620,6 +758,93 @@ describe("signalSetupWizard", () => {
     expect(mocks.spawnSignalDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
   });
 
+  it("does not accept a separate connection URL before the spawned daemon bind is ready", async () => {
+    mocks.prepareSignalManagedNativeTransport.mockReturnValueOnce({
+      kind: "managed-native",
+      cliPath: "/opt/openclaw/signal-cli",
+      configPath: "/var/lib/signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+      url: "https://signal.example.test",
+    });
+    const stop = vi.fn(async () => undefined);
+    mocks.spawnSignalDaemon.mockReturnValueOnce({
+      pid: 1234,
+      stop,
+      exited: Promise.resolve({ code: 1, signal: null }),
+      isExited: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+    });
+    mocks.probeSignalTransport.mockImplementation(async ({ transport }) => ({
+      ok: transport.url === "https://signal.example.test",
+      ...(transport.url === "https://signal.example.test"
+        ? { status: 200 }
+        : { error: "spawned bind is not ready" }),
+    }));
+    const queued = createQueuedWizardPrompter({ selectValues: ["stop"] });
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {},
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+
+    expect(mocks.probeSignalTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          kind: "managed-native",
+          url: "http://127.0.0.1:8080",
+        }),
+      }),
+    );
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an occupied managed bind before probing a different process", async () => {
+    mocks.assertSignalDaemonBindAvailable.mockRejectedValueOnce(
+      new Error(
+        "Signal cannot start a managed daemon on 127.0.0.1:8080 because that address is already in use.",
+      ),
+    );
+    const queued = createQueuedWizardPrompter({ selectValues: ["stop"] });
+
+    await expect(
+      runSetupWizardFinalize({
+        finalize: signalSetupWizard.finalize,
+        cfg: {
+          channels: {
+            signal: {
+              accounts: {
+                work: {
+                  account: "+15555550123",
+                  transport: {
+                    kind: "external-native",
+                    url: "http://127.0.0.1:8080",
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "work",
+        credentialValues: managedSignalCredentialValues,
+        prompter: queued.prompter,
+        runtime: createRuntimeEnv({ throwOnExit: false }),
+      }),
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+
+    expect(queued.note).toHaveBeenCalledWith(
+      expect.stringContaining("address is already in use"),
+      "Signal setup",
+    );
+    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
+    expect(mocks.probeSignalTransport).not.toHaveBeenCalled();
+  });
+
   it("stops managed validation immediately when the remote wizard is cancelled", async () => {
     const abortController = new AbortController();
     const cancellation = new WizardCancelledError("Signal setup stopped");
@@ -655,230 +880,6 @@ describe("signalSetupWizard", () => {
     ).rejects.toBe(cancellation);
 
     expect(stop).toHaveBeenCalledOnce();
-  });
-
-  it("probes an unchanged running managed daemon without starting a competing process", async () => {
-    const queued = createQueuedWizardPrompter();
-
-    const finalized = await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: configuredManagedSignalConfig(),
-      accountId: "work",
-      credentialValues: managedSignalCredentialValues,
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
-    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
-    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
-    expect(queued.progress).not.toHaveBeenCalled();
-    expect(
-      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
-    ).toBe("123e4567-e89b-12d3-a456-426614174000");
-  });
-
-  it("does not enumerate accounts locked by an unchanged running daemon", async () => {
-    mocks.runPluginCommandWithTimeout.mockResolvedValue({
-      code: 0,
-      stdout: '[{"number":"+15555550124"}]',
-      stderr: "",
-    });
-    const queued = createQueuedWizardPrompter();
-
-    const finalized = await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: configuredManagedSignalConfig(),
-      accountId: "work",
-      credentialValues: managedSignalCredentialValues,
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
-    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
-    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
-    expect(
-      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.account,
-    ).toBe("+15555550123");
-    expect(
-      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
-    ).toBe("123e4567-e89b-12d3-a456-426614174000");
-  });
-
-  it("stops before account discovery when an accountless managed daemon is running", async () => {
-    const queued = createQueuedWizardPrompter();
-
-    await expect(
-      runSetupWizardFinalize({
-        finalize: signalSetupWizard.finalize,
-        cfg: {
-          channels: {
-            signal: {
-              accounts: {
-                work: {
-                  transport: {
-                    kind: "managed-native",
-                    cliPath: "/opt/openclaw/signal-cli",
-                    configPath: "/var/lib/signal-cli",
-                    httpHost: "127.0.0.1",
-                    httpPort: 8080,
-                  },
-                },
-              },
-            },
-          },
-        } as OpenClawConfig,
-        accountId: "work",
-        credentialValues: managedSignalCredentialValues,
-        prompter: queued.prompter,
-        runtime: createRuntimeEnv({ throwOnExit: false }),
-      }),
-    ).rejects.toThrow(
-      "The running Signal daemon is using this signal-cli config directory. Stop the OpenClaw gateway before discovering or linking an account, then retry setup.",
-    );
-
-    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
-    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
-    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
-  });
-
-  it("reuses an unchanged active transport when both data directories are implicit", async () => {
-    mocks.prepareSignalManagedNativeTransport.mockReturnValueOnce({
-      kind: "managed-native",
-      cliPath: "/opt/openclaw/signal-cli",
-      httpHost: "127.0.0.1",
-      httpPort: 8080,
-    });
-    const cfg = configuredManagedSignalConfig();
-    const work = cfg.channels?.signal?.accounts?.work;
-    if (work?.transport?.kind !== "managed-native") {
-      throw new Error("expected managed Signal fixture");
-    }
-    delete work.transport.configPath;
-
-    await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg,
-      accountId: "work",
-      credentialValues: {
-        signalTransportKind: "managed-native",
-        signalCliPath: "/opt/openclaw/signal-cli",
-      },
-      prompter: createQueuedWizardPrompter().prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
-    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
-    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when an active implicit data directory is compared with an explicit path", async () => {
-    const queued = createQueuedWizardPrompter();
-    const cfg = configuredManagedSignalConfig();
-    const work = cfg.channels?.signal?.accounts?.work;
-    if (work?.transport?.kind !== "managed-native") {
-      throw new Error("expected managed Signal fixture");
-    }
-    delete work.transport.configPath;
-
-    await expect(
-      runSetupWizardFinalize({
-        finalize: signalSetupWizard.finalize,
-        cfg,
-        accountId: "work",
-        credentialValues: managedSignalCredentialValues,
-        prompter: queued.prompter,
-        runtime: createRuntimeEnv({ throwOnExit: false }),
-      }),
-    ).rejects.toThrow("The running Signal daemon may be using this signal-cli config directory");
-
-    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
-    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
-    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
-  });
-
-  it("preserves account UUID while revalidating the same offline managed account", async () => {
-    mocks.probeSignalTransport
-      .mockResolvedValueOnce({ ok: false, error: "not running" })
-      .mockResolvedValueOnce({ ok: true, status: 200 });
-    const queued = createQueuedWizardPrompter();
-
-    const finalized = await runSetupWizardFinalize({
-      finalize: signalSetupWizard.finalize,
-      cfg: configuredManagedSignalConfig(),
-      accountId: "work",
-      credentialValues: managedSignalCredentialValues,
-      prompter: queued.prompter,
-      runtime: createRuntimeEnv({ throwOnExit: false }),
-    });
-
-    expect(mocks.runPluginCommandWithTimeout).toHaveBeenCalledOnce();
-    expect(mocks.spawnSignalDaemon).toHaveBeenCalledOnce();
-    expect(
-      resolveSignalAccount({ cfg: finalized?.cfg ?? {}, accountId: "work" }).config.accountUuid,
-    ).toBe("123e4567-e89b-12d3-a456-426614174000");
-  });
-
-  it("explains that a live daemon must stop before changing its signal-cli settings", async () => {
-    const queued = createQueuedWizardPrompter();
-
-    await expect(
-      runSetupWizardFinalize({
-        finalize: signalSetupWizard.finalize,
-        cfg: {
-          channels: {
-            signal: {
-              accounts: {
-                work: {
-                  account: "+15555550123",
-                  transport: {
-                    kind: "managed-native",
-                    cliPath: "signal-cli",
-                    configPath: "/var/lib/signal-cli",
-                    httpHost: "127.0.0.1",
-                    httpPort: 8080,
-                  },
-                },
-              },
-            },
-          },
-        } as OpenClawConfig,
-        accountId: "work",
-        credentialValues: managedSignalCredentialValues,
-        prompter: queued.prompter,
-        runtime: createRuntimeEnv({ throwOnExit: false }),
-      }),
-    ).rejects.toThrow(
-      "The running Signal daemon may be using this signal-cli config directory. Stop the OpenClaw gateway before changing its signal-cli settings, then retry setup.",
-    );
-
-    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
-    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
-    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
-  });
-
-  it("requires the live daemon to stop before switching from an explicit to implicit store", async () => {
-    const queued = createQueuedWizardPrompter();
-
-    await expect(
-      runSetupWizardFinalize({
-        finalize: signalSetupWizard.finalize,
-        cfg: configuredManagedSignalConfig(),
-        accountId: "work",
-        credentialValues: {
-          ...managedSignalCredentialValues,
-          signalCliConfigPath: "",
-        },
-        prompter: queued.prompter,
-        runtime: createRuntimeEnv({ throwOnExit: false }),
-      }),
-    ).rejects.toThrow("The running Signal daemon may be using this signal-cli config directory");
-
-    expect(mocks.probeSignalTransport).toHaveBeenCalledOnce();
-    expect(mocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
-    expect(mocks.spawnSignalDaemon).not.toHaveBeenCalled();
   });
 
   it("offers the default signal-cli directory as a choice instead of a text answer", async () => {

--- a/extensions/signal/src/setup-surface.ts
+++ b/extensions/signal/src/setup-surface.ts
@@ -7,13 +7,11 @@ import {
 } from "openclaw/plugin-sdk/setup";
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { listSignalAccountIds, resolveSignalAccount } from "./accounts.js";
-import { installSignalCli } from "./install-signal-cli.js";
+import { signalCompletionNote, signalDmPolicy, signalNumberTextInputs } from "./setup-core.js";
 import {
-  createSignalCliPathTextInput,
-  signalCompletionNote,
-  signalDmPolicy,
-  signalNumberTextInput,
-} from "./setup-core.js";
+  finalizeSignalInteractiveSetup,
+  prepareSignalInteractiveSetup,
+} from "./setup-interactive.js";
 
 const t = createSetupTranslator();
 
@@ -66,55 +64,17 @@ export const signalSetupWizard: ChannelSetupWizard = {
       return params.configured ? 1 : 0;
     },
   },
-  prepare: async ({ cfg, accountId, credentialValues, runtime, prompter, options }) => {
-    if (!options?.allowSignalInstall) {
-      return undefined;
-    }
-    const transport = resolveSignalAccount({ cfg, accountId }).transport;
-    if (transport.kind !== "managed-native") {
-      return undefined;
-    }
-    const currentCliPath =
-      (typeof credentialValues.cliPath === "string" ? credentialValues.cliPath : undefined) ??
-      (transport.kind === "managed-native" ? transport.cliPath : undefined) ??
-      "signal-cli";
-    const cliDetected = await detectBinary(currentCliPath);
-    const wantsInstall = await prompter.confirm({
-      message: cliDetected ? t("wizard.signal.reinstallPrompt") : t("wizard.signal.installPrompt"),
-      initialValue: !cliDetected,
-    });
-    if (!wantsInstall) {
-      return undefined;
-    }
-    try {
-      await options?.beforePersistentEffect?.();
-      const result = await installSignalCli(runtime);
-      if (result.ok && result.cliPath) {
-        await prompter.note(`Installed signal-cli at ${result.cliPath}`, "Signal");
-        return {
-          credentialValues: {
-            cliPath: result.cliPath,
-          },
-        };
-      }
-      if (!result.ok) {
-        await prompter.note(result.error ?? "signal-cli install failed.", "Signal");
-      }
-    } catch (error) {
-      await prompter.note(`signal-cli install failed: ${String(error)}`, "Signal");
-    }
-    return undefined;
+  introNote: {
+    title: "Signal",
+    lines: [
+      "Signal uses a real Signal account/device, not a bot token.",
+      "A dedicated Signal number is recommended for bot-like operation.",
+    ],
   },
+  prepare: prepareSignalInteractiveSetup,
   credentials: [],
-  textInputs: [
-    createSignalCliPathTextInput(async ({ cfg, accountId, currentValue }) => {
-      if (resolveSignalAccount({ cfg, accountId }).transport.kind !== "managed-native") {
-        return false;
-      }
-      return !(await detectBinary(currentValue ?? "signal-cli"));
-    }),
-    signalNumberTextInput,
-  ],
+  textInputs: signalNumberTextInputs,
+  finalize: finalizeSignalInteractiveSetup,
   completionNote: signalCompletionNote,
   dmPolicy: signalDmPolicy,
   disable: (cfg) => setSetupChannelEnabled(cfg, channel, false),

--- a/extensions/signal/src/setup-surface.ts
+++ b/extensions/signal/src/setup-surface.ts
@@ -7,7 +7,12 @@ import {
 } from "openclaw/plugin-sdk/setup";
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { listSignalAccountIds, resolveSignalAccount } from "./accounts.js";
-import { signalCompletionNote, signalDmPolicy, signalNumberTextInputs } from "./setup-core.js";
+import {
+  signalCompletionNote,
+  signalDmPolicy,
+  signalIntroNote,
+  signalNumberTextInputs,
+} from "./setup-core.js";
 import {
   finalizeSignalInteractiveSetup,
   prepareSignalInteractiveSetup,
@@ -64,13 +69,7 @@ export const signalSetupWizard: ChannelSetupWizard = {
       return params.configured ? 1 : 0;
     },
   },
-  introNote: {
-    title: "Signal",
-    lines: [
-      "Signal uses a real Signal account/device, not a bot token.",
-      "A dedicated Signal number is recommended for bot-like operation.",
-    ],
-  },
+  introNote: signalIntroNote,
   prepare: prepareSignalInteractiveSetup,
   credentials: [],
   textInputs: signalNumberTextInputs,

--- a/extensions/signal/src/signal-cli-config-path.ts
+++ b/extensions/signal/src/signal-cli-config-path.ts
@@ -1,0 +1,17 @@
+// Signal CLI paths must resolve identically for setup commands and the runtime daemon.
+import os from "node:os";
+import path from "node:path";
+
+export function resolveSignalCliConfigPath(
+  raw: string,
+  homedir: () => string = os.homedir,
+): string {
+  const value = raw.trim();
+  if (value === "~") {
+    return homedir();
+  }
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.join(homedir(), value.slice(2));
+  }
+  return value;
+}

--- a/extensions/signal/src/signal-cli-link.test.ts
+++ b/extensions/signal/src/signal-cli-link.test.ts
@@ -1,0 +1,82 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { linkSignalCliAccount } from "./signal-cli-link.js";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+
+function createMockChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    pid: number;
+    killed: boolean;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.pid = 1234;
+  child.killed = false;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = vi.fn(() => true);
+  return child;
+}
+
+let child: ReturnType<typeof createMockChild>;
+
+beforeEach(() => {
+  child = createMockChild();
+  spawnMock.mockReset();
+  spawnMock.mockReturnValue(child);
+});
+
+afterEach(() => {
+  child.stdout.end();
+  child.stderr.end();
+  child.removeAllListeners();
+});
+
+describe("linkSignalCliAccount", () => {
+  it("streams the link URI and returns the associated account", async () => {
+    const onLinkUri = vi.fn(async () => undefined);
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "/opt/openclaw/signal-cli",
+      configPath: "/var/lib/signal-cli",
+      onLinkUri,
+    });
+
+    child.stdout.write("sgnl://linkdevice?uuid=test&pub_key=test\n");
+    child.stdout.write("Associated with: +15555550123\n");
+    child.emit("close", 0, null);
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: true,
+      associatedAccount: "+15555550123",
+    });
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/opt/openclaw/signal-cli",
+      ["--config", "/var/lib/signal-cli", "link", "-n", "OpenClaw"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    expect(onLinkUri).toHaveBeenCalledOnce();
+    expect(onLinkUri).toHaveBeenCalledWith("sgnl://linkdevice?uuid=test&pub_key=test");
+  });
+
+  it("returns signal-cli's error when linking fails", async () => {
+    const onLinkUri = vi.fn(async () => undefined);
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri,
+    });
+
+    child.stderr.write("Link request timed out, please try again.\n");
+    child.emit("close", 1, null);
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      error: "Link request timed out, please try again.",
+    });
+    expect(onLinkUri).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/signal/src/signal-cli-link.test.ts
+++ b/extensions/signal/src/signal-cli-link.test.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from "node:events";
+import os from "node:os";
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { linkSignalCliAccount } from "./signal-cli-link.js";
@@ -60,7 +62,69 @@ describe("linkSignalCliAccount", () => {
       { stdio: ["ignore", "pipe", "pipe"] },
     );
     expect(onLinkUri).toHaveBeenCalledOnce();
-    expect(onLinkUri).toHaveBeenCalledWith("sgnl://linkdevice?uuid=test&pub_key=test");
+    expect(onLinkUri).toHaveBeenCalledWith(
+      "sgnl://linkdevice?uuid=test&pub_key=test",
+      expect.any(Promise),
+    );
+  });
+
+  it("resolves a home-relative config path like the runtime daemon", async () => {
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      configPath: "~/.local/share/signal-cli",
+      onLinkUri: vi.fn(async () => undefined),
+    });
+
+    child.stdout.write("sgnl://linkdevice?uuid=test&pub_key=test\n");
+    child.stdout.write("Associated with: +15555550123\n");
+    child.emit("close", 0, null);
+
+    await expect(resultPromise).resolves.toMatchObject({ ok: true });
+    expect(spawnMock).toHaveBeenCalledWith(
+      "signal-cli",
+      ["--config", path.join(os.homedir(), ".local/share/signal-cli"), "link", "-n", "OpenClaw"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  });
+
+  it("releases a pending QR callback when signal-cli links successfully", async () => {
+    const onLinkUri = vi.fn(async (_uri: string, completion: Promise<{ ok: boolean }>) => {
+      await expect(completion).resolves.toEqual({ ok: true });
+    });
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri,
+    });
+
+    child.stdout.write("sgnl://linkdevice?uuid=test&pub_key=test\n");
+    child.stdout.write("Associated with: +15555550123\n");
+    child.emit("close", 0, null);
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: true,
+      associatedAccount: "+15555550123",
+    });
+    expect(onLinkUri).toHaveBeenCalledOnce();
+  });
+
+  it("releases a pending QR callback and preserves the signal-cli failure", async () => {
+    const onLinkUri = vi.fn(async (_uri: string, completion: Promise<{ ok: boolean }>) => {
+      await expect(completion).resolves.toEqual({ ok: false });
+    });
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri,
+    });
+
+    child.stdout.write("sgnl://linkdevice?uuid=test&pub_key=test\n");
+    child.stderr.write("Link request timed out, please try again.\n");
+    child.emit("close", 1, null);
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      error: "Link request timed out, please try again.",
+    });
+    expect(onLinkUri).toHaveBeenCalledOnce();
   });
 
   it("returns signal-cli's error when linking fails", async () => {
@@ -78,5 +142,37 @@ describe("linkSignalCliAccount", () => {
       error: "Link request timed out, please try again.",
     });
     expect(onLinkUri).not.toHaveBeenCalled();
+  });
+
+  it("returns an actionable error when signal-cli cannot be started asynchronously", async () => {
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "missing-signal-cli",
+      onLinkUri: vi.fn(async () => undefined),
+    });
+
+    child.emit("error", new Error("spawn ENOENT"));
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      error: "Could not start signal-cli: spawn ENOENT",
+    });
+  });
+
+  it("terminates signal-cli when the owning wizard is cancelled", async () => {
+    const abortController = new AbortController();
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      abortSignal: abortController.signal,
+      onLinkUri: vi.fn(async () => undefined),
+    });
+
+    abortController.abort();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+
+    child.emit("close", null, "SIGTERM");
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      error: "signal-cli link exited with signal SIGTERM.",
+    });
   });
 });

--- a/extensions/signal/src/signal-cli-link.ts
+++ b/extensions/signal/src/signal-cli-link.ts
@@ -1,0 +1,121 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
+
+export type SignalCliLinkResult =
+  | { ok: true; associatedAccount?: string }
+  | { ok: false; error: string };
+
+const SIGNAL_LINK_URI_PREFIX = "sgnl://linkdevice?";
+const SIGNAL_LINK_ERROR_OUTPUT_LIMIT = 8_000;
+
+function appendBoundedOutput(current: string, chunk: Buffer | string): string {
+  const combined = current + String(chunk);
+  return combined.length <= SIGNAL_LINK_ERROR_OUTPUT_LIMIT
+    ? combined
+    : combined.slice(-SIGNAL_LINK_ERROR_OUTPUT_LIMIT);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function spawnSignalCliLink(cliPath: string, args: string[]) {
+  return spawn(cliPath, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+export async function linkSignalCliAccount(params: {
+  cliPath: string;
+  configPath?: string;
+  onLinkUri: (uri: string) => Promise<void>;
+}): Promise<SignalCliLinkResult> {
+  const args = [
+    ...(params.configPath?.trim() ? ["--config", resolveUserPath(params.configPath.trim())] : []),
+    "link",
+    "-n",
+    "OpenClaw",
+  ];
+
+  return await new Promise<SignalCliLinkResult>((resolve) => {
+    let child: ReturnType<typeof spawnSignalCliLink>;
+    try {
+      child = spawnSignalCliLink(params.cliPath, args);
+    } catch (error) {
+      resolve({ ok: false, error: `Could not start signal-cli: ${errorMessage(error)}` });
+      return;
+    }
+
+    let associatedAccount: string | undefined;
+    let displayError: string | undefined;
+    let displayPromise = Promise.resolve();
+    let linkUriSeen = false;
+    let stderr = "";
+    let settled = false;
+    const stdoutLines = createInterface({ input: child.stdout });
+
+    stdoutLines.on("line", (line) => {
+      const trimmed = line.trim();
+      if (!linkUriSeen && trimmed.startsWith(SIGNAL_LINK_URI_PREFIX)) {
+        linkUriSeen = true;
+        displayPromise = params.onLinkUri(trimmed).catch((error: unknown) => {
+          displayError = `Could not display the Signal linking QR code: ${errorMessage(error)}`;
+          if (!child.killed) {
+            child.kill("SIGTERM");
+          }
+        });
+        return;
+      }
+      const associatedMatch = /^Associated with:\s*(\+\d{5,15})$/i.exec(trimmed);
+      if (associatedMatch?.[1]) {
+        associatedAccount = associatedMatch[1];
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr = appendBoundedOutput(stderr, chunk);
+    });
+
+    const settle = (result: SignalCliLinkResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      stdoutLines.close();
+      resolve(result);
+    };
+
+    child.once("error", (error) => {
+      settle({ ok: false, error: `Could not start signal-cli: ${errorMessage(error)}` });
+    });
+    child.once("close", (code, signal) => {
+      void displayPromise.then(() => {
+        if (displayError) {
+          settle({ ok: false, error: displayError });
+          return;
+        }
+        if (code !== 0) {
+          const detail = stderr.trim();
+          settle({
+            ok: false,
+            error:
+              detail ||
+              `signal-cli link exited with ${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`}.`,
+          });
+          return;
+        }
+        if (!linkUriSeen) {
+          settle({
+            ok: false,
+            error: "signal-cli link finished without producing a device-link QR code.",
+          });
+          return;
+        }
+        settle({
+          ok: true,
+          ...(associatedAccount ? { associatedAccount } : {}),
+        });
+      });
+    });
+  });
+}

--- a/extensions/signal/src/signal-cli-link.ts
+++ b/extensions/signal/src/signal-cli-link.ts
@@ -1,10 +1,12 @@
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
-import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
+import { resolveSignalCliConfigPath } from "./signal-cli-config-path.js";
 
 export type SignalCliLinkResult =
   | { ok: true; associatedAccount?: string }
   | { ok: false; error: string };
+
+export type SignalCliLinkCompletion = Promise<{ ok: boolean }>;
 
 const SIGNAL_LINK_URI_PREFIX = "sgnl://linkdevice?";
 const SIGNAL_LINK_ERROR_OUTPUT_LIMIT = 8_000;
@@ -29,10 +31,13 @@ function spawnSignalCliLink(cliPath: string, args: string[]) {
 export async function linkSignalCliAccount(params: {
   cliPath: string;
   configPath?: string;
-  onLinkUri: (uri: string) => Promise<void>;
+  abortSignal?: AbortSignal;
+  onLinkUri: (uri: string, completion: SignalCliLinkCompletion) => Promise<void>;
 }): Promise<SignalCliLinkResult> {
   const args = [
-    ...(params.configPath?.trim() ? ["--config", resolveUserPath(params.configPath.trim())] : []),
+    ...(params.configPath?.trim()
+      ? ["--config", resolveSignalCliConfigPath(params.configPath)]
+      : []),
     "link",
     "-n",
     "OpenClaw",
@@ -53,13 +58,25 @@ export async function linkSignalCliAccount(params: {
     let linkUriSeen = false;
     let stderr = "";
     let settled = false;
+    let resolveCompletion!: (result: { ok: boolean }) => void;
+    const completion = new Promise<{ ok: boolean }>((complete) => {
+      resolveCompletion = complete;
+    });
     const stdoutLines = createInterface({ input: child.stdout });
+    const abortLink = () => {
+      if (!child.killed) {
+        child.kill("SIGTERM");
+      }
+    };
 
     stdoutLines.on("line", (line) => {
       const trimmed = line.trim();
       if (!linkUriSeen && trimmed.startsWith(SIGNAL_LINK_URI_PREFIX)) {
+        if (params.abortSignal?.aborted) {
+          return;
+        }
         linkUriSeen = true;
-        displayPromise = params.onLinkUri(trimmed).catch((error: unknown) => {
+        displayPromise = params.onLinkUri(trimmed, completion).catch((error: unknown) => {
           displayError = `Could not display the Signal linking QR code: ${errorMessage(error)}`;
           if (!child.killed) {
             child.kill("SIGTERM");
@@ -81,14 +98,25 @@ export async function linkSignalCliAccount(params: {
         return;
       }
       settled = true;
+      params.abortSignal?.removeEventListener("abort", abortLink);
       stdoutLines.close();
       resolve(result);
     };
 
+    if (params.abortSignal?.aborted) {
+      abortLink();
+    } else {
+      params.abortSignal?.addEventListener("abort", abortLink, { once: true });
+    }
+
     child.once("error", (error) => {
+      resolveCompletion({ ok: false });
       settle({ ok: false, error: `Could not start signal-cli: ${errorMessage(error)}` });
     });
     child.once("close", (code, signal) => {
+      // Signal approval is authoritative. Release a still-open QR prompt before
+      // waiting for its callback so successful linking cannot deadlock config commit.
+      resolveCompletion({ ok: code === 0 });
       void displayPromise.then(() => {
         if (displayError) {
           settle({ ok: false, error: displayError });

--- a/extensions/signal/src/signal-link-qr.test.ts
+++ b/extensions/signal/src/signal-link-qr.test.ts
@@ -1,0 +1,69 @@
+import QRCode from "qrcode";
+import { describe, expect, it } from "vitest";
+import { renderSignalLinkQr } from "./signal-link-qr.js";
+
+const ANSI_SGR = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
+const QR_MARGIN_MODULES = 1;
+
+function visibleLines(output: string): string[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.replace(ANSI_SGR, ""))
+    .filter((line) => line.length > 0);
+}
+
+function decodeSignalLinkBlock(char: string): [boolean, boolean] {
+  if (char === " ") {
+    return [true, true];
+  }
+  if (char === "▄") {
+    return [true, false];
+  }
+  if (char === "▀") {
+    return [false, true];
+  }
+  if (char === "█") {
+    return [false, false];
+  }
+  throw new Error(`Unexpected Signal QR character: ${char}`);
+}
+
+function decodeSignalLinkQr(output: string, size: number): boolean[] {
+  const decoded = Array.from({ length: size * size }, () => false);
+  visibleLines(output).forEach((line, lineIndex) => {
+    Array.from(line).forEach((char, columnIndex) => {
+      const x = columnIndex - QR_MARGIN_MODULES;
+      const topY = lineIndex * 2 - QR_MARGIN_MODULES;
+      const [top, bottom] = decodeSignalLinkBlock(char);
+      for (const [y, value] of [
+        [topY, top],
+        [topY + 1, bottom],
+      ] as const) {
+        if (x >= 0 && x < size && y >= 0 && y < size) {
+          decoded[y * size + x] = value;
+        }
+      }
+    });
+  });
+  return decoded;
+}
+
+describe("renderSignalLinkQr", () => {
+  it("renders a compact black-on-white QR matrix without black foreground ANSI", async () => {
+    const uri = "sgnl://linkdevice?uuid=test&pub_key=test";
+    const qr = QRCode.create(uri);
+
+    const rendered = await renderSignalLinkQr(uri);
+
+    expect(rendered).not.toContain("\x1b[30m");
+    expect(rendered).not.toContain("\x1b[47m");
+    expect(rendered).toContain("\x1b[40m\x1b[37m");
+    expect(visibleLines(rendered)[0]?.length).toBe(qr.modules.size + QR_MARGIN_MODULES * 2);
+    expect(visibleLines(rendered)).toHaveLength(
+      Math.ceil((qr.modules.size + QR_MARGIN_MODULES * 2) / 2),
+    );
+    expect(decodeSignalLinkQr(rendered, qr.modules.size)).toEqual(
+      Array.from(qr.modules.data, Boolean),
+    );
+  });
+});

--- a/extensions/signal/src/signal-link-qr.test.ts
+++ b/extensions/signal/src/signal-link-qr.test.ts
@@ -2,36 +2,66 @@ import QRCode from "qrcode";
 import { describe, expect, it } from "vitest";
 import { renderSignalLinkQr } from "./signal-link-qr.js";
 
-const ANSI_SGR = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
+const TERMINAL_TOKEN = new RegExp(
+  `${String.fromCharCode(0x1b)}\\[(?:(?:(38|48);2;(\\d+);(\\d+);(\\d+))|(0))m|([ ▀])`,
+  "g",
+);
 const QR_QUIET_ZONE_MODULES = 4;
-const SIGNAL_LINK_COLORS = "\x1b[48;2;0;0;0m\x1b[38;2;255;255;255m";
 
-function visibleLines(output: string): string[] {
-  return output
-    .split(/\r?\n/)
-    .map((line) => line.replace(ANSI_SGR, ""))
-    .filter((line) => line.length > 0);
+function decodeColor(red: string, green: string, blue: string): boolean {
+  if (red === "0" && green === "0" && blue === "0") {
+    return true;
+  }
+  if (red === "255" && green === "255" && blue === "255") {
+    return false;
+  }
+  throw new Error(`Unexpected Signal QR color: ${red};${green};${blue}`);
 }
 
-function decodeSignalLinkBlock(char: string): [boolean, boolean] {
-  if (char === " ") {
-    return [true, true];
+function decodeSignalLinkLine(line: string): Array<[boolean, boolean]> {
+  let foregroundDark: boolean | undefined;
+  let backgroundDark: boolean | undefined;
+  let offset = 0;
+  const blocks: Array<[boolean, boolean]> = [];
+  for (const match of line.matchAll(TERMINAL_TOKEN)) {
+    if (match.index !== offset) {
+      throw new Error(`Unexpected Signal QR terminal output at offset ${offset}`);
+    }
+    offset += match[0].length;
+    const [, target, red, green, blue, reset, char] = match;
+    if (reset) {
+      foregroundDark = undefined;
+      backgroundDark = undefined;
+      continue;
+    }
+    if (target && red && green && blue) {
+      const dark = decodeColor(red, green, blue);
+      if (target === "38") {
+        foregroundDark = dark;
+      } else {
+        backgroundDark = dark;
+      }
+      continue;
+    }
+    if (char === " " && backgroundDark !== undefined) {
+      blocks.push([backgroundDark, backgroundDark]);
+      continue;
+    }
+    if (char === "▀" && foregroundDark !== undefined && backgroundDark !== undefined) {
+      blocks.push([foregroundDark, backgroundDark]);
+      continue;
+    }
+    throw new Error("Signal QR cell is missing a truecolor foreground or background");
   }
-  if (char === "▄") {
-    return [true, false];
+  if (offset !== line.length) {
+    throw new Error(`Unexpected Signal QR terminal output at offset ${offset}`);
   }
-  if (char === "▀") {
-    return [false, true];
-  }
-  if (char === "█") {
-    return [false, false];
-  }
-  throw new Error(`Unexpected Signal QR character: ${char}`);
+  return blocks;
 }
 
 function decodeSignalLinkQr(output: string): boolean[][] {
-  return visibleLines(output).flatMap((line) => {
-    const blocks = Array.from(line, decodeSignalLinkBlock);
+  return output.split(/\r?\n/).flatMap((line) => {
+    const blocks = decodeSignalLinkLine(line);
     return [blocks.map(([top]) => top), blocks.map(([, bottom]) => bottom)];
   });
 }
@@ -47,7 +77,8 @@ describe("renderSignalLinkQr", () => {
 
     expect(rendered).not.toContain("\x1b[30m");
     expect(rendered).not.toContain("\x1b[47m");
-    expect(rendered).toContain(SIGNAL_LINK_COLORS);
+    expect(rendered).not.toContain("█");
+    expect(rendered).not.toContain("▄");
     expect(decoded[0]).toHaveLength(symbolSize);
     expect(decoded).toHaveLength(Math.ceil(symbolSize / 2) * 2);
     decoded.forEach((row, y) => {

--- a/extensions/signal/src/signal-link-qr.test.ts
+++ b/extensions/signal/src/signal-link-qr.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 import { renderSignalLinkQr } from "./signal-link-qr.js";
 
 const ANSI_SGR = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
-const QR_MARGIN_MODULES = 1;
+const QR_QUIET_ZONE_MODULES = 4;
+const SIGNAL_LINK_COLORS = "\x1b[48;2;0;0;0m\x1b[38;2;255;255;255m";
 
 function visibleLines(output: string): string[] {
   return output
@@ -28,42 +29,37 @@ function decodeSignalLinkBlock(char: string): [boolean, boolean] {
   throw new Error(`Unexpected Signal QR character: ${char}`);
 }
 
-function decodeSignalLinkQr(output: string, size: number): boolean[] {
-  const decoded = Array.from({ length: size * size }, () => false);
-  visibleLines(output).forEach((line, lineIndex) => {
-    Array.from(line).forEach((char, columnIndex) => {
-      const x = columnIndex - QR_MARGIN_MODULES;
-      const topY = lineIndex * 2 - QR_MARGIN_MODULES;
-      const [top, bottom] = decodeSignalLinkBlock(char);
-      for (const [y, value] of [
-        [topY, top],
-        [topY + 1, bottom],
-      ] as const) {
-        if (x >= 0 && x < size && y >= 0 && y < size) {
-          decoded[y * size + x] = value;
-        }
-      }
-    });
+function decodeSignalLinkQr(output: string): boolean[][] {
+  return visibleLines(output).flatMap((line) => {
+    const blocks = Array.from(line, decodeSignalLinkBlock);
+    return [blocks.map(([top]) => top), blocks.map(([, bottom]) => bottom)];
   });
-  return decoded;
 }
 
 describe("renderSignalLinkQr", () => {
-  it("renders a compact black-on-white QR matrix without black foreground ANSI", async () => {
+  it("renders a compact high-contrast QR matrix with a scanner-safe quiet zone", async () => {
     const uri = "sgnl://linkdevice?uuid=test&pub_key=test";
     const qr = QRCode.create(uri);
+    const symbolSize = qr.modules.size + QR_QUIET_ZONE_MODULES * 2;
 
     const rendered = await renderSignalLinkQr(uri);
+    const decoded = decodeSignalLinkQr(rendered);
 
     expect(rendered).not.toContain("\x1b[30m");
     expect(rendered).not.toContain("\x1b[47m");
-    expect(rendered).toContain("\x1b[40m\x1b[37m");
-    expect(visibleLines(rendered)[0]?.length).toBe(qr.modules.size + QR_MARGIN_MODULES * 2);
-    expect(visibleLines(rendered)).toHaveLength(
-      Math.ceil((qr.modules.size + QR_MARGIN_MODULES * 2) / 2),
-    );
-    expect(decodeSignalLinkQr(rendered, qr.modules.size)).toEqual(
-      Array.from(qr.modules.data, Boolean),
-    );
+    expect(rendered).toContain(SIGNAL_LINK_COLORS);
+    expect(decoded[0]).toHaveLength(symbolSize);
+    expect(decoded).toHaveLength(Math.ceil(symbolSize / 2) * 2);
+    decoded.forEach((row, y) => {
+      row.forEach((dark, x) => {
+        const moduleX = x - QR_QUIET_ZONE_MODULES;
+        const moduleY = y - QR_QUIET_ZONE_MODULES;
+        const expected =
+          moduleX >= 0 && moduleX < qr.modules.size && moduleY >= 0 && moduleY < qr.modules.size
+            ? Boolean(qr.modules.data[moduleY * qr.modules.size + moduleX])
+            : false;
+        expect(dark).toBe(expected);
+      });
+    });
   });
 });

--- a/extensions/signal/src/signal-link-qr.ts
+++ b/extensions/signal/src/signal-link-qr.ts
@@ -1,31 +1,83 @@
 import { renderQrTerminal } from "openclaw/plugin-sdk/media-runtime";
 
 const ANSI_SGR = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
-const BLACK_BACKGROUND_WHITE_FOREGROUND = "\x1b[40m\x1b[37m";
+const SOURCE_QUIET_ZONE_MODULES = 1;
+const SIGNAL_LINK_QUIET_ZONE_MODULES = 4;
+const BLACK_BACKGROUND_WHITE_FOREGROUND = "\x1b[48;2;0;0;0m\x1b[38;2;255;255;255m";
 const TERMINAL_RESET = "\x1b[0m";
-const SIGNAL_LINK_BLOCKS: Record<string, string> = {
-  " ": "█",
-  "▄": "▀",
-  "▀": "▄",
-  "█": " ",
-};
+
+function decodeCompactBlock(char: string): [boolean, boolean] {
+  if (char === "█") {
+    return [true, true];
+  }
+  if (char === "▀") {
+    return [true, false];
+  }
+  if (char === "▄") {
+    return [false, true];
+  }
+  if (char === " ") {
+    return [false, false];
+  }
+  throw new Error(`Unexpected compact QR character: ${char}`);
+}
+
+function renderHighContrastBlock(topDark: boolean, bottomDark: boolean): string {
+  if (topDark && bottomDark) {
+    return " ";
+  }
+  if (topDark) {
+    return "▄";
+  }
+  if (bottomDark) {
+    return "▀";
+  }
+  return "█";
+}
 
 export async function renderSignalLinkQr(uri: string): Promise<string> {
   const compact = await renderQrTerminal(uri, { small: true });
-  // Some embedded terminals remap black foreground. Inverting both the compact glyphs
-  // and ANSI colors preserves a black-on-white QR without falling back to oversized full mode.
-  return compact
+  const sourceLines = compact
     .split(/\r?\n/)
-    .map((line) => {
-      const visible = line.replace(ANSI_SGR, "");
-      const inverted = Array.from(visible, (char) => {
-        const block = SIGNAL_LINK_BLOCKS[char];
-        if (block === undefined) {
-          throw new Error(`Unexpected compact QR character: ${char}`);
-        }
-        return block;
-      }).join("");
-      return `${BLACK_BACKGROUND_WHITE_FOREGROUND}${inverted}${TERMINAL_RESET}`;
-    })
-    .join("\n");
+    .map((line) => Array.from(line.replace(ANSI_SGR, ""), decodeCompactBlock));
+  const qrSize = (sourceLines[0]?.length ?? 0) - SOURCE_QUIET_ZONE_MODULES * 2;
+  const sourceWidth = qrSize + SOURCE_QUIET_ZONE_MODULES * 2;
+  if (qrSize <= 0 || sourceLines.some((line) => line.length !== sourceWidth)) {
+    throw new Error("Unexpected compact QR dimensions");
+  }
+  const sourceRows = sourceLines.flatMap((line) => [
+    line.map(([top]) => top),
+    line.map(([, bottom]) => bottom),
+  ]);
+  const symbolSize = qrSize + SIGNAL_LINK_QUIET_ZONE_MODULES * 2;
+  const output: string[] = [];
+
+  // Truecolor escapes avoid terminal palette remapping. Repacking also restores the
+  // four-module quiet zone that scanners require without using oversized full mode.
+  for (let y = 0; y < symbolSize; y += 2) {
+    let line = BLACK_BACKGROUND_WHITE_FOREGROUND;
+    for (let x = 0; x < symbolSize; x += 1) {
+      const moduleX = x - SIGNAL_LINK_QUIET_ZONE_MODULES;
+      const topModuleY = y - SIGNAL_LINK_QUIET_ZONE_MODULES;
+      const sourceX = moduleX + SOURCE_QUIET_ZONE_MODULES;
+      const topSourceY = topModuleY + SOURCE_QUIET_ZONE_MODULES;
+      const topDark =
+        moduleX >= 0 &&
+        moduleX < qrSize &&
+        topModuleY >= 0 &&
+        topModuleY < qrSize &&
+        (sourceRows[topSourceY]?.[sourceX] ?? false);
+      const bottomModuleY = topModuleY + 1;
+      const bottomSourceY = topSourceY + 1;
+      const bottomDark =
+        moduleX >= 0 &&
+        moduleX < qrSize &&
+        bottomModuleY >= 0 &&
+        bottomModuleY < qrSize &&
+        (sourceRows[bottomSourceY]?.[sourceX] ?? false);
+      line += renderHighContrastBlock(topDark, bottomDark);
+    }
+    output.push(`${line}${TERMINAL_RESET}`);
+  }
+  return output.join("\n");
 }

--- a/extensions/signal/src/signal-link-qr.ts
+++ b/extensions/signal/src/signal-link-qr.ts
@@ -1,0 +1,31 @@
+import { renderQrTerminal } from "openclaw/plugin-sdk/media-runtime";
+
+const ANSI_SGR = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
+const BLACK_BACKGROUND_WHITE_FOREGROUND = "\x1b[40m\x1b[37m";
+const TERMINAL_RESET = "\x1b[0m";
+const SIGNAL_LINK_BLOCKS: Record<string, string> = {
+  " ": "█",
+  "▄": "▀",
+  "▀": "▄",
+  "█": " ",
+};
+
+export async function renderSignalLinkQr(uri: string): Promise<string> {
+  const compact = await renderQrTerminal(uri, { small: true });
+  // Some embedded terminals remap black foreground. Inverting both the compact glyphs
+  // and ANSI colors preserves a black-on-white QR without falling back to oversized full mode.
+  return compact
+    .split(/\r?\n/)
+    .map((line) => {
+      const visible = line.replace(ANSI_SGR, "");
+      const inverted = Array.from(visible, (char) => {
+        const block = SIGNAL_LINK_BLOCKS[char];
+        if (block === undefined) {
+          throw new Error(`Unexpected compact QR character: ${char}`);
+        }
+        return block;
+      }).join("");
+      return `${BLACK_BACKGROUND_WHITE_FOREGROUND}${inverted}${TERMINAL_RESET}`;
+    })
+    .join("\n");
+}

--- a/extensions/signal/src/signal-link-qr.ts
+++ b/extensions/signal/src/signal-link-qr.ts
@@ -3,7 +3,10 @@ import { renderQrTerminal } from "openclaw/plugin-sdk/media-runtime";
 const ANSI_SGR = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
 const SOURCE_QUIET_ZONE_MODULES = 1;
 const SIGNAL_LINK_QUIET_ZONE_MODULES = 4;
-const BLACK_BACKGROUND_WHITE_FOREGROUND = "\x1b[48;2;0;0;0m\x1b[38;2;255;255;255m";
+const BLACK_BACKGROUND = "\x1b[48;2;0;0;0m";
+const BLACK_FOREGROUND = "\x1b[38;2;0;0;0m";
+const WHITE_BACKGROUND = "\x1b[48;2;255;255;255m";
+const WHITE_FOREGROUND = "\x1b[38;2;255;255;255m";
 const TERMINAL_RESET = "\x1b[0m";
 
 function decodeCompactBlock(char: string): [boolean, boolean] {
@@ -24,15 +27,15 @@ function decodeCompactBlock(char: string): [boolean, boolean] {
 
 function renderHighContrastBlock(topDark: boolean, bottomDark: boolean): string {
   if (topDark && bottomDark) {
-    return " ";
+    return `${BLACK_BACKGROUND} `;
   }
   if (topDark) {
-    return "▄";
+    return `${WHITE_BACKGROUND}${BLACK_FOREGROUND}▀`;
   }
   if (bottomDark) {
-    return "▀";
+    return `${BLACK_BACKGROUND}${WHITE_FOREGROUND}▀`;
   }
-  return "█";
+  return `${WHITE_BACKGROUND} `;
 }
 
 export async function renderSignalLinkQr(uri: string): Promise<string> {
@@ -52,10 +55,10 @@ export async function renderSignalLinkQr(uri: string): Promise<string> {
   const symbolSize = qrSize + SIGNAL_LINK_QUIET_ZONE_MODULES * 2;
   const output: string[] = [];
 
-  // Truecolor escapes avoid terminal palette remapping. Repacking also restores the
-  // four-module quiet zone that scanners require without using oversized full mode.
+  // Truecolor escapes avoid terminal palette remapping, while background-painted solid
+  // cells avoid font-grid seams. Repacking also restores the four-module quiet zone.
   for (let y = 0; y < symbolSize; y += 2) {
-    let line = BLACK_BACKGROUND_WHITE_FOREGROUND;
+    let line = "";
     for (let x = 0; x < symbolSize; x += 1) {
       const moduleX = x - SIGNAL_LINK_QUIET_ZONE_MODULES;
       const topModuleY = y - SIGNAL_LINK_QUIET_ZONE_MODULES;

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -1,4 +1,5 @@
 // Signal transport policy centralizes local endpoint collision handling.
+import { isIP } from "node:net";
 import type { SignalTransportConfig } from "./account-types.js";
 import { normalizeSignalTransportUrl } from "./transport-url.js";
 
@@ -9,8 +10,26 @@ export const DEFAULT_SIGNAL_MANAGED_NATIVE_HOST = "127.0.0.1";
 const SIGNAL_LOOPBACK_HOST_ALIASES = new Set(["localhost", "127.0.0.1", "::1"]);
 
 function normalizeSignalEndpointHost(hostname: string): string {
-  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const normalized = hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/%.+$/, "");
   return normalized.endsWith(".") ? normalized.slice(0, -1) : normalized;
+}
+
+export function normalizeSignalEndpointAddress(hostname: string): string {
+  const normalized = normalizeSignalEndpointHost(hostname);
+  const dottedMapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(normalized)?.[1];
+  if (dottedMapped && isIP(dottedMapped) === 4) {
+    return dottedMapped;
+  }
+  const hexMapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(normalized);
+  if (hexMapped?.[1] && hexMapped[2]) {
+    const high = Number.parseInt(hexMapped[1], 16);
+    const low = Number.parseInt(hexMapped[2], 16);
+    return `${high >>> 8}.${high & 0xff}.${low >>> 8}.${low & 0xff}`;
+  }
+  return normalized;
 }
 
 function isSignalLocalEndpointHost(hostname: string): boolean {
@@ -54,7 +73,7 @@ export function allocateSignalManagedNativePort(params: {
 export function resolveLocalSignalTransportPort(baseUrl: string): number | undefined {
   try {
     const parsed = new URL(baseUrl);
-    const hostname = normalizeSignalEndpointHost(parsed.hostname);
+    const hostname = normalizeSignalEndpointAddress(parsed.hostname);
     if (!isSignalLocalEndpointHost(hostname)) {
       return undefined;
     }
@@ -84,8 +103,8 @@ export function isSignalManagedNativeConnectionUrlForBind(
   if (connectionPort !== bindPort) {
     return false;
   }
-  const connectionHost = normalizeSignalEndpointHost(connectionUrl.hostname);
-  const bindHost = normalizeSignalEndpointHost(
+  const connectionHost = normalizeSignalEndpointAddress(connectionUrl.hostname);
+  const bindHost = normalizeSignalEndpointAddress(
     transport.httpHost ?? DEFAULT_SIGNAL_MANAGED_NATIVE_HOST,
   );
   if (connectionHost === bindHost) {

--- a/packages/gateway-protocol/src/schema/openclaw.test.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.test.ts
@@ -5,11 +5,30 @@ import {
   validateSystemAgentSetupVerifyParams,
 } from "../index.js";
 import {
+  SystemAgentChatParamsSchema,
+  SystemAgentChatResultSchema,
   SystemAgentChatQuestionSchema,
   SystemAgentChatHistoryResultSchema,
   SystemAgentSetupDetectResultSchema,
   SystemAgentSetupVerifyResultSchema,
 } from "./openclaw.js";
+
+describe("OpenClaw chat params protocol", () => {
+  it("accepts an additive QR rendering capability", () => {
+    expect(
+      Value.Check(SystemAgentChatParamsSchema, {
+        sessionId: "setup-session",
+        capabilities: { qrCodePng: true },
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(SystemAgentChatParamsSchema, {
+        sessionId: "setup-session",
+        capabilities: { qrCodePng: "yes" },
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("OpenClaw chat question protocol", () => {
   const question = {
@@ -27,6 +46,29 @@ describe("OpenClaw chat question protocol", () => {
     expect(Value.Check(SystemAgentChatQuestionSchema, { ...question, skipAction: "dismiss" })).toBe(
       false,
     );
+  });
+
+  it("accepts a single acknowledgement action", () => {
+    expect(
+      Value.Check(SystemAgentChatQuestionSchema, {
+        ...question,
+        options: [{ label: "Continue" }],
+        allowSkip: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("OpenClaw chat result protocol", () => {
+  it("accepts an additive PNG QR image for hosted setup", () => {
+    expect(
+      Value.Check(SystemAgentChatResultSchema, {
+        sessionId: "setup-session",
+        reply: "Scan this QR code, then confirm.",
+        action: "none",
+        qrCodePngBase64: "cG5n",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/gateway-protocol/src/schema/openclaw.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.ts
@@ -14,6 +14,12 @@ import { WizardStartResultSchema } from "./wizard.js";
 export const SystemAgentChatParamsSchema = closedObject({
   sessionId: NonEmptyString,
   message: Type.Optional(Type.String()),
+  /** Client-rendered setup media supported by this chat surface. */
+  capabilities: Type.Optional(
+    closedObject({
+      qrCodePng: Type.Optional(Type.Boolean()),
+    }),
+  ),
   /** Seeds a purpose-specific first greeting for a fresh conversation. */
   welcomeVariant: Type.Optional(
     Type.Union([Type.Literal("onboarding"), Type.Literal("new-agent")]),
@@ -50,10 +56,12 @@ export const SystemAgentChatQuestionSchema = closedObject({
       /** Message text a client sends when this option is chosen; defaults to label. */
       reply: Type.Optional(NonEmptyString),
     }),
-    { minItems: 2, maxItems: 4 },
+    { minItems: 1, maxItems: 4 },
   ),
   /** Free-text answers are also accepted for this question. */
   isOther: Type.Optional(Type.Boolean()),
+  /** False omits the visible skip/cancel action for acknowledgement-only prompts. */
+  allowSkip: Type.Optional(Type.Boolean()),
   /** Client-owned action for the visible skip control; omitted means send a reply. */
   skipAction: Type.Optional(Type.Literal("exit")),
 });
@@ -66,6 +74,8 @@ export const SystemAgentChatResultSchema = closedObject({
   sensitive: Type.Optional(Type.Boolean()),
   /** The hosted wizard will consume the next message as its current step answer. */
   wizardInputPending: Type.Optional(Type.Boolean()),
+  /** Raw PNG base64 for a hosted setup QR prompt. */
+  qrCodePngBase64: Type.Optional(NonEmptyString),
   action: Type.Union([
     Type.Literal("none"),
     // The user asked to talk to their agent; clients should move to their

--- a/src/channels/plugins/setup-wizard-types.ts
+++ b/src/channels/plugins/setup-wizard-types.ts
@@ -305,6 +305,8 @@ export type SetupChannelsOptions = {
   allowSignalInstall?: boolean;
   /** Revalidate host authority immediately before an installer or other durable effect. */
   beforePersistentEffect?: () => Promise<void>;
+  /** Cancels reversible setup work when the controlling wizard session stops. */
+  abortSignal?: AbortSignal;
   onSelection?: (selection: ChannelId[]) => void;
   onPostWriteHook?: (hook: ChannelOnboardingPostWriteHook) => void;
   accountIds?: Partial<Record<ChannelId, string>>;
@@ -319,6 +321,11 @@ export type SetupChannelsOptions = {
    * setup surfaces must skip terminal-interactive login/link prompts.
    */
   deferDeviceLinkToClient?: boolean;
+  /**
+   * Prompts cross a remote wizard boundary. Long-running setup must not wait
+   * on a prompt that the client cannot receive until the operation finishes.
+   */
+  remoteWizard?: boolean;
   skipStatusNote?: boolean;
   skipDmPolicyPrompt?: boolean;
   skipConfirm?: boolean;

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -55,6 +55,8 @@ type ChannelsAddWizardFlowParams = {
   prompter: WizardPrompter;
   initialChannel?: ChannelChoice;
   beforePersistentEffect?: () => Promise<void>;
+  abortSignal?: AbortSignal;
+  remoteWizard?: boolean;
   /**
    * The controlling client completes device linking itself after config is
    * written (e.g. the Control UI renders the WhatsApp QR via web.login.*), so
@@ -85,7 +87,9 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
     ...(params.beforePersistentEffect
       ? { beforePersistentEffect: params.beforePersistentEffect }
       : {}),
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
     ...(params.deferDeviceLinkToClient ? { deferDeviceLinkToClient: true } : {}),
+    ...(params.remoteWizard ? { remoteWizard: true } : {}),
     onPostWriteHook: (hook) => {
       postWriteHooks.collect(hook);
     },
@@ -247,6 +251,8 @@ export async function runChannelsSetupWizard(
     onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
     /** Revalidate/lock cancellation immediately before durable effects. */
     beforePersistentEffect?: () => Promise<void>;
+    /** Cancels reversible setup work when the remote wizard stops. */
+    abortSignal?: AbortSignal;
   },
   runtime: RuntimeEnv,
   prompter: WizardPrompter,
@@ -268,7 +274,9 @@ export async function runChannelsSetupWizard(
     prompter,
     ...(initialChannel ? { initialChannel } : {}),
     deferDeviceLinkToClient: true,
+    remoteWizard: true,
     ...(opts.onConfigured ? { onConfigured: opts.onConfigured } : {}),
     ...(opts.beforePersistentEffect ? { beforePersistentEffect: opts.beforePersistentEffect } : {}),
+    ...(opts.abortSignal ? { abortSignal: opts.abortSignal } : {}),
   });
 }

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
 import { WizardCancelledError, WizardNavigationError } from "../wizard/prompts.js";
 import {
   makeCatalogEntry,
@@ -451,6 +452,69 @@ describe("setupChannels workspace shadow exclusion", () => {
       channels: {
         "custom-chat": { token: "secret" },
       },
+    });
+  });
+
+  it("preserves QR prompts through the channel setup navigation scope", async () => {
+    const qrCode = vi.fn(async () => true);
+    let qrConfirmed: boolean | undefined;
+    const setupWizard = {
+      channel: "custom-chat",
+      getStatus: vi.fn(async () => ({
+        channel: "custom-chat",
+        configured: false,
+        statusLines: [],
+      })),
+      configure: vi.fn(
+        async ({ cfg, prompter }: { cfg: Record<string, unknown>; prompter: WizardPrompter }) => {
+          qrConfirmed = await prompter.qrCode?.({
+            title: "Link Signal",
+            message: "Scan this code",
+            pngBase64: "cG5n",
+          });
+          return { cfg };
+        },
+      ),
+    };
+    const activePlugin = makeSetupPlugin({
+      id: "custom-chat",
+      label: "Custom Chat",
+      setupWizard,
+    });
+    listActiveChannelSetupPlugins.mockReturnValue([activePlugin]);
+    resolveChannelSetupEntries.mockReturnValue(
+      makeChannelSetupEntries({
+        entries: [
+          {
+            id: "custom-chat",
+            meta: makeMeta("custom-chat", "Custom Chat"),
+          },
+        ],
+      }),
+    );
+    const select = vi.fn().mockResolvedValueOnce("custom-chat").mockResolvedValueOnce("__done__");
+
+    await setupChannels(
+      {} as never,
+      {} as never,
+      {
+        confirm: vi.fn(async () => true),
+        note: vi.fn(async () => undefined),
+        qrCode,
+        select,
+      } as never,
+      {
+        deferStatusUntilSelection: true,
+        skipConfirm: true,
+        skipDmPolicyPrompt: true,
+      },
+    );
+
+    expect(qrConfirmed).toBe(true);
+    expect(qrCode).toHaveBeenCalledWith({
+      title: "Link Signal",
+      message: "Scan this code",
+      pngBase64: "cG5n",
     });
   });
 

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -122,16 +122,20 @@ type SystemAgentHistoryTurn = {
   text: string;
 };
 
-type GatewaySystemAgentSession = {
+type GatewaySystemAgentChatReply = {
+  text: string;
+  action: "none" | "exit" | "open-tui" | "open-setup";
+  sensitive?: boolean;
+  wizardInputPending?: boolean;
+  qrCodePngBase64?: string;
+  question?: SystemAgentChatQuestion;
+};
+
+export type GatewaySystemAgentSession = {
   engine: {
-    handle: (message: string) => Promise<{
-      text: string;
-      action: "none" | "exit" | "open-tui" | "open-setup";
-      sensitive?: boolean;
-      wizardInputPending?: boolean;
-      qrCodePngBase64?: string;
-      question?: SystemAgentChatQuestion;
-    }>;
+    handle: (message: string) => Promise<GatewaySystemAgentChatReply>;
+    hasLockedHostedWizard: () => boolean;
+    resumeLockedHostedWizard: () => Promise<GatewaySystemAgentChatReply | null>;
     seedHistory: (turns: readonly SystemAgentHistoryTurn[]) => void;
     historyLength: () => number;
     historySince: (index: number) => SystemAgentHistoryTurn[];

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -128,6 +128,8 @@ type GatewaySystemAgentSession = {
       text: string;
       action: "none" | "exit" | "open-tui" | "open-setup";
       sensitive?: boolean;
+      wizardInputPending?: boolean;
+      qrCodePngBase64?: string;
       question?: SystemAgentChatQuestion;
     }>;
     seedHistory: (turns: readonly SystemAgentHistoryTurn[]) => void;
@@ -138,7 +140,8 @@ type GatewaySystemAgentSession = {
       decision: "allow-once" | "allow-always" | "deny" | null,
       proposalHash: string,
     ) => Promise<unknown>;
-    dispose: () => Promise<void>;
+    /** False while an irreversible hosted wizard still owns unfinished work. */
+    dispose: () => Promise<boolean>;
   };
   welcome: string;
   welcomeQuestion?: SystemAgentChatQuestion;
@@ -146,6 +149,8 @@ type GatewaySystemAgentSession = {
   welcomeAuditSequence?: number;
   lastUsedAt: number;
   ownerKey: string;
+  /** QR rendering is negotiated per session; a resume must use the same capability. */
+  supportsQrCode: boolean;
   pendingApproval?: { id: string; proposalHash: string };
 };
 

--- a/src/gateway/server-methods/system-agent-approval.ts
+++ b/src/gateway/server-methods/system-agent-approval.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from "node:crypto";
+import {
+  SYSTEM_AGENT_APPROVAL_DECISIONS,
+  SYSTEM_AGENT_APPROVAL_TIMEOUT_MS,
+  type SystemAgentApprovalRequestPayload,
+} from "../../infra/system-agent-approvals.js";
+import { describeSystemAgentPersistentOperation } from "../../system-agent/operations.js";
+import { buildRequestedApprovalEvent, handlePendingApprovalRequest } from "./approval-shared.js";
+import type { GatewayRequestContext, GatewaySystemAgentSession } from "./types.js";
+
+export function queueDelegatedSystemAgentApproval(params: {
+  context: GatewayRequestContext;
+  sessions: Map<string, GatewaySystemAgentSession>;
+  session: GatewaySystemAgentSession;
+  sessionId: string;
+  delegation: {
+    agentId?: string;
+    sessionKey?: string;
+  };
+  proposal: NonNullable<
+    ReturnType<GatewaySystemAgentSession["engine"]["getPendingOperatorProposal"]>
+  >;
+}): string {
+  if (params.session.pendingApproval?.proposalHash === params.proposal.hash) {
+    return params.session.pendingApproval.id;
+  }
+  const manager = params.context.systemAgentApprovalManager;
+  if (!manager) {
+    throw new Error("OpenClaw approval registry unavailable");
+  }
+  const description = describeSystemAgentPersistentOperation(params.proposal.operation);
+  const request: SystemAgentApprovalRequestPayload = {
+    title: "OpenClaw change",
+    description,
+    command: description,
+    proposalHash: params.proposal.hash,
+    allowedDecisions: SYSTEM_AGENT_APPROVAL_DECISIONS,
+    agentId: params.delegation.agentId ?? null,
+    sessionKey: params.delegation.sessionKey ?? null,
+    sessionId: params.sessionId,
+    turnSourceChannel: null,
+    turnSourceAccountId: null,
+  };
+  const record = manager.create(
+    request,
+    SYSTEM_AGENT_APPROVAL_TIMEOUT_MS,
+    `system-agent:${randomUUID()}`,
+  );
+  const decisionPromise = manager.register(record, SYSTEM_AGENT_APPROVAL_TIMEOUT_MS);
+  params.session.pendingApproval = { id: record.id, proposalHash: params.proposal.hash };
+  const requestEvent = buildRequestedApprovalEvent(record);
+  void handlePendingApprovalRequest({
+    manager,
+    record,
+    decisionPromise,
+    respond: () => undefined,
+    context: params.context,
+    requestEventName: "openclaw.approval.requested",
+    requestEvent,
+    twoPhase: true,
+    deliverRequest: () => false,
+    keepPendingWithoutRoute: true,
+    requireDeliveryRoute: false,
+    afterDecision: async (decision) => {
+      if (params.sessions.get(params.sessionId) !== params.session) {
+        return;
+      }
+      if (params.session.pendingApproval?.id === record.id) {
+        params.session.pendingApproval = undefined;
+      }
+      await params.session.engine.resolveOperatorApproval(decision, params.proposal.hash);
+    },
+    afterDecisionErrorLabel: "OpenClaw approval apply failed",
+  });
+  return record.id;
+}

--- a/src/gateway/server-methods/system-agent-greeting-welcome.test.ts
+++ b/src/gateway/server-methods/system-agent-greeting-welcome.test.ts
@@ -47,6 +47,8 @@ type FakeEngine = {
   getPendingOperatorProposal: ReturnType<typeof vi.fn>;
   resolveOperatorApproval: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
+  hasLockedHostedWizard: ReturnType<typeof vi.fn>;
+  resumeLockedHostedWizard: ReturnType<typeof vi.fn>;
   loadOverview: ReturnType<typeof vi.fn>;
   noteAssistantMessage: ReturnType<typeof vi.fn>;
   planGreeting: ReturnType<typeof vi.fn>;
@@ -64,6 +66,8 @@ function makeEngine(): FakeEngine {
     getPendingOperatorProposal: vi.fn(() => null),
     resolveOperatorApproval: vi.fn(async () => null),
     dispose: vi.fn(async () => undefined),
+    hasLockedHostedWizard: vi.fn(() => false),
+    resumeLockedHostedWizard: vi.fn(async () => null),
     loadOverview: vi.fn(async () => ({})),
     noteAssistantMessage: vi.fn((text: string) => {
       history.push({ role: "assistant", text });

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -3,6 +3,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import { SystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
 import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
@@ -45,6 +46,8 @@ type FakeEngine = {
   getPendingOperatorProposal: ReturnType<typeof vi.fn>;
   resolveOperatorApproval: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
+  hasLockedHostedWizard: ReturnType<typeof vi.fn>;
+  resumeLockedHostedWizard: ReturnType<typeof vi.fn>;
   loadOverview: ReturnType<typeof vi.fn>;
   noteAssistantMessage: ReturnType<typeof vi.fn>;
 };
@@ -57,17 +60,32 @@ function makeEngine(): FakeEngine {
     historySince: vi.fn(() => []),
     getPendingOperatorProposal: vi.fn(() => null),
     resolveOperatorApproval: vi.fn(async () => null),
-    dispose: vi.fn(async () => undefined),
+    dispose: vi.fn(async () => true),
+    hasLockedHostedWizard: vi.fn(() => false),
+    resumeLockedHostedWizard: vi.fn(async () => null),
     loadOverview: vi.fn(async () => ({})),
     noteAssistantMessage: vi.fn(),
   };
 }
 
 const createdEngines = vi.hoisted(() => [] as FakeEngine[]);
+const createdEngineOptions = vi.hoisted(() => [] as Array<{ supportsQrCode?: boolean }>);
 
 vi.mock("../../system-agent/chat-engine.js", () => ({
-  SystemAgentChatEngine: function FakeSystemAgentChatEngine(this: FakeEngine) {
+  SystemAgentChatEngine: function FakeSystemAgentChatEngine(
+    this: FakeEngine,
+    options: { supportsQrCode?: boolean },
+  ) {
     const engine = makeEngine();
+    createdEngineOptions.push(options);
+    if (options.supportsQrCode === true) {
+      engine.handle.mockResolvedValue({
+        text: "Scan this code.",
+        action: "none",
+        qrCodePngBase64: "cG5n",
+        wizardInputPending: true,
+      });
+    }
     createdEngines.push(engine);
     Object.assign(this, engine);
   },
@@ -102,12 +120,14 @@ function makeContext(sessions: Map<string, SystemAgentChatSession>): GatewayRequ
 function seededSession(params?: {
   engine?: FakeEngine;
   ownerKey?: string;
+  supportsQrCode?: boolean;
 }): SystemAgentChatSession {
   return {
     engine: params?.engine ?? makeEngine(),
     welcome: "welcome text",
     lastUsedAt: 1,
     ownerKey: params?.ownerKey ?? "device:device-test",
+    supportsQrCode: params?.supportsQrCode ?? false,
   } as unknown as SystemAgentChatSession;
 }
 
@@ -132,6 +152,7 @@ async function callChat(
 
 beforeEach(() => {
   createdEngines.length = 0;
+  createdEngineOptions.length = 0;
   setupInferenceMocks.verifySetupInference.mockResolvedValue({ ok: true, binding: {} });
   delegatedInferenceMocks.verifySystemAgentInferenceWithFallback.mockResolvedValue({
     ok: true,
@@ -145,6 +166,67 @@ afterEach(() => {
 });
 
 describe("openclaw.chat session ownership", () => {
+  it("negotiates QR projection for fresh and reset sessions", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    const params = {
+      sessionId: "fresh-qr",
+      message: "connect signal",
+      capabilities: { qrCodePng: true },
+    };
+
+    const prompt = await callChat(context, params);
+    const resetPrompt = await callChat(context, { ...params, reset: true });
+
+    expect(prompt).toMatchObject({
+      ok: true,
+      payload: {
+        qrCodePngBase64: "cG5n",
+        wizardInputPending: true,
+      },
+    });
+    expect(resetPrompt).toMatchObject({
+      ok: true,
+      payload: {
+        qrCodePngBase64: "cG5n",
+        wizardInputPending: true,
+      },
+    });
+    expect(createdEngineOptions).toEqual([
+      expect.objectContaining({ supportsQrCode: true }),
+      expect.objectContaining({ supportsQrCode: true }),
+    ]);
+  });
+
+  it.each([
+    { initialQr: true, resumedQr: false },
+    { initialQr: false, resumedQr: true },
+  ])("rejects a session resumed with QR support changed", async ({ initialQr, resumedQr }) => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    const capabilities = (supported: boolean) =>
+      supported ? { capabilities: { qrCodePng: true } } : {};
+
+    const first = await callChat(context, {
+      sessionId: "qr-capability-change",
+      ...capabilities(initialQr),
+    });
+    const resumed = await callChat(context, {
+      sessionId: "qr-capability-change",
+      message: "continue",
+      ...capabilities(resumedQr),
+    });
+
+    expect(first.ok).toBe(true);
+    expect(resumed).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "OpenClaw chat capabilities changed; retry with reset=true.",
+      },
+    });
+  });
+
   it("binds a new non-delegated session and rejects another principal", async () => {
     const sessions = new Map<string, SystemAgentChatSession>();
     const context = makeContext(sessions);
@@ -244,6 +326,196 @@ describe("openclaw.chat session ownership", () => {
 
     expect(resumed.ok).toBe(true);
     expect(handle).toHaveBeenCalledWith("continue");
+  });
+
+  it("adopts a locked wizard when the same owner reconnects with a fresh session id", async () => {
+    const engine = makeEngine();
+    engine.hasLockedHostedWizard.mockReturnValue(true);
+    engine.resumeLockedHostedWizard.mockResolvedValue({
+      text: "Scan and continue.",
+      action: "none",
+      wizardInputPending: true,
+      qrCodePngBase64: "cG5n",
+    });
+    const sessions = new Map<string, SystemAgentChatSession>([
+      [
+        "old-session",
+        seededSession({
+          engine,
+          ownerKey: "user:owner@example.com",
+          supportsQrCode: true,
+        }),
+      ],
+    ]);
+
+    const resumed = await callChat(
+      makeContext(sessions),
+      {
+        sessionId: "fresh-session",
+        capabilities: { qrCodePng: true },
+      },
+      makeClient({
+        connId: "conn-new",
+        deviceId: "device-new",
+        authenticatedUserId: "owner@example.com",
+      }),
+    );
+
+    expect(resumed).toMatchObject({
+      ok: true,
+      payload: {
+        sessionId: "fresh-session",
+        reply: "Scan and continue.",
+        action: "none",
+        wizardInputPending: true,
+        qrCodePngBase64: "cG5n",
+      },
+    });
+    expect(sessions.has("old-session")).toBe(false);
+    expect(sessions.get("fresh-session")?.engine).toBe(engine);
+    expect(engine.resumeLockedHostedWizard).toHaveBeenCalledOnce();
+    expect(setupInferenceMocks.verifySetupInference).not.toHaveBeenCalled();
+  });
+
+  it("rejects ambiguous locked wizards instead of adopting one by map order", async () => {
+    const firstEngine = makeEngine();
+    const secondEngine = makeEngine();
+    firstEngine.hasLockedHostedWizard.mockReturnValue(true);
+    secondEngine.hasLockedHostedWizard.mockReturnValue(true);
+    const sessions = new Map<string, SystemAgentChatSession>([
+      [
+        "old-session-a",
+        seededSession({
+          engine: firstEngine,
+          ownerKey: "user:owner@example.com",
+        }),
+      ],
+      [
+        "old-session-b",
+        seededSession({
+          engine: secondEngine,
+          ownerKey: "user:owner@example.com",
+        }),
+      ],
+    ]);
+
+    const resumed = await callChat(
+      makeContext(sessions),
+      { sessionId: "fresh-session" },
+      makeClient({
+        connId: "conn-new",
+        deviceId: "device-new",
+        authenticatedUserId: "owner@example.com",
+      }),
+    );
+
+    expect(resumed).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Multiple locked OpenClaw setup sessions need manual recovery.",
+      },
+    });
+    expect(sessions.has("old-session-a")).toBe(true);
+    expect(sessions.has("old-session-b")).toBe(true);
+    expect(sessions.has("fresh-session")).toBe(false);
+    expect(firstEngine.resumeLockedHostedWizard).not.toHaveBeenCalled();
+    expect(secondEngine.resumeLockedHostedWizard).not.toHaveBeenCalled();
+  });
+
+  it("retains a cancellation-locked wizard when inference becomes unavailable", async () => {
+    const engine = makeEngine();
+    engine.handle.mockRejectedValue(new SystemAgentInferenceUnavailableError("conversation"));
+    engine.dispose.mockResolvedValue(false);
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
+
+    const failed = await callChat(makeContext(sessions), {
+      sessionId: "s1",
+      message: "continue",
+    });
+
+    expect(failed).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("working inference"),
+      },
+    });
+    expect(engine.dispose).toHaveBeenCalledOnce();
+    expect(sessions.get("s1")?.engine).toBe(engine);
+  });
+
+  it("skips a cancellation-locked wizard when evicting an old chat session", async () => {
+    const lockedEngine = makeEngine();
+    lockedEngine.dispose.mockResolvedValue(false);
+    const evictableEngine = makeEngine();
+    evictableEngine.dispose.mockResolvedValue(true);
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["locked", seededSession({ engine: lockedEngine })],
+      ["evictable", seededSession({ engine: evictableEngine })],
+    ]);
+    for (let index = 2; index < 8; index += 1) {
+      const session = seededSession();
+      session.lastUsedAt = index;
+      sessions.set(`existing-${index}`, session);
+    }
+
+    const created = await callChat(makeContext(sessions), { sessionId: "new" });
+
+    expect(created.ok).toBe(true);
+    expect(lockedEngine.dispose).toHaveBeenCalledOnce();
+    expect(evictableEngine.dispose).toHaveBeenCalledOnce();
+    expect(sessions.has("locked")).toBe(true);
+    expect(sessions.has("evictable")).toBe(false);
+    expect(sessions.has("new")).toBe(true);
+    expect(sessions.size).toBe(8);
+  });
+
+  it("does not persist a new session when every existing setup is locked", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    for (let index = 0; index < 8; index += 1) {
+      const engine = makeEngine();
+      engine.dispose.mockResolvedValue(false);
+      const session = seededSession({ engine });
+      session.lastUsedAt = index;
+      sessions.set(`locked-${index}`, session);
+    }
+
+    const created = await callChat(makeContext(sessions), {
+      sessionId: "new",
+      reset: true,
+    });
+
+    expect(created).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: "OpenClaw is finishing channel setup. Try again shortly.",
+      },
+    });
+    expect(sessions.size).toBe(8);
+    expect(sessions.has("new")).toBe(false);
+  });
+
+  it("refuses to reset a cancellation-locked channel setup", async () => {
+    const engine = makeEngine();
+    engine.dispose.mockResolvedValue(false);
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
+
+    const reset = await callChat(makeContext(sessions), {
+      sessionId: "s1",
+      reset: true,
+    });
+
+    expect(reset).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Channel setup is already applying and cannot be reset yet.",
+      },
+    });
+    expect(engine.dispose).toHaveBeenCalledOnce();
+    expect(sessions.has("s1")).toBe(true);
   });
 
   it("rejects non-delegated chat without a server-authenticated identity", async () => {

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines -- Gateway chat integration tests share one module-mock harness. */
 // OpenClaw gateway tests cover activation serialization and chat sessions.
 
 import { expectDefined } from "@openclaw/normalization-core";
@@ -11,6 +12,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
 import { SystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
 import { createSystemAgentVerifiedInferenceTestFixture } from "../../system-agent/system-agent.test-helpers.js";
+import * as verifiedInferenceRuntime from "../../system-agent/verified-inference.js";
 import type {
   SystemAgentVerifiedInferenceBinding,
   SystemAgentVerifiedInferenceDeps,
@@ -55,6 +57,10 @@ const greetingMocks = vi.hoisted(() => ({
 const onboardingWelcomeMocks = vi.hoisted(() => ({
   buildOnboardingWelcome: vi.fn(),
 }));
+const onboardChannelsMocks = vi.hoisted(() => ({
+  setupChannels: vi.fn(),
+  runCollectedChannelOnboardingPostWriteHooks: vi.fn(async () => undefined),
+}));
 
 vi.mock("../../system-agent/setup-inference.js", () => ({
   activateSetupInference: setupInferenceMocks.activateSetupInference,
@@ -87,6 +93,15 @@ vi.mock("../../system-agent/greeting.js", async (importOriginal) => {
 });
 vi.mock("../../system-agent/onboarding-welcome.js", () => ({
   buildOnboardingWelcome: onboardingWelcomeMocks.buildOnboardingWelcome,
+}));
+vi.mock("../../commands/onboard-channels.js", () => ({
+  createChannelOnboardingPostWriteHookCollector: () => ({
+    collect: vi.fn(),
+    drain: () => [],
+  }),
+  runCollectedChannelOnboardingPostWriteHooks:
+    onboardChannelsMocks.runCollectedChannelOnboardingPostWriteHooks,
+  setupChannels: onboardChannelsMocks.setupChannels,
 }));
 
 type RespondCall = {
@@ -183,6 +198,7 @@ function seededSession(overrides?: Partial<SystemAgentChatSession>): SystemAgent
     welcome: "welcome text",
     lastUsedAt: 1,
     ownerKey: "device:device-test",
+    supportsQrCode: false,
     ...overrides,
   };
 }
@@ -224,6 +240,8 @@ beforeEach(async () => {
   onboardingWelcomeMocks.buildOnboardingWelcome.mockReset().mockResolvedValue({
     text: "Inference is ready. Let's finish setup.",
   });
+  onboardChannelsMocks.setupChannels.mockReset();
+  onboardChannelsMocks.runCollectedChannelOnboardingPostWriteHooks.mockClear();
 });
 
 afterEach(() => {
@@ -727,6 +745,77 @@ describe("openclaw.chat", () => {
     expect(JSON.stringify(persisted)).not.toContain("raw-secret-value");
   });
 
+  it("negotiates hosted-wizard QR images for fresh and reset chat sessions", async () => {
+    stubEngineOverview();
+    vi.spyOn(
+      verifiedInferenceRuntime,
+      "resolveSystemAgentVerifiedInferenceRoute",
+    ).mockResolvedValue(requireVerifiedInferenceFixture().execution);
+    onboardChannelsMocks.setupChannels.mockImplementation(
+      async (cfg: OpenClawConfig, _runtime: unknown, prompter: WizardPrompter) => {
+        await prompter.qrCode?.({
+          title: "Signal account linking",
+          message: "Scan this code, then confirm.",
+          pngBase64: "cG5n",
+        });
+        return cfg;
+      },
+    );
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    const params = {
+      sessionId: "fresh-qr",
+      message: "connect signal",
+      capabilities: { qrCodePng: true },
+    };
+
+    const prompt = await callChat(context, params);
+
+    expect(prompt.ok, JSON.stringify(prompt.error)).toBe(true);
+    expect(prompt.payload).toMatchObject({
+      qrCodePngBase64: "cG5n",
+      wizardInputPending: true,
+    });
+
+    const resetPrompt = await callChat(context, { ...params, reset: true });
+
+    expect(resetPrompt.payload).toMatchObject({
+      qrCodePngBase64: "cG5n",
+      wizardInputPending: true,
+    });
+    expect(onboardChannelsMocks.setupChannels).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { initialQr: true, resumedQr: false },
+    { initialQr: false, resumedQr: true },
+  ])("rejects a session resumed with QR support changed", async ({ initialQr, resumedQr }) => {
+    stubEngineOverview();
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    const capabilities = (supported: boolean) =>
+      supported ? { capabilities: { qrCodePng: true } } : {};
+
+    const first = await callChat(context, {
+      sessionId: "qr-capability-change",
+      ...capabilities(initialQr),
+    });
+    const resumed = await callChat(context, {
+      sessionId: "qr-capability-change",
+      message: "continue",
+      ...capabilities(resumedQr),
+    });
+
+    expect(first.ok).toBe(true);
+    expect(resumed).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "OpenClaw chat capabilities changed; retry with reset=true.",
+      },
+    });
+  });
+
   it("returns history oldest-first with default and explicit bounded limits", async () => {
     const turns = [
       { role: "user" as const, text: "one", at: 1 },
@@ -831,7 +920,7 @@ describe("openclaw.chat", () => {
     vi.spyOn(engine, "handle").mockRejectedValue(
       new SystemAgentInferenceUnavailableError("conversation"),
     );
-    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue();
+    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue(true);
     const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
     const context = makeContext(sessions);
 
@@ -854,6 +943,31 @@ describe("openclaw.chat", () => {
     expect(retried.ok).toBe(true);
     expect(setupInferenceMocks.verifySetupInference).toHaveBeenCalledOnce();
     expect(sessions.has("s1")).toBe(true);
+  });
+
+  it("retains a cancellation-locked wizard when inference becomes unavailable", async () => {
+    const engine = makeVerifiedEngine();
+    vi.spyOn(engine, "handle").mockRejectedValue(
+      new SystemAgentInferenceUnavailableError("conversation"),
+    );
+    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue(false);
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
+
+    const failed = await callChat(makeContext(sessions), {
+      sessionId: "s1",
+      message: "continue",
+    });
+
+    expect(failed).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("working inference"),
+      },
+    });
+    expect((failed.error as { details?: unknown } | undefined)?.details).toBeUndefined();
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(sessions.get("s1")?.engine).toBe(engine);
   });
 
   it("does not relabel unrelated session failures as inference errors", async () => {
@@ -940,6 +1054,7 @@ describe("openclaw.chat", () => {
     const disposeOldest = vi.spyOn(oldest.engine, "dispose").mockImplementation(async () => {
       evictionStarted.resolve();
       await releaseEviction.promise;
+      return true;
     });
     const sessions = new Map<string, SystemAgentChatSession>([["oldest", oldest]]);
     for (let index = 1; index < 8; index += 1) {
@@ -963,12 +1078,64 @@ describe("openclaw.chat", () => {
     expect(sessions.has("new-2")).toBe(true);
   });
 
+  it("skips a cancellation-locked wizard when evicting an old chat session", async () => {
+    const locked = seededSession({ lastUsedAt: 0 });
+    const disposeLocked = vi.spyOn(locked.engine, "dispose").mockResolvedValue(false);
+    const evictable = seededSession({ lastUsedAt: 1 });
+    const disposeEvictable = vi.spyOn(evictable.engine, "dispose").mockResolvedValue(true);
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["locked", locked],
+      ["evictable", evictable],
+    ]);
+    for (let index = 2; index < 8; index += 1) {
+      sessions.set(`existing-${index}`, seededSession({ lastUsedAt: index }));
+    }
+    stubEngineOverview();
+
+    const created = await callChat(makeContext(sessions), { sessionId: "new" });
+
+    expect(created.ok).toBe(true);
+    expect(disposeLocked).toHaveBeenCalledOnce();
+    expect(disposeEvictable).toHaveBeenCalledOnce();
+    expect(sessions.has("locked")).toBe(true);
+    expect(sessions.has("evictable")).toBe(false);
+    expect(sessions.has("new")).toBe(true);
+    expect(sessions.size).toBe(8);
+  });
+
+  it("does not persist a rejected session when every existing setup is locked", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    for (let index = 0; index < 8; index += 1) {
+      const session = seededSession({ lastUsedAt: index });
+      vi.spyOn(session.engine, "dispose").mockResolvedValue(false);
+      sessions.set(`locked-${index}`, session);
+    }
+    stubEngineOverview();
+
+    const created = await callChat(makeContext(sessions), {
+      sessionId: "new",
+      reset: true,
+    });
+
+    expect(created).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: "OpenClaw is finishing channel setup. Try again shortly.",
+      },
+    });
+    expect(sessions.size).toBe(8);
+    expect(sessions.has("new")).toBe(false);
+    expect(transcriptStoreMocks.appendTranscriptReset).not.toHaveBeenCalled();
+    expect(transcriptStoreMocks.appendTranscriptTurn).not.toHaveBeenCalled();
+  });
+
   it("resets a session on request", async () => {
     stubEngineOverview();
     transcriptStoreMocks.readTranscriptTail.mockReturnValue([]);
     const engine = makeVerifiedEngine();
     const handle = vi.spyOn(engine, "handle");
-    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue();
+    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue(true);
     const seedHistory = vi.spyOn(SystemAgentChatEngine.prototype, "seedHistory");
     const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
     // Reset drops the stored session; loading a fresh welcome would hit real
@@ -1006,5 +1173,25 @@ describe("openclaw.chat", () => {
     expect(transcriptStoreMocks.readTranscriptTail).toHaveBeenLastCalledWith(30, {
       afterLastReset: true,
     });
+  });
+
+  it("refuses to reset a cancellation-locked channel setup", async () => {
+    const engine = makeVerifiedEngine();
+    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue(false);
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
+
+    const reset = await callChat(makeContext(sessions), { sessionId: "s1", reset: true });
+
+    expect(reset).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("cannot be reset yet"),
+      },
+    });
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(sessions.get("s1")?.engine).toBe(engine);
+    expect(transcriptStoreMocks.appendTranscriptReset).not.toHaveBeenCalled();
+    expect(setupInferenceMocks.verifySetupInference).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines -- Gateway chat integration tests share one module-mock harness. */
 // OpenClaw gateway tests cover activation serialization and chat sessions.
 
 import { expectDefined } from "@openclaw/normalization-core";
@@ -12,7 +11,6 @@ import { defaultRuntime } from "../../runtime.js";
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
 import { SystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
 import { createSystemAgentVerifiedInferenceTestFixture } from "../../system-agent/system-agent.test-helpers.js";
-import * as verifiedInferenceRuntime from "../../system-agent/verified-inference.js";
 import type {
   SystemAgentVerifiedInferenceBinding,
   SystemAgentVerifiedInferenceDeps,
@@ -57,10 +55,6 @@ const greetingMocks = vi.hoisted(() => ({
 const onboardingWelcomeMocks = vi.hoisted(() => ({
   buildOnboardingWelcome: vi.fn(),
 }));
-const onboardChannelsMocks = vi.hoisted(() => ({
-  setupChannels: vi.fn(),
-  runCollectedChannelOnboardingPostWriteHooks: vi.fn(async () => undefined),
-}));
 
 vi.mock("../../system-agent/setup-inference.js", () => ({
   activateSetupInference: setupInferenceMocks.activateSetupInference,
@@ -93,15 +87,6 @@ vi.mock("../../system-agent/greeting.js", async (importOriginal) => {
 });
 vi.mock("../../system-agent/onboarding-welcome.js", () => ({
   buildOnboardingWelcome: onboardingWelcomeMocks.buildOnboardingWelcome,
-}));
-vi.mock("../../commands/onboard-channels.js", () => ({
-  createChannelOnboardingPostWriteHookCollector: () => ({
-    collect: vi.fn(),
-    drain: () => [],
-  }),
-  runCollectedChannelOnboardingPostWriteHooks:
-    onboardChannelsMocks.runCollectedChannelOnboardingPostWriteHooks,
-  setupChannels: onboardChannelsMocks.setupChannels,
 }));
 
 type RespondCall = {
@@ -240,8 +225,6 @@ beforeEach(async () => {
   onboardingWelcomeMocks.buildOnboardingWelcome.mockReset().mockResolvedValue({
     text: "Inference is ready. Let's finish setup.",
   });
-  onboardChannelsMocks.setupChannels.mockReset();
-  onboardChannelsMocks.runCollectedChannelOnboardingPostWriteHooks.mockClear();
 });
 
 afterEach(() => {
@@ -745,77 +728,6 @@ describe("openclaw.chat", () => {
     expect(JSON.stringify(persisted)).not.toContain("raw-secret-value");
   });
 
-  it("negotiates hosted-wizard QR images for fresh and reset chat sessions", async () => {
-    stubEngineOverview();
-    vi.spyOn(
-      verifiedInferenceRuntime,
-      "resolveSystemAgentVerifiedInferenceRoute",
-    ).mockResolvedValue(requireVerifiedInferenceFixture().execution);
-    onboardChannelsMocks.setupChannels.mockImplementation(
-      async (cfg: OpenClawConfig, _runtime: unknown, prompter: WizardPrompter) => {
-        await prompter.qrCode?.({
-          title: "Signal account linking",
-          message: "Scan this code, then confirm.",
-          pngBase64: "cG5n",
-        });
-        return cfg;
-      },
-    );
-    const sessions = new Map<string, SystemAgentChatSession>();
-    const context = makeContext(sessions);
-    const params = {
-      sessionId: "fresh-qr",
-      message: "connect signal",
-      capabilities: { qrCodePng: true },
-    };
-
-    const prompt = await callChat(context, params);
-
-    expect(prompt.ok, JSON.stringify(prompt.error)).toBe(true);
-    expect(prompt.payload).toMatchObject({
-      qrCodePngBase64: "cG5n",
-      wizardInputPending: true,
-    });
-
-    const resetPrompt = await callChat(context, { ...params, reset: true });
-
-    expect(resetPrompt.payload).toMatchObject({
-      qrCodePngBase64: "cG5n",
-      wizardInputPending: true,
-    });
-    expect(onboardChannelsMocks.setupChannels).toHaveBeenCalledTimes(2);
-  });
-
-  it.each([
-    { initialQr: true, resumedQr: false },
-    { initialQr: false, resumedQr: true },
-  ])("rejects a session resumed with QR support changed", async ({ initialQr, resumedQr }) => {
-    stubEngineOverview();
-    const sessions = new Map<string, SystemAgentChatSession>();
-    const context = makeContext(sessions);
-    const capabilities = (supported: boolean) =>
-      supported ? { capabilities: { qrCodePng: true } } : {};
-
-    const first = await callChat(context, {
-      sessionId: "qr-capability-change",
-      ...capabilities(initialQr),
-    });
-    const resumed = await callChat(context, {
-      sessionId: "qr-capability-change",
-      message: "continue",
-      ...capabilities(resumedQr),
-    });
-
-    expect(first.ok).toBe(true);
-    expect(resumed).toMatchObject({
-      ok: false,
-      error: {
-        code: "INVALID_REQUEST",
-        message: "OpenClaw chat capabilities changed; retry with reset=true.",
-      },
-    });
-  });
-
   it("returns history oldest-first with default and explicit bounded limits", async () => {
     const turns = [
       { role: "user" as const, text: "one", at: 1 },
@@ -945,31 +857,6 @@ describe("openclaw.chat", () => {
     expect(sessions.has("s1")).toBe(true);
   });
 
-  it("retains a cancellation-locked wizard when inference becomes unavailable", async () => {
-    const engine = makeVerifiedEngine();
-    vi.spyOn(engine, "handle").mockRejectedValue(
-      new SystemAgentInferenceUnavailableError("conversation"),
-    );
-    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue(false);
-    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
-
-    const failed = await callChat(makeContext(sessions), {
-      sessionId: "s1",
-      message: "continue",
-    });
-
-    expect(failed).toMatchObject({
-      ok: false,
-      error: {
-        code: "UNAVAILABLE",
-        message: expect.stringContaining("working inference"),
-      },
-    });
-    expect((failed.error as { details?: unknown } | undefined)?.details).toBeUndefined();
-    expect(dispose).toHaveBeenCalledOnce();
-    expect(sessions.get("s1")?.engine).toBe(engine);
-  });
-
   it("does not relabel unrelated session failures as inference errors", async () => {
     const engine = makeVerifiedEngine();
     vi.spyOn(engine, "handle").mockRejectedValue(new Error("wizard bug"));
@@ -1078,58 +965,6 @@ describe("openclaw.chat", () => {
     expect(sessions.has("new-2")).toBe(true);
   });
 
-  it("skips a cancellation-locked wizard when evicting an old chat session", async () => {
-    const locked = seededSession({ lastUsedAt: 0 });
-    const disposeLocked = vi.spyOn(locked.engine, "dispose").mockResolvedValue(false);
-    const evictable = seededSession({ lastUsedAt: 1 });
-    const disposeEvictable = vi.spyOn(evictable.engine, "dispose").mockResolvedValue(true);
-    const sessions = new Map<string, SystemAgentChatSession>([
-      ["locked", locked],
-      ["evictable", evictable],
-    ]);
-    for (let index = 2; index < 8; index += 1) {
-      sessions.set(`existing-${index}`, seededSession({ lastUsedAt: index }));
-    }
-    stubEngineOverview();
-
-    const created = await callChat(makeContext(sessions), { sessionId: "new" });
-
-    expect(created.ok).toBe(true);
-    expect(disposeLocked).toHaveBeenCalledOnce();
-    expect(disposeEvictable).toHaveBeenCalledOnce();
-    expect(sessions.has("locked")).toBe(true);
-    expect(sessions.has("evictable")).toBe(false);
-    expect(sessions.has("new")).toBe(true);
-    expect(sessions.size).toBe(8);
-  });
-
-  it("does not persist a rejected session when every existing setup is locked", async () => {
-    const sessions = new Map<string, SystemAgentChatSession>();
-    for (let index = 0; index < 8; index += 1) {
-      const session = seededSession({ lastUsedAt: index });
-      vi.spyOn(session.engine, "dispose").mockResolvedValue(false);
-      sessions.set(`locked-${index}`, session);
-    }
-    stubEngineOverview();
-
-    const created = await callChat(makeContext(sessions), {
-      sessionId: "new",
-      reset: true,
-    });
-
-    expect(created).toMatchObject({
-      ok: false,
-      error: {
-        code: "UNAVAILABLE",
-        message: "OpenClaw is finishing channel setup. Try again shortly.",
-      },
-    });
-    expect(sessions.size).toBe(8);
-    expect(sessions.has("new")).toBe(false);
-    expect(transcriptStoreMocks.appendTranscriptReset).not.toHaveBeenCalled();
-    expect(transcriptStoreMocks.appendTranscriptTurn).not.toHaveBeenCalled();
-  });
-
   it("resets a session on request", async () => {
     stubEngineOverview();
     transcriptStoreMocks.readTranscriptTail.mockReturnValue([]);
@@ -1173,25 +1008,5 @@ describe("openclaw.chat", () => {
     expect(transcriptStoreMocks.readTranscriptTail).toHaveBeenLastCalledWith(30, {
       afterLastReset: true,
     });
-  });
-
-  it("refuses to reset a cancellation-locked channel setup", async () => {
-    const engine = makeVerifiedEngine();
-    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue(false);
-    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
-
-    const reset = await callChat(makeContext(sessions), { sessionId: "s1", reset: true });
-
-    expect(reset).toMatchObject({
-      ok: false,
-      error: {
-        code: "INVALID_REQUEST",
-        message: expect.stringContaining("cannot be reset yet"),
-      },
-    });
-    expect(dispose).toHaveBeenCalledOnce();
-    expect(sessions.get("s1")?.engine).toBe(engine);
-    expect(transcriptStoreMocks.appendTranscriptReset).not.toHaveBeenCalled();
-    expect(setupInferenceMocks.verifySetupInference).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -67,6 +67,8 @@ const DEFAULT_SYSTEM_AGENT_HISTORY_LIMIT = 100;
 const PROVIDER_AUTH_SESSION_TIMEOUT_MS = 25 * 60 * 1000;
 const PROVIDER_PREPARE_SESSION_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 const SYSTEM_AGENT_GATEWAY_EXECUTION_KEY = "gateway";
+const LOCKED_SETUP_RESET_ERROR = "Channel setup is already applying and cannot be reset yet.";
+const LOCKED_SETUP_BUSY_ERROR = "OpenClaw is finishing channel setup. Try again shortly.";
 const systemAgentGatewayExecutionQueue = new KeyedAsyncQueue();
 const systemAgentSessionQueues = new WeakMap<
   Map<string, SystemAgentChatSession>,
@@ -153,26 +155,24 @@ export async function runExclusiveSystemAgentSetupActivation<T>(
 async function evictOldestSession(
   sessions: Map<string, SystemAgentChatSession>,
   context: GatewayRequestContext,
-): Promise<void> {
+): Promise<boolean> {
   if (sessions.size < MAX_SYSTEM_AGENT_SESSIONS) {
-    return;
+    return true;
   }
-  let oldestKey: string | undefined;
-  let oldestAt = Number.POSITIVE_INFINITY;
-  for (const [key, session] of sessions) {
-    if (session.lastUsedAt < oldestAt) {
-      oldestAt = session.lastUsedAt;
-      oldestKey = key;
+  const oldestFirst = [...sessions.entries()].toSorted(([, left], [, right]) => {
+    return left.lastUsedAt - right.lastUsedAt;
+  });
+  for (const [key, session] of oldestFirst) {
+    if (!(await session.engine.dispose())) {
+      continue;
     }
-  }
-  if (oldestKey !== undefined) {
-    const oldest = sessions.get(oldestKey);
-    if (oldest?.pendingApproval) {
-      context.systemAgentApprovalManager?.expire(oldest.pendingApproval.id, "session-evicted");
+    if (session.pendingApproval) {
+      context.systemAgentApprovalManager?.expire(session.pendingApproval.id, "session-evicted");
     }
-    await oldest?.engine.dispose();
-    sessions.delete(oldestKey);
+    sessions.delete(key);
+    return true;
   }
+  return false;
 }
 
 function persistEngineHistory(engine: SystemAgentChatSession["engine"], startIndex: number): void {
@@ -523,8 +523,30 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           );
           return;
         }
+        const supportsQrCode = params.capabilities?.qrCodePng === true;
+        if (boundSession && !params.reset && boundSession.supportsQrCode !== supportsQrCode) {
+          // A retained wizard may already be waiting on a QR-only acknowledgement.
+          // Do not resume it on a client that negotiated a different rendering contract.
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              "OpenClaw chat capabilities changed; retry with reset=true.",
+            ),
+          );
+          return;
+        }
         if (params.reset) {
           const existing = sessions.get(sessionId);
+          if (existing && !(await existing.engine.dispose())) {
+            respond(
+              false,
+              undefined,
+              errorShape(ErrorCodes.INVALID_REQUEST, LOCKED_SETUP_RESET_ERROR),
+            );
+            return;
+          }
           sessions.delete(sessionId);
           if (existing?.pendingApproval) {
             context.systemAgentApprovalManager?.expire(
@@ -532,7 +554,6 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
               "session-reset",
             );
           }
-          await existing?.engine.dispose();
         }
         let session = sessions.get(sessionId);
         let greetingAuditSequence: number | undefined;
@@ -565,6 +586,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           // engine's setup path honors this via surface: "gateway".
           const engine = new SystemAgentChatEngine({
             surface: "gateway",
+            supportsQrCode,
             verifiedInference: inference.binding,
             operatorApprovalOnly: params.delegation !== undefined,
           });
@@ -610,11 +632,15 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, error.message));
             return;
           }
+          if (!(await evictOldestSession(sessions, context))) {
+            await engine.dispose().catch(() => undefined);
+            respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, LOCKED_SETUP_BUSY_ERROR));
+            return;
+          }
           if (params.reset) {
             appendTranscriptReset();
           }
           persistEngineHistory(engine, welcomeHistoryStart);
-          await evictOldestSession(sessions, context);
           session = {
             engine,
             welcome,
@@ -624,6 +650,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
               : {}),
             lastUsedAt: Date.now(),
             ownerKey,
+            supportsQrCode,
           };
           sessions.set(sessionId, session);
           if (welcomeOnly) {
@@ -666,24 +693,23 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           if (!isSystemAgentInferenceUnavailableError(error)) {
             throw error;
           }
-          // A failed inference turn invalidates this conversation. Remove the
-          // exact engine before cleanup so a retry must pass the live gate and
-          // cannot resume partial proposal or CLI-session state.
-          // Initialization failures stay unmarked because no live session existed.
-          if (sessions.get(sessionId)?.engine === session.engine) {
-            sessions.delete(sessionId);
-          }
+          // Keep a cancellation-locked wizard owned through config commit or recovery.
+          let retainedForWizard = false;
           try {
-            await session.engine.dispose();
+            retainedForWizard = !(await session.engine.dispose());
           } catch {
             // The inference error is authoritative; cleanup stays best-effort.
           }
+          if (!retainedForWizard && sessions.get(sessionId)?.engine === session.engine) {
+            sessions.delete(sessionId);
+          }
+          const errorDetails = retainedForWizard
+            ? undefined
+            : { details: buildSystemAgentSessionInvalidatedErrorDetails() };
           respond(
             false,
             undefined,
-            errorShape(ErrorCodes.UNAVAILABLE, error.message, {
-              details: buildSystemAgentSessionInvalidatedErrorDetails(),
-            }),
+            errorShape(ErrorCodes.UNAVAILABLE, error.message, errorDetails),
           );
           return;
         }
@@ -731,6 +757,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
               : {}),
             ...(reply.sensitive === true ? { sensitive: true } : {}),
             ...(reply.wizardInputPending === true ? { wizardInputPending: true } : {}),
+            ...(reply.qrCodePngBase64 ? { qrCodePngBase64: reply.qrCodePngBase64 } : {}),
             ...(reply.question ? { question: reply.question } : {}),
             ...(proposalId ? { needsApproval: true, proposalId } : {}),
           },

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 // OpenClaw gateway methods host the setup/repair conversation for clients.
 import {
   buildSystemAgentSessionInvalidatedErrorDetails,
@@ -12,11 +11,6 @@ import {
   validateSystemAgentSetupVerifyParams,
   type SystemAgentChatQuestion,
 } from "../../../packages/gateway-protocol/src/index.js";
-import {
-  SYSTEM_AGENT_APPROVAL_DECISIONS,
-  SYSTEM_AGENT_APPROVAL_TIMEOUT_MS,
-  type SystemAgentApprovalRequestPayload,
-} from "../../infra/system-agent-approvals.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { enqueueCommandInLane, setCommandLaneConcurrency } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
@@ -32,7 +26,6 @@ import {
 import { isSystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
 import { buildNewAgentWelcome } from "../../system-agent/new-agent-welcome.js";
 import { buildOnboardingWelcome } from "../../system-agent/onboarding-welcome.js";
-import { describeSystemAgentPersistentOperation } from "../../system-agent/operations.js";
 import {
   appendTranscriptReset,
   appendTranscriptTurn,
@@ -40,11 +33,8 @@ import {
 } from "../../system-agent/transcript-store.js";
 import { resolveUserPath } from "../../utils.js";
 import { WizardSession } from "../../wizard/session.js";
-import {
-  buildRequestedApprovalEvent,
-  handlePendingApprovalRequest,
-  listVisiblePendingApprovalRequests,
-} from "./approval-shared.js";
+import { listVisiblePendingApprovalRequests } from "./approval-shared.js";
+import { queueDelegatedSystemAgentApproval } from "./system-agent-approval.js";
 import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -182,71 +172,6 @@ function persistEngineHistory(engine: SystemAgentChatSession["engine"], startInd
     // been replaced by the mask marker before it crosses this boundary.
     appendTranscriptTurn({ ...turn, at });
   }
-}
-
-function queueDelegatedApproval(params: {
-  context: GatewayRequestContext;
-  sessions: Map<string, SystemAgentChatSession>;
-  session: SystemAgentChatSession;
-  sessionId: string;
-  delegation: {
-    agentId?: string;
-    sessionKey?: string;
-  };
-  proposal: NonNullable<ReturnType<SystemAgentChatSession["engine"]["getPendingOperatorProposal"]>>;
-}): string {
-  if (params.session.pendingApproval?.proposalHash === params.proposal.hash) {
-    return params.session.pendingApproval.id;
-  }
-  const manager = params.context.systemAgentApprovalManager;
-  if (!manager) {
-    throw new Error("OpenClaw approval registry unavailable");
-  }
-  const description = describeSystemAgentPersistentOperation(params.proposal.operation);
-  const request: SystemAgentApprovalRequestPayload = {
-    title: "OpenClaw change",
-    description,
-    command: description,
-    proposalHash: params.proposal.hash,
-    allowedDecisions: SYSTEM_AGENT_APPROVAL_DECISIONS,
-    agentId: params.delegation?.agentId ?? null,
-    sessionKey: params.delegation?.sessionKey ?? null,
-    sessionId: params.sessionId,
-    turnSourceChannel: null,
-    turnSourceAccountId: null,
-  };
-  const record = manager.create(
-    request,
-    SYSTEM_AGENT_APPROVAL_TIMEOUT_MS,
-    `system-agent:${randomUUID()}`,
-  );
-  const decisionPromise = manager.register(record, SYSTEM_AGENT_APPROVAL_TIMEOUT_MS);
-  params.session.pendingApproval = { id: record.id, proposalHash: params.proposal.hash };
-  const requestEvent = buildRequestedApprovalEvent(record);
-  void handlePendingApprovalRequest({
-    manager,
-    record,
-    decisionPromise,
-    respond: () => undefined,
-    context: params.context,
-    requestEventName: "openclaw.approval.requested",
-    requestEvent,
-    twoPhase: true,
-    deliverRequest: () => false,
-    keepPendingWithoutRoute: true,
-    requireDeliveryRoute: false,
-    afterDecision: async (decision) => {
-      if (params.sessions.get(params.sessionId) !== params.session) {
-        return;
-      }
-      if (params.session.pendingApproval?.id === record.id) {
-        params.session.pendingApproval = undefined;
-      }
-      await params.session.engine.resolveOperatorApproval(decision, params.proposal.hash);
-    },
-    afterDecisionErrorLabel: "OpenClaw approval apply failed",
-  });
-  return record.id;
 }
 
 export const systemAgentHandlers: GatewayRequestHandlers = {
@@ -514,7 +439,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           );
           return;
         }
-        const boundSession = sessions.get(sessionId);
+        let boundSession = sessions.get(sessionId);
         if (boundSession && boundSession.ownerKey !== ownerKey) {
           respond(
             false,
@@ -524,6 +449,58 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           return;
         }
         const supportsQrCode = params.capabilities?.qrCodePng === true;
+        let adoptedLockedWizard = false;
+        if (!boundSession) {
+          const retainedEntries = [...sessions.entries()].filter(
+            ([candidateId, candidate]) =>
+              candidateId !== sessionId &&
+              candidate.ownerKey === ownerKey &&
+              candidate.engine.hasLockedHostedWizard(),
+          );
+          if (retainedEntries.length > 1) {
+            // Session ids are caller-selected and carry no resume token. Never
+            // choose between multiple durable wizards by map insertion order.
+            respond(
+              false,
+              undefined,
+              errorShape(
+                ErrorCodes.INVALID_REQUEST,
+                "Multiple locked OpenClaw setup sessions need manual recovery.",
+              ),
+            );
+            return;
+          }
+          const retainedEntry = retainedEntries[0];
+          if (retainedEntry) {
+            const [retainedSessionId, retainedSession] = retainedEntry;
+            if (params.reset) {
+              respond(
+                false,
+                undefined,
+                errorShape(ErrorCodes.INVALID_REQUEST, LOCKED_SETUP_RESET_ERROR),
+              );
+              return;
+            }
+            if (retainedSession.supportsQrCode !== supportsQrCode) {
+              respond(
+                false,
+                undefined,
+                errorShape(
+                  ErrorCodes.INVALID_REQUEST,
+                  "OpenClaw chat capabilities changed; reconnect with the same QR support to resume setup.",
+                ),
+              );
+              return;
+            }
+            // GUI clients rotate volatile ids after reconnecting. Transfer only
+            // the authenticated owner's locked wizard so its durable operation
+            // and pending recovery step keep one execution owner.
+            sessions.delete(retainedSessionId);
+            sessions.set(sessionId, retainedSession);
+            boundSession = retainedSession;
+            adoptedLockedWizard = true;
+          }
+        }
         if (boundSession && !params.reset && boundSession.supportsQrCode !== supportsQrCode) {
           // A retained wizard may already be waiting on a QR-only acknowledgement.
           // Do not resume it on a client that negotiated a different rendering contract.
@@ -669,6 +646,25 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           }
         }
         session.lastUsedAt = Date.now();
+        if (adoptedLockedWizard && welcomeOnly) {
+          const resumed = await session.engine.resumeLockedHostedWizard();
+          if (resumed) {
+            respond(
+              true,
+              {
+                sessionId,
+                reply: resumed.text || "Channel setup is still applying.",
+                action: "none",
+                ...(resumed.sensitive === true ? { sensitive: true } : {}),
+                ...(resumed.wizardInputPending === true ? { wizardInputPending: true } : {}),
+                ...(resumed.qrCodePngBase64 ? { qrCodePngBase64: resumed.qrCodePngBase64 } : {}),
+                ...(resumed.question ? { question: resumed.question } : {}),
+              },
+              undefined,
+            );
+            return;
+          }
+        }
         // Inline check (not `welcomeOnly`) so TS narrows params.message below.
         if (params.message === undefined || !params.message.trim()) {
           respond(
@@ -727,7 +723,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
         if (delegation) {
           const proposal = session.engine.getPendingOperatorProposal();
           if (proposal) {
-            proposalId = queueDelegatedApproval({
+            proposalId = queueDelegatedSystemAgentApproval({
               context,
               sessions,
               session,

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -1,6 +1,7 @@
 // Wizard server-method tests cover stable lifecycle errors for process-local sessions.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { WizardSession } from "../../wizard/session.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 import { wizardHandlers } from "./wizard.js";
 
@@ -31,5 +32,189 @@ describe("wizard session lookup", () => {
       message: "wizard not found",
       details: { code: "WIZARD_NOT_FOUND" },
     });
+  });
+});
+
+describe("channel wizard lifecycle", () => {
+  it("rejects a persistent effect after cancellation wins the lock race", async () => {
+    let beforePersistentEffect: (() => Promise<void>) | undefined;
+    const wizardSessions = new Map<string, WizardSession>();
+    const respond = vi.fn();
+    const handler = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const context = {
+      wizardSessions,
+      findRunningWizard: () => null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (
+        options: { beforePersistentEffect?: () => Promise<void> },
+        _runtime: unknown,
+        prompter: { note: (message: string) => Promise<void> },
+      ) => {
+        beforePersistentEffect = options.beforePersistentEffect;
+        await prompter.note("Ready");
+      },
+    };
+
+    await handler({
+      req: {
+        type: "req",
+        id: "wizard-lock-race",
+        method: "wizard.start",
+        params: { flow: "channels", channel: "signal" },
+      },
+      params: { flow: "channels", channel: "signal" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context,
+    } as never);
+
+    const session = expectDefined(
+      wizardSessions.values().next().value,
+      "running channel wizard session",
+    );
+    expect(session.cancel()).toBe(true);
+    await expect(expectDefined(beforePersistentEffect, "persistent effect hook")()).rejects.toThrow(
+      "cancelled before its persistent change started",
+    );
+  });
+
+  it("resumes a cancellation-locked channel wizard and expires it when abandoned", async () => {
+    vi.useFakeTimers();
+    try {
+      const ownerClient = {
+        connId: "conn-owner",
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+      };
+      const otherClient = {
+        connId: "conn-other",
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+      };
+      const wizardSessions = new Map<string, WizardSession>();
+      const findRunningWizard = () =>
+        [...wizardSessions].find(([, session]) => session.isRunning())?.[0] ?? null;
+      const context = {
+        wizardSessions,
+        findRunningWizard,
+        purgeWizardSession: (id: string) => wizardSessions.delete(id),
+        channelWizardRunner: async (
+          _options: unknown,
+          _runtime: unknown,
+          prompter: { note: (message: string) => Promise<void> },
+        ) => {
+          await prompter.note("Installing Signal");
+        },
+      };
+      const start = expectDefined(
+        wizardHandlers["wizard.start"],
+        "wizardHandlers[wizard.start] test invariant",
+      );
+      const cancel = expectDefined(
+        wizardHandlers["wizard.cancel"],
+        "wizardHandlers[wizard.cancel] test invariant",
+      );
+      const firstRespond = vi.fn();
+
+      await start({
+        req: {
+          type: "req",
+          id: "wizard-first-owner",
+          method: "wizard.start",
+          params: { flow: "channels", channel: "signal" },
+        },
+        params: { flow: "channels", channel: "signal" },
+        client: ownerClient,
+        isWebchatConnect: () => false,
+        respond: firstRespond,
+        context,
+      } as never);
+
+      const firstResult = firstRespond.mock.calls[0]?.[1] as
+        | { sessionId?: string; step?: { id?: string } }
+        | undefined;
+      const sessionId = expectDefined(firstResult?.sessionId, "channel wizard session id");
+      const stepId = expectDefined(firstResult?.step?.id, "channel wizard step id");
+      const session = expectDefined(wizardSessions.get(sessionId), "channel wizard session");
+      expect(session.lockCancellation()).toBe(true);
+
+      const cancelRespond = vi.fn();
+      await cancel({
+        req: {
+          type: "req",
+          id: "wizard-refused-cancel",
+          method: "wizard.cancel",
+          params: { sessionId },
+        },
+        params: { sessionId },
+        client: null,
+        isWebchatConnect: () => false,
+        respond: cancelRespond,
+        context,
+      } as never);
+      expect(cancelRespond).toHaveBeenCalledWith(
+        true,
+        { status: "running", error: undefined },
+        undefined,
+      );
+
+      for (const attempt of [
+        { id: "wizard-wrong-owner", client: otherClient, channel: "signal" },
+        { id: "wizard-wrong-channel", client: ownerClient, channel: "telegram" },
+      ]) {
+        const deniedRespond = vi.fn();
+        await start({
+          req: {
+            type: "req",
+            id: attempt.id,
+            method: "wizard.start",
+            params: { flow: "channels", channel: attempt.channel },
+          },
+          params: { flow: "channels", channel: attempt.channel },
+          client: attempt.client,
+          isWebchatConnect: () => false,
+          respond: deniedRespond,
+          context,
+        } as never);
+        expect(deniedRespond).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({ code: "UNAVAILABLE", message: "wizard already running" }),
+        );
+      }
+
+      const resumedRespond = vi.fn();
+      await start({
+        req: {
+          type: "req",
+          id: "wizard-resumed-owner",
+          method: "wizard.start",
+          params: { flow: "channels", channel: "signal" },
+        },
+        params: { flow: "channels", channel: "signal" },
+        client: ownerClient,
+        isWebchatConnect: () => false,
+        respond: resumedRespond,
+        context,
+      } as never);
+      expect(resumedRespond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          sessionId,
+          done: false,
+          status: "running",
+          step: expect.objectContaining({ id: stepId }),
+        }),
+        undefined,
+      );
+
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      expect(session.getStatus()).toBe("cancelled");
+      expect(findRunningWizard()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -30,6 +30,7 @@ export type ChannelSetupWizardRunner = (
     channel?: string;
     onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
     beforePersistentEffect?: () => Promise<void>;
+    abortSignal?: AbortSignal;
   },
   runtime: RuntimeEnv,
   prompter: WizardPrompter,
@@ -87,11 +88,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const flow = params.flow ?? "setup";
     const session =
       flow === "channels"
-        ? new WizardSession((prompter, _signal, wizardSession) =>
+        ? new WizardSession((prompter, signal, wizardSession) =>
             context.channelWizardRunner(
               {
                 channel: readStringValue(params.channel),
                 onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
+                abortSignal: signal,
                 // Durable effects (plugin installs, config commit) must finish
                 // even if the client cancels mid-write.
                 beforePersistentEffect: async () => wizardSession.lockCancellation(),

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -16,8 +16,29 @@ import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { WizardSession } from "../../wizard/session.js";
 import { formatForLog } from "../ws-log.js";
-import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
+import type {
+  GatewayClient,
+  GatewayRequestContext,
+  GatewayRequestHandlers,
+  RespondFn,
+} from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+const CHANNEL_WIZARD_RESUME_KEY = "gateway-channel-setup";
+const CHANNEL_WIZARD_TIMEOUT_MS = 25 * 60 * 1000;
+
+function resolveChannelWizardResumeKey(params: {
+  client: GatewayClient | null;
+  channel: string | undefined;
+}): string | undefined {
+  const connId = params.client?.connId?.trim();
+  if (!connId) {
+    return undefined;
+  }
+  // Reattachment is deliberately connection- and channel-exact. A broader
+  // admin identity could expose another tab's pending setup prompt.
+  return JSON.stringify([CHANNEL_WIZARD_RESUME_KEY, connId, params.channel ?? null]);
+}
 
 export type SetupWizardRunner = (
   opts: OnboardOptions,
@@ -75,32 +96,60 @@ function findWizardSessionOrRespond(params: {
 
 /** Gateway handlers for the interactive setup wizard session lifecycle. */
 export const wizardHandlers: GatewayRequestHandlers = {
-  "wizard.start": async ({ params, respond, context }) => {
+  "wizard.start": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateWizardStartParams, "wizard.start", respond)) {
       return;
     }
+    const flow = params.flow ?? "setup";
+    const channel = readStringValue(params.channel);
+    const resumeKey =
+      flow === "channels" ? resolveChannelWizardResumeKey({ client, channel }) : undefined;
     const running = context.findRunningWizard();
     if (running) {
+      const existing = context.wizardSessions.get(running);
+      if (
+        flow === "channels" &&
+        resumeKey !== undefined &&
+        existing?.isCancellationLocked() &&
+        existing.canResume(resumeKey)
+      ) {
+        const result = await existing.next();
+        if (result.done) {
+          context.purgeWizardSession(running);
+        }
+        respond(true, { sessionId: running, ...result }, undefined);
+        return;
+      }
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
       return;
     }
     const sessionId = randomUUID();
-    const flow = params.flow ?? "setup";
     const session =
       flow === "channels"
-        ? new WizardSession((prompter, signal, wizardSession) =>
-            context.channelWizardRunner(
-              {
-                channel: readStringValue(params.channel),
-                onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
-                abortSignal: signal,
-                // Durable effects (plugin installs, config commit) must finish
-                // even if the client cancels mid-write.
-                beforePersistentEffect: async () => wizardSession.lockCancellation(),
-              },
-              defaultRuntime,
-              prompter,
-            ),
+        ? new WizardSession(
+            (prompter, signal, wizardSession) =>
+              context.channelWizardRunner(
+                {
+                  channel,
+                  onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
+                  abortSignal: signal,
+                  // Durable effects (plugin installs, config commit) must finish
+                  // even if the client cancels mid-write.
+                  beforePersistentEffect: async () => {
+                    if (!wizardSession.lockCancellation()) {
+                      throw new Error(
+                        "Channel setup was cancelled before its persistent change started.",
+                      );
+                    }
+                  },
+                },
+                defaultRuntime,
+                prompter,
+              ),
+            {
+              ...(resumeKey ? { resumeKey } : {}),
+              timeoutMs: CHANNEL_WIZARD_TIMEOUT_MS,
+            },
           )
         : new WizardSession((prompter) =>
             context.wizardRunner(

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -846,6 +846,7 @@ describe("SystemAgentChatEngine", () => {
     };
     let currentConfig = structuredClone(baseConfig);
     let currentHash = "base-hash";
+    let setupOptions: { remoteWizard?: boolean } | undefined;
     mocks.readSetupConfigFileSnapshot.mockImplementation(async () => ({
       exists: true,
       valid: true,
@@ -856,7 +857,13 @@ describe("SystemAgentChatEngine", () => {
       issues: [],
     }));
     mocks.setupChannels.mockImplementation(
-      async (config: OpenClawConfig, _runtime: unknown, prompter: WizardPrompter) => {
+      async (
+        config: OpenClawConfig,
+        _runtime: unknown,
+        prompter: WizardPrompter,
+        options: { remoteWizard?: boolean },
+      ) => {
+        setupOptions = options;
         const token = await prompter.text({ message: "Bot token" });
         return {
           ...config,
@@ -886,6 +893,7 @@ describe("SystemAgentChatEngine", () => {
 
     const tokenStep = await engine.handle("connect telegram");
     expect(tokenStep.text).toContain("Bot token");
+    expect(setupOptions).toMatchObject({ remoteWizard: true });
 
     const concurrentConfig: OpenClawConfig = {
       agents: { defaults: { model: { primary: "anthropic/claude-opus-4-8" } } },
@@ -910,6 +918,54 @@ describe("SystemAgentChatEngine", () => {
       }),
     );
     expect(currentConfig).toEqual(concurrentConfig);
+  });
+
+  it("forwards hosted wizard cancellation to setupChannels before config writes", async () => {
+    useTempStateDir();
+    const baseConfig: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+      auth: {
+        profiles: { "openai:main": { provider: "openai", mode: "api_key" } },
+      },
+    };
+    let setupAbortSignal: AbortSignal | undefined;
+    mocks.readSetupConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      path: "/tmp/openclaw.json",
+      hash: "base-hash",
+      config: baseConfig,
+      sourceConfig: baseConfig,
+      issues: [],
+    });
+    mocks.setupChannels.mockImplementation(
+      async (
+        config: OpenClawConfig,
+        _runtime: unknown,
+        prompter: WizardPrompter,
+        options: { abortSignal?: AbortSignal },
+      ) => {
+        setupAbortSignal = options.abortSignal;
+        await prompter.text({ message: "Bot token" });
+        return config;
+      },
+    );
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+    });
+
+    const prompt = await engine.handle("connect telegram");
+    expect(prompt.text).toContain("Bot token");
+    expect(setupAbortSignal?.aborted).toBe(false);
+
+    const cancelled = await engine.handle("cancel");
+
+    expect(cancelled.text).toContain("cancelled");
+    expect(setupAbortSignal?.aborted).toBe(true);
+    expect(mocks.writeWizardConfigFile).not.toHaveBeenCalled();
   });
 
   it("rechecks inference authority immediately before a hosted channel write", async () => {
@@ -1049,6 +1105,109 @@ describe("SystemAgentChatEngine", () => {
     expect(hook.run).not.toHaveBeenCalled();
   });
 
+  it("finishes the config commit after a channel crosses its durable effect boundary", async () => {
+    useTempStateDir();
+    const baseConfig: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+      auth: { profiles: { "openai:main": { provider: "openai", mode: "api_key" } } },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: "test-key",
+            auth: "api-key",
+            models: [],
+          },
+        },
+      },
+    };
+    const changedConfig: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-8" } } },
+    };
+    const verifiedInference = await createAmbientVerifiedBinding(baseConfig);
+    let currentConfig = structuredClone(baseConfig);
+    mocks.readSetupConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      path: "/tmp/openclaw.json",
+      hash: "base-hash",
+      config: structuredClone(baseConfig),
+      sourceConfig: structuredClone(baseConfig),
+      issues: [],
+    });
+    mocks.setupChannels.mockImplementation(
+      async (
+        config: OpenClawConfig,
+        _runtime: unknown,
+        prompter: WizardPrompter,
+        options: { beforePersistentEffect?: () => Promise<void> },
+      ) => {
+        await options.beforePersistentEffect?.();
+        await prompter.confirm({ message: "Confirm linked account" });
+        currentConfig = changedConfig;
+        return {
+          ...config,
+          channels: { signal: { account: "+15555550123" } },
+        };
+      },
+    );
+    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => config);
+    mocks.runCollectedChannelOnboardingPostWriteHooks.mockResolvedValue(undefined);
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      verifiedInference,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: {
+        loadOverview: fakeOverviewLoader(),
+        readConfigFileSnapshot: vi.fn(async () => configSnapshot(currentConfig)) as never,
+      },
+    });
+
+    const confirmation = await engine.handle("connect signal");
+    const completed = await engine.handle("yes");
+
+    expect(confirmation.text).toContain("Confirm linked account");
+    expect(completed.text).toContain("Done — signal is configured");
+    expect(mocks.writeWizardConfigFile).toHaveBeenCalledOnce();
+  });
+
+  it("accepts a locked wizard answer after its inference route disappears", async () => {
+    useTempStateDir();
+    let inferenceConfig: OpenClawConfig = structuredClone(sharedVerifiedInferenceConfig);
+    const readConfigFileSnapshot = vi.fn(async () => configSnapshot(inferenceConfig));
+    const completed = vi.fn();
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: {
+        loadOverview: fakeOverviewLoader(),
+        readConfigFileSnapshot: readConfigFileSnapshot as never,
+      },
+      runChannelSetupWizard: async (_channel, prompter, beforePersistentApply) => {
+        await beforePersistentApply({
+          log: () => {},
+          error: () => {},
+          exit: () => {},
+        });
+        await prompter.confirm({ message: "Retry Signal validation?" });
+        completed();
+      },
+    });
+
+    const recovery = await engine.handle("connect signal");
+    expect(recovery.text).toContain("Retry Signal validation?");
+    const checksBeforeLoss = readConfigFileSnapshot.mock.calls.length;
+    inferenceConfig = {};
+
+    const result = await engine.handle("yes");
+
+    expect(result.text).toContain("Done — signal is configured.");
+    expect(completed).toHaveBeenCalledOnce();
+    expect(readConfigFileSnapshot).toHaveBeenCalledTimes(checksBeforeLoss);
+  });
+
   it("marks sensitive hosted-wizard replies and auto-advances notes", async () => {
     useTempStateDir();
     const engine = new SystemAgentChatEngine({
@@ -1088,6 +1247,200 @@ describe("SystemAgentChatEngine", () => {
     expect(textStep.question).toBeUndefined();
     expect(textStep.sensitive).toBeUndefined();
     expect(textStep.wizardInputPending).toBe(true);
+  });
+
+  it("returns hosted wizard QR images to Gateway chat clients", async () => {
+    useTempStateDir();
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      supportsQrCode: true,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
+        await prompter.qrCode?.({
+          title: "Signal account linking",
+          message: "Scan this code, then confirm.",
+          pngBase64: "cG5n",
+        });
+      },
+    });
+
+    const qrStep = await engine.handle("connect signal");
+
+    expect(qrStep.text).toContain("Scan this code");
+    expect(qrStep.text).not.toContain("cancel");
+    expect(qrStep.qrCodePngBase64).toBe("cG5n");
+    expect(qrStep.question?.options.map((option) => option.label)).toEqual(["Continue"]);
+    expect(qrStep.question?.allowSkip).toBe(false);
+    expect(qrStep.wizardInputPending).toBe(true);
+  });
+
+  it("accepts the cached QR acknowledgement after external completion advances the wizard", async () => {
+    useTempStateDir();
+    let complete!: () => void;
+    const externalCompletion = new Promise<void>((resolve) => {
+      complete = resolve;
+    });
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      supportsQrCode: true,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
+        await prompter.qrCode?.({
+          title: "Signal account linking",
+          message: "Scan this code, then confirm.",
+          pngBase64: "cG5n",
+          dismissWhen: externalCompletion,
+        });
+        await prompter.note("Signal linked.", "Signal");
+      },
+    });
+
+    const qrStep = await engine.handle("connect signal");
+    complete();
+    await externalCompletion;
+    await Promise.resolve();
+    const finished = await engine.handle("continue");
+
+    expect(qrStep.qrCodePngBase64).toBe("cG5n");
+    expect(finished.text).toContain("Signal linked.");
+    expect(finished.text).toContain("Done — signal is configured.");
+  });
+
+  it("does not offer image QR prompts to the CLI chat surface", async () => {
+    useTempStateDir();
+    let qrCodeCapability: unknown;
+    const engine = new SystemAgentChatEngine({
+      surface: "cli",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
+        qrCodeCapability = prompter.qrCode;
+      },
+    });
+
+    await engine.handle("connect signal");
+
+    expect(qrCodeCapability).toBeUndefined();
+  });
+
+  it("does not infer image QR support from the Gateway surface", async () => {
+    useTempStateDir();
+    let qrCodeCapability: unknown;
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
+        qrCodeCapability = prompter.qrCode;
+      },
+    });
+
+    await engine.handle("connect signal");
+
+    expect(qrCodeCapability).toBeUndefined();
+  });
+
+  it("locks cancellation before a hosted wizard persistent effect", async () => {
+    useTempStateDir();
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      supportsQrCode: true,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel, prompter, beforePersistentApply) => {
+        await beforePersistentApply({
+          log: () => {},
+          error: () => {},
+          exit: () => {},
+        });
+        await prompter.qrCode?.({
+          title: "Signal account linking",
+          message: "Confirm the linked device",
+          pngBase64: "cG5n",
+        });
+      },
+    });
+
+    const prompt = await engine.handle("connect signal");
+    const cancelAttempt = await engine.handle("cancel");
+
+    expect(prompt.text).toContain("Confirm the linked device");
+    expect(cancelAttempt.text).toContain("already applying");
+    expect(cancelAttempt.text).not.toContain("Channel setup cancelled.");
+  });
+
+  it("retains a locked QR wizard until its config path reaches completion", async () => {
+    useTempStateDir();
+    const completed = vi.fn();
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      supportsQrCode: true,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel, prompter, beforePersistentApply) => {
+        await beforePersistentApply({
+          log: () => {},
+          error: () => {},
+          exit: () => {},
+        });
+        await prompter.qrCode?.({
+          title: "Signal account linking",
+          message: "Confirm the linked device",
+          pngBase64: "cG5n",
+        });
+        await prompter.note("Signal setup is ready to save.", "Signal");
+        completed();
+      },
+    });
+
+    const prompt = await engine.handle("connect signal");
+    const disposedWhileLocked = await engine.dispose();
+    const completion = await engine.handle("continue");
+
+    expect(prompt.qrCodePngBase64).toBe("cG5n");
+    expect(disposedWhileLocked).toBe(false);
+    expect(completed).toHaveBeenCalledOnce();
+    expect(completion.text).toContain("Done — signal is configured.");
+    await expect(engine.dispose()).resolves.toBe(true);
+  });
+
+  it("eventually releases an abandoned locked hosted wizard", async () => {
+    vi.useFakeTimers();
+    try {
+      useTempStateDir();
+      const engine = new SystemAgentChatEngine({
+        surface: "gateway",
+        runAgentTurn: async () => null,
+        planWithAssistant: async () => null,
+        deps: { loadOverview: fakeOverviewLoader() },
+        runChannelSetupWizard: async (_channel, prompter, beforePersistentApply) => {
+          await beforePersistentApply({
+            log: () => {},
+            error: () => {},
+            exit: () => {},
+          });
+          await prompter.text({ message: "Recovery path" });
+        },
+      });
+
+      const recovery = await engine.handle("connect signal");
+      expect(recovery.text).toContain("Recovery path");
+      await expect(engine.dispose()).resolves.toBe(false);
+
+      await vi.advanceTimersByTimeAsync(25 * 60 * 1000);
+
+      await expect(engine.dispose()).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("routes sensitive CLI wizard prompts to the masked channel setup flow", async () => {
@@ -1210,20 +1563,29 @@ describe("SystemAgentChatEngine", () => {
 
   it("cancels a hosted wizard mid-flight", async () => {
     useTempStateDir();
+    let wizardAbortSignal: AbortSignal | undefined;
     const engine = new SystemAgentChatEngine({
       runAgentTurn: async () => null,
       planWithAssistant: async () => null,
       deps: { loadOverview: fakeOverviewLoader() },
-      runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
+      runChannelSetupWizard: async (
+        _channel: string,
+        prompter: WizardPrompter,
+        _beforePersistentApply,
+        abortSignal,
+      ) => {
+        wizardAbortSignal = abortSignal;
         await prompter.text({ message: "Bot token" });
       },
     });
 
     const tokenStep = await engine.handle("connect discord");
     expect(tokenStep.text).toContain("Bot token");
+    expect(wizardAbortSignal?.aborted).toBe(false);
 
     const cancelled = await engine.handle("cancel");
     expect(cancelled.text).toContain("cancelled");
+    expect(wizardAbortSignal?.aborted).toBe(true);
   });
 
   it("voids a stale host proposal before an exact wizard, including cancellation", async () => {

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -1172,6 +1172,57 @@ describe("SystemAgentChatEngine", () => {
     expect(mocks.writeWizardConfigFile).toHaveBeenCalledOnce();
   });
 
+  it("does not cross the durable setup boundary after cancellation wins during inference", async () => {
+    useTempStateDir();
+    const verifiedInference = await createAmbientVerifiedBinding(sharedVerifiedInferenceConfig);
+    let pausePersistentRead = false;
+    let releasePersistentRead: (() => void) | undefined;
+    let markPersistentReadStarted: (() => void) | undefined;
+    const persistentReadStarted = new Promise<void>((resolve) => {
+      markPersistentReadStarted = resolve;
+    });
+    const persistentReadReleased = new Promise<void>((resolve) => {
+      releasePersistentRead = resolve;
+    });
+    const durableEffect = vi.fn();
+    const readConfigFileSnapshot = vi.fn(async () => {
+      if (pausePersistentRead) {
+        markPersistentReadStarted?.();
+        await persistentReadReleased;
+      }
+      return configSnapshot(sharedVerifiedInferenceConfig);
+    });
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      verifiedInference,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: {
+        loadOverview: fakeOverviewLoader(),
+        readConfigFileSnapshot: readConfigFileSnapshot as never,
+      },
+      runChannelSetupWizard: async (_channel, _prompter, beforePersistentApply) => {
+        pausePersistentRead = true;
+        await beforePersistentApply({
+          log: () => {},
+          error: () => {},
+          exit: () => {},
+        });
+        durableEffect();
+      },
+    });
+
+    const setup = engine.handle("connect signal");
+    await persistentReadStarted;
+    await expect(engine.dispose()).resolves.toBe(true);
+    releasePersistentRead?.();
+
+    await expect(setup).resolves.toMatchObject({
+      text: expect.stringContaining("Channel setup cancelled"),
+    });
+    expect(durableEffect).not.toHaveBeenCalled();
+  });
+
   it("accepts a locked wizard answer after its inference route disappears", async () => {
     useTempStateDir();
     let inferenceConfig: OpenClawConfig = structuredClone(sharedVerifiedInferenceConfig);
@@ -1403,12 +1454,50 @@ describe("SystemAgentChatEngine", () => {
 
     const prompt = await engine.handle("connect signal");
     const disposedWhileLocked = await engine.dispose();
+    const resumed = await engine.resumeLockedHostedWizard();
     const completion = await engine.handle("continue");
 
     expect(prompt.qrCodePngBase64).toBe("cG5n");
     expect(disposedWhileLocked).toBe(false);
+    expect(resumed?.qrCodePngBase64).toBe("cG5n");
     expect(completed).toHaveBeenCalledOnce();
     expect(completion.text).toContain("Done — signal is configured.");
+    await expect(engine.dispose()).resolves.toBe(true);
+  });
+
+  it("re-projects a locked QR wizard for a same-owner reconnect", async () => {
+    useTempStateDir();
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      supportsQrCode: true,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel, prompter, beforePersistentApply) => {
+        await beforePersistentApply({
+          log: () => {},
+          error: () => {},
+          exit: () => {},
+        });
+        await prompter.qrCode?.({
+          title: "Signal account linking",
+          message: "Confirm the linked device",
+          pngBase64: "cG5n",
+        });
+      },
+    });
+
+    await engine.handle("connect signal");
+    await expect(engine.dispose()).resolves.toBe(false);
+
+    expect(engine.hasLockedHostedWizard()).toBe(true);
+    await expect(engine.resumeLockedHostedWizard()).resolves.toMatchObject({
+      text: expect.stringContaining("Confirm the linked device"),
+      action: "none",
+      wizardInputPending: true,
+      qrCodePngBase64: "cG5n",
+    });
+    await engine.handle("continue");
     await expect(engine.dispose()).resolves.toBe(true);
   });
 
@@ -1437,6 +1526,34 @@ describe("SystemAgentChatEngine", () => {
 
       await vi.advanceTimersByTimeAsync(25 * 60 * 1000);
 
+      await expect(engine.dispose()).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports hosted wizard cancellation when a cached prompt expires", async () => {
+    vi.useFakeTimers();
+    try {
+      useTempStateDir();
+      const engine = new SystemAgentChatEngine({
+        surface: "gateway",
+        runAgentTurn: async () => null,
+        planWithAssistant: async () => null,
+        deps: { loadOverview: fakeOverviewLoader() },
+        runChannelSetupWizard: async (_channel, prompter) => {
+          await prompter.text({ message: "Signal account" });
+        },
+      });
+
+      const prompt = await engine.handle("connect signal");
+      expect(prompt.text).toContain("Signal account");
+
+      await vi.advanceTimersByTimeAsync(25 * 60 * 1000);
+
+      await expect(engine.handle("+15555550123")).resolves.toMatchObject({
+        text: expect.stringContaining("Channel setup cancelled"),
+      });
       await expect(engine.dispose()).resolves.toBe(true);
     } finally {
       vi.useRealTimers();

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -76,11 +76,14 @@ export type SystemAgentChatEngineOptions = {
   appendAuditEntry?: typeof import("./audit.js").appendSystemAgentAuditEntry;
   /** Where side effects run; the gateway surface never manages its own daemon. */
   surface?: "cli" | "gateway";
+  /** The current chat client can render raw PNG QR payloads. */
+  supportsQrCode?: boolean;
   /** Test seam for the channel-setup wizard hosted by the chat bridge. */
   runChannelSetupWizard?: (
     channel: string,
     prompter: WizardPrompterLike,
     beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
+    abortSignal: AbortSignal,
   ) => Promise<void>;
   /** Exact route/credential that passed the host's live inference gate. */
   readonly verifiedInference: SystemAgentVerifiedInferenceBinding;
@@ -102,6 +105,8 @@ type SystemAgentChatReply = {
   handoff?: SystemAgentOperation;
   /** Structured choice mirroring the awaited wizard step for card-capable clients. */
   question?: SystemAgentChatQuestion;
+  /** Raw PNG base64 for a hosted wizard QR prompt. */
+  qrCodePngBase64?: string;
 };
 
 type WizardPrompterLike = import("../wizard/prompts.js").WizardPrompter;
@@ -119,6 +124,7 @@ type CaptureRuntime = RuntimeEnv & {
 };
 
 const log = createSubsystemLogger("system-agent/chat-engine");
+const HOSTED_CHANNEL_SETUP_TIMEOUT_MS = 25 * 60 * 1000;
 
 function createHostedWizardRuntime(runtime: RuntimeEnv): RuntimeEnv {
   return {
@@ -144,6 +150,7 @@ function createCaptureRuntime(): CaptureRuntime {
 function defaultChannelSetupWizardRunner(
   channel: string,
   beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
+  abortSignal: AbortSignal,
 ): (prompter: WizardPrompterLike) => Promise<void> {
   return async (prompter) => {
     const [
@@ -168,6 +175,7 @@ function defaultChannelSetupWizardRunner(
     const { defaultRuntime } = await import("../runtime.js");
     const runtime = createHostedWizardRuntime(defaultRuntime);
     const postWriteHooks = createChannelOnboardingPostWriteHookCollector();
+    let channelPersistentEffectStarted = false;
     const nextConfig = await setupChannels(baseConfig, runtime, prompter, {
       initialSelection: [channel],
       forceAllowFromChannels: [channel],
@@ -177,10 +185,17 @@ function defaultChannelSetupWizardRunner(
       quickstartDefaults: true,
       skipDmPolicyPrompt: true,
       skipConfirm: true,
-      beforePersistentEffect: async () => await beforePersistentApply(runtime),
+      remoteWizard: true,
+      abortSignal,
+      beforePersistentEffect: async () => {
+        await beforePersistentApply(runtime);
+        channelPersistentEffectStarted = true;
+      },
       onPostWriteHook: (hook) => postWriteHooks.collect(hook),
     });
-    await beforePersistentApply(runtime);
+    if (!channelPersistentEffectStarted) {
+      await beforePersistentApply(runtime);
+    }
     const committedConfig = await writeWizardConfigFile(nextConfig, {
       allowConfigSizeDrop: false,
       baseHash,
@@ -227,13 +242,14 @@ function wizardStepChatQuestion(step: WizardStep | null): SystemAgentChatQuestio
     return undefined;
   }
   const options = step.options ?? [];
-  if (options.length < 2 || options.length > 4) {
+  if (options.length < 1 || options.length > 4) {
     return undefined;
   }
   return {
     id: step.id,
     header: step.title ?? "Choose one",
     question: step.message ?? "Choose one.",
+    ...(step.qrCodePngBase64 ? { allowSkip: false } : {}),
     options: options.map((option) => {
       const mapped: SystemAgentChatQuestion["options"][number] = { label: option.label };
       if (option.hint) {
@@ -274,7 +290,9 @@ function renderWizardStep(step: WizardStep): string {
     default:
       break;
   }
-  lines.push("Say `cancel` to stop this setup.");
+  if (!step.qrCodePngBase64) {
+    lines.push("Say `cancel` to stop this setup.");
+  }
   return lines.filter(Boolean).join("\n");
 }
 
@@ -459,12 +477,22 @@ export class SystemAgentChatEngine {
     return this.history.slice(index).map((turn) => ({ role: turn.role, text: turn.text }));
   }
 
-  async dispose(): Promise<void> {
-    this.wizardBridge?.session.cancel();
+  async dispose(): Promise<boolean> {
+    const bridge = this.wizardBridge;
+    const wizardSession = bridge?.session;
+    if (wizardSession && !wizardSession.cancel() && wizardSession.isRunning()) {
+      // A linked device can already exist after a QR is displayed. Keep the
+      // engine alive until its locked wizard reaches config commit or recovery.
+      if (bridge.step?.qrCodePngBase64) {
+        bridge.step = null;
+      }
+      return false;
+    }
     this.wizardBridge = null;
     this.lastSensitiveChannel = undefined;
     this.awaitingSetupChannel = false;
     await cleanupSystemAgentSession(this.agentSession);
+    return true;
   }
 
   async handle(text: string): Promise<SystemAgentChatReply> {
@@ -475,7 +503,11 @@ export class SystemAgentChatEngine {
   }
 
   private async handleSerialized(text: string): Promise<SystemAgentChatReply> {
-    await this.requireVerifiedInference();
+    // Hosted wizard replies are deterministic and may be the only way to finish
+    // an irreversible setup after its inference route disappears.
+    if (!this.wizardBridge) {
+      await this.requireVerifiedInference();
+    }
     // Snapshot before resolving: wizard answers to sensitive steps (tokens,
     // passwords) must never enter the AI-visible history.
     const sensitiveTurn = this.wizardBridge?.step?.sensitive === true;
@@ -495,6 +527,9 @@ export class SystemAgentChatEngine {
       ...(this.wizardBridge?.step?.sensitive === true ? { sensitive: true } : {}),
       ...(this.wizardBridge ? { wizardInputPending: true } : {}),
       ...(question ? { question } : {}),
+      ...(this.wizardBridge?.step?.qrCodePngBase64
+        ? { qrCodePngBase64: this.wizardBridge.step.qrCodePngBase64 }
+        : {}),
     };
   }
 
@@ -1083,10 +1118,18 @@ export class SystemAgentChatEngine {
     this.agentSession.proposalRef.current = undefined;
     this.agentSession.proposalRef.operation = undefined;
     delete this.agentSession.cliSession;
-    if (cancelWizard) {
-      this.wizardBridge?.session.cancel();
+    let retainWizard = false;
+    if (cancelWizard && this.wizardBridge) {
+      const bridge = this.wizardBridge;
+      const wizardSession = bridge.session;
+      retainWizard = !wizardSession.cancel() && wizardSession.isRunning();
+      if (retainWizard && bridge.step?.qrCodePngBase64) {
+        bridge.step = null;
+      }
     }
-    this.wizardBridge = null;
+    if (!retainWizard) {
+      this.wizardBridge = null;
+    }
     this.lastSensitiveChannel = undefined;
     this.awaitingSetupChannel = false;
     this.history.splice(0);
@@ -1139,10 +1182,27 @@ export class SystemAgentChatEngine {
     };
     const runWizard =
       this.opts.runChannelSetupWizard ??
-      ((ch: string, prompter: WizardPrompterLike, guard: (runtime: RuntimeEnv) => Promise<void>) =>
-        defaultChannelSetupWizardRunner(ch, guard)(prompter));
-    const session = new WizardSession((prompter) =>
-      runWizard(channel, prompter, beforePersistentApply),
+      ((
+        ch: string,
+        prompter: WizardPrompterLike,
+        guard: (runtime: RuntimeEnv) => Promise<void>,
+        signal: AbortSignal,
+      ) => defaultChannelSetupWizardRunner(ch, guard, signal)(prompter));
+    const session = new WizardSession(
+      (prompter, signal, wizardSession) =>
+        runWizard(
+          channel,
+          prompter,
+          async (runtime) => {
+            await beforePersistentApply(runtime);
+            wizardSession.lockCancellation();
+          },
+          signal,
+        ),
+      {
+        supportsQrCode: this.opts.supportsQrCode === true,
+        ...(this.opts.surface === "gateway" ? { timeoutMs: HOSTED_CHANNEL_SETUP_TIMEOUT_MS } : {}),
+      },
     );
     this.wizardBridge = {
       session,
@@ -1266,7 +1326,12 @@ export class SystemAgentChatEngine {
       return "";
     }
     if (/^(cancel|abort|stop|quit|exit)$/i.test(text.trim())) {
-      bridge.session.cancel();
+      if (!bridge.session.cancel()) {
+        if (bridge.step?.qrCodePngBase64) {
+          bridge.step = null;
+        }
+        return "Channel setup is already applying and can no longer be cancelled.";
+      }
       return await this.pumpWizardBridge();
     }
     const step = bridge.step;

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -495,6 +495,25 @@ export class SystemAgentChatEngine {
     return true;
   }
 
+  hasLockedHostedWizard(): boolean {
+    return this.wizardBridge?.session.isCancellationLocked() === true;
+  }
+
+  async resumeLockedHostedWizard(): Promise<SystemAgentChatReply | null> {
+    const turn = this.turnQueue.then(async () => {
+      if (!this.hasLockedHostedWizard()) {
+        return null;
+      }
+      const reply: SystemAgentChatReply = {
+        text: await this.pumpWizardBridge(),
+        action: "none",
+      };
+      return this.projectWizardReply(reply);
+    });
+    this.turnQueue = turn.catch(() => undefined);
+    return await turn;
+  }
+
   async handle(text: string): Promise<SystemAgentChatReply> {
     const turn = this.turnQueue.then(() => this.handleSerialized(text));
     // The queue must survive a failed turn or every later message would reject.
@@ -521,6 +540,10 @@ export class SystemAgentChatEngine {
     }
     // While a hosted wizard awaits a step, every turn routes to it, so the
     // awaited step is always the question this reply asks.
+    return this.projectWizardReply(reply);
+  }
+
+  private projectWizardReply(reply: SystemAgentChatReply): SystemAgentChatReply {
     const question = wizardStepChatQuestion(this.wizardBridge?.step ?? null);
     return {
       ...reply,
@@ -1195,7 +1218,10 @@ export class SystemAgentChatEngine {
           prompter,
           async (runtime) => {
             await beforePersistentApply(runtime);
-            wizardSession.lockCancellation();
+            signal.throwIfAborted();
+            if (!wizardSession.lockCancellation()) {
+              throw new Error("Channel setup was cancelled before its persistent change started.");
+            }
           },
           signal,
         ),
@@ -1324,6 +1350,12 @@ export class SystemAgentChatEngine {
     const bridge = this.wizardBridge;
     if (!bridge) {
       return "";
+    }
+    if (!bridge.session.isRunning()) {
+      // Expiry clears the session-owned answer but cannot reach this cached
+      // projection. Surface the terminal result before handling a stale step.
+      bridge.step = null;
+      return await this.pumpWizardBridge();
     }
     if (/^(cancel|abort|stop|quit|exit)$/i.test(text.trim())) {
       if (!bridge.session.cancel()) {

--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -479,6 +479,79 @@ describe("runSystemAgentTui", () => {
     expect(dispose).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps a cancellation-locked setup recoverable when the TUI throws", async () => {
+    const dispose = vi.fn().mockResolvedValue(true).mockResolvedValueOnce(false);
+    const runTui = vi
+      .fn()
+      .mockImplementationOnce(async (opts) => {
+        const backend = opts.backend as unknown as {
+          engine: { dispose: typeof dispose };
+        };
+        backend.engine.dispose = dispose;
+        throw new Error("terminal failed");
+      })
+      .mockResolvedValueOnce({ exitReason: "exit" as const });
+    const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
+
+    await expect(runSystemAgentTui({ ...verified, runTui }, createRuntime())).rejects.toThrow(
+      "terminal failed",
+    );
+
+    expect(runTui).toHaveBeenCalledTimes(2);
+    expect(runTui.mock.calls[0]?.[0].backend).toBe(runTui.mock.calls[1]?.[0].backend);
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the first TUI error after a locked session can finally be disposed", async () => {
+    const dispose = vi
+      .fn()
+      .mockResolvedValue(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    let runCount = 0;
+    const runTui = vi.fn(async (opts) => {
+      const backend = opts.backend as unknown as {
+        engine: { dispose: typeof dispose };
+      };
+      backend.engine.dispose = dispose;
+      runCount += 1;
+      throw new Error(runCount === 1 ? "terminal failed" : "terminal still failing");
+    });
+    const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
+
+    await expect(runSystemAgentTui({ ...verified, runTui }, createRuntime())).rejects.toThrow(
+      "terminal failed",
+    );
+
+    expect(runTui).toHaveBeenCalledTimes(4);
+    expect(runTui.mock.calls[0]?.[0].backend).toBe(runTui.mock.calls[3]?.[0].backend);
+    expect(dispose).toHaveBeenCalledTimes(4);
+  });
+
+  it("reopens after repeated normal exits until locked setup can be disposed", async () => {
+    const dispose = vi
+      .fn()
+      .mockResolvedValue(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    const runTui = vi.fn(async (opts) => {
+      const backend = opts.backend as unknown as {
+        engine: { dispose: typeof dispose };
+      };
+      backend.engine.dispose = dispose;
+      return { exitReason: "exit" as const };
+    });
+    const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
+
+    await runSystemAgentTui({ ...verified, runTui }, createRuntime());
+
+    expect(runTui).toHaveBeenCalledTimes(4);
+    expect(runTui.mock.calls[0]?.[0].backend).toBe(runTui.mock.calls[3]?.[0].backend);
+    expect(dispose).toHaveBeenCalledTimes(4);
+  });
+
   it("launches setup handoffs after the chat TUI is disposed", async () => {
     const cases: Array<{
       handoff: Extract<SystemAgentOperation, { kind: "open-setup" }>;

--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -382,7 +382,7 @@ describe("runSystemAgentTui", () => {
       .fn()
       .mockRejectedValueOnce(new SystemAgentInferenceUnavailableError("conversation"))
       .mockResolvedValue({ text: "mutation ran", action: "none" });
-    const dispose = vi.fn(async () => undefined);
+    const dispose = vi.fn(async () => true);
     const events: Array<{ payload?: { state?: string; errorMessage?: string } }> = [];
     const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
 
@@ -434,6 +434,51 @@ describe("runSystemAgentTui", () => {
     expect(events.some((event) => event.payload?.state === "final")).toBe(false);
   });
 
+  it("refuses to reset while a cancellation-locked setup still owns the engine", async () => {
+    const dispose = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
+
+    await runSystemAgentTui(
+      {
+        ...verified,
+        runTui: async (opts) => {
+          const backend = opts.backend as unknown as {
+            resetSession: () => Promise<{ ok: boolean }>;
+            engine: { dispose: typeof dispose };
+          };
+          backend.engine.dispose = dispose;
+
+          await expect(backend.resetSession()).rejects.toThrow(
+            "Channel setup is already applying and cannot be reset yet",
+          );
+          expect(dispose).toHaveBeenCalledOnce();
+          return { exitReason: "exit" };
+        },
+      },
+      createRuntime(),
+    );
+
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
+  it("reopens the same TUI until a cancellation-locked setup can be disposed", async () => {
+    const dispose = vi.fn().mockResolvedValue(true).mockResolvedValueOnce(false);
+    const runTui = vi.fn(async (opts) => {
+      const backend = opts.backend as unknown as {
+        engine: { dispose: typeof dispose };
+      };
+      backend.engine.dispose = dispose;
+      return { exitReason: "exit" as const };
+    });
+    const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
+
+    await runSystemAgentTui({ ...verified, runTui }, createRuntime());
+
+    expect(runTui).toHaveBeenCalledTimes(2);
+    expect(runTui.mock.calls[0]?.[0].backend).toBe(runTui.mock.calls[1]?.[0].backend);
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
   it("launches setup handoffs after the chat TUI is disposed", async () => {
     const cases: Array<{
       handoff: Extract<SystemAgentOperation, { kind: "open-setup" }>;
@@ -462,7 +507,7 @@ describe("runSystemAgentTui", () => {
                   action: "open-setup";
                   handoff: SystemAgentOperation;
                 }>;
-                dispose: () => Promise<void>;
+                dispose: () => Promise<boolean>;
               };
             };
             backend.engine.handle = async () => ({
@@ -472,6 +517,7 @@ describe("runSystemAgentTui", () => {
             });
             backend.engine.dispose = async () => {
               events.push("disposed");
+              return true;
             };
             const requestedExit = new Promise<void>((resolve) => {
               backend.setRequestExitHandler(resolve);

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -123,7 +123,7 @@ class SystemAgentTuiBackend implements TuiBackend {
 
   private seq = 0;
   private engine: SystemAgentChatEngine;
-  private engineDisposal: Promise<void> | null = null;
+  private engineDisposal: Promise<boolean> | null = null;
   private inferenceFailure: SystemAgentInferenceUnavailableError | null = null;
   private handoff: SystemAgentOperation | null = null;
   private requestExit: (() => void) | null = null;
@@ -249,8 +249,11 @@ class SystemAgentTuiBackend implements TuiBackend {
     if (this.inferenceFailure) {
       throw this.inferenceFailure;
     }
-    // Reset drops in-flight approvals/wizards along with the transcript.
-    await this.disposeEngine();
+    if (!(await this.disposeEngine())) {
+      throw new Error(
+        "Channel setup is already applying and cannot be reset yet. Continue the current setup first.",
+      );
+    }
     this.engine = createChatEngine(this.opts);
     this.engineDisposal = null;
     const overview = await loadOverviewForTui(this.opts);
@@ -280,20 +283,25 @@ class SystemAgentTuiBackend implements TuiBackend {
     return [];
   }
 
-  async dispose(): Promise<void> {
+  async dispose(): Promise<boolean> {
     try {
-      await this.disposeEngine();
+      return await this.disposeEngine();
     } catch (error) {
       if (!this.inferenceFailure) {
         throw error;
       }
       // Inference failure remains authoritative; retirement cleanup is best-effort.
+      return true;
     }
   }
 
-  private disposeEngine(): Promise<void> {
-    this.engineDisposal ??= this.engine.dispose();
-    return this.engineDisposal;
+  private async disposeEngine(): Promise<boolean> {
+    const disposal = (this.engineDisposal ??= this.engine.dispose());
+    const disposed = await disposal;
+    if (!disposed && this.engineDisposal === disposal) {
+      this.engineDisposal = null;
+    }
+    return disposed;
   }
 
   private nextSeq(): number {
@@ -356,18 +364,22 @@ class SystemAgentTuiBackend implements TuiBackend {
       this.emitFinal(runId, sessionKey, reply.text);
     } catch (error) {
       if (isSystemAgentInferenceUnavailableError(error)) {
-        // Match the Gateway session boundary: the failed conversation is dead.
-        // Clear handoffs and dispose before exit so no queued exact command can
-        // bypass the inference-first gate through this backend instance.
-        this.inferenceFailure = error;
         this.handoff = null;
+        let disposed = false;
         try {
-          await this.disposeEngine();
+          disposed = await this.disposeEngine();
         } catch {
           // The inference error is authoritative; cleanup stays best-effort.
         }
+        // A locked wizard still owns an irreversible setup. Keep this backend
+        // available for recovery instead of abandoning it on inference loss.
+        if (disposed) {
+          this.inferenceFailure = error;
+        }
         this.emitError(runId, sessionKey, error);
-        queueMicrotask(() => this.requestExit?.());
+        if (disposed) {
+          queueMicrotask(() => this.requestExit?.());
+        }
         return;
       }
       this.emitError(runId, sessionKey, error);
@@ -454,18 +466,23 @@ export async function runSystemAgentTui(
     welcomeVariant = undefined;
     const backend = new SystemAgentTuiBackend(boundOpts, welcome, engine, route);
     const runTui = boundOpts.runTui ?? defaultRunTui;
-    try {
-      await runTui({
-        local: true,
-        session: SYSTEM_AGENT_SESSION_KEY,
-        historyLimit: 200,
-        backend,
-        config: {},
-        title: "openclaw setup",
-        ...(initialMessage ? { message: initialMessage } : {}),
-      });
-    } finally {
-      await backend.dispose();
+    let disposed = false;
+    let shellInitialMessage = initialMessage;
+    while (!disposed) {
+      try {
+        await runTui({
+          local: true,
+          session: SYSTEM_AGENT_SESSION_KEY,
+          historyLimit: 200,
+          backend,
+          config: {},
+          title: "openclaw setup",
+          ...(shellInitialMessage ? { message: shellInitialMessage } : {}),
+        });
+        shellInitialMessage = undefined;
+      } finally {
+        disposed = await backend.dispose();
+      }
     }
 
     const handoff = backend.consumeHandoff();

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -1,5 +1,6 @@
 // OpenClaw TUI backend runs setup-helper dialogue inside the shared local TUI shell.
 import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import type {
   SessionsPatchParams,
   SessionsPatchResult,
@@ -71,6 +72,7 @@ type SystemAgentTuiRoute = {
 };
 
 const SYSTEM_AGENT_SESSION_KEY = buildAgentMainSessionKey({ agentId: SYSTEM_AGENT_ID });
+const LOCKED_TUI_REOPEN_DELAY_MS = 250;
 
 function createChatEngine(opts: SystemAgentTuiOptions): SystemAgentChatEngine {
   return new SystemAgentChatEngine({
@@ -468,6 +470,8 @@ export async function runSystemAgentTui(
     const runTui = boundOpts.runTui ?? defaultRunTui;
     let disposed = false;
     let shellInitialMessage = initialMessage;
+    let runFailed = false;
+    let runError: unknown;
     while (!disposed) {
       try {
         await runTui({
@@ -480,9 +484,22 @@ export async function runSystemAgentTui(
           ...(shellInitialMessage ? { message: shellInitialMessage } : {}),
         });
         shellInitialMessage = undefined;
+      } catch (error) {
+        if (!runFailed) {
+          runFailed = true;
+          runError = error;
+        }
       } finally {
         disposed = await backend.dispose();
       }
+      if (!disposed) {
+        // A disposal refusal means the durable wizard must retain this prompt
+        // owner. Reopen the same backend until commit or recovery finishes.
+        await delay(LOCKED_TUI_REOPEN_DELAY_MS);
+      }
+    }
+    if (runFailed) {
+      throw runError;
     }
 
     const handoff = backend.consumeHandoff();

--- a/src/wizard/navigation-prompter.test.ts
+++ b/src/wizard/navigation-prompter.test.ts
@@ -242,16 +242,29 @@ describe("runWizardWithPromptNavigationScope", () => {
   it("preserves optional client actions inside a navigation scope", async () => {
     const deviceCode = vi.fn(async () => undefined);
     const openUrl = vi.fn(async () => undefined);
-    const prompter = createWizardPrompter({ deviceCode, openUrl });
+    const qrCode = vi.fn(async () => true);
+    const prompter = createWizardPrompter({ deviceCode, openUrl, qrCode });
 
     const outcome = await runWizardWithPromptNavigationScope(prompter, async (scopedPrompter) => {
       await scopedPrompter.deviceCode?.({ title: "Link device", code: "ABCD" });
+      expect(
+        await scopedPrompter.qrCode?.({
+          title: "Link Signal",
+          message: "Scan this code",
+          pngBase64: "cG5n",
+        }),
+      ).toBe(true);
       await scopedPrompter.openUrl?.("https://example.com/link");
       return "completed";
     });
 
     expect(outcome).toEqual({ status: "completed", value: "completed" });
     expect(deviceCode).toHaveBeenCalledWith({ title: "Link device", code: "ABCD" });
+    expect(qrCode).toHaveBeenCalledWith({
+      title: "Link Signal",
+      message: "Scan this code",
+      pngBase64: "cG5n",
+    });
     expect(openUrl).toHaveBeenCalledWith("https://example.com/link");
   });
 });

--- a/src/wizard/navigation-prompter.ts
+++ b/src/wizard/navigation-prompter.ts
@@ -123,6 +123,15 @@ class WizardPromptNavigator {
           },
         }
       : {}),
+    ...(this.base.qrCode
+      ? {
+          qrCode: async (params) => {
+            // Navigation replay has already passed this acknowledgement; avoid
+            // showing or blocking on the same QR twice.
+            return this.shouldSuppressOutput() ? true : (await this.base.qrCode?.(params)) === true;
+          },
+        }
+      : {}),
     plain: async (message) => {
       if (!this.shouldSuppressOutput()) {
         await this.base.plain?.(message);

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -57,12 +57,22 @@ type WizardDeviceCodeParams = {
   message?: string;
 };
 
+export type WizardQrCodeParams = {
+  title: string;
+  message: string;
+  pngBase64: string;
+  /** Retire the acknowledgement prompt when the external QR operation completes. */
+  dismissWhen?: Promise<unknown>;
+};
+
 export type WizardPrompter = {
   intro: (title: string) => Promise<void>;
   outro: (message: string) => Promise<void>;
   note: (message: string, title?: string) => Promise<void>;
   /** Present a browser device code as structured UI when the client supports it. */
   deviceCode?: (params: WizardDeviceCodeParams) => Promise<void>;
+  /** Present a PNG QR code and wait for the user to confirm that it was scanned. */
+  qrCode?: (params: WizardQrCodeParams) => Promise<boolean>;
   plain?: (message: string) => Promise<void>;
   select: <T>(params: WizardSelectParams<T>) => Promise<T>;
   multiselect: <T>(params: WizardMultiSelectParams<T>) => Promise<T[]>;

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -61,7 +61,7 @@ export type WizardQrCodeParams = {
   title: string;
   message: string;
   pngBase64: string;
-  /** Retire the acknowledgement prompt when the external QR operation completes. */
+  /** Accept acknowledgement after the external QR operation settles; the caller owns its result. */
   dismissWhen?: Promise<unknown>;
 };
 

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -107,6 +107,43 @@ describe("WizardSession", () => {
     });
   });
 
+  test("exposes QR image prompts only to sessions whose client supports them", async () => {
+    let unsupportedQrCode: unknown;
+    const unsupported = new WizardSession(async (prompter) => {
+      unsupportedQrCode = prompter.qrCode;
+    });
+
+    expect((await unsupported.next()).status).toBe("done");
+    expect(unsupportedQrCode).toBeUndefined();
+
+    const supported = new WizardSession(
+      async (prompter) => {
+        const confirmed = await prompter.qrCode?.({
+          title: "Link Signal",
+          message: "Scan this code, then confirm.",
+          pngBase64: "cG5n",
+        });
+        expect(confirmed).toBe(true);
+      },
+      { supportsQrCode: true },
+    );
+
+    const qrStep = await supported.next();
+    expect(qrStep.step).toMatchObject({
+      type: "select",
+      title: "Link Signal",
+      message: "Scan this code, then confirm.",
+      options: [{ value: true, label: "Continue" }],
+      initialValue: true,
+      qrCodePngBase64: "cG5n",
+    });
+    if (!qrStep.step) {
+      throw new Error("expected QR step");
+    }
+    await supported.answer(qrStep.step.id, true);
+    expect((await supported.next()).status).toBe("done");
+  });
+
   test("invalid answers throw", async () => {
     const session = noteRunner();
     const first = await session.next();
@@ -192,6 +229,117 @@ describe("WizardSession", () => {
 
     finish();
     expect((await session.next()).status).toBe("done");
+  });
+
+  test("releases a locked QR prompt so its durable operation can finish", async () => {
+    let answer: boolean | undefined;
+    const session = new WizardSession(
+      async (prompter, _signal, wizardSession) => {
+        wizardSession.lockCancellation();
+        answer = await prompter.qrCode?.({
+          title: "Link account",
+          message: "Scan this code",
+          pngBase64: "cG5n",
+        });
+      },
+      { supportsQrCode: true },
+    );
+
+    expect((await session.next()).step?.qrCodePngBase64).toBe("cG5n");
+    expect(session.cancel()).toBe(false);
+    expect((await session.next()).status).toBe("done");
+    expect(answer).toBe(true);
+    expect(session.signal.aborted).toBe(false);
+  });
+
+  test("retires a QR prompt when its external operation completes", async () => {
+    let complete!: () => void;
+    const completion = new Promise<void>((resolve) => {
+      complete = resolve;
+    });
+    const session = new WizardSession(
+      async (prompter, _signal, wizardSession) => {
+        wizardSession.lockCancellation();
+        await prompter.qrCode?.({
+          title: "Link account",
+          message: "Scan this code",
+          pngBase64: "cG5n",
+          dismissWhen: completion,
+        });
+        await prompter.text({ message: "Recovery path" });
+      },
+      { supportsQrCode: true },
+    );
+
+    const qr = await session.next();
+    expect(qr.step?.qrCodePngBase64).toBe("cG5n");
+    if (!qr.step) {
+      throw new Error("expected QR step");
+    }
+    complete();
+    await completion;
+    await Promise.resolve();
+    await expect(session.answer(qr.step.id, true)).resolves.toBeUndefined();
+    const recovery = await session.next();
+    expect(recovery.step?.message).toBe("Recovery path");
+    if (!recovery.step) {
+      throw new Error("expected recovery step");
+    }
+    await session.answer(recovery.step.id, "retry");
+    expect((await session.next()).status).toBe("done");
+  });
+
+  test("retains a locked session that has moved on to a recovery prompt", async () => {
+    const session = new WizardSession(async (prompter, _signal, wizardSession) => {
+      wizardSession.lockCancellation();
+      await prompter.text({ message: "Recovery path" });
+    });
+
+    const recovery = await session.next();
+    expect(recovery.step?.type).toBe("text");
+    expect(session.cancel()).toBe(false);
+    expect(session.getStatus()).toBe("running");
+    expect(session.signal.aborted).toBe(false);
+    if (!recovery.step) {
+      throw new Error("expected recovery step");
+    }
+    await session.answer(recovery.step.id, "retry");
+    expect((await session.next()).status).toBe("done");
+  });
+
+  test("gives a newly locked operation a full idle window before expiry", async () => {
+    vi.useFakeTimers();
+    try {
+      let beginLockedOperation!: () => void;
+      const ready = new Promise<void>((resolve) => {
+        beginLockedOperation = resolve;
+      });
+      const session = new WizardSession(
+        async (prompter, _signal, wizardSession) => {
+          await ready;
+          wizardSession.lockCancellation();
+          await prompter.text({ message: "Recovery path" });
+        },
+        { timeoutMs: 1_000 },
+      );
+
+      await vi.advanceTimersByTimeAsync(900);
+      beginLockedOperation();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(session.cancel()).toBe(false);
+      await vi.advanceTimersByTimeAsync(999);
+      expect(session.getStatus()).toBe("running");
+      expect(session.signal.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      const done = await session.next();
+      expect(done.status).toBe("cancelled");
+      expect(session.signal.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("expires an abandoned interactive session", async () => {

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -231,12 +231,11 @@ describe("WizardSession", () => {
     expect((await session.next()).status).toBe("done");
   });
 
-  test("releases a locked QR prompt so its durable operation can finish", async () => {
-    let answer: boolean | undefined;
+  test("keeps a locked QR prompt pending when its owner disconnects", async () => {
     const session = new WizardSession(
       async (prompter, _signal, wizardSession) => {
         wizardSession.lockCancellation();
-        answer = await prompter.qrCode?.({
+        await prompter.qrCode?.({
           title: "Link account",
           message: "Scan this code",
           pngBase64: "cG5n",
@@ -247,16 +246,16 @@ describe("WizardSession", () => {
 
     expect((await session.next()).step?.qrCodePngBase64).toBe("cG5n");
     expect(session.cancel()).toBe(false);
-    expect((await session.next()).status).toBe("done");
-    expect(answer).toBe(true);
+    expect(session.getStatus()).toBe("running");
     expect(session.signal.aborted).toBe(false);
   });
 
-  test("retires a QR prompt when its external operation completes", async () => {
+  test("advances an externally completed QR only from the next owned answer", async () => {
     let complete!: () => void;
     const completion = new Promise<void>((resolve) => {
       complete = resolve;
     });
+    const advanced = vi.fn();
     const session = new WizardSession(
       async (prompter, _signal, wizardSession) => {
         wizardSession.lockCancellation();
@@ -266,6 +265,7 @@ describe("WizardSession", () => {
           pngBase64: "cG5n",
           dismissWhen: completion,
         });
+        advanced();
         await prompter.text({ message: "Recovery path" });
       },
       { supportsQrCode: true },
@@ -276,17 +276,56 @@ describe("WizardSession", () => {
     if (!qr.step) {
       throw new Error("expected QR step");
     }
+    await expect(session.answer(qr.step.id, true)).resolves.toContain(
+      "still waiting for the external operation",
+    );
+    expect(advanced).not.toHaveBeenCalled();
     complete();
     await completion;
     await Promise.resolve();
+    expect(advanced).not.toHaveBeenCalled();
     await expect(session.answer(qr.step.id, true)).resolves.toBeUndefined();
     const recovery = await session.next();
+    expect(advanced).toHaveBeenCalledOnce();
     expect(recovery.step?.message).toBe("Recovery path");
     if (!recovery.step) {
       throw new Error("expected recovery step");
     }
     await session.answer(recovery.step.id, "retry");
     expect((await session.next()).status).toBe("done");
+  });
+
+  test("advances after external QR completion rejects so the runner can surface the error", async () => {
+    let rejectCompletion!: (error: Error) => void;
+    const completion = new Promise<void>((_resolve, reject) => {
+      rejectCompletion = reject;
+    });
+    const session = new WizardSession(
+      async (prompter, _signal, wizardSession) => {
+        wizardSession.lockCancellation();
+        await prompter.qrCode?.({
+          title: "Link account",
+          message: "Scan this code",
+          pngBase64: "cG5n",
+          dismissWhen: completion,
+        });
+        await completion;
+      },
+      { supportsQrCode: true },
+    );
+
+    const qr = await session.next();
+    if (!qr.step) {
+      throw new Error("expected QR step");
+    }
+    rejectCompletion(new Error("external link failed"));
+    await Promise.resolve();
+    await expect(session.answer(qr.step.id, true)).resolves.toBeUndefined();
+    await expect(session.next()).resolves.toMatchObject({
+      done: true,
+      status: "error",
+      error: "Error: external link failed",
+    });
   });
 
   test("retains a locked session that has moved on to a recovery prompt", async () => {

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -1,7 +1,12 @@
 // Wizard session helpers track onboarding session ids and state.
 import { randomUUID } from "node:crypto";
 import { createDeferred, type Deferred } from "../shared/deferred.js";
-import { WizardCancelledError, type WizardProgress, type WizardPrompter } from "./prompts.js";
+import {
+  WizardCancelledError,
+  type WizardProgress,
+  type WizardPrompter,
+  type WizardQrCodeParams,
+} from "./prompts.js";
 
 // WizardSession exposes interactive setup as a step/answer protocol for remote
 // clients while reusing the same WizardPrompter contract as the local CLI.
@@ -28,6 +33,7 @@ export type WizardStep = {
     expiresInMinutes?: number;
     message?: string;
   };
+  qrCodePngBase64?: string;
 };
 
 type WizardSessionStatus = "running" | "done" | "cancelled" | "error";
@@ -55,7 +61,28 @@ function normalizeTextAnswer(value: unknown): string | undefined {
 }
 
 class WizardSessionPrompter implements WizardPrompter {
-  constructor(private session: WizardSession) {}
+  readonly qrCode?: (params: WizardQrCodeParams) => Promise<boolean>;
+
+  constructor(
+    private session: WizardSession,
+    supportsQrCode: boolean,
+  ) {
+    if (supportsQrCode) {
+      this.qrCode = async (params) => {
+        const step = this.createStep({
+          type: "select",
+          title: params.title,
+          message: params.message,
+          options: [{ value: true, label: "Continue" }],
+          initialValue: true,
+          qrCodePngBase64: params.pngBase64,
+          executor: "client",
+        });
+        const result = await this.session.awaitAnswer(step, undefined, params.dismissWhen);
+        return Boolean(result);
+      };
+    }
+  }
 
   async intro(title: string): Promise<void> {
     await this.prompt({
@@ -230,10 +257,12 @@ class WizardSessionPrompter implements WizardPrompter {
 
 export class WizardSession {
   private readonly abortController = new AbortController();
-  private readonly expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly timeoutMs: number | undefined;
+  private expiryTimer: ReturnType<typeof setTimeout> | undefined;
   private currentStep: WizardStep | null = null;
   private progressSteps: WizardStep[] = [];
   private deliveredProgressStepIds = new Set<string>();
+  private retiredAnswerStepIds = new Set<string>();
   private stepDeferred: Deferred<WizardStep | null> | null = null;
   private pendingTerminalResolution = false;
   private cancellationLocked = false;
@@ -256,17 +285,16 @@ export class WizardSession {
       signal: AbortSignal,
       session: WizardSession,
     ) => Promise<void>,
-    options?: { timeoutMs?: number },
+    options?: { timeoutMs?: number; supportsQrCode?: boolean },
   ) {
-    const prompter = new WizardSessionPrompter(this);
-    if (options?.timeoutMs !== undefined) {
-      this.expiryTimer = setTimeout(() => this.cancel(), options.timeoutMs);
-      this.expiryTimer.unref?.();
-    }
+    const prompter = new WizardSessionPrompter(this, options?.supportsQrCode === true);
+    this.timeoutMs = options?.timeoutMs;
+    this.refreshExpiryTimer();
     void this.run(prompter);
   }
 
   async next(): Promise<WizardNextResult> {
+    this.refreshExpiryTimer();
     const progressStep = this.progressSteps.shift();
     if (progressStep) {
       this.rememberDeliveredProgressStep(progressStep.id);
@@ -319,6 +347,11 @@ export class WizardSession {
       if (this.deliveredProgressStepIds.delete(stepId)) {
         return undefined;
       }
+      // An external QR completion can advance the runner before the client
+      // retires its cached card. Accept that card's one stale acknowledgement.
+      if (this.retiredAnswerStepIds.delete(stepId)) {
+        return undefined;
+      }
       throw new Error("wizard: no pending step");
     }
     const normalizedValue = pending.text ? normalizeTextAnswer(value) : value;
@@ -329,6 +362,7 @@ export class WizardSession {
     if (validationError) {
       return validationError;
     }
+    this.refreshExpiryTimer();
     this.answerDeferred.delete(stepId);
     this.currentStep = null;
     pending.deferred.resolve(normalizedValue);
@@ -336,9 +370,38 @@ export class WizardSession {
   }
 
   cancel(): boolean {
-    if (this.status !== "running" || this.cancellationLocked) {
+    if (this.status !== "running") {
       return false;
     }
+    if (this.cancellationLocked) {
+      this.continueLockedQrPrompt();
+      return false;
+    }
+    this.finishCancellation();
+    return true;
+  }
+
+  private expire(): void {
+    if (this.status !== "running") {
+      return;
+    }
+    // A cancellation lock protects a durable operation from client teardown,
+    // but a lost client must not retain an un-evictable session forever.
+    this.finishCancellation();
+  }
+
+  private refreshExpiryTimer(): void {
+    if (this.timeoutMs === undefined || this.status !== "running") {
+      return;
+    }
+    if (this.expiryTimer) {
+      clearTimeout(this.expiryTimer);
+    }
+    this.expiryTimer = setTimeout(() => this.expire(), this.timeoutMs);
+    this.expiryTimer.unref?.();
+  }
+
+  private finishCancellation(): void {
     this.status = "cancelled";
     this.error = "cancelled";
     this.abortController.abort(new WizardCancelledError());
@@ -351,13 +414,34 @@ export class WizardSession {
     this.answerDeferred.clear();
     this.progressSteps = [];
     this.deliveredProgressStepIds.clear();
+    this.retiredAnswerStepIds.clear();
     this.resolveStep(null);
-    return true;
+  }
+
+  isRunning(): boolean {
+    return this.status === "running";
   }
 
   /** The underlying mutation crossed its durable commit point and must finish. */
   lockCancellation() {
     this.cancellationLocked = true;
+    // Give the irreversible operation a complete idle window. Otherwise an
+    // operation started near the session deadline can be aborted mid-commit.
+    this.refreshExpiryTimer();
+  }
+
+  private continueLockedQrPrompt(): boolean {
+    const step = this.currentStep;
+    if (!step?.qrCodePngBase64) {
+      return false;
+    }
+    const pending = this.answerDeferred.get(step.id);
+    if (!pending) {
+      return false;
+    }
+    // Once a displayed QR can cause an external durable effect, disconnecting
+    // the client must release the prompt so the runner can finish its config commit.
+    return this.retirePendingAnswer(step.id, true);
   }
 
   get signal(): AbortSignal {
@@ -434,6 +518,7 @@ export class WizardSession {
     } finally {
       if (this.expiryTimer) {
         clearTimeout(this.expiryTimer);
+        this.expiryTimer = undefined;
       }
       this.resolveStep(null);
     }
@@ -442,14 +527,44 @@ export class WizardSession {
   async awaitAnswer(
     step: WizardStep,
     validate?: (value: string) => string | undefined,
+    dismissWhen?: Promise<unknown>,
   ): Promise<unknown> {
     if (this.status !== "running") {
       throw new Error("wizard: session not running");
     }
+    this.refreshExpiryTimer();
     this.pushStep(step);
     const deferred = createDeferred<unknown>();
     this.answerDeferred.set(step.id, { deferred, text: step.type === "text", validate });
+    if (dismissWhen) {
+      void dismissWhen.then(() => this.retirePendingAnswer(step.id, true)).catch(() => undefined);
+    }
     return await deferred.promise;
+  }
+
+  private retirePendingAnswer(stepId: string, value: unknown): boolean {
+    const pending = this.answerDeferred.get(stepId);
+    if (!pending) {
+      return false;
+    }
+    this.answerDeferred.delete(stepId);
+    if (this.currentStep?.id === stepId) {
+      this.currentStep = null;
+    }
+    this.rememberRetiredAnswerStep(stepId);
+    pending.deferred.resolve(value);
+    return true;
+  }
+
+  private rememberRetiredAnswerStep(stepId: string) {
+    this.retiredAnswerStepIds.add(stepId);
+    if (this.retiredAnswerStepIds.size <= 64) {
+      return;
+    }
+    const oldest = this.retiredAnswerStepIds.values().next().value;
+    if (oldest) {
+      this.retiredAnswerStepIds.delete(oldest);
+    }
   }
 
   private resolveStep(step: WizardStep | null) {

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -262,17 +262,18 @@ export class WizardSession {
   private currentStep: WizardStep | null = null;
   private progressSteps: WizardStep[] = [];
   private deliveredProgressStepIds = new Set<string>();
-  private retiredAnswerStepIds = new Set<string>();
   private stepDeferred: Deferred<WizardStep | null> | null = null;
   private pendingTerminalResolution = false;
   private cancellationLocked = false;
   private pendingExternalUrl: string | undefined;
+  private readonly resumeKey: string | undefined;
   private answerDeferred = new Map<
     string,
     {
       deferred: Deferred<unknown>;
       text: boolean;
       validate?: (value: string) => string | undefined;
+      externalCompletion?: { settled: boolean };
     }
   >();
   private status: WizardSessionStatus = "running";
@@ -285,10 +286,11 @@ export class WizardSession {
       signal: AbortSignal,
       session: WizardSession,
     ) => Promise<void>,
-    options?: { timeoutMs?: number; supportsQrCode?: boolean },
+    options?: { timeoutMs?: number; supportsQrCode?: boolean; resumeKey?: string },
   ) {
     const prompter = new WizardSessionPrompter(this, options?.supportsQrCode === true);
     this.timeoutMs = options?.timeoutMs;
+    this.resumeKey = options?.resumeKey;
     this.refreshExpiryTimer();
     void this.run(prompter);
   }
@@ -347,12 +349,11 @@ export class WizardSession {
       if (this.deliveredProgressStepIds.delete(stepId)) {
         return undefined;
       }
-      // An external QR completion can advance the runner before the client
-      // retires its cached card. Accept that card's one stale acknowledgement.
-      if (this.retiredAnswerStepIds.delete(stepId)) {
-        return undefined;
-      }
       throw new Error("wizard: no pending step");
+    }
+    this.refreshExpiryTimer();
+    if (pending.externalCompletion && !pending.externalCompletion.settled) {
+      return "Setup is still waiting for the external operation to finish. Complete it, then choose Continue again.";
     }
     const normalizedValue = pending.text ? normalizeTextAnswer(value) : value;
     if (pending.text && normalizedValue === undefined) {
@@ -362,7 +363,6 @@ export class WizardSession {
     if (validationError) {
       return validationError;
     }
-    this.refreshExpiryTimer();
     this.answerDeferred.delete(stepId);
     this.currentStep = null;
     pending.deferred.resolve(normalizedValue);
@@ -374,7 +374,6 @@ export class WizardSession {
       return false;
     }
     if (this.cancellationLocked) {
-      this.continueLockedQrPrompt();
       return false;
     }
     this.finishCancellation();
@@ -414,7 +413,6 @@ export class WizardSession {
     this.answerDeferred.clear();
     this.progressSteps = [];
     this.deliveredProgressStepIds.clear();
-    this.retiredAnswerStepIds.clear();
     this.resolveStep(null);
   }
 
@@ -422,26 +420,25 @@ export class WizardSession {
     return this.status === "running";
   }
 
+  isCancellationLocked(): boolean {
+    return this.status === "running" && this.cancellationLocked;
+  }
+
+  /** A replacement client may reclaim only the flow that created this session. */
+  canResume(resumeKey: string): boolean {
+    return this.status === "running" && this.resumeKey === resumeKey;
+  }
+
   /** The underlying mutation crossed its durable commit point and must finish. */
-  lockCancellation() {
+  lockCancellation(): boolean {
+    if (this.status !== "running") {
+      return false;
+    }
     this.cancellationLocked = true;
     // Give the irreversible operation a complete idle window. Otherwise an
     // operation started near the session deadline can be aborted mid-commit.
     this.refreshExpiryTimer();
-  }
-
-  private continueLockedQrPrompt(): boolean {
-    const step = this.currentStep;
-    if (!step?.qrCodePngBase64) {
-      return false;
-    }
-    const pending = this.answerDeferred.get(step.id);
-    if (!pending) {
-      return false;
-    }
-    // Once a displayed QR can cause an external durable effect, disconnecting
-    // the client must release the prompt so the runner can finish its config commit.
-    return this.retirePendingAnswer(step.id, true);
+    return true;
   }
 
   get signal(): AbortSignal {
@@ -535,36 +532,26 @@ export class WizardSession {
     this.refreshExpiryTimer();
     this.pushStep(step);
     const deferred = createDeferred<unknown>();
-    this.answerDeferred.set(step.id, { deferred, text: step.type === "text", validate });
-    if (dismissWhen) {
-      void dismissWhen.then(() => this.retirePendingAnswer(step.id, true)).catch(() => undefined);
+    const externalCompletion = dismissWhen ? { settled: false } : undefined;
+    this.answerDeferred.set(step.id, {
+      deferred,
+      text: step.type === "text",
+      validate,
+      ...(externalCompletion ? { externalCompletion } : {}),
+    });
+    if (dismissWhen && externalCompletion) {
+      // Settlement only unlocks the next owner acknowledgement. The caller
+      // still awaits the original promise and owns its success or failure.
+      void dismissWhen.then(
+        () => {
+          externalCompletion.settled = true;
+        },
+        () => {
+          externalCompletion.settled = true;
+        },
+      );
     }
     return await deferred.promise;
-  }
-
-  private retirePendingAnswer(stepId: string, value: unknown): boolean {
-    const pending = this.answerDeferred.get(stepId);
-    if (!pending) {
-      return false;
-    }
-    this.answerDeferred.delete(stepId);
-    if (this.currentStep?.id === stepId) {
-      this.currentStep = null;
-    }
-    this.rememberRetiredAnswerStep(stepId);
-    pending.deferred.resolve(value);
-    return true;
-  }
-
-  private rememberRetiredAnswerStep(stepId: string) {
-    this.retiredAnswerStepIds.add(stepId);
-    if (this.retiredAnswerStepIds.size <= 64) {
-      return;
-    }
-    const oldest = this.retiredAnswerStepIds.values().next().value;
-    if (oldest) {
-      this.retiredAnswerStepIds.delete(oldest);
-    }
   }
 
   private resolveStep(step: WizardStep | null) {

--- a/ui/src/components/option-card.test.ts
+++ b/ui/src/components/option-card.test.ts
@@ -56,7 +56,7 @@ describe("option card", () => {
     expect(selectEvent.detail).toEqual({ value: "full" });
   });
 
-  it("always renders a skip affordance and emits dismissal", async () => {
+  it("renders a skip affordance when a handler is provided", async () => {
     const onSkip = vi.fn();
     const skipped = vi.fn();
     container.addEventListener("option-skip", skipped);
@@ -78,5 +78,20 @@ describe("option card", () => {
 
     expect(onSkip).toHaveBeenCalledOnce();
     expect(skipped).toHaveBeenCalledOnce();
+  });
+
+  it("omits the skip affordance without a handler", async () => {
+    render(
+      html`<openclaw-option-card
+        .props=${{
+          question: "Acknowledge",
+          options: [{ value: "continue", label: "Continue" }],
+        }}
+      ></openclaw-option-card>`,
+      container,
+    );
+    await container.querySelector("openclaw-option-card")!.updateComplete;
+
+    expect(container.querySelector(".option-card__skip")).toBeNull();
   });
 });

--- a/ui/src/components/option-card.ts
+++ b/ui/src/components/option-card.ts
@@ -123,14 +123,16 @@ class OptionCard extends LitElement {
             `;
           })}
         </div>
-        <button
-          class="option-card__skip"
-          type="button"
-          ?disabled=${props.disabled}
-          @click=${() => this.skip()}
-        >
-          ${t("optionCard.skip")}
-        </button>
+        ${props.onSkip
+          ? html`<button
+              class="option-card__skip"
+              type="button"
+              ?disabled=${props.disabled}
+              @click=${() => this.skip()}
+            >
+              ${t("optionCard.skip")}
+            </button>`
+          : nothing}
       </section>
     `;
   }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2027,6 +2027,7 @@ export const en: TranslationMap = {
     send: "Send",
     thinking: "OpenClaw is thinking",
     earlier: "Earlier",
+    setupQrCodeAlt: "Setup QR code",
     requestFailed: "OpenClaw could not reply. Try again.",
     connectionChanged: "The Gateway connection changed. Retry to continue this setup.",
     sessionRestarted:

--- a/ui/src/pages/channels/wizard-controller.test.ts
+++ b/ui/src/pages/channels/wizard-controller.test.ts
@@ -352,6 +352,28 @@ describe("ChannelWizardController", () => {
     expect(calls).toContain("wizard.cancel");
   });
 
+  it("keeps ownership when the gateway refuses cancellation during a durable step", async () => {
+    const { controller, request } = createController(async (method) => {
+      if (method === "wizard.start") {
+        return { sessionId: "s1", done: false, status: "running", step: selectStep };
+      }
+      if (method === "wizard.cancel") {
+        return { status: "running" };
+      }
+      throw new Error(`unexpected ${method}`);
+    });
+
+    await controller.start("signal");
+    await controller.cancel();
+
+    expect(controller.state).toMatchObject({
+      phase: "step",
+      channel: "signal",
+      step: { id: "step-select" },
+    });
+    expect(request).toHaveBeenCalledWith("wizard.cancel", { sessionId: "s1" });
+  });
+
   it("ignores answers while a previous answer is in flight", async () => {
     let resolveNext: (value: unknown) => void = () => {};
     const { controller, request } = createController(async (method) => {

--- a/ui/src/pages/channels/wizard-controller.ts
+++ b/ui/src/pages/channels/wizard-controller.ts
@@ -69,6 +69,8 @@ type WizardNextResult = {
   accounts?: Array<{ channel: string; accountId: string }>;
 };
 
+type WizardStatusResult = Pick<WizardNextResult, "status" | "error">;
+
 function cancelRunningWizardResult(client: WizardGatewayClient, result: WizardNextResult): void {
   if (!result.sessionId || result.done) {
     return;
@@ -198,17 +200,22 @@ export class ChannelWizardController {
   async cancel(): Promise<void> {
     const client = this.getClient();
     const sessionId = this.sessionId;
-    this.generation += 1;
-    this.sessionId = null;
-    this.channel = null;
-    this.setState({ phase: "idle" });
     if (client && sessionId) {
       try {
-        await client.request("wizard.cancel", { sessionId });
+        const result = await client.request<WizardStatusResult>("wizard.cancel", { sessionId });
+        if (result.status === "running") {
+          // A durable operation owns this session now. Keep the modal and its
+          // in-flight answer attached until the gateway reaches a safe prompt.
+          return;
+        }
       } catch {
         // Session may already be finished/purged; closing the modal wins.
       }
     }
+    this.generation += 1;
+    this.sessionId = null;
+    this.channel = null;
+    this.setState({ phase: "idle" });
   }
 
   private applyResult(result: WizardNextResult): void {

--- a/ui/src/pages/custodian/chat-request.ts
+++ b/ui/src/pages/custodian/chat-request.ts
@@ -1,0 +1,43 @@
+import type { SystemAgentChatParams, SystemAgentChatResult } from "@openclaw/gateway-protocol";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+
+const SYSTEM_AGENT_CHAT_TIMEOUT_MS = 190_000;
+const INVALID_CHAT_PARAMS_MESSAGE = "invalid openclaw.chat params";
+
+function shouldRetryWithoutCapabilities(error: unknown, params: SystemAgentChatParams): boolean {
+  return (
+    params.capabilities?.qrCodePng === true &&
+    error instanceof GatewayRequestError &&
+    error.code === "INVALID_REQUEST" &&
+    error.message.toLowerCase().includes(INVALID_CHAT_PARAMS_MESSAGE)
+  );
+}
+
+export async function requestCustodianChat(params: {
+  client: GatewayBrowserClient;
+  request: SystemAgentChatParams;
+  onSent: () => void;
+}): Promise<SystemAgentChatResult> {
+  const request: SystemAgentChatParams = {
+    ...params.request,
+    capabilities: { qrCodePng: true },
+  };
+  const options = {
+    timeoutMs: SYSTEM_AGENT_CHAT_TIMEOUT_MS,
+    onSent: params.onSent,
+  };
+  try {
+    return await params.client.request<SystemAgentChatResult>("openclaw.chat", request, options);
+  } catch (error) {
+    if (!shouldRetryWithoutCapabilities(error, request)) {
+      throw error;
+    }
+    const legacyRequest = { ...request };
+    delete legacyRequest.capabilities;
+    return await params.client.request<SystemAgentChatResult>(
+      "openclaw.chat",
+      legacyRequest,
+      options,
+    );
+  }
+}

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
 
@@ -63,15 +63,78 @@ describe("custodian page", () => {
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await page.updateComplete;
     expect(request.mock.calls[0]?.[0]).toBe("openclaw.chat");
-    expect(request.mock.calls[0]?.[1]).toMatchObject({ welcomeVariant: "onboarding" });
+    expect(request.mock.calls[0]?.[1]).toMatchObject({
+      capabilities: { qrCodePng: true },
+      welcomeVariant: "onboarding",
+    });
     // The engine receives the parseable reply text; the transcript shows the label.
     expect(request.mock.calls[1]?.[1]).toMatchObject({
+      capabilities: { qrCodePng: true },
       welcomeVariant: "onboarding",
       message: "connect whatsapp",
     });
     const userGroup = page.querySelector<HTMLElement>(".chat-group.user")!;
     expect(userGroup.textContent).toContain("Connect WhatsApp");
     expect(connectOption.disabled).toBe(true);
+  });
+
+  it("renders a setup QR code returned by the gateway", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Scan this code, then confirm.",
+      action: "none",
+      qrCodePngBase64: "cXItcG5n",
+      question: {
+        id: "signal-link",
+        header: "Signal account linking",
+        question: "Scan the QR code, then continue.",
+        options: [{ label: "Continue" }],
+        allowSkip: false,
+      },
+    });
+    const { context } = createContext(request);
+    const { page } = await mountPage(context);
+
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    await page.updateComplete;
+
+    const image = page.querySelector<HTMLImageElement>(".custodian__qr-code img");
+    expect(image?.getAttribute("src")).toBe("data:image/png;base64,cXItcG5n");
+    expect(image?.getAttribute("alt")).toBe("Setup QR code");
+    expect(page.querySelector(".option-card__skip")).toBeNull();
+
+    page.querySelector<HTMLButtonElement>("[data-option-value]")?.click();
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(request.mock.calls[1]?.[1]).toMatchObject({
+      capabilities: { qrCodePng: true },
+      message: "Continue",
+    });
+  });
+
+  it("retries the greeting without QR capabilities for an older gateway", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: "invalid openclaw.chat params",
+        }),
+      )
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Legacy gateway welcome.",
+        action: "none",
+      });
+    const { context } = createContext(request);
+    const { page } = await mountPage(context);
+
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+
+    expect(request.mock.calls[0]?.[1]).toMatchObject({
+      capabilities: { qrCodePng: true },
+    });
+    expect(request.mock.calls[1]?.[1]).not.toHaveProperty("capabilities");
+    await waitForFast(() => expect(page.textContent).toContain("Legacy gateway welcome."));
   });
 
   it("renders advertised durable history before the live welcome with a divider", async () => {

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -1,7 +1,6 @@
 import { consume } from "@lit/context";
 import type {
   SystemAgentChatParams,
-  SystemAgentChatResult,
   SystemChangeEntry,
   SystemChangesListResult,
 } from "@openclaw/gateway-protocol";
@@ -21,6 +20,7 @@ import "../../styles/chat/layout.css";
 import "../../styles/chat/text.css";
 import "../../styles/custodian.css";
 import { renderChatAvatar } from "../chat/chat-avatar.ts";
+import { requestCustodianChat } from "./chat-request.ts";
 import { renderCustodianChangeHistory } from "./custodian-history.ts";
 import * as eventNudgeState from "./event-nudge.ts";
 import {
@@ -29,7 +29,7 @@ import {
   type CustodianSessionVariant,
   welcomeVariant,
 } from "./session-lifecycle.ts";
-import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./structured-question.ts";
+import { parseCustodianQuestion } from "./structured-question.ts";
 import {
   createCustodianSessionId,
   createCustodianTranscriptMessages,
@@ -41,7 +41,6 @@ import {
   type CustodianMessage,
 } from "./transcript.ts";
 
-const SYSTEM_AGENT_CHAT_TIMEOUT_MS = 190_000;
 const SYSTEM_CHANGE_PAGE_SIZE = 50;
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 
@@ -151,7 +150,11 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.sessionStarted = true;
     void this.initializeSession(
       client,
-      { sessionId: this.sessionId, ...welcomeVariant(variant) },
+      {
+        sessionId: this.sessionId,
+        capabilities: { qrCodePng: true },
+        ...welcomeVariant(variant),
+      },
       loadTranscript,
     );
   }
@@ -392,15 +395,16 @@ export class CustodianPage extends OpenClawLightDomElement {
     }
   }
 
-  private appendAssistant(reply: string, question: CustodianStructuredQuestion | null): void {
+  private appendReply(text: string, question: CustodianMessage["question"], qr?: string): void {
     this.messages = [
       ...this.messages,
       {
         id: this.nextMessageId++,
         role: "assistant",
-        text: reply,
+        text,
         at: Date.now(),
         question,
+        qrCodePngBase64: qr,
       },
     ];
   }
@@ -415,8 +419,9 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.error = null;
     this.retryParams = params;
     try {
-      const result = await client.request<SystemAgentChatResult>("openclaw.chat", params, {
-        timeoutMs: SYSTEM_AGENT_CHAT_TIMEOUT_MS,
+      const result = await requestCustodianChat({
+        client,
+        request: params,
         onSent: () => (delivery = "sent"),
       });
       delivery = "received";
@@ -431,7 +436,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       // Match regular chat: NO_REPLY is a delivery sentinel, not transcript content.
       const silentReply = SILENT_REPLY_PATTERN.test(result.reply);
       if (!silentReply || question) {
-        this.appendAssistant(silentReply ? "" : result.reply, question);
+        this.appendReply(silentReply ? "" : result.reply, question, result.qrCodePngBase64);
       }
       if (result.action === "open-agent") {
         let sessionKey = this.context.gateway.snapshot.sessionKey?.trim();

--- a/ui/src/pages/custodian/custodian-question-card.ts
+++ b/ui/src/pages/custodian/custodian-question-card.ts
@@ -21,7 +21,7 @@ export function renderCustodianQuestionCard(params: {
         })),
         disabled: params.disabled,
         onSelect: params.onSelect,
-        onSkip: params.onSkip,
+        onSkip: params.question.allowSkip ? params.onSkip : undefined,
       }}
     ></openclaw-option-card>
   </div>`;

--- a/ui/src/pages/custodian/structured-question.test.ts
+++ b/ui/src/pages/custodian/structured-question.test.ts
@@ -25,6 +25,7 @@ describe("custodian typed question", () => {
         { label: "Connect WhatsApp", reply: "connect whatsapp", description: "Chat there." },
       ],
       isOther: true,
+      allowSkip: true,
       skipAction: "exit",
     });
   });
@@ -40,16 +41,20 @@ describe("custodian typed question", () => {
     expect(parsed?.isOther).toBe(false);
   });
 
+  it("accepts a single acknowledgement action", () => {
+    const parsed = parseCustodianQuestion({
+      id: "signal-link",
+      header: "Signal account linking",
+      question: "Scan the QR code, then continue.",
+      options: [{ label: "Continue" }],
+      allowSkip: false,
+    });
+    expect(parsed?.options).toEqual([{ label: "Continue" }]);
+    expect(parsed?.allowSkip).toBe(false);
+  });
+
   it("rejects malformed questions instead of rendering broken cards", () => {
     expect(parseCustodianQuestion(undefined)).toBeNull();
-    expect(
-      parseCustodianQuestion({
-        id: "one-option",
-        header: "H",
-        question: "Q",
-        options: [{ label: "Only" }],
-      }),
-    ).toBeNull();
     expect(
       parseCustodianQuestion({
         id: "dupes",

--- a/ui/src/pages/custodian/structured-question.ts
+++ b/ui/src/pages/custodian/structured-question.ts
@@ -6,6 +6,7 @@ export type CustodianStructuredQuestion = {
   question: string;
   options: Array<{ label: string; description?: string; recommended?: boolean; reply?: string }>;
   isOther: boolean;
+  allowSkip: boolean;
   skipAction?: "exit";
 };
 
@@ -16,7 +17,7 @@ function nonEmptyString(value: unknown): string | null {
 /**
  * Sanitize the typed `question` field from `openclaw.chat`. The gateway owns
  * the schema, but this state renders buttons that send messages, so the page
- * still enforces the card contract locally: 2-4 unique options, at most one
+ * still enforces the card contract locally: 1-4 unique options, at most one
  * recommended. Anything else degrades to the prose reply.
  */
 export function parseCustodianQuestion(
@@ -31,7 +32,7 @@ export function parseCustodianQuestion(
   if (!id || !header || !question || !Array.isArray(value.options)) {
     return null;
   }
-  if (value.options.length < 2 || value.options.length > 4) {
+  if (value.options.length < 1 || value.options.length > 4) {
     return null;
   }
   const options: CustodianStructuredQuestion["options"] = [];
@@ -61,6 +62,7 @@ export function parseCustodianQuestion(
     question,
     options,
     isOther: value.isOther === true,
+    allowSkip: value.allowSkip !== false,
     ...(value.skipAction === "exit" ? { skipAction: "exit" as const } : {}),
   };
 }

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -19,6 +19,7 @@ export type CustodianMessage = {
   text: string;
   at: number;
   question: CustodianStructuredQuestion | null;
+  qrCodePngBase64?: string;
 };
 
 export function hasUnresolvedCustodianQuestion(
@@ -153,6 +154,14 @@ export function renderCustodianTranscriptEntry(params: {
           assistantName: t("custodian.title"),
           assistantAvatar: "OC",
         })
+      : nothing}
+    ${params.message.qrCodePngBase64
+      ? html`<div class="custodian__qr-code">
+          <img
+            src=${`data:image/png;base64,${params.message.qrCodePngBase64}`}
+            alt=${t("custodian.setupQrCodeAlt")}
+          />
+        </div>`
       : nothing}
     ${renderCustodianEarlierDivider(params.message, params.boundaryAfterId)}
     ${params.showQuestion && question

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -128,6 +128,22 @@
   margin: -12px 16px 14px 46px;
 }
 
+.custodian__qr-code {
+  width: min(280px, calc(100% - 62px));
+  margin: -10px 16px 18px 46px;
+  padding: 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: #fff;
+}
+
+.custodian__qr-code img {
+  display: block;
+  width: 100%;
+  height: auto;
+  image-rendering: pixelated;
+}
+
 .custodian__thinking {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Related: #100906

AI-assisted: yes

## Landing plan

This PR is the canonical continuation of #100906. It retains the Signal plugin-owned setup work, adds the chat/client path, and should supersede #100906 rather than landing both branches independently.

## New behavior

Signal can now be configured from the chat-based setup flow instead of requiring a separate terminal wizard.

- Local setup installs or reuses `signal-cli`, discovers linked accounts, and can link a new account by showing a scanner-safe PNG QR code in the Control UI, Android, iOS, and macOS chat clients.
- Setup continues when `signal-cli` completes the link, validates the resulting managed transport, and writes only the selected account's configuration.
- Existing-server setup detects native versus container transports, requires an account where the server contract needs one, probes before persistence, and offers retry/change recovery with actionable error text.
- Managed-daemon aliases are rejected across loopback, DNS, wildcard, and dual-stack IPv4/IPv6 forms so setup cannot accidentally save the endpoint that OpenClaw itself owns.
- Durable setup steps reject cancellation races. A refused close retains ownership; classic channel setup can resume only on the original connection and channel, and abandoned sessions expire after a bounded idle window.

Older gateways remain compatible: clients retry `openclaw.chat` without the QR capability when the gateway rejects the new additive parameter.

## UI proof

![Signal chat setup showing the explicit default config choice and successful validation](https://github.com/user-attachments/assets/e4e46f6d-2541-4371-8d19-dc74f60ac989)

**What this shows:** The Control UI presents the default `signal-cli` config location as an explicit selectable action, records that choice in the transcript, and reaches the validated/selected/completed states without requiring a blank chat reply.

**State:** Local `/custodian` chat on this PR branch after selecting the default config location, 768×1024 viewport crop. The phone number, account identifier, and one-time linked-device QR are not present.

Native client screenshots are not included because the automated Android, iOS, and macOS validation ran without interactive screenshot artifacts; those clients consume the same typed QR PNG response, and their adapter behavior is covered by focused client tests.

## Linked-device proof

An owned-device Signal run completed the linked-device path:

1. The Control UI displayed the generated Signal link QR.
2. The QR was scanned from Signal under **Settings → Linked devices**.
3. Setup advanced after `signal-cli` completed the link.
4. OpenClaw started the account-scoped daemon on loopback, validated the transport, stopped the validation daemon cleanly, and displayed `Signal setup is validated and ready for the gateway.`

The phone number and one-time QR payload are intentionally redacted from this public PR. Local Control UI validation also passed at 390×844, 768×1024, and 1440×900 without targeted overflow or console errors.

A live no-listener run reproduced the original `Connection refused` failure. The revised flow now explains that an existing server must already be running with a linked account and offers retry/change recovery. The no-partial-write guarantee is covered at the setup apply boundary and in the Signal recovery tests.

Known limitation: Signal's primary phone must scan the linked-device QR from another display. A QR shown on that same phone cannot be self-scanned; use the desktop Control UI or terminal flow for that case.

## How to verify

1. Open the system-agent chat and ask to connect Signal.
2. Choose local `signal-cli`, then install or reuse it.
3. Choose an existing linked account or link another account.
4. Scan the displayed QR code in Signal under **Settings → Linked devices**.
5. Confirm that chat advances, validates the daemon, and reports Signal ready.
6. Repeat with **Existing Signal server** and confirm that an unreachable server gives recovery choices without saving partial config.
7. During installation, try closing and reopening setup. Confirm cancellation is refused during the durable step and only the original connection/channel can resume it.

## Checks

- Focused Signal proof passed 9 files / 164 tests on Blacksmith Testbox ([run 30185096576](https://github.com/openclaw/openclaw/actions/runs/30185096576)).
- The full changed-file gate passed on Blacksmith Testbox ([run 30186502415](https://github.com/openclaw/openclaw/actions/runs/30186502415)): dependency and source ratchets, formatting, SDK and plugin boundaries, core/core-test/UI/extension/extension-test typechecks, core and extension lint, app-related checks, and runtime guards.
- The production build passed on Node 24 in Blacksmith Testbox ([run 30185819608](https://github.com/openclaw/openclaw/actions/runs/30185819608)), including declarations, all 142 public plugin SDK subpaths, startup metadata, the production Control UI build, and its performance budget.
- Focused Control UI behavior passed 2 files / 29 tests locally.
- `git diff --check` passes on the final rebased range.

## Implementation notes

The size is real, but most of the added lines are proof rather than runtime: 4,715 of 7,494 additions are tests. The remaining product work crosses three necessary review boundaries:

- The Signal plugin owns installation, account discovery and linking, endpoint identity, transport validation, recovery, and persistence.
- The shared hosted wizard owns typed QR presentation, cancellation locking, expiry, and exact-owner recovery.
- The existing web, Android, iOS, and macOS chat clients each adapt the typed QR response and preserve compatibility with older gateways.

Signal-specific behavior remains in the plugin; shared surfaces contain only the channel-agnostic lifecycle and presentation contracts needed to make chat-based setup reliable.

External-native readiness continues to use the existing public probe contract. Proving that a selected account belongs to an external native daemon is separate readiness work and is intentionally not changed here.
