### PR TITLE
feat(snapshot): capture final recovery points

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -436,8 +436,8 @@ const config = {
     // asserted by the focused Beam mirror tests; production wires only the service.
     "extensions/beam/src/mirror.ts": ["exports", "types"],
     "src/infra/heartbeat-wake.ts": ["exports"],
-    // Private RFC 0013 recovery helpers are direct unit-test contracts until
-    // their hidden host-facing caller lands in the next stacked slice.
+    // The recovery-point composer is now reached by the hidden final-capture
+    // command; these remaining named exports are retained contract entrypoints.
     "src/snapshot/recovery-point.ts": ["exports"],
     // The hidden final-capture request contract is imported directly by its
     // focused tests before a production host adapter exists.

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -381,6 +381,9 @@ const config = {
     // Declaration companions describe executable JavaScript modules; they are not standalone roots.
     "scripts/**/*.d.{mts,ts}",
     "**/live-*.ts",
+    // PR 112385 proves this private RFC slice before its hidden production
+    // caller lands in the next stacked PR.
+    "src/snapshot/recovery-point.ts",
     "src/shared/text/assistant-visible-text.ts",
     bundledPluginFile("telegram", "src/bot/reply-threading.ts"),
     bundledPluginFile("telegram", "src/draft-chunking.ts"),

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -436,9 +436,6 @@ const config = {
     // asserted by the focused Beam mirror tests; production wires only the service.
     "extensions/beam/src/mirror.ts": ["exports", "types"],
     "src/infra/heartbeat-wake.ts": ["exports"],
-    // Private RFC 0013 recovery helpers are direct unit-test contracts until
-    // their hidden host-facing caller lands in the next stacked slice.
-    "src/snapshot/recovery-point.ts": ["exports"],
   },
   workspaces: {
     ".": {

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -433,6 +433,9 @@ const config = {
     // asserted by the focused Beam mirror tests; production wires only the service.
     "extensions/beam/src/mirror.ts": ["exports", "types"],
     "src/infra/heartbeat-wake.ts": ["exports"],
+    // Private RFC 0013 recovery helpers are direct unit-test contracts until
+    // their hidden host-facing caller lands in the next stacked slice.
+    "src/snapshot/recovery-point.ts": ["exports"],
   },
   workspaces: {
     ".": {

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -436,6 +436,12 @@ const config = {
     // asserted by the focused Beam mirror tests; production wires only the service.
     "extensions/beam/src/mirror.ts": ["exports", "types"],
     "src/infra/heartbeat-wake.ts": ["exports"],
+    // Private RFC 0013 recovery helpers are direct unit-test contracts until
+    // their hidden host-facing caller lands in the next stacked slice.
+    "src/snapshot/recovery-point.ts": ["exports"],
+    // The hidden final-capture request contract is imported directly by its
+    // focused tests before a production host adapter exists.
+    "src/snapshot/final-recovery-point.ts": ["exports", "types"],
   },
   workspaces: {
     ".": {

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -395,6 +395,17 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { configGuard: "skip", networkProxy: "bypass" },
   },
   { commandPath: ["backup"], policy: { configGuard: "skip", networkProxy: "bypass" } },
+  {
+    commandPath: ["backup", "capture-final"],
+    exact: true,
+    policy: {
+      configGuard: "skip",
+      hideBanner: true,
+      loadPlugins: "never",
+      ownsProtocolStdout: true,
+      networkProxy: "bypass",
+    },
+  },
   { commandPath: ["chat"], policy: { networkProxy: "bypass" } },
   { commandPath: ["config"], policy: { networkProxy: "bypass" } },
   { commandPath: ["cron"], policy: { configGuard: "skip", networkProxy: "bypass" } },

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -383,6 +383,14 @@ describe("command-startup-policy", () => {
     expect(policy.suppressDoctorStdout).toBe(true);
   });
 
+  it("reserves stdout for the final recovery capture protocol", () => {
+    const policy = resolvePolicy({ commandPath: ["backup", "capture-final"] });
+
+    expect(policy.hideBanner).toBe(true);
+    expect(policy.loadPlugins).toBe(false);
+    expect(policy.suppressDoctorStdout).toBe(true);
+  });
+
   it("reserves stdout for the node worker protocol", () => {
     const policy = resolvePolicy({ commandPath: ["node", "worker"] });
 

--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerBackupCommand } from "./register.backup.js";
 
 const mocks = vi.hoisted(() => ({
+  backupCaptureFinalCommand: vi.fn(),
   backupCreateCommand: vi.fn(),
   backupRestoreCommand: vi.fn(),
   backupSqliteCreateCommand: vi.fn(),
@@ -20,6 +21,7 @@ const mocks = vi.hoisted(() => ({
 
 const backupCreateCommand = mocks.backupCreateCommand;
 const backupRestoreCommand = mocks.backupRestoreCommand;
+const backupCaptureFinalCommand = mocks.backupCaptureFinalCommand;
 const backupSqliteCreateCommand = mocks.backupSqliteCreateCommand;
 const backupSqliteListCommand = mocks.backupSqliteListCommand;
 const backupSqliteRestoreCommand = mocks.backupSqliteRestoreCommand;
@@ -33,6 +35,10 @@ vi.mock("../../commands/backup.js", () => ({
 
 vi.mock("../../commands/backup-restore.js", () => ({
   backupRestoreCommand: mocks.backupRestoreCommand,
+}));
+
+vi.mock("../../commands/backup-capture-final.js", () => ({
+  backupCaptureFinalCommand: mocks.backupCaptureFinalCommand,
 }));
 
 vi.mock("../../commands/backup-verify.js", () => ({
@@ -61,6 +67,7 @@ describe("registerBackupCommand", () => {
     vi.clearAllMocks();
     backupCreateCommand.mockResolvedValue(undefined);
     backupRestoreCommand.mockResolvedValue(undefined);
+    backupCaptureFinalCommand.mockResolvedValue(undefined);
     backupSqliteCreateCommand.mockResolvedValue(undefined);
     backupSqliteListCommand.mockResolvedValue(undefined);
     backupSqliteRestoreCommand.mockResolvedValue(undefined);
@@ -151,6 +158,17 @@ describe("registerBackupCommand", () => {
       "restore",
       "verify",
     ]);
+  });
+
+  it("keeps final capture hidden and invokes its structured stdin command", async () => {
+    const program = new Command();
+    registerBackupCommand(program);
+    const backup = program.commands.find((command) => command.name() === "backup");
+    expect(backup?.helpInformation()).not.toContain("capture-final");
+
+    await program.parseAsync(["backup", "capture-final"], { from: "user" });
+
+    expect(backupCaptureFinalCommand).toHaveBeenCalledWith(runtime);
   });
 
   it("runs SQLite snapshot create for named OpenClaw databases", async () => {

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -2,6 +2,7 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { backupCaptureFinalCommand } from "../../commands/backup-capture-final.js";
 import {
   backupGitCreateCommand,
   backupGitInitCommand,
@@ -138,6 +139,16 @@ export function registerBackupCommand(program: Command) {
     });
 
   registerBackupSqliteCommands(backup);
+
+  backup
+    .command("capture-final", { hidden: true })
+    .description("Capture one host-fenced final RFC 0013 recovery point")
+    .action(async () => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await backupCaptureFinalCommand(defaultRuntime);
+      });
+    });
+
   registerBackupGitCommands(backup);
   registerBackupScheduleCommands(backup);
 }

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -32,6 +32,7 @@ const JSON_NOT_APPLICABLE = {
       "backup",
       "backup git",
       "backup sqlite",
+      "backup capture-final",
       "database",
       "database ownership",
       "message",

--- a/src/commands/backup-capture-final.test.ts
+++ b/src/commands/backup-capture-final.test.ts
@@ -19,14 +19,15 @@ describe("backup capture-final command", () => {
   });
 });
 
-function createRuntimeCapture(): RuntimeEnv & { logs: string[]; exit: ReturnType<typeof vi.fn> } {
+function createRuntimeCapture() {
   const logs: string[] = [];
+  const exit = vi.fn<RuntimeEnv["exit"]>();
   return {
     logs,
-    log(value) {
+    log(value: unknown) {
       logs.push(String(value));
     },
     error: vi.fn(),
-    exit: vi.fn(),
+    exit,
   };
 }

--- a/src/commands/backup-capture-final.test.ts
+++ b/src/commands/backup-capture-final.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import { backupCaptureFinalCommand } from "./backup-capture-final.js";
+
+describe("backup capture-final command", () => {
+  it("returns the structured request failure for oversized input", async () => {
+    const runtime = createRuntimeCapture();
+
+    const result = await backupCaptureFinalCommand(runtime, "x".repeat(1024 * 1024 + 1));
+
+    expect(result).toEqual({
+      version: "openclaw-final-recovery-point-result/v1",
+      ok: false,
+      code: "final-capture.request-invalid",
+      disposition: "quarantine",
+    });
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(JSON.parse(runtime.logs[0]!)).toEqual(result);
+  });
+});
+
+function createRuntimeCapture(): RuntimeEnv & { logs: string[]; exit: ReturnType<typeof vi.fn> } {
+  const logs: string[] = [];
+  return {
+    logs,
+    log(value) {
+      logs.push(String(value));
+    },
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}

--- a/src/commands/backup-capture-final.ts
+++ b/src/commands/backup-capture-final.ts
@@ -1,0 +1,62 @@
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import {
+  captureFinalRecoveryPoint,
+  FinalRecoveryPointError,
+  parseFinalRecoveryPointRequest,
+  type FinalRecoveryPointFailureCode,
+  type FinalRecoveryPointResult,
+} from "../snapshot/final-recovery-point.js";
+
+const MAX_REQUEST_BYTES = 1024 * 1024;
+
+export type FinalRecoveryPointCommandResult =
+  | FinalRecoveryPointResult
+  | {
+      version: "openclaw-final-recovery-point-result/v1";
+      ok: false;
+      code: FinalRecoveryPointFailureCode;
+      disposition: "hold" | "quarantine";
+    };
+
+export async function backupCaptureFinalCommand(
+  runtime: RuntimeEnv,
+  rawRequest?: string,
+): Promise<FinalRecoveryPointCommandResult> {
+  try {
+    const requestText = rawRequest ?? (await readFinalRecoveryPointRequestFromStdin());
+    const result = await captureFinalRecoveryPoint(parseFinalRecoveryPointRequest(requestText));
+    writeRuntimeJson(runtime, result);
+    return result;
+  } catch (error) {
+    if (!(error instanceof FinalRecoveryPointError)) {
+      throw error;
+    }
+    const result: FinalRecoveryPointCommandResult = {
+      version: "openclaw-final-recovery-point-result/v1",
+      ok: false,
+      code: error.code,
+      disposition: error.disposition,
+    };
+    writeRuntimeJson(runtime, result);
+    runtime.exit(1);
+    return result;
+  }
+}
+
+export async function readFinalRecoveryPointRequestFromStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of process.stdin) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > MAX_REQUEST_BYTES) {
+      throw new FinalRecoveryPointError(
+        "final-capture.request-invalid",
+        "quarantine",
+        "Final recovery-point request is too large.",
+      );
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/src/commands/backup-capture-final.ts
+++ b/src/commands/backup-capture-final.ts
@@ -9,7 +9,7 @@ import {
 
 const MAX_REQUEST_BYTES = 1024 * 1024;
 
-export type FinalRecoveryPointCommandResult =
+type FinalRecoveryPointCommandResult =
   | FinalRecoveryPointResult
   | {
       version: "openclaw-final-recovery-point-result/v1";
@@ -43,7 +43,7 @@ export async function backupCaptureFinalCommand(
   }
 }
 
-export async function readFinalRecoveryPointRequestFromStdin(): Promise<string> {
+async function readFinalRecoveryPointRequestFromStdin(): Promise<string> {
   const chunks: Buffer[] = [];
   let size = 0;
   for await (const chunk of process.stdin) {

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -171,7 +171,7 @@ function createDatabase(databasePath: string, role: "global" | "agent", agentId?
           meta_key, role, schema_version, agent_id, app_version, created_at, updated_at
         ) VALUES ('primary', ?, ?, ?, NULL, 1, 1)`,
       )
-      .run(role, version, role === "agent" ? agentId : null);
+      .run(role, version, role === "agent" ? agentId! : null);
   } finally {
     database.close();
   }

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { stableStringify } from "../agents/stable-stringify.js";
+import { sha256Hex } from "../infra/crypto-digest.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.generated.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.generated.js";
+import {
+  captureFinalRecoveryPoint,
+  FINAL_RECOVERY_POINT_REQUEST_VERSION,
+  parseFinalRecoveryPointRequest,
+  type FinalRecoveryPointRequest,
+} from "./final-recovery-point.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let previousStateDir: string | undefined;
+
+beforeEach(() => {
+  previousStateDir = process.env.OPENCLAW_STATE_DIR;
+});
+
+afterEach(() => {
+  if (previousStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = previousStateDir;
+  }
+});
+
+describe("final recovery-point capture", () => {
+  it("captures closed global and agent state and replays the exact committed result", async () => {
+    const fixture = await createFixture();
+
+    const first = await captureFinalRecoveryPoint(fixture.request);
+    const replay = await captureFinalRecoveryPoint(fixture.request);
+
+    expect(replay).toEqual(first);
+    expect(first).toMatchObject({
+      ok: true,
+      runtimeLineage: "runtime/tenant-7",
+      handoffId: "handoff-7",
+      sourceGeneration: "generation-7",
+      closureEvidenceId: "supervisor-stop-7",
+    });
+    expect(first.components.map((component) => component.componentId)).toEqual([
+      "sqlite/global",
+      "sqlite/agent/main",
+    ]);
+    expect(JSON.parse(await fs.readFile(first.aggregateManifestPath, "utf8"))).toMatchObject({
+      recoveryPointId: first.recoveryPointId,
+      protection: { mode: "host-protected" },
+    });
+    await expect(countCommittedSnapshots(first.recoveryPointPath)).resolves.toBe(2);
+  });
+
+  it("quarantines a changed request under the same handoff and generation", async () => {
+    const fixture = await createFixture();
+    await captureFinalRecoveryPoint(fixture.request);
+
+    await expect(
+      captureFinalRecoveryPoint({
+        ...fixture.request,
+        closure: { ...fixture.request.closure, evidenceId: "different-stop" },
+      }),
+    ).rejects.toMatchObject({
+      code: "final-capture.operation-conflict",
+      disposition: "quarantine",
+    });
+  });
+
+  it("quarantines durable intent without a committed result", async () => {
+    const fixture = await createFixture();
+    const operationPath = path.join(fixture.request.repositoryPath, operationId(fixture.request));
+    await fs.mkdir(operationPath, { recursive: true, mode: 0o700 });
+    await fs.writeFile(
+      path.join(operationPath, "intent.json"),
+      `${stableStringify(fixture.request)}\n`,
+      { mode: 0o600 },
+    );
+
+    await expect(captureFinalRecoveryPoint(fixture.request)).rejects.toMatchObject({
+      code: "final-capture.operation-conflict",
+      disposition: "quarantine",
+    });
+    await expect(fs.access(path.join(operationPath, "components"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("quarantines a committed recovery point whose component bytes changed", async () => {
+    const fixture = await createFixture();
+    const result = await captureFinalRecoveryPoint(fixture.request);
+    await fs.appendFile(path.join(result.components[0]!.snapshotPath, "database.sqlite"), "x");
+
+    await expect(captureFinalRecoveryPoint(fixture.request)).rejects.toMatchObject({
+      code: "final-capture.verification-failed",
+      disposition: "quarantine",
+    });
+  });
+
+  it("requires explicit closed-writer evidence and canonical owner inventory", () => {
+    const base = {
+      version: FINAL_RECOVERY_POINT_REQUEST_VERSION,
+      runtimeLineage: "runtime/tenant-7",
+      handoffId: "handoff-7",
+      sourceGeneration: "generation-7",
+      capturedAt: "2026-07-22T18:00:00.000Z",
+      repositoryPath: path.resolve("final-recovery-points"),
+      expectedAgentIds: ["research", "main"],
+      closure: {
+        gateway: "cleanly-stopped",
+        authoritativeWriters: "stopped",
+        evidenceId: "supervisor-stop-7",
+      },
+    };
+    expect(() => parseFinalRecoveryPointRequest(JSON.stringify(base))).toThrow(
+      "unique, normalized, and sorted",
+    );
+    expect(() =>
+      parseFinalRecoveryPointRequest(
+        JSON.stringify({ ...base, expectedAgentIds: ["main"], closure: undefined }),
+      ),
+    ).toThrow("request is invalid");
+  });
+});
+
+async function createFixture(): Promise<{ request: FinalRecoveryPointRequest }> {
+  const tempDir = tempDirs.make("openclaw-final-recovery-point-");
+  const stateDir = path.join(tempDir, "state");
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  const globalPath = resolveOpenClawStateSqlitePath();
+  const agentPath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
+  await fs.mkdir(path.dirname(globalPath), { recursive: true });
+  await fs.mkdir(path.dirname(agentPath), { recursive: true });
+  createDatabase(globalPath, "global");
+  createDatabase(agentPath, "agent", "main");
+  return {
+    request: {
+      version: FINAL_RECOVERY_POINT_REQUEST_VERSION,
+      runtimeLineage: "runtime/tenant-7",
+      handoffId: "handoff-7",
+      sourceGeneration: "generation-7",
+      capturedAt: "2026-07-22T18:00:00.000Z",
+      repositoryPath: path.join(tempDir, "recovery-points"),
+      expectedAgentIds: ["main"],
+      closure: {
+        gateway: "cleanly-stopped",
+        authoritativeWriters: "stopped",
+        evidenceId: "supervisor-stop-7",
+      },
+    },
+  };
+}
+
+function createDatabase(databasePath: string, role: "global" | "agent", agentId?: string): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(databasePath);
+  const schema = role === "global" ? OPENCLAW_STATE_SCHEMA_SQL : OPENCLAW_AGENT_SCHEMA_SQL;
+  const version = role === "global" ? OPENCLAW_STATE_SCHEMA_VERSION : OPENCLAW_AGENT_SCHEMA_VERSION;
+  try {
+    database.exec(`${schema}\nPRAGMA user_version = ${version};`);
+    database
+      .prepare(
+        `INSERT INTO schema_meta (
+          meta_key, role, schema_version, agent_id, app_version, created_at, updated_at
+        ) VALUES ('primary', ?, ?, ?, NULL, 1, 1)`,
+      )
+      .run(role, version, role === "agent" ? agentId : null);
+  } finally {
+    database.close();
+  }
+}
+
+async function countCommittedSnapshots(recoveryPointPath: string): Promise<number> {
+  const global = await fs.readdir(path.join(recoveryPointPath, "components", "global"));
+  const agent = await fs.readdir(path.join(recoveryPointPath, "components", "agents", "main"));
+  return (
+    global.filter((entry) => !entry.startsWith(".tmp-")).length +
+    agent.filter((entry) => !entry.startsWith(".tmp-")).length
+  );
+}
+
+function operationId(request: FinalRecoveryPointRequest): string {
+  return sha256Hex(
+    stableStringify({
+      runtimeLineage: request.runtimeLineage,
+      handoffId: request.handoffId,
+      sourceGeneration: request.sourceGeneration,
+    }),
+  );
+}

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -93,6 +93,20 @@ describe("final recovery-point capture", () => {
     });
   });
 
+  it("quarantines the first failure after durable intent and its exact replay", async () => {
+    const fixture = await createFixture();
+    await fs.rm(resolveOpenClawStateSqlitePath());
+
+    await expect(captureFinalRecoveryPoint(fixture.request)).rejects.toMatchObject({
+      code: "final-capture.snapshot-failed",
+      disposition: "quarantine",
+    });
+    await expect(captureFinalRecoveryPoint(fixture.request)).rejects.toMatchObject({
+      code: "final-capture.operation-conflict",
+      disposition: "quarantine",
+    });
+  });
+
   it("quarantines a committed recovery point whose component bytes changed", async () => {
     const fixture = await createFixture();
     const result = await captureFinalRecoveryPoint(fixture.request);

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -127,7 +127,13 @@ describe("final recovery-point capture", () => {
       sourceGeneration: "generation-7",
       capturedAt: "2026-07-22T18:00:00.000Z",
       repositoryPath: path.resolve("final-recovery-points"),
-      expectedAgentIds: ["research", "main"],
+      ownerInventory: {
+        version: "openclaw-runtime-sqlite-inventory/v1",
+        owner: "openclaw-state",
+        sourceRuntimeGeneration: "generation-7",
+        revision: "selected-agents-7",
+        agentIds: ["research", "main"],
+      },
       closure: {
         gateway: "cleanly-stopped",
         authoritativeWriters: "stopped",
@@ -139,9 +145,25 @@ describe("final recovery-point capture", () => {
     );
     expect(() =>
       parseFinalRecoveryPointRequest(
-        JSON.stringify({ ...base, expectedAgentIds: ["main"], closure: undefined }),
+        JSON.stringify({
+          ...base,
+          ownerInventory: { ...base.ownerInventory, agentIds: ["main"] },
+          closure: undefined,
+        }),
       ),
     ).toThrow("request is invalid");
+    expect(() =>
+      parseFinalRecoveryPointRequest(
+        JSON.stringify({
+          ...base,
+          ownerInventory: {
+            ...base.ownerInventory,
+            sourceRuntimeGeneration: "generation-8",
+            agentIds: ["main"],
+          },
+        }),
+      ),
+    ).toThrow("must match sourceGeneration");
   });
 });
 
@@ -163,7 +185,13 @@ async function createFixture(): Promise<{ request: FinalRecoveryPointRequest }> 
       sourceGeneration: "generation-7",
       capturedAt: "2026-07-22T18:00:00.000Z",
       repositoryPath: path.join(tempDir, "recovery-points"),
-      expectedAgentIds: ["main"],
+      ownerInventory: {
+        version: "openclaw-runtime-sqlite-inventory/v1",
+        owner: "openclaw-state",
+        sourceRuntimeGeneration: "generation-7",
+        revision: "selected-agents-7",
+        agentIds: ["main"],
+      },
       closure: {
         gateway: "cleanly-stopped",
         authoritativeWriters: "stopped",

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -17,6 +17,7 @@ import {
   parseFinalRecoveryPointRequest,
   type FinalRecoveryPointRequest,
 } from "./final-recovery-point.js";
+import { resolveRecoveryJournalPath, writeRecoveryJournalRecord } from "./recovery-journal.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 let previousStateDir: string | undefined;
@@ -78,10 +79,10 @@ describe("final recovery-point capture", () => {
     const fixture = await createFixture();
     const operationPath = path.join(fixture.request.repositoryPath, operationId(fixture.request));
     await fs.mkdir(operationPath, { recursive: true, mode: 0o700 });
-    await fs.writeFile(
-      path.join(operationPath, "intent.json"),
-      `${stableStringify(fixture.request)}\n`,
-      { mode: 0o600 },
+    await writeRecoveryJournalRecord(
+      resolveRecoveryJournalPath(operationPath),
+      "intent",
+      fixture.request,
     );
 
     await expect(captureFinalRecoveryPoint(fixture.request)).rejects.toMatchObject({

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { stableStringify } from "../agents/stable-stringify.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -24,6 +24,34 @@ import {
 } from "./final-recovery-point.js";
 import { resolveRecoveryJournalPath, writeRecoveryJournalRecord } from "./recovery-journal.js";
 
+const { durabilityTestState } = vi.hoisted(() => ({
+  durabilityTestState: {
+    durableDirectoryParentSyncOutcome: undefined as
+      | { status: "synced" }
+      | { status: "unsupported"; code?: string }
+      | undefined,
+    syncOutcome: undefined as
+      | { status: "synced" }
+      | { status: "unsupported"; code?: string }
+      | undefined,
+  },
+}));
+
+vi.mock("@openclaw/fs-safe/durability", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@openclaw/fs-safe/durability")>();
+  return {
+    ...actual,
+    ensureDurableDirectory: async (...args: Parameters<typeof actual.ensureDurableDirectory>) => {
+      const receipt = await actual.ensureDurableDirectory(...args);
+      return durabilityTestState.durableDirectoryParentSyncOutcome === undefined
+        ? receipt
+        : { ...receipt, parentSync: durabilityTestState.durableDirectoryParentSyncOutcome };
+    },
+    syncDirectory: async (...args: Parameters<typeof actual.syncDirectory>) =>
+      durabilityTestState.syncOutcome ?? (await actual.syncDirectory(...args)),
+  };
+});
+
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 let previousStateDir: string | undefined;
 
@@ -32,6 +60,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  durabilityTestState.durableDirectoryParentSyncOutcome = undefined;
+  durabilityTestState.syncOutcome = undefined;
   closeOpenClawStateDatabaseForTest();
   if (previousStateDir === undefined) {
     delete process.env.OPENCLAW_STATE_DIR;
@@ -80,6 +110,35 @@ describe("final recovery-point capture", () => {
     ]);
     expect(agentManifest.database).toMatchObject({ role: "agent", agentId: "main" });
   });
+
+  it("quarantines incompatible registered agent databases instead of omitting them", async () => {
+    const fixture = await createFixture();
+    rewriteRegisteredAgentSchemaVersion(
+      fixture.request.ownerInventory.agentIds[0]!,
+      OPENCLAW_AGENT_SCHEMA_VERSION + 1,
+    );
+
+    await expect(captureFinalRecoveryPoint(fixture.request)).rejects.toMatchObject({
+      code: "final-capture.operation-conflict",
+      disposition: "quarantine",
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "fails closed when recovery-root parent synchronization is unsupported",
+    async () => {
+      const fixture = await createFixture();
+      durabilityTestState.durableDirectoryParentSyncOutcome = {
+        status: "unsupported",
+        code: "ENOTSUP",
+      };
+
+      await expect(captureFinalRecoveryPoint(fixture.request)).rejects.toMatchObject({
+        code: "final-capture.snapshot-failed",
+        disposition: "hold",
+      });
+    },
+  );
 
   it("quarantines a changed request under the same handoff and generation", async () => {
     const fixture = await createFixture();
@@ -267,6 +326,18 @@ function createDatabase(databasePath: string, role: "global" | "agent", agentId?
         ) VALUES ('primary', ?, ?, ?, NULL, 1, 1)`,
       )
       .run(role, version, role === "agent" ? agentId! : null);
+  } finally {
+    database.close();
+  }
+}
+
+function rewriteRegisteredAgentSchemaVersion(agentId: string, schemaVersion: number): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(resolveOpenClawStateSqlitePath());
+  try {
+    database
+      .prepare("UPDATE agent_databases SET schema_version = ? WHERE agent_id = ?")
+      .run(schemaVersion, agentId);
   } finally {
     database.close();
   }

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -6,10 +6,14 @@ import { stableStringify } from "../agents/stable-stringify.js";
 import { resolveStateDir } from "../config/paths.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.generated.js";
-import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.generated.js";
 import {
@@ -28,6 +32,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
   if (previousStateDir === undefined) {
     delete process.env.OPENCLAW_STATE_DIR;
   } else {
@@ -59,6 +64,21 @@ describe("final recovery-point capture", () => {
       protection: { mode: "host-protected" },
     });
     await expect(countCommittedSnapshots(first.recoveryPointPath)).resolves.toBe(2);
+  });
+
+  it("captures the exact registered agent database path instead of deriving the default path", async () => {
+    const fixture = await createFixture({ relocatedAgent: true });
+
+    const result = await captureFinalRecoveryPoint(fixture.request);
+    const agentManifest = JSON.parse(
+      await fs.readFile(path.join(result.components[1]!.snapshotPath, "manifest.json"), "utf8"),
+    ) as { database?: { role?: string; agentId?: string } };
+
+    expect(result.components.map((component) => component.componentId)).toEqual([
+      "sqlite/global",
+      "sqlite/agent/main",
+    ]);
+    expect(agentManifest.database).toMatchObject({ role: "agent", agentId: "main" });
   });
 
   it("quarantines a changed request under the same handoff and generation", async () => {
@@ -132,6 +152,20 @@ describe("final recovery-point capture", () => {
     });
   });
 
+  it("quarantines a committed recovery point whose aggregate manifest bytes changed", async () => {
+    const fixture = await createFixture();
+    const result = await captureFinalRecoveryPoint(fixture.request);
+    const manifest = JSON.parse(await fs.readFile(result.aggregateManifestPath, "utf8"));
+    await fs.writeFile(result.aggregateManifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+      mode: 0o600,
+    });
+
+    await expect(captureFinalRecoveryPoint(fixture.request)).rejects.toMatchObject({
+      code: "final-capture.operation-conflict",
+      disposition: "quarantine",
+    });
+  });
+
   it("requires explicit closed-writer evidence and canonical owner inventory", () => {
     const base = {
       version: FINAL_RECOVERY_POINT_REQUEST_VERSION,
@@ -180,16 +214,21 @@ describe("final recovery-point capture", () => {
   });
 });
 
-async function createFixture(): Promise<{ request: FinalRecoveryPointRequest }> {
+async function createFixture(
+  options: { relocatedAgent?: boolean } = {},
+): Promise<{ request: FinalRecoveryPointRequest }> {
   const tempDir = tempDirs.make("openclaw-final-recovery-point-");
   const stateDir = path.join(tempDir, "state");
   process.env.OPENCLAW_STATE_DIR = stateDir;
   const globalPath = resolveOpenClawStateSqlitePath();
-  const agentPath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
+  const agentPath = options.relocatedAgent
+    ? path.join(tempDir, "relocated", "openclaw-main.sqlite")
+    : resolveOpenClawAgentSqlitePath({ agentId: "main" });
   await fs.mkdir(path.dirname(globalPath), { recursive: true });
   await fs.mkdir(path.dirname(agentPath), { recursive: true });
   createDatabase(globalPath, "global");
   createDatabase(agentPath, "agent", "main");
+  registerOpenClawAgentDatabase({ agentId: "main", path: agentPath });
   return {
     request: {
       version: FINAL_RECOVERY_POINT_REQUEST_VERSION,

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -154,7 +154,7 @@ describe("final recovery-point capture", () => {
       },
     };
     expect(() => parseFinalRecoveryPointRequest(JSON.stringify(base))).toThrow(
-      "unique, normalized, and sorted",
+      "inventory is invalid",
     );
     expect(() =>
       parseFinalRecoveryPointRequest(

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stableStringify } from "@openclaw/normalization-core";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { stableStringify } from "../agents/stable-stringify.js";
 import { resolveStateDir } from "../config/paths.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { stableStringify } from "../agents/stable-stringify.js";
+import { resolveStateDir } from "../config/paths.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db.js";
@@ -75,15 +76,27 @@ describe("final recovery-point capture", () => {
     });
   });
 
+  it("fences a handoff independently of the requested repository", async () => {
+    const fixture = await createFixture();
+    await captureFinalRecoveryPoint(fixture.request);
+    const otherRepository = path.join(path.dirname(fixture.request.repositoryPath), "other");
+
+    await expect(
+      captureFinalRecoveryPoint({ ...fixture.request, repositoryPath: otherRepository }),
+    ).rejects.toMatchObject({
+      code: "final-capture.operation-conflict",
+      disposition: "quarantine",
+    });
+    await expect(fs.access(otherRepository)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("quarantines durable intent without a committed result", async () => {
     const fixture = await createFixture();
     const operationPath = path.join(fixture.request.repositoryPath, operationId(fixture.request));
     await fs.mkdir(operationPath, { recursive: true, mode: 0o700 });
-    await writeRecoveryJournalRecord(
-      resolveRecoveryJournalPath(operationPath),
-      "intent",
-      fixture.request,
-    );
+    const journalPath = operationJournalPath(fixture.request);
+    await fs.mkdir(path.dirname(journalPath), { recursive: true, mode: 0o700 });
+    await writeRecoveryJournalRecord(journalPath, "intent", fixture.request);
 
     await expect(captureFinalRecoveryPoint(fixture.request)).rejects.toMatchObject({
       code: "final-capture.operation-conflict",
@@ -236,5 +249,11 @@ function operationId(request: FinalRecoveryPointRequest): string {
       handoffId: request.handoffId,
       sourceGeneration: request.sourceGeneration,
     }),
+  );
+}
+
+function operationJournalPath(request: FinalRecoveryPointRequest): string {
+  return resolveRecoveryJournalPath(
+    path.join(resolveStateDir(), "recovery", "final-capture", operationId(request)),
   );
 }

--- a/src/snapshot/final-recovery-point.test.ts
+++ b/src/snapshot/final-recovery-point.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stableStringify } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resolveStateDir } from "../config/paths.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
@@ -9,13 +9,13 @@ import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
-import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.generated.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.js";
 import {
   closeOpenClawStateDatabaseForTest,
   OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.generated.js";
+import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
 import {
   captureFinalRecoveryPoint,
   FINAL_RECOVERY_POINT_REQUEST_VERSION,

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -1,0 +1,487 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { z } from "zod";
+import { stableStringify } from "../agents/stable-stringify.js";
+import { sha256Hex } from "../infra/crypto-digest.js";
+import { ensureAbsoluteDirectory, FsSafeError, root } from "../infra/fs-safe.js";
+import { applyPrivateModeSync } from "../infra/private-mode.js";
+import { syncDirectoryBestEffort } from "../infra/sqlite-snapshot.js";
+import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { createLocalSqliteSnapshotProvider } from "./local-repository.js";
+import {
+  createRecoveryPointManifest,
+  verifyRecoveryPoint,
+  type RecoveryPointAcceptance,
+  type RecoveryPointManifest,
+  type RecoveryPointSqliteSnapshot,
+} from "./recovery-point.js";
+
+export const FINAL_RECOVERY_POINT_REQUEST_VERSION = "openclaw-final-recovery-point-request/v1";
+export const FINAL_RECOVERY_POINT_RESULT_VERSION = "openclaw-final-recovery-point-result/v1";
+
+const MAX_RECORD_BYTES = 1024 * 1024;
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const SAFE_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,254}$/u;
+
+const finalRecoveryPointRequestSchema = z
+  .object({
+    version: z.literal(FINAL_RECOVERY_POINT_REQUEST_VERSION),
+    runtimeLineage: z.string().regex(SAFE_ID_PATTERN),
+    handoffId: z.string().regex(SAFE_ID_PATTERN),
+    sourceGeneration: z.string().regex(SAFE_ID_PATTERN),
+    capturedAt: z.string(),
+    repositoryPath: z.string().min(1),
+    expectedAgentIds: z.array(z.string().min(1).max(64)).min(1),
+    closure: z
+      .object({
+        gateway: z.literal("cleanly-stopped"),
+        authoritativeWriters: z.literal("stopped"),
+        evidenceId: z.string().regex(SAFE_ID_PATTERN),
+      })
+      .strict(),
+  })
+  .strict();
+
+const finalRecoveryPointResultSchema = z
+  .object({
+    version: z.literal(FINAL_RECOVERY_POINT_RESULT_VERSION),
+    ok: z.literal(true),
+    runtimeLineage: z.string().regex(SAFE_ID_PATTERN),
+    handoffId: z.string().regex(SAFE_ID_PATTERN),
+    sourceGeneration: z.string().regex(SAFE_ID_PATTERN),
+    closureEvidenceId: z.string().regex(SAFE_ID_PATTERN),
+    recoveryPointPath: z.string().min(1),
+    aggregateManifestPath: z.string().min(1),
+    recoveryPointId: z.string().regex(/^[a-f0-9]{64}$/u),
+    acceptanceSetId: z.string().regex(/^[a-f0-9]{64}$/u),
+    aggregateManifestSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+    aggregateManifestSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    components: z.array(
+      z
+        .object({
+          componentId: z.string().min(1),
+          snapshotPath: z.string().min(1),
+          ownerManifestSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+          ownerManifestSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+          artifactSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+          artifactSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+export type FinalRecoveryPointRequest = z.infer<typeof finalRecoveryPointRequestSchema>;
+export type FinalRecoveryPointResult = z.infer<typeof finalRecoveryPointResultSchema>;
+
+export type FinalRecoveryPointFailureCode =
+  | "final-capture.request-invalid"
+  | "final-capture.operation-conflict"
+  | "final-capture.snapshot-failed"
+  | "final-capture.verification-failed";
+
+export class FinalRecoveryPointError extends Error {
+  constructor(
+    public readonly code: FinalRecoveryPointFailureCode,
+    public readonly disposition: "hold" | "quarantine",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "FinalRecoveryPointError";
+  }
+}
+
+export function parseFinalRecoveryPointRequest(raw: string): FinalRecoveryPointRequest {
+  if (Buffer.byteLength(raw) > MAX_RECORD_BYTES) {
+    throw new FinalRecoveryPointError(
+      "final-capture.request-invalid",
+      "quarantine",
+      "Final recovery-point request is too large.",
+    );
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(raw) as unknown;
+  } catch (error) {
+    throw new FinalRecoveryPointError(
+      "final-capture.request-invalid",
+      "quarantine",
+      "Final recovery-point request is not valid JSON.",
+      { cause: error },
+    );
+  }
+  const parsed = finalRecoveryPointRequestSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new FinalRecoveryPointError(
+      "final-capture.request-invalid",
+      "quarantine",
+      `Final recovery-point request is invalid: ${parsed.error.message}`,
+    );
+  }
+  const request = parsed.data;
+  if (
+    !path.isAbsolute(request.repositoryPath) ||
+    path.normalize(request.repositoryPath) !== request.repositoryPath
+  ) {
+    throw new FinalRecoveryPointError(
+      "final-capture.request-invalid",
+      "quarantine",
+      "Final recovery-point repositoryPath must be a normalized absolute path.",
+    );
+  }
+  assertCanonicalTimestamp(request.capturedAt);
+  assertAgentInventory(request.expectedAgentIds);
+  return request;
+}
+
+export async function captureFinalRecoveryPoint(
+  requestValue: FinalRecoveryPointRequest,
+): Promise<FinalRecoveryPointResult> {
+  const request = parseFinalRecoveryPointRequest(stableStringify(requestValue));
+  const operationId = sha256Hex(
+    stableStringify({
+      runtimeLineage: request.runtimeLineage,
+      handoffId: request.handoffId,
+      sourceGeneration: request.sourceGeneration,
+    }),
+  );
+  const recoveryPointPath = path.join(request.repositoryPath, operationId);
+  try {
+    await ensurePrivateDirectory(recoveryPointPath);
+  } catch (error) {
+    if (error instanceof FinalRecoveryPointError) {
+      throw error;
+    }
+    throw new FinalRecoveryPointError(
+      "final-capture.snapshot-failed",
+      "hold",
+      "Final recovery-point repository could not be prepared.",
+      { cause: error },
+    );
+  }
+
+  const intentPath = path.join(recoveryPointPath, "intent.json");
+  const resultPath = path.join(recoveryPointPath, "result.json");
+  const existingResult = await readJsonIfPresent(recoveryPointPath, "result.json");
+  const existingIntent = await readJsonIfPresent(recoveryPointPath, "intent.json");
+  if (existingResult !== undefined) {
+    if (!isDeepStrictEqual(existingIntent, request)) {
+      throw operationConflict("Committed final recovery point has conflicting intent evidence.");
+    }
+    return await verifyCommittedResult(request, recoveryPointPath, existingResult);
+  }
+  if (existingIntent !== undefined) {
+    throw operationConflict(
+      "Final recovery-point capture has durable intent without a committed result.",
+    );
+  }
+  await writeCaptureRecord(intentPath, request, "intent");
+
+  let snapshots: RecoveryPointSqliteSnapshot[];
+  try {
+    snapshots = await captureSqliteInventory(request, recoveryPointPath);
+  } catch (error) {
+    if (error instanceof FinalRecoveryPointError) {
+      throw error;
+    }
+    throw new FinalRecoveryPointError(
+      "final-capture.snapshot-failed",
+      "hold",
+      "Final recovery-point SQLite capture failed after durable intent.",
+      { cause: error },
+    );
+  }
+
+  let manifest: RecoveryPointManifest;
+  let acceptance: RecoveryPointAcceptance;
+  try {
+    manifest = await createRecoveryPointManifest({
+      snapshots,
+      expectedAgentIds: request.expectedAgentIds,
+      now: () => new Date(request.capturedAt),
+    });
+    ({ acceptance } = await verifyRecoveryPoint({
+      manifest,
+      snapshots,
+      expectedAgentIds: request.expectedAgentIds,
+    }));
+  } catch (error) {
+    throw new FinalRecoveryPointError(
+      "final-capture.verification-failed",
+      "hold",
+      "Final recovery-point aggregate verification failed after durable intent.",
+      { cause: error },
+    );
+  }
+
+  const aggregateManifestPath = path.join(recoveryPointPath, "manifest.json");
+  await writeCaptureBytes(
+    aggregateManifestPath,
+    Buffer.from(stableStringify(manifest), "utf8"),
+    "aggregate manifest",
+  );
+  const result = buildResult({
+    request,
+    recoveryPointPath,
+    aggregateManifestPath,
+    manifest,
+    acceptance,
+    snapshots,
+  });
+  await writeCaptureRecord(resultPath, result, "committed result");
+  return result;
+}
+
+async function captureSqliteInventory(
+  request: FinalRecoveryPointRequest,
+  recoveryPointPath: string,
+): Promise<RecoveryPointSqliteSnapshot[]> {
+  const capturedAt = () => new Date(request.capturedAt);
+  const componentsRoot = path.join(recoveryPointPath, "components");
+  const captures = [
+    {
+      repositoryPath: path.join(componentsRoot, "global"),
+      databasePath: await fs.realpath(resolveOpenClawStateSqlitePath()),
+      identity: { role: "global" as const },
+    },
+    ...(await Promise.all(
+      request.expectedAgentIds.map(async (agentId) => ({
+        repositoryPath: path.join(componentsRoot, "agents", agentId),
+        databasePath: await fs.realpath(resolveOpenClawAgentSqlitePath({ agentId })),
+        identity: { role: "agent" as const, agentId },
+      })),
+    )),
+  ];
+  const snapshots: RecoveryPointSqliteSnapshot[] = [];
+  for (const capture of captures) {
+    const provider = createLocalSqliteSnapshotProvider({
+      repositoryPath: capture.repositoryPath,
+      allowedDatabaseRoles: [capture.identity.role],
+      now: capturedAt,
+    });
+    if ((await provider.list()).length !== 0) {
+      throw operationConflict("Final recovery-point component repository is not empty.");
+    }
+    const created = await provider.create({
+      path: capture.databasePath,
+      identity: capture.identity,
+    });
+    snapshots.push({ provider, ref: created.ref });
+  }
+  return snapshots;
+}
+
+async function verifyCommittedResult(
+  request: FinalRecoveryPointRequest,
+  recoveryPointPath: string,
+  value: unknown,
+): Promise<FinalRecoveryPointResult> {
+  const parsedResult = finalRecoveryPointResultSchema.safeParse(value);
+  if (!parsedResult.success) {
+    throw operationConflict("Committed final recovery-point result is invalid.");
+  }
+  let manifest: RecoveryPointManifest;
+  let snapshots: RecoveryPointSqliteSnapshot[];
+  let verified: Awaited<ReturnType<typeof verifyRecoveryPoint>>;
+  try {
+    manifest = (await readJson(recoveryPointPath, "manifest.json")) as RecoveryPointManifest;
+    snapshots = await resolveCommittedSnapshots(recoveryPointPath, request.expectedAgentIds);
+    verified = await verifyRecoveryPoint({
+      manifest,
+      snapshots,
+      expectedAgentIds: request.expectedAgentIds,
+    });
+  } catch (error) {
+    throw new FinalRecoveryPointError(
+      "final-capture.verification-failed",
+      "quarantine",
+      "Committed final recovery point no longer verifies.",
+      { cause: error },
+    );
+  }
+  const expected = buildResult({
+    request,
+    recoveryPointPath,
+    aggregateManifestPath: path.join(recoveryPointPath, "manifest.json"),
+    manifest: verified.manifest,
+    acceptance: verified.acceptance,
+    snapshots,
+  });
+  if (!isDeepStrictEqual(parsedResult.data, expected)) {
+    throw operationConflict("Committed final recovery-point result conflicts with verified bytes.");
+  }
+  return parsedResult.data;
+}
+
+async function resolveCommittedSnapshots(
+  recoveryPointPath: string,
+  expectedAgentIds: readonly string[],
+): Promise<RecoveryPointSqliteSnapshot[]> {
+  const repositories = [
+    {
+      repositoryPath: path.join(recoveryPointPath, "components", "global"),
+      role: "global" as const,
+    },
+    ...expectedAgentIds.map((agentId) => ({
+      repositoryPath: path.join(recoveryPointPath, "components", "agents", agentId),
+      role: "agent" as const,
+    })),
+  ];
+  const snapshots: RecoveryPointSqliteSnapshot[] = [];
+  for (const repository of repositories) {
+    const provider = createLocalSqliteSnapshotProvider({
+      repositoryPath: repository.repositoryPath,
+      allowedDatabaseRoles: [repository.role],
+    });
+    const entries = await provider.list();
+    if (entries.length !== 1) {
+      throw operationConflict("Committed final recovery point has an invalid component set.");
+    }
+    snapshots.push({ provider, ref: entries[0]!.ref });
+  }
+  return snapshots;
+}
+
+function buildResult(params: {
+  request: FinalRecoveryPointRequest;
+  recoveryPointPath: string;
+  aggregateManifestPath: string;
+  manifest: RecoveryPointManifest;
+  acceptance: RecoveryPointAcceptance;
+  snapshots: readonly RecoveryPointSqliteSnapshot[];
+}): FinalRecoveryPointResult {
+  return finalRecoveryPointResultSchema.parse({
+    version: FINAL_RECOVERY_POINT_RESULT_VERSION,
+    ok: true,
+    runtimeLineage: params.request.runtimeLineage,
+    handoffId: params.request.handoffId,
+    sourceGeneration: params.request.sourceGeneration,
+    closureEvidenceId: params.request.closure.evidenceId,
+    recoveryPointPath: params.recoveryPointPath,
+    aggregateManifestPath: params.aggregateManifestPath,
+    recoveryPointId: params.manifest.recoveryPointId,
+    acceptanceSetId: params.acceptance.acceptanceSetId,
+    aggregateManifestSha256: params.acceptance.aggregateManifestSha256,
+    aggregateManifestSizeBytes: params.acceptance.aggregateManifestSizeBytes,
+    components: params.manifest.components.map((component, index) => ({
+      componentId: component.id,
+      snapshotPath: params.snapshots[index]!.ref.path,
+      ownerManifestSha256: params.acceptance.components[index]!.ownerManifestSha256,
+      ownerManifestSizeBytes: params.acceptance.components[index]!.ownerManifestSizeBytes,
+      artifactSha256: params.acceptance.components[index]!.artifactSha256,
+      artifactSizeBytes: params.acceptance.components[index]!.artifactSizeBytes,
+    })),
+  });
+}
+
+async function ensurePrivateDirectory(directoryPath: string): Promise<void> {
+  const result = await ensureAbsoluteDirectory(directoryPath, {
+    mode: PRIVATE_DIRECTORY_MODE,
+    scopeLabel: "final recovery-point repository",
+  });
+  if (!result.ok) {
+    throw result.error;
+  }
+  const stat = await fs.lstat(result.path);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw operationConflict("Final recovery-point path is not a trusted directory.");
+  }
+  applyPrivateModeSync(result.path, PRIVATE_DIRECTORY_MODE);
+}
+
+async function writeCaptureRecord(filePath: string, value: unknown, label: string): Promise<void> {
+  await writeCaptureBytes(filePath, Buffer.from(`${stableStringify(value)}\n`, "utf8"), label);
+}
+
+async function writeCaptureBytes(filePath: string, value: Buffer, label: string): Promise<void> {
+  try {
+    await writeNewBytes(filePath, value);
+  } catch (error) {
+    throw operationConflict(`Final recovery-point ${label} could not be committed.`, error);
+  }
+}
+
+async function writeNewBytes(filePath: string, value: Buffer): Promise<void> {
+  const handle = await fs.open(filePath, "wx", PRIVATE_FILE_MODE);
+  try {
+    await handle.writeFile(value);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  await syncDirectoryBestEffort(path.dirname(filePath));
+}
+
+async function readJsonIfPresent(
+  rootPath: string,
+  relativePath: string,
+): Promise<unknown | undefined> {
+  try {
+    return await readJson(rootPath, relativePath);
+  } catch (error) {
+    if (
+      (error as NodeJS.ErrnoException).code === "ENOENT" ||
+      (error instanceof FsSafeError && error.code === "not-found")
+    ) {
+      return undefined;
+    }
+    throw operationConflict(`Final recovery-point ${relativePath} is unreadable.`, error);
+  }
+}
+
+async function readJson(rootPath: string, relativePath: string): Promise<unknown> {
+  const read = await (
+    await root(rootPath)
+  ).read(relativePath, {
+    hardlinks: "reject",
+    maxBytes: MAX_RECORD_BYTES,
+    symlinks: "reject",
+  });
+  try {
+    return JSON.parse(read.buffer.toString("utf8")) as unknown;
+  } catch (error) {
+    throw operationConflict(`Final recovery-point ${relativePath} is not valid JSON.`, error);
+  }
+}
+
+function assertCanonicalTimestamp(value: string): void {
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString() !== value) {
+    throw new FinalRecoveryPointError(
+      "final-capture.request-invalid",
+      "quarantine",
+      "Final recovery-point capturedAt must be a canonical timestamp.",
+    );
+  }
+}
+
+function assertAgentInventory(agentIds: readonly string[]): void {
+  const normalized = agentIds.map((agentId) => normalizeAgentId(agentId));
+  if (
+    normalized.some(
+      (agentId, index) => !isValidAgentId(agentIds[index]!) || agentId !== agentIds[index],
+    ) ||
+    new Set(normalized).size !== normalized.length ||
+    !isDeepStrictEqual(normalized, normalized.toSorted())
+  ) {
+    throw new FinalRecoveryPointError(
+      "final-capture.request-invalid",
+      "quarantine",
+      "Final recovery-point expectedAgentIds must be unique, normalized, and sorted.",
+    );
+  }
+}
+
+function operationConflict(message: string, cause?: unknown): FinalRecoveryPointError {
+  return new FinalRecoveryPointError(
+    "final-capture.operation-conflict",
+    "quarantine",
+    message,
+    cause === undefined ? undefined : { cause },
+  );
+}

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -417,10 +417,7 @@ async function writeNewBytes(filePath: string, value: Buffer): Promise<void> {
   await syncDirectoryBestEffort(path.dirname(filePath));
 }
 
-async function readJsonIfPresent(
-  rootPath: string,
-  relativePath: string,
-): Promise<unknown> {
+async function readJsonIfPresent(rootPath: string, relativePath: string): Promise<unknown> {
   try {
     return await readJson(rootPath, relativePath);
   } catch (error) {

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -420,7 +420,7 @@ async function writeNewBytes(filePath: string, value: Buffer): Promise<void> {
 async function readJsonIfPresent(
   rootPath: string,
   relativePath: string,
-): Promise<unknown | undefined> {
+): Promise<unknown> {
   try {
     return await readJson(rootPath, relativePath);
   } catch (error) {

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -20,7 +20,7 @@ import {
 } from "./recovery-point.js";
 
 export const FINAL_RECOVERY_POINT_REQUEST_VERSION = "openclaw-final-recovery-point-request/v1";
-export const FINAL_RECOVERY_POINT_RESULT_VERSION = "openclaw-final-recovery-point-result/v1";
+const FINAL_RECOVERY_POINT_RESULT_VERSION = "openclaw-final-recovery-point-result/v1";
 
 const MAX_RECORD_BYTES = 1024 * 1024;
 const PRIVATE_DIRECTORY_MODE = 0o700;

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
+import { stableStringify } from "@openclaw/normalization-core";
 import { z } from "zod";
-import { stableStringify } from "../agents/stable-stringify.js";
 import { resolveStateDir } from "../config/paths.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import {

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { z } from "zod";
 import { stableStringify } from "../agents/stable-stringify.js";
+import { resolveStateDir } from "../config/paths.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { requireDirectorySync, syncDirectory } from "../infra/directory-durability.js";
 import { ensureAbsoluteDirectory, root } from "../infra/fs-safe.js";
@@ -163,22 +164,10 @@ export async function captureFinalRecoveryPoint(
       sourceGeneration: request.sourceGeneration,
     }),
   );
+  const journalDirectory = path.join(resolveStateDir(), "recovery", "final-capture", operationId);
   const recoveryPointPath = path.join(request.repositoryPath, operationId);
-  try {
-    await ensurePrivateDirectory(recoveryPointPath);
-  } catch (error) {
-    if (error instanceof FinalRecoveryPointError) {
-      throw error;
-    }
-    throw new FinalRecoveryPointError(
-      "final-capture.snapshot-failed",
-      "hold",
-      "Final recovery-point repository could not be prepared.",
-      { cause: error },
-    );
-  }
-
-  const journalPath = resolveRecoveryJournalPath(recoveryPointPath);
+  await prepareOperationDirectory(journalDirectory, "operation journal");
+  const journalPath = resolveRecoveryJournalPath(journalDirectory);
   const existingResult = await readJournalRecord(journalPath, "result");
   const existingIntent = await readJournalRecord(journalPath, "intent");
   if (existingResult !== undefined) {
@@ -192,6 +181,7 @@ export async function captureFinalRecoveryPoint(
       "Final recovery-point capture has durable intent without a committed result.",
     );
   }
+  await prepareOperationDirectory(recoveryPointPath, "repository");
   await writeJournalRecord(journalPath, "intent", request);
 
   let snapshots: RecoveryPointSqliteSnapshot[];
@@ -389,6 +379,22 @@ function buildResult(params: {
       artifactSizeBytes: params.acceptance.components[index]!.artifactSizeBytes,
     })),
   });
+}
+
+async function prepareOperationDirectory(directoryPath: string, label: string): Promise<void> {
+  try {
+    await ensurePrivateDirectory(directoryPath);
+  } catch (error) {
+    if (error instanceof FinalRecoveryPointError) {
+      throw error;
+    }
+    throw new FinalRecoveryPointError(
+      "final-capture.snapshot-failed",
+      "hold",
+      `Final recovery-point ${label} could not be prepared.`,
+      { cause: error },
+    );
+  }
 }
 
 async function ensurePrivateDirectory(directoryPath: string): Promise<void> {

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -191,7 +191,7 @@ export async function captureFinalRecoveryPoint(
     }
     throw new FinalRecoveryPointError(
       "final-capture.snapshot-failed",
-      "hold",
+      "quarantine",
       "Final recovery-point SQLite capture failed after durable intent.",
       { cause: error },
     );
@@ -213,7 +213,7 @@ export async function captureFinalRecoveryPoint(
   } catch (error) {
     throw new FinalRecoveryPointError(
       "final-capture.verification-failed",
-      "hold",
+      "quarantine",
       "Final recovery-point aggregate verification failed after durable intent.",
       { cause: error },
     );

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -8,7 +8,6 @@ import { sha256Hex } from "../infra/crypto-digest.js";
 import { requireDirectorySync, syncDirectory } from "../infra/directory-durability.js";
 import { ensureAbsoluteDirectory, root } from "../infra/fs-safe.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
-import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createLocalSqliteSnapshotProvider } from "./local-repository.js";
@@ -21,6 +20,7 @@ import {
   createRecoveryPointManifest,
   recoveryPointOwnerInventorySchema,
   verifyRecoveryPoint,
+  verifyRecoveryPointOwnerInventory,
   type RecoveryPointAcceptance,
   type RecoveryPointManifest,
   type RecoveryPointSqliteSnapshot,
@@ -142,7 +142,16 @@ export function parseFinalRecoveryPointRequest(raw: string): FinalRecoveryPointR
     );
   }
   assertCanonicalTimestamp(request.capturedAt);
-  assertAgentInventory(request.ownerInventory.agentIds);
+  try {
+    verifyRecoveryPointOwnerInventory(request.ownerInventory);
+  } catch (error) {
+    throw new FinalRecoveryPointError(
+      "final-capture.request-invalid",
+      "quarantine",
+      "Final recovery-point owner inventory is invalid.",
+      { cause: error },
+    );
+  }
   if (request.ownerInventory.sourceRuntimeGeneration !== request.sourceGeneration) {
     throw new FinalRecoveryPointError(
       "final-capture.request-invalid",
@@ -473,23 +482,6 @@ function assertCanonicalTimestamp(value: string): void {
       "final-capture.request-invalid",
       "quarantine",
       "Final recovery-point capturedAt must be a canonical timestamp.",
-    );
-  }
-}
-
-function assertAgentInventory(agentIds: readonly string[]): void {
-  const normalized = agentIds.map((agentId) => normalizeAgentId(agentId));
-  if (
-    normalized.some(
-      (agentId, index) => !isValidAgentId(agentIds[index]!) || agentId !== agentIds[index],
-    ) ||
-    new Set(normalized).size !== normalized.length ||
-    !isDeepStrictEqual(normalized, normalized.toSorted())
-  ) {
-    throw new FinalRecoveryPointError(
-      "final-capture.request-invalid",
-      "quarantine",
-      "Final recovery-point owner inventory agentIds must be unique, normalized, and sorted.",
     );
   }
 }

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -5,12 +5,17 @@ import { z } from "zod";
 import { stableStringify } from "../agents/stable-stringify.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { requireDirectorySync, syncDirectory } from "../infra/directory-durability.js";
-import { ensureAbsoluteDirectory, FsSafeError, root } from "../infra/fs-safe.js";
+import { ensureAbsoluteDirectory, root } from "../infra/fs-safe.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createLocalSqliteSnapshotProvider } from "./local-repository.js";
+import {
+  readRecoveryJournalRecord,
+  resolveRecoveryJournalPath,
+  writeRecoveryJournalRecord,
+} from "./recovery-journal.js";
 import {
   createRecoveryPointManifest,
   verifyRecoveryPoint,
@@ -165,10 +170,9 @@ export async function captureFinalRecoveryPoint(
     );
   }
 
-  const intentPath = path.join(recoveryPointPath, "intent.json");
-  const resultPath = path.join(recoveryPointPath, "result.json");
-  const existingResult = await readJsonIfPresent(recoveryPointPath, "result.json");
-  const existingIntent = await readJsonIfPresent(recoveryPointPath, "intent.json");
+  const journalPath = resolveRecoveryJournalPath(recoveryPointPath);
+  const existingResult = await readJournalRecord(journalPath, "result");
+  const existingIntent = await readJournalRecord(journalPath, "intent");
   if (existingResult !== undefined) {
     if (!isDeepStrictEqual(existingIntent, request)) {
       throw operationConflict("Committed final recovery point has conflicting intent evidence.");
@@ -180,7 +184,7 @@ export async function captureFinalRecoveryPoint(
       "Final recovery-point capture has durable intent without a committed result.",
     );
   }
-  await writeCaptureRecord(intentPath, request, "intent");
+  await writeJournalRecord(journalPath, "intent", request);
 
   let snapshots: RecoveryPointSqliteSnapshot[];
   try {
@@ -233,7 +237,7 @@ export async function captureFinalRecoveryPoint(
     acceptance,
     snapshots,
   });
-  await writeCaptureRecord(resultPath, result, "committed result");
+  await writeJournalRecord(journalPath, "result", result);
   return result;
 }
 
@@ -394,10 +398,6 @@ async function ensurePrivateDirectory(directoryPath: string): Promise<void> {
   applyPrivateModeSync(result.path, PRIVATE_DIRECTORY_MODE);
 }
 
-async function writeCaptureRecord(filePath: string, value: unknown, label: string): Promise<void> {
-  await writeCaptureBytes(filePath, Buffer.from(`${stableStringify(value)}\n`, "utf8"), label);
-}
-
 async function writeCaptureBytes(filePath: string, value: Buffer, label: string): Promise<void> {
   try {
     await writeNewBytes(filePath, value);
@@ -417,17 +417,23 @@ async function writeNewBytes(filePath: string, value: Buffer): Promise<void> {
   requireDirectorySync(await syncDirectory(path.dirname(filePath)), "Final recovery-point journal");
 }
 
-async function readJsonIfPresent(rootPath: string, relativePath: string): Promise<unknown> {
+async function readJournalRecord(databasePath: string, recordType: string): Promise<unknown> {
   try {
-    return await readJson(rootPath, relativePath);
+    return await readRecoveryJournalRecord(databasePath, recordType);
   } catch (error) {
-    if (
-      (error as NodeJS.ErrnoException).code === "ENOENT" ||
-      (error instanceof FsSafeError && error.code === "not-found")
-    ) {
-      return undefined;
-    }
-    throw operationConflict(`Final recovery-point ${relativePath} is unreadable.`, error);
+    throw operationConflict(`Final recovery-point ${recordType} is unreadable.`, error);
+  }
+}
+
+async function writeJournalRecord(
+  databasePath: string,
+  recordType: string,
+  value: unknown,
+): Promise<void> {
+  try {
+    await writeRecoveryJournalRecord(databasePath, recordType, value);
+  } catch (error) {
+    throw operationConflict(`Final recovery-point ${recordType} could not be committed.`, error);
   }
 }
 

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -4,9 +4,9 @@ import { isDeepStrictEqual } from "node:util";
 import { z } from "zod";
 import { stableStringify } from "../agents/stable-stringify.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
+import { requireDirectorySync, syncDirectory } from "../infra/directory-durability.js";
 import { ensureAbsoluteDirectory, FsSafeError, root } from "../infra/fs-safe.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
-import { syncDirectoryBestEffort } from "../infra/sqlite-snapshot.js";
 import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
@@ -414,7 +414,7 @@ async function writeNewBytes(filePath: string, value: Buffer): Promise<void> {
   } finally {
     await handle.close();
   }
-  await syncDirectoryBestEffort(path.dirname(filePath));
+  requireDirectorySync(await syncDirectory(path.dirname(filePath)), "Final recovery-point journal");
 }
 
 async function readJsonIfPresent(rootPath: string, relativePath: string): Promise<unknown> {

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -6,6 +6,7 @@ import { stableStringify } from "../agents/stable-stringify.js";
 import { resolveStateDir } from "../config/paths.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import {
+  ensureDurableDirectory,
   pinDirectory,
   requireDirectorySync,
   type PinnedDirectory,
@@ -13,6 +14,7 @@ import {
 import { ensureAbsoluteDirectory, root } from "../infra/fs-safe.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db-registry.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createLocalSqliteSnapshotProvider } from "./local-repository.js";
 import {
@@ -309,12 +311,19 @@ function resolveOwnerAgentDatabases(request: FinalRecoveryPointRequest): Array<{
 }> {
   const expectedAgentIds = request.ownerInventory.agentIds;
   const expected = new Set(expectedAgentIds);
-  const registered = listOpenClawRegisteredAgentDatabases();
+  const registered = listOpenClawRegisteredAgentDatabases({
+    includeIncompatibleSchemaVersions: true,
+  });
   const byAgentId = new Map<string, string>();
   for (const entry of registered) {
     if (!expected.has(entry.agentId)) {
       throw operationConflict(
         `Final recovery-point inventory omitted registered agent database: ${entry.agentId}.`,
+      );
+    }
+    if (entry.schemaVersion !== OPENCLAW_AGENT_SCHEMA_VERSION) {
+      throw operationConflict(
+        `Final recovery-point inventory cannot capture incompatible registered agent database: ${entry.agentId}.`,
       );
     }
     const existing = byAgentId.get(entry.agentId);
@@ -466,18 +475,26 @@ async function prepareOperationDirectory(directoryPath: string, label: string): 
 }
 
 async function ensurePrivateDirectory(directoryPath: string): Promise<void> {
-  const result = await ensureAbsoluteDirectory(directoryPath, {
-    mode: PRIVATE_DIRECTORY_MODE,
-    scopeLabel: "final recovery-point repository",
+  const receipt = await ensureDurableDirectory({
+    directoryPath,
+    label: "final recovery-point repository",
+    create: async (targetPath) => {
+      const result = await ensureAbsoluteDirectory(targetPath, {
+        mode: PRIVATE_DIRECTORY_MODE,
+        scopeLabel: "final recovery-point repository",
+      });
+      if (!result.ok) {
+        throw result.error;
+      }
+      applyPrivateModeSync(result.path, PRIVATE_DIRECTORY_MODE);
+    },
   });
-  if (!result.ok) {
-    throw result.error;
-  }
-  const stat = await fs.lstat(result.path);
+  requireDirectorySync(receipt.parentSync, "final recovery-point repository");
+  const stat = await fs.lstat(receipt.path);
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw operationConflict("Final recovery-point path is not a trusted directory.");
   }
-  applyPrivateModeSync(result.path, PRIVATE_DIRECTORY_MODE);
+  applyPrivateModeSync(receipt.path, PRIVATE_DIRECTORY_MODE);
 }
 
 async function pinRecoveryPointDirectory(directoryPath: string): Promise<PinnedDirectory> {

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -5,10 +5,14 @@ import { z } from "zod";
 import { stableStringify } from "../agents/stable-stringify.js";
 import { resolveStateDir } from "../config/paths.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
-import { requireDirectorySync, syncDirectory } from "../infra/directory-durability.js";
+import {
+  pinDirectory,
+  requireDirectorySync,
+  type PinnedDirectory,
+} from "../infra/directory-durability.js";
 import { ensureAbsoluteDirectory, root } from "../infra/fs-safe.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
-import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
+import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createLocalSqliteSnapshotProvider } from "./local-repository.js";
 import {
@@ -191,69 +195,78 @@ export async function captureFinalRecoveryPoint(
     );
   }
   await prepareOperationDirectory(recoveryPointPath, "repository");
-  await writeJournalRecord(journalPath, "intent", request);
-
-  let snapshots: RecoveryPointSqliteSnapshot[];
+  const recoveryPointDirectory = await pinRecoveryPointDirectory(recoveryPointPath);
   try {
-    snapshots = await captureSqliteInventory(request, recoveryPointPath);
-  } catch (error) {
-    if (error instanceof FinalRecoveryPointError) {
-      throw error;
+    await writeJournalRecord(journalPath, "intent", request);
+
+    let snapshots: RecoveryPointSqliteSnapshot[];
+    try {
+      snapshots = await captureSqliteInventory(request, recoveryPointPath, recoveryPointDirectory);
+    } catch (error) {
+      if (error instanceof FinalRecoveryPointError) {
+        throw error;
+      }
+      throw new FinalRecoveryPointError(
+        "final-capture.snapshot-failed",
+        "quarantine",
+        "Final recovery-point SQLite capture failed after durable intent.",
+        { cause: error },
+      );
     }
-    throw new FinalRecoveryPointError(
-      "final-capture.snapshot-failed",
-      "quarantine",
-      "Final recovery-point SQLite capture failed after durable intent.",
-      { cause: error },
-    );
-  }
 
-  let manifest: RecoveryPointManifest;
-  let acceptance: RecoveryPointAcceptance;
-  try {
-    manifest = await createRecoveryPointManifest({
-      snapshots,
-      ownerInventory: request.ownerInventory,
-      now: () => new Date(request.capturedAt),
-    });
-    ({ acceptance } = await verifyRecoveryPoint({
+    let manifest: RecoveryPointManifest;
+    let acceptance: RecoveryPointAcceptance;
+    try {
+      manifest = await createRecoveryPointManifest({
+        snapshots,
+        ownerInventory: request.ownerInventory,
+        now: () => new Date(request.capturedAt),
+      });
+      ({ acceptance } = await verifyRecoveryPoint({
+        manifest,
+        snapshots,
+        ownerInventory: request.ownerInventory,
+      }));
+    } catch (error) {
+      throw new FinalRecoveryPointError(
+        "final-capture.verification-failed",
+        "quarantine",
+        "Final recovery-point aggregate verification failed after durable intent.",
+        { cause: error },
+      );
+    }
+
+    const aggregateManifestPath = path.join(recoveryPointPath, "manifest.json");
+    await recoveryPointDirectory.assertCurrent();
+    await writeCaptureBytes(
+      aggregateManifestPath,
+      Buffer.from(stableStringify(manifest), "utf8"),
+      "aggregate manifest",
+      recoveryPointDirectory,
+    );
+    const result = buildResult({
+      request,
+      recoveryPointPath,
+      aggregateManifestPath,
       manifest,
+      acceptance,
       snapshots,
-      ownerInventory: request.ownerInventory,
-    }));
-  } catch (error) {
-    throw new FinalRecoveryPointError(
-      "final-capture.verification-failed",
-      "quarantine",
-      "Final recovery-point aggregate verification failed after durable intent.",
-      { cause: error },
-    );
+    });
+    await writeJournalRecord(journalPath, "result", result);
+    return result;
+  } finally {
+    await recoveryPointDirectory.close().catch(() => undefined);
   }
-
-  const aggregateManifestPath = path.join(recoveryPointPath, "manifest.json");
-  await writeCaptureBytes(
-    aggregateManifestPath,
-    Buffer.from(stableStringify(manifest), "utf8"),
-    "aggregate manifest",
-  );
-  const result = buildResult({
-    request,
-    recoveryPointPath,
-    aggregateManifestPath,
-    manifest,
-    acceptance,
-    snapshots,
-  });
-  await writeJournalRecord(journalPath, "result", result);
-  return result;
 }
 
 async function captureSqliteInventory(
   request: FinalRecoveryPointRequest,
   recoveryPointPath: string,
+  recoveryPointDirectory: PinnedDirectory,
 ): Promise<RecoveryPointSqliteSnapshot[]> {
   const capturedAt = () => new Date(request.capturedAt);
   const componentsRoot = path.join(recoveryPointPath, "components");
+  const agentDatabases = resolveOwnerAgentDatabases(request);
   const captures = [
     {
       repositoryPath: path.join(componentsRoot, "global"),
@@ -261,15 +274,16 @@ async function captureSqliteInventory(
       identity: { role: "global" as const },
     },
     ...(await Promise.all(
-      request.ownerInventory.agentIds.map(async (agentId) => ({
+      agentDatabases.map(async ({ agentId, path: databasePath }) => ({
         repositoryPath: path.join(componentsRoot, "agents", agentId),
-        databasePath: await fs.realpath(resolveOpenClawAgentSqlitePath({ agentId })),
+        databasePath: await fs.realpath(databasePath),
         identity: { role: "agent" as const, agentId },
       })),
     )),
   ];
   const snapshots: RecoveryPointSqliteSnapshot[] = [];
   for (const capture of captures) {
+    await recoveryPointDirectory.assertCurrent();
     const provider = createLocalSqliteSnapshotProvider({
       repositoryPath: capture.repositoryPath,
       allowedDatabaseRoles: [capture.identity.role],
@@ -282,9 +296,44 @@ async function captureSqliteInventory(
       path: capture.databasePath,
       identity: capture.identity,
     });
+    await recoveryPointDirectory.assertCurrent();
     snapshots.push({ provider, ref: created.ref });
   }
+  requireDirectorySync(await recoveryPointDirectory.sync(), "Final recovery-point repository");
   return snapshots;
+}
+
+function resolveOwnerAgentDatabases(request: FinalRecoveryPointRequest): Array<{
+  agentId: string;
+  path: string;
+}> {
+  const expectedAgentIds = request.ownerInventory.agentIds;
+  const expected = new Set(expectedAgentIds);
+  const registered = listOpenClawRegisteredAgentDatabases();
+  const byAgentId = new Map<string, string>();
+  for (const entry of registered) {
+    if (!expected.has(entry.agentId)) {
+      throw operationConflict(
+        `Final recovery-point inventory omitted registered agent database: ${entry.agentId}.`,
+      );
+    }
+    const existing = byAgentId.get(entry.agentId);
+    if (existing !== undefined && existing !== entry.path) {
+      throw operationConflict(
+        `Final recovery-point inventory cannot represent multiple registered databases for agent: ${entry.agentId}.`,
+      );
+    }
+    byAgentId.set(entry.agentId, entry.path);
+  }
+  return expectedAgentIds.map((agentId) => {
+    const databasePath = byAgentId.get(agentId);
+    if (!databasePath) {
+      throw operationConflict(
+        `Final recovery-point inventory includes unregistered agent database: ${agentId}.`,
+      );
+    }
+    return { agentId, path: databasePath };
+  });
 }
 
 async function verifyCommittedResult(
@@ -300,7 +349,14 @@ async function verifyCommittedResult(
   let snapshots: RecoveryPointSqliteSnapshot[];
   let verified: Awaited<ReturnType<typeof verifyRecoveryPoint>>;
   try {
-    manifest = (await readJson(recoveryPointPath, "manifest.json")) as RecoveryPointManifest;
+    const manifestRead = await readAggregateManifest(recoveryPointPath, "manifest.json");
+    if (
+      manifestRead.sha256 !== parsedResult.data.aggregateManifestSha256 ||
+      manifestRead.sizeBytes !== parsedResult.data.aggregateManifestSizeBytes
+    ) {
+      throw operationConflict("Committed final recovery-point manifest bytes changed.");
+    }
+    manifest = manifestRead.parsed as RecoveryPointManifest;
     snapshots = await resolveCommittedSnapshots(recoveryPointPath, request.ownerInventory.agentIds);
     verified = await verifyRecoveryPoint({
       manifest,
@@ -308,6 +364,9 @@ async function verifyCommittedResult(
       ownerInventory: request.ownerInventory,
     });
   } catch (error) {
+    if (error instanceof FinalRecoveryPointError) {
+      throw error;
+    }
     throw new FinalRecoveryPointError(
       "final-capture.verification-failed",
       "quarantine",
@@ -421,15 +480,41 @@ async function ensurePrivateDirectory(directoryPath: string): Promise<void> {
   applyPrivateModeSync(result.path, PRIVATE_DIRECTORY_MODE);
 }
 
-async function writeCaptureBytes(filePath: string, value: Buffer, label: string): Promise<void> {
+async function pinRecoveryPointDirectory(directoryPath: string): Promise<PinnedDirectory> {
   try {
-    await writeNewBytes(filePath, value);
+    const pinned = await pinDirectory(directoryPath, { label: "Final recovery-point repository" });
+    await pinned.assertCurrent();
+    requireDirectorySync(await pinned.sync(), "Final recovery-point repository");
+    return pinned;
+  } catch (error) {
+    throw new FinalRecoveryPointError(
+      "final-capture.snapshot-failed",
+      "hold",
+      "Final recovery-point repository could not be pinned.",
+      { cause: error },
+    );
+  }
+}
+
+async function writeCaptureBytes(
+  filePath: string,
+  value: Buffer,
+  label: string,
+  parentDirectory: PinnedDirectory,
+): Promise<void> {
+  try {
+    await writeNewBytes(filePath, value, parentDirectory);
   } catch (error) {
     throw operationConflict(`Final recovery-point ${label} could not be committed.`, error);
   }
 }
 
-async function writeNewBytes(filePath: string, value: Buffer): Promise<void> {
+async function writeNewBytes(
+  filePath: string,
+  value: Buffer,
+  parentDirectory: PinnedDirectory,
+): Promise<void> {
+  await parentDirectory.assertCurrent();
   const handle = await fs.open(filePath, "wx", PRIVATE_FILE_MODE);
   try {
     await handle.writeFile(value);
@@ -437,7 +522,8 @@ async function writeNewBytes(filePath: string, value: Buffer): Promise<void> {
   } finally {
     await handle.close();
   }
-  requireDirectorySync(await syncDirectory(path.dirname(filePath)), "Final recovery-point journal");
+  await parentDirectory.assertCurrent();
+  requireDirectorySync(await parentDirectory.sync(), "Final recovery-point repository");
 }
 
 async function readJournalRecord(databasePath: string, recordType: string): Promise<unknown> {
@@ -460,7 +546,10 @@ async function writeJournalRecord(
   }
 }
 
-async function readJson(rootPath: string, relativePath: string): Promise<unknown> {
+async function readAggregateManifest(
+  rootPath: string,
+  relativePath: string,
+): Promise<{ parsed: unknown; sha256: string; sizeBytes: number }> {
   const read = await (
     await root(rootPath)
   ).read(relativePath, {
@@ -469,7 +558,11 @@ async function readJson(rootPath: string, relativePath: string): Promise<unknown
     symlinks: "reject",
   });
   try {
-    return JSON.parse(read.buffer.toString("utf8")) as unknown;
+    return {
+      parsed: JSON.parse(read.buffer.toString("utf8")) as unknown,
+      sha256: sha256Hex(read.buffer),
+      sizeBytes: read.buffer.byteLength,
+    };
   } catch (error) {
     throw operationConflict(`Final recovery-point ${relativePath} is not valid JSON.`, error);
   }

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -18,6 +18,7 @@ import {
 } from "./recovery-journal.js";
 import {
   createRecoveryPointManifest,
+  recoveryPointOwnerInventorySchema,
   verifyRecoveryPoint,
   type RecoveryPointAcceptance,
   type RecoveryPointManifest,
@@ -40,7 +41,7 @@ const finalRecoveryPointRequestSchema = z
     sourceGeneration: z.string().regex(SAFE_ID_PATTERN),
     capturedAt: z.string(),
     repositoryPath: z.string().min(1),
-    expectedAgentIds: z.array(z.string().min(1).max(64)).min(1),
+    ownerInventory: recoveryPointOwnerInventorySchema,
     closure: z
       .object({
         gateway: z.literal("cleanly-stopped"),
@@ -140,7 +141,14 @@ export function parseFinalRecoveryPointRequest(raw: string): FinalRecoveryPointR
     );
   }
   assertCanonicalTimestamp(request.capturedAt);
-  assertAgentInventory(request.expectedAgentIds);
+  assertAgentInventory(request.ownerInventory.agentIds);
+  if (request.ownerInventory.sourceRuntimeGeneration !== request.sourceGeneration) {
+    throw new FinalRecoveryPointError(
+      "final-capture.request-invalid",
+      "quarantine",
+      "Final recovery-point owner inventory must match sourceGeneration.",
+    );
+  }
   return request;
 }
 
@@ -206,13 +214,13 @@ export async function captureFinalRecoveryPoint(
   try {
     manifest = await createRecoveryPointManifest({
       snapshots,
-      expectedAgentIds: request.expectedAgentIds,
+      ownerInventory: request.ownerInventory,
       now: () => new Date(request.capturedAt),
     });
     ({ acceptance } = await verifyRecoveryPoint({
       manifest,
       snapshots,
-      expectedAgentIds: request.expectedAgentIds,
+      ownerInventory: request.ownerInventory,
     }));
   } catch (error) {
     throw new FinalRecoveryPointError(
@@ -254,7 +262,7 @@ async function captureSqliteInventory(
       identity: { role: "global" as const },
     },
     ...(await Promise.all(
-      request.expectedAgentIds.map(async (agentId) => ({
+      request.ownerInventory.agentIds.map(async (agentId) => ({
         repositoryPath: path.join(componentsRoot, "agents", agentId),
         databasePath: await fs.realpath(resolveOpenClawAgentSqlitePath({ agentId })),
         identity: { role: "agent" as const, agentId },
@@ -294,11 +302,11 @@ async function verifyCommittedResult(
   let verified: Awaited<ReturnType<typeof verifyRecoveryPoint>>;
   try {
     manifest = (await readJson(recoveryPointPath, "manifest.json")) as RecoveryPointManifest;
-    snapshots = await resolveCommittedSnapshots(recoveryPointPath, request.expectedAgentIds);
+    snapshots = await resolveCommittedSnapshots(recoveryPointPath, request.ownerInventory.agentIds);
     verified = await verifyRecoveryPoint({
       manifest,
       snapshots,
-      expectedAgentIds: request.expectedAgentIds,
+      ownerInventory: request.ownerInventory,
     });
   } catch (error) {
     throw new FinalRecoveryPointError(
@@ -324,14 +332,14 @@ async function verifyCommittedResult(
 
 async function resolveCommittedSnapshots(
   recoveryPointPath: string,
-  expectedAgentIds: readonly string[],
+  agentIds: readonly string[],
 ): Promise<RecoveryPointSqliteSnapshot[]> {
   const repositories = [
     {
       repositoryPath: path.join(recoveryPointPath, "components", "global"),
       role: "global" as const,
     },
-    ...expectedAgentIds.map((agentId) => ({
+    ...agentIds.map((agentId) => ({
       repositoryPath: path.join(recoveryPointPath, "components", "agents", agentId),
       role: "agent" as const,
     })),
@@ -475,7 +483,7 @@ function assertAgentInventory(agentIds: readonly string[]): void {
     throw new FinalRecoveryPointError(
       "final-capture.request-invalid",
       "quarantine",
-      "Final recovery-point expectedAgentIds must be unique, normalized, and sorted.",
+      "Final recovery-point owner inventory agentIds must be unique, normalized, and sorted.",
     );
   }
 }

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -364,7 +364,6 @@ async function verifyCommittedResult(
   if (!parsedResult.success) {
     throw operationConflict("Committed final recovery-point result is invalid.");
   }
-  let manifest: RecoveryPointManifest;
   let snapshots: RecoveryPointSqliteSnapshot[];
   let verified: Awaited<ReturnType<typeof verifyRecoveryPoint>>;
   try {
@@ -375,10 +374,9 @@ async function verifyCommittedResult(
     ) {
       throw operationConflict("Committed final recovery-point manifest bytes changed.");
     }
-    manifest = manifestRead.parsed as RecoveryPointManifest;
     snapshots = await resolveCommittedSnapshots(recoveryPointPath, request.ownerInventory.agentIds);
     verified = await verifyRecoveryPoint({
-      manifest,
+      manifest: manifestRead.parsed,
       snapshots,
       ownerInventory: request.ownerInventory,
     });

--- a/src/snapshot/final-recovery-point.ts
+++ b/src/snapshot/final-recovery-point.ts
@@ -24,13 +24,23 @@ import {
 } from "./recovery-journal.js";
 import {
   createRecoveryPointManifest,
-  recoveryPointOwnerInventorySchema,
   verifyRecoveryPoint,
   verifyRecoveryPointOwnerInventory,
   type RecoveryPointAcceptance,
   type RecoveryPointManifest,
   type RecoveryPointSqliteSnapshot,
 } from "./recovery-point.js";
+
+const recoveryPointOwnerInventoryInputSchema = z.custom<
+  ReturnType<typeof verifyRecoveryPointOwnerInventory>
+>((value) => {
+  try {
+    verifyRecoveryPointOwnerInventory(value);
+    return true;
+  } catch {
+    return false;
+  }
+}, "inventory is invalid");
 
 export const FINAL_RECOVERY_POINT_REQUEST_VERSION = "openclaw-final-recovery-point-request/v1";
 const FINAL_RECOVERY_POINT_RESULT_VERSION = "openclaw-final-recovery-point-result/v1";
@@ -48,7 +58,7 @@ const finalRecoveryPointRequestSchema = z
     sourceGeneration: z.string().regex(SAFE_ID_PATTERN),
     capturedAt: z.string(),
     repositoryPath: z.string().min(1),
-    ownerInventory: recoveryPointOwnerInventorySchema,
+    ownerInventory: recoveryPointOwnerInventoryInputSchema,
     closure: z
       .object({
         gateway: z.literal("cleanly-stopped"),

--- a/src/snapshot/recovery-journal.test.ts
+++ b/src/snapshot/recovery-journal.test.ts
@@ -1,0 +1,47 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const sqliteOpenState = vi.hoisted(() => ({
+  beforeOpen: undefined as undefined | ((databasePath: string) => Promise<void> | void),
+}));
+
+vi.mock("../infra/node-sqlite.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/node-sqlite.js")>();
+  return {
+    ...actual,
+    openNodeSqliteDatabase: (
+      ...args: Parameters<typeof actual.openNodeSqliteDatabase>
+    ): ReturnType<typeof actual.openNodeSqliteDatabase> => {
+      const [databasePath] = args;
+      sqliteOpenState.beforeOpen?.(databasePath);
+      return actual.openNodeSqliteDatabase(...args);
+    },
+  };
+});
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  sqliteOpenState.beforeOpen = undefined;
+});
+
+describe("recovery journal", () => {
+  it("rejects a journal pathname replacement before SQLite writes", async () => {
+    const { writeRecoveryJournalRecord } = await import("./recovery-journal.js");
+    const root = tempDirs.make("openclaw-recovery-journal-race-");
+    const journalPath = path.join(root, "recovery-journal.sqlite");
+    await fs.mkdir(root, { recursive: true, mode: 0o700 });
+    await fs.writeFile(journalPath, "", { mode: 0o600 });
+    sqliteOpenState.beforeOpen = (databasePath) => {
+      fsSync.renameSync(databasePath, `${databasePath}.replaced`);
+      fsSync.writeFileSync(databasePath, "", { mode: 0o600 });
+    };
+
+    await expect(writeRecoveryJournalRecord(journalPath, "intent", { ok: true })).rejects.toThrow(
+      "Recovery journal identity changed before SQLite ownership was established.",
+    );
+  });
+});

--- a/src/snapshot/recovery-journal.test.ts
+++ b/src/snapshot/recovery-journal.test.ts
@@ -16,7 +16,7 @@ vi.mock("../infra/node-sqlite.js", async (importOriginal) => {
       ...args: Parameters<typeof actual.openNodeSqliteDatabase>
     ): ReturnType<typeof actual.openNodeSqliteDatabase> => {
       const [databasePath] = args;
-      sqliteOpenState.beforeOpen?.(databasePath);
+      void sqliteOpenState.beforeOpen?.(databasePath);
       return actual.openNodeSqliteDatabase(...args);
     },
   };

--- a/src/snapshot/recovery-journal.test.ts
+++ b/src/snapshot/recovery-journal.test.ts
@@ -6,7 +6,20 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const sqliteOpenState = vi.hoisted(() => ({
   beforeOpen: undefined as undefined | ((databasePath: string) => Promise<void> | void),
+  afterQuery: undefined as undefined | (() => void),
 }));
+
+vi.mock("../infra/kysely-sync.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/kysely-sync.js")>();
+  return {
+    ...actual,
+    executeSqliteQuerySync: (...args: Parameters<typeof actual.executeSqliteQuerySync>) => {
+      const result = actual.executeSqliteQuerySync(...args);
+      sqliteOpenState.afterQuery?.();
+      return result;
+    },
+  };
+});
 
 vi.mock("../infra/node-sqlite.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../infra/node-sqlite.js")>();
@@ -26,6 +39,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
   sqliteOpenState.beforeOpen = undefined;
+  sqliteOpenState.afterQuery = undefined;
 });
 
 describe("recovery journal", () => {
@@ -42,6 +56,22 @@ describe("recovery journal", () => {
 
     await expect(writeRecoveryJournalRecord(journalPath, "intent", { ok: true })).rejects.toThrow(
       "Recovery journal identity changed before SQLite ownership was established.",
+    );
+  });
+
+  it("rejects a journal pathname replacement after the record write", async () => {
+    const { writeRecoveryJournalRecord } = await import("./recovery-journal.js");
+    const root = tempDirs.make("openclaw-recovery-journal-late-race-");
+    const journalPath = path.join(root, "recovery-journal.sqlite");
+    await fs.mkdir(root, { recursive: true, mode: 0o700 });
+    sqliteOpenState.afterQuery = () => {
+      fsSync.renameSync(journalPath, `${journalPath}.replaced`);
+      fsSync.writeFileSync(journalPath, "", { mode: 0o600 });
+      sqliteOpenState.afterQuery = undefined;
+    };
+
+    await expect(writeRecoveryJournalRecord(journalPath, "intent", { ok: true })).rejects.toThrow(
+      "Recovery journal identity changed during record commit.",
     );
   });
 });

--- a/src/snapshot/recovery-journal.ts
+++ b/src/snapshot/recovery-journal.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { stableStringify } from "@openclaw/normalization-core";
 import type { Insertable, Selectable } from "kysely";
-import { stableStringify } from "../agents/stable-stringify.js";
 import { requireDirectorySync, syncDirectory } from "../infra/directory-durability.js";
 import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";

--- a/src/snapshot/recovery-journal.ts
+++ b/src/snapshot/recovery-journal.ts
@@ -96,7 +96,7 @@ export async function writeRecoveryJournalRecord(
 }
 
 async function openRecoveryJournal(databasePath: string) {
-  const existed = await fs
+  await fs
     .lstat(databasePath)
     .then((stat) => {
       if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
@@ -122,9 +122,7 @@ async function openRecoveryJournal(databasePath: string) {
       ) STRICT;
     `);
     applyPrivateModeSync(databasePath, PRIVATE_FILE_MODE);
-    if (!existed) {
-      requireDirectorySync(await syncDirectory(path.dirname(databasePath)), "Recovery journal");
-    }
+    requireDirectorySync(await syncDirectory(path.dirname(databasePath)), "Recovery journal");
     return database;
   } catch (error) {
     database.close();

--- a/src/snapshot/recovery-journal.ts
+++ b/src/snapshot/recovery-journal.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { Insertable, Selectable } from "kysely";
 import { stableStringify } from "../agents/stable-stringify.js";
 import { requireDirectorySync, syncDirectory } from "../infra/directory-durability.js";
+import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
@@ -96,22 +97,18 @@ export async function writeRecoveryJournalRecord(
 }
 
 async function openRecoveryJournal(databasePath: string) {
-  await fs
-    .lstat(databasePath)
-    .then((stat) => {
-      if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
-        throw new RecoveryJournalError("corrupt", "Recovery journal is not a trusted file.");
-      }
-      return true;
-    })
-    .catch((error: unknown) => {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        return false;
-      }
-      throw error;
-    });
+  const expectedIdentity =
+    (await readTrustedRecoveryJournalIdentity(databasePath)) ??
+    (await createTrustedRecoveryJournalFile(databasePath));
   const database = openNodeSqliteDatabase(databasePath);
   try {
+    const openedIdentity = await readTrustedRecoveryJournalIdentity(databasePath);
+    if (!openedIdentity || !sameFileIdentity(expectedIdentity, openedIdentity)) {
+      throw new RecoveryJournalError(
+        "corrupt",
+        "Recovery journal identity changed before SQLite ownership was established.",
+      );
+    }
     // sqlite-allow-raw -- this boundary owns dedicated journal bootstrap DDL and durability pragmas.
     database.exec(`
       PRAGMA journal_mode = DELETE;
@@ -127,5 +124,36 @@ async function openRecoveryJournal(databasePath: string) {
   } catch (error) {
     database.close();
     throw error;
+  }
+}
+
+async function readTrustedRecoveryJournalIdentity(databasePath: string) {
+  return await fs
+    .lstat(databasePath)
+    .then((stat) => {
+      if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
+        throw new RecoveryJournalError("corrupt", "Recovery journal is not a trusted file.");
+      }
+      return stat;
+    })
+    .catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return undefined;
+      }
+      throw error;
+    });
+}
+
+async function createTrustedRecoveryJournalFile(databasePath: string) {
+  const handle = await fs.open(databasePath, "wx", PRIVATE_FILE_MODE);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.nlink !== 1) {
+      throw new RecoveryJournalError("corrupt", "Recovery journal is not a trusted file.");
+    }
+    await handle.sync();
+    return stat;
+  } finally {
+    await handle.close();
   }
 }

--- a/src/snapshot/recovery-journal.ts
+++ b/src/snapshot/recovery-journal.ts
@@ -19,7 +19,7 @@ type RecoveryJournalDatabase = {
   recovery_journal_records: RecoveryJournalRecordTable;
 };
 
-export class RecoveryJournalError extends Error {
+class RecoveryJournalError extends Error {
   constructor(
     public readonly kind: "conflict" | "corrupt",
     message: string,
@@ -37,7 +37,7 @@ export function resolveRecoveryJournalPath(directoryPath: string): string {
 export async function readRecoveryJournalRecord(
   databasePath: string,
   recordType: string,
-): Promise<unknown | undefined> {
+): Promise<unknown> {
   const database = await openRecoveryJournal(databasePath);
   try {
     const kysely = getNodeSqliteKysely<RecoveryJournalDatabase>(database);
@@ -112,6 +112,7 @@ async function openRecoveryJournal(databasePath: string) {
     });
   const database = openNodeSqliteDatabase(databasePath);
   try {
+    // sqlite-allow-raw -- this boundary owns dedicated journal bootstrap DDL and durability pragmas.
     database.exec(`
       PRAGMA journal_mode = DELETE;
       PRAGMA synchronous = FULL;

--- a/src/snapshot/recovery-journal.ts
+++ b/src/snapshot/recovery-journal.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { Insertable, Selectable } from "kysely";
+import { stableStringify } from "../agents/stable-stringify.js";
+import { requireDirectorySync, syncDirectory } from "../infra/directory-durability.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { applyPrivateModeSync } from "../infra/private-mode.js";
+
+const DATABASE_FILENAME = "recovery-journal.sqlite";
+const PRIVATE_FILE_MODE = 0o600;
+
+type RecoveryJournalRecordTable = {
+  record_type: string;
+  payload_json: string;
+};
+
+type RecoveryJournalDatabase = {
+  recovery_journal_records: RecoveryJournalRecordTable;
+};
+
+export class RecoveryJournalError extends Error {
+  constructor(
+    public readonly kind: "conflict" | "corrupt",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "RecoveryJournalError";
+  }
+}
+
+export function resolveRecoveryJournalPath(directoryPath: string): string {
+  return path.join(directoryPath, DATABASE_FILENAME);
+}
+
+export async function readRecoveryJournalRecord(
+  databasePath: string,
+  recordType: string,
+): Promise<unknown | undefined> {
+  const database = await openRecoveryJournal(databasePath);
+  try {
+    const kysely = getNodeSqliteKysely<RecoveryJournalDatabase>(database);
+    const row = executeSqliteQuerySync(
+      database,
+      kysely
+        .selectFrom("recovery_journal_records")
+        .select(["record_type", "payload_json"])
+        .where("record_type", "=", recordType),
+    ).rows[0] as Selectable<RecoveryJournalRecordTable> | undefined;
+    if (!row) {
+      return undefined;
+    }
+    try {
+      return JSON.parse(row.payload_json) as unknown;
+    } catch (error) {
+      throw new RecoveryJournalError(
+        "corrupt",
+        `Recovery journal record is not valid JSON: ${recordType}.`,
+        { cause: error },
+      );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+export async function writeRecoveryJournalRecord(
+  databasePath: string,
+  recordType: string,
+  value: unknown,
+): Promise<void> {
+  const database = await openRecoveryJournal(databasePath);
+  try {
+    const kysely = getNodeSqliteKysely<RecoveryJournalDatabase>(database);
+    const record: Insertable<RecoveryJournalRecordTable> = {
+      record_type: recordType,
+      payload_json: stableStringify(value),
+    };
+    const written = executeSqliteQuerySync(
+      database,
+      kysely
+        .insertInto("recovery_journal_records")
+        .values(record)
+        .onConflict((conflict) => conflict.column("record_type").doNothing()),
+    );
+    if (written.numAffectedRows !== 1n) {
+      throw new RecoveryJournalError(
+        "conflict",
+        `Recovery journal record already exists: ${recordType}.`,
+      );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function openRecoveryJournal(databasePath: string) {
+  const existed = await fs
+    .lstat(databasePath)
+    .then((stat) => {
+      if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
+        throw new RecoveryJournalError("corrupt", "Recovery journal is not a trusted file.");
+      }
+      return true;
+    })
+    .catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return false;
+      }
+      throw error;
+    });
+  const database = openNodeSqliteDatabase(databasePath);
+  try {
+    database.exec(`
+      PRAGMA journal_mode = DELETE;
+      PRAGMA synchronous = FULL;
+      CREATE TABLE IF NOT EXISTS recovery_journal_records (
+        record_type TEXT PRIMARY KEY NOT NULL,
+        payload_json TEXT NOT NULL
+      ) STRICT;
+    `);
+    applyPrivateModeSync(databasePath, PRIVATE_FILE_MODE);
+    if (!existed) {
+      requireDirectorySync(await syncDirectory(path.dirname(databasePath)), "Recovery journal");
+    }
+    return database;
+  } catch (error) {
+    database.close();
+    throw error;
+  }
+}

--- a/src/snapshot/recovery-journal.ts
+++ b/src/snapshot/recovery-journal.ts
@@ -39,7 +39,7 @@ export async function readRecoveryJournalRecord(
   databasePath: string,
   recordType: string,
 ): Promise<unknown> {
-  const database = await openRecoveryJournal(databasePath);
+  const { database } = await openRecoveryJournal(databasePath);
   try {
     const kysely = getNodeSqliteKysely<RecoveryJournalDatabase>(database);
     const row = executeSqliteQuerySync(
@@ -71,7 +71,7 @@ export async function writeRecoveryJournalRecord(
   recordType: string,
   value: unknown,
 ): Promise<void> {
-  const database = await openRecoveryJournal(databasePath);
+  const { database, expectedIdentity } = await openRecoveryJournal(databasePath);
   try {
     const kysely = getNodeSqliteKysely<RecoveryJournalDatabase>(database);
     const record: Insertable<RecoveryJournalRecordTable> = {
@@ -91,6 +91,9 @@ export async function writeRecoveryJournalRecord(
         `Recovery journal record already exists: ${recordType}.`,
       );
     }
+    await assertRecoveryJournalIdentity(databasePath, expectedIdentity, "during record commit");
+    requireDirectorySync(await syncDirectory(path.dirname(databasePath)), "Recovery journal");
+    await assertRecoveryJournalIdentity(databasePath, expectedIdentity, "during record commit");
   } finally {
     database.close();
   }
@@ -120,7 +123,7 @@ async function openRecoveryJournal(databasePath: string) {
     `);
     applyPrivateModeSync(databasePath, PRIVATE_FILE_MODE);
     requireDirectorySync(await syncDirectory(path.dirname(databasePath)), "Recovery journal");
-    return database;
+    return { database, expectedIdentity };
   } catch (error) {
     database.close();
     throw error;
@@ -155,5 +158,16 @@ async function createTrustedRecoveryJournalFile(databasePath: string) {
     return stat;
   } finally {
     await handle.close();
+  }
+}
+
+async function assertRecoveryJournalIdentity(
+  databasePath: string,
+  expectedIdentity: Awaited<ReturnType<typeof createTrustedRecoveryJournalFile>>,
+  phase: string,
+): Promise<void> {
+  const currentIdentity = await readTrustedRecoveryJournalIdentity(databasePath);
+  if (!currentIdentity || !sameFileIdentity(expectedIdentity, currentIdentity)) {
+    throw new RecoveryJournalError("corrupt", `Recovery journal identity changed ${phase}.`);
   }
 }

--- a/src/snapshot/recovery-journal.ts
+++ b/src/snapshot/recovery-journal.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { stableStringify } from "@openclaw/normalization-core";
-import type { Insertable, Selectable } from "kysely";
+import type { Insertable } from "kysely";
 import { requireDirectorySync, syncDirectory } from "../infra/directory-durability.js";
+import { isErrno } from "../infra/errno.js";
 import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
@@ -48,7 +49,7 @@ export async function readRecoveryJournalRecord(
         .selectFrom("recovery_journal_records")
         .select(["record_type", "payload_json"])
         .where("record_type", "=", recordType),
-    ).rows[0] as Selectable<RecoveryJournalRecordTable> | undefined;
+    ).rows[0];
     if (!row) {
       return undefined;
     }
@@ -140,7 +141,7 @@ async function readTrustedRecoveryJournalIdentity(databasePath: string) {
       return stat;
     })
     .catch((error: unknown) => {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      if (isErrno(error) && error.code === "ENOENT") {
         return undefined;
       }
       throw error;

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -9,6 +9,8 @@ import {
   createRecoveryPointManifest,
   verifyRecoveryPoint,
   verifyRecoveryPointManifest,
+  type RecoveryPointAcceptance,
+  type RecoveryPointManifest,
   type RecoveryPointSqliteSnapshot,
 } from "./recovery-point.js";
 import type { SnapshotManifest, SnapshotRef, SqliteSnapshotProvider } from "./snapshot-provider.js";
@@ -50,7 +52,7 @@ describe("recovery point composition", () => {
       ],
     } as const;
 
-    const first = await createRecoveryPointManifest({
+    const first: RecoveryPointManifest = await createRecoveryPointManifest({
       snapshots: [agent.snapshot, global.snapshot],
       expectedAgentIds: ["main"],
       obligations,
@@ -76,7 +78,8 @@ describe("recovery point composition", () => {
     ]);
     expect(first.obligations.external).toEqual(obligations.external);
     expect(first.components.every((component) => component.ownerManifestSizeBytes > 0)).toBe(true);
-    expect(createRecoveryPointAcceptance(first)).toEqual(createRecoveryPointAcceptance(second));
+    const firstAcceptance: RecoveryPointAcceptance = createRecoveryPointAcceptance(first);
+    expect(firstAcceptance).toEqual(createRecoveryPointAcceptance(second));
     expect(global.verify).toHaveBeenCalledTimes(4);
     expect(agent.verify).toHaveBeenCalledTimes(4);
   });

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -1,0 +1,263 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
+import { stableStringify } from "../agents/stable-stringify.js";
+import {
+  createRecoveryPointManifest,
+  verifyRecoveryPoint,
+  verifyRecoveryPointManifest,
+  type RecoveryPointSqliteSnapshot,
+} from "./recovery-point.js";
+import type { SnapshotManifest, SnapshotRef, SqliteSnapshotProvider } from "./snapshot-provider.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((entry) => fs.rm(entry, { force: true, recursive: true })),
+  );
+});
+
+describe("recovery point composition", () => {
+  it("composes verified global and agent snapshots into one deterministic identity", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const now = () => new Date("2026-07-21T16:00:00.000Z");
+    const obligations = {
+      external: [{ id: "secret/provider-api-key", owner: "secrets", readinessRequired: true }],
+      reconstructed: [{ id: "plugin/optional-source", owner: "plugins", readinessRequired: false }],
+    } as const;
+
+    const first = await createRecoveryPointManifest({
+      snapshots: [agent.snapshot, global.snapshot],
+      obligations,
+      now,
+    });
+    const second = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, agent.snapshot],
+      obligations,
+      now,
+    });
+
+    expect(first).toEqual(second);
+    expect(first.recoveryPointId).toMatch(/^[a-f0-9]{64}$/u);
+    expect(first.components.map((component) => component.id)).toEqual([
+      "sqlite/global",
+      "sqlite/agent/main",
+    ]);
+    expect(first.obligations.external).toEqual(obligations.external);
+    expect(global.verify).toHaveBeenCalledTimes(4);
+    expect(agent.verify).toHaveBeenCalledTimes(4);
+  });
+
+  it("re-verifies every owner snapshot against the aggregate manifest", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const manifest = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, agent.snapshot],
+      now: () => new Date("2026-07-21T16:00:00.000Z"),
+    });
+
+    await expect(
+      verifyRecoveryPoint({ manifest, snapshots: [agent.snapshot, global.snapshot] }),
+    ).resolves.toEqual(manifest);
+
+    const mismatched = structuredClone(manifest);
+    mismatched.components[1]!.artifactSha256 = "c".repeat(64);
+    mismatched.recoveryPointId = recomputeIdentity(mismatched);
+    await expect(
+      verifyRecoveryPoint({ manifest: mismatched, snapshots: [global.snapshot, agent.snapshot] }),
+    ).rejects.toThrow("do not match the verified owner snapshots");
+  });
+
+  it("rejects reordered, duplicate, unknown, and secret-shaped metadata", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const manifest = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, agent.snapshot],
+      obligations: {
+        external: [
+          { id: "secret/z", owner: "secrets", readinessRequired: true },
+          { id: "secret/a", owner: "secrets", readinessRequired: true },
+        ],
+      },
+      now: () => new Date("2026-07-21T16:00:00.000Z"),
+    });
+
+    const reordered = structuredClone(manifest);
+    reordered.components.reverse();
+    reordered.recoveryPointId = recomputeIdentity(reordered);
+    expect(() => verifyRecoveryPointManifest(reordered)).toThrow("canonical order");
+
+    const reorderedObligations = structuredClone(manifest);
+    reorderedObligations.obligations.external.reverse();
+    reorderedObligations.recoveryPointId = recomputeIdentity(reorderedObligations);
+    expect(() => verifyRecoveryPointManifest(reorderedObligations)).toThrow(
+      "obligations are not in canonical order",
+    );
+
+    const invalidAgent = structuredClone(manifest);
+    const agentComponent = invalidAgent.components[1];
+    if (agentComponent?.kind !== "sqlite-agent") {
+      throw new Error("expected agent component fixture");
+    }
+    agentComponent.agentId = "foo/bar";
+    agentComponent.id = "sqlite/agent/foo/bar";
+    invalidAgent.recoveryPointId = recomputeIdentity(invalidAgent);
+    expect(() => verifyRecoveryPointManifest(invalidAgent)).toThrow("agent id is invalid");
+
+    const duplicate = structuredClone(manifest);
+    duplicate.components.push(structuredClone(duplicate.components[1]!));
+    duplicate.recoveryPointId = recomputeIdentity(duplicate);
+    expect(() => verifyRecoveryPointManifest(duplicate)).toThrow("duplicate component id");
+
+    const unknown = structuredClone(manifest) as unknown as {
+      components: Array<Record<string, unknown>>;
+    };
+    unknown.components[0]!.kind = "workspace";
+    expect(() => verifyRecoveryPointManifest(unknown)).toThrow("manifest is invalid");
+
+    const secretShaped = structuredClone(manifest) as unknown as {
+      obligations: { external: Array<Record<string, unknown>> };
+    };
+    secretShaped.obligations.external.push({
+      id: "secret/provider-api-key",
+      owner: "secrets",
+      readinessRequired: true,
+      value: "must-not-appear",
+    });
+    expect(() => verifyRecoveryPointManifest(secretShaped)).toThrow("manifest is invalid");
+  });
+
+  it("rejects owner manifest byte rewrites during composition", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    global.verify.mockImplementationOnce(async () => ({
+      ok: true as const,
+      manifest: global.manifest,
+    }));
+    global.verify.mockImplementationOnce(async () => {
+      await fs.writeFile(
+        path.join(global.snapshot.ref.path, "manifest.json"),
+        JSON.stringify(global.manifest),
+        { mode: 0o600 },
+      );
+      return { ok: true as const, manifest: global.manifest };
+    });
+
+    await expect(
+      createRecoveryPointManifest({ snapshots: [global.snapshot, agent.snapshot] }),
+    ).rejects.toThrow("changed during recovery-point composition");
+  });
+
+  it("rejects generic snapshots and incomplete SQLite inventories", async () => {
+    const generic = await createSnapshotFixture({
+      role: "generic",
+      id: "custom",
+      userVersion: 1,
+      byte: "a",
+    });
+    await expect(createRecoveryPointManifest({ snapshots: [generic.snapshot] })).rejects.toThrow(
+      "Generic SQLite snapshots are not eligible",
+    );
+
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "b" });
+    await expect(createRecoveryPointManifest({ snapshots: [global.snapshot] })).rejects.toThrow(
+      "at least one agent",
+    );
+  });
+});
+
+type SnapshotFixtureOptions =
+  | { role: "global"; userVersion: number; byte: string }
+  | { role: "agent"; agentId: string; userVersion: number; byte: string }
+  | { role: "generic"; id: string; userVersion: number; byte: string };
+
+async function createSnapshotFixture(options: SnapshotFixtureOptions): Promise<{
+  snapshot: RecoveryPointSqliteSnapshot;
+  manifest: SnapshotManifest;
+  verify: Mock<SqliteSnapshotProvider["verify"]>;
+}> {
+  const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-recovery-point-"));
+  tempRoots.push(rootPath);
+  const snapshotPath = path.join(rootPath, "snapshot-1");
+  await fs.mkdir(snapshotPath, { mode: 0o700 });
+  const database =
+    options.role === "global"
+      ? { role: "global" as const, basename: "state.sqlite", userVersion: options.userVersion }
+      : options.role === "agent"
+        ? {
+            role: "agent" as const,
+            agentId: options.agentId,
+            basename: "agent.sqlite",
+            userVersion: options.userVersion,
+          }
+        : {
+            role: "generic" as const,
+            id: options.id,
+            basename: "custom.sqlite",
+            userVersion: options.userVersion,
+          };
+  const manifest: SnapshotManifest = {
+    schemaVersion: 1,
+    snapshotId: "snapshot-1",
+    createdAt: "2026-07-21T15:00:00.000Z",
+    database,
+    artifact: {
+      path: "database.sqlite",
+      sha256: options.byte.repeat(64),
+      sizeBytes: 1024,
+    },
+  };
+  await fs.writeFile(
+    path.join(snapshotPath, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    {
+      mode: 0o600,
+    },
+  );
+  const verify = vi.fn<SqliteSnapshotProvider["verify"]>(async () => ({
+    ok: true as const,
+    manifest,
+  }));
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unsupported in recovery-point fixture");
+  };
+  const provider: SqliteSnapshotProvider = {
+    create: unsupported,
+    list: async () => [],
+    restoreFresh: unsupported,
+    verify,
+  };
+  const ref: SnapshotRef = { path: snapshotPath };
+  return { snapshot: { provider, ref }, manifest, verify };
+}
+
+function recomputeIdentity(
+  manifest: { recoveryPointId: string } & Record<string, unknown>,
+): string {
+  const { recoveryPointId: _recoveryPointId, ...withoutId } = manifest;
+  return createHash("sha256").update(stableStringify(withoutId)).digest("hex");
+}

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -268,6 +268,33 @@ describe("recovery point composition", () => {
     ).rejects.toThrow("does not match the state owner's expected agents");
   });
 
+  it("rejects non-canonical dependency ordering", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const main = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const research = await createSnapshotFixture({
+      role: "agent",
+      agentId: "research",
+      userVersion: 12,
+      byte: "c",
+    });
+    const manifest = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, main.snapshot, research.snapshot],
+      expectedAgentIds: ["main", "research"],
+      now: () => new Date("2026-07-21T16:00:00.000Z"),
+    });
+    manifest.components[2]!.dependsOn = ["sqlite/global", "sqlite/agent/main"];
+    manifest.recoveryPointId = recomputeIdentity(manifest);
+
+    expect(() => verifyRecoveryPointManifest(manifest)).toThrow(
+      "dependencies are not in canonical order",
+    );
+  });
+
   it("rejects unsupported obligation treatment, kind, and owner combinations", async () => {
     const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
     const agent = await createSnapshotFixture({

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
 import { stableStringify } from "../agents/stable-stringify.js";
 import {
+  createRecoveryPointAcceptance,
   createRecoveryPointManifest,
   verifyRecoveryPoint,
   verifyRecoveryPointManifest,
@@ -31,28 +32,51 @@ describe("recovery point composition", () => {
     });
     const now = () => new Date("2026-07-21T16:00:00.000Z");
     const obligations = {
-      external: [{ id: "secret/provider-api-key", owner: "secrets", readinessRequired: true }],
-      reconstructed: [{ id: "plugin/optional-source", owner: "plugins", readinessRequired: false }],
+      external: [
+        {
+          id: "secret/provider-api-key",
+          kind: "secret-ref",
+          owner: "secrets",
+          readinessRequired: true,
+        },
+      ],
+      reconstructed: [
+        {
+          id: "plugin/optional-source",
+          kind: "plugin-dependency",
+          owner: "plugins",
+          readinessRequired: false,
+        },
+      ],
     } as const;
 
     const first = await createRecoveryPointManifest({
       snapshots: [agent.snapshot, global.snapshot],
+      expectedAgentIds: ["main"],
       obligations,
       now,
     });
     const second = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
+      expectedAgentIds: ["main"],
       obligations,
       now,
     });
 
     expect(first).toEqual(second);
     expect(first.recoveryPointId).toMatch(/^[a-f0-9]{64}$/u);
+    expect(first.inventory).toEqual({
+      version: "openclaw-runtime-sqlite-inventory/v1",
+      requiredComponentIds: ["sqlite/global", "sqlite/agent/main"],
+    });
+    expect(first.protection).toEqual({ mode: "host-protected" });
     expect(first.components.map((component) => component.id)).toEqual([
       "sqlite/global",
       "sqlite/agent/main",
     ]);
     expect(first.obligations.external).toEqual(obligations.external);
+    expect(first.components.every((component) => component.ownerManifestSizeBytes > 0)).toBe(true);
+    expect(createRecoveryPointAcceptance(first)).toEqual(createRecoveryPointAcceptance(second));
     expect(global.verify).toHaveBeenCalledTimes(4);
     expect(agent.verify).toHaveBeenCalledTimes(4);
   });
@@ -67,18 +91,27 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
+      expectedAgentIds: ["main"],
       now: () => new Date("2026-07-21T16:00:00.000Z"),
     });
 
     await expect(
-      verifyRecoveryPoint({ manifest, snapshots: [agent.snapshot, global.snapshot] }),
-    ).resolves.toEqual(manifest);
+      verifyRecoveryPoint({
+        manifest,
+        snapshots: [agent.snapshot, global.snapshot],
+        expectedAgentIds: ["main"],
+      }),
+    ).resolves.toEqual({ manifest, acceptance: createRecoveryPointAcceptance(manifest) });
 
     const mismatched = structuredClone(manifest);
     mismatched.components[1]!.artifactSha256 = "c".repeat(64);
     mismatched.recoveryPointId = recomputeIdentity(mismatched);
     await expect(
-      verifyRecoveryPoint({ manifest: mismatched, snapshots: [global.snapshot, agent.snapshot] }),
+      verifyRecoveryPoint({
+        manifest: mismatched,
+        snapshots: [global.snapshot, agent.snapshot],
+        expectedAgentIds: ["main"],
+      }),
     ).rejects.toThrow("do not match the verified owner snapshots");
   });
 
@@ -92,10 +125,11 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
+      expectedAgentIds: ["main"],
       obligations: {
         external: [
-          { id: "secret/z", owner: "secrets", readinessRequired: true },
-          { id: "secret/a", owner: "secrets", readinessRequired: true },
+          { id: "secret/z", kind: "secret-ref", owner: "secrets", readinessRequired: true },
+          { id: "secret/a", kind: "secret-ref", owner: "secrets", readinessRequired: true },
         ],
       },
       now: () => new Date("2026-07-21T16:00:00.000Z"),
@@ -139,6 +173,7 @@ describe("recovery point composition", () => {
     };
     secretShaped.obligations.external.push({
       id: "secret/provider-api-key",
+      kind: "secret-ref",
       owner: "secrets",
       readinessRequired: true,
       value: "must-not-appear",
@@ -168,7 +203,10 @@ describe("recovery point composition", () => {
     });
 
     await expect(
-      createRecoveryPointManifest({ snapshots: [global.snapshot, agent.snapshot] }),
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot, agent.snapshot],
+        expectedAgentIds: ["main"],
+      }),
     ).rejects.toThrow("changed during recovery-point composition");
   });
 
@@ -179,14 +217,81 @@ describe("recovery point composition", () => {
       userVersion: 1,
       byte: "a",
     });
-    await expect(createRecoveryPointManifest({ snapshots: [generic.snapshot] })).rejects.toThrow(
-      "Generic SQLite snapshots are not eligible",
-    );
+    await expect(
+      createRecoveryPointManifest({ snapshots: [generic.snapshot], expectedAgentIds: ["main"] }),
+    ).rejects.toThrow("Generic SQLite snapshots are not eligible");
 
     const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "b" });
-    await expect(createRecoveryPointManifest({ snapshots: [global.snapshot] })).rejects.toThrow(
-      "at least one agent",
-    );
+    await expect(
+      createRecoveryPointManifest({ snapshots: [global.snapshot], expectedAgentIds: ["main"] }),
+    ).rejects.toThrow("do not match the required inventory");
+  });
+
+  it("rejects incomplete, extra, and self-consistent but owner-mismatched inventories", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const main = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const research = await createSnapshotFixture({
+      role: "agent",
+      agentId: "research",
+      userVersion: 12,
+      byte: "c",
+    });
+
+    await expect(
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot, main.snapshot],
+        expectedAgentIds: ["main", "research"],
+      }),
+    ).rejects.toThrow("do not match the required inventory");
+    await expect(
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot, main.snapshot, research.snapshot],
+        expectedAgentIds: ["main"],
+      }),
+    ).rejects.toThrow("do not match the required inventory");
+
+    const manifest = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, main.snapshot],
+      expectedAgentIds: ["main"],
+    });
+    await expect(
+      verifyRecoveryPoint({
+        manifest,
+        snapshots: [global.snapshot, main.snapshot],
+        expectedAgentIds: ["main", "research"],
+      }),
+    ).rejects.toThrow("does not match the state owner's expected agents");
+  });
+
+  it("rejects unsupported obligation treatment, kind, and owner combinations", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    await expect(
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot, agent.snapshot],
+        expectedAgentIds: ["main"],
+        obligations: {
+          reconstructed: [
+            {
+              id: "secret/provider-api-key",
+              kind: "secret-ref",
+              owner: "secrets",
+              readinessRequired: true,
+            },
+          ],
+        },
+      }),
+    ).rejects.toThrow("unsupported treatment, kind, or owner");
   });
 });
 

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -9,6 +9,7 @@ import {
   createRecoveryPointManifest,
   verifyRecoveryPoint,
   verifyRecoveryPointManifest,
+  verifyRecoveryPointOwnerInventory,
   type RecoveryPointAcceptance,
   type RecoveryPointManifest,
   type RecoveryPointOwnerInventory,
@@ -256,6 +257,13 @@ describe("recovery point composition", () => {
         } as unknown as RecoveryPointOwnerInventory,
       }),
     ).rejects.toThrow();
+
+    expect(() =>
+      verifyRecoveryPointOwnerInventory(stateOwnerInventory(["research", "main"])),
+    ).toThrow("canonical order");
+    expect(() => verifyRecoveryPointOwnerInventory(stateOwnerInventory(["../../outside"]))).toThrow(
+      "expected agent id is invalid",
+    );
   });
 
   it("rejects incomplete, extra, and self-consistent but owner-mismatched inventories", async () => {

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -11,6 +11,7 @@ import {
   verifyRecoveryPointManifest,
   type RecoveryPointAcceptance,
   type RecoveryPointManifest,
+  type RecoveryPointOwnerInventory,
   type RecoveryPointSqliteSnapshot,
 } from "./recovery-point.js";
 import type { SnapshotManifest, SnapshotRef, SqliteSnapshotProvider } from "./snapshot-provider.js";
@@ -54,21 +55,32 @@ describe("recovery point composition", () => {
 
     const first: RecoveryPointManifest = await createRecoveryPointManifest({
       snapshots: [agent.snapshot, global.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
       obligations,
       now,
     });
     const second = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
+      obligations,
+      now,
+    });
+
+    const revised = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, agent.snapshot],
+      ownerInventory: stateOwnerInventory(["main"], { revision: "inventory-revision-2" }),
       obligations,
       now,
     });
 
     expect(first).toEqual(second);
+    expect(revised.recoveryPointId).not.toBe(first.recoveryPointId);
     expect(first.recoveryPointId).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.inventory).toEqual({
       version: "openclaw-runtime-sqlite-inventory/v1",
+      owner: "openclaw-state",
+      sourceRuntimeGeneration: "runtime-generation-1",
+      revision: "inventory-revision-1",
       requiredComponentIds: ["sqlite/global", "sqlite/agent/main"],
     });
     expect(first.protection).toEqual({ mode: "host-protected" });
@@ -80,8 +92,8 @@ describe("recovery point composition", () => {
     expect(first.components.every((component) => component.ownerManifestSizeBytes > 0)).toBe(true);
     const firstAcceptance: RecoveryPointAcceptance = createRecoveryPointAcceptance(first);
     expect(firstAcceptance).toEqual(createRecoveryPointAcceptance(second));
-    expect(global.verify).toHaveBeenCalledTimes(4);
-    expect(agent.verify).toHaveBeenCalledTimes(4);
+    expect(global.verify).toHaveBeenCalledTimes(6);
+    expect(agent.verify).toHaveBeenCalledTimes(6);
   });
 
   it("re-verifies every owner snapshot against the aggregate manifest", async () => {
@@ -94,7 +106,7 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
       now: () => new Date("2026-07-21T16:00:00.000Z"),
     });
 
@@ -102,7 +114,7 @@ describe("recovery point composition", () => {
       verifyRecoveryPoint({
         manifest,
         snapshots: [agent.snapshot, global.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
       }),
     ).resolves.toEqual({ manifest, acceptance: createRecoveryPointAcceptance(manifest) });
 
@@ -113,7 +125,7 @@ describe("recovery point composition", () => {
       verifyRecoveryPoint({
         manifest: mismatched,
         snapshots: [global.snapshot, agent.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
       }),
     ).rejects.toThrow("do not match the verified owner snapshots");
   });
@@ -128,7 +140,7 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
       obligations: {
         external: [
           { id: "secret/z", kind: "secret-ref", owner: "secrets", readinessRequired: true },
@@ -208,7 +220,7 @@ describe("recovery point composition", () => {
     await expect(
       createRecoveryPointManifest({
         snapshots: [global.snapshot, agent.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
       }),
     ).rejects.toThrow("changed during recovery-point composition");
   });
@@ -221,13 +233,29 @@ describe("recovery point composition", () => {
       byte: "a",
     });
     await expect(
-      createRecoveryPointManifest({ snapshots: [generic.snapshot], expectedAgentIds: ["main"] }),
+      createRecoveryPointManifest({
+        snapshots: [generic.snapshot],
+        ownerInventory: stateOwnerInventory(["main"]),
+      }),
     ).rejects.toThrow("Generic SQLite snapshots are not eligible");
 
     const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "b" });
     await expect(
-      createRecoveryPointManifest({ snapshots: [global.snapshot], expectedAgentIds: ["main"] }),
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot],
+        ownerInventory: stateOwnerInventory(["main"]),
+      }),
     ).rejects.toThrow("do not match the required inventory");
+
+    await expect(
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot],
+        ownerInventory: {
+          ...stateOwnerInventory(["main"]),
+          owner: "host",
+        } as unknown as RecoveryPointOwnerInventory,
+      }),
+    ).rejects.toThrow();
   });
 
   it("rejects incomplete, extra, and self-consistent but owner-mismatched inventories", async () => {
@@ -248,27 +276,35 @@ describe("recovery point composition", () => {
     await expect(
       createRecoveryPointManifest({
         snapshots: [global.snapshot, main.snapshot],
-        expectedAgentIds: ["main", "research"],
+        ownerInventory: stateOwnerInventory(["main", "research"]),
       }),
     ).rejects.toThrow("do not match the required inventory");
     await expect(
       createRecoveryPointManifest({
         snapshots: [global.snapshot, main.snapshot, research.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
       }),
     ).rejects.toThrow("do not match the required inventory");
 
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, main.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
     });
     await expect(
       verifyRecoveryPoint({
         manifest,
         snapshots: [global.snapshot, main.snapshot],
-        expectedAgentIds: ["main", "research"],
+        ownerInventory: stateOwnerInventory(["main", "research"]),
       }),
-    ).rejects.toThrow("does not match the state owner's expected agents");
+    ).rejects.toThrow("does not match the state owner's inventory receipt");
+
+    await expect(
+      verifyRecoveryPoint({
+        manifest,
+        snapshots: [global.snapshot, main.snapshot],
+        ownerInventory: stateOwnerInventory(["main"], { revision: "inventory-revision-2" }),
+      }),
+    ).rejects.toThrow("does not match the state owner's inventory receipt");
   });
 
   it("rejects non-canonical dependency ordering", async () => {
@@ -287,7 +323,7 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, main.snapshot, research.snapshot],
-      expectedAgentIds: ["main", "research"],
+      ownerInventory: stateOwnerInventory(["main", "research"]),
       now: () => new Date("2026-07-21T16:00:00.000Z"),
     });
     manifest.components[2]!.dependsOn = ["sqlite/global", "sqlite/agent/main"];
@@ -309,7 +345,7 @@ describe("recovery point composition", () => {
     await expect(
       createRecoveryPointManifest({
         snapshots: [global.snapshot, agent.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
         obligations: {
           reconstructed: [
             {
@@ -324,6 +360,19 @@ describe("recovery point composition", () => {
     ).rejects.toThrow("unsupported treatment, kind, or owner");
   });
 });
+
+function stateOwnerInventory(
+  agentIds: string[],
+  overrides: { sourceRuntimeGeneration?: string; revision?: string } = {},
+): RecoveryPointOwnerInventory {
+  return {
+    version: "openclaw-runtime-sqlite-inventory/v1",
+    owner: "openclaw-state",
+    sourceRuntimeGeneration: overrides.sourceRuntimeGeneration ?? "runtime-generation-1",
+    revision: overrides.revision ?? "inventory-revision-1",
+    agentIds,
+  };
+}
 
 type SnapshotFixtureOptions =
   | { role: "global"; userVersion: number; byte: string }

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -2,8 +2,8 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
-import { stableStringify } from "../agents/stable-stringify.js";
 import {
   createRecoveryPointAcceptance,
   createRecoveryPointManifest,
@@ -12,12 +12,15 @@ import {
   verifyRecoveryPointOwnerInventory,
   type RecoveryPointAcceptance,
   type RecoveryPointManifest,
-  type RecoveryPointOwnerInventory,
   type RecoveryPointSqliteSnapshot,
 } from "./recovery-point.js";
 import type { SnapshotManifest, SnapshotRef, SqliteSnapshotProvider } from "./snapshot-provider.js";
 
 const tempRoots: string[] = [];
+
+type RecoveryPointOwnerInventory = Parameters<
+  typeof createRecoveryPointManifest
+>[0]["ownerInventory"];
 
 afterEach(async () => {
   await Promise.all(

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
+import { stableStringify } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
 import {
   createRecoveryPointAcceptance,

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -396,6 +396,11 @@ function assertCanonicalComponentOrder(components: readonly RecoveryPointCompone
 function assertDependencies(components: readonly RecoveryPointComponent[]): void {
   const byId = new Map(components.map((component) => [component.id, component]));
   for (const component of components) {
+    if (!isDeepStrictEqual(component.dependsOn, component.dependsOn.toSorted(compareCodeUnits))) {
+      throw new Error(
+        `Recovery point component ${component.id} dependencies are not in canonical order.`,
+      );
+    }
     const dependencies = new Set<string>();
     for (const dependency of component.dependsOn) {
       if (!byId.has(dependency)) {

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -243,6 +243,7 @@ async function buildVerifiedComponent(
   if (
     !isDeepStrictEqual(firstVerification.manifest, secondVerification.manifest) ||
     !isDeepStrictEqual(firstManifestRead.parsed, secondVerification.manifest) ||
+    !isDeepStrictEqual(secondManifestRead.parsed, secondVerification.manifest) ||
     firstManifestRead.sha256 !== secondManifestRead.sha256
   ) {
     throw new Error(

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -11,8 +11,8 @@ import {
   type SqliteSnapshotProvider,
 } from "./snapshot-provider.js";
 
-export const RECOVERY_POINT_VERSION = "openclaw-recovery-point/v1";
-export const RECOVERY_POINT_ACCEPTANCE_VERSION = "openclaw-recovery-point-acceptance/v1";
+const RECOVERY_POINT_VERSION = "openclaw-recovery-point/v1";
+const RECOVERY_POINT_ACCEPTANCE_VERSION = "openclaw-recovery-point-acceptance/v1";
 
 const RECOVERY_POINT_INVENTORY_VERSION = "openclaw-runtime-sqlite-inventory/v1";
 
@@ -104,8 +104,8 @@ const recoveryPointAcceptanceSchema = z
   })
   .strict();
 
-export type RecoveryPointObligation = z.infer<typeof obligationSchema>;
-export type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
+type RecoveryPointObligation = z.infer<typeof obligationSchema>;
+type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
 export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
 
@@ -114,7 +114,7 @@ export type RecoveryPointSqliteSnapshot = {
   readonly ref: SnapshotRef;
 };
 
-export type RecoveryPointObligations = {
+type RecoveryPointObligations = {
   readonly external?: readonly RecoveryPointObligation[];
   readonly reconstructed?: readonly RecoveryPointObligation[];
   readonly ephemeral?: readonly RecoveryPointObligation[];

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -1,0 +1,368 @@
+import { isDeepStrictEqual } from "node:util";
+import { z } from "zod";
+import { stableStringify } from "../agents/stable-stringify.js";
+import { sha256Hex } from "../infra/crypto-digest.js";
+import { root } from "../infra/fs-safe.js";
+import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
+import {
+  SNAPSHOT_MANIFEST_FILENAME,
+  type SnapshotManifest,
+  type SnapshotRef,
+  type SqliteSnapshotProvider,
+} from "./snapshot-provider.js";
+
+export const RECOVERY_POINT_VERSION = "openclaw-recovery-point/v1";
+
+const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
+
+const obligationSchema = z
+  .object({
+    id: z.string().regex(SAFE_ID_PATTERN),
+    owner: z.string().regex(SAFE_ID_PATTERN),
+    readinessRequired: z.boolean(),
+  })
+  .strict();
+
+const componentBaseSchema = {
+  id: z.string().regex(SAFE_ID_PATTERN),
+  artifactSha256: z.string().regex(SHA256_PATTERN),
+  artifactSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  ownerManifestSha256: z.string().regex(SHA256_PATTERN),
+  compatibility: z.string().regex(SAFE_ID_PATTERN),
+  dependsOn: z.array(z.string().regex(SAFE_ID_PATTERN)),
+  capturedAt: z.string(),
+  required: z.boolean(),
+};
+
+const recoveryPointComponentSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      ...componentBaseSchema,
+      id: z.literal("sqlite/global"),
+      kind: z.literal("sqlite-global"),
+      owner: z.literal("openclaw-state"),
+    })
+    .strict(),
+  z
+    .object({
+      ...componentBaseSchema,
+      kind: z.literal("sqlite-agent"),
+      owner: z.literal("openclaw-agent-state"),
+      agentId: z.string().min(1).max(64),
+    })
+    .strict(),
+]);
+
+const recoveryPointManifestSchema = z
+  .object({
+    version: z.literal(RECOVERY_POINT_VERSION),
+    recoveryPointId: z.string().regex(SHA256_PATTERN),
+    createdAt: z.string(),
+    components: z.array(recoveryPointComponentSchema).min(1),
+    obligations: z
+      .object({
+        external: z.array(obligationSchema),
+        reconstructed: z.array(obligationSchema),
+        ephemeral: z.array(obligationSchema),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type RecoveryPointObligation = z.infer<typeof obligationSchema>;
+export type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
+export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
+
+export type RecoveryPointSqliteSnapshot = {
+  readonly provider: SqliteSnapshotProvider;
+  readonly ref: SnapshotRef;
+};
+
+export type RecoveryPointObligations = {
+  readonly external?: readonly RecoveryPointObligation[];
+  readonly reconstructed?: readonly RecoveryPointObligation[];
+  readonly ephemeral?: readonly RecoveryPointObligation[];
+};
+
+export async function createRecoveryPointManifest(params: {
+  snapshots: readonly RecoveryPointSqliteSnapshot[];
+  obligations?: RecoveryPointObligations;
+  now?: () => Date;
+}): Promise<RecoveryPointManifest> {
+  const now = (params.now ?? (() => new Date()))();
+  if (!Number.isFinite(now.getTime())) {
+    throw new Error("Recovery point timestamp is invalid.");
+  }
+
+  const components = await Promise.all(params.snapshots.map(buildVerifiedComponent));
+  components.sort(compareComponents);
+  assertRequiredSqliteInventory(components);
+
+  const manifestWithoutId = {
+    version: RECOVERY_POINT_VERSION,
+    createdAt: now.toISOString(),
+    components,
+    obligations: normalizeObligations(params.obligations),
+  };
+  return verifyRecoveryPointManifest({
+    ...manifestWithoutId,
+    recoveryPointId: digestRecoveryPoint(manifestWithoutId),
+  });
+}
+
+export function verifyRecoveryPointManifest(value: unknown): RecoveryPointManifest {
+  const parsed = recoveryPointManifestSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Recovery point manifest is invalid: ${parsed.error.message}`);
+  }
+  const manifest = parsed.data;
+  assertCanonicalTimestamp(manifest.createdAt, "createdAt");
+  for (const component of manifest.components) {
+    assertCanonicalTimestamp(component.capturedAt, `${component.id}.capturedAt`);
+    if (component.kind === "sqlite-agent") {
+      if (
+        !isValidAgentId(component.agentId) ||
+        normalizeAgentId(component.agentId) !== component.agentId
+      ) {
+        throw new Error(`Recovery point component agent id is invalid: ${component.agentId}.`);
+      }
+      if (component.id !== `sqlite/agent/${component.agentId}`) {
+        throw new Error(`Recovery point component id does not match agent ${component.agentId}.`);
+      }
+    }
+  }
+  assertCanonicalComponentOrder(manifest.components);
+  assertRequiredSqliteInventory(manifest.components);
+  assertDependencies(manifest.components);
+  assertCanonicalObligationOrder(manifest.obligations);
+  assertObligationIds(manifest.obligations);
+
+  const { recoveryPointId: _recoveryPointId, ...manifestWithoutId } = manifest;
+  const expectedId = digestRecoveryPoint(manifestWithoutId);
+  if (manifest.recoveryPointId !== expectedId) {
+    throw new Error(
+      `Recovery point identity mismatch: expected ${expectedId}, got ${manifest.recoveryPointId}.`,
+    );
+  }
+  return manifest;
+}
+
+export async function verifyRecoveryPoint(params: {
+  manifest: unknown;
+  snapshots: readonly RecoveryPointSqliteSnapshot[];
+}): Promise<RecoveryPointManifest> {
+  const manifest = verifyRecoveryPointManifest(params.manifest);
+  const actualComponents = await Promise.all(params.snapshots.map(buildVerifiedComponent));
+  actualComponents.sort(compareComponents);
+  if (!isDeepStrictEqual(actualComponents, manifest.components)) {
+    throw new Error("Recovery point SQLite components do not match the verified owner snapshots.");
+  }
+  return manifest;
+}
+
+async function buildVerifiedComponent(
+  snapshot: RecoveryPointSqliteSnapshot,
+): Promise<RecoveryPointComponent> {
+  const firstVerification = await snapshot.provider.verify(snapshot.ref);
+  const firstManifestRead = await readOwnerManifest(snapshot.ref);
+  const secondVerification = await snapshot.provider.verify(snapshot.ref);
+  const secondManifestRead = await readOwnerManifest(snapshot.ref);
+  if (
+    !isDeepStrictEqual(firstVerification.manifest, secondVerification.manifest) ||
+    !isDeepStrictEqual(firstManifestRead.parsed, secondVerification.manifest) ||
+    firstManifestRead.sha256 !== secondManifestRead.sha256
+  ) {
+    throw new Error(
+      `SQLite owner manifest changed during recovery-point composition: ${snapshot.ref.path}`,
+    );
+  }
+  return componentFromSnapshotManifest(secondVerification.manifest, secondManifestRead.sha256);
+}
+
+async function readOwnerManifest(ref: SnapshotRef): Promise<{ parsed: unknown; sha256: string }> {
+  const snapshotRoot = await root(ref.path);
+  const manifestRead = await snapshotRoot.read(SNAPSHOT_MANIFEST_FILENAME, {
+    hardlinks: "reject",
+    maxBytes: MAX_OWNER_MANIFEST_BYTES,
+    symlinks: "reject",
+  });
+  try {
+    return {
+      parsed: JSON.parse(manifestRead.buffer.toString("utf8")) as unknown,
+      sha256: sha256Hex(manifestRead.buffer),
+    };
+  } catch (error) {
+    throw new Error(`Verified SQLite owner manifest is not valid JSON: ${ref.path}`, {
+      cause: error,
+    });
+  }
+}
+
+function componentFromSnapshotManifest(
+  manifest: SnapshotManifest,
+  ownerManifestSha256: string,
+): RecoveryPointComponent {
+  const common = {
+    artifactSha256: manifest.artifact.sha256,
+    artifactSizeBytes: manifest.artifact.sizeBytes,
+    ownerManifestSha256,
+    dependsOn: [],
+    capturedAt: manifest.createdAt,
+    required: true,
+  };
+  if (manifest.database.role === "global") {
+    return recoveryPointComponentSchema.parse({
+      ...common,
+      id: "sqlite/global",
+      kind: "sqlite-global",
+      owner: "openclaw-state",
+      compatibility: `openclaw-state-schema/${manifest.database.userVersion}`,
+    });
+  }
+  if (manifest.database.role === "agent") {
+    return recoveryPointComponentSchema.parse({
+      ...common,
+      id: `sqlite/agent/${manifest.database.agentId}`,
+      kind: "sqlite-agent",
+      owner: "openclaw-agent-state",
+      agentId: manifest.database.agentId,
+      compatibility: `openclaw-agent-schema/${manifest.database.userVersion}`,
+    });
+  }
+  throw new Error("Generic SQLite snapshots are not eligible recovery-point components.");
+}
+
+function normalizeObligations(obligations: RecoveryPointObligations | undefined) {
+  const normalized = {
+    external: (obligations?.external ?? []).toSorted(compareObligations),
+    reconstructed: (obligations?.reconstructed ?? []).toSorted(compareObligations),
+    ephemeral: (obligations?.ephemeral ?? []).toSorted(compareObligations),
+  };
+  assertObligationIds(normalized);
+  return normalized;
+}
+
+function assertRequiredSqliteInventory(components: readonly RecoveryPointComponent[]): void {
+  const globalCount = components.filter((component) => component.kind === "sqlite-global").length;
+  const agentCount = components.filter((component) => component.kind === "sqlite-agent").length;
+  if (globalCount !== 1 || agentCount < 1) {
+    throw new Error(
+      "Recovery point V1 requires exactly one global and at least one agent SQLite component.",
+    );
+  }
+  const ids = new Set<string>();
+  for (const component of components) {
+    if (ids.has(component.id)) {
+      throw new Error(`Recovery point contains duplicate component id: ${component.id}.`);
+    }
+    ids.add(component.id);
+  }
+}
+
+function assertCanonicalComponentOrder(components: readonly RecoveryPointComponent[]): void {
+  const sorted = components.toSorted(compareComponents);
+  if (!components.every((component, index) => component.id === sorted[index]?.id)) {
+    throw new Error("Recovery point components are not in canonical order.");
+  }
+}
+
+function assertDependencies(components: readonly RecoveryPointComponent[]): void {
+  const byId = new Map(components.map((component) => [component.id, component]));
+  for (const component of components) {
+    const dependencies = new Set<string>();
+    for (const dependency of component.dependsOn) {
+      if (!byId.has(dependency)) {
+        throw new Error(
+          `Recovery point component ${component.id} has missing dependency ${dependency}.`,
+        );
+      }
+      if (dependency === component.id || dependencies.has(dependency)) {
+        throw new Error(
+          `Recovery point component ${component.id} has invalid dependency ${dependency}.`,
+        );
+      }
+      dependencies.add(dependency);
+    }
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (id: string): void => {
+    if (visiting.has(id)) {
+      throw new Error(`Recovery point component dependency cycle includes ${id}.`);
+    }
+    if (visited.has(id)) {
+      return;
+    }
+    visiting.add(id);
+    for (const dependency of byId.get(id)?.dependsOn ?? []) {
+      visit(dependency);
+    }
+    visiting.delete(id);
+    visited.add(id);
+  };
+  for (const component of components) {
+    visit(component.id);
+  }
+}
+
+function assertCanonicalObligationOrder(obligations: {
+  external: readonly RecoveryPointObligation[];
+  reconstructed: readonly RecoveryPointObligation[];
+  ephemeral: readonly RecoveryPointObligation[];
+}): void {
+  for (const entries of [obligations.external, obligations.reconstructed, obligations.ephemeral]) {
+    const sorted = entries.toSorted(compareObligations);
+    if (
+      !entries.every(
+        (entry, index) => entry.id === sorted[index]?.id && entry.owner === sorted[index]?.owner,
+      )
+    ) {
+      throw new Error("Recovery point obligations are not in canonical order.");
+    }
+  }
+}
+
+function assertObligationIds(obligations: {
+  external: readonly RecoveryPointObligation[];
+  reconstructed: readonly RecoveryPointObligation[];
+  ephemeral: readonly RecoveryPointObligation[];
+}): void {
+  const ids = new Set<string>();
+  for (const entries of [obligations.external, obligations.reconstructed, obligations.ephemeral]) {
+    for (const obligation of entries) {
+      if (ids.has(obligation.id)) {
+        throw new Error(`Recovery point contains duplicate obligation id: ${obligation.id}.`);
+      }
+      ids.add(obligation.id);
+    }
+  }
+}
+
+function assertCanonicalTimestamp(value: string, label: string): void {
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString() !== value) {
+    throw new Error(`Recovery point ${label} is not a canonical timestamp.`);
+  }
+}
+
+function digestRecoveryPoint(manifestWithoutId: object): string {
+  return sha256Hex(stableStringify(manifestWithoutId));
+}
+
+function compareComponents(left: RecoveryPointComponent, right: RecoveryPointComponent): number {
+  if (left.kind !== right.kind) {
+    return left.kind === "sqlite-global" ? -1 : 1;
+  }
+  return compareCodeUnits(left.id, right.id);
+}
+
+function compareObligations(left: RecoveryPointObligation, right: RecoveryPointObligation): number {
+  return compareCodeUnits(left.id, right.id) || compareCodeUnits(left.owner, right.owner);
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -12,6 +12,9 @@ import {
 } from "./snapshot-provider.js";
 
 export const RECOVERY_POINT_VERSION = "openclaw-recovery-point/v1";
+export const RECOVERY_POINT_ACCEPTANCE_VERSION = "openclaw-recovery-point-acceptance/v1";
+
+const RECOVERY_POINT_INVENTORY_VERSION = "openclaw-runtime-sqlite-inventory/v1";
 
 const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
@@ -20,6 +23,7 @@ const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
 const obligationSchema = z
   .object({
     id: z.string().regex(SAFE_ID_PATTERN),
+    kind: z.enum(["secret-ref", "plugin-dependency", "runtime-cache"]),
     owner: z.string().regex(SAFE_ID_PATTERN),
     readinessRequired: z.boolean(),
   })
@@ -30,6 +34,7 @@ const componentBaseSchema = {
   artifactSha256: z.string().regex(SHA256_PATTERN),
   artifactSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   ownerManifestSha256: z.string().regex(SHA256_PATTERN),
+  ownerManifestSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   compatibility: z.string().regex(SAFE_ID_PATTERN),
   dependsOn: z.array(z.string().regex(SAFE_ID_PATTERN)),
   capturedAt: z.string(),
@@ -60,6 +65,13 @@ const recoveryPointManifestSchema = z
     version: z.literal(RECOVERY_POINT_VERSION),
     recoveryPointId: z.string().regex(SHA256_PATTERN),
     createdAt: z.string(),
+    inventory: z
+      .object({
+        version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
+        requiredComponentIds: z.array(z.string().regex(SAFE_ID_PATTERN)).min(2),
+      })
+      .strict(),
+    protection: z.object({ mode: z.literal("host-protected") }).strict(),
     components: z.array(recoveryPointComponentSchema).min(1),
     obligations: z
       .object({
@@ -71,9 +83,31 @@ const recoveryPointManifestSchema = z
   })
   .strict();
 
+const recoveryPointAcceptanceSchema = z
+  .object({
+    version: z.literal(RECOVERY_POINT_ACCEPTANCE_VERSION),
+    acceptanceSetId: z.string().regex(SHA256_PATTERN),
+    recoveryPointId: z.string().regex(SHA256_PATTERN),
+    aggregateManifestSha256: z.string().regex(SHA256_PATTERN),
+    aggregateManifestSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    components: z.array(
+      z
+        .object({
+          componentId: z.string().regex(SAFE_ID_PATTERN),
+          ownerManifestSha256: z.string().regex(SHA256_PATTERN),
+          ownerManifestSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+          artifactSha256: z.string().regex(SHA256_PATTERN),
+          artifactSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
 export type RecoveryPointObligation = z.infer<typeof obligationSchema>;
 export type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
+export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
 
 export type RecoveryPointSqliteSnapshot = {
   readonly provider: SqliteSnapshotProvider;
@@ -88,6 +122,7 @@ export type RecoveryPointObligations = {
 
 export async function createRecoveryPointManifest(params: {
   snapshots: readonly RecoveryPointSqliteSnapshot[];
+  expectedAgentIds: readonly string[];
   obligations?: RecoveryPointObligations;
   now?: () => Date;
 }): Promise<RecoveryPointManifest> {
@@ -98,11 +133,17 @@ export async function createRecoveryPointManifest(params: {
 
   const components = await Promise.all(params.snapshots.map(buildVerifiedComponent));
   components.sort(compareComponents);
-  assertRequiredSqliteInventory(components);
+  const requiredComponentIds = normalizeRequiredComponentIds(params.expectedAgentIds);
+  assertRequiredSqliteInventory(components, requiredComponentIds);
 
   const manifestWithoutId = {
     version: RECOVERY_POINT_VERSION,
     createdAt: now.toISOString(),
+    inventory: {
+      version: RECOVERY_POINT_INVENTORY_VERSION,
+      requiredComponentIds,
+    },
+    protection: { mode: "host-protected" },
     components,
     obligations: normalizeObligations(params.obligations),
   };
@@ -134,10 +175,12 @@ export function verifyRecoveryPointManifest(value: unknown): RecoveryPointManife
     }
   }
   assertCanonicalComponentOrder(manifest.components);
-  assertRequiredSqliteInventory(manifest.components);
+  assertCanonicalRequiredInventory(manifest.inventory.requiredComponentIds);
+  assertRequiredSqliteInventory(manifest.components, manifest.inventory.requiredComponentIds);
   assertDependencies(manifest.components);
   assertCanonicalObligationOrder(manifest.obligations);
   assertObligationIds(manifest.obligations);
+  assertSupportedObligations(manifest.obligations);
 
   const { recoveryPointId: _recoveryPointId, ...manifestWithoutId } = manifest;
   const expectedId = digestRecoveryPoint(manifestWithoutId);
@@ -152,14 +195,42 @@ export function verifyRecoveryPointManifest(value: unknown): RecoveryPointManife
 export async function verifyRecoveryPoint(params: {
   manifest: unknown;
   snapshots: readonly RecoveryPointSqliteSnapshot[];
-}): Promise<RecoveryPointManifest> {
+  expectedAgentIds: readonly string[];
+}): Promise<{ manifest: RecoveryPointManifest; acceptance: RecoveryPointAcceptance }> {
   const manifest = verifyRecoveryPointManifest(params.manifest);
+  const requiredComponentIds = normalizeRequiredComponentIds(params.expectedAgentIds);
+  if (!isDeepStrictEqual(manifest.inventory.requiredComponentIds, requiredComponentIds)) {
+    throw new Error("Recovery point inventory does not match the state owner's expected agents.");
+  }
   const actualComponents = await Promise.all(params.snapshots.map(buildVerifiedComponent));
   actualComponents.sort(compareComponents);
+  assertRequiredSqliteInventory(actualComponents, requiredComponentIds);
   if (!isDeepStrictEqual(actualComponents, manifest.components)) {
     throw new Error("Recovery point SQLite components do not match the verified owner snapshots.");
   }
-  return manifest;
+  return { manifest, acceptance: createRecoveryPointAcceptance(manifest) };
+}
+
+export function createRecoveryPointAcceptance(value: unknown): RecoveryPointAcceptance {
+  const manifest = verifyRecoveryPointManifest(value);
+  const manifestBytes = Buffer.from(stableStringify(manifest), "utf8");
+  const acceptanceWithoutId = {
+    version: RECOVERY_POINT_ACCEPTANCE_VERSION,
+    recoveryPointId: manifest.recoveryPointId,
+    aggregateManifestSha256: sha256Hex(manifestBytes),
+    aggregateManifestSizeBytes: manifestBytes.byteLength,
+    components: manifest.components.map((component) => ({
+      componentId: component.id,
+      ownerManifestSha256: component.ownerManifestSha256,
+      ownerManifestSizeBytes: component.ownerManifestSizeBytes,
+      artifactSha256: component.artifactSha256,
+      artifactSizeBytes: component.artifactSizeBytes,
+    })),
+  };
+  return recoveryPointAcceptanceSchema.parse({
+    ...acceptanceWithoutId,
+    acceptanceSetId: sha256Hex(stableStringify(acceptanceWithoutId)),
+  });
 }
 
 async function buildVerifiedComponent(
@@ -178,10 +249,16 @@ async function buildVerifiedComponent(
       `SQLite owner manifest changed during recovery-point composition: ${snapshot.ref.path}`,
     );
   }
-  return componentFromSnapshotManifest(secondVerification.manifest, secondManifestRead.sha256);
+  return componentFromSnapshotManifest(
+    secondVerification.manifest,
+    secondManifestRead.sha256,
+    secondManifestRead.sizeBytes,
+  );
 }
 
-async function readOwnerManifest(ref: SnapshotRef): Promise<{ parsed: unknown; sha256: string }> {
+async function readOwnerManifest(
+  ref: SnapshotRef,
+): Promise<{ parsed: unknown; sha256: string; sizeBytes: number }> {
   const snapshotRoot = await root(ref.path);
   const manifestRead = await snapshotRoot.read(SNAPSHOT_MANIFEST_FILENAME, {
     hardlinks: "reject",
@@ -192,6 +269,7 @@ async function readOwnerManifest(ref: SnapshotRef): Promise<{ parsed: unknown; s
     return {
       parsed: JSON.parse(manifestRead.buffer.toString("utf8")) as unknown,
       sha256: sha256Hex(manifestRead.buffer),
+      sizeBytes: manifestRead.buffer.byteLength,
     };
   } catch (error) {
     throw new Error(`Verified SQLite owner manifest is not valid JSON: ${ref.path}`, {
@@ -203,11 +281,13 @@ async function readOwnerManifest(ref: SnapshotRef): Promise<{ parsed: unknown; s
 function componentFromSnapshotManifest(
   manifest: SnapshotManifest,
   ownerManifestSha256: string,
+  ownerManifestSizeBytes: number,
 ): RecoveryPointComponent {
   const common = {
     artifactSha256: manifest.artifact.sha256,
     artifactSizeBytes: manifest.artifact.sizeBytes,
     ownerManifestSha256,
+    ownerManifestSizeBytes,
     dependsOn: [],
     capturedAt: manifest.createdAt,
     required: true,
@@ -241,23 +321,67 @@ function normalizeObligations(obligations: RecoveryPointObligations | undefined)
     ephemeral: (obligations?.ephemeral ?? []).toSorted(compareObligations),
   };
   assertObligationIds(normalized);
+  assertSupportedObligations(normalized);
   return normalized;
 }
 
-function assertRequiredSqliteInventory(components: readonly RecoveryPointComponent[]): void {
-  const globalCount = components.filter((component) => component.kind === "sqlite-global").length;
-  const agentCount = components.filter((component) => component.kind === "sqlite-agent").length;
-  if (globalCount !== 1 || agentCount < 1) {
-    throw new Error(
-      "Recovery point V1 requires exactly one global and at least one agent SQLite component.",
-    );
+function normalizeRequiredComponentIds(expectedAgentIds: readonly string[]): string[] {
+  if (expectedAgentIds.length === 0) {
+    throw new Error("Recovery point V1 requires at least one expected agent.");
   }
+  const normalizedAgentIds = expectedAgentIds.map((agentId) => normalizeAgentId(agentId));
+  for (let index = 0; index < expectedAgentIds.length; index += 1) {
+    if (
+      !isValidAgentId(expectedAgentIds[index] ?? "") ||
+      normalizedAgentIds[index] !== expectedAgentIds[index]
+    ) {
+      throw new Error(`Recovery point expected agent id is invalid: ${expectedAgentIds[index]}.`);
+    }
+  }
+  const uniqueAgentIds = new Set(normalizedAgentIds);
+  if (uniqueAgentIds.size !== normalizedAgentIds.length) {
+    throw new Error("Recovery point expected agent inventory contains duplicates.");
+  }
+  return [
+    "sqlite/global",
+    ...normalizedAgentIds.toSorted(compareCodeUnits).map((agentId) => `sqlite/agent/${agentId}`),
+  ];
+}
+
+function assertCanonicalRequiredInventory(requiredComponentIds: readonly string[]): void {
+  const agentIds = requiredComponentIds.map((componentId, index) => {
+    if (index === 0 && componentId === "sqlite/global") {
+      return undefined;
+    }
+    return componentId.startsWith("sqlite/agent/")
+      ? componentId.slice("sqlite/agent/".length)
+      : null;
+  });
+  if (agentIds.some((agentId) => agentId === null)) {
+    throw new Error("Recovery point required-component inventory is invalid.");
+  }
+  const expected = normalizeRequiredComponentIds(
+    agentIds.filter((agentId): agentId is string => agentId !== undefined),
+  );
+  if (!isDeepStrictEqual(requiredComponentIds, expected)) {
+    throw new Error("Recovery point required-component inventory is not canonical.");
+  }
+}
+
+function assertRequiredSqliteInventory(
+  components: readonly RecoveryPointComponent[],
+  requiredComponentIds: readonly string[],
+): void {
   const ids = new Set<string>();
   for (const component of components) {
     if (ids.has(component.id)) {
       throw new Error(`Recovery point contains duplicate component id: ${component.id}.`);
     }
     ids.add(component.id);
+  }
+  const componentIds = components.map((component) => component.id);
+  if (!isDeepStrictEqual(componentIds, requiredComponentIds)) {
+    throw new Error("Recovery point SQLite components do not match the required inventory.");
   }
 }
 
@@ -337,6 +461,33 @@ function assertObligationIds(obligations: {
         throw new Error(`Recovery point contains duplicate obligation id: ${obligation.id}.`);
       }
       ids.add(obligation.id);
+    }
+  }
+}
+
+function assertSupportedObligations(obligations: {
+  external: readonly RecoveryPointObligation[];
+  reconstructed: readonly RecoveryPointObligation[];
+  ephemeral: readonly RecoveryPointObligation[];
+}): void {
+  const supported = new Set([
+    "external:secret-ref:secrets",
+    "external:plugin-dependency:plugins",
+    "reconstructed:plugin-dependency:plugins",
+    "ephemeral:runtime-cache:openclaw-runtime",
+  ]);
+  const treatments = [
+    ["external", obligations.external],
+    ["reconstructed", obligations.reconstructed],
+    ["ephemeral", obligations.ephemeral],
+  ] as const;
+  for (const [treatment, entries] of treatments) {
+    for (const obligation of entries) {
+      if (!supported.has(`${treatment}:${obligation.kind}:${obligation.owner}`)) {
+        throw new Error(
+          `Recovery point obligation ${obligation.id} has unsupported treatment, kind, or owner.`,
+        );
+      }
     }
   }
 }

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -20,7 +20,7 @@ const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
 
-const stateOwnerInventorySchema = z
+export const recoveryPointOwnerInventorySchema = z
   .object({
     version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
     owner: z.literal("openclaw-state"),
@@ -121,7 +121,7 @@ type RecoveryPointObligation = z.infer<typeof obligationSchema>;
 type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
 export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
-export type RecoveryPointOwnerInventory = z.input<typeof stateOwnerInventorySchema>;
+export type RecoveryPointOwnerInventory = z.input<typeof recoveryPointOwnerInventorySchema>;
 
 export type RecoveryPointSqliteSnapshot = {
   readonly provider: SqliteSnapshotProvider;
@@ -361,7 +361,7 @@ function normalizeRequiredComponentIds(expectedAgentIds: readonly string[]): str
 }
 
 function normalizeOwnerInventory(value: RecoveryPointOwnerInventory) {
-  const inventory = stateOwnerInventorySchema.parse(value);
+  const inventory = recoveryPointOwnerInventorySchema.parse(value);
   return {
     version: inventory.version,
     owner: inventory.owner,

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -20,6 +20,16 @@ const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
 
+const stateOwnerInventorySchema = z
+  .object({
+    version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
+    owner: z.literal("openclaw-state"),
+    sourceRuntimeGeneration: z.string().regex(SAFE_ID_PATTERN),
+    revision: z.string().regex(SAFE_ID_PATTERN),
+    agentIds: z.array(z.string().min(1).max(64)).min(1),
+  })
+  .strict();
+
 const obligationSchema = z
   .object({
     id: z.string().regex(SAFE_ID_PATTERN),
@@ -68,6 +78,9 @@ const recoveryPointManifestSchema = z
     inventory: z
       .object({
         version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
+        owner: z.literal("openclaw-state"),
+        sourceRuntimeGeneration: z.string().regex(SAFE_ID_PATTERN),
+        revision: z.string().regex(SAFE_ID_PATTERN),
         requiredComponentIds: z.array(z.string().regex(SAFE_ID_PATTERN)).min(2),
       })
       .strict(),
@@ -108,6 +121,7 @@ type RecoveryPointObligation = z.infer<typeof obligationSchema>;
 type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
 export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
+export type RecoveryPointOwnerInventory = z.input<typeof stateOwnerInventorySchema>;
 
 export type RecoveryPointSqliteSnapshot = {
   readonly provider: SqliteSnapshotProvider;
@@ -122,7 +136,7 @@ type RecoveryPointObligations = {
 
 export async function createRecoveryPointManifest(params: {
   snapshots: readonly RecoveryPointSqliteSnapshot[];
-  expectedAgentIds: readonly string[];
+  ownerInventory: RecoveryPointOwnerInventory;
   obligations?: RecoveryPointObligations;
   now?: () => Date;
 }): Promise<RecoveryPointManifest> {
@@ -133,16 +147,13 @@ export async function createRecoveryPointManifest(params: {
 
   const components = await Promise.all(params.snapshots.map(buildVerifiedComponent));
   components.sort(compareComponents);
-  const requiredComponentIds = normalizeRequiredComponentIds(params.expectedAgentIds);
-  assertRequiredSqliteInventory(components, requiredComponentIds);
+  const inventory = normalizeOwnerInventory(params.ownerInventory);
+  assertRequiredSqliteInventory(components, inventory.requiredComponentIds);
 
   const manifestWithoutId = {
     version: RECOVERY_POINT_VERSION,
     createdAt: now.toISOString(),
-    inventory: {
-      version: RECOVERY_POINT_INVENTORY_VERSION,
-      requiredComponentIds,
-    },
+    inventory,
     protection: { mode: "host-protected" },
     components,
     obligations: normalizeObligations(params.obligations),
@@ -195,16 +206,16 @@ export function verifyRecoveryPointManifest(value: unknown): RecoveryPointManife
 export async function verifyRecoveryPoint(params: {
   manifest: unknown;
   snapshots: readonly RecoveryPointSqliteSnapshot[];
-  expectedAgentIds: readonly string[];
+  ownerInventory: RecoveryPointOwnerInventory;
 }): Promise<{ manifest: RecoveryPointManifest; acceptance: RecoveryPointAcceptance }> {
   const manifest = verifyRecoveryPointManifest(params.manifest);
-  const requiredComponentIds = normalizeRequiredComponentIds(params.expectedAgentIds);
-  if (!isDeepStrictEqual(manifest.inventory.requiredComponentIds, requiredComponentIds)) {
-    throw new Error("Recovery point inventory does not match the state owner's expected agents.");
+  const ownerInventory = normalizeOwnerInventory(params.ownerInventory);
+  if (!isDeepStrictEqual(manifest.inventory, ownerInventory)) {
+    throw new Error("Recovery point inventory does not match the state owner's inventory receipt.");
   }
   const actualComponents = await Promise.all(params.snapshots.map(buildVerifiedComponent));
   actualComponents.sort(compareComponents);
-  assertRequiredSqliteInventory(actualComponents, requiredComponentIds);
+  assertRequiredSqliteInventory(actualComponents, ownerInventory.requiredComponentIds);
   if (!isDeepStrictEqual(actualComponents, manifest.components)) {
     throw new Error("Recovery point SQLite components do not match the verified owner snapshots.");
   }
@@ -347,6 +358,17 @@ function normalizeRequiredComponentIds(expectedAgentIds: readonly string[]): str
     "sqlite/global",
     ...normalizedAgentIds.toSorted(compareCodeUnits).map((agentId) => `sqlite/agent/${agentId}`),
   ];
+}
+
+function normalizeOwnerInventory(value: RecoveryPointOwnerInventory) {
+  const inventory = stateOwnerInventorySchema.parse(value);
+  return {
+    version: inventory.version,
+    owner: inventory.owner,
+    sourceRuntimeGeneration: inventory.sourceRuntimeGeneration,
+    revision: inventory.revision,
+    requiredComponentIds: normalizeRequiredComponentIds(inventory.agentIds),
+  };
 }
 
 function assertCanonicalRequiredInventory(requiredComponentIds: readonly string[]): void {

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -360,8 +360,19 @@ function normalizeRequiredComponentIds(expectedAgentIds: readonly string[]): str
   ];
 }
 
-function normalizeOwnerInventory(value: RecoveryPointOwnerInventory) {
+export function verifyRecoveryPointOwnerInventory(value: unknown): RecoveryPointOwnerInventory {
   const inventory = recoveryPointOwnerInventorySchema.parse(value);
+  const canonicalAgentIds = normalizeRequiredComponentIds(inventory.agentIds)
+    .slice(1)
+    .map((componentId) => componentId.slice("sqlite/agent/".length));
+  if (!isDeepStrictEqual(inventory.agentIds, canonicalAgentIds)) {
+    throw new Error("Recovery point owner inventory agent ids are not in canonical order.");
+  }
+  return inventory;
+}
+
+function normalizeOwnerInventory(value: RecoveryPointOwnerInventory) {
+  const inventory = verifyRecoveryPointOwnerInventory(value);
   return {
     version: inventory.version,
     owner: inventory.owner,

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
-import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
+import { stableStringify } from "@openclaw/normalization-core";
 import { z } from "zod";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { root } from "../infra/fs-safe.js";

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -20,7 +20,7 @@ const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
 
-export const recoveryPointOwnerInventorySchema = z
+const recoveryPointOwnerInventorySchema = z
   .object({
     version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
     owner: z.literal("openclaw-state"),
@@ -121,7 +121,7 @@ type RecoveryPointObligation = z.infer<typeof obligationSchema>;
 type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
 export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
-export type RecoveryPointOwnerInventory = z.input<typeof recoveryPointOwnerInventorySchema>;
+type RecoveryPointOwnerInventory = z.input<typeof recoveryPointOwnerInventorySchema>;
 
 export type RecoveryPointSqliteSnapshot = {
   readonly provider: SqliteSnapshotProvider;

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -1,6 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import { z } from "zod";
-import { stableStringify } from "../agents/stable-stringify.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { root } from "../infra/fs-safe.js";
 import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -5,7 +5,12 @@ import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 
-function runBuiltCli(tempHome: string, args: string[], envOverrides: NodeJS.ProcessEnv = {}) {
+function runBuiltCli(
+  tempHome: string,
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {},
+  input?: string,
+) {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     HOME: tempHome,
@@ -23,6 +28,7 @@ function runBuiltCli(tempHome: string, args: string[], envOverrides: NodeJS.Proc
     cwd: process.cwd(),
     env,
     encoding: "utf8",
+    input,
     maxBuffer: 10 * 1024 * 1024,
     timeout: 60_000,
   });
@@ -853,6 +859,33 @@ describe("cli json stdout contract", () => {
         });
       },
       { prefix: "openclaw-doctor-packaged-json-e2e-" },
+    );
+  });
+
+  it("keeps hidden final recovery capture stdout to one JSON document", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const result = runBuiltCli(
+          tempHome,
+          ["backup", "capture-final"],
+          { OPENCLAW_LOG_LEVEL: "debug" },
+          "x".repeat(1024 * 1024 + 1),
+        );
+
+        expect(result.status).toBe(1);
+        const stdout = result.stdout.trim();
+        const parsed = JSON.parse(stdout);
+        expect(parsed).toEqual({
+          version: "openclaw-final-recovery-point-result/v1",
+          ok: false,
+          code: "final-capture.request-invalid",
+          disposition: "quarantine",
+        });
+        expect(stdout).toBe(JSON.stringify(parsed, null, 2));
+        expect(stdout).not.toContain("OpenClaw");
+        expect(stdout).not.toContain("Loading OpenClaw CLI");
+      },
+      { prefix: "openclaw-final-capture-json-e2e-" },
     );
   });
 });


### PR DESCRIPTION
Related RFC: https://github.com/openclaw/rfcs/pull/46

Umbrella outcome: https://github.com/openclaw/openclaw/issues/114145

Non-normative host follow-on evidence (Microsoft access): https://microsoft.ghe.com/giodl/lobster/pull/51

Stacked on: https://github.com/openclaw/openclaw/pull/112385

Stacked follow-up: https://github.com/openclaw/openclaw/pull/112896

Current head: `77e09a8f5c94263cb405f5068f5e3a3af2dbf473`

## Latest restack

The branch was rebuilt on #112385 head `32809a14fc6` and current OpenClaw
`main`. The resulting branch is mergeable. The full final-capture suite passed
11/11 on this exact restack, and the complete child stack passed production and
test types plus the focused Gateway integration matrix.

## What problem this solves

After the host has fenced ingress and stopped authoritative writers, it needs one exact final recovery point before retiring a Gateway generation. This PR adds a private, stdin-only `openclaw backup capture-final` command that binds host-supplied closure evidence, captures the complete owner inventory through the existing SQLite provider, verifies the aggregate, and durably journals one committed result for exact replay in an operation-scoped SQLite database.

The request carries the same canonical, generation-bound owner inventory receipt used by aggregate composition and replay verification. The journal lives under OpenClaw state rather than the caller-selected artifact repository, so changing a repository path cannot recapture the same handoff. The final capture path now derives agent database paths from OpenClaw's registered state-owner inventory instead of deriving default paths from caller-supplied agent IDs, pins the recovery-point repository before publication, syncs the journal directory on every open, and rejects aggregate manifest byte rewrites during replay.

This is the final-capture slice of the host-neutral scale-to-zero contract tracked in #114145. It is motivated by unified backup/restore (#13616) and the need for an owner-safe SQLite snapshot boundary (#101290); adjacent snapshot hardening remains tracked separately in #113306. It does not claim to close those broader issues by itself. It builds on Vincent's snapshot primitive (#105718), Peter's suspension fence (#103618), Vincent's validation repair (#103925), and Josh Lehman's SQLite session/transcript runtime (#98236).

The result is `host-protected`, not credential-free portable. The host still owns ingress fencing, clean shutdown, acceptance, encryption, upload, retention, wake, placement, and source destruction.

## Decisions requested

1. Final capture may trust explicit host closure evidence only after the host has actually stopped authoritative writers.
2. The selected-agent inventory must be canonical and exact.
3. Once durable intent exists, capture or verification failure quarantines; retry cannot silently recapture under the same operation identity.
4. The hidden command remains private until the RFC ownership split is accepted.

## Real behavior proof

Behavior or issue addressed:
Final capture now uses the state owner's exact registered agent database paths, includes incompatible registered agent database rows in its inventory conflict check instead of silently omitting them, keeps recovery-point publication behind a pinned repository directory, requires a crash-durable parent edge when creating recovery-root directories, revalidates recovery-journal directory durability on every open, rejects recovery-journal pathname replacement before SQLite DDL, keeps the hidden stdin command's stdout owned by the JSON protocol from startup, and rejects aggregate manifest byte rewrites on replay.

Real environment tested:
Ubuntu 24.04 WSL worktree `/root/src/openclaw-rfc0013-restack-final`,
Node `v24.15.0`, pnpm `11.15.1`, exact head
`77e09a8f5c94263cb405f5068f5e3a3af2dbf473`. The final-capture tests use real
current-schema SQLite global and agent databases, the real OpenClaw state
registry, the local SQLite snapshot provider, the dedicated SQLite recovery
journal, and a real source CLI process for hidden stdin/stdout behavior.

Exact steps or command run after this patch:

1. `node scripts/run-vitest.mjs run src/cli/command-startup-policy.test.ts src/snapshot/recovery-journal.test.ts src/commands/backup-capture-final.test.ts test/cli-json-stdout.e2e.test.ts --reporter=verbose --maxWorkers=1`
2. `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src-pr112865-repair.tsbuildinfo`
3. `pnpm deadcode:exports`
4. `pnpm exec oxfmt --check src/cli/command-catalog.ts src/cli/command-startup-policy.test.ts src/snapshot/recovery-journal.ts src/snapshot/recovery-journal.test.ts test/cli-json-stdout.e2e.test.ts src/commands/backup-capture-final.test.ts`
5. `git diff --check`
6. `node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/program/root-command-descriptions.test.ts --reporter=verbose --maxWorkers=1`
7. `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-src.config.ts src/snapshot/recovery-journal.test.ts --reporter=verbose --maxWorkers=1`
8. `pnpm exec oxlint src/snapshot/recovery-journal.test.ts src/cli/program/root-command-descriptions.test.ts`
9. `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src-pr112865-ci-repair.tsbuildinfo`

Evidence after fix:
Formatter, diff whitespace, tsgo, oxlint, and deadcode export checks passed. The focused WSL Vitest run passed 4 final-capture shards: `src/snapshot/recovery-journal.test.ts` 1/1, `src/cli/command-startup-policy.test.ts` 12/12, `src/commands/backup-capture-final.test.ts` 1/1, and `test/cli-json-stdout.e2e.test.ts` 4/4. The exact-head CI repair also passed the CLI root-command JSON decision test and the recovery-journal unit test that GitHub had failed. The final-capture suite includes relocated registered agent database capture, incompatible registered agent schema quarantine, unsupported recovery-root parent-sync hold, component byte tamper quarantine, aggregate manifest byte tamper quarantine, durable-intent quarantine, exact replay, recovery-journal pathname replacement rejection, and hidden command stdout parseability from a real stdin process.

Observed result after fix:
The final-capture source harness captured a recovery point from registered SQLite owner state, replayed the exact committed result, refused a different repository path for the same operation identity, quarantined post-intent failures, rejected both component-byte and aggregate-manifest byte changes, rejected a journal replacement race before SQLite DDL, and kept hidden command stdout to one JSON document with no startup banner/progress text.

What was not tested:
A production host supervisor supplying closure evidence, external durable acceptance, upload/encryption, source destruction, full CLI happy-path capture against live host state, crash injection at every fsync boundary, or cross-OS proof.

## Merge gate

Ready for code review of the repaired head. Merge remains gated on owner acceptance of closure evidence, inventory ownership, and host-protected versus portable semantics in openclaw/rfcs#46. This PR is one bounded implementation of #114145, not a mandate for this exact seam; retained ingress, wake, placement, and compute lifecycle remain host-owned.

