### PR TITLE
fix(ui): pin session observer to pane header edge

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -580,6 +580,35 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("pins the session observer to the pane header edge", async () => {
+    const page = await openBrowserPage(922, 282);
+    try {
+      const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}\n${splitViewCss}</style></head><body>
+          <div class="chat-split-view__cell" style="width: 922px; height: 282px;">
+            <div class="chat-pane__header">Current session</div>
+            <div class="chat-split-view__pane">
+              <div class="chat-main" style="height: 100%;">
+                <div class="chat-observer-hud chat-observer-hud--pill">
+                  <span class="chat-observer-hud__status" data-health="on-track">On track</span>
+                  <span class="chat-observer-hud__headline">Investigating repository guidance</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </body></html>`,
+      );
+
+      const header = await getBoundingBox(page, ".chat-pane__header");
+      const observer = await getBoundingBox(page, ".chat-observer-hud");
+
+      expect(observer.y).toBeCloseTo(header.y + header.height, 0);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it.each([
     [430, 720],
     [1366, 900],

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1689,7 +1689,7 @@ openclaw-session-owner-chip {
    yields to /btw by collapsing to its one-line pill. */
 .chat-observer-hud {
   position: absolute;
-  top: clamp(44px, 5vh, 52px);
+  top: 0;
   right: 12px;
   z-index: 29;
   border: 1px solid var(--border);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the session observer/background-task notification appeared 44px below the chat pane header instead of sitting against the top-bar edge.

## Why This Change Was Made

The desktop observer now anchors to the top of its existing `.chat-main` containing block. The mobile bottom-docked override is unchanged, and a browser geometry regression test locks the desktop observer to the pane-header boundary.

## User Impact

Background-task status stays fixed at the top edge of the chat pane, making it easier to notice without leaving an unexplained gap below the header.

AI-assisted change; the implementation and proof were reviewed before submission.

## Evidence

- Red baseline: representative Chromium geometry measured a 44px gap between the pane-header edge and observer.
- Green behavior validation: 4/4 clauses passed for the desktop pill, reload persistence, expanded card, and mobile bottom-dock negative control.
- Exact head `8cd4be981d268c8164b798df55b80091c4f259ff`: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts` — 69/69 passed.
- Patch-identical remote proof: all 69 responsive browser tests and `pnpm check:changed` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29973000018
- Fresh structured autoreview: no accepted or actionable findings; patch rated correct at 0.95 confidence.
- The patched build was deployed to Rosita and manually exercised before this PR was requested.

Raw red/green recordings and manifests are retained in the private maintainer-proof workspace; no private session data or proof assets were uploaded.
