### PR TITLE
fix(cli): keep public CA roots for macOS one-shot commands

### DIFF
--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -103,7 +103,7 @@ describe("buildCliRespawnPlan", () => {
     expect(respawnPlan.detachForProcessTree).toBe(false);
   });
 
-  it("uses the file-backed CA store for one-shot macOS commands", () => {
+  it("uses bundled public roots for one-shot macOS commands", () => {
     const plan = buildCliRespawnPlan({
       argv: ["node", "openclaw", "cron", "list", "--json"],
       env: { NODE_USE_SYSTEM_CA: "1" },
@@ -115,7 +115,7 @@ describe("buildCliRespawnPlan", () => {
     const respawnPlan = expectCliRespawnPlan(plan);
     expect(respawnPlan.argv).toEqual([
       EXPERIMENTAL_WARNING_FLAG,
-      OPENSSL_CA_FLAG,
+      BUNDLED_CA_FLAG,
       "openclaw",
       "cron",
       "list",
@@ -182,15 +182,15 @@ describe("buildCliRespawnPlan", () => {
     },
   );
 
-  it("does not respawn again after selecting the macOS file-backed CA store", () => {
+  it("does not respawn again after selecting bundled public roots", () => {
     expect(
       buildCliRespawnPlan({
         argv: ["node", "openclaw", "cron", "list", "--json"],
         env: {
-          NODE_USE_SYSTEM_CA: "1",
+          NODE_USE_SYSTEM_CA: "0",
           [OPENCLAW_NODE_OPTIONS_READY]: "1",
         },
-        execArgv: [OPENSSL_CA_FLAG, EXPERIMENTAL_WARNING_FLAG],
+        execArgv: [BUNDLED_CA_FLAG, EXPERIMENTAL_WARNING_FLAG],
         autoNodeExtraCaCerts: undefined,
         platform: "darwin",
       }),

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -152,11 +152,11 @@ export function buildCliRespawnPlan(
     !hasNodeRuntimeOption({ env, execArgv, option: OPENSSL_CA_FLAG })
   ) {
     // Node loads the macOS Keychain off-thread on the first TLS import, then joins
-    // that worker during shutdown. One-shot CLIs use the file-backed CA store instead;
+    // that worker during shutdown. One-shot CLIs use Node's bundled public roots;
     // an explicit --use-system-ca remains the opt-in for Keychain-only trust.
     childEnv.NODE_USE_SYSTEM_CA = "0";
     if (!hasNodeRuntimeOption({ env, execArgv, option: BUNDLED_CA_FLAG })) {
-      childExecArgv.unshift(OPENSSL_CA_FLAG);
+      childExecArgv.unshift(BUNDLED_CA_FLAG);
     }
     needsRespawn = true;
   }


### PR DESCRIPTION
Closes #112862
Related: #89655
Follow-up to #110341

## What Problem This Solves

Fixes an issue where macOS one-shot commands disabled Keychain CA loading to avoid a shutdown hang but selected an unconfigured OpenSSL CA store. Valid provider calls could then fail with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` even though plain Node, curl, and direct provider requests succeeded.

## Why This Change Was Made

One-shot macOS respawns now use Node's bundled public CA roots instead of `--use-openssl-ca`. This retains the original shutdown-hang mitigation—`NODE_USE_SYSTEM_CA` stays disabled in the child—while ensuring public provider TLS does not depend on a version-manager Node build having `SSL_CERT_FILE` configured. Explicit `--use-system-ca` remains the opt-in for private roots available only through macOS Keychain.

The fix stays in CLI lifecycle ownership. Provider transports and Undici dispatchers continue inheriting the process CA policy and do not gain provider-specific trust exceptions.

## User Impact

macOS users can run one-shot provider commands such as `openclaw agent --local` without losing public TLS trust or hanging at process shutdown. Private enterprise/Keychain roots remain available through the existing explicit system-CA flag.

## Evidence

- Current-main authenticated Gemini reproduction: onboarding succeeded, then the default one-shot respawn failed with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`.
- Same environment with explicit `--use-system-ca`: onboarding 0, agent 0, `LIVE_OK`, no exit timeout.
- Patched default bundled-CA respawn: onboarding 0, agent 0, `LIVE_OK`, no exit timeout.
- Deterministic no-credential probes: system CA and bundled CA reached the Google endpoint; generated OpenSSL mode failed TLS.
- `node scripts/run-vitest.mjs src/entry.respawn.test.ts src/cli/gateway-backed-exit.process.test.ts`: 29/29 passed.
- Targeted formatting, lint, and `git diff --check`: clean.
- Codex autoreview (`gpt-5.6-sol`, xhigh): no accepted or actionable findings.

AI-assisted: yes. The root cause and Node/Undici trust-store contracts were reviewed before implementation.
