### PR TITLE
fix(release): invoke frozen Telegram CLI directly

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -2222,6 +2222,13 @@ jobs:
           } >"${output_dir}/source-attestation.txt"
           echo "output_dir=$output_dir" >>"$GITHUB_OUTPUT"
 
+          # The frozen archive is mounted read-only for the isolated SUT. Invoke
+          # its built CLI directly so pnpm cannot attempt an implicit install.
+          run_candidate_telegram_qa() (
+            cd "$CANDIDATE_ROOT"
+            exec node ./dist/index.js qa telegram "$@"
+          )
+
           run_qa_attempt() (
             set -euo pipefail
             exec 2>&1
@@ -2232,7 +2239,7 @@ jobs:
             trap 'printf "::%s::\n" "$workflow_command_token"' EXIT
             set +e
             TMPDIR="${SUT_RUNTIME_ROOT}/tmp" \
-              pnpm --dir "$CANDIDATE_ROOT" openclaw qa telegram \
+              run_candidate_telegram_qa \
                 --repo-root "$CANDIDATE_ROOT" \
                 --output-dir "${EVIDENCE_RELATIVE}/${output_name}" \
                 --provider-mode mock-openai \
@@ -2260,7 +2267,7 @@ jobs:
             fi
           done < <(
             TMPDIR="${SUT_RUNTIME_ROOT}/tmp" \
-              pnpm --dir "$CANDIDATE_ROOT" openclaw qa telegram \
+              run_candidate_telegram_qa \
                 --repo-root "$CANDIDATE_ROOT" \
                 --provider-mode mock-openai \
                 --list-scenarios

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -578,7 +578,9 @@ describe("release Telegram QA workflow", () => {
     expect(runStep?.run).toContain("! grep -Fq '\"openai/gpt-5.6-luna\": {'");
     expect(runStep?.run).toContain('qa_model="mock-openai/gpt-5.5"');
     expect(runStep?.run).toContain('--model "$qa_model"');
-    expect(runStep?.run).toContain('pnpm --dir "$CANDIDATE_ROOT" openclaw qa telegram');
+    expect(runStep?.run).toContain("run_candidate_telegram_qa() (");
+    expect(runStep?.run).toContain("exec node ./dist/index.js qa telegram");
+    expect(runStep?.run).not.toContain('pnpm --dir "$CANDIDATE_ROOT" openclaw qa telegram');
     expect(runStep?.run).toContain(
       "Telegram channel canary failed; skipping the remaining scenarios.",
     );


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation run `29977049409` reached the trusted Telegram QA child `29977865658`, but the frozen candidate CLI was launched with `pnpm --dir` from an isolated read-only SUT archive. pnpm attempted an implicit install and failed with `EACCES` before the channel canary could start.

## Solution

Invoke the candidate archive’s already-built `dist/index.js` directly from its root for both scenario discovery and live execution. This preserves the frozen candidate CLI/config contract while avoiding package-manager mutation in the protected tree.

## Evidence

- Failing Telegram child: https://github.com/openclaw/openclaw/actions/runs/29977865658
- Failure: `EACCES` during pnpm implicit install at the candidate root; candidate process did not start.
- `git diff --check` passed.
- Fresh structured autoreview: clean, 0.93 confidence.
- Hosted CI will validate the workflow contract at the exact PR head.
