### PR TITLE
fix(agents): keep queued runs from expiring

### DIFF
--- a/src/agents/embedded-agent-runner/run/lane-controller.run-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.run-context.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import {
+  getAgentEventLifecycleGeneration,
+  getAgentRunContext,
+  registerAgentRunContext,
+  resetAgentEventsForTest,
+  sweepStaleRunContexts,
+} from "../../../infra/agent-events.js";
+import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types.js";
+import type { EmbeddedAgentRunResult } from "../types.js";
+import { createEmbeddedRunLaneController } from "./lane-controller.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+
+type LaneParams = RunEmbeddedAgentParams & { sessionFile: string };
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+});
+
+function createDeferredEnqueue() {
+  const queuedTasks: Array<() => Promise<void>> = [];
+  const enqueue: CommandQueueEnqueueFn = <T>(task: () => Promise<T>) =>
+    new Promise<T>((resolve, reject) => {
+      queuedTasks.push(async () => {
+        try {
+          resolve(await task());
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+    });
+  return { enqueue, queuedTasks };
+}
+
+function createController(
+  runId: string,
+  lifecycleGeneration: string,
+  enqueue: CommandQueueEnqueueFn,
+) {
+  let params: LaneParams = {
+    enqueue,
+    prompt: "test",
+    runId,
+    sessionFile: `/tmp/${runId}.jsonl`,
+    sessionId: `${runId}-session`,
+    sessionKey: `session-${runId}`,
+    timeoutMs: 60_000,
+    workspaceDir: "/tmp",
+  };
+  return createEmbeddedRunLaneController({
+    getLifecycleGeneration: () => lifecycleGeneration,
+    getParams: () => params,
+    globalLane: "subagent",
+    initialQueuedLifecycleGeneration: lifecycleGeneration,
+    sessionLane: `session:${runId}`,
+    setLifecycleGeneration: () => {},
+    setParams: (nextParams) => {
+      params = nextParams;
+    },
+  });
+}
+
+test("does not count command-lane queue wait against run-context inactivity", async () => {
+  const now = vi.spyOn(Date, "now").mockReturnValue(100);
+  const runId = "queued-run";
+  const lifecycleGeneration = getAgentEventLifecycleGeneration();
+  registerAgentRunContext(runId, {
+    lifecycleGeneration,
+    registeredAt: Date.now(),
+    sessionKey: "session-queued-run",
+  });
+
+  const { enqueue, queuedTasks } = createDeferredEnqueue();
+  const controller = createController(runId, lifecycleGeneration, enqueue);
+  const result: EmbeddedAgentRunResult = { meta: { durationMs: 0 } };
+  const queuedResult = controller.enqueueGlobal(async () => result);
+
+  now.mockReturnValue(1_000);
+  expect(sweepStaleRunContexts(500)).toBe(0);
+  expect(getAgentRunContext(runId)).toBeDefined();
+
+  const startQueuedTask = queuedTasks.shift();
+  expect(startQueuedTask).toBeDefined();
+  await startQueuedTask?.();
+  await expect(queuedResult).resolves.toBe(result);
+
+  now.mockReturnValue(1_499);
+  expect(sweepStaleRunContexts(500)).toBe(0);
+  now.mockReturnValue(1_501);
+  expect(sweepStaleRunContexts(500)).toBe(1);
+  now.mockRestore();
+});
+
+test("keeps run context active until every overlapping enqueue is admitted", async () => {
+  const now = vi.spyOn(Date, "now").mockReturnValue(100);
+  const runId = "overlapping-queued-run";
+  const lifecycleGeneration = getAgentEventLifecycleGeneration();
+  registerAgentRunContext(runId, {
+    lifecycleGeneration,
+    registeredAt: Date.now(),
+    sessionKey: "session-overlapping-queued-run",
+  });
+
+  const { enqueue, queuedTasks } = createDeferredEnqueue();
+  const controller = createController(runId, lifecycleGeneration, enqueue);
+  const firstResult: EmbeddedAgentRunResult = { meta: { durationMs: 1 } };
+  const secondResult: EmbeddedAgentRunResult = { meta: { durationMs: 2 } };
+  const firstQueuedResult = controller.enqueueGlobal(async () => firstResult);
+  const secondQueuedResult = controller.enqueueGlobal(async () => secondResult);
+
+  now.mockReturnValue(1_000);
+  expect(sweepStaleRunContexts(500)).toBe(0);
+
+  const startFirstTask = queuedTasks.shift();
+  expect(startFirstTask).toBeDefined();
+  await startFirstTask?.();
+  await expect(firstQueuedResult).resolves.toBe(firstResult);
+
+  now.mockReturnValue(2_000);
+  expect(sweepStaleRunContexts(500)).toBe(0);
+  expect(getAgentRunContext(runId)).toBeDefined();
+
+  const startSecondTask = queuedTasks.shift();
+  expect(startSecondTask).toBeDefined();
+  await startSecondTask?.();
+  await expect(secondQueuedResult).resolves.toBe(secondResult);
+
+  now.mockReturnValue(2_499);
+  expect(sweepStaleRunContexts(500)).toBe(0);
+  now.mockReturnValue(2_501);
+  expect(sweepStaleRunContexts(500)).toBe(1);
+  now.mockRestore();
+});

--- a/src/agents/embedded-agent-runner/run/lane-controller.run-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.run-context.test.ts
@@ -3,6 +3,7 @@ import {
   getAgentEventLifecycleGeneration,
   registerAgentRunContext,
   resetAgentEventsForTest,
+  rotateAgentEventLifecycleGeneration,
   sweepStaleRunContexts,
 } from "../../../infra/agent-events.js";
 import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types.js";
@@ -14,9 +15,7 @@ type LaneParams = RunEmbeddedAgentParams & { sessionFile: string };
 beforeEach(() => resetAgentEventsForTest());
 afterEach(() => vi.restoreAllMocks());
 
-test("keeps run context active until every overlapping enqueue is admitted", async () => {
-  const now = vi.spyOn(Date, "now").mockReturnValue(100);
-  const runId = "overlapping-queued-run";
+function createQueuedLaneController(runId: string) {
   const sessionKey = `agent:main:${runId}`;
   const lifecycleGeneration = getAgentEventLifecycleGeneration();
   registerAgentRunContext(runId, {
@@ -28,9 +27,9 @@ test("keeps run context active until every overlapping enqueue is admitted", asy
   const queuedTasks: Array<() => Promise<void>> = [];
   const enqueue: CommandQueueEnqueueFn = <T>(task: () => Promise<T>) =>
     new Promise<T>((resolve, reject) => {
-      queuedTasks.push(() => task().then(resolve, reject));
+      queuedTasks.push(() => Promise.resolve().then(task).then(resolve, reject));
     });
-  let params: LaneParams = {
+  let laneParams: LaneParams = {
     enqueue,
     prompt: "test",
     runId,
@@ -38,19 +37,26 @@ test("keeps run context active until every overlapping enqueue is admitted", asy
     sessionId: `${runId}-session`,
     sessionKey,
     timeoutMs: 60_000,
+    trigger: "cron",
     workspaceDir: "/tmp",
   };
   const controller = createEmbeddedRunLaneController({
     getLifecycleGeneration: () => lifecycleGeneration,
-    getParams: () => params,
+    getParams: () => laneParams,
     globalLane: "subagent",
     initialQueuedLifecycleGeneration: lifecycleGeneration,
     sessionLane: `session:${runId}`,
     setLifecycleGeneration: () => {},
     setParams: (nextParams) => {
-      params = nextParams;
+      laneParams = nextParams;
     },
   });
+  return { controller, queuedTasks };
+}
+
+test("keeps run context active until every overlapping enqueue is admitted", async () => {
+  const now = vi.spyOn(Date, "now").mockReturnValue(100);
+  const { controller, queuedTasks } = createQueuedLaneController("overlapping-queued-run");
   const firstResult = { meta: { durationMs: 1 } };
   const secondResult = { meta: { durationMs: 2 } };
   const firstQueuedResult = controller.enqueueGlobal(async () => firstResult);
@@ -77,3 +83,28 @@ test("keeps run context active until every overlapping enqueue is admitted", asy
   now.mockReturnValue(2_501);
   expect(sweepStaleRunContexts(500)).toBe(1);
 });
+
+test.each(["global", "session"] as const)(
+  "releases a non-resumable %s-lane wait after lifecycle rotation",
+  async (lane) => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(100);
+    const runId = `rotated-${lane}-lane-run`;
+    const { controller, queuedTasks } = createQueuedLaneController(runId);
+    const queuedResult =
+      lane === "global"
+        ? controller.enqueueGlobal(async () => ({ meta: { durationMs: 1 } }))
+        : controller.enqueueSession(async () => ({ meta: { durationMs: 1 } }));
+
+    now.mockReturnValue(1_000);
+    expect(sweepStaleRunContexts(500)).toBe(0);
+    rotateAgentEventLifecycleGeneration();
+    now.mockReturnValue(1_501);
+    expect(sweepStaleRunContexts(500)).toBe(1);
+    const rejection = queuedResult.catch((error: unknown) => error);
+    await queuedTasks.shift()?.();
+    await expect(rejection).resolves.toMatchObject({
+      name: "AbortError",
+      message: "Agent run belongs to a stale gateway lifecycle",
+    });
+  },
+);

--- a/src/agents/embedded-agent-runner/run/lane-controller.run-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.run-context.test.ts
@@ -1,53 +1,46 @@
-import { beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import {
   getAgentEventLifecycleGeneration,
-  getAgentRunContext,
   registerAgentRunContext,
   resetAgentEventsForTest,
   sweepStaleRunContexts,
 } from "../../../infra/agent-events.js";
 import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types.js";
-import type { EmbeddedAgentRunResult } from "../types.js";
 import { createEmbeddedRunLaneController } from "./lane-controller.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
 
 type LaneParams = RunEmbeddedAgentParams & { sessionFile: string };
 
-beforeEach(() => {
-  resetAgentEventsForTest();
-});
+beforeEach(() => resetAgentEventsForTest());
+afterEach(() => vi.restoreAllMocks());
 
-function createDeferredEnqueue() {
+test("keeps run context active until every overlapping enqueue is admitted", async () => {
+  const now = vi.spyOn(Date, "now").mockReturnValue(100);
+  const runId = "overlapping-queued-run";
+  const sessionKey = `agent:main:${runId}`;
+  const lifecycleGeneration = getAgentEventLifecycleGeneration();
+  registerAgentRunContext(runId, {
+    lifecycleGeneration,
+    registeredAt: Date.now(),
+    sessionKey,
+  });
+
   const queuedTasks: Array<() => Promise<void>> = [];
   const enqueue: CommandQueueEnqueueFn = <T>(task: () => Promise<T>) =>
     new Promise<T>((resolve, reject) => {
-      queuedTasks.push(async () => {
-        try {
-          resolve(await task());
-        } catch (error) {
-          reject(error instanceof Error ? error : new Error(String(error)));
-        }
-      });
+      queuedTasks.push(() => task().then(resolve, reject));
     });
-  return { enqueue, queuedTasks };
-}
-
-function createController(
-  runId: string,
-  lifecycleGeneration: string,
-  enqueue: CommandQueueEnqueueFn,
-) {
   let params: LaneParams = {
     enqueue,
     prompt: "test",
     runId,
     sessionFile: `/tmp/${runId}.jsonl`,
     sessionId: `${runId}-session`,
-    sessionKey: `session-${runId}`,
+    sessionKey,
     timeoutMs: 60_000,
     workspaceDir: "/tmp",
   };
-  return createEmbeddedRunLaneController({
+  const controller = createEmbeddedRunLaneController({
     getLifecycleGeneration: () => lifecycleGeneration,
     getParams: () => params,
     globalLane: "subagent",
@@ -58,53 +51,8 @@ function createController(
       params = nextParams;
     },
   });
-}
-
-test("does not count command-lane queue wait against run-context inactivity", async () => {
-  const now = vi.spyOn(Date, "now").mockReturnValue(100);
-  const runId = "queued-run";
-  const lifecycleGeneration = getAgentEventLifecycleGeneration();
-  registerAgentRunContext(runId, {
-    lifecycleGeneration,
-    registeredAt: Date.now(),
-    sessionKey: "session-queued-run",
-  });
-
-  const { enqueue, queuedTasks } = createDeferredEnqueue();
-  const controller = createController(runId, lifecycleGeneration, enqueue);
-  const result: EmbeddedAgentRunResult = { meta: { durationMs: 0 } };
-  const queuedResult = controller.enqueueGlobal(async () => result);
-
-  now.mockReturnValue(1_000);
-  expect(sweepStaleRunContexts(500)).toBe(0);
-  expect(getAgentRunContext(runId)).toBeDefined();
-
-  const startQueuedTask = queuedTasks.shift();
-  expect(startQueuedTask).toBeDefined();
-  await startQueuedTask?.();
-  await expect(queuedResult).resolves.toBe(result);
-
-  now.mockReturnValue(1_499);
-  expect(sweepStaleRunContexts(500)).toBe(0);
-  now.mockReturnValue(1_501);
-  expect(sweepStaleRunContexts(500)).toBe(1);
-  now.mockRestore();
-});
-
-test("keeps run context active until every overlapping enqueue is admitted", async () => {
-  const now = vi.spyOn(Date, "now").mockReturnValue(100);
-  const runId = "overlapping-queued-run";
-  const lifecycleGeneration = getAgentEventLifecycleGeneration();
-  registerAgentRunContext(runId, {
-    lifecycleGeneration,
-    registeredAt: Date.now(),
-    sessionKey: "session-overlapping-queued-run",
-  });
-
-  const { enqueue, queuedTasks } = createDeferredEnqueue();
-  const controller = createController(runId, lifecycleGeneration, enqueue);
-  const firstResult: EmbeddedAgentRunResult = { meta: { durationMs: 1 } };
-  const secondResult: EmbeddedAgentRunResult = { meta: { durationMs: 2 } };
+  const firstResult = { meta: { durationMs: 1 } };
+  const secondResult = { meta: { durationMs: 2 } };
   const firstQueuedResult = controller.enqueueGlobal(async () => firstResult);
   const secondQueuedResult = controller.enqueueGlobal(async () => secondResult);
 
@@ -118,7 +66,6 @@ test("keeps run context active until every overlapping enqueue is admitted", asy
 
   now.mockReturnValue(2_000);
   expect(sweepStaleRunContexts(500)).toBe(0);
-  expect(getAgentRunContext(runId)).toBeDefined();
 
   const startSecondTask = queuedTasks.shift();
   expect(startSecondTask).toBeDefined();
@@ -129,5 +76,4 @@ test("keeps run context active until every overlapping enqueue is admitted", asy
   expect(sweepStaleRunContexts(500)).toBe(0);
   now.mockReturnValue(2_501);
   expect(sweepStaleRunContexts(500)).toBe(1);
-  now.mockRestore();
 });

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -1,8 +1,10 @@
 import {
   assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
+  claimAgentRunContextQueue,
   getAgentEventLifecycleGeneration,
   getAgentRunContext,
+  releaseAgentRunContextQueue,
   withAgentRunLifecycleGeneration,
 } from "../../../infra/agent-events.js";
 import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../../process/command-queue.js";
@@ -60,6 +62,25 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     abortError.name = "AbortError";
     throw abortError;
   };
+  const createRunContextQueueClaim = () => {
+    const runId = options.getParams().runId;
+    const lifecycleGeneration = options.getLifecycleGeneration();
+    const queueClaimId = claimAgentRunContextQueue(runId, lifecycleGeneration);
+    return () => {
+      releaseAgentRunContextQueue(runId, queueClaimId, lifecycleGeneration);
+    };
+  };
+  const enqueueWithRunContextQueueState = <T>(
+    releaseQueueClaim: () => void,
+    enqueue: () => Promise<T>,
+  ): Promise<T> => {
+    try {
+      return enqueue().finally(releaseQueueClaim);
+    } catch (error) {
+      releaseQueueClaim();
+      throw error;
+    }
+  };
   const withLaneTimeout = (opts?: CommandQueueEnqueueOptions) =>
     withEmbeddedRunLaneTimeout(
       {
@@ -105,11 +126,13 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     // Global-lane admission is healthy waiting, not run execution. Keep reply
     // staleness and stuck recovery fenced until this queue grants capacity.
     options.getParams().replyOperation?.markWaitingForGlobalLane();
+    const releaseQueueClaim = createRunContextQueueClaim();
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: sessionQueuePriority,
     };
     const taskWithCurrentLifecycle = async () => {
+      releaseQueueClaim();
       let params = options.getParams();
       params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
       params.replyOperation?.markGlobalLaneWaitEnded();
@@ -161,30 +184,42 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     };
     const params = options.getParams();
     if (params.enqueue) {
-      return params.enqueue(taskWithCurrentLifecycle, withLaneTimeout(withRunLaneWait(globalOpts)));
+      const enqueue = params.enqueue;
+      return enqueueWithRunContextQueueState(releaseQueueClaim, () =>
+        enqueue(taskWithCurrentLifecycle, withLaneTimeout(withRunLaneWait(globalOpts))),
+      );
     }
     noteLaneWaitIfBusy(options.globalLane);
-    return enqueueCommandInLane(
-      options.globalLane,
-      taskWithCurrentLifecycle,
-      withLaneTimeout(withRunLaneWait(globalOpts)),
+    return enqueueWithRunContextQueueState(releaseQueueClaim, () =>
+      enqueueCommandInLane(
+        options.globalLane,
+        taskWithCurrentLifecycle,
+        withLaneTimeout(withRunLaneWait(globalOpts)),
+      ),
     );
   };
   const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
+    const releaseQueueClaim = createRunContextQueueClaim();
     const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
     const taskWithLaneAdmission = () => {
+      releaseQueueClaim();
       options.getParams().onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
       return task();
     };
     const params = options.getParams();
     if (params.enqueue) {
-      return params.enqueue(taskWithLaneAdmission, withRunLaneWait(sessionOpts));
+      const enqueue = params.enqueue;
+      return enqueueWithRunContextQueueState(releaseQueueClaim, () =>
+        enqueue(taskWithLaneAdmission, withRunLaneWait(sessionOpts)),
+      );
     }
     noteLaneWaitIfBusy(options.sessionLane);
-    return enqueueCommandInLane(
-      options.sessionLane,
-      taskWithLaneAdmission,
-      withRunLaneWait(sessionOpts),
+    return enqueueWithRunContextQueueState(releaseQueueClaim, () =>
+      enqueueCommandInLane(
+        options.sessionLane,
+        taskWithLaneAdmission,
+        withRunLaneWait(sessionOpts),
+      ),
     );
   };
 

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -37,6 +37,16 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     initialParams.trigger,
     initialParams.inputProvenance,
   );
+  const canResumeAcrossLifecycleRotation = (lifecycleGeneration: string) =>
+    sessionQueuePriority === "foreground" &&
+    options.initialQueuedLifecycleGeneration === lifecycleGeneration;
+  const beginRunContextQueueWait = () => {
+    const lifecycleGeneration = options.getLifecycleGeneration();
+    return beginAgentRunContextQueueWait(options.getParams().runId, {
+      lifecycleGeneration,
+      resumeAcrossLifecycleRotation: canResumeAcrossLifecycleRotation(lifecycleGeneration),
+    });
+  };
   const laneTaskTimeoutMs = resolveEmbeddedRunLaneTimeoutMs(initialParams.timeoutMs);
   const laneTaskAbortController = new AbortController();
   const laneTaskReleaseController = new AbortController();
@@ -117,10 +127,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     // Global-lane admission is healthy waiting, not run execution. Keep reply
     // staleness and stuck recovery fenced until this queue grants capacity.
     options.getParams().replyOperation?.markWaitingForGlobalLane();
-    const releaseQueueWait = beginAgentRunContextQueueWait(
-      options.getParams().runId,
-      options.getLifecycleGeneration(),
-    );
+    const releaseQueueWait = beginRunContextQueueWait();
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: sessionQueuePriority,
@@ -135,14 +142,10 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
       const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
       const existingContext = getAgentRunContext(params.runId);
       if (lifecycleGeneration !== currentLifecycleGeneration) {
-        const wasQueuedBeforeRotation =
-          options.initialQueuedLifecycleGeneration === lifecycleGeneration;
-        const canResumeAcrossRotation = sessionQueuePriority === "foreground";
         const newerSameIdExecutionOwnsContext =
           existingContext?.lifecycleGeneration === currentLifecycleGeneration;
         if (
-          !wasQueuedBeforeRotation ||
-          !canResumeAcrossRotation ||
+          !canResumeAcrossLifecycleRotation(lifecycleGeneration) ||
           newerSameIdExecutionOwnsContext
         ) {
           assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
@@ -193,14 +196,16 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     );
   };
   const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
-    const releaseQueueWait = beginAgentRunContextQueueWait(
-      options.getParams().runId,
-      options.getLifecycleGeneration(),
-    );
+    const releaseQueueWait = beginRunContextQueueWait();
     const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
     const taskWithLaneAdmission = () => {
       releaseQueueWait();
       options.getParams().onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
+      const lifecycleGeneration = options.getLifecycleGeneration();
+      if (!canResumeAcrossLifecycleRotation(lifecycleGeneration)) {
+        assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+      }
+      // The session task only advances to global admission, which reclaims lifecycle ownership.
       return task();
     };
     const params = options.getParams();

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -1,10 +1,9 @@
 import {
   assertAgentRunLifecycleGenerationCurrent,
+  beginAgentRunContextQueueWait,
   claimAgentRunContext,
-  claimAgentRunContextQueue,
   getAgentEventLifecycleGeneration,
   getAgentRunContext,
-  releaseAgentRunContextQueue,
   withAgentRunLifecycleGeneration,
 } from "../../../infra/agent-events.js";
 import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../../process/command-queue.js";
@@ -62,22 +61,14 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     abortError.name = "AbortError";
     throw abortError;
   };
-  const createRunContextQueueClaim = () => {
-    const runId = options.getParams().runId;
-    const lifecycleGeneration = options.getLifecycleGeneration();
-    const queueClaimId = claimAgentRunContextQueue(runId, lifecycleGeneration);
-    return () => {
-      releaseAgentRunContextQueue(runId, queueClaimId, lifecycleGeneration);
-    };
-  };
-  const enqueueWithRunContextQueueState = <T>(
-    releaseQueueClaim: () => void,
+  const enqueueWithRunContextQueueWait = <T>(
+    releaseQueueWait: () => void,
     enqueue: () => Promise<T>,
   ): Promise<T> => {
     try {
-      return enqueue().finally(releaseQueueClaim);
+      return enqueue().finally(releaseQueueWait);
     } catch (error) {
-      releaseQueueClaim();
+      releaseQueueWait();
       throw error;
     }
   };
@@ -126,13 +117,16 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     // Global-lane admission is healthy waiting, not run execution. Keep reply
     // staleness and stuck recovery fenced until this queue grants capacity.
     options.getParams().replyOperation?.markWaitingForGlobalLane();
-    const releaseQueueClaim = createRunContextQueueClaim();
+    const releaseQueueWait = beginAgentRunContextQueueWait(
+      options.getParams().runId,
+      options.getLifecycleGeneration(),
+    );
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: sessionQueuePriority,
     };
     const taskWithCurrentLifecycle = async () => {
-      releaseQueueClaim();
+      releaseQueueWait();
       let params = options.getParams();
       params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
       params.replyOperation?.markGlobalLaneWaitEnded();
@@ -185,12 +179,12 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     const params = options.getParams();
     if (params.enqueue) {
       const enqueue = params.enqueue;
-      return enqueueWithRunContextQueueState(releaseQueueClaim, () =>
+      return enqueueWithRunContextQueueWait(releaseQueueWait, () =>
         enqueue(taskWithCurrentLifecycle, withLaneTimeout(withRunLaneWait(globalOpts))),
       );
     }
     noteLaneWaitIfBusy(options.globalLane);
-    return enqueueWithRunContextQueueState(releaseQueueClaim, () =>
+    return enqueueWithRunContextQueueWait(releaseQueueWait, () =>
       enqueueCommandInLane(
         options.globalLane,
         taskWithCurrentLifecycle,
@@ -199,22 +193,25 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     );
   };
   const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
-    const releaseQueueClaim = createRunContextQueueClaim();
+    const releaseQueueWait = beginAgentRunContextQueueWait(
+      options.getParams().runId,
+      options.getLifecycleGeneration(),
+    );
     const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
     const taskWithLaneAdmission = () => {
-      releaseQueueClaim();
+      releaseQueueWait();
       options.getParams().onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
       return task();
     };
     const params = options.getParams();
     if (params.enqueue) {
       const enqueue = params.enqueue;
-      return enqueueWithRunContextQueueState(releaseQueueClaim, () =>
+      return enqueueWithRunContextQueueWait(releaseQueueWait, () =>
         enqueue(taskWithLaneAdmission, withRunLaneWait(sessionOpts)),
       );
     }
     noteLaneWaitIfBusy(options.sessionLane);
-    return enqueueWithRunContextQueueState(releaseQueueClaim, () =>
+    return enqueueWithRunContextQueueWait(releaseQueueWait, () =>
       enqueueCommandInLane(
         options.sessionLane,
         taskWithLaneAdmission,

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -75,6 +75,8 @@ export type AgentEventRuntimePayload = AgentEventPayload & {
 };
 
 /** Per-run metadata used to stamp events and gate Control UI visibility. */
+type AgentRunContextQueueWait = { resumeAcrossLifecycleRotation: boolean };
+
 type AgentRunContext = {
   sessionKey?: string;
   /** Resolved agent owner, including for unscoped session keys. */
@@ -95,7 +97,7 @@ type AgentRunContext = {
   /** Timestamp of last activity (updated on every emitAgentEvent). */
   lastActiveAt?: number;
   /** Active command-lane waits that keep this context eligible for admission. */
-  activeQueueWaits?: number;
+  activeQueueWaits?: Set<AgentRunContextQueueWait>;
 };
 
 type AgentEventState = {
@@ -209,6 +211,15 @@ export function captureAgentRunLifecycleGeneration(runId: string): string {
 export function rotateAgentEventLifecycleGeneration(): string {
   const state = getAgentEventState();
   state.lifecycleGeneration = randomUUID();
+  // Queue claims follow the same restart-resume contract as lane admission.
+  // Retiring blocked stale work here prevents a paused lane from pinning it forever.
+  for (const [runId, context] of state.runContextById) {
+    for (const wait of context.activeQueueWaits ?? []) {
+      if (!wait.resumeAcrossLifecycleRotation) {
+        releaseAgentRunContextQueueWait(state, runId, context, wait);
+      }
+    }
+  }
   // Rotation is the liveness choke point: after it returns, no prior-generation
   // owner is operationally reachable. Recovery and runtime consumers therefore
   // agree that only current-generation owners can drive or receive work.
@@ -380,7 +391,7 @@ export function claimAgentRunContext(
     registeredAt: context.registeredAt ?? Date.now(),
   };
   // Queue waits belong to the exact context object they started against.
-  // Carrying the count across lifecycle replacement would pin a newer run.
+  // Carrying the claims across lifecycle replacement would pin a newer run.
   delete claimedContext.activeQueueWaits;
   state.runContextById.set(runId, claimedContext);
   state.seqByRun.delete(runId);
@@ -399,37 +410,40 @@ export function getAgentRunContext(runId: string) {
  */
 export function beginAgentRunContextQueueWait(
   runId: string,
-  lifecycleGeneration?: string,
+  options: { lifecycleGeneration: string; resumeAcrossLifecycleRotation: boolean },
 ): () => void {
   const state = getAgentEventState();
   const context = state.runContextById.get(runId);
   const contextLifecycleGeneration = context?.lifecycleGeneration ?? state.lifecycleGeneration;
   if (
     !context ||
-    (lifecycleGeneration !== undefined && contextLifecycleGeneration !== lifecycleGeneration)
+    contextLifecycleGeneration !== options.lifecycleGeneration ||
+    (!options.resumeAcrossLifecycleRotation &&
+      contextLifecycleGeneration !== state.lifecycleGeneration)
   ) {
     return () => {};
   }
-  context.activeQueueWaits = (context.activeQueueWaits ?? 0) + 1;
-  let released = false;
-  return () => {
-    if (released) {
-      return;
-    }
-    released = true;
-    // Object identity prevents a stale waiter from releasing a replacement
-    // context that happens to reuse the same run id and lifecycle generation.
-    if (state.runContextById.get(runId) !== context) {
-      return;
-    }
-    const remaining = (context.activeQueueWaits ?? 1) - 1;
-    if (remaining > 0) {
-      context.activeQueueWaits = remaining;
-      return;
-    }
-    delete context.activeQueueWaits;
-    context.lastActiveAt = Date.now();
-  };
+  const wait = { resumeAcrossLifecycleRotation: options.resumeAcrossLifecycleRotation };
+  (context.activeQueueWaits ??= new Set()).add(wait);
+  return () => releaseAgentRunContextQueueWait(state, runId, context, wait);
+}
+
+function releaseAgentRunContextQueueWait(
+  state: AgentEventState,
+  runId: string,
+  context: AgentRunContext,
+  wait: AgentRunContextQueueWait,
+): void {
+  // Exact object ownership keeps a stale queue callback from changing a
+  // replacement context that reused the run id after lifecycle rotation.
+  if (state.runContextById.get(runId) !== context || !context.activeQueueWaits?.delete(wait)) {
+    return;
+  }
+  if (context.activeQueueWaits.size > 0) {
+    return;
+  }
+  delete context.activeQueueWaits;
+  context.lastActiveAt = Date.now();
 }
 
 /** Records the latest next-check proposal on the matching paced cron run. */
@@ -610,7 +624,7 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
   for (const [runId, ctx] of state.runContextById.entries()) {
     // Command-lane ownership is active scheduler state. Sweeping it would let
     // registry maintenance false-terminal work before the lane admits it.
-    if (ctx.activeQueueWaits) {
+    if (ctx.activeQueueWaits?.size) {
       continue;
     }
     // Use lastActiveAt (refreshed on every event) to avoid sweeping active runs.

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -94,6 +94,8 @@ type AgentRunContext = {
   registeredAt?: number;
   /** Timestamp of last activity (updated on every emitAgentEvent). */
   lastActiveAt?: number;
+  /** Active command-lane waits that keep this context eligible for admission. */
+  activeQueueWaits?: number;
 };
 
 type AgentEventState = {
@@ -110,13 +112,6 @@ type AgentEventState = {
       clearRequested: boolean;
       exclusiveClaimId?: string;
       clearListeners?: Map<string, (claimId: string) => void>;
-    }
-  >;
-  runContextQueueClaimsById?: Map<
-    string,
-    {
-      lifecycleGeneration: string;
-      claimIds: Set<string>;
     }
   >;
   lifecycleGeneration: string;
@@ -246,12 +241,13 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext,
   }
   const existing = state.runContextById.get(runId);
   if (!existing) {
-    state.runContextQueueClaimsById?.delete(runId);
-    state.runContextById.set(runId, {
+    const registeredContext = {
       ...context,
       lifecycleGeneration: context.lifecycleGeneration ?? state.lifecycleGeneration,
       registeredAt: context.registeredAt ?? Date.now(),
-    });
+    };
+    delete registeredContext.activeQueueWaits;
+    state.runContextById.set(runId, registeredContext);
     return;
   }
   if (
@@ -378,12 +374,15 @@ export function claimAgentRunContext(
     );
     return claimId;
   }
-  state.runContextQueueClaimsById?.delete(runId);
-  state.runContextById.set(runId, {
+  const claimedContext = {
     ...context,
     lifecycleGeneration,
     registeredAt: context.registeredAt ?? Date.now(),
-  });
+  };
+  // Queue waits belong to the exact context object they started against.
+  // Carrying the count across lifecycle replacement would pin a newer run.
+  delete claimedContext.activeQueueWaits;
+  state.runContextById.set(runId, claimedContext);
   state.seqByRun.delete(runId);
   clearAgentRunUsage(runId);
   return claimId;
@@ -394,18 +393,14 @@ export function getAgentRunContext(runId: string) {
   return getAgentEventState().runContextById.get(runId);
 }
 
-function getAgentRunContextQueueClaims(state = getAgentEventState()) {
-  state.runContextQueueClaimsById ??= new Map();
-  return state.runContextQueueClaimsById;
-}
-
 /**
- * Claims command-lane queue ownership so scheduler wait is not mistaken for run inactivity.
+ * Pins one run context while it waits for command-lane admission.
+ * The returned release is idempotent and restarts inactivity after the final wait.
  */
-export function claimAgentRunContextQueue(
+export function beginAgentRunContextQueueWait(
   runId: string,
   lifecycleGeneration?: string,
-): string | undefined {
+): () => void {
   const state = getAgentEventState();
   const context = state.runContextById.get(runId);
   const contextLifecycleGeneration = context?.lifecycleGeneration ?? state.lifecycleGeneration;
@@ -413,53 +408,28 @@ export function claimAgentRunContextQueue(
     !context ||
     (lifecycleGeneration !== undefined && contextLifecycleGeneration !== lifecycleGeneration)
   ) {
-    return undefined;
+    return () => {};
   }
-  const claimId = randomUUID();
-  const claimsById = getAgentRunContextQueueClaims(state);
-  const existing = claimsById.get(runId);
-  if (existing && existing.lifecycleGeneration === contextLifecycleGeneration) {
-    existing.claimIds.add(claimId);
-  } else {
-    claimsById.set(runId, {
-      lifecycleGeneration: contextLifecycleGeneration,
-      claimIds: new Set([claimId]),
-    });
-  }
-  return claimId;
-}
-
-/**
- * Releases one enqueue's queue ownership.
- * The final release restarts the inactivity clock at actual execution admission.
- */
-export function releaseAgentRunContextQueue(
-  runId: string,
-  claimId: string | undefined,
-  lifecycleGeneration?: string,
-): void {
-  if (!claimId) {
-    return;
-  }
-  const state = getAgentEventState();
-  const claimsById = getAgentRunContextQueueClaims(state);
-  const claims = claimsById.get(runId);
-  if (
-    !claims ||
-    (lifecycleGeneration !== undefined && claims.lifecycleGeneration !== lifecycleGeneration) ||
-    !claims.claimIds.delete(claimId)
-  ) {
-    return;
-  }
-  if (claims.claimIds.size > 0) {
-    return;
-  }
-  claimsById.delete(runId);
-  const context = state.runContextById.get(runId);
-  if (!context || context.lifecycleGeneration !== claims.lifecycleGeneration) {
-    return;
-  }
-  context.lastActiveAt = Date.now();
+  context.activeQueueWaits = (context.activeQueueWaits ?? 0) + 1;
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    // Object identity prevents a stale waiter from releasing a replacement
+    // context that happens to reuse the same run id and lifecycle generation.
+    if (state.runContextById.get(runId) !== context) {
+      return;
+    }
+    const remaining = (context.activeQueueWaits ?? 1) - 1;
+    if (remaining > 0) {
+      context.activeQueueWaits = remaining;
+      return;
+    }
+    delete context.activeQueueWaits;
+    context.lastActiveAt = Date.now();
+  };
 }
 
 /** Records the latest next-check proposal on the matching paced cron run. */
@@ -601,7 +571,6 @@ export function clearAgentRunContext(
     return;
   }
   state.runContextById.delete(runId);
-  state.runContextQueueClaimsById?.delete(runId);
   state.seqByRun.delete(runId);
   clearAgentRunUsage(runId, lifecycleGeneration ?? existing?.lifecycleGeneration);
 }
@@ -639,14 +608,9 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
   const now = Date.now();
   let swept = 0;
   for (const [runId, ctx] of state.runContextById.entries()) {
-    const queueClaims = state.runContextQueueClaimsById?.get(runId);
     // Command-lane ownership is active scheduler state. Sweeping it would let
     // registry maintenance false-terminal work before the lane admits it.
-    if (
-      queueClaims &&
-      queueClaims.lifecycleGeneration === ctx.lifecycleGeneration &&
-      queueClaims.claimIds.size > 0
-    ) {
+    if (ctx.activeQueueWaits) {
       continue;
     }
     // Use lastActiveAt (refreshed on every event) to avoid sweeping active runs.
@@ -655,7 +619,6 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
     const age = lastSeen ? now - lastSeen : Infinity;
     if (age > maxAgeMs) {
       state.runContextById.delete(runId);
-      state.runContextQueueClaimsById?.delete(runId);
       state.seqByRun.delete(runId);
       clearAgentRunUsage(runId, ctx.lifecycleGeneration);
       getAgentRunContextOwners(state).delete(runId);
@@ -829,6 +792,5 @@ export function resetAgentEventsForTest(options?: { preserveListeners?: boolean 
     state.auditListeners.clear();
   }
   state.runContextById.clear();
-  getAgentRunContextQueueClaims(state).clear();
   getAgentRunContextOwners(state).clear();
 }

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -112,6 +112,13 @@ type AgentEventState = {
       clearListeners?: Map<string, (claimId: string) => void>;
     }
   >;
+  runContextQueueClaimsById?: Map<
+    string,
+    {
+      lifecycleGeneration: string;
+      claimIds: Set<string>;
+    }
+  >;
   lifecycleGeneration: string;
   lifecycleRotationHandlers?: Map<string, (lifecycleGeneration: string) => void>;
 };
@@ -239,6 +246,7 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext,
   }
   const existing = state.runContextById.get(runId);
   if (!existing) {
+    state.runContextQueueClaimsById?.delete(runId);
     state.runContextById.set(runId, {
       ...context,
       lifecycleGeneration: context.lifecycleGeneration ?? state.lifecycleGeneration,
@@ -370,6 +378,7 @@ export function claimAgentRunContext(
     );
     return claimId;
   }
+  state.runContextQueueClaimsById?.delete(runId);
   state.runContextById.set(runId, {
     ...context,
     lifecycleGeneration,
@@ -383,6 +392,74 @@ export function claimAgentRunContext(
 /** Returns the currently registered context for a run, if it has not been cleared or swept. */
 export function getAgentRunContext(runId: string) {
   return getAgentEventState().runContextById.get(runId);
+}
+
+function getAgentRunContextQueueClaims(state = getAgentEventState()) {
+  state.runContextQueueClaimsById ??= new Map();
+  return state.runContextQueueClaimsById;
+}
+
+/**
+ * Claims command-lane queue ownership so scheduler wait is not mistaken for run inactivity.
+ */
+export function claimAgentRunContextQueue(
+  runId: string,
+  lifecycleGeneration?: string,
+): string | undefined {
+  const state = getAgentEventState();
+  const context = state.runContextById.get(runId);
+  const contextLifecycleGeneration = context?.lifecycleGeneration ?? state.lifecycleGeneration;
+  if (
+    !context ||
+    (lifecycleGeneration !== undefined && contextLifecycleGeneration !== lifecycleGeneration)
+  ) {
+    return undefined;
+  }
+  const claimId = randomUUID();
+  const claimsById = getAgentRunContextQueueClaims(state);
+  const existing = claimsById.get(runId);
+  if (existing && existing.lifecycleGeneration === contextLifecycleGeneration) {
+    existing.claimIds.add(claimId);
+  } else {
+    claimsById.set(runId, {
+      lifecycleGeneration: contextLifecycleGeneration,
+      claimIds: new Set([claimId]),
+    });
+  }
+  return claimId;
+}
+
+/**
+ * Releases one enqueue's queue ownership.
+ * The final release restarts the inactivity clock at actual execution admission.
+ */
+export function releaseAgentRunContextQueue(
+  runId: string,
+  claimId: string | undefined,
+  lifecycleGeneration?: string,
+): void {
+  if (!claimId) {
+    return;
+  }
+  const state = getAgentEventState();
+  const claimsById = getAgentRunContextQueueClaims(state);
+  const claims = claimsById.get(runId);
+  if (
+    !claims ||
+    (lifecycleGeneration !== undefined && claims.lifecycleGeneration !== lifecycleGeneration) ||
+    !claims.claimIds.delete(claimId)
+  ) {
+    return;
+  }
+  if (claims.claimIds.size > 0) {
+    return;
+  }
+  claimsById.delete(runId);
+  const context = state.runContextById.get(runId);
+  if (!context || context.lifecycleGeneration !== claims.lifecycleGeneration) {
+    return;
+  }
+  context.lastActiveAt = Date.now();
 }
 
 /** Records the latest next-check proposal on the matching paced cron run. */
@@ -524,6 +601,7 @@ export function clearAgentRunContext(
     return;
   }
   state.runContextById.delete(runId);
+  state.runContextQueueClaimsById?.delete(runId);
   state.seqByRun.delete(runId);
   clearAgentRunUsage(runId, lifecycleGeneration ?? existing?.lifecycleGeneration);
 }
@@ -561,12 +639,23 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
   const now = Date.now();
   let swept = 0;
   for (const [runId, ctx] of state.runContextById.entries()) {
+    const queueClaims = state.runContextQueueClaimsById?.get(runId);
+    // Command-lane ownership is active scheduler state. Sweeping it would let
+    // registry maintenance false-terminal work before the lane admits it.
+    if (
+      queueClaims &&
+      queueClaims.lifecycleGeneration === ctx.lifecycleGeneration &&
+      queueClaims.claimIds.size > 0
+    ) {
+      continue;
+    }
     // Use lastActiveAt (refreshed on every event) to avoid sweeping active runs.
     // Fall back to registeredAt, then treat missing timestamps as infinitely old.
     const lastSeen = ctx.lastActiveAt ?? ctx.registeredAt;
     const age = lastSeen ? now - lastSeen : Infinity;
     if (age > maxAgeMs) {
       state.runContextById.delete(runId);
+      state.runContextQueueClaimsById?.delete(runId);
       state.seqByRun.delete(runId);
       clearAgentRunUsage(runId, ctx.lifecycleGeneration);
       getAgentRunContextOwners(state).delete(runId);
@@ -740,5 +829,6 @@ export function resetAgentEventsForTest(options?: { preserveListeners?: boolean 
     state.auditListeners.clear();
   }
   state.runContextById.clear();
+  getAgentRunContextQueueClaims(state).clear();
   getAgentRunContextOwners(state).clear();
 }


### PR DESCRIPTION
Closes #112614

## What Problem This Solves

Healthy agent and subagent runs could be reported as `lost active execution context` when command-lane saturation kept them queued longer than the run-context inactivity TTL.

The run context is registered before lane admission, but queue wait produces no agent activity. Stale-context cleanup could therefore mistake scheduler delay for an abandoned run and false-terminal work that had not started.

## Why This Change Was Made

Global and session lane waits now hold per-wait claims on the exact run-context object until admission or enqueue settlement. The stale sweep preserves contexts with active claims, and the final idempotent release restarts the inactivity clock.

Claims carry the same lifecycle-resume decision as lane admission. Lifecycle rotation immediately retires blocked normal/background claims, allowing those unreachable contexts to age out even if a lane stays paused. Eligible foreground work remains protected, then revalidates lifecycle, harness, placement, and same-ID ownership at global admission before rebinding to the current generation.

Object identity prevents a stale callback from mutating a replacement context, while per-wait tracking keeps overlapping enqueues independent. The shared command-queue API is unchanged.

AI-assisted: yes. I reviewed the implementation, caller path, test coverage, CI logs, and validation results.

## User Impact

Queued work can wait beyond the normal inactivity TTL without being falsely marked lost. Non-resumable work no longer pins stale contexts across lifecycle rotation, and ordinary cleanup resumes after the final eligible wait is admitted.

## Evidence

### Current-head lifecycle proof

Exact head: `2b7200f10f1a29c82d4ebe9baff82650270ef132`

[GitHub CI run 30483257324](https://github.com/openclaw/openclaw/actions/runs/30483257324) completed successfully on that exact head. `check-lint`, `checks-node-compact-large-1`, and `openclaw/ci-gate` all passed.

The focused test invokes the production lane controller, run-context registry, lifecycle rotation, and stale-context sweep. Its three passing cases cover:

- overlapping waits remain protected independently; admitting one cannot expose the sibling, and cleanup resumes after the final admission;
- a paused normal/background global-lane wait becomes sweepable after rotation and its eventual callback rejects the stale lifecycle;
- the same rotation-retirement behavior for a paused session-lane wait.

The parameterized global/session assertions are visible in the [exact-head focused test](https://github.com/openclaw/openclaw/blob/2b7200f10f1a29c82d4ebe9baff82650270ef132/src/agents/embedded-agent-runner/run/lane-controller.run-context.test.ts#L86-L109). The existing full runner regression independently proves eligible foreground work survives rotation, is admitted, and rebinds to the current lifecycle in [run.overflow-compaction.test.ts](https://github.com/openclaw/openclaw/blob/2b7200f10f1a29c82d4ebe9baff82650270ef132/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts#L1101-L1138).

Redacted terminal output from the exact-head agent-runtime shard:

```text
✓ rebinds preserved queued work to the current lifecycle generation 1465ms
✓ src/agents/embedded-agent-runner/run/lane-controller.run-context.test.ts (3 tests) 354ms
  ✓ keeps run context active until every overlapping enqueue is admitted 351ms
Test Files  74 passed (74)
Tests       960 passed (960)
```

The focused file reports three tests because the lifecycle-rotation case runs once for `global` and once for `session`.

### Historical saturated-lane proof

The original queue-expiry behavior was exercised at head `fc4d89dc77d640780e1939149cba539e329f0e23` in an isolated Linux Node 24 container using the production command queue, embedded-run lane controller, run-context registry, and stale-context sweeper. This historical trace proves the original saturation symptom and post-admission cleanup; the current-head CI evidence above is authoritative for the later lifecycle-rotation repair.

```text
PROOF_BLOCKER_ACTIVE lane=proof:112614:848
PROOF_SURVIVED_TTL {"ttlMs":1000,"waitedMs":1252,"activeCount":1,"queuedCount":1,"swept":0,"contextPresent":true}
PROOF_TARGET_ADMITTED waitedMs=1603
PROOF_CLEANUP_RESUMED {"ttlMs":1000,"idleMs":1250,"swept":1,"contextPresent":false}
PROOF_PASS saturated_lane_survival_admission_cleanup
```

Provider: `local-container` (historical isolated Linux proof; accurately not remote proof)  
Lease: `cbx_58ecc490a35b` (`jade-shrimp`)  
Result: exit 0; container stopped cleanly

A sanitized direct-AWS rerun was attempted on this exact head with Crabbox v0.40.0. The broker denied the external-author account with `GitHub user MonkeyLeeT is not an active member of openclaw.` Per untrusted-fork policy, the checkout was not run locally or on a credential-hydrated Testbox; current-head execution remains limited to secretless upstream GitHub CI. A maintainer must either run the prepared exact-head saturated-lane scenario under an allowed isolated lease or explicitly accept the current-head lifecycle tests plus the historical runtime trace.

### Review and scope

- ClawSweeper's implementation review on the preceding runtime-identical head found no actionable code findings and rated patch quality 4/6; this head changes only the focused test harness to match production queue normalization.
- Autoreview findings on repeat-rotation eligibility and stale session admission were accepted and fixed. A suggestion to reclaim lifecycle ownership at session admission was rejected after reading the sole production caller: that task only advances to global admission, where lifecycle, harness, placement, and ownership are revalidated together.
- The patch remains limited to 3 files (`+232/-19`): the registry, the lane controller, and its focused regression test.