### PR TITLE
refactor(diagnostics-otel): consolidate service test fixtures

### DIFF
--- a/extensions/diagnostics-otel/src/service.test-helpers.ts
+++ b/extensions/diagnostics-otel/src/service.test-helpers.ts
@@ -1,0 +1,127 @@
+import {
+  emitTrustedDiagnosticEventWithPrivateData,
+  type DiagnosticTraceContext,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+import { onTrustedInternalDiagnosticEvent } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { vi } from "vitest";
+import type { OpenClawPluginServiceContext } from "../api.js";
+import { createDiagnosticsOtelService } from "./service.js";
+
+export const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
+export const OTEL_TEST_ENDPOINT = "http://otel-collector:4318";
+export const OTEL_TEST_PROTOCOL = "http/protobuf";
+export const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+export const SPAN_ID = "00f067aa0ba902b7";
+export const CHILD_SPAN_ID = "1111111111111111";
+export const GRANDCHILD_SPAN_ID = "2222222222222222";
+export const TOOL_SPAN_ID = "3333333333333333";
+export const MODEL_CALL_SPAN_ID = "4444444444444444";
+export const MODEL_USAGE_SPAN_ID = "5555555555555555";
+export const MODEL_FIXTURE = {
+  provider: "openai",
+  model: "gpt-5.4",
+} as const;
+export const RUN_FIXTURE = { runId: "run-1", ...MODEL_FIXTURE } as const;
+export const MODEL_CALL_FIXTURE = { ...RUN_FIXTURE, callId: "call-1" } as const;
+export const MODEL_CONTENT_CAPTURE = {
+  enabled: true,
+  inputMessages: true,
+  outputMessages: true,
+  systemPrompt: true,
+  toolDefinitions: true,
+} as const;
+export const INPUT_ONLY_CAPTURE = {
+  enabled: true,
+  inputMessages: true,
+  outputMessages: false,
+} as const;
+
+type OtelConfig = NonNullable<
+  NonNullable<OpenClawPluginServiceContext["config"]["diagnostics"]>["otel"]
+>;
+export type OtelContextFlags = Pick<
+  OtelConfig,
+  "traces" | "metrics" | "logs" | "protocol" | "logsExporter" | "captureContent"
+>;
+
+type StartOtelServiceOptions = OtelContextFlags & {
+  endpoint?: string;
+  configure?: (ctx: OpenClawPluginServiceContext) => void;
+};
+
+type StartedService = {
+  service: ReturnType<typeof createDiagnosticsOtelService>;
+  ctx: OpenClawPluginServiceContext;
+};
+
+const startedServices = new Set<StartedService>();
+
+export function createOtelContext(
+  endpoint: string,
+  {
+    traces = false,
+    metrics = false,
+    logs = false,
+    protocol = OTEL_TEST_PROTOCOL,
+    logsExporter,
+    captureContent,
+  }: OtelContextFlags = {},
+): OpenClawPluginServiceContext {
+  return {
+    config: {
+      diagnostics: {
+        enabled: true,
+        otel: {
+          enabled: true,
+          endpoint,
+          protocol,
+          traces,
+          metrics,
+          logs,
+          ...(logsExporter !== undefined ? { logsExporter } : {}),
+          ...(captureContent !== undefined ? { captureContent } : {}),
+        },
+      },
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    stateDir: OTEL_TEST_STATE_DIR,
+    internalDiagnostics: {
+      emit: emitTrustedDiagnosticEventWithPrivateData,
+      onEvent: onTrustedInternalDiagnosticEvent,
+    },
+  };
+}
+
+export async function startOtelService({
+  endpoint = OTEL_TEST_ENDPOINT,
+  configure,
+  ...flags
+}: StartOtelServiceOptions = {}): Promise<StartedService> {
+  const service = createDiagnosticsOtelService();
+  const ctx = createOtelContext(endpoint, flags);
+  configure?.(ctx);
+  await service.start(ctx);
+  const started = { service, ctx };
+  startedServices.add(started);
+  return started;
+}
+
+export async function stopStartedOtelServices() {
+  const services = [...startedServices];
+  startedServices.clear();
+  await Promise.all(services.map(({ service, ctx }) => Promise.resolve(service.stop?.(ctx))));
+}
+
+export function createTestTrace(spanId: string, parentSpanId?: string): DiagnosticTraceContext {
+  return {
+    traceId: TRACE_ID,
+    spanId,
+    ...(parentSpanId === undefined ? {} : { parentSpanId }),
+    traceFlags: "01",
+  };
+}

--- a/extensions/diagnostics-otel/src/service.test-helpers.ts
+++ b/extensions/diagnostics-otel/src/service.test-helpers.ts
@@ -7,9 +7,9 @@ import { vi } from "vitest";
 import type { OpenClawPluginServiceContext } from "../api.js";
 import { createDiagnosticsOtelService } from "./service.js";
 
-export const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
+const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
 export const OTEL_TEST_ENDPOINT = "http://otel-collector:4318";
-export const OTEL_TEST_PROTOCOL = "http/protobuf";
+const OTEL_TEST_PROTOCOL = "http/protobuf";
 export const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
 export const SPAN_ID = "00f067aa0ba902b7";
 export const CHILD_SPAN_ID = "1111111111111111";

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -188,23 +188,30 @@ import {
   emitTrustedSecurityEvent,
   logMessageDispatchStarted,
   logMessageProcessed,
-  onTrustedInternalDiagnosticEvent,
   runWithDiagnosticTraceContext,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import type { OpenClawPluginServiceContext } from "../api.js";
 import { emitDiagnosticEvent } from "../api.js";
 import { createDiagnosticsOtelService } from "./service.js";
-
-const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
-const OTEL_TEST_ENDPOINT = "http://otel-collector:4318";
-const OTEL_TEST_PROTOCOL = "http/protobuf";
-const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
-const SPAN_ID = "00f067aa0ba902b7";
-const CHILD_SPAN_ID = "1111111111111111";
-const GRANDCHILD_SPAN_ID = "2222222222222222";
-const TOOL_SPAN_ID = "3333333333333333";
-const MODEL_CALL_SPAN_ID = "4444444444444444";
-const MODEL_USAGE_SPAN_ID = "5555555555555555";
+import {
+  CHILD_SPAN_ID,
+  createOtelContext,
+  createTestTrace,
+  GRANDCHILD_SPAN_ID,
+  INPUT_ONLY_CAPTURE,
+  MODEL_CALL_SPAN_ID,
+  MODEL_CALL_FIXTURE,
+  MODEL_CONTENT_CAPTURE,
+  MODEL_FIXTURE,
+  MODEL_USAGE_SPAN_ID,
+  type OtelContextFlags,
+  OTEL_TEST_ENDPOINT,
+  RUN_FIXTURE,
+  SPAN_ID,
+  startOtelService,
+  stopStartedOtelServices,
+  TOOL_SPAN_ID,
+  TRACE_ID,
+} from "./service.test-helpers.js";
 
 function numberedSpanId(index: number) {
   return (index + 0x1000).toString(16).padStart(16, "0");
@@ -236,69 +243,6 @@ const OTEL_CERT_ENV_KEYS = [
 const ORIGINAL_OTEL_CERT_ENV = Object.fromEntries(
   OTEL_CERT_ENV_KEYS.map((key) => [key, process.env[key]]),
 ) as Record<(typeof OTEL_CERT_ENV_KEYS)[number], string | undefined>;
-
-function createLogger() {
-  return {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  };
-}
-
-type OtelContextFlags = {
-  traces?: boolean;
-  metrics?: boolean;
-  logs?: boolean;
-  protocol?: NonNullable<
-    NonNullable<OpenClawPluginServiceContext["config"]["diagnostics"]>["otel"]
-  >["protocol"];
-  logsExporter?: NonNullable<
-    NonNullable<OpenClawPluginServiceContext["config"]["diagnostics"]>["otel"]
-  >["logsExporter"];
-  captureContent?: NonNullable<
-    NonNullable<OpenClawPluginServiceContext["config"]["diagnostics"]>["otel"]
-  >["captureContent"];
-};
-function createOtelContext(
-  endpoint: string,
-  {
-    traces = false,
-    metrics = false,
-    logs = false,
-    protocol = OTEL_TEST_PROTOCOL,
-    logsExporter,
-    captureContent,
-  }: OtelContextFlags = {},
-): OpenClawPluginServiceContext {
-  return {
-    config: {
-      diagnostics: {
-        enabled: true,
-        otel: {
-          enabled: true,
-          endpoint,
-          protocol,
-          traces,
-          metrics,
-          logs,
-          ...(logsExporter !== undefined ? { logsExporter } : {}),
-          ...(captureContent !== undefined ? { captureContent } : {}),
-        },
-      },
-    },
-    logger: createLogger(),
-    stateDir: OTEL_TEST_STATE_DIR,
-    internalDiagnostics: {
-      emit: emitTrustedDiagnosticEventWithPrivateData,
-      onEvent: onTrustedInternalDiagnosticEvent,
-    },
-  };
-}
-
-function createTraceOnlyContext(endpoint: string): OpenClawPluginServiceContext {
-  return createOtelContext(endpoint, { traces: true });
-}
 
 function startedSpanCall(name: string) {
   const calls = telemetryState.tracer.startSpan.mock.calls as unknown as Array<
@@ -491,12 +435,10 @@ async function emitAndCaptureLog(
     trustedTraceContext?: boolean;
   } = {},
 ) {
-  const service = createDiagnosticsOtelService();
-  const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+  await startOtelService({
     logs: true,
     ...(options.captureContent !== undefined ? { captureContent: options.captureContent } : {}),
   });
-  await service.start(ctx);
   const emit = options.trusted
     ? emitTrustedDiagnosticEvent
     : options.trustedTraceContext
@@ -513,13 +455,71 @@ async function emitAndCaptureLog(
     body?: string;
     context?: unknown;
   };
-  await service.stop?.(ctx);
   return emitCall;
 }
 
 function flushDiagnosticEvents() {
   return new Promise<void>((resolve) => {
     setImmediate(resolve);
+  });
+}
+
+async function emitAndFlush(event: Parameters<typeof emitDiagnosticEvent>[0]) {
+  emitDiagnosticEvent(event);
+  await flushDiagnosticEvents();
+}
+
+async function emitTrustedAndFlush(event: Parameters<typeof emitTrustedDiagnosticEvent>[0]) {
+  emitTrustedDiagnosticEvent(event);
+  await flushDiagnosticEvents();
+}
+
+type TrustedEvent = Parameters<typeof emitTrustedDiagnosticEvent>[0];
+type TrustedEventOf<T extends TrustedEvent["type"]> = Extract<TrustedEvent, { type: T }>;
+
+function emitRunStarted(overrides: Partial<Omit<TrustedEventOf<"run.started">, "type">> = {}) {
+  emitTrustedDiagnosticEvent({
+    type: "run.started",
+    ...RUN_FIXTURE,
+    trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
+    ...overrides,
+  });
+}
+
+function emitRunCompleted(overrides: Partial<Omit<TrustedEventOf<"run.completed">, "type">> = {}) {
+  emitTrustedDiagnosticEvent({
+    type: "run.completed",
+    ...RUN_FIXTURE,
+    outcome: "completed",
+    durationMs: 100,
+    trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
+    ...overrides,
+  });
+}
+
+function emitQueuedRunWithModelCalls() {
+  emitRunStarted();
+  for (let index = 0; index < 125; index += 1) {
+    emitTrustedDiagnosticEvent({
+      type: "model.call.completed",
+      runId: "run-1",
+      callId: `call-${index}`,
+      ...MODEL_FIXTURE,
+      durationMs: 80,
+      trace: createTestTrace(numberedSpanId(index), CHILD_SPAN_ID),
+    });
+  }
+  emitRunCompleted();
+}
+
+function emitDefaultModelUsage() {
+  emitTrustedDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.4",
+    usage: { input: 3, output: 2, total: 5 },
+    durationMs: 10,
+    trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
   });
 }
 
@@ -604,7 +604,8 @@ describe("diagnostics-otel service", () => {
     }
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stopStartedOtelServices();
     resetDiagnosticEventsForTest();
     if (ORIGINAL_OPENCLAW_OTEL_PRELOADED === undefined) {
       delete process.env.OPENCLAW_OTEL_PRELOADED;
@@ -704,9 +705,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("records message-flow metrics and spans", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true, logs: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true, logs: true });
 
     emitDiagnosticEvent({
       type: "webhook.received",
@@ -930,22 +929,17 @@ describe("diagnostics-otel service", () => {
     expect(messageSpanOptions?.attributes).not.toHaveProperty("openclaw.messageId");
     expect(messageSpanOptions?.startTime).toBeTypeOf("number");
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "log.record",
       level: "INFO",
       message: "hello",
       attributes: { subsystem: "diagnostic" },
     });
-    await flushDiagnosticEvents();
     expect(logEmit).toHaveBeenCalled();
-
-    await service.stop?.(ctx);
   });
 
   test("restarts without retaining prior listeners or log transports", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true, logs: true });
-    await service.start(ctx);
+    const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
     await service.start(ctx);
 
     expect(logShutdown).toHaveBeenCalledTimes(1);
@@ -975,10 +969,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("registers and removes an OTLP exporter unhandled rejection handler", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true, logs: true });
-
-    await service.start(ctx);
+    const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
 
     expect(unhandledRejectionHandlerState.register).toHaveBeenCalledTimes(1);
     const handler = unhandledRejectionHandlerState.getHandlers()[0];
@@ -1024,9 +1015,7 @@ describe("diagnostics-otel service", () => {
 
   test("uses a preloaded OpenTelemetry SDK without dropping diagnostic listeners", async () => {
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true, logs: true });
-    await service.start(ctx);
+    const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
 
     expect(sdkStart).not.toHaveBeenCalled();
     expect(traceExporterCtor).not.toHaveBeenCalled();
@@ -1036,18 +1025,15 @@ describe("diagnostics-otel service", () => {
 
     emitDiagnosticEvent({
       type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...RUN_FIXTURE,
       outcome: "completed",
       durationMs: 100,
     });
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "log.record",
       level: "INFO",
       message: "preloaded log",
     });
-    await flushDiagnosticEvents();
 
     const runDurationRecordCall = lastHistogramRecord("openclaw.run.duration_ms");
     expect(runDurationRecordCall?.[0]).toBe(100);
@@ -1070,10 +1056,7 @@ describe("diagnostics-otel service", () => {
         events.push(event);
       }
     });
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true, logs: true });
-
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true, logs: true });
 
     const exporterEvents = events.filter((event) => event.type === "telemetry.exporter");
     for (const signal of ["traces", "metrics", "logs"]) {
@@ -1093,19 +1076,12 @@ describe("diagnostics-otel service", () => {
     });
 
     unsubscribe();
-    await service.stop?.(ctx);
   });
 
   test("exports trusted security events as bounded OTLP logs", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { logs: true });
-    const trace = createDiagnosticTraceContext({
-      traceId: TRACE_ID,
-      spanId: SPAN_ID,
-      traceFlags: "01",
-    });
+    await startOtelService({ logs: true });
+    const trace = createDiagnosticTraceContext(createTestTrace(SPAN_ID));
 
-    await service.start(ctx);
     emitTrustedSecurityEvent({
       eventId: "security-event-1",
       category: "tool",
@@ -1186,15 +1162,10 @@ describe("diagnostics-otel service", () => {
       false,
     );
     expect(JSON.stringify(emitCall)).not.toContain("sk-test-secret");
-
-    await service.stop?.(ctx);
   });
 
   test("does not export security events when OTLP logs are disabled", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { logs: false, metrics: true });
-
-    await service.start(ctx);
+    await startOtelService({ logs: false, metrics: true });
     emitTrustedSecurityEvent({
       eventId: "security-event-logs-disabled",
       category: "auth",
@@ -1205,13 +1176,10 @@ describe("diagnostics-otel service", () => {
     await flushDiagnosticEvents();
 
     expect(logEmit).not.toHaveBeenCalled();
-
-    await service.stop?.(ctx);
   });
 
   test("starts stdout-only logs when OTLP protocol is unsupported", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    const { ctx } = await startOtelService({
       traces: false,
       metrics: false,
       logs: true,
@@ -1220,7 +1188,6 @@ describe("diagnostics-otel service", () => {
     });
     const capture = captureStdoutWrites();
     try {
-      await service.start(ctx);
       emitDiagnosticEvent({
         type: "log.record",
         level: "INFO",
@@ -1238,60 +1205,48 @@ describe("diagnostics-otel service", () => {
       );
     } finally {
       capture.spy.mockRestore();
-      await service.stop?.(ctx);
     }
   });
 
-  test("ignores blank OTLP protocol env overrides", async () => {
-    process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "   ";
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    if (ctx.config.diagnostics?.otel) {
-      delete ctx.config.diagnostics.otel.protocol;
-    }
+  test.each([
+    {
+      name: "ignores blank OTLP protocol env overrides",
+      value: "   ",
+      exporterCalls: 1,
+    },
+    {
+      name: "preserves nonblank OTLP protocol env overrides",
+      value: " http/protobuf ",
+      exporterCalls: 0,
+      warning: "diagnostics-otel: unsupported protocol  http/protobuf ",
+    },
+  ])("$name", async ({ value, exporterCalls, warning }) => {
+    process.env.OTEL_EXPORTER_OTLP_PROTOCOL = value;
+    const { ctx } = await startOtelService({
+      traces: true,
+      metrics: true,
+      configure: (context) => {
+        delete context.config.diagnostics?.otel?.protocol;
+      },
+    });
 
-    try {
-      await service.start(ctx);
-
-      expect(traceExporterCtor).toHaveBeenCalledOnce();
-      expect(metricExporterCtor).toHaveBeenCalledOnce();
+    expect(traceExporterCtor).toHaveBeenCalledTimes(exporterCalls);
+    expect(metricExporterCtor).toHaveBeenCalledTimes(exporterCalls);
+    if (warning) {
+      expect(ctx.logger.warn).toHaveBeenCalledWith(warning);
+    } else {
       expect(ctx.logger.warn).not.toHaveBeenCalledWith(
         "diagnostics-otel: unsupported protocol    ",
       );
-    } finally {
-      await service.stop?.(ctx);
     }
-  });
-
-  test("preserves nonblank OTLP protocol env overrides", async () => {
-    process.env.OTEL_EXPORTER_OTLP_PROTOCOL = " http/protobuf ";
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    if (ctx.config.diagnostics?.otel) {
-      delete ctx.config.diagnostics.otel.protocol;
-    }
-
-    await service.start(ctx);
-
-    expect(traceExporterCtor).not.toHaveBeenCalled();
-    expect(metricExporterCtor).not.toHaveBeenCalled();
-    expect(ctx.logger.warn).toHaveBeenCalledWith(
-      "diagnostics-otel: unsupported protocol  http/protobuf ",
-    );
   });
 
   test("exports trusted security events as stdout JSONL logs", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext("", { logs: true, logsExporter: "stdout" });
-    const trace = createDiagnosticTraceContext({
-      traceId: TRACE_ID,
-      spanId: SPAN_ID,
-      traceFlags: "01",
-    });
+    await startOtelService({ endpoint: "", logs: true, logsExporter: "stdout" });
+    const trace = createDiagnosticTraceContext(createTestTrace(SPAN_ID));
     const stdout = captureStdoutWrites();
 
     try {
-      await service.start(ctx);
       emitTrustedSecurityEvent({
         eventId: "security-event-stdout",
         category: "tool",
@@ -1331,16 +1286,12 @@ describe("diagnostics-otel service", () => {
       expect(JSON.stringify(record)).not.toContain("sk-test-secret");
     } finally {
       stdout.spy.mockRestore();
-      await service.stop?.(ctx);
     }
   });
 
   test("records liveness warning diagnostics", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-
-    await service.start(ctx);
-    emitDiagnosticEvent({
+    await startOtelService({ traces: true, metrics: true });
+    await emitAndFlush({
       type: "diagnostic.liveness.warning",
       reasons: ["event_loop_delay", "cpu"],
       intervalMs: 30_000,
@@ -1355,7 +1306,6 @@ describe("diagnostics-otel service", () => {
       waiting: 1,
       queued: 4,
     });
-    await flushDiagnosticEvents();
 
     expect(telemetryState.counters.get("openclaw.liveness.warning")?.add).toHaveBeenCalledWith(1, {
       "openclaw.liveness.reason": "event_loop_delay:cpu",
@@ -1381,16 +1331,11 @@ describe("diagnostics-otel service", () => {
       code: 2,
       message: "event_loop_delay:cpu",
     });
-
-    await service.stop?.(ctx);
   });
 
   test("records oversized payload metrics without raw identifiers", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true, traces: false });
-
-    await service.start(ctx);
-    emitTrustedDiagnosticEvent({
+    await startOtelService({ metrics: true, traces: false });
+    await emitTrustedAndFlush({
       type: "payload.large",
       surface: "gateway.frame",
       action: "rejected",
@@ -1400,7 +1345,6 @@ describe("diagnostics-otel service", () => {
       pluginId: "agent:qa:otel-trace-smoke",
       reason: "body-too-large",
     });
-    await flushDiagnosticEvents();
 
     expect(telemetryState.counters.get("openclaw.payload.large")?.add).toHaveBeenCalledWith(1, {
       "openclaw.payload.action": "rejected",
@@ -1418,8 +1362,6 @@ describe("diagnostics-otel service", () => {
       "openclaw.plugin": "none",
       "openclaw.reason": "body-too-large",
     });
-
-    await service.stop?.(ctx);
   });
 
   test("reports log exporter emit failures without exporting raw error text", async () => {
@@ -1429,19 +1371,16 @@ describe("diagnostics-otel service", () => {
         events.push(event);
       }
     });
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { logs: true });
     logEmit.mockImplementationOnce(() => {
       throw new TypeError("token sk-test-secret should not leave as telemetry");
     });
 
-    await service.start(ctx);
-    emitDiagnosticEvent({
+    await startOtelService({ logs: true });
+    await emitAndFlush({
       type: "log.record",
       level: "INFO",
       message: "export me",
     });
-    await flushDiagnosticEvents();
 
     const exporterEvents = events.filter((event) => event.type === "telemetry.exporter");
     const failureEvent = exporterEvents.find((event) => event.status === "failure");
@@ -1462,14 +1401,10 @@ describe("diagnostics-otel service", () => {
     });
 
     unsubscribe();
-    await service.stop?.(ctx);
   });
 
   test("ignores untrusted telemetry exporter events for OTEL metrics", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-
-    await service.start(ctx);
+    await startOtelService({ metrics: true });
     telemetryState.counters.get("openclaw.telemetry.exporter.events")?.add.mockClear();
     emitDiagnosticEvent({
       type: "telemetry.exporter",
@@ -1482,39 +1417,28 @@ describe("diagnostics-otel service", () => {
     expect(
       telemetryState.counters.get("openclaw.telemetry.exporter.events")?.add,
     ).not.toHaveBeenCalled();
-
-    await service.stop?.(ctx);
   });
 
   test("records hook-blocked run metrics with safe blocker originator", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...RUN_FIXTURE,
       outcome: "blocked",
       blockedBy: "policy-plugin",
       durationMs: 100,
     });
-    await flushDiagnosticEvents();
 
     const runDurationRecordCall = lastHistogramRecord("openclaw.run.duration_ms");
     expect(runDurationRecordCall?.[0]).toBe(100);
     expect(runDurationRecordCall?.[1]?.["openclaw.outcome"]).toBe("blocked");
     expect(runDurationRecordCall?.[1]?.["openclaw.blocked_by"]).toBe("policy-plugin");
     expect(JSON.stringify(telemetryState)).not.toContain("matched secret prompt");
-
-    await service.stop?.(ctx);
   });
 
   test("run.completed error span carries the redacted message off the metric attrs", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitTrustedDiagnosticEventWithPrivateData(
       {
@@ -1541,14 +1465,10 @@ describe("diagnostics-otel service", () => {
     const runDuration = lastHistogramRecord("openclaw.run.duration_ms");
     expect(runDuration?.[1]?.["openclaw.outcome"]).toBe("error");
     expect(Object.hasOwn(runDuration?.[1] ?? {}, "openclaw.error")).toBe(false);
-
-    await service.stop?.(ctx);
   });
 
   test("run.completed bounds sensitive error text before export", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true });
     const secret = "sk-1234567890abcdef";
 
     emitTrustedDiagnosticEventWithPrivateData(
@@ -1569,14 +1489,10 @@ describe("diagnostics-otel service", () => {
     expect(status.message).not.toContain(secret);
     expect(status.message).toMatch(/\.\.\.\(truncated\)$/u);
     expect(status.message?.length).toBeLessThanOrEqual(4 * 1024 + 20);
-
-    await service.stop?.(ctx);
   });
 
   test("harness.run.completed error span carries the redacted message", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitTrustedDiagnosticEventWithPrivateData(
       {
@@ -1602,14 +1518,10 @@ describe("diagnostics-otel service", () => {
     });
     const harnessDuration = lastHistogramRecord("openclaw.harness.duration_ms");
     expect(Object.hasOwn(harnessDuration?.[1] ?? {}, "openclaw.error")).toBe(false);
-
-    await service.stop?.(ctx);
   });
 
   test("harness.run.error span prefers the redacted message over the category", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitTrustedDiagnosticEventWithPrivateData(
       {
@@ -1633,25 +1545,18 @@ describe("diagnostics-otel service", () => {
       code: 2,
       message: "harness cleanup threw",
     });
-
-    await service.stop?.(ctx);
   });
 
   test("honors disabled traces when an OpenTelemetry SDK is preloaded", async () => {
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: false, metrics: true });
-    await service.start(ctx);
+    const { service, ctx } = await startOtelService({ traces: false, metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...RUN_FIXTURE,
       outcome: "completed",
       durationMs: 100,
     });
-    await flushDiagnosticEvents();
 
     expect(sdkStart).not.toHaveBeenCalled();
     const runDurationRecordCall = lastHistogramRecord("openclaw.run.duration_ms");
@@ -1664,13 +1569,13 @@ describe("diagnostics-otel service", () => {
   });
 
   test("treats omitted diagnostics enabled flag as enabled", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
       captureContent: true,
+      configure: (ctx) => {
+        delete (ctx.config.diagnostics as { enabled?: boolean }).enabled;
+      },
     });
-    delete (ctx.config.diagnostics as { enabled?: boolean }).enabled;
-    await service.start(ctx);
 
     emitTrustedModelCallCompletedWithContent(
       {
@@ -1684,24 +1589,16 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
     expect(attrs?.["openclaw.content.input_messages"]).toBe("user prompt");
-
-    await service.stop?.(ctx);
   });
 
   test("tears down active handles when restarted with diagnostics disabled", async () => {
-    const service = createDiagnosticsOtelService();
-    const enabledCtx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    const { service, ctx: enabledCtx } = await startOtelService({
       traces: true,
       metrics: true,
       logs: true,
     });
-    await service.start(enabledCtx);
     await service.start({
       ...enabledCtx,
       config: { diagnostics: { enabled: false } },
@@ -1720,104 +1617,80 @@ describe("diagnostics-otel service", () => {
     expect(telemetryState.tracer.startSpan).not.toHaveBeenCalled();
   });
 
-  test("appends signal path when endpoint contains non-signal /v1 segment", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://www.comet.com/opik/api/v1/private/otel");
-    await service.start(ctx);
+  test.each([
+    [
+      "appends signal path when endpoint contains non-signal /v1 segment",
+      "https://www.comet.com/opik/api/v1/private/otel",
+      "https://www.comet.com/opik/api/v1/private/otel/v1/traces",
+    ],
+    [
+      "keeps already signal-qualified endpoint unchanged",
+      "https://collector.example.com/v1/traces",
+      "https://collector.example.com/v1/traces",
+    ],
+    [
+      "keeps signal-qualified endpoint unchanged when it has query params",
+      "https://collector.example.com/v1/traces?timeout=30s",
+      "https://collector.example.com/v1/traces?timeout=30s",
+    ],
+    [
+      "inserts signal path before shared endpoint query params",
+      "https://collector.example.com/otlp?timeout=30s",
+      "https://collector.example.com/otlp/v1/traces?timeout=30s",
+    ],
+    [
+      "inserts signal path before shared endpoint fragments",
+      "https://collector.example.com/otlp#tenant-a",
+      "https://collector.example.com/otlp/v1/traces#tenant-a",
+    ],
+    [
+      "keeps signal-qualified endpoint unchanged when signal path casing differs",
+      "https://collector.example.com/v1/Traces",
+      "https://collector.example.com/v1/Traces",
+    ],
+  ])("%s", async (_name, endpoint, expected) => {
+    await startOtelService({ endpoint, traces: true });
 
-    const options = firstExporterOptions(traceExporterCtor);
-    expect(options.url).toBe("https://www.comet.com/opik/api/v1/private/otel/v1/traces");
-    await service.stop?.(ctx);
-  });
-
-  test("keeps already signal-qualified endpoint unchanged", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://collector.example.com/v1/traces");
-    await service.start(ctx);
-
-    const options = firstExporterOptions(traceExporterCtor);
-    expect(options.url).toBe("https://collector.example.com/v1/traces");
-    await service.stop?.(ctx);
-  });
-
-  test("keeps signal-qualified endpoint unchanged when it has query params", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://collector.example.com/v1/traces?timeout=30s");
-    await service.start(ctx);
-
-    const options = firstExporterOptions(traceExporterCtor);
-    expect(options.url).toBe("https://collector.example.com/v1/traces?timeout=30s");
-    await service.stop?.(ctx);
-  });
-
-  test("inserts signal path before shared endpoint query params", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://collector.example.com/otlp?timeout=30s");
-    await service.start(ctx);
-
-    const options = firstExporterOptions(traceExporterCtor);
-    expect(options.url).toBe("https://collector.example.com/otlp/v1/traces?timeout=30s");
-    await service.stop?.(ctx);
-  });
-
-  test("inserts signal path before shared endpoint fragments", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://collector.example.com/otlp#tenant-a");
-    await service.start(ctx);
-
-    const options = firstExporterOptions(traceExporterCtor);
-    expect(options.url).toBe("https://collector.example.com/otlp/v1/traces#tenant-a");
-    await service.stop?.(ctx);
-  });
-
-  test("keeps signal-qualified endpoint unchanged when signal path casing differs", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://collector.example.com/v1/Traces");
-    await service.start(ctx);
-
-    const options = firstExporterOptions(traceExporterCtor);
-    expect(options.url).toBe("https://collector.example.com/v1/Traces");
-    await service.stop?.(ctx);
+    expect(firstExporterOptions(traceExporterCtor).url).toBe(expected);
   });
 
   test("applies flush interval to trace batching", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext(OTEL_TEST_ENDPOINT);
-    ctx.config.diagnostics!.otel!.flushIntervalMs = 250;
-
-    await service.start(ctx);
+    await startOtelService({
+      traces: true,
+      configure: (ctx) => {
+        ctx.config.diagnostics!.otel!.flushIntervalMs = 250;
+      },
+    });
 
     expect(spanProcessorCtor).toHaveBeenCalledTimes(1);
     expect(firstSpanProcessorOptions().scheduledDelayMillis).toBe(1000);
-    await service.stop?.(ctx);
   });
 
   test("applies flush interval to log batching", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { logs: true });
-    ctx.config.diagnostics!.otel!.flushIntervalMs = 250;
-
-    await service.start(ctx);
+    await startOtelService({
+      logs: true,
+      configure: (ctx) => {
+        ctx.config.diagnostics!.otel!.flushIntervalMs = 250;
+      },
+    });
 
     expect(logProcessorCtor).toHaveBeenCalledTimes(1);
     const options = firstLogProcessorOptions();
     expect(options.exporter).toBeDefined();
     expect(options.scheduledDelayMillis).toBe(1000);
-    await service.stop?.(ctx);
   });
 
   test("uses signal-specific OTLP endpoints ahead of the shared endpoint", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
       metrics: true,
       logs: true,
+      configure: (ctx) => {
+        ctx.config.diagnostics!.otel!.tracesEndpoint = "https://trace.example.com/otlp";
+        ctx.config.diagnostics!.otel!.metricsEndpoint = "https://metric.example.com/v1/metrics";
+        ctx.config.diagnostics!.otel!.logsEndpoint = "https://log.example.com/otlp";
+      },
     });
-    ctx.config.diagnostics!.otel!.tracesEndpoint = "https://trace.example.com/otlp";
-    ctx.config.diagnostics!.otel!.metricsEndpoint = "https://metric.example.com/v1/metrics";
-    ctx.config.diagnostics!.otel!.logsEndpoint = "https://log.example.com/otlp";
-
-    await service.start(ctx);
 
     const traceOptions = firstExporterOptions(traceExporterCtor);
     const metricOptions = firstExporterOptions(metricExporterCtor);
@@ -1825,7 +1698,6 @@ describe("diagnostics-otel service", () => {
     expect(traceOptions.url).toBe("https://trace.example.com/otlp/v1/traces");
     expect(metricOptions.url).toBe("https://metric.example.com/v1/metrics");
     expect(logOptions.url).toBe("https://log.example.com/otlp/v1/logs");
-    await service.stop?.(ctx);
   });
 
   test("uses signal-specific OTLP env endpoints when config is unset", async () => {
@@ -1833,13 +1705,11 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "https://metric-env.example.com/otlp";
     process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "https://log-env.example.com/otlp";
 
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
       metrics: true,
       logs: true,
     });
-    await service.start(ctx);
 
     const traceOptions = firstExporterOptions(traceExporterCtor);
     const metricOptions = firstExporterOptions(metricExporterCtor);
@@ -1847,19 +1717,17 @@ describe("diagnostics-otel service", () => {
     expect(traceOptions.url).toBe("https://trace-env.example.com/v1/traces");
     expect(metricOptions.url).toBe("https://metric-env.example.com/otlp/v1/metrics");
     expect(logOptions.url).toBe("https://log-env.example.com/otlp/v1/logs");
-    await service.stop?.(ctx);
   });
 
   test("passes env proxy agents to OTLP HTTP exporters", async () => {
     createNodeProxyAgentMock.mockReturnValue(nodeProxyAgent);
 
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext("https://collector.example.com/otlp", {
+    await startOtelService({
+      endpoint: "https://collector.example.com/otlp",
       traces: true,
       metrics: true,
       logs: true,
     });
-    await service.start(ctx);
 
     const traceOptions = firstExporterOptions(traceExporterCtor);
     const metricOptions = firstExporterOptions(metricExporterCtor);
@@ -1886,7 +1754,6 @@ describe("diagnostics-otel service", () => {
         }),
       ]),
     );
-    await service.stop?.(ctx);
   });
 
   test("preserves OTLP TLS env options when passing env proxy agents", async () => {
@@ -1903,13 +1770,12 @@ describe("diagnostics-otel service", () => {
       process.env.OTEL_EXPORTER_OTLP_CLIENT_KEY = clientKeyPath;
       createNodeProxyAgentMock.mockReturnValue(nodeProxyAgent);
 
-      const service = createDiagnosticsOtelService();
-      const ctx = createOtelContext("https://collector.example.com/otlp", {
+      await startOtelService({
+        endpoint: "https://collector.example.com/otlp",
         traces: true,
         metrics: true,
         logs: true,
       });
-      await service.start(ctx);
 
       const traceCall = findCreateNodeProxyAgentCall(
         "https://collector.example.com/otlp/v1/traces",
@@ -1928,7 +1794,6 @@ describe("diagnostics-otel service", () => {
         ca: Buffer.from("root-certificate"),
         key: Buffer.from("client-key"),
       });
-      await service.stop?.(ctx);
     } finally {
       rmSync(certDir, { force: true, recursive: true });
     }
@@ -1943,11 +1808,10 @@ describe("diagnostics-otel service", () => {
       process.env.OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE = "   ";
       createNodeProxyAgentMock.mockReturnValue(nodeProxyAgent);
 
-      const service = createDiagnosticsOtelService();
-      const ctx = createOtelContext("https://collector.example.com/otlp", {
+      await startOtelService({
+        endpoint: "https://collector.example.com/otlp",
         traces: true,
       });
-      await service.start(ctx);
 
       const traceCall = findCreateNodeProxyAgentCall(
         "https://collector.example.com/otlp/v1/traces",
@@ -1956,7 +1820,6 @@ describe("diagnostics-otel service", () => {
         keepAlive: true,
         ca: Buffer.from("shared-root-certificate"),
       });
-      await service.stop?.(ctx);
     } finally {
       rmSync(certDir, { force: true, recursive: true });
     }
@@ -1967,13 +1830,12 @@ describe("diagnostics-otel service", () => {
       throw new Error("unsupported proxy protocol");
     });
 
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext("https://collector.example.com/otlp", {
+    const { ctx } = await startOtelService({
+      endpoint: "https://collector.example.com/otlp",
       traces: true,
       metrics: true,
       logs: true,
     });
-    await service.start(ctx);
 
     expect(firstExporterOptions(traceExporterCtor).httpAgentOptions).toBeUndefined();
     expect(firstExporterOptions(metricExporterCtor).httpAgentOptions).toBeUndefined();
@@ -1987,38 +1849,35 @@ describe("diagnostics-otel service", () => {
     expect(ctx.logger.warn).toHaveBeenCalledWith(
       "diagnostics-otel: env proxy agent unavailable for OTLP logs exporter; falling back to default Node agent",
     );
-    await service.stop?.(ctx);
   });
 
   test("leaves OTLP HTTP exporters on their default agents when env proxy is bypassed", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext("https://collector.example.com/otlp", {
+    await startOtelService({
+      endpoint: "https://collector.example.com/otlp",
       traces: true,
       metrics: true,
       logs: true,
     });
-    await service.start(ctx);
 
     expect(firstExporterOptions(traceExporterCtor).httpAgentOptions).toBeUndefined();
     expect(firstExporterOptions(metricExporterCtor).httpAgentOptions).toBeUndefined();
     expect(firstExporterOptions(logExporterCtor).httpAgentOptions).toBeUndefined();
     expect(createNodeProxyAgentMock).toHaveBeenCalledTimes(3);
-    await service.stop?.(ctx);
   });
 
   test("exports diagnostic logs as stdout JSONL without constructing the OTLP log exporter", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext("", {
+    await startOtelService({
+      endpoint: "",
       logs: true,
       logsExporter: "stdout",
       captureContent: true,
+      configure: (ctx) => {
+        ctx.config.diagnostics!.otel!.serviceName = "rovoclaw-openclaw";
+      },
     });
-    ctx.config.diagnostics!.otel!.serviceName = "rovoclaw-openclaw";
     const stdout = captureStdoutWrites();
 
     try {
-      await service.start(ctx);
-
       expect(logExporterCtor).not.toHaveBeenCalled();
       emitDiagnosticEventWithTrustedTraceContext({
         type: "log.record",
@@ -2028,11 +1887,7 @@ describe("diagnostics-otel service", () => {
           token: "ghp_abcdefghijklmnopqrstuvwxyz123456", // pragma: allowlist secret
           subsystem: "diagnostic",
         },
-        trace: {
-          traceId: TRACE_ID,
-          spanId: SPAN_ID,
-          traceFlags: "01",
-        },
+        trace: createTestTrace(SPAN_ID),
       });
       await flushDiagnosticEvents();
 
@@ -2056,20 +1911,14 @@ describe("diagnostics-otel service", () => {
       expect(JSON.stringify(record)).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz123456"); // pragma: allowlist secret
     } finally {
       stdout.spy.mockRestore();
-      await service.stop?.(ctx);
     }
   });
 
   test("keeps explicit OTLP log export off stdout", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
-      logs: true,
-      logsExporter: "otlp",
-    });
     const stdout = captureStdoutWrites();
 
     try {
-      await service.start(ctx);
+      await startOtelService({ logs: true, logsExporter: "otlp" });
       emitDiagnosticEvent({
         type: "log.record",
         level: "INFO",
@@ -2082,20 +1931,14 @@ describe("diagnostics-otel service", () => {
       expect(stdout.writes).toEqual([]);
     } finally {
       stdout.spy.mockRestore();
-      await service.stop?.(ctx);
     }
   });
 
   test("exports diagnostic logs to OTLP and stdout when logsExporter is both", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
-      logs: true,
-      logsExporter: "both",
-    });
     const stdout = captureStdoutWrites();
 
     try {
-      await service.start(ctx);
+      await startOtelService({ logs: true, logsExporter: "both" });
       emitDiagnosticEvent({
         type: "log.record",
         level: "ERROR",
@@ -2119,7 +1962,6 @@ describe("diagnostics-otel service", () => {
       expect(record.attributes).toEqual(emitCall.attributes);
     } finally {
       stdout.spy.mockRestore();
-      await service.stop?.(ctx);
     }
   });
 
@@ -2181,11 +2023,7 @@ describe("diagnostics-otel service", () => {
       attributes: {
         subsystem: "diagnostic",
       },
-      trace: {
-        traceId: TRACE_ID,
-        spanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(SPAN_ID),
     });
 
     expect(Object.hasOwn(emitCall?.attributes ?? {}, "openclaw.traceId")).toBe(false);
@@ -2200,11 +2038,7 @@ describe("diagnostics-otel service", () => {
       {
         level: "INFO",
         message: "traceable log",
-        trace: {
-          traceId: TRACE_ID,
-          spanId: SPAN_ID,
-          traceFlags: "01",
-        },
+        trace: createTestTrace(SPAN_ID),
       },
       { trustedTraceContext: true },
     );
@@ -2222,11 +2056,7 @@ describe("diagnostics-otel service", () => {
       {
         level: "INFO",
         message: "traceable log",
-        trace: {
-          traceId: TRACE_ID,
-          spanId: SPAN_ID,
-          traceFlags: "01",
-        },
+        trace: createTestTrace(SPAN_ID),
       },
       { trusted: true },
     );
@@ -2244,9 +2074,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("bounds plugin-emitted log attributes and omits source paths", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { logs: true, captureContent: true });
-    await service.start(ctx);
+    await startOtelService({ logs: true, captureContent: true });
 
     const boundaryMessage = `${"x".repeat(4095)}🚀tail`;
     const boundaryAttribute = `${"y".repeat(4095)}🚀tail`;
@@ -2292,18 +2120,15 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(emitCall.attributes, "openclaw.bad key")).toBe(false);
     expect(Object.hasOwn(emitCall.attributes, "code.filepath")).toBe(false);
     expect(Object.hasOwn(emitCall.attributes, "openclaw.code.location")).toBe(false);
-    await service.stop?.(ctx);
   });
 
   test("rate-limits repeated log export failure reports", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { logs: true });
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
     logEmit.mockImplementation(() => {
       throw new Error("export failed");
     });
     try {
-      await service.start(ctx);
+      const { ctx } = await startOtelService({ logs: true });
 
       emitDiagnosticEvent({
         type: "log.record",
@@ -2330,24 +2155,16 @@ describe("diagnostics-otel service", () => {
       expect(ctx.logger.error).toHaveBeenCalledTimes(2);
     } finally {
       nowSpy.mockRestore();
-      await service.stop?.(ctx);
     }
   });
 
   test("does not parent diagnostic event spans from plugin-emittable trace context", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "model.usage",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: SPAN_ID,
-        traceFlags: "01",
-      },
-      provider: "openai",
-      model: "gpt-5.4",
+      trace: createTestTrace(SPAN_ID),
+      ...MODEL_FIXTURE,
       usage: { total: 4 },
       durationMs: 12,
     });
@@ -2357,21 +2174,17 @@ describe("diagnostics-otel service", () => {
     );
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
     expect(modelUsageCall?.[2]).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
   test("exports GenAI client token usage histogram for input and output only", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-    await service.start(ctx);
+    await startOtelService({ metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "model.usage",
       sessionKey: "session-key",
       channel: "webchat",
       agentId: "ops",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_FIXTURE,
       usage: {
         input: 12,
         output: 7,
@@ -2381,7 +2194,6 @@ describe("diagnostics-otel service", () => {
         total: 24,
       },
     });
-    await flushDiagnosticEvents();
 
     const tokenUsageOptions = histogramCreateOptions("gen_ai.client.token.usage");
     expect(tokenUsageOptions?.unit).toBe("{token}");
@@ -2412,54 +2224,49 @@ describe("diagnostics-otel service", () => {
       "gen_ai.token.type": "output",
     });
     expect(JSON.stringify(genAiTokenUsage?.record.mock.calls)).not.toContain("session-key");
-    await service.stop?.(ctx);
   });
 
   test("advertises explicit duration buckets on the openclaw run/harness/context histograms", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
     const priorSdkBoundaries = [
       0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000,
     ];
-    try {
-      await service.start(ctx);
+    await startOtelService({ metrics: true });
 
-      const runDurationOptions = histogramCreateOptions("openclaw.run.duration_ms");
-      expect(runDurationOptions?.unit).toBe("ms");
-      const runBoundaries = runDurationOptions?.advice?.explicitBucketBoundaries;
-      expect(runBoundaries).toEqual(expect.arrayContaining(priorSdkBoundaries));
-      for (const boundary of [60000, 3_600_000]) {
-        expect(runBoundaries).toContain(boundary);
-      }
+    const runDurationOptions = histogramCreateOptions("openclaw.run.duration_ms");
+    expect(runDurationOptions?.unit).toBe("ms");
+    const runBoundaries = runDurationOptions?.advice?.explicitBucketBoundaries;
+    expect(runBoundaries).toEqual(expect.arrayContaining(priorSdkBoundaries));
+    for (const boundary of [60000, 3_600_000]) {
+      expect(runBoundaries).toContain(boundary);
+    }
 
-      const harnessDurationOptions = histogramCreateOptions("openclaw.harness.duration_ms");
-      const harnessBoundaries = harnessDurationOptions?.advice?.explicitBucketBoundaries;
-      expect(harnessBoundaries).toEqual(runBoundaries);
+    const harnessDurationOptions = histogramCreateOptions("openclaw.harness.duration_ms");
+    const harnessBoundaries = harnessDurationOptions?.advice?.explicitBucketBoundaries;
+    expect(harnessBoundaries).toEqual(runBoundaries);
 
-      const contextOptions = histogramCreateOptions("openclaw.context.tokens");
-      const contextBoundaries = contextOptions?.advice?.explicitBucketBoundaries;
-      expect(contextBoundaries).toEqual(expect.arrayContaining(priorSdkBoundaries));
-      for (const boundary of [128000, 1_000_000]) {
-        expect(contextBoundaries).toContain(boundary);
-      }
-    } finally {
-      await service.stop?.(ctx);
+    const contextOptions = histogramCreateOptions("openclaw.context.tokens");
+    const contextBoundaries = contextOptions?.advice?.explicitBucketBoundaries;
+    expect(contextBoundaries).toEqual(expect.arrayContaining(priorSdkBoundaries));
+    for (const boundary of [128000, 1_000_000]) {
+      expect(contextBoundaries).toContain(boundary);
     }
   });
 
-  test("bounds agent identifiers on model usage metric attributes", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-    await service.start(ctx);
+  test.each([
+    ["bounds agent identifiers on model usage metric attributes", "Bearer sk-test-secret-value"],
+    [
+      "drops session-shaped agent identifiers from model usage metric attributes",
+      "Agent:qa:otel-trace-smoke",
+    ],
+  ])("%s", async (_name, agentId) => {
+    await startOtelService({ metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "model.usage",
-      agentId: "Bearer sk-test-secret-value",
-      provider: "openai",
-      model: "gpt-5.4",
+      agentId,
+      ...MODEL_FIXTURE,
       usage: { input: 2 },
     });
-    await flushDiagnosticEvents();
 
     expect(telemetryState.counters.get("openclaw.tokens")?.add).toHaveBeenCalledWith(2, {
       "openclaw.channel": "unknown",
@@ -2470,96 +2277,50 @@ describe("diagnostics-otel service", () => {
     });
     expect(
       JSON.stringify(telemetryState.counters.get("openclaw.tokens")?.add.mock.calls),
-    ).not.toContain("sk-test-secret-value");
-    await service.stop?.(ctx);
+    ).not.toContain(agentId);
   });
 
-  test("drops session-shaped agent identifiers from model usage metric attributes", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-    await service.start(ctx);
+  test.each([
+    [
+      "drops session-shaped queue lane metric attributes",
+      "session:Agent:qa:otel-trace-smoke",
+      "session",
+      "Agent:qa:otel-trace-smoke",
+    ],
+    [
+      "keeps only the bounded prefix from scoped queue lane metric attributes",
+      "dreaming-narrative:session-main",
+      "dreaming-narrative",
+      "session-main",
+    ],
+  ])("%s", async (_name, lane, expected, omitted) => {
+    await startOtelService({ metrics: true });
 
-    emitDiagnosticEvent({
-      type: "model.usage",
-      agentId: "Agent:qa:otel-trace-smoke",
-      provider: "openai",
-      model: "gpt-5.4",
-      usage: { input: 2 },
-    });
-    await flushDiagnosticEvents();
-
-    expect(telemetryState.counters.get("openclaw.tokens")?.add).toHaveBeenCalledWith(2, {
-      "openclaw.channel": "unknown",
-      "openclaw.agent": "unknown",
-      "openclaw.provider": "openai",
-      "openclaw.model": "gpt-5.4",
-      "openclaw.token": "input",
-    });
-    expect(
-      JSON.stringify(telemetryState.counters.get("openclaw.tokens")?.add.mock.calls),
-    ).not.toContain("Agent:qa:otel-trace-smoke");
-    await service.stop?.(ctx);
-  });
-
-  test("drops session-shaped queue lane metric attributes", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-    await service.start(ctx);
-
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "queue.lane.enqueue",
-      lane: "session:Agent:qa:otel-trace-smoke",
+      lane,
       queueSize: 2,
     });
-    await flushDiagnosticEvents();
 
     expect(telemetryState.counters.get("openclaw.queue.lane.enqueue")?.add).toHaveBeenCalledWith(
       1,
       {
-        "openclaw.lane": "session",
+        "openclaw.lane": expected,
       },
     );
     expect(
       JSON.stringify(telemetryState.counters.get("openclaw.queue.lane.enqueue")?.add.mock.calls),
-    ).not.toContain("Agent:qa:otel-trace-smoke");
-    await service.stop?.(ctx);
-  });
-
-  test("keeps only the bounded prefix from scoped queue lane metric attributes", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-    await service.start(ctx);
-
-    emitDiagnosticEvent({
-      type: "queue.lane.enqueue",
-      lane: "dreaming-narrative:session-main",
-      queueSize: 2,
-    });
-    await flushDiagnosticEvents();
-
-    expect(telemetryState.counters.get("openclaw.queue.lane.enqueue")?.add).toHaveBeenCalledWith(
-      1,
-      {
-        "openclaw.lane": "dreaming-narrative",
-      },
-    );
-    expect(
-      JSON.stringify(telemetryState.counters.get("openclaw.queue.lane.enqueue")?.add.mock.calls),
-    ).not.toContain("session-main");
-    await service.stop?.(ctx);
+    ).not.toContain(omitted);
   });
 
   test("keeps GenAI token usage metric model attribute present when model is unavailable", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-    await service.start(ctx);
+    await startOtelService({ metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "model.usage",
       provider: "openai",
       usage: { input: 2 },
     });
-    await flushDiagnosticEvents();
 
     expect(telemetryState.histograms.get("gen_ai.client.token.usage")?.record).toHaveBeenCalledWith(
       2,
@@ -2570,15 +2331,12 @@ describe("diagnostics-otel service", () => {
         "gen_ai.token.type": "input",
       },
     );
-    await service.stop?.(ctx);
   });
 
   test("exports GenAI usage attributes on model usage spans without diagnostic identifiers", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "model.usage",
       sessionKey: "session-key",
       sessionId: "session-id",
@@ -2594,7 +2352,6 @@ describe("diagnostics-otel service", () => {
       },
       durationMs: 25,
     });
-    await flushDiagnosticEvents();
 
     const modelUsageOptions = startedSpanOptions("openclaw.model.usage");
     expect(modelUsageOptions?.attributes?.["gen_ai.operation.name"]).toBe("chat");
@@ -2615,13 +2372,10 @@ describe("diagnostics-otel service", () => {
     );
     expect(modelUsageOptions?.startTime).toBeTypeOf("number");
     expect(JSON.stringify(modelUsageOptions)).not.toContain("session-key");
-    await service.stop?.(ctx);
   });
 
   test("separates request and turn GenAI client duration by operation", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "model.call.completed",
@@ -2656,19 +2410,17 @@ describe("diagnostics-otel service", () => {
       observationUnit: "turn",
       durationMs: 2500,
     });
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "model.call.error",
       runId: "run-1",
       callId: "call-4",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_FIXTURE,
       api: "openai-responses",
       transport: "stdio",
       observationUnit: "turn",
       durationMs: 3000,
       errorCategory: "TurnError",
     });
-    await flushDiagnosticEvents();
 
     const operationDurationOptions = histogramCreateOptions("gen_ai.client.operation.duration");
     expect(operationDurationOptions?.unit).toBe("s");
@@ -2736,15 +2488,12 @@ describe("diagnostics-otel service", () => {
     ]);
     expect(JSON.stringify(genAiOperationDuration?.record.mock.calls)).not.toContain("session-key");
     expect(JSON.stringify(genAiOperationDuration?.record.mock.calls)).not.toContain("run-1");
-    await service.stop?.(ctx);
   });
 
   test("exports skill usage counter and span without raw identifiers", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "skill.used",
       agentId: "main",
       runId: "run-should-not-export",
@@ -2753,14 +2502,8 @@ describe("diagnostics-otel service", () => {
       skillSource: "workspace",
       activation: "read",
       toolName: "read",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: TOOL_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(TOOL_SPAN_ID, CHILD_SPAN_ID),
     });
-    await flushDiagnosticEvents();
 
     const expectedAttrs = {
       "openclaw.agent": "main",
@@ -2779,35 +2522,24 @@ describe("diagnostics-otel service", () => {
     expect(skillSpanCall?.[1]).toMatchObject({ attributes: expectedAttrs });
     expect(JSON.stringify(skillSpanCall)).not.toContain("run-should-not-export");
     expect(JSON.stringify(skillSpanCall)).not.toContain("session-should-not-export");
-    await service.stop?.(ctx);
   });
 
   test("exports run, model call, and tool execution lifecycle spans", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "run.completed",
       runId: "run-1",
       sessionKey: "session-key",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_FIXTURE,
       channel: "webchat",
       outcome: "completed",
       durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(SPAN_ID),
     });
     emitDiagnosticEvent({
       type: "model.call.completed",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
       api: "completions",
       transport: "http",
       durationMs: 80,
@@ -2831,12 +2563,7 @@ describe("diagnostics-otel service", () => {
         promptTokens: 135,
         total: 155,
       },
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
     });
     emitDiagnosticEvent({
       type: "harness.run.completed",
@@ -2853,14 +2580,9 @@ describe("diagnostics-otel service", () => {
       resultClassification: "reasoning-only",
       yieldDetected: true,
       itemLifecycle: { startedCount: 3, completedCount: 2, activeCount: 1 },
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "tool.execution.error",
       runId: "run-1",
       toolName: "read",
@@ -2869,14 +2591,8 @@ describe("diagnostics-otel service", () => {
       durationMs: 20,
       errorCategory: "TypeError",
       errorCode: "429",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    await flushDiagnosticEvents();
 
     const spanNames = telemetryState.tracer.startSpan.mock.calls.map((call) => call[0]);
     expect(spanNames).toContain("openclaw.run");
@@ -3004,15 +2720,12 @@ describe("diagnostics-otel service", () => {
     });
     expect(firstSpanEndTime("openclaw.tool.execution")).toBeTypeOf("number");
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
-    await service.stop?.(ctx);
   });
 
   test("exports model failover spans", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true });
 
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "model.failover",
       sessionId: "session-1",
       lane: "main",
@@ -3024,7 +2737,6 @@ describe("diagnostics-otel service", () => {
       suspended: true,
       cascadeDepth: 1,
     });
-    await flushDiagnosticEvents();
 
     const failoverOptions = startedSpanOptions("openclaw.model.failover");
     expect(failoverOptions?.attributes?.["openclaw.provider"]).toBe("anthropic");
@@ -3051,15 +2763,12 @@ describe("diagnostics-otel service", () => {
         "openclaw.failover.to_provider": "openai",
       },
     ]);
-    await service.stop?.(ctx);
   });
 
   test("records blocked tool metrics even when traces are disabled", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true, traces: false });
-    await service.start(ctx);
+    await startOtelService({ metrics: true, traces: false });
 
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "tool.execution.blocked",
       runId: "run-should-not-export",
       toolName: "browser",
@@ -3069,7 +2778,6 @@ describe("diagnostics-otel service", () => {
       reason: "matched browser",
       paramsSummary: { kind: "object" },
     });
-    await flushDiagnosticEvents();
 
     expect(firstCounterAddCall("openclaw.tool.execution.blocked")).toStrictEqual([
       1,
@@ -3087,41 +2795,30 @@ describe("diagnostics-otel service", () => {
       expect.anything(),
       expect.anything(),
     );
-
-    await service.stop?.(ctx);
   });
 
   test("drops session-shaped queue lanes from model failover spans", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "model.failover",
       lane: "session:Agent:qa:otel-trace-smoke",
       reason: "overloaded",
       fromProvider: "anthropic",
       fromModel: "claude-opus-4-6",
     });
-    await flushDiagnosticEvents();
 
     const failoverOptions = startedSpanOptions("openclaw.model.failover");
     expect(failoverOptions?.attributes?.["openclaw.lane"]).toBe("session");
     expect(JSON.stringify(failoverOptions?.attributes)).not.toContain("Agent:qa:otel-trace-smoke");
-    await service.stop?.(ctx);
   });
 
   test("maps model call APIs to GenAI operation names and error type", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "model.call.completed",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
       api: "openai-completions",
       durationMs: 80,
     });
@@ -3134,17 +2831,15 @@ describe("diagnostics-otel service", () => {
       api: "google-generative-ai",
       durationMs: 90,
     });
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "model.call.error",
       runId: "run-1",
       callId: "call-3",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_FIXTURE,
       api: "openai-responses",
       durationMs: 40,
       errorCategory: "TimeoutError",
     });
-    await flushDiagnosticEvents();
 
     const modelCallAttrs = telemetryState.tracer.startSpan.mock.calls
       .filter((call) => call[0] === "openclaw.model.call")
@@ -3160,22 +2855,16 @@ describe("diagnostics-otel service", () => {
     expect(modelCallAttrs[2]?.["gen_ai.request.model"]).toBe("gpt-5.4");
     expect(modelCallAttrs[2]?.["gen_ai.operation.name"]).toBe("chat");
     expect(modelCallAttrs[2]?.["error.type"]).toBe("TimeoutError");
-    await service.stop?.(ctx);
   });
 
   test("uses latest GenAI request and agent span shapes only when semconv opt-in is set", async () => {
     process.env.OTEL_SEMCONV_STABILITY_OPT_IN = "http,gen_ai_latest_experimental";
 
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "model.call.completed",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
       api: "openai-completions",
       durationMs: 80,
     });
@@ -3190,14 +2879,12 @@ describe("diagnostics-otel service", () => {
       observationUnit: "turn",
       durationMs: 90,
     });
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "model.usage",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_FIXTURE,
       usage: { input: 3, output: 2 },
       durationMs: 10,
     });
-    await flushDiagnosticEvents();
 
     expect(startedSpanOptions("openclaw.model.call")).toBeUndefined();
     const modelCallOptions = startedSpanOptions("text_completion gpt-5.4");
@@ -3220,27 +2907,20 @@ describe("diagnostics-otel service", () => {
     expect(modelUsageOptions?.attributes?.["gen_ai.operation.name"]).toBe("chat");
     expect(Object.hasOwn(modelUsageOptions?.attributes ?? {}, "gen_ai.system")).toBe(false);
     expect(modelUsageOptions?.startTime).toBeTypeOf("number");
-    await service.stop?.(ctx);
   });
 
   test("records upstream request id hashes as model call span events only", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "model.call.error",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
       api: "openai-responses",
       durationMs: 40,
       errorCategory: "ProviderError",
       failureKind: "terminated",
       upstreamRequestIdHash: "sha256:123456abcdef",
     });
-    await flushDiagnosticEvents();
 
     const modelCallOptions = startedSpanOptions("openclaw.model.call");
     expect(modelCallOptions?.attributes?.["openclaw.failureKind"]).toBe("terminated");
@@ -3258,32 +2938,22 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(modelCallDuration?.[1] ?? {}, "openclaw.upstreamRequestIdHash")).toBe(
       false,
     );
-    await service.stop?.(ctx);
   });
 
   test("exports trusted context assembly spans without prompt content", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitTrustedDiagnosticEvent({
       type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      ...RUN_FIXTURE,
+      trace: createTestTrace(SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "context.assembled",
       runId: "run-1",
       sessionKey: "session-key",
       sessionId: "session-id",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_FIXTURE,
       channel: "webchat",
       trigger: "message",
       messageCount: 12,
@@ -3295,14 +2965,8 @@ describe("diagnostics-otel service", () => {
       promptImages: 1,
       contextTokenBudget: 128_000,
       reserveTokens: 4096,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, SPAN_ID),
     });
-    await flushDiagnosticEvents();
 
     const contextCall = startedSpanCall("openclaw.context.assembled");
     const contextOptions = contextCall?.[1];
@@ -3331,15 +2995,12 @@ describe("diagnostics-otel service", () => {
     expect(
       (contextCall?.[2] as { spanContext?: { spanId?: string } } | undefined)?.spanContext?.spanId,
     ).toBe(runSpanId);
-    await service.stop?.(ctx);
   });
 
   test("exports tool loop diagnostics without loop messages or session identifiers", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "tool.loop",
       sessionKey: "session-key",
       sessionId: "session-id",
@@ -3351,7 +3012,6 @@ describe("diagnostics-otel service", () => {
       message: "CRITICAL: repeated secret-bearing tool output",
       pairedToolName: "read",
     });
-    await flushDiagnosticEvents();
 
     expect(telemetryState.counters.get("openclaw.tool.loop")?.add).toHaveBeenCalledWith(1, {
       "openclaw.toolName": "process",
@@ -3376,13 +3036,10 @@ describe("diagnostics-otel service", () => {
     });
     expect(JSON.stringify(loopSpanCall)).not.toContain("session-key");
     expect(JSON.stringify(loopSpanCall)).not.toContain("secret-bearing");
-    await service.stop?.(ctx);
   });
 
   test("exports diagnostic memory samples and pressure without session identifiers", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "diagnostic.memory.sample",
@@ -3395,7 +3052,7 @@ describe("diagnostics-otel service", () => {
         arrayBuffersBytes: 5,
       },
     });
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "diagnostic.memory.pressure",
       level: "critical",
       reason: "rss_growth",
@@ -3410,7 +3067,6 @@ describe("diagnostics-otel service", () => {
         arrayBuffersBytes: 6,
       },
     });
-    await flushDiagnosticEvents();
 
     expect(telemetryState.histograms.get("openclaw.memory.rss_bytes")?.record).toHaveBeenCalledWith(
       100,
@@ -3447,15 +3103,12 @@ describe("diagnostics-otel service", () => {
       message: "rss_growth",
     });
     expect(JSON.stringify(pressureCall)).not.toContain("session");
-    await service.stop?.(ctx);
   });
 
   test("records async diagnostic queue drop summaries", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-    await service.start(ctx);
+    await startOtelService({ metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "diagnostic.async_queue.dropped",
       droppedEvents: 4,
       droppedTrustedEvents: 1,
@@ -3465,7 +3118,6 @@ describe("diagnostics-otel service", () => {
       maxQueueLength: 10_000,
       drainBatchSize: 100,
     });
-    await flushDiagnosticEvents();
 
     const counter = telemetryState.counters.get("openclaw.diagnostic.async_queue.dropped");
     expect(counter?.add).toHaveBeenCalledWith(4, {
@@ -3480,50 +3132,22 @@ describe("diagnostics-otel service", () => {
     expect(counter?.add).toHaveBeenCalledWith(1, {
       "openclaw.diagnostic.async_queue.drop_class": "priority",
     });
-
-    await service.stop?.(ctx);
   });
 
   test("parents trusted diagnostic lifecycle spans from active started spans", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
+    emitRunStarted();
     emitTrustedDiagnosticEvent({
       type: "model.call.started",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      ...MODEL_CALL_FIXTURE,
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
     emitTrustedDiagnosticEvent({
       type: "tool.execution.started",
       runId: "run-1",
       toolName: "read",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: TOOL_SPAN_ID,
-        parentSpanId: GRANDCHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
     });
     emitTrustedDiagnosticEvent({
       type: "tool.execution.error",
@@ -3531,42 +3155,21 @@ describe("diagnostics-otel service", () => {
       toolName: "read",
       durationMs: 20,
       errorCategory: "TypeError",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: TOOL_SPAN_ID,
-        parentSpanId: GRANDCHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
     });
     emitTrustedDiagnosticEvent({
       type: "model.call.completed",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
       durationMs: 80,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...RUN_FIXTURE,
       outcome: "completed",
       durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
     });
-    await flushDiagnosticEvents();
 
     const runSpan = telemetryState.spans.find((span) => span.name === "openclaw.run");
     const modelSpan = telemetryState.spans.find((span) => span.name === "openclaw.model.call");
@@ -3596,25 +3199,17 @@ describe("diagnostics-otel service", () => {
       code: 2,
       message: "TypeError",
     });
-    await service.stop?.(ctx);
   });
 
   test("correlates one channel message waterfall across message, harness, usage, and model spans", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitTrustedDiagnosticEvent({
       type: "message.dispatch.started",
       channel: "slack",
       source: "replyResolver",
       sessionKey: "agent:main:slack:channel:c1",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
     });
     emitTrustedDiagnosticEvent({
       type: "harness.run.started",
@@ -3624,12 +3219,7 @@ describe("diagnostics-otel service", () => {
       provider: "openai",
       model: "gpt-5.5",
       channel: "slack",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
     emitTrustedDiagnosticEvent({
       type: "run.started",
@@ -3637,12 +3227,7 @@ describe("diagnostics-otel service", () => {
       provider: "openai",
       model: "gpt-5.5",
       channel: "slack",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: TOOL_SPAN_ID,
-        parentSpanId: GRANDCHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
     });
     emitTrustedDiagnosticEvent({
       type: "model.call.started",
@@ -3652,12 +3237,7 @@ describe("diagnostics-otel service", () => {
       model: "gpt-5.5",
       api: "openai-codex-responses",
       transport: "stdio",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: MODEL_CALL_SPAN_ID,
-        parentSpanId: TOOL_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(MODEL_CALL_SPAN_ID, TOOL_SPAN_ID),
     });
     emitTrustedDiagnosticEvent({
       type: "model.call.completed",
@@ -3668,12 +3248,7 @@ describe("diagnostics-otel service", () => {
       api: "openai-codex-responses",
       transport: "stdio",
       durationMs: 80,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: MODEL_CALL_SPAN_ID,
-        parentSpanId: TOOL_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(MODEL_CALL_SPAN_ID, TOOL_SPAN_ID),
     });
     emitTrustedDiagnosticEvent({
       type: "harness.run.completed",
@@ -3686,12 +3261,7 @@ describe("diagnostics-otel service", () => {
       durationMs: 100,
       outcome: "completed",
       itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
     emitTrustedDiagnosticEvent({
       type: "model.usage",
@@ -3702,27 +3272,16 @@ describe("diagnostics-otel service", () => {
       model: "gpt-5.5",
       usage: { input: 3, output: 2, total: 5 },
       durationMs: 10,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: MODEL_USAGE_SPAN_ID,
-        parentSpanId: GRANDCHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(MODEL_USAGE_SPAN_ID, GRANDCHILD_SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "message.processed",
       channel: "slack",
       sessionKey: "agent:main:slack:channel:c1",
       durationMs: 120,
       outcome: "completed",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
     });
-    await flushDiagnosticEvents();
 
     const messageSpan = spanByName("openclaw.message.processed");
     const harnessSpan = spanByName("openclaw.harness.run");
@@ -3752,20 +3311,12 @@ describe("diagnostics-otel service", () => {
     expect(parentBySpanName["openclaw.run"]?.spanId).toBe(harnessSpanContext.spanId);
     expect(parentBySpanName["openclaw.model.usage"]?.spanId).toBe(harnessSpanContext.spanId);
     expect(parentBySpanName["openclaw.model.call"]?.spanId).toBe(runSpanContext.spanId);
-    await service.stop?.(ctx);
   });
 
   test("uses production message lifecycle helpers as the message span anchor", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    const messageTrace = createDiagnosticTraceContext({
-      traceId: TRACE_ID,
-      spanId: CHILD_SPAN_ID,
-      parentSpanId: SPAN_ID,
-      traceFlags: "01",
-    });
+    const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID, SPAN_ID));
 
     runWithDiagnosticTraceContext(messageTrace, () => {
       logMessageDispatchStarted({
@@ -3781,12 +3332,7 @@ describe("diagnostics-otel service", () => {
         provider: "openai",
         model: "gpt-5.5",
         channel: "slack",
-        trace: {
-          traceId: TRACE_ID,
-          spanId: GRANDCHILD_SPAN_ID,
-          parentSpanId: CHILD_SPAN_ID,
-          traceFlags: "01",
-        },
+        trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
       });
       emitTrustedDiagnosticEvent({
         type: "model.usage",
@@ -3797,12 +3343,7 @@ describe("diagnostics-otel service", () => {
         model: "gpt-5.5",
         usage: { input: 3, output: 2, total: 5 },
         durationMs: 10,
-        trace: {
-          traceId: TRACE_ID,
-          spanId: MODEL_USAGE_SPAN_ID,
-          parentSpanId: GRANDCHILD_SPAN_ID,
-          traceFlags: "01",
-        },
+        trace: createTestTrace(MODEL_USAGE_SPAN_ID, GRANDCHILD_SPAN_ID),
       });
       logMessageProcessed({
         channel: "slack",
@@ -3830,19 +3371,12 @@ describe("diagnostics-otel service", () => {
     expect(parentBySpanName["openclaw.model.usage"]?.spanId).toBe(harnessSpanContext.spanId);
     expect(messageSpanContext.traceId).toBe(TRACE_ID);
     expect(harnessSpanContext.traceId).toBe(TRACE_ID);
-    await service.stop?.(ctx);
   });
 
   test("does not force a remote parent for root message lifecycle helpers", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    const messageTrace = createDiagnosticTraceContext({
-      traceId: TRACE_ID,
-      spanId: CHILD_SPAN_ID,
-      traceFlags: "01",
-    });
+    const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID));
 
     runWithDiagnosticTraceContext(messageTrace, () => {
       logMessageDispatchStarted({
@@ -3861,20 +3395,12 @@ describe("diagnostics-otel service", () => {
 
     expect(spanByName("openclaw.message.processed").spanContext().traceId).toBe(TRACE_ID);
     expect(startedSpanParentContexts("openclaw.message.processed")[0]).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
   test("parents outbound delivery spans under the active message lifecycle span", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    const messageTrace = createDiagnosticTraceContext({
-      traceId: TRACE_ID,
-      spanId: CHILD_SPAN_ID,
-      parentSpanId: SPAN_ID,
-      traceFlags: "01",
-    });
+    const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID, SPAN_ID));
 
     runWithDiagnosticTraceContext(messageTrace, () => {
       logMessageDispatchStarted({
@@ -3915,20 +3441,12 @@ describe("diagnostics-otel service", () => {
     expect(deliveryParentContexts[0]?.spanId).toBe(messageSpanContext.spanId);
     expect(deliveryParentContexts[1]?.traceId).toBe(TRACE_ID);
     expect(deliveryParentContexts[1]?.spanId).toBe(messageSpanContext.spanId);
-    await service.stop?.(ctx);
   });
 
   test("parents multi-batch late delivery spans from the retained message context", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    const messageTrace = createDiagnosticTraceContext({
-      traceId: TRACE_ID,
-      spanId: CHILD_SPAN_ID,
-      parentSpanId: SPAN_ID,
-      traceFlags: "01",
-    });
+    const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID, SPAN_ID));
 
     runWithDiagnosticTraceContext(messageTrace, () => {
       logMessageDispatchStarted({
@@ -3965,20 +3483,12 @@ describe("diagnostics-otel service", () => {
     expect(
       deliveryParentContexts.every((parent) => parent?.spanId === messageSpanContext.spanId),
     ).toBe(true);
-    await service.stop?.(ctx);
   });
 
   test("correlates skipped duplicate message lifecycle helpers to the active inbound trace", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    const messageTrace = createDiagnosticTraceContext({
-      traceId: TRACE_ID,
-      spanId: CHILD_SPAN_ID,
-      parentSpanId: SPAN_ID,
-      traceFlags: "01",
-    });
+    const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID, SPAN_ID));
 
     runWithDiagnosticTraceContext(messageTrace, () => {
       logMessageProcessed({
@@ -4002,37 +3512,26 @@ describe("diagnostics-otel service", () => {
     expect(parentContext?.spanId).toBe(SPAN_ID);
     expect(firstSpanAttributes("openclaw.message.processed")["openclaw.reason"]).toBe("duplicate");
     expect(messageSpan.end).toHaveBeenCalledTimes(1);
-    await service.stop?.(ctx);
   });
 
   test("does not force a remote parent for fallback root message processed spans", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "message.processed",
       channel: "slack",
       sessionKey: "agent:main:slack:channel:c1",
       durationMs: 25,
       outcome: "skipped",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(CHILD_SPAN_ID),
     });
-    await flushDiagnosticEvents();
 
     expect(spanByName("openclaw.message.processed").spanContext().traceId).toBe(TRACE_ID);
     expect(startedSpanParentContexts("openclaw.message.processed")[0]).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
   test("does not retain fallback message processed spans as active parents", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitTrustedDiagnosticEvent({
       type: "message.processed",
@@ -4040,12 +3539,7 @@ describe("diagnostics-otel service", () => {
       sessionKey: "agent:main:slack:channel:c1",
       durationMs: 25,
       outcome: "skipped",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
     });
     expect(spanByName("openclaw.message.processed").end).toHaveBeenCalledTimes(1);
 
@@ -4058,65 +3552,26 @@ describe("diagnostics-otel service", () => {
       provider: "openai",
       model: "gpt-5.5",
       channel: "slack",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
 
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
     expect(startedSpanCall("openclaw.harness.run")?.[2]).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
   test("retains trusted run context long enough for exact post-completion usage parenting", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
-    emitTrustedDiagnosticEvent({
-      type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      outcome: "completed",
-      durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
+    emitRunStarted();
+    emitRunCompleted();
     await Promise.resolve();
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "model.usage",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_FIXTURE,
       usage: { input: 3, output: 2, total: 5 },
       durationMs: 10,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    await flushDiagnosticEvents();
 
     const runSpan = telemetryState.spans.find((span) => span.name === "openclaw.run");
     const runSpanId = runSpan?.spanContext.mock.results[0]?.value?.spanId;
@@ -4132,37 +3587,29 @@ describe("diagnostics-otel service", () => {
         ?.spanId,
     ).toBe(runSpanId);
     expect(firstSpanEndTime("openclaw.run")).toBeTypeOf("number");
-    await service.stop?.(ctx);
   });
 
-  test("does not parent sibling active runs through shared upstream aliases", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+  test.each([
+    ["does not parent sibling active runs through shared upstream aliases", false],
+    ["does not parent sibling runs through retained upstream aliases", true],
+  ])("%s", async (_name, completeFirstRun) => {
+    await startOtelService({ traces: true, metrics: true });
 
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
+    emitRunStarted();
+    if (completeFirstRun) {
+      emitTrustedDiagnosticEvent({
+        type: "run.completed",
+        ...RUN_FIXTURE,
+        outcome: "completed",
+        durationMs: 100,
+        trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
+      });
+    }
     emitTrustedDiagnosticEvent({
       type: "run.started",
       runId: "run-2",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      ...MODEL_FIXTURE,
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, SPAN_ID),
     });
 
     const runContexts = startedSpanParentContextsByName("openclaw.run");
@@ -4170,163 +3617,37 @@ describe("diagnostics-otel service", () => {
     expect(runContexts).toHaveLength(2);
     expect(runContexts[0]?.parentContext).toBeUndefined();
     expect(runContexts[1]?.parentContext).toBeUndefined();
-    await service.stop?.(ctx);
-  });
-
-  test("does not parent sibling runs through retained upstream aliases", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
-
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
-    emitTrustedDiagnosticEvent({
-      type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      outcome: "completed",
-      durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      runId: "run-2",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
-
-    const runContexts = startedSpanParentContextsByName("openclaw.run");
-
-    expect(runContexts).toHaveLength(2);
-    expect(runContexts[0]?.parentContext).toBeUndefined();
-    expect(runContexts[1]?.parentContext).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
   test("parents retained upstream alias events only when the owner matches", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
+    emitRunStarted();
     emitTrustedDiagnosticEvent({
       type: "model.call.completed",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
       durationMs: 80,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: MODEL_CALL_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(MODEL_CALL_SPAN_ID, SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...RUN_FIXTURE,
       outcome: "completed",
       durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
     });
-    await flushDiagnosticEvents();
 
     const runSpanContext = spanByName("openclaw.run").spanContext();
     const modelParentContext = startedSpanParentContexts("openclaw.model.call")[0];
 
     expect(modelParentContext?.traceId).toBe(TRACE_ID);
     expect(modelParentContext?.spanId).toBe(runSpanContext.spanId);
-    await service.stop?.(ctx);
   });
 
   test("parents multi-batch late model spans from the retained run context", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
-    for (let index = 0; index < 125; index += 1) {
-      emitTrustedDiagnosticEvent({
-        type: "model.call.completed",
-        runId: "run-1",
-        callId: `call-${index}`,
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-        trace: {
-          traceId: TRACE_ID,
-          spanId: numberedSpanId(index),
-          parentSpanId: CHILD_SPAN_ID,
-          traceFlags: "01",
-        },
-      });
-    }
-    emitTrustedDiagnosticEvent({
-      type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      outcome: "completed",
-      durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
+    emitQueuedRunWithModelCalls();
 
     const runSpan = spanByName("openclaw.run");
     const runSpanContext = runSpan.spanContext();
@@ -4339,56 +3660,12 @@ describe("diagnostics-otel service", () => {
     expect(modelParentContexts.every((parent) => parent?.spanId === runSpanContext.spanId)).toBe(
       true,
     );
-    await service.stop?.(ctx);
   });
 
   test("removes retained run contexts after queued diagnostics drain", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
-    for (let index = 0; index < 125; index += 1) {
-      emitTrustedDiagnosticEvent({
-        type: "model.call.completed",
-        runId: "run-1",
-        callId: `call-${index}`,
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-        trace: {
-          traceId: TRACE_ID,
-          spanId: numberedSpanId(index),
-          parentSpanId: CHILD_SPAN_ID,
-          traceFlags: "01",
-        },
-      });
-    }
-    emitTrustedDiagnosticEvent({
-      type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      outcome: "completed",
-      durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
+    emitQueuedRunWithModelCalls();
 
     await waitForDiagnosticEventsDrained();
     await new Promise<void>((resolve) => {
@@ -4399,115 +3676,56 @@ describe("diagnostics-otel service", () => {
     telemetryState.tracer.setSpanContext.mockClear();
     telemetryState.tracer.startSpan.mockClear();
 
-    emitTrustedDiagnosticEvent({
-      type: "model.usage",
-      provider: "openai",
-      model: "gpt-5.4",
-      usage: { input: 3, output: 2, total: 5 },
-      durationMs: 10,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
-    });
+    emitDefaultModelUsage();
 
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
     expect(startedSpanCall("openclaw.model.usage")?.[2]).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
   test("clears retained run contexts when the service stops", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    const { service, ctx } = await startOtelService({ traces: true, metrics: true });
 
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
-    emitTrustedDiagnosticEvent({
-      type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      outcome: "completed",
-      durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
-    });
+    emitRunStarted();
+    emitRunCompleted();
 
     await service.stop?.(ctx);
     await service.start(ctx);
     telemetryState.tracer.setSpanContext.mockClear();
     telemetryState.tracer.startSpan.mockClear();
 
-    emitTrustedDiagnosticEvent({
-      type: "model.usage",
-      provider: "openai",
-      model: "gpt-5.4",
-      usage: { input: 3, output: 2, total: 5 },
-      durationMs: 10,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
-    });
+    emitDefaultModelUsage();
 
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
     expect(startedSpanCall("openclaw.model.usage")?.[2]).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
-  test("does not force remote parents for completed-only trusted lifecycle spans", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+  test.each([
+    [
+      "does not force remote parents for completed-only trusted lifecycle spans",
+      createTestTrace(CHILD_SPAN_ID, SPAN_ID),
+      createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
+    ],
+    [
+      "does not self-parent trusted diagnostic lifecycle spans without parent ids",
+      createTestTrace(CHILD_SPAN_ID),
+      createTestTrace(GRANDCHILD_SPAN_ID),
+    ],
+  ])("%s", async (_name, runTrace, modelTrace) => {
+    await startOtelService({ traces: true, metrics: true });
 
     emitTrustedDiagnosticEvent({
       type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...RUN_FIXTURE,
       outcome: "completed",
       durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: runTrace,
     });
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "model.call.completed",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
       durationMs: 80,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: modelTrace,
     });
-    await flushDiagnosticEvents();
 
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
     const parentBySpanName = Object.fromEntries(
@@ -4515,97 +3733,31 @@ describe("diagnostics-otel service", () => {
     );
     expect(parentBySpanName["openclaw.run"]).toBeUndefined();
     expect(parentBySpanName["openclaw.model.call"]).toBeUndefined();
-    await service.stop?.(ctx);
-  });
-
-  test("does not self-parent trusted diagnostic lifecycle spans without parent ids", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
-
-    emitTrustedDiagnosticEvent({
-      type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      outcome: "completed",
-      durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
-    });
-    emitTrustedDiagnosticEvent({
-      type: "model.call.completed",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      durationMs: 80,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        traceFlags: "01",
-      },
-    });
-    await flushDiagnosticEvents();
-
-    expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
-    const parentBySpanName = Object.fromEntries(
-      telemetryState.tracer.startSpan.mock.calls.map((call) => [call[0], call[2]]),
-    );
-    expect(parentBySpanName["openclaw.run"]).toBeUndefined();
-    expect(parentBySpanName["openclaw.model.call"]).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
   test("does not parent untrusted diagnostic lifecycle spans from injected trace ids", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...RUN_FIXTURE,
       outcome: "completed",
       durationMs: 100,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: CHILD_SPAN_ID,
-        parentSpanId: SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
     });
     emitDiagnosticEvent({
       type: "model.call.completed",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
       durationMs: 80,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: GRANDCHILD_SPAN_ID,
-        parentSpanId: CHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "tool.execution.completed",
       runId: "run-1",
       toolName: "read",
       durationMs: 20,
-      trace: {
-        traceId: TRACE_ID,
-        spanId: TOOL_SPAN_ID,
-        parentSpanId: GRANDCHILD_SPAN_ID,
-        traceFlags: "01",
-      },
+      trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
     });
-    await flushDiagnosticEvents();
 
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
     const parentBySpanName = Object.fromEntries(
@@ -4614,41 +3766,28 @@ describe("diagnostics-otel service", () => {
     expect(parentBySpanName["openclaw.run"]).toBeUndefined();
     expect(parentBySpanName["openclaw.model.call"]).toBeUndefined();
     expect(parentBySpanName["openclaw.tool.execution"]).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
   test("does not create live started spans for untrusted lifecycle diagnostics", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "run.started",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...RUN_FIXTURE,
     });
     emitDiagnosticEvent({
       type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...RUN_FIXTURE,
       outcome: "completed",
       durationMs: 100,
     });
     emitDiagnosticEvent({
       type: "model.call.started",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
     });
     emitDiagnosticEvent({
       type: "model.call.completed",
-      runId: "run-1",
-      callId: "call-1",
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_CALL_FIXTURE,
       durationMs: 80,
     });
     emitDiagnosticEvent({
@@ -4671,7 +3810,7 @@ describe("diagnostics-otel service", () => {
       harnessId: "codex",
       pluginId: "codex-plugin",
     });
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "harness.run.completed",
       runId: "run-1",
       provider: "codex",
@@ -4681,7 +3820,6 @@ describe("diagnostics-otel service", () => {
       outcome: "completed",
       durationMs: 90,
     });
-    await flushDiagnosticEvents();
 
     expect(
       telemetryState.tracer.startSpan.mock.calls.filter((call) => call[0] === "openclaw.run"),
@@ -4701,15 +3839,12 @@ describe("diagnostics-otel service", () => {
         (call) => call[0] === "openclaw.harness.run",
       ),
     ).toHaveLength(1);
-    await service.stop?.(ctx);
   });
 
   test("exports exec process spans without command text", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "exec.process.completed",
       target: "host",
       mode: "child",
@@ -4720,7 +3855,6 @@ describe("diagnostics-otel service", () => {
       timedOut: false,
       failureKind: "runtime-error",
     });
-    await flushDiagnosticEvents();
 
     const execDuration = lastHistogramRecord("openclaw.exec.duration_ms");
     expect(execDuration?.[0]).toBe(30);
@@ -4749,13 +3883,10 @@ describe("diagnostics-otel service", () => {
       message: "runtime-error",
     });
     expect(firstSpanEndTime("openclaw.exec")).toBeTypeOf("number");
-    await service.stop?.(ctx);
   });
 
   test("exports message delivery spans and metrics with low-cardinality attributes", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "message.delivery.started",
@@ -4771,7 +3902,7 @@ describe("diagnostics-otel service", () => {
       resultCount: 1,
       sessionKey: "session-secret",
     });
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "message.delivery.error",
       channel: "discord",
       deliveryKind: "media",
@@ -4779,7 +3910,6 @@ describe("diagnostics-otel service", () => {
       errorCategory: "TypeError",
       sessionKey: "session-secret",
     });
-    await flushDiagnosticEvents();
 
     expect(
       telemetryState.counters.get("openclaw.message.delivery.started")?.add,
@@ -4837,15 +3967,12 @@ describe("diagnostics-otel service", () => {
       code: 2,
       message: "TypeError",
     });
-    await service.stop?.(ctx);
   });
 
   test("bounds unsafe message delivery attributes before export", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
-    emitDiagnosticEvent({
+    await emitAndFlush({
       type: "message.delivery.completed",
       channel: "discord/custom",
       deliveryKind: "progress draft" as never,
@@ -4853,7 +3980,6 @@ describe("diagnostics-otel service", () => {
       resultCount: 1,
       sessionKey: "session-secret",
     });
-    await flushDiagnosticEvents();
 
     const deliveryDuration = lastHistogramRecord("openclaw.message.delivery.duration_ms");
     expect(deliveryDuration?.[0]).toBe(20);
@@ -4867,13 +3993,10 @@ describe("diagnostics-otel service", () => {
     expect(deliveryOptions?.attributes?.["openclaw.outcome"]).toBe("completed");
     expect(deliveryOptions?.attributes?.["openclaw.delivery.result_count"]).toBe(1);
     expect(deliveryOptions?.startTime).toBeTypeOf("number");
-    await service.stop?.(ctx);
   });
 
   test("exports session recovery and talk metrics with bounded attributes", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-    await service.start(ctx);
+    await startOtelService({ metrics: true });
 
     emitTrustedDiagnosticEvent({
       type: "session.recovery.requested",
@@ -4907,7 +4030,7 @@ describe("diagnostics-otel service", () => {
       provider: "openai",
       byteLength: 320,
     });
-    emitTrustedDiagnosticEvent({
+    await emitTrustedAndFlush({
       type: "talk.event",
       sessionId: "talk-session-should-not-export",
       talkEventType: "latency.metrics",
@@ -4917,7 +4040,6 @@ describe("diagnostics-otel service", () => {
       provider: "openai",
       durationMs: 45,
     });
-    await flushDiagnosticEvents();
 
     const recoveryRequestedCall = firstCounterAddCall("openclaw.session.recovery.requested");
     expect(recoveryRequestedCall[0]).toBe(1);
@@ -4964,13 +4086,10 @@ describe("diagnostics-otel service", () => {
     );
     expect(talkCounterCalls).not.toContain("talk-session-should-not-export");
     expect(talkCounterCalls).not.toContain("turn-should-not-export");
-    await service.stop?.(ctx);
   });
 
   test("does not export model or tool content unless capture is explicitly enabled", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitTrustedModelCallCompletedWithContent(
       {
@@ -5021,12 +4140,10 @@ describe("diagnostics-otel service", () => {
     expect(toolOptions?.attributes?.["gen_ai.tool.call.id"]).toBe("tool-1");
     expect(toolOptions?.attributes?.["gen_ai.operation.name"]).toBe("execute_tool");
     expect(toolOptions?.startTime).toBeTypeOf("number");
-    await service.stop?.(ctx);
   });
 
   test("exports bounded redacted content when capture fields are opted in", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
       metrics: true,
       captureContent: {
@@ -5038,7 +4155,6 @@ describe("diagnostics-otel service", () => {
         systemPrompt: true,
       },
     });
-    await service.start(ctx);
 
     emitTrustedModelCallCompletedWithContent(
       {
@@ -5068,16 +4184,8 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const toolCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.tool.execution",
-    );
-    const modelAttrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
-    const toolAttrs = (toolCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const modelAttrs = startedSpanOptions("openclaw.model.call")?.attributes;
+    const toolAttrs = startedSpanOptions("openclaw.tool.execution")?.attributes;
 
     expect(modelAttrs?.["openclaw.content.output_messages"]).toBe("model reply");
     expect(modelAttrs?.["openclaw.content.system_prompt"]).toBe("system prompt");
@@ -5098,22 +4206,13 @@ describe("diagnostics-otel service", () => {
     expect(toolAttrs?.["gen_ai.tool.call.result"]).toBe(
       toolAttrs?.["openclaw.content.tool_output"],
     );
-    await service.stop?.(ctx);
   });
 
   test("omits absent model content fields when capture fields are opted in", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: true,
-        outputMessages: true,
-        systemPrompt: true,
-        toolDefinitions: true,
-      },
+      captureContent: MODEL_CONTENT_CAPTURE,
     });
-    await service.start(ctx);
 
     emitTrustedModelCallCompletedWithContent(
       {
@@ -5127,11 +4226,7 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs =
-      (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)?.attributes ?? {};
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes ?? {};
     expect(attrs["openclaw.content.input_messages"]).toBe("user prompt");
     expect(Object.hasOwn(attrs, "openclaw.content.output_messages")).toBe(false);
     expect(Object.hasOwn(attrs, "openclaw.content.system_prompt")).toBe(false);
@@ -5139,22 +4234,13 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(attrs, "gen_ai.output.messages")).toBe(false);
     expect(Object.hasOwn(attrs, "gen_ai.system_instructions")).toBe(false);
     expect(Object.hasOwn(attrs, "gen_ai.tool.definitions")).toBe(false);
-    await service.stop?.(ctx);
   });
 
   test("exports Phoenix-readable GenAI prompt, output, and tool definition attributes", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: true,
-        outputMessages: true,
-        systemPrompt: true,
-        toolDefinitions: true,
-      },
+      captureContent: MODEL_CONTENT_CAPTURE,
     });
-    await service.start(ctx);
 
     emitTrustedModelCallCompletedWithContent(
       {
@@ -5190,11 +4276,7 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
     expect(attrs?.["gen_ai.system_instructions"]).toBe(
       JSON.stringify([{ type: "text", content: "be exact" }]),
     );
@@ -5233,22 +4315,13 @@ describe("diagnostics-otel service", () => {
     ]);
     expect(attrs?.["input.mime_type"]).toBe("application/json");
     expect(attrs?.["output.mime_type"]).toBe("application/json");
-    await service.stop?.(ctx);
   });
 
   test("exports Claude CLI turn content through the existing Phoenix GenAI keys", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: true,
-        outputMessages: true,
-        systemPrompt: true,
-        toolDefinitions: true,
-      },
+      captureContent: MODEL_CONTENT_CAPTURE,
     });
-    await service.start(ctx);
 
     emitTrustedModelCallCompletedWithContent(
       {
@@ -5278,11 +4351,7 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
     expect(attrs?.["openclaw.api"]).toBe("claude-code");
     expect(attrs?.["openclaw.transport"]).toBe("stdio-live");
     expect(JSON.parse(stringAttribute(attrs, "gen_ai.input.messages"))).toEqual([
@@ -5303,20 +4372,13 @@ describe("diagnostics-otel service", () => {
       { type: "text", content: "OpenClaw appended instructions" },
     ]);
     expect(Object.hasOwn(attrs ?? {}, "gen_ai.tool.definitions")).toBe(false);
-    await service.stop?.(ctx);
   });
 
   test("emits semconv response text for tool response parts", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: true,
-        outputMessages: false,
-      },
+      captureContent: INPUT_ONLY_CAPTURE,
     });
-    await service.start(ctx);
 
     emitTrustedModelCallCompletedWithContent(
       {
@@ -5354,11 +4416,7 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
     expect(JSON.parse(stringAttribute(attrs, "gen_ai.input.messages"))).toEqual([
       {
         role: "tool",
@@ -5381,20 +4439,13 @@ describe("diagnostics-otel service", () => {
         ],
       },
     ]);
-    await service.stop?.(ctx);
   });
 
   test("flattens oversized pure-text tool results with a truncation marker", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: true,
-        outputMessages: false,
-      },
+      captureContent: INPUT_ONLY_CAPTURE,
     });
-    await service.start(ctx);
 
     const textParts = Array.from({ length: 201 }, (_, index) => ({
       type: "text",
@@ -5414,11 +4465,7 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
     const messages = JSON.parse(stringAttribute(attrs, "gen_ai.input.messages")) as {
       parts: { response?: unknown }[];
     }[];
@@ -5427,20 +4474,13 @@ describe("diagnostics-otel service", () => {
       .map((part) => part.text)
       .join("\n")}\n...(1 more text parts omitted)`;
     expect(messages[0]?.parts[0]?.response).toBe(expected);
-    await service.stop?.(ctx);
   });
 
   test("normalizes snake_case tool_call parts the same as camelCase toolCall parts", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: true,
-        outputMessages: false,
-      },
+      captureContent: INPUT_ONLY_CAPTURE,
     });
-    await service.start(ctx);
 
     emitTrustedModelCallCompletedWithContent(
       {
@@ -5469,11 +4509,7 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
     const parsed = JSON.parse(stringAttribute(attrs, "gen_ai.input.messages"));
     expect(parsed[0].parts[0]).toEqual({
       type: "tool_call",
@@ -5482,20 +4518,13 @@ describe("diagnostics-otel service", () => {
       arguments: { q: "x" },
     });
     expect(JSON.stringify(parsed)).not.toContain("leaked");
-    await service.stop?.(ctx);
   });
 
   test("truncates oversized GenAI input messages instead of silently dropping them", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: true,
-        outputMessages: false,
-      },
+      captureContent: INPUT_ONLY_CAPTURE,
     });
-    await service.start(ctx);
 
     // Build messages that exceed MAX_OTEL_CONTENT_ATTRIBUTE_CHARS (128KB) in total.
     const largeMessages = Array.from({ length: 200 }, (_, i) => ({
@@ -5515,11 +4544,7 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
     const genAiInput = stringAttribute(attrs, "gen_ai.input.messages");
     // Must not be empty — a truncated subset should appear.
     expect(genAiInput.length).toBeGreaterThan(0);
@@ -5531,12 +4556,10 @@ describe("diagnostics-otel service", () => {
       role: "user",
       parts: [{ type: "text" }],
     });
-    await service.stop?.(ctx);
   });
 
   test("keeps single oversized GenAI messages and tool definitions parseable", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
       captureContent: {
         enabled: true,
@@ -5545,7 +4568,6 @@ describe("diagnostics-otel service", () => {
         toolDefinitions: true,
       },
     });
-    await service.start(ctx);
 
     // The 8,192-character candidate budget leaves an 8,178-character text prefix;
     // place a surrogate pair across that boundary so serialized JSON must stay valid.
@@ -5586,11 +4608,7 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
     const genAiInput = stringAttribute(attrs, "gen_ai.input.messages");
     const toolDefinitions = stringAttribute(attrs, "gen_ai.tool.definitions");
     expect(genAiInput.length).toBeLessThanOrEqual(MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS);
@@ -5614,12 +4632,10 @@ describe("diagnostics-otel service", () => {
         type: "object",
       },
     });
-    await service.stop?.(ctx);
   });
 
   test("exports tool definitions without requiring input message capture", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+    await startOtelService({
       traces: true,
       captureContent: {
         enabled: true,
@@ -5627,7 +4643,6 @@ describe("diagnostics-otel service", () => {
         toolDefinitions: true,
       },
     });
-    await service.start(ctx);
 
     emitTrustedModelCallCompletedWithContent(
       {
@@ -5646,11 +4661,7 @@ describe("diagnostics-otel service", () => {
     );
     await flushDiagnosticEvents();
 
-    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
-      (call) => call[0] === "openclaw.model.call",
-    );
-    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
-      ?.attributes;
+    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
     expect(Object.hasOwn(attrs ?? {}, "gen_ai.input.messages")).toBe(false);
     expect(Object.hasOwn(attrs ?? {}, "input.value")).toBe(false);
     expect(Object.hasOwn(attrs ?? {}, "openclaw.content.input_messages")).toBe(false);
@@ -5669,13 +4680,10 @@ describe("diagnostics-otel service", () => {
         parameters: { type: "object" },
       },
     ]);
-    await service.stop?.(ctx);
   });
 
   test("ignores invalid diagnostic event trace parents", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
-    await service.start(ctx);
+    await startOtelService({ traces: true, metrics: true });
 
     emitDiagnosticEvent({
       type: "model.usage",
@@ -5684,8 +4692,7 @@ describe("diagnostics-otel service", () => {
         spanId: "not-a-span",
         traceFlags: "zz",
       },
-      provider: "openai",
-      model: "gpt-5.4",
+      ...MODEL_FIXTURE,
       usage: { total: 4 },
       durationMs: 12,
     });
@@ -5695,13 +4702,10 @@ describe("diagnostics-otel service", () => {
     );
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
     expect(modelUsageCall?.[2]).toBeUndefined();
-    await service.stop?.(ctx);
   });
 
   test("redacts sensitive reason in session.state metric attributes", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
-    await service.start(ctx);
+    await startOtelService({ metrics: true });
 
     emitDiagnosticEvent({
       type: "session.state",
@@ -5717,7 +4721,6 @@ describe("diagnostics-otel service", () => {
     expect(String(attrs?.["openclaw.reason"])).not.toContain(
       "ghp_abcdefghijklmnopqrstuvwxyz123456", // pragma: allowlist secret
     );
-    await service.stop?.(ctx);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The diagnostics OTEL service test had grown to 5,723 lines, with repeated service lifecycle setup, trace fixtures, and near-identical cases obscuring the behavior each assertion protects. This maintainer-commissioned consolidation reduces that maintenance surface without changing runtime behavior or test coverage.

## Why This Change Was Made

This extracts a colocated test helper for OTEL context defaults, trace fixtures, and failure-safe service teardown; reuses narrow event fixtures; and table-drives only equivalent endpoint, protocol, identifier, lane, and parenting cases. Semantically distinct telemetry scenarios remain separate.

This PR is AI-assisted. No production code, config, schema, protocol, changelog, snapshot, inventory, or baseline file changes.

## User Impact

No user-visible impact. The diagnostics OTEL test suite is smaller and easier to maintain while preserving all 111 existing test cases and their assertion semantics.

## Evidence

- LOC: test `+603/-1473`, net `-870` lines (15.2%); production `+0/-0`.
- Test count: 111 before, 111 after.
- Preservation audit: every original test name appears exactly once; the 17 fewer static `expect` sites are the assertions now shared across equivalent table rows, preserving the same runtime assertion coverage.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts` — 111/111 passed before commit and again after rebasing onto current `origin/main`.
- `node scripts/check-changed.mjs -- extensions/diagnostics-otel/src/service.test.ts extensions/diagnostics-otel/src/service.test-helpers.ts` — passed all selected extension production/test typechecks, formatting, lint, boundary guards, max-lines ratchet, and import-cycle checks on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29978193664
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings; overall correctness 0.94.
- `git diff --check origin/main...HEAD` — passed.
