### PR TITLE
fix: align QA channel coverage ownership

### DIFF
--- a/qa/scenarios/channels/discord-thread-reply-filepath-attachment.yaml
+++ b/qa/scenarios/channels/discord-thread-reply-filepath-attachment.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - discord.thread-actions
+    secondary:
       - discord.media-and-rich-content
   execution:
     kind: flow

--- a/qa/scenarios/channels/slack-allowlist-block.yaml
+++ b/qa/scenarios/channels/slack-allowlist-block.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - slack.access-and-identity
+      - slack.channel-allowlists
   execution:
     profiles: { "slack:default": 2 }
     kind: flow

--- a/qa/scenarios/channels/slack-approval-exec-native.yaml
+++ b/qa/scenarios/channels/slack-approval-exec-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 7 }

--- a/qa/scenarios/channels/slack-approval-plugin-native.yaml
+++ b/qa/scenarios/channels/slack-approval-plugin-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 8 }

--- a/qa/scenarios/channels/slack-canary.yaml
+++ b/qa/scenarios/channels/slack-canary.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.socket
+    secondary:
       - slack.runtime-lifecycle
   execution:
     profiles: { "slack:default": 0 }

--- a/qa/scenarios/channels/slack-channel-disabled-warning.yaml
+++ b/qa/scenarios/channels/slack-channel-disabled-warning.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - slack.access-and-identity
+      - slack.channel-allowlists
   execution:
     kind: flow
     channel: slack

--- a/qa/scenarios/channels/slack-codex-approval-exec-native.yaml
+++ b/qa/scenarios/channels/slack-codex-approval-exec-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 9 }

--- a/qa/scenarios/channels/slack-codex-approval-plugin-native.yaml
+++ b/qa/scenarios/channels/slack-codex-approval-plugin-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 10 }


### PR DESCRIPTION
## What Problem This Solves

The QA catalog currently attributes several Slack and Discord live scenarios to broad/shared coverage owners even though their assertions exercise more specific channel behavior. That makes the generated coverage inventory less useful when looking for exact behavior proof for Slack allowlists, Slack native approvals, Slack Socket Mode, and Discord thread actions.

Fixes #112842.

## Summary

- Retarget Slack channel-denial live scenarios to `slack.channel-allowlists` instead of broad Slack access/identity coverage.
- Mark Slack native approval scenarios as primary `slack.native-approvals` while preserving shared approval prompt coverage as secondary.
- Mark the Slack Socket Mode canary and Discord thread-reply filepath attachment scenario with their exact behavior owners while keeping previous broad coverage as secondary.

## Evidence

- `node scripts/run-vitest.mjs run extensions/qa-lab/src/scenario-catalog.test.ts --maxWorkers=1` passed locally (35 tests).
- `git diff --check` passed locally.
- I also ran `coverage-report.test.ts` before and after the change; it currently fails on existing unknown scenario coverage IDs unrelated to this metadata fix, so I did not use it as the gating signal for this PR.
