### PR TITLE
fix(test): fully redact live media credentials

### DIFF
--- a/src/image-generation/live-test-helpers.test.ts
+++ b/src/image-generation/live-test-helpers.test.ts
@@ -87,7 +87,8 @@ describe("image-generation live-test helpers", () => {
 
   it("redacts live API keys for diagnostics", () => {
     expect(redactLiveApiKey(undefined)).toBe("none");
-    expect(redactLiveApiKey("short-key")).toBe("short-key");
-    expect(redactLiveApiKey("sk-proj-1234567890")).toBe("sk-proj-...7890");
+    expect(redactLiveApiKey("   ")).toBe("none");
+    expect(redactLiveApiKey("synthetic-12")).toBe("<redacted>");
+    expect(redactLiveApiKey("synthetic-credential-value")).toBe("<redacted>");
   });
 });

--- a/src/media-generation/live-test-helpers.ts
+++ b/src/media-generation/live-test-helpers.ts
@@ -12,16 +12,13 @@ type LiveProviderModelConfig =
     }
   | undefined;
 
-/** Redacts live API keys while preserving enough shape for diagnostics. */
+/** Redacts live API keys without retaining credential-derived text in test output. */
 export function redactLiveApiKey(value: string | undefined): string {
   const trimmed = value?.trim();
   if (!trimmed) {
     return "none";
   }
-  if (trimmed.length <= 12) {
-    return trimmed;
-  }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-4)}`;
+  return "<redacted>";
 }
 
 /** Parses comma-separated live-test filters; null means "all". */

--- a/src/video-generation/live-test-helpers.test.ts
+++ b/src/video-generation/live-test-helpers.test.ts
@@ -80,8 +80,9 @@ describe("video-generation live-test helpers", () => {
 
   it("redacts live API keys for diagnostics", () => {
     expect(redactLiveApiKey(undefined)).toBe("none");
-    expect(redactLiveApiKey("short-key")).toBe("short-key");
-    expect(redactLiveApiKey("sk-proj-1234567890")).toBe("sk-proj-...7890");
+    expect(redactLiveApiKey("   ")).toBe("none");
+    expect(redactLiveApiKey("synthetic-12")).toBe("<redacted>");
+    expect(redactLiveApiKey("synthetic-credential-value")).toBe("<redacted>");
   });
 
   it("runs buffer-backed video-to-video only for supported providers/models", () => {


### PR DESCRIPTION
## What Problem This Solves

Media-generation live tests included a redacted API-key label in their diagnostic output, but credentials of 12 characters or fewer were returned unchanged. That made short provider credentials visible in music and video live-test logs.

## Why This Change Was Made

The shared `redactLiveApiKey()` helper now maps every non-empty credential to the constant `<redacted>` marker. This is simpler and safer than preserving prefixes or suffixes; the existing auth-source label already provides the useful diagnostic context.

The fix stays at the shared media-generation helper boundary used by the image, music, and video live-test facades.

## User Impact

No production runtime behavior changes. Source-checkout live tests no longer include credential-derived text in authentication labels.

## Evidence

- Blacksmith Testbox focused proof: image/video live-test helper suites, 15/15 tests passed.
- Blacksmith Testbox changed gate: core and core-test typechecks, changed-file lint, formatting, API/plugin boundaries, import-cycle checks, and guards passed.
- Fresh Codex autoreview on the current-main branch diff: no accepted/actionable findings, correctness 0.99.
- `git diff --check` passed.
