### PR TITLE
refactor(memory): consolidate QMD manager test fixtures

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -57,6 +57,29 @@ type WatchOptions = {
 
 type LeaseCall = Parameters<PluginStateLeaseRunner>;
 
+type QmdTestConfig = NonNullable<NonNullable<OpenClawConfig["memory"]>["qmd"]> & {
+  mcporter?: { enabled?: boolean; serverName?: string; startDaemon?: boolean };
+  update?: {
+    commandTimeoutMs?: number;
+    debounceMs?: number;
+    embedInterval?: string;
+    embedTimeoutMs?: number;
+    interval?: string;
+    onBoot?: boolean;
+    startup?: "off" | "idle" | "blocking";
+    startupDelayMs?: number;
+    updateTimeoutMs?: number;
+    waitForBootSync?: boolean;
+  };
+};
+
+type QmdConfigOverrides = {
+  agents?: OpenClawConfig["agents"];
+  search?: NonNullable<NonNullable<OpenClawConfig["memory"]>["search"]> & {
+    sync?: { watch?: boolean; onSessionStart?: boolean; onSearch?: boolean };
+  };
+};
+
 type MockStream = EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
 
 interface MockChild extends EventEmitter {
@@ -356,6 +379,23 @@ describe("QmdMemoryManager", () => {
     expect(mockMessages(mock).join("\n")).not.toContain(text);
   }
 
+  function configureQmd(qmd: QmdTestConfig = {}, overrides: QmdConfigOverrides = {}): void {
+    cfg = {
+      ...cfg,
+      ...(overrides.agents ? { agents: overrides.agents } : {}),
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          ...qmd,
+        },
+        ...(overrides.search ? { search: overrides.search } : {}),
+      },
+    } as OpenClawConfig;
+  }
+
   it("caps mcporter search process timeout grace", () => {
     expect(resolveQmdMcporterSearchProcessTimeoutMs(1_000)).toBe(5_000);
     expect(resolveQmdMcporterSearchProcessTimeoutMs(10_000)).toBe(12_000);
@@ -586,18 +626,7 @@ describe("QmdMemoryManager", () => {
 
   it("reuses persisted qmd multi-collection support probe across managers", async () => {
     await configureMemoryCoreDreamingStateForTests();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true } });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "--help") {
         const child = createMockChild({ autoClose: false });
@@ -637,18 +666,7 @@ describe("QmdMemoryManager", () => {
 
   it("reports multi-collection probe debug only when the probe runs", async () => {
     await configureMemoryCoreDreamingStateForTests();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true } });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "--help") {
         const child = createMockChild({ autoClose: false });
@@ -685,18 +703,7 @@ describe("QmdMemoryManager", () => {
 
   it("keeps concurrent search debug isolated on a shared qmd manager", async () => {
     await configureMemoryCoreDreamingStateForTests();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true } });
     let firstSearchChild: MockChild | undefined;
     let searchCalls = 0;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -746,21 +753,15 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps remember-only session exports out of ordinary manager searches", async () => {
-    cfg = {
-      ...cfg,
-      agents: {
-        ...cfg.agents,
-        list: [{ id: "main", memory: { search: { rememberAcrossConversations: true } } }],
-      },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+    configureQmd(
+      {},
+      {
+        agents: {
+          ...cfg.agents,
+          list: [{ id: "main", memory: { search: { rememberAcrossConversations: true } } }],
         },
       },
-    } as OpenClawConfig;
+    );
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
         const child = createMockChild({ autoClose: false });
@@ -787,20 +788,12 @@ describe("QmdMemoryManager", () => {
     await configureMemoryCoreDreamingStateForTests();
     const otherWorkspaceDir = path.join(tmpRoot, "other-workspace");
     await fs.mkdir(otherWorkspaceDir, { recursive: true });
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-            { path: otherWorkspaceDir, pattern: "**/*.md", name: "other" },
-          ],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      paths: [
+        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+        { path: otherWorkspaceDir, pattern: "**/*.md", name: "other" },
+      ],
+    });
     const isCombinedSearch = (args: string[]) =>
       (args[0] === "search" || args[0] === "query") &&
       args.filter((token) => token === "-c").length > 1;
@@ -1022,21 +1015,13 @@ describe("QmdMemoryManager", () => {
     // Keep the default Windows path unresolved for most tests so spawn mocks can
     // match the logical package command. Tests that verify wrapper resolution
     // install explicit shim fixtures inline.
-    cfg = {
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
+    configureQmd(
+      {},
+      {
+        agents: {
+          defaults: { workspace: workspaceDir },
+          list: [{ id: agentId, default: true, workspace: workspaceDir }],
         },
-        list: [{ id: agentId, default: true, workspace: workspaceDir }],
-      },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-
         search: {
           provider: "openai",
           model: "mock-embed",
@@ -1045,7 +1030,7 @@ describe("QmdMemoryManager", () => {
           sync: { watch: false, onSessionStart: false, onSearch: false },
         },
       },
-    } as OpenClawConfig;
+    );
     seedMemoryEmbeddingProviders();
     embedStartupJitterSpy = vi
       .spyOn(
@@ -1111,21 +1096,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("runs a qmd sync once for the first search in a fresh session", async () => {
-    cfg = {
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
-        },
-        list: [{ id: agentId, default: true, workspace: workspaceDir }],
-      },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-
+    configureQmd(
+      { update: { interval: "0s", debounceMs: 0, onBoot: false } },
+      {
         search: {
           provider: "openai",
           model: "mock-embed",
@@ -1133,7 +1106,7 @@ describe("QmdMemoryManager", () => {
           sync: { watch: false, onSessionStart: true, onSearch: false },
         },
       },
-    } as OpenClawConfig;
+    );
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -1156,21 +1129,9 @@ describe("QmdMemoryManager", () => {
 
   it("does not block first search on session-start sync completion", async () => {
     vi.useFakeTimers();
-    cfg = {
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
-        },
-        list: [{ id: agentId, default: true, workspace: workspaceDir }],
-      },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-
+    configureQmd(
+      { update: { interval: "0s", debounceMs: 0, onBoot: false } },
+      {
         search: {
           provider: "openai",
           model: "mock-embed",
@@ -1178,7 +1139,7 @@ describe("QmdMemoryManager", () => {
           sync: { watch: false, onSessionStart: true, onSearch: false },
         },
       },
-    } as OpenClawConfig;
+    );
 
     let releaseUpdate: (() => void) | null = null;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -1212,21 +1173,9 @@ describe("QmdMemoryManager", () => {
 
   it("runs qmd sync when watched collection files change", async () => {
     vi.useFakeTimers();
-    cfg = {
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
-        },
-        list: [{ id: agentId, default: true, workspace: workspaceDir }],
-      },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-
+    configureQmd(
+      { update: { interval: "0s", debounceMs: 0, onBoot: false } },
+      {
         search: {
           provider: "openai",
           model: "mock-embed",
@@ -1234,7 +1183,7 @@ describe("QmdMemoryManager", () => {
           sync: { watch: true, onSessionStart: false, onSearch: false },
         },
       },
-    } as OpenClawConfig;
+    );
 
     const { manager } = await createManager({ mode: "full" });
     expect(watchMock).toHaveBeenCalledTimes(1);
@@ -1281,25 +1230,16 @@ describe("QmdMemoryManager", () => {
   it("keeps explicit qmd collection roots watchable when their directory name is ignored", async () => {
     const rootNames = ["build", "dist", "vendor", ".cache"];
     const roots = rootNames.map((name) => path.join(workspaceDir, name));
-    cfg = {
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
-        },
-        list: [{ id: agentId, default: true, workspace: workspaceDir }],
+    configureQmd(
+      {
+        update: { interval: "0s", debounceMs: 0, onBoot: false },
+        paths: roots.map((root) => ({
+          path: root,
+          pattern: "**/*.md",
+          name: path.basename(root),
+        })),
       },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: roots.map((root) => ({
-            path: root,
-            pattern: "**/*.md",
-            name: path.basename(root),
-          })),
-        },
-
+      {
         search: {
           provider: "openai",
           model: "mock-embed",
@@ -1307,7 +1247,7 @@ describe("QmdMemoryManager", () => {
           sync: { watch: true, onSessionStart: false, onSearch: false },
         },
       },
-    } as OpenClawConfig;
+    );
 
     const { manager } = await createManager({ mode: "full" });
     expect(watchMock).toHaveBeenCalledTimes(1);
@@ -1329,24 +1269,15 @@ describe("QmdMemoryManager", () => {
 
   it("prefers a nested explicit qmd collection root over a broader watched root", async () => {
     const nestedRoot = path.join(workspaceDir, "build");
-    cfg = {
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
-        },
-        list: [{ id: agentId, default: true, workspace: workspaceDir }],
+    configureQmd(
+      {
+        update: { interval: "0s", debounceMs: 0, onBoot: false },
+        paths: [
+          { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+          { path: nestedRoot, pattern: "**/*.md", name: "build" },
+        ],
       },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [
-            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-            { path: nestedRoot, pattern: "**/*.md", name: "build" },
-          ],
-        },
-
+      {
         search: {
           provider: "openai",
           model: "mock-embed",
@@ -1354,7 +1285,7 @@ describe("QmdMemoryManager", () => {
           sync: { watch: true, onSessionStart: false, onSearch: false },
         },
       },
-    } as OpenClawConfig;
+    );
 
     const { manager } = await createManager({ mode: "full" });
     const ignored = firstWatchOptions().ignored;
@@ -1368,21 +1299,9 @@ describe("QmdMemoryManager", () => {
 
   it("delays qmd watch sync until changed file stats settle", async () => {
     vi.useFakeTimers();
-    cfg = {
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
-        },
-        list: [{ id: agentId, default: true, workspace: workspaceDir }],
-      },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-
+    configureQmd(
+      { update: { interval: "0s", debounceMs: 0, onBoot: false } },
+      {
         search: {
           provider: "openai",
           model: "mock-embed",
@@ -1390,7 +1309,7 @@ describe("QmdMemoryManager", () => {
           sync: { watch: true, onSessionStart: false, onSearch: false },
         },
       },
-    } as OpenClawConfig;
+    );
 
     const notesPath = path.join(workspaceDir, "notes.md");
     await fs.writeFile(notesPath, "hello");
@@ -1417,17 +1336,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("runs boot update in background by default", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ update: { interval: "0s", debounceMs: 60_000, onBoot: true } });
 
     let releaseUpdate: (() => void) | null = null;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -1450,17 +1359,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("skips qmd command side effects in status mode initialization", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "5m", debounceMs: 60_000, onBoot: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "5m", debounceMs: 60_000, onBoot: true },
+    });
 
     const { manager } = await createManager({ mode: "status" });
     expect(spawnMock).not.toHaveBeenCalled();
@@ -1468,17 +1369,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("initializes one-shot CLI mode without watchers or background updates", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "5m", debounceMs: 60_000, onBoot: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "5m", debounceMs: 60_000, onBoot: true },
+    });
 
     const { manager } = await createManager({ mode: "cli" });
 
@@ -1492,22 +1385,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("preserves blocking boot update freshness for one-shot CLI mode", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: {
-            interval: "5m",
-            debounceMs: 60_000,
-            onBoot: true,
-            waitForBootSync: true,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "5m", debounceMs: 60_000, onBoot: true, waitForBootSync: true },
+    });
 
     const updateSpawned = createDeferred<void>();
     let releaseUpdate: (() => void) | null = null;
@@ -1545,30 +1425,19 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps one-shot CLI searches from scheduling session-start updates", async () => {
-    cfg = {
-      ...cfg,
-      agents: {
-        ...cfg.agents,
-        defaults: {
-          ...cfg.agents?.defaults,
-          workspace: workspaceDir,
+    configureQmd(
+      { searchMode: "search" },
+      {
+        agents: {
+          ...cfg.agents,
+          defaults: { ...cfg.agents?.defaults, workspace: workspaceDir },
         },
-      },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-
         search: {
           ...cfg.memory?.search,
           sync: { watch: false, onSessionStart: true, onSearch: true },
         },
       },
-    } as OpenClawConfig;
+    );
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
         const child = createMockChild({ autoClose: false });
@@ -1595,22 +1464,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("can be configured to block startup on boot update", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: {
-            interval: "0s",
-            debounceMs: 60_000,
-            onBoot: true,
-            waitForBootSync: true,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "0s", debounceMs: 60_000, onBoot: true, waitForBootSync: true },
+    });
 
     const updateSpawned = createDeferred<void>();
     let releaseUpdate: (() => void) | null = null;
@@ -1648,22 +1504,9 @@ describe("QmdMemoryManager", () => {
 
   it("times out collection bootstrap commands", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: {
-            interval: "0s",
-            debounceMs: 60_000,
-            onBoot: false,
-            commandTimeoutMs: 15,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "0s", debounceMs: 60_000, onBoot: false, commandTimeoutMs: 15 },
+    });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
@@ -1691,24 +1534,20 @@ describe("QmdMemoryManager", () => {
     const devAgentId = "dev";
     const devWorkspaceDir = path.join(tmpRoot, "workspace-dev");
     await fs.mkdir(devWorkspaceDir);
-    cfg = {
-      ...cfg,
-      agents: {
-        list: [
-          { id: agentId, default: true, workspace: workspaceDir },
-          { id: devAgentId, workspace: devWorkspaceDir },
-        ],
+    configureQmd(
+      {
+        paths: [{ path: devWorkspaceDir, pattern: "**/*.md", name: "workspace" }],
+        sessions: { enabled: true },
       },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: devWorkspaceDir, pattern: "**/*.md", name: "workspace" }],
-          sessions: { enabled: true },
+      {
+        agents: {
+          list: [
+            { id: agentId, default: true, workspace: workspaceDir },
+            { id: devAgentId, workspace: devWorkspaceDir },
+          ],
         },
       },
-    } as OpenClawConfig;
+    );
 
     const sessionCollectionName = `sessions-${devAgentId}`;
     const wrongSessionsPath = path.join(stateDir, "agents", agentId, "qmd", "sessions");
@@ -1759,18 +1598,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("avoids destructive rebind when qmd only reports collection names", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          sessions: { enabled: true },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true } });
 
     const sessionCollectionName = `sessions-${agentId}`;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -1798,17 +1626,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("rebinds collection when qmd text output exposes a changed pattern without a path", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd();
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
@@ -1847,17 +1665,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("migrates unscoped legacy collections before adding scoped names", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, paths: [] });
 
     const legacyCollections = new Map<
       string,
@@ -1931,17 +1739,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("rebinds conflicting collection name when path+pattern slot is already occupied", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, paths: [] });
 
     const listedCollections = new Map<
       string,
@@ -2009,17 +1807,7 @@ describe("QmdMemoryManager", () => {
 
   it("adds canonical memory-root without treating legacy memory-alt as equivalent", async () => {
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# canonical root");
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, paths: [] });
 
     const listedCollections = new Map<
       string,
@@ -2089,17 +1877,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("warns instead of silently succeeding when add conflict metadata is unavailable", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd();
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
@@ -2123,17 +1901,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("surfaces a manual repair hint for stderr-only path-pattern conflicts", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd();
 
     let staleCollectionExists = true;
     const removeCalls: string[] = [];
@@ -2197,17 +1965,7 @@ describe("QmdMemoryManager", () => {
 
   it("recreates a managed collection when list fails but add reports the same name exists", async () => {
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# canonical root");
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, paths: [] });
 
     const removed: string[] = [];
     const added = new Map<string, string>();
@@ -2261,17 +2019,7 @@ describe("QmdMemoryManager", () => {
 
   it("rebinds memory-root when qmd table output has a stale broad pattern", async () => {
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# canonical root");
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, paths: [] });
 
     const removed: string[] = [];
     const added = new Map<string, string>();
@@ -2326,17 +2074,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("falls back to --glob when qmd collection add rejects --mask", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, paths: [] });
 
     const addFlagCalls: string[] = [];
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -2366,17 +2104,7 @@ describe("QmdMemoryManager", () => {
     expectMockMessageContains(logWarnMock, "retrying with legacy compatibility flag");
   });
   it("migrates unscoped legacy collections from plain-text collection list output", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, paths: [] });
 
     const removeCalls: string[] = [];
     const addCalls: string[] = [];
@@ -2422,17 +2150,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("does not migrate unscoped collections when listed metadata differs", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, paths: [] });
 
     const differentPath = path.join(tmpRoot, "other-memory");
     await fs.mkdir(differentPath, { recursive: true });
@@ -2468,23 +2186,10 @@ describe("QmdMemoryManager", () => {
 
   it("times out qmd update during sync when configured", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: {
-            interval: "0s",
-            debounceMs: 0,
-            onBoot: false,
-            updateTimeoutMs: 20,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "0s", debounceMs: 0, onBoot: false, updateTimeoutMs: 20 },
+    });
     const updateSpawned = createDeferred<void>();
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "update") {
@@ -2513,18 +2218,28 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("rebuilds managed collections once when qmd update fails with null-byte ENOTDIR", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+  it.each([
+    {
+      name: "rebuilds managed collections once when qmd update fails with null-byte ENOTDIR",
+      error: "ENOTDIR: not a directory, open '/tmp/workspace/MEMORY.md^@'",
+      warning: "suspected null-byte collection metadata",
+    },
+    {
+      name: "rebuilds managed collections once when qmd update fails with null-byte ENOENT",
+      error: "ENOENT: no such file or directory, open '/tmp/workspace/MEMORY.md\\x00'",
+      warning: "suspected null-byte collection metadata",
+    },
+    {
+      name: "rebuilds managed collections once when qmd update hits duplicate document constraint",
+      error: "SQLiteError: UNIQUE constraint failed: documents.collection, documents.path",
+      warning: "duplicate document constraint",
+    },
+  ])("$name", async ({ error, warning }) => {
+    configureQmd({
+      includeDefaultMemory: true,
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+      paths: [],
+    });
 
     let updateCalls = 0;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -2532,12 +2247,7 @@ describe("QmdMemoryManager", () => {
         updateCalls += 1;
         const child = createMockChild({ autoClose: false });
         if (updateCalls === 1) {
-          emitAndClose(
-            child,
-            "stderr",
-            "ENOTDIR: not a directory, open '/tmp/workspace/MEMORY.md^@'",
-            1,
-          );
+          emitAndClose(child, "stderr", error, 1);
           return child;
         }
         queueMicrotask(() => {
@@ -2563,117 +2273,7 @@ describe("QmdMemoryManager", () => {
     expect(updateCalls).toBe(2);
     expect(removeCalls).toEqual(["memory-root-main", "memory-dir-main"]);
     expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
-    expectMockMessageContains(logWarnMock, "suspected null-byte collection metadata");
-
-    await manager.close();
-  });
-
-  it("rebuilds managed collections once when qmd update fails with null-byte ENOENT", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
-
-    let updateCalls = 0;
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "update") {
-        updateCalls += 1;
-        const child = createMockChild({ autoClose: false });
-        if (updateCalls === 1) {
-          emitAndClose(
-            child,
-            "stderr",
-            "ENOENT: no such file or directory, open '/tmp/workspace/MEMORY.md\\x00'",
-            1,
-          );
-          return child;
-        }
-        queueMicrotask(() => {
-          child.closeWith(0);
-        });
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager } = await createManager({ mode: "status" });
-    await expect(manager.sync({ reason: "manual" })).resolves.toBeUndefined();
-
-    const removeCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "collection" && args[1] === "remove")
-      .map((args) => args[2]);
-    const addCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "collection" && args[1] === "add")
-      .map((args) => args[args.indexOf("--name") + 1]);
-
-    expect(updateCalls).toBe(2);
-    expect(removeCalls).toEqual(["memory-root-main", "memory-dir-main"]);
-    expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
-    expectMockMessageContains(logWarnMock, "suspected null-byte collection metadata");
-
-    await manager.close();
-  });
-
-  it("rebuilds managed collections once when qmd update hits duplicate document constraint", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
-
-    let updateCalls = 0;
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "update") {
-        updateCalls += 1;
-        const child = createMockChild({ autoClose: false });
-        if (updateCalls === 1) {
-          emitAndClose(
-            child,
-            "stderr",
-            "SQLiteError: UNIQUE constraint failed: documents.collection, documents.path",
-            1,
-          );
-          return child;
-        }
-        queueMicrotask(() => {
-          child.closeWith(0);
-        });
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager } = await createManager({ mode: "status" });
-    await expect(manager.sync({ reason: "manual" })).resolves.toBeUndefined();
-
-    const removeCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "collection" && args[1] === "remove")
-      .map((args) => args[2]);
-    const addCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "collection" && args[1] === "add")
-      .map((args) => args[args.indexOf("--name") + 1]);
-
-    expect(updateCalls).toBe(2);
-    expect(removeCalls).toEqual(["memory-root-main", "memory-dir-main"]);
-    expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
-    expectMockMessageContains(logWarnMock, "duplicate document constraint");
+    expectMockMessageContains(logWarnMock, warning);
 
     await manager.close();
   });
@@ -2681,17 +2281,10 @@ describe("QmdMemoryManager", () => {
   it("refreshes qmd index config with quoted collection values during update repair", async () => {
     const notesDir = path.join(workspaceDir, "Notes #1: blue");
     await fs.mkdir(notesDir, { recursive: true });
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: notesDir, pattern: "**/* #tag: [draft].md", name: "notes" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+      paths: [{ path: notesDir, pattern: "**/* #tag: [draft].md", name: "notes" }],
+    });
 
     let updateCalls = 0;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -2728,17 +2321,11 @@ describe("QmdMemoryManager", () => {
   });
 
   it("forces repair remove/add even when managed collections are still listed", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      includeDefaultMemory: true,
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+      paths: [],
+    });
 
     let updateCalls = 0;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -2794,17 +2381,11 @@ describe("QmdMemoryManager", () => {
   });
 
   it("does not rebuild collections for unrelated unique constraint failures", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      includeDefaultMemory: true,
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+      paths: [],
+    });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "update") {
@@ -2829,17 +2410,11 @@ describe("QmdMemoryManager", () => {
   });
 
   it("does not rebuild collections for generic qmd update failures", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      includeDefaultMemory: true,
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+      paths: [],
+    });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "update") {
@@ -2869,18 +2444,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("uses configured qmd search mode command", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
         const child = createMockChild({ autoClose: false });
@@ -2920,18 +2484,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("uses valid qmd query JSON captured before a non-zero exit", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "query" });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
@@ -2982,18 +2535,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps invalid qmd query stdout failed after a non-zero exit", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "query" });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
@@ -3013,18 +2555,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("does not use qmd query JSON from a non-crash search failure", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "query" });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
@@ -3051,18 +2582,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("repairs missing managed collections and retries search once", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, searchMode: "search", paths: [] });
 
     const expectedDocId = "abc123";
     let missingCollectionSeen = false;
@@ -3196,18 +2716,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps mixed Han-script BM25 queries intact before qmd search", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
         const child = createMockChild({ autoClose: false });
@@ -3243,18 +2752,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("falls back to the original query when Han normalization yields no BM25 tokens", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
         const child = createMockChild({ autoClose: false });
@@ -3277,18 +2775,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps spaced Han queries intact before qmd search", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
         const child = createMockChild({ autoClose: false });
@@ -3312,18 +2799,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps original Han queries in qmd query mode", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "query" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
         const child = createMockChild({ autoClose: false });
@@ -3346,18 +2822,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("retries search with qmd query when configured mode rejects flags", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
         const child = createMockChild({ autoClose: false });
@@ -3395,19 +2860,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("passes --no-rerank to direct qmd query when query reranking is disabled", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          rerank: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "query", rerank: false });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
         const child = createMockChild({ autoClose: false });
@@ -3437,18 +2890,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("aborts the in-flight qmd search subprocess when the caller signal aborts", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "query" });
 
     // The query child never closes on its own so the only way the search can
     // settle is the caller-owned abort signal killing the subprocess.
@@ -3489,18 +2931,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("rejects the qmd search before spawning when the caller signal is already aborted", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "query" });
 
     const { manager } = await createManager();
     const controller = new AbortController();
@@ -3525,18 +2956,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("aborts the in-flight grouped qmd search subprocess when the caller signal aborts", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true } });
 
     // Mixed memory/session sources route the search through
     // runQueryAcrossCollectionGroups. The first grouped search child never
@@ -3590,20 +3010,12 @@ describe("QmdMemoryManager", () => {
   });
 
   it("aborts the multi-collection capability probe without caching a failure", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
-          ],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      paths: [
+        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+      ],
+    });
 
     let helpChildKill: ReturnType<typeof vi.fn> | undefined;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -3644,19 +3056,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("aborts the in-flight mcporter search subprocess when the caller signal aborts", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     // The mcporter `call` child never closes on its own, so the only way the
     // search can settle is the caller-owned abort signal reaching the mcporter
@@ -3698,19 +3101,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("rejects the mcporter search before spawning a call subprocess when the caller signal is already aborted", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -3745,19 +3139,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("does not pass --no-rerank to direct query fallback from search mode", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          rerank: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "search", rerank: false });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
         const child = createMockChild({ autoClose: false });
@@ -3795,23 +3177,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("queues a forced sync behind an in-flight update", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: {
-            interval: "0s",
-            debounceMs: 0,
-            onBoot: false,
-            updateTimeoutMs: 1_000,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "0s", debounceMs: 0, onBoot: false, updateTimeoutMs: 1_000 },
+    });
 
     const firstUpdateSpawned = createDeferred<void>();
     let updateCalls = 0;
@@ -3848,22 +3217,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("honors multiple forced sync requests while forced queue is active", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: {
-            interval: "0s",
-            debounceMs: 0,
-            onBoot: false,
-            updateTimeoutMs: 1_000,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "0s", debounceMs: 0, onBoot: false, updateTimeoutMs: 1_000 },
+    });
 
     const firstUpdateSpawned = createDeferred<void>();
     const secondUpdateSpawned = createDeferred<void>();
@@ -3916,20 +3272,12 @@ describe("QmdMemoryManager", () => {
   });
 
   it("scopes qmd queries to managed collections", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
-          ],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      paths: [
+        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+      ],
+    });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
@@ -3958,20 +3306,12 @@ describe("QmdMemoryManager", () => {
   });
 
   it("groups same-source qmd queries when the installed qmd supports multiple collection filters", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
-          ],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      paths: [
+        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+      ],
+    });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "--help") {
@@ -4018,18 +3358,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps mixed-source qmd queries in separate source groups", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true } });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "--help") {
@@ -4068,17 +3397,7 @@ describe("QmdMemoryManager", () => {
 
   it("does not query phantom memory-alt collections when MEMORY.md exists", async () => {
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# canonical root");
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: true,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ includeDefaultMemory: true, paths: [] });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
@@ -4109,17 +3428,9 @@ describe("QmdMemoryManager", () => {
   it("uses explicit external custom collection names verbatim at query time", async () => {
     const sharedMirrorDir = path.join(tmpRoot, "shared-notion-mirror");
     await fs.mkdir(sharedMirrorDir);
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: sharedMirrorDir, pattern: "**/*.md", name: "notion-mirror" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      paths: [{ path: sharedMirrorDir, pattern: "**/*.md", name: "notion-mirror" }],
+    });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
@@ -4147,21 +3458,13 @@ describe("QmdMemoryManager", () => {
   });
 
   it("runs qmd query per collection when query mode has multiple collection filters", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
-          ],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      paths: [
+        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+      ],
+    });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
@@ -4193,21 +3496,13 @@ describe("QmdMemoryManager", () => {
   });
 
   it("uses per-collection query fallback when search mode rejects flags", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
-          ],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "search",
+      paths: [
+        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+      ],
+    });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
@@ -4245,18 +3540,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("runs qmd searches via mcporter and warns when startDaemon=false", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -4288,19 +3574,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("uses QMD 1.1+ query tool with searches array via mcporter", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     const commandPhases: string[] = [];
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
@@ -4342,20 +3619,11 @@ describe("QmdMemoryManager", () => {
   });
 
   it("passes rerank false to QMD 1.1+ query tool via mcporter when query reranking is disabled", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          rerank: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      rerank: false,
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -4385,19 +3653,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("disables the LLM reranker (rerank:false) for vsearch mode via mcporter", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "vsearch",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "vsearch",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     let captured: Record<string, unknown> | null = null;
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
@@ -4425,19 +3684,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps hyphenated tokens in lexical QMD searches while normalizing semantic searches", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -4464,19 +3714,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("normalizes hyphenated tokens for vector-only QMD searches", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "vsearch",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "vsearch",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -4499,19 +3740,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("wraps non-JSON mcporter stdout as a typed error instead of a raw SyntaxError", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -4536,19 +3768,10 @@ describe("QmdMemoryManager", () => {
   it("falls back to QMD <1.1 tool names when query tool is not found", async () => {
     // qmdMcpToolVersion is an instance field — each createManager() starts fresh.
 
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     let callCount = 0;
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
@@ -4595,20 +3818,11 @@ describe("QmdMemoryManager", () => {
   });
 
   it("uses an explicit mcporter search tool override with flat query args", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          searchTool: "hybrid_search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      searchTool: "hybrid_search",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     let expectedLimit = 0;
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
@@ -4637,19 +3851,10 @@ describe("QmdMemoryManager", () => {
 
   it("prefers mcporter start and end lines over snippet header offsets", async () => {
     const expectedDocId = "line-123";
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -4780,19 +3985,10 @@ describe("QmdMemoryManager", () => {
 
   it("uses snippet header width when mcporter only returns a start line", async () => {
     const expectedDocId = "line-456";
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -4852,20 +4048,11 @@ describe("QmdMemoryManager", () => {
   });
 
   it('uses unified v2 args when the explicit mcporter search tool override is "query"', async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          searchTool: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "search",
+      searchTool: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -4890,21 +4077,12 @@ describe("QmdMemoryManager", () => {
   });
 
   it('passes rerank false when explicit mcporter search tool override is "query"', async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          searchTool: "query",
-          rerank: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      searchTool: "query",
+      rerank: false,
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -4936,23 +4114,15 @@ describe("QmdMemoryManager", () => {
   });
 
   it('reuses the cached v1 tool across collections when the explicit mcporter override is "query"', async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          searchTool: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: path.join(workspaceDir, "notes-a"), pattern: "**/*.md", name: "workspace-a" },
-            { path: path.join(workspaceDir, "notes-b"), pattern: "**/*.md", name: "workspace-b" },
-          ],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "search",
+      searchTool: "query",
+      paths: [
+        { path: path.join(workspaceDir, "notes-a"), pattern: "**/*.md", name: "workspace-a" },
+        { path: path.join(workspaceDir, "notes-b"), pattern: "**/*.md", name: "workspace-b" },
+      ],
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     const selectors: string[] = [];
     let expectedLimit = 0;
@@ -4990,23 +4160,15 @@ describe("QmdMemoryManager", () => {
   });
 
   it("uses an explicit mcporter search tool override across multiple collections", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          searchTool: "hybrid_search",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: path.join(workspaceDir, "notes-a"), pattern: "**/*.md", name: "workspace-a" },
-            { path: path.join(workspaceDir, "notes-b"), pattern: "**/*.md", name: "workspace-b" },
-          ],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      searchTool: "hybrid_search",
+      paths: [
+        { path: path.join(workspaceDir, "notes-a"), pattern: "**/*.md", name: "workspace-a" },
+        { path: path.join(workspaceDir, "notes-b"), pattern: "**/*.md", name: "workspace-b" },
+      ],
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     const selectors: string[] = [];
     const collections: string[] = [];
@@ -5040,19 +4202,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("does not pin v1 fallback when only the serialized query text contains tool-not-found words", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     const selectors: string[] = [];
     let firstQueryCall = true;
@@ -5093,19 +4246,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("does not pin v1 fallback when a timed out query contains tool-not-found words", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     const selectors: string[] = [];
     let firstQueryCall = true;
@@ -5186,18 +4330,9 @@ describe("QmdMemoryManager", () => {
         await fs.writeFile(scriptPath, "module.exports = {};\n", "utf8");
         process.env.PATH = `${shimDir};${previousPath ?? ""}`;
 
-        cfg = {
-          ...cfg,
-          memory: {
-            backend: "qmd",
-            qmd: {
-              includeDefaultMemory: false,
-              update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-              paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-              mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-            },
-          },
-        } as OpenClawConfig;
+        configureQmd({
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        });
 
         spawnMock.mockImplementation((_cmd: string, args: string[]) => {
           const child = createMockChild({ autoClose: false });
@@ -5237,18 +4372,9 @@ describe("QmdMemoryManager", () => {
         await fs.writeFile(path.join(shimDir, "mcporter.cmd"), "@echo off\n");
         process.env.PATH = `${shimDir};${previousPath ?? ""}`;
 
-        cfg = {
-          ...cfg,
-          memory: {
-            backend: "qmd",
-            qmd: {
-              includeDefaultMemory: false,
-              update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-              paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-              mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-            },
-          },
-        } as OpenClawConfig;
+        configureQmd({
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        });
 
         let firstCallCommand: string | null = null;
         spawnMock.mockImplementation((cmd: string, args: string[]) => {
@@ -5290,18 +4416,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("passes manager-scoped XDG env to mcporter commands", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -5333,18 +4450,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("retries mcporter daemon start after a failure", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: true },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: true },
+    });
 
     let daemonAttempts = 0;
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
@@ -5377,18 +4485,9 @@ describe("QmdMemoryManager", () => {
   });
 
   it("starts the mcporter daemon only once when enabled", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          mcporter: { enabled: true, serverName: "qmd", startDaemon: true },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: true },
+    });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -5418,17 +4517,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("fails closed when no managed collections are configured", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ paths: [] });
 
     const { manager } = await createManager();
 
@@ -5441,18 +4530,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("diversifies mixed session and memory search results so memory hits are retained", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true } });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search" && args.includes("workspace-main")) {
@@ -5523,22 +4601,9 @@ describe("QmdMemoryManager", () => {
 
   it("logs and continues when qmd embed times out", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: {
-            interval: "0s",
-            debounceMs: 0,
-            onBoot: false,
-            embedTimeoutMs: 20,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "0s", debounceMs: 0, onBoot: false, embedTimeoutMs: 20 },
+    });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "embed") {
         return createMockChild({ autoClose: false });
@@ -5564,22 +4629,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("does not store qmd embed backoff when the process clock is invalid", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: {
-            interval: "0s",
-            debounceMs: 0,
-            onBoot: false,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+    });
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(8_640_000_000_000_001);
     const { manager } = await createManager({ mode: "status" });
     try {
@@ -5599,23 +4652,10 @@ describe("QmdMemoryManager", () => {
 
   it("runs periodic embed maintenance even when regular update scheduling is disabled", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: {
-            interval: "0s",
-            debounceMs: 0,
-            onBoot: false,
-            embedInterval: "5m",
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "0s", debounceMs: 0, onBoot: false, embedInterval: "5m" },
+    });
 
     const { manager } = await createManager({ mode: "full" });
 
@@ -5637,23 +4677,10 @@ describe("QmdMemoryManager", () => {
 
   it("runs periodic embed maintenance when embed cadence is faster than update cadence", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: {
-            interval: "20m",
-            debounceMs: 0,
-            onBoot: false,
-            embedInterval: "5m",
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "20m", debounceMs: 0, onBoot: false, embedInterval: "5m" },
+    });
 
     const { manager } = await createManager({ mode: "full" });
 
@@ -5669,23 +4696,10 @@ describe("QmdMemoryManager", () => {
 
   it("does not schedule redundant embed maintenance when regular updates are already more frequent", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: {
-            interval: "5m",
-            debounceMs: 0,
-            onBoot: false,
-            embedInterval: "20m",
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "5m", debounceMs: 0, onBoot: false, embedInterval: "20m" },
+    });
 
     const { manager } = await createManager({ mode: "full" });
 
@@ -5701,23 +4715,10 @@ describe("QmdMemoryManager", () => {
 
   it("skips periodic embed maintenance in lexical search mode", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: {
-            interval: "0s",
-            debounceMs: 0,
-            onBoot: false,
-            embedInterval: "5m",
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "search",
+      update: { interval: "0s", debounceMs: 0, onBoot: false, embedInterval: "5m" },
+    });
 
     const { manager } = await createManager({ mode: "full" });
 
@@ -5742,23 +4743,10 @@ describe("QmdMemoryManager", () => {
         "resolveEmbedStartupJitterMs",
       )
       .mockReturnValue(60_000);
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: {
-            interval: "0s",
-            debounceMs: 0,
-            onBoot: false,
-            embedInterval: "5m",
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "0s", debounceMs: 0, onBoot: false, embedInterval: "5m" },
+    });
 
     const { manager } = await createManager({ mode: "full" });
 
@@ -5779,18 +4767,10 @@ describe("QmdMemoryManager", () => {
 
   it("serializes qmd embeds within a process before taking the shared SQLite lease", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+    });
     const embedChildren: MockChild[] = [];
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "embed") {
@@ -5833,18 +4813,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("drops a queued embed when its manager closes", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+    });
     const embedChildren: MockChild[] = [];
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "embed") {
@@ -5879,18 +4851,10 @@ describe("QmdMemoryManager", () => {
     // cannot serialize, so the writers collided with SQLITE_BUSY. Both writes now
     // take one per-agent SQLite write lease; embed additionally keeps the
     // global SQLite lease for ML-resource serialization.
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+    });
     spawnMock.mockImplementation(() => createMockChild());
 
     const { manager } = await createManager({ mode: "status" });
@@ -5919,24 +4883,16 @@ describe("QmdMemoryManager", () => {
   });
 
   it("clamps derived lease durations to the public timer-safe maximum", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: {
-            interval: "0s",
-            debounceMs: 0,
-            onBoot: false,
-            updateTimeoutMs: MAX_TIMER_TIMEOUT_MS,
-            embedTimeoutMs: MAX_TIMER_TIMEOUT_MS,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
+    configureQmd({
+      searchMode: "query",
+      update: {
+        interval: "0s",
+        debounceMs: 0,
+        onBoot: false,
+        updateTimeoutMs: MAX_TIMER_TIMEOUT_MS,
+        embedTimeoutMs: MAX_TIMER_TIMEOUT_MS,
       },
-    } as OpenClawConfig;
+    });
 
     const { manager } = await createManager({ mode: "status" });
     withLeaseMock.mockClear();
@@ -5951,18 +4907,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("preserves update and embed intent when the write lease fails after the callback", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "query",
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+    });
     const { manager } = await createManager({ mode: "status" });
     (manager as unknown as { dirty: boolean }).dirty = true;
     (manager as unknown as { lastEmbedAt: number | null }).lastEmbedAt = Date.now();
@@ -6049,18 +4997,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("aborts an in-flight qmd update when its write lease is lost", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "search",
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+    });
     const { manager } = await createManager({ mode: "status" });
     const leaseController = new AbortController();
     const leaseLost = new PluginStateLeaseError("update lease lost", {
@@ -6109,18 +5049,10 @@ describe("QmdMemoryManager", () => {
   it.each(["shared", "agent"] as const)(
     "fails closed when the %s embed lease is lost",
     async (lostScope) => {
-      cfg = {
-        ...cfg,
-        memory: {
-          backend: "qmd",
-          qmd: {
-            includeDefaultMemory: false,
-            searchMode: "query",
-            update: { interval: "0s", debounceMs: 0, onBoot: false },
-            paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          },
-        },
-      } as OpenClawConfig;
+      configureQmd({
+        searchMode: "query",
+        update: { interval: "0s", debounceMs: 0, onBoot: false },
+      });
       const { manager } = await createManager({ mode: "status" });
       // A forced sync must retain explicit embed intent after lease loss even
       // when the normal embed interval would consider a recent embed fresh.
@@ -6198,25 +5130,21 @@ describe("QmdMemoryManager", () => {
   );
 
   it("does not hold the per-agent write lease while waiting for embed capacity", async () => {
-    cfg = {
-      ...cfg,
-      agents: {
-        ...cfg.agents,
-        list: [
-          { id: agentId, default: true, workspace: workspaceDir },
-          { id: "other", workspace: workspaceDir },
-        ],
+    configureQmd(
+      {
+        searchMode: "query",
+        update: { interval: "0s", debounceMs: 0, onBoot: false },
       },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+      {
+        agents: {
+          ...cfg.agents,
+          list: [
+            { id: agentId, default: true, workspace: workspaceDir },
+            { id: "other", workspace: workspaceDir },
+          ],
         },
       },
-    } as OpenClawConfig;
+    );
     spawnMock.mockImplementation(() => createMockChild());
 
     let releaseFirstEmbed!: () => void;
@@ -6265,18 +5193,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("serializes session exports across managers for the same agent", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+      sessions: { enabled: true },
+    });
 
     const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
@@ -6338,18 +5258,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("maps exported QMD artifacts to the persisted session identity", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+      sessions: { enabled: true },
+    });
 
     await seedQmdSessionTranscript({
       agentId,
@@ -6387,18 +5299,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("does not publish session artifact mappings after lease ownership is lost", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+      sessions: { enabled: true },
+    });
     await seedQmdSessionTranscript({
       agentId,
       content: "lease guarded session",
@@ -6444,18 +5348,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("skips queued session export work after close while waiting on the shared update queue", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+      sessions: { enabled: true },
+    });
 
     const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
@@ -6513,18 +5409,10 @@ describe("QmdMemoryManager", () => {
   });
 
   it("skips qmd embed in lexical search mode for forced sync", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "search",
+      update: { interval: "0s", debounceMs: 0, onBoot: false },
+    });
 
     const { manager } = await createManager({ mode: "status" });
     await manager.sync({ reason: "manual", force: true });
@@ -6538,23 +5426,10 @@ describe("QmdMemoryManager", () => {
 
   it("retries boot update when qmd reports a retryable lock error", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "search",
-          update: {
-            interval: "0s",
-            debounceMs: 60_000,
-            onBoot: true,
-            waitForBootSync: true,
-          },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      searchMode: "search",
+      update: { interval: "0s", debounceMs: 60_000, onBoot: true, waitForBootSync: true },
+    });
 
     let updateCalls = 0;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -6601,21 +5476,12 @@ describe("QmdMemoryManager", () => {
   });
 
   it("scopes by channel for agent-prefixed session keys", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          scope: {
-            default: "deny",
-            rules: [{ action: "allow", match: { channel: "slack" } }],
-          },
-        },
+    configureQmd({
+      scope: {
+        default: "deny",
+        rules: [{ action: "allow", match: { channel: "slack" } }],
       },
-    } as OpenClawConfig;
+    });
     const { manager } = await createManager();
 
     const isAllowed = (key?: string) =>
@@ -6630,21 +5496,12 @@ describe("QmdMemoryManager", () => {
   });
 
   it("logs when qmd scope denies search", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          scope: {
-            default: "deny",
-            rules: [{ action: "allow", match: { chatType: "direct" } }],
-          },
-        },
+    configureQmd({
+      scope: {
+        default: "deny",
+        rules: [{ action: "allow", match: { chatType: "direct" } }],
       },
-    } as OpenClawConfig;
+    });
     const { manager } = await createManager();
 
     logWarnMock.mockClear();
@@ -6681,21 +5538,15 @@ describe("QmdMemoryManager", () => {
   });
 
   it("blocks memory_get reads of remember-only session exports", async () => {
-    cfg = {
-      ...cfg,
-      agents: {
-        ...cfg.agents,
-        list: [{ id: "main", memory: { search: { rememberAcrossConversations: true } } }],
-      },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+    configureQmd(
+      {},
+      {
+        agents: {
+          ...cfg.agents,
+          list: [{ id: "main", memory: { search: { rememberAcrossConversations: true } } }],
         },
       },
-    } as OpenClawConfig;
+    );
     const { manager } = await createManager();
 
     // Remember-only export is search-only for trusted recall; ordinary
@@ -6708,18 +5559,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps explicitly configured session exports readable via memory_get", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true } });
     const { manager } = await createManager();
 
     await expect(manager.readFile({ relPath: "qmd/sessions-main/export.md" })).resolves.toEqual({
@@ -6877,18 +5717,10 @@ describe("QmdMemoryManager", () => {
     await seedQmdSessionTranscript({ agentId, content: "hello", sessionId: "session-1", stateDir });
 
     const currentMemory = cfg.memory;
-    cfg = {
-      ...cfg,
-      memory: {
-        ...currentMemory,
-        qmd: {
-          ...currentMemory?.qmd,
-          sessions: {
-            enabled: true,
-          },
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd(
+      { ...currentMemory?.qmd, sessions: { enabled: true } },
+      { search: currentMemory?.search },
+    );
 
     const { manager } = await createManager();
 
@@ -7048,20 +5880,12 @@ describe("QmdMemoryManager", () => {
   });
 
   it("prefers collection hint when resolving duplicate qmd document hashes", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
-          ],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      paths: [
+        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+      ],
+    });
 
     const duplicateDocid = "dup-123";
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -7118,17 +5942,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("resolves search hits when qmd returns qmd:// file URIs without docid", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd();
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
@@ -7170,20 +5984,10 @@ describe("QmdMemoryManager", () => {
   it("returns collection-scoped qmd paths when session exports live under the workspace qmd directory", async () => {
     workspaceDir = path.join(stateDir, "agents", agentId);
     await fs.mkdir(workspaceDir, { recursive: true });
-    cfg = {
-      agents: {
-        list: [{ id: agentId, default: true, workspace: workspaceDir }],
-      },
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          sessions: { enabled: true },
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd(
+      { sessions: { enabled: true } },
+      { agents: { list: [{ id: agentId, default: true, workspace: workspaceDir }] } },
+    );
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
@@ -7267,18 +6071,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("restricts qmd search to session collections before result limiting", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          sessions: { enabled: true },
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true } });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search" && args.includes("workspace-main")) {
@@ -7343,20 +6136,12 @@ describe("QmdMemoryManager", () => {
   });
 
   it("preserves multi-collection qmd search hits when results only include file URIs", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [
-            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
-          ],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      paths: [
+        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+      ],
+    });
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search" && args.includes("workspace-main")) {
@@ -7504,19 +6289,7 @@ describe("QmdMemoryManager", () => {
 
   it("uses the configured qmd timeout for status probes", async () => {
     vi.useFakeTimers();
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          searchMode: "query",
-          limits: { timeoutMs: 6000 },
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ searchMode: "query", limits: { timeoutMs: 6000 } });
 
     let statusKill: Mock | null = null;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
@@ -7546,17 +6319,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("exports valid session transcripts whose IDs contain checkpoint words", async () => {
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          sessions: { enabled: true },
-          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({ sessions: { enabled: true }, update: undefined });
 
     await seedQmdSessionTranscript({
       agentId,
@@ -7833,17 +6596,9 @@ describe("QmdMemoryManager", () => {
     const oldWorkspaceDir = path.join(tmpRoot, "old-workspace");
     const newWorkspaceDir = workspaceDir; // the manager is configured for this new path
 
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: newWorkspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      paths: [{ path: newWorkspaceDir, pattern: "**/*.md", name: "workspace" }],
+    });
 
     const collectionName = `workspace-${agentId}`;
 
@@ -7902,17 +6657,9 @@ describe("QmdMemoryManager", () => {
     const containerRoot = "/home/node/.openclaw/teams/x/workspace";
     const newWorkspaceDir = workspaceDir; // host path the manager is configured for
 
-    cfg = {
-      ...cfg,
-      memory: {
-        backend: "qmd",
-        qmd: {
-          includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
-          paths: [{ path: newWorkspaceDir, pattern: "**/*.md", name: "workspace" }],
-        },
-      },
-    } as OpenClawConfig;
+    configureQmd({
+      paths: [{ path: newWorkspaceDir, pattern: "**/*.md", name: "workspace" }],
+    });
 
     const collectionName = `workspace-${agentId}`;
 


### PR DESCRIPTION
## What Problem This Solves

`extensions/memory-core/src/memory/qmd-manager.test.ts` repeated the same QMD configuration and process-fixture setup across most of its 162 cases, making the suite much harder to review and maintain than its behavior coverage requires. This maintainer-commissioned LOC-reduction batch consolidates that boilerplate without changing production behavior or test coverage.

## Why This Change Was Made

The suite now uses one typed local QMD config builder with defaults and explicit overrides, and the three semantically identical collection-repair cases use a named table. All other cases retain their distinct assertions and fixtures. This is AI-assisted maintainer work; no transcript is attached.

## User Impact

No user-visible behavior changes. The same QMD manager behaviors remain covered with substantially less duplicated test code.

## Evidence

- LOC: test `+543/-1796` (net `-1253`); production `+0/-0`.
- Test count: `162` before and `162` after (baseline: 156 direct cases + 6 table rows; after: 153 direct cases + 9 table rows).
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/qmd-manager.test.ts` — 1 file passed, 162 tests passed.
- `node scripts/check-changed.mjs -- extensions/memory-core/src/memory/qmd-manager.test.ts` — passed on Blacksmith Testbox `tbx_01ky6jmfvqj1wsn396c719hvtg`; max-lines ratchet, format, extension test typecheck, and extension lint all clean: https://github.com/openclaw/openclaw/actions/runs/29978835750
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings (`patch is correct`, confidence 0.91).
- `git diff --check` — clean.

The existing `config/max-lines-baseline.txt` entry remains because the reduced file is still above the repository max-lines budget; the ratchet stayed green.
