### PR TITLE
test: align QA channel coverage owners

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -110,6 +110,33 @@ describe("qa scenario catalog channel contracts", () => {
     });
   });
 
+  it("assigns Slack and Discord channel scenarios to exact asserted coverage owners", () => {
+    expect(readQaScenarioById("slack-canary").coverage?.primary).toEqual(["slack.socket"]);
+    expect(readQaScenarioById("slack-allowlist-block").coverage?.primary).toEqual([
+      "slack.channel-allowlists",
+    ]);
+    expect(readQaScenarioById("slack-channel-disabled-warning").coverage?.primary).toEqual([
+      "slack.channel-allowlists",
+    ]);
+
+    for (const scenarioId of [
+      "slack-approval-exec-native",
+      "slack-approval-plugin-native",
+      "slack-codex-approval-exec-native",
+      "slack-codex-approval-plugin-native",
+    ]) {
+      const scenario = readQaScenarioById(scenarioId);
+      expect(scenario.coverage?.primary, scenarioId).toEqual(["slack.native-approvals"]);
+      expect(scenario.coverage?.secondary, scenarioId).toContain(
+        "channels.channel-native-approval-prompts",
+      );
+    }
+
+    const discordThreadReply = readQaScenarioById("discord-thread-reply-filepath-attachment");
+    expect(discordThreadReply.coverage?.primary).toEqual(["discord.thread-actions"]);
+    expect(discordThreadReply.coverage?.secondary).toContain("discord.media-and-rich-content");
+  });
+
   it("rejects malformed string matcher lists before running a flow", () => {
     expect(() =>
       validateQaScenarioExecutionConfig({

--- a/qa/scenarios/channels/discord-thread-reply-filepath-attachment.yaml
+++ b/qa/scenarios/channels/discord-thread-reply-filepath-attachment.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - discord.thread-actions
+    secondary:
       - discord.media-and-rich-content
   execution:
     kind: flow

--- a/qa/scenarios/channels/slack-allowlist-block.yaml
+++ b/qa/scenarios/channels/slack-allowlist-block.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - slack.access-and-identity
+      - slack.channel-allowlists
   execution:
     profiles: { "slack:default": 2 }
     kind: flow

--- a/qa/scenarios/channels/slack-approval-exec-native.yaml
+++ b/qa/scenarios/channels/slack-approval-exec-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 7 }

--- a/qa/scenarios/channels/slack-approval-plugin-native.yaml
+++ b/qa/scenarios/channels/slack-approval-plugin-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 8 }

--- a/qa/scenarios/channels/slack-canary.yaml
+++ b/qa/scenarios/channels/slack-canary.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - slack.runtime-lifecycle
+      - slack.socket
   execution:
     profiles: { "slack:default": 0 }
     kind: flow

--- a/qa/scenarios/channels/slack-channel-disabled-warning.yaml
+++ b/qa/scenarios/channels/slack-channel-disabled-warning.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - slack.access-and-identity
+      - slack.channel-allowlists
   execution:
     kind: flow
     channel: slack

--- a/qa/scenarios/channels/slack-codex-approval-exec-native.yaml
+++ b/qa/scenarios/channels/slack-codex-approval-exec-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 9 }

--- a/qa/scenarios/channels/slack-codex-approval-plugin-native.yaml
+++ b/qa/scenarios/channels/slack-codex-approval-plugin-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 10 }


### PR DESCRIPTION
## Summary

- narrow Slack channel QA scenarios to the coverage owners their assertions actually exercise
- mark native approval scenarios as Slack native-approval coverage while keeping the shared channel-native-approval prompt owner as secondary
- mark the Discord filepath attachment scenario as thread-action coverage while retaining rich-content coverage as secondary
- add catalog regression assertions for the corrected owner mappings

Fixes #112842.

## What Problem This Solves

The channel QA catalog had several scenarios attributed to broad or adjacent coverage owners instead of the specific behavior each scenario asserts. That makes coverage reporting less actionable: Slack allowlist cases looked like access/identity coverage, native approval cases were only counted under the shared prompt owner, and a Discord thread reply attachment case was only counted as rich-content coverage. This patch aligns those scenario owners with the behavior being validated and adds a regression test so the mappings do not drift silently.

## Evidence

- CI for this PR shows the main validation jobs for the patch passing, including `build-artifacts`, all four `QA Smoke CI` profiles, `check-lint`, `check-prod-types`, `check-test-types`, `check-dependencies`, `check-guards`, and the catalog-related compact shards except the currently failing `checks-node-compact-large-5` shard.
- The PR diff adds `extensions/qa-lab/src/scenario-catalog-channels.test.ts` assertions that directly read the affected scenario IDs and verify the corrected primary/secondary coverage owners.
- Patch-level test command recorded in the test plan: `node scripts/run-vitest.mjs run extensions/qa-lab/src/scenario-catalog-channels.test.ts`.

## Test plan

- `node scripts/run-vitest.mjs run extensions/qa-lab/src/scenario-catalog-channels.test.ts`
- `git diff --check`
