### PR TITLE
test(memory): clear embedding watchdog timers

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -40,6 +40,23 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+async function settleWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<T | "timeout"> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<"timeout">((resolve) => {
+        timer = setTimeout(() => resolve("timeout"), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 function mockLocalEmbeddingRuntime(
   vector: ArrayLike<number> = new Float32Array([2.35, 3.45, 0.63, 4.3]),
 ) {
@@ -668,23 +685,19 @@ process.on("message", (message) => {
       })
       .toBe(true);
 
-    const queuedEmbedResult = Promise.race([
+    const queuedEmbedResult = settleWithin(
       provider.embedQuery("queued").then(
         () => "resolved" as const,
         (err: unknown) => err,
       ),
-      new Promise<"timeout">((resolve) => {
-        setTimeout(() => resolve("timeout"), 1_000);
-      }),
-    ]);
+      1_000,
+    );
 
     const closePromise = provider.close?.() ?? Promise.resolve();
-    const closeResult = await Promise.race([
+    const closeResult = await settleWithin(
       closePromise.then(() => "closed" as const),
-      new Promise<"timeout">((resolve) => {
-        setTimeout(() => resolve("timeout"), 1_000);
-      }),
-    ]);
+      1_000,
+    );
 
     expect(closeResult).toBe("closed");
     await expect(firstEmbedError).resolves.toMatchObject({


### PR DESCRIPTION
## What Problem This Solves

A memory-host worker shutdown test creates two referenced one-second `Promise.race` watchdogs. When the worker operations settle first, those test-owned timers remain alive until their deadlines and can leak handles into later shared-worker tests.

## Why This Change Was Made

Replace the two raw watchdog promises with one local `settleWithin` helper that preserves the timeout result, calls `unref()` where available, and clears the timer in `finally` on every settlement path. Production worker timeout ownership is unchanged; `embeddings-worker.ts` already clears its own close timer.

## User Impact

Developers get cleaner, faster test teardown without changing production behavior or timeout assertions.

## Evidence

- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/embeddings.test.ts`
  - 1 file passed
  - 22 tests passed
  - before test duration: 708ms
  - after test duration: 648ms after final rebase
- oxfmt check: passed
- `git diff --check`: passed
- Formal Codex autoreview: clean, no accepted/actionable findings

AI-assisted: yes.
