### PR TITLE
fix(models): keep external-CLI OAuth providers available when persisted snapshot expires

### DIFF
--- a/src/agents/model-auth-availability.test.ts
+++ b/src/agents/model-auth-availability.test.ts
@@ -724,6 +724,37 @@ describe("createModelAuthAvailabilityResolver", () => {
     });
   });
 
+  it("treats an expired external-CLI OAuth snapshot with refresh material as available", () => {
+    const store = authStore({
+      "acme:cli": {
+        type: "oauth",
+        provider: "acme-cli",
+        access: "",
+        refresh: "stored-refresh",
+        expires: Date.now() - 60_000,
+      },
+    });
+    // Without external-CLI scope the caller cannot own OAuth refresh, so an
+    // expired-but-refreshable snapshot stays unknown (may hydrate at runtime).
+    expect(
+      createModelAuthAvailabilityResolver({
+        cfg: {} as OpenClawConfig,
+        authStore: store,
+        env: {},
+      }).resolveProviderAuthAvailability("acme-cli"),
+    ).toBeUndefined();
+    // Declaring the provider as external-CLI-managed means the CLI owns refresh,
+    // so the same expired snapshot reads as available.
+    expect(
+      createModelAuthAvailabilityResolver({
+        cfg: {} as OpenClawConfig,
+        authStore: store,
+        env: {},
+        externalCliProviderIds: ["acme-cli"],
+      }).resolveProviderAuthAvailability("acme-cli"),
+    ).toBe(true);
+  });
+
   it("keeps a non-OpenAI provider SecretRef unresolved without reading it", () => {
     const result = createModelAuthAvailabilityResolver({
       cfg: {

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -271,6 +271,11 @@ export function createModelAuthAvailabilityResolver(
     const normalized = normalizeProviderIdForAuth(provider);
     return aliasMap[normalized] ?? normalized;
   };
+  // External-CLI-managed providers (e.g. claude-cli) delegate OAuth refresh to the
+  // owning CLI, so an expired-but-refreshable stored snapshot still reads available.
+  const externalCliProviderIdSet = new Set(
+    (params.externalCliProviderIds ?? []).map((id) => normalizeProvider(id)),
+  );
   const providerConfig = (provider: string) =>
     resolveMergedModelProviderConfig(params.cfg, provider);
   const prepareAuthTarget = (provider: string, ref: ModelAuthAvailabilityRef): AuthTarget => {
@@ -375,7 +380,9 @@ export function createModelAuthAvailabilityResolver(
       cfg: params.cfg,
       env,
       now,
-      canRefreshOAuth: provider === OPENAI_PROVIDER_ID,
+      canRefreshOAuth:
+        provider === OPENAI_PROVIDER_ID ||
+        externalCliProviderIdSet.has(normalizeProvider(provider)),
     });
   };
   const resolvedProfileAvailability = (

--- a/src/gateway/server-methods/models-list-result.cli-runtime-fallback.test.ts
+++ b/src/gateway/server-methods/models-list-result.cli-runtime-fallback.test.ts
@@ -1,0 +1,116 @@
+// Regression coverage for issue #112848: a provider bound to a CLI runtime
+// (e.g. anthropic -> claude-cli) must report available in models.list when the
+// persisted OAuth snapshot is expired but refreshable, because the owning CLI
+// refreshes it. This exercises the CLI-runtime provider discovery wired into the
+// models.list auth resolver plus the external-CLI refreshable generalization.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { buildModelsListResult } from "./models-list-result.js";
+import type { GatewayRequestContext } from "./types.js";
+
+const WITHOUT_ANTHROPIC_ENV_AUTH = {
+  ANTHROPIC_API_KEY: undefined,
+  ANTHROPIC_AUTH_TOKEN: undefined,
+  CLAUDE_API_KEY: undefined,
+  CLAUDE_CODE_OAUTH_TOKEN: undefined,
+} as const;
+
+const anthropicEntry: ModelCatalogEntry = {
+  id: "claude-opus-4-7",
+  name: "Claude Opus 4.7",
+  provider: "anthropic",
+  api: "anthropic-messages",
+};
+
+async function listModels(cfg: OpenClawConfig) {
+  const context = {
+    getRuntimeConfig: () => cfg,
+    loadGatewayModelCatalogSnapshot: vi.fn(() =>
+      Promise.resolve({ entries: [anthropicEntry], routeVariants: [anthropicEntry] }),
+    ),
+    logGateway: { debug: vi.fn() },
+  } as unknown as GatewayRequestContext;
+  return await buildModelsListResult({ context, params: { view: "all" } });
+}
+
+describe("models.list CLI-runtime OAuth fallback", () => {
+  beforeEach(() => {
+    // The claude-cli runtime backend is plugin-provided at runtime; inject it so
+    // the resolver can map anthropic execution onto claude-cli, as in production.
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupRegistry: () => ({
+        providers: [],
+        cliBackends: [],
+        configMigrations: [],
+        autoEnableProbes: [],
+        diagnostics: [],
+      }),
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude" },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    cliBackendsTesting.resetDepsForTest();
+  });
+
+  it("keeps an anthropic model available via an expired-but-refreshable claude-cli snapshot", async () => {
+    await withEnvAsync(WITHOUT_ANTHROPIC_ENV_AUTH, async () => {
+      await withOpenClawTestState(
+        {
+          layout: "home",
+          prefix: "openclaw-models-list-claude-cli-oauth-",
+          agentEnv: "main",
+        },
+        async (state) => {
+          // Persisted snapshot is expired but carries refresh material; the live
+          // keychain read is isolated to the empty temp HOME, so availability
+          // depends entirely on the refreshable-snapshot fallback under test.
+          await state.writeAuthProfiles({
+            version: 1,
+            profiles: {
+              "anthropic:claude-cli": {
+                type: "oauth",
+                provider: "claude-cli",
+                access: "",
+                refresh: "stored-refresh",
+                expires: Date.now() - 60_000,
+              },
+            },
+          });
+          const cfg = {
+            models: {
+              providers: {
+                anthropic: {
+                  agentRuntime: { id: "claude-cli" },
+                  models: [{ id: anthropicEntry.id, name: anthropicEntry.name }],
+                },
+              },
+            },
+          } as unknown as OpenClawConfig;
+
+          const result = await listModels(cfg);
+          expect(result.models).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                id: anthropicEntry.id,
+                provider: "anthropic",
+                available: true,
+              }),
+            ]),
+          );
+        },
+      );
+    });
+  });
+});

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -8,6 +8,7 @@ import {
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
 import { loadAuthProfileStoreWithoutExternalProfiles } from "../../agents/auth-profiles.js";
+import { listCliRuntimeProviderIds } from "../../agents/cli-backends.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import {
@@ -154,7 +155,15 @@ function createModelsListAuthResolver(params: {
     env: process.env,
     skipSetupProviderFallback: true,
     syntheticAuthProviderRefs: listEnabledSyntheticAuthProviderRefs(params),
-    externalCliProviderIds: params.includeOpenAIExternalProfiles ? ["openai"] : [],
+    // OpenAI external profiles stay gated on visibility; CLI-runtime providers
+    // (e.g. claude-cli, when a provider like anthropic binds agentRuntime) are
+    // added so the live-keychain overlay and legacy CLI fallback can read them.
+    externalCliProviderIds: [
+      ...new Set([
+        ...(params.includeOpenAIExternalProfiles ? ["openai"] : []),
+        ...listCliRuntimeProviderIds({ config: params.cfg, env: process.env }),
+      ]),
+    ],
     routeResolverFactory: params.routeResolverFactory,
   });
 }


### PR DESCRIPTION
## Summary

Fixes #112848. On installs where a provider (e.g. `anthropic`) is bound via `agentRuntime` to an external CLI such as `claude-cli` (OAuth stored in the OS keychain and refreshed by that CLI), the Dashboard model selector intermittently drops the provider. It happens when OpenClaw's **persisted** auth-profile snapshot's `expires` lapses during an idle gap — even though the live keychain token is valid and the CLI refreshes it on demand. Recovery only happens on the next inference (which re-imports the token) or a full reload, so it looks like a UI glitch, but the cause is backend availability resolution.

## Root cause

The gateway already has the intended fallback for CLI-runtime providers (`resolveLegacyEntryAvailability` → resolves the runtime provider and checks its availability). Two OpenAI-only assumptions starved it:

1. `createModelAuthAvailabilityResolver` set `canRefreshOAuth` only for the `openai` provider. So `resolveStoredCredentialReadOnlyAvailability` returned `undefined` for an expired-but-refreshable `claude-cli` snapshot, and the row builder (`availability !== true` → drop) hid it.
2. The gateway `models.list` auth resolver passed only `["openai"]` as external-CLI providers, so neither the live-keychain overlay nor the legacy CLI fallback ever covered `claude-cli`.

## Change

- **`model-auth-availability.ts`**: `canRefreshOAuth` is now also true for external-CLI-managed providers (they delegate OAuth refresh to the owning CLI), using the resolver's normalized `externalCliProviderIds` set.
- **`models-list-result.ts`**: the model.list external-CLI set now includes configured CLI-runtime providers via the existing `listCliRuntimeProviderIds()` helper, alongside `openai`. OpenAI external-profile gating is unchanged.

Both are minimal and route through existing architecture; no behavior change for API-key or non-external OAuth providers.

## Tests

- `model-auth-availability.test.ts`: expired-but-refreshable external-CLI OAuth snapshot resolves available.
- `models-list-result.cli-runtime-fallback.test.ts`: regression for a `claude-cli`-bound `anthropic` entry staying available in `models.list` when the persisted snapshot is expired.

## Verification

- `tsc --noEmit -p tsconfig.json` → clean (exit 0).
- `vitest run` on both affected files → 71/71 passing, including the new regression tests.
