### PR TITLE
fix(ui): keep system agents out of page scopes

### DIFF
--- a/ui/src/app/agent-selection.test.ts
+++ b/ui/src/app/agent-selection.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { AgentsListResult } from "../api/types.ts";
 import { createAgentSelectionCapability } from "./agent-selection.ts";
 
-function createGateway() {
-  let snapshot = { client: null as GatewayBrowserClient | null, assistantAgentId: "Main" };
+function createGateway(assistantAgentId = "Main") {
+  let snapshot = { client: null as GatewayBrowserClient | null, assistantAgentId };
   const listeners = new Set<(next: typeof snapshot) => void>();
   return {
     gateway: {
@@ -24,10 +25,32 @@ function createGateway() {
   };
 }
 
+function createRoster() {
+  let state = { agentsList: null as AgentsListResult | null };
+  const listeners = new Set<() => void>();
+  return {
+    roster: {
+      get state() {
+        return state;
+      },
+      subscribe(listener: () => void) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    },
+    publish(agentsList: AgentsListResult) {
+      state = { agentsList };
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+  };
+}
+
 describe("agent selection", () => {
   it("keeps page scope separate from the concrete chat agent", () => {
     const harness = createGateway();
-    const selection = createAgentSelectionCapability(harness.gateway);
+    const selection = createAgentSelectionCapability(harness.gateway, createRoster().roster);
 
     expect(selection.state).toEqual({ selectedId: "main", scopeId: "main" });
     selection.setScope(null);
@@ -37,9 +60,34 @@ describe("agent selection", () => {
     expect(selection.state).toEqual({ selectedId: "writer", scopeId: "writer" });
   });
 
+  it("clears system page scopes when the typed roster becomes known", () => {
+    const gateway = createGateway("OpenClaw");
+    const roster = createRoster();
+    const selection = createAgentSelectionCapability(gateway.gateway, roster.roster);
+
+    expect(selection.state).toEqual({ selectedId: "openclaw", scopeId: "openclaw" });
+    roster.publish({
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [
+        { id: "main", kind: "agent" },
+        { id: "openclaw", kind: "system" },
+      ],
+    });
+    expect(selection.state).toEqual({ selectedId: "openclaw", scopeId: null });
+
+    selection.setScope("historical");
+    expect(selection.state.scopeId).toBe("historical");
+    selection.setScope("main");
+    expect(selection.state.scopeId).toBe("main");
+    selection.setScope("openclaw");
+    expect(selection.state.scopeId).toBeNull();
+  });
+
   it("resets selection and scope together for a new gateway client", () => {
     const harness = createGateway();
-    const selection = createAgentSelectionCapability(harness.gateway);
+    const selection = createAgentSelectionCapability(harness.gateway, createRoster().roster);
     selection.setScope(null);
 
     harness.publish({

--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -1,4 +1,5 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { AgentsListResult } from "../api/types.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 
 type AgentSelectionGateway = {
@@ -7,6 +8,11 @@ type AgentSelectionGateway = {
     assistantAgentId: string | null;
   };
   subscribe: (listener: (snapshot: AgentSelectionGateway["snapshot"]) => void) => () => void;
+};
+
+type AgentSelectionRoster = {
+  readonly state: { agentsList: AgentsListResult | null };
+  subscribe: (listener: () => void) => () => void;
 };
 
 type AgentSelectionState = {
@@ -24,19 +30,35 @@ export type AgentSelectionCapability = {
 
 export function createAgentSelectionCapability(
   gateway: AgentSelectionGateway,
+  roster: AgentSelectionRoster,
 ): AgentSelectionCapability {
+  const resolveScopeId = (value: string | null): string | null => {
+    const scopeId = value?.trim() ? normalizeAgentId(value) : null;
+    if (!scopeId) {
+      return null;
+    }
+    // System agents remain valid concrete chat targets, but never become shared page filters.
+    const rosterEntry = roster.state.agentsList?.agents.find(
+      (agent) => normalizeAgentId(agent.id) === scopeId,
+    );
+    return rosterEntry?.kind === "system" ? null : scopeId;
+  };
   const initialId = gateway.snapshot.assistantAgentId
     ? normalizeAgentId(gateway.snapshot.assistantAgentId)
     : null;
-  let state: AgentSelectionState = { selectedId: initialId, scopeId: initialId };
+  let state: AgentSelectionState = {
+    selectedId: initialId,
+    scopeId: resolveScopeId(initialId),
+  };
   let client = gateway.snapshot.client;
   const listeners = new Set<(next: AgentSelectionState) => void>();
 
   const publish = (next: AgentSelectionState) => {
-    if (state.selectedId === next.selectedId && state.scopeId === next.scopeId) {
+    const reconciled = { ...next, scopeId: resolveScopeId(next.scopeId) };
+    if (state.selectedId === reconciled.selectedId && state.scopeId === reconciled.scopeId) {
       return;
     }
-    state = next;
+    state = reconciled;
     for (const listener of listeners) {
       listener(state);
     }
@@ -49,6 +71,7 @@ export function createAgentSelectionCapability(
       publish({ selectedId, scopeId: selectedId });
     }
   });
+  roster.subscribe(() => publish(state));
 
   return {
     get state() {

--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -34,14 +34,11 @@ export function createAgentSelectionCapability(
 ): AgentSelectionCapability {
   const resolveScopeId = (value: string | null): string | null => {
     const scopeId = value?.trim() ? normalizeAgentId(value) : null;
-    if (!scopeId) {
-      return null;
-    }
     // System agents remain valid concrete chat targets, but never become shared page filters.
-    const rosterEntry = roster.state.agentsList?.agents.find(
-      (agent) => normalizeAgentId(agent.id) === scopeId,
+    const isSystem = roster.state.agentsList?.agents.some(
+      (agent) => agent.kind === "system" && normalizeAgentId(agent.id) === scopeId,
     );
-    return rosterEntry?.kind === "system" ? null : scopeId;
+    return isSystem ? null : scopeId;
   };
   const initialId = gateway.snapshot.assistantAgentId
     ? normalizeAgentId(gateway.snapshot.assistantAgentId)

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -296,7 +296,7 @@ export function bootstrapApplication(): ApplicationRuntime {
   );
   const agents = createAgentCapability(gateway);
   const agentIdentity = createAgentIdentityCapability(gateway);
-  const agentSelection = createAgentSelectionCapability(gateway);
+  const agentSelection = createAgentSelectionCapability(gateway, agents);
   const channels = createChannelCapability(gateway);
   const config = createApplicationConfigCapability({
     basePath,

--- a/ui/src/components/agent-scope-control.test.ts
+++ b/ui/src/components/agent-scope-control.test.ts
@@ -52,6 +52,61 @@ describe("renderAgentScopeControl", () => {
     container.remove();
   });
 
+  it("keeps semantic system agents out of roster and historical options", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(
+      renderAgentScopeControl({
+        agents: [
+          { id: "main", kind: "agent", name: "Main agent" },
+          { id: "ordinary-looking-id", kind: "system", name: "System" },
+          { id: "writer", kind: "agent", name: "Writer" },
+        ],
+        additionalAgentIds: ["ordinary-looking-id", "retired"],
+        selection: createSelection(vi.fn()),
+        selectedId: "ordinary-looking-id",
+      }),
+      container,
+    );
+
+    const select = container.querySelector<AgentSelectElement>("openclaw-agent-select");
+    await select?.updateComplete;
+    expect(select?.value).toBe("");
+    expect(select?.options.map((option) => option.value)).toEqual([
+      "",
+      "main",
+      "retired",
+      "writer",
+    ]);
+    container.remove();
+  });
+
+  it("uses the first selectable agent when a concrete selector receives a system id", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(
+      renderAgentScopeControl({
+        agents: [
+          { id: "main", kind: "agent", name: "Main agent" },
+          { id: "ordinary-looking-id", kind: "system", name: "System" },
+          { id: "writer", kind: "agent", name: "Writer" },
+        ],
+        selection: createSelection(vi.fn()),
+        allowAll: false,
+        selectedId: "ordinary-looking-id",
+      }),
+      container,
+    );
+
+    const select = container.querySelector<AgentSelectElement>("openclaw-agent-select");
+    await select?.updateComplete;
+    expect(select?.value).toBe("main");
+    expect(select?.options.map((option) => option.value)).toEqual(["main", "writer"]);
+    container.remove();
+  });
+
   it("supports a concrete-agent selector without an all-agents option", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/ui/src/components/agent-scope-control.ts
+++ b/ui/src/components/agent-scope-control.ts
@@ -20,13 +20,11 @@ export function renderAgentScopeControl(params: AgentScopeControlParams) {
   const requestedSelected = params.selectedId ?? params.selection.state.scopeId ?? "";
   const selectedId = requestedSelected ? normalizeAgentId(requestedSelected) : "";
   const allowAll = params.allowAll !== false;
-  // Historical and selected IDs may be absent from the current roster, but a known
-  // system row must not be synthesized back into an ordinary-agent selector.
-  const systemAgentIds = new Set(
-    params.agents
-      .filter((agent) => agent.kind === "system")
-      .map((agent) => normalizeAgentId(agent.id)),
-  );
+  // Do not let historical or selected IDs reintroduce a typed system row.
+  const isSystemAgentId = (agentId: string) =>
+    params.agents.some(
+      (agent) => agent.kind === "system" && normalizeAgentId(agent.id) === agentId,
+    );
   const selectableAgents = listSelectableAgents(params.agents);
   const agentsById = new Map(
     selectableAgents.map((agent) => {
@@ -39,17 +37,17 @@ export function renderAgentScopeControl(params: AgentScopeControlParams) {
       continue;
     }
     const agentId = normalizeAgentId(value);
-    if (!systemAgentIds.has(agentId) && !agentsById.has(agentId)) {
+    if (!isSystemAgentId(agentId) && !agentsById.has(agentId)) {
       agentsById.set(agentId, { id: agentId });
     }
   }
-  if (selectedId && !systemAgentIds.has(selectedId) && !agentsById.has(selectedId)) {
+  if (selectedId && !isSystemAgentId(selectedId) && !agentsById.has(selectedId)) {
     agentsById.set(selectedId, { id: selectedId });
   }
   const agents = [...agentsById.values()].toSorted((left, right) =>
     normalizeAgentLabel(left).localeCompare(normalizeAgentLabel(right)),
   );
-  const selected = systemAgentIds.has(selectedId)
+  const selected = isSystemAgentId(selectedId)
     ? allowAll
       ? ""
       : (agents[0]?.id ?? "")

--- a/ui/src/components/agent-scope-control.ts
+++ b/ui/src/components/agent-scope-control.ts
@@ -2,7 +2,7 @@ import { html } from "lit";
 import type { GatewayAgentRow } from "../api/types.ts";
 import type { AgentSelectionCapability } from "../app/agent-selection.ts";
 import { t } from "../i18n/index.ts";
-import { normalizeAgentLabel } from "../lib/agents/display.ts";
+import { listSelectableAgents, normalizeAgentLabel } from "../lib/agents/display.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import type { AgentSelectOption } from "./agent-select.ts";
 import "./agent-select-registration.ts";
@@ -17,10 +17,19 @@ type AgentScopeControlParams = {
 };
 
 export function renderAgentScopeControl(params: AgentScopeControlParams) {
-  const selected = params.selectedId ?? params.selection.state.scopeId ?? "";
+  const requestedSelected = params.selectedId ?? params.selection.state.scopeId ?? "";
+  const selectedId = requestedSelected ? normalizeAgentId(requestedSelected) : "";
   const allowAll = params.allowAll !== false;
+  // Historical and selected IDs may be absent from the current roster, but a known
+  // system row must not be synthesized back into an ordinary-agent selector.
+  const systemAgentIds = new Set(
+    params.agents
+      .filter((agent) => agent.kind === "system")
+      .map((agent) => normalizeAgentId(agent.id)),
+  );
+  const selectableAgents = listSelectableAgents(params.agents);
   const agentsById = new Map(
-    params.agents.map((agent) => {
+    selectableAgents.map((agent) => {
       const agentId = normalizeAgentId(agent.id);
       return [agentId, agentId === agent.id ? agent : { ...agent, id: agentId }] as const;
     }),
@@ -30,16 +39,21 @@ export function renderAgentScopeControl(params: AgentScopeControlParams) {
       continue;
     }
     const agentId = normalizeAgentId(value);
-    if (!agentsById.has(agentId)) {
+    if (!systemAgentIds.has(agentId) && !agentsById.has(agentId)) {
       agentsById.set(agentId, { id: agentId });
     }
   }
-  if (selected && !agentsById.has(selected)) {
-    agentsById.set(selected, { id: selected });
+  if (selectedId && !systemAgentIds.has(selectedId) && !agentsById.has(selectedId)) {
+    agentsById.set(selectedId, { id: selectedId });
   }
   const agents = [...agentsById.values()].toSorted((left, right) =>
     normalizeAgentLabel(left).localeCompare(normalizeAgentLabel(right)),
   );
+  const selected = systemAgentIds.has(selectedId)
+    ? allowAll
+      ? ""
+      : (agents[0]?.id ?? "")
+    : selectedId;
   const options: AgentSelectOption[] = [
     ...(allowAll ? [{ value: "", label: t("agentScope.allAgents"), icon: icons.users }] : []),
     ...agents.map((agent) => ({


### PR DESCRIPTION
Related: #111920
Regression follow-up to #112488

## What Problem This Solves

Fixes an issue where users could see and select the built-in OpenClaw system agent in the shared page-scope picker on Tasks, Usage, Model Providers, Sessions, Workboard, and Cron after the typed roster was introduced.

The same system ID could also be synthesized back into the picker from historical page data or an already-selected scope, causing page requests to remain scoped to a hidden system agent.

## Why This Change Was Made

The application-level selection capability now observes the canonical agent roster and clears only the shared page scope when its row is classified as `kind: "system"`; the concrete chat agent remains intact. The shared scope control also filters semantic system rows and prevents historical or selected-ID fallback paths from adding them back.

Diagnostic surfaces that intentionally retain system rows, such as the Workboard filter, are unchanged. This change was AI-assisted and passed the repository's structured Codex autoreview workflow.

## User Impact

Ordinary page-scope selectors now show only normal agents. If a system scope was selected before roster metadata arrived, the page returns to All agents, while concrete-only surfaces resolve their normal default agent.

## Evidence

- `node scripts/run-vitest.mjs ui/src/app/agent-selection.test.ts ui/src/components/agent-scope-control.test.ts ui/src/lib/agents/display.test.ts ui/src/pages/workboard/agent-filter.test.ts` — 26 tests passed.
- `node scripts/check-changed.mjs -- ui/src/app/agent-selection.ts ui/src/app/agent-selection.test.ts ui/src/app/bootstrap.ts ui/src/components/agent-scope-control.ts ui/src/components/agent-scope-control.test.ts` — passed formatting, Control UI i18n verification, core-test and UI typechecks, lint, and repository guards on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/29979117769.
- `autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high` — clean on the final rebased branch; no accepted or actionable findings.
- Known proof gap: no screenshot is attached. The mock Control UI has no source-blind fixture that combines a typed system roster row with the historical-ID fallback path; the behavior is covered at the state-owner and rendered-control boundaries instead.
