### PR TITLE
fix: preserve signed URL tool details

### DIFF
--- a/src/agents/tool-display-common.test.ts
+++ b/src/agents/tool-display-common.test.ts
@@ -29,6 +29,75 @@ function hasLoneSurrogate(value: string): boolean {
 }
 
 describe("coerceDisplayValue surrogate-safe truncation", () => {
+  it("preserves long URL display details beyond the generic string limit", () => {
+    const url = `https://example.test/result/${"x".repeat(170)}?safe=value`;
+    expect(url.length).toBeGreaterThan(160);
+
+    const { detail } = resolveToolVerbAndDetailForArgs({
+      toolKey: "image",
+      args: { url },
+      fallbackDetailKeys: ["url"],
+      detailMode: "first",
+    });
+
+    expect(detail).toBe(url);
+    expect(detail).not.toContain("…");
+  });
+
+  it("keeps signed URL credentials redacted while preserving the surrounding URL detail", () => {
+    const url =
+      "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/output/generated-image.png" +
+      `?Expires=1800000000&${"x".repeat(120)}` +
+      "&OSSAccessKeyId=CAzABCDEFGHIJKLMNOPQRSTUVWX" +
+      "&Signature=abcdefghijklmnopqrstuvwxyz0123456789abcdef";
+
+    const { detail } = resolveToolVerbAndDetailForArgs({
+      toolKey: "image",
+      args: { url },
+      fallbackDetailKeys: ["url"],
+      detailMode: "first",
+    });
+
+    expect(detail).toContain("https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com");
+    expect(detail).toContain("OSSAccessKeyId=");
+    expect(detail).toContain("Signature=");
+    expect(detail).not.toContain("abcdefghijklmnopqrstuvwxyz0123456789abcdef");
+  });
+
+  it("still bounds unusually long URL strings", () => {
+    const longUrl = `https://example.test/result?${"x".repeat(1200)}&safe=tail`;
+
+    const { detail } = resolveToolVerbAndDetailForArgs({
+      toolKey: "image",
+      args: { url: longUrl },
+      fallbackDetailKeys: ["url"],
+      detailMode: "first",
+    });
+
+    expect(detail).toBeDefined();
+    expect((detail as string).length).toBeLessThan(longUrl.length);
+    expect(detail).toContain("…");
+    expect(detail).toContain("safe=tail");
+  });
+
+  it("continues to redact bearer tokens in URL query parameters", () => {
+    const url =
+      "https://example.test/callback?access_token=abcdef1234567890ghij&safe=value&Signature=abc123";
+
+    const { detail } = resolveToolVerbAndDetailForArgs({
+      toolKey: "api",
+      args: { url },
+      fallbackDetailKeys: ["url"],
+      detailMode: "first",
+    });
+
+    expect(detail).toBe(
+      "https://example.test/callback?access_token=abcdef…ghij&safe=value&Signature=***",
+    );
+    expect(detail).not.toContain("abcdef1234567890ghij");
+    expect(detail).not.toContain("Signature=abc123");
+  });
+
   it("does not split an emoji across the truncation boundary (default maxStringChars=160)", () => {
     // 200 UTF-16 units: 78 'a', an emoji (surrogate pair at indices 78-79), 120 'b'.
     // With maxStringChars=160, half = floor(159/2) = 79, so the naive

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -40,8 +40,25 @@ type CoerceDisplayValueOptions = {
   includeZero?: boolean;
   includeNonFinite?: boolean;
   maxStringChars?: number;
+  maxUrlStringChars?: number;
   maxArrayEntries?: number;
 };
+
+const DEFAULT_MAX_STRING_CHARS = 160;
+const DEFAULT_MAX_URL_STRING_CHARS = 1024;
+
+function parseHttpUrl(value: string): URL | undefined {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isHttpUrl(value: string): boolean {
+  return Boolean(parseHttpUrl(value));
+}
 
 /** Normalize a tool name for fallback display. */
 export function normalizeToolName(name?: string): string {
@@ -117,7 +134,8 @@ function coerceDisplayValue(
   value: unknown,
   opts: CoerceDisplayValueOptions = {},
 ): string | undefined {
-  const maxStringChars = opts.maxStringChars ?? 160;
+  const maxStringChars = opts.maxStringChars ?? DEFAULT_MAX_STRING_CHARS;
+  const maxUrlStringChars = opts.maxUrlStringChars ?? DEFAULT_MAX_URL_STRING_CHARS;
   const maxArrayEntries = opts.maxArrayEntries ?? 3;
 
   if (value === null || value === undefined) {
@@ -133,9 +151,10 @@ function coerceDisplayValue(
       return undefined;
     }
     const firstLine = redactToolPayloadText(rawLine);
-    if (firstLine.length > maxStringChars) {
-      const half = Math.floor((maxStringChars - 1) / 2);
-      return `${sliceUtf16Safe(firstLine, 0, half)}…${sliceUtf16Safe(firstLine, -(maxStringChars - 1 - half))}`;
+    const maxChars = isHttpUrl(rawLine) ? maxUrlStringChars : maxStringChars;
+    if (firstLine.length > maxChars) {
+      const half = Math.floor((maxChars - 1) / 2);
+      return `${sliceUtf16Safe(firstLine, 0, half)}…${sliceUtf16Safe(firstLine, -(maxChars - 1 - half))}`;
     }
     return firstLine;
   }


### PR DESCRIPTION
## What Problem This Solves

Generated asset tools can return signed HTTP(S) URLs that are long by design. The existing tool-display sanitization truncated all long strings to the generic 160-character limit, which could remove the usable portion of signed asset URLs from tool details. At the same time, ordinary token-like query parameters still need to be redacted so tool output does not expose credentials.

This change preserves useful signed URL details up to a URL-specific display limit while keeping generic non-URL strings bounded at the existing default and continuing to redact ordinary bearer/access token query parameters.

Fixes #112839.

## Evidence

Local validation run before opening the PR:

```bash
node scripts/run-vitest.mjs src/agents/tool-display-common.test.ts src/agents/tool-display.test.ts
git diff --check
```

The focused Vitest run covered signed URL preservation, long URL bounding, and token redaction regressions. `git diff --check` completed without whitespace errors.
