### PR TITLE
refactor: consolidate live model switch tests

### DIFF
--- a/src/agents/agent-command.live-model-switch.test-helpers.ts
+++ b/src/agents/agent-command.live-model-switch.test-helpers.ts
@@ -1,0 +1,245 @@
+import type { SessionEntry } from "../config/sessions.js";
+
+export function createCommandSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "session-1",
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+export function createCommandSessionFixture(
+  overrides: Partial<SessionEntry> = {},
+  sessionKey = "agent:main:main",
+): { entry: SessionEntry; store: Record<string, SessionEntry> } {
+  const entry = createCommandSessionEntry({
+    skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    ...overrides,
+  });
+  return { entry, store: { [sessionKey]: entry } };
+}
+
+export function createChannelModelRuntimeConfig({
+  channel = "discord",
+  matchKey = "channel-123",
+  model = "openai/channel-model",
+  additionalModels = {},
+}: {
+  channel?: string;
+  matchKey?: string;
+  model?: string;
+  additionalModels?: Record<string, unknown>;
+} = {}): Record<string, unknown> {
+  return {
+    agents: {
+      defaults: {
+        model: "anthropic/default-model",
+        models: {
+          "anthropic/default-model": {},
+          [model]: {},
+          ...additionalModels,
+        },
+      },
+    },
+    channels: { modelByChannel: { [channel]: { [matchKey]: model } } },
+  };
+}
+
+export function createConfiguredModelCompatRuntimeConfig(allowlisted: boolean) {
+  return {
+    agents: {
+      defaults: {
+        model: { primary: "gmn/gpt-5.4" },
+        ...(allowlisted ? { models: { "gmn/gpt-5.4": {} } } : {}),
+      },
+    },
+    models: {
+      providers: {
+        gmn: {
+          models: [
+            {
+              id: "gpt-5.4",
+              name: "GPT 5.4 via GMN",
+              reasoning: true,
+              compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+type ModelCatalogEntry = {
+  provider: string;
+  id: string;
+  name?: string;
+  reasoning?: boolean;
+  compat?: unknown;
+};
+
+type ModelSelectionParams = {
+  cfg?: unknown;
+  catalog?: ModelCatalogEntry[];
+  defaultProvider: string;
+  defaultModel?: string;
+};
+
+export const normalizeTestProviderId = (provider: string) => provider.trim().toLowerCase();
+
+export function isTestModelKeyAllowed(allowedKeys: ReadonlySet<string>, key: string): boolean {
+  if (allowedKeys.has(key)) {
+    return true;
+  }
+  let separator = key.indexOf("/");
+  while (separator > 0) {
+    if (allowedKeys.has(`${key.slice(0, separator + 1)}*`)) {
+      return true;
+    }
+    separator = key.indexOf("/", separator + 1);
+  }
+  return false;
+}
+
+export function buildTestConfiguredModelCatalog(cfg?: unknown): ModelCatalogEntry[] {
+  const providers = (cfg as { models?: { providers?: Record<string, { models?: unknown[] }> } })
+    ?.models?.providers;
+  if (!providers) {
+    return [];
+  }
+  return Object.entries(providers).flatMap(([provider, entry]) =>
+    Array.isArray(entry?.models)
+      ? entry.models
+          .filter(
+            (model): model is Record<string, unknown> =>
+              Boolean(model) && typeof model === "object",
+          )
+          .map((model) => {
+            const id = typeof model.id === "string" ? model.id : "";
+            return {
+              provider,
+              id,
+              name: typeof model.name === "string" ? model.name : id,
+              reasoning: typeof model.reasoning === "boolean" ? model.reasoning : undefined,
+              compat: model.compat,
+            };
+          })
+          .filter((model) => model.id)
+      : [],
+  );
+}
+
+export function buildTestAllowedModelSet({
+  cfg,
+  catalog,
+  defaultProvider,
+  defaultModel,
+}: ModelSelectionParams) {
+  const modelMap =
+    (cfg as { agents?: { defaults?: { models?: Record<string, unknown> } } } | undefined)?.agents
+      ?.defaults?.models ?? {};
+  const allowedKeys = new Set(Object.keys(modelMap));
+  if (defaultModel) {
+    allowedKeys.add(`${defaultProvider}/${defaultModel}`);
+  }
+  const allowedCatalog = [...(catalog ?? []), ...buildTestConfiguredModelCatalog(cfg)];
+  if (Object.keys(modelMap).length === 0) {
+    return { allowedKeys, allowedCatalog, allowAny: true };
+  }
+  return {
+    allowedKeys,
+    allowedCatalog: allowedCatalog.filter((entry) =>
+      allowedKeys.has(`${entry.provider}/${entry.id}`),
+    ),
+    allowAny: false,
+  };
+}
+
+export function createTestModelVisibilityPolicy(params: ModelSelectionParams) {
+  const allowed = buildTestAllowedModelSet(params);
+  const wildcardModelKeys = new Set([...allowed.allowedKeys].filter((key) => key.endsWith("/*")));
+  const allowsKey = (key: string) =>
+    allowed.allowAny || isTestModelKeyAllowed(allowed.allowedKeys, key);
+  return {
+    ...allowed,
+    exactModelRefs: [],
+    providerWildcards: new Set<string>(),
+    hasConfiguredEntries: !allowed.allowAny,
+    hasProviderWildcards: wildcardModelKeys.size > 0,
+    allowsKey,
+    allows: ({ provider, model }: { provider: string; model: string }) =>
+      allowsKey(`${provider}/${model}`),
+    allowsByWildcard: ({ provider, model }: { provider: string; model: string }) =>
+      isTestModelKeyAllowed(wildcardModelKeys, `${provider}/${model}`),
+    resolveSelection: ({ provider, model }: { provider: string; model: string }) => {
+      if (allowsKey(`${provider}/${model}`)) {
+        return { provider, model };
+      }
+      const fallback = allowed.allowedCatalog[0];
+      return fallback ? { provider: fallback.provider, model: fallback.id } : null;
+    },
+    visibleCatalog: ({ catalog }: { catalog: ModelCatalogEntry[] }) => catalog,
+  };
+}
+
+export function buildTestModelAliasIndex({
+  cfg,
+}: {
+  cfg?: { agents?: { defaults?: { models?: Record<string, { alias?: string }> } } };
+}) {
+  const byAlias = new Map<string, { alias: string; ref: { provider: string; model: string } }>();
+  const byKey = new Map<string, string[]>();
+  for (const [ref, entry] of Object.entries(cfg?.agents?.defaults?.models ?? {})) {
+    const alias = entry?.alias?.trim();
+    if (!alias) {
+      continue;
+    }
+    const [provider, ...modelParts] = ref.split("/");
+    if (!provider) {
+      throw new Error(`expected provider in model ref ${ref}`);
+    }
+    const model = modelParts.join("/");
+    byAlias.set(alias.toLowerCase(), { alias, ref: { provider, model } });
+    byKey.set(`${provider}/${model}`, [alias]);
+  }
+  return { byAlias, byKey };
+}
+
+export function resolveTestModelRefFromString({
+  raw,
+  defaultProvider,
+  aliasIndex,
+}: {
+  raw: string;
+  defaultProvider: string;
+  aliasIndex?: ReturnType<typeof buildTestModelAliasIndex>;
+}) {
+  const aliasMatch = aliasIndex?.byAlias.get(raw.trim().toLowerCase());
+  if (aliasMatch) {
+    return { ref: aliasMatch.ref, alias: aliasMatch.alias };
+  }
+  const slash = raw.indexOf("/");
+  return {
+    ref:
+      slash > 0
+        ? { provider: raw.slice(0, slash), model: raw.slice(slash + 1) }
+        : { provider: defaultProvider, model: raw },
+  };
+}
+
+function configuredPrimary(cfg?: unknown): string {
+  const raw = (cfg as { agents?: { defaults?: { model?: string | { primary?: string } } } })?.agents
+    ?.defaults?.model;
+  return (typeof raw === "string" ? raw : raw?.primary) ?? "anthropic/claude";
+}
+
+export function resolveTestConfiguredModelRef({ cfg }: { cfg?: unknown }) {
+  const [provider = "anthropic", ...modelParts] = configuredPrimary(cfg).split("/");
+  return { provider, model: modelParts.join("/") || "claude" };
+}
+
+export function resolveTestDefaultModelForAgent({ cfg }: { cfg?: unknown }) {
+  const { provider, model: modelWithProfile } = resolveTestConfiguredModelRef({ cfg });
+  const [model = "claude", authProfileId] = modelWithProfile.split("@");
+  return { provider, model, ...(authProfileId ? { authProfileId } : {}) };
+}

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -4,6 +4,21 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import {
+  buildTestAllowedModelSet,
+  buildTestConfiguredModelCatalog,
+  buildTestModelAliasIndex,
+  createChannelModelRuntimeConfig,
+  createCommandSessionEntry,
+  createCommandSessionFixture,
+  createConfiguredModelCompatRuntimeConfig,
+  createTestModelVisibilityPolicy,
+  isTestModelKeyAllowed,
+  normalizeTestProviderId,
+  resolveTestConfiguredModelRef,
+  resolveTestDefaultModelForAgent,
+  resolveTestModelRefFromString,
+} from "./agent-command.live-model-switch.test-helpers.js";
+import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "./internal-runtime-context.js";
@@ -507,302 +522,33 @@ vi.mock("./model-catalog.js", () => ({
   loadManifestModelCatalog: state.loadManifestModelCatalogMock,
 }));
 
-vi.mock("./model-selection.js", () => {
-  const normalizeProviderId = (provider: string) => provider.trim().toLowerCase();
-  const isModelKeyAllowedBySet = (allowedKeys: ReadonlySet<string>, key: string) => {
-    if (allowedKeys.has(key)) {
-      return true;
-    }
-    let separator = key.indexOf("/");
-    while (separator > 0) {
-      if (allowedKeys.has(`${key.slice(0, separator + 1)}*`)) {
-        return true;
-      }
-      separator = key.indexOf("/", separator + 1);
-    }
-    return false;
-  };
-  const buildAllowedModelSet = ({
-    cfg,
-    catalog,
-    defaultProvider,
-    defaultModel,
-  }: {
-    cfg?: unknown;
-    catalog?: Array<{ provider: string; id: string }>;
-    defaultProvider: string;
-    defaultModel?: string;
-  }) => {
-    const modelMap =
-      (cfg as { agents?: { defaults?: { models?: Record<string, unknown> } } } | undefined)?.agents
-        ?.defaults?.models ?? {};
-    const configuredCatalog = (
-      (cfg as { models?: { providers?: Record<string, { models?: unknown[] }> } } | undefined)
-        ?.models?.providers
-        ? Object.entries(
-            (cfg as { models?: { providers?: Record<string, { models?: unknown[] }> } }).models!
-              .providers!,
-          ).flatMap(([provider, entry]) =>
-            Array.isArray(entry?.models)
-              ? entry.models
-                  .filter(
-                    (model): model is Record<string, unknown> =>
-                      Boolean(model) && typeof model === "object",
-                  )
-                  .map((model) => {
-                    const id = typeof model.id === "string" ? model.id : "";
-                    return {
-                      provider,
-                      id,
-                      name: typeof model.name === "string" ? model.name : id,
-                      reasoning: typeof model.reasoning === "boolean" ? model.reasoning : undefined,
-                      compat: model.compat,
-                    };
-                  })
-                  .filter((model) => model.id)
-              : [],
-          )
-        : []
-    ) as Array<{ provider: string; id: string }>;
-    const combinedCatalog = [...(catalog ?? []), ...configuredCatalog];
-    const allowedKeys = new Set<string>(
-      Object.keys(modelMap).map((ref) => {
-        const [provider, ...modelParts] = ref.split("/");
-        return `${provider}/${modelParts.join("/")}`;
-      }),
-    );
-    if (defaultModel) {
-      allowedKeys.add(`${defaultProvider}/${defaultModel}`);
-    }
-    if (Object.keys(modelMap).length === 0) {
-      return {
-        allowedKeys,
-        allowedCatalog: combinedCatalog,
-        allowAny: true,
-      };
-    }
-    return {
-      allowedKeys,
-      allowedCatalog: combinedCatalog.filter((entry) =>
-        allowedKeys.has(`${entry.provider}/${entry.id}`),
-      ),
-      allowAny: false,
-    };
-  };
-  return {
-    buildAllowedModelSet,
-    createModelVisibilityPolicy: (params: {
-      cfg?: unknown;
-      catalog?: Array<{ provider: string; id: string }>;
-      defaultProvider: string;
-      defaultModel?: string;
-    }) => {
-      const allowed = buildAllowedModelSet(params);
-      const wildcardModelKeys = new Set(
-        [...allowed.allowedKeys].filter((key) => key.endsWith("/*")),
-      );
-      const allowsKey = (key: string) =>
-        allowed.allowAny || isModelKeyAllowedBySet(allowed.allowedKeys, key);
-      return {
-        ...allowed,
-        exactModelRefs: [],
-        providerWildcards: new Set<string>(),
-        hasConfiguredEntries: !allowed.allowAny,
-        hasProviderWildcards: wildcardModelKeys.size > 0,
-        allowsKey,
-        allows: ({ provider, model }: { provider: string; model: string }) =>
-          allowsKey(`${provider}/${model}`),
-        allowsByWildcard: ({ provider, model }: { provider: string; model: string }) =>
-          isModelKeyAllowedBySet(wildcardModelKeys, `${provider}/${model}`),
-        resolveSelection: ({ provider, model }: { provider: string; model: string }) => {
-          const key = `${provider}/${model}`;
-          if (allowsKey(key)) {
-            return { provider, model };
-          }
-          const fallback = allowed.allowedCatalog[0];
-          return fallback ? { provider: fallback.provider, model: fallback.id } : null;
-        },
-        visibleCatalog: ({ catalog }: { catalog: Array<{ provider: string; id: string }> }) =>
-          catalog,
-      };
-    },
-    buildConfiguredModelCatalog: ({ cfg }: { cfg?: unknown }) => {
-      const providers = (cfg as { models?: { providers?: Record<string, { models?: unknown[] }> } })
-        ?.models?.providers;
-      if (!providers) {
-        return [];
-      }
-      return Object.entries(providers).flatMap(([provider, entry]) =>
-        Array.isArray(entry?.models)
-          ? entry.models
-              .filter(
-                (model): model is Record<string, unknown> =>
-                  Boolean(model) && typeof model === "object",
-              )
-              .map((model) => {
-                const id = typeof model.id === "string" ? model.id : "";
-                return {
-                  provider,
-                  id,
-                  name: typeof model.name === "string" ? model.name : id,
-                  reasoning: typeof model.reasoning === "boolean" ? model.reasoning : undefined,
-                  compat: model.compat,
-                };
-              })
-              .filter((model) => model.id)
-          : [],
-      );
-    },
-    isModelKeyAllowedBySet,
-    buildModelAliasIndex: ({
-      cfg,
-    }: {
-      cfg?: { agents?: { defaults?: { models?: Record<string, { alias?: string }> } } };
-    }) => {
-      const byAlias = new Map<
-        string,
-        { alias: string; ref: { provider: string; model: string } }
-      >();
-      const byKey = new Map<string, string[]>();
-      for (const [ref, entry] of Object.entries(cfg?.agents?.defaults?.models ?? {})) {
-        const alias = entry?.alias?.trim();
-        if (!alias) {
-          continue;
-        }
-        const [rawProvider, ...modelParts] = ref.split("/");
-        const provider = expectDefined(rawProvider, `provider in model ref ${ref}`);
-        const model = modelParts.join("/");
-        byAlias.set(alias.toLowerCase(), {
-          alias,
-          ref: { provider, model },
-        });
-        byKey.set(`${provider}/${model}`, [alias]);
-      }
-      return { byAlias, byKey };
-    },
-    modelKey: (p: string, m: string) => `${p}/${m}`,
-    normalizeModelRef: (p: string, m: string) => ({ provider: normalizeProviderId(p), model: m }),
-    normalizeProviderId,
-    normalizeProviderIdForAuth: normalizeProviderId,
-    parseModelRef: (m: string, p: string) => {
-      const slash = m.indexOf("/");
-      return slash > 0
-        ? { provider: m.slice(0, slash), model: m.slice(slash + 1) }
-        : { provider: p, model: m };
-    },
-    resolveModelRefFromString: ({
-      raw,
-      defaultProvider,
-      aliasIndex,
-    }: {
-      raw: string;
-      defaultProvider: string;
-      aliasIndex?: {
-        byAlias: Map<string, { alias: string; ref: { provider: string; model: string } }>;
-      };
-    }) => {
-      const aliasMatch = aliasIndex?.byAlias.get(raw.trim().toLowerCase());
-      if (aliasMatch) {
-        return { ref: aliasMatch.ref, alias: aliasMatch.alias };
-      }
-      const slash = raw.indexOf("/");
-      return {
-        ref:
-          slash > 0
-            ? { provider: raw.slice(0, slash), model: raw.slice(slash + 1) }
-            : { provider: defaultProvider, model: raw },
-      };
-    },
-    resolveConfiguredModelRef: ({ cfg }: { cfg?: unknown }) => {
-      const raw = (cfg as { agents?: { defaults?: { model?: string | { primary?: string } } } })
-        ?.agents?.defaults?.model;
-      const primary = typeof raw === "string" ? raw : raw?.primary;
-      const [provider, ...modelParts] = (primary ?? "anthropic/claude").split("/");
-      return { provider, model: modelParts.join("/") || "claude" };
-    },
-    resolveDefaultModelForAgent: ({ cfg }: { cfg?: unknown }) => {
-      const raw = (cfg as { agents?: { defaults?: { model?: string | { primary?: string } } } })
-        ?.agents?.defaults?.model;
-      const primary = typeof raw === "string" ? raw : raw?.primary;
-      const [provider, ...modelParts] = (primary ?? "anthropic/claude").split("/");
-      const [model, authProfileId] = (modelParts.join("/") || "claude").split("@");
-      return { provider, model, ...(authProfileId ? { authProfileId } : {}) };
-    },
-    resolveThinkingDefault: (args: unknown) => state.resolveThinkingDefaultMock(args),
-  };
-});
+vi.mock("./model-selection.js", () => ({
+  buildAllowedModelSet: buildTestAllowedModelSet,
+  createModelVisibilityPolicy: createTestModelVisibilityPolicy,
+  buildConfiguredModelCatalog: ({ cfg }: { cfg?: unknown }) => buildTestConfiguredModelCatalog(cfg),
+  isModelKeyAllowedBySet: isTestModelKeyAllowed,
+  buildModelAliasIndex: buildTestModelAliasIndex,
+  modelKey: (provider: string, model: string) => `${provider}/${model}`,
+  normalizeModelRef: (provider: string, model: string) => ({
+    provider: normalizeTestProviderId(provider),
+    model,
+  }),
+  normalizeProviderId: normalizeTestProviderId,
+  normalizeProviderIdForAuth: normalizeTestProviderId,
+  parseModelRef: (model: string, provider: string) => {
+    const slash = model.indexOf("/");
+    return slash > 0
+      ? { provider: model.slice(0, slash), model: model.slice(slash + 1) }
+      : { provider, model };
+  },
+  resolveModelRefFromString: resolveTestModelRefFromString,
+  resolveConfiguredModelRef: resolveTestConfiguredModelRef,
+  resolveDefaultModelForAgent: resolveTestDefaultModelForAgent,
+  resolveThinkingDefault: (args: unknown) => state.resolveThinkingDefaultMock(args),
+}));
 
 vi.mock("./model-visibility-policy.js", () => ({
-  createModelVisibilityPolicy: ({
-    cfg,
-    catalog,
-    defaultProvider,
-    defaultModel,
-  }: {
-    cfg?: unknown;
-    catalog?: Array<{ provider: string; id: string }>;
-    defaultProvider: string;
-    defaultModel?: string;
-  }) => {
-    const modelMap =
-      (cfg as { agents?: { defaults?: { models?: Record<string, unknown> } } } | undefined)?.agents
-        ?.defaults?.models ?? {};
-    const allowedKeys = new Set<string>(
-      Object.keys(modelMap).map((ref) => {
-        const [provider, ...modelParts] = ref.split("/");
-        return `${provider}/${modelParts.join("/")}`;
-      }),
-    );
-    if (defaultModel) {
-      allowedKeys.add(`${defaultProvider}/${defaultModel}`);
-    }
-    const allowAny = Object.keys(modelMap).length === 0;
-    const allowedCatalog = allowAny
-      ? (catalog ?? [])
-      : (catalog ?? []).filter((entry) => allowedKeys.has(`${entry.provider}/${entry.id}`));
-    const isModelKeyAllowedBySet = (keys: ReadonlySet<string>, key: string) => {
-      if (keys.has(key)) {
-        return true;
-      }
-      let separator = key.indexOf("/");
-      while (separator > 0) {
-        if (keys.has(`${key.slice(0, separator + 1)}*`)) {
-          return true;
-        }
-        separator = key.indexOf("/", separator + 1);
-      }
-      return false;
-    };
-    const wildcardModelKeys = new Set([...allowedKeys].filter((key) => key.endsWith("/*")));
-    const allowsKey = (key: string) => allowAny || isModelKeyAllowedBySet(allowedKeys, key);
-    return {
-      allowAny,
-      allowedKeys,
-      allowedCatalog,
-      exactModelRefs: [],
-      providerWildcards: new Set<string>(),
-      hasConfiguredEntries: !allowAny,
-      hasProviderWildcards: wildcardModelKeys.size > 0,
-      allowsKey,
-      allows: ({ provider, model }: { provider: string; model: string }) =>
-        allowsKey(`${provider}/${model}`),
-      allowsByWildcard: ({ provider, model }: { provider: string; model: string }) =>
-        isModelKeyAllowedBySet(wildcardModelKeys, `${provider}/${model}`),
-      resolveSelection: ({ provider, model }: { provider: string; model: string }) => {
-        const key = `${provider}/${model}`;
-        if (allowsKey(key)) {
-          return { provider, model };
-        }
-        const fallback = allowedCatalog[0];
-        return fallback ? { provider: fallback.provider, model: fallback.id } : null;
-      },
-      visibleCatalog: ({
-        catalog: catalogLocal,
-      }: {
-        catalog: Array<{ provider: string; id: string }>;
-      }) => catalogLocal,
-    };
-  },
+  createModelVisibilityPolicy: createTestModelVisibilityPolicy,
 }));
 
 vi.mock("./provider-auth-aliases.js", () => ({
@@ -965,6 +711,18 @@ function setupSingleAttemptFallback() {
   });
 }
 
+function setupSuccessfulAttempt(provider = "openai", model = "gpt-5.4"): void {
+  setupSingleAttemptFallback();
+  state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult(provider, model));
+}
+
+function setupAcpSession(): void {
+  state.acpResolveSessionMock.mockReturnValue({
+    kind: "ready",
+    meta: { agent: "claude", cwd: "/tmp/workspace" },
+  });
+}
+
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== "object") {
     throw new Error(`expected ${label} to be an object`);
@@ -1001,15 +759,51 @@ async function runBasicAgentCommand() {
   });
 }
 
-function setupSessionTouchStore(): void {
-  const sessionEntry: SessionEntry = {
-    sessionId: "session-1",
-    updatedAt: 1,
-    skillsSnapshot: { prompt: "", skills: [], version: 0 },
-  };
-  state.sessionEntryMock = sessionEntry;
-  state.sessionStoreMock = { "agent:main:main": sessionEntry };
-  state.storePathMock = "/tmp/openclaw-sessions.json";
+function runDiscordDelivery(overrides: Partial<Parameters<typeof agentCommand>[0]> = {}) {
+  return agentCommand({
+    message: "hello",
+    channel: "discord",
+    to: "discord:dm:123",
+    accountId: "main",
+    deliver: true,
+    ...overrides,
+  });
+}
+
+function runInternalModelCommand(runId: string) {
+  return agentCommand({
+    message: "probe",
+    to: "+1234567890",
+    runId,
+    modelRun: true,
+    promptMode: "none",
+    sessionEffects: "internal",
+  });
+}
+
+function setupStoredSession(
+  overrides: Partial<SessionEntry> = {},
+  storePath = "/tmp/openclaw-sessions.json",
+  sessionKey = "agent:main:main",
+): { entry: SessionEntry; store: Record<string, SessionEntry> } {
+  const fixture = createCommandSessionFixture(overrides, sessionKey);
+  state.sessionEntryMock = fixture.entry;
+  state.sessionStoreMock = fixture.store;
+  state.storePathMock = storePath;
+  return fixture;
+}
+
+function setupBareStoredSession(
+  overrides: Partial<SessionEntry> = {},
+  storePath = "/tmp/openclaw-sessions.json",
+  sessionKey = "agent:main:main",
+): { entry: SessionEntry; store: Record<string, SessionEntry> } {
+  const entry = createCommandSessionEntry(overrides);
+  const store = { [sessionKey]: entry };
+  state.sessionEntryMock = entry;
+  state.sessionStoreMock = store;
+  state.storePathMock = storePath;
+  return { entry, store };
 }
 
 function expectFallbackOverrideCalls(first: boolean, second: boolean) {
@@ -1572,13 +1366,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("preserves restart ownership when an aborted ACP turn resolves normally", async () => {
-    state.acpResolveSessionMock.mockReturnValue({
-      kind: "ready",
-      meta: {
-        agent: "claude",
-        cwd: "/tmp/workspace",
-      },
-    });
+    setupAcpSession();
     const controller = new AbortController();
     controller.abort(createAgentRunRestartAbortError());
 
@@ -1595,13 +1383,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("suppresses ACP delivery when restart begins during transcript persistence", async () => {
-    state.acpResolveSessionMock.mockReturnValue({
-      kind: "ready",
-      meta: {
-        agent: "claude",
-        cwd: "/tmp/workspace",
-      },
-    });
+    setupAcpSession();
     const controller = new AbortController();
     state.persistAcpTurnTranscriptMock.mockImplementation(
       async (params: { sessionEntry?: unknown }) => {
@@ -1636,13 +1418,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("threads lifecycle ownership into ACP delivery", async () => {
-    state.acpResolveSessionMock.mockReturnValue({
-      kind: "ready",
-      meta: {
-        agent: "claude",
-        cwd: "/tmp/workspace",
-      },
-    });
+    setupAcpSession();
 
     await agentCommand({
       message: "hello",
@@ -1659,13 +1435,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("persists structured transcript media for ACP turns", async () => {
-    state.acpResolveSessionMock.mockReturnValue({
-      kind: "ready",
-      meta: {
-        agent: "claude",
-        cwd: "/tmp/workspace",
-      },
-    });
+    setupAcpSession();
 
     await agentCommand({
       message: "[media attached: media://inbound/image-1]",
@@ -1688,7 +1458,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("keeps the initial session touch for local runs", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    setupSessionTouchStore();
+    setupStoredSession();
 
     await runBasicAgentCommand();
 
@@ -1703,7 +1473,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("threads lifecycle ownership into normal delivery", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    setupSessionTouchStore();
+    setupStoredSession();
 
     await runBasicAgentCommand();
 
@@ -1752,10 +1522,20 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
   });
 
-  it("rejects unsupported explicit thinking for interactive subagent-key runs", async () => {
-    setupSingleAttemptFallback();
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude-fable-5"));
-    state.resolvedSessionKeyMock = "agent:planner:subagent:00000000-0000-4000-8000-000000000000";
+  it.each([
+    {
+      name: "rejects unsupported explicit thinking for interactive subagent-key runs",
+      sessionKey: "agent:planner:subagent:00000000-0000-4000-8000-000000000000",
+      lane: undefined,
+    },
+    {
+      name: "rejects unsupported explicit thinking for non-subagent sessions on the subagent lane",
+      sessionKey: "agent:main:main",
+      lane: "subagent" as const,
+    },
+  ])("$name", async ({ sessionKey, lane }) => {
+    setupSuccessfulAttempt("anthropic", "claude-fable-5");
+    state.resolvedSessionKeyMock = sessionKey;
     state.isThinkingLevelSupportedMock.mockReturnValue(false);
 
     await expect(
@@ -1763,23 +1543,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         message: "hello",
         sessionKey: state.resolvedSessionKeyMock,
         thinking: "xhigh",
-      }),
-    ).rejects.toThrow(/is not supported/u);
-    expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects unsupported explicit thinking for non-subagent sessions on the subagent lane", async () => {
-    setupSingleAttemptFallback();
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude-fable-5"));
-    state.resolvedSessionKeyMock = "agent:main:main";
-    state.isThinkingLevelSupportedMock.mockReturnValue(false);
-
-    await expect(
-      agentCommand({
-        message: "hello",
-        sessionKey: state.resolvedSessionKeyMock,
-        thinking: "xhigh",
-        lane: "subagent",
+        lane,
       }),
     ).rejects.toThrow(/is not supported/u);
     expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
@@ -1790,15 +1554,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude-fable-5"));
     state.resolvedSessionKeyMock = "agent:main:main";
     state.isThinkingLevelSupportedMock.mockReturnValue(false);
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-      skillsSnapshot: { prompt: "", skills: [], version: 0 },
-      thinkingLevel: "low",
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    const { store } = setupStoredSession({ thinkingLevel: "low" });
 
     await expect(
       agentCommand({
@@ -1808,9 +1564,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       }),
     ).rejects.toThrow(/is not supported/u);
     expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
-    expect(
-      (state.sessionStoreMock as Record<string, SessionEntry>)["agent:main:main"]?.thinkingLevel,
-    ).toBe("low");
+    expect(store["agent:main:main"]?.thinkingLevel).toBe("low");
     expect(state.persistSessionEntryMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
         entry: expect.objectContaining({ thinkingLevel: "ultra" }),
@@ -1821,7 +1575,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("skips the initial session touch after gateway ingress already persisted activity", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    setupSessionTouchStore();
+    setupStoredSession();
 
     await agentCommand({
       message: "hello",
@@ -1837,167 +1591,89 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(state.updateSessionStoreAfterAgentRunMock).toHaveBeenCalledTimes(1);
   });
 
-  it("uses channel model override as the initial run model for channel-backed sessions", async () => {
-    setupSingleAttemptFallback();
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: "anthropic/default-model",
-          models: {
-            "anthropic/default-model": {},
-            "openai/channel-model": {},
-          },
-        },
+  it.each([
+    {
+      name: "uses channel model override as the initial run model for channel-backed sessions",
+      sessionEntry: createCommandSessionFixture({ channel: "discord", groupId: "channel-123" })
+        .entry,
+      command: undefined,
+      legacyFallback: false,
+      expectResolverContext: true,
+      expectAttemptModel: true,
+    },
+    {
+      name: "uses current run channel context when persisted session metadata is absent",
+      sessionEntry: undefined,
+      command: {
+        message: "hello",
+        channel: "discord",
+        groupId: "channel-123",
+        to: "discord:channel:channel-123",
       },
-      channels: {
-        modelByChannel: {
-          discord: {
-            "channel-123": "openai/channel-model",
-          },
-        },
+      legacyFallback: false,
+      expectResolverContext: false,
+      expectAttemptModel: false,
+    },
+    {
+      name: "keeps persisted channel model override when current run context is internal",
+      sessionEntry: createCommandSessionFixture({ channel: "discord", groupId: "channel-123" })
+        .entry,
+      command: {
+        message: "hello",
+        channel: "internal",
+        messageChannel: "internal",
+        to: "internal",
       },
-    };
-    state.sessionEntryMock = {
-      sessionId: "session-1",
-      updatedAt: 1,
-      channel: "discord",
-      groupId: "channel-123",
-      skillsSnapshot: { prompt: "", skills: [], version: 0 },
-    };
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "channel-model"));
+      legacyFallback: false,
+      expectResolverContext: true,
+      expectAttemptModel: false,
+    },
+    {
+      name: "uses channel model override after ignoring stale legacy fallback overrides",
+      sessionEntry: createCommandSessionFixture({
+        channel: "discord",
+        groupId: "channel-123",
+        providerOverride: "anthropic",
+        modelOverride: "stale-fallback-model",
+      }).entry,
+      command: undefined,
+      legacyFallback: true,
+      expectResolverContext: false,
+      expectAttemptModel: false,
+    },
+  ])(
+    "$name",
+    async ({
+      sessionEntry,
+      command,
+      legacyFallback,
+      expectResolverContext,
+      expectAttemptModel,
+    }) => {
+      setupSuccessfulAttempt("openai", "channel-model");
+      state.runtimeConfigMock = createChannelModelRuntimeConfig();
+      state.sessionEntryMock = sessionEntry;
+      state.hasLegacyAutoFallbackWithoutOriginMock.mockReturnValue(legacyFallback);
 
-    await runBasicAgentCommand();
+      await (command ? agentCommand(command) : runBasicAgentCommand());
 
-    expect(mockCallArg(state.resolveChannelModelOverrideMock)).toMatchObject({
-      channel: "discord",
-      groupId: "channel-123",
-    });
-    const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
-    expect(fallbackParams.provider).toBe("openai");
-    expect(fallbackParams.model).toBe("channel-model");
-    expectRecordFields(mockCallArg(state.runAgentAttemptMock), {
-      providerOverride: "openai",
-      modelOverride: "channel-model",
-    });
-  });
-
-  it("uses current run channel context when persisted session metadata is absent", async () => {
-    setupSingleAttemptFallback();
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: "anthropic/default-model",
-          models: {
-            "anthropic/default-model": {},
-            "openai/channel-model": {},
-          },
-        },
-      },
-      channels: {
-        modelByChannel: {
-          discord: {
-            "channel-123": "openai/channel-model",
-          },
-        },
-      },
-    };
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "channel-model"));
-
-    await agentCommand({
-      message: "hello",
-      channel: "discord",
-      groupId: "channel-123",
-      to: "discord:channel:channel-123",
-    });
-
-    const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
-    expect(fallbackParams.provider).toBe("openai");
-    expect(fallbackParams.model).toBe("channel-model");
-  });
-
-  it("keeps persisted channel model override when current run context is internal", async () => {
-    setupSingleAttemptFallback();
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: "anthropic/default-model",
-          models: {
-            "anthropic/default-model": {},
-            "openai/channel-model": {},
-          },
-        },
-      },
-      channels: {
-        modelByChannel: {
-          discord: {
-            "channel-123": "openai/channel-model",
-          },
-        },
-      },
-    };
-    state.sessionEntryMock = {
-      sessionId: "session-1",
-      updatedAt: 1,
-      channel: "discord",
-      groupId: "channel-123",
-      skillsSnapshot: { prompt: "", skills: [], version: 0 },
-    };
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "channel-model"));
-
-    await agentCommand({
-      message: "hello",
-      channel: "internal",
-      messageChannel: "internal",
-      to: "internal",
-    });
-
-    expect(mockCallArg(state.resolveChannelModelOverrideMock)).toMatchObject({
-      channel: "discord",
-      groupId: "channel-123",
-    });
-    const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
-    expect(fallbackParams.provider).toBe("openai");
-    expect(fallbackParams.model).toBe("channel-model");
-  });
-
-  it("uses channel model override after ignoring stale legacy fallback overrides", async () => {
-    setupSingleAttemptFallback();
-    state.hasLegacyAutoFallbackWithoutOriginMock.mockReturnValue(true);
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: "anthropic/default-model",
-          models: {
-            "anthropic/default-model": {},
-            "openai/channel-model": {},
-          },
-        },
-      },
-      channels: {
-        modelByChannel: {
-          discord: {
-            "channel-123": "openai/channel-model",
-          },
-        },
-      },
-    };
-    state.sessionEntryMock = {
-      sessionId: "session-1",
-      updatedAt: 1,
-      channel: "discord",
-      groupId: "channel-123",
-      providerOverride: "anthropic",
-      modelOverride: "stale-fallback-model",
-      skillsSnapshot: { prompt: "", skills: [], version: 0 },
-    };
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "channel-model"));
-
-    await runBasicAgentCommand();
-
-    const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
-    expect(fallbackParams.provider).toBe("openai");
-    expect(fallbackParams.model).toBe("channel-model");
-  });
+      if (expectResolverContext) {
+        expect(mockCallArg(state.resolveChannelModelOverrideMock)).toMatchObject({
+          channel: "discord",
+          groupId: "channel-123",
+        });
+      }
+      if (expectAttemptModel) {
+        expectRecordFields(mockCallArg(state.runAgentAttemptMock), {
+          providerOverride: "openai",
+          modelOverride: "channel-model",
+        });
+      }
+      const fallbackParams = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
+      expect(fallbackParams.provider).toBe("openai");
+      expect(fallbackParams.model).toBe("channel-model");
+    },
+  );
 
   it("uses a concurrent user override adopted during legacy fallback repair", async () => {
     setupSingleAttemptFallback();
@@ -2065,25 +1741,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       fallbackProvider: "anthropic",
       fallbackModel: "fallback-model",
     });
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: "anthropic/default-model",
-          models: {
-            "anthropic/default-model": {},
-            "anthropic/fallback-model": {},
-            "openai/channel-model": {},
-          },
-        },
-      },
-      channels: {
-        modelByChannel: {
-          discord: {
-            "channel-123": "openai/channel-model",
-          },
-        },
-      },
-    };
+    state.runtimeConfigMock = createChannelModelRuntimeConfig({
+      additionalModels: { "anthropic/fallback-model": {} },
+    });
     state.sessionEntryMock = {
       sessionId: "session-1",
       updatedAt: 1,
@@ -2111,24 +1771,11 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
   it("uses current threaded session key for parent channel model overrides", async () => {
     setupSingleAttemptFallback();
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: "anthropic/default-model",
-          models: {
-            "anthropic/default-model": {},
-            "openai/parent-channel-model": {},
-          },
-        },
-      },
-      channels: {
-        modelByChannel: {
-          slack: {
-            general: "openai/parent-channel-model",
-          },
-        },
-      },
-    };
+    state.runtimeConfigMock = createChannelModelRuntimeConfig({
+      channel: "slack",
+      matchKey: "general",
+      model: "openai/parent-channel-model",
+    });
     state.resolvedSessionKeyMock = "agent:main:slack:channel:general:thread:thread-1";
     state.sessionEntryMock = {
       sessionId: "session-1",
@@ -2150,25 +1797,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
   it("keeps stored session model overrides ahead of channel model overrides", async () => {
     setupSingleAttemptFallback();
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: "anthropic/default-model",
-          models: {
-            "anthropic/default-model": {},
-            "openai/channel-model": {},
-            "anthropic/stored-model": {},
-          },
-        },
-      },
-      channels: {
-        modelByChannel: {
-          discord: {
-            "channel-123": "openai/channel-model",
-          },
-        },
-      },
-    };
+    state.runtimeConfigMock = createChannelModelRuntimeConfig({
+      additionalModels: { "anthropic/stored-model": {} },
+    });
     state.sessionEntryMock = {
       sessionId: "session-1",
       updatedAt: 1,
@@ -2190,25 +1821,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
   it("keeps explicit run model overrides ahead of channel model overrides", async () => {
     setupSingleAttemptFallback();
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: "anthropic/default-model",
-          models: {
-            "anthropic/default-model": {},
-            "openai/channel-model": {},
-            "openai/explicit-model": {},
-          },
-        },
-      },
-      channels: {
-        modelByChannel: {
-          discord: {
-            "channel-123": "openai/channel-model",
-          },
-        },
-      },
-    };
+    state.runtimeConfigMock = createChannelModelRuntimeConfig({
+      additionalModels: { "openai/explicit-model": {} },
+    });
     state.sessionEntryMock = {
       sessionId: "session-1",
       updatedAt: 1,
@@ -2232,7 +1847,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
   it("uses rotated session identity for all post-run session persistence", async () => {
     setupSingleAttemptFallback();
-    setupSessionTouchStore();
+    setupStoredSession();
     const rotatedEntry: SessionEntry = {
       sessionId: "rotated-session",
       sessionFile: "/tmp/rotated-session.jsonl",
@@ -2286,7 +1901,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
   it("skips post-run persistence after the session is deleted", async () => {
     setupSingleAttemptFallback();
-    setupSessionTouchStore();
+    setupStoredSession();
     const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
       typeof makeSuccessResult
     > & {
@@ -2313,7 +1928,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
   it("preserves restart recovery ownership when delivery fails after a session rebound", async () => {
     setupSingleAttemptFallback();
-    setupSessionTouchStore();
+    setupStoredSession();
     const sessionStore = state.sessionStoreMock as Record<string, SessionEntry>;
     const claimedEntry = expectDefined(
       sessionStore["agent:main:main"],
@@ -2356,58 +1971,32 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryRunId).toBe("session-1");
   });
 
-  it("persists only the CLI assistant reply after the runner persists the current user turn", async () => {
-    type AttemptCall = {
-      onUserMessagePersisted?: () => void;
-    };
-    setupSingleAttemptFallback();
-    setupSessionTouchStore();
-    const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
-      typeof makeSuccessResult
-    > & {
-      meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
-    };
-    result.meta.executionTrace = {
+  it.each([
+    {
+      name: "persists only the CLI assistant reply after the runner persists the current user turn",
       runner: "cli",
-      fallbackUsed: false,
-      winnerProvider: "openai",
-      winnerModel: "gpt-5.4",
-    };
-    state.runAgentAttemptMock.mockImplementation(async (attemptParams: AttemptCall) => {
-      attemptParams.onUserMessagePersisted?.();
-      return result;
-    });
-    state.persistCliTurnTranscriptMock.mockResolvedValue({
-      kind: "persisted",
-      sessionEntry: state.sessionEntryMock,
-    });
-
-    await agentCommand({
-      message: "hello",
-      to: "+1234567890",
-      userTurnTranscriptRecorder: {} as NonNullable<
-        Parameters<typeof agentCommand>[0]["userTurnTranscriptRecorder"]
-      >,
-    });
-
-    expectRecordFields(mockCallArg(state.persistCliTurnTranscriptMock), {
+      canonicalUserRecorder: true,
       embeddedAssistantGapFill: false,
-    });
-  });
-
-  it("persists the full embedded turn when no canonical user recorder exists", async () => {
+    },
+    {
+      name: "persists the full embedded turn when no canonical user recorder exists",
+      runner: "embedded",
+      canonicalUserRecorder: false,
+      embeddedAssistantGapFill: true,
+    },
+  ])("$name", async ({ runner, canonicalUserRecorder, embeddedAssistantGapFill }) => {
     type AttemptCall = {
       onUserMessagePersisted?: () => void;
     };
     setupSingleAttemptFallback();
-    setupSessionTouchStore();
+    setupStoredSession();
     const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
       typeof makeSuccessResult
     > & {
       meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
     };
     result.meta.executionTrace = {
-      runner: "embedded",
+      runner,
       fallbackUsed: false,
       winnerProvider: "openai",
       winnerModel: "gpt-5.4",
@@ -2421,16 +2010,24 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       sessionEntry: state.sessionEntryMock,
     });
 
-    await runBasicAgentCommand();
+    await (canonicalUserRecorder
+      ? agentCommand({
+          message: "hello",
+          to: "+1234567890",
+          userTurnTranscriptRecorder: {} as NonNullable<
+            Parameters<typeof agentCommand>[0]["userTurnTranscriptRecorder"]
+          >,
+        })
+      : runBasicAgentCommand());
 
     expectRecordFields(mockCallArg(state.persistCliTurnTranscriptMock), {
-      embeddedAssistantGapFill: true,
+      embeddedAssistantGapFill,
     });
   });
 
   it("does not treat backend CLI session id as OpenClaw session identity", async () => {
     setupSingleAttemptFallback();
-    setupSessionTouchStore();
+    setupStoredSession();
     const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
       typeof makeSuccessResult
     > & {
@@ -2472,7 +2069,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("persists explicit overrides even when ingress skips the initial touch", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    setupSessionTouchStore();
+    setupStoredSession();
 
     await agentCommand({
       message: "hello",
@@ -2499,16 +2096,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         },
       },
     };
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-      skillsSnapshot: { prompt: "", skills: [], version: 0 },
-      agentRuntimeOverride: "openclaw",
-      agentHarnessId: "codex",
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    setupStoredSession({ agentRuntimeOverride: "openclaw", agentHarnessId: "codex" });
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
 
     await runBasicAgentCommand();
@@ -2526,16 +2114,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
   it("does not persist turn-local thinking fallback over a stored session override", async () => {
     setupSingleAttemptFallback();
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    const { entry: sessionEntry, store: sessionStore } = setupStoredSession({
       thinkingLevel: "high",
-    };
-    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = sessionStore;
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    });
     state.isThinkingLevelSupportedMock.mockReturnValue(false);
     state.resolveSupportedThinkingLevelMock.mockReturnValue("off");
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
@@ -2555,15 +2136,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("revalidates immutable Ultra for each model fallback without persisting the remap", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-      skillsSnapshot: { prompt: "", skills: [], version: 0 },
-      thinkingLevel: "ultra",
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    const { entry: sessionEntry } = setupStoredSession({ thinkingLevel: "ultra" });
     state.runtimeConfigMock = {
       agents: {
         defaults: {
@@ -2625,14 +2198,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("recomputes a model-derived thinking default for each fallback candidate", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-      skillsSnapshot: { prompt: "", skills: [], version: 0 },
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    setupStoredSession();
     state.runtimeConfigMock = {
       agents: {
         defaults: {
@@ -2678,13 +2244,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("persists and clears current run delivery context for restart recovery", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    setupBareStoredSession();
     state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
 
     await agentCommand({
@@ -2716,13 +2276,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("records generated-media delivery runs as durable terminal sources", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    setupBareStoredSession();
     state.deliverAgentCommandResultMock.mockImplementation(async (params: unknown) => {
       const onDeliveryResult = (params as { onDeliveryResult?: (result: unknown) => void })
         .onDeliveryResult;
@@ -2814,13 +2368,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("does not make an unconstrained message-tool completion replayable", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    setupBareStoredSession();
 
     await agentCommand({
       message: "generated image ready",
@@ -2897,9 +2445,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       ...makeSuccessResult("openai", "gpt-5.4"),
       payloads: [{ text: "ready", mediaUrls: ["/tmp/model-selected.png"] }],
     });
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
+    setupBareStoredSession({
       restartRecoveryDeliveryRunId: "recovery-run",
       restartRecoveryDeliverySourceRunId: "image:task-policy:agent-loop",
       restartRecoveryDeliveryContext: { channel: "discord", to: "channel:123" },
@@ -2908,10 +2454,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       restartRecoverySuppressTextDelivery: true,
       restartRecoverySourceReplyDeliveryMode: "automatic",
       restartRecoveryForceSafeTools: true,
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    });
 
     await agentCommand({
       message: "continue generated media delivery",
@@ -2963,15 +2506,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("retains and clears a preclaimed transcript-only recovery run", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
+    setupBareStoredSession({
       restartRecoveryDeliveryRunId: "recovery-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
-      updatedAt: 1,
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    });
 
     await agentCommand({
       message: "continue after restart",
@@ -3013,10 +2551,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("refreshes delivery session entries through the session accessor", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
+    setupBareStoredSession();
     const freshEntry: SessionEntry = {
       sessionId: "session-1",
       updatedAt: 2,
@@ -3026,10 +2561,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         accountId: "main",
       },
     };
-    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = sessionStore;
-    state.storePathMock = "/tmp/openclaw-sessions.json";
     state.loadSessionEntryMock.mockReturnValue(freshEntry);
     state.deliverAgentCommandResultMock.mockImplementation(async (params: unknown) => {
       const resolver = (
@@ -3042,13 +2573,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       return { deliverySucceeded: true };
     });
 
-    await agentCommand({
-      message: "hello",
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      deliver: true,
-    });
+    await runDiscordDelivery();
 
     expect(state.loadSessionEntryMock).toHaveBeenCalledWith({
       storePath: "/tmp/openclaw-sessions.json",
@@ -3061,13 +2586,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("preserves parsed explicit target threads for restart recovery", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    setupBareStoredSession();
     state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
     state.resolveAgentDeliveryPlanMock.mockReturnValueOnce({
       baseDelivery: {
@@ -3082,13 +2601,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       deliveryTargetMode: "explicit",
     });
 
-    await agentCommand({
-      message: "hello",
-      channel: "discord",
-      to: "discord:channel:general/thread:thread-1",
-      accountId: "main",
-      deliver: true,
-    });
+    await runDiscordDelivery({ to: "discord:channel:general/thread:thread-1" });
 
     const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
       const params = call[0] as { entry?: SessionEntry };
@@ -3105,23 +2618,12 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("does not inherit a stale thread when restart recovery uses an explicit target", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
+    setupBareStoredSession({
       lastThreadId: "stale-thread",
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    });
     state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
 
-    await agentCommand({
-      message: "hello",
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      deliver: true,
-    });
+    await runDiscordDelivery();
 
     const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
       const params = call[0] as { entry?: SessionEntry };
@@ -3137,19 +2639,14 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("persists implicit session delivery route for restart recovery", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
+    setupBareStoredSession({
       deliveryContext: {
         channel: "discord",
         to: "discord:channel:general",
         accountId: "main",
         threadId: "thread-1",
       },
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    });
     state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
 
     await agentCommand({
@@ -3183,13 +2680,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("persists default target delivery route for restart recovery", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    setupBareStoredSession();
     state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
     state.resolveMessageChannelSelectionMock.mockResolvedValue({
       channel: "discord",
@@ -3218,15 +2709,20 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
   });
 
-  it("does not overwrite another active run's restart recovery context", async () => {
+  it.each([
+    {
+      name: "does not overwrite another active run's restart recovery context",
+      attemptResult: makeEmptyResult("openai", "gpt-5.4"),
+    },
+    {
+      name: "does not clear another active run's restart recovery context",
+      attemptResult: makeEmptyResult("openai", "gpt-5.4"),
+    },
+  ])("$name", async ({ attemptResult }) => {
     setupSingleAttemptFallback();
-    state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
-    const staleEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    const laterRunEntry: SessionEntry = {
-      sessionId: "session-1",
+    state.runAgentAttemptMock.mockResolvedValue(attemptResult);
+    const staleEntry = createCommandSessionEntry();
+    const laterRunEntry = createCommandSessionEntry({
       updatedAt: 2,
       restartRecoveryDeliveryContext: {
         channel: "discord",
@@ -3234,63 +2730,13 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         accountId: "main",
       },
       restartRecoveryDeliveryRunId: "later-run",
-    };
-    const sessionStore: Record<string, SessionEntry> = {
-      "agent:main:main": laterRunEntry,
-    };
+    });
+    const sessionStore = { "agent:main:main": laterRunEntry };
     state.sessionEntryMock = staleEntry;
     state.sessionStoreMock = sessionStore;
     state.storePathMock = "/tmp/openclaw-sessions.json";
 
-    await agentCommand({
-      message: "hello",
-      sessionKey: "agent:main:main",
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      deliver: true,
-      runId: "stale-run",
-    });
-
-    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryContext).toEqual(
-      laterRunEntry.restartRecoveryDeliveryContext,
-    );
-    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryRunId).toBe("later-run");
-  });
-
-  it("does not clear another active run's restart recovery context", async () => {
-    setupSingleAttemptFallback();
-    state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
-    const staleEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    const laterRunEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 2,
-      restartRecoveryDeliveryContext: {
-        channel: "discord",
-        to: "discord:dm:456",
-        accountId: "main",
-      },
-      restartRecoveryDeliveryRunId: "later-run",
-    };
-    const sessionStore: Record<string, SessionEntry> = {
-      "agent:main:main": laterRunEntry,
-    };
-    state.sessionEntryMock = staleEntry;
-    state.sessionStoreMock = sessionStore;
-    state.storePathMock = "/tmp/openclaw-sessions.json";
-
-    await agentCommand({
-      message: "hello",
-      sessionKey: "agent:main:main",
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      deliver: true,
-      runId: "stale-run",
-    });
+    await runDiscordDelivery({ sessionKey: "agent:main:main", runId: "stale-run" });
 
     expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryContext).toEqual(
       laterRunEntry.restartRecoveryDeliveryContext,
@@ -3301,14 +2747,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("keeps current run delivery context when restart marker wins the cleanup race", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = sessionStore;
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    const { store: sessionStore } = setupBareStoredSession();
     state.deliverAgentCommandResultMock.mockImplementation(async () => {
       const current = sessionStore["agent:main:main"];
       if (current) {
@@ -3317,13 +2756,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       return { deliverySucceeded: false };
     });
 
-    await agentCommand({
-      message: "hello",
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      deliver: true,
-    });
+    await runDiscordDelivery();
 
     expect(sessionStore["agent:main:main"]?.abortedLastRun).toBe(true);
     expect(state.persistSessionEntryMock).toHaveBeenCalledWith(
@@ -3343,26 +2776,13 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("does not recreate a deleted session entry during restart recovery cleanup", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = sessionStore;
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    const { store: sessionStore } = setupBareStoredSession();
     state.deliverAgentCommandResultMock.mockImplementation(async () => {
       delete sessionStore["agent:main:main"];
       return { deliverySucceeded: true };
     });
 
-    await agentCommand({
-      message: "hello",
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      deliver: true,
-    });
+    await runDiscordDelivery();
 
     expect(sessionStore["agent:main:main"]).toBeUndefined();
   });
@@ -3370,11 +2790,8 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("does not clear restart recovery context from a rotated session entry", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    const rotatedEntry: SessionEntry = {
+    const { store: sessionStore } = setupBareStoredSession();
+    const rotatedEntry = createCommandSessionEntry({
       sessionId: "session-2",
       updatedAt: 2,
       restartRecoveryDeliveryContext: {
@@ -3382,23 +2799,13 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         to: "discord:dm:456",
         accountId: "main",
       },
-    };
-    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = sessionStore;
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    });
     state.deliverAgentCommandResultMock.mockImplementation(async () => {
       sessionStore["agent:main:main"] = rotatedEntry;
       return { deliverySucceeded: true };
     });
 
-    await agentCommand({
-      message: "hello",
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      deliver: true,
-    });
+    await runDiscordDelivery();
 
     expect(sessionStore["agent:main:main"]).toEqual(rotatedEntry);
   });
@@ -3406,12 +2813,8 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("does not clear restart recovery context from another active run in the same session", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    const laterRunEntry: SessionEntry = {
-      sessionId: "session-1",
+    const { store: sessionStore } = setupBareStoredSession();
+    const laterRunEntry = createCommandSessionEntry({
       updatedAt: 2,
       restartRecoveryDeliveryContext: {
         channel: "discord",
@@ -3419,23 +2822,13 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         accountId: "main",
       },
       restartRecoveryDeliveryRunId: "later-run",
-    };
-    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = sessionStore;
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    });
     state.deliverAgentCommandResultMock.mockImplementation(async () => {
       sessionStore["agent:main:main"] = laterRunEntry;
       return { deliverySucceeded: false };
     });
 
-    await agentCommand({
-      message: "hello",
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      deliver: true,
-    });
+    await runDiscordDelivery();
 
     expect(sessionStore["agent:main:main"]).toEqual(laterRunEntry);
   });
@@ -3443,13 +2836,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   it("stores and delivers with the prepared canonical current-run target", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    setupBareStoredSession();
     state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: false });
     state.resolveAgentDeliveryPlanWithSessionRouteMock.mockResolvedValueOnce({
       baseDelivery: {},
@@ -3459,13 +2846,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       deliveryTargetMode: "explicit",
     });
 
-    await agentCommand({
-      message: "hello",
-      channel: "discord",
-      to: "channel:general",
-      accountId: "main",
-      deliver: true,
-    });
+    await runDiscordDelivery({ to: "channel:general" });
 
     const pendingEntries = state.persistSessionEntryMock.mock.calls
       .map((call) => (call[0] as { entry?: SessionEntry }).entry)
@@ -3547,9 +2928,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
 
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-1",
-      updatedAt: 1,
+    setupBareStoredSession({
       pendingFinalDelivery: true,
       pendingFinalDeliveryCreatedAt: 2,
       pendingFinalDeliveryLastAttemptAt: 3,
@@ -3557,10 +2936,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       pendingFinalDeliveryLastError: "previous failure",
       pendingFinalDeliveryContext: { channel: "tui" },
       pendingFinalDeliveryIntentId: "intent-1",
-    };
-    state.sessionEntryMock = sessionEntry;
-    state.sessionStoreMock = { "agent:main:main": sessionEntry };
-    state.storePathMock = "/tmp/openclaw-sessions.json";
+    });
     state.deliverAgentCommandResultMock.mockResolvedValue(undefined);
 
     await agentCommand({
@@ -3680,35 +3056,21 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(state.removeInternalSessionEffectsSessionMock).not.toHaveBeenCalled();
   });
 
-  it("rejects session-id-resolved model runs for harness-owned sessions", async () => {
-    state.resolvedSessionKeyMock = "agent:main:harness:codex:supervision:native-thread";
-    state.sessionEntryMock = {
+  it.each([
+    {
+      name: "rejects session-id-resolved model runs for harness-owned sessions",
+      sessionKey: "agent:main:harness:codex:supervision:native-thread",
+    },
+    {
+      name: "rejects one-shot model runs for locked harness sessions with ordinary keys",
+      sessionKey: "agent:main:plugin-owned",
+    },
+  ])("$name", async ({ sessionKey }) => {
+    state.resolvedSessionKeyMock = sessionKey;
+    state.sessionEntryMock = createCommandSessionEntry({
       agentHarnessId: "codex",
       modelSelectionLocked: true,
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
-
-    await expect(
-      agentCommand({
-        message: "probe",
-        sessionId: "session-1",
-        modelRun: true,
-        promptMode: "none",
-        sessionEffects: "internal",
-      }),
-    ).rejects.toThrow("Agent harness-owned sessions cannot be used for one-shot model runs.");
-    expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects one-shot model runs for locked harness sessions with ordinary keys", async () => {
-    state.resolvedSessionKeyMock = "agent:main:plugin-owned";
-    state.sessionEntryMock = {
-      agentHarnessId: "codex",
-      modelSelectionLocked: true,
-      sessionId: "session-1",
-      updatedAt: 1,
-    };
+    });
 
     await expect(
       agentCommand({
@@ -3787,14 +3149,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       },
     });
 
-    await agentCommand({
-      message: "probe",
-      to: "+1234567890",
-      runId: "model-run-success",
-      modelRun: true,
-      promptMode: "none",
-      sessionEffects: "internal",
-    });
+    await runInternalModelCommand("model-run-success");
 
     expect(state.createTrajectoryRuntimeRecorderMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -3826,16 +3181,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockRejectedValueOnce(new Error("probe failed"));
 
-    await expect(
-      agentCommand({
-        message: "probe",
-        to: "+1234567890",
-        runId: "model-run-failure",
-        modelRun: true,
-        promptMode: "none",
-        sessionEffects: "internal",
-      }),
-    ).rejects.toThrow("probe failed");
+    await expect(runInternalModelCommand("model-run-failure")).rejects.toThrow("probe failed");
 
     expect(state.removeInternalSessionEffectsSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -3853,16 +3199,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       new Error("session preparation failed"),
     );
 
-    await expect(
-      agentCommand({
-        message: "probe",
-        to: "+1234567890",
-        runId: "model-run-prepare-failure",
-        modelRun: true,
-        promptMode: "none",
-        sessionEffects: "internal",
-      }),
-    ).rejects.toThrow("session preparation failed");
+    await expect(runInternalModelCommand("model-run-prepare-failure")).rejects.toThrow(
+      "session preparation failed",
+    );
 
     expect(state.removeInternalSessionEffectsSessionMock).toHaveBeenCalledWith({
       agentId: "default",
@@ -3881,16 +3220,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       new Error("database is locked"),
     );
 
-    await expect(
-      agentCommand({
-        message: "probe",
-        to: "+1234567890",
-        runId: "model-run-cleanup-failure",
-        modelRun: true,
-        promptMode: "none",
-        sessionEffects: "internal",
-      }),
-    ).resolves.toBeUndefined();
+    await expect(runInternalModelCommand("model-run-cleanup-failure")).resolves.toBeUndefined();
 
     expect(state.removeInternalSessionEffectsSessionMock).toHaveBeenCalled();
   });
@@ -3924,38 +3254,21 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(lifecycleFinishingCalls).toHaveLength(1);
   });
 
-  it("validates explicit thinking against configured model compat without an allowlist", async () => {
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: { primary: "gmn/gpt-5.4" },
-        },
-      },
-      models: {
-        providers: {
-          gmn: {
-            models: [
-              {
-                id: "gpt-5.4",
-                name: "GPT 5.4 via GMN",
-                reasoning: true,
-                compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
-              },
-            ],
-          },
-        },
-      },
-    };
-    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
-      const result = await params.run(params.provider, params.model);
-      return {
-        result,
-        provider: params.provider,
-        model: params.model,
-        attempts: [],
-      };
-    });
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("gmn", "gpt-5.4"));
+  it.each([
+    {
+      name: "validates explicit thinking against configured model compat without an allowlist",
+      allowlisted: false,
+    },
+    {
+      name: "validates explicit thinking against allowlisted configured model compat when manifest catalog is empty",
+      allowlisted: true,
+    },
+  ])("$name", async ({ allowlisted }) => {
+    state.runtimeConfigMock = createConfiguredModelCompatRuntimeConfig(allowlisted);
+    if (allowlisted) {
+      state.loadManifestModelCatalogMock.mockReturnValue([]);
+    }
+    setupSuccessfulAttempt("gmn", "gpt-5.4");
 
     await agentCommand({
       message: "hello",
@@ -3963,65 +3276,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       thinking: "xhigh",
     });
 
-    const thinkingArgs = requireRecord(
-      mockCallArg(state.isThinkingLevelSupportedMock),
-      "thinking args",
-    );
-    expect(thinkingArgs.provider).toBe("gmn");
-    expect(thinkingArgs.model).toBe("gpt-5.4");
-    expect(thinkingArgs.level).toBe("xhigh");
-    const catalog = requireArray(thinkingArgs.catalog, "thinking catalog");
-    expectRecordFields(catalog[0], {
-      provider: "gmn",
-      id: "gpt-5.4",
-      compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
-    });
-  });
-
-  it("validates explicit thinking against allowlisted configured model compat when manifest catalog is empty", async () => {
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          model: { primary: "gmn/gpt-5.4" },
-          models: {
-            "gmn/gpt-5.4": {},
-          },
-        },
-      },
-      models: {
-        providers: {
-          gmn: {
-            models: [
-              {
-                id: "gpt-5.4",
-                name: "GPT 5.4 via GMN",
-                reasoning: true,
-                compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
-              },
-            ],
-          },
-        },
-      },
-    };
-    state.loadManifestModelCatalogMock.mockReturnValue([]);
-    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
-      const result = await params.run(params.provider, params.model);
-      return {
-        result,
-        provider: params.provider,
-        model: params.model,
-        attempts: [],
-      };
-    });
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("gmn", "gpt-5.4"));
-
-    await agentCommand({
-      message: "hello",
-      to: "+1234567890",
-      thinking: "xhigh",
-    });
-
-    expect(state.loadManifestModelCatalogMock).toHaveBeenCalledTimes(1);
+    if (allowlisted) {
+      expect(state.loadManifestModelCatalogMock).toHaveBeenCalledTimes(1);
+    }
     const thinkingArgs = requireRecord(
       mockCallArg(state.isThinkingLevelSupportedMock),
       "thinking args",
@@ -4838,44 +4095,41 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(JSON.stringify(lifecycleEvents)).not.toContain("raw provider detail");
   });
 
-  it("updates hasSessionModelOverride for fallback resolution after switch", async () => {
-    setupModelSwitchRetry({
-      provider: "openai",
-      model: "gpt-5.4",
-    });
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
-
+  it.each([
+    {
+      name: "updates hasSessionModelOverride for fallback resolution after switch",
+      switchOptions: { provider: "openai", model: "gpt-5.4" },
+      expectedOverride: true,
+    },
+    {
+      name: "does not flip hasSessionModelOverride on auth-only switch with same model",
+      switchOptions: {
+        provider: "anthropic",
+        model: "claude",
+        authProfileId: "profile-99",
+        authProfileIdSource: "user" as const,
+      },
+      expectedOverride: false,
+    },
+    {
+      name: "flips hasSessionModelOverride on provider-only switch with same model",
+      switchOptions: { provider: "openai", model: "claude" },
+      expectedOverride: true,
+    },
+  ])("$name", async ({ switchOptions, expectedOverride }) => {
+    setupModelSwitchRetry(switchOptions);
+    state.runAgentAttemptMock.mockResolvedValue(
+      makeSuccessResult(switchOptions.provider, switchOptions.model),
+    );
     state.resolveEffectiveModelFallbacksMock.mockClear();
 
     await runBasicAgentCommand();
 
-    expectFallbackOverrideCalls(false, true);
-  });
-
-  it("does not flip hasSessionModelOverride on auth-only switch with same model", async () => {
-    setupModelSwitchRetry({
-      provider: "anthropic",
-      model: "claude",
-      authProfileId: "profile-99",
-      authProfileIdSource: "user",
-    });
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude"));
-
-    state.resolveEffectiveModelFallbacksMock.mockClear();
-
-    await runBasicAgentCommand();
-
-    expectFallbackOverrideCalls(false, false);
+    expectFallbackOverrideCalls(false, expectedOverride);
   });
 
   it("sends internal completion wakes to ACP sessions as plain prompt text", async () => {
-    state.acpResolveSessionMock.mockReturnValue({
-      kind: "ready",
-      meta: {
-        agent: "claude",
-        cwd: "/tmp/workspace",
-      },
-    });
+    setupAcpSession();
 
     await agentCommand({
       message: [
@@ -4921,13 +4175,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("keeps session provenance for internal ACP turns", async () => {
-    state.acpResolveSessionMock.mockReturnValue({
-      kind: "ready",
-      meta: {
-        agent: "claude",
-        cwd: "/tmp/workspace",
-      },
-    });
+    setupAcpSession();
 
     await agentCommand({
       message: "internal ACP turn",
@@ -4946,13 +4194,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("allows manual ACP spawn turns when ACP dispatch is disabled", async () => {
-    state.acpResolveSessionMock.mockReturnValue({
-      kind: "ready",
-      meta: {
-        agent: "claude",
-        cwd: "/tmp/workspace",
-      },
-    });
+    setupAcpSession();
     state.resolveAcpDispatchPolicyErrorMock.mockReturnValue(
       new Error("ACP dispatch is disabled by policy (`acp.dispatch.enabled=false`)."),
     );
@@ -4969,13 +4211,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("keeps ordinary ACP turns blocked when ACP dispatch is disabled", async () => {
-    state.acpResolveSessionMock.mockReturnValue({
-      kind: "ready",
-      meta: {
-        agent: "claude",
-        cwd: "/tmp/workspace",
-      },
-    });
+    setupAcpSession();
     state.resolveAcpDispatchPolicyErrorMock.mockReturnValue(
       new Error("ACP dispatch is disabled by policy (`acp.dispatch.enabled=false`)."),
     );
@@ -4996,13 +4232,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("preserves ACP cancelled results without a stop reason", async () => {
-    state.acpResolveSessionMock.mockReturnValue({
-      kind: "ready",
-      meta: {
-        agent: "claude",
-        cwd: "/tmp/workspace",
-      },
-    });
+    setupAcpSession();
     state.acpRunTurnMock.mockImplementationOnce(async (params: unknown) => {
       const onEvent = (params as { onEvent?: (event: unknown) => void }).onEvent;
       onEvent?.({ type: "done", status: "cancelled" });
@@ -5019,20 +4249,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(state.buildAcpResultMock).toHaveBeenCalledWith(
       expect.objectContaining({ resultStatus: "cancelled", stopReason: undefined }),
     );
-  });
-
-  it("flips hasSessionModelOverride on provider-only switch with same model", async () => {
-    setupModelSwitchRetry({
-      provider: "openai",
-      model: "claude",
-    });
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "claude"));
-
-    state.resolveEffectiveModelFallbacksMock.mockClear();
-
-    await runBasicAgentCommand();
-
-    expectFallbackOverrideCalls(false, true);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The live model-switch command suite had grown to 5,038 lines, with repeated session/store construction, model-policy fixtures, ACP setup, and near-identical cases obscuring the behavior each test protects. This maintainer-commissioned LOC-reduction batch consolidates that boilerplate while preserving all 107 test cases.

## Why This Change Was Made

This extracts colocated builders for command-session and model-policy fixtures, reuses narrow setup helpers, and table-drives only cases with the same execution shape. Semantically distinct assertions remain separate, no production behavior or public surface changes, and the max-lines suppression remains because the target is still above the repository budget.

AI-assisted: implemented and reviewed with Codex. No agent transcript is attached because public transcript inclusion was not explicitly approved.

## User Impact

No user-visible behavior changes. Maintainers get a smaller, faster-to-read suite with unchanged coverage and clearer named table rows.

## Evidence

- Numstat: +668 / -1,207 across 2 test files, net -539 lines. Production LOC: +0 / -0. Test LOC: +668 / -1,207.
- Target file: 5,038 -> 4,254 lines (-784, 15.6%). New colocated fixture module: 245 lines. Total surface: 5,038 -> 4,499 lines (-539, 10.7%).
- Test count: 107 before, 107 after; no fixtures or assertions deleted.
- `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts` — 1 file passed, 107/107 tests passed after the final rebase.
- `node scripts/check-changed.mjs -- src/agents/agent-command.live-model-switch.test.ts src/agents/agent-command.live-model-switch.test-helpers.ts` — passed on Blacksmith Testbox `tbx_01ky6k8r8v18372qyzkycx2pbz`; Actions run https://github.com/openclaw/openclaw/actions/runs/29979316808.
- `$autoreview --mode uncommitted --stream-engine-output` — clean: no accepted/actionable findings reported.
