### PR TITLE
fix(release): build private QA candidate artifacts

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -472,6 +472,7 @@ jobs:
             LANG=C.UTF-8 \
             NODE_OPTIONS=--max-old-space-size=8192 \
             NPM_CONFIG_USERCONFIG=/dev/null \
+            OPENCLAW_BUILD_PRIVATE_QA=1 \
             PATH="$PATH" \
             RUNNER_TEMP="$RUNNER_TEMP" \
             pnpm --dir .candidate exec node scripts/build-all.mjs qaRuntime

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -435,8 +435,14 @@ describe("release Telegram QA workflow", () => {
     };
     const buildJob = workflow.jobs?.build_candidate;
     const runJob = workflow.jobs?.run_telegram;
+    const buildRuntimeStep = buildJob?.steps?.find(
+      (step) => step.name === "Build candidate runtime without runner credentials",
+    );
 
     expect(JSON.stringify(buildJob)).not.toContain("secrets.");
+    // The frozen archive must already contain the private QA module: the
+    // isolated execution tree is intentionally read-only and cannot rebuild it.
+    expect(buildRuntimeStep?.run).toContain("OPENCLAW_BUILD_PRIVATE_QA=1");
     expect(runJob?.environment).toBe("qa-live-shared");
     const secretSteps = runJob?.steps
       ?.filter((step) => JSON.stringify(step).includes("secrets."))


### PR DESCRIPTION
## Summary

Fixes the frozen extended-stable candidate Telegram QA harness. Its secretless `env -i` build discarded `OPENCLAW_BUILD_PRIVATE_QA`, so the archived candidate omitted `dist/plugin-sdk/qa-lab.js`. The isolated archive is intentionally read-only: pnpm could not repair it, and the direct CLI could not load the private QA route.

This keeps the build credential-free while explicitly retaining the private-QA artifact flag, and adds a workflow regression assertion.

## Evidence

- Exact candidate failure: Full Release Validation #29978843017, Telegram child #29979226299.
- Root cause: `env -i` at the candidate build step omitted the workflow-level private QA flag; `tsdown.config.ts` emits `plugin-sdk/qa-lab` only when that flag is `1`.
- `git diff --check` passed.
- Fresh autoreview passed with no actionable findings.