### PR TITLE
refactor(ui): consolidate workboard controller tests

### DIFF
--- a/ui/src/lib/workboard/index.test-helpers.ts
+++ b/ui/src/lib/workboard/index.test-helpers.ts
@@ -1,0 +1,118 @@
+import { vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import { getWorkboardState } from "./runtime.ts";
+import type { WorkboardCard, WorkboardTaskSummary } from "./types.ts";
+
+type RequestHandler = (method: string, params: unknown) => unknown;
+type RequestResponses = Record<string, unknown> | RequestHandler;
+
+export type WorkboardTestClient = GatewayBrowserClient & {
+  request: ReturnType<typeof vi.fn<RequestHandler>>;
+};
+
+export function createWorkboardTestClient(responses: RequestResponses): WorkboardTestClient {
+  const request = vi.fn(async (method: string, params: unknown) =>
+    typeof responses === "function" ? responses(method, params) : responses[method],
+  );
+  return { request } as unknown as WorkboardTestClient;
+}
+
+export function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+export function createWorkboardCard(overrides: Partial<WorkboardCard> = {}): WorkboardCard {
+  const title = overrides.title ?? "Build board";
+  return {
+    id: "card-1",
+    title,
+    status: "todo",
+    priority: "normal",
+    labels: [],
+    position: 1000,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+export function createWorkboardExecution(
+  overrides: Partial<NonNullable<WorkboardCard["execution"]>> = {},
+): NonNullable<WorkboardCard["execution"]> {
+  return {
+    id: "exec-1",
+    kind: "agent-session",
+    engine: "codex",
+    mode: "autonomous",
+    status: "running",
+    model: "openai/gpt-5.5",
+    sessionKey: "agent:main:dashboard:1",
+    startedAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+export function createGatewaySession(
+  overrides: Partial<GatewaySessionRow> = {},
+): GatewaySessionRow {
+  return {
+    key: "agent:main:dashboard:1",
+    kind: "direct",
+    updatedAt: Date.now(),
+    displayName: "Dashboard session",
+    hasActiveRun: true,
+    status: "running",
+    ...overrides,
+  };
+}
+
+export function createWorkboardTask(
+  overrides: Partial<WorkboardTaskSummary> = {},
+): WorkboardTaskSummary {
+  const title = overrides.title ?? "Build board";
+  return {
+    id: "task-1",
+    taskId: "task-1",
+    status: "running",
+    title,
+    childSessionKey: "subagent:workboard-default-card-1",
+    runId: "run-1",
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+export function createLifecycleHarness(
+  host: object,
+  options: {
+    card?: Partial<WorkboardCard>;
+    task?: Partial<WorkboardTaskSummary> | null;
+    prepared?: boolean;
+  } = {},
+) {
+  const card = createWorkboardCard({
+    status: "running",
+    sessionKey: "subagent:workboard-default-card-1",
+    runId: "run-1",
+    taskId: "task-1",
+    ...options.card,
+  });
+  const state = getWorkboardState(host);
+  state.loaded = true;
+  state.cards = [card];
+  const task = options.task === null ? null : createWorkboardTask(options.task);
+  if (task) {
+    state.tasksByCardId.set(card.id, task);
+  }
+  if (options.prepared) {
+    state.lifecycleTasksPrepared = true;
+    state.lifecycleTasksPreparedAt = Date.now();
+  }
+  return { state, card, task };
+}

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -1,10 +1,20 @@
 // @vitest-environment node
 // Control UI tests cover workboard behavior.
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
+import {
+  createDeferred,
+  createGatewaySession,
+  createLifecycleHarness,
+  createWorkboardCard,
+  createWorkboardExecution,
+  createWorkboardTask,
+  createWorkboardTestClient as createClient,
+  type WorkboardTestClient,
+} from "./index.test-helpers.ts";
 import {
   addWorkboardCardComment,
   archiveWorkboardCard,
@@ -29,63 +39,50 @@ import {
 } from "./index.ts";
 import { normalizeExecution, normalizeMetadata } from "./metadata-normalization.ts";
 
-function createClient(
-  responses: Record<string, unknown> | ((method: string, params: unknown) => unknown),
-) {
-  const request = vi.fn(async (method: string, params: unknown) =>
-    typeof responses === "function" ? responses(method, params) : responses[method],
-  );
-  return { request };
-}
-
 function requestPatch(client: ReturnType<typeof createClient>, index: number) {
   return (client.request.mock.calls[index]?.[1] as { patch?: Record<string, unknown> } | undefined)
     ?.patch;
 }
 
-function createDeferred<T>() {
-  let resolve: ((value: T) => void) | undefined;
-  const promise = new Promise<T>((res) => {
-    resolve = res;
-  });
-  if (!resolve) {
-    throw new Error("Expected deferred resolver");
-  }
-  return { promise, resolve };
-}
-
-const sampleCard: WorkboardCard = {
-  id: "card-1",
-  title: "Build board",
-  status: "todo",
-  priority: "normal",
-  labels: [],
-  position: 1000,
-  createdAt: 1,
-  updatedAt: 1,
-};
-
-const sampleSession: GatewaySessionRow = {
-  key: "agent:main:dashboard:1",
-  kind: "direct",
-  updatedAt: Date.now(),
-  displayName: "Dashboard session",
-  hasActiveRun: true,
-  status: "running",
-};
+const sampleCard = createWorkboardCard();
+const sampleSession = createGatewaySession();
 
 const sampleTaskSessionKey = "subagent:workboard-default-card-1";
-const sampleTask = {
-  id: "task-1",
-  taskId: "task-1",
-  status: "running",
-  title: "Build board",
-  childSessionKey: sampleTaskSessionKey,
-  runId: "run-1",
-  updatedAt: 2,
-} satisfies WorkboardTaskSummary;
+const sampleTask = createWorkboardTask();
+
+let host: object;
+let state: ReturnType<typeof getWorkboardState>;
+
+function syncLifecycle(
+  client: WorkboardTestClient,
+  sessions: GatewaySessionRow[] = [],
+  options: Omit<Parameters<typeof syncWorkboardLifecycle>[0], "host" | "client" | "sessions"> = {},
+) {
+  return syncWorkboardLifecycle({ host, client, sessions, ...options });
+}
+
+function refreshBoard(client: WorkboardTestClient, source: "live" | "manual") {
+  return refreshWorkboard({ host, client, source });
+}
+
+function captureSession(client: WorkboardTestClient, session: GatewaySessionRow = sampleSession) {
+  return captureSessionToWorkboard({ host, client, session });
+}
+
+function setLoadedCard(card: WorkboardCard, task?: WorkboardTaskSummary) {
+  state.loaded = true;
+  state.cards = [card];
+  if (task) {
+    state.tasksByCardId.set(card.id, task);
+  }
+}
 
 describe("workboard controller", () => {
+  beforeEach(() => {
+    host = {};
+    state = getWorkboardState(host);
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -125,11 +122,11 @@ describe("workboard controller", () => {
 
   describe("runtime ownership", () => {
     it("keeps state pristine when lifecycle teardown happens before first access", () => {
-      const host = {};
+      const pristineHost = {};
 
-      stopWorkboardLifecycleRefresh(host);
+      stopWorkboardLifecycleRefresh(pristineHost);
 
-      expect(getWorkboardState(host).mutationReadiness).toBe("ready");
+      expect(getWorkboardState(pristineHost).mutationReadiness).toBe("ready");
     });
 
     it("isolates state and loads between hosts", async () => {
@@ -160,7 +157,6 @@ describe("workboard controller", () => {
     });
 
     it("loads persisted board summaries with canonical cards", async () => {
-      const host = {};
       const client = createClient({
         "workboard.cards.list": {
           cards: [sampleCard],
@@ -216,7 +212,6 @@ describe("workboard controller", () => {
     });
 
     it("rejects an invalidated generation after its replacement loads", async () => {
-      const host = {};
       const staleList = createDeferred<unknown>();
       const currentCard = { ...sampleCard, title: "Current generation" };
       let listCalls = 0;
@@ -246,11 +241,9 @@ describe("workboard controller", () => {
     });
 
     it("tracks lifecycle writes until a same-host reload can proceed", async () => {
-      const host = {};
       const linkedCard = { ...sampleCard, sessionKey: sampleSession.key };
       const updatedCard = { ...linkedCard, status: "running" as const };
       const lifecycleWrite = createDeferred<{ card: WorkboardCard }>();
-      const state = getWorkboardState(host);
       state.loaded = true;
       state.cards = [linkedCard];
       state.lifecycleTasksPrepared = true;
@@ -296,7 +289,6 @@ describe("workboard controller", () => {
   });
 
   it("loads cards through the plugin gateway method", async () => {
-    const host = {};
     const client = createClient({
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
     });
@@ -308,7 +300,6 @@ describe("workboard controller", () => {
   });
 
   it("refreshes diagnostics before listing cards when requested", async () => {
-    const host = {};
     const client = createClient({
       "workboard.cards.diagnostics.refresh": { diagnostics: [], count: 0 },
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
@@ -326,7 +317,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps loading cards when diagnostics refresh fails", async () => {
-    const host = {};
     const client = createClient((method) => {
       if (method === "workboard.cards.diagnostics.refresh") {
         throw new Error("diagnostics denied");
@@ -341,7 +331,6 @@ describe("workboard controller", () => {
       refreshDiagnostics: true,
     });
 
-    const state = getWorkboardState(host);
     expect(client.request).toHaveBeenNthCalledWith(1, "workboard.cards.diagnostics.refresh", {});
     expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.list", {});
     expect(state.cards).toEqual([sampleCard]);
@@ -350,7 +339,6 @@ describe("workboard controller", () => {
   });
 
   it("links loaded cards to matching Gateway tasks", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       sessionKey: sampleTaskSessionKey,
@@ -363,7 +351,6 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(state.cards[0]).toMatchObject({ id: "card-1", taskId: "task-1" });
     expect(state.tasksByCardId.get("card-1")).toMatchObject({
@@ -373,8 +360,6 @@ describe("workboard controller", () => {
   });
 
   it("preserves matching task links when full task enrichment fails", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
@@ -402,7 +387,6 @@ describe("workboard controller", () => {
   });
 
   it("confirms persisted task ids before marking paginated omissions missing", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       taskId: sampleTask.taskId,
@@ -427,14 +411,12 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     expect(client.request).toHaveBeenCalledWith("tasks.get", { taskId: sampleTask.taskId });
     expect(state.cards[0]).toMatchObject({ taskId: sampleTask.taskId });
     expect(state.missingTaskIds).toEqual(new Set([sampleTask.taskId]));
   });
 
   it("keeps paginated task omissions unresolved when exact lookup finds the task", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       taskId: sampleTask.taskId,
@@ -449,7 +431,6 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     expect(client.request).toHaveBeenCalledWith("tasks.get", { taskId: sampleTask.taskId });
     expect(state.cards[0]).toMatchObject({ taskId: sampleTask.taskId });
     expect(state.tasksByCardId.get(sampleCard.id)).toEqual(sampleTask);
@@ -457,7 +438,6 @@ describe("workboard controller", () => {
   });
 
   it("defers lifecycle sync when exact task confirmation fails", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       status: "running",
@@ -480,7 +460,6 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     expect(state.lifecycleTaskRefreshFailed).toBe(true);
     expect(state.lastRefreshError).toBe("task confirmation unavailable");
     vi.clearAllMocks();
@@ -491,8 +470,6 @@ describe("workboard controller", () => {
   });
 
   it("preserves cached task summaries when full exact confirmation partially fails", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
@@ -523,8 +500,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps linked-poll task failures sticky until a full refresh succeeds", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const cards = Array.from({ length: 33 }, (_, index) => ({
       ...sampleCard,
       id: `card-${index}`,
@@ -581,34 +556,16 @@ describe("workboard controller", () => {
     expect(state.lastRefreshError).toBeNull();
   });
 
-  it("clears lifecycle task errors when a linked poll finds no cards", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
+  it.each([
+    { name: "no cards", cards: [] },
+    { name: "no cards needing task data", cards: [sampleCard] },
+  ])("clears lifecycle task errors when a linked poll finds $name", async ({ cards }) => {
     state.lifecycleTaskRefreshFailed = true;
     state.lifecycleTaskRefreshRetryAt = Date.now() + 5000;
     state.lifecycleTaskRefreshError = "tasks unavailable";
     state.lastRefreshError = "tasks unavailable";
     const client = createClient({
-      "workboard.cards.list": { cards: [], statuses: ["todo", "running", "done"] },
-    });
-
-    await loadWorkboard({ host, client: client as never, force: true, taskRefresh: "linked" });
-
-    expect(state.lifecycleTaskRefreshFailed).toBe(false);
-    expect(state.lifecycleTaskRefreshRetryAt).toBeNull();
-    expect(state.lifecycleTaskRefreshError).toBeNull();
-    expect(state.lastRefreshError).toBeNull();
-  });
-
-  it("clears lifecycle task errors when linked polls find no cards needing task data", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.lifecycleTaskRefreshFailed = true;
-    state.lifecycleTaskRefreshRetryAt = Date.now() + 5000;
-    state.lifecycleTaskRefreshError = "tasks unavailable";
-    state.lastRefreshError = "tasks unavailable";
-    const client = createClient({
-      "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "running", "done"] },
+      "workboard.cards.list": { cards, statuses: ["todo", "running", "done"] },
     });
 
     await loadWorkboard({ host, client: client as never, force: true, taskRefresh: "linked" });
@@ -620,7 +577,6 @@ describe("workboard controller", () => {
   });
 
   it("reuses exact-confirmed full-load tasks for the next lifecycle sync", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       status: "running",
@@ -636,7 +592,6 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     expect(state.lifecycleTasksPrepared).toBe(true);
     vi.clearAllMocks();
 
@@ -647,7 +602,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps a canonical task link over a newer loose session match", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       taskId: sampleTask.taskId,
@@ -667,13 +621,11 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     expect(state.cards[0]).toMatchObject({ taskId: sampleTask.taskId });
     expect(state.tasksByCardId.get(sampleCard.id)).toEqual(sampleTask);
   });
 
   it("records live refresh metadata after reconciliation", async () => {
-    const host = {};
     const client = createClient({
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
       "tasks.list": { tasks: [] },
@@ -684,7 +636,6 @@ describe("workboard controller", () => {
       source: "live",
     });
 
-    const state = getWorkboardState(host);
     expect(client.request).toHaveBeenCalledWith("workboard.cards.list", {});
     expect(state.lastRefreshSource).toBe("live");
     expect(state.lastRefreshAt).toEqual(expect.any(Number));
@@ -693,8 +644,6 @@ describe("workboard controller", () => {
   });
 
   it("preserves mutation errors during successful live refreshes", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.error = "move denied";
     const client = createClient({
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
@@ -713,7 +662,6 @@ describe("workboard controller", () => {
   });
 
   it("clears a recovered load error during successful live refreshes", async () => {
-    const host = {};
     let cardsAvailable = false;
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
@@ -730,7 +678,6 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     expect(state.loaded).toBe(false);
     expect(state.error).toBe("cards unavailable");
 
@@ -752,7 +699,6 @@ describe("workboard controller", () => {
   });
 
   it("preserves newer mutation errors while recovering failed loads", async () => {
-    const host = {};
     let cardsAvailable = false;
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
@@ -769,7 +715,6 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     state.error = "move denied";
     cardsAvailable = true;
 
@@ -786,8 +731,6 @@ describe("workboard controller", () => {
   });
 
   it("records live refresh failures without replacing mutation errors", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.error = "move denied";
     const client = createClient(() => {
       throw new Error("refresh unavailable");
@@ -805,7 +748,6 @@ describe("workboard controller", () => {
   });
 
   it("does not mark a disconnected refresh as successful", async () => {
-    const host = {};
     const updates: Array<string | null> = [];
 
     await refreshWorkboard({
@@ -815,14 +757,12 @@ describe("workboard controller", () => {
       requestUpdate: () => updates.push(getWorkboardState(host).lastRefreshError),
     });
 
-    const state = getWorkboardState(host);
     expect(state.lastRefreshAt).toBeNull();
     expect(state.lastRefreshError).toBe("Gateway client unavailable");
     expect(updates).toContain("Gateway client unavailable");
   });
 
   it("clears stale refresh errors after a later direct load succeeds", async () => {
-    const host = {};
     await refreshWorkboard({
       host,
       client: null,
@@ -835,14 +775,12 @@ describe("workboard controller", () => {
     });
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     expect(state.loaded).toBe(true);
     expect(state.error).toBeNull();
     expect(state.lastRefreshError).toBeNull();
   });
 
   it("keeps refreshed cards when task enrichment fails", async () => {
-    const host = {};
     const refreshedCard = { ...sampleCard, title: "Refreshed card" };
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
@@ -860,7 +798,6 @@ describe("workboard controller", () => {
       source: "manual",
     });
 
-    const state = getWorkboardState(host);
     expect(state.cards).toMatchObject([{ title: "Refreshed card" }]);
     expect(state.error).toBeNull();
     expect(state.lastRefreshError).toBe("tasks unavailable");
@@ -868,7 +805,6 @@ describe("workboard controller", () => {
   });
 
   it("defers task-backed lifecycle sync until a later load enrichment succeeds", async () => {
-    const host = {};
     const linkedCard = {
       ...sampleCard,
       taskId: sampleTask.taskId,
@@ -914,8 +850,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps prepared task summaries when bounded poll enrichment fails", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linkedCard = {
       ...sampleCard,
       sessionKey: sampleTaskSessionKey,
@@ -944,8 +878,6 @@ describe("workboard controller", () => {
   });
 
   it("tracks terminal task links after authoritative task pruning", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linkedCard = {
       ...sampleCard,
       taskId: sampleTask.taskId,
@@ -989,8 +921,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps canonical task unlinks during bounded live refreshes", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.tasksByCardId.set(sampleCard.id, sampleTask);
     const client = createClient({
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
@@ -1007,7 +937,6 @@ describe("workboard controller", () => {
   });
 
   it("refreshes live state through the read path without write methods", async () => {
-    const host = {};
     const linkedCard = {
       ...sampleCard,
       sessionKey: sampleTaskSessionKey,
@@ -1042,7 +971,6 @@ describe("workboard controller", () => {
       }
       return {};
     });
-    const state = getWorkboardState(host);
     state.tasksByCardId.set(sampleCard.id, sampleTask);
     state.tasksByCardId.set(olderCard.id, olderTask);
 
@@ -1066,8 +994,6 @@ describe("workboard controller", () => {
   });
 
   it("polls a canonical replacement task instead of a stale session-matched task", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const replacementCard = {
       ...sampleCard,
       sessionKey: sampleTaskSessionKey,
@@ -1104,8 +1030,6 @@ describe("workboard controller", () => {
   });
 
   it("rotates bounded linked-task polling batches", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.cards = Array.from({ length: 40 }, (_, index) => ({
       ...sampleCard,
       id: `card-${index}`,
@@ -1138,7 +1062,6 @@ describe("workboard controller", () => {
   });
 
   it("requires a full lifecycle refresh after a partial bounded task poll", async () => {
-    const host = {};
     const cards = Array.from({ length: 33 }, (_, index) => ({
       ...sampleCard,
       id: `card-${index}`,
@@ -1175,7 +1098,6 @@ describe("workboard controller", () => {
   });
 
   it("rediscovers a bounded batch of running task links during polls", async () => {
-    const host = {};
     const cards = Array.from({ length: 6 }, (_, index) => ({
       ...sampleCard,
       id: `card-${index}`,
@@ -1226,7 +1148,6 @@ describe("workboard controller", () => {
   });
 
   it("rediscovers default-agent task links from an unfiltered bounded page", async () => {
-    const host = {};
     const linkedCard = {
       ...sampleCard,
       status: "running",
@@ -1252,7 +1173,6 @@ describe("workboard controller", () => {
   });
 
   it("preserves discovered replacements across consecutive polls", async () => {
-    const host = {};
     const missingTaskId = "task-pruned-from-ledger";
     const replacementTaskId = "task-replacement";
     const replacementTask = {
@@ -1268,7 +1188,6 @@ describe("workboard controller", () => {
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
     } satisfies WorkboardCard;
-    const state = getWorkboardState(host);
     state.missingTaskIds = new Set([missingTaskId]);
     const client = createClient((method, params) => {
       if (method === "workboard.cards.list") {
@@ -1310,7 +1229,6 @@ describe("workboard controller", () => {
   });
 
   it("cycles default-agent task discovery through bounded task pages", async () => {
-    const host = {};
     const linkedCard = {
       ...sampleCard,
       status: "running",
@@ -1343,7 +1261,6 @@ describe("workboard controller", () => {
   });
 
   it("restarts default-agent task discovery after a terminal page", async () => {
-    const host = {};
     const linkedCard = {
       ...sampleCard,
       status: "running",
@@ -1374,11 +1291,12 @@ describe("workboard controller", () => {
     ]);
   });
 
-  it("discards an in-flight poll when a card drag starts", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
+  it.each([
+    { name: "a card drag starts", title: "Drag target", interaction: "drag" },
+    { name: "an edit draft opens", title: "Edit target", interaction: "edit" },
+  ] as const)("discards an in-flight poll when $name", async ({ title, interaction }) => {
     const listedCards = createDeferred<unknown>();
-    const initialCard = { ...sampleCard, title: "Drag target" };
+    const initialCard = { ...sampleCard, title };
     const refreshedCard = { ...sampleCard, title: "Server refresh" };
     state.cards = [initialCard];
     state.loaded = true;
@@ -1389,57 +1307,29 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const refresh = refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    const refresh = refreshBoard(client, "live");
     await Promise.resolve();
-    state.draggedCardId = initialCard.id;
+    if (interaction === "drag") {
+      state.draggedCardId = initialCard.id;
+    } else {
+      state.draftOpen = true;
+      state.editingCardId = initialCard.id;
+      state.draftTitle = initialCard.title;
+    }
     listedCards.resolve({ cards: [refreshedCard], statuses: ["todo", "done"] });
     await refresh;
 
     expect(state.cards).toEqual([initialCard]);
-    expect(state.draggedCardId).toBe(initialCard.id);
-    expect(state.lastRefreshAt).toBeNull();
-  });
-
-  it("discards an in-flight poll when an edit draft opens", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const listedCards = createDeferred<unknown>();
-    const initialCard = { ...sampleCard, title: "Edit target" };
-    const refreshedCard = { ...sampleCard, title: "Server refresh" };
-    state.cards = [initialCard];
-    state.loaded = true;
-    const client = createClient((method) => {
-      if (method === "workboard.cards.list") {
-        return listedCards.promise;
-      }
-      return {};
-    });
-
-    const refresh = refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
-    await Promise.resolve();
-    state.draftOpen = true;
-    state.editingCardId = initialCard.id;
-    state.draftTitle = initialCard.title;
-    listedCards.resolve({ cards: [refreshedCard], statuses: ["todo", "done"] });
-    await refresh;
-
-    expect(state.cards).toEqual([initialCard]);
-    expect(state.editingCardId).toBe(initialCard.id);
-    expect(state.draftTitle).toBe(initialCard.title);
+    if (interaction === "drag") {
+      expect(state.draggedCardId).toBe(initialCard.id);
+    } else {
+      expect(state.editingCardId).toBe(initialCard.id);
+      expect(state.draftTitle).toBe(initialCard.title);
+    }
     expect(state.lastRefreshAt).toBeNull();
   });
 
   it("tracks dispatch independently from refresh loading state", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.loading = true;
     state.lifecycleTaskRefreshFailed = true;
     state.lifecycleTaskRefreshError = "task ledger unavailable";
@@ -1472,8 +1362,6 @@ describe("workboard controller", () => {
   });
 
   it("clears stale refresh errors after a successful dispatch reload", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.lastRefreshError = "poll unavailable";
     const client = createClient({
       "workboard.cards.dispatch": {
@@ -1493,8 +1381,6 @@ describe("workboard controller", () => {
   });
 
   it("blocks dispatch while a card draft write is in flight", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const update = createDeferred<unknown>();
     state.cards = [sampleCard];
     state.draftTitle = "Move out of ready";
@@ -1527,7 +1413,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps concurrent card writes busy until each write finishes", async () => {
-    const host = {};
     const first = createDeferred<unknown>();
     const second = createDeferred<unknown>();
     const secondCard = { ...sampleCard, id: "card-2", title: "Second card" };
@@ -1588,27 +1473,29 @@ describe("workboard controller", () => {
     expect(getWorkboardState(host).draggedCardId).toBeNull();
   });
 
-  it("does not refresh while a card write is active", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.busyCardIds.add(sampleCard.id);
-    const client = createClient({
-      "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
-      "tasks.list": { tasks: [] },
-    });
+  it.each(["card write", "dispatch"] as const)(
+    "does not refresh while a %s is active",
+    async (mutation) => {
+      if (mutation === "card write") {
+        state.busyCardIds.add(sampleCard.id);
+      } else {
+        state.dispatching = true;
+      }
+      const client = createClient({
+        "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
+        "tasks.list": { tasks: [] },
+      });
 
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "manual",
-    });
+      await refreshWorkboard({ host, client: client as never, source: "manual" });
 
-    expect(client.request).not.toHaveBeenCalled();
-  });
+      expect(client.request).not.toHaveBeenCalled();
+      if (mutation === "dispatch") {
+        expect(state.lastRefreshStartedAt).toBeNull();
+      }
+    },
+  );
 
   it("clears stale task summaries when dispatch task refresh fails", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.tasksByCardId.set("card-1", sampleTask);
     const dispatchedCard = { ...sampleCard, status: "ready" as const };
     const client = createClient((method) => {
@@ -1639,29 +1526,9 @@ describe("workboard controller", () => {
     expect(state.lastRefreshError).toBe("task ledger unavailable");
   });
 
-  it("skips refreshes while dispatch is in flight", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.dispatching = true;
-    const client = createClient({
-      "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
-    });
-
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "manual",
-    });
-
-    expect(client.request).not.toHaveBeenCalled();
-    expect(state.lastRefreshStartedAt).toBeNull();
-  });
-
   it.each(["dispatch", "card write"] as const)(
     "blocks direct forced loads while a %s is active",
     async (activeMutation) => {
-      const host = {};
-      const state = getWorkboardState(host);
       if (activeMutation === "dispatch") {
         state.dispatching = true;
       } else {
@@ -1680,8 +1547,6 @@ describe("workboard controller", () => {
   );
 
   it("blocks card writes while dispatch is relisting cards", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.dispatching = true;
     state.cards = [sampleCard];
     state.draftTitle = "Queued edit";
@@ -1710,7 +1575,6 @@ describe("workboard controller", () => {
   });
 
   it("does not let an older refresh overwrite cards listed after dispatch", async () => {
-    const host = {};
     const refreshList = createDeferred<unknown>();
     const staleCard = { ...sampleCard, title: "Stale refresh card" };
     const dispatchedCard = { ...sampleCard, title: "Dispatched card" };
@@ -1737,11 +1601,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const refresh = refreshWorkboard({
-      host,
-      client: client as never,
-      source: "manual",
-    });
+    const refresh = refreshBoard(client, "manual");
     await Promise.resolve();
     expect(getWorkboardState(host).loading).toBe(true);
 
@@ -1751,14 +1611,12 @@ describe("workboard controller", () => {
     refreshList.resolve({ cards: [staleCard], statuses: ["todo", "done"] });
     await refresh;
 
-    const state = getWorkboardState(host);
     expect(state.cards).toMatchObject([{ title: "Dispatched card" }]);
     expect(state.loading).toBe(false);
     expect(state.lastRefreshAt).toBeNull();
   });
 
   it("does not let an older refresh overwrite a card move", async () => {
-    const host = {};
     const refreshList = createDeferred<unknown>();
     const staleCard = { ...sampleCard, status: "ready" as const, title: "Stale ready card" };
     const movedCard = { ...sampleCard, status: "review" as const, title: "Moved card" };
@@ -1775,11 +1633,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const refresh = refreshWorkboard({
-      host,
-      client: client as never,
-      source: "manual",
-    });
+    const refresh = refreshBoard(client, "manual");
     await Promise.resolve();
 
     await moveWorkboardCard({
@@ -1792,12 +1646,10 @@ describe("workboard controller", () => {
     refreshList.resolve({ cards: [staleCard], statuses: ["ready", "review"] });
     await refresh;
 
-    const state = getWorkboardState(host);
     expect(state.cards).toMatchObject([{ title: "Moved card", status: "review" }]);
   });
 
   it("allows automatic reload after an initial load is invalidated by a write", async () => {
-    const host = {};
     const initialList = createDeferred<unknown>();
     const reloadedList = createDeferred<unknown>();
     const movedCard = { ...sampleCard, title: "Moved during initial load" };
@@ -1827,7 +1679,6 @@ describe("workboard controller", () => {
       position: 2000,
     });
 
-    const state = getWorkboardState(host);
     expect(state.loaded).toBe(false);
     expect(state.loadAttempted).toBe(false);
     expect(state.loading).toBe(false);
@@ -1845,8 +1696,6 @@ describe("workboard controller", () => {
   });
 
   it("does not clear draft-save loading state from an invalidated refresh", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const refreshList = createDeferred<unknown>();
     const saveResponse = createDeferred<{ card: WorkboardCard }>();
     const client = createClient((method) => {
@@ -1888,7 +1737,6 @@ describe("workboard controller", () => {
   });
 
   it("queues a forced full refresh behind an in-flight bounded poll load", async () => {
-    const host = {};
     const pollList = createDeferred<unknown>();
     const forcedCard = { ...sampleCard, title: "Forced full refresh" };
     let cardListCalls = 0;
@@ -1931,7 +1779,6 @@ describe("workboard controller", () => {
   });
 
   it("preserves a stronger forced refresh behind another queued forced refresh", async () => {
-    const host = {};
     const initialList = createDeferred<unknown>();
     const weakerCard = { ...sampleCard, title: "Weaker queued refresh" };
     const strongerCard = { ...sampleCard, title: "Stronger queued refresh" };
@@ -1985,7 +1832,6 @@ describe("workboard controller", () => {
   });
 
   it("does not restart a queued forced refresh after lifecycle teardown", async () => {
-    const host = {};
     const pollList = createDeferred<unknown>();
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
@@ -2020,7 +1866,6 @@ describe("workboard controller", () => {
   });
 
   it("reloads a previously loaded board after lifecycle teardown", async () => {
-    const host = {};
     const reopenedCard = { ...sampleCard, title: "Reopened board" };
     let listCalls = 0;
     const client = createClient((method) => {
@@ -2036,7 +1881,6 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never });
 
-    const state = getWorkboardState(host);
     expect(state.loaded).toBe(true);
     expect(state.cards).toEqual([sampleCard]);
 
@@ -2098,8 +1942,6 @@ describe("workboard controller", () => {
   });
 
   it("preserves an edit draft when its in-flight save fails after teardown", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     let rejectSave: ((reason?: unknown) => void) | undefined;
     const saveResponse = new Promise<unknown>((_resolve, reject) => {
       rejectSave = reject;
@@ -2116,8 +1958,7 @@ describe("workboard controller", () => {
       }
       return {};
     });
-    state.loaded = true;
-    state.cards = [sampleCard];
+    setLoadedCard(sampleCard);
     state.draftOpen = true;
     state.editingCardId = sampleCard.id;
     state.draftTitle = "Unsaved edit";
@@ -2139,8 +1980,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps an in-flight dispatch reload-required after lifecycle teardown", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const dispatchResult = createDeferred<unknown>();
     const client = createClient((method) => {
       if (method === "workboard.cards.dispatch") {
@@ -2154,8 +1993,7 @@ describe("workboard controller", () => {
       }
       return {};
     });
-    state.loaded = true;
-    state.cards = [sampleCard];
+    setLoadedCard(sampleCard);
 
     const dispatch = dispatchWorkboard({ host, client: client as never });
     await waitForFast(() => {
@@ -2174,7 +2012,6 @@ describe("workboard controller", () => {
   });
 
   it("does not attach a stale forced refresh to a reopened board load", async () => {
-    const host = {};
     const staleList = createDeferred<unknown>();
     const reopenedList = createDeferred<unknown>();
     const reopenedCard = { ...sampleCard, title: "Reopened board" };
@@ -2217,7 +2054,6 @@ describe("workboard controller", () => {
   });
 
   it("detaches a stalled initial load during lifecycle teardown", async () => {
-    const host = {};
     const initialList = createDeferred<unknown>();
     const reopenedCard = { ...sampleCard, title: "Reopened board" };
     let listCalls = 0;
@@ -2233,7 +2069,6 @@ describe("workboard controller", () => {
 
     const initialLoad = loadWorkboard({ host, client: client as never });
     await Promise.resolve();
-    const state = getWorkboardState(host);
     expect(state.loading).toBe(true);
     expect(state.loadAttempted).toBe(true);
 
@@ -2251,7 +2086,6 @@ describe("workboard controller", () => {
   });
 
   it("does not start a queued forced refresh after a card write begins", async () => {
-    const host = {};
     const pollList = createDeferred<unknown>();
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
@@ -2285,7 +2119,6 @@ describe("workboard controller", () => {
   });
 
   it("does not mark a load successful when task enrichment is invalidated by a write", async () => {
-    const host = {};
     const taskList = createDeferred<unknown>();
     const movedCard = { ...sampleCard, title: "Moved during task enrichment" };
     const reloadedCard = { ...sampleCard, title: "Reloaded after task invalidation" };
@@ -2323,7 +2156,6 @@ describe("workboard controller", () => {
     taskList.resolve({ tasks: [sampleTask] });
     await expect(initialLoad).resolves.toBe(false);
 
-    const state = getWorkboardState(host);
     expect(state.loaded).toBe(false);
     expect(state.loadAttempted).toBe(false);
 
@@ -2333,7 +2165,6 @@ describe("workboard controller", () => {
   });
 
   it("links cards from paginated Gateway task results", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       sessionKey: sampleTaskSessionKey,
@@ -2644,7 +2475,6 @@ describe("workboard controller", () => {
   });
 
   it("links unassigned default-agent tasks with canonicalized session keys", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       sessionKey: sampleTaskSessionKey,
@@ -2669,7 +2499,6 @@ describe("workboard controller", () => {
   });
 
   it("does not relink a loaded card to a stale task from another session", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       sessionKey: "agent:main:dashboard:new",
@@ -2690,13 +2519,11 @@ describe("workboard controller", () => {
 
     await loadWorkboard({ host, client: client as never, force: true });
 
-    const state = getWorkboardState(host);
     expect(state.cards[0]).not.toHaveProperty("taskId");
     expect(state.tasksByCardId.has("card-1")).toBe(false);
   });
 
   it("preserves contract-owned metadata loaded from the plugin gateway method", async () => {
-    const host = {};
     const client = createClient({
       "workboard.cards.list": {
         cards: [
@@ -2795,8 +2622,6 @@ describe("workboard controller", () => {
   });
 
   it("updates cards from draft state when editing", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.cards = [sampleCard];
     state.draftOpen = true;
     state.editingCardId = sampleCard.id;
@@ -2839,8 +2664,6 @@ describe("workboard controller", () => {
   });
 
   it("creates cards from draft state through the save action", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.draftTitle = "Write tests";
     state.draftNotes = "Cover the happy path";
     state.draftSessionKey = "agent:main:dashboard:1";
@@ -2869,8 +2692,6 @@ describe("workboard controller", () => {
   });
 
   it("creates template-backed cards through the save action", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.draftTitle = "Fix: flaky worker";
     state.draftTemplateId = "bugfix";
     const created = {
@@ -2895,25 +2716,11 @@ describe("workboard controller", () => {
   });
 
   it("keeps edit-modal status saves from being rewritten by stale lifecycle sync", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
+    const linked = createWorkboardCard({
       sessionKey: sampleSession.key,
-      execution: {
-        id: "exec-1",
-        kind: "agent-session",
-        engine: "codex",
-        mode: "autonomous",
-        status: "running",
-        model: "openai/gpt-5.5",
-        sessionKey: sampleSession.key,
-        startedAt: 1,
-        updatedAt: 1,
-      },
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+      execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
+    });
+    setLoadedCard(linked);
     state.draftOpen = true;
     state.editingCardId = linked.id;
     state.draftTitle = linked.title;
@@ -2945,11 +2752,9 @@ describe("workboard controller", () => {
     });
 
     await saveWorkboardCardDraft({ host, client: client as never });
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 }],
-    });
+    await syncLifecycle(client, [
+      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+    ]);
 
     expect(client.request).toHaveBeenCalledTimes(3);
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
@@ -2966,8 +2771,6 @@ describe("workboard controller", () => {
   });
 
   it("does not start lifecycle writes while dispatch is active", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.loaded = true;
     state.dispatching = true;
     state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
@@ -2975,11 +2778,7 @@ describe("workboard controller", () => {
       "workboard.cards.update": { card: { ...sampleCard, status: "running" } },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, status: "running", hasActiveRun: true }],
-    });
+    await syncLifecycle(client, [{ ...sampleSession, status: "running", hasActiveRun: true }]);
 
     expect(client.request).not.toHaveBeenCalled();
   });
@@ -2987,8 +2786,6 @@ describe("workboard controller", () => {
   it.each(["editing", "dragging"] as const)(
     "does not start lifecycle writes while a card is %s",
     async (interaction) => {
-      const host = {};
-      const state = getWorkboardState(host);
       state.loaded = true;
       state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
       if (interaction === "editing") {
@@ -3012,8 +2809,6 @@ describe("workboard controller", () => {
   );
 
   it("does not start lifecycle writes while a canonical refresh is loading", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.loaded = true;
     state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
     const loadResponse = createDeferred<unknown>();
@@ -3029,11 +2824,7 @@ describe("workboard controller", () => {
 
     const loading = loadWorkboard({ host, client: client as never, force: true });
     await Promise.resolve();
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, status: "running", hasActiveRun: true }],
-    });
+    await syncLifecycle(client, [{ ...sampleSession, status: "running", hasActiveRun: true }]);
 
     expect(client.request).toHaveBeenCalledTimes(1);
     expect(client.request).toHaveBeenCalledWith("workboard.cards.list", {});
@@ -3042,25 +2833,11 @@ describe("workboard controller", () => {
   });
 
   it("does not start lifecycle writes while edit-modal saves are in flight", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
+    const linked = createWorkboardCard({
       sessionKey: sampleSession.key,
-      execution: {
-        id: "exec-1",
-        kind: "agent-session",
-        engine: "codex",
-        mode: "autonomous",
-        status: "running",
-        model: "openai/gpt-5.5",
-        sessionKey: sampleSession.key,
-        startedAt: 1,
-        updatedAt: 1,
-      },
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+      execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
+    });
+    setLoadedCard(linked);
     state.draftOpen = true;
     state.editingCardId = linked.id;
     state.draftTitle = linked.title;
@@ -3094,11 +2871,9 @@ describe("workboard controller", () => {
 
     const saving = saveWorkboardCardDraft({ host, client: client as never });
     await Promise.resolve();
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 }],
-    });
+    await syncLifecycle(client, [
+      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+    ]);
 
     expect(client.request).toHaveBeenCalledOnce();
     saveResponse.resolve({ card: saved });
@@ -3107,8 +2882,6 @@ describe("workboard controller", () => {
   });
 
   it("adds operator notes to a selected detail card without opening the edit draft", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.cards = [sampleCard];
     state.detailCardId = sampleCard.id;
     state.detailCommentBody = "Need one more proof run.";
@@ -3137,7 +2910,6 @@ describe("workboard controller", () => {
   });
 
   it("captures existing sessions as linked workboard cards", async () => {
-    const host = {};
     const session = {
       ...sampleSession,
       label: "Fix login",
@@ -3197,39 +2969,19 @@ describe("workboard controller", () => {
   });
 
   it("does not duplicate existing captured sessions", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const existing = {
-      ...sampleCard,
-      execution: {
-        id: "exec-1",
-        kind: "agent-session",
-        engine: "codex",
-        mode: "autonomous",
-        model: "openai/gpt-5.5",
-        status: "running",
-        sessionKey: sampleSession.key,
-        startedAt: 1,
-        updatedAt: 1,
-      },
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [existing];
+    const existing = createWorkboardCard({
+      execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
+    });
+    setLoadedCard(existing);
     const client = createClient({});
 
-    const card = await captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: sampleSession,
-    });
+    const card = await captureSession(client, sampleSession);
 
     expect(card).toBe(existing);
     expect(client.request).not.toHaveBeenCalled();
   });
 
   it("restores archived captured sessions instead of leaving them hidden", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const archived = {
       ...sampleCard,
       sessionKey: sampleSession.key,
@@ -3239,17 +2991,12 @@ describe("workboard controller", () => {
       ...archived,
       metadata: {},
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [archived];
+    setLoadedCard(archived);
     const client = createClient({
       "workboard.cards.archive": { card: restored },
     });
 
-    const card = await captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: sampleSession,
-    });
+    const card = await captureSession(client, sampleSession);
 
     expect(card).toMatchObject({ id: restored.id, sessionKey: sampleSession.key });
     expect(card?.metadata?.archivedAt).toBeUndefined();
@@ -3261,26 +3008,18 @@ describe("workboard controller", () => {
   });
 
   it("does not start duplicate capture requests while a session is in flight", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.capturingSessionKeys.add(sampleSession.key);
     const existing = { ...sampleCard, sessionKey: sampleSession.key };
     state.cards = [existing];
     const client = createClient({});
 
-    const card = await captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: sampleSession,
-    });
+    const card = await captureSession(client, sampleSession);
 
     expect(card).toBe(existing);
     expect(client.request).not.toHaveBeenCalled();
   });
 
   it("captures different sessions concurrently", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.loaded = true;
     const firstSession = { ...sampleSession, key: "agent:main:dashboard:first" };
     const secondSession = { ...sampleSession, key: "agent:main:dashboard:second" };
@@ -3299,11 +3038,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const firstCapture = captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: firstSession,
-    });
+    const firstCapture = captureSession(client, firstSession);
     await waitForFast(() => {
       expect(client.request).toHaveBeenCalledWith(
         "workboard.cards.create",
@@ -3326,8 +3061,6 @@ describe("workboard controller", () => {
   });
 
   it("does not duplicate same-session captures waiting on the initial load", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const list = createDeferred<unknown>();
     const create = createDeferred<unknown>();
     const created = { ...sampleCard, sessionKey: sampleSession.key };
@@ -3344,16 +3077,8 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const firstCapture = captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: sampleSession,
-    });
-    const secondCapture = captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: sampleSession,
-    });
+    const firstCapture = captureSession(client, sampleSession);
+    const secondCapture = captureSession(client, sampleSession);
     list.resolve({ cards: [], statuses: ["todo"] });
     await waitForFast(() => {
       expect(client.request).toHaveBeenCalledWith(
@@ -3374,23 +3099,16 @@ describe("workboard controller", () => {
   });
 
   it("does not capture sessions while dispatch is active", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.dispatching = true;
     const client = createClient({});
 
-    const card = await captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: sampleSession,
-    });
+    const card = await captureSession(client, sampleSession);
 
     expect(card).toBeNull();
     expect(client.request).not.toHaveBeenCalled();
   });
 
   it("does not create capture cards when the duplicate preflight list fails", async () => {
-    const host = {};
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         throw new Error("list unavailable");
@@ -3398,11 +3116,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const card = await captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: sampleSession,
-    });
+    const card = await captureSession(client, sampleSession);
 
     expect(card).toBeNull();
     expect(client.request).toHaveBeenCalledOnce();
@@ -3410,7 +3124,6 @@ describe("workboard controller", () => {
   });
 
   it("waits for an in-flight Workboard load before capturing a session", async () => {
-    const host = {};
     const list = createDeferred<unknown>();
     const created = { ...sampleCard, sessionKey: sampleSession.key };
     const client = createClient((method) => {
@@ -3427,11 +3140,7 @@ describe("workboard controller", () => {
     });
 
     const loading = loadWorkboard({ host, client: client as never, force: true });
-    const captured = captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: sampleSession,
-    });
+    const captured = captureSession(client, sampleSession);
 
     await Promise.resolve();
     expect(client.request).toHaveBeenCalledTimes(1);
@@ -3443,8 +3152,6 @@ describe("workboard controller", () => {
   });
 
   it("waits for retained lifecycle writes before capturing after teardown", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const lifecycleCard = {
       ...sampleCard,
       sessionKey: sampleSession.key,
@@ -3480,25 +3187,16 @@ describe("workboard controller", () => {
       }
       return {};
     });
-    state.loaded = true;
-    state.cards = [lifecycleCard];
+    setLoadedCard(lifecycleCard);
     state.lifecycleTasksPrepared = true;
     state.lifecycleTasksPreparedAt = Date.now();
 
-    const syncing = syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [sampleSession],
-    });
+    const syncing = syncLifecycle(client, [sampleSession]);
     await waitForFast(() => {
       expect(client.request).toHaveBeenCalledWith("workboard.cards.update", expect.anything());
     });
     stopWorkboardLifecycleRefresh(host);
-    const capture = captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: capturedSession,
-    });
+    const capture = captureSession(client, capturedSession);
     await Promise.resolve();
 
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.list", {});
@@ -3515,7 +3213,6 @@ describe("workboard controller", () => {
   });
 
   it("clamps captured session fields without splitting surrogate pairs", async () => {
-    const host = {};
     const titlePrefix = "x".repeat(176);
     const textPrefix = "y".repeat(696);
     const client = createClient((method) => {
@@ -3533,11 +3230,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await captureSessionToWorkboard({
-      host,
-      client: client as never,
-      session: { ...sampleSession, label: `${titlePrefix}😀tail` },
-    });
+    await captureSession(client, { ...sampleSession, label: `${titlePrefix}😀tail` });
 
     expect(client.request).toHaveBeenNthCalledWith(
       3,
@@ -3552,7 +3245,6 @@ describe("workboard controller", () => {
   });
 
   it("starts a task run and links it back to the card", async () => {
-    const host = {};
     const running = {
       ...sampleCard,
       status: "running",
@@ -3609,7 +3301,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps bounded task session labels on a UTF-16 boundary", async () => {
-    const host = {};
     const title = `${"a".repeat(499)}🚀tail`;
     const client = createClient({
       agent: { sessionKey: sampleTaskSessionKey, runId: "run-1" },
@@ -3633,7 +3324,6 @@ describe("workboard controller", () => {
   });
 
   it("starts reassigned cards with the current task session key", async () => {
-    const host = {};
     const expectedSessionKey = "agent:codex-main:subagent:workboard-default-card-1";
     const staleLinked = {
       ...sampleCard,
@@ -3674,7 +3364,6 @@ describe("workboard controller", () => {
 
   it("waits briefly for task ledger registration after a started run", async () => {
     vi.useFakeTimers();
-    const host = {};
     const running = {
       ...sampleCard,
       status: "running",
@@ -3714,7 +3403,6 @@ describe("workboard controller", () => {
 
   it("keeps a successfully started run when task lookup stays unavailable", async () => {
     vi.useFakeTimers();
-    const host = {};
     const running = {
       ...sampleCard,
       status: "running",
@@ -3755,7 +3443,6 @@ describe("workboard controller", () => {
   });
 
   it("lets the gateway decide starts when cached parent dependencies are stale", async () => {
-    const host = {};
     const parent = { ...sampleCard, id: "parent-1", title: "Parent", status: "running" };
     const child: WorkboardCard = {
       ...sampleCard,
@@ -3806,7 +3493,6 @@ describe("workboard controller", () => {
   });
 
   it("does not create a session when the gateway rejects start preflight", async () => {
-    const host = {};
     const client = createClient((method) => {
       if (method === "workboard.cards.update") {
         throw new Error("Parent cards must be done before starting this card.");
@@ -3832,7 +3518,6 @@ describe("workboard controller", () => {
   });
 
   it("rolls back the running preflight when task run creation fails", async () => {
-    const host = {};
     const running = { ...sampleCard, status: "running" } satisfies WorkboardCard;
     let updateCalls = 0;
     const client = createClient((method) => {
@@ -3874,7 +3559,6 @@ describe("workboard controller", () => {
   });
 
   it("rolls back the running preflight when final session link update fails", async () => {
-    const host = {};
     const running = { ...sampleCard, status: "running" } satisfies WorkboardCard;
     let updateCalls = 0;
     const client = createClient((method) => {
@@ -3927,7 +3611,6 @@ describe("workboard controller", () => {
   });
 
   it("does not start a card before its scheduled time", async () => {
-    const host = {};
     const scheduled = {
       ...sampleCard,
       id: "scheduled-1",
@@ -3963,17 +3646,12 @@ describe("workboard controller", () => {
       status: "todo",
       metadata: {},
       sessionKey: "agent:main:dashboard:manual",
-      execution: {
+      execution: createWorkboardExecution({
         id: "exec-manual",
-        kind: "agent-session",
-        engine: "codex",
         mode: "manual",
         status: "idle",
-        model: "openai/gpt-5.5",
         sessionKey: "agent:main:dashboard:manual",
-        startedAt: 1,
-        updatedAt: 1,
-      },
+      }),
     } satisfies WorkboardCard;
     const manualClient = createClient({
       "sessions.create": { key: "agent:main:dashboard:manual" },
@@ -4086,25 +3764,19 @@ describe("workboard controller", () => {
   });
 
   it("starts a Codex execution with an explicit model override", async () => {
-    const host = {};
-    const running = {
-      ...sampleCard,
+    const running = createWorkboardCard({
       status: "running",
       sessionKey: sampleTaskSessionKey,
       taskId: "task-1",
-      execution: {
+      execution: createWorkboardExecution({
         id: "card-1:codex",
-        kind: "agent-session",
-        engine: "codex",
-        mode: "autonomous",
         model: "openai/gpt-5.6-sol",
-        status: "running",
         sessionKey: sampleTaskSessionKey,
         runId: "run-1",
         startedAt: 10,
         updatedAt: 10,
-      },
-    };
+      }),
+    });
     let updateCalls = 0;
     const client = createClient((method) => {
       if (method === "workboard.cards.update") {
@@ -4166,7 +3838,6 @@ describe("workboard controller", () => {
   it("resets execution start time when retrying a card run", async () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1234);
     try {
-      const host = {};
       const previous = {
         ...sampleCard,
         execution: {
@@ -4223,23 +3894,18 @@ describe("workboard controller", () => {
   });
 
   it("starts a manual Claude execution without sending the card prompt", async () => {
-    const host = {};
-    const running = {
-      ...sampleCard,
-      status: "todo",
+    const running = createWorkboardCard({
       sessionKey: "agent:main:dashboard:1",
-      execution: {
+      execution: createWorkboardExecution({
         id: "card-1:claude",
-        kind: "agent-session",
         engine: "claude",
         mode: "manual",
         status: "idle",
         model: "anthropic/claude-sonnet-4-6",
-        sessionKey: "agent:main:dashboard:1",
         startedAt: 10,
         updatedAt: 10,
-      },
-    };
+      }),
+    });
     const client = createClient({
       "sessions.create": { key: "agent:main:dashboard:1", runStarted: false },
       "workboard.cards.update": { card: running },
@@ -4282,31 +3948,23 @@ describe("workboard controller", () => {
   });
 
   it("clears stale task linkage when opening a manual execution", async () => {
-    const host = {};
-    const staleLinkedCard = {
-      ...sampleCard,
+    const staleLinkedCard = createWorkboardCard({
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
       taskId: "task-1",
-      execution: {
+      execution: createWorkboardExecution({
         id: "card-1:codex",
-        kind: "agent-session",
-        engine: "codex",
-        mode: "autonomous",
         status: "blocked",
-        model: "openai/gpt-5.5",
         sessionKey: sampleTaskSessionKey,
         runId: "run-1",
         startedAt: 10,
         updatedAt: 20,
-      },
-    } satisfies WorkboardCard;
-    const reopened = {
-      ...sampleCard,
+      }),
+    });
+    const reopened = createWorkboardCard({
       sessionKey: "agent:main:dashboard:new",
-      execution: {
+      execution: createWorkboardExecution({
         id: "card-1:claude",
-        kind: "agent-session",
         engine: "claude",
         mode: "manual",
         status: "idle",
@@ -4314,8 +3972,8 @@ describe("workboard controller", () => {
         sessionKey: "agent:main:dashboard:new",
         startedAt: 10,
         updatedAt: 10,
-      },
-    } satisfies WorkboardCard;
+      }),
+    });
     const client = createClient({
       "sessions.create": { key: "agent:main:dashboard:new", runStarted: false },
       "workboard.cards.update": { card: reopened },
@@ -4346,7 +4004,6 @@ describe("workboard controller", () => {
   });
 
   it("rolls back when the Gateway does not return a task run id", async () => {
-    const host = {};
     let updateCalls = 0;
     const client = createClient((method) => {
       if (method === "agent") {
@@ -4380,7 +4037,6 @@ describe("workboard controller", () => {
   });
 
   it("moves cards through the plugin gateway method", async () => {
-    const host = {};
     const moved = { ...sampleCard, status: "blocked", position: 2000 };
     const client = createClient({ "workboard.cards.move": { card: moved } });
 
@@ -4399,23 +4055,10 @@ describe("workboard controller", () => {
   });
 
   it("keeps dragged status changes from being rewritten by stale lifecycle sync", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
+    const linked = createWorkboardCard({
       sessionKey: sampleSession.key,
-      execution: {
-        id: "exec-1",
-        kind: "agent-session",
-        engine: "codex",
-        mode: "autonomous",
-        model: "openai/gpt-5.5",
-        status: "running",
-        sessionKey: sampleSession.key,
-        startedAt: 1,
-        updatedAt: 1,
-      },
-    } satisfies WorkboardCard;
+      execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
+    });
     const moved = {
       ...linked,
       status: "running",
@@ -4431,8 +4074,7 @@ describe("workboard controller", () => {
         },
       ],
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient((method) => {
       if (method === "workboard.cards.move") {
         return { card: moved };
@@ -4450,11 +4092,9 @@ describe("workboard controller", () => {
       status: "running",
       position: 2000,
     });
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 }],
-    });
+    await syncLifecycle(client, [
+      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+    ]);
 
     expect(client.request).toHaveBeenCalledTimes(3);
     expect(client.request).toHaveBeenCalledWith("workboard.cards.move", {
@@ -4472,23 +4112,10 @@ describe("workboard controller", () => {
   });
 
   it("does not start lifecycle writes while dragged status changes are in flight", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
+    const linked = createWorkboardCard({
       sessionKey: sampleSession.key,
-      execution: {
-        id: "exec-1",
-        kind: "agent-session",
-        engine: "codex",
-        mode: "autonomous",
-        status: "running",
-        model: "openai/gpt-5.5",
-        sessionKey: sampleSession.key,
-        startedAt: 1,
-        updatedAt: 1,
-      },
-    } satisfies WorkboardCard;
+      execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
+    });
     const moved = {
       ...linked,
       status: "running",
@@ -4504,8 +4131,7 @@ describe("workboard controller", () => {
         },
       ],
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const moveResponse = createDeferred<{ card: WorkboardCard }>();
     const client = createClient((method) => {
       if (method === "workboard.cards.move") {
@@ -4522,11 +4148,9 @@ describe("workboard controller", () => {
       position: 2000,
     });
     await Promise.resolve();
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 }],
-    });
+    await syncLifecycle(client, [
+      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+    ]);
 
     expect(client.request).toHaveBeenCalledOnce();
     moveResponse.resolve({ card: moved });
@@ -4535,8 +4159,6 @@ describe("workboard controller", () => {
   });
 
   it("ignores stale lifecycle responses when dragged status changes while sync is in flight", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = { ...sampleCard, sessionKey: sampleSession.key } satisfies WorkboardCard;
     const moved = {
       ...linked,
@@ -4559,8 +4181,7 @@ describe("workboard controller", () => {
       updatedAt: 3,
       metadata: { lifecycleStatusSourceUpdatedAt: 1 },
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const lifecycleResponse = createDeferred<{ card: WorkboardCard }>();
     const client = createClient((method) => {
       if (method === "workboard.cards.update") {
@@ -4572,11 +4193,9 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const syncing = syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 }],
-    });
+    const syncing = syncLifecycle(client, [
+      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+    ]);
     await Promise.resolve();
     await moveWorkboardCard({
       host,
@@ -4604,8 +4223,6 @@ describe("workboard controller", () => {
   });
 
   it("ignores lifecycle responses after a newer comment write", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = { ...sampleCard, sessionKey: sampleSession.key } satisfies WorkboardCard;
     const commented = {
       ...linked,
@@ -4615,8 +4232,7 @@ describe("workboard controller", () => {
       },
     } satisfies WorkboardCard;
     const lifecycleResponse = createDeferred<{ card: WorkboardCard }>();
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient((method) => {
       if (method === "workboard.cards.update") {
         return lifecycleResponse.promise;
@@ -4627,11 +4243,9 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const syncing = syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 }],
-    });
+    const syncing = syncLifecycle(client, [
+      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+    ]);
     await Promise.resolve();
     await addWorkboardCardComment({
       host,
@@ -4646,23 +4260,10 @@ describe("workboard controller", () => {
   });
 
   it("ignores lifecycle responses without provenance when dragged status changes while sync is in flight", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
+    const linked = createWorkboardCard({
       sessionKey: sampleSession.key,
-      execution: {
-        id: "exec-1",
-        kind: "agent-session",
-        engine: "codex",
-        mode: "autonomous",
-        model: "openai/gpt-5.5",
-        status: "running",
-        sessionKey: sampleSession.key,
-        startedAt: 1,
-        updatedAt: 1,
-      },
-    } satisfies WorkboardCard;
+      execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
+    });
     const moved = {
       ...linked,
       status: "running",
@@ -4682,10 +4283,13 @@ describe("workboard controller", () => {
       ...linked,
       status: "review",
       updatedAt: 3,
-      execution: { ...linked.execution, status: "review" as const, updatedAt: 3 },
+      execution: createWorkboardExecution({
+        ...linked.execution,
+        status: "review",
+        updatedAt: 3,
+      }),
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const lifecycleResponse = createDeferred<{ card: WorkboardCard }>();
     const client = createClient((method) => {
       if (method === "workboard.cards.update") {
@@ -4697,11 +4301,9 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const syncing = syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: null }],
-    });
+    const syncing = syncLifecycle(client, [
+      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: null },
+    ]);
     await Promise.resolve();
     await moveWorkboardCard({
       host,
@@ -4726,8 +4328,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps non-status edits following newer linked session lifecycle sync", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const edited = {
       ...sampleCard,
       title: "Renamed only",
@@ -4745,19 +4345,16 @@ describe("workboard controller", () => {
         { id: "edit-1", kind: "edited", at: 5 },
       ],
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [edited];
+    setLoadedCard(edited);
     const client = createClient({
       "workboard.cards.update": {
         card: { ...edited, status: "review", updatedAt: 6 },
       },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 }],
-    });
+    await syncLifecycle(client, [
+      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 },
+    ]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
       id: "card-1",
@@ -4767,8 +4364,6 @@ describe("workboard controller", () => {
   });
 
   it("keeps lifecycle-created moves following newer linked session lifecycle sync", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const lifecycleMoved = {
       ...sampleCard,
       status: "running",
@@ -4785,8 +4380,7 @@ describe("workboard controller", () => {
         },
       ],
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [lifecycleMoved];
+    setLoadedCard(lifecycleMoved);
     const client = createClient({
       "workboard.cards.update": {
         card: {
@@ -4798,11 +4392,9 @@ describe("workboard controller", () => {
       },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 }],
-    });
+    await syncLifecycle(client, [
+      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 },
+    ]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
       id: "card-1",
@@ -4818,7 +4410,6 @@ describe("workboard controller", () => {
   });
 
   it("removes stale dependency links from local cards after delete", async () => {
-    const host = {};
     const parent: WorkboardCard = {
       ...sampleCard,
       id: "parent-1",
@@ -4872,121 +4463,96 @@ describe("workboard controller", () => {
   });
 
   it("derives lifecycle state from linked dashboard sessions", () => {
-    expect(getWorkboardLifecycle(sampleCard, [sampleSession])).toEqual({
-      session: null,
-      state: "unlinked",
-    });
-
-    const linked = { ...sampleCard, sessionKey: sampleSession.key };
-    expect(getWorkboardLifecycle(linked, [sampleSession])).toMatchObject({
-      state: "running",
-      targetStatus: "running",
-    });
-    expect(
-      getWorkboardLifecycle(linked, [{ ...sampleSession, hasActiveRun: false, status: "running" }]),
-    ).toMatchObject({
-      state: "running",
-      targetStatus: "running",
-    });
-    expect(
-      getWorkboardLifecycle(linked, [{ ...sampleSession, hasActiveRun: false, status: "done" }]),
-    ).toMatchObject({
-      state: "succeeded",
-      targetStatus: "review",
-    });
-    expect(
-      getWorkboardLifecycle(linked, [{ ...sampleSession, hasActiveRun: false, status: "failed" }]),
-    ).toMatchObject({
-      state: "failed",
-      targetStatus: "blocked",
-    });
-    expect(
-      getWorkboardLifecycle(linked, [
-        {
-          ...sampleSession,
-          hasActiveRun: false,
-          status: "running",
-          updatedAt: Date.now() - 31 * 60 * 1000,
-        },
-      ]),
-    ).toMatchObject({
-      state: "stale",
-      targetStatus: "running",
-    });
-    expect(
-      getWorkboardLifecycle(linked, [
-        { ...sampleSession, hasActiveRun: true, updatedAt: Date.now() - 31 * 60 * 1000 },
-      ]),
-    ).toMatchObject({
-      state: "running",
-      targetStatus: "running",
-    });
-    expect(
-      getWorkboardLifecycle(linked, [
-        { ...sampleSession, hasActiveRun: undefined, updatedAt: Date.now() - 31 * 60 * 1000 },
-      ]),
-    ).toMatchObject({
-      state: "running",
-      targetStatus: "running",
-    });
-    expect(
-      getWorkboardLifecycle(
-        {
-          ...sampleCard,
-          execution: {
-            id: "exec-1",
-            kind: "agent-session",
-            engine: "codex",
-            mode: "autonomous",
-            status: "running",
-            model: "openai/gpt-5.5",
-            sessionKey: sampleSession.key,
-            startedAt: 1,
-            updatedAt: 1,
-          },
-        },
-        [sampleSession],
+    const linked = createWorkboardCard({ sessionKey: sampleSession.key });
+    const staleAt = Date.now() - 31 * 60 * 1000;
+    const cases: ReadonlyArray<
+      readonly [string, WorkboardCard, GatewaySessionRow, Record<string, unknown>]
+    > = [
+      ["unlinked", sampleCard, sampleSession, { session: null, state: "unlinked" }],
+      ["active", linked, sampleSession, { state: "running", targetStatus: "running" }],
+      [
+        "running without an active run",
+        linked,
+        createGatewaySession({ hasActiveRun: false }),
+        { state: "running", targetStatus: "running" },
+      ],
+      [
+        "completed",
+        linked,
+        createGatewaySession({ hasActiveRun: false, status: "done" }),
+        { state: "succeeded", targetStatus: "review" },
+      ],
+      [
+        "failed",
+        linked,
+        createGatewaySession({ hasActiveRun: false, status: "failed" }),
+        { state: "failed", targetStatus: "blocked" },
+      ],
+      [
+        "stale inactive",
+        linked,
+        createGatewaySession({ hasActiveRun: false, updatedAt: staleAt }),
+        { state: "stale", targetStatus: "running" },
+      ],
+      ...([true, undefined] as const).map(
+        (hasActiveRun) =>
+          [
+            `stale timestamp with hasActiveRun=${String(hasActiveRun)}`,
+            linked,
+            createGatewaySession({ hasActiveRun, updatedAt: staleAt }),
+            { state: "running", targetStatus: "running" },
+          ] as const,
       ),
-    ).toMatchObject({
-      state: "running",
-      targetStatus: "running",
-    });
+      [
+        "execution link",
+        createWorkboardCard({
+          execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
+        }),
+        sampleSession,
+        { state: "running", targetStatus: "running" },
+      ],
+    ];
+
+    for (const [name, card, session, expected] of cases) {
+      expect(getWorkboardLifecycle(card, [session]), name).toMatchObject(expected);
+    }
   });
 
   it("derives lifecycle state from linked Gateway tasks", () => {
-    const linked = { ...sampleCard, sessionKey: sampleTaskSessionKey, runId: "run-1" };
-
-    expect(getWorkboardLifecycle(linked, [], sampleTask)).toMatchObject({
-      state: "running",
-      targetStatus: "running",
+    const card = createWorkboardCard({ sessionKey: sampleTaskSessionKey, runId: "run-1" });
+    const completedSession = createGatewaySession({
+      key: sampleTaskSessionKey,
+      hasActiveRun: false,
+      status: "done",
     });
-    expect(getWorkboardLifecycle(linked, [], { ...sampleTask, status: "completed" })).toMatchObject(
-      {
-        state: "succeeded",
-        targetStatus: "review",
-      },
-    );
-    expect(getWorkboardLifecycle(linked, [], { ...sampleTask, status: "timed_out" })).toMatchObject(
-      {
-        state: "failed",
-        targetStatus: "blocked",
-      },
-    );
-    expect(
-      getWorkboardLifecycle(
-        linked,
-        [{ ...sampleSession, key: sampleTaskSessionKey, hasActiveRun: false, status: "done" }],
+    const cases = [
+      ["running", sampleTask, [], { state: "running", targetStatus: "running" }],
+      [
+        "completed",
+        createWorkboardTask({ status: "completed" }),
+        [],
+        { state: "succeeded", targetStatus: "review" },
+      ],
+      [
+        "timed out",
+        createWorkboardTask({ status: "timed_out" }),
+        [],
+        { state: "failed", targetStatus: "blocked" },
+      ],
+      [
+        "completed session",
         sampleTask,
-      ),
-    ).toMatchObject({
-      state: "succeeded",
-      targetStatus: "review",
-    });
+        [completedSession],
+        { state: "succeeded", targetStatus: "review" },
+      ],
+    ] as const;
+
+    for (const [name, task, sessions, expected] of cases) {
+      expect(getWorkboardLifecycle(card, [...sessions], task), name).toMatchObject(expected);
+    }
   });
 
   it("syncs linked card status from session lifecycle without overriding manual review", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.loaded = true;
     state.cards = [
       { ...sampleCard, sessionKey: sampleSession.key },
@@ -4999,14 +4565,10 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [
-        sampleSession,
-        { ...sampleSession, key: "session-review", status: "failed", hasActiveRun: false },
-      ],
-    });
+    await syncLifecycle(client, [
+      sampleSession,
+      { ...sampleSession, key: "session-review", status: "failed", hasActiveRun: false },
+    ]);
 
     expect(client.request).toHaveBeenCalledOnce();
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
@@ -5022,8 +4584,6 @@ describe("workboard controller", () => {
   });
 
   it("does not sync stale linked-session status over a card creation status", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.loaded = true;
     state.cards = [
       {
@@ -5041,18 +4601,14 @@ describe("workboard controller", () => {
       },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [
-        {
-          ...sampleSession,
-          status: "done",
-          hasActiveRun: false,
-          updatedAt: 1000,
-        },
-      ],
-    });
+    await syncLifecycle(client, [
+      {
+        ...sampleSession,
+        status: "done",
+        hasActiveRun: false,
+        updatedAt: 1000,
+      },
+    ]);
 
     expect(client.request).toHaveBeenCalledOnce();
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
@@ -5061,8 +4617,6 @@ describe("workboard controller", () => {
   });
 
   it("does not sync linked card status from sessions without lifecycle provenance", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.loaded = true;
     state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
     const client = createClient({
@@ -5071,36 +4625,21 @@ describe("workboard controller", () => {
       },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [
-        {
-          ...sampleSession,
-          status: "done",
-          hasActiveRun: false,
-          updatedAt: null,
-        },
-      ],
-    });
+    await syncLifecycle(client, [
+      {
+        ...sampleSession,
+        status: "done",
+        hasActiveRun: false,
+        updatedAt: null,
+      },
+    ]);
 
     expect(client.request).not.toHaveBeenCalled();
     expect(state.cards[0]).toMatchObject({ status: "todo" });
   });
 
   it("refreshes task lifecycle before syncing task-backed cards", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: "task-1",
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set("card-1", sampleTask);
+    const { card: linked } = createLifecycleHarness(host);
     const client = createClient({
       "tasks.list": { tasks: [{ ...sampleTask, status: "completed" }] },
       "workboard.cards.update": {
@@ -5108,11 +4647,7 @@ describe("workboard controller", () => {
       },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [],
-    });
+    await syncLifecycle(client);
 
     expect(client.request).toHaveBeenNthCalledWith(1, "tasks.list", { limit: 500 });
     expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", {
@@ -5128,18 +4663,7 @@ describe("workboard controller", () => {
   });
 
   it("cancels in-flight lifecycle reconciliation when refresh stops", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: "task-1",
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set("card-1", sampleTask);
+    const { card: linked } = createLifecycleHarness(host);
     const taskList = createDeferred<unknown>();
     const client = createClient((method) => {
       if (method === "tasks.list") {
@@ -5164,8 +4688,6 @@ describe("workboard controller", () => {
   });
 
   it("cancels remaining lifecycle card writes when refresh stops", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const first = { ...sampleCard, id: "card-1", sessionKey: "session-1" };
     const second = { ...sampleCard, id: "card-2", sessionKey: "session-2" };
     const firstUpdate = createDeferred<{ card: WorkboardCard }>();
@@ -5212,18 +4734,7 @@ describe("workboard controller", () => {
   });
 
   it("reuses an in-flight lifecycle task refresh across render-driven syncs", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: "task-1",
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set("card-1", sampleTask);
+    createLifecycleHarness(host);
     const taskList = createDeferred<unknown>();
     const client = createClient((method) => {
       if (method === "tasks.list") {
@@ -5249,15 +4760,7 @@ describe("workboard controller", () => {
   });
 
   it("requests a fresh lifecycle sync after a shared task refresh is invalidated by a write", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: sampleTask.taskId,
-    } satisfies WorkboardCard;
+    const { card: linked } = createLifecycleHarness(host);
     const commented = {
       ...linked,
       updatedAt: 2,
@@ -5266,9 +4769,6 @@ describe("workboard controller", () => {
     const completedTask = { ...sampleTask, status: "completed" as const, updatedAt: 3 };
     const firstTaskList = createDeferred<unknown>();
     let taskListCalls = 0;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set(linked.id, sampleTask);
     const client = createClient((method) => {
       if (method === "tasks.list") {
         taskListCalls += 1;
@@ -5330,8 +4830,6 @@ describe("workboard controller", () => {
   });
 
   it("authoritatively refreshes running linked cards without task ids before lifecycle sync", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.loaded = true;
     state.cards = [
       {
@@ -5353,16 +4851,13 @@ describe("workboard controller", () => {
   });
 
   it("reconciles session-only cards when task discovery is unavailable", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
       sessionKey: sampleSession.key,
       runId: "run-1",
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient((method) => {
       if (method === "tasks.list") {
         throw new Error("tasks unavailable");
@@ -5373,11 +4868,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, status: "done", hasActiveRun: false }],
-    });
+    await syncLifecycle(client, [{ ...sampleSession, status: "done", hasActiveRun: false }]);
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
@@ -5388,16 +4879,13 @@ describe("workboard controller", () => {
   });
 
   it("honors task refresh backoff while reconciling session-only cards", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
       sessionKey: sampleSession.key,
       runId: "run-1",
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     state.lifecycleTaskRefreshFailed = true;
     state.lifecycleTaskRefreshRetryAt = Date.now() + 5000;
     state.lifecycleTaskRefreshError = "tasks unavailable";
@@ -5411,11 +4899,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, status: "done", hasActiveRun: false }],
-    });
+    await syncLifecycle(client, [{ ...sampleSession, status: "done", hasActiveRun: false }]);
 
     expect(client.request).not.toHaveBeenCalledWith("tasks.list", expect.anything());
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
@@ -5426,18 +4910,7 @@ describe("workboard controller", () => {
   });
 
   it("exact-confirms task list omissions before lifecycle writes", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: sampleTask.taskId,
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set(linked.id, sampleTask);
+    const { card: linked } = createLifecycleHarness(host);
     const client = createClient({
       "tasks.list": { tasks: [] },
       "tasks.get": { task: sampleTask },
@@ -5459,18 +4932,11 @@ describe("workboard controller", () => {
     ["mismatched", "run-new"],
   ])("accepts exact-confirmed task ids with %s run metadata", async (_label, taskRunId) => {
     vi.useFakeTimers();
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-stale",
-      taskId: sampleTask.taskId,
-    } satisfies WorkboardCard;
+    const { card: linked } = createLifecycleHarness(host, {
+      card: { runId: "run-stale" },
+      task: null,
+    });
     const confirmedTask = { ...sampleTask, runId: taskRunId };
-    state.loaded = true;
-    state.cards = [linked];
     const client = createClient({
       "tasks.list": { tasks: [] },
       "tasks.get": { task: confirmedTask },
@@ -5488,8 +4954,6 @@ describe("workboard controller", () => {
 
   it("rotates bounded exact confirmations before lifecycle writes", async () => {
     vi.useFakeTimers();
-    const host = {};
-    const state = getWorkboardState(host);
     const cards = Array.from({ length: 65 }, (_, index) => ({
       ...sampleCard,
       id: `card-${index}`,
@@ -5537,8 +5001,6 @@ describe("workboard controller", () => {
 
   it("fails closed when bounded confirmations exceed their freshness window", async () => {
     vi.useFakeTimers();
-    const host = {};
-    const state = getWorkboardState(host);
     const cards = Array.from({ length: 33 }, (_, index) => ({
       ...sampleCard,
       id: `card-${index}`,
@@ -5581,8 +5043,6 @@ describe("workboard controller", () => {
   });
 
   it("stops bounded exact confirmations after a transient batch failure", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const cards = Array.from({ length: 33 }, (_, index) => ({
       ...sampleCard,
       id: `card-${index}`,
@@ -5613,116 +5073,55 @@ describe("workboard controller", () => {
     expect(state.lifecycleTasksPrepared).toBe(false);
   });
 
-  it("exact-confirms a tracked replacement omitted from lifecycle task listing", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
+  it.each([
+    { name: "exact confirmation succeeds", failure: null, status: "running" },
+    { name: "task listing fails", failure: "tasks unavailable", status: "ready" },
+    {
+      name: "exact confirmation fails",
+      failure: "task confirmation unavailable",
+      status: "ready",
+    },
+  ] as const)("preserves a tracked replacement when $name", async ({ failure, status }) => {
     const missingTaskId = "task-pruned-from-ledger";
-    const replacementTask = {
-      ...sampleTask,
+    const replacementTask = createWorkboardTask({
       id: "task-replacement",
       taskId: "task-replacement",
-    };
-    const linked = {
-      ...sampleCard,
-      status: "running",
+    });
+    const linked = createWorkboardCard({
+      status,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
       taskId: missingTaskId,
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set(linked.id, replacementTask);
+    });
+    setLoadedCard(linked, replacementTask);
     state.missingTaskIds = new Set([missingTaskId]);
-    const client = createClient({
-      "tasks.list": { tasks: [] },
-      "tasks.get": { task: replacementTask },
+    const client = createClient((method) => {
+      if (failure === "tasks unavailable") {
+        throw new Error(failure);
+      }
+      if (method === "tasks.list") {
+        return { tasks: [] };
+      }
+      if (failure) {
+        throw new Error(failure);
+      }
+      return { task: replacementTask };
     });
 
     await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
 
-    expect(client.request).toHaveBeenCalledWith("tasks.get", {
-      taskId: replacementTask.taskId,
-    });
+    expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
+    if (failure !== "tasks unavailable") {
+      expect(client.request).toHaveBeenCalledWith("tasks.get", { taskId: replacementTask.taskId });
+    }
     expect(client.request).not.toHaveBeenCalledWith("tasks.get", { taskId: missingTaskId });
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
     expect(state.tasksByCardId.get(linked.id)).toEqual(replacementTask);
     expect(state.missingTaskIds).toEqual(new Set([missingTaskId]));
-  });
-
-  it("preserves a tracked replacement when lifecycle task refresh fails", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const missingTaskId = "task-pruned-from-ledger";
-    const replacementTask = {
-      ...sampleTask,
-      id: "task-replacement",
-      taskId: "task-replacement",
-    };
-    const linked = {
-      ...sampleCard,
-      status: "ready",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: missingTaskId,
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set(linked.id, replacementTask);
-    state.missingTaskIds = new Set([missingTaskId]);
-    const client = createClient(() => {
-      throw new Error("tasks unavailable");
-    });
-
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
-
-    expect(client.request).toHaveBeenCalledOnce();
-    expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
-    expect(state.tasksByCardId.get(linked.id)).toEqual(replacementTask);
-    expect(state.missingTaskIds).toEqual(new Set([missingTaskId]));
-    expect(state.lifecycleTaskRefreshError).toBe("tasks unavailable");
-  });
-
-  it("preserves a tracked replacement when exact confirmation fails", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const missingTaskId = "task-pruned-from-ledger";
-    const replacementTask = {
-      ...sampleTask,
-      id: "task-replacement",
-      taskId: "task-replacement",
-    };
-    const linked = {
-      ...sampleCard,
-      status: "ready",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: missingTaskId,
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set(linked.id, replacementTask);
-    state.missingTaskIds = new Set([missingTaskId]);
-    const client = createClient((method) => {
-      if (method === "tasks.list") {
-        return { tasks: [] };
-      }
-      throw new Error("task confirmation unavailable");
-    });
-
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
-
-    expect(client.request).toHaveBeenNthCalledWith(1, "tasks.list", { limit: 500 });
-    expect(client.request).toHaveBeenNthCalledWith(2, "tasks.get", {
-      taskId: replacementTask.taskId,
-    });
-    expect(state.tasksByCardId.get(linked.id)).toEqual(replacementTask);
-    expect(state.missingTaskIds).toEqual(new Set([missingTaskId]));
-    expect(state.lifecycleTaskRefreshError).toBe("task confirmation unavailable");
+    expect(state.lifecycleTaskRefreshError).toBe(failure);
   });
 
   it("defers lifecycle writes when exact confirmation after task listing fails", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
@@ -5730,9 +5129,7 @@ describe("workboard controller", () => {
       runId: "run-1",
       taskId: sampleTask.taskId,
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set(linked.id, sampleTask);
+    setLoadedCard(linked, sampleTask);
     const client = createClient((method) => {
       if (method === "tasks.list") {
         return { tasks: [] };
@@ -5752,15 +5149,12 @@ describe("workboard controller", () => {
   });
 
   it("requests a render after lifecycle refresh marks a task missing", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "ready",
       taskId: sampleTask.taskId,
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient((method) => {
       if (method === "tasks.list") {
         return { tasks: [] };
@@ -5784,20 +5178,7 @@ describe("workboard controller", () => {
 
   it("keeps prepared task lifecycle state after no-op syncs", async () => {
     vi.useFakeTimers();
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: "task-1",
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set("card-1", sampleTask);
-    state.lifecycleTasksPrepared = true;
-    state.lifecycleTasksPreparedAt = Date.now();
+    createLifecycleHarness(host, { prepared: true });
     const client = createClient({
       "tasks.list": { tasks: [sampleTask] },
     });
@@ -5811,20 +5192,7 @@ describe("workboard controller", () => {
 
   it("refreshes prepared task lifecycle state after its freshness window", async () => {
     vi.useFakeTimers();
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: "task-1",
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set("card-1", sampleTask);
-    state.lifecycleTasksPrepared = true;
-    state.lifecycleTasksPreparedAt = Date.now();
+    const { card: linked } = createLifecycleHarness(host, { prepared: true });
     const completedTask = { ...sampleTask, status: "completed" as const };
     const client = createClient({
       "tasks.list": { tasks: [completedTask] },
@@ -5846,18 +5214,7 @@ describe("workboard controller", () => {
 
   it("retries a failed lifecycle task refresh after backoff", async () => {
     vi.useFakeTimers();
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: "task-1",
-    } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set("card-1", sampleTask);
+    createLifecycleHarness(host);
     const requestUpdate = vi.fn();
     let tasksAvailable = false;
     const client = createClient((method) => {
@@ -5899,19 +5256,8 @@ describe("workboard controller", () => {
   });
 
   it("does not resume lifecycle writes when dispatch starts during task refresh", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: "task-1",
-    } satisfies WorkboardCard;
+    const { card: linked } = createLifecycleHarness(host);
     const taskList = createDeferred<unknown>();
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set("card-1", sampleTask);
     const client = createClient((method) => {
       if (method === "tasks.list") {
         return taskList.promise;
@@ -5919,11 +5265,7 @@ describe("workboard controller", () => {
       return { card: { ...linked, status: "review" } };
     });
 
-    const syncing = syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [],
-    });
+    const syncing = syncLifecycle(client, []);
     await Promise.resolve();
     state.dispatching = true;
     taskList.resolve({ tasks: [{ ...sampleTask, status: "completed" }] });
@@ -5934,24 +5276,13 @@ describe("workboard controller", () => {
   });
 
   it("does not apply lifecycle task refresh after a newer card write", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
-      status: "running",
-      sessionKey: sampleTaskSessionKey,
-      runId: "run-1",
-      taskId: "task-1",
-    } satisfies WorkboardCard;
+    const { card: linked } = createLifecycleHarness(host);
     const commented = {
       ...linked,
       updatedAt: 2,
       metadata: { comments: [{ id: "comment-1", body: "Keep this", createdAt: 2 }] },
     } satisfies WorkboardCard;
     const taskList = createDeferred<unknown>();
-    state.loaded = true;
-    state.cards = [linked];
-    state.tasksByCardId.set("card-1", sampleTask);
     const client = createClient((method) => {
       if (method === "tasks.list") {
         return taskList.promise;
@@ -5962,11 +5293,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const syncing = syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [],
-    });
+    const syncing = syncLifecycle(client, []);
     await Promise.resolve();
     await addWorkboardCardComment({
       host,
@@ -5983,8 +5310,6 @@ describe("workboard controller", () => {
   });
 
   it("moves stale running sessions into running while recording stale metadata", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const staleUpdatedAt = Date.now() - 31 * 60 * 1000;
     const linked = {
       ...sampleCard,
@@ -5993,8 +5318,7 @@ describe("workboard controller", () => {
         comments: [{ id: "comment-1", body: "Keep me", createdAt: 1 }],
       },
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient({
       "workboard.cards.update": {
         card: {
@@ -6011,11 +5335,9 @@ describe("workboard controller", () => {
       },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, updatedAt: staleUpdatedAt, hasActiveRun: false }],
-    });
+    await syncLifecycle(client, [
+      { ...sampleSession, updatedAt: staleUpdatedAt, hasActiveRun: false },
+    ]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
       id: "card-1",
@@ -6033,8 +5355,6 @@ describe("workboard controller", () => {
   });
 
   it("syncs stale session metadata and clears it when the session recovers", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
@@ -6048,19 +5368,14 @@ describe("workboard controller", () => {
         },
       },
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient({
       "workboard.cards.update": {
         card: { ...linked, metadata: undefined, updatedAt: 3 },
       },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, updatedAt: Date.now(), hasActiveRun: true }],
-    });
+    await syncLifecycle(client, [{ ...sampleSession, updatedAt: Date.now(), hasActiveRun: true }]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
       id: "card-1",
@@ -6073,8 +5388,6 @@ describe("workboard controller", () => {
   });
 
   it("clears stale metadata after a newer manual status move", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
@@ -6096,26 +5409,21 @@ describe("workboard controller", () => {
         },
       ],
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient({
       "workboard.cards.update": {
         card: { ...linked, metadata: undefined, updatedAt: 6 },
       },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [
-        {
-          ...sampleSession,
-          status: "running",
-          updatedAt: 3,
-          hasActiveRun: true,
-        },
-      ],
-    });
+    await syncLifecycle(client, [
+      {
+        ...sampleSession,
+        status: "running",
+        updatedAt: 3,
+        hasActiveRun: true,
+      },
+    ]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
       id: "card-1",
@@ -6125,8 +5433,6 @@ describe("workboard controller", () => {
   });
 
   it("does not rewrite unchanged stale session metadata", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const staleUpdatedAt = Date.now() - 31 * 60 * 1000;
     const linked = {
       ...sampleCard,
@@ -6140,15 +5446,12 @@ describe("workboard controller", () => {
         },
       },
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient({ "workboard.cards.update": { card: linked } });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [{ ...sampleSession, updatedAt: staleUpdatedAt, hasActiveRun: false }],
-    });
+    await syncLifecycle(client, [
+      { ...sampleSession, updatedAt: staleUpdatedAt, hasActiveRun: false },
+    ]);
 
     expect(client.request).toHaveBeenCalledOnce();
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
@@ -6156,33 +5459,15 @@ describe("workboard controller", () => {
   });
 
   it("does not mark executions blocked when the linked session is missing from the current list", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    const linked = {
-      ...sampleCard,
+    const linked = createWorkboardCard({
       status: "running",
       sessionKey: "agent:main:dashboard:missing",
-      execution: {
-        id: "exec-1",
-        kind: "agent-session",
-        engine: "codex",
-        mode: "autonomous",
-        status: "running",
-        model: "openai/gpt-5.5",
-        sessionKey: "agent:main:dashboard:missing",
-        startedAt: 1,
-        updatedAt: 1,
-      },
-    } as const;
-    state.loaded = true;
-    state.cards = [linked];
+      execution: createWorkboardExecution({ sessionKey: "agent:main:dashboard:missing" }),
+    });
+    setLoadedCard(linked);
     const client = createClient({ "workboard.cards.update": { card: linked } });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [],
-    });
+    await syncLifecycle(client);
 
     expect(client.request).toHaveBeenCalledOnce();
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
@@ -6190,8 +5475,6 @@ describe("workboard controller", () => {
   });
 
   it("skips lifecycle writeback for read-only workboard clients", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     state.loaded = true;
     state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
     const client = createClient(() => {
@@ -6210,8 +5493,6 @@ describe("workboard controller", () => {
   });
 
   it("recovers task refresh failures for read-only workboard clients", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
@@ -6219,8 +5500,7 @@ describe("workboard controller", () => {
       runId: sampleTask.runId,
       taskId: sampleTask.taskId,
     } satisfies WorkboardCard;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     state.lifecycleTaskRefreshFailed = true;
     state.lifecycleTaskRefreshError = "tasks unavailable";
     state.lastRefreshError = "tasks unavailable";
@@ -6243,8 +5523,6 @@ describe("workboard controller", () => {
   });
 
   it("resyncs cards manually moved back to an active lifecycle column", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
@@ -6257,33 +5535,22 @@ describe("workboard controller", () => {
       status: "done",
       updatedAt: 2000,
     } as const;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient({
       "workboard.cards.update": {
         card: { ...linked, status: "review", updatedAt: 3000 },
       },
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [completedSession],
-    });
+    await syncLifecycle(client, [completedSession]);
     state.cards = [{ ...linked, updatedAt: 4000 }];
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [completedSession],
-    });
+    await syncLifecycle(client, [completedSession]);
 
     expect(client.request).toHaveBeenCalledTimes(3);
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
   });
 
   it("does not retry a failed lifecycle task refresh before backoff", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const linked = {
       ...sampleCard,
       status: "running",
@@ -6296,8 +5563,7 @@ describe("workboard controller", () => {
       status: "done",
       updatedAt: 2000,
     } as const;
-    state.loaded = true;
-    state.cards = [linked];
+    setLoadedCard(linked);
     const client = createClient((method) => {
       if (method === "tasks.list") {
         throw new Error("tasks unavailable");
@@ -6308,16 +5574,8 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [completedSession],
-    });
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [completedSession],
-    });
+    await syncLifecycle(client, [completedSession]);
+    await syncLifecycle(client, [completedSession]);
 
     expect(client.request.mock.calls.filter(([method]) => method === "tasks.list")).toHaveLength(1);
     expect(
@@ -6329,7 +5587,6 @@ describe("workboard controller", () => {
   });
 
   it("stops linked sessions and marks cards blocked", async () => {
-    const host = {};
     const linked = { ...sampleCard, sessionKey: sampleSession.key, runId: "run-1" };
     const blocked = { ...linked, status: "blocked" };
     const client = createClient({
@@ -6351,7 +5608,6 @@ describe("workboard controller", () => {
   });
 
   it("cancels active linked tasks and aborts the running session", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       sessionKey: sampleTaskSessionKey,
@@ -6359,7 +5615,6 @@ describe("workboard controller", () => {
       taskId: "task-1",
     };
     const blocked = { ...linked, status: "blocked" };
-    const state = getWorkboardState(host);
     state.cards = [linked];
     state.tasksByCardId.set("card-1", sampleTask);
     const client = createClient({
@@ -6390,7 +5645,6 @@ describe("workboard controller", () => {
   });
 
   it("marks a cancelled task blocked when follow-up session abort fails", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       sessionKey: sampleTaskSessionKey,
@@ -6398,7 +5652,6 @@ describe("workboard controller", () => {
       taskId: "task-1",
     };
     const blocked = { ...linked, status: "blocked" };
-    const state = getWorkboardState(host);
     state.cards = [linked];
     state.tasksByCardId.set("card-1", sampleTask);
     const client = createClient((method) => {
@@ -6425,7 +5678,6 @@ describe("workboard controller", () => {
   });
 
   it("cancels a tracked replacement instead of its confirmed-missing task link", async () => {
-    const host = {};
     const missingTaskId = "task-pruned-from-ledger";
     const replacementTask = {
       ...sampleTask,
@@ -6439,7 +5691,6 @@ describe("workboard controller", () => {
       taskId: missingTaskId,
     };
     const blocked = { ...linked, status: "blocked" };
-    const state = getWorkboardState(host);
     state.cards = [linked];
     state.tasksByCardId.set("card-1", replacementTask);
     state.missingTaskIds = new Set([missingTaskId]);
@@ -6461,35 +5712,54 @@ describe("workboard controller", () => {
     });
   });
 
-  it("cancels unresolved task-only cards through their canonical task id", async () => {
-    const host = {};
-    const linked = { ...sampleCard, status: "running" as const, taskId: "task-1" };
-    const blocked = { ...linked, status: "blocked" as const };
-    const state = getWorkboardState(host);
+  it.each([
+    {
+      name: "successful cancellation",
+      taskId: "task-1",
+      cancel: () => ({ cancelled: true }),
+      missing: false,
+    },
+    {
+      name: "found:false cancellation",
+      taskId: "task-pruned",
+      cancel: () => ({ found: false, cancelled: false }),
+      missing: true,
+    },
+    {
+      name: "missing-task cancellation",
+      taskId: "task-pruned",
+      cancel: () => {
+        throw new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: "task not found: task-pruned",
+        });
+      },
+      missing: true,
+    },
+  ])("stops task-only cards after $name", async ({ taskId, cancel, missing }) => {
+    const linked = createWorkboardCard({ status: "running", taskId });
+    const blocked = createWorkboardCard({ status: "blocked", taskId });
     state.cards = [linked];
-    const client = createClient({
-      "tasks.cancel": { cancelled: true },
-      "workboard.cards.update": { card: blocked },
-    });
+    const client = createClient((method) =>
+      method === "tasks.cancel" ? cancel() : { card: blocked },
+    );
 
     await stopWorkboardCard({ host, client: client as never, card: linked });
 
-    expect(client.request).toHaveBeenNthCalledWith(1, "tasks.cancel", {
-      taskId: "task-1",
-      reason: "Stopped from Workboard.",
-    });
-    expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", {
-      id: "card-1",
-      patch: { status: "blocked" },
-    });
-    expect(state.tasksByCardId.get("card-1")).toMatchObject({
-      taskId: "task-1",
-      status: "cancelled",
-    });
+    expect(client.request.mock.calls).toEqual([
+      ["tasks.cancel", { taskId, reason: "Stopped from Workboard." }],
+      ["workboard.cards.update", { id: "card-1", patch: { status: "blocked" } }],
+    ]);
+    expect(state.cards).toEqual([blocked]);
+    if (missing) {
+      expect(state.missingTaskIds).toEqual(new Set([taskId]));
+    } else {
+      expect(state.tasksByCardId.get("card-1")).toMatchObject({ taskId, status: "cancelled" });
+    }
+    expect(state.error).toBeNull();
   });
 
   it("records found:false task cancellation before aborting its linked session", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       status: "running" as const,
@@ -6498,7 +5768,6 @@ describe("workboard controller", () => {
       taskId: "task-pruned",
     };
     const blocked = { ...linked, status: "blocked" as const };
-    const state = getWorkboardState(host);
     state.cards = [linked];
     const client = createClient((method) => {
       if (method === "tasks.cancel") {
@@ -6530,7 +5799,6 @@ describe("workboard controller", () => {
   });
 
   it("leaves linked cards unchanged when a missing task has no active session to abort", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       status: "running" as const,
@@ -6538,7 +5806,6 @@ describe("workboard controller", () => {
       runId: "run-1",
       taskId: "task-pruned",
     };
-    const state = getWorkboardState(host);
     state.cards = [linked];
     const client = createClient((method) => {
       if (method === "tasks.cancel") {
@@ -6563,7 +5830,6 @@ describe("workboard controller", () => {
   });
 
   it("reports linked session abort errors after a missing task cancellation", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       status: "running" as const,
@@ -6571,7 +5837,6 @@ describe("workboard controller", () => {
       runId: "run-1",
       taskId: "task-pruned",
     };
-    const state = getWorkboardState(host);
     state.cards = [linked];
     const client = createClient((method) => {
       if (method === "tasks.cancel") {
@@ -6595,75 +5860,7 @@ describe("workboard controller", () => {
     expect(state.error).toBe("session abort unavailable");
   });
 
-  it("treats found:false task cancellation as stopped for task-only cards", async () => {
-    const host = {};
-    const linked = {
-      ...sampleCard,
-      status: "running" as const,
-      taskId: "task-pruned",
-    };
-    const blocked = { ...linked, status: "blocked" as const };
-    const state = getWorkboardState(host);
-    state.cards = [linked];
-    const client = createClient((method) => {
-      if (method === "tasks.cancel") {
-        return { found: false, cancelled: false };
-      }
-      return { card: blocked };
-    });
-
-    await stopWorkboardCard({ host, client: client as never, card: linked });
-
-    expect(client.request).toHaveBeenNthCalledWith(1, "tasks.cancel", {
-      taskId: "task-pruned",
-      reason: "Stopped from Workboard.",
-    });
-    expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", {
-      id: "card-1",
-      patch: { status: "blocked" },
-    });
-    expect(state.cards).toEqual([blocked]);
-    expect(state.missingTaskIds).toEqual(new Set(["task-pruned"]));
-    expect(state.error).toBeNull();
-  });
-
-  it("treats missing task cancellation as stopped for task-only cards", async () => {
-    const host = {};
-    const linked = {
-      ...sampleCard,
-      status: "running" as const,
-      taskId: "task-pruned",
-    };
-    const blocked = { ...linked, status: "blocked" as const };
-    const state = getWorkboardState(host);
-    state.cards = [linked];
-    const client = createClient((method) => {
-      if (method === "tasks.cancel") {
-        throw new GatewayRequestError({
-          code: "INVALID_REQUEST",
-          message: "task not found: task-pruned",
-        });
-      }
-      return { card: blocked };
-    });
-
-    await stopWorkboardCard({ host, client: client as never, card: linked });
-
-    expect(client.request).toHaveBeenNthCalledWith(1, "tasks.cancel", {
-      taskId: "task-pruned",
-      reason: "Stopped from Workboard.",
-    });
-    expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", {
-      id: "card-1",
-      patch: { status: "blocked" },
-    });
-    expect(state.cards).toEqual([blocked]);
-    expect(state.missingTaskIds).toEqual(new Set(["task-pruned"]));
-    expect(state.error).toBeNull();
-  });
-
   it("reports task cancellation errors without aborting the linked session", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       status: "running" as const,
@@ -6671,7 +5868,6 @@ describe("workboard controller", () => {
       runId: "run-1",
       taskId: "task-1",
     };
-    const state = getWorkboardState(host);
     state.cards = [linked];
     state.tasksByCardId.set(linked.id, sampleTask);
     const client = createClient((method) => {
@@ -6696,14 +5892,12 @@ describe("workboard controller", () => {
   });
 
   it("marks task-linked cards blocked when task cancellation already stopped the session", async () => {
-    const host = {};
     const linked = {
       ...sampleCard,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
       taskId: "task-1",
     };
-    const state = getWorkboardState(host);
     state.cards = [linked];
     state.tasksByCardId.set("card-1", sampleTask);
     const blocked = { ...linked, status: "blocked" as const };
@@ -6738,9 +5932,7 @@ describe("workboard controller", () => {
   });
 
   it("cancels active task-only cards from the local task map", async () => {
-    const host = {};
     const blocked = { ...sampleCard, status: "blocked" };
-    const state = getWorkboardState(host);
     state.cards = [sampleCard];
     state.tasksByCardId.set("card-1", sampleTask);
     const client = createClient({
@@ -6765,7 +5957,6 @@ describe("workboard controller", () => {
   });
 
   it("archives cards through the plugin gateway method", async () => {
-    const host = {};
     const archived = {
       ...sampleCard,
       metadata: { archivedAt: 20 },
@@ -6786,7 +5977,6 @@ describe("workboard controller", () => {
   });
 
   it("falls back to the active session abort when the stored run id is stale", async () => {
-    const host = {};
     const linked = { ...sampleCard, sessionKey: sampleSession.key, runId: "old-run" };
     const blocked = { ...linked, status: "blocked" };
     const client = createClient((method, params) => {
@@ -6816,9 +6006,7 @@ describe("workboard controller", () => {
   });
 
   it("leaves cards unchanged when stop does not abort an active run", async () => {
-    const host = {};
     const linked = { ...sampleCard, sessionKey: sampleSession.key, runId: "stale-run" };
-    const state = getWorkboardState(host);
     state.cards = [linked];
     const client = createClient({
       "chat.abort": { aborted: false, runIds: [] },

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -6,16 +6,6 @@ import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
-  createDeferred,
-  createGatewaySession,
-  createLifecycleHarness,
-  createWorkboardCard,
-  createWorkboardExecution,
-  createWorkboardTask,
-  createWorkboardTestClient as createClient,
-  type WorkboardTestClient,
-} from "./index.test-helpers.ts";
-import {
   addWorkboardCardComment,
   archiveWorkboardCard,
   captureSessionToWorkboard,
@@ -38,6 +28,16 @@ import {
   type WorkboardTaskSummary,
 } from "./index.ts";
 import { normalizeExecution, normalizeMetadata } from "./metadata-normalization.ts";
+import {
+  createDeferred,
+  createGatewaySession,
+  createLifecycleHarness,
+  createWorkboardCard,
+  createWorkboardExecution,
+  createWorkboardTask,
+  createWorkboardTestClient as createClient,
+  type WorkboardTestClient,
+} from "./test/index-helpers.ts";
 
 function requestPatch(client: ReturnType<typeof createClient>, index: number) {
   return (client.request.mock.calls[index]?.[1] as { patch?: Record<string, unknown> } | undefined)

--- a/ui/src/lib/workboard/test/index-helpers.ts
+++ b/ui/src/lib/workboard/test/index-helpers.ts
@@ -1,8 +1,8 @@
 import { vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { GatewaySessionRow } from "../../api/types.ts";
-import { getWorkboardState } from "./runtime.ts";
-import type { WorkboardCard, WorkboardTaskSummary } from "./types.ts";
+import type { GatewayBrowserClient } from "../../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../../api/types.ts";
+import { getWorkboardState } from "../runtime.ts";
+import type { WorkboardCard, WorkboardTaskSummary } from "../types.ts";
 
 type RequestHandler = (method: string, params: unknown) => unknown;
 type RequestResponses = Record<string, unknown> | RequestHandler;


### PR DESCRIPTION
## What Problem This Solves

The Workboard controller test file repeated host/state setup, gateway client mocks, card/task/session fixtures, and near-identical lifecycle cases across a 6,840-line suite. That duplication made the tests harder to scan and maintain.

## Why This Change Was Made

Extracts typed colocated fixture builders and consolidates only behaviorally identical cases into named tables. Distinct concurrency, rollback, and ordering scenarios remain separate so their failures stay precise. Production behavior and test coverage are unchanged.

## User Impact

No user-visible impact. Maintainers get a smaller Workboard test surface with the same 177 runtime cases and assertions.

## Evidence

- LOC: +532 / -1226 test lines, net -694. Production LOC: +0 / -0. Test LOC: +532 / -1226.
- Test count: 177 before, 177 after.
- `node scripts/run-vitest.mjs ui/src/lib/workboard/index.test.ts` — 177 passed after rebasing onto repaired `main`.
- `node scripts/changed-lanes.mjs --json -- ui/src/lib/workboard/index.test.ts ui/src/lib/workboard/test/index-helpers.ts` — both files classify as UI tests; only the `coreTests` lane is selected.
- Exact-head CI run `29981457920` — green for `f97ea4eb89e1576eef71a22aa992a7a770404d04`: https://github.com/openclaw/openclaw/actions/runs/29981457920
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings (0.94 confidence).
