### PR TITLE
fix(browser): extension relay stays offline after gateway restart

### DIFF
--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -442,6 +442,30 @@ describe("browser plugin", () => {
     expect(runtimeApiMocks.createBrowserPluginService).toHaveBeenCalledOnce();
   });
 
+  it("loads the browser control service for a configured extension-driver profile", async () => {
+    const { api, registerService } = createApi();
+    registerBrowserPlugin(api);
+
+    const service = mockCallArg(registerService) as {
+      id: string;
+      start: (...args: unknown[]) => unknown;
+    };
+
+    await service.start({
+      config: {
+        browser: {
+          profiles: {
+            chrome: { driver: "extension" },
+          },
+        },
+      },
+      stateDir: "/tmp/openclaw",
+      logger: { warn: vi.fn() },
+    });
+
+    expect(runtimeApiMocks.createBrowserPluginService).toHaveBeenCalledOnce();
+  });
+
   for (const value of ["false", "", "disabled"]) {
     it(`keeps browser control service env value ${JSON.stringify(value)} lazy`, async () => {
       vi.stubEnv("OPENCLAW_EAGER_BROWSER_CONTROL_SERVER", value);

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -14,7 +14,7 @@ import type {
   OpenClawPluginToolContext,
   OpenClawPluginToolFactory,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { createSubsystemLogger, isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { isBrowserMachineOutput } from "./cli-output-mode.js";
 import {
   BROWSER_REQUEST_GATEWAY_METHOD,
@@ -32,8 +32,8 @@ import {
   configureSystemProfileImportStateStore,
   type SystemProfileImportState,
 } from "./src/browser/system-profile-import-state.js";
+import { resolveBrowserControlStartupMode } from "./src/plugin-start-policy.js";
 
-const EAGER_BROWSER_CONTROL_SERVICE_ENV = "OPENCLAW_EAGER_BROWSER_CONTROL_SERVER";
 const logger = createSubsystemLogger("browser");
 
 const loadBrowserRegistrationRuntimeModule = createLazyRuntimeModule(
@@ -216,7 +216,11 @@ function createLazyBrowserPluginService(): OpenClawPluginService {
   return {
     id: "browser-control",
     start: async (ctx) => {
-      if (!isTruthyEnvValue(process.env[EAGER_BROWSER_CONTROL_SERVICE_ENV])) {
+      const startupMode = resolveBrowserControlStartupMode(
+        ctx.config,
+        process.env.OPENCLAW_EAGER_BROWSER_CONTROL_SERVER,
+      );
+      if (!startupMode) {
         return;
       }
       const loaded = await loadService();

--- a/extensions/browser/src/browser/extension-relay/control-startup.test.ts
+++ b/extensions/browser/src/browser/extension-relay/control-startup.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserServerState } from "../server-context.js";
+
+const mocks = vi.hoisted(() => ({
+  startConfiguredExtensionRelays: vi.fn(async () => undefined),
+}));
+
+vi.mock("../extension-relay.runtime.js", () => ({
+  getExtensionRelayModule: async () => ({
+    startConfiguredExtensionRelays: mocks.startConfiguredExtensionRelays,
+  }),
+}));
+
+const { startControlStateExtensionRelays } = await import("./control-startup.js");
+
+function stateWithProfiles(profiles: Record<string, { driver: string }>): BrowserServerState {
+  return {
+    resolved: { profiles },
+  } as unknown as BrowserServerState;
+}
+
+describe("startControlStateExtensionRelays", () => {
+  it("starts configured relays when an extension-driver profile exists", async () => {
+    const state = stateWithProfiles({ chrome: { driver: "extension" } });
+    const onWarn = vi.fn();
+
+    await startControlStateExtensionRelays(state, onWarn);
+
+    expect(mocks.startConfiguredExtensionRelays).toHaveBeenCalledOnce();
+    expect(mocks.startConfiguredExtensionRelays).toHaveBeenCalledWith(
+      state,
+      expect.any(Function),
+      onWarn,
+    );
+  });
+
+  it("does not load relay startup for managed browser profiles", async () => {
+    mocks.startConfiguredExtensionRelays.mockClear();
+
+    await startControlStateExtensionRelays(
+      stateWithProfiles({ openclaw: { driver: "openclaw" } }),
+      vi.fn(),
+    );
+
+    expect(mocks.startConfiguredExtensionRelays).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/browser/src/browser/extension-relay/control-startup.ts
+++ b/extensions/browser/src/browser/extension-relay/control-startup.ts
@@ -1,0 +1,22 @@
+import { resolveProfile } from "../config.js";
+import { getExtensionRelayModule } from "../extension-relay.runtime.js";
+import type { BrowserServerState } from "../server-context.js";
+
+/** Start every configured extension relay for either browser-control owner. */
+export async function startControlStateExtensionRelays(
+  state: BrowserServerState,
+  onWarn: (message: string) => void,
+): Promise<void> {
+  const hasExtensionProfiles = Object.values(state.resolved.profiles).some(
+    (profile) => profile.driver === "extension",
+  );
+  if (!hasExtensionProfiles) {
+    return;
+  }
+  const { startConfiguredExtensionRelays } = await getExtensionRelayModule();
+  await startConfiguredExtensionRelays(
+    state,
+    (name) => resolveProfile(state.resolved, name),
+    onWarn,
+  );
+}

--- a/extensions/browser/src/control-service.ts
+++ b/extensions/browser/src/control-service.ts
@@ -9,9 +9,9 @@ import {
   withBrowserControlStart,
 } from "./browser-control-state.js";
 import { loadBrowserConfigForRuntimeRefresh } from "./browser/config-refresh-source.js";
-import { resolveBrowserConfig, resolveProfile } from "./browser/config.js";
+import { resolveBrowserConfig } from "./browser/config.js";
 import { ensureBrowserControlAuth } from "./browser/control-auth.js";
-import { getExtensionRelayModule } from "./browser/extension-relay.runtime.js";
+import { startControlStateExtensionRelays } from "./browser/extension-relay/control-startup.js";
 import type { BrowserServerState } from "./browser/server-context.js";
 import { getRuntimeConfig } from "./config/config.js";
 import { createSubsystemLogger } from "./logging/subsystem.js";
@@ -67,14 +67,7 @@ async function startBrowserControlServiceUnlocked(): Promise<BrowserServerState 
 
   // Extension relays listen from service start so the Chrome extension can
   // (re)connect before the first agent browser request arrives.
-  if (hasExtensionProfiles) {
-    const { startConfiguredExtensionRelays } = await getExtensionRelayModule();
-    await startConfiguredExtensionRelays(
-      state,
-      (name) => resolveProfile(resolved, name),
-      (message) => logService.warn(message),
-    );
-  }
+  await startControlStateExtensionRelays(state, (message) => logService.warn(message));
 
   logService.info(
     `Browser control service ready (profiles=${Object.keys(resolved.profiles).length})`,

--- a/extensions/browser/src/gateway/browser-request.shared-control-state.test.ts
+++ b/extensions/browser/src/gateway/browser-request.shared-control-state.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   resolveBrowserControlAuth: vi.fn(() => ({})),
   shouldAutoGenerateBrowserAuth: vi.fn(() => false),
   stopKnownBrowserProfiles: vi.fn(async () => {}),
+  startControlStateExtensionRelays: vi.fn(async () => {}),
   isChromeReachable: vi.fn(async () => false),
   isChromeCdpReady: vi.fn(async () => false),
 }));
@@ -33,6 +34,10 @@ vi.mock("../browser/control-auth.js", () => ({
 
 vi.mock("../browser/server-lifecycle.js", () => ({
   stopKnownBrowserProfiles: mocks.stopKnownBrowserProfiles,
+}));
+
+vi.mock("../browser/extension-relay/control-startup.js", () => ({
+  startControlStateExtensionRelays: mocks.startControlStateExtensionRelays,
 }));
 
 vi.mock("../browser/chrome.js", () => ({
@@ -147,6 +152,28 @@ describe("browser.request local control state", () => {
     expect(status.executablePath).toBe("/usr/bin/google-chrome");
     expect(status.headless).toBe(true);
     expect(status.noSandbox).toBe(true);
+  });
+
+  it("starts configured extension relays with the standalone HTTP server", async () => {
+    const controlPort = await getFreePort();
+    mocks.runtimeConfig = {
+      gateway: { port: controlPort - 2 },
+      browser: {
+        enabled: true,
+        profiles: {
+          chrome: { driver: "extension" },
+        },
+      },
+    };
+    mocks.runtimeSourceConfig = mocks.runtimeConfig;
+
+    const state = await startBrowserControlServerFromConfig();
+
+    expect(state).toBeTruthy();
+    expect(mocks.startControlStateExtensionRelays).toHaveBeenCalledWith(
+      state,
+      expect.any(Function),
+    );
   });
 
   it("retains port auth until a failed stop is retried successfully", async () => {

--- a/extensions/browser/src/plugin-service.test.ts
+++ b/extensions/browser/src/plugin-service.test.ts
@@ -11,14 +11,19 @@ const SERVICE_CONTEXT = {
 };
 
 type StartLazyPluginServiceModuleParams = {
+  loadDefaultModule?: () => Promise<Record<string, unknown>>;
+  startExportNames?: string[];
   validateOverrideSpecifier?: (specifier: string) => string;
 };
 type StartLazyPluginServiceModuleParamsWithValidator = {
+  loadDefaultModule: () => Promise<Record<string, unknown>>;
+  startExportNames: string[];
   validateOverrideSpecifier: (specifier: string) => string;
 };
 
 const runtimeMocks = vi.hoisted(() => ({
   startLazyPluginServiceModule: vi.fn(async (_params: StartLazyPluginServiceModuleParams) => null),
+  startBrowserControlServiceFromConfig: vi.fn(async () => null),
   stopBrowserControlService: vi.fn(async () => undefined),
   createGatewayPageShareSink: vi.fn(() => ({ id: "gateway-page-share-sink" })),
   setPageShareSink: vi.fn(),
@@ -29,6 +34,7 @@ vi.mock("./sdk-node-runtime.js", () => ({
 }));
 
 vi.mock("./control-service.js", () => ({
+  startBrowserControlServiceFromConfig: runtimeMocks.startBrowserControlServiceFromConfig,
   stopBrowserControlService: runtimeMocks.stopBrowserControlService,
 }));
 
@@ -57,10 +63,18 @@ describe("createBrowserPluginService", () => {
       throw new Error("expected browser plugin service lazy loader call");
     }
     const [params] = call;
-    if (!params?.validateOverrideSpecifier) {
-      throw new Error("expected browser plugin service to pass validateOverrideSpecifier");
+    if (
+      !params?.validateOverrideSpecifier ||
+      !params.loadDefaultModule ||
+      !params.startExportNames
+    ) {
+      throw new Error("expected complete browser plugin service lazy loader params");
     }
-    return { validateOverrideSpecifier: params.validateOverrideSpecifier };
+    return {
+      loadDefaultModule: params.loadDefaultModule,
+      startExportNames: params.startExportNames,
+      validateOverrideSpecifier: params.validateOverrideSpecifier,
+    };
   }
 
   it("does not start the control server during gateway startup by default", async () => {
@@ -83,6 +97,25 @@ describe("createBrowserPluginService", () => {
     expect(runtimeMocks.setPageShareSink).toHaveBeenLastCalledWith(null);
   });
 
+  it("starts during gateway startup when an extension-driver profile is configured", async () => {
+    const service = createBrowserPluginService();
+
+    await service.start({
+      ...SERVICE_CONTEXT,
+      config: {
+        browser: {
+          profiles: {
+            chrome: { driver: "extension" },
+          },
+        },
+      },
+    });
+
+    expect(runtimeMocks.startLazyPluginServiceModule).toHaveBeenCalledOnce();
+    const module = await getStartParams().loadDefaultModule();
+    expect(module).toHaveProperty("startBrowserControlServiceFromConfig");
+  });
+
   for (const value of ["0", "", "disabled"]) {
     it(`does not start the control server for eager env value ${JSON.stringify(value)}`, async () => {
       vi.stubEnv("OPENCLAW_EAGER_BROWSER_CONTROL_SERVER", value);
@@ -102,6 +135,18 @@ describe("createBrowserPluginService", () => {
 
     const params = getStartParams();
     expect(params.validateOverrideSpecifier(" ./server.js ")).toBe("./server.js");
+  });
+
+  it("preserves the standalone HTTP server for explicit eager startup", async () => {
+    vi.stubEnv("OPENCLAW_EAGER_BROWSER_CONTROL_SERVER", "1");
+    const service = createBrowserPluginService();
+
+    await service.start(SERVICE_CONTEXT);
+
+    const params = getStartParams();
+    const module = await params.loadDefaultModule();
+    expect(params.startExportNames[0]).toBe("startBrowserControlServerFromConfig");
+    expect(module).toHaveProperty("startBrowserControlServerFromConfig");
   });
 
   it("rejects unsafe browser override specifiers", async () => {

--- a/extensions/browser/src/plugin-service.ts
+++ b/extensions/browser/src/plugin-service.ts
@@ -1,7 +1,7 @@
 /**
  * Browser plugin service factory that lazily starts the control server.
  */
-import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
+import { resolveBrowserControlStartupMode } from "./plugin-start-policy.js";
 import {
   startLazyPluginServiceModule,
   type LazyPluginServiceHandle,
@@ -9,7 +9,6 @@ import {
 } from "./sdk-node-runtime.js";
 
 type BrowserControlHandle = LazyPluginServiceHandle | null;
-const EAGER_BROWSER_CONTROL_SERVICE_ENV = "OPENCLAW_EAGER_BROWSER_CONTROL_SERVER";
 const UNSAFE_BROWSER_CONTROL_OVERRIDE_SPECIFIER = /^(?:data|http|https|node):/i;
 
 function validateBrowserControlOverrideSpecifier(specifier: string): string {
@@ -26,12 +25,16 @@ export function createBrowserPluginService(): OpenClawPluginService {
 
   return {
     id: "browser-control",
-    start: async () => {
+    start: async (ctx) => {
       const pageShare = await import("./browser/extension-relay/page-share.js");
       // Plugin services start only in the Gateway process. The sink marks this
       // process as able to deliver page shares to the main session.
       pageShare.setPageShareSink(pageShare.createGatewayPageShareSink());
-      if (!isTruthyEnvValue(process.env[EAGER_BROWSER_CONTROL_SERVICE_ENV])) {
+      const startupMode = resolveBrowserControlStartupMode(
+        ctx.config,
+        process.env.OPENCLAW_EAGER_BROWSER_CONTROL_SERVER,
+      );
+      if (!startupMode) {
         return;
       }
       if (handle) {
@@ -42,12 +45,18 @@ export function createBrowserPluginService(): OpenClawPluginService {
         overrideEnvVar: "OPENCLAW_BROWSER_CONTROL_MODULE",
         validateOverrideSpecifier: validateBrowserControlOverrideSpecifier,
         // Keep the default module import static so compiled builds still bundle it.
-        loadDefaultModule: async () => await import("./server.js"),
-        startExportNames: [
-          "startBrowserControlServiceFromConfig",
-          "startBrowserControlServerFromConfig",
-        ],
-        stopExportNames: ["stopBrowserControlService", "stopBrowserControlServer"],
+        loadDefaultModule: async () =>
+          startupMode === "server"
+            ? await import("./server.js")
+            : await import("./control-service.js"),
+        startExportNames:
+          startupMode === "server"
+            ? ["startBrowserControlServerFromConfig", "startBrowserControlServiceFromConfig"]
+            : ["startBrowserControlServiceFromConfig", "startBrowserControlServerFromConfig"],
+        stopExportNames:
+          startupMode === "server"
+            ? ["stopBrowserControlServer", "stopBrowserControlService"]
+            : ["stopBrowserControlService", "stopBrowserControlServer"],
       });
     },
     stop: async () => {

--- a/extensions/browser/src/plugin-start-policy.ts
+++ b/extensions/browser/src/plugin-start-policy.ts
@@ -1,0 +1,24 @@
+import type { OpenClawConfig } from "./config/config.js";
+
+function isTruthyEnvValue(value: string | undefined): boolean {
+  return /^(?:1|true|yes|on)$/iu.test(value?.trim() ?? "");
+}
+
+export type BrowserControlStartupMode = "server" | "service";
+
+/** Select the early-start owner without changing the standalone HTTP server contract. */
+export function resolveBrowserControlStartupMode(
+  config: OpenClawConfig,
+  eagerEnvValue: string | undefined,
+): BrowserControlStartupMode | null {
+  if (isTruthyEnvValue(eagerEnvValue)) {
+    return "server";
+  }
+  if (config.browser?.enabled === false) {
+    return null;
+  }
+  const hasExtensionProfile = Object.values(config.browser?.profiles ?? {}).some(
+    (profile) => profile.driver === "extension",
+  );
+  return hasExtensionProfile ? "service" : null;
+}

--- a/extensions/browser/src/plugin-start-policy.ts
+++ b/extensions/browser/src/plugin-start-policy.ts
@@ -4,7 +4,7 @@ function isTruthyEnvValue(value: string | undefined): boolean {
   return /^(?:1|true|yes|on)$/iu.test(value?.trim() ?? "");
 }
 
-export type BrowserControlStartupMode = "server" | "service";
+type BrowserControlStartupMode = "server" | "service";
 
 /** Select the early-start owner without changing the standalone HTTP server contract. */
 export function resolveBrowserControlStartupMode(

--- a/extensions/browser/src/server.ts
+++ b/extensions/browser/src/server.ts
@@ -17,6 +17,7 @@ import {
   resolveBrowserControlAuth,
   shouldAutoGenerateBrowserAuth,
 } from "./browser/control-auth.js";
+import { startControlStateExtensionRelays } from "./browser/extension-relay/control-startup.js";
 import { listenBrowserHttpServer } from "./browser/http-listen.js";
 import { registerBrowserRoutes } from "./browser/routes/index.js";
 import type { BrowserRouteRegistrar } from "./browser/routes/types.js";
@@ -110,6 +111,7 @@ async function startBrowserControlServerUnlocked(): Promise<BrowserServerState |
     throw err;
   }
   setBridgeAuthForPort(port, browserAuth);
+  await startControlStateExtensionRelays(state, (message) => logServer.warn(message));
 
   const authMode = browserAuth.token ? "token" : browserAuth.password ? "password" : "off";
   logServer.info(`Browser control listening on http://127.0.0.1:${port}/ (auth=${authMode})`);


### PR DESCRIPTION
Closes #112832

## What Problem This Solves

Fixes an issue where users with an explicitly configured extension-driver browser profile would lose the Chrome extension relay after every Gateway restart. The relay stayed unavailable until a browser CLI or agent request lazily started browser control, and `OPENCLAW_EAGER_BROWSER_CONTROL_SERVER=1` started only the standalone HTTP server without the relay.

## Why This Change Was Made

Gateway startup now detects explicitly configured extension-driver profiles and starts the in-process browser control service early. Relay startup is shared by both control owners, so the explicit eager environment flag keeps its documented standalone HTTP server behavior while also starting configured extension relays.

The early-start policy remains narrow: browser control stays lazy for ordinary managed/existing-session profiles, and `browser.enabled: false` is respected unless the explicit eager flag requests the legacy server path.

## User Impact

Paired Chrome extensions can reconnect immediately after a Gateway restart without a manual `openclaw browser ...` kick or periodic workaround. Operators using the eager browser-control environment flag retain the same loopback HTTP API contract and now get relay startup as well.

## Evidence

### Real Gateway restart proof

Verified on current head `ba36c55e9b8dccb101efd209f918c115340aa59e` using a real foreground Gateway process on macOS arm64 with an isolated state directory and this configuration:

```json
{
  "gateway": {
    "mode": "local",
    "port": 32489,
    "controlUi": { "enabled": false }
  },
  "browser": {
    "profiles": {
      "chrome": { "driver": "extension" }
    }
  }
}
```

No browser CLI command, browser agent request, or browser HTTP request was issued between Gateway startup and the TCP probes below. Temporary auth values and local paths are omitted.

First start, shutdown, and restart through the normal configured-profile path:

```text
12:54:29 [browser/extension-relay] extension relay for profile "chrome" listening on 127.0.0.1:32499
12:54:29 [browser/service] Browser control service ready (profiles=3)
12:54:29 [gateway] ready
Connection to 127.0.0.1 port 32499 [tcp/*] succeeded!
node ... TCP 127.0.0.1:32499 (LISTEN)

12:55:03 [gateway] received SIGINT; shutting down
relay-closed-after-shutdown

12:55:56 [browser/extension-relay] extension relay for profile "chrome" listening on 127.0.0.1:32499
12:55:56 [browser/service] Browser control service ready (profiles=3)
12:55:56 [gateway] ready
relay-open-after-restart
node ... TCP 127.0.0.1:32499 (LISTEN)
```

The existing eager environment path was also exercised against the same isolated config:

```text
12:57:04 [browser/extension-relay] extension relay for profile "chrome" listening on 127.0.0.1:32499
12:57:04 [browser/server] Browser control listening on http://127.0.0.1:32491/ (auth=token)
12:57:04 [gateway] ready
eager-http-and-relay-open
node ... TCP 127.0.0.1:32491 (LISTEN)
node ... TCP 127.0.0.1:32499 (LISTEN)
```

### Automated validation

- Current-head focused suite: 4 directly affected files, 39 tests passed.
- Production extension type check passed after the conflict resolution: `tsconfig.extensions.json`.
- Extension test type check passed after the conflict resolution: `test/tsconfig/tsconfig.extensions.test.json`.
- Full dead-code check passed after the conflict resolution: `pnpm deadcode:full`.
- `oxfmt --check`, `oxlint`, and `git diff --check` passed for all 10 touched files.
- Earlier browser extension suite: 1,971 tests passed; its 3 remaining failures reproduced identically in a clean, unmodified baseline checkout and were unrelated to this change.

AI-assisted implementation, manually reviewed and supervised. The repository's optional `autoreview` skill was not available in this environment; the complete diff was reviewed manually, including a follow-up test that directly verifies the standalone HTTP server invokes relay startup.

