### PR TITLE
fix(openrouter): discover models when HTTP proxy is required

### DIFF
--- a/extensions/openrouter/provider-catalog.proxy.test.ts
+++ b/extensions/openrouter/provider-catalog.proxy.test.ts
@@ -1,0 +1,39 @@
+// OpenRouter proxy tests cover the live model discovery transport policy.
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+import { buildOpenrouterLiveProvider, OPENROUTER_BASE_URL } from "./provider-catalog.js";
+
+afterEach(() => {
+  clearLiveCatalogCacheForTests();
+  fetchWithSsrFGuardMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("OpenRouter model discovery proxy policy", () => {
+  it("allows the guarded official catalog request to use an eligible HTTP proxy", async () => {
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("unavailable", { status: 400 }),
+      release,
+      finalUrl: `${OPENROUTER_BASE_URL}/models`,
+    });
+
+    await buildOpenrouterLiveProvider({ apiKey: "test-token" });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "trusted_env_proxy",
+        url: `${OPENROUTER_BASE_URL}/models`,
+      }),
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/openrouter/provider-catalog.ts
+++ b/extensions/openrouter/provider-catalog.ts
@@ -1,4 +1,5 @@
 // Openrouter provider module implements model/runtime integration.
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import {
   getCachedLiveProviderModelRows,
   type LiveModelCatalogFetchGuard,
@@ -7,6 +8,7 @@ import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const OPENROUTER_MODELS_ENDPOINT = `${OPENROUTER_BASE_URL}/models`;
@@ -190,6 +192,9 @@ function parseOpenRouterLiveModels(rows: readonly unknown[]): ModelDefinitionCon
   return [...new Map(models.map((model) => [model.id, model])).values()];
 }
 
+const defaultOpenRouterFetchGuard: LiveModelCatalogFetchGuard = (params) =>
+  fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params));
+
 export async function buildOpenrouterLiveProvider(params: {
   apiKey?: string;
   discoveryApiKey?: string;
@@ -206,7 +211,7 @@ export async function buildOpenrouterLiveProvider(params: {
       endpoint: OPENROUTER_MODELS_ENDPOINT,
       apiKey: params.apiKey,
       discoveryApiKey: params.discoveryApiKey,
-      fetchGuard: params.fetchGuard,
+      fetchGuard: params.fetchGuard ?? defaultOpenRouterFetchGuard,
       signal: params.signal,
       ttlMs: OPENROUTER_MODELS_CACHE_TTL_MS,
       auditContext: "openrouter-model-discovery",


### PR DESCRIPTION
## Summary

OpenRouter live model discovery now honors `HTTPS_PROXY`/`HTTP_PROXY` by default, so proxy-required networks get the live OpenRouter catalog instead of silently falling back to the 3 bundled seed models.

## What Problem This Solves

In environments where outbound HTTPS is only possible through an HTTP(S) proxy (typical corporate egress), `openclaw models list --all --provider openrouter` waits out the 5-second discovery window and then lists only the 3 bundled seed models (`openrouter/auto`, `openrouter/moonshotai/kimi-k2.6`, `openrouter/moonshotai/kimi-k2.5`). The same request through the same proxy succeeds (the `/models` endpoint is public and anonymous), so users on proxy-required networks lose the entire live catalog. The failure is invisible: `buildOpenrouterLiveProvider` catches all errors and silently returns the bundled seed.

**Code evidence**: in `extensions/openrouter/provider-catalog.ts`, `buildOpenrouterLiveProvider` passes `fetchGuard: params.fetchGuard` straight through to `getCachedLiveProviderModelRows`, and the only production caller (`extensions/openrouter/index.ts`, catalog `run`) never supplies one. The shared helper then falls back to plain `fetchWithSsrFGuard` in STRICT mode, which by design never reads `HTTPS_PROXY`/`HTTP_PROXY`. The discovery request therefore attempts direct egress, times out, and the `catch {}` returns the seed catalog.

## Root Cause

- Introduced by commit `55cf9523e01` ("feat: discover models from live provider catalogs (#112412)", 2026-07-21), which wired OpenRouter discovery through the shared live-catalog helper with a `fetchGuard` passthrough but left the production call site without one; the helper's default guard is STRICT and intentionally ignores env proxy configuration.
- Violated invariant: discovery requests to a first-party, well-known endpoint are trusted targets and should opt into the existing `trusted_env_proxy` guarded-fetch preset — the same preset already used by huggingface (#110924), deepinfra (#111428), chutes (#111266), vercel-ai-gateway (#111209), and this repo's `extensions/google/oauth.http.ts`.
- Trigger condition: `HTTPS_PROXY` (or `HTTP_PROXY`) configured + direct egress blocked.

## Why This Fix

- Default the passthrough to the proxy-wrapped guard: `fetchGuard: params.fetchGuard ?? defaultOpenRouterFetchGuard`, where the default is the same `(params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params))` closure used by the four merged sibling fixes above.
- Defaulting at the helper-call layer (instead of only at the `index.ts` call site) fixes every current and future caller that omits the guard, while tests and advanced callers can still inject their own.
- The SSRF hostname policy, the 5s timeout, the 60s catalog cache, NO_PROXY/direct behavior, silent seed fallback, and response release semantics are all unchanged.
- Alternatives considered: changing the shared helper's global default to env-proxy (rejected: STRICT is the deliberate safe default for user-influenced URLs); wrapping at the `index.ts` call site only (rejected: leaves the same trap for the next caller).

## User Impact

- Before: users behind a required HTTP proxy see only the 3 bundled seed models in `openclaw models list --all --provider openrouter`.
- After: the same command returns the live OpenRouter catalog (342 models at verification time), matching the official `https://openrouter.ai/api/v1/models` response.

## Evidence

- Live before (Linux, Node v22, isolated state dir, throwaway `OPENROUTER_API_KEY`, required HTTPS proxy): `pnpm openclaw models list --all --provider openrouter --plain` logged a 5000ms fetch timeout and silently listed only `openrouter/auto`, `openrouter/moonshotai/kimi-k2.6`, `openrouter/moonshotai/kimi-k2.5`.
- Third-party control: a direct `curl` through the same proxy to `https://openrouter.ai/api/v1/models` returned HTTP 200 in ~1s; the same request without the proxy failed to connect — confirming this network reaches the endpoint only via the proxy.
- Live after (same command, same environment, fixed code): the CLI listed 342 live OpenRouter models.
- Mechanism check with a local CONNECT-counting proxy harness (`node --import tsx`): before, the proxy saw 0 CONNECTs while discovery attempted direct egress (FAIL); after, the proxy received `CONNECT openrouter.ai:443` (PASS).
- Regression coverage: new `provider-catalog.proxy.test.ts` asserts that a caller that omits `fetchGuard` still gets a guarded request selecting `mode: "trusted_env_proxy"` for the official catalog URL.
- Focused green: `node scripts/test-projects.mjs extensions/openrouter` — 14 test files, 134 tests passed (including the pre-existing catalog tests that inject their own guard, which are unaffected by the new default).
- `oxfmt --check` on the changed files passed; `git diff --check` clean.

## Real Behavior Proof

### Before (on main)

```bash
$ export HTTPS_PROXY=http://<required-corp-proxy> OPENROUTER_API_KEY=proof-token
$ pnpm openclaw models list --all --provider openrouter --plain
[fetch-timeout] fetch timeout after 5000ms (elapsed 5006ms) operation=fetchWithSsrFGuard url=https://openrouter.ai/api/v1/models
openrouter/auto
openrouter/moonshotai/kimi-k2.6
openrouter/moonshotai/kimi-k2.5
```

Control through the same proxy (the endpoint itself is healthy):

```bash
$ curl -s -o /dev/null -w "%{http_code}\n" -x "$HTTPS_PROXY" https://openrouter.ai/api/v1/models
200
```

### After (with fix)

```bash
$ export HTTPS_PROXY=http://<required-corp-proxy> OPENROUTER_API_KEY=proof-token
$ pnpm openclaw models list --all --provider openrouter --plain
openrouter/~anthropic/claude-fable-latest
openrouter/~anthropic/claude-haiku-latest
openrouter/~anthropic/claude-opus-latest
openrouter/~anthropic/claude-sonnet-latest
... (342 live models total)
```

Local CONNECT-counting proxy harness (deterministic, no external network):

```bash
$ node --import tsx proof.mjs   # HTTPS_PROXY pointed at a local counting proxy
# before: proxy CONNECT count: 0 -> FAIL: discovery ignored HTTPS_PROXY
# after:  proxy received CONNECT: openrouter.ai:443 -> PASS
```

## Tests and Validation

- `node scripts/test-projects.mjs extensions/openrouter` — 14 files, 134 tests passed (includes the new proxy regression test).
- `oxfmt --check extensions/openrouter/provider-catalog.ts extensions/openrouter/provider-catalog.proxy.test.ts` passed.
- Manual verification: live CLI before/after output above on a network where direct egress is blocked and the corporate proxy is required.
