### PR TITLE
refactor(ui): model gateway connection state as one closed phase union

### DIFF
--- a/ui/src/app/app-host.document-title.test.ts
+++ b/ui/src/app/app-host.document-title.test.ts
@@ -41,7 +41,7 @@ describe("OpenClaw shell document title", () => {
     return {
       gateway: {
         snapshot: {
-          connected: options.connected ?? true,
+          phase: (options.connected ?? true) ? "connected" : "reconnecting",
           assistantAgentId: options.assistantAgentId ?? null,
         },
         connection: { gatewayUrl: "ws://gateway.test" },

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -37,11 +37,11 @@ type AppLifecycleState = {
 type ShellInitializationState = {
   routeState: { routeId?: string };
   ensureAgentsList: (
-    snapshot: { client: GatewayBrowserClient | null; connected: boolean },
+    snapshot: ApplicationGatewaySnapshot,
     agents: ApplicationContext["agents"],
   ) => void;
   ensureRuntimeConfig: (
-    snapshot: { client: GatewayBrowserClient | null; connected: boolean },
+    snapshot: ApplicationGatewaySnapshot,
     runtimeConfig: ApplicationContext["runtimeConfig"],
   ) => void;
 };
@@ -244,8 +244,7 @@ describe("OpenClaw app lifecycle", () => {
     const app = document.createElement("openclaw-app") as unknown as AppLifecycleState;
     const snapshot = {
       client: null,
-      connected: false,
-      reconnecting: false,
+      phase: "stopped",
       lastError: null,
       lastErrorCode: null,
     } as ApplicationGatewaySnapshot;
@@ -317,7 +316,7 @@ describe("OpenClaw shell source initialization", () => {
     ) as unknown as ShellInitializationState;
     shell.routeState = { routeId: "usage" };
     const client = {} as GatewayBrowserClient;
-    const snapshot = { client, connected: true };
+    const snapshot = { client, phase: "connected" } as ApplicationGatewaySnapshot;
     const firstAgents = {
       state: { agentsList: null },
       ensureList: vi.fn(() => Promise.resolve(null)),
@@ -615,7 +614,7 @@ describe("OpenClaw shell keyboard shortcuts", () => {
       context: {
         gateway: {
           snapshot: {
-            connected: true,
+            phase: "connected",
             hello: {
               auth: { role: "operator", scopes: ["operator.admin"] },
               features: { methods: ["terminal.open", "browser.request"] },

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -1340,7 +1340,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     const title = formatDocumentTitle({
       context: primaryContext,
       attentionCount: context.overlays.snapshot.approvalQueue.length,
-      offline: !context.gateway.snapshot.connected,
+      offline: context.gateway.snapshot.phase !== "connected",
       queuedCount: this.outboxStoreRuntime?.summarizeStoredChatOutboxes(outboxScopeHost).total ?? 0,
     });
     if (document.title !== title) {
@@ -1747,7 +1747,7 @@ class OpenClawShell extends OpenClawLightDomElement {
                 </openclaw-tooltip>
                 ${navCollapsed
                   ? html`<openclaw-tooltip
-                      .content=${gatewaySnapshot.connected
+                      .content=${gatewaySnapshot.phase === "connected"
                         ? t("chat.runControls.newSession")
                         : t("chat.runControls.newSessionDisconnected")}
                     >
@@ -1755,7 +1755,7 @@ class OpenClawShell extends OpenClawLightDomElement {
                         type="button"
                         class="shell-chrome-controls__button shell-chrome-controls__new-thread"
                         aria-label=${t("chat.runControls.newSession")}
-                        ?disabled=${!gatewaySnapshot.connected}
+                        ?disabled=${gatewaySnapshot.phase !== "connected"}
                         @click=${() => this.openNewSession(selectedAgentId)}
                       >
                         ${icons.plus}

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -252,7 +252,7 @@ function renderApprovalDocument(runtime: ApplicationRuntime) {
 }
 
 function isBrowserPanelAvailable(snapshot: ApplicationContext["gateway"]["snapshot"]): boolean {
-  if (!snapshot.connected) {
+  if (snapshot.phase !== "connected") {
     return false;
   }
   return (
@@ -357,7 +357,7 @@ class OpenClawApp extends OpenClawLightDomElement {
     if (sourceChanged || clientChanged) {
       this.syncLoginConnection(gateway);
     }
-    if (snapshot.connected) {
+    if (snapshot.phase === "connected") {
       this.loginGatePinned = false;
     }
   }
@@ -384,6 +384,7 @@ class OpenClawApp extends OpenClawLightDomElement {
       return html`<main class="app-shell app-shell--booting" aria-busy="true"></main>`;
     }
     const gatewaySnapshot = context.gateway.snapshot;
+    const gatewayConnected = gatewaySnapshot.phase === "connected";
     const gatewayUrlConfirmation = this.pendingGatewayUrl
       ? html`
           <openclaw-gateway-url-confirmation
@@ -411,7 +412,7 @@ class OpenClawApp extends OpenClawLightDomElement {
       // Embedded clients query this host immediately; keep it stable while the chunk loads.
       return html`
         <openclaw-terminal-panel
-          .client=${gatewaySnapshot.connected ? gatewaySnapshot.client : null}
+          .client=${gatewayConnected ? gatewaySnapshot.client : null}
           .available=${terminalAvailable}
           .themeMode=${resolveTerminalThemeMode()}
           fullscreen
@@ -419,7 +420,7 @@ class OpenClawApp extends OpenClawLightDomElement {
         ${!isOptionalElementDefined(TERMINAL_PANEL_ELEMENT) && terminalAvailable
           ? renderConnectingSplash(context.basePath)
           : nothing}
-        ${!terminalAvailable && (gatewaySnapshot.connected || gatewaySnapshot.lastError)
+        ${!terminalAvailable && (gatewayConnected || gatewaySnapshot.lastError)
           ? html`<div class="terminal-view-unavailable">${t("terminal.unavailable")}</div>`
           : nothing}
       `;
@@ -432,8 +433,8 @@ class OpenClawApp extends OpenClawLightDomElement {
     // the moment the attempt fails (lastError set on every close).
     const initialConnectPending =
       this.initialAuthPresent &&
-      !gatewaySnapshot.connected &&
-      !gatewaySnapshot.reconnecting &&
+      !gatewayConnected &&
+      gatewaySnapshot.phase !== "reconnecting" &&
       !this.loginGatePinned &&
       gatewaySnapshot.lastError === null &&
       gatewaySnapshot.client !== null;
@@ -445,14 +446,14 @@ class OpenClawApp extends OpenClawLightDomElement {
       `;
     }
     const showLoginGate =
-      !gatewaySnapshot.connected && (this.loginGatePinned || !gatewaySnapshot.reconnecting);
+      !gatewayConnected && (this.loginGatePinned || gatewaySnapshot.phase !== "reconnecting");
     if (showLoginGate) {
       return html`
         <openclaw-tooltip-provider>
           <openclaw-login-gate
             .props=${{
               basePath: context.basePath,
-              connected: gatewaySnapshot.connected,
+              connected: gatewayConnected,
               lastError: gatewaySnapshot.lastError,
               lastErrorCode: gatewaySnapshot.lastErrorCode,
               hasToken: Boolean(this.loginToken.trim()),
@@ -740,7 +741,7 @@ class OpenClawShell extends OpenClawLightDomElement {
       }
       const prefs = changedServerUiPrefs(previous, next);
       const snapshot = this.context?.gateway.snapshot;
-      if (prefs && snapshot?.connected && snapshot.client) {
+      if (prefs && snapshot?.phase === "connected" && snapshot.client) {
         pushServerUiPrefs(snapshot.client, prefs);
       }
     });
@@ -1387,7 +1388,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.syncSidebarWorkboard();
     // Chunks are usually served by the gateway, so a failed idle load of the
     // outbox module recovers on reconnect, not only on a browser online event.
-    if (snapshot.connected) {
+    if (snapshot.phase === "connected") {
       void this.outboxStoreImport.load().catch(() => undefined);
     }
   }
@@ -1410,7 +1411,7 @@ class OpenClawShell extends OpenClawLightDomElement {
         this.syncSidebarWorkboard();
         return;
       }
-      runtime.sync(snapshot.client, snapshot.connected);
+      runtime.sync(snapshot.client, snapshot.phase === "connected");
       return;
     }
     if (this.sidebarWorkboardRuntimeLoad) {
@@ -1446,7 +1447,7 @@ class OpenClawShell extends OpenClawLightDomElement {
           gateway &&
           isWorkboardEnabledInConfigSnapshot(current.runtimeConfig.state.configSnapshot)
         ) {
-          loadedRuntime.sync(gateway.client, gateway.connected);
+          loadedRuntime.sync(gateway.client, gateway.phase === "connected");
         }
       })
       .catch(() => {
@@ -1474,15 +1475,12 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private ensureRuntimeConfig(
-    snapshot: {
-      client: GatewayBrowserClient | null;
-      connected: boolean;
-    },
+    snapshot: ApplicationContext["gateway"]["snapshot"],
     runtimeConfig = this.context?.runtimeConfig,
   ) {
     // The sidebar hides config-gated routes (Workboard), so the snapshot must
     // load eagerly instead of waiting for a page that happens to fetch it.
-    if (!snapshot.connected || !snapshot.client || !runtimeConfig) {
+    if (snapshot.phase !== "connected" || !snapshot.client || !runtimeConfig) {
       this.runtimeConfigClient = null;
       return;
     }
@@ -1512,10 +1510,10 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private ensureAgentsList(
-    snapshot: { client: GatewayBrowserClient | null; connected: boolean },
+    snapshot: ApplicationContext["gateway"]["snapshot"],
     agents = this.context?.agents,
   ) {
-    if (!snapshot.connected || !snapshot.client) {
+    if (snapshot.phase !== "connected" || !snapshot.client) {
       this.agentsListClient = null;
       return;
     }
@@ -1603,6 +1601,7 @@ class OpenClawShell extends OpenClawLightDomElement {
       return nothing;
     }
     const gatewaySnapshot = context.gateway.snapshot;
+    const gatewayConnected = gatewaySnapshot.phase === "connected";
     const outboxScopeHost = this.storedOutboxScopeHost(context);
     const outboxStoreRuntime = this.outboxStoreRuntime;
     const storedOutboxes = outboxStoreRuntime
@@ -1816,14 +1815,14 @@ class OpenClawShell extends OpenClawLightDomElement {
                   context.basePath,
                 ) ?? ""}
                 .sessionKey=${this.activeSessionKey}
-                .connected=${gatewaySnapshot.connected}
+                .connected=${gatewayConnected}
                 .offline=${gatewaySnapshot.offlineStable}
                 .outboxCountForSession=${outboxCountForSession}
                 .queuedOutboxCount=${storedOutboxes?.total ?? 0}
                 .lastError=${gatewaySnapshot.lastError}
                 .terminalAvailable=${terminalAvailable}
                 .catalogOpenTarget=${normalizeCatalogOpenTarget(uiSettings.catalogOpenTarget)}
-                .canPairDevice=${gatewaySnapshot.connected &&
+                .canPairDevice=${gatewayConnected &&
                 hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null)}
                 .sidebarEntries=${navigationSnapshot.sidebarEntries}
                 .workboardBoards=${this.sidebarWorkboardSnapshot.boards}
@@ -1927,12 +1926,12 @@ class OpenClawShell extends OpenClawLightDomElement {
           ></openclaw-router-outlet>
         </main>
         <openclaw-terminal-panel
-          .client=${gatewaySnapshot.connected ? gatewaySnapshot.client : null}
+          .client=${gatewayConnected ? gatewaySnapshot.client : null}
           .available=${terminalAvailable}
           .themeMode=${resolveTerminalThemeMode()}
         ></openclaw-terminal-panel>
         <openclaw-browser-panel
-          .client=${gatewaySnapshot.connected ? gatewaySnapshot.client : null}
+          .client=${gatewayConnected ? gatewaySnapshot.client : null}
           .available=${browserPanelAvailable}
           .basePath=${context.basePath}
           .authToken=${resolveControlUiAuthToken({

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -340,7 +340,7 @@ export function bootstrapApplication(): ApplicationRuntime {
       : null;
   let lastPostConnectClient: GatewayBrowserClient | null = null;
   const stopPostConnect = gateway.subscribe((snapshot) => {
-    if (!snapshot.connected || !snapshot.client) {
+    if (snapshot.phase !== "connected" || !snapshot.client) {
       lastPostConnectClient = null;
       return;
     }

--- a/ui/src/app/device-auth-migration.ts
+++ b/ui/src/app/device-auth-migration.ts
@@ -84,7 +84,7 @@ export function createDeviceAuthMigrationController(params: {
       if (
         !client ||
         !requestId ||
-        !params.gateway.snapshot.connected ||
+        params.gateway.snapshot.phase !== "connected" ||
         !params.isCurrent(client, epoch) ||
         snapshot.busy ||
         disposed

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -77,7 +77,7 @@ function createStore(
   return { gateway, clients, current };
 }
 
-describe("createApplicationGateway reconnecting snapshot", () => {
+describe("createApplicationGateway connection phase", () => {
   beforeEach(() => {
     vi.stubGlobal("localStorage", createStorageMock());
     vi.stubGlobal("sessionStorage", createStorageMock());
@@ -96,14 +96,24 @@ describe("createApplicationGateway reconnecting snapshot", () => {
     vi.restoreAllMocks();
   });
 
-  it("keeps the first connect attempt on the login gate (not reconnecting)", () => {
+  it("follows stopped -> connecting -> connected -> reconnecting -> offline", () => {
     const { gateway, current } = createStore();
+
+    expect(gateway.snapshot.phase).toBe("stopped");
     gateway.start();
 
     expect(current().started).toBe(1);
     expect(current().opts.clientVersion).toBe("2026.7.19");
-    expect(gateway.snapshot.connected).toBe(false);
-    expect(gateway.snapshot.reconnecting).toBe(false);
+    expect(gateway.snapshot.phase).toBe("connecting");
+
+    current().opts.onHello?.(HELLO);
+    expect(gateway.snapshot.phase).toBe("connected");
+
+    current().opts.onClose?.({ code: 1006, reason: "socket lost", willRetry: true });
+    expect(gateway.snapshot.phase).toBe("reconnecting");
+
+    current().opts.onClose?.({ code: 4008, reason: "connect failed", willRetry: false });
+    expect(gateway.snapshot.phase).toBe("offline");
   });
 
   it("stays on the gate when the first connect fails, even with auto-retry pending", () => {
@@ -112,22 +122,46 @@ describe("createApplicationGateway reconnecting snapshot", () => {
 
     current().opts.onClose?.({ code: 1006, reason: "refused", willRetry: true });
 
-    expect(gateway.snapshot.connected).toBe(false);
-    expect(gateway.snapshot.reconnecting).toBe(false);
+    expect(gateway.snapshot.phase).toBe("connecting");
     expect(gateway.snapshot.lastError).toContain("1006");
   });
 
-  it("marks transport drops after an established session as reconnecting", () => {
+  it("returns a never-connected terminal close to stopped", () => {
     const { gateway, current } = createStore();
     gateway.start();
-    current().opts.onHello?.(HELLO);
-    expect(gateway.snapshot.connected).toBe(true);
 
-    current().opts.onClose?.({ code: 1006, reason: "socket lost", willRetry: true });
+    current().opts.onClose?.({ code: 4008, reason: "connect failed", willRetry: false });
 
-    expect(gateway.snapshot.connected).toBe(false);
-    expect(gateway.snapshot.reconnecting).toBe(true);
+    expect(gateway.snapshot.phase).toBe("stopped");
+    expect(gateway.snapshot.lastError).toContain("4008");
   });
+
+  it.each(["stopped", "connecting", "connected", "reconnecting", "offline"] as const)(
+    "stop() resets %s to stopped",
+    (phase) => {
+      const { gateway, current } = createStore();
+      if (phase !== "stopped") {
+        gateway.start();
+      }
+      if (phase === "connected" || phase === "reconnecting" || phase === "offline") {
+        current().opts.onHello?.(HELLO);
+      }
+      if (phase === "reconnecting" || phase === "offline") {
+        current().opts.onClose?.({
+          code: 1006,
+          reason: "socket lost",
+          willRetry: phase === "reconnecting",
+        });
+      }
+      expect(gateway.snapshot.phase).toBe(phase);
+
+      gateway.stop();
+
+      expect(gateway.snapshot.phase).toBe("stopped");
+      expect(gateway.snapshot.client).toBeNull();
+      expect(gateway.snapshot.offlineStable).toBe(false);
+    },
+  );
 
   it("publishes a stable offline state only after a sustained disconnect", async () => {
     vi.useFakeTimers();
@@ -202,8 +236,7 @@ describe("createApplicationGateway reconnecting snapshot", () => {
 
     current().opts.onClose?.({ code: 4008, reason: "connect failed", willRetry: false });
 
-    expect(gateway.snapshot.connected).toBe(false);
-    expect(gateway.snapshot.reconnecting).toBe(false);
+    expect(gateway.snapshot.phase).toBe("offline");
   });
 
   it("keeps reconnecting across event-gap recovery with a fresh client", () => {
@@ -216,8 +249,7 @@ describe("createApplicationGateway reconnecting snapshot", () => {
     expect(clients).toHaveLength(2);
     expect(clients[0]?.stopped).toBe(1);
     expect(current().started).toBe(1);
-    expect(gateway.snapshot.reconnecting).toBe(true);
-    expect(gateway.snapshot.connected).toBe(false);
+    expect(gateway.snapshot.phase).toBe("reconnecting");
   });
 
   it("resets the session lineage on stop so the next start uses the gate again", () => {
@@ -226,12 +258,12 @@ describe("createApplicationGateway reconnecting snapshot", () => {
     current().opts.onHello?.(HELLO);
     gateway.stop();
 
-    expect(gateway.snapshot.reconnecting).toBe(false);
+    expect(gateway.snapshot.phase).toBe("stopped");
 
     gateway.start();
     current().opts.onClose?.({ code: 1006, reason: "refused", willRetry: true });
 
-    expect(gateway.snapshot.reconnecting).toBe(false);
+    expect(gateway.snapshot.phase).toBe("connecting");
   });
 
   it("ignores close callbacks from superseded clients", () => {
@@ -245,7 +277,7 @@ describe("createApplicationGateway reconnecting snapshot", () => {
     stale.opts.onClose?.({ code: 1006, reason: "stale", willRetry: false });
 
     // The superseded client cannot demote the fresh attempt's snapshot.
-    expect(gateway.snapshot.reconnecting).toBe(true);
+    expect(gateway.snapshot.phase).toBe("reconnecting");
   });
 
   it("projects only this browser connection's optional presence identity", () => {

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -55,9 +55,8 @@ export function createApplicationGateway(
   };
   let snapshot: ApplicationGatewaySnapshot = {
     client: null,
-    connected: false,
+    phase: "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "main",
     sessionKey: settings.sessionKey,
@@ -102,18 +101,23 @@ export function createApplicationGateway(
     }
   };
   const scheduleOfflineIndicator = () => {
-    if (stopped || snapshot.connected || snapshot.offlineStable || offlineIndicatorTimer !== null) {
+    if (
+      stopped ||
+      snapshot.phase === "connected" ||
+      snapshot.offlineStable ||
+      offlineIndicatorTimer !== null
+    ) {
       return;
     }
     offlineIndicatorTimer = globalThis.setTimeout(() => {
       offlineIndicatorTimer = null;
-      if (!stopped && !snapshot.connected) {
+      if (!stopped && snapshot.phase !== "connected") {
         setSnapshot({ ...snapshot, offlineStable: true });
       }
     }, OFFLINE_INDICATOR_DELAY_MS);
   };
   const setSnapshot = (next: ApplicationGatewaySnapshot) => {
-    if (next.connected) {
+    if (next.phase === "connected") {
       clearOfflineIndicatorTimer();
       snapshot = next.offlineStable ? { ...next, offlineStable: false } : next;
     } else {
@@ -229,8 +233,7 @@ export function createApplicationGateway(
         setSnapshot({
           ...snapshot,
           client: nextClient,
-          connected: true,
-          reconnecting: false,
+          phase: "connected",
           hello,
           assistantAgentId: sessionDefaults?.defaultAgentId ?? "main",
           sessionKey,
@@ -243,7 +246,7 @@ export function createApplicationGateway(
         });
       },
       onRecoveryScopeChange: () => {
-        if (client !== nextClient || !snapshot.connected) {
+        if (client !== nextClient || snapshot.phase !== "connected") {
           return;
         }
         setSnapshot({ ...snapshot });
@@ -255,8 +258,13 @@ export function createApplicationGateway(
         setSnapshot({
           ...snapshot,
           client: nextClient,
-          connected: false,
-          reconnecting: everConnected && willRetry,
+          phase: everConnected
+            ? willRetry
+              ? "reconnecting"
+              : "offline"
+            : willRetry
+              ? "connecting"
+              : "stopped",
           hello: null,
           selfUser: null,
           lastError: error?.message ?? `disconnected (${code}): ${reason || "no reason"}`,
@@ -281,10 +289,9 @@ export function createApplicationGateway(
     setSnapshot({
       ...snapshot,
       client: nextClient,
-      connected: false,
       // Keep the shell mounted while a fresh client attempts event-gap
       // recovery or a manual retry when a session already existed.
-      reconnecting: everConnected,
+      phase: everConnected ? "reconnecting" : "connecting",
       hello: null,
       selfUser: null,
       sessionKey: nextSessionKey,
@@ -328,9 +335,8 @@ export function createApplicationGateway(
       setSnapshot({
         ...snapshot,
         client: null,
-        connected: false,
+        phase: "stopped",
         offlineStable: false,
-        reconnecting: false,
         hello: null,
         selfUser: null,
         lastError: null,

--- a/ui/src/app/gateway.ts
+++ b/ui/src/app/gateway.ts
@@ -2,16 +2,17 @@ import type { EventLogEntry } from "../api/event-log.ts";
 import type { GatewayBrowserClient, GatewayEventListener, GatewayHelloOk } from "../api/gateway.ts";
 import type { AuthenticatedUser } from "./user-profile.ts";
 
+export type ApplicationGatewayPhase =
+  | "stopped"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "offline";
+
 export type ApplicationGatewaySnapshot = {
   client: GatewayBrowserClient | null;
-  connected: boolean;
+  phase: ApplicationGatewayPhase;
   offlineStable: boolean;
-  /**
-   * Disconnected, but a session existed this page lifetime and the client is
-   * still auto-retrying. The shell stays mounted with offline presentation in
-   * this state instead of falling back to the login gate.
-   */
-  reconnecting: boolean;
   hello: GatewayHelloOk | null;
   assistantAgentId: string | null;
   sessionKey: string;

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -45,9 +45,8 @@ function createGatewayHarness(
   let snapshot: ApplicationGatewaySnapshot = {
     assistantAgentId: "main",
     client: initialClient,
-    connected: initialConnected,
+    phase: initialConnected ? "connected" : "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     lastError: null,
     lastErrorCode: null,
@@ -133,7 +132,7 @@ describe("device-auth upgrade migration", () => {
     const overlays = createApplicationOverlays(harness.gateway);
     harness.update({
       client: client(request),
-      connected: true,
+      phase: "connected",
       hello: {
         server: { version: "1.0.0" },
         deviceAuthMigration: { pending: true },
@@ -171,7 +170,7 @@ describe("device-auth upgrade migration", () => {
     const overlays = createApplicationOverlays(harness.gateway);
     harness.update({
       client: client(request),
-      connected: true,
+      phase: "connected",
       hello: {
         server: { version: "1.0.0" },
         deviceAuthMigration: { pending: true },
@@ -211,7 +210,7 @@ describe("device-auth upgrade migration", () => {
     const overlays = createApplicationOverlays(harness.gateway);
     harness.update({
       client: client(request),
-      connected: true,
+      phase: "connected",
       hello: {
         server: { version: "1.0.0" },
         deviceAuthMigration: { pending: true },
@@ -247,7 +246,7 @@ describe("device-auth upgrade migration", () => {
     const overlays = createApplicationOverlays(harness.gateway);
     harness.update({
       client: client(firstRequest),
-      connected: true,
+      phase: "connected",
       hello: {
         server: { version: "1.0.0" },
         deviceAuthMigration: { pending: true },
@@ -279,7 +278,7 @@ describe("device-auth upgrade migration", () => {
     const overlays = createApplicationOverlays(harness.gateway);
     harness.update({
       client: client(request),
-      connected: true,
+      phase: "connected",
       hello: {
         server: { version: "1.0.0" },
         deviceAuthMigration: { pending: true },
@@ -318,14 +317,14 @@ describe("Control UI refresh nudge", () => {
       server: { version: "2.0.0" },
     } as ApplicationGatewaySnapshot["hello"];
 
-    harness.update({ client: gatewayClient, connected: true, hello: mismatchedHello });
+    harness.update({ client: gatewayClient, phase: "connected", hello: mismatchedHello });
     expect(overlays.snapshot.controlUiRefreshRequired).toBe(false);
 
     harness.update({ sessionKey: "agent:main:same-connection" });
     expect(overlays.snapshot.controlUiRefreshRequired).toBe(false);
 
-    harness.update({ connected: false, hello: null });
-    harness.update({ connected: true, hello: mismatchedHello });
+    harness.update({ phase: "stopped", hello: null });
+    harness.update({ phase: "connected", hello: mismatchedHello });
     expect(overlays.snapshot.controlUiRefreshRequired).toBe(true);
 
     harness.update({ sessionKey: "agent:main:after-reconnect" });
@@ -345,17 +344,17 @@ describe("Control UI refresh nudge", () => {
       server: { version: "2.0.0" },
     } as ApplicationGatewaySnapshot["hello"];
 
-    harness.update({ client: gatewayClient, connected: true, hello: matchingHello });
-    harness.update({ connected: false, hello: null });
-    harness.update({ connected: true, hello: matchingHello });
+    harness.update({ client: gatewayClient, phase: "connected", hello: matchingHello });
+    harness.update({ phase: "stopped", hello: null });
+    harness.update({ phase: "connected", hello: matchingHello });
     expect(overlays.snapshot.controlUiRefreshRequired).toBe(false);
 
-    harness.update({ connected: false, hello: null });
-    harness.update({ connected: true, hello: mismatchedHello });
+    harness.update({ phase: "stopped", hello: null });
+    harness.update({ phase: "connected", hello: mismatchedHello });
     expect(overlays.snapshot.controlUiRefreshRequired).toBe(true);
 
-    harness.update({ client: null, connected: false, hello: null });
-    harness.update({ client: gatewayClient, connected: true, hello: mismatchedHello });
+    harness.update({ client: null, phase: "stopped", hello: null });
+    harness.update({ client: gatewayClient, phase: "connected", hello: mismatchedHello });
     expect(overlays.snapshot.controlUiRefreshRequired).toBe(false);
 
     overlays.dispose();
@@ -396,20 +395,20 @@ describe("application approval overlays", () => {
     const harness = createGatewayHarness(null, false);
     const overlays = createApplicationOverlays(harness.gateway);
 
-    harness.update({ client: gatewayClient, connected: false });
+    harness.update({ client: gatewayClient, phase: "stopped" });
     await flushMicrotasks();
     expect(request).not.toHaveBeenCalled();
 
-    harness.update({ connected: true });
+    harness.update({ phase: "connected" });
     await flushMicrotasks();
     expect(execListRequests).toBe(1);
     expect(request).toHaveBeenCalledWith("exec.approval.list", {});
     expect(request).toHaveBeenCalledWith("plugin.approval.list", {});
     expect(request).toHaveBeenCalledWith("openclaw.approval.list", {});
 
-    harness.update({ connected: false });
+    harness.update({ phase: "stopped" });
     expect(overlays.snapshot.approvalQueue).toEqual([]);
-    harness.update({ connected: true });
+    harness.update({ phase: "connected" });
     await flushMicrotasks();
     expect(execListRequests).toBe(2);
 
@@ -542,13 +541,13 @@ describe("application approval overlays", () => {
 
     harness.emitApproval("approval-old", 1_000);
     const oldDecision = overlays.decideApproval("allow-once");
-    harness.update({ client: null, connected: false });
+    harness.update({ client: null, phase: "stopped" });
 
     const newResolve = deferred();
     const newClient = client((method) =>
       method.endsWith(".list") ? Promise.resolve([]) : newResolve.promise,
     );
-    harness.update({ client: newClient, connected: true });
+    harness.update({ client: newClient, phase: "connected" });
     await Promise.resolve();
     harness.emitApproval("approval-new", 2_000);
     const newDecision = overlays.decideApproval("deny");
@@ -577,8 +576,8 @@ describe("application approval overlays", () => {
 
     harness.emitApproval("approval-old", 1_000);
     const oldDecision = overlays.decideApproval("allow-once");
-    harness.update({ connected: false });
-    harness.update({ connected: true });
+    harness.update({ phase: "stopped" });
+    harness.update({ phase: "connected" });
     await flushMicrotasks();
     harness.emitApproval("approval-new", 2_000);
 
@@ -739,8 +738,8 @@ describe("application update overlays", () => {
 
     try {
       await overlays.runUpdate();
-      harness.update({ connected: false });
-      harness.update({ connected: true });
+      harness.update({ phase: "stopped" });
+      harness.update({ phase: "connected" });
       await flushMicrotasks();
       expect(statusRequests).toBe(1);
 

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -135,7 +135,7 @@ export function createApplicationOverlays(
   } | null = null;
   const devicePairSetupState = createDevicePairSetupState({
     client: gateway.snapshot.client,
-    connected: gateway.snapshot.connected,
+    connected: gateway.snapshot.phase === "connected",
   });
   const promptState: ExecApprovalPromptState = {
     client: activeClient,
@@ -174,7 +174,7 @@ export function createApplicationOverlays(
     !disposed &&
     activeClient === client &&
     gateway.snapshot.client === client &&
-    gateway.snapshot.connected;
+    gateway.snapshot.phase === "connected";
   const isCurrentDeviceAuthMigration = (client: NonNullable<typeof activeClient>, epoch: number) =>
     epoch === connectedEpoch &&
     isCurrentClient(client) &&
@@ -192,7 +192,7 @@ export function createApplicationOverlays(
     const client = gateway.snapshot.client;
     if (
       !client ||
-      !gateway.snapshot.connected ||
+      gateway.snapshot.phase !== "connected" ||
       disposed ||
       !devicePairSetupState.devicePairSetupOpen
     ) {
@@ -209,7 +209,7 @@ export function createApplicationOverlays(
       disposed ||
       generation !== devicePairPendingCountGeneration ||
       gateway.snapshot.client !== client ||
-      !gateway.snapshot.connected ||
+      gateway.snapshot.phase !== "connected" ||
       !devicePairSetupState.devicePairSetupOpen
     ) {
       return;
@@ -282,7 +282,7 @@ export function createApplicationOverlays(
       !disposed &&
       activeClient === client &&
       gateway.snapshot.client === client &&
-      gateway.snapshot.connected;
+      gateway.snapshot.phase === "connected";
     const deadline =
       Date.now() +
       (pendingHandoff ? UPDATE_HANDOFF_TIMEOUT_MS : UPDATE_RESTART_VERIFICATION_TIMEOUT_MS);
@@ -353,25 +353,26 @@ export function createApplicationOverlays(
 
   const synchronizeGateway = (next: ApplicationGateway["snapshot"]) => {
     const previousClient = activeClient;
-    const nextConnectedSource = next.connected ? next.client : null;
+    const connected = next.phase === "connected";
+    const nextConnectedSource = connected ? next.client : null;
     const connectedSourceChanged = connectedSource !== nextConnectedSource;
     activeClient = next.client;
     connectedSource = nextConnectedSource;
     promptState.client = next.client;
     devicePairSetupState.client = next.client;
-    devicePairSetupState.connected = next.connected;
+    devicePairSetupState.connected = connected;
     if (connectedSourceChanged) {
       updateRunGeneration += 1;
       cancelUpdateVerification();
     }
-    if (previousClient !== next.client || !next.connected) {
+    if (previousClient !== next.client || !connected) {
       approvalDecision = null;
       devicePairPendingCountGeneration += 1;
       deviceAuthMigration.reset();
       closeDevicePairSetupState(devicePairSetupState);
       devicePairSetupState.pendingCount = 0;
     }
-    if (!next.connected || !next.client) {
+    if (!connected || !next.client) {
       promptState.execApprovalQueue = [];
       promptState.execApprovalBusy = false;
       promptState.execApprovalErrors.clear();
@@ -452,7 +453,7 @@ export function createApplicationOverlays(
     },
     async runUpdate() {
       const client = gateway.snapshot.client;
-      if (!client || !gateway.snapshot.connected || disposed || snapshot.updateRunning) {
+      if (!client || gateway.snapshot.phase !== "connected" || disposed || snapshot.updateRunning) {
         return;
       }
       const generation = ++updateRunGeneration;

--- a/ui/src/app/web-push.ts
+++ b/ui/src/app/web-push.ts
@@ -106,7 +106,7 @@ export function createWebPushCapability(gateway: ApplicationGateway): WebPushCap
   void readExistingSubscription().catch(() => {});
   const stopGateway = gateway.subscribe((gatewaySnapshot) => {
     const client = gatewaySnapshot.client;
-    const connected = gatewaySnapshot.connected && client !== null;
+    const connected = gatewaySnapshot.phase === "connected" && client !== null;
     if (connected && !wasConnected && client) {
       void reconcile(client);
     }

--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -27,7 +27,7 @@ export function sessionCatalogListClient(
 ): GatewayBrowserClient | null {
   if (
     !connected ||
-    !snapshot?.connected ||
+    snapshot?.phase !== "connected" ||
     !snapshot.client ||
     isGatewayMethodAdvertised(snapshot, "sessions.catalog.list") !== true
   ) {

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -102,7 +102,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
             : null;
         return {
           client: availabilityClient,
-          connected: snapshot?.connected ?? false,
+          connected: snapshot?.phase === "connected",
           available: snapshot ? isGatewayMethodAdvertised(snapshot, "board.get") !== false : false,
           key: `${this.context?.gateway.connection?.gatewayUrl ?? ""}\u0000${
             snapshot?.hello?.server?.version ?? ""

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -170,7 +170,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     const gateway = this.context?.gateway.snapshot;
     return {
       enabled: this.sidebarLiveActivity,
-      connected: this.connected && gateway?.connected === true,
+      connected: this.connected && gateway?.phase === "connected",
       connectionIdentity: gateway?.client ?? null,
       source: this.context?.sessions ?? null,
       rows: this.visibleNarrationRowsInOrder(),

--- a/ui/src/components/board/board-widget-cell-plugin.test.ts
+++ b/ui/src/components/board/board-widget-cell-plugin.test.ts
@@ -78,7 +78,7 @@ describe("plugin board widget cells", () => {
     const context = {
       gateway: {
         snapshot: {
-          connected: false,
+          phase: "stopped",
           hello: {
             controlUiWidgetKinds: [
               { pluginId: "workboard", kind: "workboard:card", label: "Workboard card" },

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -22,9 +22,8 @@ function createGateway(connected: boolean): GatewayHarness {
   const client = {} as GatewayBrowserClient;
   let snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected,
+    phase: connected ? "connected" : "reconnecting",
     offlineStable: false,
-    reconnecting: !connected,
     hello: null,
     assistantAgentId: "main",
     sessionKey: "main",
@@ -54,8 +53,7 @@ function createGateway(connected: boolean): GatewayHarness {
     setConnected(nextConnected) {
       snapshot = {
         ...snapshot,
-        connected: nextConnected,
-        reconnecting: !nextConnected,
+        phase: nextConnected ? "connected" : "reconnecting",
       };
       for (const listener of listeners) {
         listener(snapshot);

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -404,19 +404,19 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     const previous = this.sessionSearchSource;
     const sourceChanged = previous?.gateway !== gateway;
     const clientChanged = previous?.client !== snapshot.client;
-    const reconnected = previous?.connected === false && snapshot.connected;
+    const reconnected = previous?.connected === false && snapshot.phase === "connected";
     this.sessionSearchSource = {
       gateway,
       client: snapshot.client,
-      connected: snapshot.connected,
+      connected: snapshot.phase === "connected",
     };
 
-    if (sourceChanged || clientChanged || !snapshot.connected) {
+    if (sourceChanged || clientChanged || snapshot.phase !== "connected") {
       // Query results belong to one runtime/client connection. Discard them as
       // soon as that owner changes so detached or reconnecting rows stay inert.
       this.clearSessionSearch();
     }
-    if (snapshot.connected && (sourceChanged || clientChanged || reconnected)) {
+    if (snapshot.phase === "connected" && (sourceChanged || clientChanged || reconnected)) {
       this.scheduleSessionSearch(this.query);
     }
   }
@@ -454,7 +454,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     const sessions = context?.sessions;
     const gateway = context?.gateway;
     const client = gateway?.snapshot.client;
-    if (!sessions || !gateway?.snapshot.connected || !client) {
+    if (!sessions || gateway?.snapshot.phase !== "connected" || !client) {
       return;
     }
     const requestId = ++this.sessionSearchId;
@@ -479,7 +479,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
           this.context?.sessions !== sessions ||
           this.context?.gateway !== gateway ||
           gateway.snapshot.client !== client ||
-          !gateway.snapshot.connected ||
+          gateway.snapshot.phase !== "connected" ||
           !result
         ) {
           return;

--- a/ui/src/components/mcp-servers-card.test.ts
+++ b/ui/src/components/mcp-servers-card.test.ts
@@ -26,8 +26,7 @@ function createGateway(options: { connected?: boolean; admin?: boolean } = {}): 
   const admin = options.admin ?? true;
   const snapshot = {
     client: null,
-    connected,
-    reconnecting: !connected,
+    phase: connected ? "connected" : "reconnecting",
     hello: {
       type: "hello-ok" as const,
       protocol: 1,

--- a/ui/src/components/mcp-servers-card.ts
+++ b/ui/src/components/mcp-servers-card.ts
@@ -84,7 +84,7 @@ class McpServersCard extends OpenClawLightDomElement {
 
   private mutationBlockedReason(): string | null {
     const gateway = this.context?.gateway;
-    if (!gateway?.snapshot.connected) {
+    if (gateway?.snapshot.phase !== "connected") {
       return t("mcpServers.connectRequired");
     }
     if (!hasOperatorAdminAccess(gateway.snapshot.hello?.auth ?? null)) {

--- a/ui/src/components/onboarding-memory-import.test.ts
+++ b/ui/src/components/onboarding-memory-import.test.ts
@@ -85,9 +85,8 @@ function createContext(
   const client = { request } as unknown as GatewayBrowserClient;
   const snapshot: ApplicationGatewaySnapshot = {
     client: connected ? client : null,
-    connected,
+    phase: connected ? "connected" : "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: {
       auth: {
         role: "operator",

--- a/ui/src/components/onboarding-memory-import.ts
+++ b/ui/src/components/onboarding-memory-import.ts
@@ -143,7 +143,7 @@ class OnboardingMemoryImport extends OpenClawLightDomElement {
     }
     const snapshot = context.gateway.snapshot;
     if (
-      !snapshot.connected ||
+      snapshot?.phase !== "connected" ||
       !snapshot.client ||
       !hasOperatorAdminAccess(snapshot.hello?.auth ?? null)
     ) {
@@ -363,7 +363,7 @@ class OnboardingMemoryImport extends OpenClawLightDomElement {
       this.closed ||
       guardIsDone() ||
       !context ||
-      !snapshot?.connected ||
+      snapshot?.phase !== "connected" ||
       !snapshot.client ||
       !hasOperatorAdminAccess(snapshot.hello?.auth ?? null) ||
       providers.length === 0

--- a/ui/src/components/session-attention-controller.ts
+++ b/ui/src/components/session-attention-controller.ts
@@ -73,7 +73,7 @@ export class SessionAttentionController implements ReactiveController {
   }
 
   private synchronizeAttentionGateway(gateway: ApplicationContext<RouteId>["gateway"]) {
-    const connected = gateway.snapshot.connected;
+    const connected = gateway.snapshot.phase === "connected";
     const client =
       connected &&
       isGatewayMethodAdvertised({ hello: gateway.snapshot.hello }, "question.list") === true &&
@@ -98,7 +98,7 @@ export class SessionAttentionController implements ReactiveController {
         () =>
           this.host.isConnected &&
           this.host.sessionAttentionContext?.gateway === gateway &&
-          gateway.snapshot.connected &&
+          gateway.snapshot.phase === "connected" &&
           gateway.snapshot.client === client,
       );
     }

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -385,7 +385,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       gateway === this.gatewaySource &&
       gateway.snapshot.client !== null &&
       gateway.snapshot.client === this.gatewayClient &&
-      !gateway.snapshot.connected;
+      gateway.snapshot.phase !== "connected";
     if (sameClientDisconnected && this.reconnectListRevision === null) {
       this.reconnectListRevision = sessions.canonicalListRevision + 1;
     }
@@ -420,7 +420,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       this.sessionsSource = sessions;
     }
     this.updateSessions(sessions);
-    if (this.context?.gateway.snapshot.connected) {
+    if (this.context?.gateway.snapshot.phase === "connected") {
       // Group catalog hydration is idempotent per connection.
       void sessions.groupsLoad();
       if (this.host.sidebarSessionStatusFilter() !== "active") {
@@ -431,7 +431,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
 
   private synchronizeGateway(gateway: ApplicationContext<RouteId>["gateway"]): void {
     const client = gateway.snapshot.client;
-    const connected = gateway.snapshot.connected;
+    const connected = gateway.snapshot.phase === "connected";
     const clientChanged = client !== this.gatewayClient;
     const connectedStarted = connected && !this.gatewayConnected;
     const sourceOrClientChanged = gateway !== this.gatewaySource || client !== this.gatewayClient;
@@ -623,7 +623,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       this.activeSessionLineageLoaded ||
       this.activeSessionLineageRequestToken !== null ||
       this.activeSessionLineageRetryTimer !== null ||
-      !gateway?.snapshot.connected ||
+      gateway?.snapshot.phase !== "connected" ||
       !client ||
       typeof client.request !== "function"
     ) {
@@ -728,7 +728,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     }
     const gateway = context.gateway;
     const client = gateway.snapshot.client;
-    if (!gateway.snapshot.connected || !client) {
+    if (gateway.snapshot.phase !== "connected" || !client) {
       return null;
     }
     this.sessionMutationError = null;
@@ -752,7 +752,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       context === scope.context &&
       gateway === scope.gateway &&
       context.sessions === scope.sessions &&
-      gateway.snapshot.connected &&
+      gateway.snapshot.phase === "connected" &&
       gateway.snapshot.client === scope.client
     );
   }

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -120,8 +120,7 @@ describe("sidebar attention refresh ownership", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const snapshot = {
       client,
-      connected: true,
-      reconnecting: false,
+      phase: "connected",
       hello: null,
       assistantAgentId: "main",
       sessionKey: "agent:main:main",

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -115,7 +115,7 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
       this.dismissedScope = gatewayUrl;
       this.dismissed = loadDismissals(gatewayUrl);
     }
-    if (!snapshot.connected || !snapshot.client) {
+    if (snapshot.phase !== "connected" || !snapshot.client) {
       this.loadGeneration += 1;
       this.loadedClient = null;
       this.cronJobs = [];
@@ -142,7 +142,7 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
       this.loadGeneration === generation &&
       this.loadedClient === client &&
       gateway.snapshot.client === client &&
-      gateway.snapshot.connected;
+      gateway.snapshot.phase === "connected";
     const cron = createInitialCronState({ client, connected: true });
     await Promise.allSettled([
       loadCronJobsPage(cron).then(() => {
@@ -206,7 +206,7 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
   }
 
   override render() {
-    if (!this.context?.gateway.snapshot.connected) {
+    if (this.context?.gateway.snapshot.phase !== "connected") {
       return nothing;
     }
     const items = buildSidebarAttentionItems({

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -1649,9 +1649,9 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         .poll(() =>
           page.evaluate(() => {
             const app = document.querySelector("openclaw-app") as HTMLElement & {
-              runtime?: { context: { gateway: { snapshot: { connected: boolean } } } };
+              runtime?: { context: { gateway: { snapshot: { phase: string } } } };
             };
-            return app.runtime?.context.gateway.snapshot.connected ?? false;
+            return app.runtime?.context.gateway.snapshot.phase === "connected";
           }),
         )
         .toBe(false);

--- a/ui/src/lib/agents/identity.test.ts
+++ b/ui/src/lib/agents/identity.test.ts
@@ -1,6 +1,7 @@
 import { expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentIdentityResult } from "../../api/types.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { createAgentIdentityCapability } from "./identity.ts";
 
 function deferred<T>() {
@@ -19,7 +20,10 @@ it("rejects stale identities after reconnecting the same client", async () => {
     .mockImplementationOnce(() => oldRequest.promise)
     .mockImplementationOnce(() => currentRequest.promise);
   const client = { request } as unknown as GatewayBrowserClient;
-  let snapshot = { client, phase: "connected" };
+  let snapshot: { client: GatewayBrowserClient | null; phase: ApplicationGatewayPhase } = {
+    client,
+    phase: "connected",
+  };
   const listeners = new Set<(next: typeof snapshot) => void>();
   const capability = createAgentIdentityCapability({
     get snapshot() {
@@ -60,7 +64,7 @@ it("rejects an in-flight identity after that agent is invalidated", async () => 
     .mockImplementationOnce(() => currentRequest.promise);
   const client = { request } as unknown as GatewayBrowserClient;
   const capability = createAgentIdentityCapability({
-    snapshot: { client, phase: "connected" },
+    snapshot: { client, phase: "connected" as const },
     subscribe: () => () => undefined,
   });
 

--- a/ui/src/lib/agents/identity.test.ts
+++ b/ui/src/lib/agents/identity.test.ts
@@ -19,7 +19,7 @@ it("rejects stale identities after reconnecting the same client", async () => {
     .mockImplementationOnce(() => oldRequest.promise)
     .mockImplementationOnce(() => currentRequest.promise);
   const client = { request } as unknown as GatewayBrowserClient;
-  let snapshot = { client, connected: true };
+  let snapshot = { client, phase: "connected" };
   const listeners = new Set<(next: typeof snapshot) => void>();
   const capability = createAgentIdentityCapability({
     get snapshot() {
@@ -31,7 +31,7 @@ it("rejects stale identities after reconnecting the same client", async () => {
     },
   });
   const publish = (connected: boolean) => {
-    snapshot = { client, connected };
+    snapshot = { client, phase: connected ? "connected" : "reconnecting" };
     for (const listener of listeners) {
       listener(snapshot);
     }
@@ -60,7 +60,7 @@ it("rejects an in-flight identity after that agent is invalidated", async () => 
     .mockImplementationOnce(() => currentRequest.promise);
   const client = { request } as unknown as GatewayBrowserClient;
   const capability = createAgentIdentityCapability({
-    snapshot: { client, connected: true },
+    snapshot: { client, phase: "connected" },
     subscribe: () => () => undefined,
   });
 

--- a/ui/src/lib/agents/identity.ts
+++ b/ui/src/lib/agents/identity.ts
@@ -1,9 +1,10 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentIdentityResult } from "../../api/types.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 
 type AgentIdentityGatewaySnapshot = {
   client: GatewayBrowserClient | null;
-  connected: boolean;
+  phase: ApplicationGatewayPhase;
 };
 
 type AgentIdentityGateway = {
@@ -23,7 +24,7 @@ export function createAgentIdentityCapability(
   gateway: AgentIdentityGateway,
 ): AgentIdentityCapability {
   let cachedClient: GatewayBrowserClient | null = gateway.snapshot.client;
-  let cachedConnected = gateway.snapshot.connected;
+  let cachedConnected = gateway.snapshot.phase === "connected";
   let connectionGeneration = 0;
   const identities = new Map<string, AgentIdentityResult>();
   const inFlight = new Map<string, Promise<AgentIdentityResult | null>>();
@@ -37,12 +38,13 @@ export function createAgentIdentityCapability(
   };
 
   const resetForGateway = (snapshot: AgentIdentityGatewaySnapshot) => {
-    if (snapshot.client === cachedClient && snapshot.connected === cachedConnected) {
+    const connected = snapshot.phase === "connected";
+    if (snapshot.client === cachedClient && connected === cachedConnected) {
       return;
     }
     const hadIdentities = identities.size > 0;
     cachedClient = snapshot.client;
-    cachedConnected = snapshot.connected;
+    cachedConnected = connected;
     connectionGeneration += 1;
     identities.clear();
     inFlight.clear();
@@ -94,7 +96,7 @@ export function createAgentIdentityCapability(
       const snapshot = gateway.snapshot;
       resetForGateway(snapshot);
       const client = snapshot.client;
-      if (!client || !snapshot.connected) {
+      if (!client || snapshot.phase !== "connected") {
         return;
       }
       const generation = connectionGeneration;
@@ -111,7 +113,7 @@ export function createAgentIdentityCapability(
       if (
         connectionGeneration !== generation ||
         gateway.snapshot.client !== client ||
-        !gateway.snapshot.connected
+        gateway.snapshot.phase !== "connected"
       ) {
         return;
       }

--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -22,7 +22,7 @@ function deferred<T>() {
 }
 
 function createGatewayHarness(client: GatewayBrowserClient) {
-  let snapshot = { client, connected: true };
+  let snapshot = { client, phase: "connected" };
   const listeners = new Set<(next: typeof snapshot) => void>();
   return {
     gateway: {
@@ -35,7 +35,7 @@ function createGatewayHarness(client: GatewayBrowserClient) {
       },
     },
     publish(connected: boolean) {
-      snapshot = { client, connected };
+      snapshot = { client, phase: connected ? "connected" : "reconnecting" };
       for (const listener of listeners) {
         listener(snapshot);
       }

--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover agents behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import {
   createAgentCapability,
   loadToolsCatalog,
@@ -22,7 +23,10 @@ function deferred<T>() {
 }
 
 function createGatewayHarness(client: GatewayBrowserClient) {
-  let snapshot = { client, phase: "connected" };
+  let snapshot: { client: GatewayBrowserClient | null; phase: ApplicationGatewayPhase } = {
+    client,
+    phase: "connected",
+  };
   const listeners = new Set<(next: typeof snapshot) => void>();
   return {
     gateway: {

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -7,6 +7,7 @@ import type {
   ToolsCatalogResult,
   ToolsEffectiveResult,
 } from "../../api/types.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
@@ -60,7 +61,7 @@ type AgentsConfigCapability = {
 
 type AgentGatewaySnapshot = {
   client: GatewayBrowserClient | null;
-  connected: boolean;
+  phase: ApplicationGatewayPhase;
 };
 
 type AgentGateway = {
@@ -236,7 +237,7 @@ function normalizeAgentId(agentId: string | null | undefined): string | null {
 export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   const state: AgentCapabilityState = {
     client: gateway.snapshot.client,
-    connected: gateway.snapshot.connected,
+    connected: gateway.snapshot.phase === "connected",
     agentsLoading: false,
     agentsError: null,
     agentsList: null,
@@ -375,21 +376,22 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
 
   const stopGateway = gateway.subscribe((snapshot) => {
     const clientChanged = state.client !== snapshot.client;
+    const connected = snapshot.phase === "connected";
     state.client = snapshot.client;
-    state.connected = snapshot.connected;
-    if (clientChanged || !snapshot.connected) {
+    state.connected = connected;
+    if (clientChanged || !connected) {
       requestGeneration += 1;
       agentsRequest = null;
       agentsRequestOwner = null;
       fileRequests.clear();
       fileRequestOwners.clear();
     }
-    if (clientChanged || !snapshot.connected) {
+    if (clientChanged || !connected) {
       files.clear();
       state.agentsList = null;
       state.agentsError = null;
     }
-    if (clientChanged || !snapshot.connected) {
+    if (clientChanged || !connected) {
       state.agentsLoading = false;
       for (const status of files.values()) {
         status.loading = false;

--- a/ui/src/lib/board/widgets/workboard-widget.ts
+++ b/ui/src/lib/board/widgets/workboard-widget.ts
@@ -41,7 +41,7 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
       sync();
       const unsubscribeSnapshot = gateway.subscribe(sync);
       const unsubscribeEvents = gateway.subscribeEvents((event) => {
-        if (event.event === WORKBOARD_CHANGED_EVENT && gateway.snapshot.connected) {
+        if (event.event === WORKBOARD_CHANGED_EVENT && gateway.snapshot.phase === "connected") {
           void this.refresh(true);
         }
       });
@@ -120,7 +120,7 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
   }
 
   private syncGateway(snapshot: ApplicationContext["gateway"]["snapshot"] | undefined): void {
-    const nextClient = snapshot?.connected ? snapshot.client : null;
+    const nextClient = snapshot?.phase === "connected" ? snapshot.client : null;
     if (this.client === nextClient) {
       return;
     }

--- a/ui/src/lib/board/widgets/workboard.test.ts
+++ b/ui/src/lib/board/widgets/workboard.test.ts
@@ -67,8 +67,7 @@ function createContext(
     gateway: {
       snapshot: {
         client: { request } as never,
-        connected: true,
-        reconnecting: false,
+        phase: "connected",
         hello: null,
         assistantAgentId: null,
         sessionKey: "agent:main:test",

--- a/ui/src/lib/channels/index.test.ts
+++ b/ui/src/lib/channels/index.test.ts
@@ -52,7 +52,7 @@ describe("channels controller WhatsApp wait", () => {
       return Promise.resolve(createChannelsSnapshot("fresh"));
     });
     const client = { request };
-    let snapshot = { client, connected: true };
+    let snapshot = { client, phase: "connected" };
     const listeners = new Set<(next: typeof snapshot) => void>();
     const gateway = {
       get snapshot() {
@@ -67,11 +67,11 @@ describe("channels controller WhatsApp wait", () => {
 
     const stale = channels.waitWhatsApp();
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
-    snapshot = { client, connected: false };
+    snapshot = { client, phase: "reconnecting" };
     for (const listener of listeners) {
       listener(snapshot);
     }
-    snapshot = { client, connected: true };
+    snapshot = { client, phase: "connected" };
     for (const listener of listeners) {
       listener(snapshot);
     }
@@ -112,7 +112,7 @@ describe("channels controller WhatsApp wait", () => {
     const client = { request };
     let snapshot = {
       client,
-      connected: true,
+      phase: "connected",
       hello: { auth: { role: "operator", scopes: ["operator.pairing"] } },
     };
     const listeners = new Set<(next: typeof snapshot) => void>();
@@ -159,7 +159,7 @@ describe("channels controller WhatsApp wait", () => {
     const client = { request };
     let snapshot = {
       client,
-      connected: true,
+      phase: "connected",
       hello: { auth: { role: "operator", scopes: ["operator.admin", "operator.pairing"] } },
     };
     const listeners = new Set<(next: typeof snapshot) => void>();
@@ -207,7 +207,7 @@ describe("channels controller WhatsApp wait", () => {
     const request = vi.fn(() => pending.promise);
     const client = { request };
     const gateway = {
-      snapshot: { client, connected: true },
+      snapshot: { client, phase: "connected" },
       subscribe: () => () => undefined,
     };
     const channels = createChannelCapability(gateway as never);
@@ -239,7 +239,7 @@ describe("channels controller WhatsApp logout", () => {
         : createChannelsSnapshot("refreshed"),
     );
     const channels = createChannelCapability({
-      snapshot: { client: { request }, connected: true },
+      snapshot: { client: { request }, phase: "connected" },
       subscribe: () => () => undefined,
     } as never);
     channels.state.whatsappLoginMessage = "Scan this QR.";
@@ -269,7 +269,7 @@ describe("channels controller WhatsApp logout", () => {
         : createChannelsSnapshot("refreshed"),
     );
     const channels = createChannelCapability({
-      snapshot: { client: { request }, connected: true },
+      snapshot: { client: { request }, phase: "connected" },
       subscribe: () => () => undefined,
     } as never);
     channels.state.whatsappLoginMessage = "Scan this QR.";
@@ -293,7 +293,7 @@ describe("channels controller WhatsApp logout", () => {
       return createChannelsSnapshot("refreshed");
     });
     const channels = createChannelCapability({
-      snapshot: { client: { request }, connected: true },
+      snapshot: { client: { request }, phase: "connected" },
       subscribe: () => () => undefined,
     } as never);
     channels.state.whatsappLoginQrDataUrl = "data:image/png;base64,current-qr";
@@ -360,7 +360,7 @@ describe("channels controller DM pairing", () => {
       return {};
     });
     const channels = createChannelCapability({
-      snapshot: { client: { request }, connected: true },
+      snapshot: { client: { request }, phase: "connected" },
       subscribe: () => () => undefined,
     } as never);
 
@@ -407,7 +407,7 @@ describe("channels controller DM pairing", () => {
       return approvalResult.promise;
     });
     const channels = createChannelCapability({
-      snapshot: { client: { request }, connected: true },
+      snapshot: { client: { request }, phase: "connected" },
       subscribe: () => () => undefined,
     } as never);
     await channels.refreshPairing();
@@ -453,7 +453,7 @@ describe("channels controller DM pairing", () => {
       };
     });
     const channels = createChannelCapability({
-      snapshot: { client: { request }, connected: true },
+      snapshot: { client: { request }, phase: "connected" },
       subscribe: () => () => undefined,
     } as never);
 
@@ -481,7 +481,7 @@ describe("channels controller DM pairing", () => {
     const client = { request: vi.fn() };
     let snapshot = {
       client,
-      connected: true,
+      phase: "connected",
       hello: { auth: { role: "operator", scopes: ["operator.pairing"] } },
     };
     const listeners = new Set<(next: typeof snapshot) => void>();
@@ -506,7 +506,7 @@ describe("channels controller DM pairing", () => {
     expect(channels.state.pairingSnapshot).toBeNull();
 
     channels.state.pairingSnapshot = pendingPairing;
-    snapshot = { ...snapshot, connected: false };
+    snapshot = { ...snapshot, phase: "reconnecting" };
     for (const listener of listeners) {
       listener(snapshot);
     }
@@ -530,7 +530,7 @@ describe("channels controller DM pairing", () => {
     const client = { request };
     let snapshot = {
       client,
-      connected: true,
+      phase: "connected",
       hello: { auth: { role: "operator", scopes: ["operator.pairing"] } },
     };
     const listeners = new Set<(next: typeof snapshot) => void>();
@@ -580,7 +580,7 @@ describe("channels controller DM pairing", () => {
       throw new Error("gateway unavailable");
     });
     const channels = createChannelCapability({
-      snapshot: { client: { request }, connected: true },
+      snapshot: { client: { request }, phase: "connected" },
       subscribe: () => () => undefined,
     } as never);
     channels.state.pairingSnapshot = emptyPairing;
@@ -600,7 +600,7 @@ describe("channel refresh sequencing", () => {
     const client = { request };
     let snapshot = {
       client,
-      connected: true,
+      phase: "connected",
       hello: { auth: { role: "operator", scopes: ["operator.read"] } },
     };
     const listeners = new Set<(next: typeof snapshot) => void>();
@@ -640,7 +640,7 @@ describe("channel refresh sequencing", () => {
       (params as { probe?: boolean } | undefined)?.probe ? slowProbe.promise : fastRuntime.promise,
     );
     const channels = createChannelCapability({
-      snapshot: { client: { request }, connected: true },
+      snapshot: { client: { request }, phase: "connected" },
       subscribe: () => () => undefined,
     } as never);
 
@@ -665,7 +665,7 @@ describe("channel refresh sequencing", () => {
       const pending = createDeferred<ChannelsStatusSnapshot | null>();
       const request = vi.fn(() => pending.promise);
       const channels = createChannelCapability({
-        snapshot: { client: { request }, connected: true },
+        snapshot: { client: { request }, phase: "connected" },
         subscribe: () => () => undefined,
       } as never);
       const previous = createChannelsSnapshot("previous");

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -4,6 +4,7 @@ import type {
   ChannelsPairingListResult,
   ChannelsStatusSnapshot,
 } from "../../api/types.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { t } from "../../i18n/index.ts";
 import {
   formatMissingOperatorReadScopeMessage,
@@ -20,7 +21,7 @@ type ChannelLogoutResult = {
 
 type ChannelGatewaySnapshot = {
   client: ChannelGatewayClient | null;
-  connected: boolean;
+  phase: ApplicationGatewayPhase;
   hello?: {
     auth?: { role?: string; scopes?: readonly string[] } | null;
   } | null;
@@ -107,7 +108,7 @@ function channelSnapshotAllowsScope(
 function createInitialChannelsState(snapshot: Partial<ChannelGatewaySnapshot> = {}): ChannelsState {
   return {
     client: snapshot.client ?? null,
-    connected: snapshot.connected ?? false,
+    connected: snapshot.phase === "connected",
     channelsLoading: false,
     channelsLoadingProbe: null,
     channelsRefreshSeq: 0,
@@ -596,7 +597,8 @@ export function createChannelCapability(gateway: ChannelGateway): ChannelCapabil
   };
   const stopGateway = gateway.subscribe((snapshot) => {
     const clientChanged = state.client !== snapshot.client;
-    const connectionChanged = state.connected !== snapshot.connected;
+    const connected = snapshot.phase === "connected";
+    const connectionChanged = state.connected !== connected;
     const nextChannelReadAccess = channelSnapshotAllowsScope(snapshot, "operator.read");
     const channelReadAccessChanged = currentChannelReadAccess !== nextChannelReadAccess;
     currentChannelReadAccess = nextChannelReadAccess;
@@ -607,7 +609,7 @@ export function createChannelCapability(gateway: ChannelGateway): ChannelCapabil
     const whatsappAdminAccessChanged = currentWhatsAppAdminAccess !== nextWhatsAppAdminAccess;
     currentWhatsAppAdminAccess = nextWhatsAppAdminAccess;
     state.client = snapshot.client;
-    state.connected = snapshot.connected;
+    state.connected = connected;
     const lifecycle = getChannelsLifecycle(state);
     if (clientChanged || connectionChanged || channelReadAccessChanged) {
       state.channelsLoading = false;

--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { createRuntimeConfigCapability, findAgentConfigEntryIndex } from "./index.ts";
 
 const CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS = 800;
@@ -18,7 +19,11 @@ function deferred<T>() {
 }
 
 function createGatewayHarness(client: GatewayBrowserClient) {
-  let snapshot = { client, connected: true, sessionKey: "main" };
+  let snapshot: {
+    client: GatewayBrowserClient;
+    phase: ApplicationGatewayPhase;
+    sessionKey: string;
+  } = { client, phase: "connected", sessionKey: "main" };
   const listeners = new Set<(next: typeof snapshot) => void>();
   return {
     gateway: {
@@ -31,7 +36,11 @@ function createGatewayHarness(client: GatewayBrowserClient) {
       },
     },
     publish: (connected: boolean) => {
-      snapshot = { client, connected, sessionKey: "main" };
+      snapshot = {
+        client,
+        phase: connected ? "connected" : "reconnecting",
+        sessionKey: "main",
+      };
       for (const listener of listeners) {
         listener(snapshot);
       }

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -1,6 +1,7 @@
 // Control UI runtime config capability and shared config-domain mutations.
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot, ConfigUiHints } from "../../api/types.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { schemaType, type JsonSchema } from "../../components/config-form.shared.ts";
 import { t } from "../../i18n/index.ts";
 import { copyToClipboard } from "../clipboard.ts";
@@ -76,7 +77,7 @@ const connectionEpochsByState = new WeakMap<object, number>();
 
 type RuntimeConfigGatewaySnapshot = {
   client: GatewayBrowserClient | null;
-  connected: boolean;
+  phase: ApplicationGatewayPhase;
   sessionKey: string;
 };
 
@@ -151,7 +152,7 @@ type ConfigGatewayState = Pick<
 function createInitialConfigState(snapshot?: Partial<RuntimeConfigGatewaySnapshot>): ConfigState {
   return {
     client: snapshot?.client ?? null,
-    connected: snapshot?.connected ?? false,
+    connected: snapshot?.phase === "connected",
     applySessionKey: snapshot?.sessionKey ?? "main",
     configLoading: false,
     configRaw: "{\n}\n",
@@ -1471,9 +1472,10 @@ export function createRuntimeConfigCapability(
     state.configSchema ? Promise.resolve() : loadOnce("schema", () => loadConfigSchema(state));
   const stopGateway = gateway.subscribe((snapshot) => {
     const clientChanged = state.client !== snapshot.client;
-    const connectionChanged = state.connected !== snapshot.connected;
+    const connected = snapshot.phase === "connected";
+    const connectionChanged = state.connected !== connected;
     state.client = snapshot.client;
-    state.connected = snapshot.connected;
+    state.connected = connected;
     state.applySessionKey = snapshot.sessionKey;
     if (clientChanged || connectionChanged) {
       configLoad = null;

--- a/ui/src/lib/sessions/index-list.test.ts
+++ b/ui/src/lib/sessions/index-list.test.ts
@@ -16,7 +16,7 @@ describe("session list requests", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const snapshot = {
       client,
-      phase: "connected",
+      phase: "connected" as const,
       sessionKey: "agent:main:main",
       assistantAgentId: "main",
       hello: null,
@@ -58,7 +58,7 @@ describe("session list requests", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client: { request } as unknown as GatewayBrowserClient,
-        phase: "connected",
+        phase: "connected" as const,
         sessionKey: "agent:main:main",
         assistantAgentId: "main",
         hello: null,

--- a/ui/src/lib/sessions/index-list.test.ts
+++ b/ui/src/lib/sessions/index-list.test.ts
@@ -16,7 +16,7 @@ describe("session list requests", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const snapshot = {
       client,
-      connected: true,
+      phase: "connected",
       sessionKey: "agent:main:main",
       assistantAgentId: "main",
       hello: null,
@@ -58,7 +58,7 @@ describe("session list requests", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client: { request } as unknown as GatewayBrowserClient,
-        connected: true,
+        phase: "connected",
         sessionKey: "agent:main:main",
         assistantAgentId: "main",
         hello: null,

--- a/ui/src/lib/sessions/index.create-background.test.ts
+++ b/ui/src/lib/sessions/index.create-background.test.ts
@@ -23,7 +23,7 @@ it("returns a created session before background list reconciliation finishes", a
   const sessions = createSessionCapability({
     snapshot: {
       client,
-      connected: true,
+      phase: "connected",
       hello: null,
       assistantAgentId: "main",
       sessionKey: "agent:main:main",

--- a/ui/src/lib/sessions/index.create-background.test.ts
+++ b/ui/src/lib/sessions/index.create-background.test.ts
@@ -23,7 +23,7 @@ it("returns a created session before background list reconciliation finishes", a
   const sessions = createSessionCapability({
     snapshot: {
       client,
-      phase: "connected",
+      phase: "connected" as const,
       hello: null,
       assistantAgentId: "main",
       sessionKey: "agent:main:main",

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -33,13 +33,13 @@ function deferred<T>() {
 function createGatewayHarness(client: GatewayBrowserClient, featureMethods?: string[]) {
   let snapshot: {
     client: GatewayBrowserClient | null;
-    connected: boolean;
+    phase: "connected" | "reconnecting";
     sessionKey: string;
     assistantAgentId: string | null;
     hello: GatewayHelloOk | null;
   } = {
     client,
-    connected: true,
+    phase: "connected",
     sessionKey: "agent:main:main",
     assistantAgentId: "main",
     hello:
@@ -69,7 +69,11 @@ function createGatewayHarness(client: GatewayBrowserClient, featureMethods?: str
       }
     },
     publish: (connected: boolean, nextClient: GatewayBrowserClient | null = snapshot.client) => {
-      snapshot = { ...snapshot, client: nextClient, connected };
+      snapshot = {
+        ...snapshot,
+        client: nextClient,
+        phase: connected ? "connected" : "reconnecting",
+      };
       for (const listener of listeners) {
         listener(snapshot);
       }
@@ -412,7 +416,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client,
-        connected: true,
+        phase: "connected",
         sessionKey: "agent:main:main",
         assistantAgentId: "main",
         hello: null,
@@ -552,7 +556,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client,
-        connected: true,
+        phase: "connected",
         sessionKey: "agent:main:source",
         assistantAgentId: "main",
         hello: null,
@@ -702,7 +706,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client,
-        connected: true,
+        phase: "connected",
         sessionKey: "agent:main:source",
         assistantAgentId: "main",
         hello: null,
@@ -753,7 +757,7 @@ describe("createSessionCapability", () => {
     const gateway = {
       snapshot: {
         client,
-        connected: true,
+        phase: "connected",
         sessionKey: "agent:main:oldest",
         assistantAgentId: "main",
         hello: null,
@@ -808,7 +812,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client,
-        connected: true,
+        phase: "connected",
         sessionKey: key,
         assistantAgentId: "main",
         hello: null,
@@ -1050,7 +1054,7 @@ describe("createSessionCapability", () => {
     const gateway = {
       snapshot: {
         client,
-        connected: true,
+        phase: "connected",
         sessionKey: key,
         assistantAgentId: "main",
         hello: null,

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -39,7 +39,7 @@ function createGatewayHarness(client: GatewayBrowserClient, featureMethods?: str
     hello: GatewayHelloOk | null;
   } = {
     client,
-    phase: "connected",
+    phase: "connected" as const,
     sessionKey: "agent:main:main",
     assistantAgentId: "main",
     hello:
@@ -416,7 +416,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client,
-        phase: "connected",
+        phase: "connected" as const,
         sessionKey: "agent:main:main",
         assistantAgentId: "main",
         hello: null,
@@ -556,7 +556,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client,
-        phase: "connected",
+        phase: "connected" as const,
         sessionKey: "agent:main:source",
         assistantAgentId: "main",
         hello: null,
@@ -706,7 +706,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client,
-        phase: "connected",
+        phase: "connected" as const,
         sessionKey: "agent:main:source",
         assistantAgentId: "main",
         hello: null,
@@ -757,7 +757,7 @@ describe("createSessionCapability", () => {
     const gateway = {
       snapshot: {
         client,
-        phase: "connected",
+        phase: "connected" as const,
         sessionKey: "agent:main:oldest",
         assistantAgentId: "main",
         hello: null,
@@ -812,7 +812,7 @@ describe("createSessionCapability", () => {
     const sessions = createSessionCapability({
       snapshot: {
         client,
-        phase: "connected",
+        phase: "connected" as const,
         sessionKey: key,
         assistantAgentId: "main",
         hello: null,
@@ -1054,7 +1054,7 @@ describe("createSessionCapability", () => {
     const gateway = {
       snapshot: {
         client,
-        phase: "connected",
+        phase: "connected" as const,
         sessionKey: key,
         assistantAgentId: "main",
         hello: null,

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -23,6 +23,7 @@ import type {
   SessionWorkspaceListResult,
   SessionWorkspaceSetResult,
 } from "../../api/types.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import { isGatewayMethodAdvertised } from "../gateway-methods.ts";
 import { isSessionRunActive } from "../session-run-state.ts";
@@ -159,7 +160,7 @@ type SessionResetResult = "completed" | "not-started" | "uncertain";
 type SessionGateway = {
   readonly snapshot: {
     client: GatewayBrowserClient | null;
-    connected: boolean;
+    phase: ApplicationGatewayPhase;
     hello: GatewayHelloOk | null;
     assistantAgentId?: string | null;
     sessionKey?: string;
@@ -828,7 +829,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   let disposed = false;
   let connectionEpoch = 0;
   let connectionClient = gateway.snapshot.client;
-  let connectionConnected = gateway.snapshot.connected;
+  let connectionConnected = gateway.snapshot.phase === "connected";
   const pendingModelPatches = new Map<
     string,
     { token: symbol; previous: string | null | undefined }
@@ -846,7 +847,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
 
   const captureConnection = (): SessionConnectionScope | null => {
     const snapshot = gateway.snapshot;
-    return !disposed && snapshot.connected && snapshot.client
+    return !disposed && snapshot.phase === "connected" && snapshot.client
       ? { client: snapshot.client, epoch: connectionEpoch }
       : null;
   };
@@ -856,7 +857,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     return (
       !disposed &&
       connectionEpoch === scope.epoch &&
-      snapshot.connected &&
+      snapshot.phase === "connected" &&
       snapshot.client === scope.client
     );
   };
@@ -1045,7 +1046,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   };
 
   const refresh = (options: SessionRefreshOptions = {}) => {
-    if (!gateway.snapshot.connected || !gateway.snapshot.client || disposed) {
+    if (gateway.snapshot.phase !== "connected" || !gateway.snapshot.client || disposed) {
       return Promise.resolve();
     }
     if (inFlight) {
@@ -1769,10 +1770,10 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
 
   const stopGateway = gateway.subscribe((next) => {
     const previousClient = connectionClient;
-    const connectionChanged =
-      next.client !== connectionClient || next.connected !== connectionConnected;
+    const connected = next.phase === "connected";
+    const connectionChanged = next.client !== connectionClient || connected !== connectionConnected;
     connectionClient = next.client;
-    connectionConnected = next.connected;
+    connectionConnected = connected;
     if (connectionChanged) {
       const hadPullRequestSummaries = pullRequestSummaries.size > 0;
       connectionEpoch += 1;
@@ -1789,11 +1790,11 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       pullRequestEpochs.clear();
       // A connected client replacement needs its own invalidation publish;
       // disconnects publish the cleared state in the branch immediately below.
-      if (hadPullRequestSummaries && next.connected && next.client) {
+      if (hadPullRequestSummaries && connected && next.client) {
         publish({ ...state });
       }
     }
-    if (!next.connected || !next.client) {
+    if (!connected || !next.client) {
       subscribedClient = null;
       publish({
         result: null,

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -25,7 +25,7 @@ function createSessions(client: GatewayBrowserClient, key: string) {
   return createSessionCapability({
     snapshot: {
       client,
-      connected: true,
+      phase: "connected",
       sessionKey: key,
       assistantAgentId: "main",
       hello: null,

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -25,7 +25,7 @@ function createSessions(client: GatewayBrowserClient, key: string) {
   return createSessionCapability({
     snapshot: {
       client,
-      phase: "connected",
+      phase: "connected" as const,
       sessionKey: key,
       assistantAgentId: "main",
       hello: null,

--- a/ui/src/lib/sessions/message-cut.test.ts
+++ b/ui/src/lib/sessions/message-cut.test.ts
@@ -13,13 +13,13 @@ function deferred<T>() {
 function createGatewayHarness(client: GatewayBrowserClient) {
   let snapshot: {
     client: GatewayBrowserClient | null;
-    connected: boolean;
+    phase: "connected" | "reconnecting";
     sessionKey: string;
     assistantAgentId: string | null;
     hello: GatewayHelloOk | null;
   } = {
     client,
-    connected: true,
+    phase: "connected",
     sessionKey: "agent:main:main",
     assistantAgentId: "main",
     hello: null,
@@ -41,7 +41,7 @@ function createGatewayHarness(client: GatewayBrowserClient) {
       },
     },
     publish: (connected: boolean) => {
-      snapshot = { ...snapshot, connected };
+      snapshot = { ...snapshot, phase: connected ? "connected" : "reconnecting" };
       for (const listener of listeners) {
         listener(snapshot);
       }

--- a/ui/src/lib/sessions/pull-request-state.test.ts
+++ b/ui/src/lib/sessions/pull-request-state.test.ts
@@ -16,7 +16,7 @@ function sessionsResult(sessions: SessionsListResult["sessions"]): SessionsListR
 function createGatewayHarness(client: GatewayBrowserClient) {
   let snapshot = {
     client: client as GatewayBrowserClient | null,
-    connected: true,
+    phase: "connected",
     sessionKey: "agent:main:main",
     assistantAgentId: "main",
     hello: null,
@@ -36,7 +36,11 @@ function createGatewayHarness(client: GatewayBrowserClient) {
       },
     },
     publish(connected: boolean, nextClient: GatewayBrowserClient | null = snapshot.client) {
-      snapshot = { ...snapshot, client: nextClient, connected };
+      snapshot = {
+        ...snapshot,
+        client: nextClient,
+        phase: connected ? "connected" : "reconnecting",
+      };
       for (const listener of listeners) {
         listener(snapshot);
       }

--- a/ui/src/lib/sessions/pull-request-state.test.ts
+++ b/ui/src/lib/sessions/pull-request-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
+import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { createSessionCapability } from "./index.ts";
 
 function sessionsResult(sessions: SessionsListResult["sessions"]): SessionsListResult {
@@ -16,7 +17,7 @@ function sessionsResult(sessions: SessionsListResult["sessions"]): SessionsListR
 function createGatewayHarness(client: GatewayBrowserClient) {
   let snapshot = {
     client: client as GatewayBrowserClient | null,
-    phase: "connected",
+    phase: "connected" as ApplicationGatewayPhase,
     sessionKey: "agent:main:main",
     assistantAgentId: "main",
     hello: null,

--- a/ui/src/lib/sessions/swarm-activity.integration.test.ts
+++ b/ui/src/lib/sessions/swarm-activity.integration.test.ts
@@ -17,13 +17,13 @@ function sessionsResult(sessions: SessionsListResult["sessions"], ts: number): S
 function createGatewayHarness(client: GatewayBrowserClient) {
   const snapshot: {
     client: GatewayBrowserClient | null;
-    connected: boolean;
+    phase: "connected";
     sessionKey: string;
     assistantAgentId: string | null;
     hello: GatewayHelloOk | null;
   } = {
     client,
-    connected: true,
+    phase: "connected",
     sessionKey: "agent:main:main",
     assistantAgentId: "main",
     hello: null,

--- a/ui/src/lib/sessions/swarm-activity.integration.test.ts
+++ b/ui/src/lib/sessions/swarm-activity.integration.test.ts
@@ -23,7 +23,7 @@ function createGatewayHarness(client: GatewayBrowserClient) {
     hello: GatewayHelloOk | null;
   } = {
     client,
-    phase: "connected",
+    phase: "connected" as const,
     sessionKey: "agent:main:main",
     assistantAgentId: "main",
     hello: null,

--- a/ui/src/lib/terminal-availability.ts
+++ b/ui/src/lib/terminal-availability.ts
@@ -7,7 +7,7 @@ export function isTerminalAvailable(
   terminalEnabled: boolean,
 ): boolean {
   return (
-    (snapshot.connected ?? false) &&
+    snapshot.phase === "connected" &&
     terminalEnabled &&
     hasOperatorAdminAccess(snapshot.hello?.auth ?? null) &&
     (isGatewayMethodAdvertised(snapshot, "terminal.open") ?? false)

--- a/ui/src/pages/about/about-page.ts
+++ b/ui/src/pages/about/about-page.ts
@@ -75,9 +75,10 @@ class AboutPage extends OpenClawLightDomElement {
 
   override render() {
     const gatewaySnapshot = this.context.gateway.snapshot;
-    const gatewayVersion = gatewaySnapshot.connected
-      ? gatewaySnapshot.hello?.server?.version?.trim() || null
-      : null;
+    const gatewayVersion =
+      gatewaySnapshot.phase === "connected"
+        ? gatewaySnapshot.hello?.server?.version?.trim() || null
+        : null;
     const body = renderAbout({
       buildInfo: CONTROL_UI_BUILD_INFO,
       gatewayVersion,

--- a/ui/src/pages/activity/activity-page.test.ts
+++ b/ui/src/pages/activity/activity-page.test.ts
@@ -18,9 +18,8 @@ type TestActivityPage = HTMLElement & {
 function gateway(): ApplicationContext["gateway"] {
   const snapshot: ApplicationGatewaySnapshot = {
     client: null,
-    connected: false,
+    phase: "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",

--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -54,9 +54,8 @@ function snapshot(
 ): ApplicationGatewaySnapshot {
   return {
     client,
-    connected,
+    phase: connected ? "connected" : "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -267,7 +267,7 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
     forceReset: boolean,
     initialBind = false,
   ) {
-    const connectionChanged = this.connected !== snapshot.connected;
+    const connectionChanged = this.connected !== (snapshot.phase === "connected");
     const clientChanged = this.client !== snapshot.client;
     this.syncGatewayState(snapshot);
     if (forceReset || (!initialBind && clientChanged)) {
@@ -280,11 +280,11 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
 
   private syncGatewayState(snapshot: ApplicationGatewaySnapshot) {
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.connected = snapshot.phase === "connected";
     this.cron = {
       ...this.cron,
       client: snapshot.client,
-      connected: snapshot.connected,
+      connected: snapshot.phase === "connected",
     };
   }
 

--- a/ui/src/pages/agents/memory/memory-panel.test.ts
+++ b/ui/src/pages/agents/memory/memory-panel.test.ts
@@ -36,9 +36,8 @@ function deferred<T>() {
 function contextWithGateway(client: GatewayBrowserClient, connected: boolean): ApplicationContext {
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected,
+    phase: connected ? "connected" : "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -175,8 +174,8 @@ describe("AgentMemoryPanel gateway lifecycle", () => {
 
     const previousState = page.dreaming;
     const preview = page.openWikiPage("old.md");
-    page.applyGatewaySnapshot({ client, connected: false } as ApplicationGatewaySnapshot);
-    page.applyGatewaySnapshot({ client, connected: true } as ApplicationGatewaySnapshot);
+    page.applyGatewaySnapshot({ client, phase: "stopped" } as ApplicationGatewaySnapshot);
+    page.applyGatewaySnapshot({ client, phase: "connected" } as ApplicationGatewaySnapshot);
     pending.resolve({ title: "Old", path: "old.md", content: "stale" });
 
     await expect(preview).resolves.toBeNull();

--- a/ui/src/pages/agents/memory/memory-panel.ts
+++ b/ui/src/pages/agents/memory/memory-panel.ts
@@ -208,7 +208,7 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
   private createGatewayState(snapshot = this.context.gateway.snapshot): DreamingState {
     return createDreamingState({
       client: snapshot.client,
-      connected: snapshot.connected,
+      connected: snapshot.phase === "connected",
       hello: snapshot.hello,
       configSnapshot: this.context.runtimeConfig.state.configSnapshot,
       applySessionKey: snapshot.sessionKey,
@@ -221,8 +221,8 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
     sourceBind?: "initial" | "replacement",
   ) {
     const clientChanged = this.dreaming.client !== snapshot.client;
-    const connectionChanged = this.dreaming.connected !== snapshot.connected;
-    const becameConnected = snapshot.connected && !this.dreaming.connected;
+    const connectionChanged = this.dreaming.connected !== (snapshot.phase === "connected");
+    const becameConnected = snapshot.phase === "connected" && !this.dreaming.connected;
     const replaceState = sourceBind === "replacement" || clientChanged || connectionChanged;
     if (connectionChanged) {
       this.gatewayEpoch += 1;
@@ -233,11 +233,11 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
         this.resetTransientState();
       }
     } else {
-      this.dreaming.connected = snapshot.connected;
+      this.dreaming.connected = snapshot.phase === "connected";
       this.dreaming.hello = snapshot.hello;
       this.dreaming.applySessionKey = snapshot.sessionKey;
     }
-    if (snapshot.connected && (replaceState || becameConnected)) {
+    if (snapshot.phase === "connected" && (replaceState || becameConnected)) {
       void this.loadAll();
     }
     this.requestUpdate();

--- a/ui/src/pages/agents/route.test.ts
+++ b/ui/src/pages/agents/route.test.ts
@@ -18,7 +18,7 @@ describe("agents route", () => {
       ],
     };
     const ensureList = vi.fn(async () => agentsList);
-    const gateway = { snapshot: { client: null, connected: false } };
+    const gateway = { snapshot: { client: null, phase: "stopped" } };
     const context = {
       gateway,
       agents: {

--- a/ui/src/pages/approval/approval-page.test.ts
+++ b/ui/src/pages/approval/approval-page.test.ts
@@ -74,9 +74,8 @@ function expiredApproval(): ExpiredApprovalSnapshot {
 function createGateway(client: GatewayBrowserClient, connected = true) {
   let snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected,
+    phase: connected ? "connected" : "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "main",
     sessionKey: "main",
@@ -350,8 +349,8 @@ describe("ApprovalPage", () => {
     const { page, source } = createPage({ client });
     await settle(page);
 
-    source.update({ connected: false, reconnecting: true });
-    source.update({ connected: true, reconnecting: false });
+    source.update({ phase: "reconnecting" });
+    source.update({ phase: "connected" });
     await settle(page);
     resolveFirst({ approval: pendingApproval() });
     await settle(page);
@@ -417,7 +416,7 @@ describe("ApprovalPage", () => {
     const { page, source } = createPage({ client });
     await settle(page);
 
-    source.update({ connected: false, reconnecting: true });
+    source.update({ phase: "reconnecting" });
     await page.updateComplete;
 
     expect(page.querySelector(".approval-page__preview")?.textContent).toBe("printf safe");

--- a/ui/src/pages/approval/approval-page.ts
+++ b/ui/src/pages/approval/approval-page.ts
@@ -256,17 +256,17 @@ export class ApprovalPage extends OpenClawLightDomElement {
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
     const clientChanged = snapshot.client !== this.client;
-    const connectionChanged = snapshot.connected !== this.connected;
-    const becameConnected = snapshot.connected && !this.connected;
+    const connectionChanged = (snapshot.phase === "connected") !== this.connected;
+    const becameConnected = snapshot.phase === "connected" && !this.connected;
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.connected = snapshot.phase === "connected";
     if (clientChanged || connectionChanged) {
       this.invalidateOperations();
       this.clearPollTimer();
       this.resolving = false;
       this.resolvingDecision = null;
     }
-    if (!snapshot.connected || !snapshot.client) {
+    if (snapshot.phase !== "connected" || !snapshot.client) {
       if (this.approvalId) {
         this.loading = false;
         this.requestError =

--- a/ui/src/pages/approvals/approvals-page.test.ts
+++ b/ui/src/pages/approvals/approvals-page.test.ts
@@ -32,7 +32,7 @@ function terminal(id: string, resolvedAtMs: number): ApprovalHistoryResult["item
 
 function createPage(request: GatewayBrowserClient["request"]): TestApprovalsPage {
   const client = { request } as GatewayBrowserClient;
-  const snapshot = { connected: true, client } as ApplicationGatewaySnapshot;
+  const snapshot = { phase: "connected", client } as ApplicationGatewaySnapshot;
   const gateway = {
     snapshot,
     subscribe: () => () => undefined,

--- a/ui/src/pages/approvals/approvals-page.ts
+++ b/ui/src/pages/approvals/approvals-page.ts
@@ -163,8 +163,8 @@ class ApprovalsPage extends OpenClawLightDomElement {
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
     const clientChanged = snapshot.client !== this.client;
-    const connectionChanged = snapshot.connected !== this.connected;
-    this.connected = snapshot.connected;
+    const connectionChanged = (snapshot.phase === "connected") !== this.connected;
+    this.connected = snapshot.phase === "connected";
     if (clientChanged) {
       this.client = snapshot.client;
       this.requestGeneration += 1;
@@ -178,11 +178,11 @@ class ApprovalsPage extends OpenClawLightDomElement {
       this.requestGeneration += 1;
       this.loading = false;
       this.loadingMore = false;
-      if (snapshot.connected) {
+      if (snapshot.phase === "connected") {
         this.hasLoaded = false;
       }
     }
-    if (snapshot.connected && snapshot.client && !this.hasLoaded && !this.loading) {
+    if (snapshot.phase === "connected" && snapshot.client && !this.hasLoaded && !this.loading) {
       void this.loadPage(true);
     }
   }
@@ -209,7 +209,7 @@ class ApprovalsPage extends OpenClawLightDomElement {
       this.connected &&
       this.gatewaySource === gateway &&
       this.context.gateway === gateway &&
-      gateway.snapshot.connected &&
+      gateway.snapshot.phase === "connected" &&
       this.client === client &&
       this.requestGeneration === generation;
     try {

--- a/ui/src/pages/apps/apps-page.ts
+++ b/ui/src/pages/apps/apps-page.ts
@@ -28,7 +28,7 @@ class AppsPage extends OpenClawLightDomElement {
   override render() {
     const gatewaySnapshot = this.context.gateway.snapshot;
     const canPairDevice =
-      gatewaySnapshot.connected && hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null);
+      (gatewaySnapshot.phase === "connected") && hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null);
     const body = renderApps({
       onNavigate: (routeId: RouteId) => this.context.navigate(routeId),
       onPairDevice: canPairDevice

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -78,9 +78,8 @@ function createGateway(): TestGateway {
   } as unknown as GatewayBrowserClient;
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -250,7 +249,7 @@ describe("ChannelsPage lifecycle", () => {
 
     const load = page.importNostrProfile();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-    gateway.emit({ connected: false });
+    gateway.emit({ phase: "stopped" });
     expect(page.nostrProfileFormState).toBeNull();
 
     response.resolve(

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -92,7 +92,7 @@ class ChannelsPage extends OpenClawLightDomElement {
     CHANNEL_PAIRING_POLL_INTERVAL_MS,
     () => {
       const gateway = this.context?.gateway.snapshot;
-      if (gateway?.connected && hasOperatorPairingAccess(gateway.hello?.auth ?? null)) {
+      if (gateway?.phase === "connected" && hasOperatorPairingAccess(gateway.hello?.auth ?? null)) {
         void this.context.channels.refreshPairing();
       }
     },
@@ -158,7 +158,7 @@ class ChannelsPage extends OpenClawLightDomElement {
   ) {
     const clientChanged = this.hasGatewaySnapshot && this.gatewayClient !== snapshot.client;
     const connectionChanged =
-      this.hasGatewaySnapshot && this.gatewayConnected !== snapshot.connected;
+      this.hasGatewaySnapshot && this.gatewayConnected !== (snapshot.phase === "connected");
     const pairingAccess = hasOperatorPairingAccess(snapshot.hello?.auth ?? null);
     const pairingAuthSignature = resolveChannelPairingAuthSignature(snapshot);
     const pairingAuthChanged =
@@ -166,14 +166,14 @@ class ChannelsPage extends OpenClawLightDomElement {
     if (!this.hasGatewaySnapshot || sourceChanged || clientChanged || connectionChanged) {
       this.nostrOperationGeneration += 1;
     }
-    if (sourceChanged || clientChanged || !snapshot.connected) {
+    if (sourceChanged || clientChanged || snapshot.phase !== "connected") {
       this.clearNostrForm();
     }
     if (
       sourceChanged ||
       clientChanged ||
       pairingAuthChanged ||
-      !snapshot.connected ||
+      snapshot.phase !== "connected" ||
       !pairingAccess
     ) {
       this.pairingPrompt = null;
@@ -183,10 +183,10 @@ class ChannelsPage extends OpenClawLightDomElement {
     }
     this.hasGatewaySnapshot = true;
     this.gatewayClient = snapshot.client;
-    this.gatewayConnected = snapshot.connected;
+    this.gatewayConnected = snapshot.phase === "connected";
     this.gatewayPairingAuthSignature = pairingAuthSignature;
     this.syncPairingPolling(snapshot);
-    if (snapshot.connected && snapshot.client) {
+    if (snapshot.phase === "connected" && snapshot.client) {
       this.ensureInitialData();
       if (
         (sourceChanged || clientChanged || connectionChanged || pairingAuthChanged) &&
@@ -201,7 +201,7 @@ class ChannelsPage extends OpenClawLightDomElement {
 
   private syncPairingPolling(snapshot: ApplicationContext["gateway"]["snapshot"]) {
     if (
-      snapshot.connected &&
+      snapshot.phase === "connected" &&
       snapshot.client &&
       hasOperatorPairingAccess(snapshot.hello?.auth ?? null)
     ) {
@@ -215,7 +215,7 @@ class ChannelsPage extends OpenClawLightDomElement {
     const context = this.context;
     const gateway = context.gateway.snapshot;
     const client = gateway.client;
-    if (!gateway.connected || !client) {
+    if (gateway.phase !== "connected" || !client) {
       return;
     }
 
@@ -319,7 +319,7 @@ class ChannelsPage extends OpenClawLightDomElement {
       !this.isConnected ||
       this.gatewaySource !== gateway ||
       this.channelsSource !== channels ||
-      !gateway.snapshot.connected ||
+      gateway.snapshot.phase !== "connected" ||
       !client
     ) {
       return null;
@@ -347,7 +347,7 @@ class ChannelsPage extends OpenClawLightDomElement {
       this.context.gateway !== operation.gateway ||
       this.context.channels !== operation.channels ||
       operation.gateway.snapshot.client !== operation.client ||
-      !operation.gateway.snapshot.connected
+      operation.gateway.snapshot.phase !== "connected"
     ) {
       return null;
     }

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -58,7 +58,7 @@ function createTestPane(sessions: SessionCapability = {} as SessionCapability) {
   Object.defineProperty(pane, "isConnected", { configurable: true, value: true });
   pane.context = {
     sessions,
-    gateway: { snapshot: { client, connected: true } },
+    gateway: { snapshot: { client, phase: "connected" } },
   } as unknown as ApplicationContext;
   pane.state = {
     chatError: null,
@@ -156,7 +156,7 @@ describe("chat pane board shell", () => {
     pane.state.client = client;
     pane.context = {
       ...pane.context,
-      gateway: { snapshot: { client, connected: true } },
+      gateway: { snapshot: { client, phase: "connected" } },
     } as unknown as ApplicationContext;
     pane.connectedClient = client;
     pane.boardProvider = mockBoardProvider("agent:main:current");
@@ -400,7 +400,7 @@ describe("chat pane board shell", () => {
           ...pane.context.gateway,
           snapshot: {
             client,
-            connected: true,
+            phase: "connected",
             hello: { features: { methods: testCase.methods } },
           } as never,
         },
@@ -438,7 +438,7 @@ describe("chat pane board shell", () => {
         ...pane.context.gateway,
         snapshot: {
           client,
-          connected: true,
+          phase: "connected",
           hello: {
             auth: { role: "operator", scopes: profile.scopes },
             features: {

--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -44,7 +44,7 @@ function createSessionContext(
     gateway: {
       snapshot: {
         client,
-        connected: true,
+        phase: "connected",
         hello: { features: { methods: ["taskSuggestions.list"] } },
       },
     },

--- a/ui/src/pages/chat/chat-pane-pull-requests.test.ts
+++ b/ui/src/pages/chat/chat-pane-pull-requests.test.ts
@@ -122,7 +122,7 @@ describe("chat pane pull request refresh", () => {
 
     pane.applyGatewaySnapshot({
       ...pane.context.gateway.snapshot,
-      connected: false,
+      phase: "reconnecting" as const,
     });
 
     expect(pane.sessionPullRequests).toEqual([]);

--- a/ui/src/pages/chat/chat-pane.message-cut.test.ts
+++ b/ui/src/pages/chat/chat-pane.message-cut.test.ts
@@ -30,7 +30,7 @@ function createSessionContext(
     gateway: {
       snapshot: {
         client,
-        connected: true,
+        phase: "connected",
         hello: { features: { methods: [] } },
       },
     },

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -96,7 +96,7 @@ export function createSessionContext(
     gateway: {
       snapshot: {
         client,
-        connected: true,
+        phase: "connected" as const,
         hello: { features: { methods: ["taskSuggestions.list"] } },
       },
     },

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -163,7 +163,7 @@ describe("chat pane pull request refresh", () => {
 
     pane.applyGatewaySnapshot({
       ...pane.context.gateway.snapshot,
-      connected: false,
+      phase: "reconnecting" as const,
     });
 
     expect(pane.sessionPullRequests).toEqual([]);
@@ -543,7 +543,7 @@ describe("chat pane initialization", () => {
     const snapshot = {
       ...pane.context.gateway.snapshot,
       client,
-      phase: "connected",
+      phase: "connected" as const,
       hello,
       sessionKey: canonicalSessionKey,
     };

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -543,7 +543,7 @@ describe("chat pane initialization", () => {
     const snapshot = {
       ...pane.context.gateway.snapshot,
       client,
-      connected: true,
+      phase: "connected",
       hello,
       sessionKey: canonicalSessionKey,
     };

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -701,7 +701,7 @@ class ChatPane extends OpenClawLightDomElement {
       !state?.connected ||
       !client ||
       this.connectedClient !== client ||
-      !context.gateway.snapshot.connected ||
+      context.gateway.snapshot.phase !== "connected" ||
       context.gateway.snapshot.client !== client
     ) {
       return null;
@@ -724,7 +724,7 @@ class ChatPane extends OpenClawLightDomElement {
       scope.state.connected &&
       scope.state.client === scope.client &&
       this.connectedClient === scope.client &&
-      scope.context.gateway.snapshot.connected &&
+      scope.context.gateway.snapshot.phase === "connected" &&
       scope.context.gateway.snapshot.client === scope.client &&
       this.connectionGeneration === scope.generation
     );
@@ -1756,7 +1756,7 @@ class ChatPane extends OpenClawLightDomElement {
           ...acquireBoardProviderForSession(
             key,
             client,
-            gateway.connected,
+            gateway.phase === "connected",
             canPinWidgets,
             canPinMcpApps,
             canMutate,
@@ -1769,7 +1769,7 @@ class ChatPane extends OpenClawLightDomElement {
           key,
           client,
           true,
-          gateway.connected,
+          gateway.phase === "connected",
           canPinWidgets,
           canPinMcpApps,
           canMutate,
@@ -1783,7 +1783,7 @@ class ChatPane extends OpenClawLightDomElement {
       sessionKey,
       client,
       available,
-      gateway?.connected ?? false,
+      gateway?.phase === "connected",
       canPinWidgets,
       canPinMcpApps,
       canMutate,
@@ -1801,7 +1801,12 @@ class ChatPane extends OpenClawLightDomElement {
     const enabled = isWorkboardEnabledInConfigSnapshot(
       this.context?.runtimeConfig?.state.configSnapshot,
     );
-    if (!board.hasBoard || board.face !== "dashboard" || !enabled || !gateway?.connected) {
+    if (
+      !board.hasBoard ||
+      board.face !== "dashboard" ||
+      !enabled ||
+      gateway?.phase !== "connected"
+    ) {
       return null;
     }
     const client = gateway.client;
@@ -2183,7 +2188,7 @@ class ChatPane extends OpenClawLightDomElement {
       state.connected &&
       this.connectedClient === client &&
       context.gateway.snapshot.client === client &&
-      context.gateway.snapshot.connected &&
+      context.gateway.snapshot.phase === "connected" &&
       this.connectionGeneration === connectionGeneration;
     if (!canCreateChatSession(state)) {
       state.lastError = NEW_SESSION_ACTIVE_RUN_MESSAGE;
@@ -2775,7 +2780,8 @@ class ChatPane extends OpenClawLightDomElement {
       return;
     }
     const wasConnected = state.connected;
-    const sourceChanged = state.client !== snapshot.client || wasConnected !== snapshot.connected;
+    const sourceChanged =
+      state.client !== snapshot.client || wasConnected !== (snapshot.phase === "connected");
     const clientChanged = this.connectedClient !== snapshot.client;
     if (!snapshot.connected) {
       this.presencePayload = undefined;
@@ -2807,7 +2813,7 @@ class ChatPane extends OpenClawLightDomElement {
       state.chatLoading = false;
     }
     state.client = snapshot.client;
-    state.connected = snapshot.connected;
+    state.connected = snapshot.phase === "connected";
     state.connectionEpoch = this.connectionGeneration;
     state.hello = snapshot.hello;
     if (sourceChanged && state.sidebarContent?.kind === "session-discussion") {
@@ -2816,7 +2822,7 @@ class ChatPane extends OpenClawLightDomElement {
       // re-probe below restores the action for the new source.
       state.handleCloseSidebar();
     }
-    if (sourceChanged && snapshot.connected && state.sessionKey) {
+    if (sourceChanged && snapshot.phase === "connected" && state.sessionKey) {
       // Reconnects clear the probed states above; re-probe the active session
       // so source-owned affordances reappear without a manual session switch.
       void this.probeSessionDiscussion(state.sessionKey);
@@ -2826,11 +2832,11 @@ class ChatPane extends OpenClawLightDomElement {
     }
     state.terminalAvailable =
       this.context.config.current.terminalEnabled &&
-      snapshot.connected &&
+      snapshot.phase === "connected" &&
       hasOperatorAdminAccess(snapshot.hello?.auth ?? null) &&
       isGatewayMethodAdvertised(snapshot, "terminal.open") === true;
     state.browserPanelAvailable =
-      snapshot.connected &&
+      snapshot.phase === "connected" &&
       hasOperatorAdminAccess(snapshot.hello?.auth ?? null) &&
       isGatewayMethodAdvertised(snapshot, "browser.request") === true;
     state.assistantAgentId = snapshot.assistantAgentId;
@@ -2854,7 +2860,7 @@ class ChatPane extends OpenClawLightDomElement {
       }
     }
     state.assistantName = this.context.config.current.assistantIdentity.name;
-    if (!snapshot.connected) {
+    if (snapshot.phase !== "connected") {
       if (wasConnected) {
         const currentSessionId =
           typeof state.currentSessionId === "string" ? state.currentSessionId.trim() : "";

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -2783,7 +2783,7 @@ class ChatPane extends OpenClawLightDomElement {
     const sourceChanged =
       state.client !== snapshot.client || wasConnected !== (snapshot.phase === "connected");
     const clientChanged = this.connectedClient !== snapshot.client;
-    if (!snapshot.connected) {
+    if (snapshot.phase !== "connected") {
       this.presencePayload = undefined;
     } else if (clientChanged || !wasConnected) {
       const presence = readPresenceEntries(snapshot.hello?.snapshot);

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -406,7 +406,7 @@ function makeHost(overrides?: MakeHostOverrides): TestChatHost | TestChatHostWit
     createSessionCapability({
       snapshot: {
         client: host.client,
-        connected: host.connected,
+        phase: host.connected ? "connected" : "reconnecting",
         hello: host.hello,
       },
       subscribe: () => () => undefined,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -406,7 +406,7 @@ function createChatHeaderState(
   });
   const client = { request } as unknown as GatewayBrowserClient;
   const sessions = createSessionCapability({
-    snapshot: { client, connected: true, hello: null },
+    snapshot: { client, phase: "connected", hello: null },
     subscribe: () => () => undefined,
     subscribeEvents: () => () => undefined,
   });

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -202,7 +202,7 @@ describe("ConfigPage system info", () => {
     const client = {} as GatewayBrowserClient;
     const snapshot = {
       client,
-      connected: false,
+      phase: "stopped",
       hello: null,
     } as ApplicationGatewaySnapshot;
     const page = new ConfigPage();
@@ -232,7 +232,7 @@ describe("ConfigPage system info", () => {
     } as unknown as GatewayBrowserClient;
     const snapshot = {
       client,
-      connected: true,
+      phase: "connected",
       hello: { features: { methods: ["system.info"] } },
     } as ApplicationGatewaySnapshot;
     const firstGateway = { snapshot } as ApplicationGateway;
@@ -286,7 +286,7 @@ describe("ConfigPage session observer models", () => {
     const firstClient = {} as GatewayBrowserClient;
     const secondClient = {} as GatewayBrowserClient;
     const gateway = {
-      snapshot: { client: firstClient, connected: true },
+      snapshot: { client: firstClient, phase: "connected" },
     } as unknown as ApplicationGateway;
     const page = new ConfigPage();
     const state = page as unknown as {
@@ -303,7 +303,7 @@ describe("ConfigPage session observer models", () => {
     const firstLoad = state.ensureSessionObserverModels(firstClient);
     (gateway as { snapshot: ApplicationGatewaySnapshot }).snapshot = {
       client: secondClient,
-      connected: true,
+      phase: "connected",
     } as ApplicationGatewaySnapshot;
     const secondLoad = state.ensureSessionObserverModels(secondClient);
     const currentModels = [{ id: "small", name: "Small", provider: "openai" }];
@@ -322,7 +322,7 @@ describe("ConfigPage session observer models", () => {
     vi.spyOn(chatModels, "loadModels").mockRejectedValue(new Error("catalog unavailable"));
     const client = {} as GatewayBrowserClient;
     const gateway = {
-      snapshot: { client, connected: true },
+      snapshot: { client, phase: "connected" },
     } as unknown as ApplicationGateway;
     const page = new ConfigPage();
     const state = page as unknown as {

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -541,11 +541,11 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.sessionObserverModelsClient = null;
       this.sessionObserverModels = [];
       this.sessionObserverModelsUnavailable = false;
-    } else if (!snapshot.connected) {
+    } else if (snapshot.phase !== "connected") {
       this.invalidateSystemInfoRequest();
       this.systemInfo = null;
     }
-    if (snapshot.connected && snapshot.hello) {
+    if (snapshot.phase === "connected" && snapshot.hello) {
       this.systemInfoUnavailable = !hasSystemInfo;
       if (!hasSystemInfo) {
         this.invalidateSystemInfoRequest();
@@ -561,7 +561,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.isConnected &&
       this.isSystemInfoVisible() &&
       !this.systemInfoUnavailable &&
-      gateway.connected &&
+      gateway.phase === "connected" &&
       supportsSystemInfo(gateway.hello) &&
       gateway.client != null;
     if (!shouldPoll) {
@@ -590,7 +590,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       requestId === this.systemInfoRequestId &&
       this.systemInfoGatewaySource === gatewaySource &&
       this.context.gateway === gatewaySource &&
-      gateway.connected &&
+      gateway.phase === "connected" &&
       gateway.client === client
     );
   }
@@ -603,7 +603,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     const gateway = gatewaySource.snapshot;
     const client = gateway.client;
     if (
-      !gateway.connected ||
+      gateway.phase !== "connected" ||
       !client ||
       !this.isSystemInfoVisible() ||
       this.systemInfoUnavailable ||

--- a/ui/src/pages/connection/connection-page.ts
+++ b/ui/src/pages/connection/connection-page.ts
@@ -33,7 +33,7 @@ class ConnectionPage extends OpenClawLightDomElement {
         return gateway.subscribe((snapshot) => {
           if (snapshot.client !== this.gatewayClient) {
             this.resetDraft(gateway);
-          } else if (!snapshot.connected) {
+          } else if (snapshot.phase !== "connected") {
             this.resetSensitiveUi();
           }
           this.requestUpdate();
@@ -92,7 +92,7 @@ class ConnectionPage extends OpenClawLightDomElement {
   override render() {
     const gateway = this.context.gateway.snapshot;
     const body = renderConnection({
-      connected: gateway.connected,
+      connected: gateway.phase === "connected",
       hello: gateway.hello,
       settings: this.settings,
       password: this.password,

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -37,9 +37,8 @@ function createDeferred<T>() {
 function createGateway(client: GatewayBrowserClient, connected: boolean): TestGateway {
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected,
+    phase: connected ? "connected" : "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -330,7 +329,7 @@ describe("CronPage lifecycle", () => {
     };
     page.cronModelSuggestions = ["old/model"];
 
-    gateway.emitSnapshot({ connected: false });
+    gateway.emitSnapshot({ phase: "stopped" });
     const disconnectedState = page.cron;
 
     expect(disconnectedState).not.toBe(connectedState);
@@ -339,7 +338,7 @@ describe("CronPage lifecycle", () => {
     expect(page.cronModelSuggestions).toEqual([]);
     expect(disconnectedState.cronCreateOpen).toBe(false);
 
-    gateway.emitSnapshot({ connected: true });
+    gateway.emitSnapshot({ phase: "connected" });
     expect(page.cron).not.toBe(disconnectedState);
   });
 
@@ -364,10 +363,10 @@ describe("CronPage lifecycle", () => {
     const page = createPage(createContext(gateway));
     await page.updateComplete;
 
-    gateway.emitSnapshot({ connected: true });
+    gateway.emitSnapshot({ phase: "connected" });
     await waitForCronPage(() => expect(modelRequestCount).toBe(1));
-    gateway.emitSnapshot({ connected: false });
-    gateway.emitSnapshot({ connected: true });
+    gateway.emitSnapshot({ phase: "stopped" });
+    gateway.emitSnapshot({ phase: "connected" });
     await waitForCronPage(() => expect(page.cronModelSuggestions).toEqual(["fresh/model"]));
 
     staleModels.resolve({ models: [{ id: "stale/model" }] });

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -77,8 +77,7 @@ class CronPage extends OpenClawLightDomElement {
           }
           // Replace the mutable request state so responses started for the old
           // scope cannot populate the newly selected agent's page.
-          const snapshot = { client: this.cron.client, connected: this.cron.connected };
-          this.resetGatewayState(snapshot);
+          this.resetGatewayState(this.context.gateway.snapshot);
           this.cron.cronAgentId = selection.scopeId;
           this.listTab = "tasks";
           this.detailTab = "settings";
@@ -107,7 +106,7 @@ class CronPage extends OpenClawLightDomElement {
         gateway.subscribeEvents((event) => {
           if (
             this.gatewaySource === gateway &&
-            gateway.snapshot.connected &&
+            gateway.snapshot.phase === "connected" &&
             gateway.snapshot.client &&
             event.event === "cron"
           ) {
@@ -123,10 +122,14 @@ class CronPage extends OpenClawLightDomElement {
     super.disconnectedCallback();
   }
 
-  private resetGatewayState(snapshot: Partial<Pick<CronState, "client" | "connected">> = {}) {
-    this.cron = createInitialCronState(snapshot);
+  private resetGatewayState(snapshot?: ApplicationContext["gateway"]["snapshot"]) {
+    const connected = snapshot?.phase === "connected";
+    this.cron = createInitialCronState({
+      client: snapshot?.client ?? null,
+      connected,
+    });
     this.cron.cronAgentId = this.context.agentSelection.state.scopeId;
-    this.agentsList = snapshot.connected ? this.context.agents.state.agentsList : null;
+    this.agentsList = connected ? this.context.agents.state.agentsList : null;
     this.cronModelSuggestions = [];
     this.modelSuggestionsState = null;
   }
@@ -138,7 +141,7 @@ class CronPage extends OpenClawLightDomElement {
     if (
       sourceChanged ||
       this.cron.client !== snapshot.client ||
-      this.cron.connected !== snapshot.connected
+      this.cron.connected !== (snapshot.phase === "connected")
     ) {
       // Each connection epoch owns a fresh mutable state object. In-flight work
       // can finish against the old object without leaking into the next session.

--- a/ui/src/pages/custodian/custodian-page-agent-create.test.ts
+++ b/ui/src/pages/custodian/custodian-page-agent-create.test.ts
@@ -21,9 +21,8 @@ function createContext(request: ReturnType<typeof vi.fn>) {
   const client = { request } as unknown as GatewayBrowserClient;
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: {
       type: "hello-ok",
       protocol: 1,

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -304,11 +304,11 @@ describe("custodian page nudges", () => {
     await page.updateComplete;
     expect(page.querySelector(".custodian__nudge")).not.toBeNull();
 
-    setGatewaySnapshot({ connected: false, reconnecting: true });
+    setGatewaySnapshot({ phase: "reconnecting" });
     await page.updateComplete;
     expect(page.querySelector(".custodian__nudge")).not.toBeNull();
 
-    setGatewaySnapshot({ connected: true, reconnecting: false });
+    setGatewaySnapshot({ phase: "connected" });
     await page.updateComplete;
     expect(page.querySelector(".custodian__nudge")).not.toBeNull();
     expect(request).toHaveBeenCalledOnce();
@@ -337,8 +337,7 @@ describe("custodian page nudges", () => {
     setGatewayToken("new-operator-token");
     setGatewaySnapshot({
       client: { request } as unknown as GatewayBrowserClient,
-      connected: true,
-      reconnecting: false,
+      phase: "connected",
     });
     await waitForFast(() => expect(page.querySelector(".custodian__nudge")).toBeNull());
     expect(request).toHaveBeenCalledTimes(2);
@@ -758,9 +757,9 @@ describe("custodian page nudges", () => {
     page.querySelector<HTMLButtonElement>(".option-card__skip")!.click();
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
 
-    setGatewaySnapshot({ connected: false, reconnecting: true });
+    setGatewaySnapshot({ phase: "reconnecting" });
     await page.updateComplete;
-    setGatewaySnapshot({ connected: true, reconnecting: false });
+    setGatewaySnapshot({ phase: "connected" });
     await page.updateComplete;
     resolveQuestion({
       sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
@@ -838,9 +837,9 @@ describe("custodian page nudges", () => {
     page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.click();
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
 
-    setGatewaySnapshot({ connected: false, reconnecting: true });
+    setGatewaySnapshot({ phase: "reconnecting" });
     await page.updateComplete;
-    setGatewaySnapshot({ connected: true, reconnecting: false });
+    setGatewaySnapshot({ phase: "connected" });
     await page.updateComplete;
     resolveNudge({
       sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",

--- a/ui/src/pages/custodian/custodian-page.test-harness.ts
+++ b/ui/src/pages/custodian/custodian-page.test-harness.ts
@@ -34,9 +34,8 @@ export function createContext(
   const client = { request } as unknown as GatewayBrowserClient;
   let snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: {
       type: "hello-ok" as const,
       protocol: 1,

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -293,11 +293,10 @@ describe("custodian page", () => {
     await page.updateComplete;
     expect(page.querySelector("openclaw-option-card")).not.toBeNull();
 
-    setGatewaySnapshot({ connected: false, reconnecting: true });
+    setGatewaySnapshot({ phase: "reconnecting" });
     await page.updateComplete;
     setGatewaySnapshot({
-      connected: true,
-      reconnecting: false,
+      phase: "connected",
     });
     await page.updateComplete;
 

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -185,7 +185,7 @@ export class CustodianPage extends OpenClawLightDomElement {
 
   private synchronizeClient(): void {
     const snapshot = this.context.gateway.snapshot;
-    const client = snapshot.connected ? snapshot.client : null;
+    const client = snapshot.phase === "connected" ? snapshot.client : null;
     const chatSupported =
       client !== null && isGatewayMethodAdvertised(snapshot, "openclaw.chat") === true;
     const historyAvailable =

--- a/ui/src/pages/custodian/route.test.ts
+++ b/ui/src/pages/custodian/route.test.ts
@@ -34,9 +34,8 @@ function loadRoute(search: string): CustodianRouteData {
 function createContext(): ApplicationContext {
   const snapshot: ApplicationGatewaySnapshot = {
     client: null,
-    connected: false,
+    phase: "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "main",
     sessionKey: "main",

--- a/ui/src/pages/debug/debug-page.ts
+++ b/ui/src/pages/debug/debug-page.ts
@@ -87,13 +87,13 @@ class DebugPage extends OpenClawLightDomElement {
   }
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot, resetForSourceBind = false) {
-    const connectionChanged = snapshot.connected !== this.connected;
+    const connectionChanged = (snapshot.phase === "connected") !== this.connected;
     const clientChanged = resetForSourceBind || snapshot.client !== this.client;
     if (clientChanged || connectionChanged) {
       this.requestGeneration += 1;
     }
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.connected = snapshot.phase === "connected";
     if (clientChanged) {
       this.resetServerState();
     } else if (connectionChanged) {

--- a/ui/src/pages/gateway-source-replacement.test.ts
+++ b/ui/src/pages/gateway-source-replacement.test.ts
@@ -39,9 +39,8 @@ function gatewayWithClient(
 ): ApplicationContext["gateway"] {
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected,
+    phase: connected ? "connected" : "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -113,7 +112,7 @@ function contextWithMutableGateway(client: GatewayBrowserClient) {
   return {
     context,
     emitConnected(connected: boolean) {
-      currentSnapshot = { ...currentSnapshot, connected };
+      currentSnapshot = { ...currentSnapshot, phase: connected ? "connected" : "stopped" };
       for (const listener of listeners) {
         listener(currentSnapshot);
       }
@@ -277,7 +276,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
     await page.updateComplete;
     page.refreshRuntime.applyGatewaySnapshot({
       ...context.gateway.snapshot,
-      connected: false,
+      phase: "stopped",
     });
     page.refreshRuntime.applyGatewaySnapshot(context.gateway.snapshot);
     await Promise.resolve();
@@ -322,7 +321,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
     page.usageLoading = true;
     page.refreshRuntime.applyGatewaySnapshot({
       ...context.gateway.snapshot,
-      connected: false,
+      phase: "stopped",
     });
     page.refreshRuntime.applyGatewaySnapshot(context.gateway.snapshot);
 
@@ -540,7 +539,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
     };
     document.body.append(page);
     await page.updateComplete;
-    (context.gateway.snapshot as ApplicationGatewaySnapshot).connected = true;
+    (context.gateway.snapshot as ApplicationGatewaySnapshot).phase = "connected";
     page.connected = true;
 
     const load = page.loadAgents();
@@ -620,7 +619,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
     };
     document.body.append(page);
     await page.updateComplete;
-    (context.gateway.snapshot as ApplicationGatewaySnapshot).connected = true;
+    (context.gateway.snapshot as ApplicationGatewaySnapshot).phase = "connected";
     page.connected = true;
 
     const load = page.loadDiagnostics();

--- a/ui/src/pages/logs/logs-page.test.ts
+++ b/ui/src/pages/logs/logs-page.test.ts
@@ -31,7 +31,7 @@ function contextWithClient(client: GatewayBrowserClient): ApplicationContext {
   return {
     basePath: "",
     gateway: {
-      snapshot: { client, connected: false },
+      snapshot: { client, phase: "stopped" },
       subscribe: () => () => undefined,
     },
     navigate: vi.fn(),
@@ -50,7 +50,7 @@ describe("LogsPage lifecycle", () => {
     page.context = {
       basePath: "",
       gateway: {
-        snapshot: { client: null, connected: false },
+        snapshot: { client: null, phase: "stopped" },
         subscribe: () => () => undefined,
       },
       navigate: vi.fn(),
@@ -147,7 +147,7 @@ describe("LogsPage lifecycle", () => {
     page.connected = true;
 
     const load = page.loadLogs({ reset: true });
-    page.applyGatewaySnapshot({ client, connected: false } as ApplicationGatewaySnapshot);
+    page.applyGatewaySnapshot({ client, phase: "stopped" } as ApplicationGatewaySnapshot);
     pending.resolve({ cursor: 1, lines: ["stale"], reset: true });
     await load;
 
@@ -217,12 +217,12 @@ describe("LogsPage lifecycle", () => {
     const requestFrame = vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
     document.body.append(page);
     await page.updateComplete;
-    page.applyGatewaySnapshot({ client, connected: true } as ApplicationGatewaySnapshot);
+    page.applyGatewaySnapshot({ client, phase: "connected" } as ApplicationGatewaySnapshot);
     requestFrame.mockClear();
 
     page.scheduleScroll();
-    page.applyGatewaySnapshot({ client, connected: false } as ApplicationGatewaySnapshot);
-    page.applyGatewaySnapshot({ client, connected: true } as ApplicationGatewaySnapshot);
+    page.applyGatewaySnapshot({ client, phase: "stopped" } as ApplicationGatewaySnapshot);
+    page.applyGatewaySnapshot({ client, phase: "connected" } as ApplicationGatewaySnapshot);
     await Promise.resolve();
 
     expect(requestFrame).not.toHaveBeenCalled();

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -135,14 +135,14 @@ class LogsPage extends OpenClawLightDomElement {
   }
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot, resetForSourceBind = false) {
-    const connectionChanged = snapshot.connected !== this.connected;
+    const connectionChanged = (snapshot.phase === "connected") !== this.connected;
     const clientChanged = resetForSourceBind || snapshot.client !== this.client;
     if (clientChanged || connectionChanged) {
       this.requestGeneration += 1;
       this.activeRequest = null;
     }
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.connected = snapshot.phase === "connected";
     if (clientChanged) {
       this.resetServerState();
     } else if (connectionChanged) {

--- a/ui/src/pages/memory-import/memory-import-page.test.ts
+++ b/ui/src/pages/memory-import/memory-import-page.test.ts
@@ -60,9 +60,8 @@ function createContext(request: ReturnType<typeof vi.fn>): ApplicationContext {
   const client = { request } as unknown as GatewayBrowserClient;
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "research",
     sessionKey: "agent:research:main",
@@ -324,7 +323,7 @@ describe("MemoryImportPage", () => {
       expect(page.querySelector("[data-test-id='memory-import-confirm']")).not.toBeNull(),
     );
 
-    context.gateway.snapshot.connected = false;
+    context.gateway.snapshot.phase = "stopped";
     context.gateway.snapshot.client = null;
     page.requestUpdate();
     await page.updateComplete;
@@ -333,7 +332,7 @@ describe("MemoryImportPage", () => {
 
     const replacementClient = { request } as unknown as GatewayBrowserClient;
     context.gateway.snapshot.client = replacementClient;
-    context.gateway.snapshot.connected = true;
+    context.gateway.snapshot.phase = "connected";
     page.requestUpdate();
     await waitForMemoryImport(() => expect(request).toHaveBeenCalledTimes(2));
     expect(page.querySelector("[data-test-id='memory-import-confirm']")).toBeNull();
@@ -389,7 +388,7 @@ describe("MemoryImportPage", () => {
     await waitForMemoryImport(() => expect(request).toHaveBeenCalledTimes(2));
     const firstApply = request.mock.calls[1]?.[1] as { idempotencyKey?: string } | undefined;
 
-    context.gateway.snapshot.connected = false;
+    context.gateway.snapshot.phase = "stopped";
     context.gateway.snapshot.client = null;
     page.requestUpdate();
     await page.updateComplete;
@@ -399,7 +398,7 @@ describe("MemoryImportPage", () => {
 
     const replacementClient = { request } as unknown as GatewayBrowserClient;
     context.gateway.snapshot.client = replacementClient;
-    context.gateway.snapshot.connected = true;
+    context.gateway.snapshot.phase = "connected";
     page.requestUpdate();
     await waitForMemoryImport(() => expect(request).toHaveBeenCalledTimes(3));
     await waitForMemoryImport(() =>

--- a/ui/src/pages/memory-import/memory-import-page.ts
+++ b/ui/src/pages/memory-import/memory-import-page.ts
@@ -85,7 +85,7 @@ export class MemoryImportPage extends OpenClawLightDomElement {
 
   override updated() {
     const snapshot = this.context.gateway.snapshot;
-    if (!snapshot.connected || !snapshot.client) {
+    if (snapshot.phase !== "connected" || !snapshot.client) {
       if (!this.gatewayUnavailable) {
         this.gatewayUnavailable = true;
         this.resetPlanState({ preserveAttemptedImport: true });
@@ -164,7 +164,7 @@ export class MemoryImportPage extends OpenClawLightDomElement {
   private async refresh(force = false) {
     const snapshot = this.context.gateway.snapshot;
     const agentId = this.currentAgentId();
-    if (!snapshot.connected || !snapshot.client || !agentId || this.loading) {
+    if (snapshot.phase !== "connected" || !snapshot.client || !agentId || this.loading) {
       return;
     }
     const client = snapshot.client;
@@ -319,7 +319,7 @@ export class MemoryImportPage extends OpenClawLightDomElement {
     const agentsList = this.context.agents.state.agentsList;
     const agentId = this.currentAgentId();
     const body = renderMemoryImport({
-      connected: snapshot.connected,
+      connected: snapshot.phase === "connected",
       agents: listSelectableAgents(agentsList?.agents ?? []),
       selectedAgentId: agentId,
       plan: this.plan,

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -62,9 +62,8 @@ function createHarness(initialScopeId: string) {
   });
   const snapshot: ApplicationGatewaySnapshot = {
     client: { request } as unknown as GatewayBrowserClient,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "main",
     sessionKey: "main",

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -158,7 +158,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     if (!this.context.agents.state.agentsList && !this.context.agents.state.agentsLoading) {
       void this.context.agents.ensureList();
     }
-    if (!snapshot.connected || !snapshot.client || this.refreshing) {
+    if (snapshot.phase !== "connected" || !snapshot.client || this.refreshing) {
       return;
     }
     const stale = this.data === null || this.data.updatedAt === null;
@@ -265,7 +265,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
 
   private mutationBlockedReason(): string | null {
     const snapshot = this.context.gateway.snapshot;
-    if (!snapshot.connected) {
+    if (snapshot.phase !== "connected") {
       return t("modelProviders.readOnly.disconnected");
     }
     if (!hasOperatorAdminAccess(snapshot.hello?.auth ?? null)) {
@@ -585,8 +585,8 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     const advertised = isGatewayMethodAdvertised(gatewaySnapshot, "models.probe");
     const blockedReason = this.mutationBlockedReason();
     const body = renderModelProviders({
-      connected: gatewaySnapshot.connected,
-      loading: gatewaySnapshot.connected && this.data === null,
+      connected: gatewaySnapshot.phase === "connected",
+      loading: gatewaySnapshot.phase === "connected" && this.data === null,
       refreshing: this.refreshing,
       error: data.error,
       updatedAt: data.updatedAt,

--- a/ui/src/pages/model-providers/route.ts
+++ b/ui/src/pages/model-providers/route.ts
@@ -9,7 +9,7 @@ async function loadModelProvidersRouteData(
 ): Promise<ModelProvidersRouteData> {
   const gatewaySnapshot = context.gateway.snapshot;
   const { EMPTY_MODEL_PROVIDERS_DATA, loadModelProvidersData } = await import("./load.ts");
-  const client = gatewaySnapshot.connected ? gatewaySnapshot.client : null;
+  const client = gatewaySnapshot.phase === "connected" ? gatewaySnapshot.client : null;
   const agentsList =
     context.agents.state.agentsList ?? (client ? await context.agents.ensureList() : null);
   const requestedAgentId = context.agentSelection.state.scopeId;

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -84,7 +84,7 @@ describe("model setup first-run redirect", () => {
     type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
     let listener: GatewayListener | null = null;
     const snapshot = {
-      connected: true,
+      phase: "connected",
       client,
       hello: {
         auth: { role: "operator", scopes: ["operator.admin"] },
@@ -131,7 +131,7 @@ describe("model setup first-run redirect", () => {
     type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
     let listener: GatewayListener | null = null;
     const snapshot = {
-      connected: true,
+      phase: "connected",
       client,
       hello: {
         auth: { role: "operator", scopes: ["operator.admin"] },

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -176,7 +176,7 @@ describe("model setup first-run redirect", () => {
 
     startModelSetupFirstRunRedirect({ context, isStillDefaultLanding: () => true });
     listener!({
-      connected: true,
+      phase: "connected" as const,
       client,
       hello: {
         auth: { role: "operator", scopes: ["operator.read"] },
@@ -184,7 +184,7 @@ describe("model setup first-run redirect", () => {
       },
     } as Parameters<GatewayListener>[0]);
     listener!({
-      connected: true,
+      phase: "connected" as const,
       client,
       hello: {
         auth: { role: "operator", scopes: ["operator.admin"] },

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -55,7 +55,7 @@ export function startModelSetupFirstRunRedirect(params: {
     if (
       attempted ||
       redirected ||
-      !snapshot.connected ||
+      snapshot.phase !== "connected" ||
       !snapshot.client ||
       !hasOperatorAdminAccess(snapshot.hello?.auth ?? null) ||
       isGatewayMethodAdvertised(snapshot, "openclaw.setup.detect") !== true

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -43,8 +43,7 @@ function createContext(): { context: ApplicationContext; client: GatewayBrowserC
   const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
   const snapshot = {
     client,
-    connected: true,
-    reconnecting: false,
+    phase: "connected",
     hello: {
       type: "hello-ok" as const,
       protocol: 1,

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -143,7 +143,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     const snapshot = this.context.gateway.snapshot;
     return Boolean(
       client &&
-      snapshot.connected &&
+      snapshot.phase === "connected" &&
       hasOperatorAdminAccess(snapshot.hello?.auth ?? null) &&
       isGatewayMethodAdvertised(snapshot, "openclaw.setup.detect") === true,
     );
@@ -235,7 +235,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       .then((blobUrl) => {
         if (
           this.iconRequests.get(iconUrl) !== request ||
-          !this.context.gateway.snapshot.connected ||
+          this.context.gateway.snapshot.phase !== "connected" ||
           !this.currentIconUrls().has(iconUrl)
         ) {
           if (blobUrl) {
@@ -478,7 +478,8 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     const snapshot = this.context.gateway.snapshot;
     const canAdmin = hasOperatorAdminAccess(snapshot.hello?.auth ?? null);
     const gatewayTooOld =
-      snapshot.connected && isGatewayMethodAdvertised(snapshot, "openclaw.setup.detect") !== true;
+      snapshot.phase === "connected" &&
+      isGatewayMethodAdvertised(snapshot, "openclaw.setup.detect") !== true;
     const canVerify =
       canAdmin &&
       !gatewayTooOld &&

--- a/ui/src/pages/model-setup/route.ts
+++ b/ui/src/pages/model-setup/route.ts
@@ -15,7 +15,7 @@ async function loadModelSetupRouteData(
 ): Promise<ModelSetupRouteData> {
   const firstRun = new URLSearchParams(location.search).get("firstRun") === "1";
   const snapshot = context.gateway.snapshot;
-  const client = snapshot.connected ? snapshot.client : null;
+  const client = snapshot.phase === "connected" ? snapshot.client : null;
   if (
     !client ||
     !hasOperatorAdminAccess(snapshot.hello?.auth ?? null) ||

--- a/ui/src/pages/new-session/gateway-name-discovery.ts
+++ b/ui/src/pages/new-session/gateway-name-discovery.ts
@@ -25,7 +25,7 @@ export class GatewayNameDiscovery {
     const snapshot = this.snapshot();
     const client = snapshot?.client;
     if (
-      !snapshot?.connected ||
+      snapshot?.phase !== "connected" ||
       !client ||
       isGatewayMethodAdvertised(snapshot, "system.info") !== true
     ) {

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -8,7 +8,7 @@ function contextWith(models: ModelCatalogEntry[], runtime = "openclaw") {
   const context = {
     gateway: {
       snapshot: {
-        connected: true,
+        phase: "connected",
         client: { request },
       },
     },

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -78,7 +78,7 @@ export class NewSessionModelControl {
     const normalizedAgentId = normalizeAgentId(agentId);
     const requestId = ++this.requestToken;
     this.catalog = [];
-    if (!snapshot?.connected || !client || !normalizedAgentId || !enabled) {
+    if (snapshot?.phase !== "connected" || !client || !normalizedAgentId || !enabled) {
       this.loading = false;
       this.notify();
       return;
@@ -174,7 +174,7 @@ export class NewSessionModelControl {
     return renderChatModelControls({
       activeRunId: null,
       agentDefaultModel,
-      connected: snapshot?.connected === true,
+      connected: snapshot?.phase === "connected",
       gatewayAvailable: Boolean(snapshot?.client),
       loading: false,
       modelCatalog: this.catalog,

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -152,23 +152,26 @@ class NewSessionPage extends OpenClawLightDomElement {
 
   private synchronizeGateway(gateway: ApplicationContext["gateway"]) {
     const snapshot = gateway.snapshot;
+    const connected = snapshot.phase === "connected";
     const firstBind = this.gatewaySource === null;
     const gatewayUrlChanged = !firstBind && this.gatewayUrl !== gateway.connection.gatewayUrl;
     const identityChanged =
       !firstBind && (this.gatewaySource !== gateway || this.gatewayClient !== snapshot.client);
-    const connectionChanged = !firstBind && this.gatewayConnected !== snapshot.connected;
-    const becameConnected = snapshot.connected && (identityChanged || !this.gatewayConnected);
+    const connectionChanged = !firstBind && this.gatewayConnected !== connected;
+    const becameConnected = connected && (identityChanged || !this.gatewayConnected);
     const recoveryScopeBecameReady =
-      snapshot.connected &&
-      snapshot.client?.recoveryScopeReady === true &&
-      !this.gatewayRecoveryScopeReady;
-    const recoveryScope = resolveScope(snapshot, this.gatewayRecoveryScope, firstBind);
+      connected && snapshot.client?.recoveryScopeReady === true && !this.gatewayRecoveryScopeReady;
+    const recoveryScope = resolveScope(
+      { client: snapshot.client, connected },
+      this.gatewayRecoveryScope,
+      firstBind,
+    );
     this.gatewaySource = gateway;
     this.gatewayClient = snapshot.client;
     this.gatewayUrl = gateway.connection.gatewayUrl;
     this.gatewayRecoveryScope = recoveryScope.next;
     this.gatewayRecoveryScopeReady = snapshot.client?.recoveryScopeReady === true;
-    this.gatewayConnected = snapshot.connected;
+    this.gatewayConnected = connected;
     if (gatewayUrlChanged || identityChanged || connectionChanged || recoveryScope.changed) {
       this.invalidateGatewayDiscovery(gatewayUrlChanged || recoveryScope.changed);
     }
@@ -187,7 +190,7 @@ class NewSessionPage extends OpenClawLightDomElement {
         this.pendingCloud.reset();
         this.submissionOutcomeUnknown = false;
       }
-      if (snapshot.connected && snapshot.client?.recoveryScopeReady) {
+      if (connected && snapshot.client?.recoveryScopeReady) {
         this.restorePendingCloudRecovery(this.gatewayUrl, this.gatewayRecoveryScope);
       }
     }
@@ -524,7 +527,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.nodesHydrated = false;
     const snapshot = this.context?.gateway.snapshot;
     const client = snapshot?.client;
-    if (!snapshot?.connected || !client || !this.isAdmin()) {
+    if (snapshot?.phase !== "connected" || !client || !this.isAdmin()) {
       this.nodes = [];
       this.nodesHydrated = true;
       return;
@@ -581,7 +584,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
     const snapshot = this.context?.gateway.snapshot;
     const client = snapshot?.client;
-    if (!snapshot?.connected || !client) {
+    if (snapshot?.phase !== "connected" || !client) {
       return;
     }
     this.repository = { kind: "checking", repoRoot };
@@ -680,7 +683,7 @@ class NewSessionPage extends OpenClawLightDomElement {
       this.attachmentDraft.pendingReads > 0 ||
       (!pendingCloud && this.submissionOutcomeUnknown) ||
       (!message && !hasAttachments) ||
-      !gateway?.snapshot.connected ||
+      gateway?.snapshot.phase !== "connected" ||
       !gateway.snapshot.client
     ) {
       return false;
@@ -1167,7 +1170,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     const snapshot = this.context?.gateway.snapshot;
     const client = snapshot?.client;
     const target = this.browserTarget;
-    if (!snapshot?.connected || !client || !target) {
+    if (snapshot?.phase !== "connected" || !client || !target) {
       return;
     }
     // Exec-only nodes still accept a typed cwd; never probe an unsupported fs.listDir.

--- a/ui/src/pages/new-session/route.ts
+++ b/ui/src/pages/new-session/route.ts
@@ -33,7 +33,7 @@ async function loadNewSessionData(
   const location = { ...requestedLocation, agentId };
   const plain = { ...location, model: "", catalogLabel: "" };
   const gateway = context.gateway.snapshot;
-  if (!gateway.connected || !gateway.client) {
+  if (gateway.phase !== "connected" || !gateway.client) {
     return plain;
   }
   const target = await resolveCreateTarget(gateway.client, location.catalogId, agentId);

--- a/ui/src/pages/nodes/nodes-page.test.ts
+++ b/ui/src/pages/nodes/nodes-page.test.ts
@@ -49,9 +49,8 @@ function gatewaySnapshot(
 ): ApplicationGatewaySnapshot {
   return {
     client,
-    connected,
+    phase: connected ? "connected" : "reconnecting",
     offlineStable: false,
-    reconnecting: !connected,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -63,9 +62,8 @@ function gatewaySnapshot(
 function gateway(client: GatewayBrowserClient | null): ApplicationContext["gateway"] {
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected: false,
+    phase: "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -89,7 +87,10 @@ describe("NodesPage gateway lifecycle", () => {
       gateway: currentGateway,
       gatewaySnapshot: currentGateway.snapshot,
       nodes: {
-        ...createInitialNodesState(currentGateway.snapshot),
+        ...createInitialNodesState({
+          client: currentGateway.snapshot.client,
+          connected: currentGateway.snapshot.phase === "connected",
+        }),
         nodes: preloadedNodes,
       },
     };
@@ -120,7 +121,7 @@ describe("NodesPage gateway lifecycle", () => {
       gateway: currentGateway,
       gatewaySnapshot: gatewaySnapshot(client, false),
       nodes: {
-        ...createInitialNodesState(gatewaySnapshot(client, true)),
+        ...createInitialNodesState({ client, connected: true }),
         nodes: preloadedNodes,
       },
     };

--- a/ui/src/pages/nodes/nodes-page.ts
+++ b/ui/src/pages/nodes/nodes-page.ts
@@ -192,17 +192,17 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
     initialBind = false,
   ) {
     const clientChanged = this.client !== snapshot.client;
-    const connectionChanged = this.connected !== snapshot.connected;
-    if (forceReset || clientChanged || connectionChanged || !snapshot.connected) {
+    const connectionChanged = this.connected !== (snapshot.phase === "connected");
+    if (forceReset || clientChanged || connectionChanged || snapshot.phase !== "connected") {
       this.requestGeneration += 1;
     }
     this.syncGatewayState(snapshot);
-    if (forceReset || (!initialBind && (clientChanged || !snapshot.connected))) {
+    if (forceReset || (!initialBind && (clientChanged || snapshot.phase !== "connected"))) {
       this.resetServerState(snapshot);
     }
     if (
       this.routeDataInitialized &&
-      snapshot.connected &&
+      snapshot.phase === "connected" &&
       snapshot.client &&
       (forceReset || clientChanged || connectionChanged)
     ) {
@@ -216,8 +216,9 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
 
   private syncGatewayState(snapshot: ApplicationGatewaySnapshot) {
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
-    this.canPairDevice = snapshot.connected && hasOperatorAdminAccess(snapshot.hello?.auth ?? null);
+    this.connected = snapshot.phase === "connected";
+    this.canPairDevice =
+      snapshot.phase === "connected" && hasOperatorAdminAccess(snapshot.hello?.auth ?? null);
   }
 
   private applyRouteData() {
@@ -236,7 +237,7 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
       return;
     }
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.connected = snapshot.phase === "connected";
     this.nodesLoading = data.nodes.nodesLoading;
     this.nodes = data.nodes.nodes;
     this.lastError = data.nodes.lastError;
@@ -262,7 +263,10 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
     // Drop it on client change/disconnect so a confirm can never fire removal
     // RPCs at a different gateway that reuses the same device ids.
     this.inventoryRemovalPrompt = null;
-    const next = createInitialNodesState(snapshot);
+    const next = createInitialNodesState({
+      client: snapshot.client,
+      connected: snapshot.phase === "connected",
+    });
     this.nodesLoading = next.nodesLoading;
     this.nodes = next.nodes;
     this.presenceRequestId += 1;
@@ -310,7 +314,7 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
   private async loadPresence() {
     const gateway = this.context.gateway.snapshot;
     const client = gateway.client;
-    if (!gateway.connected || !client) {
+    if (gateway.phase !== "connected" || !client) {
       return;
     }
     const generation = this.requestGeneration;
@@ -337,7 +341,7 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
   ): boolean {
     const snapshot = this.context.gateway.snapshot;
     return (
-      snapshot.connected &&
+      snapshot.phase === "connected" &&
       snapshot.client === client &&
       this.requestGeneration === generation &&
       this.presenceRequestId === requestId
@@ -366,9 +370,10 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
   override render() {
     const config = this.context.runtimeConfig.state;
     const gatewaySnapshot = this.context.gateway.snapshot;
-    const gatewayVersion = gatewaySnapshot.connected
-      ? gatewaySnapshot.hello?.server?.version?.trim() || null
-      : null;
+    const gatewayVersion =
+      gatewaySnapshot.phase === "connected"
+        ? gatewaySnapshot.hello?.server?.version?.trim() || null
+        : null;
     return html`
       <section class="content-header">
         <div>

--- a/ui/src/pages/nodes/route.ts
+++ b/ui/src/pages/nodes/route.ts
@@ -12,8 +12,11 @@ import type { NodesRouteData } from "./nodes-page.ts";
 async function loadNodesRouteData(context: ApplicationContext): Promise<NodesRouteData> {
   const gateway = context.gateway;
   const gatewaySnapshot = gateway.snapshot;
-  const nodes = createInitialNodesState(gatewaySnapshot);
-  if (!gatewaySnapshot.connected || !gatewaySnapshot.client) {
+  const nodes = createInitialNodesState({
+    client: gatewaySnapshot.client,
+    connected: gatewaySnapshot.phase === "connected",
+  });
+  if (gatewaySnapshot.phase !== "connected" || !gatewaySnapshot.client) {
     return { gateway, gatewaySnapshot, nodes };
   }
   await Promise.all([

--- a/ui/src/pages/plugin/plugin-page.test.ts
+++ b/ui/src/pages/plugin/plugin-page.test.ts
@@ -125,9 +125,8 @@ function createExternalPluginPage(
   };
   const snapshot: ApplicationGatewaySnapshot = {
     client: null,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello,
     assistantAgentId: null,
     sessionKey: "main",
@@ -352,9 +351,9 @@ describe("PluginPage", () => {
       await waitForFast(() => expect(page.querySelector("iframe")).not.toBeNull());
       const context = (page as unknown as { context: ApplicationContext<RouteId> }).context;
       const gateway = context.gateway;
-      const snapshot = gateway.snapshot as { connected: boolean };
+      const snapshot = gateway.snapshot;
 
-      snapshot.connected = false;
+      snapshot.phase = "stopped";
       (
         page as unknown as {
           updateGatewaySource: (source: ApplicationContext<RouteId>["gateway"]) => void;
@@ -363,7 +362,7 @@ describe("PluginPage", () => {
       await page.updateComplete;
       expect(page.querySelector("iframe")).toBeNull();
 
-      snapshot.connected = true;
+      snapshot.phase = "connected";
       (
         page as unknown as {
           updateGatewaySource: (source: ApplicationContext<RouteId>["gateway"]) => void;
@@ -424,9 +423,8 @@ describe("PluginPage", () => {
     };
     const snapshot: ApplicationGatewaySnapshot = {
       client: null,
-      connected: true,
+      phase: "connected",
       offlineStable: false,
-      reconnecting: false,
       hello,
       assistantAgentId: null,
       sessionKey: "main",
@@ -495,9 +493,8 @@ describe("PluginPage", () => {
     const createContext = (request: typeof firstRequest) => {
       const snapshot: ApplicationGatewaySnapshot = {
         client: { request } as unknown as GatewayBrowserClient,
-        connected: true,
+        phase: "connected",
         offlineStable: false,
-        reconnecting: false,
         hello,
         assistantAgentId: null,
         sessionKey: "main",
@@ -577,9 +574,8 @@ describe("PluginPage", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const snapshot: ApplicationGatewaySnapshot = {
       client,
-      connected: true,
+      phase: "connected",
       offlineStable: false,
-      reconnecting: false,
       hello,
       assistantAgentId: null,
       sessionKey: "main",
@@ -607,7 +603,7 @@ describe("PluginPage", () => {
       await waitForFast(() => expect(request).toHaveBeenCalledTimes(3));
       const staleHost = bundledViewHost(page);
 
-      snapshot.connected = false;
+      snapshot.phase = "stopped";
       listener?.(snapshot);
       await page.updateComplete;
       const disconnectedHost = bundledViewHost(page);
@@ -620,7 +616,7 @@ describe("PluginPage", () => {
       await waitForFast(() => expect(getLogbookState(staleHost).timeline).not.toBeNull());
       expect(getLogbookState(disconnectedHost).timeline).toBeNull();
 
-      snapshot.connected = true;
+      snapshot.phase = "connected";
       listener?.(snapshot);
       await page.updateComplete;
       expect(bundledViewHost(page)).not.toBe(disconnectedHost);
@@ -648,9 +644,8 @@ describe("PluginPage", () => {
     };
     const snapshot: ApplicationGatewaySnapshot = {
       client: null,
-      connected: true,
+      phase: "connected",
       offlineStable: false,
-      reconnecting: false,
       hello,
       assistantAgentId: null,
       sessionKey: "main",

--- a/ui/src/pages/plugin/plugin-page.ts
+++ b/ui/src/pages/plugin/plugin-page.ts
@@ -270,7 +270,7 @@ export class PluginPage extends OpenClawLightDomContentsElement {
     const context = this.context;
     if (
       !context ||
-      !context.gateway.snapshot.connected ||
+      context.gateway.snapshot.phase !== "connected" ||
       this.externalAuthTargetKey !== targetKey ||
       this.externalAuthRefreshMarker ||
       this.externalAuthProbeMarker
@@ -509,7 +509,8 @@ export class PluginPage extends OpenClawLightDomContentsElement {
   }
 
   private updateGatewaySource(gateway: ApplicationContext<RouteId>["gateway"]) {
-    const { client, connected } = gateway.snapshot;
+    const { client } = gateway.snapshot;
+    const connected = gateway.snapshot.phase === "connected";
     if (
       this.gatewaySource === gateway &&
       this.gatewayClient === client &&
@@ -549,7 +550,7 @@ export class PluginPage extends OpenClawLightDomContentsElement {
       return this.bundledView.render({
         host: this.bundledViewHost,
         client: snapshot.client,
-        connected: snapshot.connected,
+        connected: snapshot.phase === "connected",
         embed: config
           ? {
               embedSandboxMode: config.embedSandboxMode,

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -78,9 +78,8 @@ function createSnapshot(
 ): ApplicationGatewaySnapshot {
   return {
     client,
-    connected,
+    phase: connected ? "connected" : "reconnecting",
     offlineStable: false,
-    reconnecting: !connected,
     hello: {
       type: "hello-ok",
       protocol: 1,

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -195,7 +195,7 @@ class PluginsPage extends OpenClawLightDomElement {
   };
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot, sourceChanged: boolean) {
-    const connectionChanged = snapshot.connected !== this.connected;
+    const connectionChanged = (snapshot.phase === "connected") !== this.connected;
     const clientChanged = snapshot.client !== this.client;
     const nextIconAuthCandidates = resolveControlUiAuthCandidates({
       hello: snapshot.hello,
@@ -210,13 +210,13 @@ class PluginsPage extends OpenClawLightDomElement {
     this.iconAuthCandidates = nextIconAuthCandidates;
     const shouldRefreshAfterChange =
       (sourceChanged || connectionChanged || clientChanged || iconAuthChanged) &&
-      snapshot.connected &&
+      snapshot.phase === "connected" &&
       this.routeDataConsumed;
     if (sourceChanged || connectionChanged || clientChanged || iconAuthChanged) {
       this.invalidateRequests();
       this.resetPluginIcons();
       this.client = snapshot.client;
-      this.connected = snapshot.connected;
+      this.connected = snapshot.phase === "connected";
       this.loading = false;
       this.searchLoading = false;
       this.busy = {};
@@ -239,12 +239,12 @@ class PluginsPage extends OpenClawLightDomElement {
     } else {
       this.ensureInitialData();
     }
-    if (snapshot.connected) {
+    if (snapshot.phase === "connected") {
       void this.context?.runtimeConfig.ensureLoaded().then(() => this.syncMcpServers());
     }
     if (
       (sourceChanged || connectionChanged || clientChanged || iconAuthChanged) &&
-      snapshot.connected &&
+      snapshot.phase === "connected" &&
       this.activeTab === "discover"
     ) {
       this.scheduleSearch();
@@ -271,7 +271,7 @@ class PluginsPage extends OpenClawLightDomElement {
       return;
     }
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.connected = snapshot.phase === "connected";
     this.loading = false;
     this.replaceResult(data.result);
     this.error = data.error;

--- a/ui/src/pages/plugins/route.ts
+++ b/ui/src/pages/plugins/route.ts
@@ -21,7 +21,7 @@ async function loadPluginsRouteData(
   const gateway = context.gateway;
   const gatewaySnapshot = gateway.snapshot;
   const client = gatewaySnapshot.client;
-  if (!gatewaySnapshot.connected || !client) {
+  if (gatewaySnapshot.phase !== "connected" || !client) {
     return { gateway, gatewaySnapshot, result: null, error: null, initialTab };
   }
   try {

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -29,9 +29,8 @@ function createContext(
 ): ApplicationContext<RouteId> {
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected,
+    phase: connected ? "connected" : "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "main",
     sessionKey: "agent:main:main",
@@ -94,9 +93,8 @@ function createConnectedContext(
 ) {
   let snapshot: ApplicationGatewaySnapshot = {
     client: { request } as GatewayBrowserClient,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "main",
     sessionKey: "agent:main:main",
@@ -158,7 +156,7 @@ function createConnectedContext(
   return {
     context,
     emitConnected(connected: boolean) {
-      snapshot = { ...snapshot, connected };
+      snapshot = { ...snapshot, phase: connected ? "connected" : "reconnecting" };
       for (const listener of listeners) {
         listener(snapshot);
       }

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -138,13 +138,14 @@ export class ProfilePage extends OpenClawLightDomElement {
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
     const clientChanged = snapshot.client !== this.client;
-    const becameConnected = snapshot.connected && !this.connected;
-    const nextSelfUser = snapshot.connected
-      ? resolveCurrentSelfUser({ snapshotUser: snapshot.selfUser })
-      : null;
+    const becameConnected = snapshot.phase === "connected" && !this.connected;
+    const nextSelfUser =
+      snapshot.phase === "connected"
+        ? resolveCurrentSelfUser({ snapshotUser: snapshot.selfUser })
+        : null;
     const selfProfileChanged = nextSelfUser?.id !== this.selfUser?.id;
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.connected = snapshot.phase === "connected";
     this.selfUser = nextSelfUser;
     if (clientChanged) {
       // Never keep one gateway's stats on screen while another gateway loads
@@ -167,7 +168,7 @@ export class ProfilePage extends OpenClawLightDomElement {
       this.identityBusy = null;
       this.identityError = null;
     }
-    if (!snapshot.connected || !snapshot.client) {
+    if (snapshot.phase !== "connected" || !snapshot.client) {
       this.profileReloadPending ||= this.loading;
       this.requestId += 1;
       this.clearRefreshTimer();

--- a/ui/src/pages/route-provenance.test.ts
+++ b/ui/src/pages/route-provenance.test.ts
@@ -45,9 +45,8 @@ function snapshot(
 ): ApplicationGatewaySnapshot {
   return {
     client,
-    connected,
+    phase: connected ? "connected" : "reconnecting",
     offlineStable: false,
-    reconnecting: !connected,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -81,9 +81,8 @@ function deferred<T>() {
 function createGateway(client: GatewayBrowserClient): MutableGateway {
   let snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -608,8 +607,8 @@ describe("sessions page lifecycle", () => {
     const client = {} as GatewayBrowserClient;
     const mutableGateway = createGateway(client);
     const preloadedSnapshot = mutableGateway.gateway.snapshot;
-    mutableGateway.emit({ connected: false, client });
-    mutableGateway.emit({ connected: true, client });
+    mutableGateway.emit({ phase: "reconnecting", client });
+    mutableGateway.emit({ phase: "connected", client });
     const freshResult = { count: 1, sessions: [{ key: "fresh" }] } as SessionsListResult;
     const sessions = createSessions({ list: vi.fn(async () => freshResult) });
     const context = createContext(mutableGateway.gateway, sessions);
@@ -691,7 +690,7 @@ describe("sessions page lifecycle", () => {
     page.checkpointBusyKey = "busy";
     page.sessionMutationPending = true;
 
-    mutableGateway.emit({ connected: false, client });
+    mutableGateway.emit({ phase: "reconnecting", client });
 
     expect(page.checkpointLoadingKey).toBeNull();
     expect(page.checkpointBusyKey).toBeNull();
@@ -713,7 +712,7 @@ describe("sessions page lifecycle", () => {
       trigger,
     );
 
-    mutableGateway.emit({ connected: false, client });
+    mutableGateway.emit({ phase: "reconnecting", client });
 
     expect(page.sessionMenu).toBeNull();
     expect(page.sessionMenuTrigger).toBeNull();
@@ -859,7 +858,7 @@ describe("sessions page lifecycle", () => {
       expect(request).toHaveBeenCalledWith("workboard.cards.create", expect.any(Object)),
     );
 
-    mutableGateway.emit({ connected: false, client });
+    mutableGateway.emit({ phase: "reconnecting", client });
     deleted.resolve({ deleted: ["main"], errors: ["stale delete error"], preservedWorktrees: [] });
     patched.resolve({ ok: true });
     forked.resolve("forked");

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -236,10 +236,10 @@ class SessionsPage extends OpenClawLightDomElement {
     resetForSourceBind = false,
   ) {
     const clientChanged = resetForSourceBind || snapshot.client !== this.gatewayClient;
-    const connectionChanged = snapshot.connected !== this.gatewayConnected;
-    const becameConnected = snapshot.connected && !this.gatewayConnected;
+    const connectionChanged = (snapshot.phase === "connected") !== this.gatewayConnected;
+    const becameConnected = snapshot.phase === "connected" && !this.gatewayConnected;
     this.gatewayClient = snapshot.client;
-    this.gatewayConnected = snapshot.connected;
+    this.gatewayConnected = snapshot.phase === "connected";
     if (clientChanged || connectionChanged) {
       this.invalidatePageWork();
       this.ignorePendingSharedRefresh = false;
@@ -247,7 +247,7 @@ class SessionsPage extends OpenClawLightDomElement {
     if (clientChanged) {
       this.resetProviderState();
     }
-    if (!snapshot.connected || !snapshot.client) {
+    if (snapshot.phase !== "connected" || !snapshot.client) {
       this.requestUpdate();
       return;
     }
@@ -295,7 +295,7 @@ class SessionsPage extends OpenClawLightDomElement {
     }
     const gateway = context.gateway;
     const client = gateway.snapshot.client;
-    if (!gateway.snapshot.connected || !client) {
+    if (gateway.snapshot.phase !== "connected" || !client) {
       return null;
     }
     return {
@@ -318,7 +318,7 @@ class SessionsPage extends OpenClawLightDomElement {
       gateway === scope.gateway &&
       context.sessions === scope.sessions &&
       context.workboard === scope.workboard &&
-      gateway.snapshot.connected &&
+      gateway.snapshot.phase === "connected" &&
       gateway.snapshot.client === scope.client
     );
   }
@@ -359,7 +359,7 @@ class SessionsPage extends OpenClawLightDomElement {
     const gateway = context.gateway;
     const snapshot = gateway.snapshot;
     this.gatewayClient = snapshot.client;
-    this.gatewayConnected = snapshot.connected;
+    this.gatewayConnected = snapshot.phase === "connected";
     if (data.gateway !== gateway || data.gatewaySnapshot !== snapshot) {
       this.routeDataEnabled = false;
       void this.loadSessions();
@@ -397,7 +397,7 @@ class SessionsPage extends OpenClawLightDomElement {
       if (
         this.isConnected &&
         context &&
-        gateway?.connected &&
+        gateway?.phase === "connected" &&
         gateway.client &&
         !context.sessions.state.loading
       ) {

--- a/ui/src/pages/skill-workshop/history-scan.test.ts
+++ b/ui/src/pages/skill-workshop/history-scan.test.ts
@@ -24,7 +24,7 @@ function result(overrides: Partial<SkillWorkshopHistoryScanResult> = {}) {
 function gateway(request: ReturnType<typeof vi.fn>): ApplicationGateway {
   return {
     snapshot: {
-      connected: true,
+      phase: "connected",
       client: { request },
     },
   } as unknown as ApplicationGateway;

--- a/ui/src/pages/skill-workshop/history-scan.ts
+++ b/ui/src/pages/skill-workshop/history-scan.ts
@@ -38,7 +38,7 @@ export async function loadSkillWorkshopHistoryScanStatus(
   }
   if (
     !client ||
-    !params.gateway.snapshot.connected ||
+    params.gateway.snapshot.phase !== "connected" ||
     params.state.running ||
     (params.state.loaded && !params.force)
   ) {
@@ -57,7 +57,11 @@ export async function loadSkillWorkshopHistoryScanStatus(
         const pendingBeforeRequest = queue.pending;
         queue.pending = null;
         const currentClient = current.gateway.snapshot.client;
-        if (currentClient && current.gateway.snapshot.connected && !current.state.running) {
+        if (
+          currentClient &&
+          current.gateway.snapshot.phase === "connected" &&
+          !current.state.running
+        ) {
           current.state.error = null;
           try {
             current.state.result = await currentClient.request<SkillWorkshopHistoryScanResult>(
@@ -95,7 +99,7 @@ export async function runSkillWorkshopHistoryScan(params: {
   let client = params.gateway.snapshot.client;
   if (
     !client ||
-    !params.gateway.snapshot.connected ||
+    params.gateway.snapshot.phase !== "connected" ||
     params.state.running ||
     params.state.loading
   ) {
@@ -107,7 +111,7 @@ export async function runSkillWorkshopHistoryScan(params: {
       return false;
     }
     client = params.gateway.snapshot.client;
-    if (!client || !params.gateway.snapshot.connected) {
+    if (!client || params.gateway.snapshot.phase !== "connected") {
       return false;
     }
   }

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -29,9 +29,8 @@ function createFixture(
   const request = vi.fn<TestRequest>();
   const snapshot: ApplicationGatewaySnapshot = {
     client: { request } as unknown as ApplicationGatewaySnapshot["client"],
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "research",
     sessionKey: "global",

--- a/ui/src/pages/skill-workshop/proposals.ts
+++ b/ui/src/pages/skill-workshop/proposals.ts
@@ -326,7 +326,7 @@ export async function loadSkillWorkshopProposals(
 ): Promise<void> {
   const snapshot = context.gateway.snapshot;
   const client = snapshot.client;
-  if (!client || !snapshot.connected) {
+  if (!client || snapshot.phase !== "connected") {
     return;
   }
   const requestAgentId = skillWorkshopAgentParams(context).agentId;
@@ -380,7 +380,11 @@ async function loadSkillWorkshopProposalDetail(
 ): Promise<boolean> {
   const snapshot = context.gateway.snapshot;
   const client = snapshot.client;
-  if (!client || !snapshot.connected || state.skillWorkshopInspectingKey === proposalId) {
+  if (
+    !client ||
+    snapshot.phase !== "connected" ||
+    state.skillWorkshopInspectingKey === proposalId
+  ) {
     return false;
   }
   const existing = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
@@ -455,7 +459,7 @@ export async function runSkillWorkshopLifecycleAction(
 ): Promise<void> {
   const snapshot = context.gateway.snapshot;
   const client = snapshot.client;
-  if (!client || !snapshot.connected || state.skillWorkshopActionBusy) {
+  if (!client || snapshot.phase !== "connected" || state.skillWorkshopActionBusy) {
     return;
   }
   const previous = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);

--- a/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
@@ -66,9 +66,8 @@ function createContext(
   const client = { request } as unknown as GatewayBrowserClient;
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "research",
     sessionKey: "global",
@@ -285,7 +284,7 @@ describe("SkillWorkshopPage lifecycle", () => {
     );
     const loadingState = page.state;
 
-    gatewayListener?.({ ...context.gateway.snapshot, connected: false });
+    gatewayListener?.({ ...context.gateway.snapshot, phase: "stopped" });
     expect(page.state).not.toBe(loadingState);
     expect(page.state?.skillWorkshopLoaded).toBe(false);
 

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -331,7 +331,7 @@ class SkillWorkshopPage extends OpenClawLightDomElement {
           const gateway = context.gateway;
           this.gatewaySource = gateway;
           this.gatewayClient = gateway.snapshot.client;
-          this.gatewayConnected = gateway.snapshot.connected;
+          this.gatewayConnected = gateway.snapshot.phase === "connected";
           this.agentSelectionSource = context.agentSelection;
           this.selectedAgentId = context.agentSelection.state.selectedId;
           this.sessionsSource = context.sessions;
@@ -348,7 +348,8 @@ class SkillWorkshopPage extends OpenClawLightDomElement {
         const clientChanged =
           this.gatewaySource !== undefined && this.gatewayClient !== snapshot.client;
         const connectionChanged =
-          this.gatewaySource !== undefined && this.gatewayConnected !== snapshot.connected;
+          this.gatewaySource !== undefined &&
+          this.gatewayConnected !== (snapshot.phase === "connected");
         this.applyGatewaySnapshot(
           gateway,
           snapshot,
@@ -360,7 +361,7 @@ class SkillWorkshopPage extends OpenClawLightDomElement {
           }
           const sourceEpochChanged =
             nextSnapshot.client !== this.gatewayClient ||
-            nextSnapshot.connected !== this.gatewayConnected;
+            (nextSnapshot.phase === "connected") !== this.gatewayConnected;
           this.applyGatewaySnapshot(gateway, nextSnapshot, sourceEpochChanged);
         });
         return cleanup;
@@ -536,11 +537,14 @@ class SkillWorkshopPage extends OpenClawLightDomElement {
   ) {
     this.gatewaySource = gateway;
     this.gatewayClient = snapshot.client;
-    this.gatewayConnected = snapshot.connected;
+    this.gatewayConnected = snapshot.phase === "connected";
     if (sourceEpochChanged) {
       this.resetSourceState();
     }
-    if (snapshot.connected && (sourceEpochChanged || !this.state?.skillWorkshopLoaded)) {
+    if (
+      snapshot.phase === "connected" &&
+      (sourceEpochChanged || !this.state?.skillWorkshopLoaded)
+    ) {
       this.loadProposals(sourceEpochChanged);
     }
   }
@@ -564,7 +568,7 @@ class SkillWorkshopPage extends OpenClawLightDomElement {
   private loadProposals(force: boolean) {
     const state = this.state;
     const context = this.context;
-    if (!state || !context || !context.gateway.snapshot.connected) {
+    if (!state || !context || context.gateway.snapshot.phase !== "connected") {
       return;
     }
     void loadSkillWorkshopPageData({ state, context, force }).finally(this.requestPageUpdate);

--- a/ui/src/pages/skills/route.ts
+++ b/ui/src/pages/skills/route.ts
@@ -13,7 +13,7 @@ async function loadSkillsRouteData(context: ApplicationContext): Promise<SkillsR
   const gatewaySnapshot = gateway.snapshot;
   const agents = context.agents;
   const client = gatewaySnapshot.client;
-  if (!gatewaySnapshot.connected || !client) {
+  if (gatewaySnapshot.phase !== "connected" || !client) {
     return {
       gateway,
       gatewaySnapshot,

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -140,9 +140,9 @@ class SkillsPage extends OpenClawLightDomElement {
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot, resetForSourceBind = false) {
     const clientChanged = resetForSourceBind || snapshot.client !== this.client;
-    const connectionChanged = snapshot.connected !== this.connected;
+    const connectionChanged = (snapshot.phase === "connected") !== this.connected;
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.connected = snapshot.phase === "connected";
     if (clientChanged || connectionChanged) {
       this.resetLoadedSkillState();
     }
@@ -213,7 +213,7 @@ class SkillsPage extends OpenClawLightDomElement {
     const gateway = this.context.gateway;
     const snapshot = gateway.snapshot;
     this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.connected = snapshot.phase === "connected";
     if (
       data.gateway !== gateway ||
       data.gatewaySnapshot !== snapshot ||

--- a/ui/src/pages/tasks/tasks-page.test.ts
+++ b/ui/src/pages/tasks/tasks-page.test.ts
@@ -21,9 +21,8 @@ function deferred<T>() {
 function createGateway(client: GatewayBrowserClient) {
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -45,7 +44,7 @@ function createGateway(client: GatewayBrowserClient) {
   } as unknown as ApplicationContext["gateway"];
   return {
     emitConnected(connected: boolean) {
-      snapshot.connected = connected;
+      snapshot.phase = connected ? "connected" : "stopped";
       snapshotListener?.(snapshot);
     },
     gateway,

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -143,7 +143,7 @@ class TasksPage extends OpenClawLightDomElement {
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot, sourceChanged: boolean) {
     const identityChanged = sourceChanged || this.client !== snapshot.client;
-    const connectionChanged = this.connected !== snapshot.connected;
+    const connectionChanged = this.connected !== (snapshot.phase === "connected");
     if (identityChanged || connectionChanged) {
       this.invalidateGatewayWork();
     }
@@ -152,8 +152,8 @@ class TasksPage extends OpenClawLightDomElement {
       this.tasks = [];
       this.error = null;
     }
-    this.connected = snapshot.connected;
-    if (snapshot.connected) {
+    this.connected = snapshot.phase === "connected";
+    if (snapshot.phase === "connected") {
       void this.context.agents.ensureList();
     }
   }

--- a/ui/src/pages/usage/route.ts
+++ b/ui/src/pages/usage/route.ts
@@ -36,7 +36,7 @@ async function loadUsageRouteData(context: ApplicationContext): Promise<UsageRou
     timeZone: "local",
     agentId: context.agentSelection.state.scopeId,
   };
-  if (!gatewaySnapshot.connected || !gatewaySnapshot.client) {
+  if (gatewaySnapshot.phase !== "connected" || !gatewaySnapshot.client) {
     return {
       gateway,
       gatewaySnapshot,

--- a/ui/src/pages/usage/usage-page.test.ts
+++ b/ui/src/pages/usage/usage-page.test.ts
@@ -35,8 +35,7 @@ function contextWithClient(client: GatewayBrowserClient): ApplicationContext {
   const subscribe = () => () => undefined;
   const snapshot = {
     client,
-    connected: true,
-    reconnecting: false,
+    phase: "connected",
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",

--- a/ui/src/pages/usage/usage-refresh-runtime.ts
+++ b/ui/src/pages/usage/usage-refresh-runtime.ts
@@ -65,13 +65,13 @@ export class UsageRefreshRuntime {
 
   applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot, resetForSourceBind = false): void {
     const clientChanged = resetForSourceBind || snapshot.client !== this.currentClient;
-    const becameConnected = snapshot.connected && !this.currentConnected;
+    const becameConnected = snapshot.phase === "connected" && !this.currentConnected;
     this.adoptGatewaySnapshot(snapshot);
 
     if (clientChanged) {
       this.options.resetForClientChange();
     }
-    if (!snapshot.connected || !snapshot.client) {
+    if (snapshot.phase !== "connected" || !snapshot.client) {
       this.reloadPending ||= this.options.isLoading();
       this.options.invalidateRequests();
       return;
@@ -85,7 +85,7 @@ export class UsageRefreshRuntime {
 
   adoptGatewaySnapshot(snapshot: ApplicationGatewaySnapshot): void {
     this.currentClient = snapshot.client;
-    this.currentConnected = snapshot.connected;
+    this.currentConnected = snapshot.phase === "connected";
   }
 
   setLastLoadedAtMs(value: number | null): void {

--- a/ui/src/pages/workboard/workboard-page.test.ts
+++ b/ui/src/pages/workboard/workboard-page.test.ts
@@ -22,9 +22,8 @@ type WorkboardPageTestElement = HTMLElement & {
 function contextWithWorkboard(workboard: WorkboardCapability): ApplicationContext {
   const snapshot: ApplicationGatewaySnapshot = {
     client: null,
-    connected: false,
+    phase: "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -97,7 +96,7 @@ describe("WorkboardPage lifecycle", () => {
       eventListener = listener;
       return () => undefined;
     };
-    context.gateway.snapshot.connected = true;
+    context.gateway.snapshot.phase = "connected";
     context.gateway.snapshot.client = { request: vi.fn() } as never;
     const page = document.createElement("openclaw-workboard-page") as WorkboardPageTestElement;
     page.context = context;
@@ -119,7 +118,7 @@ describe("WorkboardPage lifecycle", () => {
   it("forces one canonical reload when the live client is newly installed", async () => {
     const workboard = createWorkboardCapability();
     const context = contextWithWorkboard(workboard);
-    context.gateway.snapshot.connected = true;
+    context.gateway.snapshot.phase = "connected";
     context.gateway.snapshot.client = { request: vi.fn() } as never;
     configureLiveRefresh.mockReturnValueOnce(true);
     const page = document.createElement("openclaw-workboard-page") as WorkboardPageTestElement;
@@ -140,7 +139,7 @@ describe("WorkboardPage lifecycle", () => {
       snapshotListener = listener;
       return () => undefined;
     };
-    context.gateway.snapshot.connected = true;
+    context.gateway.snapshot.phase = "connected";
     context.gateway.snapshot.client = { request: vi.fn() } as never;
     const page = document.createElement("openclaw-workboard-page") as WorkboardPageTestElement;
     page.context = context;
@@ -148,7 +147,7 @@ describe("WorkboardPage lifecycle", () => {
     await page.updateComplete;
     vi.clearAllMocks();
 
-    snapshotListener?.({ ...context.gateway.snapshot, connected: false, client: null });
+    snapshotListener?.({ ...context.gateway.snapshot, phase: "stopped", client: null });
 
     expect(stopLiveRefresh).toHaveBeenCalledWith(workboard);
     expect(stopLifecycleRefresh).toHaveBeenCalledWith(workboard);

--- a/ui/src/pages/workboard/workboard-page.ts
+++ b/ui/src/pages/workboard/workboard-page.ts
@@ -89,7 +89,7 @@ class WorkboardPage extends OpenClawLightDomElement {
       () => this.context?.gateway,
       (gateway) => {
         const handleSnapshot = (snapshot: ApplicationContext["gateway"]["snapshot"]) => {
-          if (snapshot.connected && snapshot.client) {
+          if (snapshot.phase === "connected" && snapshot.client) {
             this.ensureInitialData();
           } else if (this.context?.workboard) {
             // Teardown at the observed disconnect, not a later render that a fast reconnect may skip.
@@ -107,7 +107,11 @@ class WorkboardPage extends OpenClawLightDomElement {
       (gateway) =>
         gateway.subscribeEvents((event) => {
           const workboard = this.context?.workboard;
-          if (workboard && gateway.snapshot.connected && event.event === WORKBOARD_CHANGED_EVENT) {
+          if (
+            workboard &&
+            gateway.snapshot.phase === "connected" &&
+            event.event === WORKBOARD_CHANGED_EVENT
+          ) {
             handleWorkboardChanged(workboard, event.payload);
           }
         }),
@@ -150,7 +154,7 @@ class WorkboardPage extends OpenClawLightDomElement {
   private ensureInitialData() {
     const context = this.context;
     const gateway = context?.gateway.snapshot;
-    if (!context || !gateway?.connected || !gateway.client) {
+    if (!context || gateway?.phase !== "connected" || !gateway.client) {
       return;
     }
     if (!context.runtimeConfig.state.configSnapshot && !context.runtimeConfig.state.configLoading) {
@@ -173,7 +177,7 @@ class WorkboardPage extends OpenClawLightDomElement {
     const context = this.context;
     const gateway = context?.gateway.snapshot;
     const pluginEnabled = this.pluginEnabled();
-    if (!context || !gateway?.connected || !gateway.client || pluginEnabled !== true) {
+    if (!context || gateway?.phase !== "connected" || !gateway.client || pluginEnabled !== true) {
       if (context) {
         stopWorkboardLiveRefresh(context.workboard);
         stopWorkboardLifecycleRefresh(context.workboard);
@@ -362,7 +366,7 @@ class WorkboardPage extends OpenClawLightDomElement {
       ${renderWorkboard({
         host: context.workboard,
         client: gateway.client,
-        connected: gateway.connected,
+        connected: gateway.phase === "connected",
         canWrite: hasOperatorWriteAccess(auth),
         canGrant: hasOperatorApprovalsAccess(auth),
         canModelOverride: hasOperatorAdminAccess(auth),

--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -55,9 +55,8 @@ function worktree(id = "worktree-1"): WorktreeRecord {
 function gatewayWithSnapshot(client: GatewayBrowserClient | null, connected: boolean) {
   const snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected,
+    phase: connected ? "connected" : "stopped",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: null,
     sessionKey: "main",
@@ -90,7 +89,7 @@ function mutableGateway(client: GatewayBrowserClient) {
   } as unknown as ApplicationContext["gateway"];
   return {
     emit(connected: boolean) {
-      (snapshot as ApplicationGatewaySnapshot).connected = connected;
+      (snapshot as ApplicationGatewaySnapshot).phase = connected ? "connected" : "stopped";
       listener?.(snapshot as ApplicationGatewaySnapshot);
     },
     gateway,

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -90,10 +90,10 @@ class WorktreesPage extends OpenClawLightDomElement {
     sourceChanged = false,
   ) {
     const clientChanged = snapshot.client !== this.client;
-    const connectionChanged = snapshot.connected !== this.gatewayConnected;
+    const connectionChanged = (snapshot.phase === "connected") !== this.gatewayConnected;
     const identityChanged = sourceChanged || clientChanged;
     this.client = snapshot.client;
-    this.gatewayConnected = snapshot.connected;
+    this.gatewayConnected = snapshot.phase === "connected";
     if (identityChanged || connectionChanged) {
       this.invalidateLoad();
       this.invalidateOperations();
@@ -102,7 +102,7 @@ class WorktreesPage extends OpenClawLightDomElement {
       this.records = [];
       this.error = null;
     }
-    if (snapshot.connected && snapshot.client) {
+    if (snapshot.phase === "connected" && snapshot.client) {
       void this.load();
     }
   }

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
@@ -130,11 +130,10 @@ describe("AppSidebar session catalog pagination", () => {
 
       visibility = "hidden";
       document.dispatchEvent(new Event("visibilitychange"));
-      gateway.publish({ connected: false, reconnecting: true, hello: null });
+      gateway.publish({ phase: "reconnecting", hello: null });
       await sidebar.updateComplete;
       gateway.publish({
-        connected: true,
-        reconnecting: false,
+        phase: "connected",
         hello: {
           features: { methods: ["sessions.catalog.list"] },
         } as ApplicationGatewaySnapshot["hello"],

--- a/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
@@ -102,8 +102,8 @@ describe("AppSidebar group mutation collapsed state", () => {
     menu.querySelectorAll<HTMLButtonElement>(".session-menu__item")[0]?.click();
     await waitForFast(() => expect(harness.groupsRename).toHaveBeenCalledWith("Alpha", "Beta"));
 
-    gatewayHarness.publish({ connected: false });
-    gatewayHarness.publish({ connected: true });
+    gatewayHarness.publish({ phase: "stopped" });
+    gatewayHarness.publish({ phase: "connected" });
     resolveRename("stale");
     await Promise.resolve();
     await Promise.resolve();

--- a/ui/src/test-helpers/app-sidebar-cases/narration.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/narration.ts
@@ -202,12 +202,12 @@ describe("AppSidebar live narration", () => {
       agentId: undefined,
     });
 
-    gateway.publish({ connected: false });
+    gateway.publish({ phase: "stopped" });
     sidebar.connected = false;
     await sidebar.updateComplete;
     await waitForFast(() => expect(sessions.unsubscribeMessages).toHaveBeenCalledTimes(1));
 
-    gateway.publish({ connected: true });
+    gateway.publish({ phase: "connected" });
     sidebar.connected = true;
     await sidebar.updateComplete;
     await waitForFast(() => expect(sessions.subscribeMessages).toHaveBeenCalledTimes(2));

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -271,7 +271,7 @@ describe("AppSidebar session source lifecycle", () => {
     const { sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
     const cachedResult = sidebar.sessionData.sessionsResult;
 
-    gateway.publish({ connected: false, reconnecting: true });
+    gateway.publish({ phase: "reconnecting" });
     sessions.publish({ result: null, agentId: null, loading: false });
     await sidebar.updateComplete;
 
@@ -280,7 +280,7 @@ describe("AppSidebar session source lifecycle", () => {
     expect(Object.keys(sidebar.sessionData.sessionRowsByAgent)).toEqual(["main"]);
     expect([...sidebar.sessionData.sessionCreatedOrder.keys()]).toEqual(["main-a", "main-b"]);
 
-    gateway.publish({ connected: true, reconnecting: false });
+    gateway.publish({ phase: "connected" });
     const partial = createSessionState("main", ["main-a"]);
     sessions.publish({ result: partial.result, agentId: partial.agentId });
     await sidebar.updateComplete;
@@ -311,8 +311,7 @@ describe("AppSidebar session source lifecycle", () => {
 
     gateway.publish({
       client: {} as GatewayBrowserClient,
-      connected: false,
-      reconnecting: true,
+      phase: "reconnecting",
     });
     await sidebar.updateComplete;
 
@@ -614,8 +613,8 @@ describe("AppSidebar session mutation feedback", () => {
     menu.querySelector<HTMLButtonElement>('[data-shortcut="p"]')?.click();
     await waitForFast(() => expect(harness.patch).toHaveBeenCalledOnce());
 
-    gateway.publish({ connected: false, reconnecting: true });
-    gateway.publish({ connected: true, reconnecting: false });
+    gateway.publish({ phase: "reconnecting" });
+    gateway.publish({ phase: "connected" });
     pending.reject(new Error("late old-connection rejection"));
     await pending.promise.catch(() => undefined);
     await Promise.resolve();
@@ -639,8 +638,8 @@ describe("AppSidebar session mutation feedback", () => {
     menu?.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
     await waitForFast(() => expect(harness.patch).toHaveBeenCalledOnce());
 
-    gateway.publish({ connected: false, reconnecting: true });
-    gateway.publish({ connected: true, reconnecting: false });
+    gateway.publish({ phase: "reconnecting" });
+    gateway.publish({ phase: "connected" });
     pending.resolve(successfulSessionPatch("agent:main:a"));
     await pending.promise;
     await new Promise<void>((resolve) => {
@@ -698,8 +697,8 @@ describe("AppSidebar session mutation feedback", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockImplementation(() => {
       confirmations += 1;
       if (confirmations === 2) {
-        gateway.publish({ connected: false, reconnecting: true });
-        gateway.publish({ connected: true, reconnecting: false });
+        gateway.publish({ phase: "reconnecting" });
+        gateway.publish({ phase: "connected" });
       }
       return true;
     });

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -81,9 +81,8 @@ export type TestSessionMenu = HTMLElement & {
 export function createGatewayHarness(client: GatewayBrowserClient) {
   let snapshot: ApplicationGatewaySnapshot = {
     client,
-    connected: true,
+    phase: "connected",
     offlineStable: false,
-    reconnecting: false,
     hello: null,
     assistantAgentId: "main",
     sessionKey: "agent:main:main",


### PR DESCRIPTION
## What Problem This Solves

Closes #112741. `ApplicationGatewaySnapshot` carried `connected` and `reconnecting` as parallel booleans whose illegal combination (both true) was representable, plus `offlineStable` and `lastError` alongside — so every consumer (login gate, sidebar footer, composer hint, availability controllers, pages) re-derived connection semantics from flag combinations, a recurring bug class the repo guidelines call out ("make impossible states unrepresentable").

## Why This Change Was Made

The snapshot now carries one closed union — `phase: "stopped" | "connecting" | "connected" | "reconnecting" | "offline"` — replacing the boolean pair. Mapping preserves shipped behavior exactly:

- never-connected terminal close → `"stopped"` (login gate shows, as today)
- established-connection drop with client retry → `"reconnecting"` (shell stays mounted, as today)
- established-connection close without retry → `"offline"`
- `offlineStable` stays as the store-owned 2s-debounced presentation boolean (deliberately not folded into the phase: transport lifecycle and presentation debounce are orthogonal dimensions)
- `lastError`/`lastErrorCode` unchanged; no compat aliases or derived getters remain on the snapshot

Component props stay boolean, derived once at the app-host boundary (`phase === "connected"`), so the union stops at the snapshot's direct readers instead of being threaded through every leaf component.

## User Impact

None visible — behavior-identical refactor. Startup bundle: +109 B gzip (longer phase comparisons), within the new ratchet tolerance (322,635 B vs baseline 322,526 + 512 B).

## Evidence

- Blacksmith Testbox `tbx_01ky6k83cpfhbj081a616med5f`: 59 unit test files / 1,199 tests passed, UI E2E 38/38 passed.
- Exact UI `tsgo` lane clean (the missed-consumer catcher); type-aware oxlint clean over all 130 changed files.
- Grep-proof: no snapshot `.connected` / `.reconnecting` reads remain (remaining matches are component props, unrelated state objects, DOM lifecycle, and four intentionally-boolean cloud-helper inputs).
- Post-rebase focused suites (gateway-store, app-host, app-sidebar, chat-composer, overlays): 263 tests × 3 consecutive runs green.
- Production build + startup ratchet check pass; Codex autoreview clean.
- Numstat: 130 files, +611/−547 (store/type 2, direct consumers 62, test files/harnesses 66).
