### PR TITLE
fix(telegram): render authored tg-time entities correctly

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -38,6 +38,16 @@ describe("markdownToTelegramHtml", () => {
       ],
       ["preserves Telegram HTML", "<b>yes</b>", "<b>yes</b>"],
       [
+        "preserves Bot API tg-time attributes",
+        '<tg-time unix="1647531900" format="wDT">22:45 tomorrow</tg-time>',
+        '<tg-time unix="1647531900" format="wDT">22:45 tomorrow</tg-time>',
+      ],
+      [
+        "escapes rejected tg-time datetime attributes",
+        '<tg-time datetime="2022-03-17T22:45:00Z">22:45 tomorrow</tg-time>',
+        '&lt;tg-time datetime="2022-03-17T22:45:00Z"&gt;22:45 tomorrow&lt;/tg-time&gt;',
+      ],
+      [
         "escapes unsupported raw HTML",
         "<script>nope</script>",
         "&lt;script&gt;nope&lt;/script&gt;",
@@ -97,6 +107,9 @@ describe("markdownToTelegramHtml", () => {
       '&lt;blockquote cite="x"&gt;bad&lt;/blockquote&gt;',
     );
     expect(markdownToTelegramHtml("<sup>1</sup>")).toBe("&lt;sup&gt;1&lt;/sup&gt;");
+    expect(markdownToTelegramHtml('<tg-time unix="-1">bad</tg-time>')).toBe(
+      '&lt;tg-time unix="-1"&gt;bad&lt;/tg-time&gt;',
+    );
     expect(renderTelegramHtmlText('<b class="x">bad</b>', { textMode: "html" })).toBe(
       '&lt;b class="x"&gt;bad&lt;/b&gt;',
     );
@@ -302,16 +315,6 @@ describe("markdownToTelegramHtml", () => {
     expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
     expect(finalChunk.startsWith("<code>Assistant:</code> ")).toBe(true);
     expect(finalChunk).toContain("\n<b>user[Thu 2026-07-02]</b> authorize");
-  });
-
-  it("does not synthesize closing tags for rich void tags when chunking html", () => {
-    const chunks = splitTelegramHtmlChunks(
-      `<figure><img src="https://example.com/a.jpg"></figure><ul><li><input type="checkbox" checked>${"A".repeat(80)}</li></ul>`,
-      64,
-    );
-
-    expect(chunks.join("")).not.toContain("</img>");
-    expect(chunks.join("")).not.toContain("</input>");
   });
 
   it("fails loudly when a leading entity cannot fit inside a chunk", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -211,11 +211,10 @@ const TELEGRAM_ATTR_HTML_TAG_PATTERNS = new Map([
   ["a", /^\s+href="[^"]+"\s*$/],
   ["span", /^\s+class="tg-spoiler"\s*$/],
   ["tg-emoji", /^\s+emoji-id="[^"]+"\s*$/],
-  ["tg-time", /^\s+datetime="[^"]+"\s*$/],
+  ["tg-time", /^\s+unix="[1-9]\d*"(?:\s+format="(?:r|w?[dD]?[tT]?)")?\s*$/],
   ["blockquote", /^(\s+expandable)?\s*$/],
 ]);
 const TELEGRAM_CODE_LANGUAGE_ATTR_PATTERN = /^\s+class="language-[^"]+"\s*$/;
-const TELEGRAM_VOID_HTML_TAGS = new Set(["br", "hr", "img", "input", "tg-map"]);
 
 type TelegramHtmlTagSupport = {
   simpleTags: ReadonlySet<string>;
@@ -290,7 +289,7 @@ function preserveTelegramHtmlTag(
   if (closing) {
     return popLastTagName(openTags, tagName) ? rawTag : escapeTag(rawTag);
   }
-  if (TELEGRAM_VOID_HTML_TAGS.has(tagName) || rawTag.trimEnd().endsWith("/>")) {
+  if (rawTag.trimEnd().endsWith("/>")) {
     return rawTag;
   }
   openTags.push(tagName);
@@ -656,8 +655,6 @@ type TelegramHtmlTag = {
   closeTag: string;
 };
 
-const TELEGRAM_SELF_CLOSING_HTML_TAGS = TELEGRAM_VOID_HTML_TAGS;
-
 function buildTelegramHtmlOpenPrefix(tags: TelegramHtmlTag[]): string {
   return tags.map((tag) => tag.openTag).join("");
 }
@@ -800,9 +797,7 @@ function splitTelegramHtmlChunksRaw(html: string, limit: number): string[] {
     const rawTag = tag.raw;
     const isClosing = tag.closing;
     const tagName = tag.name;
-    const isSelfClosing =
-      !isClosing &&
-      (TELEGRAM_SELF_CLOSING_HTML_TAGS.has(tagName) || rawTag.trimEnd().endsWith("/>"));
+    const isSelfClosing = !isClosing && rawTag.trimEnd().endsWith("/>");
 
     if (!isClosing) {
       const nextCloseLength = isSelfClosing ? 0 : `</${tagName}>`.length;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users receiving agent-authored HTML date/time markup would see valid `<tg-time unix="…">` tags escaped as literal text, while the unsupported `<tg-time datetime="…">` spelling was preserved and then rejected by Telegram's classic Bot API HTML parser.

Telegram documents `tg-time` with a positive `unix` timestamp and optional `format` matching `r|w?[dD]?[tT]?`: https://core.telegram.org/bots/api#formatting-options

## Why This Change Was Made

The classic Telegram HTML allowlist now preserves the documented `unix` form, including an optional valid format, and escapes the rejected `datetime`, non-positive timestamp, and invalid-format forms. The stale rich-only void-tag accommodation was also removed: rich messages now use typed block payloads and their own block splitter, so classic HTML chunking no longer needs to recognize unsupported `<img>`, `<input>`, `<hr>`, `<br>`, or `<tg-map>` vocabulary.

The removed rich-void splitter test asserted behavior from the retired rich-HTML path; current rich-message coverage remains in the typed rich-block tests.

This PR is AI-assisted. I reviewed the implementation, dependency contract, and proof output.

## User Impact

Authored Telegram HTML date/time entities now render through the Bot API instead of appearing as literal markup. Off-spec `datetime` tags and invalid timestamp/format variants remain visible as escaped text rather than causing the entire Telegram send to fail.

## Evidence

Intended output changes:

- Before: `<tg-time unix="1647531900" format="wDT">…</tg-time>` was escaped. After: it is preserved byte-for-byte.
- Before: `<tg-time datetime="2022-03-17T22:45:00Z">…</tg-time>` was preserved. After: both tags are escaped to literal text.
- Negative `unix` and undocumented format values are escaped.

LOC (`git diff --numstat origin/main...HEAD`):

- Production: +3 / -8 (net -5)
- Tests: +13 / -10 (net +3)
- Total: +16 / -18 (net -2)

Validation:

- `node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts` — passed, 1 file / 43 tests.
- `node scripts/check-changed.mjs -- extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts` — passed on Blacksmith Testbox, exit 0; formatting, extension production/test types, lint, boundary guards, and import-cycle checks all green. Run: https://github.com/openclaw/openclaw/actions/runs/29980926012
- Source-blind exported-formatter probe — passed for `unix` with format, `unix` without format, rejected `datetime`, rejected invalid format, and rejected negative timestamp.
- Codex autoreview (`--mode uncommitted`) — clean after addressing its positive-timestamp finding.
- `git diff --check` — passed.

The batch-requested shorthand `node scripts/run-vitest.mjs extensions/telegram/src/format` currently resolves to an empty include on fresh `main` and exits with `No test files found`; the exact focused file command above is the working equivalent.

Live Telegram proof is limited to formatter/API-shape tests in this PR. A credentialed maintainer may run a live Telegram send if desired.
