### PR TITLE
fix(ui): thread-changes button leads to a dead end when the workspace is not a git checkout

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6085,17 +6085,20 @@ public struct SessionsFilesListParams: Codable, Sendable {
 public struct SessionsFilesListResult: Codable, Sendable {
     public let sessionkey: String
     public let root: String?
+    public let gitcheckout: Bool?
     public let files: [SessionFileEntry]
     public let browser: SessionFileBrowserResult?
 
     public init(
         sessionkey: String,
         root: String? = nil,
+        gitcheckout: Bool? = nil,
         files: [SessionFileEntry],
         browser: SessionFileBrowserResult? = nil)
     {
         self.sessionkey = sessionkey
         self.root = root
+        self.gitcheckout = gitcheckout
         self.files = files
         self.browser = browser
     }
@@ -6103,6 +6106,7 @@ public struct SessionsFilesListResult: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case root
+        case gitcheckout = "gitCheckout"
         case files
         case browser
     }

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -188,6 +188,8 @@ export const SessionsFilesListParamsSchema = closedObject({
 export const SessionsFilesListResultSchema = closedObject({
   sessionKey: NonEmptyString,
   root: Type.Optional(NonEmptyString),
+  /** Whether the session workspace directory is inside a git checkout; absent when the workspace root is unknown or the gateway predates the field. */
+  gitCheckout: Type.Optional(Type.Boolean()),
   files: Type.Array(SessionFileEntrySchema),
   browser: Type.Optional(SessionFileBrowserResultSchema),
 });

--- a/src/gateway/server-methods/sessions-files.test.ts
+++ b/src/gateway/server-methods/sessions-files.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 // Session file method tests cover transcript-linked files plus the workspace browser.
 import { createHash } from "node:crypto";
 import fs from "node:fs";
@@ -163,6 +164,7 @@ describe("sessions.files RPC handlers", () => {
     );
 
     expect(payload.root).toBe(workspaceRoot);
+    expect(payload.gitCheckout).toBe(false);
     expect(payload.files.map((file: Record<string, unknown>) => [file.path, file.kind])).toEqual([
       ["package.json", "modified"],
       ["ui/chat.ts", "modified"],
@@ -180,6 +182,11 @@ describe("sessions.files RPC handlers", () => {
       ["ui", "directory", "modified"],
       ["package.json", "file", "modified"],
     ]);
+    execFileSync("git", ["-C", workspaceRoot, "init", "-q", "-b", "main"]);
+    const gitPayload = expectOkPayload(
+      await invokeSessionFilesHandler("sessions.files.list", { sessionKey: "agent:main:main" }),
+    );
+    expect(gitPayload.gitCheckout).toBe(true);
   });
 
   it("reveals the same workspace root returned by sessions.files.list", async () => {

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { resolveToCwd as resolveSessionToolPathToCwd } from "../../agents/sessions/tools/path-utils.js";
+import { runGit } from "../../agents/worktrees/git.js";
 import { FsSafeError } from "../../infra/fs-safe.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { visitSessionMessagesAsync } from "../session-transcript-readers.js";
@@ -59,6 +60,7 @@ type TouchedFile = {
 type LoadedSessionFiles = {
   root?: string;
   fileRoot?: string;
+  diffCwd?: string;
   files: TouchedFile[];
 };
 
@@ -359,15 +361,21 @@ function loadSessionFileRoot(params: { sessionKey: string; agentId?: string }) {
       resolveDefaultAgentId(loaded.cfg),
   );
   const spawnedCwd = normalizePathValue(loaded.entry.spawnedCwd);
-  const root =
-    normalizePathValue(loaded.entry.spawnedWorkspaceDir) ??
-    spawnedCwd ??
-    normalizePathValue(resolveAgentWorkspaceDir(loaded.cfg, agentId));
+  const spawnedWorkspaceDir = normalizePathValue(loaded.entry.spawnedWorkspaceDir);
+  const configuredWorkspaceDir =
+    spawnedCwd || spawnedWorkspaceDir
+      ? undefined
+      : normalizePathValue(resolveAgentWorkspaceDir(loaded.cfg, agentId));
+  // Keep this cwd precedence aligned with sessions.diff so the advertised
+  // checkout state cannot disagree with the panel's fallback result.
+  const diffCwd = spawnedCwd ?? spawnedWorkspaceDir ?? configuredWorkspaceDir;
+  const root = spawnedWorkspaceDir ?? spawnedCwd ?? configuredWorkspaceDir;
   return {
     ...loaded,
     agentId,
     root,
     fileRoot: resolveFileRoot({ root, spawnedCwd }),
+    diffCwd,
   };
 }
 
@@ -542,6 +550,7 @@ async function loadSessionFiles(params: {
   return {
     root: loaded.root,
     fileRoot: loaded.fileRoot,
+    diffCwd: loaded.diffCwd,
     files: [...files.values()].toSorted((a, b) => {
       if (a.kind !== b.kind) {
         return a.kind === "modified" ? -1 : 1;
@@ -556,9 +565,23 @@ async function buildListResult(params: {
   agentId?: string;
   path?: string;
   search?: string;
-}): Promise<{ root?: string; files: SessionFileEntry[]; browser?: SessionFileBrowserResult }> {
+}): Promise<{
+  root?: string;
+  gitCheckout?: boolean;
+  files: SessionFileEntry[];
+  browser?: SessionFileBrowserResult;
+}> {
   const loaded = await loadSessionFiles(params);
   const root = loaded.root;
+  let gitCheckout: boolean | undefined;
+  if (loaded.diffCwd) {
+    try {
+      const result = await runGit(loaded.diffCwd, ["rev-parse", "--show-toplevel"]);
+      gitCheckout = result.code === 0 && Boolean(result.stdout.trim());
+    } catch {
+      gitCheckout = false;
+    }
+  }
   const workspaceFiles = root
     ? loaded.files.filter((file) =>
         Boolean(resolveTouchedFilePath({ root, fileRoot: loaded.fileRoot, filePath: file.path })),
@@ -576,6 +599,7 @@ async function buildListResult(params: {
   });
   return {
     ...(root ? { root } : {}),
+    ...(gitCheckout === undefined ? {} : { gitCheckout }),
     files,
     ...(browser ? { browser } : {}),
   };

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -431,6 +431,7 @@ type SessionWorkspaceArtifactEntry = {
 export type SessionWorkspaceListResult = {
   sessionKey: string;
   root?: string;
+  gitCheckout?: boolean;
   files: SessionWorkspaceFileEntry[];
   browser?: SessionWorkspaceBrowserResult;
   artifacts?: SessionWorkspaceArtifactEntry[];

--- a/ui/src/e2e/chat-session-diff.e2e.test.ts
+++ b/ui/src/e2e/chat-session-diff.e2e.test.ts
@@ -163,7 +163,46 @@ describeControlUiE2e("session diff panel", () => {
     await expect.poll(() => modified.locator(".chat-diff").count()).toBe(1);
   });
 
-  it("shows the not-a-git-checkout notice", async () => {
+  it("disables the diff toggle for a workspace outside a git checkout", async () => {
+    const context = await newBrowserContext();
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
+      methodResponses: {
+        "sessions.files.list": {
+          sessionKey: "main",
+          root: "/tmp/plain-workspace",
+          gitCheckout: false,
+          files: [],
+          browser: { path: "", entries: [] },
+        },
+        "sessions.diff": {
+          sessionKey: "main",
+          files: [],
+          additions: 0,
+          deletions: 0,
+          unavailableReason: "not_git",
+        },
+      },
+    });
+    await page.goto(`${server.baseUrl}chat`);
+
+    const toggle = page.locator(".chat-session-diff-toggle").first();
+    await expect.poll(() => toggle.isDisabled()).toBe(true);
+    await expect.poll(() => toggle.getAttribute("aria-label")).toBe("Show thread changes");
+    await expect
+      .poll(() =>
+        toggle.evaluate(
+          (element) =>
+            (element.closest("openclaw-tooltip") as (HTMLElement & { content?: string }) | null)
+              ?.content,
+        ),
+      )
+      .toBe("This thread's workspace is not a git checkout.");
+    await expect.poll(() => page.locator(".session-diff").count()).toBe(0);
+  });
+
+  it("keeps the panel fallback for gateways that omit checkout capability", async () => {
     const context = await newBrowserContext();
     const page = await context.newPage();
     await installMockGateway(page, {

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -62,6 +62,7 @@ export type SessionWorkspaceProps = {
   onToggleBrowser?: () => void;
   /** Opens the session diff panel; absent when the gateway lacks sessions.diff. */
   onOpenDiff?: () => void;
+  diffNotGit?: boolean;
 };
 
 type SessionWorkspaceState = {
@@ -288,6 +289,7 @@ function loadWorkspace(
       current.list = {
         sessionKey,
         ...(files?.root ? { root: files.root } : {}),
+        ...(typeof files?.gitCheckout === "boolean" ? { gitCheckout: files.gitCheckout } : {}),
         files: fileItems,
         ...(files?.browser ? { browser: files.browser } : {}),
         artifacts: artifactItems,
@@ -651,7 +653,9 @@ export function createSessionWorkspaceProps(
   state.sessionWorkspaceDraftScope = options?.draftScope;
   const workspace = getWorkspaceState(state);
   if (
-    !workspace.collapsed &&
+    // The collapsed header still renders the diff action, so load its checkout
+    // capability eagerly instead of waiting for the file rail to open.
+    (!workspace.collapsed || isGatewayMethodAdvertised(state, "sessions.diff") === true) &&
     state.connected &&
     state.agentsList &&
     !workspace.loading &&
@@ -716,6 +720,7 @@ export function createSessionWorkspaceProps(
           window.dispatchEvent(new CustomEvent(BROWSER_PANEL_TOGGLE_EVENT, {}));
         }
       : undefined,
+    diffNotGit: workspace.list?.gitCheckout === false,
     onOpenDiff:
       isGatewayMethodAdvertised(state, "sessions.diff") === true && state.client
         ? () => state.handleOpenSidebar(buildSessionDiffSidebarContent(state))
@@ -822,12 +827,14 @@ export function renderSessionDiffToggle(
     return nothing;
   }
   const label = t("chat.sessionDiff.show");
+  const tooltip = sessionWorkspace.diffNotGit ? t("chat.sessionDiff.notGit") : label;
   return html`
-    <openclaw-tooltip .content=${label}>
+    <openclaw-tooltip .content=${tooltip}>
       <button
         class="btn btn--ghost btn--icon chat-icon-btn chat-session-diff-toggle"
         type="button"
         aria-label=${label}
+        ?disabled=${sessionWorkspace.diffNotGit === true}
         @click=${sessionWorkspace.onOpenDiff}
       >
         ${icons.gitBranch}
@@ -877,11 +884,16 @@ export function renderSessionWorkspaceRail(
     : nothing;
   const diffButton = sessionWorkspace.onOpenDiff
     ? html`
-        <openclaw-tooltip .content=${t("chat.sessionDiff.show")}>
+        <openclaw-tooltip
+          .content=${sessionWorkspace.diffNotGit
+            ? t("chat.sessionDiff.notGit")
+            : t("chat.sessionDiff.show")}
+        >
           <button
             type="button"
             class="chat-workspace-rail__terminal chat-session-diff-toggle"
             aria-label=${t("chat.sessionDiff.show")}
+            ?disabled=${sessionWorkspace.diffNotGit === true}
             @click=${sessionWorkspace.onOpenDiff}
           >
             ${icons.gitBranch}


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Control UI chat view always showed the "Show thread changes" (session diff) button, even for threads whose workspace is not a git checkout. Clicking it opened a panel that could only say "This thread's workspace is not a git checkout." — a dead end the UI could have known about up front.

## Why This Change Was Made

The gateway now reports whether a session's workspace is inside a git checkout as an optional `gitCheckout` boolean on the `sessions.files.list` result (additive protocol change, no version bump). The probe runs against the exact same cwd precedence `sessions.diff` uses (`spawnedCwd` → `spawnedWorkspaceDir` → agent workspace dir), so the advertised state can never disagree with the panel. The UI keeps the button visible but renders it disabled with the existing "not a git checkout" message as its tooltip — disabled rather than hidden so the affordance stays discoverable and the icon row stays stable. Older gateways that omit the field fail open to today's enabled behavior, and the panel's in-place notice remains as the race fallback (e.g. a repo deleted between list refresh and click). Since the diff button also renders while the file rail is collapsed, the workspace list now loads eagerly when `sessions.diff` is advertised so the disabled state is truly proactive.

## User Impact

Users on non-git workspaces now see at a glance — via the disabled button and its tooltip — that thread changes are unavailable, instead of clicking through to an empty panel. Git-backed threads behave exactly as before.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-files.test.ts` — 35 tests pass, including new assertions that `gitCheckout` is `false` for a plain temp workspace and flips to `true` after `git init` in the same root.
- `node scripts/run-vitest.mjs ui/src/e2e/chat-session-diff.e2e.test.ts` — 3 tests pass: the non-git scenario asserts the toggle is disabled with the not-git tooltip and that no diff panel opens; a dedicated scenario proves gateways that omit the field keep the current enabled-button + panel-notice behavior.
- `node scripts/check-changed.mjs` over the changed files — green.
- Screenshot note: PR artifact hosting (artifacts.openclaw.ai R2 upload) is currently unavailable from this machine (no valid wrangler OAuth/R2 token), so before/after state is proven by the e2e DOM assertions above instead of images.
