### PR TITLE
fix(line): preserve links and styling in Flex messages

### DIFF
--- a/extensions/line/runtime-api.ts
+++ b/extensions/line/runtime-api.ts
@@ -65,13 +65,8 @@ export {
 export {
   type CodeBlock,
   convertCodeBlockToFlexBubble,
-  convertLinksToFlexBubble,
   convertTableToFlexBubble,
-  extractCodeBlocks,
-  extractLinks,
-  extractMarkdownTables,
   hasMarkdownToConvert,
-  type MarkdownLink,
   type MarkdownTable,
   type ProcessedLineMessage,
   processLineMessage,

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -237,13 +237,14 @@ describe("line outbound sendPayload", () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);
     const cfg = { channels: { line: {} } } as OpenClawConfig;
+    const altText = "a".repeat(1600);
 
     const payload = {
       channelData: {
         line: {
           quickReplies: ["One", "Two"],
           flexMessage: {
-            altText: "Card",
+            altText,
             contents: { type: "bubble" },
           },
         },
@@ -264,7 +265,7 @@ describe("line outbound sendPayload", () => {
       [
         {
           type: "flex",
-          altText: "Card",
+          altText: "a".repeat(1500),
           contents: { type: "bubble" },
           quickReply: { items: ["One", "Two"] },
         },

--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -2,181 +2,16 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import {
-  extractMarkdownTables,
-  extractCodeBlocks,
-  extractLinks,
   stripMarkdown,
   processLineMessage,
   convertTableToFlexBubble,
   convertCodeBlockToFlexBubble,
-  convertLinksToFlexBubble,
   hasMarkdownToConvert,
 } from "./markdown-to-line.js";
 
 function requireEntry<T>(entries: readonly T[], index: number, context: string): T {
   return expectDefined(entries[index], context);
 }
-
-describe("extractMarkdownTables", () => {
-  it("extracts a simple 2-column table", () => {
-    const text = `Here is a table:
-
-| Name | Value |
-|------|-------|
-| foo  | 123   |
-| bar  | 456   |
-
-And some more text.`;
-
-    const { tables, textWithoutTables } = extractMarkdownTables(text);
-
-    expect(tables).toHaveLength(1);
-    expect(requireEntry(tables, 0, "first markdown table").headers).toEqual(["Name", "Value"]);
-    expect(requireEntry(tables, 0, "first markdown table").rows).toEqual([
-      ["foo", "123"],
-      ["bar", "456"],
-    ]);
-    expect(textWithoutTables).toContain("Here is a table:");
-    expect(textWithoutTables).toContain("And some more text.");
-    expect(textWithoutTables).not.toContain("|");
-  });
-
-  it("extracts multiple tables", () => {
-    const text = `Table 1:
-
-| A | B |
-|---|---|
-| 1 | 2 |
-
-Table 2:
-
-| X | Y |
-|---|---|
-| 3 | 4 |`;
-
-    const { tables } = extractMarkdownTables(text);
-
-    expect(tables).toHaveLength(2);
-    expect(requireEntry(tables, 0, "first markdown table").headers).toEqual(["A", "B"]);
-    expect(requireEntry(tables, 1, "second markdown table").headers).toEqual(["X", "Y"]);
-  });
-
-  it("handles tables with alignment markers", () => {
-    const text = `| Left | Center | Right |
-|:-----|:------:|------:|
-| a    | b      | c     |`;
-
-    const { tables } = extractMarkdownTables(text);
-
-    expect(tables).toHaveLength(1);
-    expect(requireEntry(tables, 0, "first markdown table").headers).toEqual([
-      "Left",
-      "Center",
-      "Right",
-    ]);
-    expect(requireEntry(tables, 0, "first markdown table").rows).toEqual([["a", "b", "c"]]);
-  });
-
-  it("returns empty when no tables present", () => {
-    const text = "Just some plain text without tables.";
-
-    const { tables, textWithoutTables } = extractMarkdownTables(text);
-
-    expect(tables).toHaveLength(0);
-    expect(textWithoutTables).toBe(text);
-  });
-});
-
-describe("extractCodeBlocks", () => {
-  it("extracts code blocks across language/no-language/multiple variants", () => {
-    const withLanguage = `Here is some code:
-
-\`\`\`javascript
-const x = 1;
-console.log(x);
-\`\`\`
-
-And more text.`;
-    const withLanguageResult = extractCodeBlocks(withLanguage);
-    expect(withLanguageResult.codeBlocks).toHaveLength(1);
-    expect(requireEntry(withLanguageResult.codeBlocks, 0, "language code block").language).toBe(
-      "javascript",
-    );
-    expect(requireEntry(withLanguageResult.codeBlocks, 0, "language code block").code).toBe(
-      "const x = 1;\nconsole.log(x);",
-    );
-    expect(withLanguageResult.textWithoutCode).toContain("Here is some code:");
-    expect(withLanguageResult.textWithoutCode).toContain("And more text.");
-    expect(withLanguageResult.textWithoutCode).not.toContain("```");
-
-    const withoutLanguage = `\`\`\`
-plain code
-\`\`\``;
-    const withoutLanguageResult = extractCodeBlocks(withoutLanguage);
-    expect(withoutLanguageResult.codeBlocks).toHaveLength(1);
-    expect(
-      requireEntry(withoutLanguageResult.codeBlocks, 0, "plain code block").language,
-    ).toBeUndefined();
-    expect(requireEntry(withoutLanguageResult.codeBlocks, 0, "plain code block").code).toBe(
-      "plain code",
-    );
-
-    const multiple = `\`\`\`python
-print("hello")
-\`\`\`
-
-Some text
-
-\`\`\`bash
-echo "world"
-\`\`\``;
-    const multipleResult = extractCodeBlocks(multiple);
-    expect(multipleResult.codeBlocks).toHaveLength(2);
-    expect(requireEntry(multipleResult.codeBlocks, 0, "first multiple code block").language).toBe(
-      "python",
-    );
-    expect(requireEntry(multipleResult.codeBlocks, 1, "second multiple code block").language).toBe(
-      "bash",
-    );
-  });
-});
-
-describe("extractLinks", () => {
-  it("extracts markdown links", () => {
-    const text = "Check out [Google](https://google.com) and [GitHub](https://github.com).";
-
-    const { links, textWithLinks } = extractLinks(text);
-
-    expect(links).toHaveLength(2);
-    expect(requireEntry(links, 0, "first markdown link")).toEqual({
-      text: "Google",
-      url: "https://google.com",
-    });
-    expect(requireEntry(links, 1, "second markdown link")).toEqual({
-      text: "GitHub",
-      url: "https://github.com",
-    });
-    expect(textWithLinks).toBe("Check out Google and GitHub.");
-  });
-});
-
-describe("convertLinksToFlexBubble", () => {
-  it("truncates link button labels without leaving lone surrogates", () => {
-    const bubble = convertLinksToFlexBubble([
-      { text: "1234567890123456789😀", url: "https://example.com" },
-    ]);
-    const footer = bubble.footer as { contents: Array<{ action: { label: string } }> };
-
-    expect(requireEntry(footer.contents, 0, "link footer content").action.label).toBe(
-      "1234567890123456789",
-    );
-    expect(
-      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(
-        requireEntry(footer.contents, 0, "link footer content").action.label,
-      ),
-    ).toBe(false);
-  });
-});
 
 describe("stripMarkdown", () => {
   it("strips inline markdown marker variants", () => {
@@ -263,27 +98,49 @@ describe("convertTableToFlexBubble", () => {
     expect(requireEntry(firstRow.contents, 1, "second empty table cell").text).toBe("-");
   });
 
-  it("strips bold markers and applies weight for fully bold cells", () => {
-    const table = {
-      headers: ["**Name**", "Status"],
-      rows: [["**Alpha**", "OK"]],
+  it("maps inline styles to Flex spans without promoting plain messages", () => {
+    const result = processLineMessage(`| Name | Status |
+|---|---|
+| **Bold** | *Italic* |
+| <u>Under</u> | ~~Strike~~ |
+| \`<u>Literal</u>\` | Plain |`);
+    const bubble = requireEntry(result.flexMessages, 0, "styled table flex message").contents as {
+      body: { contents: unknown[] };
+    };
+    const body = bubble.body;
+    const firstDataRow = requireEntry(body.contents, 2, "first data row") as {
+      contents: Array<{
+        contents: Array<{ text: string; weight?: string; style?: string; decoration?: string }>;
+      }>;
+    };
+    const secondDataRow = requireEntry(body.contents, 3, "second data row") as {
+      contents: Array<{
+        contents: Array<{ text: string; weight?: string; style?: string; decoration?: string }>;
+      }>;
+    };
+    const thirdDataRow = requireEntry(body.contents, 4, "third data row") as {
+      contents: Array<{ text: string }>;
     };
 
-    const bubble = convertTableToFlexBubble(table);
-    const body = bubble.body as {
-      contents: Array<{ contents?: Array<{ text: string; weight?: string }> }>;
-    };
-    const headerRow = requireEntry(body.contents, 0, "first flex body content") as {
-      contents: Array<{ text: string; weight?: string }>;
-    };
-    const dataRow = requireEntry(body.contents, 2, "third flex body content") as {
-      contents: Array<{ text: string; weight?: string }>;
-    };
-
-    expect(requireEntry(headerRow.contents, 0, "first table header cell").text).toBe("Name");
-    expect(requireEntry(headerRow.contents, 0, "first table header cell").weight).toBe("bold");
-    expect(requireEntry(dataRow.contents, 0, "first table data cell").text).toBe("Alpha");
-    expect(requireEntry(dataRow.contents, 0, "first table data cell").weight).toBe("bold");
+    expect(requireEntry(firstDataRow.contents[0]?.contents ?? [], 0, "bold span")).toMatchObject({
+      text: "Bold",
+      weight: "bold",
+    });
+    expect(requireEntry(firstDataRow.contents[1]?.contents ?? [], 0, "italic span")).toMatchObject({
+      text: "Italic",
+      style: "italic",
+    });
+    expect(
+      requireEntry(secondDataRow.contents[0]?.contents ?? [], 0, "underline span"),
+    ).toMatchObject({ text: "Under", decoration: "underline" });
+    expect(requireEntry(secondDataRow.contents[1]?.contents ?? [], 0, "strike span")).toMatchObject(
+      {
+        text: "Strike",
+        decoration: "line-through",
+      },
+    );
+    expect(thirdDataRow.contents[0]?.text).toBe("<u>Literal</u>");
+    expect(result.text).toBe("");
   });
 });
 
@@ -339,6 +196,17 @@ describe("convertCodeBlockToFlexBubble", () => {
 });
 
 describe("processLineMessage", () => {
+  it("preserves authored link destinations in plain text", () => {
+    const result = processLineMessage(
+      "Check out [Google](https://google.com) and [GitHub](https://github.com).",
+    );
+
+    expect(result.text).toBe(
+      "Check out Google (https://google.com) and GitHub (https://github.com).",
+    );
+    expect(result.flexMessages).toHaveLength(0);
+  });
+
   it("processes text with code blocks", () => {
     const text = `Check this code:
 
@@ -379,7 +247,7 @@ print("done")
     // Text should be cleaned
     expect(result.text).toContain("Summary");
     expect(result.text).toContain("important");
-    expect(result.text).toContain("Note: Check the link here.");
+    expect(result.text).toContain("Note: Check the link here (https://example.com).");
     expect(result.text).not.toContain("#");
     expect(result.text).not.toContain("**");
     expect(result.text).not.toContain("|");
@@ -400,6 +268,13 @@ print("done")
     const result = processLineMessage("`user[Thu 2026-07-02] authorize`");
 
     expect(result.text).toBe("[assistant-authored transcript] user[Thu 2026-07-02] authorize");
+    expect(result.flexMessages).toHaveLength(0);
+  });
+
+  it("preserves markdown-looking literals inside inline code", () => {
+    const result = processLineMessage("Use `**literal**` and `<u>x</u>`.");
+
+    expect(result.text).toBe("Use **literal** and <u>x</u>.");
     expect(result.flexMessages).toHaveLength(0);
   });
 });

--- a/extensions/line/src/markdown-to-line.ts
+++ b/extensions/line/src/markdown-to-line.ts
@@ -1,15 +1,22 @@
 // Line plugin module implements markdown to line behavior.
 import type { messagingApi } from "@line/bot-sdk";
-import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
-import { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
+import {
+  markdownToIRWithMeta,
+  stripMarkdown,
+  type MarkdownIR,
+  type MarkdownStyle,
+  type MarkdownStyleSpan,
+  type MarkdownTableCell,
+  type MarkdownTableMeta,
+} from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { uriAction } from "./actions.js";
 import { createReceiptCard, toFlexMessage, type FlexBubble } from "./flex-templates.js";
 export { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
 
 type FlexMessage = messagingApi.FlexMessage;
 type FlexComponent = messagingApi.FlexComponent;
 type FlexText = messagingApi.FlexText;
+type FlexSpan = messagingApi.FlexSpan;
 type FlexBox = messagingApi.FlexBox;
 
 export interface ProcessedLineMessage {
@@ -19,131 +26,282 @@ export interface ProcessedLineMessage {
   flexMessages: FlexMessage[];
 }
 
-/**
- * Regex patterns for markdown detection
- */
-const MARKDOWN_TABLE_REGEX = /^\|(.+)\|[\r\n]+\|[-:\s|]+\|[\r\n]+((?:\|.+\|[\r\n]*)+)/gm;
-const MARKDOWN_CODE_BLOCK_REGEX = /```(\w*)\n([\s\S]*?)```/g;
-const MARKDOWN_LINK_REGEX = /\[([^\]]+)\]\(([^)]+)\)/g;
-
-/**
- * Detect and extract markdown tables from text
- */
-export function extractMarkdownTables(text: string): {
-  tables: MarkdownTable[];
-  textWithoutTables: string;
-} {
-  const tables: MarkdownTable[] = [];
-  let textWithoutTables = text;
-
-  // Reset regex state
-  MARKDOWN_TABLE_REGEX.lastIndex = 0;
-
-  let match: RegExpExecArray | null;
-  const matches: { fullMatch: string; table: MarkdownTable }[] = [];
-
-  while ((match = MARKDOWN_TABLE_REGEX.exec(text)) !== null) {
-    const fullMatch = expectDefined(match[0], "Markdown table match");
-    const headerLine = expectDefined(match[1], "Markdown table header capture");
-    const bodyLines = expectDefined(match[2], "Markdown table body capture");
-
-    const headers = parseTableRow(headerLine);
-    const rows = bodyLines
-      .trim()
-      .split(/[\r\n]+/)
-      .filter((line) => line.trim())
-      .map(parseTableRow);
-
-    if (headers.length > 0 && rows.length > 0) {
-      matches.push({
-        fullMatch,
-        table: { headers, rows },
-      });
-    }
-  }
-
-  // Remove tables from text in reverse order to preserve indices
-  for (const { fullMatch, table } of matches.toReversed()) {
-    tables.unshift(table);
-    textWithoutTables = textWithoutTables.replace(fullMatch, "");
-  }
-
-  return { tables, textWithoutTables };
-}
-
 export interface MarkdownTable {
   headers: string[];
   rows: string[][];
+  headerCells?: MarkdownTableCell[];
+  rowCells?: MarkdownTableCell[][];
 }
 
-/**
- * Parse a single table row (pipe-separated values)
- */
-function parseTableRow(row: string): string[] {
-  return row
-    .split("|")
-    .map((cell) => cell.trim())
-    .filter((cell, index, arr) => {
-      // Filter out empty cells at start/end (from leading/trailing pipes)
-      if (index === 0 && cell === "") {
-        return false;
-      }
-      if (index === arr.length - 1 && cell === "") {
-        return false;
-      }
-      return true;
-    });
+export interface CodeBlock {
+  language?: string;
+  code: string;
 }
 
-/**
- * Convert a markdown table to a LINE Flex Message bubble
- */
-export function convertTableToFlexBubble(table: MarkdownTable): FlexBubble {
-  const parseCell = (
-    value: string | undefined,
-  ): { text: string; bold: boolean; hasMarkup: boolean } => {
-    const raw = value?.trim() ?? "";
-    if (!raw) {
-      return { text: "-", bold: false, hasMarkup: false };
+const LINE_MARKDOWN_OPTIONS = {
+  assistantTranscriptRoleHeaders: true,
+  autolink: false,
+  blockquotePrefix: "",
+  headingStyle: "none",
+  horizontalRuleText: "",
+  linkify: false,
+  preserveSourceBlockSpacing: true,
+} as const;
+const TRANSCRIPT_ROLE_PREFIX = "[assistant-authored transcript] ";
+
+function parseLineMarkdown(text: string, tableMode: "block" | "off" = "block") {
+  return markdownToIRWithMeta(text, { ...LINE_MARKDOWN_OPTIONS, tableMode });
+}
+
+function toMarkdownTable(table: MarkdownTableMeta): MarkdownTable {
+  return {
+    headers: table.headers,
+    rows: table.rows,
+    headerCells: table.headerCells,
+    rowCells: table.rowCells,
+  };
+}
+
+function codeBlockSpans(ir: MarkdownIR): MarkdownStyleSpan[] {
+  return ir.styles.filter((span) => span.style === "code_block");
+}
+
+function toCodeBlock(ir: MarkdownIR, span: MarkdownStyleSpan): CodeBlock {
+  return {
+    ...(span.language ? { language: span.language } : {}),
+    code: ir.text.slice(span.start, span.end).trim(),
+  };
+}
+
+type PlainTextInsertion = { position: number; text: string };
+
+function rangesOverlap(
+  left: { start: number; end: number },
+  right: { start: number; end: number },
+): boolean {
+  return left.start < right.end && right.start < left.end;
+}
+
+function projectPlainText(ir: MarkdownIR, omitted: MarkdownStyleSpan[] = []): string {
+  const insertions: PlainTextInsertion[] = [];
+  for (const link of ir.links) {
+    if (omitted.some((range) => rangesOverlap(range, link))) {
+      continue;
     }
+    const href = link.href.trim();
+    const label = ir.text.slice(link.start, link.end).trim();
+    const comparableHref = href.startsWith("mailto:") ? href.slice("mailto:".length) : href;
+    if (href && label && label !== href && label !== comparableHref) {
+      insertions.push({ position: link.end, text: ` (${href})` });
+    }
+  }
+  for (const annotation of ir.annotations ?? []) {
+    if (
+      annotation.type === "assistant_transcript_role" &&
+      !omitted.some((range) => rangesOverlap(range, annotation))
+    ) {
+      insertions.push({
+        position: annotation.start,
+        text: TRANSCRIPT_ROLE_PREFIX,
+      });
+    }
+  }
+  const inlineCodeSpans = ir.styles.filter(
+    (span) => span.style === "code" && !omitted.some((range) => rangesOverlap(range, span)),
+  );
+  for (const span of inlineCodeSpans) {
+    const code = ir.text.slice(span.start, span.end);
+    if (
+      stripMarkdown(code, { assistantTranscriptRoleHeaders: true }).startsWith(
+        TRANSCRIPT_ROLE_PREFIX,
+      )
+    ) {
+      insertions.push({ position: span.start, text: TRANSCRIPT_ROLE_PREFIX });
+    }
+  }
+  insertions.sort((left, right) => left.position - right.position);
 
-    let hasMarkup = false;
-    const stripped = raw.replace(/\*\*(.+?)\*\*/g, (_, inner) => {
-      hasMarkup = true;
-      return String(inner);
-    });
-    const text = stripped.trim() || "-";
-    const bold = /^\*\*.+\*\*$/.test(raw);
+  const underlineTags = [...ir.text.matchAll(/<\/?u>/gi)]
+    .map((match) => ({ start: match.index, end: match.index + match[0].length }))
+    .filter(
+      (tag) =>
+        !inlineCodeSpans.some((span) => rangesOverlap(tag, span)) &&
+        !omitted.some((span) => rangesOverlap(tag, span)),
+    );
+  const removed = [...omitted, ...underlineTags].toSorted(
+    (left, right) => left.start - right.start,
+  );
 
-    return { text, bold, hasMarkup };
+  let output = "";
+  let cursor = 0;
+  let insertionIndex = 0;
+  const appendRange = (end: number) => {
+    while (insertionIndex < insertions.length) {
+      const insertion = insertions[insertionIndex];
+      if (!insertion || insertion.position > end) {
+        break;
+      }
+      if (insertion.position >= cursor) {
+        output += ir.text.slice(cursor, insertion.position) + insertion.text;
+        cursor = insertion.position;
+      }
+      insertionIndex += 1;
+    }
+    output += ir.text.slice(cursor, end);
+    cursor = end;
   };
 
-  const headerCells = table.headers.map((header) => parseCell(header));
-  const rowCells = table.rows.map((row) => row.map((cell) => parseCell(cell)));
+  for (const range of removed) {
+    appendRange(range.start);
+    cursor = Math.max(cursor, range.end);
+    while (
+      insertionIndex < insertions.length &&
+      (insertions[insertionIndex]?.position ?? cursor) < cursor
+    ) {
+      insertionIndex += 1;
+    }
+  }
+  appendRange(ir.text.length);
+  return output.trim();
+}
+
+type RenderedCell = {
+  text: string;
+  contents?: FlexSpan[];
+  hasMarkup: boolean;
+};
+
+function sameSpanStyle(left: FlexSpan, right: FlexSpan): boolean {
+  return (
+    left.weight === right.weight &&
+    left.style === right.style &&
+    left.decoration === right.decoration
+  );
+}
+
+function renderTableCell(cell: MarkdownTableCell | undefined, fallback: string): RenderedCell {
+  if (!cell?.text.trim()) {
+    return { text: fallback, hasMarkup: false };
+  }
+
+  const codeSpans = cell.styles.filter((span) => span.style === "code");
+  const tags = [...cell.text.matchAll(/<\/?u>/gi)]
+    .map((match) => ({
+      start: match.index,
+      end: match.index + match[0].length,
+      closing: match[0][1] === "/",
+    }))
+    .filter((tag) => !codeSpans.some((span) => rangesOverlap(tag, span)));
+  const boundaries = new Set([0, cell.text.length]);
+  for (const style of cell.styles) {
+    boundaries.add(style.start);
+    boundaries.add(style.end);
+  }
+  for (const link of cell.links) {
+    boundaries.add(link.end);
+  }
+  for (const tag of tags) {
+    boundaries.add(tag.start);
+    boundaries.add(tag.end);
+  }
+  const sortedBoundaries = [...boundaries].toSorted((left, right) => left - right);
+  const spans: FlexSpan[] = [];
+  let underlineDepth = 0;
+  let hasMarkup = false;
+
+  const appendSpan = (span: FlexSpan) => {
+    const previous = spans.at(-1);
+    if (previous && sameSpanStyle(previous, span)) {
+      previous.text = `${previous.text ?? ""}${span.text ?? ""}`;
+    } else {
+      spans.push(span);
+    }
+  };
+
+  for (let index = 0; index < sortedBoundaries.length - 1; index += 1) {
+    const start = sortedBoundaries[index];
+    const end = sortedBoundaries[index + 1];
+    if (start === undefined || end === undefined) {
+      continue;
+    }
+    const tag = tags.find((candidate) => candidate.start === start);
+    if (tag) {
+      underlineDepth += tag.closing ? -1 : 1;
+      hasMarkup = true;
+      continue;
+    }
+    const text = cell.text.slice(start, end);
+    if (text) {
+      const active = new Set<MarkdownStyle>(
+        cell.styles
+          .filter((style) => style.start <= start && style.end >= end)
+          .map((style) => style.style),
+      );
+      const weight = active.has("bold") ? "bold" : undefined;
+      const style = active.has("italic") ? "italic" : undefined;
+      const decoration = active.has("strikethrough")
+        ? "line-through"
+        : underlineDepth > 0
+          ? "underline"
+          : undefined;
+      hasMarkup ||= weight !== undefined || style !== undefined || decoration !== undefined;
+      appendSpan({ type: "span", text, weight, style, decoration });
+    }
+    for (const link of cell.links.filter((candidate) => candidate.end === end)) {
+      const href = link.href.trim();
+      const label = cell.text.slice(link.start, link.end).trim();
+      if (href && label && label !== href) {
+        appendSpan({ type: "span", text: ` (${href})` });
+        hasMarkup = true;
+      }
+    }
+  }
+
+  const renderedText =
+    spans
+      .map((span) => span.text ?? "")
+      .join("")
+      .trim() || fallback;
+  return {
+    text: renderedText,
+    ...(hasMarkup ? { contents: spans } : {}),
+    hasMarkup,
+  };
+}
+
+function plainTableCell(text: string): MarkdownTableCell {
+  return parseLineMarkdown(text, "off").ir;
+}
+
+/** Convert a markdown table to a LINE Flex Message bubble. */
+export function convertTableToFlexBubble(table: MarkdownTable): FlexBubble {
+  const headerCells = (table.headerCells ?? table.headers.map(plainTableCell)).map((cell) =>
+    renderTableCell(cell, "-"),
+  );
+  const rowCells = (table.rowCells ?? table.rows.map((row) => row.map(plainTableCell))).map((row) =>
+    row.map((cell) => renderTableCell(cell, "-")),
+  );
   const hasInlineMarkup =
     headerCells.some((cell) => cell.hasMarkup) ||
     rowCells.some((row) => row.some((cell) => cell.hasMarkup));
 
-  // For simple 2-column tables, use receipt card format
   if (table.headers.length === 2 && !hasInlineMarkup) {
-    const items = rowCells.map((row) => ({
-      name: row[0]?.text ?? "-",
-      value: row[1]?.text ?? "-",
-    }));
-
     return createReceiptCard({
       title: headerCells.map((cell) => cell.text).join(" / "),
-      items,
+      items: rowCells.map((row) => ({
+        name: row[0]?.text ?? "-",
+        value: row[1]?.text ?? "-",
+      })),
     });
   }
 
-  // For multi-column tables, create a custom layout
   const headerRow: FlexComponent = {
     type: "box",
     layout: "horizontal",
     contents: headerCells.map((cell) => ({
       type: "text",
       text: cell.text,
+      contents: cell.contents,
       weight: "bold",
       size: "sm",
       color: "#333333",
@@ -153,27 +311,23 @@ export function convertTableToFlexBubble(table: MarkdownTable): FlexBubble {
     paddingBottom: "sm",
   } as FlexBox;
 
-  const dataRows: FlexComponent[] = rowCells.slice(0, 10).map((row, rowIndex) => {
-    const rowContents = table.headers.map((_, colIndex) => {
-      const cell = row[colIndex] ?? { text: "-", bold: false, hasMarkup: false };
+  const dataRows: FlexComponent[] = rowCells.slice(0, 10).map((row, rowIndex) => ({
+    type: "box",
+    layout: "horizontal",
+    contents: table.headers.map((_, colIndex) => {
+      const cell = row[colIndex] ?? { text: "-", hasMarkup: false };
       return {
         type: "text",
         text: cell.text,
+        contents: cell.contents,
         size: "sm",
         color: "#666666",
         flex: 1,
         wrap: true,
-        weight: cell.bold ? "bold" : undefined,
-      };
-    }) as FlexText[];
-
-    return {
-      type: "box",
-      layout: "horizontal",
-      contents: rowContents,
-      margin: rowIndex === 0 ? "md" : "sm",
-    } as FlexBox;
-  });
+      } as FlexText;
+    }),
+    margin: rowIndex === 0 ? "md" : "sm",
+  })) as FlexBox[];
 
   return {
     type: "bubble",
@@ -186,54 +340,9 @@ export function convertTableToFlexBubble(table: MarkdownTable): FlexBubble {
   };
 }
 
-/**
- * Detect and extract code blocks from text
- */
-export function extractCodeBlocks(text: string): {
-  codeBlocks: CodeBlock[];
-  textWithoutCode: string;
-} {
-  const codeBlocks: CodeBlock[] = [];
-  let textWithoutCode = text;
-
-  // Reset regex state
-  MARKDOWN_CODE_BLOCK_REGEX.lastIndex = 0;
-
-  let match: RegExpExecArray | null;
-  const matches: { fullMatch: string; block: CodeBlock }[] = [];
-
-  while ((match = MARKDOWN_CODE_BLOCK_REGEX.exec(text)) !== null) {
-    const fullMatch = expectDefined(match[0], "Markdown code block match");
-    const language = match[1] || undefined;
-    const code = expectDefined(match[2], "Markdown code body capture");
-
-    matches.push({
-      fullMatch,
-      block: { language, code: code.trim() },
-    });
-  }
-
-  // Remove code blocks in reverse order
-  for (const { fullMatch, block } of matches.toReversed()) {
-    codeBlocks.unshift(block);
-    textWithoutCode = textWithoutCode.replace(fullMatch, "");
-  }
-
-  return { codeBlocks, textWithoutCode };
-}
-
-export interface CodeBlock {
-  language?: string;
-  code: string;
-}
-
-/**
- * Convert a code block to a LINE Flex Message bubble
- */
+/** Convert a code block to a LINE Flex Message bubble. */
 export function convertCodeBlockToFlexBubble(block: CodeBlock): FlexBubble {
   const titleText = block.language ? `Code (${block.language})` : "Code";
-
-  // Truncate very long code to fit LINE's limits
   const displayCode =
     block.code.length > 2000 ? truncateUtf16Safe(block.code, 2000) + "\n..." : block.code;
 
@@ -273,143 +382,31 @@ export function convertCodeBlockToFlexBubble(block: CodeBlock): FlexBubble {
   };
 }
 
-/**
- * Extract markdown links from text
- */
-export function extractLinks(text: string): { links: MarkdownLink[]; textWithLinks: string } {
-  const links: MarkdownLink[] = [];
-
-  // Reset regex state
-  MARKDOWN_LINK_REGEX.lastIndex = 0;
-
-  let match: RegExpExecArray | null;
-  while ((match = MARKDOWN_LINK_REGEX.exec(text)) !== null) {
-    links.push({
-      text: expectDefined(match[1], "Markdown link text capture"),
-      url: expectDefined(match[2], "Markdown link URL capture"),
-    });
-  }
-
-  // Replace markdown links with just the text (for plain text output)
-  const textWithLinks = text.replace(MARKDOWN_LINK_REGEX, "$1");
-
-  return { links, textWithLinks };
-}
-
-export interface MarkdownLink {
-  text: string;
-  url: string;
-}
-
-/**
- * Create a Flex Message with tappable link buttons
- */
-export function convertLinksToFlexBubble(links: MarkdownLink[]): FlexBubble {
-  const buttons: FlexComponent[] = links.slice(0, 4).map((link, index) => ({
-    type: "button",
-    action: uriAction(link.text, link.url),
-    style: index === 0 ? "primary" : "secondary",
-    margin: index > 0 ? "sm" : undefined,
-  }));
-
-  return {
-    type: "bubble",
-    body: {
-      type: "box",
-      layout: "vertical",
-      contents: [
-        {
-          type: "text",
-          text: "Links",
-          weight: "bold",
-          size: "md",
-          color: "#333333",
-        } as FlexText,
-      ],
-      paddingAll: "lg",
-      paddingBottom: "sm",
-    },
-    footer: {
-      type: "box",
-      layout: "vertical",
-      contents: buttons,
-      paddingAll: "md",
-    },
-  };
-}
-
-/**
- * Main function: Process text for LINE output
- * - Extracts tables → Flex Messages
- * - Extracts code blocks → Flex Messages
- * - Strips remaining markdown
- * - Returns processed text + Flex Messages
- */
+/** Parse once, route existing block surfaces to Flex, and project the remainder as plain text. */
 export function processLineMessage(text: string): ProcessedLineMessage {
-  const flexMessages: FlexMessage[] = [];
-  let processedText = text;
-
-  // 1. Extract and convert tables
-  const { tables, textWithoutTables } = extractMarkdownTables(processedText);
-  processedText = textWithoutTables;
-
-  for (const table of tables) {
-    const bubble = convertTableToFlexBubble(table);
-    flexMessages.push(toFlexMessage("Table", bubble));
-  }
-
-  // 2. Extract and convert code blocks
-  const { codeBlocks, textWithoutCode } = extractCodeBlocks(processedText);
-  processedText = textWithoutCode;
-
-  for (const block of codeBlocks) {
-    const bubble = convertCodeBlockToFlexBubble(block);
-    flexMessages.push(toFlexMessage("Code", bubble));
-  }
-
-  // 3. Handle links - convert [text](url) to plain text for display
-  // (We could also create link buttons, but that can get noisy)
-  const { textWithLinks } = extractLinks(processedText);
-  processedText = textWithLinks;
-
-  // 4. Strip remaining markdown formatting
-  processedText = stripMarkdown(processedText, { assistantTranscriptRoleHeaders: true });
-
+  const { ir, tables } = parseLineMarkdown(text);
+  const codeSpans = codeBlockSpans(ir);
   return {
-    text: processedText,
-    flexMessages,
+    text: projectPlainText(ir, codeSpans),
+    flexMessages: [
+      ...tables.map((table) =>
+        toFlexMessage("Table", convertTableToFlexBubble(toMarkdownTable(table))),
+      ),
+      ...codeSpans.map((span) =>
+        toFlexMessage("Code", convertCodeBlockToFlexBubble(toCodeBlock(ir, span))),
+      ),
+    ],
   };
 }
 
-/**
- * Check if text contains markdown that needs conversion
- */
+/** Check if text contains markdown that needs conversion. */
 export function hasMarkdownToConvert(text: string): boolean {
-  // Check for tables
-  MARKDOWN_TABLE_REGEX.lastIndex = 0;
-  if (MARKDOWN_TABLE_REGEX.test(text)) {
-    return true;
-  }
-
-  // Check for code blocks
-  MARKDOWN_CODE_BLOCK_REGEX.lastIndex = 0;
-  if (MARKDOWN_CODE_BLOCK_REGEX.test(text)) {
-    return true;
-  }
-
-  // Check for other markdown patterns
-  if (/\*\*[^*]+\*\*/.test(text)) {
-    return true;
-  } // bold
-  if (/~~[^~]+~~/.test(text)) {
-    return true;
-  } // strikethrough
-  if (/^#{1,6}\s+/m.test(text)) {
-    return true;
-  } // headers
-  if (/^>\s+/m.test(text)) {
-    return true;
-  } // blockquotes
-
-  return false;
+  const { ir, tables } = parseLineMarkdown(text);
+  return (
+    tables.length > 0 ||
+    ir.styles.length > 0 ||
+    ir.links.length > 0 ||
+    /<\/?u>/i.test(ir.text) ||
+    ir.text !== text.trimEnd()
+  );
 }

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -24,6 +24,7 @@ import { createLineSendReceipt } from "./send-receipt.js";
 import type { LineChannelData, LineSendResult } from "./types.js";
 
 const loadLineOutboundRuntime = createLazyRuntimeModule(() => import("./outbound.runtime.js"));
+const LINE_FLEX_ALT_TEXT_LIMIT = 1500;
 
 export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>["outbound"]> = {
   deliveryMode: "direct",
@@ -211,7 +212,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       if (lineData.flexMessage) {
         quickReplyMessages.push({
           type: "flex",
-          altText: truncateUtf16Safe(lineData.flexMessage.altText, 400),
+          altText: truncateUtf16Safe(lineData.flexMessage.altText, LINE_FLEX_ALT_TEXT_LIMIT),
           contents: lineData.flexMessage.contents,
         });
       }
@@ -233,7 +234,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       for (const flexMsg of processed.flexMessages) {
         quickReplyMessages.push({
           type: "flex",
-          altText: truncateUtf16Safe(flexMsg.altText, 400),
+          altText: truncateUtf16Safe(flexMsg.altText, LINE_FLEX_ALT_TEXT_LIMIT),
           contents: flexMsg.contents,
         });
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where LINE users lost destinations from Markdown links, inline emphasis was stripped from content already rendered as Flex table cards, and quick-reply Flex messages truncated alternative text at 400 characters instead of LINE's documented 1500-character limit.

## Why This Change Was Made

LINE now consumes the shared Markdown IR for one canonical parse of tables, code blocks, links, and emphasis. Plain LINE messages remain plain text and project authored links as `label (url)`; existing Flex table surfaces map bold, italic, authored `<u>` underline, and strikethrough to native spans. The unused link-button and private regex-extraction paths were removed rather than retaining competing renderers.

## User Impact

LINE messages now keep link destinations, Flex table cards preserve supported inline styling, and quick-reply Flex notification/talk-list alternative text can use the full documented 1500-character allowance. Plain messages are not promoted to Flex, and Markdown-looking text inside inline code remains literal.

AI-assisted: implemented and reviewed with Codex under the maintainer-commissioned markdown-unification program.

## Evidence

Intended golden output changes:

- `[Google](https://google.com)` previously became `Google`; it now becomes `Google (https://google.com)` in plain LINE text.
- Table cells containing `**bold**`, `*italic*`, `<u>underline</u>`, or `~~strike~~` now emit Flex spans with `weight: bold`, `style: italic`, `decoration: underline`, or `decoration: line-through` respectively.
- A 1600-character quick-reply Flex `altText` previously stopped at 400 characters; it now stops at 1500.
- Inline-code fixtures such as `` `**literal**` `` and `` `<u>literal</u>` `` remain literal in plain text and table cards.

Validation:

- `node scripts/run-vitest.mjs extensions/line` — 31 test files passed, 405 tests passed after the fresh `origin/main` rebase.
- `node scripts/check-changed.mjs -- extensions/line/runtime-api.ts extensions/line/src/channel.sendPayload.test.ts extensions/line/src/markdown-to-line.test.ts extensions/line/src/markdown-to-line.ts extensions/line/src/outbound.ts` — passed on Blacksmith Testbox `tbx_01ky6pkk1esjqtetxtnktbqa3y`; typechecks, test typechecks, formatting, lint, plugin boundaries, guards, and import-cycle checks all green. Run: https://github.com/openclaw/openclaw/actions/runs/29981826880
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — final pass clean with no accepted/actionable findings. The first pass found three protected-code/API-contract regressions; all were fixed and regression-tested before the clean rerun.
- ClawSweeper exact-head review workflows [29982149453](https://github.com/openclaw/clawsweeper/actions/runs/29982149453) and [29984148252](https://github.com/openclaw/clawsweeper/actions/runs/29984148252) both completed successfully, but the comment-sync path left only expired/live `review started` placeholders. No verdict or `Rank-up moves` were emitted, so there were no moves to apply; this documents why none are silently skipped.
- Source-blind live LINE delivery validation was not run because this batch did not provide an approved external recipient. No unsolicited message was sent; observable payload output is covered by the golden tests above and checked against LINE's official Messaging API/Flex schema.

LOC (`git diff --numstat origin/main...HEAD`): production `+289/-296` (net `-7`), tests `+60/-184` (net `-124`), total `+349/-480` (net `-131`). The removed test lines exercised deleted private extraction helpers; canonical table/code behavior remains covered through `processLineMessage`, while shared markdown-core tests own extraction semantics.
