### PR TITLE
test(cron): clean shared env and temp state

### DIFF
--- a/src/cron/isolated-agent.hook-content-wrapping.test.ts
+++ b/src/cron/isolated-agent.hook-content-wrapping.test.ts
@@ -25,7 +25,7 @@ function lastEmbeddedPrompt(): string {
 
 describe("runCronIsolatedAgentTurn hook content wrapping", () => {
   beforeAll(async () => {
-    process.env.OPENCLAW_TEST_FAST = "1";
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     vi.spyOn(isolatedAgentRunRuntime, "resolveThinkingDefault").mockReturnValue("off");
     vi.mocked(loadPreparedModelCatalog).mockResolvedValue([]);
     await withTempHome(async (home) => {
@@ -38,7 +38,7 @@ describe("runCronIsolatedAgentTurn hook content wrapping", () => {
   });
 
   beforeEach(() => {
-    process.env.OPENCLAW_TEST_FAST = "1";
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     vi.spyOn(isolatedAgentRunRuntime, "resolveThinkingDefault").mockReturnValue("off");
     vi.mocked(runEmbeddedAgent).mockClear();
     vi.mocked(loadPreparedModelCatalog).mockResolvedValue([]);

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // vi.hoisted runs before module imports, ensuring FAST_TEST_MODE is picked up.
 vi.hoisted(() => {
-  process.env.OPENCLAW_TEST_FAST = "1";
+  vi.stubEnv("OPENCLAW_TEST_FAST", "1");
 });
 
 import { expectsSubagentFollowup, isLikelyInterimCronMessage } from "./subagent-followup-hints.js";

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -1,12 +1,13 @@
 // Cron session reaper tests cover cleanup of sessions created by scheduled runs.
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admission.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createDeferred } from "../test-utils/deferred.js";
 import type { Logger } from "./service/state.js";
 import { sweepCronRunSessions } from "./session-reaper.js";
@@ -72,6 +73,7 @@ describe("isCronRunSessionKey", () => {
 });
 
 describe("sweepCronRunSessions", () => {
+  const tempDirs: string[] = [];
   let tmpDir: string;
   let storePath: string;
   const log = createTestLogger();
@@ -79,8 +81,14 @@ describe("sweepCronRunSessions", () => {
   beforeEach(async () => {
     resetReaperThrottle();
     taskStatusMocks.buildPendingSet.mockReset().mockReturnValue(new Set());
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cron-reaper-"));
+    tmpDir = makeTempDir(tempDirs, "cron-reaper-");
     storePath = path.join(tmpDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    cleanupTempDirs(tempDirs);
   });
 
   it("prunes expired cron run sessions", async () => {


### PR DESCRIPTION
## What Problem This Solves

Cron tests leave shared process and filesystem state behind: two suites assign `OPENCLAW_TEST_FAST` directly, and the session-reaper suite creates a new temporary session store per test without closing cached SQLite handles or removing the root.

## Why This Change Was Made

Use `vi.stubEnv` for the import-time and per-test fast-mode values so the shared runner owns restoration. Track session-reaper roots with the shared temp-dir helper, close both agent and shared state database handles after each test, then remove the tracked roots.

A sibling message-tool policy assignment was reviewed but intentionally not changed because its suite already snapshots and restores `OPENCLAW_TEST_FAST` in `beforeEach`/`afterEach`.

## User Impact

Developers get cleaner, more deterministic cron tests with no production behavior change.

## Evidence

- Blacksmith Testbox, Linux Node 24:
  - 3 test files passed
  - 49 tests passed
  - formatting check passed
- `git diff --check`: passed
- Formal Codex autoreview: clean, no accepted/actionable findings

AI-assisted: yes.
