### PR TITLE
fix(ui): restore project hierarchy and session activity

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 323342,
-  "reason": "repair red main: CI-measured startup JS after post-#112880 UI landings (#112859 #112866 #112853 #111861); Linux CI builds measure ~800B larger than macOS — baseline follows CI truth (max of 4 QA profiles, run 29980596056)",
+  "startupJsGzipBytes": 323435,
+  "reason": "catalog session activity indicator",
   "updatedAt": "2026-07-23"
 }

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -119,14 +119,18 @@ type SessionCatalogGroupsParams = {
   ) => void;
 };
 
+function renderSessionRunSpinner() {
+  return html`<span
+    class="session-run-spinner"
+    role="img"
+    aria-label=${t("sessionsView.activeRun")}
+    title=${t("sessionsView.activeRun")}
+  ></span>`;
+}
+
 function renderCatalogHeaderStatus(hasActiveRun: boolean, hasUnread: boolean) {
   if (hasActiveRun) {
-    return html`<span
-      class="session-run-spinner"
-      role="img"
-      aria-label=${t("sessionsView.activeRun")}
-      title=${t("sessionsView.activeRun")}
-    ></span>`;
+    return renderSessionRunSpinner();
   }
   return hasUnread
     ? html`<span
@@ -379,6 +383,7 @@ function renderCatalogSessionRow(
   const search = searchForSession(key);
   const href = `${pathForRoute("chat", params.basePath)}${search}`;
   const active = params.routeSessionKey !== "" && key === params.routeSessionKey;
+  const running = session.status === "active" || session.status === "running";
   const canOpenTerminal = session.canOpenTerminal === true && params.terminalAvailable;
   const openTerminal = () => params.onOpenTerminal(catalogKey);
   const openMenu = (x: number, y: number, trigger?: HTMLElement) =>
@@ -392,7 +397,9 @@ function renderCatalogSessionRow(
     <div
       class="sidebar-recent-session session-row-host ${active
         ? "sidebar-recent-session--active"
-        : ""} ${projectChild ? "sidebar-recent-session--catalog-project-child" : ""}"
+        : ""} ${projectChild ? "sidebar-recent-session--catalog-project-child" : ""} ${running
+        ? "session-row-host--running"
+        : ""}"
       data-session-key=${key}
       role="listitem"
       @contextmenu=${(event: MouseEvent) => {
@@ -417,6 +424,11 @@ function renderCatalogSessionRow(
           }
         }}
       >
+        <span class="sidebar-session-indicator"
+          >${running
+            ? renderSessionRunSpinner()
+            : html`<span class="sidebar-session-indicator__dot" aria-hidden="true"></span>`}</span
+        >
         <span class="sidebar-recent-session__text">
           <span class="sidebar-recent-session__name hover-marquee">${label}</span>
         </span>

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -330,7 +330,7 @@ function renderCatalogHostGroup(
                 ${collapsed
                   ? nothing
                   : group.sessions.map((session) =>
-                      renderCatalogSessionRow(catalog, host, session, liveRowsByKey, params),
+                      renderCatalogSessionRow(catalog, host, session, liveRowsByKey, params, true),
                     )}
               `;
             })}
@@ -351,6 +351,7 @@ function renderCatalogSessionRow(
   session: SessionCatalogSession,
   liveRowsByKey: ReadonlyMap<string, GatewaySessionRow>,
   params: SessionCatalogGroupsParams,
+  projectChild = false,
 ) {
   const rawTimestamp = session.recencyAt ?? session.updatedAt ?? session.createdAt;
   const timestamp =
@@ -391,7 +392,7 @@ function renderCatalogSessionRow(
     <div
       class="sidebar-recent-session session-row-host ${active
         ? "sidebar-recent-session--active"
-        : ""}"
+        : ""} ${projectChild ? "sidebar-recent-session--catalog-project-child" : ""}"
       data-session-key=${key}
       role="listitem"
       @contextmenu=${(event: MouseEvent) => {

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -6,6 +6,7 @@ import "../test-helpers/app-sidebar-cases/attention.ts";
 import "../test-helpers/app-sidebar-cases/basics.ts";
 import "../test-helpers/app-sidebar-cases/catalog-compat.ts";
 import "../test-helpers/app-sidebar-cases/catalog-live-events.ts";
+import "../test-helpers/app-sidebar-cases/catalog-project-activity.ts";
 import "../test-helpers/app-sidebar-cases/catalog-live.ts";
 import "../test-helpers/app-sidebar-cases/catalog-live-state.ts";
 import "../test-helpers/app-sidebar-cases/catalog-pages.ts";

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1685,7 +1685,7 @@ html.openclaw-native-macos
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 10px;
+  font-size: 13px;
   font-weight: 500;
 }
 
@@ -1701,6 +1701,10 @@ html.openclaw-native-macos
 
 .sidebar-session-catalog-host__sessions .sidebar-recent-session__link {
   padding-left: 18px;
+}
+
+.sidebar-recent-session--catalog-project-child .sidebar-recent-session__name {
+  font-size: 10px;
 }
 
 .sidebar-session-pagination {

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
@@ -238,59 +238,6 @@ describe("AppSidebar session catalog pagination", () => {
     expect(section?.textContent).not.toContain("Offline Node");
   });
 
-  it("shows thread-style activity indicators on project sessions", async () => {
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
-    sidebar.sessionCatalogs = [
-      {
-        id: "codex",
-        label: "Codex",
-        capabilities: { continueSession: true, archive: true },
-        hosts: [
-          {
-            hostId: "gateway:local",
-            label: "Local Codex",
-            kind: "gateway",
-            connected: true,
-            sessions: [
-              {
-                threadId: "active-thread",
-                name: "Active session",
-                cwd: "/work/openclaw",
-                status: "active",
-                archived: false,
-                canContinue: false,
-                canArchive: false,
-              },
-              {
-                threadId: "idle-thread",
-                name: "Idle session",
-                cwd: "/work/openclaw",
-                status: "idle",
-                archived: false,
-                canContinue: true,
-                canArchive: true,
-              },
-            ],
-          },
-        ],
-      },
-    ];
-    await sidebar.updateComplete;
-
-    const project = sidebar.querySelector('[data-session-catalog-project="/work/openclaw"]');
-    const active = sidebar.querySelector('[data-session-key*="active-thread"]');
-    const idle = sidebar.querySelector('[data-session-key*="idle-thread"]');
-    expect(project).not.toBeNull();
-    expect(active?.querySelector(".sidebar-session-indicator .session-run-spinner")).not.toBeNull();
-    expect(active?.querySelector(".session-run-spinner")?.getAttribute("aria-label")).toBe(
-      "Active run",
-    );
-    expect(
-      idle?.querySelector(".sidebar-session-indicator .sidebar-session-indicator__dot"),
-    ).not.toBeNull();
-  });
-
   it("shows a catalog-owned OpenClaw session only in its catalog section", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const backingSessionKey = "agent:main:claude-bound";

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
@@ -238,6 +238,59 @@ describe("AppSidebar session catalog pagination", () => {
     expect(section?.textContent).not.toContain("Offline Node");
   });
 
+  it("shows thread-style activity indicators on project sessions", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    sidebar.sessionCatalogs = [
+      {
+        id: "codex",
+        label: "Codex",
+        capabilities: { continueSession: true, archive: true },
+        hosts: [
+          {
+            hostId: "gateway:local",
+            label: "Local Codex",
+            kind: "gateway",
+            connected: true,
+            sessions: [
+              {
+                threadId: "active-thread",
+                name: "Active session",
+                cwd: "/work/openclaw",
+                status: "active",
+                archived: false,
+                canContinue: false,
+                canArchive: false,
+              },
+              {
+                threadId: "idle-thread",
+                name: "Idle session",
+                cwd: "/work/openclaw",
+                status: "idle",
+                archived: false,
+                canContinue: true,
+                canArchive: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    await sidebar.updateComplete;
+
+    const project = sidebar.querySelector('[data-session-catalog-project="/work/openclaw"]');
+    const active = sidebar.querySelector('[data-session-key*="active-thread"]');
+    const idle = sidebar.querySelector('[data-session-key*="idle-thread"]');
+    expect(project).not.toBeNull();
+    expect(active?.querySelector(".sidebar-session-indicator .session-run-spinner")).not.toBeNull();
+    expect(active?.querySelector(".session-run-spinner")?.getAttribute("aria-label")).toBe(
+      "Active run",
+    );
+    expect(
+      idle?.querySelector(".sidebar-session-indicator .sidebar-session-indicator__dot"),
+    ).not.toBeNull();
+  });
+
   it("shows a catalog-owned OpenClaw session only in its catalog section", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const backingSessionKey = "agent:main:claude-bound";

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-project-activity.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-project-activity.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createGateway, createSessions, mountSidebar } from "../app-sidebar.ts";
+import "../../components/app-sidebar.ts";
+
+describe("AppSidebar project session activity", () => {
+  it("shows thread-style activity indicators", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    sidebar.sessionCatalogs = [
+      {
+        id: "codex",
+        label: "Codex",
+        capabilities: { continueSession: true, archive: true },
+        hosts: [
+          {
+            hostId: "gateway:local",
+            label: "Local Codex",
+            kind: "gateway",
+            connected: true,
+            sessions: [
+              {
+                threadId: "active-thread",
+                name: "Active session",
+                cwd: "/work/openclaw",
+                status: "active",
+                archived: false,
+                canContinue: false,
+                canArchive: false,
+              },
+              {
+                threadId: "idle-thread",
+                name: "Idle session",
+                cwd: "/work/openclaw",
+                status: "idle",
+                archived: false,
+                canContinue: true,
+                canArchive: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    await sidebar.updateComplete;
+
+    const project = sidebar.querySelector('[data-session-catalog-project="/work/openclaw"]');
+    const active = sidebar.querySelector('[data-session-key*="active-thread"]');
+    const idle = sidebar.querySelector('[data-session-key*="idle-thread"]');
+    expect(project).not.toBeNull();
+    expect(active?.querySelector(".sidebar-session-indicator .session-run-spinner")).not.toBeNull();
+    expect(active?.querySelector(".session-run-spinner")?.getAttribute("aria-label")).toBe(
+      "Active run",
+    );
+    expect(
+      idle?.querySelector(".sidebar-session-indicator .sidebar-session-indicator__dot"),
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where project headings and their child sessions used the same small type, making the sidebar hierarchy hard to scan. Catalog-owned sessions also lacked the activity indicator used by regular session rows, so users could not tell which project sessions were running.

## Why This Change Was Made

Project headings now retain the standard 13px label while only grouped child sessions use the compact 10px style. Unadopted catalog sessions use the shared spinner presentation for `active` or `running` states and a muted alignment dot when idle.

The change is AI-assisted. The implementation, focused regression, build budget, and final diff were reviewed before publishing.

## User Impact

Users can distinguish project headings from child sessions at a glance and see active project sessions using the same spinner language as regular threads.

## Evidence

- Live Rosita build `55c036c1512`: visually confirmed 13px project headings, 10px child sessions, active/running spinners, and muted idle dots.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 161 tests passed.
- `oxfmt --check` and `git diff --check` passed for the touched files.
- Testbox `tbx_01ky6p4ehrg7tzzjd91paqak0p`: all TypeScript projects passed; its first lint pass caught the new case exceeding a grandfathered test-file limit, so the regression was moved to a focused 59-line test module.
- Autoreview (`gpt-5.6-sol`, high reasoning): clean, no accepted/actionable findings.
