### PR TITLE
fix: re-adopt healthy cloud workers after Gateway restart

### DIFF
--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -17,6 +17,7 @@ import {
   createWorkerPlacementDispatchService,
   type WorkerPlacementDispatchService,
 } from "./worker-environments/placement-dispatch.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "./worker-environments/placement-force-abandon.js";
 import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import { createReclaimedPlacementRedispatch } from "./worker-environments/reclaimed-placement-redispatch.js";
 import type { WorkerEnvironmentService } from "./worker-environments/service.js";
@@ -474,6 +475,13 @@ export function createGatewayWorkerPlacementRuntime(params: GatewayWorkerPlaceme
     workspaceOperations,
   });
   const recoverPendingWorkspaceReconciliations = async (): Promise<void> => {
+    const orphanedJournals = params.placements.pruneOrphanedWorkspaceReconciliations({
+      retainFailedOwner: (recoveryError) =>
+        recoveryError.startsWith(FORCED_WORKER_ABANDONMENT_ERROR),
+    });
+    for (const owner of orphanedJournals) {
+      workerPlacementLog.warn(`discarded orphaned cloud workspace journal for ${owner.sessionId}`);
+    }
     for (const owner of params.placements.listWorkspaceReconciliationOwners()) {
       try {
         const placement = params.placements.get(owner.sessionId);

--- a/src/gateway/worker-environments/bundle-staging.ts
+++ b/src/gateway/worker-environments/bundle-staging.ts
@@ -9,6 +9,7 @@ import { collectPackageDistInventory } from "../../infra/package-dist-inventory.
 // workspace packages; bootstrap installs production dependencies on the box with
 // scripts disabled, mirroring the npm channel.
 const WORKER_PACKAGE_LIFECYCLE_FIELDS = ["devDependencies", "scripts", "pnpm"] as const;
+const CONTROL_UI_DIST_PREFIX = "dist/control-ui/";
 
 export type WorkerBundleManifestEntry = {
   path: string;
@@ -272,7 +273,11 @@ export async function collectWorkerBundleManifest(
   stagingRoot: string,
 ): Promise<WorkerBundleManifestEntry[]> {
   const sourceRootRealPath = await fs.realpath(sourceRoot);
-  const distFiles = await collectPackageDistInventory(sourceRoot);
+  // Control UI assets are built lazily after the Gateway starts and never execute on workers.
+  // Excluding them keeps worker identity stable across that startup race.
+  const distFiles = (await collectPackageDistInventory(sourceRoot)).filter(
+    (relativePath) => !relativePath.startsWith(CONTROL_UI_DIST_PREFIX),
+  );
   if (distFiles.length === 0) {
     throw new Error(
       `OpenClaw worker bundle has no packaged dist files; build the running package at ${sourceRoot}`,

--- a/src/gateway/worker-environments/bundle.test.ts
+++ b/src/gateway/worker-environments/bundle.test.ts
@@ -93,6 +93,30 @@ describe("worker bundle producer", () => {
     });
   });
 
+  it("keeps lazy Control UI assets out of worker identity", async () => {
+    await withTempDir({ prefix: "openclaw-worker-bundle-control-ui-" }, async (root) => {
+      const packageRoot = path.join(root, "package");
+      const cacheDir = path.join(root, "cache");
+      await writeFixture(packageRoot, [["dist/entry.js", "export const entry = true;\n"]]);
+      const beforeUiBuild = await createWorkerBundleProducer({ packageRoot, cacheDir }).prepare();
+
+      await fs.mkdir(path.join(packageRoot, "dist/control-ui/assets"), { recursive: true });
+      await fs.writeFile(path.join(packageRoot, "dist/control-ui/index.html"), "<main>UI</main>\n");
+      await fs.writeFile(
+        path.join(packageRoot, "dist/control-ui/assets/app.js"),
+        "console.log('ui');\n",
+      );
+      const afterUiBuild = await createWorkerBundleProducer({ packageRoot, cacheDir }).prepare();
+
+      expect(afterUiBuild.bundleHash).toBe(beforeUiBuild.bundleHash);
+      await expect(listTarball(afterUiBuild.tarballPath)).resolves.toEqual([
+        "dist/entry.js",
+        "openclaw.mjs",
+        "package.json",
+      ]);
+    });
+  });
+
   it("prunes workspace deps and lifecycle fields from dev manifests", async () => {
     await withTempDir({ prefix: "openclaw-worker-bundle-prune-" }, async (root) => {
       const packageRoot = path.join(root, "package");

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -234,6 +234,45 @@ describe("worker placement dispatch reclaim", () => {
     expect(harness.environments.destroy).toHaveBeenCalledOnce();
   });
 
+  it("returns success when a dropped tunnel loses the race to durable teardown", async () => {
+    const harness = createHarness(placementStore, { terminalizeReclaimOnTunnelDrop: true });
+    await harness.service.dispatch(REQUEST);
+
+    const request = {
+      sessionId: REQUEST.sessionId,
+      sessionKey: REQUEST.sessionKey,
+      agentId: REQUEST.agentId,
+    };
+    const first = harness.service.reclaim(request);
+    const coalesced = harness.service.reclaim(request);
+
+    await expect(Promise.all([first, coalesced])).resolves.toMatchObject([
+      { state: "reclaimed", turnClaim: null },
+      { state: "reclaimed", turnClaim: null },
+    ]);
+
+    expect(harness.placements.current()).toMatchObject({ state: "reclaimed", turnClaim: null });
+    expect(harness.environments.get(REQUEST.sessionId)).toMatchObject({ state: "destroyed" });
+    expect(harness.log).toContain("teardown:destroy");
+  });
+
+  it("does not hide an unrelated failure after durable teardown", async () => {
+    const harness = createHarness(placementStore, {
+      terminalizeReclaimOnTunnelDrop: true,
+      terminalizedReclaimError: new Error("credential rejected"),
+    });
+    await harness.service.dispatch(REQUEST);
+
+    await expect(
+      harness.service.reclaim({
+        sessionId: REQUEST.sessionId,
+        sessionKey: REQUEST.sessionKey,
+        agentId: REQUEST.agentId,
+      }),
+    ).rejects.toThrow("credential rejected");
+    expect(harness.placements.current()).toMatchObject({ state: "reclaimed", turnClaim: null });
+  });
+
   it("releases a failed final-sync claim so reclaim with a retained conflict is retryable", async () => {
     const priorConflict = {
       paths: ["data.txt"],

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -15,6 +15,7 @@ import {
   seedStartingPlacement,
 } from "./placement-dispatch-test-fixtures.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
+import { WorkerTunnelOwnerDisconnectedError } from "./tunnel-contract.js";
 import type { WorkerTunnelHandle } from "./tunnel.js";
 import {
   createWorkerWorkspaceOperationCoordinator,
@@ -43,6 +44,8 @@ export function createHarness(
     reconcileConflictPaths?: string[];
     workspaceOperations?: WorkerWorkspaceOperationCoordinator;
     destroyFailureState?: "draining" | "destroying";
+    terminalizeReclaimOnTunnelDrop?: boolean;
+    terminalizedReclaimError?: Error;
   } = {},
 ) {
   const reconciledManifestRef = MANIFEST_REF.replaceAll("b", "c");
@@ -185,6 +188,29 @@ export function createHarness(
       }
       if (options.reconcileCommitsManifest !== false) {
         request.journal.commit(reconciledManifestRef);
+      }
+      if (options.terminalizeReclaimOnTunnelDrop) {
+        const owned = placementStore.get(REQUEST.sessionId);
+        const persistedClaim = owned?.turnClaim;
+        if (owned?.state !== "active" || persistedClaim?.owner !== "worker") {
+          throw new Error("tunnel-drop fixture lost its active worker claim");
+        }
+        const claim = {
+          sessionId: owned.sessionId,
+          claimId: persistedClaim.claimId,
+          runId: persistedClaim.runId,
+          placementGeneration: persistedClaim.generation,
+          owner: {
+            kind: "worker" as const,
+            environmentId: owned.environmentId,
+            ownerEpoch: persistedClaim.ownerEpoch,
+          },
+        };
+        placementStore.acceptWorkspaceResult(claim);
+        currentEnvironment = destroyedEnvironment(currentEnvironment?.ownerEpoch ?? 1);
+        log.push("teardown:destroy");
+        placementStore.completeWorkspaceResultAndReleaseTurn(claim, { reclaim: true });
+        throw options.terminalizedReclaimError ?? new WorkerTunnelOwnerDisconnectedError();
       }
       if (options.reconcileConflictPaths?.length && request.stagedResult) {
         request.stagedResult.record(request.stagedResult.ref);

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -15,6 +15,7 @@ import type {
   WorkerPlacementReclaimRequest,
 } from "./service-contract.js";
 import { type WorkerEnvironmentService, workerEnvironmentIdForIdempotencyKey } from "./service.js";
+import { WorkerTunnelOwnerDisconnectedError } from "./tunnel-contract.js";
 import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
 import {
   verifyReconciledWorkspaceFinal,
@@ -445,7 +446,15 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
     if (inFlight) {
       return await inFlight;
     }
-    const operation = reclaimOnce(request);
+    const operation = reclaimOnce(request).catch((error: unknown) => {
+      // Another teardown path can win after this call has crossed its durable completion fence.
+      // Report the committed terminal state instead of leaking a stale tunnel error to callers.
+      const completed = placements.get(request.sessionId);
+      if (error instanceof WorkerTunnelOwnerDisconnectedError && completed?.state === "reclaimed") {
+        return completed;
+      }
+      throw error;
+    });
     reclaimInFlight.set(request.sessionId, operation);
     try {
       return await operation;

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -7,6 +7,9 @@ import {
   workerWorkspaceResultRef,
 } from "./workspace-result-staging.js";
 
+export const FORCED_WORKER_ABANDONMENT_ERROR =
+  "Cloud worker result abandoned by forced operator teardown";
+
 async function tryResolveWorkspacePath(
   resolveWorkspacePath: (placement: {
     sessionId: string;
@@ -48,7 +51,7 @@ export async function forceAbandonWorkerEnvironment(params: {
   onCleanupError?: (error: unknown) => void;
 }): Promise<void> {
   const { environmentId, placements } = params;
-  const recoveryError = "Cloud worker result abandoned by forced operator teardown";
+  const recoveryError = FORCED_WORKER_ABANDONMENT_ERROR;
   const journalOwners = params.placements
     .listWorkspaceReconciliationOwners()
     .filter((owner) => owner.environmentId === environmentId);

--- a/src/gateway/worker-environments/placement-workspace-journal.test.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.test.ts
@@ -1,0 +1,115 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-force-abandon.js";
+import {
+  createWorkerSessionPlacementStore,
+  type WorkerSessionPlacementStore,
+} from "./placement-store.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("worker placement workspace journal", () => {
+  let root: string;
+  let database: OpenClawStateDatabase;
+  let store: WorkerSessionPlacementStore;
+
+  beforeEach(() => {
+    root = tempDirs.make("openclaw-journal-");
+    database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+    store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+  });
+
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  const prune = () =>
+    store.pruneOrphanedWorkspaceReconciliations({
+      retainFailedOwner: (recoveryError) =>
+        recoveryError.startsWith(FORCED_WORKER_ABANDONMENT_ERROR),
+    });
+
+  const seedJournal = () => {
+    const active = seedActivePlacement(store, { environmentId: "worker-1", ownerEpoch: 7 });
+    if (active.state !== "active") {
+      throw new Error("expected active placement");
+    }
+    const owner = {
+      sessionId: active.sessionId,
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      placementGeneration: active.generation,
+    };
+    const basePack = Buffer.from("orphaned workspace base pack");
+    store.beginWorkspaceReconciliation(owner, {
+      version: 1,
+      temporaryNonce: "c".repeat(32),
+      baseManifestRef: active.workspaceBaseManifestRef,
+      currentManifestRef: `sha256:${"d".repeat(64)}`,
+      baseEntries: [],
+      appliedEntries: [],
+      baseTree: "e".repeat(40),
+      basePackSha256: createHash("sha256").update(basePack).digest("hex"),
+      basePack,
+    });
+    return { active, owner };
+  };
+
+  it("prunes a workspace journal only after its exact owner is gone", () => {
+    const { active, owner } = seedJournal();
+
+    expect(prune()).toEqual([]);
+    const draining = store.startDrain({
+      sessionId: REQUEST.sessionId,
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      expectedGeneration: active.generation,
+    });
+    if (draining.state !== "draining") {
+      throw new Error("expected draining placement");
+    }
+    store.startReconcile({
+      sessionId: draining.sessionId,
+      environmentId: draining.environmentId,
+      ownerEpoch: draining.activeOwnerEpoch,
+      expectedGeneration: draining.generation,
+    });
+
+    expect(prune()).toEqual([owner]);
+    expect(store.listWorkspaceReconciliationOwners()).toEqual([]);
+  });
+
+  it("retains a failed owner whose forced rollback is retryable", () => {
+    const { active, owner } = seedJournal();
+    const draining = store.startDrain({
+      sessionId: active.sessionId,
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      expectedGeneration: active.generation,
+    });
+    if (draining.state !== "draining") {
+      throw new Error("expected draining placement");
+    }
+    const reconciling = store.startReconcile({
+      sessionId: draining.sessionId,
+      environmentId: draining.environmentId,
+      ownerEpoch: draining.activeOwnerEpoch,
+      expectedGeneration: draining.generation,
+    });
+    store.fail({
+      sessionId: reconciling.sessionId,
+      expectedGeneration: reconciling.generation,
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+
+    expect(prune()).toEqual([]);
+    expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
+  });
+});

--- a/src/gateway/worker-environments/placement-workspace-journal.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.ts
@@ -2,7 +2,8 @@ import { createHash } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
-import { getRequired } from "./placement-row-codec.js";
+import type { WorkerSessionPlacementRecord } from "./placement-record.js";
+import { find, getRequired } from "./placement-row-codec.js";
 import type { PlacementStoreRuntime } from "./placement-runtime.js";
 import {
   parseWorkerWorkspaceReconciliationPlan,
@@ -24,26 +25,36 @@ type WorkerWorkspaceJournalOwner = {
   placementGeneration: number;
 };
 
+function isCurrentJournalOwner(
+  placement: WorkerSessionPlacementRecord | undefined,
+  owner: WorkerWorkspaceJournalOwner,
+): boolean {
+  // Only the original active/draining generation may apply these rollback bytes.
+  // Drain/reconcile advances generation, making the prior journal permanently stale.
+  return (
+    (placement?.state === "active" || placement?.state === "draining") &&
+    placement.environmentId === owner.environmentId &&
+    placement.activeOwnerEpoch === owner.ownerEpoch &&
+    placement.generation === owner.placementGeneration
+  );
+}
+
 function assertJournalOwner(
   db: DatabaseSync,
   owner: WorkerWorkspaceJournalOwner,
   options: { allowFailedOwner?: boolean } = {},
 ) {
   const placement = getRequired(db, owner.sessionId);
-  const isCurrentOwner =
-    (placement.state === "active" || placement.state === "draining") &&
-    placement.generation === owner.placementGeneration;
+  const isCurrentOwner = isCurrentJournalOwner(placement, owner);
   // Forced teardown advances the exact owner to failed before best-effort
   // rollback. Admit that state without weakening the manifest checks below.
   const isAllowedFailedOwner =
     options.allowFailedOwner === true &&
     placement.state === "failed" &&
-    placement.generation > owner.placementGeneration;
-  if (
-    (!isCurrentOwner && !isAllowedFailedOwner) ||
-    placement.environmentId !== owner.environmentId ||
-    placement.activeOwnerEpoch !== owner.ownerEpoch
-  ) {
+    placement.generation > owner.placementGeneration &&
+    placement.environmentId === owner.environmentId &&
+    placement.activeOwnerEpoch === owner.ownerEpoch;
+  if (!isCurrentOwner && !isAllowedFailedOwner) {
     throw new Error(`Cannot reconcile stale worker workspace for session ${owner.sessionId}`);
   }
   return placement;
@@ -87,6 +98,54 @@ export function createPlacementWorkspaceJournalOps(runtime: PlacementStoreRuntim
         ownerEpoch: row.owner_epoch,
         placementGeneration: row.placement_generation,
       }));
+    },
+
+    pruneOrphanedWorkspaceReconciliations(options: {
+      retainFailedOwner: (recoveryError: string) => boolean;
+    }): WorkerWorkspaceJournalOwner[] {
+      return write((db) => {
+        const rows = executeSqliteQuerySync(
+          db,
+          query(db)
+            .selectFrom("worker_workspace_reconciliations")
+            .select(["session_id", "environment_id", "owner_epoch", "placement_generation"])
+            .orderBy("session_id"),
+        ).rows;
+        const pruned: WorkerWorkspaceJournalOwner[] = [];
+        for (const row of rows) {
+          const owner = {
+            sessionId: row.session_id,
+            environmentId: row.environment_id,
+            ownerEpoch: row.owner_epoch,
+            placementGeneration: row.placement_generation,
+          };
+          const placement = find(db, owner.sessionId);
+          const stillOwned = isCurrentJournalOwner(placement, owner);
+          const retainedFailedOwner =
+            placement?.state === "failed" &&
+            placement.environmentId === owner.environmentId &&
+            placement.activeOwnerEpoch === owner.ownerEpoch &&
+            placement.generation > owner.placementGeneration &&
+            options.retainFailedOwner(placement.recoveryError);
+          if (stillOwned || retainedFailedOwner) {
+            continue;
+          }
+          // Generation and owner epoch only advance, so a mismatched exact owner cannot rebind.
+          const deleted = executeSqliteQuerySync(
+            db,
+            query(db)
+              .deleteFrom("worker_workspace_reconciliations")
+              .where("session_id", "=", owner.sessionId)
+              .where("environment_id", "=", owner.environmentId)
+              .where("owner_epoch", "=", owner.ownerEpoch)
+              .where("placement_generation", "=", owner.placementGeneration),
+          );
+          if (deleted.numAffectedRows === 1n) {
+            pruned.push(owner);
+          }
+        }
+        return pruned;
+      });
     },
 
     loadWorkspaceReconciliation(

--- a/src/gateway/worker-environments/service.test.ts
+++ b/src/gateway/worker-environments/service.test.ts
@@ -1730,11 +1730,15 @@ describe("worker environment service", () => {
     await createService(createProvider({ destroy })).reconcileOnce();
 
     expect(destroy).toHaveBeenCalledOnce();
+    expect(destroy).toHaveBeenCalledWith({
+      leaseId: `lease:${environmentId}`,
+      profile: { region: "test" },
+    });
     expect(store.get(environmentId)).toMatchObject({
-      state: "failed",
-      leaseId: null,
+      state: "destroyed",
+      leaseId: `lease:${environmentId}`,
       attachedSessionIds: [],
-      lastError: "Attached worker build no longer matches the Gateway",
+      lastError: null,
     });
   });
 

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -92,7 +92,6 @@ class WorkerEnvironmentServiceError extends Error {
 const serviceError = (code: WorkerEnvironmentServiceErrorCode, message: string) =>
   new WorkerEnvironmentServiceError(code, message);
 const ORPHANED_LEASE_ERROR = "Worker provider no longer recognizes the lease";
-const STALE_ATTACHED_BUNDLE_ERROR = "Attached worker build no longer matches the Gateway";
 
 function workerEnvironmentIdempotencyDigest(idempotencyKey: string): string {
   return createHash("sha256").update(idempotencyKey).digest("hex");
@@ -793,14 +792,10 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
         (!record.bootstrapReceipt ||
           !verifyWorkerAdmissionHandshake(record.bootstrapReceipt, currentBundle))
       ) {
-        // A new Gateway build rejects the old worker at admission. Tear it down now so placement
-        // reconciliation can fail-stop cleanly instead of reporting active until the next turn.
-        await failBootstrap(
-          record,
-          leaseId,
-          provider,
-          new Error(STALE_ATTACHED_BUNDLE_ERROR),
-        ).catch(() => undefined);
+        // A new Gateway build rejects the old worker at admission. This is expected lifecycle
+        // teardown, not a bootstrap failure. `leaseId` above came from this record, so provider
+        // inspection and destruction share the same durable lease identity.
+        await finishDestroy(record, provider).catch(() => undefined);
       }
       return;
     }

--- a/src/gateway/worker-environments/tunnel-contract.ts
+++ b/src/gateway/worker-environments/tunnel-contract.ts
@@ -6,6 +6,13 @@ import type {
 
 export type WorkerTunnelStatus = "stopped" | "connecting" | "connected" | "reconnecting";
 
+export class WorkerTunnelOwnerDisconnectedError extends Error {
+  constructor() {
+    super("Worker tunnel owner is no longer connected");
+    this.name = "WorkerTunnelOwnerDisconnectedError";
+  }
+}
+
 export type WorkerTunnelRequest = {
   environmentId: string;
   ownerEpoch: number;

--- a/src/gateway/worker-environments/workspace-sync.ts
+++ b/src/gateway/worker-environments/workspace-sync.ts
@@ -3,13 +3,14 @@ import os from "node:os";
 import path from "node:path";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
 import { type PreparedWorkerSsh, workerSshCommandOptions } from "./ssh.js";
-import type {
-  WorkerTunnelHandle,
-  WorkerWorkspaceCommand,
-  WorkerWorkspaceReconcileRequest,
-  WorkerWorkspaceReconcileResult,
-  WorkerWorkspaceSyncRequest,
-  WorkerWorkspaceSyncResult,
+import {
+  WorkerTunnelOwnerDisconnectedError,
+  type WorkerTunnelHandle,
+  type WorkerWorkspaceCommand,
+  type WorkerWorkspaceReconcileRequest,
+  type WorkerWorkspaceReconcileResult,
+  type WorkerWorkspaceSyncRequest,
+  type WorkerWorkspaceSyncResult,
 } from "./tunnel-contract.js";
 import {
   createAcceptedWorkspacePublisherFactory,
@@ -91,7 +92,7 @@ export function createWorkerWorkspaceActions(
   const requirePrepared = (): PreparedWorkerSsh => {
     const prepared = options.getPrepared();
     if (!options.isConnected() || !prepared) {
-      throw new Error("Worker tunnel owner is no longer connected");
+      throw new WorkerTunnelOwnerDisconnectedError();
     }
     return prepared;
   };


### PR DESCRIPTION
Closes #112869
Closes #112870

AI-assisted: implemented and reviewed with Codex. The maintainer understands and approved the change.

## What Problem This Solves

Fixes an issue where restarting the Gateway discarded healthy attached cloud workers, released their leases, and forced sessions to pay the full dispatch delay again. It also resolves orphaned workspace recovery journals that logged forever, and makes a reclaim whose tunnel disappears after durable teardown report the committed success instead of a stale error.

## Why This Change Was Made

Worker bundle identity now excludes lazily built Control UI assets, which never execute on workers but previously changed the bundle hash between otherwise identical Gateway starts. Exact worker runtime bytes remain admission-fenced; incompatible workers are cleanly destroyed and reclaimed rather than recorded as bootstrap failures.

Startup journal GC now deletes only rows whose exact monotonic placement owner can no longer apply them, while retaining the named forced-teardown rollback contract. Reclaim uses a typed tunnel-owner disconnect error and normalizes the shared in-flight promise only after the placement has durably reached `reclaimed`, so coalesced callers agree and unrelated errors remain failures.

## User Impact

Gateway restarts no longer discard healthy cloud workers because of lazy Control UI build timing; dead recovery journals are collected once, and completed reclaim operations no longer surface a stale tunnel error.

## Evidence

- Live before-fix reproduction with one real AWS cloud worker: an exact-head restart changed the worker bundle from `203696a…` to `392f4a…`, moved the placement from `active` to `reclaimed`, and released the lease. Extracting the two bundles showed the only changed subtree was `dist/control-ui/**`.
- Live patched Gateway: startup emitted one `discarded orphaned cloud workspace journal` event for `a7a66d3d-8826-4382-bea9-c2a23eb9977f`; the row count became zero and Gateway health returned `ok: true`.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/`: 102 files passed, 1,263 tests passed.
- `node scripts/check-changed.mjs -- <13 touched files>`: Blacksmith Testbox `tbx_01ky6p9k690fqvszz3pe5vza25`, [Actions run 29981588569](https://github.com/openclaw/openclaw/actions/runs/29981588569), exit 0 (19m18s command time).
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.
- Cleanup verified: dev Gateway stopped, port 19001 closed, and zero AWS Crabbox leases remained.
