### PR TITLE
feat(ui): mirror active destination and connection state in the dashboard title

### DIFF
--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   SETTINGS_NAVIGATION_GROUPS,
   SIDEBAR_NAV_ROUTES,
+  formatDocumentTitle,
   isPluginsHubRoute,
   navigationIconForRoute,
   settingsSearchTextMatches,
@@ -138,6 +139,45 @@ describe("settingsSearchTextMatches", () => {
     expect(settingsSearchTextMatches("CPU usage", "cp")).toBe(true);
     expect(settingsSearchTextMatches("MCP", "cp")).toBe(false);
     expect(settingsSearchTextMatches("外観設定", "設定")).toBe(true);
+  });
+});
+
+describe("formatDocumentTitle", () => {
+  it("suffixes the brand after a plain context", () => {
+    expect(formatDocumentTitle({ context: "Usage" })).toBe("Usage — OpenClaw");
+  });
+
+  it("does not duplicate a context ending in the brand", () => {
+    expect(formatDocumentTitle({ context: "Ask OpenClaw" })).toBe("Ask OpenClaw");
+    expect(formatDocumentTitle({ context: "OpenClaw" })).toBe("OpenClaw");
+  });
+
+  it("prefixes a positive attention count", () => {
+    expect(formatDocumentTitle({ context: "Usage", attentionCount: 2 })).toBe(
+      "(2) Usage — OpenClaw",
+    );
+  });
+
+  it("does not add a queued count for an empty offline outbox", () => {
+    expect(formatDocumentTitle({ context: "Usage", offline: true, queuedCount: 0 })).toBe(
+      "(Offline) Usage — OpenClaw",
+    );
+  });
+
+  it("includes the queued outbox count in the offline marker", () => {
+    expect(formatDocumentTitle({ context: "Usage", offline: true, queuedCount: 3 })).toBe(
+      "(Offline · 3 queued) Usage — OpenClaw",
+    );
+  });
+
+  it("ignores a queued count while online", () => {
+    expect(formatDocumentTitle({ context: "Usage", queuedCount: 3 })).toBe("Usage — OpenClaw");
+  });
+
+  it("suppresses the attention count while offline", () => {
+    expect(formatDocumentTitle({ context: "Usage", attentionCount: 2, offline: true })).toBe(
+      "(Offline) Usage — OpenClaw",
+    );
   });
 });
 

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -359,6 +359,32 @@ export function titleForRoute(routeId: NavigationRouteId): string {
   return t(NAVIGATION_COPY[routeId].titleKey);
 }
 
+/** Window/tab title, markers leftmost because tabs truncate from the right.
+ * Offline replaces the approval count (a stale queue is not actionable) and
+ * carries the pending-outbox total; titles already ending in the brand
+ * ("Ask OpenClaw") skip the suffix so it never reads "… OpenClaw — OpenClaw". */
+export function formatDocumentTitle(options: {
+  context: string;
+  attentionCount?: number;
+  offline?: boolean;
+  queuedCount?: number;
+}): string {
+  const base = options.context.endsWith("OpenClaw")
+    ? options.context
+    : `${options.context} — OpenClaw`;
+  if (options.offline) {
+    const queued =
+      options.queuedCount && options.queuedCount > 0
+        ? ` · ${t("connection.queuedCount", { count: String(options.queuedCount) })}`
+        : "";
+    return `(${t("common.offline")}${queued}) ${base}`;
+  }
+  if (options.attentionCount && options.attentionCount > 0) {
+    return `(${options.attentionCount}) ${base}`;
+  }
+  return base;
+}
+
 /**
  * Sidebar item label inside the settings takeover. The config route is titled
  * "Settings" globally (gear tooltip, palette) but reads "General" next to its

--- a/ui/src/app/app-host.document-title.test.ts
+++ b/ui/src/app/app-host.document-title.test.ts
@@ -1,0 +1,174 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import type { AgentsListResult, GatewayAgentRow, GatewaySessionRow } from "../api/types.ts";
+import type { RouteId } from "../app-routes.ts";
+import "./app-host.ts";
+import type { ApplicationContext } from "./context.ts";
+
+type ShellDocumentTitleState = {
+  activeSessionKey: string;
+  outboxStoreRuntime: {
+    summarizeStoredChatOutboxes: () => { total: number };
+  } | null;
+  routeState: { routeId?: RouteId };
+  runtime?: { context: ApplicationContext };
+  syncDocumentTitle: () => void;
+};
+
+function roster(defaultId: string, agents: GatewayAgentRow[]): AgentsListResult {
+  return { defaultId, mainKey: "main", scope: "per-sender", agents };
+}
+
+describe("OpenClaw shell document title", () => {
+  function createShell(context?: ApplicationContext): ShellDocumentTitleState {
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellDocumentTitleState;
+    if (context) {
+      shell.runtime = { context };
+    }
+    return shell;
+  }
+
+  function createContext(options: {
+    connected?: boolean;
+    approvalCount?: number;
+    agentsList?: AgentsListResult | null;
+    assistantAgentId?: string;
+    sessions?: GatewaySessionRow[] | null;
+  }): ApplicationContext {
+    return {
+      gateway: {
+        snapshot: {
+          connected: options.connected ?? true,
+          assistantAgentId: options.assistantAgentId ?? null,
+        },
+        connection: { gatewayUrl: "ws://gateway.test" },
+      },
+      agents: { state: { agentsList: options.agentsList ?? null } },
+      overlays: {
+        snapshot: { approvalQueue: Array.from({ length: options.approvalCount ?? 0 }) },
+      },
+      sessions: {
+        state: { result: options.sessions ? { sessions: options.sessions } : null },
+      },
+    } as unknown as ApplicationContext;
+  }
+
+  it("keeps the boot title before a route commits", () => {
+    const shell = createShell();
+    document.title = "OpenClaw Control";
+
+    shell.routeState = {};
+    shell.syncDocumentTitle();
+    expect(document.title).toBe("OpenClaw Control");
+  });
+
+  it("uses the route title for a connected route", () => {
+    const shell = createShell(createContext({ sessions: null }));
+    shell.routeState = { routeId: "usage" };
+    shell.syncDocumentTitle();
+    expect(document.title).toBe("Usage — OpenClaw");
+  });
+
+  it("uses the active session's derived title for a non-main chat", () => {
+    const session: GatewaySessionRow = {
+      key: "agent:main:dashboard:quarterly-launch",
+      kind: "direct",
+      updatedAt: 1,
+      derivedTitle: "Quarterly launch plan",
+    };
+    const shell = createShell(createContext({ sessions: [session] }));
+    shell.routeState = { routeId: "chat" };
+    shell.activeSessionKey = session.key;
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Quarterly launch plan — OpenClaw");
+  });
+
+  it("uses the agent name for an agent main chat", () => {
+    const shell = createShell(
+      createContext({ agentsList: roster("main", [{ id: "main", name: "Molty" }]) }),
+    );
+    shell.routeState = { routeId: "chat" };
+    shell.activeSessionKey = "agent:main:main";
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Molty — OpenClaw");
+  });
+
+  it("uses the selected agent name for a global-scope main chat", () => {
+    const shell = createShell(
+      createContext({
+        assistantAgentId: "molty",
+        agentsList: roster("main", [{ id: "molty", name: "Molty" }]),
+      }),
+    );
+    shell.routeState = { routeId: "chat" };
+    shell.activeSessionKey = "global";
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Molty — OpenClaw");
+  });
+
+  it("falls back to the session display name when the main agent is missing", () => {
+    const session: GatewaySessionRow = {
+      key: "agent:missing:main",
+      kind: "direct",
+      updatedAt: 1,
+      label: "Fallback thread",
+    };
+    const shell = createShell(
+      createContext({ sessions: [session], agentsList: roster("main", []) }),
+    );
+    shell.routeState = { routeId: "chat" };
+    shell.activeSessionKey = session.key;
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Fallback thread — OpenClaw");
+  });
+
+  it("prefixes the pending approval count", () => {
+    const shell = createShell(createContext({ approvalCount: 2 }));
+    shell.routeState = { routeId: "usage" };
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("(2) Usage — OpenClaw");
+  });
+
+  it("shows offline instead of a stale approval count", () => {
+    const shell = createShell(createContext({ connected: false, approvalCount: 2 }));
+    shell.routeState = { routeId: "usage" };
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("(Offline) Usage — OpenClaw");
+  });
+
+  it("includes stored chat outbox messages in the offline marker", () => {
+    const shell = createShell(createContext({ connected: false }));
+    shell.routeState = { routeId: "usage" };
+    shell.outboxStoreRuntime = {
+      summarizeStoredChatOutboxes: () => ({ total: 3 }),
+    };
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("(Offline · 3 queued) Usage — OpenClaw");
+  });
+
+  it("uses the meaningful custodian label without a brand suffix", () => {
+    const shell = createShell(createContext({}));
+    shell.routeState = { routeId: "custodian" };
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Ask OpenClaw");
+  });
+});

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -3,7 +3,8 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import type { AgentsListResult, GatewayAgentRow } from "../api/types.ts";
+import type { AgentsListResult, GatewayAgentRow, GatewaySessionRow } from "../api/types.ts";
+import type { RouteId } from "../app-routes.ts";
 import {
   COMMAND_PALETTE_OPEN_EVENT,
   SHELL_NAV_DRAWER_TOGGLE_EVENT,
@@ -44,6 +45,16 @@ type ShellInitializationState = {
     snapshot: { client: GatewayBrowserClient | null; connected: boolean },
     runtimeConfig: ApplicationContext["runtimeConfig"],
   ) => void;
+};
+
+type ShellDocumentTitleState = {
+  activeSessionKey: string;
+  outboxStoreRuntime: {
+    summarizeStoredChatOutboxes: () => { total: number };
+  } | null;
+  routeState: { routeId?: RouteId };
+  runtime?: { context: ApplicationContext };
+  syncDocumentTitle: () => void;
 };
 
 type ShellServerPreferencesState = {
@@ -344,6 +355,109 @@ describe("OpenClaw shell source initialization", () => {
     expect(secondAgents.ensureList).toHaveBeenCalledOnce();
     expect(firstRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
     expect(secondRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
+  });
+});
+
+describe("OpenClaw shell document title", () => {
+  function createShell(context?: ApplicationContext): ShellDocumentTitleState {
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellDocumentTitleState;
+    if (context) {
+      shell.runtime = { context };
+    }
+    return shell;
+  }
+
+  function createContext(options: {
+    connected?: boolean;
+    approvalCount?: number;
+    sessions?: GatewaySessionRow[] | null;
+  }): ApplicationContext {
+    return {
+      gateway: {
+        snapshot: { connected: options.connected ?? true },
+        connection: { gatewayUrl: "ws://gateway.test" },
+      },
+      agents: { state: { agentsList: null } },
+      overlays: {
+        snapshot: { approvalQueue: Array.from({ length: options.approvalCount ?? 0 }) },
+      },
+      sessions: {
+        state: { result: options.sessions ? { sessions: options.sessions } : null },
+      },
+    } as unknown as ApplicationContext;
+  }
+
+  it("keeps the boot title before a route commits", () => {
+    const shell = createShell();
+    document.title = "OpenClaw Control";
+
+    shell.routeState = {};
+    shell.syncDocumentTitle();
+    expect(document.title).toBe("OpenClaw Control");
+  });
+
+  it("uses the route title for a connected route", () => {
+    const shell = createShell(createContext({ sessions: null }));
+    shell.routeState = { routeId: "usage" };
+    shell.syncDocumentTitle();
+    expect(document.title).toBe("Usage — OpenClaw");
+  });
+
+  it("uses the active session's derived title for chat", () => {
+    const session: GatewaySessionRow = {
+      key: "agent:main:dashboard:quarterly-launch",
+      kind: "direct",
+      updatedAt: 1,
+      derivedTitle: "Quarterly launch plan",
+    };
+    const shell = createShell(createContext({ sessions: [session] }));
+    shell.routeState = { routeId: "chat" };
+    shell.activeSessionKey = session.key;
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Quarterly launch plan — OpenClaw");
+  });
+
+  it("prefixes the pending approval count", () => {
+    const shell = createShell(createContext({ approvalCount: 2 }));
+    shell.routeState = { routeId: "usage" };
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("(2) Usage — OpenClaw");
+  });
+
+  it("shows offline instead of a stale approval count", () => {
+    const shell = createShell(createContext({ connected: false, approvalCount: 2 }));
+    shell.routeState = { routeId: "usage" };
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("(Offline) Usage — OpenClaw");
+  });
+
+  it("includes stored chat outbox messages in the offline marker", () => {
+    const shell = createShell(createContext({ connected: false }));
+    shell.routeState = { routeId: "usage" };
+    shell.outboxStoreRuntime = {
+      summarizeStoredChatOutboxes: () => ({ total: 3 }),
+    };
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("(Offline · 3 queued) Usage — OpenClaw");
+  });
+
+  it("uses the meaningful custodian label without a brand suffix", () => {
+    const shell = createShell(createContext({}));
+    shell.routeState = { routeId: "custodian" };
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Ask OpenClaw");
   });
 });
 

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -3,8 +3,7 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import type { AgentsListResult, GatewayAgentRow, GatewaySessionRow } from "../api/types.ts";
-import type { RouteId } from "../app-routes.ts";
+import type { AgentsListResult, GatewayAgentRow } from "../api/types.ts";
 import {
   COMMAND_PALETTE_OPEN_EVENT,
   SHELL_NAV_DRAWER_TOGGLE_EVENT,
@@ -45,16 +44,6 @@ type ShellInitializationState = {
     snapshot: { client: GatewayBrowserClient | null; connected: boolean },
     runtimeConfig: ApplicationContext["runtimeConfig"],
   ) => void;
-};
-
-type ShellDocumentTitleState = {
-  activeSessionKey: string;
-  outboxStoreRuntime: {
-    summarizeStoredChatOutboxes: () => { total: number };
-  } | null;
-  routeState: { routeId?: RouteId };
-  runtime?: { context: ApplicationContext };
-  syncDocumentTitle: () => void;
 };
 
 type ShellServerPreferencesState = {
@@ -355,159 +344,6 @@ describe("OpenClaw shell source initialization", () => {
     expect(secondAgents.ensureList).toHaveBeenCalledOnce();
     expect(firstRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
     expect(secondRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
-  });
-});
-
-describe("OpenClaw shell document title", () => {
-  function createShell(context?: ApplicationContext): ShellDocumentTitleState {
-    const shell = document.createElement(
-      "openclaw-app-shell",
-    ) as unknown as ShellDocumentTitleState;
-    if (context) {
-      shell.runtime = { context };
-    }
-    return shell;
-  }
-
-  function createContext(options: {
-    connected?: boolean;
-    approvalCount?: number;
-    agentsList?: AgentsListResult | null;
-    assistantAgentId?: string;
-    sessions?: GatewaySessionRow[] | null;
-  }): ApplicationContext {
-    return {
-      gateway: {
-        snapshot: {
-          connected: options.connected ?? true,
-          assistantAgentId: options.assistantAgentId ?? null,
-        },
-        connection: { gatewayUrl: "ws://gateway.test" },
-      },
-      agents: { state: { agentsList: options.agentsList ?? null } },
-      overlays: {
-        snapshot: { approvalQueue: Array.from({ length: options.approvalCount ?? 0 }) },
-      },
-      sessions: {
-        state: { result: options.sessions ? { sessions: options.sessions } : null },
-      },
-    } as unknown as ApplicationContext;
-  }
-
-  it("keeps the boot title before a route commits", () => {
-    const shell = createShell();
-    document.title = "OpenClaw Control";
-
-    shell.routeState = {};
-    shell.syncDocumentTitle();
-    expect(document.title).toBe("OpenClaw Control");
-  });
-
-  it("uses the route title for a connected route", () => {
-    const shell = createShell(createContext({ sessions: null }));
-    shell.routeState = { routeId: "usage" };
-    shell.syncDocumentTitle();
-    expect(document.title).toBe("Usage — OpenClaw");
-  });
-
-  it("uses the active session's derived title for a non-main chat", () => {
-    const session: GatewaySessionRow = {
-      key: "agent:main:dashboard:quarterly-launch",
-      kind: "direct",
-      updatedAt: 1,
-      derivedTitle: "Quarterly launch plan",
-    };
-    const shell = createShell(createContext({ sessions: [session] }));
-    shell.routeState = { routeId: "chat" };
-    shell.activeSessionKey = session.key;
-
-    shell.syncDocumentTitle();
-
-    expect(document.title).toBe("Quarterly launch plan — OpenClaw");
-  });
-
-  it("uses the agent name for an agent main chat", () => {
-    const shell = createShell(
-      createContext({ agentsList: roster("main", [{ id: "main", name: "Molty" }]) }),
-    );
-    shell.routeState = { routeId: "chat" };
-    shell.activeSessionKey = "agent:main:main";
-
-    shell.syncDocumentTitle();
-
-    expect(document.title).toBe("Molty — OpenClaw");
-  });
-
-  it("uses the selected agent name for a global-scope main chat", () => {
-    const shell = createShell(
-      createContext({
-        assistantAgentId: "molty",
-        agentsList: roster("main", [{ id: "molty", name: "Molty" }]),
-      }),
-    );
-    shell.routeState = { routeId: "chat" };
-    shell.activeSessionKey = "global";
-
-    shell.syncDocumentTitle();
-
-    expect(document.title).toBe("Molty — OpenClaw");
-  });
-
-  it("falls back to the session display name when the main agent is missing", () => {
-    const session: GatewaySessionRow = {
-      key: "agent:missing:main",
-      kind: "direct",
-      updatedAt: 1,
-      label: "Fallback thread",
-    };
-    const shell = createShell(
-      createContext({ sessions: [session], agentsList: roster("main", []) }),
-    );
-    shell.routeState = { routeId: "chat" };
-    shell.activeSessionKey = session.key;
-
-    shell.syncDocumentTitle();
-
-    expect(document.title).toBe("Fallback thread — OpenClaw");
-  });
-
-  it("prefixes the pending approval count", () => {
-    const shell = createShell(createContext({ approvalCount: 2 }));
-    shell.routeState = { routeId: "usage" };
-
-    shell.syncDocumentTitle();
-
-    expect(document.title).toBe("(2) Usage — OpenClaw");
-  });
-
-  it("shows offline instead of a stale approval count", () => {
-    const shell = createShell(createContext({ connected: false, approvalCount: 2 }));
-    shell.routeState = { routeId: "usage" };
-
-    shell.syncDocumentTitle();
-
-    expect(document.title).toBe("(Offline) Usage — OpenClaw");
-  });
-
-  it("includes stored chat outbox messages in the offline marker", () => {
-    const shell = createShell(createContext({ connected: false }));
-    shell.routeState = { routeId: "usage" };
-    shell.outboxStoreRuntime = {
-      summarizeStoredChatOutboxes: () => ({ total: 3 }),
-    };
-
-    shell.syncDocumentTitle();
-
-    expect(document.title).toBe("(Offline · 3 queued) Usage — OpenClaw");
-  });
-
-  it("uses the meaningful custodian label without a brand suffix", () => {
-    const shell = createShell(createContext({}));
-    shell.routeState = { routeId: "custodian" };
-
-    shell.syncDocumentTitle();
-
-    expect(document.title).toBe("Ask OpenClaw");
   });
 });
 

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -372,14 +372,19 @@ describe("OpenClaw shell document title", () => {
   function createContext(options: {
     connected?: boolean;
     approvalCount?: number;
+    agentsList?: AgentsListResult | null;
+    assistantAgentId?: string;
     sessions?: GatewaySessionRow[] | null;
   }): ApplicationContext {
     return {
       gateway: {
-        snapshot: { connected: options.connected ?? true },
+        snapshot: {
+          connected: options.connected ?? true,
+          assistantAgentId: options.assistantAgentId ?? null,
+        },
         connection: { gatewayUrl: "ws://gateway.test" },
       },
-      agents: { state: { agentsList: null } },
+      agents: { state: { agentsList: options.agentsList ?? null } },
       overlays: {
         snapshot: { approvalQueue: Array.from({ length: options.approvalCount ?? 0 }) },
       },
@@ -405,7 +410,7 @@ describe("OpenClaw shell document title", () => {
     expect(document.title).toBe("Usage — OpenClaw");
   });
 
-  it("uses the active session's derived title for chat", () => {
+  it("uses the active session's derived title for a non-main chat", () => {
     const session: GatewaySessionRow = {
       key: "agent:main:dashboard:quarterly-launch",
       kind: "direct",
@@ -419,6 +424,51 @@ describe("OpenClaw shell document title", () => {
     shell.syncDocumentTitle();
 
     expect(document.title).toBe("Quarterly launch plan — OpenClaw");
+  });
+
+  it("uses the agent name for an agent main chat", () => {
+    const shell = createShell(
+      createContext({ agentsList: roster("main", [{ id: "main", name: "Molty" }]) }),
+    );
+    shell.routeState = { routeId: "chat" };
+    shell.activeSessionKey = "agent:main:main";
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Molty — OpenClaw");
+  });
+
+  it("uses the selected agent name for a global-scope main chat", () => {
+    const shell = createShell(
+      createContext({
+        assistantAgentId: "molty",
+        agentsList: roster("main", [{ id: "molty", name: "Molty" }]),
+      }),
+    );
+    shell.routeState = { routeId: "chat" };
+    shell.activeSessionKey = "global";
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Molty — OpenClaw");
+  });
+
+  it("falls back to the session display name when the main agent is missing", () => {
+    const session: GatewaySessionRow = {
+      key: "agent:missing:main",
+      kind: "direct",
+      updatedAt: 1,
+      label: "Fallback thread",
+    };
+    const shell = createShell(
+      createContext({ sessions: [session], agentsList: roster("main", []) }),
+    );
+    shell.routeState = { routeId: "chat" };
+    shell.activeSessionKey = session.key;
+
+    shell.syncDocumentTitle();
+
+    expect(document.title).toBe("Fallback thread — OpenClaw");
   });
 
   it("prefixes the pending approval count", () => {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -20,7 +20,11 @@ import "../components/resizable-divider.ts";
 import "../components/sidebar-update-card.ts";
 import "../components/tooltip.ts";
 import "../components/update-banner.ts";
-import { isSettingsNavigationRoute } from "../app-navigation.ts";
+import {
+  formatDocumentTitle,
+  isSettingsNavigationRoute,
+  titleForRoute,
+} from "../app-navigation.ts";
 import { workboardBoardIdFromPath } from "../app-route-paths.ts";
 import { APP_ROUTE_IDS, isRouteId, type RouteId } from "../app-routes.ts";
 import {
@@ -53,6 +57,7 @@ import { copyToClipboard } from "../lib/clipboard.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
+import { resolveSessionDisplayName } from "../lib/session-display.ts";
 import { searchForSession } from "../lib/sessions/index.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import "../lib/toast.ts";
@@ -557,6 +562,16 @@ class OpenClawShell extends OpenClawLightDomElement {
     return routeSearch === undefined ? this.onboarding : resolveOnboardingMode(routeSearch);
   }
 
+  private storedOutboxScopeHost(context: ApplicationContext<RouteId>): StoredOutboxScopeHost {
+    const gatewaySnapshot = context.gateway.snapshot;
+    return {
+      settings: { gatewayUrl: context.gateway.connection.gatewayUrl },
+      assistantAgentId: gatewaySnapshot.assistantAgentId,
+      agentsList: context.agents.state.agentsList,
+      hello: gatewaySnapshot.hello,
+    };
+  }
+
   constructor() {
     super();
     this.subscriptions
@@ -615,6 +630,10 @@ class OpenClawShell extends OpenClawLightDomElement {
       .watch(
         () => this.context?.overlays,
         (overlays, notify) => overlays.subscribe(notify),
+      )
+      .watch(
+        () => this.context?.sessions,
+        (sessions, notify) => sessions.subscribe(notify),
       )
       .watch(
         () => this.context?.runtimeConfig,
@@ -1273,7 +1292,39 @@ class OpenClawShell extends OpenClawLightDomElement {
     );
   }
 
+  /** Keep the tab/window title on the active destination. Runs after every
+   * render so route changes and locale switches both refresh it; before the
+   * first committed route the static boot title from index.html stays. */
+  private syncDocumentTitle() {
+    const routeId = this.routeState.routeId;
+    const context = this.context;
+    if (!routeId || !context) {
+      return;
+    }
+    let primaryContext = titleForRoute(routeId);
+    if (routeId === "chat" && this.activeSessionKey) {
+      const row = context.sessions.state.result?.sessions.find(
+        (session) => session.key === this.activeSessionKey,
+      );
+      primaryContext = resolveSessionDisplayName(this.activeSessionKey, row) || primaryContext;
+    } else if (routeId === "custodian") {
+      primaryContext = t("nav.askOpenClaw");
+    }
+    const title = formatDocumentTitle({
+      context: primaryContext,
+      attentionCount: context.overlays.snapshot.approvalQueue.length,
+      offline: !context.gateway.snapshot.connected,
+      queuedCount:
+        this.outboxStoreRuntime?.summarizeStoredChatOutboxes(this.storedOutboxScopeHost(context))
+          .total ?? 0,
+    });
+    if (document.title !== title) {
+      document.title = title;
+    }
+  }
+
   override updated() {
+    this.syncDocumentTitle();
     const context = this.context;
     if (!context) {
       return;
@@ -1528,12 +1579,7 @@ class OpenClawShell extends OpenClawLightDomElement {
       return nothing;
     }
     const gatewaySnapshot = context.gateway.snapshot;
-    const outboxScopeHost = {
-      settings: { gatewayUrl: context.gateway.connection.gatewayUrl },
-      assistantAgentId: gatewaySnapshot.assistantAgentId,
-      agentsList: context.agents.state.agentsList,
-      hello: gatewaySnapshot.hello,
-    };
+    const outboxScopeHost = this.storedOutboxScopeHost(context);
     const outboxStoreRuntime = this.outboxStoreRuntime;
     const storedOutboxes = outboxStoreRuntime
       ? outboxStoreRuntime.summarizeStoredChatOutboxes(outboxScopeHost)

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -53,13 +53,20 @@ import {
 import { renderSettingsSidebar } from "../components/settings-sidebar.ts";
 import type { ThemeModeChangeDetail } from "../components/theme-mode-toggle.ts";
 import { i18n, isSupportedLocale, t } from "../i18n/index.ts";
+import { normalizeAgentLabel } from "../lib/agents/display.ts";
 import { copyToClipboard } from "../lib/clipboard.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
 import { searchForSession } from "../lib/sessions/index.ts";
-import { normalizeAgentId } from "../lib/sessions/session-key.ts";
+import {
+  isUiGlobalSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveUiConfiguredMainKey,
+  resolveUiKnownSelectedGlobalAgentId,
+} from "../lib/sessions/session-key.ts";
 import "../lib/toast.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
@@ -570,6 +577,27 @@ class OpenClawShell extends OpenClawLightDomElement {
       agentsList: context.agents.state.agentsList,
       hello: gatewaySnapshot.hello,
     };
+  }
+
+  private chatTitleContext(
+    context: ApplicationContext<RouteId>,
+    outboxScopeHost: StoredOutboxScopeHost,
+  ): string {
+    const sessionKey = this.activeSessionKey;
+    const row = context.sessions.state.result?.sessions.find(
+      (session) => session.key === sessionKey,
+    );
+    // An agent's main chat is its identity, so use its roster label when available.
+    const parsed = parseAgentSessionKey(sessionKey);
+    const mainAgentId = isUiGlobalSessionKey(sessionKey)
+      ? resolveUiKnownSelectedGlobalAgentId(outboxScopeHost)
+      : parsed?.rest === resolveUiConfiguredMainKey(outboxScopeHost)
+        ? normalizeAgentId(parsed.agentId)
+        : undefined;
+    const agent = context.agents.state.agentsList?.agents.find(
+      (candidate) => normalizeAgentId(candidate.id) === mainAgentId,
+    );
+    return agent ? normalizeAgentLabel(agent) : resolveSessionDisplayName(sessionKey, row);
   }
 
   constructor() {
@@ -1301,12 +1329,10 @@ class OpenClawShell extends OpenClawLightDomElement {
     if (!routeId || !context) {
       return;
     }
+    const outboxScopeHost = this.storedOutboxScopeHost(context);
     let primaryContext = titleForRoute(routeId);
     if (routeId === "chat" && this.activeSessionKey) {
-      const row = context.sessions.state.result?.sessions.find(
-        (session) => session.key === this.activeSessionKey,
-      );
-      primaryContext = resolveSessionDisplayName(this.activeSessionKey, row) || primaryContext;
+      primaryContext = this.chatTitleContext(context, outboxScopeHost) || primaryContext;
     } else if (routeId === "custodian") {
       primaryContext = t("nav.askOpenClaw");
     }
@@ -1314,9 +1340,7 @@ class OpenClawShell extends OpenClawLightDomElement {
       context: primaryContext,
       attentionCount: context.overlays.snapshot.approvalQueue.length,
       offline: !context.gateway.snapshot.connected,
-      queuedCount:
-        this.outboxStoreRuntime?.summarizeStoredChatOutboxes(this.storedOutboxScopeHost(context))
-          .total ?? 0,
+      queuedCount: this.outboxStoreRuntime?.summarizeStoredChatOutboxes(outboxScopeHost).total ?? 0,
     });
     if (document.title !== title) {
       document.title = title;


### PR DESCRIPTION
## What Problem This Solves

The Control UI document title was the static boot string "OpenClaw Control" forever: every browser tab and the Mac app window titlebar read the same regardless of which sidebar destination, chat session, or connection state was active. Users with several dashboard tabs (or a backgrounded window) had no way to tell them apart or notice that the gateway dropped.

## Why This Change Was Made

Maintainer-requested (direct request, no issue): the window/tab title should mirror the active sidebar selection with the brand demoted to a secondary suffix, following the pattern the standalone approval page already established ("<page> — OpenClaw").

- New pure `formatDocumentTitle()` in `ui/src/app-navigation.ts` composes the title; `OpenClawShell.syncDocumentTitle()` stamps it from `updated()`, so route changes and locale switches both refresh it.
- Routes render their localized nav title: "Usage — OpenClaw", "Threads — OpenClaw", ….
- Chat renders the session's display name via `resolveSessionDisplayName` (async `derivedTitle` arrival refreshes through a new `context.sessions` subscription): "Quarterly launch plan — OpenClaw".
- Pending approvals prefix an attention count: "(2) Approvals — OpenClaw".
- A disconnected gateway prefixes "(Offline)" and, when chat messages are parked in the stored outbox, "(Offline · 3 queued)"; offline suppresses the approval count since a stale queue is not actionable. Markers sit leftmost because tabs truncate from the right.
- The custodian route window-titles as the existing "Ask OpenClaw" label instead of the bare brand; titles already ending in "OpenClaw" skip the suffix so nothing reads "OpenClaw — OpenClaw".
- The outbox scope host previously inlined in `render()` is extracted to `storedOutboxScopeHost()` and shared with the title sync.

No new i18n keys, no visible page markup changes, boot title in `index.html` untouched (login gate/pre-connect keeps "OpenClaw Control").

## User Impact

Dashboard tabs and the Mac app window now say where you are ("Usage — OpenClaw"), which conversation you're in ("Main Thread — OpenClaw"), how many approvals are waiting ("(2) …"), and whether the gateway is down with messages queued ("(Offline · 1 queued) …") — all visible from the tab strip without focusing the window.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs ui/src/app-navigation.test.ts ui/src/app/app-host.test.ts` — 2 files, 104 tests passing, covering the formatter matrix (suffix/dedupe/count/offline/queued precedence) and shell composition (boot-title preservation, session titles, custodian label, markers).
- Live end-to-end against a session-owned dev gateway + Vite dev UI: navigated `/usage`, `/sessions`, `/custodian`, `/chat`, first-run model setup — all titles correct; stopped the gateway → title flipped to "(Offline) Main Thread — OpenClaw"; sent a chat message while offline → "(Offline · 1 queued) Main Thread — OpenClaw"; restarted the gateway → outbox flushed and title recovered to "Main Thread — OpenClaw".
- `oxfmt --check` and `scripts/run-oxlint.mjs` clean on all touched files; Codex autoreview (gpt-5.6-sol, xhigh) clean.
