### PR TITLE
fix(gateway): dedupe redacted local transcripts against full CLI imports

### DIFF
--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -6,6 +6,7 @@ import {
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import { redactSensitiveText } from "../logging/redact.js";
 
 const DEDUPE_TIMESTAMP_WINDOW_MS = 5 * 60 * 1000;
 
@@ -113,7 +114,14 @@ function isEquivalentImportedMessage(existing: unknown, imported: unknown): bool
 
   const existingText = extractComparableText(existing);
   const importedText = extractComparableText(imported);
-  if (!existingText || !importedText || existingText !== importedText) {
+  if (!existingText || !importedText) {
+    return false;
+  }
+  // The gateway transcript persists the redacted form while the CLI import
+  // keeps the full text, so also accept the redacted form of the import.
+  // (Only mask the import side: masking is not idempotent, an already
+  // masked token can degrade to "***" on a second pass.)
+  if (existingText !== importedText && existingText !== redactSensitiveText(importedText)) {
     return false;
   }
 

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -101,37 +101,150 @@ function hasSameExternalIdentity(existing: unknown, imported: unknown): boolean 
   );
 }
 
-function isEquivalentImportedMessage(existing: unknown, imported: unknown): boolean {
+function hasConflictingExternalIdentity(existing: unknown, imported: unknown): boolean {
+  const existingIdentity = resolveImportedExternalIdentity(existing);
+  const importedIdentity = resolveImportedExternalIdentity(imported);
+  return Boolean(
+    existingIdentity && importedIdentity && !hasSameExternalIdentity(existing, imported),
+  );
+}
+
+type ImportedMessageMatch = "lossless" | "lossy-redaction";
+
+function resolveImportedMessageMatch(
+  existing: unknown,
+  imported: unknown,
+): ImportedMessageMatch | undefined {
   if (hasSameExternalIdentity(existing, imported)) {
-    return true;
+    return "lossless";
   }
 
   const existingRole = resolveComparableRole(existing);
   const importedRole = resolveComparableRole(imported);
   if (!existingRole || existingRole !== importedRole) {
-    return false;
+    return undefined;
   }
 
   const existingText = extractComparableText(existing);
   const importedText = extractComparableText(imported);
   if (!existingText || !importedText) {
-    return false;
+    return undefined;
   }
-  // The gateway transcript persists the redacted form while the CLI import
-  // keeps the full text, so also accept the redacted form of the import.
-  // (Only mask the import side: masking is not idempotent, an already
-  // masked token can degrade to "***" on a second pass.)
-  if (existingText !== importedText && existingText !== redactSensitiveText(importedText)) {
-    return false;
+  let textMatch: ImportedMessageMatch;
+  if (existingText === importedText) {
+    textMatch = "lossless";
+  } else if (hasConflictingExternalIdentity(existing, imported)) {
+    return undefined;
+  } else if (
+    existingText === redactSensitiveText(importedText) ||
+    redactSensitiveText(existingText) === importedText
+  ) {
+    // Compare each original with one redaction pass of the other; never compare
+    // two redacted results because masking is lossy and not idempotent.
+    textMatch = "lossy-redaction";
+  } else {
+    return undefined;
   }
 
   const existingTimestamp = resolveComparableTimestamp(existing);
   const importedTimestamp = resolveComparableTimestamp(imported);
   if (existingTimestamp === undefined || importedTimestamp === undefined) {
-    return true;
+    return textMatch;
   }
 
-  return Math.abs(existingTimestamp - importedTimestamp) <= DEDUPE_TIMESTAMP_WINDOW_MS;
+  return Math.abs(existingTimestamp - importedTimestamp) <= DEDUPE_TIMESTAMP_WINDOW_MS
+    ? textMatch
+    : undefined;
+}
+
+function redactionVariantKey(role: string, redactedText: string): string {
+  return `${role}\0${redactedText}`;
+}
+
+function resolveLossyRedactionMatch(
+  existing: unknown,
+  imported: unknown,
+): { key: string; masked: unknown } | undefined {
+  const existingRole = resolveComparableRole(existing);
+  if (!existingRole || existingRole !== resolveComparableRole(imported)) {
+    return undefined;
+  }
+  const existingText = extractComparableText(existing);
+  const importedText = extractComparableText(imported);
+  if (!existingText || !importedText) {
+    return undefined;
+  }
+  if (existingText === redactSensitiveText(importedText)) {
+    return { key: redactionVariantKey(existingRole, existingText), masked: existing };
+  }
+  return redactSensitiveText(existingText) === importedText
+    ? { key: redactionVariantKey(existingRole, importedText), masked: imported }
+    : undefined;
+}
+
+type RedactionVariant = { message: unknown; text: string };
+type RedactionVariantIndex = Map<string, RedactionVariant[]>;
+
+function collectRedactionVariants(messages: unknown[]): RedactionVariantIndex {
+  const variants: RedactionVariantIndex = new Map();
+  for (const message of messages) {
+    const role = resolveComparableRole(message);
+    const text = extractComparableText(message);
+    if (!role || !text) {
+      continue;
+    }
+    const redacted = redactSensitiveText(text);
+    if (redacted === text) {
+      continue;
+    }
+    const key = redactionVariantKey(role, redacted);
+    const entries = variants.get(key) ?? [];
+    entries.push({ message, text });
+    variants.set(key, entries);
+  }
+  return variants;
+}
+
+function haveCompatibleTimestamps(left: unknown, right: unknown): boolean {
+  const leftTimestamp = resolveComparableTimestamp(left);
+  const rightTimestamp = resolveComparableTimestamp(right);
+  return (
+    leftTimestamp === undefined ||
+    rightTimestamp === undefined ||
+    Math.abs(leftTimestamp - rightTimestamp) <= DEDUPE_TIMESTAMP_WINDOW_MS
+  );
+}
+
+function hasUniqueCompatibleRedactionVariant(params: {
+  existing: unknown;
+  imported: unknown;
+  variants: RedactionVariantIndex;
+  cache: Map<unknown, Map<string, boolean>>;
+}): boolean {
+  const lossyMatch = resolveLossyRedactionMatch(params.existing, params.imported);
+  if (!lossyMatch) {
+    return false;
+  }
+  const cachedByKey = params.cache.get(lossyMatch.masked);
+  const cached = cachedByKey?.get(lossyMatch.key);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const compatibleTexts = new Set<string>();
+  for (const variant of params.variants.get(lossyMatch.key) ?? []) {
+    if (!haveCompatibleTimestamps(lossyMatch.masked, variant.message)) {
+      continue;
+    }
+    compatibleTexts.add(variant.text);
+    if (compatibleTexts.size > 1) {
+      break;
+    }
+  }
+  const unique = compatibleTexts.size === 1;
+  const nextCachedByKey = cachedByKey ?? new Map<string, boolean>();
+  nextCachedByKey.set(lossyMatch.key, unique);
+  params.cache.set(lossyMatch.masked, nextCachedByKey);
+  return unique;
 }
 
 function compareHistoryMessages(
@@ -155,9 +268,32 @@ export function mergeImportedChatHistoryMessages(params: {
     return params.localMessages;
   }
   const merged = params.localMessages.map((message, index) => ({ message, order: index }));
+  const redactionVariants = collectRedactionVariants([
+    ...params.localMessages,
+    ...params.importedMessages,
+  ]);
+  const redactionVariantCache = new Map<unknown, Map<string, boolean>>();
+
   let nextOrder = merged.length;
   for (const imported of params.importedMessages) {
-    if (merged.some((existing) => isEquivalentImportedMessage(existing.message, imported))) {
+    const duplicate = merged.some((existing) => {
+      const match = resolveImportedMessageMatch(existing.message, imported);
+      if (match === "lossless") {
+        return true;
+      }
+      if (match !== "lossy-redaction") {
+        return false;
+      }
+      // A mask is not an identity. Only collapse it when every observed full
+      // representation agrees; collisions stay visible rather than being guessed.
+      return hasUniqueCompatibleRedactionVariant({
+        existing: existing.message,
+        imported,
+        variants: redactionVariants,
+        cache: redactionVariantCache,
+      });
+    });
+    if (duplicate) {
       continue;
     }
     merged.push({ message: imported, order: nextOrder });

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { hashCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { redactSensitiveText } from "../logging/redact.js";
 import { readClaudeCliSessionMessages } from "./cli-session-history.claude.js";
 import {
   augmentChatHistoryWithCliSessionImports,
@@ -842,6 +843,31 @@ describe("cli session history", () => {
     const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
     expect(merged[0]).toBe(localMessages[0]);
     expect(merged[1]).toBe(importedMessages[0]);
+  });
+
+  it("dedupes a redacted local transcript against the full imported text", () => {
+    const fullText =
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me";
+    const redactedText = redactSensitiveText(fullText);
+    expect(redactedText).not.toBe(fullText);
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const localMessages = [{ role: "user", content: redactedText, timestamp }];
+    const importedMessages = [{ role: "user", content: fullText, timestamp }];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    expect(merged).toHaveLength(1);
+  });
+
+  it("keeps both messages when the imported text differs beyond redaction", () => {
+    const fullText =
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me";
+    const redactedText = redactSensitiveText(fullText);
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const localMessages = [{ role: "user", content: `${redactedText} (edited)`, timestamp }];
+    const importedMessages = [{ role: "user", content: fullText, timestamp }];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    expect(merged).toHaveLength(2);
   });
 
   it("augments chat history when a session has a claude-cli binding", async () => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -5,8 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { hashCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
-import { withEnvAsync } from "../test-utils/env.js";
 import { redactSensitiveText } from "../logging/redact.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { readClaudeCliSessionMessages } from "./cli-session-history.claude.js";
 import {
   augmentChatHistoryWithCliSessionImports,
@@ -845,17 +845,25 @@ describe("cli session history", () => {
     expect(merged[1]).toBe(importedMessages[0]);
   });
 
-  it("dedupes a redacted local transcript against the full imported text", () => {
+  it("dedupes full and redacted transcript copies in either merge direction", () => {
     const fullText =
       "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me";
     const redactedText = redactSensitiveText(fullText);
-    expect(redactedText).not.toBe(fullText);
     const timestamp = Date.parse("2026-07-23T00:00:00Z");
-    const localMessages = [{ role: "user", content: redactedText, timestamp }];
-    const importedMessages = [{ role: "user", content: fullText, timestamp }];
 
-    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
-    expect(merged).toHaveLength(1);
+    expect(redactedText).not.toBe(fullText);
+    expect(redactSensitiveText(redactedText)).not.toBe(redactedText);
+    for (const [localText, importedText] of [
+      [redactedText, fullText],
+      [fullText, redactedText],
+    ]) {
+      const localMessage = { role: "user", content: localText, timestamp };
+      const merged = mergeImportedChatHistoryMessages({
+        localMessages: [localMessage],
+        importedMessages: [{ role: "user", content: importedText, timestamp }],
+      });
+      expect(merged).toEqual([localMessage]);
+    }
   });
 
   it("keeps both messages when the imported text differs beyond redaction", () => {
@@ -868,6 +876,273 @@ describe("cli session history", () => {
 
     const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
     expect(merged).toHaveLength(2);
+  });
+
+  it("consumes a redaction mask once when distinct imports collide", () => {
+    const fullTexts: readonly [string, string] = [
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me",
+      "open https://host.example/chat?session=agent%3Amain%3Adifferent%3A123e4567-e89b-12d3-a456-426614174000 for me",
+    ];
+    const redactedText = redactSensitiveText(fullTexts[0]);
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const localMessage = { role: "user", content: redactedText, timestamp };
+
+    expect(redactSensitiveText(fullTexts[1])).toBe(redactedText);
+    for (const importedTexts of [
+      fullTexts,
+      fullTexts.toReversed(),
+      [redactedText, ...fullTexts],
+      [...fullTexts, redactedText],
+    ]) {
+      const importedMessages = importedTexts.map((content) => ({
+        role: "user",
+        content,
+        timestamp,
+      }));
+      const merged = mergeImportedChatHistoryMessages({
+        localMessages: [localMessage],
+        importedMessages,
+      });
+      expect(merged).toEqual([
+        localMessage,
+        ...importedMessages.filter((message) => message.content !== redactedText),
+      ]);
+    }
+  });
+
+  it("scopes redaction collisions to the timestamp match window", () => {
+    const fullTexts: readonly [string, string] = [
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me",
+      "open https://host.example/chat?session=agent%3Amain%3Adifferent%3A123e4567-e89b-12d3-a456-426614174000 for me",
+    ];
+    const start = Date.parse("2026-07-23T00:00:00Z");
+    const cases = [
+      { text: fullTexts[0], timestamp: start },
+      { text: fullTexts[1], timestamp: start + 60 * 60 * 1000 },
+    ];
+    const localMessages = cases.map(({ text, timestamp }) => ({
+      role: "user",
+      content: redactSensitiveText(text),
+      timestamp,
+    }));
+    const importedMessages = cases.map(({ text: content, timestamp }) => ({
+      role: "user",
+      content,
+      timestamp,
+    }));
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    expect(merged).toEqual(localMessages);
+  });
+
+  it("counts identity-matched full text when detecting redaction collisions", () => {
+    const fullTexts: readonly [string, string] = [
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me",
+      "open https://host.example/chat?session=agent%3Amain%3Adifferent%3A123e4567-e89b-12d3-a456-426614174000 for me",
+    ];
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const identity = (externalId: string) => ({
+      importedFrom: "claude-cli",
+      externalId,
+      cliSessionId: "session-1",
+    });
+    const localMessage = {
+      role: "user",
+      content: redactSensitiveText(fullTexts[0]),
+      timestamp,
+      __openclaw: identity("message-a"),
+    };
+    const importedMessages = [
+      {
+        role: "user",
+        content: fullTexts[1],
+        timestamp,
+        __openclaw: identity("message-b"),
+      },
+      {
+        role: "user",
+        content: fullTexts[0],
+        timestamp,
+        __openclaw: identity("message-a"),
+      },
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages,
+    });
+    expect(merged).toEqual([localMessage, importedMessages[0]]);
+  });
+
+  it("does not use redaction equivalence across conflicting external identities", () => {
+    const fullText =
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me";
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const identity = (externalId: string) => ({
+      importedFrom: "claude-cli",
+      externalId,
+      cliSessionId: "session-1",
+    });
+    const localMessage = {
+      role: "user",
+      content: fullText,
+      timestamp,
+      __openclaw: identity("message-a"),
+    };
+    const importedMessage = {
+      role: "user",
+      content: redactSensitiveText(fullText),
+      timestamp,
+      __openclaw: identity("message-b"),
+    };
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages: [importedMessage],
+    });
+    expect(merged).toEqual([localMessage, importedMessage]);
+  });
+
+  it("keeps a consumed full import as an exact dedupe representative", () => {
+    const fullText =
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me";
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const localMessage = {
+      role: "user",
+      content: redactSensitiveText(fullText),
+      timestamp,
+    };
+    const importedMessage = { role: "user", content: fullText, timestamp };
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages: [importedMessage, importedMessage],
+    });
+    expect(merged).toEqual([localMessage]);
+  });
+
+  it("retains non-comparable imported messages", () => {
+    const importedMessage = {
+      role: "assistant",
+      content: [{ type: "toolcall", name: "read", arguments: {} }],
+    };
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [],
+      importedMessages: [importedMessage],
+    });
+    expect(merged).toEqual([importedMessage]);
+  });
+
+  it("dedupes imports only against retained timestamp representatives", () => {
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const fiveMinutes = 5 * 60 * 1000;
+    const importedMessages = [0, fiveMinutes, fiveMinutes * 2].map((offset) => ({
+      role: "user",
+      content: "repeated prompt",
+      timestamp: timestamp + offset,
+    }));
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages: [], importedMessages });
+    expect(merged).toEqual([importedMessages[0], importedMessages[2]]);
+  });
+
+  it("retains a later import outside the surviving local timestamp window", () => {
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const fiveMinutes = 5 * 60 * 1000;
+    const localMessage = { role: "user", content: "repeated prompt", timestamp };
+    const importedMessages = [fiveMinutes, fiveMinutes * 2].map((offset) => ({
+      role: "user",
+      content: "repeated prompt",
+      timestamp: timestamp + offset,
+    }));
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages,
+    });
+    expect(merged).toEqual([localMessage, importedMessages[1]]);
+  });
+
+  it("does not extend a retained local timestamp through a skipped lossy import", () => {
+    const fullText =
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me";
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const fiveMinutes = 5 * 60 * 1000;
+    const localMessage = {
+      role: "user",
+      content: redactSensitiveText(fullText),
+      timestamp,
+    };
+    const importedMessages = [fiveMinutes, fiveMinutes * 2].map((offset) => ({
+      role: "user",
+      content: fullText,
+      timestamp: timestamp + offset,
+    }));
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages,
+    });
+    expect(merged).toEqual([localMessage, importedMessages[1]]);
+  });
+
+  it("dedupes a full and redacted pair retained entirely from imports", () => {
+    const fullText =
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me";
+    const redactedText = redactSensitiveText(fullText);
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+
+    for (const contents of [
+      [redactedText, fullText],
+      [fullText, redactedText],
+      [redactedText, redactedText, fullText],
+      [redactedText, fullText, redactedText],
+    ]) {
+      const importedMessages = contents.map((content) => ({ role: "user", content, timestamp }));
+      const merged = mergeImportedChatHistoryMessages({ localMessages: [], importedMessages });
+      expect(merged).toEqual([importedMessages[0]]);
+    }
+  });
+
+  it("reserves exact local matches one-to-one before lossy matches", () => {
+    const fullText =
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me";
+    const redactedText = redactSensitiveText(fullText);
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const fiveMinutes = 5 * 60 * 1000;
+    const localMessages = [0, fiveMinutes * 2].map((offset) => ({
+      role: "user",
+      content: redactedText,
+      timestamp: timestamp + offset,
+    }));
+    const importedMessages = [
+      { role: "user", content: redactedText, timestamp: timestamp + fiveMinutes },
+      { role: "user", content: fullText, timestamp: timestamp + fiveMinutes * 3 },
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    expect(merged).toEqual(localMessages);
+  });
+
+  it("reassigns a flexible exact match away from a constrained lossy match", () => {
+    const fullText =
+      "open https://host.example/chat?session=agent%3Amain%3Adashboard%3A123e4567-e89b-12d3-a456-426614174000 for me";
+    const redactedText = redactSensitiveText(fullText);
+    const timestamp = Date.parse("2026-07-23T00:00:00Z");
+    const minute = 60 * 1000;
+    const localMessages = [0, 9].map((offset) => ({
+      role: "user",
+      content: redactedText,
+      timestamp: timestamp + offset * minute,
+    }));
+    const importedMessages = [
+      { role: "user", content: fullText, timestamp: timestamp - 2 * minute },
+      { role: "user", content: redactedText, timestamp: timestamp + 4 * minute },
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    expect(merged).toEqual(localMessages);
   });
 
   it("augments chat history when a session has a claude-cli binding", async () => {


### PR DESCRIPTION
## What Problem This Solves

The gateway persists the redacted form of an inbound message to its local transcript (e.g. `agent%…4000`), while the bound claude-cli session file keeps the full text. `isEquivalentImportedMessage` in `cli-session-history.merge.ts` deduped the two histories on exact text equality, so the redacted local and the full import never matched and both survived the merge, rendering the message twice in the Control UI (#112930).

The fix also accepts the redacted form of the imported text as equivalent. Only the import side is transformed: masking is not idempotent (an already masked token degrades to `***` on a second pass), so transforming both sides would break the comparison instead of fixing it. The exact-equality fast path is unchanged, so unredacted messages dedupe the same way as before.

## Evidence

Two new cases in `cli-session-history.test.ts`: a redacted local plus the full import now merges to one entry, and a local entry that differs beyond redaction (`(edited)`) still merges as two, so the change does not over-dedupe. Suite is 123/123 green locally, oxlint and tsc clean.

Fixes #112930.
