### PR TITLE
refactor(ui): move sidebar menus into a reactive controller

### DIFF
--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -78,10 +78,14 @@ function renderSessionSection(params: {
     "sidebar-recent-sessions__group",
     `sidebar-recent-sessions__group--zone-${zone}`,
     collapsed ? "sidebar-recent-sessions__group--collapsed" : "",
-    group && host.draggingSessionGroup === group ? "sidebar-recent-sessions__group--dragging" : "",
-    host.sessionDropTarget === section.id ? "sidebar-recent-sessions__group--session-drop" : "",
-    group && host.sessionGroupDropTarget?.group === group
-      ? `sidebar-recent-sessions__group--group-drop-${host.sessionGroupDropTarget.position}`
+    group && host.sessionOrganizer.draggingSessionGroup === group
+      ? "sidebar-recent-sessions__group--dragging"
+      : "",
+    host.sessionOrganizer.sessionDropTarget === section.id
+      ? "sidebar-recent-sessions__group--session-drop"
+      : "",
+    group && host.sessionOrganizer.sessionGroupDropTarget?.group === group
+      ? `sidebar-recent-sessions__group--group-drop-${host.sessionOrganizer.sessionGroupDropTarget.position}`
       : "",
   ]
     .filter(Boolean)
@@ -122,7 +126,7 @@ function renderSessionSection(params: {
           @contextmenu=${group
             ? (event: MouseEvent) => {
                 event.preventDefault();
-                host.openSessionGroupMenu(group, event.clientX, event.clientY, null);
+                host.sidebarMenus.openSessionGroupMenu(group, event.clientX, event.clientY, null);
               }
             : nothing}
         >
@@ -168,10 +172,10 @@ function renderSessionSection(params: {
                   title=${t("chat.sidebar.sortSessions")}
                   aria-label=${t("chat.sidebar.sortSessions")}
                   aria-haspopup="menu"
-                  aria-expanded=${String(host.sessionSortMenuPosition !== null)}
+                  aria-expanded=${String(host.sidebarMenus.sessionSortMenuPosition !== null)}
                   @click=${(event: MouseEvent) => {
                     event.stopPropagation();
-                    host.toggleSessionSortMenu(event.currentTarget as HTMLElement);
+                    host.sidebarMenus.toggleSessionSortMenu(event.currentTarget as HTMLElement);
                   }}
                 >
                   ${icons.listFilter}
@@ -201,12 +205,17 @@ function renderSessionSection(params: {
                   title=${t("sessionsView.groupMenu", { group })}
                   aria-label=${t("sessionsView.groupMenu", { group })}
                   aria-haspopup="menu"
-                  aria-expanded=${String(host.sessionGroupMenu?.group === group)}
+                  aria-expanded=${String(host.sidebarMenus.sessionGroupMenu?.group === group)}
                   @click=${(event: MouseEvent) => {
                     event.stopPropagation();
                     const trigger = event.currentTarget as HTMLElement;
                     const rect = trigger.getBoundingClientRect();
-                    host.openSessionGroupMenu(group, rect.right, rect.bottom + 4, trigger);
+                    host.sidebarMenus.openSessionGroupMenu(
+                      group,
+                      rect.right,
+                      rect.bottom + 4,
+                      trigger,
+                    );
                   }}
                 >
                   ${icons.moreHorizontal}
@@ -354,7 +363,7 @@ function renderSessionListBody(params: {
         section.totalRowCount === 0 &&
         !showDraft &&
         host.sessionsStatusFilter === "active" &&
-        host.draggingSessionKey === null
+        host.sessionOrganizer.draggingSessionKey === null
       ) {
         return nothing;
       }
@@ -381,7 +390,7 @@ export function renderSessionList(params: {
   const { host } = params;
   return html`
     <section
-      class="sidebar-sessions ${host.sessionListRemovalDrop
+      class="sidebar-sessions ${host.sessionOrganizer.sessionListRemovalDrop
         ? "sidebar-sessions--removal-drop"
         : ""}"
       @dragover=${(event: DragEvent) => host.handleSessionListDragOver(event)}

--- a/ui/src/components/app-sidebar-session-list.ts
+++ b/ui/src/components/app-sidebar-session-list.ts
@@ -50,12 +50,12 @@ export abstract class AppSidebarSessionListElement
     menuSession: SidebarRecentSession,
     trigger: HTMLElement,
   ): void {
-    if (this.sessionMenu?.session.key === session.key) {
-      this.closeSessionMenu();
+    if (this.sidebarMenus.sessionMenu?.session.key === session.key) {
+      this.sidebarMenus.closeSessionMenu();
       return;
     }
     const rect = trigger.getBoundingClientRect();
-    this.openSessionMenu(menuSession, rect.right, rect.bottom + 4, trigger);
+    this.sidebarMenus.openSessionMenu(menuSession, rect.right, rect.bottom + 4, trigger);
   }
 
   startSessionGroupDrag(group: string): void {
@@ -118,7 +118,7 @@ export abstract class AppSidebarSessionListElement
     y: number,
     trigger?: HTMLElement,
   ): void {
-    this.catalogMenu.open(request, x, y, trigger);
+    this.sidebarMenus.catalogMenu.open(request, x, y, trigger);
   }
 
   protected renderPinnedSidebarSession(session: SidebarRecentSession): TemplateResult {

--- a/ui/src/components/app-sidebar-session-narration-element.ts
+++ b/ui/src/components/app-sidebar-session-narration-element.ts
@@ -2,18 +2,35 @@ import type { PropertyValues } from "lit";
 import { state } from "lit/decorators.js";
 import type { SessionObserverDigest } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
-import { AppSidebarMenusElement } from "./app-sidebar-menus.ts";
 import type {
   SidebarNarrationSyncInput,
   SidebarSessionNarrationController,
 } from "./app-sidebar-session-narration.ts";
+import { AppSidebarSessionNavigationElement } from "./app-sidebar-session-navigation.ts";
 import { visibleSessionChildren } from "./app-sidebar-session-row-render.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
+import { SessionOrganizerController } from "./session-organizer-controller.ts";
+import { SidebarMenusController } from "./sidebar-menus-controller.ts";
 
 /** Gateway subscription and reactive narration state for the session-list renderer. */
-export abstract class AppSidebarSessionNarrationElement extends AppSidebarMenusElement {
+export abstract class AppSidebarSessionNarrationElement extends AppSidebarSessionNavigationElement {
   @state() sidebarNarrationLines: ReadonlyMap<string, string> = new Map();
   @state() sidebarObserverDigests: ReadonlyMap<string, SessionObserverDigest> = new Map();
+
+  readonly sessionOrganizer = new SessionOrganizerController(this);
+  readonly sidebarMenus = new SidebarMenusController(this);
+
+  get collapsedSessionSections(): ReadonlySet<string> {
+    return this.sessionOrganizer.collapsedSessionSections;
+  }
+
+  dismissTransientMenus(): boolean {
+    return this.sidebarMenus.dismissTransientMenus();
+  }
+
+  protected closeAgentMenu(options?: { restoreFocus?: boolean }): void {
+    this.sidebarMenus.closeAgentMenu(options);
+  }
 
   // Lazy: the controller pulls core token-suppression modules that must stay
   // out of the startup chunk (QA smoke startup-JS budget). It loads on the

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -123,7 +123,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
     return this.getSessionNavigationState().toSidebarSession(row);
   }
 
-  protected getRouteSessionKey(): string {
+  getRouteSessionKey(): string {
     return this.sessionKey.trim() || this.context?.gateway.snapshot.sessionKey.trim() || "";
   }
 
@@ -131,7 +131,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
     return this.outboxCountForSession(sessionKey);
   }
 
-  protected getSessionNavigationState() {
+  getSessionNavigationState() {
     const context = this.context;
     const routeSessionKey = this.getRouteSessionKey();
     const navigation = resolveSessionNavigation({
@@ -341,7 +341,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
     return [...pinnedRows, ...visibleRows];
   }
 
-  protected selectedVisibleSessions(): SidebarRecentSession[] {
+  selectedVisibleSessions(): SidebarRecentSession[] {
     if (this.selectedSessionKeys.size === 0) {
       return [];
     }
@@ -452,7 +452,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
       : normalizeAgentId(this.getSessionNavigationState().selectedAgentId);
   }
 
-  protected activeChipAgent() {
+  activeChipAgent() {
     const roster = this.context?.agents.state.agentsList?.agents ?? [];
     const activeId = this.expandedAgentId();
     const agent = roster.find((entry) => normalizeAgentId(entry.id) === activeId);
@@ -514,13 +514,13 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
     return t("agentChip.ready");
   }
 
-  protected switchChipAgent(agentId: string) {
+  switchChipAgent(agentId: string) {
     this.closeAgentMenu();
     this.expandAgent(agentId);
     this.openAgentConversation(agentId);
   }
 
-  protected askAgentCapabilities(agentId: string) {
+  askAgentCapabilities(agentId: string) {
     this.closeAgentMenu();
     if (!this.connected) {
       return;
@@ -733,7 +733,7 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
     this.fullyShownChildSessionKeys = new Set(this.fullyShownChildSessionKeys).add(sessionKey);
   }
 
-  protected agentUnreadCount(agentId: string): number {
+  agentUnreadCount(agentId: string): number {
     const rows = this.sessionData.sessionRowsByAgent[normalizeAgentId(agentId)] ?? [];
     return rows.filter((row) => row.unread === true && row.archived !== true).length;
   }

--- a/ui/src/components/app-sidebar-session-projection.ts
+++ b/ui/src/components/app-sidebar-session-projection.ts
@@ -13,7 +13,7 @@ import { SessionDataController } from "./session-data-controller.ts";
 
 /** Shared ordering and PR-state projection used by sidebar navigation. */
 export abstract class AppSidebarSessionProjectionElement extends AppSidebarBase {
-  @state() protected sessionSortMode: SidebarSessionSortMode = "created";
+  @state() sessionSortMode: SidebarSessionSortMode = "created";
 
   readonly sessionData = new SessionDataController(this);
   private readonly sessionPullRequestIndicators = new SessionPullRequestIndicatorsController(this, {

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -19,19 +19,20 @@ import {
   rowDemandsVisibility,
   sidebarSessionMetaId,
   type SidebarRecentSession,
-  type SidebarSessionGroupDropTarget,
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
 import type { SessionDataController } from "./session-data-controller.ts";
 import { renderSessionLeadingState } from "./session-leading-indicator.ts";
 import type { SessionPullRequestIndicatorState } from "./session-menu-work.ts";
+import type { SessionOrganizerController } from "./session-organizer-controller.ts";
 import { renderSessionOwnerChip } from "./session-owner-chip.ts";
 import { renderSessionRowBadges } from "./session-row-badges.ts";
 import {
   renderSidebarSessionSubtitle,
   resolveSidebarSessionSubtitle,
 } from "./session-row-subtitle.ts";
+import type { SidebarMenusController } from "./sidebar-menus-controller.ts";
 import "./elapsed-time.ts";
 
 const SIDEBAR_VISIBLE_CHILD_SESSION_LIMIT = 4;
@@ -41,7 +42,6 @@ export interface SessionListHost {
   readonly sidebarNarrationLines: ReadonlyMap<string, string>;
   readonly sidebarObserverDigests: ReadonlyMap<string, SessionObserverDigest>;
   readonly selectedSessionKeys: ReadonlySet<string>;
-  readonly draggingSessionKey: string | null;
   readonly connected: boolean;
   readonly sessionData: Pick<
     SessionDataController,
@@ -54,14 +54,24 @@ export interface SessionListHost {
   readonly fullyShownChildSessionKeys: ReadonlySet<string>;
   readonly sessionsGrouping: SidebarSessionsGrouping;
   readonly collapsedSessionSections: ReadonlySet<string>;
-  readonly draggingSessionGroup: string | null;
-  readonly sessionDropTarget: string | null;
-  readonly sessionGroupDropTarget: SidebarSessionGroupDropTarget | null;
-  readonly sessionSortMenuPosition: { readonly x: number; readonly y: number } | null;
-  readonly sessionMenu: { readonly session: SidebarRecentSession } | null;
-  readonly sessionGroupMenu: { readonly group: string } | null;
+  readonly sessionOrganizer: Pick<
+    SessionOrganizerController,
+    | "draggingSessionGroup"
+    | "draggingSessionKey"
+    | "sessionDropTarget"
+    | "sessionGroupDropTarget"
+    | "sessionListRemovalDrop"
+  >;
+  readonly sidebarMenus: Pick<
+    SidebarMenusController,
+    | "openSessionGroupMenu"
+    | "openSessionMenu"
+    | "sessionGroupMenu"
+    | "sessionMenu"
+    | "sessionSortMenuPosition"
+    | "toggleSessionSortMenu"
+  >;
   readonly sessionsStatusFilter: SidebarSessionStatusFilter;
-  readonly sessionListRemovalDrop: boolean;
   readonly sessionOwnershipVisible: boolean;
   readonly onOpenNewSession?: (agentId: string, target?: NewSessionTarget) => void;
   readonly onNavigate?: (
@@ -76,7 +86,6 @@ export interface SessionListHost {
   isSessionChildrenExpanded(session: SidebarRecentSession): boolean;
   startSessionDrag(session: SidebarRecentSession): void;
   finishSessionDrag(): void;
-  openSessionMenu(session: SidebarRecentSession, x: number, y: number, trigger?: HTMLElement): void;
   handleSessionRowClick(event: MouseEvent, session: SidebarRecentSession): void;
   toggleSessionChildren(session: SidebarRecentSession): void;
   toggleSessionPin(session: SidebarRecentSession): void;
@@ -91,9 +100,7 @@ export interface SessionListHost {
   sectionDrop(event: DragEvent, sectionId: string, group?: string): void;
   startSessionGroupDrag(group: string): void;
   finishSessionGroupDrag(): void;
-  openSessionGroupMenu(group: string, x: number, y: number, trigger: HTMLElement | null): void;
   toggleSection(sectionId: string): void;
-  toggleSessionSortMenu(trigger: HTMLElement): void;
   openNewSession(): void;
   setVisibleSessionLimit(limit: number): void;
   clearSessionSelection(): void;
@@ -166,7 +173,9 @@ export function renderRecentSession(params: {
       : session.attention.kind !== "none"
         ? "sidebar-recent-session--attention-amber"
         : "",
-    host.draggingSessionKey === session.key ? "sidebar-recent-session--dragging" : "",
+    host.sessionOrganizer.draggingSessionKey === session.key
+      ? "sidebar-recent-session--dragging"
+      : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -194,7 +203,7 @@ export function renderRecentSession(params: {
         ? nothing
         : (event: MouseEvent) => {
             event.preventDefault();
-            host.openSessionMenu(menuSession, event.clientX, event.clientY);
+            host.sidebarMenus.openSessionMenu(menuSession, event.clientX, event.clientY);
           }}
       @mouseenter=${(event: MouseEvent) => startHoverMarquee(event.currentTarget as HTMLElement)}
       @mouseleave=${(event: MouseEvent) => stopHoverMarquee(event.currentTarget as HTMLElement)}
@@ -319,7 +328,7 @@ export function renderRecentSession(params: {
                 title=${t("chat.sidebar.openSessionMenu")}
                 aria-label=${t("chat.sidebar.openSessionMenu")}
                 aria-haspopup="menu"
-                aria-expanded=${String(host.sessionMenu?.session.key === session.key)}
+                aria-expanded=${String(host.sidebarMenus.sessionMenu?.session.key === session.key)}
                 @click=${(event: MouseEvent) => {
                   event.stopPropagation();
                   const trigger = event.currentTarget as HTMLElement;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -141,11 +141,11 @@ class AppSidebar extends AppSidebarSessionListElement {
           .avatarUrl=${cardAgent ? resolveAgentAvatarUrl(cardAgent) : null}
           .avatarText=${cardAvatarText}
           .subtitle=${this.agentChipSubtitle(cardAgentId)}
-          .menuOpen=${this.agentMenuPosition !== null}
+          .menuOpen=${this.sidebarMenus.agentMenuPosition !== null}
           .menuUnread=${menuUnread}
           .approvalCount=${approvalCount}
           .switcherAvailable=${cardAgents.length > 1}
-          .onToggleMenu=${(trigger: HTMLElement) => this.toggleAgentMenu(trigger)}
+          .onToggleMenu=${(trigger: HTMLElement) => this.sidebarMenus.toggleAgentMenu(trigger)}
         ></openclaw-sidebar-agent-card>
         <div class="sidebar-brand__actions">
           <openclaw-tooltip
@@ -263,9 +263,10 @@ class AppSidebar extends AppSidebarSessionListElement {
           type="button"
           class="sidebar-nav__head-action"
           aria-haspopup="menu"
-          aria-expanded=${String(this.moreMenuPosition !== null)}
+          aria-expanded=${String(this.sidebarMenus.moreMenuPosition !== null)}
           aria-label=${t("nav.customize")}
-          @click=${(event: MouseEvent) => this.toggleMoreMenu(event.currentTarget as HTMLElement)}
+          @click=${(event: MouseEvent) =>
+            this.sidebarMenus.toggleMoreMenu(event.currentTarget as HTMLElement)}
         >
           ${icons.penLine}
         </button>
@@ -369,17 +370,19 @@ class AppSidebar extends AppSidebarSessionListElement {
     workboardRows: ReadonlyMap<string, SidebarWorkboardBoard>,
   ) {
     if (
-      (entry.type === "route" && !this.isRouteEnabled(entry.route)) ||
-      (entry.type === "workboard" && !this.isRouteEnabled("workboard"))
+      (entry.type === "route" && !this.sidebarMenus.isRouteEnabled(entry.route)) ||
+      (entry.type === "workboard" && !this.sidebarMenus.isRouteEnabled("workboard"))
     ) {
       return nothing;
     }
     const serialized = serializeSidebarEntry(entry);
     const dropPosition =
-      this.sidebarZoneDropTarget?.entry === serialized ? this.sidebarZoneDropTarget.position : null;
+      this.sessionOrganizer.sidebarZoneDropTarget?.entry === serialized
+        ? this.sessionOrganizer.sidebarZoneDropTarget.position
+        : null;
     const content =
       entry.type === "route"
-        ? this.renderRoute(entry.route)
+        ? this.sidebarMenus.renderRoute(entry.route)
         : entry.type === "workboard"
           ? workboardRows.has(entry.boardId)
             ? this.renderWorkboardBoard(workboardRows.get(entry.boardId)!)
@@ -392,7 +395,9 @@ class AppSidebar extends AppSidebarSessionListElement {
       <div
         class="sidebar-zone-entry ${dropPosition
           ? `sidebar-zone-entry--drop-${dropPosition}`
-          : ""} ${this.draggingSidebarEntry === serialized ? "sidebar-zone-entry--dragging" : ""}"
+          : ""} ${this.sessionOrganizer.draggingSidebarEntry === serialized
+          ? "sidebar-zone-entry--dragging"
+          : ""}"
         data-sidebar-entry=${serialized}
         draggable=${draggable ? "true" : "false"}
         @dragstart=${entry.type === "route"
@@ -451,7 +456,7 @@ class AppSidebar extends AppSidebarSessionListElement {
             @scroll=${(event: Event) =>
               this.sessionData.updateSessionsScrollState(event.currentTarget as HTMLElement)}
           >
-            <nav class="sidebar-nav" @contextmenu=${this.openCustomizeMenuFromContext}>
+            <nav class="sidebar-nav" @contextmenu=${this.sidebarMenus.openCustomizeMenuFromContext}>
               ${this.renderPagesHead()}
               <div
                 class="nav-section__items"
@@ -510,9 +515,10 @@ class AppSidebar extends AppSidebarSessionListElement {
             ${this.renderFooterBar()}
           </div>
         </div>
-        ${this.renderCustomizeMenu()} ${this.renderMoreMenu()} ${this.renderAgentMenu()}
-        ${this.renderSessionMenu()} ${this.catalogMenu.render()} ${this.renderSessionGroupMenu()}
-        ${this.renderSessionSortMenu()}
+        ${this.sidebarMenus.renderCustomizeMenu()} ${this.sidebarMenus.renderMoreMenu()}
+        ${this.sidebarMenus.renderAgentMenu()} ${this.sidebarMenus.renderSessionMenu()}
+        ${this.sidebarMenus.catalogMenu.render()} ${this.sidebarMenus.renderSessionGroupMenu()}
+        ${this.sidebarMenus.renderSessionSortMenu()}
       </aside>
     `;
   }

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -1,5 +1,4 @@
-import { html, nothing } from "lit";
-import { state } from "lit/decorators.js";
+import { html, nothing, type ReactiveController, type ReactiveControllerHost } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import {
   cancelRoutePreload,
@@ -7,8 +6,11 @@ import {
   scheduleRoutePreload,
   serializeSidebarEntry,
   type NavigationRouteId,
+  type SidebarZoneEntry,
 } from "../app-navigation.ts";
-import { pathForRoute } from "../app-route-paths.ts";
+import { pathForRoute, type RouteId } from "../app-route-paths.ts";
+import type { ApplicationContext, ApplicationNavigationOptions } from "../app/context.ts";
+import type { ThemeMode } from "../app/theme.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
 import { openEditor } from "../lib/editor-links.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
@@ -32,61 +34,91 @@ import {
   renderSidebarSessionGroupMenu,
   renderSidebarSessionSortMenu,
 } from "./app-sidebar-session-menu-renderers.ts";
-import { AppSidebarSessionNavigationElement } from "./app-sidebar-session-navigation.ts";
 import type {
   SidebarRecentSession,
   SidebarSessionGroupMenuState,
   SidebarSessionMenuState,
+  SidebarSessionSortMode,
 } from "./app-sidebar-session-types.ts";
+import type { SidebarWorkboardBoard, SidebarWorkboardRenderers } from "./app-sidebar-workboard.ts";
+import type { SessionDataController } from "./session-data-controller.ts";
 import { fetchSessionMenuWork } from "./session-menu-work.ts";
 import type { SessionMenuAction, SessionMenuWork } from "./session-menu.ts";
-import { SessionOrganizerController } from "./session-organizer-controller.ts";
+import type { SessionOrganizerController } from "./session-organizer-controller.ts";
+import type { SessionOrganizerControllerHost } from "./session-organizer-operations.runtime.ts";
+
+type SidebarMenuAgent = {
+  id: string;
+  name?: string;
+  identity?: { name?: string; emoji?: string; avatar?: string; avatarUrl?: string };
+};
+
+interface SidebarMenusControllerState {
+  customizeMenuPosition: { x: number; y: number } | null;
+  moreMenuPosition: { x: number; y: number } | null;
+  sessionMenu: SidebarSessionMenuState | null;
+  sessionMenuWork: SessionMenuWork | null;
+  sessionGroupMenu: SidebarSessionGroupMenuState | null;
+  sessionSortMenuPosition: { x: number; y: number } | null;
+  agentMenuPosition: { x: number; bottom: number } | null;
+  agentMenuFilter: string;
+}
+
+interface SidebarMenusControllerHost
+  extends ReactiveControllerHost, SessionOrganizerControllerHost {
+  readonly activeRouteId?: NavigationRouteId;
+  readonly activeWorkboardBoardId: string;
+  readonly basePath: string;
+  readonly canPairDevice: boolean;
+  readonly connected: boolean;
+  readonly enabledRouteIds?: readonly NavigationRouteId[];
+  readonly gatewayVersion: string | null;
+  readonly onNavigate?: (
+    routeId: NavigationRouteId,
+    options?: ApplicationNavigationOptions,
+  ) => void;
+  readonly onPairMobile?: () => void;
+  readonly onPreloadRoute?: (routeId: NavigationRouteId) => Promise<void>;
+  readonly pinnedAgentIds: readonly string[];
+  readonly selectedSessionKeys: ReadonlySet<string>;
+  readonly sessionData: SessionOrganizerControllerHost["sessionData"] &
+    Pick<SessionDataController, "approvalBadgeSnapshot" | "sessionsLoading">;
+  readonly sessionDataContext: ApplicationContext<RouteId> | undefined;
+  readonly sessionOrganizer: SessionOrganizerController;
+  readonly sidebarEntries: readonly string[];
+  sessionSortMode: SidebarSessionSortMode;
+  readonly terminalAvailable: boolean;
+  readonly themeMode: ThemeMode;
+  readonly workboardBoards: readonly SidebarWorkboardBoard[];
+  readonly workboardRenderers?: SidebarWorkboardRenderers;
+  activeChipAgent(): {
+    activeId: string;
+    agent: SidebarMenuAgent | undefined;
+    agents: readonly SidebarMenuAgent[];
+  };
+  agentUnreadCount(agentId: string): number;
+  askAgentCapabilities(agentId: string): void;
+  getRouteSessionKey(): string;
+  getSessionNavigationState(): { selectedAgentId: string };
+  reconciledSidebarZone(): {
+    entries: readonly SidebarZoneEntry[];
+    sidebarEntries: readonly string[];
+  };
+  selectedVisibleSessions(): SidebarRecentSession[];
+  switchChipAgent(agentId: string): void;
+}
 
 /** Popup ownership and stateless menu-renderer wiring. */
-export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigationElement {
-  @state() protected customizeMenuPosition: { x: number; y: number } | null = null;
-  @state() protected moreMenuPosition: { x: number; y: number } | null = null;
-  @state() sessionMenu: SidebarSessionMenuState | null = null;
-  @state() protected sessionMenuWork: SessionMenuWork | null = null;
-  @state() sessionGroupMenu: SidebarSessionGroupMenuState | null = null;
-  @state() sessionSortMenuPosition: { x: number; y: number } | null = null;
+export class SidebarMenusController implements ReactiveController, SidebarMenusControllerState {
+  customizeMenuPosition: { x: number; y: number } | null = null;
+  moreMenuPosition: { x: number; y: number } | null = null;
+  sessionMenu: SidebarSessionMenuState | null = null;
+  sessionMenuWork: SessionMenuWork | null = null;
+  sessionGroupMenu: SidebarSessionGroupMenuState | null = null;
+  sessionSortMenuPosition: { x: number; y: number } | null = null;
   // Anchored by its bottom edge so the footer menu grows upward regardless of height.
-  @state() protected agentMenuPosition: { x: number; bottom: number } | null = null;
-  @state() protected agentMenuFilter = "";
-
-  readonly sessionOrganizer = new SessionOrganizerController(this);
-
-  get collapsedSessionSections(): ReadonlySet<string> {
-    return this.sessionOrganizer.collapsedSessionSections;
-  }
-
-  get draggingSessionKey(): string | null {
-    return this.sessionOrganizer.draggingSessionKey;
-  }
-
-  get draggingSessionGroup(): string | null {
-    return this.sessionOrganizer.draggingSessionGroup;
-  }
-
-  get sessionDropTarget(): string | null {
-    return this.sessionOrganizer.sessionDropTarget;
-  }
-
-  get sessionGroupDropTarget() {
-    return this.sessionOrganizer.sessionGroupDropTarget;
-  }
-
-  get sessionListRemovalDrop(): boolean {
-    return this.sessionOrganizer.sessionListRemovalDrop;
-  }
-
-  protected get draggingSidebarEntry(): string | null {
-    return this.sessionOrganizer.draggingSidebarEntry;
-  }
-
-  protected get sidebarZoneDropTarget() {
-    return this.sessionOrganizer.sidebarZoneDropTarget;
-  }
+  agentMenuPosition: { x: number; bottom: number } | null = null;
+  agentMenuFilter = "";
 
   private customizeMenuTrigger: HTMLElement | null = null;
   private moreMenuTrigger: HTMLElement | null = null;
@@ -99,20 +131,34 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     EventTarget,
     ReturnType<typeof globalThis.setTimeout>
   >();
-  protected readonly catalogMenu = new SidebarCatalogMenuController({
-    // Closing every transient menu keeps one popover at a time.
-    beforeOpen: () => void this.dismissTransientMenus(),
-    requestUpdate: () => this.requestUpdate(),
-    terminalAvailable: () => this.terminalAvailable,
-    navigate: (search) => this.onNavigate?.("chat", { search }),
-  });
+  readonly catalogMenu: SidebarCatalogMenuController;
 
-  override disconnectedCallback() {
+  constructor(private readonly host: SidebarMenusControllerHost) {
+    host.addController(this);
+    this.catalogMenu = new SidebarCatalogMenuController({
+      // Closing every transient menu keeps one popover at a time.
+      beforeOpen: () => void this.dismissTransientMenus(),
+      requestUpdate: () => host.requestUpdate(),
+      terminalAvailable: () => host.terminalAvailable,
+      navigate: (search) => host.onNavigate?.("chat", { search }),
+    });
+  }
+
+  hostConnected(): void {}
+
+  hostDisconnected(): void {
     for (const timer of this.routePreloadTimers.values()) {
       globalThis.clearTimeout(timer);
     }
     this.routePreloadTimers.clear();
-    super.disconnectedCallback();
+  }
+
+  private updateState<Key extends keyof SidebarMenusControllerState>(
+    key: Key,
+    value: SidebarMenusControllerState[Key],
+  ): void {
+    Object.assign(this, { [key]: value });
+    this.host.requestUpdate();
   }
 
   // The shell calls this before CSS hides the panel or drawer. Mounted menus
@@ -137,13 +183,13 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     return hadTransientMenu;
   }
 
-  protected preloadRoute(routeId: NavigationRouteId, event: Event, immediate = false) {
+  private preloadRoute(routeId: NavigationRouteId, event: Event, immediate = false) {
     scheduleRoutePreload(
       this.routePreloadTimers,
       routeId,
       event,
-      (nextRouteId) => this.onPreloadRoute?.(nextRouteId),
-      routeId === this.activeRouteId || !this.isRouteEnabled(routeId),
+      (nextRouteId) => this.host.onPreloadRoute?.(nextRouteId),
+      routeId === this.host.activeRouteId || !this.isRouteEnabled(routeId),
       immediate,
     );
   }
@@ -152,11 +198,11 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     cancelRoutePreload(this.routePreloadTimers, event);
   };
 
-  protected isRouteEnabled(routeId: NavigationRouteId): boolean {
-    return this.enabledRouteIds?.includes(routeId) ?? true;
+  isRouteEnabled(routeId: NavigationRouteId): boolean {
+    return this.host.enabledRouteIds?.includes(routeId) ?? true;
   }
 
-  protected readonly openCustomizeMenuFromContext = (event: MouseEvent) => {
+  readonly openCustomizeMenuFromContext = (event: MouseEvent) => {
     event.preventDefault();
     this.openCustomizeMenu(event.clientX, event.clientY);
   };
@@ -166,22 +212,22 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     const menuMaxHeight = 420;
     this.dismissTransientMenus();
     this.customizeMenuTrigger = trigger;
-    this.customizeMenuPosition = {
+    this.updateState("customizeMenuPosition", {
       x: Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8)),
       y: Math.max(8, Math.min(y, window.innerHeight - menuMaxHeight - 8)),
-    };
+    });
   }
 
   private closeCustomizeMenu(options: { restoreFocus?: boolean } = {}) {
     const trigger = this.customizeMenuTrigger;
     this.customizeMenuTrigger = null;
-    this.customizeMenuPosition = null;
+    this.updateState("customizeMenuPosition", null);
     if (options.restoreFocus) {
       trigger?.focus();
     }
   }
 
-  protected toggleMoreMenu(trigger: HTMLElement) {
+  toggleMoreMenu(trigger: HTMLElement) {
     if (this.moreMenuPosition) {
       this.closeMoreMenu();
       return;
@@ -191,16 +237,16 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     const rect = trigger.getBoundingClientRect();
     this.dismissTransientMenus();
     this.moreMenuTrigger = trigger;
-    this.moreMenuPosition = {
+    this.updateState("moreMenuPosition", {
       x: Math.max(8, Math.min(rect.left, window.innerWidth - menuWidth - 8)),
       y: Math.max(8, Math.min(rect.bottom + 4, window.innerHeight - menuMaxHeight - 8)),
-    };
+    });
   }
 
   private closeMoreMenu(options: { restoreFocus?: boolean } = {}) {
     const trigger = this.moreMenuTrigger;
     this.moreMenuTrigger = null;
-    this.moreMenuPosition = null;
+    this.updateState("moreMenuPosition", null);
     if (options.restoreFocus) {
       trigger?.focus();
     }
@@ -213,8 +259,8 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     y: number,
     trigger: HTMLElement | null = null,
   ) {
-    if (!this.selectedSessionKeys.has(session.key)) {
-      this.clearSessionSelection();
+    if (!this.host.selectedSessionKeys.has(session.key)) {
+      this.host.clearSessionSelection();
     }
     this.showSessionMenu(session, x, y, trigger);
   }
@@ -227,31 +273,39 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
   ) {
     this.dismissTransientMenus();
     this.sessionMenuTrigger = trigger;
-    this.sessionMenu = { session, x, y };
+    this.updateState("sessionMenu", { session, x, y });
     this.loadSessionMenuWork(session);
   }
 
-  protected closeSessionMenu() {
+  closeSessionMenu() {
     this.sessionMenuTrigger = null;
-    this.sessionMenu = null;
     this.sessionMenuWorkVersion += 1;
-    this.sessionMenuWork = null;
+    this.updateState("sessionMenu", null);
+    this.updateState("sessionMenuWork", null);
   }
 
   private loadSessionMenuWork(session: SidebarRecentSession) {
     const version = ++this.sessionMenuWorkVersion;
     if (!session.worktreeId) {
-      this.sessionMenuWork = null;
+      this.updateState("sessionMenuWork", null);
       return;
     }
-    this.sessionMenuWork = { loading: true, pullRequestUrl: null, worktreePath: null };
-    const context = this.context;
+    this.updateState("sessionMenuWork", {
+      loading: true,
+      pullRequestUrl: null,
+      worktreePath: null,
+    });
+    const context = this.host.sessionDataContext;
     const client = context?.gateway.snapshot.client;
     if (!context || !client) {
-      this.sessionMenuWork = { loading: false, pullRequestUrl: null, worktreePath: null };
+      this.updateState("sessionMenuWork", {
+        loading: false,
+        pullRequestUrl: null,
+        worktreePath: null,
+      });
       return;
     }
-    const { selectedAgentId } = this.getSessionNavigationState();
+    const { selectedAgentId } = this.host.getSessionNavigationState();
     void fetchSessionMenuWork({
       client,
       pullRequestsAvailable:
@@ -262,7 +316,7 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
       worktreeId: session.worktreeId,
     }).then((work) => {
       if (version === this.sessionMenuWorkVersion) {
-        this.sessionMenuWork = { loading: false, ...work };
+        this.updateState("sessionMenuWork", { loading: false, ...work });
       }
     });
   }
@@ -272,17 +326,17 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     const menuMaxHeight = 160;
     this.dismissTransientMenus();
     this.sessionGroupMenuTrigger = trigger;
-    this.sessionGroupMenu = {
+    this.updateState("sessionGroupMenu", {
       group,
       x: Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8)),
       y: Math.max(8, Math.min(y, window.innerHeight - menuMaxHeight - 8)),
-    };
+    });
   }
 
   private closeSessionGroupMenu(options: { restoreFocus?: boolean } = {}) {
     const trigger = this.sessionGroupMenuTrigger;
     this.sessionGroupMenuTrigger = null;
-    this.sessionGroupMenu = null;
+    this.updateState("sessionGroupMenu", null);
     if (options.restoreFocus) {
       trigger?.focus();
     }
@@ -298,22 +352,22 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     const rect = trigger.getBoundingClientRect();
     this.dismissTransientMenus();
     this.sessionSortMenuTrigger = trigger;
-    this.sessionSortMenuPosition = {
+    this.updateState("sessionSortMenuPosition", {
       x: Math.max(8, Math.min(rect.right, window.innerWidth - menuWidth - 8)),
       y: Math.max(8, Math.min(rect.bottom + 4, window.innerHeight - menuMaxHeight - 8)),
-    };
+    });
   }
 
   private closeSessionSortMenu(options: { restoreFocus?: boolean } = {}) {
     const trigger = this.sessionSortMenuTrigger;
     this.sessionSortMenuTrigger = null;
-    this.sessionSortMenuPosition = null;
+    this.updateState("sessionSortMenuPosition", null);
     if (options.restoreFocus) {
       trigger?.focus();
     }
   }
 
-  protected toggleAgentMenu(trigger: HTMLElement) {
+  toggleAgentMenu(trigger: HTMLElement) {
     if (this.agentMenuPosition) {
       this.closeAgentMenu();
       return;
@@ -326,32 +380,32 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     this.closeSessionGroupMenu();
     this.closeSessionSortMenu();
     this.agentMenuTrigger = trigger;
-    this.agentMenuFilter = "";
-    this.agentMenuPosition = {
+    this.updateState("agentMenuFilter", "");
+    this.updateState("agentMenuPosition", {
       x: Math.max(8, Math.min(rect.right - menuWidth, window.innerWidth - menuWidth - 8)),
       bottom: Math.max(8, window.innerHeight - rect.top + 4),
-    };
+    });
   }
 
-  protected closeAgentMenu(options: { restoreFocus?: boolean } = {}) {
+  closeAgentMenu(options: { restoreFocus?: boolean } = {}) {
     const trigger = this.agentMenuTrigger;
     this.agentMenuTrigger = null;
-    this.agentMenuPosition = null;
-    this.agentMenuFilter = "";
+    this.updateState("agentMenuPosition", null);
+    this.updateState("agentMenuFilter", "");
     if (options.restoreFocus) {
       trigger?.focus();
     }
   }
 
-  protected renderCustomizeMenu() {
+  renderCustomizeMenu() {
     const position = this.customizeMenuPosition;
     const trigger = this.customizeMenuTrigger;
     return renderSidebarCustomizeMenu({
       position,
-      sidebarEntries: this.sidebarEntries,
+      sidebarEntries: this.host.sidebarEntries,
       isRouteEnabled: (routeId) => this.isRouteEnabled(routeId),
-      workboardBoards: this.workboardBoards,
-      workboardRenderers: this.workboardRenderers,
+      workboardBoards: this.host.workboardBoards,
+      workboardRenderers: this.host.workboardRenderers,
       onTabAway: () => trigger?.focus(),
       onClose: (restoreFocus) => {
         if (this.customizeMenuPosition !== position) {
@@ -361,56 +415,57 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
       },
       onToggleRoute: (routeId) => {
         const entry = serializeSidebarEntry({ type: "route", route: routeId });
-        const canonical = this.reconciledSidebarZone().sidebarEntries;
+        const canonical = this.host.reconciledSidebarZone().sidebarEntries;
         const next = canonical.includes(entry)
           ? canonical.filter((candidate) => candidate !== entry)
           : [...canonical, entry];
-        this.onUpdateSidebarEntries?.(next);
+        this.host.onUpdateSidebarEntries?.(next);
       },
       onToggleWorkboardBoard: (boardId) => {
         const entry = serializeSidebarEntry({ type: "workboard", boardId });
-        const canonical = this.reconciledSidebarZone().sidebarEntries;
+        const canonical = this.host.reconciledSidebarZone().sidebarEntries;
         const next = canonical.includes(entry)
           ? canonical.filter((candidate) => candidate !== entry)
           : [...canonical, entry];
-        this.onUpdateSidebarEntries?.(next);
+        this.host.onUpdateSidebarEntries?.(next);
       },
       onReset: () => {
         // Canonical list, not the render list: unknown-state session slots
         // (other agents, still-loading caches) must survive a route reset.
-        const sessions = this.reconciledSidebarZone().sidebarEntries.filter((entry) =>
-          entry.startsWith("session:"),
-        );
-        this.onUpdateSidebarEntries?.([...DEFAULT_SIDEBAR_ENTRIES, ...sessions]);
+        const sessions = this.host
+          .reconciledSidebarZone()
+          .sidebarEntries.filter((entry) => entry.startsWith("session:"));
+        this.host.onUpdateSidebarEntries?.([...DEFAULT_SIDEBAR_ENTRIES, ...sessions]);
         this.closeCustomizeMenu({ restoreFocus: true });
       },
     });
   }
 
-  protected renderAgentMenu() {
+  renderAgentMenu() {
     const position = this.agentMenuPosition;
     const trigger = this.agentMenuTrigger;
-    const { activeId, agent, agents } = this.activeChipAgent();
+    const { activeId, agent, agents } = this.host.activeChipAgent();
     return renderSidebarAgentMenu({
       position,
       activeId,
       activeName: agent ? normalizeAgentLabel(agent) : activeId,
       agents,
       filter: this.agentMenuFilter,
-      pinnedAgentIds: this.pinnedAgentIds,
-      connected: this.connected,
-      canPairDevice: this.canPairDevice,
-      basePath: this.basePath,
-      gatewayVersion: this.gatewayVersion,
-      themeMode: this.themeMode,
-      agentUnreadCount: (agentId) => this.agentUnreadCount(agentId),
+      pinnedAgentIds: this.host.pinnedAgentIds,
+      connected: this.host.connected,
+      canPairDevice: this.host.canPairDevice,
+      basePath: this.host.basePath,
+      gatewayVersion: this.host.gatewayVersion,
+      themeMode: this.host.themeMode,
+      agentUnreadCount: (agentId) => this.host.agentUnreadCount(agentId),
       agentApprovalCount: (agentId) =>
-        this.sessionData.approvalBadgeSnapshot().agentCounts.get(normalizeAgentId(agentId)) ?? 0,
+        this.host.sessionData.approvalBadgeSnapshot().agentCounts.get(normalizeAgentId(agentId)) ??
+        0,
       onFilterChange: (next) => {
-        this.agentMenuFilter = next;
+        this.updateState("agentMenuFilter", next);
       },
-      onSwitchAgent: (agentId) => this.switchChipAgent(agentId),
-      onAskCapabilities: (agentId) => this.askAgentCapabilities(agentId),
+      onSwitchAgent: (agentId) => this.host.switchChipAgent(agentId),
+      onAskCapabilities: (agentId) => this.host.askAgentCapabilities(agentId),
       onTabAway: () => trigger?.focus(),
       onClose: (restoreFocus) => {
         if (this.agentMenuPosition !== position) {
@@ -418,23 +473,23 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
         }
         this.closeAgentMenu({ restoreFocus });
       },
-      onNavigate: (routeId, options) => this.onNavigate?.(routeId, options),
-      onPairMobile: () => this.onPairMobile?.(),
+      onNavigate: (routeId, options) => this.host.onNavigate?.(routeId, options),
+      onPairMobile: () => this.host.onPairMobile?.(),
     });
   }
 
-  protected renderSessionMenu() {
+  renderSessionMenu() {
     const menu = this.sessionMenu;
     if (!menu) {
       return nothing;
     }
-    const context = this.context;
+    const context = this.host.sessionDataContext;
     const { session } = menu;
     const mainKey = resolveUiConfiguredMainKey({
-      agentsList: this.context?.agents.state.agentsList,
-      hello: this.context?.gateway.snapshot.hello,
+      agentsList: this.host.sessionDataContext?.agents.state.agentsList,
+      hello: this.host.sessionDataContext?.gateway.snapshot.hello,
     });
-    const selection = this.selectedVisibleSessions();
+    const selection = this.host.selectedVisibleSessions();
     const batchRows =
       selection.length > 1 && selection.some((row) => row.key === session.key) ? selection : null;
     const rows = batchRows ?? [session];
@@ -462,8 +517,8 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
           .lastActive=${batchRows ? "" : session.meta}
           .anchor=${menu}
           .trigger=${this.sessionMenuTrigger}
-          .disabled=${!this.connected}
-          .forkDisabled=${this.sessionData.sessionsLoading || session.modelSelectionLocked}
+          .disabled=${!this.host.connected}
+          .forkDisabled=${this.host.sessionData.sessionsLoading || session.modelSelectionLocked}
           .archiveAllowed=${archiveAllowed}
           .cloudWorkerStopAllowed=${Boolean(
             !batchRows &&
@@ -472,7 +527,7 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
             context &&
             isGatewayMethodAdvertised(context.gateway.snapshot, "sessions.reclaim") === true,
           )}
-          .groups=${this.knownSessionGroups()}
+          .groups=${this.host.knownSessionGroups()}
           .canOpenChat=${true}
           .work=${batchRows ? null : this.sessionMenuWork}
           .workboard=${null}
@@ -483,12 +538,12 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
           }}
           .onAction=${(action: SessionMenuAction) => {
             if (batchRows) {
-              void this.sessionOrganizer.runBatchSessionAction(action, batchRows, allUnread);
+              void this.host.sessionOrganizer.runBatchSessionAction(action, batchRows, allUnread);
               return;
             }
             switch (action.kind) {
               case "open-chat":
-                this.selectSession(session.key);
+                this.host.selectSession(session.key);
                 break;
               case "open-pr":
                 openExternalUrlSafe(action.url);
@@ -497,42 +552,42 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
                 openEditor(action.editor, action.path);
                 break;
               case "toggle-pin":
-                void this.sessionOrganizer.patchSession(session, { pinned: !session.pinned });
+                void this.host.sessionOrganizer.patchSession(session, { pinned: !session.pinned });
                 break;
               case "set-icon":
-                void this.sessionOrganizer.patchSession(session, { icon: action.icon });
+                void this.host.sessionOrganizer.patchSession(session, { icon: action.icon });
                 break;
               case "toggle-unread":
-                void this.sessionOrganizer.patchSession(session, { unread: !session.unread });
+                void this.host.sessionOrganizer.patchSession(session, { unread: !session.unread });
                 break;
               case "rename":
-                void this.sessionOrganizer.renameSession(session);
+                void this.host.sessionOrganizer.renameSession(session);
                 break;
               case "fork":
-                void this.sessionOrganizer.forkSession(session);
+                void this.host.sessionOrganizer.forkSession(session);
                 break;
               case "workboard":
                 break;
               case "move-to-group":
                 if (action.category === null || session.category !== action.category) {
-                  void this.sessionOrganizer.assignSessionCategory(session, action.category);
+                  void this.host.sessionOrganizer.assignSessionCategory(session, action.category);
                 }
                 break;
               case "new-group":
-                void this.sessionOrganizer.createSessionGroup([session]);
+                void this.host.sessionOrganizer.createSessionGroup([session]);
                 break;
               case "toggle-archived":
                 if (session.archived) {
-                  void this.sessionOrganizer.patchSession(session, { archived: false });
+                  void this.host.sessionOrganizer.patchSession(session, { archived: false });
                 } else {
-                  void this.sessionOrganizer.archiveSessionWithUndo(session);
+                  void this.host.sessionOrganizer.archiveSessionWithUndo(session);
                 }
                 break;
               case "stop-cloud-worker":
-                void this.sessionOrganizer.stopCloudWorker(session);
+                void this.host.sessionOrganizer.stopCloudWorker(session);
                 break;
               case "delete":
-                void this.sessionOrganizer.deleteSession(session);
+                void this.host.sessionOrganizer.deleteSession(session);
                 break;
             }
           }}
@@ -541,23 +596,23 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     );
   }
 
-  protected renderSessionGroupMenu() {
+  renderSessionGroupMenu() {
     const menu = this.sessionGroupMenu;
     return renderSidebarSessionGroupMenu({
       menu,
       trigger: this.sessionGroupMenuTrigger,
-      connected: this.connected,
+      connected: this.host.connected,
       onAction: (action, group) => {
         this.closeSessionGroupMenu({ restoreFocus: true });
         switch (action) {
           case "rename-group":
-            void this.sessionOrganizer.renameSessionGroupFromMenu(group);
+            void this.host.sessionOrganizer.renameSessionGroupFromMenu(group);
             break;
           case "new-group":
-            void this.sessionOrganizer.createSessionGroup();
+            void this.host.sessionOrganizer.createSessionGroup();
             break;
           case "delete-group":
-            void this.sessionOrganizer.deleteSessionGroupFromMenu(group);
+            void this.host.sessionOrganizer.deleteSessionGroupFromMenu(group);
             break;
         }
       },
@@ -570,29 +625,29 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     });
   }
 
-  protected renderSessionSortMenu() {
+  renderSessionSortMenu() {
     const position = this.sessionSortMenuPosition;
     return renderSidebarSessionSortMenu({
       position,
       trigger: this.sessionSortMenuTrigger,
-      grouping: this.sessionsGrouping,
-      sortMode: this.sessionSortMode,
-      statusFilter: this.sessionsStatusFilter,
-      showCron: this.sessionsShowCron,
+      grouping: this.host.sessionsGrouping,
+      sortMode: this.host.sessionSortMode,
+      statusFilter: this.host.sessionsStatusFilter,
+      showCron: this.host.sessionsShowCron,
       onGroupingChange: (grouping) => {
-        this.sessionOrganizer.setSessionsGrouping(grouping);
+        this.host.sessionOrganizer.setSessionsGrouping(grouping);
         this.closeSessionSortMenu({ restoreFocus: true });
       },
       onSortModeChange: (mode) => {
-        this.sessionSortMode = mode;
+        this.host.sessionSortMode = mode;
         this.closeSessionSortMenu({ restoreFocus: true });
       },
       onStatusFilterChange: (statusFilter) => {
-        this.sessionOrganizer.setSessionsStatusFilter(statusFilter);
+        this.host.sessionOrganizer.setSessionsStatusFilter(statusFilter);
         this.closeSessionSortMenu({ restoreFocus: true });
       },
       onShowCronChange: (show) => {
-        this.sessionOrganizer.setSessionsShowCron(show);
+        this.host.sessionOrganizer.setSessionsShowCron(show);
         this.closeSessionSortMenu({ restoreFocus: true });
       },
       onClose: (restoreFocus) => {
@@ -604,40 +659,40 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
     });
   }
 
-  protected renderRoute(routeId: NavigationRouteId) {
+  renderRoute(routeId: NavigationRouteId) {
     if (!this.isRouteEnabled(routeId)) {
       return nothing;
     }
-    const routeSessionKey = routeId === "chat" ? this.getRouteSessionKey() : "";
+    const routeSessionKey = routeId === "chat" ? this.host.getRouteSessionKey() : "";
     const chatSearch =
       routeId === "chat" && routeSessionKey ? searchForSession(routeSessionKey) : "";
     return renderSidebarNavRoute({
       routeId,
       href: chatSearch
-        ? `${pathForRoute("chat", this.basePath)}${chatSearch}`
-        : pathForRoute(routeId, this.basePath),
+        ? `${pathForRoute("chat", this.host.basePath)}${chatSearch}`
+        : pathForRoute(routeId, this.host.basePath),
       active:
-        isSidebarRouteActive(this.activeRouteId, routeId) &&
+        isSidebarRouteActive(this.host.activeRouteId, routeId) &&
         !(routeId === "workboard" && this.activeWorkboardBoardIsPinned()),
       onNavigate: () => {
-        this.onNavigate?.(routeId, chatSearch ? { search: chatSearch } : undefined);
+        this.host.onNavigate?.(routeId, chatSearch ? { search: chatSearch } : undefined);
       },
       onPreload: (event, immediate) => this.preloadRoute(routeId, event, immediate),
       onCancelPreload: this.cancelPreload,
     });
   }
 
-  protected renderMoreMenu() {
+  renderMoreMenu() {
     const position = this.moreMenuPosition;
     const trigger = this.moreMenuTrigger;
     return renderSidebarMoreMenu({
       position,
-      basePath: this.basePath,
-      activeRouteId: this.activeRouteId,
+      basePath: this.host.basePath,
+      activeRouteId: this.host.activeRouteId,
       activeWorkboardBoardId: this.activeWorkboardBoardIsPinned()
-        ? this.activeWorkboardBoardId
+        ? this.host.activeWorkboardBoardId
         : "",
-      sidebarEntries: this.sidebarEntries,
+      sidebarEntries: this.host.sidebarEntries,
       isRouteEnabled: (routeId) => this.isRouteEnabled(routeId),
       onTabAway: () => trigger?.focus(),
       onClose: (restoreFocus) => {
@@ -648,7 +703,7 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
       },
       onNavigateRoute: (routeId) => {
         this.closeMoreMenu({ restoreFocus: true });
-        this.onNavigate?.(routeId);
+        this.host.onNavigate?.(routeId);
       },
       onPreloadRoute: (routeId, event) => this.preloadRoute(routeId, event),
       onCancelPreload: this.cancelPreload,
@@ -664,10 +719,13 @@ export abstract class AppSidebarMenusElement extends AppSidebarSessionNavigation
 
   private activeWorkboardBoardIsPinned(): boolean {
     return Boolean(
-      this.activeWorkboardBoardId &&
-      this.reconciledSidebarZone().entries.some(
-        (entry) => entry.type === "workboard" && entry.boardId === this.activeWorkboardBoardId,
-      ),
+      this.host.activeWorkboardBoardId &&
+      this.host
+        .reconciledSidebarZone()
+        .entries.some(
+          (entry) =>
+            entry.type === "workboard" && entry.boardId === this.host.activeWorkboardBoardId,
+        ),
     );
   }
 }


### PR DESCRIPTION
PR 5 of the sidebar-flattening series. Prior work: #112753, #112809, #112817, #112853, and #112923.

## What Problem This Solves

The Control UI sidebar still carried popup ownership and menu rendering in a dedicated inheritance layer, keeping the sidebar class tower deeper than necessary.

## Why This Change Was Made

Moves menu state, lifecycle cleanup, and renderer wiring into `SidebarMenusController`, reparents session narration directly onto session navigation, and deletes the old menus element layer without compatibility shims. The controller owns the existing catalog-menu helper; organizer drag state is read directly from `SessionOrganizerController` instead of preserving forwarding getters.

## User Impact

None. This is a behavior-neutral ownership refactor.

## Evidence

- State parity audit: all eight former `@state` fields update through the controller helper, which calls `host.requestUpdate()`; trigger anchors, preload timers, and `sessionMenuWorkVersion` remain non-reactive.
- Focus restoration and context-menu behavior: covered by the full `app-sidebar.test.ts` DOM suite, including transient replacement guards, session/group/sort menus, footer agent menu, and pinned-item customization.
- Focused tests: 198 passed across `app-sidebar.test.ts`, `session-menu.test.ts`, `session-menu-work.test.ts`, and `catalog-session-menu.test.ts`.
- Hosted checks: UI tsgo and the exact touched-path `check-changed` plan passed on Blacksmith Testbox run 29983608676, including format, i18n, typechecks, and lint.
- Production UI build and precompressed-asset verification passed. Startup JavaScript is 322,901 bytes gzip, 534 bytes below the 323,435-byte baseline; no budget update was made.
- Autoreview: clean, no accepted/actionable findings (Codex, 0.94 confidence).
