### PR TITLE
fix(gateway): keep streaming OpenAI-compatible requests admitted

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -31,6 +31,7 @@ import {
   testState,
   withGatewayServer,
 } from "./test-helpers.js";
+import { createPostHandlerGate, waitForRootWorkCount } from "./test-helpers.root-work.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -103,40 +104,6 @@ function parseSseDataLines(text: string): string[] {
     .map((line) => line.trim())
     .filter((line) => line.startsWith("data: "))
     .map((line) => line.slice("data: ".length));
-}
-
-/**
- * Holds mocked agent work until the streaming HTTP handler has returned.
- * SSE headers reach the client before the handler unwinds, so one extra
- * macrotask turn guarantees the request's root-work lease was released.
- */
-function createPostHandlerGate() {
-  let open = () => {};
-  const opened = new Promise<void>((resolve) => {
-    open = resolve;
-  });
-  return {
-    opened,
-    openAfterHandlerReturned: async () => {
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      open();
-    },
-  };
-}
-
-async function waitForRootWorkCount(expected: number): Promise<number> {
-  for (let attempt = 0; attempt < 200; attempt += 1) {
-    const active = getActiveGatewayRootWorkCount();
-    if (active === expected) {
-      return active;
-    }
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 5);
-    });
-  }
-  return getActiveGatewayRootWorkCount();
 }
 
 type FirstAgentCommandOptions = {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -15,6 +15,10 @@ import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  GatewayDrainingError,
+  isGatewaySubordinateWorkAdmissionClosed,
+} from "../process/gateway-work-admission.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
   agentCommand,
@@ -2330,6 +2334,32 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       );
     },
   );
+
+  it("keeps streaming agent work admitted after the HTTP handler returns", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async () => {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      if (isGatewaySubordinateWorkAdmissionClosed()) {
+        throw new GatewayDrainingError();
+      }
+      return { payloads: [{ text: "hello" }] };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    const data = parseSseDataLines(await res.text());
+    expect(data.at(-1)).toBe("[DONE]");
+    expect(data.join("\n")).toContain("hello");
+    expect(data.join("\n")).not.toContain("Error: internal error");
+  });
 
   it("buffers replaceable assistant events for streaming chat completions", async () => {
     const port = enabledPort;

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -15,9 +15,12 @@ import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
-  GatewayDrainingError,
-  isGatewaySubordinateWorkAdmissionClosed,
+  getActiveGatewayRootWorkCount,
+  isGatewayRestartDraining,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
@@ -100,6 +103,40 @@ function parseSseDataLines(text: string): string[] {
     .map((line) => line.trim())
     .filter((line) => line.startsWith("data: "))
     .map((line) => line.slice("data: ".length));
+}
+
+/**
+ * Holds mocked agent work until the streaming HTTP handler has returned.
+ * SSE headers reach the client before the handler unwinds, so one extra
+ * macrotask turn guarantees the request's root-work lease was released.
+ */
+function createPostHandlerGate() {
+  let open = () => {};
+  const opened = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return {
+    opened,
+    openAfterHandlerReturned: async () => {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      open();
+    },
+  };
+}
+
+async function waitForRootWorkCount(expected: number): Promise<number> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const active = getActiveGatewayRootWorkCount();
+    if (active === expected) {
+      return active;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 5);
+    });
+  }
+  return getActiveGatewayRootWorkCount();
 }
 
 type FirstAgentCommandOptions = {
@@ -2335,17 +2372,16 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     },
   );
 
-  it("keeps streaming agent work admitted after the HTTP handler returns", async () => {
+  it("streams the answer when the agent queues lane work after the handler returned", async () => {
     const port = enabledPort;
     agentCommand.mockClear();
+    const gate = createPostHandlerGate();
     agentCommand.mockImplementationOnce((async () => {
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      if (isGatewaySubordinateWorkAdmissionClosed()) {
-        throw new GatewayDrainingError();
-      }
-      return { payloads: [{ text: "hello" }] };
+      await gate.opened;
+      // The command queue refuses subordinate work whose root was already
+      // released, which is how a detached streaming continuation used to fail.
+      const lane = await enqueueCommandInLane("openai-http-admission-probe", async () => "queued");
+      return { payloads: [{ text: `answer ${lane}` }] };
     }) as never);
 
     const res = await postChatCompletions(port, {
@@ -2353,12 +2389,62 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       model: "openclaw",
       messages: [{ role: "user", content: "hi" }],
     });
+    await gate.openAfterHandlerReturned();
 
     expect(res.status).toBe(200);
-    const data = parseSseDataLines(await res.text());
-    expect(data.at(-1)).toBe("[DONE]");
-    expect(data.join("\n")).toContain("hello");
-    expect(data.join("\n")).not.toContain("Error: internal error");
+    const streamed = parseSseDataLines(await res.text()).join("\n");
+    expect(streamed).toContain("answer queued");
+    expect(streamed).not.toContain("Error: internal error");
+  });
+
+  it("keeps one root-work lease alive from handler return to stream end", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    const gate = createPostHandlerGate();
+    let leasesDuringRun = -1;
+    agentCommand.mockImplementationOnce((async () => {
+      await gate.opened;
+      // Counted without `excludeCurrent`: the lease being proven is the one the
+      // streaming continuation owns right here, so it must be part of the count.
+      leasesDuringRun = getActiveGatewayRootWorkCount();
+      return { payloads: [{ text: "late answer" }] };
+    }) as never);
+
+    const idleLeases = getActiveGatewayRootWorkCount();
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    await gate.openAfterHandlerReturned();
+    await res.text();
+
+    expect(leasesDuringRun).toBeGreaterThan(idleLeases);
+    // A leaked lease would stall a later restart drain forever.
+    await expect(waitForRootWorkCount(idleLeases)).resolves.toBe(idleLeases);
+  });
+
+  it("refuses streaming chat completions while the gateway drains for restart", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    markGatewayRestartDraining();
+    try {
+      expect(isGatewayRestartDraining()).toBe(true);
+      const res = await postChatCompletions(port, {
+        stream: true,
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBe("1");
+      const body = (await res.json()) as { error?: { code?: string } };
+      expect(body.error?.code).toBe("gateway_unavailable");
+      expect(agentCommand).not.toHaveBeenCalled();
+    } finally {
+      resetGatewayWorkAdmission();
+    }
+    expect(isGatewayRestartDraining()).toBe(false);
   });
 
   it("buffers replaceable assistant events for streaming chat completions", async () => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1283,6 +1283,9 @@ export async function handleOpenAiHttpRequest(
   wroteRole = true;
   writeAssistantRoleChunk(res, { runId, model });
 
+  // The continuation body never throws, but the admission fence rejects when it
+  // has no live parent root and the gateway is draining. Nothing awaits this
+  // detached promise, so log instead of leaking an unhandled rejection.
   void runWithGatewayIndependentRootWorkContinuation(async () => {
     try {
       const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
@@ -1425,6 +1428,8 @@ export async function handleOpenAiHttpRequest(
         });
       }
     }
+  }).catch((err: unknown) => {
+    logWarn(`openai-compat: streaming continuation failed: ${String(err)}`);
   });
 
   return true;

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -33,6 +33,7 @@ import {
   type InputImageLimits,
   type InputImageSource,
 } from "../media/input-files.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
 import { defaultRuntime } from "../runtime.js";
 import {
   isReplaceableAssistantStreamEvent,
@@ -1282,7 +1283,7 @@ export async function handleOpenAiHttpRequest(
   wroteRole = true;
   writeAssistantRoleChunk(res, { runId, model });
 
-  void (async () => {
+  void runWithGatewayIndependentRootWorkContinuation(async () => {
     try {
       const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
       resultResolved = true;
@@ -1424,7 +1425,7 @@ export async function handleOpenAiHttpRequest(
         });
       }
     }
-  })();
+  });
 
   return true;
 }

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -10,9 +10,12 @@ import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
-  GatewayDrainingError,
-  isGatewaySubordinateWorkAdmissionClosed,
+  getActiveGatewayRootWorkCount,
+  isGatewayRestartDraining,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
@@ -178,6 +181,40 @@ function firstAgentOpts(callIndex = 0): Record<string, unknown> {
     throw new Error(`expected agentCommand call #${callIndex + 1}`);
   }
   return call[0] as Record<string, unknown>;
+}
+
+/**
+ * Holds mocked agent work until the streaming HTTP handler has returned.
+ * SSE headers reach the client before the handler unwinds, so one extra
+ * macrotask turn guarantees the request's root-work lease was released.
+ */
+function createPostHandlerGate() {
+  let open = () => {};
+  const opened = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return {
+    opened,
+    openAfterHandlerReturned: async () => {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      open();
+    },
+  };
+}
+
+async function waitForRootWorkCount(expected: number): Promise<number> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const active = getActiveGatewayRootWorkCount();
+    if (active === expected) {
+      return active;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 5);
+    });
+  }
+  return getActiveGatewayRootWorkCount();
 }
 
 async function ensureResponseConsumed(res: Response) {
@@ -1099,30 +1136,71 @@ describe("OpenResponses HTTP API (e2e)", () => {
     }
   });
 
-  it("keeps streaming agent work admitted after the HTTP handler returns", async () => {
+  it("streams the answer when the agent queues lane work after the handler returned", async () => {
     const port = enabledPort;
     agentCommand.mockClear();
+    const gate = createPostHandlerGate();
     agentCommand.mockImplementationOnce((async () => {
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      if (isGatewaySubordinateWorkAdmissionClosed()) {
-        throw new GatewayDrainingError();
-      }
-      return { payloads: [{ text: "hello" }] };
+      await gate.opened;
+      // The command queue refuses subordinate work whose root was already
+      // released, which is how a detached streaming continuation used to fail.
+      const lane = await enqueueCommandInLane(
+        "openresponses-http-admission-probe",
+        async () => "queued",
+      );
+      return { payloads: [{ text: `answer ${lane}` }] };
     }) as never);
 
-    const res = await postResponses(port, {
-      stream: true,
-      model: "openclaw",
-      input: "hi",
-    });
+    const res = await postResponses(port, { stream: true, model: "openclaw", input: "hi" });
+    await gate.openAfterHandlerReturned();
 
     expect(res.status).toBe(200);
-    const text = await res.text();
-    expect(text).toContain("response.completed");
-    expect(text).toContain("hello");
-    expect(text).not.toContain("response.failed");
+    const events = parseSseEvents(await res.text());
+    expect(collectSseEventTypes(events)).toContain("response.completed");
+    expect(collectSseEventTypes(events)).not.toContain("response.failed");
+    expect(findSseEvent(events, "response.completed").data).toContain("answer queued");
+  });
+
+  it("keeps one root-work lease alive from handler return to stream end", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    const gate = createPostHandlerGate();
+    let leasesDuringRun = -1;
+    agentCommand.mockImplementationOnce((async () => {
+      await gate.opened;
+      // Counted without `excludeCurrent`: the lease being proven is the one the
+      // streaming continuation owns right here, so it must be part of the count.
+      leasesDuringRun = getActiveGatewayRootWorkCount();
+      return { payloads: [{ text: "late answer" }] };
+    }) as never);
+
+    const idleLeases = getActiveGatewayRootWorkCount();
+    const res = await postResponses(port, { stream: true, model: "openclaw", input: "hi" });
+    await gate.openAfterHandlerReturned();
+    await res.text();
+
+    expect(leasesDuringRun).toBeGreaterThan(idleLeases);
+    // A leaked lease would stall a later restart drain forever.
+    await expect(waitForRootWorkCount(idleLeases)).resolves.toBe(idleLeases);
+  });
+
+  it("refuses streaming responses while the gateway drains for restart", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    markGatewayRestartDraining();
+    try {
+      expect(isGatewayRestartDraining()).toBe(true);
+      const res = await postResponses(port, { stream: true, model: "openclaw", input: "hi" });
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBe("1");
+      const body = (await res.json()) as { error?: { code?: string } };
+      expect(body.error?.code).toBe("gateway_unavailable");
+      expect(agentCommand).not.toHaveBeenCalled();
+    } finally {
+      resetGatewayWorkAdmission();
+    }
+    expect(isGatewayRestartDraining()).toBe(false);
   });
 
   it("preserves assistant text alongside non-stream function_call output", async () => {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -26,6 +26,7 @@ import {
   startGatewayServerWithRetries,
   testState,
 } from "./test-helpers.js";
+import { createPostHandlerGate, waitForRootWorkCount } from "./test-helpers.root-work.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -181,40 +182,6 @@ function firstAgentOpts(callIndex = 0): Record<string, unknown> {
     throw new Error(`expected agentCommand call #${callIndex + 1}`);
   }
   return call[0] as Record<string, unknown>;
-}
-
-/**
- * Holds mocked agent work until the streaming HTTP handler has returned.
- * SSE headers reach the client before the handler unwinds, so one extra
- * macrotask turn guarantees the request's root-work lease was released.
- */
-function createPostHandlerGate() {
-  let open = () => {};
-  const opened = new Promise<void>((resolve) => {
-    open = resolve;
-  });
-  return {
-    opened,
-    openAfterHandlerReturned: async () => {
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      open();
-    },
-  };
-}
-
-async function waitForRootWorkCount(expected: number): Promise<number> {
-  for (let attempt = 0; attempt < 200; attempt += 1) {
-    const active = getActiveGatewayRootWorkCount();
-    if (active === expected) {
-      return active;
-    }
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 5);
-    });
-  }
-  return getActiveGatewayRootWorkCount();
 }
 
 async function ensureResponseConsumed(res: Response) {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -10,6 +10,10 @@ import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  GatewayDrainingError,
+  isGatewaySubordinateWorkAdmissionClosed,
+} from "../process/gateway-work-admission.js";
 import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
@@ -1093,6 +1097,32 @@ describe("OpenResponses HTTP API (e2e)", () => {
     } finally {
       await server.close({ reason: "openresponses token auth owner test done" });
     }
+  });
+
+  it("keeps streaming agent work admitted after the HTTP handler returns", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async () => {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      if (isGatewaySubordinateWorkAdmissionClosed()) {
+        throw new GatewayDrainingError();
+      }
+      return { payloads: [{ text: "hello" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("response.completed");
+    expect(text).toContain("hello");
+    expect(text).not.toContain("response.failed");
   });
 
   it("preserves assistant text alongside non-stream function_call output", async () => {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -32,6 +32,7 @@ import {
   type InputImageLimits,
   type InputImageSource,
 } from "../media/input-files.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
 import { defaultRuntime } from "../runtime.js";
 import {
   isReplaceableAssistantStreamEvent,
@@ -1108,7 +1109,7 @@ export async function handleOpenResponsesHttpRequest(
     unsubscribe();
   });
 
-  void (async () => {
+  void runWithGatewayIndependentRootWorkContinuation(async () => {
     try {
       const result = await runResponsesAgentCommand({
         message: prompt.message,
@@ -1363,7 +1364,7 @@ export async function handleOpenResponsesHttpRequest(
         });
       }
     }
-  })();
+  });
 
   return true;
 }

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1109,6 +1109,9 @@ export async function handleOpenResponsesHttpRequest(
     unsubscribe();
   });
 
+  // The continuation body never throws, but the admission fence rejects when it
+  // has no live parent root and the gateway is draining. Nothing awaits this
+  // detached promise, so log instead of leaking an unhandled rejection.
   void runWithGatewayIndependentRootWorkContinuation(async () => {
     try {
       const result = await runResponsesAgentCommand({
@@ -1364,6 +1367,8 @@ export async function handleOpenResponsesHttpRequest(
         });
       }
     }
+  }).catch((err: unknown) => {
+    logWarn(`openresponses: streaming continuation failed: ${String(err)}`);
   });
 
   return true;

--- a/src/gateway/test-helpers.root-work.ts
+++ b/src/gateway/test-helpers.root-work.ts
@@ -1,0 +1,38 @@
+/**
+ * Gateway root-work admission helpers shared by streaming HTTP tests.
+ */
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+
+/**
+ * Holds mocked agent work until the streaming HTTP handler has returned.
+ * SSE headers reach the client before the handler unwinds, so one extra
+ * macrotask turn guarantees the request's root-work lease was released.
+ */
+export function createPostHandlerGate() {
+  let open = () => {};
+  const opened = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return {
+    opened,
+    openAfterHandlerReturned: async () => {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      open();
+    },
+  };
+}
+
+export async function waitForRootWorkCount(expected: number): Promise<number> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const active = getActiveGatewayRootWorkCount();
+    if (active === expected) {
+      return active;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 5);
+    });
+  }
+  return getActiveGatewayRootWorkCount();
+}


### PR DESCRIPTION
Closes #111752

## What Problem This Solves

Every `stream: true` request to the gateway's OpenAI-compatible endpoints fails with `GatewayDrainingError` on a gateway that is not draining. The same request with `stream: false` succeeds. Because OpenAI-compatible clients default to streaming, the endpoints are effectively unusable rather than degraded — reported independently against both raw `curl` and Open WebUI 0.10.2.

Every gateway HTTP route runs inside a root-work admission that is released as soon as the handler's promise resolves (`src/gateway/server/http-work-admission.ts:17-21`). The non-streaming branch `await`s the agent command inside the handler, so its admission is still live. The streaming branch writes the SSE role chunk, then runs the agent command inside a **detached** `void (async () => { ... })()` and returns immediately — so the wrapper releases the root admission while the continuation is still executing in that `AsyncLocalStorage` context. When the command is enqueued, `isGatewaySubordinateWorkAdmissionClosed()` finds `released === true` and `enqueueCommandInLane` rejects, though no drain, suspend, or restart flag is set.

This affects **both** streaming endpoints, not only the one reported:

- `/v1/chat/completions` — `src/gateway/openai-http.ts:1285`
- `/v1/responses` — `src/gateway/openresponses-http.ts:1108`

## Why This Change Was Made

The repository already owns the right primitive for detached-but-required follow-up work: `runWithGatewayIndependentRootWorkContinuation()` — *"Detaches required follow-up from the current admitted transaction"* (`src/process/gateway-work-admission.ts:321-336`). It reads the parent root synchronously at call time, so a handler still on the stack reserves a tracked root before returning, and releases it only when the whole continuation settles (`admission.run(run).finally(admission.release)`).

This is the established convention in this layer. `src/gateway/server-methods/chat-send-dispatch-errors.ts:149-210` performs detached follow-up from an admitted root and reserves it with `retainGatewayRootWorkAdmissionContinuation()`; `src/gateway/server-methods/chat-send-background.ts:54` uses the same continuation helper this PR uses. The two OpenAI-compat streaming handlers were the only detached continuations in the gateway that inherited an admitted HTTP root without reserving it.

The other detached continuations under `src/gateway` are unaffected for structural reasons rather than by luck, so the ownership boundary is narrow and well defined:

- `src/gateway/mcp-http.ts:213` runs on its own loopback `createHttpServer`, outside the gateway HTTP admission boundary
- `src/gateway/probe.ts:314,407` and `src/gateway/call.ts:1021` are gateway *client* paths, not route handlers
- `src/gateway/cron-exit-watchers.ts:120` belongs to the cron scheduler, not an HTTP route

Real drain behaviour is untouched. A genuine restart-drain is rejected upstream at the HTTP boundary, where `tryBeginGatewayRootWorkAdmission()` returns `null` and the route answers `503 gateway_unavailable` without ever reaching the changed code.

The continuation promise is now returned rather than swallowed by an IIFE, so both call sites attach a `.catch` that logs. The body itself cannot throw; the fence can, when it has no live parent root. That is unreachable from today's callers — both handlers are only invoked under `runWithGatewayHttpWorkAdmission` (`src/gateway/server-http.ts:727-728,742-743`) — but leaving an unhandled rejection latent for a future embedded host would be careless.

## User Impact

Streaming Chat Completions and Responses requests complete normally instead of returning an internal error. Restart-drain and suspension behaviour are unchanged. No config, API, or response-shape changes.

## Evidence

Environment: Linux x86_64, Node 22. Focused Vitest runs, one file per invocation:
`OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs <file>`

**Reproduced on current `main` (`1de4a099ca`).** With only the new tests applied and production code untouched:

```
FAIL  src/gateway/openai-http.test.ts
      > streams the answer when the agent queues lane work after the handler returned
AssertionError: expected '{"id":"chatcmpl_6e56b72b-867f-4fcc-88...' to contain 'answer queued'
- answer queued
+ {"...","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
+ {"...","choices":[{"index":0,"delta":{"content":"Error: internal error"},"finish_reason":"stop"}]}
+ [DONE]

FAIL  src/gateway/openai-http.test.ts
      > keeps one root-work lease alive from handler return to stream end
AssertionError: expected 0 to be greater than 0

Tests  2 failed | 21 passed (23)
```

Same reversion against `/v1/responses`:

```
× streams the answer when the agent queues lane work after the handler returned
AssertionError: expected [ 'response.created', …(8) ] to not include 'response.failed'
× keeps one root-work lease alive from handler return to stream end
AssertionError: expected 0 to be greater than 0
Tests  2 failed | 33 passed (35)
```

**After the fix:** `src/gateway/openai-http.test.ts` 23/23, `src/gateway/openresponses-http.test.ts` 35/35.

**What the tests assert.** Rather than checking the admission flag inline, the regression tests drive the real rejecting caller. The mocked agent command blocks on a deferred gate that the test opens only after `fetch` has resolved the SSE headers plus one macrotask turn — deterministically placing the agent work after the handler returned and its lease was released. It then calls the production seam `enqueueCommandInLane()` (`src/process/command-queue.ts:545`), the code that actually threw in this issue.

A second test asserts the lease is genuinely held rather than the request merely succeeding: it samples `getActiveGatewayRootWorkCount()` from inside the continuation after the handler returned, requires it above the idle baseline, then requires a return to baseline once the stream ends — so the fix cannot pass by leaking a lease that would later stall a drain.

A third test is a **guard, not a regression test**, and is labelled as such in the source. It puts the gateway into a real restart-drain and asserts `503`, `Retry-After: 1`, `error.code === "gateway_unavailable"`, and that the agent command is never invoked. It passes with or without the production fix, because drain rejection happens upstream at the HTTP boundary. It earns its place because `runWithGatewayIndependentRootWorkContinuation` deliberately reserves a root *even when admission is closed* — so proving the boundary still rejects shows this change did not open a drain bypass.

**Static checks:** `node scripts/run-oxlint.mjs`, `oxfmt --check`, and `git diff --check` clean on all changed files.

**Production:** this change has been running as a `dist` patch on a production gateway since the issue was filed. Streaming works; restart-drain still rejects correctly.

**Proof gaps, stated rather than glossed:** this was developed under a hard memory constraint, so no `pnpm build`, typecheck, or full suite was run — only focused per-file Vitest. The change adds one import to two files and touches no lazy-loading or dynamic-import boundary, so build risk should be low, but I have not proven it. Cross-file interaction beyond the two changed test files is unverified; the drain guard mutates process-global admission state and restores it in `finally`, but was not exercised against other suites under `--isolate=false`.

## AI Assistance

AI-assisted. I reviewed the admission boundary, both detached streaming paths, the continuation primitive, the sibling Responses implementation, and the affected Gateway tests, and I understand the submitted change.
