### PR TITLE
fix: SQLite WAL file can stay inflated on a running gateway until restart

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -319,7 +319,7 @@ Task records and delivery state persist in the shared OpenClaw SQLite state data
 
 Set `OPENCLAW_STATE_DIR` to move the whole state root (default `~/.openclaw`) elsewhere; the shared database path moves with it.
 
-The registry loads into memory on first use and persists every write back to SQLite, so records survive gateway restarts. WAL growth stays bounded through SQLite's default autocheckpoint threshold plus periodic `PASSIVE` checkpoints; shutdown and explicit maintenance checkpoints use `TRUNCATE` so normal closes reclaim WAL space without making the background sweeper wait on active readers.
+The registry loads into memory on first use and persists every write back to SQLite, so records survive gateway restarts. WAL growth stays bounded through SQLite's default autocheckpoint threshold plus periodic `PASSIVE` checkpoints, with a `journal_size_limit` ceiling that truncates the WAL file back down whenever a checkpoint completes — so a checkpoint transiently blocked by a reader cannot leave the WAL inflated on disk until the next restart. Shutdown and explicit maintenance checkpoints use `TRUNCATE` so normal closes reclaim WAL space without making the background sweeper wait on active readers.
 
 Legacy sidecar stores from older installs (`tasks/runs.sqlite`, `flows/registry.sqlite`) are imported into the shared database by `openclaw doctor`.
 

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -319,7 +319,7 @@ Task records and delivery state persist in the shared OpenClaw SQLite state data
 
 Set `OPENCLAW_STATE_DIR` to move the whole state root (default `~/.openclaw`) elsewhere; the shared database path moves with it.
 
-The registry loads into memory on first use and persists every write back to SQLite, so records survive gateway restarts. WAL growth stays bounded through SQLite's default autocheckpoint threshold plus periodic `PASSIVE` checkpoints, with a `journal_size_limit` ceiling that truncates the WAL file back down whenever a checkpoint completes — so a checkpoint transiently blocked by a reader cannot leave the WAL inflated on disk until the next restart. Shutdown and explicit maintenance checkpoints use `TRUNCATE` so normal closes reclaim WAL space without making the background sweeper wait on active readers.
+The registry loads into memory on first use and persists every write back to SQLite, so records survive gateway restarts. WAL growth stays bounded through SQLite's default autocheckpoint threshold plus periodic `PASSIVE` checkpoints. After a checkpoint completes, the next commit resets the WAL and applies a 64 MiB `journal_size_limit` ceiling, so a reader cannot leave the file parked at a pathological high-water mark until restart. Shutdown and explicit maintenance checkpoints use `TRUNCATE` so normal closes reclaim WAL space without making the background sweeper wait on active readers.
 
 Legacy sidecar stores from older installs (`tasks/runs.sqlite`, `flows/registry.sqlite`) are imported into the shared database by `openclaw doctor`.
 

--- a/src/infra/sqlite-pragma.test-support.ts
+++ b/src/infra/sqlite-pragma.test-support.ts
@@ -6,6 +6,7 @@ type SqliteNumberPragma =
   | "auto_vacuum"
   | "busy_timeout"
   | "foreign_keys"
+  | "journal_size_limit"
   | "schema_version"
   | "synchronous"
   | "user_version"

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -201,6 +201,59 @@ describe("sqlite WAL maintenance", () => {
     }
   });
 
+  describe("journal_size_limit ceiling", () => {
+    it("bounds the WAL to the default 64 MiB ceiling", () => {
+      const sqlite = requireNodeSqlite();
+      const dir = tempDirs.make("openclaw-sqlite-wal-size-");
+      const dbPath = path.join(dir, "openclaw.sqlite");
+      const db = new sqlite.DatabaseSync(dbPath);
+      try {
+        configureSqliteWalMaintenance(db, {
+          checkpointIntervalMs: 0,
+          databaseLabel: "wal-size-default",
+          databasePath: dbPath,
+        });
+
+        expect(db.prepare("PRAGMA journal_mode;").get()).toEqual({ journal_mode: "wal" });
+        expect(db.prepare("PRAGMA journal_size_limit;").get()).toEqual({
+          journal_size_limit: 64 * 1024 * 1024,
+        });
+      } finally {
+        db.close();
+      }
+    });
+
+    it("honors a custom journalSizeLimitBytes", () => {
+      const sqlite = requireNodeSqlite();
+      const dir = tempDirs.make("openclaw-sqlite-wal-size-custom-");
+      const dbPath = path.join(dir, "openclaw.sqlite");
+      const db = new sqlite.DatabaseSync(dbPath);
+      try {
+        configureSqliteWalMaintenance(db, {
+          checkpointIntervalMs: 0,
+          databaseLabel: "wal-size-custom",
+          databasePath: dbPath,
+          journalSizeLimitBytes: 1024 * 1024,
+        });
+
+        expect(db.prepare("PRAGMA journal_size_limit;").get()).toEqual({
+          journal_size_limit: 1024 * 1024,
+        });
+      } finally {
+        db.close();
+      }
+    });
+
+    it("rejects a negative journalSizeLimitBytes", () => {
+      expect(() =>
+        configureSqliteWalMaintenance(createMockDb(), {
+          checkpointIntervalMs: 0,
+          journalSizeLimitBytes: -1,
+        }),
+      ).toThrow("journalSizeLimitBytes must be a non-negative integer");
+    });
+  });
+
   it("rejects a memory journal for a file-backed database", () => {
     const db = createMockDb();
     vi.mocked(db["prepare"]).mockImplementation(
@@ -503,19 +556,20 @@ describe("sqlite WAL maintenance", () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");
 
     const maintenance = configureSqliteWalMaintenance(db, { checkpointIntervalMs: 100 });
-    expect(db["exec"]).toHaveBeenCalledTimes(2);
+    // journal_mode=WAL, wal_autocheckpoint, journal_size_limit.
+    expect(db["exec"]).toHaveBeenCalledTimes(3);
 
     vi.advanceTimersByTime(100);
     expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(PASSIVE);");
-    expect(db["exec"]).toHaveBeenNthCalledWith(3, "PRAGMA incremental_vacuum(512);");
-    expect(db["exec"]).toHaveBeenCalledTimes(3);
+    expect(db["exec"]).toHaveBeenNthCalledWith(4, "PRAGMA incremental_vacuum(512);");
+    expect(db["exec"]).toHaveBeenCalledTimes(4);
 
     expect(maintenance.close()).toBe(true);
     expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(TRUNCATE);");
-    expect(db["exec"]).toHaveBeenCalledTimes(3);
+    expect(db["exec"]).toHaveBeenCalledTimes(4);
 
     vi.advanceTimersByTime(200);
-    expect(db["exec"]).toHaveBeenCalledTimes(3);
+    expect(db["exec"]).toHaveBeenCalledTimes(4);
   });
 
   it("clamps oversized checkpoint intervals before arming timers", () => {
@@ -544,7 +598,7 @@ describe("sqlite WAL maintenance", () => {
 
     vi.advanceTimersByTime(100);
     expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(FULL);");
-    expect(db["exec"]).toHaveBeenNthCalledWith(3, "PRAGMA incremental_vacuum(512);");
+    expect(db["exec"]).toHaveBeenNthCalledWith(4, "PRAGMA incremental_vacuum(512);");
 
     expect(maintenance.close()).toBe(true);
     expect(db["prepare"]).toHaveBeenLastCalledWith("PRAGMA wal_checkpoint(FULL);");

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -201,57 +201,49 @@ describe("sqlite WAL maintenance", () => {
     }
   });
 
-  describe("journal_size_limit ceiling", () => {
-    it("bounds the WAL to the default 64 MiB ceiling", () => {
-      const sqlite = requireNodeSqlite();
-      const dir = tempDirs.make("openclaw-sqlite-wal-size-");
-      const dbPath = path.join(dir, "openclaw.sqlite");
-      const db = new sqlite.DatabaseSync(dbPath);
-      try {
-        configureSqliteWalMaintenance(db, {
-          checkpointIntervalMs: 0,
-          databaseLabel: "wal-size-default",
-          databasePath: dbPath,
-        });
+  it("reclaims an inflated WAL on the first commit after a completed checkpoint", () => {
+    const sqlite = requireNodeSqlite();
+    const dir = tempDirs.make("openclaw-sqlite-wal-size-");
+    const dbPath = path.join(dir, "openclaw.sqlite");
+    const walPath = `${dbPath}-wal`;
+    const db = new sqlite.DatabaseSync(dbPath);
+    let maintenance: ReturnType<typeof configureSqliteWalMaintenance> | undefined;
+    try {
+      maintenance = configureSqliteWalMaintenance(db, {
+        autoCheckpointPages: 0,
+        checkpointIntervalMs: 0,
+        databaseLabel: "wal-size-default",
+        databasePath: dbPath,
+      });
+      db.exec("CREATE TABLE payload (id INTEGER PRIMARY KEY, value TEXT NOT NULL);");
+      db.prepare("INSERT INTO payload (value) VALUES (?)").run("before-checkpoint");
 
-        expect(db.prepare("PRAGMA journal_mode;").get()).toEqual({ journal_mode: "wal" });
-        expect(db.prepare("PRAGMA journal_size_limit;").get()).toEqual({
-          journal_size_limit: 64 * 1024 * 1024,
-        });
-      } finally {
-        db.close();
-      }
-    });
+      const checkpoint = db.prepare("PRAGMA wal_checkpoint(PASSIVE);").get() as {
+        busy: number;
+        checkpointed: number;
+        log: number;
+      };
+      expect(checkpoint.busy).toBe(0);
+      expect(checkpoint.checkpointed).toBe(checkpoint.log);
 
-    it("honors a custom journalSizeLimitBytes", () => {
-      const sqlite = requireNodeSqlite();
-      const dir = tempDirs.make("openclaw-sqlite-wal-size-custom-");
-      const dbPath = path.join(dir, "openclaw.sqlite");
-      const db = new sqlite.DatabaseSync(dbPath);
-      try {
-        configureSqliteWalMaintenance(db, {
-          checkpointIntervalMs: 0,
-          databaseLabel: "wal-size-custom",
-          databasePath: dbPath,
-          journalSizeLimitBytes: 1024 * 1024,
-        });
+      const sizeLimit = Number(
+        (
+          db.prepare("PRAGMA journal_size_limit;").get() as {
+            journal_size_limit: number | bigint;
+          }
+        ).journal_size_limit,
+      );
+      expect(sizeLimit).toBe(64 * 1024 * 1024);
+      // A sparse extension models a retained high-water WAL without writing a 65 MiB fixture.
+      fs.truncateSync(walPath, sizeLimit + 1024 * 1024);
 
-        expect(db.prepare("PRAGMA journal_size_limit;").get()).toEqual({
-          journal_size_limit: 1024 * 1024,
-        });
-      } finally {
-        db.close();
-      }
-    });
+      db.prepare("INSERT INTO payload (value) VALUES (?)").run("after-checkpoint");
 
-    it("rejects a negative journalSizeLimitBytes", () => {
-      expect(() =>
-        configureSqliteWalMaintenance(createMockDb(), {
-          checkpointIntervalMs: 0,
-          journalSizeLimitBytes: -1,
-        }),
-      ).toThrow("journalSizeLimitBytes must be a non-negative integer");
-    });
+      expect(fs.statSync(walPath).size).toBe(sizeLimit);
+    } finally {
+      maintenance?.close();
+      db.close();
+    }
   });
 
   it("rejects a memory journal for a file-backed database", () => {

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -10,6 +10,17 @@ import { isSqliteLockError } from "./sqlite-transaction.js";
 // checkpoints so state databases do not accumulate unbounded WAL files.
 const DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
 const DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS = 30 * 60 * 1000;
+// Cap the on-disk WAL size. Since periodic checkpoints default to PASSIVE (#82366,
+// to keep WAL maintenance off the event loop), a running process no longer
+// truncates the WAL file — only close() does. wal_autocheckpoint recycles WAL
+// space in place but never shrinks the file, and is itself a PASSIVE checkpoint a
+// reader can block. So a checkpoint transiently blocked by a reader (e.g. a memory
+// reindex) inflates the WAL and it then stays parked at that high-water mark until
+// the gateway restarts. journal_size_limit makes any completing checkpoint —
+// including the PASSIVE periodic/auto ones — truncate the file back to this
+// ceiling, without blocking. Set well above the autocheckpoint steady state
+// (~4MB at 1000 pages) so it is inert until growth is genuinely pathological.
+const DEFAULT_SQLITE_WAL_JOURNAL_SIZE_LIMIT_BYTES = 64 * 1024 * 1024;
 // 512 pages (~2MB at 4KB pages) per periodic pass keeps page release strictly
 // bounded so maintenance can never behave like a blocking full VACUUM.
 const INCREMENTAL_VACUUM_MAX_PAGES_PER_PASS = 512;
@@ -45,6 +56,7 @@ export type SqliteWalMaintenanceOptions = {
   checkpointMode?: SqliteWalCheckpointMode;
   databaseLabel?: string;
   databasePath?: string;
+  journalSizeLimitBytes?: number;
   onCheckpointError?: (error: unknown) => void;
 };
 
@@ -443,6 +455,10 @@ export function configureSqliteWalMaintenance(
     options.checkpointIntervalMs ?? DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS,
     "checkpointIntervalMs",
   );
+  const journalSizeLimitBytes = normalizeNonNegativeInteger(
+    options.journalSizeLimitBytes ?? DEFAULT_SQLITE_WAL_JOURNAL_SIZE_LIMIT_BYTES,
+    "journalSizeLimitBytes",
+  );
   const timerIntervalMs = Math.min(checkpointIntervalMs, MAX_TIMER_TIMEOUT_MS);
   const checkpointMode = options.checkpointMode ?? "TRUNCATE";
   const periodicCheckpointMode = options.checkpointMode ?? "PASSIVE";
@@ -467,6 +483,10 @@ export function configureSqliteWalMaintenance(
   }
   enableMacosCheckpointFullfsync(db);
   db.exec(`PRAGMA wal_autocheckpoint = ${autoCheckpointPages};`);
+  // Bound the WAL file size (see DEFAULT_SQLITE_WAL_JOURNAL_SIZE_LIMIT_BYTES): a
+  // completing checkpoint truncates the file back to this ceiling. Non-blocking —
+  // journal_size_limit changes only how far truncation goes, never checkpoint timing.
+  db.exec(`PRAGMA journal_size_limit = ${journalSizeLimitBytes};`);
 
   const runCheckpoint = (mode: SqliteWalCheckpointMode): boolean => {
     try {

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -10,16 +10,9 @@ import { isSqliteLockError } from "./sqlite-transaction.js";
 // checkpoints so state databases do not accumulate unbounded WAL files.
 const DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
 const DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS = 30 * 60 * 1000;
-// Cap the on-disk WAL size. Since periodic checkpoints default to PASSIVE (#82366,
-// to keep WAL maintenance off the event loop), a running process no longer
-// truncates the WAL file — only close() does. wal_autocheckpoint recycles WAL
-// space in place but never shrinks the file, and is itself a PASSIVE checkpoint a
-// reader can block. So a checkpoint transiently blocked by a reader (e.g. a memory
-// reindex) inflates the WAL and it then stays parked at that high-water mark until
-// the gateway restarts. journal_size_limit makes any completing checkpoint —
-// including the PASSIVE periodic/auto ones — truncate the file back to this
-// ceiling, without blocking. Set well above the autocheckpoint steady state
-// (~4MB at 1000 pages) so it is inert until growth is genuinely pathological.
+// SQLite applies this ceiling when a fully checkpointed WAL resets on the next
+// commit. Keep it well above the usual ~4 MiB autocheckpoint window so only
+// pathological high-water marks pay the truncation cost.
 const DEFAULT_SQLITE_WAL_JOURNAL_SIZE_LIMIT_BYTES = 64 * 1024 * 1024;
 // 512 pages (~2MB at 4KB pages) per periodic pass keeps page release strictly
 // bounded so maintenance can never behave like a blocking full VACUUM.
@@ -56,7 +49,6 @@ export type SqliteWalMaintenanceOptions = {
   checkpointMode?: SqliteWalCheckpointMode;
   databaseLabel?: string;
   databasePath?: string;
-  journalSizeLimitBytes?: number;
   onCheckpointError?: (error: unknown) => void;
 };
 
@@ -455,10 +447,6 @@ export function configureSqliteWalMaintenance(
     options.checkpointIntervalMs ?? DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS,
     "checkpointIntervalMs",
   );
-  const journalSizeLimitBytes = normalizeNonNegativeInteger(
-    options.journalSizeLimitBytes ?? DEFAULT_SQLITE_WAL_JOURNAL_SIZE_LIMIT_BYTES,
-    "journalSizeLimitBytes",
-  );
   const timerIntervalMs = Math.min(checkpointIntervalMs, MAX_TIMER_TIMEOUT_MS);
   const checkpointMode = options.checkpointMode ?? "TRUNCATE";
   const periodicCheckpointMode = options.checkpointMode ?? "PASSIVE";
@@ -483,10 +471,7 @@ export function configureSqliteWalMaintenance(
   }
   enableMacosCheckpointFullfsync(db);
   db.exec(`PRAGMA wal_autocheckpoint = ${autoCheckpointPages};`);
-  // Bound the WAL file size (see DEFAULT_SQLITE_WAL_JOURNAL_SIZE_LIMIT_BYTES): a
-  // completing checkpoint truncates the file back to this ceiling. Non-blocking —
-  // journal_size_limit changes only how far truncation goes, never checkpoint timing.
-  db.exec(`PRAGMA journal_size_limit = ${journalSizeLimitBytes};`);
+  db.exec(`PRAGMA journal_size_limit = ${DEFAULT_SQLITE_WAL_JOURNAL_SIZE_LIMIT_BYTES};`);
 
   const runCheckpoint = (mode: SqliteWalCheckpointMode): boolean => {
     try {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -2605,6 +2605,7 @@ describe("openclaw agent database", () => {
     expect(readSqliteNumberPragma(database.db, "auto_vacuum")).toBe(2);
     expect(readSqliteNumberPragma(database.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
     expect(readSqliteNumberPragma(database.db, "wal_autocheckpoint")).toBe(1000);
+    expect(readSqliteNumberPragma(database.db, "journal_size_limit")).toBe(64 * 1024 * 1024);
     const journalMode = database.db.prepare("PRAGMA journal_mode").get() as
       | { journal_mode?: string }
       | undefined;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -2530,7 +2530,10 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     const rmSync = fs.rmSync.bind(fs);
     let failRemoval = true;
     vi.spyOn(fs, "rmSync").mockImplementation(((pathname, options) => {
-      if (pathname === privateDirectory && failRemoval) {
+      if (
+        fs.realpathSync.native(String(pathname)) === fs.realpathSync.native(privateDirectory) &&
+        failRemoval
+      ) {
         failRemoval = false;
         const error = new Error("busy");
         (error as NodeJS.ErrnoException).code = "EBUSY";
@@ -3951,6 +3954,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     expect(readSqliteNumberPragma(database.db, "auto_vacuum")).toBe(2);
     expect(readSqliteNumberPragma(database.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
     expect(readSqliteNumberPragma(database.db, "wal_autocheckpoint")).toBe(1000);
+    expect(readSqliteNumberPragma(database.db, "journal_size_limit")).toBe(64 * 1024 * 1024);
     const journalMode = database.db.prepare("PRAGMA journal_mode").get() as
       | { journal_mode?: string }
       | undefined;


### PR DESCRIPTION
Closes #112950
Related: #82366, #81715

## What Problem This Solves

Fixes an issue where a running gateway could retain a pathologically large SQLite `-wal` file after a reader temporarily blocked checkpoint progress. Once the reader released, periodic `PASSIVE` checkpoints could catch up, but the WAL file stayed at its high-water size until a later restart or manual `TRUNCATE` checkpoint.

## Why This Change Was Made

The shared WAL-maintenance owner now sets SQLite's `journal_size_limit` to 64 MiB on every WAL-backed database open. After a checkpoint fully catches up, SQLite resets the WAL on the next commit and trims the retained file to that ceiling. This preserves the non-waiting periodic `PASSIVE` policy from #82366 and adds no new config or public tuning parameter.

The fix is centralized in `configureSqliteWalMaintenance`, so it covers the shared state database, per-agent databases, memory, plugin state, proxy capture, logbook, and workboard without adding request-time work. Network-backed rollback-journal paths and in-memory databases continue to skip WAL maintenance.

## User Impact

Operators no longer need to restart the gateway or manually run `wal_checkpoint(TRUNCATE)` to reclaim a WAL left at a pathological high-water mark. Normal WAL operation remains unchanged; the 64 MiB ceiling is well above the usual roughly 4 MiB autocheckpoint window.

## Evidence

Current-main reproduction with real `node:sqlite` / SQLite 3.53.3:

- A reader-blocked workload grew the WAL to 84,497,112 bytes.
- After the reader released, `PASSIVE` checkpointed all 20,509 frames, but the file remained 84,497,112 bytes.
- With current main's unlimited retention, the next commit still left it at 84,497,112 bytes.
- With the 64 MiB ceiling, the same next reset commit reduced it to exactly 67,108,864 bytes.

Exact focused proof for head `e86f9a123956a45f50ab3cb7e37692f9ca53cccc`:

- `node scripts/run-vitest.mjs src/infra/sqlite-wal.test.ts src/state/openclaw-agent-db.test.ts src/state/openclaw-state-db.test.ts` — 228 passed, 5 skipped at the exact pushed head.
- `node scripts/run-vitest.mjs src/infra/sqlite-wal.test.ts` — 40 passed.
- Both shared-state and per-agent durable-pragma tests assert `journal_size_limit = 67108864`.
- `node scripts/check-changed.mjs -- docs/automation/tasks.md src/infra/sqlite-pragma.test-support.ts src/infra/sqlite-wal.test.ts src/infra/sqlite-wal.ts src/state/openclaw-agent-db.test.ts src/state/openclaw-state-db.test.ts` — passed on Blacksmith Testbox `tbx_01kycc4k3zpg9n46r7d5xwhg1w`, Actions run 30154045152.
- Independent high-reasoning refuter verdict: `NO-ACTIONABLE-OBJECTION.`
- Final branch autoreview: clean, no accepted/actionable findings; correctness confidence 0.94.

The exact-head hosted CI run is the final merge gate. A live 1.6 GB production gateway was not mutated for this proof; the regression test and standalone trace exercise SQLite's real blocked-checkpoint/reset lifecycle on isolated databases.
