### PR TITLE
feat(sessions): show preambles as live subtitles

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2270,
+      "line": 2278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2300,
+      "line": 2308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2300,
+      "line": 2308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2313,
+      "line": 2321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2344,
+      "line": 2352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2344,
+      "line": 2352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2366,
+      "line": 2374,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2372,
+      "line": 2380,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2387,
+      "line": 2395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2637,
+      "line": 2645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2648,
+      "line": 2656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2669,
+      "line": 2677,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2680,
+      "line": 2688,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3766,
+      "line": 3774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3794,
+      "line": 3802,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3803,
+      "line": 3811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4514,
+      "line": 4522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4518,
+      "line": 4526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4522,
+      "line": 4530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4572,
+      "line": 4580,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4782,
+      "line": 4790,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5557,
+      "line": 5565,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5588,
+      "line": 5596,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5590,
+      "line": 5598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5606,
+      "line": 5614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5693,
+      "line": 5701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5779,
+      "line": 5787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5789,
+      "line": 5797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5793,
+      "line": 5801,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5805,
+      "line": 5813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5836,
+      "line": 5844,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5853,
+      "line": 5861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5862,
+      "line": 5870,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5874,
+      "line": 5882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5921,
+      "line": 5929,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6048,
+      "line": 6056,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6083,
+      "line": 6091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6096,
+      "line": 6104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6100,
+      "line": 6108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6115,
+      "line": 6123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6115,
+      "line": 6123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6133,
+      "line": 6141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6179,
+      "line": 6187,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6192,
+      "line": 6200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6225,
+      "line": 6233,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6241,
+      "line": 6249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6257,
+      "line": 6265,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6273,
+      "line": 6281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6363,
+      "line": 6371,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6370,
+      "line": 6378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6410,
+      "line": 6418,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6450,
+      "line": 6458,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6470,
+      "line": 6478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6522,
+      "line": 6530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6542,
+      "line": 6550,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6547,
+      "line": 6555,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6737,
+      "line": 6745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not verify the device pairing change. Refresh and try again.",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6819,
+      "line": 6827,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6849,
+      "line": 6857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7508,
+      "line": 7516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7538,
+      "line": 7546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7575,
+      "line": 7583,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8044,
+      "line": 8052,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8053,
+      "line": 8061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8054,
+      "line": 8062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8062,
+      "line": 8070,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8063,
+      "line": 8071,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8064,
+      "line": 8072,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8065,
+      "line": 8073,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8081,
+      "line": 8089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8098,
+      "line": 8106,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8106,
+      "line": 8114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8107,
+      "line": 8115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8109,
+      "line": 8117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8113,
+      "line": 8121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8116,
+      "line": 8124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8121,
+      "line": 8129,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8122,
+      "line": 8130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8124,
+      "line": 8132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8128,
+      "line": 8136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8131,
+      "line": 8139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8136,
+      "line": 8144,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1555,7 +1555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8137,
+      "line": 8145,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1563,7 +1563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8139,
+      "line": 8147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1571,7 +1571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8143,
+      "line": 8151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1579,7 +1579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8146,
+      "line": 8154,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1587,7 +1587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8178,
+      "line": 8186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1595,7 +1595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8193,
+      "line": 8201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1603,7 +1603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8194,
+      "line": 8202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1611,7 +1611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8195,
+      "line": 8203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1619,7 +1619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8850,
+      "line": 8858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1603,6 +1603,14 @@ class NodeRuntime private constructor(
     } catch (err: Throwable) {
       Log.d("OpenClawRuntime", "sessions.subscribe failed: ${err.message ?: err::class.java.simpleName}")
     }
+    try {
+      operatorSession.request("sessions.observer.visibility", """{"visible":true}""")
+    } catch (err: Throwable) {
+      Log.d(
+        "OpenClawRuntime",
+        "sessions.observer.visibility failed: ${err.message ?: err::class.java.simpleName}",
+      )
+    }
   }
 
   private val nodeSession =

--- a/apps/ios/Sources/RootSidebarModel.swift
+++ b/apps/ios/Sources/RootSidebarModel.swift
@@ -155,6 +155,10 @@ final class RootSidebarModel {
                     method: "sessions.subscribe",
                     paramsJSON: nil,
                     timeoutSeconds: 12)
+                _ = try? await appModel.operatorSession.request(
+                    method: "sessions.observer.visibility",
+                    paramsJSON: #"{"visible":true}"#,
+                    timeoutSeconds: 12)
             },
             onEvent: { [weak self] frame in
                 await self?.handleSessionEvent(frame, appModel: appModel) ?? false

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -653,6 +653,9 @@ methods. Treat this as feature discovery, not a full enumeration of
 - `session.approval`: sanitized pending and terminal approval truth for an
   explicitly opted-in exact-session subscriber. Child approvals use the
   persisted ancestor audience; events never mutate transcripts or wake agents.
+- `session.observer`: safe live session headline and status digest. A model-authored
+  preamble can update the headline immediately; utility-model assessments replace
+  it later when available. Web, iOS, and Android use the same run-scoped digest.
 - `sessions.changed`: session index or metadata changed.
 - `presence`: system presence snapshot updates.
 - `tick`: periodic keepalive/liveness event.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -14,13 +14,13 @@ The Control UI is a small **Vite + Lit** single-page app served by the Gateway:
 
 It speaks **directly to the Gateway WebSocket** on the same port.
 
-While you watch a running session, the Gateway can use that agent's utility model to produce a compact status digest. Chat shows it as a one-line status pill that expands into a card with the assessment, plan progress, pull requests, and elapsed time. The card can expand once when a run becomes stuck or needs input; the `/btw` side chat takes priority over the expanded card.
+While you watch a running session, the Gateway shows the model's latest safe preamble immediately as the session headline. When a utility model is available, it can replace that headline with a richer compact status digest after enough activity accumulates. Chat shows the result as a one-line status pill that expands into a card with the assessment, plan progress, pull requests, and elapsed time. The card can expand once when a run becomes stuck or needs input; the `/btw` side chat takes priority over the expanded card.
 
 The expanded card also accepts short questions about the run. Answers use only the observer's current digest and sanitized bounded notes, stay in the browser for that session, and never enter or interrupt the main agent run. If the observations do not contain the answer, the observer says that it cannot know.
 
-After the first digest arrives, it owns that run's sidebar subtitle instead of heuristic live activity. A final done or failed digest remains visible while the session is unread, then the row returns to its normal work subtitle.
+The headline owns that run's sidebar subtitle instead of heuristic live activity. It is shared with the official iOS and Android session lists. A final done or failed digest remains visible while the session is unread, then the row returns to its normal work subtitle.
 
-Session observation is enabled by default. In **Settings > Appearance > Sidebar**, you can turn it off gateway-wide, inspect the resolved small model and its provenance, or choose automatic routing, disable utility tasks, or select an explicit `agents.defaults.utilityModel`. The equivalent config controls are `gateway.controlUi.sessionObserver: false` and `agents.defaults.utilityModel: ""`.
+Session observation is enabled by default. Safe preamble headlines do not require a utility model; the utility model only owns richer assessments and terminal summaries. In **Settings > Appearance > Sidebar**, you can turn observation off gateway-wide, inspect the resolved small model and its provenance, or choose automatic routing, disable utility tasks, or select an explicit `agents.defaults.utilityModel`. The equivalent config controls are `gateway.controlUi.sessionObserver: false` and `agents.defaults.utilityModel: ""`.
 
 ## Quick open (local)
 

--- a/src/agents/session-preamble.ts
+++ b/src/agents/session-preamble.ts
@@ -1,0 +1,15 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeProgressStatusText } from "../channels/progress-draft-status-text.js";
+import { stripMarkdown } from "../shared/text/strip-markdown.js";
+
+export function normalizeSessionPreambleText(value: unknown, maxChars: number): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const sanitized = sanitizeProgressStatusText(value);
+  if (!sanitized) {
+    return "";
+  }
+  const normalized = stripMarkdown(sanitized, { linkStyle: "label" }).replace(/\s+/gu, " ").trim();
+  return truncateUtf16Safe(normalized, maxChars);
+}

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -76,6 +76,7 @@ export function startGatewayEventSubscriptions(params: {
   const sessionObserver = createSessionObserver({
     getConfig: getRuntimeConfig,
     subscribers: params.sessionMessageSubscribers,
+    sessionEventSubscribers: params.sessionEventSubscribers,
     broadcastToConnIds: params.broadcastToConnIds,
   });
   const unsubscribePrivateAuditEvents = auditEnabled

--- a/src/gateway/session-observer-audience.ts
+++ b/src/gateway/session-observer-audience.ts
@@ -1,0 +1,36 @@
+import type {
+  SessionEventSubscriberRegistry,
+  SessionMessageSubscriberRegistry,
+} from "./server-chat-state.js";
+
+export function createSessionObserverAudience(params: {
+  subscribers: SessionMessageSubscriberRegistry;
+  sessionEventSubscribers?: SessionEventSubscriberRegistry;
+  isVisible: (connId: string) => boolean;
+}) {
+  return {
+    has(sessionKey: string): boolean {
+      for (const connId of params.subscribers.get(sessionKey)) {
+        if (params.isVisible(connId)) {
+          return true;
+        }
+      }
+      for (const connId of params.sessionEventSubscribers?.getAll() ?? []) {
+        if (params.isVisible(connId)) {
+          return true;
+        }
+      }
+      return false;
+    },
+
+    recipients(sessionKey: string): ReadonlySet<string> {
+      const recipients = new Set(params.subscribers.get(sessionKey));
+      for (const connId of params.sessionEventSubscribers?.getAll() ?? []) {
+        if (params.isVisible(connId)) {
+          recipients.add(connId);
+        }
+      }
+      return recipients;
+    },
+  };
+}

--- a/src/gateway/session-observer-completion.ts
+++ b/src/gateway/session-observer-completion.ts
@@ -1,0 +1,108 @@
+import {
+  buildSessionObserverPrompt,
+  normalizeSessionObserverModelOutput,
+  SESSION_OBSERVER_MODEL_MAX_TOKENS,
+  SESSION_OBSERVER_SYSTEM_PROMPT,
+} from "./session-observer-model.js";
+import type { SessionObserverDeps, SessionObserverState } from "./session-observer-model.js";
+
+const MODEL_TIMEOUT_MS = 10_000;
+
+type PrepareModel = NonNullable<SessionObserverDeps["prepareModel"]>;
+type CompleteModel = NonNullable<SessionObserverDeps["completeModel"]>;
+
+export function createSessionObserverCompletion(params: {
+  getConfig: SessionObserverDeps["getConfig"];
+  prepareModel: PrepareModel;
+  completeModel: CompleteModel;
+  now: () => number;
+  setTimeoutFn: typeof setTimeout;
+  clearTimeoutFn: typeof clearTimeout;
+  isCurrent: (state: SessionObserverState) => boolean;
+}) {
+  const ensurePrepared = async (state: SessionObserverState) => {
+    const modelRef = state.utilityModelRef;
+    if (!modelRef) {
+      throw new Error("session observer utility model is unavailable");
+    }
+    state.preparedPromise ??= params.prepareModel({
+      cfg: params.getConfig(),
+      agentId: state.agentId,
+      modelRef,
+      useUtilityModel: true,
+      allowMissingApiKeyModes: ["aws-sdk"],
+    });
+    return await state.preparedPromise;
+  };
+
+  return async (state: SessionObserverState, notes: readonly string[]) => {
+    const controller = new AbortController();
+    state.activeController = controller;
+    const timeout = params.setTimeoutFn(() => controller.abort(), MODEL_TIMEOUT_MS);
+    const aborted = new Promise<never>((_resolve, reject) => {
+      controller.signal.addEventListener(
+        "abort",
+        () => reject(new Error("session observer model call timed out or was cancelled")),
+        { once: true },
+      );
+    });
+    try {
+      const execute = async () => {
+        const prepared = await ensurePrepared(state);
+        if (!params.isCurrent(state) || controller.signal.aborted) {
+          throw new Error("session observer state is no longer active");
+        }
+        if ("error" in prepared) {
+          throw new Error(prepared.error);
+        }
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          if (!params.isCurrent(state) || controller.signal.aborted) {
+            throw new Error("session observer state is no longer active");
+          }
+          const result = await params.completeModel({
+            model: prepared.model,
+            auth: prepared.auth,
+            cfg: params.getConfig(),
+            context: {
+              systemPrompt: SESSION_OBSERVER_SYSTEM_PROMPT,
+              messages: [
+                {
+                  role: "user",
+                  content: buildSessionObserverPrompt(state, notes),
+                  timestamp: params.now(),
+                },
+              ],
+            },
+            options: {
+              maxTokens: Math.min(
+                SESSION_OBSERVER_MODEL_MAX_TOKENS,
+                Math.floor(prepared.model.maxTokens),
+              ),
+              temperature: 0.2,
+              signal: controller.signal,
+            },
+          });
+          if (result.stopReason === "error") {
+            throw new Error(result.errorMessage?.trim() || "session observer completion failed");
+          }
+          const text = result.content
+            .filter((block): block is { type: "text"; text: string } => block.type === "text")
+            .map((block) => block.text)
+            .join("")
+            .trim();
+          const parsed = normalizeSessionObserverModelOutput(text);
+          if (parsed) {
+            return parsed;
+          }
+        }
+        throw new Error("session observer returned invalid JSON twice");
+      };
+      return await Promise.race([execute(), aborted]);
+    } finally {
+      params.clearTimeoutFn(timeout);
+      if (state.activeController === controller) {
+        state.activeController = undefined;
+      }
+    }
+  };
+}

--- a/src/gateway/session-observer-model-slots.test.ts
+++ b/src/gateway/session-observer-model-slots.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSessionActivityNoteState } from "../agents/session-activity-notes.js";
+import { createSessionObserverModelSlots } from "./session-observer-model-slots.js";
+import type { SessionObserverState } from "./session-observer-model.js";
+
+function modelState(index: number, terminalHealth?: "done" | "failed"): SessionObserverState {
+  return {
+    ...createSessionActivityNoteState(),
+    sessionKey: `agent:main:session-${index}`,
+    runId: `run-${index}`,
+    agentId: "main",
+    utilityModelRef: "openai/gpt-test",
+    startedAt: index,
+    lastActivityAt: index,
+    lastRunAt: index,
+    revision: 0,
+    digestCount: 0,
+    consecutiveFailures: 0,
+    lastDigestNoteSequence: 0,
+    inFlight: terminalHealth !== undefined,
+    finalPending: terminalHealth !== undefined,
+    ...(terminalHealth ? { terminalHealth } : {}),
+  };
+}
+
+describe("session observer model slots", () => {
+  it("demotes the oldest nonterminal model state", () => {
+    const states = new Map<string, SessionObserverState>();
+    const terminal = modelState(0, "done");
+    states.set(terminal.sessionKey, terminal);
+    for (let index = 1; index < 6; index += 1) {
+      const state = modelState(index);
+      states.set(state.sessionKey, state);
+    }
+    const demote = vi.fn();
+    const slots = createSessionObserverModelSlots({
+      states,
+      maxSessions: 6,
+      resolve: () => "openai/gpt-test",
+      demote,
+    });
+
+    expect(slots.claim("main")).toBe("openai/gpt-test");
+    expect(demote).toHaveBeenCalledWith(states.get("agent:main:session-1"));
+    expect(demote).not.toHaveBeenCalledWith(terminal);
+  });
+
+  it("does not evict terminal finalizations when every slot is protected", () => {
+    const states = new Map<string, SessionObserverState>();
+    for (let index = 0; index < 6; index += 1) {
+      const state = modelState(index, "done");
+      states.set(state.sessionKey, state);
+    }
+    const demote = vi.fn();
+    const slots = createSessionObserverModelSlots({
+      states,
+      maxSessions: 6,
+      resolve: () => "openai/gpt-test",
+      demote,
+    });
+
+    expect(slots.claim("main")).toBeUndefined();
+    expect(demote).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/session-observer-model-slots.ts
+++ b/src/gateway/session-observer-model-slots.ts
@@ -1,0 +1,44 @@
+import type { SessionObserverState } from "./session-observer-model.js";
+
+export function createSessionObserverModelSlots(params: {
+  states: Map<string, SessionObserverState>;
+  maxSessions: number;
+  resolve: (agentId: string) => string | undefined;
+  demote: (state: SessionObserverState) => void;
+}) {
+  const demoted = new WeakSet<SessionObserverState>();
+
+  return {
+    claim(agentId: string, current?: SessionObserverState): string | undefined {
+      const resolved = params.resolve(agentId);
+      if (!resolved || current?.utilityModelRef === resolved) {
+        return resolved;
+      }
+      const occupied = [...params.states.values()].filter(
+        (state) => state !== current && state.utilityModelRef,
+      );
+      if (current && demoted.has(current)) {
+        if (occupied.length >= params.maxSessions) {
+          return undefined;
+        }
+        demoted.delete(current);
+        return resolved;
+      }
+      if (occupied.length >= params.maxSessions) {
+        const evicted = occupied
+          .filter((state) => !state.terminalHealth && !state.finalPending)
+          .toSorted(
+            (left, right) =>
+              left.lastActivityAt - right.lastActivityAt ||
+              left.sessionKey.localeCompare(right.sessionKey),
+          )[0];
+        if (!evicted) {
+          return undefined;
+        }
+        demoted.add(evicted);
+        params.demote(evicted);
+      }
+      return resolved;
+    },
+  };
+}

--- a/src/gateway/session-observer-model-slots.ts
+++ b/src/gateway/session-observer-model-slots.ts
@@ -7,8 +7,24 @@ export function createSessionObserverModelSlots(params: {
   demote: (state: SessionObserverState) => void;
 }) {
   const demoted = new WeakSet<SessionObserverState>();
+  const requestGenerations = new WeakMap<SessionObserverState, number>();
 
   return {
+    beginRequest(state: SessionObserverState): number {
+      const generation = (requestGenerations.get(state) ?? 0) + 1;
+      requestGenerations.set(state, generation);
+      return generation;
+    },
+
+    invalidateRequest(state: SessionObserverState): void {
+      requestGenerations.set(state, (requestGenerations.get(state) ?? 0) + 1);
+      state.activeController?.abort();
+    },
+
+    requestIsCurrent(state: SessionObserverState, generation: number): boolean {
+      return requestGenerations.get(state) === generation;
+    },
+
     claim(agentId: string, current?: SessionObserverState): string | undefined {
       const resolved = params.resolve(agentId);
       if (!resolved || current?.utilityModelRef === resolved) {

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -38,7 +38,7 @@ const MAX_DISABLED_RUNS = 512;
 export const SESSION_OBSERVER_MODEL_MAX_TOKENS = 300;
 type PrepareModel = typeof prepareSimpleCompletionModelForAgent;
 type CompleteModel = typeof completeWithPreparedSimpleCompletionModel;
-export type PreparedModel = Awaited<ReturnType<PrepareModel>>;
+type PreparedModel = Awaited<ReturnType<PrepareModel>>;
 
 export type SessionObserverState = SessionActivityNoteState & {
   sessionKey: string;

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -55,6 +55,7 @@ export type SessionObserverState = SessionActivityNoteState & {
   consecutiveFailures: number;
   lastDigestNoteSequence: number;
   lastPreambleHeadline?: string;
+  lastPublishedPreambleHeadline?: string;
   previousDigest?: SessionObserverDigest;
   preparedPromise?: Promise<PreparedModel>;
   activeController?: AbortController;
@@ -172,7 +173,9 @@ export function createDormantSessionObserverRun(
     revision: state.revision,
     digestCount: state.digestCount,
     consecutiveFailures: state.consecutiveFailures,
-    ...(state.lastPreambleHeadline ? { lastPreambleHeadline: state.lastPreambleHeadline } : {}),
+    ...(state.lastPublishedPreambleHeadline
+      ? { lastPreambleHeadline: state.lastPublishedPreambleHeadline }
+      : {}),
     planProgress: state.planProgress,
     previousDigest: state.previousDigest,
   };

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -23,7 +23,10 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import { redactToolPayloadText } from "../logging/redact.js";
-import type { SessionMessageSubscriberRegistry } from "./server-chat-state.js";
+import type {
+  SessionEventSubscriberRegistry,
+  SessionMessageSubscriberRegistry,
+} from "./server-chat-state.js";
 
 const HEADLINE_MAX_CHARS = 120;
 const ASSESSMENT_MAX_CHARS = 320;
@@ -42,7 +45,7 @@ export type SessionObserverState = SessionActivityNoteState & {
   sessionId?: string;
   runId: string;
   agentId: string;
-  utilityModelRef: string;
+  utilityModelRef?: string;
   startedAt: number;
   lastActivityAt: number;
   lastRunAt: number;
@@ -161,7 +164,7 @@ export function createDormantSessionObserverRun(
     sessionId: state.sessionId,
     runId: state.runId,
     agentId: state.agentId,
-    utilityModelRef: state.utilityModelRef,
+    ...(state.utilityModelRef ? { utilityModelRef: state.utilityModelRef } : {}),
     startedAt: state.startedAt,
     lastPersistedAt: state.lastPersistedAt,
     revision: state.revision,
@@ -175,6 +178,7 @@ export function createDormantSessionObserverRun(
 export type SessionObserverDeps = {
   getConfig: () => OpenClawConfig;
   subscribers: SessionMessageSubscriberRegistry;
+  sessionEventSubscribers?: SessionEventSubscriberRegistry;
   broadcastToConnIds: (
     event: string,
     payload: unknown,

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -54,6 +54,7 @@ export type SessionObserverState = SessionActivityNoteState & {
   digestCount: number;
   consecutiveFailures: number;
   lastDigestNoteSequence: number;
+  lastPreambleHeadline?: string;
   previousDigest?: SessionObserverDigest;
   preparedPromise?: Promise<PreparedModel>;
   activeController?: AbortController;
@@ -75,6 +76,7 @@ export type DormantSessionObserverRun = Pick<
   | "revision"
   | "digestCount"
   | "consecutiveFailures"
+  | "lastPreambleHeadline"
   | "planProgress"
   | "previousDigest"
 >;
@@ -170,6 +172,7 @@ export function createDormantSessionObserverRun(
     revision: state.revision,
     digestCount: state.digestCount,
     consecutiveFailures: state.consecutiveFailures,
+    ...(state.lastPreambleHeadline ? { lastPreambleHeadline: state.lastPreambleHeadline } : {}),
     planProgress: state.planProgress,
     previousDigest: state.previousDigest,
   };

--- a/src/gateway/session-observer-persistence.test.ts
+++ b/src/gateway/session-observer-persistence.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSessionActivityNoteState } from "../agents/session-activity-notes.js";
+import type { SessionObserverState } from "./session-observer-model.js";
+import { createSessionObserverDigestPersister } from "./session-observer-persistence.js";
+
+function state(): SessionObserverState {
+  return {
+    ...createSessionActivityNoteState(),
+    sessionKey: "agent:main:session-1",
+    runId: "run-1",
+    agentId: "main",
+    startedAt: 0,
+    lastActivityAt: 0,
+    lastRunAt: 0,
+    revision: 0,
+    digestCount: 0,
+    consecutiveFailures: 0,
+    lastDigestNoteSequence: 0,
+    inFlight: false,
+    finalPending: false,
+  };
+}
+
+const digest = {
+  sessionKey: "agent:main:session-1",
+  runId: "run-1",
+  revision: 1,
+  updatedAt: 0,
+  headline: "Checking files",
+  health: "on-track" as const,
+};
+
+describe("session observer digest persistence", () => {
+  it("does not let preamble persistence throttle the first model digest", async () => {
+    let now = 0;
+    const persistDigest = vi.fn(async () => true);
+    const persist = createSessionObserverDigestPersister({
+      now: () => now,
+      persistDigest,
+      stillCurrent: () => () => true,
+      onError: vi.fn(),
+    });
+    const session = state();
+
+    await persist(session, digest, false, "preamble");
+    now = 1_000;
+    await persist(session, { ...digest, revision: 2, headline: "Reviewing implementation" }, false);
+    now = 2_000;
+    await persist(session, { ...digest, revision: 3, headline: "Still reviewing" }, false);
+
+    expect(persistDigest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/session-observer-persistence.ts
+++ b/src/gateway/session-observer-persistence.ts
@@ -1,0 +1,43 @@
+import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
+import type { SessionObserverDeps, SessionObserverState } from "./session-observer-model.js";
+
+const PERSIST_INTERVAL_MS = 60_000;
+
+type PersistDigest = NonNullable<SessionObserverDeps["persistDigest"]>;
+
+export function createSessionObserverDigestPersister(params: {
+  now: () => number;
+  persistDigest: PersistDigest;
+  stillCurrent: (runId: string, sessionKey: string) => () => boolean;
+  onError: (state: SessionObserverState, error: unknown) => void;
+}) {
+  return async (state: SessionObserverState, digest: SessionObserverDigest, final: boolean) => {
+    const due =
+      state.lastPersistedAt === undefined ||
+      params.now() - state.lastPersistedAt >= PERSIST_INTERVAL_MS;
+    if (!final && !due) {
+      return;
+    }
+    // Live broadcasts are immediate; terminal persistence gets one bounded retry.
+    const attempts = final ? 2 : 1;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      try {
+        const accepted = await params.persistDigest({
+          sessionKey: state.sessionKey,
+          sessionId: state.sessionId,
+          agentId: state.agentId,
+          digest,
+          stillCurrent: params.stillCurrent(state.runId, state.sessionKey),
+        });
+        if (accepted) {
+          state.lastPersistedAt = params.now();
+        }
+        return;
+      } catch (error) {
+        if (attempt + 1 === attempts) {
+          params.onError(state, error);
+        }
+      }
+    }
+  };
+}

--- a/src/gateway/session-observer-persistence.ts
+++ b/src/gateway/session-observer-persistence.ts
@@ -11,10 +11,17 @@ export function createSessionObserverDigestPersister(params: {
   stillCurrent: (runId: string, sessionKey: string) => () => boolean;
   onError: (state: SessionObserverState, error: unknown) => void;
 }) {
-  return async (state: SessionObserverState, digest: SessionObserverDigest, final: boolean) => {
+  const preamblePersistedAt = new WeakMap<SessionObserverState, number>();
+  return async (
+    state: SessionObserverState,
+    digest: SessionObserverDigest,
+    final: boolean,
+    kind: "model" | "preamble" = "model",
+  ) => {
+    const lastPersistedAt =
+      kind === "preamble" ? preamblePersistedAt.get(state) : state.lastPersistedAt;
     const due =
-      state.lastPersistedAt === undefined ||
-      params.now() - state.lastPersistedAt >= PERSIST_INTERVAL_MS;
+      lastPersistedAt === undefined || params.now() - lastPersistedAt >= PERSIST_INTERVAL_MS;
     if (!final && !due) {
       return;
     }
@@ -30,7 +37,11 @@ export function createSessionObserverDigestPersister(params: {
           stillCurrent: params.stillCurrent(state.runId, state.sessionKey),
         });
         if (accepted) {
-          state.lastPersistedAt = params.now();
+          if (kind === "preamble") {
+            preamblePersistedAt.set(state, params.now());
+          } else {
+            state.lastPersistedAt = params.now();
+          }
         }
         return;
       } catch (error) {

--- a/src/gateway/session-observer-preamble.test.ts
+++ b/src/gateway/session-observer-preamble.test.ts
@@ -91,7 +91,7 @@ describe("session observer preamble publisher", () => {
       });
     }
 
-    expect(publisher.generation(session)).toBe(2);
+    expect(publisher.generation(session)).toBe(0);
     publisher.dispose();
   });
 });

--- a/src/gateway/session-observer-preamble.test.ts
+++ b/src/gateway/session-observer-preamble.test.ts
@@ -95,6 +95,45 @@ describe("session observer preamble publisher", () => {
     publisher.dispose();
   });
 
+  it("remembers a preamble that matches a restored digest", () => {
+    const session = state("Checking files");
+    const publish = vi.fn();
+    const publisher = createSessionObserverPreamblePublisher({
+      now: () => 1_000,
+      setTimeoutFn: setTimeout,
+      clearTimeoutFn: clearTimeout,
+      isCurrent: () => true,
+      publish,
+    });
+    const event = {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: 1_000,
+      sessionKey: session.sessionKey,
+      agentId: session.agentId,
+      data: { kind: "preamble", progressText: "Checking files" },
+    };
+
+    publisher.handle(session, event);
+    const previousDigest = session.previousDigest;
+    if (!previousDigest) {
+      throw new Error("expected previous digest");
+    }
+    session.previousDigest = {
+      ...previousDigest,
+      revision: 2,
+      headline: "Reviewing the implementation",
+      updatedAt: 2_000,
+    };
+    publisher.handle(session, { ...event, seq: 2, ts: 2_001 });
+
+    expect(session.lastPreambleHeadline).toBe("Checking files");
+    expect(publish).not.toHaveBeenCalled();
+    expect(publisher.generation(session)).toBe(0);
+    publisher.dispose();
+  });
+
   it("does not restore an unchanged preamble after a richer digest replaces it", () => {
     const session = state("Earlier headline");
     const publish = vi.fn();

--- a/src/gateway/session-observer-preamble.test.ts
+++ b/src/gateway/session-observer-preamble.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSessionActivityNoteState } from "../agents/session-activity-notes.js";
-import type { SessionObserverState } from "./session-observer-model.js";
+import {
+  createDormantSessionObserverRun,
+  type SessionObserverState,
+} from "./session-observer-model.js";
 import { createSessionObserverPreamblePublisher } from "./session-observer-preamble.js";
 
 function state(headline: string): SessionObserverState {
@@ -46,7 +49,7 @@ describe("session observer preamble publisher", () => {
     publisher.handle(session, {
       runId: "run-1",
       seq: 1,
-      stream: "item",
+      stream: "item" as const,
       ts: 1_000,
       sessionKey: session.sessionKey,
       agentId: session.agentId,
@@ -55,7 +58,7 @@ describe("session observer preamble publisher", () => {
     publisher.handle(session, {
       runId: "run-1",
       seq: 2,
-      stream: "item",
+      stream: "item" as const,
       ts: 1_000,
       sessionKey: session.sessionKey,
       agentId: session.agentId,
@@ -83,7 +86,7 @@ describe("session observer preamble publisher", () => {
       publisher.handle(session, {
         runId: "run-1",
         seq: sequence,
-        stream: "item",
+        stream: "item" as const,
         ts: 1_000,
         sessionKey: session.sessionKey,
         agentId: session.agentId,
@@ -108,7 +111,7 @@ describe("session observer preamble publisher", () => {
     const event = {
       runId: "run-1",
       seq: 1,
-      stream: "item",
+      stream: "item" as const,
       ts: 1_000,
       sessionKey: session.sessionKey,
       agentId: session.agentId,
@@ -147,7 +150,7 @@ describe("session observer preamble publisher", () => {
     const event = {
       runId: "run-1",
       seq: 1,
-      stream: "item",
+      stream: "item" as const,
       ts: 1_000,
       sessionKey: session.sessionKey,
       agentId: session.agentId,
@@ -173,6 +176,49 @@ describe("session observer preamble publisher", () => {
     publisher.dispose();
   });
 
+  it("replays a queued preamble after dormant-state revival", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const original = state("Earlier headline");
+    const publish = vi.fn();
+    const publisher = createSessionObserverPreamblePublisher({
+      now: Date.now,
+      setTimeoutFn: setTimeout,
+      clearTimeoutFn: clearTimeout,
+      isCurrent: () => true,
+      publish,
+    });
+    const preamble = (sequence: number, progressText: string) => ({
+      runId: "run-1",
+      seq: sequence,
+      stream: "item" as const,
+      ts: Date.now(),
+      sessionKey: original.sessionKey,
+      agentId: original.agentId,
+      data: { kind: "preamble" as const, progressText },
+    });
+
+    publisher.handle(original, preamble(1, "Published headline"));
+    vi.setSystemTime(1_100);
+    publisher.handle(original, preamble(2, "Queued headline"));
+    const dormant = createDormantSessionObserverRun(original);
+    publisher.clear(original);
+
+    expect(dormant.lastPreambleHeadline).toBe("Published headline");
+    const revived = state("Published headline");
+    revived.lastPreambleHeadline = dormant.lastPreambleHeadline;
+    publisher.handle(revived, {
+      ...preamble(3, "Queued headline"),
+      sessionKey: revived.sessionKey,
+      agentId: revived.agentId,
+    });
+
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(revived.previousDigest?.headline).toBe("Queued headline");
+    publisher.dispose();
+    vi.useRealTimers();
+  });
+
   it("preserves duplicate suppression across dormant-state revival", () => {
     const original = state("Earlier headline");
     const publish = vi.fn();
@@ -186,7 +232,7 @@ describe("session observer preamble publisher", () => {
     publisher.handle(original, {
       runId: "run-1",
       seq: 1,
-      stream: "item",
+      stream: "item" as const,
       ts: 1_000,
       sessionKey: original.sessionKey,
       agentId: original.agentId,
@@ -198,7 +244,7 @@ describe("session observer preamble publisher", () => {
     publisher.handle(revived, {
       runId: "run-1",
       seq: 2,
-      stream: "item",
+      stream: "item" as const,
       ts: 2_000,
       sessionKey: revived.sessionKey,
       agentId: revived.agentId,

--- a/src/gateway/session-observer-preamble.test.ts
+++ b/src/gateway/session-observer-preamble.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSessionActivityNoteState } from "../agents/session-activity-notes.js";
+import type { SessionObserverState } from "./session-observer-model.js";
+import { createSessionObserverPreamblePublisher } from "./session-observer-preamble.js";
+
+function state(headline: string): SessionObserverState {
+  return {
+    ...createSessionActivityNoteState(),
+    sessionKey: "agent:main:session-1",
+    runId: "run-1",
+    agentId: "main",
+    startedAt: 0,
+    lastActivityAt: 0,
+    lastRunAt: 0,
+    revision: 1,
+    digestCount: 0,
+    consecutiveFailures: 0,
+    lastDigestNoteSequence: 0,
+    previousDigest: {
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      revision: 1,
+      updatedAt: 1,
+      headline,
+      health: "on-track",
+    },
+    inFlight: false,
+    finalPending: false,
+  };
+}
+
+describe("session observer preamble publisher", () => {
+  it("keeps generation stable for duplicate snapshots while clearing publication state", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const session = state("Earlier headline");
+    const publish = vi.fn();
+    const publisher = createSessionObserverPreamblePublisher({
+      now: Date.now,
+      setTimeoutFn: setTimeout,
+      clearTimeoutFn: clearTimeout,
+      isCurrent: () => true,
+      publish,
+    });
+
+    publisher.handle(session, {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: 1_000,
+      sessionKey: session.sessionKey,
+      agentId: session.agentId,
+      data: { kind: "preamble", progressText: "Current headline" },
+    });
+    publisher.handle(session, {
+      runId: "run-1",
+      seq: 2,
+      stream: "item",
+      ts: 1_000,
+      sessionKey: session.sessionKey,
+      agentId: session.agentId,
+      data: { kind: "preamble", progressText: "Current headline" },
+    });
+    expect(publisher.generation(session)).toBe(1);
+
+    vi.advanceTimersByTime(2_000);
+    expect(publisher.generation(session)).toBe(1);
+    publisher.dispose();
+    vi.useRealTimers();
+  });
+
+  it("retains newer mutation generations when publication matches the current digest", () => {
+    const session = state("Same headline");
+    const publisher = createSessionObserverPreamblePublisher({
+      now: () => 1_000,
+      setTimeoutFn: setTimeout,
+      clearTimeoutFn: clearTimeout,
+      isCurrent: () => true,
+      publish: vi.fn(),
+    });
+
+    for (let sequence = 1; sequence <= 2; sequence += 1) {
+      publisher.handle(session, {
+        runId: "run-1",
+        seq: sequence,
+        stream: "item",
+        ts: 1_000,
+        sessionKey: session.sessionKey,
+        agentId: session.agentId,
+        data: { kind: "preamble", progressText: "Same headline" },
+      });
+    }
+
+    expect(publisher.generation(session)).toBe(2);
+    publisher.dispose();
+  });
+});

--- a/src/gateway/session-observer-preamble.test.ts
+++ b/src/gateway/session-observer-preamble.test.ts
@@ -133,4 +133,40 @@ describe("session observer preamble publisher", () => {
     expect(publisher.generation(session)).toBe(1);
     publisher.dispose();
   });
+
+  it("preserves duplicate suppression across dormant-state revival", () => {
+    const original = state("Earlier headline");
+    const publish = vi.fn();
+    const publisher = createSessionObserverPreamblePublisher({
+      now: () => 1_000,
+      setTimeoutFn: setTimeout,
+      clearTimeoutFn: clearTimeout,
+      isCurrent: () => true,
+      publish,
+    });
+    publisher.handle(original, {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: 1_000,
+      sessionKey: original.sessionKey,
+      agentId: original.agentId,
+      data: { kind: "preamble", progressText: "Checking files" },
+    });
+
+    const revived = state("Reviewing the implementation");
+    revived.lastPreambleHeadline = original.lastPreambleHeadline;
+    publisher.handle(revived, {
+      runId: "run-1",
+      seq: 2,
+      stream: "item",
+      ts: 2_000,
+      sessionKey: revived.sessionKey,
+      agentId: revived.agentId,
+      data: { kind: "preamble", progressText: "Checking files" },
+    });
+
+    expect(publish).toHaveBeenCalledOnce();
+    publisher.dispose();
+  });
 });

--- a/src/gateway/session-observer-preamble.test.ts
+++ b/src/gateway/session-observer-preamble.test.ts
@@ -69,7 +69,7 @@ describe("session observer preamble publisher", () => {
     vi.useRealTimers();
   });
 
-  it("retains newer mutation generations when publication matches the current digest", () => {
+  it("does not advance generation when the headline already matches the digest", () => {
     const session = state("Same headline");
     const publisher = createSessionObserverPreamblePublisher({
       now: () => 1_000,
@@ -92,6 +92,45 @@ describe("session observer preamble publisher", () => {
     }
 
     expect(publisher.generation(session)).toBe(0);
+    publisher.dispose();
+  });
+
+  it("does not restore an unchanged preamble after a richer digest replaces it", () => {
+    const session = state("Earlier headline");
+    const publish = vi.fn();
+    const publisher = createSessionObserverPreamblePublisher({
+      now: () => 1_000,
+      setTimeoutFn: setTimeout,
+      clearTimeoutFn: clearTimeout,
+      isCurrent: () => true,
+      publish,
+    });
+    const event = {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: 1_000,
+      sessionKey: session.sessionKey,
+      agentId: session.agentId,
+      data: { kind: "preamble", progressText: "Checking files" },
+    };
+
+    publisher.handle(session, event);
+    publisher.clear(session);
+    const previousDigest = session.previousDigest;
+    if (!previousDigest) {
+      throw new Error("expected previous digest");
+    }
+    session.previousDigest = {
+      ...previousDigest,
+      revision: 2,
+      headline: "Reviewing the implementation",
+      updatedAt: 2_000,
+    };
+    publisher.handle(session, { ...event, seq: 2, ts: 2_001 });
+
+    expect(publish).toHaveBeenCalledOnce();
+    expect(publisher.generation(session)).toBe(1);
     publisher.dispose();
   });
 });

--- a/src/gateway/session-observer-preamble.ts
+++ b/src/gateway/session-observer-preamble.ts
@@ -1,0 +1,126 @@
+import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
+import { normalizeSessionPreambleText } from "../agents/session-preamble.js";
+import type { SessionObserverEvent } from "./session-observer-contract.js";
+import type { SessionObserverState } from "./session-observer-model.js";
+
+const PREAMBLE_HEADLINE_MAX_CHARS = 120;
+const PREAMBLE_PUBLISH_INTERVAL_MS = 2_000;
+
+type PreambleEntry = {
+  headline: string;
+  lastPublishedAt: number;
+  published: boolean;
+  timer?: ReturnType<typeof setTimeout>;
+  updatedAt: number;
+};
+
+export function createSessionObserverPreamblePublisher(params: {
+  now: () => number;
+  setTimeoutFn: typeof setTimeout;
+  clearTimeoutFn: typeof clearTimeout;
+  isCurrent: (state: SessionObserverState) => boolean;
+  publish: (state: SessionObserverState, digest: SessionObserverDigest) => void;
+}) {
+  const entries = new Map<SessionObserverState, PreambleEntry>();
+  const generations = new WeakMap<SessionObserverState, number>();
+
+  const clear = (state: SessionObserverState): void => {
+    const entry = entries.get(state);
+    if (entry?.timer) {
+      params.clearTimeoutFn(entry.timer);
+    }
+    entries.delete(state);
+  };
+
+  const publish = (state: SessionObserverState, entry: PreambleEntry): void => {
+    entry.timer = undefined;
+    if (!params.isCurrent(state)) {
+      clear(state);
+      return;
+    }
+    const previous = state.previousDigest;
+    if (previous?.runId === state.runId && previous.headline === entry.headline) {
+      clear(state);
+      return;
+    }
+    state.revision += 1;
+    const digest: SessionObserverDigest = {
+      sessionKey: state.sessionKey,
+      runId: state.runId,
+      revision: state.revision,
+      updatedAt: Math.max(entry.updatedAt, (previous?.updatedAt ?? -1) + 1),
+      headline: entry.headline,
+      health:
+        previous?.runId === state.runId &&
+        previous.health !== "done" &&
+        previous.health !== "failed"
+          ? previous.health
+          : "on-track",
+      ...(state.planProgress ? { planProgress: state.planProgress } : {}),
+    };
+    state.previousDigest = digest;
+    entry.lastPublishedAt = params.now();
+    entry.published = true;
+    params.publish(state, digest);
+  };
+
+  return {
+    handle(state: SessionObserverState, event: SessionObserverEvent): boolean {
+      if (event.stream !== "item" || event.data.kind !== "preamble") {
+        return false;
+      }
+      const headline = normalizeSessionPreambleText(
+        event.data.progressText,
+        PREAMBLE_HEADLINE_MAX_CHARS,
+      );
+      if (!headline) {
+        return true;
+      }
+      const entry = entries.get(state) ?? {
+        headline: "",
+        lastPublishedAt: 0,
+        published: false,
+        updatedAt: event.ts,
+      };
+      if (entry.headline !== headline) {
+        generations.set(state, (generations.get(state) ?? 0) + 1);
+      }
+      entry.headline = headline;
+      entry.updatedAt = event.ts;
+      entries.set(state, entry);
+
+      const elapsed = params.now() - entry.lastPublishedAt;
+      if (!entry.published || elapsed >= PREAMBLE_PUBLISH_INTERVAL_MS) {
+        if (entry.timer) {
+          params.clearTimeoutFn(entry.timer);
+        }
+        publish(state, entry);
+      } else if (!entry.timer) {
+        entry.timer = params.setTimeoutFn(
+          () => publish(state, entry),
+          PREAMBLE_PUBLISH_INTERVAL_MS - elapsed,
+        );
+        entry.timer.unref?.();
+      }
+      return true;
+    },
+    generation(state: SessionObserverState): number {
+      return generations.get(state) ?? 0;
+    },
+    flush(state: SessionObserverState): void {
+      const entry = entries.get(state);
+      if (entry) {
+        if (entry.timer) {
+          params.clearTimeoutFn(entry.timer);
+        }
+        publish(state, entry);
+      }
+    },
+    clear,
+    dispose(): void {
+      for (const state of entries.keys()) {
+        clear(state);
+      }
+    },
+  };
+}

--- a/src/gateway/session-observer-preamble.ts
+++ b/src/gateway/session-observer-preamble.ts
@@ -81,6 +81,7 @@ export function createSessionObserverPreamblePublisher(params: {
         state.lastPreambleHeadline ??
         (state.previousDigest?.runId === state.runId ? state.previousDigest.headline : "");
       if (!existing && previousHeadline === headline) {
+        state.lastPreambleHeadline = headline;
         return true;
       }
       const entry = existing ?? {

--- a/src/gateway/session-observer-preamble.ts
+++ b/src/gateway/session-observer-preamble.ts
@@ -77,15 +77,19 @@ export function createSessionObserverPreamblePublisher(params: {
       if (!headline) {
         return true;
       }
-      const entry = entries.get(state) ?? {
+      const existing = entries.get(state);
+      const previousHeadline =
+        lastHeadlines.get(state) ??
+        (state.previousDigest?.runId === state.runId ? state.previousDigest.headline : "");
+      if (!existing && previousHeadline === headline) {
+        return true;
+      }
+      const entry = existing ?? {
         headline: "",
         lastPublishedAt: 0,
         published: false,
         updatedAt: event.ts,
       };
-      const previousHeadline =
-        lastHeadlines.get(state) ??
-        (state.previousDigest?.runId === state.runId ? state.previousDigest.headline : "");
       if (previousHeadline !== headline) {
         generations.set(state, (generations.get(state) ?? 0) + 1);
       }

--- a/src/gateway/session-observer-preamble.ts
+++ b/src/gateway/session-observer-preamble.ts
@@ -59,6 +59,7 @@ export function createSessionObserverPreamblePublisher(params: {
       ...(state.planProgress ? { planProgress: state.planProgress } : {}),
     };
     state.previousDigest = digest;
+    state.lastPublishedPreambleHeadline = entry.headline;
     entry.lastPublishedAt = params.now();
     entry.published = true;
     params.publish(state, digest);
@@ -82,6 +83,7 @@ export function createSessionObserverPreamblePublisher(params: {
         (state.previousDigest?.runId === state.runId ? state.previousDigest.headline : "");
       if (!existing && previousHeadline === headline) {
         state.lastPreambleHeadline = headline;
+        state.lastPublishedPreambleHeadline = headline;
         return true;
       }
       const entry = existing ?? {

--- a/src/gateway/session-observer-preamble.ts
+++ b/src/gateway/session-observer-preamble.ts
@@ -23,6 +23,7 @@ export function createSessionObserverPreamblePublisher(params: {
 }) {
   const entries = new Map<SessionObserverState, PreambleEntry>();
   const generations = new WeakMap<SessionObserverState, number>();
+  const lastHeadlines = new WeakMap<SessionObserverState, string>();
 
   const clear = (state: SessionObserverState): void => {
     const entry = entries.get(state);
@@ -82,9 +83,13 @@ export function createSessionObserverPreamblePublisher(params: {
         published: false,
         updatedAt: event.ts,
       };
-      if (entry.headline !== headline) {
+      const previousHeadline =
+        lastHeadlines.get(state) ??
+        (state.previousDigest?.runId === state.runId ? state.previousDigest.headline : "");
+      if (previousHeadline !== headline) {
         generations.set(state, (generations.get(state) ?? 0) + 1);
       }
+      lastHeadlines.set(state, headline);
       entry.headline = headline;
       entry.updatedAt = event.ts;
       entries.set(state, entry);

--- a/src/gateway/session-observer-preamble.ts
+++ b/src/gateway/session-observer-preamble.ts
@@ -23,7 +23,6 @@ export function createSessionObserverPreamblePublisher(params: {
 }) {
   const entries = new Map<SessionObserverState, PreambleEntry>();
   const generations = new WeakMap<SessionObserverState, number>();
-  const lastHeadlines = new WeakMap<SessionObserverState, string>();
 
   const clear = (state: SessionObserverState): void => {
     const entry = entries.get(state);
@@ -79,7 +78,7 @@ export function createSessionObserverPreamblePublisher(params: {
       }
       const existing = entries.get(state);
       const previousHeadline =
-        lastHeadlines.get(state) ??
+        state.lastPreambleHeadline ??
         (state.previousDigest?.runId === state.runId ? state.previousDigest.headline : "");
       if (!existing && previousHeadline === headline) {
         return true;
@@ -93,7 +92,7 @@ export function createSessionObserverPreamblePublisher(params: {
       if (previousHeadline !== headline) {
         generations.set(state, (generations.get(state) ?? 0) + 1);
       }
-      lastHeadlines.set(state, headline);
+      state.lastPreambleHeadline = headline;
       entry.headline = headline;
       entry.updatedAt = event.ts;
       entries.set(state, entry);

--- a/src/gateway/session-observer.terminal.test.ts
+++ b/src/gateway/session-observer.terminal.test.ts
@@ -73,6 +73,29 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     harness.observer.dispose();
   });
 
+  it("finalizes an active run from a contextless terminal", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const harness = createHarness();
+    harness.observer.handleEvent(event({ stream: "lifecycle", data: { phase: "start" } }));
+    vi.setSystemTime(30_000);
+    const contextlessTerminal = event({
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 0, endedAt: 30_000 },
+    });
+    delete contextlessTerminal.sessionKey;
+
+    harness.observer.handleEvent(contextlessTerminal);
+    await flushObserver();
+
+    const digest = harness.broadcastToConnIds.mock.calls.at(-1)?.[1] as
+      | SessionObserverDigest
+      | undefined;
+    expect(digest?.health).toBe("done");
+    expect(harness.persistDigest).toHaveBeenCalledOnce();
+    harness.observer.dispose();
+  });
+
   it("suppresses live events after a contextless terminal", () => {
     const harness = createHarness();
     const contextlessTerminal = event({ stream: "lifecycle", data: { phase: "end" } });

--- a/src/gateway/session-observer.terminal.test.ts
+++ b/src/gateway/session-observer.terminal.test.ts
@@ -46,6 +46,51 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     harness.observer.dispose();
   });
 
+  it("accepts a routed terminal event after a contextless duplicate", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(30_000);
+    const storedDigest = persistedLiveDigest();
+    const readSession = vi.fn(() => ({
+      sessionId: "session-id",
+      updatedAt: 1_000,
+      observerDigest: storedDigest,
+    }));
+    const harness = createHarness({ subscribe: false, readSession });
+    const contextlessTerminal = event({
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 0, endedAt: 30_000 },
+    });
+    delete contextlessTerminal.sessionKey;
+
+    harness.observer.handleEvent(contextlessTerminal);
+    harness.observer.handleEvent(
+      event({ stream: "lifecycle", data: { phase: "end", startedAt: 0, endedAt: 30_000 } }),
+    );
+    await flushObserver();
+
+    expect(harness.persistDigest).toHaveBeenCalledOnce();
+    expect(harness.persistDigest.mock.calls[0]?.[0]?.digest).toMatchObject({ health: "done" });
+    harness.observer.dispose();
+  });
+
+  it("suppresses live events after a contextless terminal", () => {
+    const harness = createHarness();
+    const contextlessTerminal = event({ stream: "lifecycle", data: { phase: "end" } });
+    delete contextlessTerminal.sessionKey;
+
+    harness.observer.handleEvent(contextlessTerminal);
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Late progress" },
+      }),
+    );
+
+    expect(harness.broadcastToConnIds).not.toHaveBeenCalled();
+    expect(harness.persistDigest).not.toHaveBeenCalled();
+    harness.observer.dispose();
+  });
+
   it.each([
     { phase: "end", expected: "done" },
     { phase: "error", expected: "failed" },

--- a/src/gateway/session-observer.terminal.test.ts
+++ b/src/gateway/session-observer.terminal.test.ts
@@ -96,6 +96,37 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     harness.observer.dispose();
   });
 
+  it("finalizes a dormant run from a contextless terminal", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const storedDigest = persistedLiveDigest();
+    const readSession = vi.fn(() => ({
+      sessionId: "session-id",
+      updatedAt: 1_000,
+      observerDigest: storedDigest,
+    }));
+    const harness = createHarness({ readSession });
+    harness.observer.handleEvent(event({ stream: "lifecycle", data: { phase: "start" } }));
+    harness.observer.removeConnection("conn-1");
+    vi.setSystemTime(30_000);
+    const contextlessTerminal = event({
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 0, endedAt: 30_000 },
+    });
+    delete contextlessTerminal.sessionKey;
+    delete contextlessTerminal.agentId;
+
+    harness.observer.handleEvent(contextlessTerminal);
+    await flushObserver();
+
+    expect(harness.persistDigest).toHaveBeenCalledOnce();
+    expect(harness.persistDigest.mock.calls[0]?.[0]?.digest).toMatchObject({
+      runId: "run-1",
+      health: "done",
+    });
+    harness.observer.dispose();
+  });
+
   it("suppresses live events after a contextless terminal", () => {
     const harness = createHarness();
     const contextlessTerminal = event({ stream: "lifecycle", data: { phase: "end" } });

--- a/src/gateway/session-observer.test-utils.ts
+++ b/src/gateway/session-observer.test-utils.ts
@@ -2,7 +2,10 @@ import { vi } from "vitest";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
-import { createSessionMessageSubscriberRegistry } from "./server-chat-state.js";
+import {
+  createSessionEventSubscriberRegistry,
+  createSessionMessageSubscriberRegistry,
+} from "./server-chat-state.js";
 import type { SessionObserverDeps } from "./session-observer-model.js";
 import { createSessionObserver } from "./session-observer.js";
 
@@ -77,6 +80,7 @@ export async function flushObserver(): Promise<void> {
 
 export function createHarness(options?: {
   subscribe?: boolean;
+  broadSubscribe?: boolean;
   visible?: boolean;
   completeModel?: ReturnType<typeof vi.fn>;
   prepareModel?: ReturnType<typeof vi.fn>;
@@ -87,8 +91,12 @@ export function createHarness(options?: {
   resolveUtilityModelRef?: ReturnType<typeof vi.fn>;
 }) {
   const subscribers = createSessionMessageSubscriberRegistry();
+  const sessionEventSubscribers = createSessionEventSubscriberRegistry();
   if (options?.subscribe !== false) {
     subscribers.subscribe("conn-1", "agent:main:session-1")?.commit();
+  }
+  if (options?.broadSubscribe) {
+    sessionEventSubscribers.subscribe("conn-1");
   }
   const prepareModel = options?.prepareModel ?? vi.fn(async () => preparedModel());
   const completeModel =
@@ -107,6 +115,7 @@ export function createHarness(options?: {
   const observer = createSessionObserver({
     getConfig: () => options?.config ?? cfg,
     subscribers,
+    sessionEventSubscribers,
     broadcastToConnIds,
     resolveUtilityModelRef: (options?.resolveUtilityModelRef ??
       (() =>
@@ -118,12 +127,13 @@ export function createHarness(options?: {
     readSession: readSession as never,
     persistDigest: persistDigest as never,
   });
-  if (options?.subscribe !== false && options?.visible !== false) {
+  if ((options?.subscribe !== false || options?.broadSubscribe) && options?.visible !== false) {
     declareObserverVisibility(observer);
   }
   return {
     observer,
     subscribers,
+    sessionEventSubscribers,
     prepareModel,
     completeModel,
     broadcastToConnIds,

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -139,6 +139,15 @@ describe("session observer", () => {
       revision: 3,
     });
     const terminalCount = harness.broadcastToConnIds.mock.calls.length;
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Late preamble" },
+      }),
+    );
+    harness.observer.handleEvent(
+      event({ stream: "lifecycle", data: { phase: "end", startedAt: 0, endedAt: 40_001 } }),
+    );
     await vi.advanceTimersByTimeAsync(2_000);
     expect(harness.broadcastToConnIds).toHaveBeenCalledTimes(terminalCount);
     harness.observer.dispose();
@@ -498,7 +507,7 @@ describe("session observer", () => {
     harness.observer.dispose();
   });
 
-  it("disables a run after two consecutive model failures", async () => {
+  it("disables only model work after two consecutive failures", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     const completeModel = vi.fn(async () => {
@@ -518,6 +527,15 @@ describe("session observer", () => {
     }
     await vi.advanceTimersByTimeAsync(24_000);
     expect(completeModel).toHaveBeenCalledTimes(2);
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Continuing without model" },
+      }),
+    );
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Continuing without model",
+    });
     harness.observer.dispose();
   });
 
@@ -623,6 +641,40 @@ describe("session observer", () => {
 
     expect(harness.prepareModel).not.toHaveBeenCalled();
     expect(harness.completeModel).not.toHaveBeenCalled();
+    harness.observer.dispose();
+  });
+
+  it("rejects an in-flight result after utility-model replacement", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let utilityModelRef: string | undefined = "openai/gpt-a";
+    let resolveModel: ((value: ReturnType<typeof modelMessage>) => void) | undefined;
+    const completeModel = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof modelMessage>>((resolve) => {
+          resolveModel = resolve;
+        }),
+    );
+    const harness = createHarness({
+      completeModel,
+      resolveUtilityModelRef: vi.fn(() => utilityModelRef),
+    });
+    startAndAddToolNotes(harness.observer);
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(completeModel).toHaveBeenCalledOnce();
+
+    utilityModelRef = "openai/gpt-b";
+    harness.observer.handleEvent(
+      event({ stream: "tool", data: { phase: "start", name: "read", args: { path: "next" } } }),
+    );
+    resolveModel?.(modelMessage({ headline: "Stale model A", health: "on-track" }));
+    await flushObserver();
+
+    expect(
+      harness.broadcastToConnIds.mock.calls.some(
+        (call) => (call[1] as SessionObserverDigest).headline === "Stale model A",
+      ),
+    ).toBe(false);
     harness.observer.dispose();
   });
 

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -44,6 +44,283 @@ describe("session observer", () => {
     harness.observer.dispose();
   });
 
+  it("publishes safe preambles immediately without a model call", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const harness = createHarness();
+    harness.observer.handleEvent(event({ stream: "lifecycle", data: { phase: "start" } }));
+
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: {
+          kind: "preamble",
+          phase: "update",
+          progressText: "**Checking** the [gateway](https://example.com) [[reply_to_current]]",
+        },
+      }),
+    );
+    await flushObserver();
+
+    expect(harness.completeModel).not.toHaveBeenCalled();
+    expect(harness.broadcastToConnIds).toHaveBeenCalledOnce();
+    expect(harness.broadcastToConnIds.mock.calls[0]?.[1]).toMatchObject({
+      headline: "Checking the gateway",
+      health: "on-track",
+      revision: 1,
+      runId: "run-1",
+    });
+    expect(harness.persistDigest).toHaveBeenCalledOnce();
+    harness.observer.dispose();
+  });
+
+  it("publishes preambles to visible session-list subscribers without a utility model", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const harness = createHarness({
+      subscribe: false,
+      broadSubscribe: true,
+      utilityModelRef: null,
+    });
+
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Inspecting mobile rows" },
+      }),
+    );
+    await flushObserver();
+
+    expect(harness.prepareModel).not.toHaveBeenCalled();
+    expect(harness.completeModel).not.toHaveBeenCalled();
+    expect(harness.broadcastToConnIds).toHaveBeenCalledWith(
+      "session.observer",
+      expect.objectContaining({ headline: "Inspecting mobile rows", health: "on-track" }),
+      new Set(["conn-1"]),
+      { dropIfSlow: true },
+    );
+    expect(harness.persistDigest).toHaveBeenCalledOnce();
+    harness.observer.dispose();
+  });
+
+  it("terminalizes a preamble-only digest without a utility model", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const harness = createHarness({
+      subscribe: false,
+      broadSubscribe: true,
+      utilityModelRef: null,
+    });
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Running tests" },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(100);
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Wrapping up" },
+      }),
+    );
+    harness.observer.handleEvent(
+      event({
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 0, endedAt: 40_000 },
+      }),
+    );
+    await flushObserver();
+
+    expect(harness.completeModel).not.toHaveBeenCalled();
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Wrapping up",
+      health: "done",
+      revision: 3,
+    });
+    const terminalCount = harness.broadcastToConnIds.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(harness.broadcastToConnIds).toHaveBeenCalledTimes(terminalCount);
+    harness.observer.dispose();
+  });
+
+  it("does not cap model-free preamble headlines at six sessions", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const harness = createHarness({
+      subscribe: false,
+      broadSubscribe: true,
+      utilityModelRef: null,
+    });
+
+    for (let index = 0; index < 7; index += 1) {
+      harness.observer.handleEvent(
+        event({
+          runId: `run-${index}`,
+          sessionKey: `agent:main:session-${index}`,
+          stream: "item",
+          data: { kind: "preamble", phase: "update", progressText: `Session ${index}` },
+        }),
+      );
+    }
+
+    expect(harness.broadcastToConnIds).toHaveBeenCalledTimes(7);
+    harness.observer.dispose();
+  });
+
+  it("coalesces incremental preamble snapshots behind a trailing update", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const harness = createHarness();
+    harness.observer.handleEvent(event({ stream: "lifecycle", data: { phase: "start" } }));
+
+    for (const progressText of ["Checking", "Checking the gateway", "Running tests"]) {
+      harness.observer.handleEvent(
+        event({
+          stream: "item",
+          data: { kind: "preamble", phase: "update", progressText },
+        }),
+      );
+    }
+
+    expect(harness.broadcastToConnIds).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(harness.broadcastToConnIds).toHaveBeenCalledTimes(2);
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Running tests",
+      revision: 2,
+    });
+    harness.observer.dispose();
+  });
+
+  it("does not let an older model result overwrite a newer preamble", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let resolveModel: ((value: ReturnType<typeof modelMessage>) => void) | undefined;
+    const completeModel = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof modelMessage>>((resolve) => {
+          resolveModel = resolve;
+        }),
+    );
+    const harness = createHarness({ completeModel });
+    startAndAddToolNotes(harness.observer);
+    await vi.advanceTimersByTimeAsync(11_500);
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Checking files" },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    expect(completeModel).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(100);
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Running focused tests" },
+      }),
+    );
+    resolveModel?.(modelMessage({ headline: "Stale model summary", health: "on-track" }));
+    await flushObserver();
+    expect(
+      harness.broadcastToConnIds.mock.calls.some(
+        (call) => (call[1] as SessionObserverDigest).headline === "Stale model summary",
+      ),
+    ).toBe(false);
+    await vi.advanceTimersByTimeAsync(1_900);
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Running focused tests",
+    });
+    harness.observer.dispose();
+  });
+
+  it("aborts a live assessment when the run becomes terminal", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let firstCall = true;
+    const completeModel = vi.fn(async (params: { options: { signal: AbortSignal } }) => {
+      if (firstCall) {
+        firstCall = false;
+        return await new Promise<ReturnType<typeof modelMessage>>((_resolve, reject) => {
+          params.options.signal.addEventListener("abort", () => reject(new Error("aborted")), {
+            once: true,
+          });
+        });
+      }
+      return modelMessage({ headline: "Run completed", health: "done" });
+    });
+    const harness = createHarness({ completeModel });
+    startAndAddToolNotes(harness.observer);
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(completeModel).toHaveBeenCalledOnce();
+
+    harness.observer.handleEvent(
+      event({
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 0, endedAt: 40_000 },
+      }),
+    );
+    await flushObserver();
+
+    expect(completeModel).toHaveBeenCalledTimes(2);
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Run completed",
+      health: "done",
+    });
+    harness.observer.dispose();
+  });
+
+  it("retires a queued preamble when a richer digest is accepted", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let resolveModel: ((value: ReturnType<typeof modelMessage>) => void) | undefined;
+    const completeModel = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof modelMessage>>((resolve) => {
+          resolveModel = resolve;
+        }),
+    );
+    const harness = createHarness({ completeModel });
+    harness.observer.handleEvent(event({ stream: "lifecycle", data: { phase: "start" } }));
+    await vi.advanceTimersByTimeAsync(12_000);
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Checking files" },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(100);
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Running tests" },
+      }),
+    );
+    for (let index = 0; index < 3; index += 1) {
+      harness.observer.handleEvent(
+        event({ stream: "tool", data: { phase: "start", name: "read", args: { index } } }),
+      );
+    }
+    await flushObserver();
+    expect(completeModel).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1_900);
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Running tests",
+    });
+
+    resolveModel?.(modelMessage({ headline: "Reviewing test results", health: "on-track" }));
+    await flushObserver();
+    const acceptedCount = harness.broadcastToConnIds.mock.calls.length;
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Reviewing test results",
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(harness.broadcastToConnIds).toHaveBeenCalledTimes(acceptedCount);
+    harness.observer.dispose();
+  });
+
   it("never includes tool results or command output and redacts tool arguments", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -383,7 +660,7 @@ describe("session observer", () => {
     harness.observer.dispose();
   });
 
-  it("evicts the least recently active session at the concurrency cap", async () => {
+  it("demotes the least recently active model while retaining preamble state", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     const harness = createHarness();
@@ -405,10 +682,32 @@ describe("session observer", () => {
     );
     expect(sessions).toHaveLength(6);
     expect(sessions).not.toContain("agent:main:session-0");
+
+    const beforePreamble = harness.broadcastToConnIds.mock.calls.length;
+    harness.observer.handleEvent(
+      event({
+        runId: "run-0",
+        sessionKey: "agent:main:session-0",
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Checking files" },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(100);
+    harness.observer.handleEvent(
+      event({
+        runId: "run-0",
+        sessionKey: "agent:main:session-0",
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Running tests" },
+      }),
+    );
+    expect(harness.broadcastToConnIds).toHaveBeenCalledTimes(beforePreamble + 1);
+    await vi.advanceTimersByTimeAsync(1_900);
+    expect(harness.broadcastToConnIds).toHaveBeenCalledTimes(beforePreamble + 2);
     harness.observer.dispose();
   });
 
-  it("preserves revision continuity when an observed run is evicted", async () => {
+  it("preserves revision continuity when a run's model is demoted", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     const harness = createHarness();

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -153,6 +153,47 @@ describe("session observer", () => {
     harness.observer.dispose();
   });
 
+  it("synthesizes terminal health when the final model request becomes stale", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let utilityModelRef: string | undefined = "openai/gpt-a";
+    let resolveModel: ((value: ReturnType<typeof modelMessage>) => void) | undefined;
+    const harness = createHarness({
+      completeModel: vi.fn(
+        () =>
+          new Promise<ReturnType<typeof modelMessage>>((resolve) => {
+            resolveModel = resolve;
+          }),
+      ),
+      resolveUtilityModelRef: vi.fn(() => utilityModelRef),
+    });
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Running tests" },
+      }),
+    );
+    harness.observer.handleEvent(
+      event({
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 0, endedAt: 40_000 },
+      }),
+    );
+    await flushObserver();
+    expect(harness.completeModel).toHaveBeenCalledOnce();
+
+    utilityModelRef = "openai/gpt-b";
+    resolveModel?.(modelMessage({ headline: "Stale final model", health: "done" }));
+    await flushObserver();
+
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Running tests",
+      health: "done",
+      revision: 2,
+    });
+    harness.observer.dispose();
+  });
+
   it("does not cap model-free preamble headlines at six sessions", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -459,6 +459,9 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       const state: SessionObserverState = {
         ...createSessionActivityNoteState(),
         ...dormantState,
+        ...(dormantState.lastPreambleHeadline
+          ? { lastPublishedPreambleHeadline: dormantState.lastPreambleHeadline }
+          : {}),
         ...(utilityModelRef ? { utilityModelRef } : {}),
         lastActivityAt: event.ts,
         lastRunAt: now(),

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -438,10 +438,10 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   const admitState = (
     event: SessionObserverEvent,
     allowPreambleOnly: boolean,
+    sessionKey: string,
+    agentId: string | undefined,
   ): SessionObserverState | undefined => {
-    const sessionKey = event.sessionKey?.trim();
-    const agentId = event.agentId?.trim();
-    if (!sessionKey || !agentId || !audience.has(sessionKey)) {
+    if (!agentId || !audience.has(sessionKey)) {
       return undefined;
     }
     const cfg = deps.getConfig();
@@ -513,18 +513,31 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       }
       return;
     }
-    // A contextless terminal still closes the live run, but one routed terminal
-    // duplicate must pass through later so durable state can be finalized.
+    // A terminal with no recoverable run context still closes the live run, but
+    // one routed terminal duplicate must pass later to finalize durable state.
     if (contextlessTerminalRuns.has(event.runId) && !terminal) {
       return;
     }
-    const sessionKey = event.sessionKey?.trim();
+    const eventSessionKey = event.sessionKey?.trim();
+    const eventAgentId = event.agentId?.trim();
+    let knownRun: SessionObserverState | DormantSessionObserverRun | undefined;
+    if (terminal && (!eventSessionKey || !eventAgentId)) {
+      for (const candidate of states.values()) {
+        if (candidate.runId === event.runId) {
+          knownRun = candidate;
+          break;
+        }
+      }
+      knownRun ??= dormantRuns.get(event.runId);
+    }
+    const sessionKey = eventSessionKey || knownRun?.sessionKey;
     if (!sessionKey) {
       if (terminal) {
         markSessionObserverRunSuperseded(contextlessTerminalRuns, event.runId, event.ts);
       }
       return;
     }
+    const agentId = eventAgentId || knownRun?.agentId;
     if (terminal) {
       contextlessTerminalRuns.delete(event.runId);
       markSessionObserverRunSuperseded(terminalRuns, event.runId, event.ts);
@@ -582,7 +595,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       state = undefined;
     }
     if (!state) {
-      state = admitState(event, isPreamble);
+      state = admitState(event, isPreamble, sessionKey, agentId);
     }
     if (!state) {
       if (terminal) {

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -64,6 +64,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   const dormantRuns = new Map<string, DormantSessionObserverRun>();
   const revisionFloors = new Map<string, SessionObserverRevisionFloor>();
   const supersededRuns = new Map<string, number>();
+  const contextlessTerminalRuns = new Map<string, number>();
   const terminalRuns = new Map<string, number>();
   const disabledRuns = new Set<string>();
   const visibleConnections = new Set<string>();
@@ -502,20 +503,31 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     if (terminalRuns.has(event.runId)) {
       return;
     }
-    if (terminal) {
-      markSessionObserverRunSuperseded(terminalRuns, event.runId, event.ts);
-    }
     if (supersededRuns.has(event.runId)) {
       if (terminal) {
+        markSessionObserverRunSuperseded(terminalRuns, event.runId, event.ts);
+        contextlessTerminalRuns.delete(event.runId);
         supersededRuns.delete(event.runId);
         dormantRuns.delete(event.runId);
         disabledRuns.delete(event.runId);
       }
       return;
     }
+    // A contextless terminal still closes the live run, but one routed terminal
+    // duplicate must pass through later so durable state can be finalized.
+    if (contextlessTerminalRuns.has(event.runId) && !terminal) {
+      return;
+    }
     const sessionKey = event.sessionKey?.trim();
     if (!sessionKey) {
+      if (terminal) {
+        markSessionObserverRunSuperseded(contextlessTerminalRuns, event.runId, event.ts);
+      }
       return;
+    }
+    if (terminal) {
+      contextlessTerminalRuns.delete(event.runId);
+      markSessionObserverRunSuperseded(terminalRuns, event.runId, event.ts);
     }
     const isPreamble = event.stream === "item" && event.data.kind === "preamble";
     if (terminal && audience.recipients(sessionKey).size === 0) {

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -11,10 +11,10 @@ import { getAgentRunContext } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createSessionObserverAskRuntime } from "./session-observer-ask.js";
 import { createSessionObserverAudience } from "./session-observer-audience.js";
+import { createSessionObserverCompletion } from "./session-observer-completion.js";
 import type { SessionObserverEvent, SessionObserverService } from "./session-observer-contract.js";
 import { createSessionObserverModelSlots } from "./session-observer-model-slots.js";
 import {
-  buildSessionObserverPrompt,
   createDormantSessionObserverRun,
   defaultCompleteModel,
   defaultPersistDigest,
@@ -22,17 +22,13 @@ import {
   defaultReadSession,
   isTerminalLifecycleEvent,
   markSessionObserverRunSuperseded,
-  normalizeSessionObserverModelOutput,
   rememberSessionObserverDisabledRun,
   rememberSessionObserverDormantRun,
   rememberSessionObserverRevisionFloor,
-  SESSION_OBSERVER_MODEL_MAX_TOKENS,
-  SESSION_OBSERVER_SYSTEM_PROMPT,
   synthesizeSessionObserverTerminalDigest,
 } from "./session-observer-model.js";
 import type {
   DormantSessionObserverRun,
-  PreparedModel,
   SessionObserverDeps,
   SessionObserverRevisionFloor,
   SessionObserverState,
@@ -44,7 +40,6 @@ const observerLog = createSubsystemLogger("gateway/session-observer");
 
 const MIN_NOTES_PER_DIGEST = 4;
 const MIN_DIGEST_INTERVAL_MS = 12_000;
-const MODEL_TIMEOUT_MS = 10_000;
 const MAX_DIGESTS_PER_RUN = 40;
 const MAX_LIVE_DIGESTS_PER_RUN = MAX_DIGESTS_PER_RUN - 1;
 const MAX_CONSECUTIVE_FAILURES = 2;
@@ -116,7 +111,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       deps.broadcastToConnIds("session.observer", digest, audience.recipients(state.sessionKey), {
         dropIfSlow: true,
       });
-      void persistAcceptedDigest(state, digest, false);
+      void persistAcceptedDigest(state, digest, false, "preamble");
     },
   });
 
@@ -249,91 +244,15 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     );
   }
 
-  const ensurePrepared = async (state: SessionObserverState): Promise<PreparedModel> => {
-    const modelRef = state.utilityModelRef;
-    if (!modelRef) {
-      throw new Error("session observer utility model is unavailable");
-    }
-    state.preparedPromise ??= prepareModel({
-      cfg: deps.getConfig(),
-      agentId: state.agentId,
-      modelRef,
-      useUtilityModel: true,
-      allowMissingApiKeyModes: ["aws-sdk"],
-    });
-    return await state.preparedPromise;
-  };
-
-  const requestModelDigest = async (state: SessionObserverState, notes: readonly string[]) => {
-    const controller = new AbortController();
-    state.activeController = controller;
-    const timeout = setTimeoutFn(() => controller.abort(), MODEL_TIMEOUT_MS);
-    const aborted = new Promise<never>((_resolve, reject) => {
-      controller.signal.addEventListener(
-        "abort",
-        () => reject(new Error("session observer model call timed out or was cancelled")),
-        { once: true },
-      );
-    });
-    try {
-      const execute = async () => {
-        const prepared = await ensurePrepared(state);
-        if (!modelStateIsCurrent(state) || controller.signal.aborted) {
-          throw new Error("session observer state is no longer active");
-        }
-        if ("error" in prepared) {
-          throw new Error(prepared.error);
-        }
-        for (let attempt = 0; attempt < 2; attempt += 1) {
-          if (!modelStateIsCurrent(state) || controller.signal.aborted) {
-            throw new Error("session observer state is no longer active");
-          }
-          const result = await completeModel({
-            model: prepared.model,
-            auth: prepared.auth,
-            cfg: deps.getConfig(),
-            context: {
-              systemPrompt: SESSION_OBSERVER_SYSTEM_PROMPT,
-              messages: [
-                {
-                  role: "user",
-                  content: buildSessionObserverPrompt(state, notes),
-                  timestamp: now(),
-                },
-              ],
-            },
-            options: {
-              maxTokens: Math.min(
-                SESSION_OBSERVER_MODEL_MAX_TOKENS,
-                Math.floor(prepared.model.maxTokens),
-              ),
-              temperature: 0.2,
-              signal: controller.signal,
-            },
-          });
-          if (result.stopReason === "error") {
-            throw new Error(result.errorMessage?.trim() || "session observer completion failed");
-          }
-          const text = result.content
-            .filter((block): block is { type: "text"; text: string } => block.type === "text")
-            .map((block) => block.text)
-            .join("")
-            .trim();
-          const parsed = normalizeSessionObserverModelOutput(text);
-          if (parsed) {
-            return parsed;
-          }
-        }
-        throw new Error("session observer returned invalid JSON twice");
-      };
-      return await Promise.race([execute(), aborted]);
-    } finally {
-      clearTimeoutFn(timeout);
-      if (state.activeController === controller) {
-        state.activeController = undefined;
-      }
-    }
-  };
+  const requestModelDigest = createSessionObserverCompletion({
+    getConfig: deps.getConfig,
+    prepareModel,
+    completeModel,
+    now,
+    setTimeoutFn,
+    clearTimeoutFn,
+    isCurrent: modelStateIsCurrent,
+  });
 
   const pendingNotes = (state: SessionObserverState) =>
     state.notes.filter((note) => note.sequence > state.lastDigestNoteSequence);
@@ -422,12 +341,17 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           state,
           selectedNotes.map((note) => note.text),
         );
-        if (
+        const stale =
           !modelStateIsCurrent(state) ||
           !modelSlots.requestIsCurrent(state, requestGeneration) ||
           (!final && state.terminalHealth !== undefined) ||
-          preamblePublisher.generation(state) !== requestedPreambleGeneration
-        ) {
+          preamblePublisher.generation(state) !== requestedPreambleGeneration;
+        if (stale) {
+          if (final && states.get(state.sessionKey) === state) {
+            void synthesizeTerminalDigest({ state });
+            dormantRuns.delete(state.runId);
+            dropState(state);
+          }
           return;
         }
         // A session reset swaps sessionId under the same key; a digest accepted
@@ -464,11 +388,16 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           dormantRuns.delete(state.runId);
         }
       } catch (error) {
-        if (
+        const stale =
           !modelStateIsCurrent(state) ||
           !modelSlots.requestIsCurrent(state, requestGeneration) ||
-          (!final && state.terminalHealth !== undefined)
-        ) {
+          (!final && state.terminalHealth !== undefined);
+        if (stale) {
+          if (final && states.get(state.sessionKey) === state) {
+            void synthesizeTerminalDigest({ state });
+            dormantRuns.delete(state.runId);
+            dropState(state);
+          }
           return;
         }
         state.consecutiveFailures += 1;

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -69,6 +69,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   const dormantRuns = new Map<string, DormantSessionObserverRun>();
   const revisionFloors = new Map<string, SessionObserverRevisionFloor>();
   const supersededRuns = new Map<string, number>();
+  const terminalRuns = new Map<string, number>();
   const disabledRuns = new Set<string>();
   const visibleConnections = new Set<string>();
   let disposed = false;
@@ -169,7 +170,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     if (state.timer) {
       clearTimeoutFn(state.timer);
     }
-    state.activeController?.abort();
+    modelSlots.invalidateRequest(state);
     if (states.get(state.sessionKey) === state) {
       states.delete(state.sessionKey);
     }
@@ -195,7 +196,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       clearTimeoutFn(state.timer);
       state.timer = undefined;
     }
-    state.activeController?.abort();
+    modelSlots.invalidateRequest(state);
     state.preparedPromise = undefined;
     state.utilityModelRef = undefined;
     state.consecutiveFailures = 0;
@@ -207,14 +208,9 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     demote: demoteUtilityModel,
   });
 
-  const disableRun = (state: SessionObserverState) => {
+  const disableModelForRun = (state: SessionObserverState) => {
     rememberSessionObserverDisabledRun(disabledRuns, state.runId);
-    rememberSessionObserverDormantRun(
-      dormantRuns,
-      revisionFloors,
-      createDormantSessionObserverRun(state),
-    );
-    dropState(state);
+    demoteUtilityModel(state);
   };
 
   const suspendStatesWithoutAudience = () => {
@@ -418,15 +414,17 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     state.inFlight = true;
     state.lastRunAt = now();
     const lastSelectedSequence = selectedNotes.at(-1)?.sequence ?? state.lastDigestNoteSequence;
+    const requestedPreambleGeneration = preamblePublisher.generation(state);
+    const requestGeneration = modelSlots.beginRequest(state);
     void (async () => {
       try {
-        const requestedPreambleGeneration = preamblePublisher.generation(state);
         const modelDigest = await requestModelDigest(
           state,
           selectedNotes.map((note) => note.text),
         );
         if (
           !modelStateIsCurrent(state) ||
+          !modelSlots.requestIsCurrent(state, requestGeneration) ||
           (!final && state.terminalHealth !== undefined) ||
           preamblePublisher.generation(state) !== requestedPreambleGeneration
         ) {
@@ -466,7 +464,11 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           dormantRuns.delete(state.runId);
         }
       } catch (error) {
-        if (!modelStateIsCurrent(state) || (!final && state.terminalHealth !== undefined)) {
+        if (
+          !modelStateIsCurrent(state) ||
+          !modelSlots.requestIsCurrent(state, requestGeneration) ||
+          (!final && state.terminalHealth !== undefined)
+        ) {
           return;
         }
         state.consecutiveFailures += 1;
@@ -481,7 +483,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
             dormantRuns.delete(state.runId);
             dropState(state);
           } else {
-            disableRun(state);
+            disableModelForRun(state);
           }
         } else if (final) {
           state.finalPending = true;
@@ -516,7 +518,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     if (cfg.gateway?.controlUi?.sessionObserver === false) {
       return undefined;
     }
-    const utilityModelRef = modelSlots.claim(agentId);
+    const utilityModelRef = disabledRuns.has(event.runId) ? undefined : modelSlots.claim(agentId);
     if (!utilityModelRef && !allowPreambleOnly) {
       return undefined;
     }
@@ -568,18 +570,17 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       return;
     }
     const terminal = isTerminalLifecycleEvent(event);
+    if (terminalRuns.has(event.runId)) {
+      return;
+    }
+    if (terminal) {
+      markSessionObserverRunSuperseded(terminalRuns, event.runId, event.ts);
+    }
     if (supersededRuns.has(event.runId)) {
       if (terminal) {
         supersededRuns.delete(event.runId);
         dormantRuns.delete(event.runId);
-      }
-      return;
-    }
-    if (disabledRuns.has(event.runId)) {
-      if (terminal) {
-        void synthesizeTerminalDigest({ event });
         disabledRuns.delete(event.runId);
-        dormantRuns.delete(event.runId);
       }
       return;
     }
@@ -591,6 +592,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     if (terminal && audience.recipients(sessionKey).size === 0) {
       void synthesizeTerminalDigest({ event, state: states.get(sessionKey) });
       dormantRuns.delete(event.runId);
+      disabledRuns.delete(event.runId);
       return;
     }
     const isRunStart = event.stream === "lifecycle" && event.data.phase === "start";
@@ -645,7 +647,11 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       if (terminal) {
         void synthesizeTerminalDigest({ event });
         dormantRuns.delete(event.runId);
+        disabledRuns.delete(event.runId);
       }
+      return;
+    }
+    if (state.terminalHealth) {
       return;
     }
     if (revisionFloor && revisionFloor.revision > state.revision) {
@@ -653,10 +659,11 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       state.previousDigest = revisionFloor.previousDigest;
     }
     revisionFloors.delete(sessionKey);
-    const utilityModelRef = modelSlots.claim(state.agentId, state);
+    const utilityModelRef = disabledRuns.has(state.runId)
+      ? undefined
+      : modelSlots.claim(state.agentId, state);
     if (state.utilityModelRef !== utilityModelRef) {
-      state.activeController?.abort();
-      state.activeController = undefined;
+      modelSlots.invalidateRequest(state);
       state.preparedPromise = undefined;
       state.utilityModelRef = utilityModelRef;
       state.consecutiveFailures = 0;
@@ -669,10 +676,13 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     noteSessionActivityEvent(state, event);
     preamblePublisher.handle(state, event);
     if (terminal) {
-      state.activeController?.abort();
+      if (!state.terminalHealth) {
+        modelSlots.invalidateRequest(state);
+      }
       preamblePublisher.flush(state);
       preamblePublisher.clear(state);
       state.terminalHealth = terminalHealthFor(event);
+      disabledRuns.delete(event.runId);
       const endedAt = readFiniteNumber(event.data.endedAt) ?? now();
       const hasRunDigest = state.digestCount > 0 || state.previousDigest?.runId === state.runId;
       if (!hasRunDigest && endedAt - state.startedAt < FINAL_DIGEST_MIN_RUN_MS) {
@@ -714,6 +724,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       dormantRuns.clear();
       revisionFloors.clear();
       supersededRuns.clear();
+      terminalRuns.clear();
       disabledRuns.clear();
       visibleConnections.clear();
     },

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -10,7 +10,9 @@ import { resolveUtilityModelRefForAgent } from "../agents/utility-model.js";
 import { getAgentRunContext } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createSessionObserverAskRuntime } from "./session-observer-ask.js";
+import { createSessionObserverAudience } from "./session-observer-audience.js";
 import type { SessionObserverEvent, SessionObserverService } from "./session-observer-contract.js";
+import { createSessionObserverModelSlots } from "./session-observer-model-slots.js";
 import {
   buildSessionObserverPrompt,
   createDormantSessionObserverRun,
@@ -35,6 +37,8 @@ import type {
   SessionObserverRevisionFloor,
   SessionObserverState,
 } from "./session-observer-model.js";
+import { createSessionObserverDigestPersister } from "./session-observer-persistence.js";
+import { createSessionObserverPreamblePublisher } from "./session-observer-preamble.js";
 
 const observerLog = createSubsystemLogger("gateway/session-observer");
 
@@ -45,10 +49,9 @@ const MAX_DIGESTS_PER_RUN = 40;
 const MAX_LIVE_DIGESTS_PER_RUN = MAX_DIGESTS_PER_RUN - 1;
 const MAX_CONSECUTIVE_FAILURES = 2;
 const FINAL_DIGEST_MIN_RUN_MS = 30_000;
-const PERSIST_INTERVAL_MS = 60_000;
 // The Control UI opens at most six live session subscriptions; matching that cap
 // prevents background observer calls from outgrowing the surface consuming them.
-const MAX_CONCURRENT_OBSERVED_SESSIONS = 6;
+const MAX_CONCURRENT_MODEL_SESSIONS = 6;
 
 type SessionObserver = SessionObserverService &
   Pick<ReturnType<typeof createSessionObserverAskRuntime>, "getSnapshot">;
@@ -82,11 +85,39 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     clearTimeoutFn,
     isDisposed: () => disposed,
   });
-
+  const audience = createSessionObserverAudience({
+    subscribers: deps.subscribers,
+    sessionEventSubscribers: deps.sessionEventSubscribers,
+    isVisible: (connId) => visibleConnections.has(connId),
+  });
   // Narrow run-identity guard shared by persist paths: a digest may still land
   // while its session is unwatched, but never after a newer run replaces it.
   const runStillCurrent = (runId: string, sessionKey: string) => () =>
     !disposed && !supersededRuns.has(runId) && (states.get(sessionKey)?.runId ?? runId) === runId;
+  const persistAcceptedDigest = createSessionObserverDigestPersister({
+    now,
+    persistDigest,
+    stillCurrent: runStillCurrent,
+    onError: (state, error) => {
+      observerLog.warn("session observer digest persistence failed", {
+        sessionKey: state.sessionKey,
+        runId: state.runId,
+        error,
+      });
+    },
+  });
+  const preamblePublisher = createSessionObserverPreamblePublisher({
+    now,
+    setTimeoutFn,
+    clearTimeoutFn,
+    isCurrent: stateIsCurrent,
+    publish: (state, digest) => {
+      deps.broadcastToConnIds("session.observer", digest, audience.recipients(state.sessionKey), {
+        dropIfSlow: true,
+      });
+      void persistAcceptedDigest(state, digest, false);
+    },
+  });
 
   // Terminal paths that cannot run the model must still retire same-run live
   // health, or idle session rows can display a stale in-progress judgment forever.
@@ -122,7 +153,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         deps.broadcastToConnIds(
           "session.observer",
           digest,
-          deps.subscribers.get(digest.sessionKey),
+          audience.recipients(digest.sessionKey),
           {
             dropIfSlow: true,
           },
@@ -134,12 +165,11 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   }
 
   const dropState = (state: SessionObserverState) => {
+    preamblePublisher.clear(state);
     if (state.timer) {
       clearTimeoutFn(state.timer);
-      state.timer = undefined;
     }
     state.activeController?.abort();
-    state.activeController = undefined;
     if (states.get(state.sessionKey) === state) {
       states.delete(state.sessionKey);
     }
@@ -160,6 +190,23 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     dropState(state);
   };
 
+  const demoteUtilityModel = (state: SessionObserverState): void => {
+    if (state.timer) {
+      clearTimeoutFn(state.timer);
+      state.timer = undefined;
+    }
+    state.activeController?.abort();
+    state.preparedPromise = undefined;
+    state.utilityModelRef = undefined;
+    state.consecutiveFailures = 0;
+  };
+  const modelSlots = createSessionObserverModelSlots({
+    states,
+    maxSessions: MAX_CONCURRENT_MODEL_SESSIONS,
+    resolve: (agentId) => resolveUtilityModelRef({ cfg: deps.getConfig(), agentId }),
+    demote: demoteUtilityModel,
+  });
+
   const disableRun = (state: SessionObserverState) => {
     rememberSessionObserverDisabledRun(disabledRuns, state.runId);
     rememberSessionObserverDormantRun(
@@ -170,63 +217,51 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     dropState(state);
   };
 
-  const hasSubscribers = (sessionKey: string) => deps.subscribers.get(sessionKey).size > 0;
-
-  const hasObserverAudience = (sessionKey: string) => {
-    // Only the Control UI renders these model-backed digests. Fail closed for
-    // undeclared subscribers so TUI and script connections never spend unseen
-    // tokens. Accepted tradeoff: a pre-2026.7 Control UI tab left open across a
-    // gateway upgrade cannot declare visibility and misses live digests until
-    // reload; terminal digests still reach it, and a fail-open default would
-    // re-enable unseen spend for every non-rendering subscriber permanently.
-    for (const connId of deps.subscribers.get(sessionKey)) {
-      if (visibleConnections.has(connId)) {
-        return true;
-      }
-    }
-    return false;
-  };
-
   const suspendStatesWithoutAudience = () => {
     // suspendState deletes from `states`; Map iteration tolerates removal of
     // the entry being visited.
     for (const state of states.values()) {
-      if (!hasObserverAudience(state.sessionKey)) {
+      if (!audience.has(state.sessionKey)) {
         suspendState(state);
       }
     }
   };
 
-  const markSuperseded = (runId: string, observedAt: number) =>
-    markSessionObserverRunSuperseded(supersededRuns, runId, observedAt);
-
   const unsubscribeChanges = deps.subscribers.onChange((sessionKey) => {
     const state = states.get(sessionKey);
-    if (state && !hasObserverAudience(sessionKey)) {
+    if (state && !audience.has(sessionKey)) {
       suspendState(state);
     }
   });
 
-  const stateIsCurrent = (state: SessionObserverState) => {
-    if (
-      disposed ||
-      states.get(state.sessionKey) !== state ||
-      !hasObserverAudience(state.sessionKey)
-    ) {
+  function stateIsCurrent(state: SessionObserverState): boolean {
+    return (
+      !disposed &&
+      states.get(state.sessionKey) === state &&
+      audience.has(state.sessionKey) &&
+      deps.getConfig().gateway?.controlUi?.sessionObserver !== false
+    );
+  }
+
+  function modelStateIsCurrent(state: SessionObserverState): boolean {
+    if (!stateIsCurrent(state) || !state.utilityModelRef) {
       return false;
     }
-    const cfg = deps.getConfig();
-    if (cfg.gateway?.controlUi?.sessionObserver === false) {
-      return false;
-    }
-    return resolveUtilityModelRef({ cfg, agentId: state.agentId }) === state.utilityModelRef;
-  };
+    return (
+      resolveUtilityModelRef({ cfg: deps.getConfig(), agentId: state.agentId }) ===
+      state.utilityModelRef
+    );
+  }
 
   const ensurePrepared = async (state: SessionObserverState): Promise<PreparedModel> => {
+    const modelRef = state.utilityModelRef;
+    if (!modelRef) {
+      throw new Error("session observer utility model is unavailable");
+    }
     state.preparedPromise ??= prepareModel({
       cfg: deps.getConfig(),
       agentId: state.agentId,
-      modelRef: state.utilityModelRef,
+      modelRef,
       useUtilityModel: true,
       allowMissingApiKeyModes: ["aws-sdk"],
     });
@@ -247,14 +282,14 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     try {
       const execute = async () => {
         const prepared = await ensurePrepared(state);
-        if (!stateIsCurrent(state) || controller.signal.aborted) {
+        if (!modelStateIsCurrent(state) || controller.signal.aborted) {
           throw new Error("session observer state is no longer active");
         }
         if ("error" in prepared) {
           throw new Error(prepared.error);
         }
         for (let attempt = 0; attempt < 2; attempt += 1) {
-          if (!stateIsCurrent(state) || controller.signal.aborted) {
+          if (!modelStateIsCurrent(state) || controller.signal.aborted) {
             throw new Error("session observer state is no longer active");
           }
           const result = await completeModel({
@@ -304,47 +339,6 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     }
   };
 
-  const persistAcceptedDigest = async (
-    state: SessionObserverState,
-    digest: SessionObserverDigest,
-    final: boolean,
-  ) => {
-    const due =
-      state.lastPersistedAt === undefined || now() - state.lastPersistedAt >= PERSIST_INTERVAL_MS;
-    if (!final && !due) {
-      return;
-    }
-    // Broadcasts remain live while durable writes are throttled; terminal
-    // persistence gets one bounded retry so idle rows keep the final judgment.
-    const attempts = final ? 2 : 1;
-    for (let attempt = 0; attempt < attempts; attempt += 1) {
-      try {
-        const accepted = await persistDigest({
-          sessionKey: state.sessionKey,
-          sessionId: state.sessionId,
-          agentId: state.agentId,
-          digest,
-          stillCurrent: runStillCurrent(state.runId, state.sessionKey),
-        });
-        if (accepted) {
-          state.lastPersistedAt = now();
-        }
-        // A rejection is the store guard firing (rollover, reset, stale
-        // revision) — retrying the same candidate can never succeed, but the
-        // next valid digest must not inherit the 60s throttle.
-        return;
-      } catch (error) {
-        if (attempt + 1 === attempts) {
-          observerLog.warn("session observer digest persistence failed", {
-            sessionKey: state.sessionKey,
-            runId: state.runId,
-            error,
-          });
-        }
-      }
-    }
-  };
-
   const pendingNotes = (state: SessionObserverState) =>
     state.notes.filter((note) => note.sequence > state.lastDigestNoteSequence);
 
@@ -358,6 +352,9 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       } else {
         suspendState(state);
       }
+      return;
+    }
+    if (!modelStateIsCurrent(state)) {
       return;
     }
     if (state.inFlight || state.timer || state.terminalHealth) {
@@ -389,6 +386,14 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       }
       return;
     }
+    if (!modelStateIsCurrent(state)) {
+      if (final) {
+        void synthesizeTerminalDigest({ state });
+        dormantRuns.delete(state.runId);
+        dropState(state);
+      }
+      return;
+    }
     if (state.inFlight) {
       state.finalPending ||= final;
       return;
@@ -415,11 +420,16 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     const lastSelectedSequence = selectedNotes.at(-1)?.sequence ?? state.lastDigestNoteSequence;
     void (async () => {
       try {
+        const requestedPreambleGeneration = preamblePublisher.generation(state);
         const modelDigest = await requestModelDigest(
           state,
           selectedNotes.map((note) => note.text),
         );
-        if (!stateIsCurrent(state)) {
+        if (
+          !modelStateIsCurrent(state) ||
+          (!final && state.terminalHealth !== undefined) ||
+          preamblePublisher.generation(state) !== requestedPreambleGeneration
+        ) {
           return;
         }
         // A session reset swaps sessionId under the same key; a digest accepted
@@ -430,6 +440,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         ) {
           return;
         }
+        preamblePublisher.clear(state);
         state.consecutiveFailures = 0;
         state.revision += 1;
         state.digestCount += 1;
@@ -447,18 +458,15 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
             : {}),
         };
         state.previousDigest = digest;
-        deps.broadcastToConnIds(
-          "session.observer",
-          digest,
-          deps.subscribers.get(state.sessionKey),
-          { dropIfSlow: true },
-        );
+        deps.broadcastToConnIds("session.observer", digest, audience.recipients(state.sessionKey), {
+          dropIfSlow: true,
+        });
         await persistAcceptedDigest(state, digest, final);
         if (final) {
           dormantRuns.delete(state.runId);
         }
       } catch (error) {
-        if (!stateIsCurrent(state)) {
+        if (!modelStateIsCurrent(state) || (!final && state.terminalHealth !== undefined)) {
           return;
         }
         state.consecutiveFailures += 1;
@@ -495,37 +503,31 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     })();
   };
 
-  const admitState = (event: SessionObserverEvent): SessionObserverState | undefined => {
+  const admitState = (
+    event: SessionObserverEvent,
+    allowPreambleOnly: boolean,
+  ): SessionObserverState | undefined => {
     const sessionKey = event.sessionKey?.trim();
     const agentId = event.agentId?.trim();
-    if (!sessionKey || !agentId || !hasObserverAudience(sessionKey)) {
+    if (!sessionKey || !agentId || !audience.has(sessionKey)) {
       return undefined;
     }
     const cfg = deps.getConfig();
     if (cfg.gateway?.controlUi?.sessionObserver === false) {
       return undefined;
     }
-    const utilityModelRef = resolveUtilityModelRef({ cfg, agentId });
-    if (!utilityModelRef) {
+    const utilityModelRef = modelSlots.claim(agentId);
+    if (!utilityModelRef && !allowPreambleOnly) {
       return undefined;
-    }
-    if (states.size >= MAX_CONCURRENT_OBSERVED_SESSIONS) {
-      const evicted = [...states.values()].toSorted(
-        (left, right) =>
-          left.lastActivityAt - right.lastActivityAt ||
-          left.sessionKey.localeCompare(right.sessionKey),
-      )[0];
-      if (evicted) {
-        suspendState(evicted);
-      }
     }
     const dormant = dormantRuns.get(event.runId);
     if (dormant) {
       dormantRuns.delete(event.runId);
+      const { utilityModelRef: _dormantModelRef, ...dormantState } = dormant;
       const state: SessionObserverState = {
         ...createSessionActivityNoteState(),
-        ...dormant,
-        utilityModelRef,
+        ...dormantState,
+        ...(utilityModelRef ? { utilityModelRef } : {}),
         lastActivityAt: event.ts,
         lastRunAt: now(),
         lastDigestNoteSequence: 0,
@@ -544,7 +546,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       sessionId: event.sessionId ?? session?.sessionId,
       runId: event.runId,
       agentId,
-      utilityModelRef,
+      ...(utilityModelRef ? { utilityModelRef } : {}),
       startedAt,
       lastActivityAt: event.ts,
       lastRunAt: startedAt,
@@ -585,7 +587,8 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     if (!sessionKey) {
       return;
     }
-    if (terminal && !hasSubscribers(sessionKey)) {
+    const isPreamble = event.stream === "item" && event.data.kind === "preamble";
+    if (terminal && audience.recipients(sessionKey).size === 0) {
       void synthesizeTerminalDigest({ event, state: states.get(sessionKey) });
       dormantRuns.delete(event.runId);
       return;
@@ -600,7 +603,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       }
       const supersededRunId = state.runId;
       if (isRunStart) {
-        markSuperseded(supersededRunId, event.ts);
+        markSessionObserverRunSuperseded(supersededRuns, supersededRunId, event.ts);
       }
       suspendState(state);
       if (isRunStart) {
@@ -623,21 +626,20 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           rememberSessionObserverRevisionFloor(revisionFloors, sessionKey, revisionFloor);
         }
         for (const run of superseded) {
-          markSuperseded(run.runId, event.ts);
+          markSessionObserverRunSuperseded(supersededRuns, run.runId, event.ts);
           dormantRuns.delete(run.runId);
         }
       }
     }
     if (
       state &&
-      (!hasObserverAudience(sessionKey) ||
-        deps.getConfig().gateway?.controlUi?.sessionObserver === false)
+      (!audience.has(sessionKey) || deps.getConfig().gateway?.controlUi?.sessionObserver === false)
     ) {
       suspendState(state);
       state = undefined;
     }
     if (!state) {
-      state = admitState(event);
+      state = admitState(event, isPreamble);
     }
     if (!state) {
       if (terminal) {
@@ -651,13 +653,25 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       state.previousDigest = revisionFloor.previousDigest;
     }
     revisionFloors.delete(sessionKey);
+    const utilityModelRef = modelSlots.claim(state.agentId, state);
+    if (state.utilityModelRef !== utilityModelRef) {
+      state.activeController?.abort();
+      state.activeController = undefined;
+      state.preparedPromise = undefined;
+      state.utilityModelRef = utilityModelRef;
+      state.consecutiveFailures = 0;
+    }
     state.lastActivityAt = event.ts;
     const eventStartedAt = readFiniteNumber(event.data.startedAt);
     if (eventStartedAt !== undefined) {
       state.startedAt = Math.min(state.startedAt, eventStartedAt);
     }
     noteSessionActivityEvent(state, event);
+    preamblePublisher.handle(state, event);
     if (terminal) {
+      state.activeController?.abort();
+      preamblePublisher.flush(state);
+      preamblePublisher.clear(state);
       state.terminalHealth = terminalHealthFor(event);
       const endedAt = readFiniteNumber(event.data.endedAt) ?? now();
       const hasRunDigest = state.digestCount > 0 || state.previousDigest?.runId === state.runId;
@@ -691,6 +705,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     ask: askRuntime.ask,
     dispose() {
       disposed = true;
+      preamblePublisher.dispose();
       unsubscribeChanges();
       askRuntime.dispose();
       for (const state of states.values()) {


### PR DESCRIPTION
Related: #80039

## What Problem This Solves

Fixes an issue where web, iOS, and Android session lists could show generic or delayed status text while the model was already emitting a safe, user-visible preamble describing its current work.

## Why This Change Was Made

Safe `item/preamble` text now enters the existing `session.observer` headline pipeline immediately. The Gateway strips delivery directives and Markdown, bounds the text, coalesces incremental snapshots, and shares the same run-scoped digest with web and the official mobile clients. Utility-model assessments can still replace the preamble later; preambles work even when no utility model is configured.

The change reuses the existing observer protocol and client rendering rather than adding another session-activity event or persisted store. Utility-model concurrency remains capped at six without dropping model-free preamble state, and terminal/stale-run fencing prevents old model output or late preambles from reviving completed sessions.

## User Impact

Running sessions show subtitles such as “Checking gateway wiring” immediately on web, iOS, and Android by default. Richer observer assessments may replace that line later. Completed or failed runs still settle to terminal observer state, and messaging-channel delivery is unchanged.

This addresses the safe subtitle portion of #80039. The broader request for a dedicated reasoning/progress panel remains open.

## Evidence

- Focused Gateway observer suite: 7 files, 90 tests passed before final rebase; exact-head focused suites remained green through the final lifecycle fixes.
- iOS Simulator: `RootTabsPresentationTests` passed on `OpenClaw-iPhone-16-iOS18` (`1D105BD8-0455-4727-BA52-2BAC5F86E9D6`).
- Android: `SessionObserverDigestTest` and `ktlintMainSourceSetCheck` passed for the ThirdParty debug variant.
- Public runtime smoke: `openclaw qa manual --provider-mode aimock` completed successfully with `AIMOCK_QA_OK`.
- Blacksmith Testbox changed-scope run: https://github.com/openclaw/openclaw/actions/runs/29983230052
- Final structured autoreviews were clean after fixing request-generation, terminal, persistence-throttle, dormant-revival, duplicate-snapshot, and model-slot races.
- `git diff --check`, focused oxlint, type checks, max-lines ratchet, and changed-scope gates passed.

The visual session-row chrome is unchanged; this PR changes which existing observer headline arrives first, so the meaningful proof is event/lifecycle behavior rather than a layout before/after.

AI-assisted change; implementation and review were supervised by a maintainer.
