### PR TITLE
fix(plugins): avoid lifecycle lease result race

### DIFF
--- a/src/plugins/plugin-lifecycle-lease.test.ts
+++ b/src/plugins/plugin-lifecycle-lease.test.ts
@@ -143,7 +143,9 @@ describe("plugin lifecycle lease", () => {
       await waitForPath(firstMarker);
       const second = runLeaseChild(childScript, ["second", ...childArgs]);
       await waitForPath(secondReady);
-      await waitForPath(secondResult);
+      // Wait for the child to close so its result write is fully flushed before
+      // reading; file existence alone can race with the write after open().
+      await second;
 
       let assertionError: unknown;
       try {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation race where the cross-process plugin lifecycle lease test can read a newly created result file before the child process has finished writing its timeout code. This produced an empty string and cancelled the remaining Plugin Prerelease matrix.

## Why This Change Was Made

The test now awaits the second child process exit before reading its result. Process close is the ownership boundary that guarantees the child write has completed; waiting only for path existence can observe the file between creation and content flush.

## User Impact

No product behavior changes. Release and main CI no longer fail intermittently on this cross-process lease assertion.

## Evidence

- Failing Plugin Prerelease run: https://github.com/openclaw/openclaw/actions/runs/29986993737
- Failing job: https://github.com/openclaw/openclaw/actions/runs/29986993737/job/89141300400
- Focused test passed: 3/3
- Ten consecutive focused reruns passed
- `git diff --check` passed
- Fresh Codex autoreview passed with no accepted/actionable findings

AI-assisted: yes. The change and failure path were reviewed directly; optional transcript logs were not included.
