### PR TITLE
fix(irc): send plain text instead of Markdown source

### DIFF
--- a/extensions/irc/src/send.test.ts
+++ b/extensions/irc/src/send.test.ts
@@ -10,11 +10,13 @@ const hoisted = vi.hoisted(() => {
   const loadConfig = vi.fn();
   const resolveMarkdownTableMode = vi.fn(() => "preserve");
   const convertMarkdownTables = vi.fn((text: string) => text);
+  const stripMarkdown = vi.fn((text: string) => text);
   const record = vi.fn();
   return {
     loadConfig,
     resolveMarkdownTableMode,
     convertMarkdownTables,
+    stripMarkdown,
     record,
     normalizeIrcMessagingTarget: vi.fn((value: string) => value.trim()),
     connectIrcClient: vi.fn(),
@@ -47,6 +49,14 @@ vi.mock("openclaw/plugin-sdk/plugin-config-runtime", async () => {
     string,
     unknown
   >;
+  return original;
+});
+
+vi.mock("openclaw/plugin-sdk/markdown-table-runtime", async () => {
+  const original = (await vi.importActual("openclaw/plugin-sdk/markdown-table-runtime")) as Record<
+    string,
+    unknown
+  >;
   return {
     ...original,
     resolveMarkdownTableMode: hoisted.resolveMarkdownTableMode,
@@ -61,6 +71,7 @@ vi.mock("openclaw/plugin-sdk/text-chunking", async () => {
   return {
     ...original,
     convertMarkdownTables: hoisted.convertMarkdownTables,
+    stripMarkdown: hoisted.stripMarkdown,
   };
 });
 
@@ -71,6 +82,7 @@ function resetHoistedMocks() {
   hoisted.loadConfig.mockReset();
   hoisted.resolveMarkdownTableMode.mockReset().mockReturnValue("preserve");
   hoisted.convertMarkdownTables.mockReset().mockImplementation((text: string) => text);
+  hoisted.stripMarkdown.mockReset().mockImplementation((text: string) => text);
   hoisted.record.mockReset();
   hoisted.normalizeIrcMessagingTarget
     .mockReset()
@@ -85,6 +97,7 @@ afterAll(() => {
   vi.doUnmock("./connect-options.js");
   vi.doUnmock("./protocol.js");
   vi.doUnmock("openclaw/plugin-sdk/plugin-config-runtime");
+  vi.doUnmock("openclaw/plugin-sdk/markdown-table-runtime");
   vi.doUnmock("openclaw/plugin-sdk/text-chunking");
   vi.resetModules();
 });
@@ -157,6 +170,39 @@ describe("sendMessageIrc cfg threading", () => {
         },
       ],
     });
+  });
+
+  it("strips markdown after table conversion before sending to IRC", async () => {
+    const providedCfg = {
+      channels: {
+        irc: {
+          host: "irc.example.com",
+          nick: "openclaw",
+        },
+      },
+    } as unknown as CoreConfig;
+    const client = {
+      isReady: vi.fn(() => true),
+      sendPrivmsg: vi.fn(),
+    } as unknown as IrcClient;
+    hoisted.resolveMarkdownTableMode.mockReturnValue("bullets");
+    hoisted.convertMarkdownTables.mockReturnValue("**Status**\n- [docs](https://example.com)");
+    hoisted.stripMarkdown.mockReturnValue("Status\n- docs (https://example.com)");
+
+    await sendMessageIrc("#room", "  | a |\n| - |\n| **docs** |  ", {
+      cfg: providedCfg,
+      client,
+    });
+
+    expect(hoisted.convertMarkdownTables).toHaveBeenCalledWith(
+      "| a |\n| - |\n| **docs** |",
+      "bullets",
+    );
+    expect(hoisted.stripMarkdown).toHaveBeenCalledWith("**Status**\n- [docs](https://example.com)");
+    expect(client.sendPrivmsg).toHaveBeenCalledWith(
+      "#room",
+      "Status\n- docs (https://example.com)",
+    );
   });
 
   it("fails hard when cfg is omitted", async () => {
@@ -252,6 +298,33 @@ describe("sendMessageIrc cfg threading", () => {
         },
       ],
     });
+  });
+
+  it("rejects stripped-empty replies before adding reply metadata", async () => {
+    const providedCfg = {
+      channels: {
+        irc: {
+          host: "irc.example.com",
+          nick: "openclaw",
+        },
+      },
+    } as unknown as CoreConfig;
+    const client = {
+      isReady: vi.fn(() => true),
+      sendPrivmsg: vi.fn(),
+    } as unknown as IrcClient;
+    hoisted.stripMarkdown.mockReturnValue("");
+
+    await expect(
+      sendMessageIrc("#room", "#", {
+        cfg: providedCfg,
+        client,
+        replyTo: "irc-parent-1",
+      }),
+    ).rejects.toThrow("Message must be non-empty for IRC sends");
+
+    expect(client.sendPrivmsg).not.toHaveBeenCalled();
+    expect(hoisted.record).not.toHaveBeenCalled();
   });
 
   it("declares message adapter durable text, media, and reply with receipt proofs", async () => {

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
-import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
+import { convertMarkdownTables, stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
 import { resolveIrcAccount } from "./accounts.js";
 import type { IrcClient } from "./client.js";
 import { connectIrcClient } from "./client.js";
@@ -78,12 +78,11 @@ export async function sendMessageIrc(
     channel: "irc",
     accountId: account.accountId,
   });
-  const prepared = convertMarkdownTables(text.trim(), tableMode);
-  const payload = opts.replyTo ? `${prepared}\n\n[reply:${opts.replyTo}]` : prepared;
-
-  if (!payload.trim()) {
+  const prepared = stripMarkdown(convertMarkdownTables(text.trim(), tableMode));
+  if (!prepared.trim()) {
     throw new Error("Message must be non-empty for IRC sends");
   }
+  const payload = opts.replyTo ? `${prepared}\n\n[reply:${opts.replyTo}]` : prepared;
 
   const client = opts.client;
   if (client?.isReady()) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where IRC users could receive raw Markdown markers such as bold delimiters or link syntax when agent replies were sent to IRC.

## Why This Change Was Made

IRC is a plain-text transport, so outbound replies now reuse the shared Markdown stripping helper after table conversion and before appending IRC reply metadata.

## User Impact

IRC recipients see readable plain text instead of Markdown source formatting.

## Evidence

- Real connected IRC proof: the production sender opened a TCP connection to a loopback IRC server, joined `#proof`, and sent a real `PRIVMSG`; a second production IRC client received the stripped payload.
- Reply-path negative control: a Markdown-only body with `replyTo` was rejected before reply metadata was appended; the loopback server's wire count remained unchanged, proving no marker-only `PRIVMSG` was emitted.
- Focused test: `node scripts/run-vitest.mjs extensions/irc/src/send.test.ts` (7 tests passed).

```text
$ node --import tsx proof-irc-loopback.mts
wire=PRIVMSG #proof :Status: docs (https://example.com)
recipient={"senderNick":"proofbot","target":"#proof","text":"Status: docs (https://example.com)"}
reply-negative-control-blank-markdown-rejected=true
reply-negative-control-privmsg-count=1
```

<details>
<summary>proof-irc-loopback.mts</summary>

```ts
import net, { type Socket } from "node:net";
import { connectIrcClient } from "./extensions/irc/src/client.js";
import { sendMessageIrc } from "./extensions/irc/src/send.js";

type Peer = {
  socket: Socket;
  nick: string;
  user: string;
  welcomed: boolean;
  channels: Set<string>;
  buffer: string;
};

const peers = new Set<Peer>();
const wireLines: string[] = [];

function maybeWelcome(peer: Peer): void {
  if (peer.welcomed || !peer.nick || !peer.user) {
    return;
  }
  peer.welcomed = true;
  peer.socket.write(`:loopback 001 ${peer.nick} :welcome\r\n`);
}

function handleLine(peer: Peer, line: string): void {
  const [command = "", ...params] = line.split(" ");
  if (command === "NICK") {
    peer.nick = params[0] ?? "";
    maybeWelcome(peer);
    return;
  }
  if (command === "USER") {
    peer.user = params[0] ?? "";
    maybeWelcome(peer);
    return;
  }
  if (command === "JOIN") {
    const channel = params[0] ?? "";
    if (channel) {
      peer.channels.add(channel);
      peer.socket.write(`:${peer.nick}!${peer.user}@loopback JOIN ${channel}\r\n`);
    }
    return;
  }
  if (command === "PRIVMSG") {
    wireLines.push(line);
    const separator = line.indexOf(" :");
    const target = params[0] ?? "";
    const text = separator >= 0 ? line.slice(separator + 2) : "";
    for (const recipient of peers) {
      if (recipient !== peer && recipient.channels.has(target)) {
        recipient.socket.write(
          `:${peer.nick}!${peer.user}@loopback PRIVMSG ${target} :${text}\r\n`,
        );
      }
    }
  }
}

const server = net.createServer((socket) => {
  socket.setEncoding("utf8");
  const peer: Peer = {
    socket,
    nick: "",
    user: "",
    welcomed: false,
    channels: new Set(),
    buffer: "",
  };
  peers.add(peer);
  socket.on("data", (chunk: string) => {
    peer.buffer += chunk;
    let newline = peer.buffer.indexOf("\n");
    while (newline >= 0) {
      const line = peer.buffer.slice(0, newline).replace(/\r$/, "");
      peer.buffer = peer.buffer.slice(newline + 1);
      if (line) {
        handleLine(peer, line);
      }
      newline = peer.buffer.indexOf("\n");
    }
  });
  socket.on("close", () => peers.delete(peer));
});

await new Promise<void>((resolve, reject) => {
  server.once("error", reject);
  server.listen(0, "127.0.0.1", resolve);
});

const address = server.address();
if (!address || typeof address === "string") {
  throw new Error("loopback IRC server did not expose a TCP port");
}

let resolveReceived: ((value: { senderNick: string; target: string; text: string }) => void) | null =
  null;
const receivedPromise = new Promise<{ senderNick: string; target: string; text: string }>(
  (resolve) => {
    resolveReceived = resolve;
  },
);

const observer = await connectIrcClient({
  host: "127.0.0.1",
  port: address.port,
  tls: false,
  nick: "observer",
  username: "observer",
  realname: "Proof Observer",
  channels: ["#proof"],
  connectTimeoutMs: 3000,
  onPrivmsg: (event) => {
    resolveReceived?.({
      senderNick: event.senderNick,
      target: event.target,
      text: event.text,
    });
    resolveReceived = null;
  },
});

const cfg = {
  channels: {
    irc: {
      host: "127.0.0.1",
      port: address.port,
      tls: false,
      nick: "proofbot",
      username: "proofbot",
      realname: "Proof Bot",
    },
  },
};

try {
  await sendMessageIrc("#proof", "**Status**: [docs](https://example.com)", { cfg });
  const received = await Promise.race([
    receivedPromise,
    new Promise<never>((_, reject) =>
      setTimeout(() => reject(new Error("recipient did not receive PRIVMSG")), 3000),
    ),
  ]);

  let rejectedBlank = false;
  try {
    await sendMessageIrc("#proof", "#", { cfg, replyTo: "parent-proof" });
  } catch (error) {
    rejectedBlank =
      error instanceof Error && error.message === "Message must be non-empty for IRC sends";
  }

  console.log(`wire=${wireLines.find((line) => line.startsWith("PRIVMSG #proof :"))}`);
  console.log(`recipient=${JSON.stringify(received)}`);
  console.log(`reply-negative-control-blank-markdown-rejected=${rejectedBlank}`);
  console.log(`reply-negative-control-privmsg-count=${wireLines.length}`);
} finally {
  observer.quit("proof complete");
  for (const peer of peers) {
    peer.socket.destroy();
  }
  await new Promise<void>((resolve) => server.close(() => resolve()));
}
```

</details>

AI-assisted: built with Codex

## Maintainer Exact-Head Two-Client Wire Verification

Original contributor @RileyJJY, original Git author/email, original first authored timestamp, and both original owner files are preserved. Refreshed exact head `a254cc332c68b6f3a69cbf6aee4a6324e4cd948d` is **net -1 production line**; no issue was fabricated.

A real localhost TCP IRC server accepted two production `connectIrcClient` clients. The actual `sendMessageIrc` sender joined the channel, emitted a real wire-level `PRIVMSG`, and the actual observer client parsed the delivered message. A second attempted reply used a markdown-only `#` body to verify metadata is never sent by itself.

Before, current main:

```json
{
  "transport": "real localhost TCP",
  "clients": [
    "production observer",
    "production transient sender"
  ],
  "joined": [
    {
      "nick": "observer",
      "channel": "#proof"
    },
    {
      "nick": "proofbot",
      "channel": "#proof"
    },
    {
      "nick": "proofbot",
      "channel": "#proof"
    }
  ],
  "wire": [
    "PRIVMSG #proof :**Status**: [docs](https://example.com)",
    "PRIVMSG #proof :#  [reply:parent-proof]"
  ],
  "recipient": {
    "senderNick": "proofbot",
    "target": "#proof",
    "text": "**Status**: [docs](https://example.com)"
  },
  "negative": {
    "body": "#",
    "replyTo": "parent-proof",
    "rejected": false,
    "error": null,
    "wireBefore": 1,
    "wireAfter": 2,
    "metadataOnlyEmitted": true
  }
}
```

After, exact refreshed original-contributor head:

```json
{
  "transport": "real localhost TCP",
  "clients": [
    "production observer",
    "production transient sender"
  ],
  "joined": [
    {
      "nick": "observer",
      "channel": "#proof"
    },
    {
      "nick": "proofbot",
      "channel": "#proof"
    }
  ],
  "wire": [
    "PRIVMSG #proof :Status: docs (https://example.com)"
  ],
  "recipient": {
    "senderNick": "proofbot",
    "target": "#proof",
    "text": "Status: docs (https://example.com)"
  },
  "negative": {
    "body": "#",
    "replyTo": "parent-proof",
    "rejected": true,
    "error": "Message must be non-empty for IRC sends",
    "wireBefore": 1,
    "wireAfter": 1,
    "metadataOnlyEmitted": false
  }
}
```

Before, the recipient receives literal Markdown and a second metadata-only wire message leaks; after, it receives `Status: docs (https://example.com)`, the empty-after-stripping reply is rejected, and the wire message count stays at one.

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-112961-irc node scripts/run-vitest.mjs extensions/irc/src/send.test.ts extensions/irc/src/client.test.ts extensions/irc/src/protocol.test.ts
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex --thinking xhigh
```

All three focused IRC owner/client/protocol suites pass: **33 tests**. Targeted formatter and `git diff --check` pass; fresh Codex Sol xhigh autoreview is clean. Exact-head hosted CI must finish green before landing.