### PR TITLE
feat(tlon): render Markdown lists as native listings

### DIFF
--- a/extensions/tlon/src/urbit/story.test.ts
+++ b/extensions/tlon/src/urbit/story.test.ts
@@ -1,0 +1,492 @@
+import { describe, expect, it } from "vitest";
+import { markdownToStory, type Story } from "./story.js";
+
+type ListRenderingFixture = {
+  name: string;
+  markdown: string;
+  before: Story;
+  after: Story;
+};
+
+const listRenderingFixtures: ListRenderingFixture[] = [
+  {
+    name: "unordered markers become one native unordered listing",
+    markdown: "- alpha\n- **beta**\n- [site](https://example.com)",
+    before: [
+      {
+        inline: [
+          "- alpha",
+          { break: null },
+          "- ",
+          { bold: ["beta"] },
+          { break: null },
+          "- ",
+          { link: { href: "https://example.com", content: "site" } },
+        ],
+      },
+    ],
+    after: [
+      {
+        block: {
+          listing: {
+            list: {
+              type: "unordered",
+              contents: [],
+              items: [
+                { item: ["alpha"] },
+                { item: [{ bold: ["beta"] }] },
+                {
+                  item: [{ link: { href: "https://example.com", content: "site" } }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+  {
+    name: "ordered markers become a native ordered listing",
+    markdown: "1. first\n2. second",
+    before: [{ inline: ["1. first", { break: null }, "2. second"] }],
+    after: [
+      {
+        block: {
+          listing: {
+            list: {
+              type: "ordered",
+              contents: [],
+              items: [{ item: ["first"] }, { item: ["second"] }],
+            },
+          },
+        },
+      },
+    ],
+  },
+  {
+    name: "task markers become native task inlines inside a task listing",
+    markdown: "- [ ] todo\n- [x] **done**",
+    before: [
+      {
+        inline: ["- [ ] todo", { break: null }, "- [x] ", { bold: ["done"] }],
+      },
+    ],
+    after: [
+      {
+        block: {
+          listing: {
+            list: {
+              type: "tasklist",
+              contents: [],
+              items: [
+                { item: [{ task: { checked: false, content: ["todo"] } }] },
+                {
+                  item: [{ task: { checked: true, content: [{ bold: ["done"] }] } }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+  {
+    name: "nested ordered items stay recursive under their unordered parent",
+    markdown: "- parent\n  1. first\n  2. second\n- sibling",
+    before: [
+      {
+        inline: [
+          "- parent",
+          { break: null },
+          "  1. first",
+          { break: null },
+          "  2. second",
+          { break: null },
+          "- sibling",
+        ],
+      },
+    ],
+    after: [
+      {
+        block: {
+          listing: {
+            list: {
+              type: "unordered",
+              contents: [],
+              items: [
+                {
+                  list: {
+                    type: "ordered",
+                    contents: ["parent"],
+                    items: [{ item: ["first"] }, { item: ["second"] }],
+                  },
+                },
+                { item: ["sibling"] },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+  {
+    name: "mixed task and plain children stay in their nested bullet list",
+    markdown: "- parent\n  - [ ] todo\n  - note\n- sibling",
+    before: [
+      {
+        inline: [
+          "- parent",
+          { break: null },
+          "  - [ ] todo",
+          { break: null },
+          "  - note",
+          { break: null },
+          "- sibling",
+        ],
+      },
+    ],
+    after: [
+      {
+        block: {
+          listing: {
+            list: {
+              type: "unordered",
+              contents: [],
+              items: [
+                {
+                  list: {
+                    type: "unordered",
+                    contents: ["parent"],
+                    items: [
+                      { item: [{ task: { checked: false, content: ["todo"] } }] },
+                      { item: ["note"] },
+                    ],
+                  },
+                },
+                { item: ["sibling"] },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+  {
+    name: "empty bullet items stay inside their native listing",
+    markdown: "- first\n-\n- third",
+    before: [{ inline: ["- first", { break: null }, "-", { break: null }, "- third"] }],
+    after: [
+      {
+        block: {
+          listing: {
+            list: {
+              type: "unordered",
+              contents: [],
+              items: [{ item: ["first"] }, { item: [] }, { item: ["third"] }],
+            },
+          },
+        },
+      },
+    ],
+  },
+];
+
+describe("markdownToStory list rendering", () => {
+  it.each(listRenderingFixtures)("$name", ({ markdown, before, after }) => {
+    expect(before).not.toEqual(after);
+    expect(markdownToStory(markdown)).toEqual(after);
+  });
+
+  it("preserves a list with lazy continuation after preceding paragraph text", () => {
+    expect(markdownToStory("intro\n- one\n- two\noutro")).toEqual([
+      {
+        inline: [
+          "intro",
+          { break: null },
+          "- one",
+          { break: null },
+          "- two",
+          { break: null },
+          "outro",
+        ],
+      },
+    ]);
+  });
+
+  it("keeps a blank-separated outer sibling attached after a nested list", () => {
+    expect(markdownToStory("- parent\n  - child\n\n- sibling")).toEqual([
+      {
+        block: {
+          listing: {
+            list: {
+              type: "unordered",
+              contents: [],
+              items: [
+                {
+                  list: {
+                    type: "unordered",
+                    contents: ["parent"],
+                    items: [{ item: ["child"] }],
+                  },
+                },
+                { item: ["sibling"] },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "non-1 ordered starts",
+      markdown: "5. five\n6. six",
+      expected: [{ inline: ["5. five", { break: null }, "6. six"] }],
+    },
+    {
+      name: "consecutive nested list styles",
+      markdown: "- parent\n  - bullet child\n  1. numbered child",
+      expected: [
+        {
+          inline: [
+            "- parent",
+            { break: null },
+            "  - bullet child",
+            { break: null },
+            "  1. numbered child",
+          ],
+        },
+      ],
+    },
+    {
+      name: "four-space-indented list-like text",
+      markdown: "    - literal",
+      expected: [{ inline: ["    - literal"] }],
+    },
+    {
+      name: "under-indented children of wide ordered markers",
+      markdown: "1. parent\n  - child",
+      expected: [{ inline: ["1. parent", { break: null }, "  - child"] }],
+    },
+    {
+      name: "block-level content inside list items",
+      markdown: "- foo\n\n      bar",
+      expected: [{ inline: ["- foo"] }, { inline: ["      bar"] }],
+    },
+    {
+      name: "block syntax on the marker line",
+      markdown: "- # heading",
+      expected: [{ inline: ["- # heading"] }],
+    },
+    {
+      name: "blank-separated item paragraphs",
+      markdown: "- first\n\n  second",
+      expected: [{ inline: ["- first"] }, { inline: ["  second"] }],
+    },
+    {
+      name: "indented code beginning with a marker",
+      markdown: "- foo\n\n      - literal",
+      expected: [{ inline: ["- foo"] }, { inline: ["      - literal"] }],
+    },
+    {
+      name: "parent content after a nested list",
+      markdown: "- parent\n  - child\n\n  tail",
+      expected: [{ inline: ["- parent", { break: null }, "  - child"] }, { inline: ["  tail"] }],
+    },
+    {
+      name: "images inside list items",
+      markdown: "- ![diagram](https://example.com/diagram.png)",
+      expected: [
+        {
+          inline: [
+            "- !",
+            { link: { href: "https://example.com/diagram.png", content: "diagram" } },
+          ],
+        },
+      ],
+    },
+    {
+      name: "indented continuation lines",
+      markdown: "- first line\n  continued\n- second",
+      expected: [
+        {
+          inline: ["- first line", { break: null }, "  continued", { break: null }, "- second"],
+        },
+      ],
+    },
+    {
+      name: "tab-indented underflow beneath a padded marker",
+      markdown: "-    parent\n \t- child",
+      expected: [{ inline: ["-    parent", { break: null }, " \t- child"] }],
+    },
+    {
+      name: "ordered markers longer than nine digits",
+      markdown: "0000000001. value",
+      expected: [{ inline: ["0000000001. value"] }],
+    },
+    {
+      name: "same-line nested list syntax",
+      markdown: "- - child",
+      expected: [{ inline: ["- - child"] }],
+    },
+    {
+      name: "blockquote marker without whitespace",
+      markdown: "- >quoted",
+      expected: [{ inline: ["- >quoted"] }],
+    },
+  ])("preserves $name as plain story content", ({ markdown, expected }) => {
+    expect(markdownToStory(markdown)).toEqual(expected);
+  });
+
+  it("keeps different ordered delimiters as separate native lists", () => {
+    expect(markdownToStory("1. first\n1) reset")).toEqual([
+      {
+        block: {
+          listing: {
+            list: {
+              type: "ordered",
+              contents: [],
+              items: [{ item: ["first"] }],
+            },
+          },
+        },
+      },
+      {
+        block: {
+          listing: {
+            list: {
+              type: "ordered",
+              contents: [],
+              items: [{ item: ["reset"] }],
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("keeps ordered task items in an ordered native listing", () => {
+    expect(markdownToStory("1. [ ] first\n2. [x] second")).toEqual([
+      {
+        block: {
+          listing: {
+            list: {
+              type: "ordered",
+              contents: [],
+              items: [
+                { item: [{ task: { checked: false, content: ["first"] } }] },
+                { item: [{ task: { checked: true, content: ["second"] } }] },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("keeps variably indented ordered siblings in one native list", () => {
+    expect(markdownToStory(" 1. first\n2. second")).toEqual([
+      {
+        block: {
+          listing: {
+            list: {
+              type: "ordered",
+              contents: [],
+              items: [{ item: ["first"] }, { item: ["second"] }],
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("preserves a non-interrupting ordered marker as lazy text", () => {
+    expect(markdownToStory("- first\n2. continuation")).toEqual([
+      { inline: ["- first", { break: null }, "2. continuation"] },
+    ]);
+  });
+
+  it.each(["- [ ] - follow up", "- [x] # heading"])(
+    "keeps block-looking task text representable for %s",
+    (markdown) => {
+      const checked = markdown.includes("[x]");
+      const content = markdown.replace(/^- \[[ x]\] /, "");
+      expect(markdownToStory(markdown)).toEqual([
+        {
+          block: {
+            listing: {
+              list: {
+                type: "tasklist",
+                contents: [],
+                items: [{ item: [{ task: { checked, content: [content] } }] }],
+              },
+            },
+          },
+        },
+      ]);
+    },
+  );
+
+  it("keeps whitespace-only items in their native list", () => {
+    expect(markdownToStory("- first\n-     \n- third")).toEqual([
+      {
+        block: {
+          listing: {
+            list: {
+              type: "unordered",
+              contents: [],
+              items: [{ item: ["first"] }, { item: [] }, { item: ["third"] }],
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("preserves an empty same-marker nested item as paragraph text", () => {
+    expect(markdownToStory("- parent\n  -")).toEqual([
+      { inline: ["- parent", { break: null }, "  -"] },
+    ]);
+  });
+
+  it("accepts a tab as an unchecked task marker", () => {
+    expect(markdownToStory("- [\t] todo")).toEqual([
+      {
+        block: {
+          listing: {
+            list: {
+              type: "tasklist",
+              contents: [],
+              items: [{ item: [{ task: { checked: false, content: ["todo"] } }] }],
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("does not let an empty list item interrupt a paragraph", () => {
+    expect(markdownToStory("foo\n*")).toEqual([{ inline: ["foo", { break: null }, "*"] }]);
+  });
+
+  it.each(["- ~~~", "- >", "- ___", "-     code"])(
+    "preserves block-level marker body %s as plain content",
+    (markdown) => {
+      expect(markdownToStory(markdown)).toEqual([{ inline: [markdown] }]);
+    },
+  );
+
+  it.each([
+    { markdown: "- - -", expected: [{ inline: ["- - -"] }] },
+    { markdown: "* * *", expected: [{ inline: [{ italics: [" "] }, " *"] }] },
+  ])("does not convert thematic break $markdown into a listing", ({ markdown, expected }) => {
+    expect(markdownToStory(markdown)).toEqual(expected);
+  });
+
+  it("preserves lazy continuation text with its list markers", () => {
+    expect(markdownToStory("- first\ncontinued\n- second")).toEqual([
+      { inline: ["- first", { break: null }, "continued", { break: null }, "- second"] },
+    ]);
+  });
+});

--- a/extensions/tlon/src/urbit/story.test.ts
+++ b/extensions/tlon/src/urbit/story.test.ts
@@ -466,6 +466,24 @@ describe("markdownToStory list rendering", () => {
     ]);
   });
 
+  it("preserves blank-separated siblings after an unsupported list item", () => {
+    expect(markdownToStory("- # heading\n\n- sibling")).toEqual([
+      { inline: ["- # heading"] },
+      { inline: ["- sibling"] },
+    ]);
+  });
+
+  it("keeps ordinary inline Markdown outside loose-list preservation", () => {
+    expect(markdownToStory("**bold**")).toEqual([{ inline: [{ bold: ["bold"] }] }]);
+  });
+
+  it("keeps the unsupported outer marker across nested marker styles", () => {
+    expect(markdownToStory("- # heading\n  * child\n\n- sibling")).toEqual([
+      { inline: ["- # heading", { break: null }, "  * child"] },
+      { inline: ["- sibling"] },
+    ]);
+  });
+
   it("does not let an empty list item interrupt a paragraph", () => {
     expect(markdownToStory("foo\n*")).toEqual([{ inline: ["foo", { break: null }, "*"] }]);
   });

--- a/extensions/tlon/src/urbit/story.ts
+++ b/extensions/tlon/src/urbit/story.ts
@@ -540,9 +540,20 @@ export function markdownToStory(markdown: string): Story {
   const story: Story = [];
   const lines = markdown.split("\n");
   let i = 0;
+  let preservedListMarkerKey: string | undefined;
 
   while (i < lines.length) {
     const line = expectDefined(lines[i], "Markdown line index is in bounds");
+    const lineListItem = parseMarkdownListItem(line);
+    if (
+      line.trim() !== "" &&
+      preservedListMarkerKey !== undefined &&
+      (lineListItem !== undefined
+        ? lineListItem.markerKey !== preservedListMarkerKey
+        : lineIndent(line) === 0)
+    ) {
+      preservedListMarkerKey = undefined;
+    }
 
     // Code block: ```lang\ncode\n```
     if (line.startsWith("```")) {
@@ -616,16 +627,22 @@ export function markdownToStory(markdown: string): Story {
       continue;
     }
 
-    const listing = parseListingBlock(lines, i);
+    const preservesLooseList =
+      preservedListMarkerKey !== undefined && lineListItem?.markerKey === preservedListMarkerKey;
+    const listing = preservesLooseList ? undefined : parseListingBlock(lines, i);
     if (listing) {
       story.push(...listing.verses);
       i = listing.nextIndex;
+      preservedListMarkerKey = undefined;
       continue;
+    }
+    if (lineListItem) {
+      preservedListMarkerKey = lineListItem.markerKey;
     }
 
     // If a list-like block cannot be represented without losing Markdown semantics,
     // preserve the whole block in the existing plain paragraph path.
-    let preserveListText = MARKDOWN_LIST_ITEM_PATTERN.test(line);
+    let preserveListText = preservesLooseList || MARKDOWN_LIST_ITEM_PATTERN.test(line);
 
     // Regular paragraph - collect consecutive non-empty lines
     const paragraphLines: string[] = [];
@@ -651,6 +668,9 @@ export function markdownToStory(markdown: string): Story {
         // Once one candidate is not safely representable, keep the remaining
         // paragraph byte-compatible instead of repeatedly reparsing its suffixes.
         preserveListText = true;
+        if (item) {
+          preservedListMarkerKey = item.markerKey;
+        }
       }
       paragraphLines.push(paragraphLine);
       i++;

--- a/extensions/tlon/src/urbit/story.ts
+++ b/extensions/tlon/src/urbit/story.ts
@@ -17,8 +17,11 @@ type StoryInline =
   | { code: string }
   | { ship: string }
   | { link: { href: string; content: string } }
+  | { task: { checked: boolean; content: StoryInline[] } }
   | { break: null }
   | { tag: string };
+
+type StoryListType = "ordered" | "unordered" | "tasklist";
 
 // Block content types
 type StoryBlock =
@@ -31,7 +34,7 @@ type StoryBlock =
 type StoryListing =
   | {
       list: {
-        type: "ordered" | "unordered" | "tasklist";
+        type: StoryListType;
         items: StoryListing[];
         contents: StoryInline[];
       };
@@ -238,6 +241,298 @@ function processInlinesForImages(inlines: StoryInline[]): {
   return { inlines: cleanInlines, imageBlocks };
 }
 
+function parseInlinesWithBreaks(text: string): {
+  inlines: StoryInline[];
+  imageBlocks: StoryVerse[];
+} {
+  const withBreaks: StoryInline[] = [];
+  for (const inline of parseInlineMarkdown(text)) {
+    if (typeof inline !== "string" || !inline.includes("\n")) {
+      withBreaks.push(inline);
+      continue;
+    }
+    const parts = inline.split("\n");
+    for (const [index, part] of parts.entries()) {
+      if (part) {
+        withBreaks.push(part);
+      }
+      if (index < parts.length - 1) {
+        withBreaks.push({ break: null });
+      }
+    }
+  }
+  return processInlinesForImages(withBreaks);
+}
+
+type MarkdownListItem = {
+  indent: number;
+  contentIndent: number;
+  markerType: Exclude<StoryListType, "tasklist">;
+  markerKey: string;
+  orderedStart?: number;
+  hasSourceBody: boolean;
+  hasBlockBody: boolean;
+  hasImages: boolean;
+  content: StoryInline[];
+  checked?: boolean;
+};
+
+const MARKDOWN_LIST_ITEM_PATTERN = /^([ \t]*)([-+*]|\d{1,9}[.)])(?:([ \t]+)(.*))?$/;
+
+function isMarkdownThematicBreak(text: string): boolean {
+  return /^(?:(?:\*\s*){3,}|(?:-\s*){3,}|(?:_\s*){3,})$/.test(text);
+}
+
+function startsListBlockSyntax(text: string): boolean {
+  return (
+    /^(`{3,}|~{3,})/.test(text) ||
+    text.startsWith(">") ||
+    /^#{1,6}(?:\s|$)/.test(text) ||
+    isMarkdownThematicBreak(text) ||
+    /^(?:[-+*]|\d{1,9}[.)])(?:\s|$)/.test(text)
+  );
+}
+
+function whitespaceColumns(text: string, startColumn = 0): number {
+  let column = startColumn;
+  for (const char of text) {
+    column += char === "\t" ? 4 - (column % 4) : 1;
+  }
+  return column;
+}
+
+function parseMarkdownListItem(line: string): MarkdownListItem | undefined {
+  const match = line.match(MARKDOWN_LIST_ITEM_PATTERN);
+  if (!match || isMarkdownThematicBreak(line.trim())) {
+    return undefined;
+  }
+
+  const marker = expectDefined(match[2], "list marker capture");
+  const markerType = /^\d/.test(marker) ? "ordered" : "unordered";
+  const padding = match[3] ?? " ";
+  const sourceBody = match[4] ?? "";
+  let body = sourceBody;
+  const task = body.match(/^\[([\t xX])\](?:\s+(.*))?$/);
+  let checked: boolean | undefined;
+  if (task) {
+    checked = expectDefined(task[1], "task state capture").toLowerCase() === "x";
+    body = task[2] ?? "";
+  }
+
+  const { inlines, imageBlocks } = parseInlinesWithBreaks(body);
+  const indent = whitespaceColumns(expectDefined(match[1], "list indent capture"));
+  const markerEnd = indent + marker.length;
+  const contentIndent = whitespaceColumns(padding, markerEnd);
+  return {
+    indent,
+    contentIndent,
+    markerType,
+    markerKey: markerType === "ordered" ? marker.slice(-1) : marker,
+    ...(markerType === "ordered" ? { orderedStart: Number.parseInt(marker, 10) } : {}),
+    hasSourceBody: sourceBody.length > 0,
+    hasBlockBody:
+      sourceBody.length > 0 &&
+      (contentIndent - markerEnd >= 5 || startsListBlockSyntax(sourceBody)),
+    hasImages: imageBlocks.length > 0,
+    content: inlines,
+    ...(checked === undefined ? {} : { checked }),
+  };
+}
+
+function lineIndent(line: string): number {
+  return whitespaceColumns(line.match(/^[ \t]*/)?.[0] ?? "");
+}
+
+function startsTopLevelStoryBlock(line: string): boolean {
+  return (
+    /^(#{1,6})\s+(.+)$/.test(line) ||
+    line.startsWith("```") ||
+    line.startsWith("> ") ||
+    /^(-{3,}|\*{3,})$/.test(line.trim())
+  );
+}
+
+function listItemContent(item: MarkdownListItem): StoryInline[] {
+  return item.checked === undefined
+    ? item.content
+    : [{ task: { checked: item.checked, content: item.content } }];
+}
+
+function canInterruptWithListItem(item: MarkdownListItem): boolean {
+  return item.hasSourceBody && (item.markerType === "unordered" || item.orderedStart === 1);
+}
+
+function parseListingBlock(
+  lines: string[],
+  startIndex: number,
+): { verses: StoryVerse[]; nextIndex: number } | undefined {
+  const first = parseMarkdownListItem(expectDefined(lines[startIndex], "list start line"));
+  if (!first) {
+    return undefined;
+  }
+  if (first.indent >= 4 || (first.markerType === "ordered" && first.orderedStart !== 1)) {
+    return undefined;
+  }
+
+  function parseLevel(
+    index: number,
+    minIndent: number,
+    markerKey: string,
+  ): { type: StoryListType; items: StoryListing[]; nextIndex: number } | undefined {
+    const firstItem = parseMarkdownListItem(expectDefined(lines[index], "list level start"));
+    if (
+      !firstItem ||
+      firstItem.indent < minIndent ||
+      firstItem.indent > minIndent + 3 ||
+      (firstItem.markerType === "ordered" && firstItem.orderedStart !== 1)
+    ) {
+      return undefined;
+    }
+
+    const items: StoryListing[] = [];
+    const markerType = firstItem.markerType;
+    let allTasks = true;
+    let cursor = index;
+    while (cursor < lines.length) {
+      const item = parseMarkdownListItem(expectDefined(lines[cursor], "list line index"));
+      if (
+        !item ||
+        item.indent < minIndent ||
+        item.indent > minIndent + 3 ||
+        item.markerKey !== markerKey
+      ) {
+        break;
+      }
+      if (item.hasBlockBody || item.hasImages) {
+        return undefined;
+      }
+
+      allTasks &&= item.checked !== undefined;
+      cursor++;
+
+      while (cursor < lines.length) {
+        const continuationLine = expectDefined(lines[cursor], "continuation line index");
+        if (continuationLine.trim() === "") {
+          let nextContentIndex = cursor + 1;
+          while (lines[nextContentIndex]?.trim() === "") {
+            nextContentIndex++;
+          }
+          const nextContent = lines.at(nextContentIndex);
+          if (nextContent === undefined) {
+            break;
+          }
+          const nextListItem = parseMarkdownListItem(nextContent);
+          if (nextListItem) {
+            cursor = nextContentIndex;
+            continue;
+          }
+          if (lineIndent(nextContent) > item.indent) {
+            return undefined;
+          }
+          break;
+        }
+
+        if (parseMarkdownListItem(continuationLine)) {
+          break;
+        }
+        if (
+          lineIndent(continuationLine) <= item.indent &&
+          startsTopLevelStoryBlock(continuationLine)
+        ) {
+          break;
+        }
+        return undefined;
+      }
+
+      const childLine = lines.at(cursor);
+      const child = childLine === undefined ? undefined : parseMarkdownListItem(childLine);
+      const childIsSibling =
+        child !== undefined &&
+        child.markerKey === markerKey &&
+        child.indent >= minIndent &&
+        child.indent <= minIndent + 3 &&
+        child.indent < item.contentIndent;
+      if (childIsSibling) {
+        items.push({ item: listItemContent(item) });
+        continue;
+      }
+      if (child && child.markerKey !== markerKey && !canInterruptWithListItem(child)) {
+        return undefined;
+      }
+      if (child && child.indent >= item.contentIndent && !canInterruptWithListItem(child)) {
+        return undefined;
+      }
+      if (child && child.indent > item.indent) {
+        if (child.indent < item.contentIndent || child.indent >= item.contentIndent + 4) {
+          return undefined;
+        }
+        const nested = parseLevel(cursor, item.contentIndent, child.markerKey);
+        if (!nested) {
+          return undefined;
+        }
+        // A nested node stores its parent item's contents, while its type controls
+        // the child markers. Preserve that type when list styles change by depth.
+        items.push({
+          list: {
+            type: nested.type,
+            contents: listItemContent(item),
+            items: nested.items,
+          },
+        });
+        cursor = nested.nextIndex;
+        const strandedChildLine = lines.at(cursor);
+        const strandedChild =
+          strandedChildLine === undefined ? undefined : parseMarkdownListItem(strandedChildLine);
+        const strandedIsSibling =
+          strandedChild !== undefined &&
+          strandedChild.markerKey === markerKey &&
+          strandedChild.indent >= minIndent &&
+          strandedChild.indent <= minIndent + 3 &&
+          strandedChild.indent < item.contentIndent;
+        if (!strandedIsSibling && strandedChild && strandedChild.indent > item.indent) {
+          return undefined;
+        }
+        let trailingIndex = cursor;
+        while (lines[trailingIndex]?.trim() === "") {
+          trailingIndex++;
+        }
+        const trailingLine = lines.at(trailingIndex);
+        if (
+          trailingLine !== undefined &&
+          !parseMarkdownListItem(trailingLine) &&
+          lineIndent(trailingLine) > item.indent
+        ) {
+          return undefined;
+        }
+      } else {
+        items.push({ item: listItemContent(item) });
+      }
+    }
+    return {
+      type: markerType === "unordered" && allTasks && items.length > 0 ? "tasklist" : markerType,
+      items,
+      nextIndex: cursor,
+    };
+  }
+
+  const parsed = parseLevel(startIndex, 0, first.markerKey);
+  if (!parsed) {
+    return undefined;
+  }
+  return {
+    verses: [
+      {
+        block: {
+          listing: {
+            list: { type: parsed.type, contents: [], items: parsed.items },
+          },
+        },
+      },
+    ],
+    nextIndex: parsed.nextIndex,
+  };
+}
+
 /**
  * Convert markdown text to Tlon story format
  */
@@ -321,6 +616,17 @@ export function markdownToStory(markdown: string): Story {
       continue;
     }
 
+    const listing = parseListingBlock(lines, i);
+    if (listing) {
+      story.push(...listing.verses);
+      i = listing.nextIndex;
+      continue;
+    }
+
+    // If a list-like block cannot be represented without losing Markdown semantics,
+    // preserve the whole block in the existing plain paragraph path.
+    let preserveListText = MARKDOWN_LIST_ITEM_PATTERN.test(line);
+
     // Regular paragraph - collect consecutive non-empty lines
     const paragraphLines: string[] = [];
     while (true) {
@@ -335,37 +641,26 @@ export function markdownToStory(markdown: string): Story {
       ) {
         break;
       }
+
+      if (!preserveListText && MARKDOWN_LIST_ITEM_PATTERN.test(paragraphLine)) {
+        const item = parseMarkdownListItem(paragraphLine);
+        const candidate = parseListingBlock(lines, i);
+        if (item?.hasSourceBody === true && candidate) {
+          break;
+        }
+        // Once one candidate is not safely representable, keep the remaining
+        // paragraph byte-compatible instead of repeatedly reparsing its suffixes.
+        preserveListText = true;
+      }
       paragraphLines.push(paragraphLine);
       i++;
     }
 
     if (paragraphLines.length > 0) {
-      const paragraphText = paragraphLines.join("\n");
-      // Convert newlines within paragraph to break elements
-      const inlines = parseInlineMarkdown(paragraphText);
-      // Replace \n in strings with break elements
-      const withBreaks: StoryInline[] = [];
-      for (const inline of inlines) {
-        if (typeof inline === "string" && inline.includes("\n")) {
-          const parts = inline.split("\n");
-          for (const [j, part] of parts.entries()) {
-            if (part) {
-              withBreaks.push(part);
-            }
-            if (j < parts.length - 1) {
-              withBreaks.push({ break: null });
-            }
-          }
-        } else {
-          withBreaks.push(inline);
-        }
-      }
+      const { inlines, imageBlocks } = parseInlinesWithBreaks(paragraphLines.join("\n"));
 
-      // Extract any images from inlines and add as separate blocks
-      const { inlines: cleanInlines, imageBlocks } = processInlinesForImages(withBreaks);
-
-      if (cleanInlines.length > 0) {
-        story.push({ inline: cleanInlines });
+      if (inlines.length > 0) {
+        story.push({ inline: inlines });
       }
       story.push(...imageBlocks);
     }


### PR DESCRIPTION
## What Problem This Solves

Tlon users currently see Markdown bullet, ordered, and task lists as flattened text lines even though Tlon Story supports native recursive listings and task inlines.

## Why This Change Was Made

This extends the existing Tlon Story line parser to emit native unordered, ordered, task, and nested listing structures without adding a second Markdown parser. The parser converts only list forms that the Story contract can represent losslessly; unsupported loose or block-bearing forms retain the previous plain output. Blockquotes remain unchanged and native tags remain disabled.

AI-assisted implementation; I understand and reviewed the resulting parser and wire structures.

## User Impact

Markdown lists in Tlon replies now render with native bullets, numbering, nesting, and task state. There are no config, protocol, schema, or setup changes.

## Evidence

- Golden before-to-after fixtures cover unordered, ordered, task, ordered-task, nested, mixed task/plain, and empty-item listings. Preservation fixtures cover unsupported loose lists, block content, indentation, delimiter, thematic-break, image, and paragraph-interruption boundaries.
- Inspectable redacted Story outputs:

  - Nested input `- parent\n  1. child` changes from:

    ```json
    [{"inline":["- parent",{"break":null},"  1. child"]}]
    ```

    to:

    ```json
    [{"block":{"listing":{"list":{"type":"unordered","contents":[],"items":[{"list":{"type":"ordered","contents":["parent"],"items":[{"item":["child"]}]}}]}}}}]
    ```

  - Task input `- [ ] todo\n- [x] done` changes from:

    ```json
    [{"inline":["- [ ] todo",{"break":null},"- [x] done"]}]
    ```

    to:

    ```json
    [{"block":{"listing":{"list":{"type":"tasklist","contents":[],"items":[{"item":[{"task":{"checked":false,"content":["todo"]}}]},{"item":[{"task":{"checked":true,"content":["done"]}}]}]}}}}]
    ```

  - Unsupported loose input `- # heading\n\n- sibling` remains:

    ```json
    [{"inline":["- # heading"]},{"inline":["- sibling"]}]
    ```

    rather than being partially converted.
- Maintainer decision: this is the explicitly commissioned Tlon batch in the markdown-unification program. The accepted product boundary is native conversion for losslessly representable list forms and preservation of unsupported forms on the existing plain path.
- `node scripts/run-vitest.mjs extensions/tlon` — 23 files passed, 238 tests passed.
- Remote Testbox production typecheck, extension-test typecheck, and targeted oxlint passed on the exact final source diff.
- Source-blind generated-artifact contract: 39/39 cases passed against the Tlon Story JSON output.
- Final autoreview: no accepted/actionable findings. One later proposed nested-marker state finding was rejected after its exact reported input passed both the focused regression and source-blind contract.
- Upstream contract checked against `tloncorp/tlon-apps` `desk/sur/story.hoon`, `desk/lib/story-json.hoon`, and the Tlon client list renderer.
- Numstat: production +341/-26 (net +315); tests +510/-0 (net +510); total +851/-26 (net +825). The correctness-wave exception applies: the production increase is the bounded recursive parser and lossless fallback policy; no parallel parser or config surface was added.
