### PR TITLE
fix: deliver generated media once after image_generate completion

### DIFF
--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -473,6 +473,60 @@ describe("deliverAgentCommandResult payload normalization", () => {
     ]);
   });
 
+  it("delivers generated-media handoff artifacts once when the resumed reply re-attaches them", async () => {
+    // The completion handoff names the artifact in the internal event, so a model
+    // that ignores the caption-only instruction can echo it as a MEDIA line and as
+    // a structured attachment. Delivery, not the prompt, keeps it single-owned.
+    deliverOutboundPayloadsMock.mockResolvedValue([]);
+    const runtime = { log: vi.fn(), error: vi.fn() };
+
+    await deliverAgentCommandResult({
+      cfg: {
+        agents: { list: [{ id: "tester", workspace: "/tmp/agent-workspace" }] },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: runtime as never,
+      opts: {
+        message: "image generation task finished",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "#general",
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "image_generation",
+            childSessionKey: "image_generate:task-1",
+            announceType: "image generation task",
+            taskLabel: "proof dog image",
+            status: "ok",
+            statusLabel: "completed successfully",
+            result: "Generated 1 image.",
+            mediaUrls: ["/tmp/generated-dog.png"],
+            attachments: [{ type: "image", path: "/tmp/generated-dog.png" }],
+            replyInstruction: "caption only",
+          },
+        ],
+      } as AgentCommandOpts,
+      outboundSession: { key: "agent:tester:slack:direct:alice", agentId: "tester" } as never,
+      sessionEntry: undefined,
+      payloads: [
+        { text: "Here is your dog!", mediaUrls: ["/tmp/generated-dog.png"] },
+        { mediaUrl: "/tmp/generated-dog.png" },
+      ],
+      result: createResult(),
+    });
+
+    const deliverArgs = latestOutboundDeliveryArgs();
+    const deliveredMediaUrls: string[] = [];
+    for (const payload of deliverArgs.payloads) {
+      if (payload.mediaUrl) {
+        deliveredMediaUrls.push(payload.mediaUrl);
+      }
+      deliveredMediaUrls.push(...(payload.mediaUrls ?? []));
+    }
+    expect(deliveredMediaUrls).toStrictEqual(["/tmp/generated-dog.png"]);
+  });
+
   it("reports successful requested delivery", async () => {
     deliverOutboundPayloadsMock.mockResolvedValue([]);
 

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -48,6 +48,10 @@ import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { MessagingToolSend } from "../embedded-agent-messaging.types.js";
 import type { EmbeddedAgentRunMeta } from "../embedded-agent-runner/types.js";
+import {
+  collectHandoffOwnedMediaUrls,
+  enforceHandoffMediaDeliveryOwnership,
+} from "../handoff-media-delivery-ownership.js";
 import { isNestedAgentLane } from "../lanes.js";
 import { isAgentRunRestartAbortReason } from "../run-termination.js";
 import type { AgentCommandOpts } from "./types.js";
@@ -832,10 +836,16 @@ export async function deliverAgentCommandResult(
           accountId: resolvedAccountId,
         })
       : { payloads: rawFilteredReplyPayloads };
-  const mediaNormalizedReplyPayloads = await filterDeliveredPayloads(
-    mediaNormalization.payloads,
-    mediaNormalization.normalizeMediaPaths,
-  );
+  const mediaNormalizedReplyPayloads = enforceHandoffMediaDeliveryOwnership({
+    payloads: await filterDeliveredPayloads(
+      mediaNormalization.payloads,
+      mediaNormalization.normalizeMediaPaths,
+    ),
+    // Completion handoffs hand the resumed agent the generated media by name, so
+    // a noncompliant reply can echo the same artifact through several payloads.
+    // The prompt contract cannot prevent that; this batch can.
+    handoffMediaUrls: collectHandoffOwnedMediaUrls(opts.internalEvents),
+  });
   params.assertDeliveryCurrent?.();
   const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads);
   const normalizedPayloads = projectOutboundPayloadPlanForJson(outboundPayloadPlan);

--- a/src/agents/handoff-media-delivery-ownership.test.ts
+++ b/src/agents/handoff-media-delivery-ownership.test.ts
@@ -133,7 +133,7 @@ describe("equivalent spellings inside one payload", () => {
   it("attaches an owned artifact once when a single payload lists two spellings", () => {
     const payloads = [
       { text: "here you go", mediaUrls: ["/tmp/generated-dog.png", "/tmp/./generated-dog.png"] },
-    ] as ReplyPayload[];
+    ];
 
     const out = enforceHandoffMediaDeliveryOwnership({
       payloads,
@@ -145,9 +145,7 @@ describe("equivalent spellings inside one payload", () => {
   });
 
   it("does not collapse two spellings of media the handoff does not own", () => {
-    const payloads = [
-      { text: "chart", mediaUrls: ["/tmp/chart.png", "/tmp/./chart.png"] },
-    ] as ReplyPayload[];
+    const payloads = [{ text: "chart", mediaUrls: ["/tmp/chart.png", "/tmp/./chart.png"] }];
 
     const out = enforceHandoffMediaDeliveryOwnership({
       payloads,
@@ -164,7 +162,7 @@ describe("equivalent spellings inside one payload", () => {
         mediaUrl: "/tmp/generated-dog.png",
         mediaUrls: ["/tmp/./generated-dog.png"],
       },
-    ] as ReplyPayload[];
+    ];
 
     const out = enforceHandoffMediaDeliveryOwnership({
       payloads,

--- a/src/agents/handoff-media-delivery-ownership.test.ts
+++ b/src/agents/handoff-media-delivery-ownership.test.ts
@@ -128,3 +128,50 @@ describe("enforceHandoffMediaDeliveryOwnership", () => {
     expect(enforceHandoffMediaDeliveryOwnership({ payloads, handoffMediaUrls })).toBe(payloads);
   });
 });
+
+describe("equivalent spellings inside one payload", () => {
+  it("attaches an owned artifact once when a single payload lists two spellings", () => {
+    const payloads = [
+      { text: "here you go", mediaUrls: ["/tmp/generated-dog.png", "/tmp/./generated-dog.png"] },
+    ] as ReplyPayload[];
+
+    const out = enforceHandoffMediaDeliveryOwnership({
+      payloads,
+      handoffMediaUrls: ["/tmp/generated-dog.png"],
+    });
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.mediaUrls).toStrictEqual(["/tmp/generated-dog.png"]);
+  });
+
+  it("does not collapse two spellings of media the handoff does not own", () => {
+    const payloads = [
+      { text: "chart", mediaUrls: ["/tmp/chart.png", "/tmp/./chart.png"] },
+    ] as ReplyPayload[];
+
+    const out = enforceHandoffMediaDeliveryOwnership({
+      payloads,
+      handoffMediaUrls: ["/tmp/generated-dog.png"],
+    });
+
+    expect(out[0]?.mediaUrls).toStrictEqual(["/tmp/chart.png", "/tmp/./chart.png"]);
+  });
+
+  it("keeps mediaUrl and drops an equivalent entry in the same payload's mediaUrls", () => {
+    const payloads = [
+      {
+        text: "here you go",
+        mediaUrl: "/tmp/generated-dog.png",
+        mediaUrls: ["/tmp/./generated-dog.png"],
+      },
+    ] as ReplyPayload[];
+
+    const out = enforceHandoffMediaDeliveryOwnership({
+      payloads,
+      handoffMediaUrls: ["/tmp/generated-dog.png"],
+    });
+
+    expect(out[0]?.mediaUrl).toBe("/tmp/generated-dog.png");
+    expect(out[0]?.mediaUrls).toBeUndefined();
+  });
+});

--- a/src/agents/handoff-media-delivery-ownership.test.ts
+++ b/src/agents/handoff-media-delivery-ownership.test.ts
@@ -1,0 +1,130 @@
+// Handoff media ownership is a delivery-boundary invariant, so these cases model
+// a resumed agent that ignores the caption-only reply instruction.
+import { describe, expect, it } from "vitest";
+import {
+  collectHandoffOwnedMediaUrls,
+  enforceHandoffMediaDeliveryOwnership,
+} from "./handoff-media-delivery-ownership.js";
+
+const generatedImageEvent = {
+  type: "task_completion",
+  source: "image_generation" as const,
+  mediaUrls: ["/tmp/generated-dog.png"],
+  attachments: [
+    { type: "image" as const, path: "/tmp/generated-dog.png", name: "generated-dog.png" },
+    { type: "image" as const, url: "/tmp/generated-cat.png", name: "generated-cat.png" },
+  ],
+};
+
+const handoffMediaUrls = collectHandoffOwnedMediaUrls([generatedImageEvent]);
+
+describe("collectHandoffOwnedMediaUrls", () => {
+  it("collects generated media from event urls and attachments", () => {
+    expect(handoffMediaUrls).toEqual(["/tmp/generated-dog.png", "/tmp/generated-cat.png"]);
+  });
+
+  it("ignores completions that do not carry generated media", () => {
+    expect(
+      collectHandoffOwnedMediaUrls([
+        { type: "task_completion", source: "subagent", mediaUrls: ["/tmp/subagent.png"] },
+        { type: "progress", source: "image_generation", mediaUrls: ["/tmp/progress.png"] },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("enforceHandoffMediaDeliveryOwnership", () => {
+  it("delivers handoff media once when the reply echoes it as a MEDIA line and an attachment", () => {
+    expect(
+      enforceHandoffMediaDeliveryOwnership({
+        payloads: [
+          { text: "Here is your dog!", mediaUrls: ["/tmp/generated-dog.png"] },
+          { mediaUrl: "/tmp/generated-dog.png" },
+        ],
+        handoffMediaUrls,
+      }),
+    ).toEqual([{ text: "Here is your dog!", mediaUrls: ["/tmp/generated-dog.png"] }]);
+  });
+
+  it("treats equivalent local references as the same delivery", () => {
+    expect(
+      enforceHandoffMediaDeliveryOwnership({
+        payloads: [
+          { text: "dog", mediaUrls: ["/tmp/generated-dog.png"] },
+          { text: "dog again", mediaUrl: "/tmp/./generated-dog.png" },
+        ],
+        handoffMediaUrls,
+      }),
+    ).toEqual([{ text: "dog", mediaUrls: ["/tmp/generated-dog.png"] }, { text: "dog again" }]);
+  });
+
+  it("keeps the first copy of every handoff artifact across payloads", () => {
+    expect(
+      enforceHandoffMediaDeliveryOwnership({
+        payloads: [
+          { text: "both", mediaUrls: ["/tmp/generated-dog.png", "/tmp/generated-cat.png"] },
+          { text: "dog again", mediaUrl: "/tmp/generated-dog.png" },
+          { mediaUrls: ["/tmp/generated-cat.png"] },
+        ],
+        handoffMediaUrls,
+      }),
+    ).toEqual([
+      { text: "both", mediaUrls: ["/tmp/generated-dog.png", "/tmp/generated-cat.png"] },
+      { text: "dog again" },
+    ]);
+  });
+
+  it("keeps media the handoff does not own", () => {
+    expect(
+      enforceHandoffMediaDeliveryOwnership({
+        payloads: [
+          { text: "first", mediaUrls: ["/tmp/generated-dog.png"] },
+          { text: "second", mediaUrls: ["/tmp/generated-dog.png", "/tmp/unrelated-chart.png"] },
+          { text: "third", mediaUrls: ["/tmp/unrelated-chart.png"] },
+        ],
+        handoffMediaUrls,
+      }),
+    ).toEqual([
+      { text: "first", mediaUrls: ["/tmp/generated-dog.png"] },
+      { text: "second", mediaUrls: ["/tmp/unrelated-chart.png"] },
+      { text: "third", mediaUrls: ["/tmp/unrelated-chart.png"] },
+    ]);
+  });
+
+  it("leaves payloads untouched without a generated-media handoff", () => {
+    const payloads = [
+      { text: "hi", mediaUrls: ["/tmp/generated-dog.png"] },
+      { mediaUrl: "/tmp/generated-dog.png" },
+    ];
+    expect(enforceHandoffMediaDeliveryOwnership({ payloads, handoffMediaUrls: [] })).toBe(payloads);
+  });
+
+  it("preserves payload flags while stripping a repeat", () => {
+    expect(
+      enforceHandoffMediaDeliveryOwnership({
+        payloads: [
+          { mediaUrls: ["/tmp/generated-dog.png"] },
+          {
+            text: "done",
+            mediaUrl: "/tmp/generated-dog.png",
+            mediaUrls: ["/tmp/generated-dog.png"],
+            trustedLocalMedia: true,
+            audioAsVoice: true,
+          },
+        ],
+        handoffMediaUrls,
+      }),
+    ).toEqual([
+      { mediaUrls: ["/tmp/generated-dog.png"] },
+      { text: "done", trustedLocalMedia: true },
+    ]);
+  });
+
+  it("does not rewrite payloads that carry a delivery operation", () => {
+    const payloads = [
+      { mediaUrls: ["/tmp/generated-dog.png"] },
+      { text: "pinned", mediaUrl: "/tmp/generated-dog.png", delivery: { pin: true as const } },
+    ];
+    expect(enforceHandoffMediaDeliveryOwnership({ payloads, handoffMediaUrls })).toBe(payloads);
+  });
+});

--- a/src/agents/handoff-media-delivery-ownership.ts
+++ b/src/agents/handoff-media-delivery-ownership.ts
@@ -102,8 +102,24 @@ export function enforceHandoffMediaDeliveryOwnership(params: {
       decisions.set(key, keep);
       return keep;
     };
-    const mediaUrl = payload.mediaUrl && keepMedia(payload.mediaUrl) ? payload.mediaUrl : undefined;
-    const mediaUrls = payload.mediaUrls?.filter((url) => keepMedia(url));
+    // `decisions` keeps mediaUrl and mediaUrls consistent for the same key, which
+    // also means every equivalent spelling inside one payload would be kept. Merging
+    // upstream only dedupes byte-identical strings, so `/tmp/x.png` alongside
+    // `/tmp/./x.png` would attach the same artifact twice to one message. Claim each
+    // owned artifact once per payload as well as once per batch.
+    const seenInPayload = new Set<string>();
+    const takeOnce = (url: string): boolean => {
+      const key = normalizeMediaReferenceForComparison(url);
+      if (owned.has(key)) {
+        if (seenInPayload.has(key)) {
+          return false;
+        }
+        seenInPayload.add(key);
+      }
+      return keepMedia(url);
+    };
+    const mediaUrl = payload.mediaUrl && takeOnce(payload.mediaUrl) ? payload.mediaUrl : undefined;
+    const mediaUrls = payload.mediaUrls?.filter((url) => takeOnce(url));
     if (mediaUrl === payload.mediaUrl && mediaUrls?.length === payload.mediaUrls?.length) {
       constrained.push(payload);
       continue;

--- a/src/agents/handoff-media-delivery-ownership.ts
+++ b/src/agents/handoff-media-delivery-ownership.ts
@@ -1,0 +1,127 @@
+/**
+ * Single-ownership enforcement for durable generated-media completion handoffs.
+ *
+ * A completion handoff resumes the requester session with an internal event that
+ * names the generated media. Prompt text can only ask the model not to re-attach
+ * that media, so the outbound batch owns the invariant instead: one delivery of a
+ * handoff artifact per batch, whatever the model emits.
+ */
+import { copyReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-payload.js";
+import { hasEnabledDeliveryOperation } from "../auto-reply/reply/reply-payloads-dedupe.runtime.js";
+import { normalizeMediaReferenceForComparison } from "../media/media-reference-comparison.js";
+import {
+  type AgentGeneratedAttachment,
+  mediaUrlsFromGeneratedAttachments,
+} from "./generated-attachments.js";
+import {
+  type AgentInternalEventSource,
+  hasGeneratedMediaCompletionEvent,
+} from "./internal-event-contract.js";
+
+type HandoffMediaCompletionEvent = {
+  type: string;
+  source: AgentInternalEventSource;
+  mediaUrls?: string[];
+  attachments?: AgentGeneratedAttachment[];
+};
+
+/** Media references a generated-media completion handoff already owns. */
+export function collectHandoffOwnedMediaUrls(
+  events: readonly HandoffMediaCompletionEvent[] | undefined,
+): string[] {
+  const owned = new Set<string>();
+  for (const event of events ?? []) {
+    if (!hasGeneratedMediaCompletionEvent([event])) {
+      continue;
+    }
+    for (const url of [
+      ...(event.mediaUrls ?? []),
+      ...mediaUrlsFromGeneratedAttachments(event.attachments),
+    ]) {
+      const trimmed = url.trim();
+      if (trimmed) {
+        owned.add(trimmed);
+      }
+    }
+  }
+  return Array.from(owned);
+}
+
+function hasNonMediaDeliverableContent(payload: ReplyPayload): boolean {
+  return Boolean(
+    payload.text?.trim() ||
+    payload.fallbackText ||
+    payload.presentation ||
+    payload.interactive ||
+    payload.location ||
+    payload.spokenText?.trim() ||
+    payload.btw ||
+    payload.channelData,
+  );
+}
+
+/**
+ * Keeps the first delivery of each handoff-owned media reference in an outbound
+ * batch and strips the repeats. Media the handoff does not own is untouched, so
+ * ordinary attachments and deliberate resends on other routes still flow.
+ */
+export function enforceHandoffMediaDeliveryOwnership(params: {
+  payloads: ReplyPayload[];
+  handoffMediaUrls: readonly string[];
+}): ReplyPayload[] {
+  const owned = new Set(
+    params.handoffMediaUrls
+      .map((url) => normalizeMediaReferenceForComparison(url))
+      .filter((url) => url.length > 0),
+  );
+  if (owned.size === 0) {
+    return params.payloads;
+  }
+  const claimed = new Set<string>();
+  const constrained: ReplyPayload[] = [];
+  let changed = false;
+  for (const payload of params.payloads) {
+    // Delivery operations act on the message this payload creates, so leave its
+    // content alone rather than silently skipping the operation.
+    if (hasEnabledDeliveryOperation(payload)) {
+      constrained.push(payload);
+      continue;
+    }
+    const decisions = new Map<string, boolean>();
+    const keepMedia = (url: string): boolean => {
+      const key = normalizeMediaReferenceForComparison(url);
+      if (!owned.has(key)) {
+        return true;
+      }
+      const decided = decisions.get(key);
+      if (decided !== undefined) {
+        return decided;
+      }
+      const keep = !claimed.has(key);
+      claimed.add(key);
+      decisions.set(key, keep);
+      return keep;
+    };
+    const mediaUrl = payload.mediaUrl && keepMedia(payload.mediaUrl) ? payload.mediaUrl : undefined;
+    const mediaUrls = payload.mediaUrls?.filter((url) => keepMedia(url));
+    if (mediaUrl === payload.mediaUrl && mediaUrls?.length === payload.mediaUrls?.length) {
+      constrained.push(payload);
+      continue;
+    }
+    changed = true;
+    if (!mediaUrl && !mediaUrls?.length && !hasNonMediaDeliverableContent(payload)) {
+      continue;
+    }
+    constrained.push(
+      copyReplyPayloadMetadata(payload, {
+        ...payload,
+        mediaUrl,
+        mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
+        ...(payload.audioAsVoice === true && !mediaUrl && !mediaUrls?.length
+          ? { audioAsVoice: undefined }
+          : {}),
+      }),
+    );
+  }
+  return changed ? constrained : params.payloads;
+}

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -1098,6 +1098,62 @@ describe("createMediaGenerationTaskLifecycle", () => {
     expect(taskRegistryDeliveryRuntimeMocks.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("assigns completion-handoff ownership so the agent is not told to re-attach MEDIA", async () => {
+    // Host-owned durable delivery already carries the generated artifact. Asking
+    // the resumed agent to also attach MEDIA lines produces a second channel send.
+    subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
+      delivered: true,
+      path: "queued",
+    });
+    const lifecycle = createImageMediaLifecycle();
+
+    await expect(
+      lifecycle.wakeTaskCompletion({
+        handle: {
+          taskId: "task-image-once",
+          runId: "tool:image_generate:once",
+          requesterSessionKey: "agent:main:telegram:direct:123",
+          taskLabel: "proof dog image",
+          requesterOrigin: {
+            channel: "telegram",
+            to: "telegram:123",
+          },
+        },
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "Generated 1 image.\nMEDIA:/tmp/generated-dog.png",
+        mediaUrls: ["/tmp/generated-dog.png"],
+        attachments: [
+          {
+            type: "image",
+            path: "/tmp/generated-dog.png",
+            mimeType: "image/png",
+            name: "generated-dog.png",
+          },
+        ],
+      }),
+    ).resolves.toEqual({ status: "delivered" });
+
+    const announceParams = subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mock
+      .calls[0]?.[0] as
+      | {
+          durableGeneratedMediaHandoff?: boolean;
+          internalEvents?: Array<{ replyInstruction?: string; mediaUrls?: string[] }>;
+        }
+      | undefined;
+    expect(announceParams?.durableGeneratedMediaHandoff).toBe(true);
+    const replyInstruction = announceParams?.internalEvents?.[0]?.replyInstruction ?? "";
+    expect(announceParams?.internalEvents?.[0]?.mediaUrls).toEqual(["/tmp/generated-dog.png"]);
+    expect(replyInstruction).toMatch(/owned by this completion handoff/i);
+    expect(replyInstruction).toMatch(/Do not re-send, re-attach, or echo MEDIA lines/i);
+    expect(replyInstruction).not.toMatch(/final-reply MEDIA lines/i);
+    expect(replyInstruction).not.toMatch(/every structured attachment from the internal event/i);
+    // Message-tool-only routes still need a caption path; attachments stay host-owned.
+    expect(replyInstruction).toMatch(/message\(action=["']send["']\)/i);
+    expect(replyInstruction).toMatch(/short caption and no attachments/i);
+    expect(replyInstruction).toMatch(/short normal final reply caption/i);
+  });
+
   it("does not direct-deliver generated media after requester abandonment", async () => {
     // Abandoned requester sessions are terminal; direct delivery would re-open a
     // conversation the task lifecycle already decided to stop.

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -40,6 +40,11 @@ vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskRegistryDeliv
 vi.mock("../../tasks/cron-run-continuation-cleanup.js", () => cronContinuationCleanupMocks);
 
 import {
+  collectHandoffOwnedMediaUrls,
+  enforceHandoffMediaDeliveryOwnership,
+} from "../handoff-media-delivery-ownership.js";
+import type { AgentInternalEvent } from "../internal-events.js";
+import {
   createMediaGenerationTaskLifecycle,
   scheduleMediaGenerationTaskCompletion,
   shouldDetachMediaGenerationTask,
@@ -1152,6 +1157,64 @@ describe("createMediaGenerationTaskLifecycle", () => {
     expect(replyInstruction).toMatch(/message\(action=["']send["']\)/i);
     expect(replyInstruction).toMatch(/short caption and no attachments/i);
     expect(replyInstruction).toMatch(/short normal final reply caption/i);
+  });
+
+  it("delivers the handoff media once even when the resumed reply ignores the instruction", async () => {
+    subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
+      delivered: true,
+      path: "direct",
+    });
+    const lifecycle = createImageMediaLifecycle();
+
+    await expect(
+      lifecycle.wakeTaskCompletion({
+        handle: {
+          taskId: "task-image-noncompliant",
+          runId: "tool:image_generate:noncompliant",
+          requesterSessionKey: "agent:main:telegram:direct:123",
+          taskLabel: "proof dog image",
+          requesterOrigin: { channel: "telegram", to: "telegram:123" },
+        },
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "Generated 1 image.\nMEDIA:/tmp/generated-dog.png",
+        mediaUrls: ["/tmp/generated-dog.png"],
+        attachments: [
+          {
+            type: "image",
+            path: "/tmp/generated-dog.png",
+            mimeType: "image/png",
+            name: "generated-dog.png",
+          },
+        ],
+      }),
+    ).resolves.toEqual({ status: "delivered" });
+
+    const announceParams = subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mock
+      .calls[0]?.[0] as { internalEvents?: AgentInternalEvent[] } | undefined;
+    const handoffMediaUrls = collectHandoffOwnedMediaUrls(announceParams?.internalEvents);
+    expect(handoffMediaUrls).toEqual(["/tmp/generated-dog.png"]);
+
+    // The resumed agent ignores the caption-only instruction and echoes the
+    // handoff artifact as a MEDIA line and again as a structured attachment.
+    const deliveredPayloads = enforceHandoffMediaDeliveryOwnership({
+      payloads: [
+        { text: "Here is your dog!", mediaUrls: ["/tmp/generated-dog.png"] },
+        { mediaUrl: "/tmp/generated-dog.png" },
+      ],
+      handoffMediaUrls,
+    });
+
+    const deliveredMediaCount = deliveredPayloads
+      .flatMap((payload) => [
+        ...(payload.mediaUrl ? [payload.mediaUrl] : []),
+        ...(payload.mediaUrls ?? []),
+      ])
+      .filter((url) => url === "/tmp/generated-dog.png").length;
+    expect(deliveredMediaCount).toBe(1);
+    expect(deliveredPayloads).toEqual([
+      { text: "Here is your dog!", mediaUrls: ["/tmp/generated-dog.png"] },
+    ]);
   });
 
   it("does not direct-deliver generated media after requester abandonment", async () => {

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -377,6 +377,11 @@ function failMediaGenerationTaskRun(params: {
   }
 }
 
+/**
+ * Durable completion handoffs already own outbound media delivery.
+ * The resumed agent may only supply caption text through the active
+ * visible-reply contract; re-attaching MEDIA creates a second channel send.
+ */
 function buildMediaGenerationReplyInstruction(params: {
   status: "ok" | "error";
   completionLabel: string;
@@ -384,8 +389,10 @@ function buildMediaGenerationReplyInstruction(params: {
   if (params.status === "ok") {
     return [
       `The ${params.completionLabel} is ready for the original chat.`,
-      'Use the current visible-reply contract: if this session requires message-tool replies, call message(action="send") with a short caption and every structured attachment from the internal event, then reply only NO_REPLY.',
-      "Otherwise, write the normal final reply and attach every generated media path with final-reply MEDIA lines.",
+      "Generated media delivery is already owned by this completion handoff.",
+      "Do not re-send, re-attach, or echo MEDIA lines / structured attachments from the internal event.",
+      'Use the current visible-reply contract for caption text only: if this session requires message-tool replies, call message(action="send") with a short caption and no attachments, then reply only NO_REPLY.',
+      "Otherwise, write a short normal final reply caption with no MEDIA lines, or reply NO_REPLY if no caption is needed.",
     ].join(" ");
   }
   return [

--- a/src/agents/tools/music-generate-background.test.ts
+++ b/src/agents/tools/music-generate-background.test.ts
@@ -138,8 +138,12 @@ describe("music generate background helpers", () => {
       },
     });
 
+    // Shared helper assigns host-owned completion delivery; agent gets caption-only
+    // guidance (including message-tool caption sends without attachments).
     expectReplyInstructionContains("visible-reply contract");
-    expectReplyInstructionContains("final-reply MEDIA lines");
+    expectReplyInstructionContains("completion handoff");
+    expectReplyInstructionContains("Do not re-send, re-attach, or echo MEDIA lines");
+    expectReplyInstructionContains("short caption and no attachments");
   });
 
   it("keeps failed completion notices in the durable agent-loop handoff", async () => {
@@ -189,8 +193,10 @@ describe("music generate background helpers", () => {
         },
       });
 
+      // Same shared ownership instruction for legacy group/channel keys.
       expectReplyInstructionContains("visible-reply contract");
-      expectReplyInstructionContains("final-reply MEDIA lines");
+      expectReplyInstructionContains("completion handoff");
+      expectReplyInstructionContains("Do not re-send, re-attach, or echo MEDIA lines");
     },
   );
 });


### PR DESCRIPTION
Closes #108976

## What Problem This Solves

Telegram (and other channel) users received each `image_generate` result twice: once from the resumed agent reply that re-attached the media, and once from the completion handoff that already owns delivery.

## Why This Change Was Made

The first revision of this PR only changed the wake instruction, telling the resumed agent not to re-attach the artifact. Review pointed out the flaw and it was right: that puts correctness in the model's hands. A noncompliant reply, or any alternate visible-reply path, still delivers the attachment twice.

This revision moves the rule into the delivery boundary, keyed on artifact identity rather than on the model obeying prose. `enforceHandoffMediaDeliveryOwnership` runs in `deliverAgentCommandResult` after the existing route dedupe and after media-path normalization, and lets each handoff-owned artifact through once per batch and once per payload. Media the handoff does not own is passed through untouched, and payloads carrying an enabled delivery operation are returned unchanged. The prompt wording stays as reinforcement, no longer as the only line of defence.

### Which path was actually unguarded

Worth stating plainly, since it corrects the premise of the first revision. The durable queued path was already structurally safe: `internalDeliveryMediaUrls` forces `constrainRestartRecoveryDeliveryPayloads` (`agent-command-restart-recovery.ts:41-84`), which discards model-selected media and appends exactly the host set. The gaps were elsewhere:

- the non-durable direct path (`subagent-announce-delivery.ts:1878-1904`), which passes no `internalDeliveryMediaUrls` and does not disable the message tool
- a cross-payload echo inside a single batch: one reply rendering the artifact as a MEDIA line and again as a structured attachment produces two payloads, and `createOutboundPayloadPlan` does no media dedupe

### Why not revoke ownership from the resumed path

Considered and rejected. `agent-command.ts:88-101` throws unless `internalDeliveryMediaUrls` comes with `forceRestartSafeTools`, `disableMessageTool`, and automatic delivery mode. Completion routes resolving to `message_tool_only` have no automatic transport, so revoking media there would leave the handoff with no deliverer at all. Revoking it route-agnostically would also break the legitimate "generate an image and also post it in #general" case.

## User Impact

Each generated artifact arrives once with an optional caption, regardless of whether the resumed model follows the prompt.

## Evidence

The load-bearing test drives the real `deliverAgentCommandResult` with a deliberately noncompliant reply (caption plus MEDIA line, then a second payload re-attaching the same file) and asserts on the payloads actually handed to the outbound sender:

```
delivery.test.ts: deliveredMediaUrls === ["/tmp/generated-dog.png"]   (one send, not two)
```

An A/B on the same code with the handoff event removed produces two sends, so the single send is attributable to this guard rather than to pre-existing dedupe.

```
handoff-media-delivery-ownership.test.ts   12 passed
```

covering: MEDIA-line-plus-attachment echo, `/tmp/./x.png` treated as the same reference, first-copy-wins across payloads, equivalent spellings inside one payload, non-handoff media untouched, identity return with no handoff, `audioAsVoice` cleared when its media is gone, and payloads with `delivery.pin` returned byte-identical.

`media-generate-background-shared.test.ts` links producer to boundary: it drives the real completion lifecycle, captures the internal event the code actually emits, and feeds that through the guard.

Typecheck clean (`tsconfig.core.json`). Two failures in `delivery.test.ts` reproduce identically without this change and are Windows path-separator assertions (`expected 'C:\tmp\agent-workspace' to be '/tmp/agent-workspace'`) in tests this diff does not touch.

## Limitations

- The guard is batch-scoped, not a durable "delivered once ever" ledger. Two separate message-tool sends within a run remain covered only by the existing route-keyed dedupe in `filterMessagingToolMediaDuplicates`.
- Cross-run repeats stay governed by `expectedMediaUrls` in the restart sentinel, untouched here.
- No live channel run. The deterministic path was chosen deliberately: a live run shows one occasion without a duplicate, whereas these tests assert the invariant holds even when the model disobeys. Happy to add a live capture if you would rather see one.

## AI Assistance

AI-assisted (Claude). Human author: Stan Shih (stantheman0128). The delivery-boundary rewrite came from acting on the review feedback on the first revision, and an independent pass verified the guard does not drop media it should keep.
