### PR TITLE
fix(process): Windows exec/read empty output when detached spawn leaks

### DIFF
--- a/src/process/spawn-utils.test.ts
+++ b/src/process/spawn-utils.test.ts
@@ -1,9 +1,9 @@
 // Spawn utility tests cover child process setup and stream handling helpers.
-import type { ChildProcess } from "node:child_process";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
-import { spawnWithFallback } from "./spawn-utils.js";
+import { sanitizeSpawnOptionsForPlatform, spawnWithFallback } from "./spawn-utils.js";
 
 function createStubChild() {
   const child = new EventEmitter() as ChildProcess;
@@ -22,7 +22,7 @@ function createStubChild() {
 function spawnOptionsAt(
   spawnMock: { mock: { calls: readonly unknown[][] } },
   callIndex: number,
-): { stdio?: unknown } {
+): SpawnOptions {
   const call = spawnMock.mock.calls[callIndex];
   if (!call) {
     throw new Error(`expected spawn call ${callIndex}`);
@@ -31,8 +31,33 @@ function spawnOptionsAt(
   if (typeof options !== "object" || options === null || Array.isArray(options)) {
     throw new Error(`expected spawn call ${callIndex} options`);
   }
-  return options;
+  return options as SpawnOptions;
 }
+
+describe("sanitizeSpawnOptionsForPlatform", () => {
+  it("forces detached false on Windows when callers request detached true (#105528)", () => {
+    const sanitized = sanitizeSpawnOptionsForPlatform(
+      { detached: true, stdio: ["pipe", "pipe", "pipe"], windowsHide: true },
+      "win32",
+    );
+    expect(sanitized.detached).toBe(false);
+    expect(sanitized.windowsHide).toBe(true);
+    expect(sanitized.stdio).toEqual(["pipe", "pipe", "pipe"]);
+  });
+
+  it("leaves detached true alone on POSIX", () => {
+    const sanitized = sanitizeSpawnOptionsForPlatform(
+      { detached: true, stdio: ["ignore", "pipe", "pipe"] },
+      "linux",
+    );
+    expect(sanitized.detached).toBe(true);
+  });
+
+  it("leaves already-attached Windows options unchanged", () => {
+    const options = { detached: false, stdio: ["pipe", "pipe", "pipe"] as const };
+    expect(sanitizeSpawnOptionsForPlatform(options, "win32")).toBe(options);
+  });
+});
 
 describe("spawnWithFallback", () => {
   it("retries on EBADF using fallback options", async () => {
@@ -76,4 +101,81 @@ describe("spawnWithFallback", () => {
     ).rejects.toThrow(/ENOENT/);
     expect(spawnMock).toHaveBeenCalledTimes(1);
   });
+
+  it("strips detached true before spawn on Windows (#105528)", async () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const spawnMock = vi.fn().mockImplementation(() => createStubChild());
+    try {
+      await spawnWithFallback({
+        argv: ["cmd.exe", "/c", "echo", "hello"],
+        options: {
+          detached: true,
+          stdio: ["ignore", "pipe", "pipe"],
+          windowsHide: true,
+        },
+        fallbacks: [{ label: "retry-detach", options: { detached: true } }],
+        spawnImpl: spawnMock,
+        retryCodes: ["EBADF"],
+      });
+
+      expect(spawnOptionsAt(spawnMock, 0).detached).toBe(false);
+    } finally {
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, "platform", originalPlatformDescriptor);
+      }
+    }
+  });
+
+  it("keeps detached true on POSIX hosts", async () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const spawnMock = vi.fn().mockImplementation(() => createStubChild());
+    try {
+      await spawnWithFallback({
+        argv: ["echo", "hello"],
+        options: {
+          detached: true,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+        spawnImpl: spawnMock,
+      });
+
+      expect(spawnOptionsAt(spawnMock, 0).detached).toBe(true);
+    } finally {
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, "platform", originalPlatformDescriptor);
+      }
+    }
+  });
+
+  it.runIf(process.platform === "win32")(
+    "captures stdout for Windows cmd echo through spawnWithFallback",
+    async () => {
+      const { spawn } = await import("node:child_process");
+      const result = await spawnWithFallback({
+        argv: ["cmd.exe", "/d", "/s", "/c", "echo hello-105528"],
+        options: {
+          // Intentionally request detached; the Windows guard must clear it.
+          detached: true,
+          windowsHide: true,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+        spawnImpl: spawn,
+      });
+
+      const chunks: Buffer[] = [];
+      result.child.stdout?.on("data", (chunk: Buffer) => {
+        chunks.push(Buffer.from(chunk));
+      });
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        result.child.once("error", reject);
+        result.child.once("close", (code) => resolve(code));
+      });
+      const stdout = Buffer.concat(chunks).toString("utf8");
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("hello-105528");
+    },
+  );
 });

--- a/src/process/spawn-utils.test.ts
+++ b/src/process/spawn-utils.test.ts
@@ -3,7 +3,7 @@ import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
-import { sanitizeSpawnOptionsForPlatform, spawnWithFallback } from "./spawn-utils.js";
+import { spawnWithFallback } from "./spawn-utils.js";
 
 function createStubChild() {
   const child = new EventEmitter() as ChildProcess;
@@ -33,31 +33,6 @@ function spawnOptionsAt(
   }
   return options as SpawnOptions;
 }
-
-describe("sanitizeSpawnOptionsForPlatform", () => {
-  it("forces detached false on Windows when callers request detached true (#105528)", () => {
-    const sanitized = sanitizeSpawnOptionsForPlatform(
-      { detached: true, stdio: ["pipe", "pipe", "pipe"], windowsHide: true },
-      "win32",
-    );
-    expect(sanitized.detached).toBe(false);
-    expect(sanitized.windowsHide).toBe(true);
-    expect(sanitized.stdio).toEqual(["pipe", "pipe", "pipe"]);
-  });
-
-  it("leaves detached true alone on POSIX", () => {
-    const sanitized = sanitizeSpawnOptionsForPlatform(
-      { detached: true, stdio: ["ignore", "pipe", "pipe"] },
-      "linux",
-    );
-    expect(sanitized.detached).toBe(true);
-  });
-
-  it("leaves already-attached Windows options unchanged", () => {
-    const options = { detached: false, stdio: ["pipe", "pipe", "pipe"] as const };
-    expect(sanitizeSpawnOptionsForPlatform(options, "win32")).toBe(options);
-  });
-});
 
 describe("spawnWithFallback", () => {
   it("retries on EBADF using fallback options", async () => {

--- a/src/process/spawn-utils.test.ts
+++ b/src/process/spawn-utils.test.ts
@@ -153,4 +153,67 @@ describe("spawnWithFallback", () => {
       expect(stdout).toContain("hello-105528");
     },
   );
+
+  it.runIf(process.platform === "win32")(
+    "restores PowerShell stdout when caller requests detached true (#105528)",
+    async () => {
+      const { spawn } = await import("node:child_process");
+
+      // BEFORE: unsanitized detached:true loses PowerShell stdout on this host.
+      const before = spawn(
+        "powershell.exe",
+        ["-NoProfile", "-Command", "Write-Output hello-ps-105528"],
+        {
+          detached: true,
+          windowsHide: true,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      const beforeChunks: Buffer[] = [];
+      before.stdout?.on("data", (chunk: Buffer) => {
+        beforeChunks.push(Buffer.from(chunk));
+      });
+      const beforeCode = await new Promise<number | null>((resolve, reject) => {
+        before.once("error", reject);
+        before.once("close", (code) => resolve(code));
+      });
+      const beforeStdout = Buffer.concat(beforeChunks).toString("utf8");
+      expect(beforeCode).toBe(0);
+      expect(beforeStdout).toBe("");
+
+      // AFTER: spawnWithFallback forces detached:false and captures stdout.
+      let detachedPassedToNode: boolean | undefined;
+      const spawnImpl: typeof spawn = ((...args: Parameters<typeof spawn>) => {
+        const options = args[2];
+        if (options && typeof options === "object" && !Array.isArray(options)) {
+          detachedPassedToNode = Boolean((options as { detached?: boolean }).detached);
+        }
+        return spawn(...args);
+      }) as typeof spawn;
+
+      const result = await spawnWithFallback({
+        argv: ["powershell.exe", "-NoProfile", "-Command", "Write-Output hello-ps-105528"],
+        options: {
+          detached: true,
+          windowsHide: true,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+        spawnImpl,
+      });
+
+      const afterChunks: Buffer[] = [];
+      result.child.stdout?.on("data", (chunk: Buffer) => {
+        afterChunks.push(Buffer.from(chunk));
+      });
+      const afterCode = await new Promise<number | null>((resolve, reject) => {
+        result.child.once("error", reject);
+        result.child.once("close", (code) => resolve(code));
+      });
+      const afterStdout = Buffer.concat(afterChunks).toString("utf8");
+
+      expect(detachedPassedToNode).toBe(false);
+      expect(afterCode).toBe(0);
+      expect(afterStdout).toContain("hello-ps-105528");
+    },
+  );
 });

--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -26,6 +26,23 @@ type SpawnWithFallbackParams = {
 
 const DEFAULT_RETRY_CODES = ["EBADF"];
 
+/**
+ * On Windows, `detached: true` can break stdout/stderr pipe capture for
+ * headless hosts (Scheduled Task / service) so exec/read-style tools return
+ * empty output with no error. Call sites mostly opt out already; keep a
+ * central belt-and-suspenders guard so every spawnWithFallback caller is safe.
+ * See #105528 / historical #17806 / #18035.
+ */
+export function sanitizeSpawnOptionsForPlatform(
+  options: SpawnOptions,
+  platform: NodeJS.Platform = process.platform,
+): SpawnOptions {
+  if (platform !== "win32" || !options.detached) {
+    return options;
+  }
+  return { ...options, detached: false };
+}
+
 export function resolveCommandStdio(params: {
   hasInput: boolean;
   preferInherit: boolean;
@@ -88,13 +105,13 @@ export async function spawnWithFallback(
 ): Promise<SpawnWithFallbackResult> {
   const spawnImpl = params.spawnImpl ?? spawn;
   const retryCodes = params.retryCodes ?? DEFAULT_RETRY_CODES;
-  const baseOptions = { ...params.options };
+  const baseOptions = sanitizeSpawnOptionsForPlatform({ ...params.options });
   const fallbacks = params.fallbacks ?? [];
   const attempts: Array<{ label?: string; options: SpawnOptions }> = [
     { options: baseOptions },
     ...fallbacks.map((fallback) => ({
       label: fallback.label,
-      options: { ...baseOptions, ...fallback.options },
+      options: sanitizeSpawnOptionsForPlatform({ ...baseOptions, ...fallback.options }),
     })),
   ];
 

--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -29,11 +29,12 @@ const DEFAULT_RETRY_CODES = ["EBADF"];
 /**
  * On Windows, `detached: true` can break stdout/stderr pipe capture for
  * headless hosts (Scheduled Task / service) so exec/read-style tools return
- * empty output with no error. Call sites mostly opt out already; keep a
- * central belt-and-suspenders guard so every spawnWithFallback caller is safe.
+ * empty output with no error. The sole production caller
+ * (`createChildAdapter`) already opts out on win32; keep this as a local
+ * guard so future spawnWithFallback callers cannot reintroduce the footgun.
  * See #105528 / historical #17806 / #18035.
  */
-export function sanitizeSpawnOptionsForPlatform(
+function sanitizeSpawnOptionsForPlatform(
   options: SpawnOptions,
   platform: NodeJS.Platform = process.platform,
 ): SpawnOptions {


### PR DESCRIPTION
﻿Closes #105528

## What Problem This Solves

Fixes an issue where Windows users running OpenClaw under a headless host (Scheduled Task / service) can see `exec` and `read` tools return empty output with no error when `detached: true` reaches Node `child_process.spawn`.

## Why This Change Was Made

Call sites already try to disable detached spawn on Windows, but those guards are scattered. This adds a centralized belt-and-suspenders guard in `spawnWithFallback` so every caller is covered, matching the historical Windows empty-stdout fix (#17806 / #18035) and the reporter's proposed upstream patch.

## User Impact

Windows users should get real tool stdout/stderr from supervisor-backed exec paths even if a caller accidentally requests `detached: true`. POSIX detached behavior is unchanged.

## AI Assistance

AI-assisted (Cursor/Grok). Human author: Stan Shih (stantheman0128).

## Evidence

Labels on #105528 at publish time: `bug`, `docs` (no `clawsweeper:no-new-fix-pr` / `needs-*`). Covering open PR search for `105528` only hits meta tracker #74163.

### Gold A/B (Windows 11, Node v24.15.0, tip `aa3274f658`)

Re-ran 2026-07-23 on this host with `powershell.exe -NoProfile -Command Write-Output hello-ps-105528` when `detached: true` is passed straight to Node `spawn`. The branch `spawnWithFallback` / Windows sanitizer forces `detached: false` and restores stdout.

```
BEFORE unsanitized spawn (powershell-write):
  detached=false empty=false stdout="hello-ps-105528\r\n"
  detached=true  empty=true  stdout=""

AFTER sanitize (caller requests detached:true):
  detachedRequested=true detachedPassedToNode=false forcedDetachedFalse=true
  empty=false stdout="hello-ps-105528\r\n"
```

Regression test (same tip):

```
node scripts/run-vitest.mjs src/process/spawn-utils.test.ts
Test Files  1 passed (1)
Tests  6 passed (6)
```

Note: `cmd.exe /c echo` and plain `node -e process.stdout.write` both returned stdout even with `detached: true` on this interactive host. The PowerShell path is the clear empty-before / non-empty-after signal.

### Unit / helper (retained)

Windows forcing `detached: false` even when callers pass `detached: true`; POSIX keeping `detached: true`; cmd echo via `spawnWithFallback`.

### Earlier Gateway after-fix path (still valid)

Isolated Gateway from this PR tree previously returned non-empty `exec`/`read` (`hello-exec-105528`, `hello-read-105528-from-workspace`) via Gateway-backed agent turn. That run did not show empty-before; the PowerShell A/B above is the missing before/after.

### Maintainer note

`createChildAdapter` already passes `detached: false` on Windows today. This PR remains a defense-in-depth guard in `spawnWithFallback` for any future caller that requests `detached: true` (PowerShell-style capture loss is now proven on this box).

Made with [Cursor](https://cursor.com)

---

Note: original PR #110198 was accidentally closed during a branch refresh while rebasing onto latest main. This replacement keeps the same fix commits on `fix/105528-windows-empty-output` (plus an empty refresh commit).
