### PR TITLE
test(plugins): clean loader fixture root

### DIFF
--- a/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
@@ -1,6 +1,9 @@
 // Standalone runtime registry loader tests cover registry loading outside gateway startup.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { clearPluginLoaderCache } from "../loader.test-fixtures.js";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  clearPluginLoaderCache,
+} from "../loader.test-fixtures.js";
 import { createEmptyPluginRegistry } from "../registry-empty.js";
 import type { PluginRegistry } from "../registry-types.js";
 import {
@@ -43,6 +46,10 @@ beforeEach(() => {
 afterEach(() => {
   clearPluginLoaderCache();
   resetPluginRuntimeStateForTest();
+});
+
+afterAll(() => {
+  cleanupPluginLoaderFixturesForTest();
 });
 
 describe("ensureStandaloneRuntimePluginRegistryLoaded tool-discovery installs", () => {


### PR DESCRIPTION
## What Problem This Solves

Importing the shared plugin loader test fixtures creates a module-level temporary root. The standalone runtime registry loader test resets loader/runtime state after each case but never removes that fixture root.

## Why This Change Was Made

Call the fixture-owned `cleanupPluginLoaderFixturesForTest()` from `afterAll`, while retaining the existing per-test cache and runtime resets. This pairs allocation and cleanup at the owning fixture boundary without duplicating filesystem logic.

## User Impact

Developers get cleaner plugin test teardown. Production behavior is unchanged.

## Evidence

- Blacksmith Linux Node 24: 1 file / 4 tests passed
- oxfmt check: passed
- `git diff --check`: passed
- Formal Codex autoreview: clean

AI-assisted: yes.
