### PR TITLE
fix: gmail setup fails to load gcloud when an unsupported Python is first on PATH

### DIFF
--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -40,7 +40,7 @@ describe("runGcloud interpreter resolution", () => {
         await withEnvAsync({ PATH: `${shimDir}${path.delimiter}/usr/bin` }, async () => {
           runCommandWithTimeoutMock
             .mockResolvedValueOnce({
-              stdout: `${realPython}\n`,
+              stdout: `${realPython}\n3.12\n`,
               stderr: "",
               code: 0,
               signal: null,
@@ -63,6 +63,68 @@ describe("runGcloud interpreter resolution", () => {
           expect(runCommandWithTimeoutMock).toHaveBeenLastCalledWith(["gcloud", "config", "list"], {
             timeoutMs: 120_000,
             env: { CLOUDSDK_PYTHON: realPython, CLOUDSDK_PYTHON_ARGS: undefined },
+          });
+        });
+      } finally {
+        await fs.rm(tmp, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  itUnix(
+    "skips a python whose version is outside gcloud's supported range",
+    async () => {
+      const { runGcloud } = await loadGmailSetupUtils();
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-python-ver-"));
+      try {
+        const oldPython = path.join(tmp, "python-old");
+        await fs.writeFile(oldPython, "#!/bin/sh\nexit 0\n", "utf-8");
+        await fs.chmod(oldPython, 0o755);
+        const goodPython = path.join(tmp, "python-good");
+        await fs.writeFile(goodPython, "#!/bin/sh\nexit 0\n", "utf-8");
+        await fs.chmod(goodPython, 0o755);
+
+        const shimDir = path.join(tmp, "shims");
+        await fs.mkdir(shimDir, { recursive: true });
+        // Two interpreters on PATH: the incompatible one is discovered first.
+        for (const name of ["python3", "python"]) {
+          const shim = path.join(shimDir, name);
+          await fs.writeFile(shim, "#!/bin/sh\nexit 0\n", "utf-8");
+          await fs.chmod(shim, 0o755);
+        }
+
+        await withEnvAsync({ PATH: shimDir }, async () => {
+          runCommandWithTimeoutMock
+            // python3 -> Python 3.9 (unsupported by gcloud): must be skipped.
+            .mockResolvedValueOnce({
+              stdout: `${oldPython}\n3.9\n`,
+              stderr: "",
+              code: 0,
+              signal: null,
+              killed: false,
+            })
+            // python -> Python 3.12 (supported): should be selected.
+            .mockResolvedValueOnce({
+              stdout: `${goodPython}\n3.12\n`,
+              stderr: "",
+              code: 0,
+              signal: null,
+              killed: false,
+            })
+            .mockResolvedValue({
+              stdout: "",
+              stderr: "",
+              code: 0,
+              signal: null,
+              killed: false,
+            });
+
+          await runGcloud(["config", "list"]);
+
+          expect(runCommandWithTimeoutMock).toHaveBeenLastCalledWith(["gcloud", "config", "list"], {
+            timeoutMs: 120_000,
+            env: { CLOUDSDK_PYTHON: goodPython, CLOUDSDK_PYTHON_ARGS: undefined },
           });
         });
       } finally {
@@ -99,7 +161,7 @@ describe("runGcloud", () => {
           async () => {
             runCommandWithTimeoutMock
               .mockResolvedValueOnce({
-                stdout: `${realPython}\n`,
+                stdout: `${realPython}\n3.12\n`,
                 stderr: "",
                 code: 0,
                 signal: null,

--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -73,7 +73,7 @@ describe("runGcloud interpreter resolution", () => {
   );
 
   itUnix(
-    "skips a python whose version is outside gcloud's supported range",
+    "skips Python versions below and above gcloud's supported range",
     async () => {
       const { runGcloud } = await loadGmailSetupUtils();
       const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-python-ver-"));
@@ -85,16 +85,17 @@ describe("runGcloud interpreter resolution", () => {
         await fs.writeFile(goodPython, "#!/bin/sh\nexit 0\n", "utf-8");
         await fs.chmod(goodPython, 0o755);
 
-        const shimDir = path.join(tmp, "shims");
-        await fs.mkdir(shimDir, { recursive: true });
-        // Two interpreters on PATH: the incompatible one is discovered first.
-        for (const name of ["python3", "python"]) {
-          const shim = path.join(shimDir, name);
+        const shimDirs = ["old", "future", "supported"].map((name) =>
+          path.join(tmp, `${name}-shims`),
+        );
+        for (const shimDir of shimDirs) {
+          await fs.mkdir(shimDir, { recursive: true });
+          const shim = path.join(shimDir, "python3");
           await fs.writeFile(shim, "#!/bin/sh\nexit 0\n", "utf-8");
           await fs.chmod(shim, 0o755);
         }
 
-        await withEnvAsync({ PATH: shimDir }, async () => {
+        await withEnvAsync({ PATH: shimDirs.join(path.delimiter) }, async () => {
           runCommandWithTimeoutMock
             // python3 -> Python 3.9 (unsupported by gcloud): must be skipped.
             .mockResolvedValueOnce({
@@ -104,7 +105,15 @@ describe("runGcloud interpreter resolution", () => {
               signal: null,
               killed: false,
             })
-            // python -> Python 3.12 (supported): should be selected.
+            // A future Python beyond gcloud's current cap must also be skipped.
+            .mockResolvedValueOnce({
+              stdout: `${path.join(tmp, "python-future")}\n3.15\n`,
+              stderr: "",
+              code: 0,
+              signal: null,
+              killed: false,
+            })
+            // Python 3.12 is supported and should be selected.
             .mockResolvedValueOnce({
               stdout: `${goodPython}\n3.12\n`,
               stderr: "",

--- a/src/hooks/gmail-setup-utils.ts
+++ b/src/hooks/gmail-setup-utils.ts
@@ -116,6 +116,18 @@ function ensureGcloudOnPath(): boolean {
   return false;
 }
 
+// gcloud requires a Python interpreter in this range to run; picking an
+// interpreter outside it makes `gcloud` fail to load. See `gcloud topic startup`.
+const MIN_GCLOUD_PYTHON: readonly [number, number] = [3, 10];
+const MAX_GCLOUD_PYTHON: readonly [number, number] = [3, 14];
+
+function isSupportedGcloudPythonVersion(major: number, minor: number): boolean {
+  if (major !== MIN_GCLOUD_PYTHON[0]) {
+    return false;
+  }
+  return minor >= MIN_GCLOUD_PYTHON[1] && minor <= MAX_GCLOUD_PYTHON[1];
+}
+
 async function resolvePythonExecutablePath(): Promise<string | undefined> {
   if (cachedPythonPath !== undefined) {
     return cachedPythonPath ?? undefined;
@@ -123,14 +135,28 @@ async function resolvePythonExecutablePath(): Promise<string | undefined> {
   const candidates = findExecutablesOnPath(["python3", "python"]);
   for (const candidate of candidates) {
     const res = await runCommandWithTimeout(
-      [candidate, "-c", "import os, sys; print(os.path.realpath(sys.executable))"],
+      [
+        candidate,
+        "-c",
+        "import os, sys; print(os.path.realpath(sys.executable)); print('%d.%d' % sys.version_info[:2])",
+      ],
       { timeoutMs: 2_000 },
     );
     if (res.code !== 0) {
       continue;
     }
-    const resolved = res.stdout.trim().split(/\s+/)[0];
+    const lines = res.stdout.trim().split(/\r?\n/);
+    const resolved = lines[0]?.trim().split(/\s+/)[0];
     if (!resolved) {
+      continue;
+    }
+    const version = lines[1]?.trim().match(/^(\d+)\.(\d+)/);
+    if (!version) {
+      continue;
+    }
+    if (!isSupportedGcloudPythonVersion(Number(version[1]), Number(version[2]))) {
+      // Skip interpreters gcloud cannot use (e.g. macOS' bundled Python 3.9)
+      // so a compatible interpreter later on PATH is selected instead.
       continue;
     }
     try {


### PR DESCRIPTION
Closes #112712

## What Problem This Solves

Fixes an issue where `openclaw webhooks gmail setup` fails with `gcloud failed to load. You are running gcloud with Python 3.9, which is no longer supported` on machines that have an old Python earlier on PATH than a compatible one. On macOS this happens routinely: `/usr/bin/python3` (Apple/Xcode's bundled 3.9) sits ahead of a Homebrew `python3` (3.10-3.14), so setup dies even though a compatible interpreter is installed.

## Why This Change Was Made

`resolvePythonExecutablePath()` picked the first `python3`/`python` it found on PATH and handed it to gcloud as `CLOUDSDK_PYTHON` without checking the interpreter's version. gcloud only runs on Python 3.10-3.14, so a 3.9 chosen first was a guaranteed failure. The fix asks each candidate to print its version alongside its resolved path and skips any interpreter outside gcloud's supported 3.10-3.14 range, so scanning continues to the next candidate. No change to how the interpreter is invoked or cached.

## User Impact

Operators with a mix of Python versions on PATH (very common on macOS) can now run the Gmail setup without manually reordering PATH or hand-setting `CLOUDSDK_PYTHON`. A compatible interpreter is selected automatically; if none exists, behavior is unchanged (no interpreter is forced).

## Evidence

Added a regression test that puts an unsupported Python 3.9 first on PATH and a supported 3.12 second, then asserts gcloud is invoked with the 3.12 interpreter.

- On `main` (no source fix): the new test fails — `CLOUDSDK_PYTHON` resolves to the 3.9 `python-old`.
- With the fix: the new test passes — `CLOUDSDK_PYTHON` resolves to the 3.12 `python-good`.

Full file suite:

```
npx vitest run src/hooks/gmail-setup-utils.test.ts
 ✓ src/hooks/gmail-setup-utils.test.ts (7 tests) 
   Test Files  1 passed (1)
        Tests  7 passed (7)
```

Lint:

```
npx oxlint src/hooks/gmail-setup-utils.ts src/hooks/gmail-setup-utils.test.ts
Found 0 warnings and 0 errors.
```
