### PR TITLE
fix(telegram): classify unreachable-recipient errors as non-retryable in ingress drain

### DIFF
--- a/extensions/telegram/src/dm-access.test.ts
+++ b/extensions/telegram/src/dm-access.test.ts
@@ -171,4 +171,65 @@ describe("enforceTelegramDmAccess", () => {
       "telegram pairing request",
     );
   });
+
+  it("rethrows recipient-unreachable pairing reply errors for ingress drain classification", async () => {
+    const blockedError = Object.assign(new Error("403: Forbidden: bot was blocked by the user"), {
+      error_code: 403,
+    });
+    createChannelPairingChallengeIssuerMock.mockReturnValueOnce(
+      ({
+        sendPairingReply,
+      }: Parameters<ReturnType<typeof createChannelPairingChallengeIssuer>>[0]) =>
+        (async () => {
+          await sendPairingReply("Pairing code: 123456");
+        })(),
+    );
+
+    await expect(
+      enforceTelegramDmAccess({
+        isGroup: false,
+        dmPolicy: "pairing",
+        msg: createDmMessage(),
+        chatId: 42,
+        effectiveDmAllow: normalizeAllowFrom([]),
+        accountId: "main",
+        bot: { api: { sendMessage: vi.fn(() => Promise.reject(blockedError)) } } as never,
+        logger: { info: vi.fn() },
+        upsertPairingRequest: upsertChannelPairingRequestMock,
+      }),
+    ).rejects.toThrow("bot was blocked by the user");
+  });
+
+  it("rethrows recipient-unreachable errors delivered via onReplyError", async () => {
+    const blockedError = Object.assign(new Error("403: Forbidden: bot was blocked by the user"), {
+      error_code: 403,
+    });
+    createChannelPairingChallengeIssuerMock.mockReturnValueOnce(
+      ({
+        sendPairingReply,
+        onReplyError,
+      }: Parameters<ReturnType<typeof createChannelPairingChallengeIssuer>>[0]) =>
+        (async () => {
+          try {
+            await sendPairingReply("Pairing code: 123456");
+          } catch (err) {
+            onReplyError?.(err);
+          }
+        })(),
+    );
+
+    await expect(
+      enforceTelegramDmAccess({
+        isGroup: false,
+        dmPolicy: "pairing",
+        msg: createDmMessage(),
+        chatId: 42,
+        effectiveDmAllow: normalizeAllowFrom([]),
+        accountId: "main",
+        bot: { api: { sendMessage: vi.fn(() => Promise.reject(blockedError)) } } as never,
+        logger: { info: vi.fn() },
+        upsertPairingRequest: upsertChannelPairingRequestMock,
+      }),
+    ).rejects.toThrow("bot was blocked by the user");
+  });
 });

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -13,6 +13,7 @@ import {
   createTelegramIngressResolver,
   telegramAllowEntries,
 } from "./ingress.js";
+import { resolveTelegramIngressNonRetryableFailure } from "./telegram-ingress-non-retryable.js";
 
 type TelegramDmAccessLogger = {
   info: (obj: Record<string, unknown>, msg: string) => void;
@@ -163,10 +164,18 @@ export async function enforceTelegramDmAccess(params: {
           });
         },
         onReplyError: (err) => {
+          const nonRetryable = resolveTelegramIngressNonRetryableFailure(err);
+          if (nonRetryable?.reason === "recipient-unreachable") {
+            throw err;
+          }
           logVerbose(`telegram pairing reply failed for chat ${chatId}: ${String(err)}`);
         },
       });
     } catch (err) {
+      const nonRetryable = resolveTelegramIngressNonRetryableFailure(err);
+      if (nonRetryable?.reason === "recipient-unreachable") {
+        throw err;
+      }
       logVerbose(`telegram pairing reply failed for chat ${chatId}: ${String(err)}`);
     }
     return false;

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -109,4 +109,51 @@ describe("createTelegramIngressMonitor", () => {
       await monitor.stop();
     });
   });
+
+  it("dead-letters a blocked-recipient Telegram API error instead of retrying", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+        channelId: "telegram",
+        accountId: "default",
+        stateDir,
+      });
+      const eventId = "3".padStart(16, "0");
+      const payload = updatePayload(3);
+      const laneKey = telegramSpooledUpdateLaneKey(payload.update);
+      await queue.enqueue(eventId, payload, { laneKey });
+
+      const blockedError = Object.assign(new Error("403: Forbidden: bot was blocked by the user"), {
+        error_code: 403,
+      });
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg,
+        accountId: "default",
+        dispatch: async () => {
+          throw blockedError;
+        },
+      });
+
+      monitor.start();
+      await monitor.waitForIdle();
+
+      // Terminal ingress failures must tombstone the row as failed
+      // (dead-lettered), not leave it pending for retry.
+      const status = await queue.enqueue(eventId, payload, { laneKey });
+      expect(status.kind).toBe("failed");
+      if (status.kind === "failed") {
+        expect(status.record.reason).toBe("recipient-unreachable");
+      }
+
+      const pending = await queue.listPending({ limit: "all" });
+      expect(pending.some((row) => row.id === eventId)).toBe(false);
+
+      const failed = await queue.listFailed!({ limit: "all" });
+      expect(
+        failed.some((row) => row.id === eventId && row.reason === "recipient-unreachable"),
+      ).toBe(true);
+
+      await monitor.stop();
+    });
+  });
 });

--- a/extensions/telegram/src/telegram-ingress-non-retryable.test.ts
+++ b/extensions/telegram/src/telegram-ingress-non-retryable.test.ts
@@ -8,13 +8,13 @@ describe("resolveTelegramIngressNonRetryableFailure", () => {
 
   it("returns null for a transient network error", () => {
     const err = new Error("ECONNREFUSED");
-    (err as Record<string, unknown>).code = "ECONNREFUSED";
+    (err as unknown as Record<string, unknown>).code = "ECONNREFUSED";
     expect(resolveTelegramIngressNonRetryableFailure(err)).toBeNull();
   });
 
   it("classifies bot-blocked error as non-retryable", () => {
     const err = new Error("403: Forbidden: bot was blocked by the user");
-    (err as Record<string, unknown>).error_code = 403;
+    (err as unknown as Record<string, unknown>).error_code = 403;
     const result = resolveTelegramIngressNonRetryableFailure(err);
     expect(result).not.toBeNull();
     expect(result!.reason).toBe("recipient-unreachable");
@@ -23,7 +23,7 @@ describe("resolveTelegramIngressNonRetryableFailure", () => {
 
   it("classifies bot-kicked error as non-retryable", () => {
     const err = new Error("403: Forbidden: bot was kicked from the group chat");
-    (err as Record<string, unknown>).error_code = 403;
+    (err as unknown as Record<string, unknown>).error_code = 403;
     const result = resolveTelegramIngressNonRetryableFailure(err);
     expect(result).not.toBeNull();
     expect(result!.reason).toBe("recipient-unreachable");
@@ -32,7 +32,7 @@ describe("resolveTelegramIngressNonRetryableFailure", () => {
 
   it("classifies chat-not-found error as non-retryable", () => {
     const err = new Error("400: Bad Request: chat not found");
-    (err as Record<string, unknown>).error_code = 400;
+    (err as unknown as Record<string, unknown>).error_code = 400;
     const result = resolveTelegramIngressNonRetryableFailure(err);
     expect(result).not.toBeNull();
     expect(result!.reason).toBe("recipient-unreachable");
@@ -41,7 +41,7 @@ describe("resolveTelegramIngressNonRetryableFailure", () => {
 
   it("classifies user-not-found error as non-retryable", () => {
     const err = new Error("400: Bad Request: user not found");
-    (err as Record<string, unknown>).error_code = 400;
+    (err as unknown as Record<string, unknown>).error_code = 400;
     const result = resolveTelegramIngressNonRetryableFailure(err);
     expect(result).not.toBeNull();
     expect(result!.reason).toBe("recipient-unreachable");
@@ -50,7 +50,7 @@ describe("resolveTelegramIngressNonRetryableFailure", () => {
 
   it("classifies bot-not-member error as non-retryable", () => {
     const err = new Error("403: Forbidden: bot is not a member of the channel chat");
-    (err as Record<string, unknown>).error_code = 403;
+    (err as unknown as Record<string, unknown>).error_code = 403;
     const result = resolveTelegramIngressNonRetryableFailure(err);
     expect(result).not.toBeNull();
     expect(result!.reason).toBe("recipient-unreachable");
@@ -59,7 +59,7 @@ describe("resolveTelegramIngressNonRetryableFailure", () => {
 
   it("detects permanent error nested in cause chain", () => {
     const cause = new Error("403: Forbidden: bot was blocked by the user");
-    (cause as Record<string, unknown>).error_code = 403;
+    (cause as unknown as Record<string, unknown>).error_code = 403;
     const err = new Error("dispatch failed", { cause });
     const result = resolveTelegramIngressNonRetryableFailure(err);
     expect(result).not.toBeNull();
@@ -68,7 +68,7 @@ describe("resolveTelegramIngressNonRetryableFailure", () => {
 
   it("detects permanent error nested in error property (GrammyError shape)", () => {
     const inner = new Error("Forbidden: bot was blocked by the user");
-    (inner as Record<string, unknown>).error_code = 403;
+    (inner as unknown as Record<string, unknown>).error_code = 403;
     const err = Object.assign(new Error("HttpError"), { error: inner });
     const result = resolveTelegramIngressNonRetryableFailure(err);
     expect(result).not.toBeNull();

--- a/extensions/telegram/src/telegram-ingress-non-retryable.test.ts
+++ b/extensions/telegram/src/telegram-ingress-non-retryable.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { resolveTelegramIngressNonRetryableFailure } from "./telegram-ingress-non-retryable.js";
+
+describe("resolveTelegramIngressNonRetryableFailure", () => {
+  it("returns null for a generic error", () => {
+    expect(resolveTelegramIngressNonRetryableFailure(new Error("something went wrong"))).toBeNull();
+  });
+
+  it("returns null for a transient network error", () => {
+    const err = new Error("ECONNREFUSED");
+    (err as Record<string, unknown>).code = "ECONNREFUSED";
+    expect(resolveTelegramIngressNonRetryableFailure(err)).toBeNull();
+  });
+
+  it("classifies bot-blocked error as non-retryable", () => {
+    const err = new Error("403: Forbidden: bot was blocked by the user");
+    (err as Record<string, unknown>).error_code = 403;
+    const result = resolveTelegramIngressNonRetryableFailure(err);
+    expect(result).not.toBeNull();
+    expect(result!.reason).toBe("recipient-unreachable");
+    expect(result!.message).toContain("bot was blocked by the user");
+  });
+
+  it("classifies bot-kicked error as non-retryable", () => {
+    const err = new Error("403: Forbidden: bot was kicked from the group chat");
+    (err as Record<string, unknown>).error_code = 403;
+    const result = resolveTelegramIngressNonRetryableFailure(err);
+    expect(result).not.toBeNull();
+    expect(result!.reason).toBe("recipient-unreachable");
+    expect(result!.message).toContain("bot was kicked");
+  });
+
+  it("classifies chat-not-found error as non-retryable", () => {
+    const err = new Error("400: Bad Request: chat not found");
+    (err as Record<string, unknown>).error_code = 400;
+    const result = resolveTelegramIngressNonRetryableFailure(err);
+    expect(result).not.toBeNull();
+    expect(result!.reason).toBe("recipient-unreachable");
+    expect(result!.message).toContain("chat not found");
+  });
+
+  it("classifies user-not-found error as non-retryable", () => {
+    const err = new Error("400: Bad Request: user not found");
+    (err as Record<string, unknown>).error_code = 400;
+    const result = resolveTelegramIngressNonRetryableFailure(err);
+    expect(result).not.toBeNull();
+    expect(result!.reason).toBe("recipient-unreachable");
+    expect(result!.message).toContain("user not found");
+  });
+
+  it("classifies bot-not-member error as non-retryable", () => {
+    const err = new Error("403: Forbidden: bot is not a member of the channel chat");
+    (err as Record<string, unknown>).error_code = 403;
+    const result = resolveTelegramIngressNonRetryableFailure(err);
+    expect(result).not.toBeNull();
+    expect(result!.reason).toBe("recipient-unreachable");
+    expect(result!.message).toContain("not a member");
+  });
+
+  it("detects permanent error nested in cause chain", () => {
+    const cause = new Error("403: Forbidden: bot was blocked by the user");
+    (cause as Record<string, unknown>).error_code = 403;
+    const err = new Error("dispatch failed", { cause });
+    const result = resolveTelegramIngressNonRetryableFailure(err);
+    expect(result).not.toBeNull();
+    expect(result!.reason).toBe("recipient-unreachable");
+  });
+
+  it("detects permanent error nested in error property (GrammyError shape)", () => {
+    const inner = new Error("Forbidden: bot was blocked by the user");
+    (inner as Record<string, unknown>).error_code = 403;
+    const err = Object.assign(new Error("HttpError"), { error: inner });
+    const result = resolveTelegramIngressNonRetryableFailure(err);
+    expect(result).not.toBeNull();
+    expect(result!.reason).toBe("recipient-unreachable");
+  });
+});

--- a/extensions/telegram/src/telegram-ingress-non-retryable.test.ts
+++ b/extensions/telegram/src/telegram-ingress-non-retryable.test.ts
@@ -12,6 +12,17 @@ describe("resolveTelegramIngressNonRetryableFailure", () => {
     expect(resolveTelegramIngressNonRetryableFailure(err)).toBeNull();
   });
 
+  it("keeps lookalike non-Telegram messages retryable", () => {
+    expect(resolveTelegramIngressNonRetryableFailure(new Error("chat not found"))).toBeNull();
+    expect(resolveTelegramIngressNonRetryableFailure(new Error("user not found"))).toBeNull();
+    expect(
+      resolveTelegramIngressNonRetryableFailure(new Error("bot was blocked by the user")),
+    ).toBeNull();
+    expect(
+      resolveTelegramIngressNonRetryableFailure(new Error("Forbidden: bot was kicked")),
+    ).toBeNull();
+  });
+
   it("classifies bot-blocked error as non-retryable", () => {
     const err = new Error("403: Forbidden: bot was blocked by the user");
     (err as unknown as Record<string, unknown>).error_code = 403;

--- a/extensions/telegram/src/telegram-ingress-non-retryable.ts
+++ b/extensions/telegram/src/telegram-ingress-non-retryable.ts
@@ -11,9 +11,26 @@ const MISSING_AGENT_HARNESS_ERROR_NAME = "MissingAgentHarnessError";
 const MISSING_AGENT_HARNESS_MESSAGE_RE = /Requested agent harness "[^"]+" is not registered\./u;
 
 type TelegramIngressNonRetryableFailure = {
-  reason: "invalid-event" | "missing-agent-harness" | "dispatch-dedupe-rollback-failed";
+  reason:
+    | "invalid-event"
+    | "missing-agent-harness"
+    | "dispatch-dedupe-rollback-failed"
+    | "recipient-unreachable";
   message: string;
 };
+
+/**
+ * Patterns shared with outbound delivery-queue-recovery PERMANENT_ERROR_PATTERNS.
+ * Keep the two lists aligned so ingress and outbound treat the same permanent
+ * errors consistently.
+ */
+const PERMANENT_INGRESS_ERROR_PATTERNS: readonly RegExp[] = [
+  /bot was blocked by the user/i,
+  /forbidden: bot was kicked/i,
+  /chat not found/i,
+  /user not found/i,
+  /bot.*not.*member/i,
+];
 
 /** Channel-owned non-retryable predicate for the core ingress drain. */
 export function resolveTelegramIngressNonRetryableFailure(
@@ -37,6 +54,9 @@ export function resolveTelegramIngressNonRetryableFailure(
       MISSING_AGENT_HARNESS_MESSAGE_RE.test(message)
     ) {
       return { reason: "missing-agent-harness", message };
+    }
+    if (PERMANENT_INGRESS_ERROR_PATTERNS.some((re) => re.test(message))) {
+      return { reason: "recipient-unreachable", message };
     }
   }
   return null;

--- a/extensions/telegram/src/telegram-ingress-non-retryable.ts
+++ b/extensions/telegram/src/telegram-ingress-non-retryable.ts
@@ -32,6 +32,19 @@ const PERMANENT_INGRESS_ERROR_PATTERNS: readonly RegExp[] = [
   /bot.*not.*member/i,
 ];
 
+/**
+ * Confirms the candidate carries a Telegram Bot API error_code. Ingress
+ * terminal classification must only fire for explicit API rejections, not for
+ * unrelated dispatch errors that happen to contain the same message text.
+ */
+function isConfirmedTelegramApiClientError(candidate: unknown): boolean {
+  if (!candidate || typeof candidate !== "object") {
+    return false;
+  }
+  const code = (candidate as { error_code?: unknown }).error_code;
+  return typeof code === "number" && (code === 400 || code === 403);
+}
+
 /** Channel-owned non-retryable predicate for the core ingress drain. */
 export function resolveTelegramIngressNonRetryableFailure(
   err: unknown,
@@ -55,7 +68,10 @@ export function resolveTelegramIngressNonRetryableFailure(
     ) {
       return { reason: "missing-agent-harness", message };
     }
-    if (PERMANENT_INGRESS_ERROR_PATTERNS.some((re) => re.test(message))) {
+    if (
+      isConfirmedTelegramApiClientError(candidate) &&
+      PERMANENT_INGRESS_ERROR_PATTERNS.some((re) => re.test(message))
+    ) {
       return { reason: "recipient-unreachable", message };
     }
   }


### PR DESCRIPTION
Fixes #112893

## What Problem This Solves

Fixes an issue where Telegram ingress spooled updates would keep retrying for up to 24 hours when the bot was blocked, kicked, or the chat/user no longer existed. The outgoing pairing-code reply fails with a Telegram 403 error (e.g. "bot was blocked by the user"), but the ingress non-retryable classifier didn't recognize these as permanent — so the update was released for retry instead of being immediately dead-lettered.

## Why This Change Was Made

The Telegram ingress non-retryable classifier (`resolveTelegramIngressNonRetryableFailure`) only recognized three error types: `invalid-event`, `missing-agent-harness`, and `dispatch-dedupe-rollback-failed`. Telegram API 403 permanent errors (blocked, kicked, chat not found, user not found, bot not member) were never classified as non-retryable.

This adds a `recipient-unreachable` reason with permanent error patterns aligned with the outbound delivery queue recovery (`delivery-queue-recovery.ts`). To avoid dropping unrelated dispatch errors that happen to contain the same text, the new branch gates on a confirmed Telegram Bot API `error_code` of `400` or `403` before dead-lettering.

Additionally, the pairing-code reply path in `enforceTelegramDmAccess` swallows send errors inside `issuePairingChallenge` and delivers them to `onReplyError`. The fix now rethrows errors classified as `recipient-unreachable` from `onReplyError` so they propagate to the ingress drain and are dead-lettered instead of being logged and ignored.

## User Impact

Operators no longer see ingress retry storms in logs when a Telegram bot is blocked or kicked — the spooled update is immediately dead-lettered as `recipient-unreachable` instead of retrying until the 24-hour age cap.

## Revision notes

- Removed the unrelated `extensions/telegram/src/send.ts` rewrite per ClawSweeper review feedback. The diff is now focused on the ingress classifier, DM-access rethrow, and their regression tests.
- Rebased onto current `upstream/main` (`e144bc16d87`).
- Re-ran focused tests, lint, and format checks on the narrowed change set.

## Evidence

### Before fix

A 403 "bot was blocked by the user" error from Telegram would be treated as retryable by the ingress drain, causing repeated retries:

```
[telegram] sendMessage failed: (403: Forbidden: bot was blocked by the user)
[telegram] [diag] spooled update 585236308 failed; keeping for retry: ...
```

### After fix

The same error is classified as non-retryable and dead-lettered immediately:

```
spooled update 585236308 failed with non-retryable recipient-unreachable: <error message>; dead-lettered
```

### Real behavior proof (redacted)

A real Telegram Bot API call to a user who has blocked the test bot returns the exact 403 error the gateway sees:

```bash
curl -s -X POST "https://api.telegram.org/bot<REDACTED>/sendMessage" \
  -H "Content-Type: application/json" \
  -d '{"chat_id":"<REDACTED>","text":"pairing challenge"}'
```

Output:

```json
{"ok":false,"error_code":403,"description":"Forbidden: bot was blocked by the user"}
```

A focused harness feeds that authentic error shape through the production classifier and pairing path:

```bash
OPENCLAW_CONFIG_PATH=/tmp/openclaw-telegram-proof-<REDACTED>/state/openclaw.json \
OPENCLAW_STATE_DIR=/tmp/openclaw-telegram-proof-<REDACTED>/state \
  node_modules/.bin/tsx .tmp/proof/real-blocked-classification.mts
```

Both layers proven: real Telegram 403 classified as `recipient-unreachable`, DM access rethrows it for the ingress drain.

### Real gateway dead-letter proof (production gateway, dmPolicy=pairing)

A real gateway running the fix was verified end-to-end with a real Telegram bot (`@block_xialong_bot`) and a real user who blocked the bot after triggering the pairing flow. The gateway used `dmPolicy: "pairing"` with an empty `allowFrom` so every DM triggers a pairing challenge reply.

> **Test note**: The drain's poll interval is 500ms in production, which is too fast for a human to block between sending a DM and the pairing reply being dispatched. A temporary 10s `setTimeout` was injected into the dist bundle's `sendPairingReply` for proof purposes only — this delay is not part of the PR and was reverted before submission. It simulates the real-world scenario where the bot is already blocked when an existing spooled update is processed.

**Production pipeline verified:**

1. User sends DM → Telegram delivers to bot → polling spools to ingress queue
2. Drain claims the event → `enforceTelegramDmAccess` → `createChannelPairingChallengeIssuer` → `sendPairingReply`
3. `bot.api.sendMessage` returns `403: Forbidden: bot was blocked by the user` (user blocked during processing)
4. Error caught by `onReplyError` → `resolveTelegramIngressNonRetryableFailure` → classified as `recipient-unreachable` → rethrown
5. Drain catches the throw → `resolveIngressFailureDisposition` → dead-letter immediately (no retry, no 24h wait)

**Gateway log evidence:**

```
telegram sendMessage failed: Call to 'sendMessage' failed! (403: Forbidden: bot was blocked by the user)
handler failed: GrammyError: Call to 'sendMessage' failed! (403: Forbidden: bot was blocked by the user)
spooled update 813715124 failed with non-retryable recipient-unreachable: Call to 'sendMessage' failed! (403: Forbidden: bot was blocked by the user); dead-lettered
```

**SQLite queue state (production state DB):**

```
event_id           | status | failed_reason
0000000813715124   | failed | recipient-unreachable
```

The companion event (0000000813715125) was processed afterward and completed normally, confirming that dead-lettering one event does not affect subsequent events on the same lane.

### Unit / integration tests (rebased on upstream/main, clean)

```bash
node scripts/run-vitest.mjs \
  extensions/telegram/src/dm-access.test.ts \
  extensions/telegram/src/telegram-ingress-drain.test.ts \
  extensions/telegram/src/telegram-ingress-non-retryable.test.ts
```

```
 RUN  v4.1.10 /home/0668000452/codes/OPENSOURCES/openclaw

 ✓ |extension-telegram| extensions/telegram/src/telegram-ingress-drain.test.ts (3 tests) 873ms
 ✓ |extension-telegram| extensions/telegram/src/dm-access.test.ts (8 tests) 107ms
 ✓ |extension-telegram| extensions/telegram/src/telegram-ingress-non-retryable.test.ts (10 tests) 8ms

 Test Files  3 passed (3)
      Tests  21 passed (21)
   Start at  03:27:23
   Duration  45.91s
```

### Lint / format (clean)

```bash
./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json \
  extensions/telegram/src/dm-access.ts \
  extensions/telegram/src/dm-access.test.ts \
  extensions/telegram/src/telegram-ingress-drain.test.ts \
  extensions/telegram/src/telegram-ingress-non-retryable.test.ts \
  extensions/telegram/src/telegram-ingress-non-retryable.ts
```

```
Found 0 warnings and 0 errors.
Finished in 22ms on 5 files with 212 rules using 8 threads.
```

```bash
./node_modules/.bin/oxfmt --check \
  extensions/telegram/src/dm-access.ts \
  extensions/telegram/src/dm-access.test.ts \
  extensions/telegram/src/telegram-ingress-drain.test.ts \
  extensions/telegram/src/telegram-ingress-non-retryable.test.ts \
  extensions/telegram/src/telegram-ingress-non-retryable.ts
```

```
All matched files use the correct format.
```

```bash
git diff --check
```

No whitespace errors.
