### PR TITLE
refactor(meetings): share runtime probes and node wrappers

### DIFF
--- a/extensions/teams-meetings/src/node-host.ts
+++ b/extensions/teams-meetings/src/node-host.ts
@@ -1,5 +1,4 @@
-import { spawnSync } from "node:child_process";
-import { createMeetingNodeHost } from "openclaw/plugin-sdk/meeting-runtime";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import {
   DEFAULT_TEAMS_MEETINGS_AUDIO_INPUT_COMMAND,
   DEFAULT_TEAMS_MEETINGS_AUDIO_OUTPUT_COMMAND,
@@ -11,65 +10,10 @@ import {
 import { TEAMS_MEETINGS_PLATFORM_ADAPTER } from "./transports/teams-meetings-platform-adapter.js";
 import { TEAMS_MEETINGS_NODE_COMMAND } from "./transports/teams-meetings-platform-constants.js";
 
-function commandExists(command: string, timeoutMs: number): boolean {
-  const result = spawnSync("/bin/sh", ["-lc", 'command -v "$1" >/dev/null 2>&1', "sh", command], {
-    encoding: "utf8",
-    timeout: timeoutMs,
-  });
-  return result.status === 0;
-}
-
-function assertTalkBackPrerequisites(
-  timeoutMs: number,
-  commands: readonly (readonly string[])[] = [
-    DEFAULT_TEAMS_MEETINGS_AUDIO_INPUT_COMMAND,
-    DEFAULT_TEAMS_MEETINGS_AUDIO_OUTPUT_COMMAND,
-  ],
-) {
-  if (process.platform !== "darwin") {
-    throw new Error("Microsoft Teams meeting talk-back with BlackHole 2ch is macOS-only");
-  }
-  const result = spawnSync(TEAMS_MEETINGS_SYSTEM_PROFILER_COMMAND, ["SPAudioDataType"], {
-    encoding: "utf8",
-    timeout: timeoutMs,
-  });
-  const stderr =
-    result.stderr ??
-    (result.error
-      ? result.error instanceof Error
-        ? result.error.message
-        : String(result.error)
-      : "");
-  const output = `${result.stdout ?? ""}\n${stderr}`;
-  if (
-    (typeof result.status === "number" ? result.status : result.error ? 1 : 0) !== 0 ||
-    !outputMentionsBlackHole2ch(output)
-  ) {
-    throw new Error("BlackHole 2ch audio device not found on the node.");
-  }
-  for (const argv of commands) {
-    const command = argv[0];
-    if (!command || !commandExists(command, timeoutMs)) {
-      throw new Error(`Configured audio command not found on the node: ${command || "<empty>"}`);
-    }
-  }
-}
-
-function readCommand(params: Record<string, unknown>, name: string): string[] {
-  const value = params[name];
-  if (
-    !Array.isArray(value) ||
-    value.length === 0 ||
-    value.some((entry) => typeof entry !== "string")
-  ) {
-    throw new Error(`${name} must be a non-empty string array.`);
-  }
-  return value as string[];
-}
-
-const teamsMeetingsNodeHost = createMeetingNodeHost({
+export const handleTeamsMeetingsNodeHostCommand = MeetingPlatformAdapter.createNodeHostHandler({
   commandName: TEAMS_MEETINGS_NODE_COMMAND,
   displayName: "Microsoft Teams meetings",
+  meetingLabel: "Microsoft Teams meeting",
   browserLabel: "Teams meeting",
   bridgeIdPrefix: "teams_meeting_node_",
   defaultAudioInputCommand: DEFAULT_TEAMS_MEETINGS_AUDIO_INPUT_COMMAND,
@@ -78,7 +22,9 @@ const teamsMeetingsNodeHost = createMeetingNodeHost({
   agentMode: "agent",
   normalizeUrl: (url) => TEAMS_MEETINGS_PLATFORM_ADAPTER.urls.validateAndNormalize(url),
   normalizeMeetingKey: (url) => TEAMS_MEETINGS_PLATFORM_ADAPTER.urls.normalizeForReuse(url),
-  assertAudioAvailable: assertTalkBackPrerequisites,
+  outputMentionsAudioDevice: outputMentionsBlackHole2ch,
+  sharePrerequisiteDeadline: false,
+  systemProfilerCommand: TEAMS_MEETINGS_SYSTEM_PROFILER_COMMAND,
   browser: {
     application: "Google Chrome",
     buildProfileArgs: (profile) => ["--args", `--profile-directory=${profile}`],
@@ -88,30 +34,3 @@ const teamsMeetingsNodeHost = createMeetingNodeHost({
     ],
   },
 });
-
-export async function handleTeamsMeetingsNodeHostCommand(
-  paramsJSON?: string | null,
-): Promise<string> {
-  if (paramsJSON) {
-    let raw: unknown;
-    try {
-      raw = JSON.parse(paramsJSON) as unknown;
-    } catch {
-      throw new Error("Microsoft Teams meetings node host received malformed params JSON.");
-    }
-    const params =
-      raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
-    if (params.action === "setup") {
-      const commands = [
-        readCommand(params, "audioInputCommand"),
-        readCommand(params, "audioOutputCommand"),
-      ];
-      if (params.bargeInInputCommand !== undefined) {
-        commands.push(readCommand(params, "bargeInInputCommand"));
-      }
-      assertTalkBackPrerequisites(10_000, commands);
-      return JSON.stringify({ ok: true });
-    }
-  }
-  return await teamsMeetingsNodeHost.handleCommand(paramsJSON);
-}

--- a/extensions/teams-meetings/src/node-invoke-policy.ts
+++ b/extensions/teams-meetings/src/node-invoke-policy.ts
@@ -1,43 +1,16 @@
 import { createMeetingBrowserNodeInvokePolicy } from "openclaw/plugin-sdk/meeting-runtime";
-import type {
-  OpenClawPluginNodeInvokePolicy,
-  OpenClawPluginNodeInvokePolicyContext,
-} from "openclaw/plugin-sdk/plugin-entry";
 import type { TeamsMeetingsConfig } from "./config.js";
 import { TEAMS_MEETINGS_PLATFORM_ADAPTER } from "./transports/teams-meetings-platform-adapter.js";
 import { TEAMS_MEETINGS_NODE_COMMAND } from "./transports/teams-meetings-platform-constants.js";
 
-export function createTeamsMeetingsNodeInvokePolicy(
-  config: TeamsMeetingsConfig,
-): OpenClawPluginNodeInvokePolicy {
-  const base = createMeetingBrowserNodeInvokePolicy({
+export function createTeamsMeetingsNodeInvokePolicy(config: TeamsMeetingsConfig) {
+  return createMeetingBrowserNodeInvokePolicy({
     commandName: TEAMS_MEETINGS_NODE_COMMAND,
     displayName: "Microsoft Teams meetings",
     deniedCode: "TEAMS_MEETINGS_NODE_POLICY_DENIED",
     supportedModes: new Set(["agent", "bidi", "transcribe"]),
     normalizeUrl: (url) => TEAMS_MEETINGS_PLATFORM_ADAPTER.urls.validateAndNormalize(url),
+    useConfiguredSetupCommands: true,
     start: config.chrome,
   });
-  return {
-    ...base,
-    async handle(ctx: OpenClawPluginNodeInvokePolicyContext) {
-      const params =
-        ctx.params && typeof ctx.params === "object" && !Array.isArray(ctx.params)
-          ? (ctx.params as Record<string, unknown>)
-          : {};
-      if (ctx.command !== TEAMS_MEETINGS_NODE_COMMAND || params.action !== "setup") {
-        return await base.handle(ctx);
-      }
-      return await ctx.invokeNode({
-        params: {
-          action: "setup",
-          audioInputCommand: [...config.chrome.audioInputCommand],
-          audioOutputCommand: [...config.chrome.audioOutputCommand],
-          ...(config.chrome.bargeInInputCommand
-            ? { bargeInInputCommand: [...config.chrome.bargeInInputCommand] }
-            : {}),
-        },
-      });
-    },
-  };
 }

--- a/extensions/teams-meetings/src/runtime-probes.ts
+++ b/extensions/teams-meetings/src/runtime-probes.ts
@@ -1,6 +1,7 @@
-import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { TeamsMeetingsConfig, TeamsMeetingsMode, TeamsMeetingsTransport } from "./config.js";
 import type {
+  TeamsMeetingsChromeHealth,
   TeamsMeetingsJoinRequest,
   TeamsMeetingsJoinResult,
   TeamsMeetingsSession,
@@ -25,10 +26,6 @@ export type TeamsMeetingsProbeContext = {
   refreshCaptionHealth(session: TeamsMeetingsSession, timeoutMs: number): Promise<void>;
 };
 
-function talkBackMode(mode: TeamsMeetingsMode): boolean {
-  return mode === "agent" || mode === "bidi";
-}
-
 function resolveProbeTimeoutMs(input: number | undefined, fallback: number): number {
   if (input === undefined) {
     return Math.min(Math.max(fallback, 1), 120_000);
@@ -39,173 +36,27 @@ function resolveProbeTimeoutMs(input: number | undefined, fallback: number): num
   return Math.min(Math.trunc(input), 120_000);
 }
 
-export async function testTeamsMeetingSpeech(
-  context: TeamsMeetingsProbeContext,
-  request: TeamsMeetingsJoinRequest,
-) {
-  if (request.mode === "transcribe") {
-    throw new Error("test_speech requires mode: agent or bidi");
-  }
-  const mode = talkBackMode(request.mode ?? context.config.defaultMode)
-    ? (request.mode ?? context.config.defaultMode)
-    : "agent";
-  const resolved = {
-    url: request.url,
-    transport: request.transport ?? (context.config.chromeNode.node ? "chrome-node" : "chrome"),
-    mode,
-    agentId: context.resolveAgentId(request),
-  } satisfies {
-    url: string;
-    transport: TeamsMeetingsTransport;
-    mode: TeamsMeetingsMode;
-    agentId: string;
-  };
-  const beforeSessions = context.list();
-  const before = new Set(beforeSessions.map((session) => session.id));
-  const existing = beforeSessions.find((session) => context.isReusable(session, resolved));
-  const existingBaseline = {
-    outputBytes: existing?.chrome?.health?.lastOutputBytes ?? 0,
-    outputGeneration: existing?.chrome?.health?.outputGeneration ?? 0,
-  };
-  const result = await context.join({
-    ...request,
-    ...resolved,
-    message: request.message ?? "Say exactly: Microsoft Teams speech test complete.",
-  });
-  const baseline =
-    existing?.id === result.session.id ? existingBaseline : { outputBytes: 0, outputGeneration: 0 };
-  let health = result.session.chrome?.health;
-  const verified = () =>
-    (health?.lastOutputBytes ?? 0) > baseline.outputBytes &&
-    (health?.outputGeneration ?? 0) > baseline.outputGeneration &&
-    health?.verifiedOutputGeneration === health?.outputGeneration;
-  const shouldWait =
-    result.spoken === true &&
-    health?.manualActionRequired !== true &&
-    context.hasHealthHandle(result.session.id);
-  if (shouldWait && !verified()) {
-    const deadline =
-      Date.now() + resolveProbeTimeoutMs(request.timeoutMs, context.config.chrome.joinTimeoutMs);
-    while (Date.now() < deadline && !verified()) {
-      await sleep(100);
-      context.refreshHealth(result.session.id);
-      health = result.session.chrome?.health;
-    }
-  }
-  const speechOutputVerified = verified();
-  return {
-    createdSession: !before.has(result.session.id),
-    inCall: health?.inCall,
-    manualActionRequired: health?.manualActionRequired,
-    manualActionReason: health?.manualActionReason,
-    manualActionMessage: health?.manualActionMessage,
-    spoken: result.spoken ?? false,
-    speechOutputVerified,
-    speechOutputTimedOut: shouldWait && !speechOutputVerified,
-    speechReady: health?.speechReady,
-    speechBlockedReason: health?.speechBlockedReason,
-    speechBlockedMessage: health?.speechBlockedMessage,
-    audioOutputActive: health?.audioOutputActive,
-    lastOutputBytes: health?.lastOutputBytes,
-    outputLoopbackSignalBytes: health?.outputLoopbackSignalBytes,
-    lastOutputLoopbackAt: health?.lastOutputLoopbackAt,
-    lastOutputLoopbackCorrelation: health?.lastOutputLoopbackCorrelation,
-    lastOutputLoopbackRms: health?.lastOutputLoopbackRms,
-    lastOutputLoopbackPeak: health?.lastOutputLoopbackPeak,
-    outputGeneration: health?.outputGeneration,
-    verifiedOutputGeneration: health?.verifiedOutputGeneration,
-    session: result.session,
-  };
-}
+const probes = MeetingPlatformAdapter.createRuntimeProbes<
+  TeamsMeetingsConfig,
+  TeamsMeetingsMode,
+  TeamsMeetingsTransport,
+  TeamsMeetingsChromeHealth,
+  TeamsMeetingsSession,
+  TeamsMeetingsJoinRequest
+>({
+  defaultSpeechMessage: "Say exactly: Microsoft Teams speech test complete.",
+  invalidRequest: (message) => new Error(message),
+  resolveTimeoutMs: resolveProbeTimeoutMs,
+  shouldWaitForListening: (session) => Boolean(session.chrome?.launched),
+  talkBackMode: (mode) => mode === "agent" || mode === "bidi",
+});
 
-export async function testTeamsMeetingListening(
+export const testTeamsMeetingListening: (
   context: TeamsMeetingsProbeContext,
   request: TeamsMeetingsJoinRequest,
-) {
-  if (request.mode && request.mode !== "transcribe") {
-    throw new Error("test_listen requires mode: transcribe");
-  }
-  const resolved = {
-    url: request.url,
-    transport: request.transport ?? (context.config.chromeNode.node ? "chrome-node" : "chrome"),
-    mode: "transcribe" as const,
-    agentId: context.resolveAgentId(request),
-  };
-  const beforeSessions = context.list();
-  const before = new Set(beforeSessions.map((session) => session.id));
-  const existing = beforeSessions.find((session) => context.isReusable(session, resolved));
-  const start = {
-    lines: existing?.chrome?.health?.transcriptLines ?? 0,
-    at: existing?.chrome?.health?.lastCaptionAt,
-    text: existing?.chrome?.health?.lastCaptionText,
-  };
-  const result = await context.join({ ...request, ...resolved, message: undefined });
-  let health = result.session.chrome?.health;
-  const advanced = () =>
-    (health?.transcriptLines ?? 0) > (existing?.id === result.session.id ? start.lines : 0) ||
-    Boolean(health?.lastCaptionAt && health.lastCaptionAt !== start.at) ||
-    Boolean(health?.lastCaptionText && health.lastCaptionText !== start.text);
-  const shouldWait =
-    health?.manualActionRequired !== true && Boolean(result.session.chrome?.launched);
-  let listenVerified = advanced();
-  if (shouldWait && !listenVerified) {
-    const deadline =
-      Date.now() + resolveProbeTimeoutMs(request.timeoutMs, context.config.chrome.joinTimeoutMs);
-    while (Date.now() < deadline) {
-      const remainingMs = deadline - Date.now();
-      if (remainingMs <= 0) {
-        break;
-      }
-      let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
-      const deadlineReached = new Promise<boolean>((resolve) => {
-        deadlineTimer = setTimeout(() => resolve(false), remainingMs);
-      });
-      // Browser recovery receives this same remaining budget. The outer race
-      // keeps the probe wall-clock bounded while the inner deadline prevents
-      // the per-target browser act from lingering on its normal longer timeout.
-      const refreshed = await Promise.race([
-        context.refreshCaptionHealth(result.session, remainingMs).then(() => true),
-        deadlineReached,
-      ]).finally(() => {
-        if (deadlineTimer !== undefined) {
-          clearTimeout(deadlineTimer);
-        }
-      });
-      if (!refreshed) {
-        break;
-      }
-      health = result.session.chrome?.health;
-      if (Date.now() >= deadline) {
-        break;
-      }
-      if (advanced()) {
-        listenVerified = true;
-      }
-      if (listenVerified || health?.manualActionRequired) {
-        break;
-      }
-      const retryDelayMs = deadline - Date.now();
-      if (retryDelayMs <= 0) {
-        break;
-      }
-      await sleep(Math.min(250, retryDelayMs));
-    }
-  }
-  return {
-    createdSession: !before.has(result.session.id),
-    inCall: health?.inCall,
-    manualActionRequired: health?.manualActionRequired,
-    manualActionReason: health?.manualActionReason,
-    manualActionMessage: health?.manualActionMessage,
-    listenVerified,
-    listenTimedOut: shouldWait && !listenVerified && health?.manualActionRequired !== true,
-    captioning: health?.captioning,
-    captionsEnabledAttempted: health?.captionsEnabledAttempted,
-    transcriptLines: health?.transcriptLines,
-    lastCaptionAt: health?.lastCaptionAt,
-    lastCaptionSpeaker: health?.lastCaptionSpeaker,
-    lastCaptionText: health?.lastCaptionText,
-    recentTranscript: health?.recentTranscript,
-    session: result.session,
-  };
-}
+) => ReturnType<typeof probes.testListening> = probes.testListening;
+
+export const testTeamsMeetingSpeech: (
+  context: TeamsMeetingsProbeContext,
+  request: TeamsMeetingsJoinRequest,
+) => ReturnType<typeof probes.testSpeech> = probes.testSpeech;

--- a/extensions/zoom-meetings/src/node-host.ts
+++ b/extensions/zoom-meetings/src/node-host.ts
@@ -1,5 +1,4 @@
-import { spawnSync } from "node:child_process";
-import { createMeetingNodeHost } from "openclaw/plugin-sdk/meeting-runtime";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import {
   DEFAULT_ZOOM_MEETINGS_AUDIO_INPUT_COMMAND,
   DEFAULT_ZOOM_MEETINGS_AUDIO_OUTPUT_COMMAND,
@@ -11,67 +10,10 @@ import {
 import { ZOOM_MEETINGS_PLATFORM_ADAPTER } from "./transports/zoom-meetings-platform-adapter.js";
 import { ZOOM_MEETINGS_NODE_COMMAND } from "./transports/zoom-meetings-platform-constants.js";
 
-function commandExists(command: string, timeoutMs: number): boolean {
-  const result = spawnSync("/bin/sh", ["-lc", 'command -v "$1" >/dev/null 2>&1', "sh", command], {
-    encoding: "utf8",
-    timeout: timeoutMs,
-  });
-  return result.status === 0;
-}
-
-function assertTalkBackPrerequisites(
-  timeoutMs: number,
-  commands: readonly (readonly string[])[] = [
-    DEFAULT_ZOOM_MEETINGS_AUDIO_INPUT_COMMAND,
-    DEFAULT_ZOOM_MEETINGS_AUDIO_OUTPUT_COMMAND,
-  ],
-) {
-  if (process.platform !== "darwin") {
-    throw new Error("Zoom meeting talk-back with BlackHole 2ch is macOS-only");
-  }
-  const deadline = Date.now() + timeoutMs;
-  const remainingMs = () => Math.max(1, deadline - Date.now());
-  const result = spawnSync(ZOOM_MEETINGS_SYSTEM_PROFILER_COMMAND, ["SPAudioDataType"], {
-    encoding: "utf8",
-    timeout: remainingMs(),
-  });
-  const stderr =
-    result.stderr ??
-    (result.error
-      ? result.error instanceof Error
-        ? result.error.message
-        : String(result.error)
-      : "");
-  const output = `${result.stdout ?? ""}\n${stderr}`;
-  if (
-    (typeof result.status === "number" ? result.status : result.error ? 1 : 0) !== 0 ||
-    !outputMentionsBlackHole2ch(output)
-  ) {
-    throw new Error("BlackHole 2ch audio device not found on the node.");
-  }
-  for (const argv of commands) {
-    const command = argv[0];
-    if (!command || Date.now() >= deadline || !commandExists(command, remainingMs())) {
-      throw new Error(`Configured audio command not found on the node: ${command || "<empty>"}`);
-    }
-  }
-}
-
-function readCommand(params: Record<string, unknown>, name: string): string[] {
-  const value = params[name];
-  if (
-    !Array.isArray(value) ||
-    value.length === 0 ||
-    value.some((entry) => typeof entry !== "string")
-  ) {
-    throw new Error(`${name} must be a non-empty string array.`);
-  }
-  return value as string[];
-}
-
-const zoomMeetingsNodeHost = createMeetingNodeHost({
+export const handleZoomMeetingsNodeHostCommand = MeetingPlatformAdapter.createNodeHostHandler({
   commandName: ZOOM_MEETINGS_NODE_COMMAND,
   displayName: "Zoom meetings",
+  meetingLabel: "Zoom meeting",
   browserLabel: "Zoom meeting",
   bridgeIdPrefix: "zoom_meeting_node_",
   defaultAudioInputCommand: DEFAULT_ZOOM_MEETINGS_AUDIO_INPUT_COMMAND,
@@ -80,7 +22,9 @@ const zoomMeetingsNodeHost = createMeetingNodeHost({
   agentMode: "agent",
   normalizeUrl: (url) => ZOOM_MEETINGS_PLATFORM_ADAPTER.urls.validateAndNormalize(url),
   normalizeMeetingKey: (url) => ZOOM_MEETINGS_PLATFORM_ADAPTER.urls.normalizeForReuse(url),
-  assertAudioAvailable: assertTalkBackPrerequisites,
+  outputMentionsAudioDevice: outputMentionsBlackHole2ch,
+  sharePrerequisiteDeadline: true,
+  systemProfilerCommand: ZOOM_MEETINGS_SYSTEM_PROFILER_COMMAND,
   browser: {
     application: "Google Chrome",
     buildProfileArgs: (profile) => ["--args", `--profile-directory=${profile}`],
@@ -90,30 +34,3 @@ const zoomMeetingsNodeHost = createMeetingNodeHost({
     ],
   },
 });
-
-export async function handleZoomMeetingsNodeHostCommand(
-  paramsJSON?: string | null,
-): Promise<string> {
-  if (paramsJSON) {
-    let raw: unknown;
-    try {
-      raw = JSON.parse(paramsJSON) as unknown;
-    } catch {
-      throw new Error("Zoom meetings node host received malformed params JSON.");
-    }
-    const params =
-      raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
-    if (params.action === "setup") {
-      const commands = [
-        readCommand(params, "audioInputCommand"),
-        readCommand(params, "audioOutputCommand"),
-      ];
-      if (params.bargeInInputCommand !== undefined) {
-        commands.push(readCommand(params, "bargeInInputCommand"));
-      }
-      assertTalkBackPrerequisites(10_000, commands);
-      return JSON.stringify({ ok: true });
-    }
-  }
-  return await zoomMeetingsNodeHost.handleCommand(paramsJSON);
-}

--- a/extensions/zoom-meetings/src/node-invoke-policy.ts
+++ b/extensions/zoom-meetings/src/node-invoke-policy.ts
@@ -1,43 +1,16 @@
 import { createMeetingBrowserNodeInvokePolicy } from "openclaw/plugin-sdk/meeting-runtime";
-import type {
-  OpenClawPluginNodeInvokePolicy,
-  OpenClawPluginNodeInvokePolicyContext,
-} from "openclaw/plugin-sdk/plugin-entry";
 import type { ZoomMeetingsConfig } from "./config.js";
 import { ZOOM_MEETINGS_PLATFORM_ADAPTER } from "./transports/zoom-meetings-platform-adapter.js";
 import { ZOOM_MEETINGS_NODE_COMMAND } from "./transports/zoom-meetings-platform-constants.js";
 
-export function createZoomMeetingsNodeInvokePolicy(
-  config: ZoomMeetingsConfig,
-): OpenClawPluginNodeInvokePolicy {
-  const base = createMeetingBrowserNodeInvokePolicy({
+export function createZoomMeetingsNodeInvokePolicy(config: ZoomMeetingsConfig) {
+  return createMeetingBrowserNodeInvokePolicy({
     commandName: ZOOM_MEETINGS_NODE_COMMAND,
     displayName: "Zoom meetings",
     deniedCode: "ZOOM_MEETINGS_NODE_POLICY_DENIED",
     supportedModes: new Set(["agent", "bidi", "transcribe"]),
     normalizeUrl: (url) => ZOOM_MEETINGS_PLATFORM_ADAPTER.urls.validateAndNormalize(url),
+    useConfiguredSetupCommands: true,
     start: config.chrome,
   });
-  return {
-    ...base,
-    async handle(ctx: OpenClawPluginNodeInvokePolicyContext) {
-      const params =
-        ctx.params && typeof ctx.params === "object" && !Array.isArray(ctx.params)
-          ? (ctx.params as Record<string, unknown>)
-          : {};
-      if (ctx.command !== ZOOM_MEETINGS_NODE_COMMAND || params.action !== "setup") {
-        return await base.handle(ctx);
-      }
-      return await ctx.invokeNode({
-        params: {
-          action: "setup",
-          audioInputCommand: [...config.chrome.audioInputCommand],
-          audioOutputCommand: [...config.chrome.audioOutputCommand],
-          ...(config.chrome.bargeInInputCommand
-            ? { bargeInInputCommand: [...config.chrome.bargeInInputCommand] }
-            : {}),
-        },
-      });
-    },
-  };
 }

--- a/extensions/zoom-meetings/src/runtime-probes.ts
+++ b/extensions/zoom-meetings/src/runtime-probes.ts
@@ -1,8 +1,9 @@
-import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { ZoomMeetingsConfig, ZoomMeetingsMode, ZoomMeetingsTransport } from "./config.js";
-import { zoomMeetingsInvalidRequest as invalidRequest } from "./errors.js";
+import { zoomMeetingsInvalidRequest } from "./errors.js";
 import { resolveZoomMeetingsProbeTimeoutMs } from "./probe-timeout.js";
 import type {
+  ZoomMeetingsChromeHealth,
   ZoomMeetingsJoinRequest,
   ZoomMeetingsJoinResult,
   ZoomMeetingsSession,
@@ -27,179 +28,27 @@ export type ZoomMeetingsProbeContext = {
   refreshCaptionHealth(session: ZoomMeetingsSession, timeoutMs: number): Promise<void>;
 };
 
-function talkBackMode(mode: ZoomMeetingsMode): boolean {
-  return mode === "agent" || mode === "bidi";
-}
+const probes = MeetingPlatformAdapter.createRuntimeProbes<
+  ZoomMeetingsConfig,
+  ZoomMeetingsMode,
+  ZoomMeetingsTransport,
+  ZoomMeetingsChromeHealth,
+  ZoomMeetingsSession,
+  ZoomMeetingsJoinRequest
+>({
+  defaultSpeechMessage: "Say exactly: Zoom speech test complete.",
+  invalidRequest: zoomMeetingsInvalidRequest,
+  resolveTimeoutMs: resolveZoomMeetingsProbeTimeoutMs,
+  shouldWaitForListening: (session) => Boolean(session.chrome?.browserTab?.targetId),
+  talkBackMode: (mode) => mode === "agent" || mode === "bidi",
+});
 
-export async function testZoomMeetingSpeech(
+export const testZoomMeetingListening: (
   context: ZoomMeetingsProbeContext,
   request: ZoomMeetingsJoinRequest,
-) {
-  if (request.mode === "transcribe") {
-    throw invalidRequest("test_speech requires mode: agent or bidi");
-  }
-  const mode = talkBackMode(request.mode ?? context.config.defaultMode)
-    ? (request.mode ?? context.config.defaultMode)
-    : "agent";
-  const resolved = {
-    url: request.url,
-    transport: request.transport ?? (context.config.chromeNode.node ? "chrome-node" : "chrome"),
-    mode,
-    agentId: context.resolveAgentId(request),
-  } satisfies {
-    url: string;
-    transport: ZoomMeetingsTransport;
-    mode: ZoomMeetingsMode;
-    agentId: string;
-  };
-  const beforeSessions = context.list();
-  const before = new Set(beforeSessions.map((session) => session.id));
-  const existing = beforeSessions.find((session) => context.isReusable(session, resolved));
-  const existingBaseline = {
-    outputBytes: existing?.chrome?.health?.lastOutputBytes ?? 0,
-    outputGeneration: existing?.chrome?.health?.outputGeneration ?? 0,
-  };
-  const result = await context.join({
-    ...request,
-    ...resolved,
-    message: request.message ?? "Say exactly: Zoom speech test complete.",
-  });
-  const baseline =
-    existing?.id === result.session.id ? existingBaseline : { outputBytes: 0, outputGeneration: 0 };
-  let health = result.session.chrome?.health;
-  const verified = () =>
-    (health?.lastOutputBytes ?? 0) > baseline.outputBytes &&
-    (health?.outputGeneration ?? 0) > baseline.outputGeneration &&
-    health?.verifiedOutputGeneration === health?.outputGeneration;
-  const shouldWait =
-    result.spoken === true &&
-    health?.manualActionRequired !== true &&
-    context.hasHealthHandle(result.session.id);
-  if (shouldWait && !verified()) {
-    const deadline =
-      Date.now() +
-      resolveZoomMeetingsProbeTimeoutMs(request.timeoutMs, context.config.chrome.joinTimeoutMs);
-    while (Date.now() < deadline && !verified()) {
-      await sleep(100);
-      context.refreshHealth(result.session.id);
-      health = result.session.chrome?.health;
-    }
-  }
-  const speechOutputVerified = verified();
-  return {
-    createdSession: !before.has(result.session.id),
-    inCall: health?.inCall,
-    manualActionRequired: health?.manualActionRequired,
-    manualActionReason: health?.manualActionReason,
-    manualActionMessage: health?.manualActionMessage,
-    spoken: result.spoken ?? false,
-    speechOutputVerified,
-    speechOutputTimedOut: shouldWait && !speechOutputVerified,
-    speechReady: health?.speechReady,
-    speechBlockedReason: health?.speechBlockedReason,
-    speechBlockedMessage: health?.speechBlockedMessage,
-    audioOutputActive: health?.audioOutputActive,
-    lastOutputBytes: health?.lastOutputBytes,
-    outputLoopbackSignalBytes: health?.outputLoopbackSignalBytes,
-    lastOutputLoopbackAt: health?.lastOutputLoopbackAt,
-    lastOutputLoopbackCorrelation: health?.lastOutputLoopbackCorrelation,
-    lastOutputLoopbackRms: health?.lastOutputLoopbackRms,
-    lastOutputLoopbackPeak: health?.lastOutputLoopbackPeak,
-    outputGeneration: health?.outputGeneration,
-    verifiedOutputGeneration: health?.verifiedOutputGeneration,
-    session: result.session,
-  };
-}
+) => ReturnType<typeof probes.testListening> = probes.testListening;
 
-export async function testZoomMeetingListening(
+export const testZoomMeetingSpeech: (
   context: ZoomMeetingsProbeContext,
   request: ZoomMeetingsJoinRequest,
-) {
-  if (request.mode && request.mode !== "transcribe") {
-    throw invalidRequest("test_listen requires mode: transcribe");
-  }
-  const resolved = {
-    url: request.url,
-    transport: request.transport ?? (context.config.chromeNode.node ? "chrome-node" : "chrome"),
-    mode: "transcribe" as const,
-    agentId: context.resolveAgentId(request),
-  };
-  const beforeSessions = context.list();
-  const before = new Set(beforeSessions.map((session) => session.id));
-  const existing = beforeSessions.find((session) => context.isReusable(session, resolved));
-  const start = {
-    lines: existing?.chrome?.health?.transcriptLines ?? 0,
-    at: existing?.chrome?.health?.lastCaptionAt,
-    text: existing?.chrome?.health?.lastCaptionText,
-  };
-  const result = await context.join({ ...request, ...resolved, message: undefined });
-  let health = result.session.chrome?.health;
-  const advanced = () =>
-    (health?.transcriptLines ?? 0) > (existing?.id === result.session.id ? start.lines : 0) ||
-    Boolean(health?.lastCaptionAt && health.lastCaptionAt !== start.at) ||
-    Boolean(health?.lastCaptionText && health.lastCaptionText !== start.text);
-  const shouldWait =
-    health?.manualActionRequired !== true && Boolean(result.session.chrome?.browserTab?.targetId);
-  let listenVerified = advanced();
-  if (shouldWait && !listenVerified) {
-    const deadline =
-      Date.now() +
-      resolveZoomMeetingsProbeTimeoutMs(request.timeoutMs, context.config.chrome.joinTimeoutMs);
-    while (Date.now() < deadline) {
-      const remainingMs = deadline - Date.now();
-      if (remainingMs <= 0) {
-        break;
-      }
-      let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
-      const deadlineReached = new Promise<boolean>((resolve) => {
-        deadlineTimer = setTimeout(() => resolve(false), remainingMs);
-      });
-      // Browser recovery receives this same remaining budget. The outer race
-      // keeps the probe wall-clock bounded while the inner deadline prevents
-      // the per-target browser act from lingering on its normal longer timeout.
-      const refreshed = await Promise.race([
-        context.refreshCaptionHealth(result.session, remainingMs).then(() => true),
-        deadlineReached,
-      ]).finally(() => {
-        if (deadlineTimer !== undefined) {
-          clearTimeout(deadlineTimer);
-        }
-      });
-      if (!refreshed) {
-        break;
-      }
-      health = result.session.chrome?.health;
-      if (Date.now() >= deadline) {
-        break;
-      }
-      if (advanced()) {
-        listenVerified = true;
-      }
-      if (listenVerified || health?.manualActionRequired) {
-        break;
-      }
-      const retryDelayMs = deadline - Date.now();
-      if (retryDelayMs <= 0) {
-        break;
-      }
-      await sleep(Math.min(250, retryDelayMs));
-    }
-  }
-  return {
-    createdSession: !before.has(result.session.id),
-    inCall: health?.inCall,
-    manualActionRequired: health?.manualActionRequired,
-    manualActionReason: health?.manualActionReason,
-    manualActionMessage: health?.manualActionMessage,
-    listenVerified,
-    listenTimedOut: shouldWait && !listenVerified && health?.manualActionRequired !== true,
-    captioning: health?.captioning,
-    captionsEnabledAttempted: health?.captionsEnabledAttempted,
-    transcriptLines: health?.transcriptLines,
-    lastCaptionAt: health?.lastCaptionAt,
-    lastCaptionSpeaker: health?.lastCaptionSpeaker,
-    lastCaptionText: health?.lastCaptionText,
-    recentTranscript: health?.recentTranscript,
-    session: result.session,
-  };
-}
+) => ReturnType<typeof probes.testSpeech> = probes.testSpeech;

--- a/src/meeting-bot/node-host.ts
+++ b/src/meeting-bot/node-host.ts
@@ -48,6 +48,13 @@ export type MeetingNodeHostOptions = {
   };
 };
 
+type MeetingConfiguredNodeHostOptions = Omit<MeetingNodeHostOptions, "assertAudioAvailable"> & {
+  meetingLabel: string;
+  outputMentionsAudioDevice(output: string): boolean;
+  sharePrerequisiteDeadline: boolean;
+  systemProfilerCommand: string;
+};
+
 function readStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -498,5 +505,94 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
       }
       return JSON.stringify(result);
     },
+  };
+}
+
+function readSetupCommand(params: Record<string, unknown>, name: string): string[] {
+  const value = params[name];
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
+    throw new Error(`${name} must be a non-empty string array.`);
+  }
+  return value as string[];
+}
+
+export function createMeetingConfiguredNodeHost(options: MeetingConfiguredNodeHostOptions) {
+  const commandExists = (command: string, timeoutMs: number): boolean => {
+    const result = spawnSync("/bin/sh", ["-lc", 'command -v "$1" >/dev/null 2>&1', "sh", command], {
+      encoding: "utf8",
+      timeout: timeoutMs,
+    });
+    return result.status === 0;
+  };
+  const assertAudioAvailable = (
+    timeoutMs: number,
+    commands: readonly (readonly string[])[] = [
+      options.defaultAudioInputCommand,
+      options.defaultAudioOutputCommand,
+    ],
+  ) => {
+    if (process.platform !== "darwin") {
+      throw new Error(`${options.meetingLabel} talk-back with BlackHole 2ch is macOS-only`);
+    }
+    const deadline = Date.now() + timeoutMs;
+    const commandTimeout = () =>
+      options.sharePrerequisiteDeadline ? Math.max(1, deadline - Date.now()) : timeoutMs;
+    const result = spawnSync(options.systemProfilerCommand, ["SPAudioDataType"], {
+      encoding: "utf8",
+      timeout: commandTimeout(),
+    });
+    const stderr =
+      result.stderr ??
+      (result.error
+        ? result.error instanceof Error
+          ? result.error.message
+          : String(result.error)
+        : "");
+    const output = `${result.stdout ?? ""}\n${stderr}`;
+    if (
+      (typeof result.status === "number" ? result.status : result.error ? 1 : 0) !== 0 ||
+      !options.outputMentionsAudioDevice(output)
+    ) {
+      throw new Error("BlackHole 2ch audio device not found on the node.");
+    }
+    for (const argv of commands) {
+      const command = argv[0];
+      if (
+        !command ||
+        (options.sharePrerequisiteDeadline && Date.now() >= deadline) ||
+        !commandExists(command, commandTimeout())
+      ) {
+        throw new Error(`Configured audio command not found on the node: ${command || "<empty>"}`);
+      }
+    }
+  };
+  const host = createMeetingNodeHost({ ...options, assertAudioAvailable });
+
+  return async (paramsJSON?: string | null): Promise<string> => {
+    if (paramsJSON) {
+      let raw: unknown;
+      try {
+        raw = JSON.parse(paramsJSON) as unknown;
+      } catch {
+        throw new Error(`${options.displayName} node host received malformed params JSON.`);
+      }
+      const params = asRecord(raw);
+      if (params.action === "setup") {
+        const commands = [
+          readSetupCommand(params, "audioInputCommand"),
+          readSetupCommand(params, "audioOutputCommand"),
+        ];
+        if (params.bargeInInputCommand !== undefined) {
+          commands.push(readSetupCommand(params, "bargeInInputCommand"));
+        }
+        assertAudioAvailable(10_000, commands);
+        return JSON.stringify({ ok: true });
+      }
+    }
+    return await host.handleCommand(paramsJSON);
   };
 }

--- a/src/meeting-bot/node-invoke-policy.ts
+++ b/src/meeting-bot/node-invoke-policy.ts
@@ -10,6 +10,7 @@ export type MeetingBrowserNodeStartConfig = {
   joinTimeoutMs: number;
   audioInputCommand?: string[];
   audioOutputCommand?: string[];
+  bargeInInputCommand?: string[];
   audioBridgeCommand?: string[];
   audioBridgeHealthCommand?: string[];
 };
@@ -20,6 +21,7 @@ export type MeetingBrowserNodePolicyOptions = {
   deniedCode: string;
   supportedModes: ReadonlySet<string>;
   normalizeUrl(input: unknown): string;
+  useConfiguredSetupCommands?: boolean;
   start: MeetingBrowserNodeStartConfig;
 };
 
@@ -230,6 +232,20 @@ export function createMeetingBrowserNodeInvokePolicy(
       }
       const params = asRecord(ctx.params);
       const action = readString(params.action);
+      if (action === "setup" && options.useConfiguredSetupCommands) {
+        const setupParams: Record<string, unknown> = { action };
+        for (const key of [
+          "audioInputCommand",
+          "audioOutputCommand",
+          "bargeInInputCommand",
+        ] as const) {
+          const command = copyCommand(options.start[key]);
+          if (command) {
+            setupParams[key] = command;
+          }
+        }
+        return await ctx.invokeNode({ params: setupParams });
+      }
       const decision =
         action === "start"
           ? buildStartParams(params, options)

--- a/src/meeting-bot/platform-adapter.ts
+++ b/src/meeting-bot/platform-adapter.ts
@@ -1,5 +1,6 @@
 import { formatErrorMessage } from "../infra/errors.js";
 import { createMeetingChromeTransport } from "./chrome-transport.js";
+import { createMeetingConfiguredNodeHost } from "./node-host.js";
 import type {
   MeetingBrowserAdapter,
   MeetingBrowserLeaveStep,
@@ -7,6 +8,7 @@ import type {
   MeetingPlatformAdapter as MeetingPlatformAdapterContract,
   MeetingPlatformRuntimeMetadata,
 } from "./platform-adapter-contract.js";
+import { createMeetingRuntimeProbes } from "./runtime-probes.js";
 import type { MeetingBrowserHealth, MeetingTranscriptSnapshot } from "./session-types.js";
 import { createMeetingStatusCallSource } from "./status-call-source.js";
 import { createMeetingStatusPreludeSource } from "./status-prejoin-source.js";
@@ -358,6 +360,8 @@ function createMeetingPlatformAdapter<
 export const MeetingPlatformAdapter = {
   create: createMeetingPlatformAdapter,
   createChromeTransport: createMeetingChromeTransport,
+  createRuntimeProbes: createMeetingRuntimeProbes,
+  createNodeHostHandler: createMeetingConfiguredNodeHost,
   createStatusCallSource: createMeetingStatusCallSource,
   createStatusPreludeSource: createMeetingStatusPreludeSource,
 };

--- a/src/meeting-bot/runtime-probes.test.ts
+++ b/src/meeting-bot/runtime-probes.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMeetingRuntimeProbes } from "./runtime-probes.js";
+import type { MeetingBrowserHealth } from "./session-types.js";
+
+type Mode = "agent" | "bidi" | "transcribe";
+type Transport = "chrome" | "chrome-node";
+type Health = MeetingBrowserHealth & {
+  transcriptLines?: number;
+  lastCaptionAt?: string;
+  lastCaptionText?: string;
+};
+type Session = {
+  id: string;
+  chrome?: {
+    launched: boolean;
+    browserTab?: { targetId?: string };
+    health?: Health;
+  };
+};
+type Request = {
+  url: string;
+  mode?: Mode;
+  transport?: Transport;
+  timeoutMs?: number;
+  message?: string;
+  agentId?: string;
+};
+type Config = {
+  defaultMode: Mode;
+  chrome: { joinTimeoutMs: number };
+  chromeNode: { node?: string };
+};
+
+const cases = [
+  {
+    name: "Teams",
+    invalidRequestName: "Error",
+    session: { id: "teams", chrome: { launched: true } } satisfies Session,
+    shouldWaitForListening: (session: Session) => Boolean(session.chrome?.launched),
+  },
+  {
+    name: "Zoom",
+    invalidRequestName: "ZoomInvalidRequest",
+    session: { id: "zoom", chrome: { launched: true } } satisfies Session,
+    shouldWaitForListening: (session: Session) => Boolean(session.chrome?.browserTab?.targetId),
+  },
+] as const;
+
+describe.each(cases)("$name meeting runtime probe parity", (testCase) => {
+  const createProbes = () =>
+    createMeetingRuntimeProbes<Config, Mode, Transport, Health, Session, Request>({
+      defaultSpeechMessage: `Say exactly: ${testCase.name} speech test complete.`,
+      invalidRequest: (message) => {
+        const error = new Error(message);
+        error.name = testCase.invalidRequestName;
+        return error;
+      },
+      resolveTimeoutMs: () => 5,
+      shouldWaitForListening: testCase.shouldWaitForListening,
+      talkBackMode: (mode) => mode === "agent" || mode === "bidi",
+    });
+
+  it("preserves the platform invalid-request contract", async () => {
+    const probes = createProbes();
+    await expect(
+      probes.testSpeech(
+        {
+          config: { defaultMode: "agent", chrome: { joinTimeoutMs: 5 }, chromeNode: {} },
+          resolveAgentId: () => "main",
+          list: () => [],
+          join: vi.fn(),
+          isReusable: () => false,
+          hasHealthHandle: () => false,
+          refreshHealth: vi.fn(),
+          refreshCaptionHealth: vi.fn(),
+        },
+        { url: "https://example.test/meeting", mode: "transcribe" },
+      ),
+    ).rejects.toMatchObject({
+      name: testCase.invalidRequestName,
+      message: "test_speech requires mode: agent or bidi",
+    });
+  });
+
+  it("preserves the platform listening wait ownership", async () => {
+    const probes = createProbes();
+    const refreshCaptionHealth = vi.fn(async () => undefined);
+    const context = {
+      config: { defaultMode: "agent" as const, chrome: { joinTimeoutMs: 5 }, chromeNode: {} },
+      resolveAgentId: () => "main",
+      list: () => [],
+      join: vi.fn(async () => ({ session: testCase.session })),
+      isReusable: () => false,
+      hasHealthHandle: () => false,
+      refreshHealth: vi.fn(),
+      refreshCaptionHealth,
+    };
+
+    await probes.testListening(context, {
+      url: "https://example.test/meeting",
+      mode: "transcribe",
+      timeoutMs: 5,
+    });
+
+    if (testCase.name === "Teams") {
+      expect(refreshCaptionHealth).toHaveBeenCalled();
+    } else {
+      expect(refreshCaptionHealth).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/meeting-bot/runtime-probes.ts
+++ b/src/meeting-bot/runtime-probes.ts
@@ -1,0 +1,255 @@
+import { sleep } from "../utils/sleep.js";
+import type { MeetingBrowserHealth } from "./session-types.js";
+
+type MeetingProbeHealth = MeetingBrowserHealth & {
+  audioOutputActive?: boolean;
+  captioning?: boolean;
+  captionsEnabledAttempted?: boolean;
+  lastCaptionAt?: string;
+  lastCaptionSpeaker?: string;
+  lastCaptionText?: string;
+  lastOutputBytes?: number;
+  lastOutputLoopbackAt?: string;
+  lastOutputLoopbackCorrelation?: number;
+  lastOutputLoopbackPeak?: number;
+  lastOutputLoopbackRms?: number;
+  outputGeneration?: number;
+  outputLoopbackSignalBytes?: number;
+  recentTranscript?: Array<{ at?: string; speaker?: string; text: string }>;
+  transcriptLines?: number;
+  verifiedOutputGeneration?: number;
+};
+
+type MeetingProbeSession<Health extends MeetingProbeHealth> = {
+  id: string;
+  chrome?: {
+    launched: boolean;
+    browserTab?: { targetId?: string };
+    health?: Health;
+  };
+};
+
+type MeetingProbeRequest<Mode extends string, Transport extends string> = {
+  agentId?: string;
+  message?: string;
+  mode?: Mode;
+  timeoutMs?: number;
+  transport?: Transport;
+  url: string;
+};
+
+type MeetingProbeConfig<Mode extends string> = {
+  defaultMode: Mode;
+  chrome: { joinTimeoutMs: number };
+  chromeNode: { node?: string };
+};
+
+type MeetingProbeContext<
+  Config extends MeetingProbeConfig<Mode>,
+  Mode extends string,
+  Transport extends string,
+  Health extends MeetingProbeHealth,
+  Session extends MeetingProbeSession<Health>,
+  Request extends MeetingProbeRequest<Mode, Transport>,
+> = {
+  config: Config;
+  resolveAgentId(request: Request): string;
+  list(): Session[];
+  join(request: Request): Promise<{ session: Session; spoken?: boolean }>;
+  isReusable(
+    session: Session,
+    resolved: { url: string; transport: Transport; mode: Mode; agentId: string },
+  ): boolean;
+  hasHealthHandle(sessionId: string): boolean;
+  refreshHealth(sessionId: string): void;
+  refreshCaptionHealth(session: Session, timeoutMs: number): Promise<void>;
+};
+
+type MeetingRuntimeProbeOptions<
+  Mode extends string,
+  Health extends MeetingProbeHealth,
+  Session extends MeetingProbeSession<Health>,
+> = {
+  defaultSpeechMessage: string;
+  invalidRequest(message: string): Error;
+  resolveTimeoutMs(input: number | undefined, fallback: number): number;
+  shouldWaitForListening(session: Session): boolean;
+  talkBackMode(mode: Mode): boolean;
+};
+
+export function createMeetingRuntimeProbes<
+  Config extends MeetingProbeConfig<Mode>,
+  Mode extends string,
+  Transport extends string,
+  Health extends MeetingProbeHealth,
+  Session extends MeetingProbeSession<Health>,
+  Request extends MeetingProbeRequest<Mode, Transport>,
+>(options: MeetingRuntimeProbeOptions<Mode, Health, Session>) {
+  type Context = MeetingProbeContext<Config, Mode, Transport, Health, Session, Request>;
+
+  const testSpeech = async (context: Context, request: Request) => {
+    if (request.mode === "transcribe") {
+      throw options.invalidRequest("test_speech requires mode: agent or bidi");
+    }
+    const requestedMode = request.mode ?? context.config.defaultMode;
+    const mode = options.talkBackMode(requestedMode) ? requestedMode : ("agent" as Mode);
+    const resolved = {
+      url: request.url,
+      transport:
+        request.transport ??
+        (context.config.chromeNode.node ? ("chrome-node" as Transport) : ("chrome" as Transport)),
+      mode,
+      agentId: context.resolveAgentId(request),
+    };
+    const beforeSessions = context.list();
+    const before = new Set(beforeSessions.map((session) => session.id));
+    const existing = beforeSessions.find((session) => context.isReusable(session, resolved));
+    const existingBaseline = {
+      outputBytes: existing?.chrome?.health?.lastOutputBytes ?? 0,
+      outputGeneration: existing?.chrome?.health?.outputGeneration ?? 0,
+    };
+    const result = await context.join({
+      ...request,
+      ...resolved,
+      message: request.message ?? options.defaultSpeechMessage,
+    });
+    const baseline =
+      existing?.id === result.session.id
+        ? existingBaseline
+        : { outputBytes: 0, outputGeneration: 0 };
+    let health = result.session.chrome?.health;
+    const verified = () =>
+      (health?.lastOutputBytes ?? 0) > baseline.outputBytes &&
+      (health?.outputGeneration ?? 0) > baseline.outputGeneration &&
+      health?.verifiedOutputGeneration === health?.outputGeneration;
+    const shouldWait =
+      result.spoken === true &&
+      health?.manualActionRequired !== true &&
+      context.hasHealthHandle(result.session.id);
+    if (shouldWait && !verified()) {
+      const deadline =
+        Date.now() +
+        options.resolveTimeoutMs(request.timeoutMs, context.config.chrome.joinTimeoutMs);
+      while (Date.now() < deadline && !verified()) {
+        await sleep(100);
+        context.refreshHealth(result.session.id);
+        health = result.session.chrome?.health;
+      }
+    }
+    const speechOutputVerified = verified();
+    return {
+      createdSession: !before.has(result.session.id),
+      inCall: health?.inCall,
+      manualActionRequired: health?.manualActionRequired,
+      manualActionReason: health?.manualActionReason,
+      manualActionMessage: health?.manualActionMessage,
+      spoken: result.spoken ?? false,
+      speechOutputVerified,
+      speechOutputTimedOut: shouldWait && !speechOutputVerified,
+      speechReady: health?.speechReady,
+      speechBlockedReason: health?.speechBlockedReason,
+      speechBlockedMessage: health?.speechBlockedMessage,
+      audioOutputActive: health?.audioOutputActive,
+      lastOutputBytes: health?.lastOutputBytes,
+      outputLoopbackSignalBytes: health?.outputLoopbackSignalBytes,
+      lastOutputLoopbackAt: health?.lastOutputLoopbackAt,
+      lastOutputLoopbackCorrelation: health?.lastOutputLoopbackCorrelation,
+      lastOutputLoopbackRms: health?.lastOutputLoopbackRms,
+      lastOutputLoopbackPeak: health?.lastOutputLoopbackPeak,
+      outputGeneration: health?.outputGeneration,
+      verifiedOutputGeneration: health?.verifiedOutputGeneration,
+      session: result.session,
+    };
+  };
+
+  const testListening = async (context: Context, request: Request) => {
+    if (request.mode && request.mode !== "transcribe") {
+      throw options.invalidRequest("test_listen requires mode: transcribe");
+    }
+    const resolved = {
+      url: request.url,
+      transport:
+        request.transport ??
+        (context.config.chromeNode.node ? ("chrome-node" as Transport) : ("chrome" as Transport)),
+      mode: "transcribe" as Mode,
+      agentId: context.resolveAgentId(request),
+    };
+    const beforeSessions = context.list();
+    const before = new Set(beforeSessions.map((session) => session.id));
+    const existing = beforeSessions.find((session) => context.isReusable(session, resolved));
+    const start = {
+      lines: existing?.chrome?.health?.transcriptLines ?? 0,
+      at: existing?.chrome?.health?.lastCaptionAt,
+      text: existing?.chrome?.health?.lastCaptionText,
+    };
+    const result = await context.join({ ...request, ...resolved, message: undefined });
+    let health = result.session.chrome?.health;
+    const advanced = () =>
+      (health?.transcriptLines ?? 0) > (existing?.id === result.session.id ? start.lines : 0) ||
+      Boolean(health?.lastCaptionAt && health.lastCaptionAt !== start.at) ||
+      Boolean(health?.lastCaptionText && health.lastCaptionText !== start.text);
+    const shouldWait =
+      health?.manualActionRequired !== true && options.shouldWaitForListening(result.session);
+    let listenVerified = advanced();
+    if (shouldWait && !listenVerified) {
+      const deadline =
+        Date.now() +
+        options.resolveTimeoutMs(request.timeoutMs, context.config.chrome.joinTimeoutMs);
+      while (Date.now() < deadline) {
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          break;
+        }
+        let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+        const deadlineReached = new Promise<boolean>((resolve) => {
+          deadlineTimer = setTimeout(() => resolve(false), remainingMs);
+        });
+        const refreshed = await Promise.race([
+          context.refreshCaptionHealth(result.session, remainingMs).then(() => true),
+          deadlineReached,
+        ]).finally(() => {
+          if (deadlineTimer !== undefined) {
+            clearTimeout(deadlineTimer);
+          }
+        });
+        if (!refreshed) {
+          break;
+        }
+        health = result.session.chrome?.health;
+        if (Date.now() >= deadline) {
+          break;
+        }
+        if (advanced()) {
+          listenVerified = true;
+        }
+        if (listenVerified || health?.manualActionRequired) {
+          break;
+        }
+        const retryDelayMs = deadline - Date.now();
+        if (retryDelayMs <= 0) {
+          break;
+        }
+        await sleep(Math.min(250, retryDelayMs));
+      }
+    }
+    return {
+      createdSession: !before.has(result.session.id),
+      inCall: health?.inCall,
+      manualActionRequired: health?.manualActionRequired,
+      manualActionReason: health?.manualActionReason,
+      manualActionMessage: health?.manualActionMessage,
+      listenVerified,
+      listenTimedOut: shouldWait && !listenVerified && health?.manualActionRequired !== true,
+      captioning: health?.captioning,
+      captionsEnabledAttempted: health?.captionsEnabledAttempted,
+      transcriptLines: health?.transcriptLines,
+      lastCaptionAt: health?.lastCaptionAt,
+      lastCaptionSpeaker: health?.lastCaptionSpeaker,
+      lastCaptionText: health?.lastCaptionText,
+      recentTranscript: health?.recentTranscript,
+      session: result.session,
+    };
+  };
+
+  return { testListening, testSpeech };
+}


### PR DESCRIPTION
## What Problem This Solves

The Teams and Zoom meeting plugins maintained duplicate runtime speech/listening probes, node-host prerequisite/setup wrappers, and node invoke-policy wrappers. Shared fixes could drift, while the small platform differences were buried inside otherwise identical control flow.

## Why This Change Was Made

This maintainer-directed refactor moves the shared probe and node-wrapper mechanics into `src/meeting-bot`, exposed through the existing `MeetingPlatformAdapter` runtime companion and the existing node-policy facade. Typed hooks retain each platform contract: invalid-request errors, probe timeouts, listening ownership, prerequisite deadline semantics, and trusted setup-command substitution.

Google Meet remains excluded.

## User Impact

No user-visible behavior changes. Teams and Zoom keep their current speech/listening verification, timeout, node prerequisite, setup, and invoke-policy behavior.

## Evidence

- Focused shared + unchanged Teams/Zoom probe/node suites: 9 files, 20 tests passed.
- New table-driven Teams/Zoom runtime-probe parity: 4 tests passed.
- `node scripts/check-changed.mjs`: all selected core/extension typecheck, lint, Plugin SDK, import-cycle, schema, and boundary gates passed on Blacksmith Testbox `tbx_01ky724bb667sd5nn0tngh5fj4` (Actions run 29991886794).
- `autoreview --mode uncommitted` and `autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.
- Net non-test LOC: -147. No changelog change.

AI-assisted; the trusted setup-command boundary and every platform delta were reviewed against unchanged tests.
