### PR TITLE
test(gateway): consolidate reload handler fixtures

### DIFF
--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -70,6 +70,13 @@ import { createTerminalLaunchPolicy } from "./terminal/launch.js";
 
 type ReloadHandlerParams = Parameters<typeof createGatewayReloadHandlersImpl>[0];
 type ManagedReloaderParams = Parameters<typeof startManagedGatewayConfigReloaderImpl>[0];
+type ConfigWriteListener = (event: ConfigWriteNotification) => void;
+type ConfigWriteListenerRef = { current: ConfigWriteListener | null };
+type ManagedReloaderTestParams = Pick<
+  ManagedReloaderParams,
+  "initialConfig" | "readSnapshot" | "subscribeToWrites"
+> &
+  Partial<ManagedReloaderParams>;
 
 function waitForFast<T>(
   callback: () => T | Promise<T>,
@@ -89,13 +96,28 @@ const restartTesting = {
 };
 
 function createGatewayReloadHandlers(
-  params: Omit<ReloadHandlerParams, "cronReconciliation" | "requestRecoveryRestart"> & {
-    cronReconciliation?: ReloadHandlerParams["cronReconciliation"];
+  params: Partial<Omit<ReloadHandlerParams, "requestRecoveryRestart">> & {
     requestRecoveryRestart?: NonNullable<ReloadHandlerParams["requestRecoveryRestart"]> | null;
   },
 ) {
   const { requestRecoveryRestart, ...handlerParams } = params;
   return createGatewayReloadHandlersImpl({
+    deps: {} as never,
+    broadcast: vi.fn(),
+    getState: createDefaultGatewayReloadState,
+    setState: vi.fn(),
+    startChannel: vi.fn(async () => {}),
+    stopChannel: vi.fn(async () => {}),
+    stopPostReadySidecars: vi.fn(),
+    reloadPlugins: vi.fn(async () => ({
+      restartChannels: new Set<ChannelKind>(),
+      activeChannels: new Set<ChannelKind>(),
+    })),
+    logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    logChannels: { info: vi.fn(), error: vi.fn() },
+    logCron: { error: vi.fn() },
+    logReload: { info: vi.fn(), warn: vi.fn() },
+    createHealthMonitor: () => null,
     ...handlerParams,
     cronReconciliation: params.cronReconciliation ?? createTestCronReconciliation(),
     ...(requestRecoveryRestart === null
@@ -107,25 +129,56 @@ function createGatewayReloadHandlers(
   });
 }
 
-function startManagedGatewayConfigReloader(
-  params: Omit<
-    ManagedReloaderParams,
-    | "cronReconciliation"
-    | "prepareTerminalConfig"
-    | "initialSnapshotRawHash"
-    | "initialAuthoredConfig"
-    | "initialSnapshotValid"
-    | "initialSnapshotIssues"
-  > & {
-    cronReconciliation?: ManagedReloaderParams["cronReconciliation"];
-    prepareTerminalConfig?: ManagedReloaderParams["prepareTerminalConfig"];
-    initialSnapshotRawHash?: string | null;
-    initialAuthoredConfig?: unknown;
-    initialSnapshotValid?: boolean;
-    initialSnapshotIssues?: ManagedReloaderParams["initialSnapshotIssues"];
-  },
-) {
+function createDefaultGatewayReloadState() {
+  return {
+    hooksConfig: {} as never,
+    hookClientIpConfig: {} as never,
+    heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+    cronState: {
+      cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+      storePath: "/tmp/cron.json",
+      cronEnabled: false,
+    } as never,
+    channelHealthMonitor: null,
+  };
+}
+
+function startManagedGatewayConfigReloader(params: ManagedReloaderTestParams) {
   return startManagedGatewayConfigReloaderImpl({
+    minimalTestGateway: false,
+    initialCompareConfig: params.initialConfig,
+    initialInternalWriteHash: null,
+    watchPath: "/tmp/openclaw.json",
+    promoteSnapshot: vi.fn(async () => true) as never,
+    deps: {} as never,
+    broadcast: vi.fn(),
+    getState: createDefaultGatewayReloadState,
+    setState: vi.fn(),
+    startChannel: vi.fn(async () => {}),
+    stopChannel: vi.fn(async () => {}),
+    reloadPlugins: vi.fn(async () => ({
+      restartChannels: new Set<ChannelKind>(),
+      activeChannels: new Set<ChannelKind>(),
+    })),
+    logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    logChannels: { info: vi.fn(), error: vi.fn() },
+    logCron: { error: vi.fn() },
+    logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    channelManager: {} as never,
+    activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
+      sourceConfig: config,
+      config,
+      authStores: [],
+      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      warnings: [],
+      webTools: createEmptyRuntimeWebToolsMetadata(),
+    })) as never,
+    resolveSharedGatewaySessionGenerationForConfig: () => undefined,
+    sharedGatewaySessionGenerationState: { current: undefined, required: null },
+    clients: [],
+    reconcileTerminalSessions: vi.fn(),
+    commitTerminalConfig: vi.fn(),
+    acceptTerminalConfig: vi.fn(),
     ...params,
     initialSnapshotRawHash: params.initialSnapshotRawHash ?? null,
     initialAuthoredConfig: params.initialAuthoredConfig ?? {},
@@ -372,6 +425,80 @@ function createHotTailPlan(overrides: Partial<GatewayReloadPlan> = {}): GatewayR
   };
 }
 
+function createGatewayRestartPlan(changedPath = "gateway.port"): GatewayReloadPlan {
+  return createHotTailPlan({
+    changedPaths: [changedPath],
+    restartGateway: true,
+    restartReasons: [changedPath],
+    hotReasons: [],
+  });
+}
+
+function createPluginReloadPlan(): GatewayReloadPlan {
+  return createHotTailPlan({
+    changedPaths: ["plugins.enabled"],
+    hotReasons: ["plugins.enabled"],
+    reloadPlugins: true,
+  });
+}
+
+function createValidConfigSnapshot(config: OpenClawConfig, hash: string) {
+  return {
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: "{}",
+    parsed: {},
+    sourceConfig: config,
+    resolved: config,
+    valid: true,
+    runtimeConfig: config,
+    config,
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+    hash,
+  };
+}
+
+function createConfigWriteNotification(
+  config: OpenClawConfig,
+  persistedHash: string,
+  revision: number,
+  fingerprint: string,
+  sourceFingerprint: string,
+  overrides: Partial<ConfigWriteNotification> = {},
+): ConfigWriteNotification {
+  return {
+    configPath: "/tmp/openclaw.json",
+    sourceConfig: config,
+    runtimeConfig: config,
+    persistedHash,
+    revision,
+    fingerprint,
+    sourceFingerprint,
+    writtenAtMs: Date.now(),
+    ...overrides,
+  };
+}
+
+function createConfigWriteListenerRef(): ConfigWriteListenerRef {
+  return { current: null };
+}
+
+function captureConfigWriteListener(
+  ref: ConfigWriteListenerRef,
+  clearOnlyIfCurrent = true,
+): ManagedReloaderParams["subscribeToWrites"] {
+  return (listener) => {
+    ref.current = listener;
+    return () => {
+      if (!clearOnlyIfCurrent || ref.current === listener) {
+        ref.current = null;
+      }
+    };
+  };
+}
+
 function createDeferredVoid() {
   let resolve: (() => void) | undefined;
   const promise = new Promise<void>((resolvePromise) => {
@@ -418,23 +545,13 @@ function createReloadHandlersForTest(
   const logCron = { error: vi.fn() };
   const logChannels = { info: vi.fn(), error: vi.fn() };
   const handlers = createGatewayReloadHandlers({
-    deps: {} as never,
-    broadcast: vi.fn(),
     getState: () => state,
     setState,
     startChannel: channels?.start ?? vi.fn(async () => {}),
     stopChannel: channels?.stop ?? vi.fn(async () => {}),
+    ...(reloadPlugins ? { reloadPlugins } : {}),
     getChannelAutostartSuppression: options?.getChannelAutostartSuppression,
     stopPostReadySidecars,
-    reloadPlugins:
-      reloadPlugins ??
-      vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-    logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     logChannels,
     logCron,
     logReload,
@@ -446,7 +563,6 @@ function createReloadHandlersForTest(
           ? requestGatewayRestartWithSignalAdmission
           : null,
     ...(typeof recovery === "boolean" ? { restartRecoveryAvailable: recovery } : {}),
-    createHealthMonitor: () => null,
   });
   return {
     ...handlers,
@@ -542,9 +658,7 @@ function createManagedRestartSequenceHarness(
     },
   } as OpenClawConfig;
   const terminalPolicy = createTerminalLaunchPolicy(initialConfig);
-  const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-    current: null,
-  };
+  const writeListenerRef = createConfigWriteListenerRef();
   let snapshotConfig = initialConfig;
   let snapshotHash = "initial";
   const unavailableSecretIds = new Set(["MISSING_RESTART_TOKEN", "MISSING_HOT_TOKEN"]);
@@ -604,66 +718,14 @@ function createManagedRestartSequenceHarness(
   const sharedGatewaySessionGenerationState = { current: undefined, required: null };
   let generationInvalidated = false;
   const reloader = startManagedGatewayConfigReloader({
-    minimalTestGateway: false,
     initialConfig,
-    initialCompareConfig: initialConfig,
-    initialInternalWriteHash: null,
-    watchPath: "/tmp/openclaw.json",
-    readSnapshot: vi.fn(async () => ({
-      path: "/tmp/openclaw.json",
-      exists: true,
-      raw: "{}",
-      parsed: snapshotConfig,
-      sourceConfig: snapshotConfig,
-      resolved: snapshotConfig,
-      valid: true,
-      runtimeConfig: snapshotConfig,
-      config: snapshotConfig,
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
-      hash: snapshotHash,
-    })) as never,
+    readSnapshot: vi.fn(async () =>
+      createValidConfigSnapshot(snapshotConfig, snapshotHash),
+    ) as never,
     promoteSnapshot: promoteSnapshot as never,
-    subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-      writeListenerRef.current = listener;
-      return () => {
-        if (writeListenerRef.current === listener) {
-          writeListenerRef.current = null;
-        }
-      };
-    }) as never,
-    deps: {} as never,
-    broadcast: vi.fn(),
-    getState: () => ({
-      hooksConfig: {} as never,
-      hookClientIpConfig: {} as never,
-      heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-      cronState: {
-        cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-        storePath: "/tmp/cron.json",
-        cronEnabled: false,
-      } as never,
-      channelHealthMonitor: null,
-    }),
-    setState: vi.fn(),
-    startChannel: vi.fn(async () => {}),
-    stopChannel: vi.fn(async () => {}),
-    reloadPlugins: vi.fn(
-      async (): Promise<GatewayPluginReloadResult> => ({
-        restartChannels: new Set(),
-        activeChannels: new Set(),
-      }),
-    ),
-    logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    logChannels: { info: vi.fn(), error: vi.fn() },
-    logCron: { error: vi.fn() },
+    subscribeToWrites: captureConfigWriteListener(writeListenerRef),
     logReload,
-    channelManager: {} as never,
     activateRuntimeSecrets: activateRuntimeSecrets as never,
-    resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-    sharedGatewaySessionGenerationState,
-    clients: [],
     prepareTerminalConfig: (plan, nextConfig) => {
       terminalPolicy.prepareConfig(nextConfig, { restartPending: plan.restartGateway });
     },
@@ -680,6 +742,7 @@ function createManagedRestartSequenceHarness(
     }),
     commitTerminalConfig: terminalPolicy.commitConfig,
     acceptTerminalConfig: terminalPolicy.acceptConfig,
+    sharedGatewaySessionGenerationState,
     requestRecoveryRestart,
   });
   const writeConfig = (
@@ -816,9 +879,7 @@ async function runManagedOwnershipScenario(params: {
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
   });
-  const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-    current: null,
-  };
+  const writeListenerRef = createConfigWriteListenerRef();
   let resolveAccepted: (() => void) | undefined;
   const accepted = new Promise<void>((resolve) => {
     resolveAccepted = resolve;
@@ -832,93 +893,27 @@ async function runManagedOwnershipScenario(params: {
   const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig) => {
     if (params.queueRevert && !queuedB) {
       queuedB = true;
-      writeListenerRef.current?.({
-        configPath: "/tmp/openclaw.json",
-        sourceConfig: configB,
-        runtimeConfig: configB,
-        persistedHash: "hash-b",
-        revision: 2,
-        fingerprint: "runtime-b",
-        sourceFingerprint: "source-b",
-        writtenAtMs: Date.now(),
-      });
+      writeListenerRef.current?.(
+        createConfigWriteNotification(configB, "hash-b", 2, "runtime-b", "source-b"),
+      );
     }
     return snapshot(config);
   });
   activateSecretsRuntimeSnapshot(snapshot(initialConfig));
   const reloader = startManagedGatewayConfigReloader({
-    minimalTestGateway: false,
     initialConfig,
-    initialCompareConfig: initialConfig,
-    initialInternalWriteHash: null,
-    watchPath: "/tmp/openclaw.json",
-    readSnapshot: vi.fn(async () => ({
-      path: "/tmp/openclaw.json",
-      exists: true,
-      raw: "{}",
-      parsed: {},
-      sourceConfig: configB,
-      resolved: configB,
-      valid: true,
-      runtimeConfig: configB,
-      config: configB,
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
-      hash: "hash-b",
-    })) as never,
-    promoteSnapshot: vi.fn(async () => true) as never,
-    subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-      writeListenerRef.current = listener;
-      return () => {
-        writeListenerRef.current = null;
-      };
-    }) as never,
-    deps: {} as never,
-    broadcast: vi.fn(),
-    getState: () => ({
-      hooksConfig: {} as never,
-      hookClientIpConfig: {} as never,
-      heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-      cronState: {
-        cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-        storePath: "/tmp/cron.json",
-        cronEnabled: false,
-      } as never,
-      channelHealthMonitor: null,
-    }),
-    setState: vi.fn(),
-    startChannel: vi.fn(async () => {}),
-    stopChannel: vi.fn(async () => {}),
-    reloadPlugins: vi.fn(async () => ({
-      restartChannels: new Set<ChannelKind>(),
-      activeChannels: new Set<ChannelKind>(),
-    })),
-    logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    logChannels: { info: vi.fn(), error: vi.fn() },
-    logCron: { error: vi.fn() },
-    logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    channelManager: {} as never,
+    readSnapshot: vi.fn(async () => createValidConfigSnapshot(configB, "hash-b")) as never,
+    subscribeToWrites: captureConfigWriteListener(writeListenerRef, false),
     activateRuntimeSecrets: activateRuntimeSecrets as never,
-    resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-    sharedGatewaySessionGenerationState: { current: undefined, required: null },
-    clients: [],
     prepareTerminalConfig,
     reconcileTerminalSessions,
     commitTerminalConfig,
     acceptTerminalConfig,
     requestRecoveryRestart,
   });
-  writeListenerRef.current?.({
-    configPath: "/tmp/openclaw.json",
-    sourceConfig: configA,
-    runtimeConfig: configA,
-    persistedHash: "hash-a",
-    revision: 1,
-    fingerprint: "runtime-a",
-    sourceFingerprint: "source-a",
-    writtenAtMs: Date.now(),
-  });
+  writeListenerRef.current?.(
+    createConfigWriteNotification(configA, "hash-a", 1, "runtime-a", "source-a"),
+  );
   try {
     await accepted;
     return {
@@ -1268,49 +1263,12 @@ describe("gateway hot reload model state", () => {
     });
     const logReload = { info: vi.fn(), warn: vi.fn() };
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
       reloadPlugins,
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
       logReload,
-      createHealthMonitor: () => null,
     });
 
     const nextConfig = { plugins: { enabled: true } } as OpenClawConfig;
-    await applyHotReload(
-      {
-        changedPaths: ["plugins.enabled"],
-        restartGateway: false,
-        restartReasons: [],
-        hotReasons: ["plugins.enabled"],
-        reloadHooks: false,
-        restartGmailWatcher: false,
-        restartCron: false,
-        restartHeartbeat: false,
-        restartHealthMonitor: false,
-        reloadPlugins: true,
-        restartChannels: new Set(),
-        disposeMcpRuntimes: false,
-        noopPaths: [],
-      },
-      nextConfig,
-    );
+    await applyHotReload(createPluginReloadPlan(), nextConfig);
 
     const firstResetIndex = hoisted.reloadEvents.indexOf("clear-provider-auth");
     expect(firstResetIndex).toBeGreaterThanOrEqual(0);
@@ -1773,25 +1731,13 @@ describe("gateway hot reload commit policy", () => {
       state = nextState;
     });
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
       getState: () => state,
       setState,
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(async () => ({
-        restartChannels: new Set<ChannelKind>(),
-        activeChannels: new Set<ChannelKind>(),
-      })),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      requestRecoveryRestart: vi.fn(() => ({ status: "emitted" as const })),
       createHealthMonitor: vi.fn(() => {
         events.push("create");
         return nextMonitor as never;
       }),
+      requestRecoveryRestart: vi.fn(() => ({ status: "emitted" as const })),
     });
 
     await applyHotReload(createHotTailPlan({ restartHealthMonitor: true }), {} as OpenClawConfig);
@@ -1847,26 +1793,7 @@ describe("gateway restart deferral preflight", () => {
     vi.useFakeTimers();
 
     try {
-      expect(
-        requestGatewayRestart(
-          {
-            changedPaths: ["gateway.port"],
-            restartGateway: true,
-            restartReasons: ["gateway.port"],
-            hotReasons: [],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: false,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
-          {},
-        ).status,
-      ).toBe("recovery-pending");
+      expect(requestGatewayRestart(createGatewayRestartPlan(), {}).status).toBe("recovery-pending");
       expect(requestRecoveryRestart).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(1_000);
@@ -1902,24 +1829,7 @@ describe("gateway restart deferral preflight", () => {
 
     try {
       const initialResult = await runWithGatewayIndependentRootWorkAdmission(async () =>
-        requestGatewayRestart(
-          {
-            changedPaths: ["gateway.port"],
-            restartGateway: true,
-            restartReasons: ["gateway.port"],
-            hotReasons: [],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: false,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
-          {},
-        ),
+        requestGatewayRestart(createGatewayRestartPlan(), {}),
       );
       expect(initialResult.status).toBe("recovery-pending");
       suspension = tryBeginGatewaySuspendAdmission(() => {});
@@ -1953,21 +1863,7 @@ describe("gateway restart deferral preflight", () => {
       undefined,
       requestRecoveryRestart,
     );
-    const restartPlan = {
-      changedPaths: ["gateway.port"],
-      restartGateway: true,
-      restartReasons: ["gateway.port"],
-      hotReasons: [],
-      reloadHooks: false,
-      restartGmailWatcher: false,
-      restartCron: false,
-      restartHeartbeat: false,
-      restartHealthMonitor: false,
-      reloadPlugins: false,
-      restartChannels: new Set<ChannelKind>(),
-      disposeMcpRuntimes: false,
-      noopPaths: [],
-    } satisfies GatewayReloadPlan;
+    const restartPlan = createGatewayRestartPlan() satisfies GatewayReloadPlan;
     vi.useFakeTimers();
 
     try {
@@ -2328,24 +2224,7 @@ describe("gateway restart deferral preflight", () => {
 
     try {
       expect(
-        requestGatewayRestart(
-          {
-            changedPaths: ["gateway.port"],
-            restartGateway: true,
-            restartReasons: ["gateway.port"],
-            hotReasons: [],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: false,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
-          { gateway: { port: 18790 } },
-        ).status,
+        requestGatewayRestart(createGatewayRestartPlan(), { gateway: { port: 18790 } }).status,
       ).toBe("recovery-pending");
 
       expect(
@@ -2384,26 +2263,7 @@ describe("gateway restart deferral preflight", () => {
     const { requestGatewayRestart } = createReloadHandlersForTest();
 
     try {
-      expect(
-        requestGatewayRestart(
-          {
-            changedPaths: ["gateway.port"],
-            restartGateway: true,
-            restartReasons: ["gateway.port"],
-            hotReasons: [],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: false,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
-          {},
-        ).status,
-      ).toBe("accepted");
+      expect(requestGatewayRestart(createGatewayRestartPlan(), {}).status).toBe("accepted");
 
       expect(signalSpy).toHaveBeenCalledOnce();
       expect(isGatewayWorkAdmissionClosed()).toBe(true);
@@ -2435,26 +2295,7 @@ describe("gateway restart deferral preflight", () => {
     vi.useFakeTimers();
 
     try {
-      expect(
-        requestGatewayRestart(
-          {
-            changedPaths: ["gateway.port"],
-            restartGateway: true,
-            restartReasons: ["gateway.port"],
-            hotReasons: [],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: false,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
-          {},
-        ).status,
-      ).toBe("accepted");
+      expect(requestGatewayRestart(createGatewayRestartPlan(), {}).status).toBe("accepted");
 
       expect(signalSpy).not.toHaveBeenCalled();
       expect(logReload.warn).toHaveBeenCalledWith(
@@ -2501,26 +2342,7 @@ describe("gateway restart deferral preflight", () => {
     vi.useFakeTimers();
 
     try {
-      expect(
-        requestGatewayRestart(
-          {
-            changedPaths: ["gateway.port"],
-            restartGateway: true,
-            restartReasons: ["gateway.port"],
-            hotReasons: [],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: false,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
-          {},
-        ).status,
-      ).toBe("accepted");
+      expect(requestGatewayRestart(createGatewayRestartPlan(), {}).status).toBe("accepted");
 
       markExited(session, 0, null, "completed");
       await vi.advanceTimersByTimeAsync(500);
@@ -2551,26 +2373,7 @@ describe("gateway restart deferral preflight", () => {
     vi.useFakeTimers();
 
     try {
-      expect(
-        requestGatewayRestart(
-          {
-            changedPaths: ["gateway.port"],
-            restartGateway: true,
-            restartReasons: ["gateway.port"],
-            hotReasons: [],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: false,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
-          {},
-        ).status,
-      ).toBe("accepted");
+      expect(requestGatewayRestart(createGatewayRestartPlan(), {}).status).toBe("accepted");
       expect(signalSpy).not.toHaveBeenCalled();
       expect(logReload.warn).toHaveBeenCalledWith(
         "config change requires gateway restart (gateway.port) — deferring until 1 gateway request(s) complete",
@@ -2599,33 +2402,10 @@ describe("gateway restart deferral preflight", () => {
     let runtimePublished = false;
     const logReload = { info: vi.fn(), warn: vi.fn() };
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
       setState,
       startChannel,
       stopChannel,
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
       logReload,
-      createHealthMonitor: () => null,
     });
     hoisted.activeEmbeddedRunCount.value = 1;
     vi.useFakeTimers();
@@ -2700,33 +2480,9 @@ describe("gateway restart deferral preflight", () => {
     const stopChannel = vi.fn(async () => {});
     const logReload = { info: vi.fn(), warn: vi.fn() };
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
       startChannel,
       stopChannel,
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
       logReload,
-      createHealthMonitor: () => null,
     });
     hoisted.activeEmbeddedRunCount.value = 1;
     vi.useFakeTimers();
@@ -2802,26 +2558,9 @@ describe("gateway restart deferral preflight", () => {
     vi.useFakeTimers();
 
     try {
-      requestGatewayRestart(
-        {
-          changedPaths: ["gateway.port"],
-          restartGateway: true,
-          restartReasons: ["gateway.port"],
-          hotReasons: [],
-          reloadHooks: false,
-          restartGmailWatcher: false,
-          restartCron: false,
-          restartHeartbeat: false,
-          restartHealthMonitor: false,
-          reloadPlugins: false,
-          restartChannels: new Set(),
-          disposeMcpRuntimes: false,
-          noopPaths: [],
-        },
-        {
-          gateway: { reload: {} },
-        },
-      );
+      requestGatewayRestart(createGatewayRestartPlan(), {
+        gateway: { reload: {} },
+      });
 
       expect(logReload.warn.mock.calls).toEqual(
         expect.arrayContaining([
@@ -2878,24 +2617,7 @@ describe("gateway restart deferral preflight", () => {
     vi.useFakeTimers();
 
     try {
-      requestGatewayRestart(
-        {
-          changedPaths: ["gateway.port"],
-          restartGateway: true,
-          restartReasons: ["gateway.port"],
-          hotReasons: [],
-          reloadHooks: false,
-          restartGmailWatcher: false,
-          restartCron: false,
-          restartHeartbeat: false,
-          restartHealthMonitor: false,
-          reloadPlugins: false,
-          restartChannels: new Set(),
-          disposeMcpRuntimes: false,
-          noopPaths: [],
-        },
-        {},
-      );
+      requestGatewayRestart(createGatewayRestartPlan(), {});
 
       await vi.advanceTimersByTimeAsync(299_500);
       expect(signalSpy).not.toHaveBeenCalled();
@@ -3319,38 +3041,13 @@ describe("gateway channel hot reload handlers", () => {
       stop: vi.fn(async () => {}),
     };
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
       startChannel: channels.start,
       stopChannel: channels.stop,
       getChannelAutostartSuppression: () => ({
         reason: "crash-loop-breaker",
         message: "safe mode",
       }),
-      stopPostReadySidecars: vi.fn(),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       logChannels,
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      createHealthMonitor: () => null,
     });
 
     await withChannelReloadsEnabled(() => applyHotReload(createChannelReloadPlan(["discord"]), {}));
@@ -3416,33 +3113,11 @@ describe("gateway channel hot reload handlers", () => {
       events.push(`start:${channel}`);
     });
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
       setState,
       startChannel,
       stopChannel,
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       logChannels,
-      logCron: { error: vi.fn() },
       logReload,
-      createHealthMonitor: () => null,
     });
 
     await withGatewayRestartSignal(async (signalSpy) => {
@@ -3479,33 +3154,11 @@ describe("gateway channel hot reload handlers", () => {
       }
     });
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
       setState,
       startChannel,
       stopChannel,
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       logChannels,
-      logCron: { error: vi.fn() },
       logReload,
-      createHealthMonitor: () => null,
     });
 
     await withGatewayRestartSignal(async (signalSpy) => {
@@ -3557,34 +3210,7 @@ describe("gateway Gmail hot reload handlers", () => {
   it("stops queued post-ready sidecars before restarting Gmail watcher", async () => {
     const stopPostReadySidecars = vi.fn();
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
       stopPostReadySidecars,
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      createHealthMonitor: () => null,
     });
     const nextConfig = {
       hooks: { enabled: true, gmail: { account: "next@example.com" } },
@@ -3656,33 +3282,6 @@ describe("gateway Gmail hot reload handlers", () => {
     const abortController = new AbortController();
     const clearGmailRestartAbortController = vi.fn();
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      createHealthMonitor: () => null,
       createGmailRestartAbortController: () => abortController,
       clearGmailRestartAbortController,
     });
@@ -3701,9 +3300,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("retries managed no-op reloads without publishing superseded secret failures", async () => {
     vi.useFakeTimers();
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     const initialConfig: OpenClawConfig = {
       gateway: { reload: {} },
       messages: { visibleReplies: "automatic" },
@@ -3746,37 +3343,9 @@ describe("gateway Gmail hot reload handlers", () => {
     const acceptTerminalConfig = vi.fn();
     const commitTerminalConfig = vi.fn();
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig,
-      initialCompareConfig: initialConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
-      readSnapshot: vi.fn(async () => ({
-        path: "/tmp/openclaw.json",
-        exists: true,
-        raw: "{}",
-        parsed: {},
-        sourceConfig: nextConfig,
-        resolved: nextConfig,
-        valid: true,
-        runtimeConfig: nextConfig,
-        config: nextConfig,
-        issues: [],
-        warnings: [],
-        legacyIssues: [],
-        hash: "hash-next",
-      })) as never,
-      promoteSnapshot: vi.fn(async () => true) as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          if (writeListenerRef.current === listener) {
-            writeListenerRef.current = null;
-          }
-        };
-      }) as never,
-      deps: {} as never,
-      broadcast: vi.fn(),
+      readSnapshot: vi.fn(async () => createValidConfigSnapshot(nextConfig, "hash-next")) as never,
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef),
       getState: () => ({
         hooksConfig: {} as never,
         hookClientIpConfig: {} as never,
@@ -3788,25 +3357,7 @@ describe("gateway Gmail hot reload handlers", () => {
         } as never,
         channelHealthMonitor: null,
       }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      channelManager: {} as never,
       activateRuntimeSecrets: activateRuntimeSecrets as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
-      reconcileTerminalSessions: vi.fn(),
       commitTerminalConfig,
       acceptTerminalConfig,
     });
@@ -3815,16 +3366,15 @@ describe("gateway Gmail hot reload handlers", () => {
       throw new Error("Expected config write listener to be registered");
     }
 
-    registeredWriteListener({
-      configPath: "/tmp/openclaw.json",
-      sourceConfig: nextConfig,
-      runtimeConfig: nextConfig,
-      persistedHash: "hash-next",
-      revision: 1,
-      fingerprint: "runtime-hash-next",
-      sourceFingerprint: "source-hash-next",
-      writtenAtMs: Date.now(),
-    });
+    registeredWriteListener(
+      createConfigWriteNotification(
+        nextConfig,
+        "hash-next",
+        1,
+        "runtime-hash-next",
+        "source-hash-next",
+      ),
+    );
     await vi.runAllTimersAsync();
 
     expect(activateRuntimeSecrets).toHaveBeenCalledTimes(3);
@@ -3927,9 +3477,7 @@ describe("gateway Gmail hot reload handlers", () => {
       ],
       webTools: createEmptyRuntimeWebToolsMetadata(),
     });
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig, _params: unknown) => ({
       sourceConfig: config,
       config: runtimeConfig,
@@ -3967,11 +3515,7 @@ describe("gateway Gmail hot reload handlers", () => {
       webTools: createEmptyRuntimeWebToolsMetadata(),
     }));
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig: runtimeConfig,
-      initialCompareConfig: runtimeConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
       readSnapshot: vi.fn(async () => ({
         path: "/tmp/openclaw.json",
         exists: true,
@@ -3987,51 +3531,12 @@ describe("gateway Gmail hot reload handlers", () => {
         legacyIssues: [],
         hash: "same-runtime-next-source",
       })) as never,
-      promoteSnapshot: vi.fn(async () => true) as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          if (writeListenerRef.current === listener) {
-            writeListenerRef.current = null;
-          }
-        };
-      }) as never,
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef),
       prepareConfigCandidate: ({ runtimeConfig: candidateRuntime }) => ({
         runtimeConfig: candidateRuntime,
         compareConfig: candidateRuntime,
       }),
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(async () => ({
-        restartChannels: new Set<ChannelKind>(),
-        activeChannels: new Set<ChannelKind>(),
-      })),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      channelManager: {} as never,
       activateRuntimeSecrets: activateRuntimeSecrets as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
-      reconcileTerminalSessions: vi.fn(),
-      commitTerminalConfig: vi.fn(),
-      acceptTerminalConfig: vi.fn(),
     });
 
     try {
@@ -4257,9 +3762,7 @@ describe("gateway Gmail hot reload handlers", () => {
     const setState = vi.fn();
     const promoteSnapshot = vi.fn(async () => true);
     const logReload = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     let snapshotConfig = initialConfig;
     let snapshotHash = "initial";
     const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig) => ({
@@ -4271,62 +3774,15 @@ describe("gateway Gmail hot reload handlers", () => {
       webTools: createEmptyRuntimeWebToolsMetadata(),
     }));
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig,
-      initialCompareConfig: initialConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
-      readSnapshot: vi.fn(async () => ({
-        path: "/tmp/openclaw.json",
-        exists: true,
-        raw: "{}",
-        parsed: snapshotConfig,
-        sourceConfig: snapshotConfig,
-        resolved: snapshotConfig,
-        valid: true,
-        runtimeConfig: snapshotConfig,
-        config: snapshotConfig,
-        issues: [],
-        warnings: [],
-        legacyIssues: [],
-        hash: snapshotHash,
-      })) as never,
+      readSnapshot: vi.fn(async () =>
+        createValidConfigSnapshot(snapshotConfig, snapshotHash),
+      ) as never,
       promoteSnapshot: promoteSnapshot as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          writeListenerRef.current = null;
-        };
-      }) as never,
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef, false),
       setState,
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(async () => ({
-        restartChannels: new Set<ChannelKind>(),
-        activeChannels: new Set<ChannelKind>(),
-      })),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
       logReload,
-      channelManager: {} as never,
       activateRuntimeSecrets: activateRuntimeSecrets as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
       prepareTerminalConfig,
       reconcileTerminalSessions,
       commitTerminalConfig: terminalPolicy.commitConfig,
@@ -4422,9 +3878,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("retires terminal restrictions after restart secrets preflight rejects and config reverts", async () => {
     vi.useFakeTimers();
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     const initialConfig = {
       gateway: {
         port: 18789,
@@ -4487,70 +3941,16 @@ describe("gateway Gmail hot reload handlers", () => {
       webTools: createEmptyRuntimeWebToolsMetadata(),
     });
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig,
-      initialCompareConfig: initialConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
-      readSnapshot: vi.fn(async () => ({
-        path: "/tmp/openclaw.json",
-        exists: true,
-        raw: "{}",
-        parsed: initialConfig,
-        sourceConfig: initialConfig,
-        resolved: initialConfig,
-        valid: true,
-        runtimeConfig: initialConfig,
-        config: initialConfig,
-        issues: [],
-        warnings: [],
-        legacyIssues: [],
-        hash: "accepted-revert",
-      })) as never,
-      promoteSnapshot: vi.fn(async () => true) as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          if (writeListenerRef.current === listener) {
-            writeListenerRef.current = null;
-          }
-        };
-      }) as never,
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
+      readSnapshot: vi.fn(async () =>
+        createValidConfigSnapshot(initialConfig, "accepted-revert"),
+      ) as never,
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef),
       logReload,
-      channelManager: {} as never,
       activateRuntimeSecrets: activateRuntimeSecrets as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
       prepareTerminalConfig: (plan, nextConfig) => {
         terminalPolicy.prepareConfig(nextConfig, { restartPending: plan.restartGateway });
       },
-      reconcileTerminalSessions: vi.fn(),
       commitTerminalConfig: terminalPolicy.commitConfig,
       acceptTerminalConfig,
       requestRecoveryRestart,
@@ -4561,16 +3961,15 @@ describe("gateway Gmail hot reload handlers", () => {
     }
 
     try {
-      registeredWriteListener({
-        configPath: "/tmp/openclaw.json",
-        sourceConfig: rejectedConfig,
-        runtimeConfig: rejectedConfig,
-        persistedHash: "rejected-restart",
-        revision: 1,
-        fingerprint: "runtime-rejected-restart",
-        sourceFingerprint: "source-rejected-restart",
-        writtenAtMs: Date.now(),
-      });
+      registeredWriteListener(
+        createConfigWriteNotification(
+          rejectedConfig,
+          "rejected-restart",
+          1,
+          "runtime-rejected-restart",
+          "source-rejected-restart",
+        ),
+      );
       await vi.advanceTimersByTimeAsync(0);
       await reloadFailed;
 
@@ -4578,16 +3977,15 @@ describe("gateway Gmail hot reload handlers", () => {
       expect(logReload.error).toHaveBeenCalledWith(expectedReloadError);
       expect(requestRecoveryRestart).not.toHaveBeenCalled();
 
-      registeredWriteListener({
-        configPath: "/tmp/openclaw.json",
-        sourceConfig: initialConfig,
-        runtimeConfig: initialConfig,
-        persistedHash: "accepted-revert",
-        revision: 2,
-        fingerprint: "runtime-accepted-revert",
-        sourceFingerprint: "source-accepted-revert",
-        writtenAtMs: Date.now(),
-      });
+      registeredWriteListener(
+        createConfigWriteNotification(
+          initialConfig,
+          "accepted-revert",
+          2,
+          "runtime-accepted-revert",
+          "source-accepted-revert",
+        ),
+      );
       await vi.advanceTimersByTimeAsync(0);
       await restartRetired;
 
@@ -5026,9 +4424,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("retries managed hot reload when secrets change before publication", async () => {
     vi.useFakeTimers();
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     const initialConfig = {
       gateway: { reload: {} },
       hooks: { enabled: true, token: "test-token", path: "/old" },
@@ -5112,85 +4508,31 @@ describe("gateway Gmail hot reload handlers", () => {
     };
     const setState = vi.fn();
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig,
-      initialCompareConfig: initialConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
-      readSnapshot: vi.fn(async () => ({
-        path: "/tmp/openclaw.json",
-        exists: true,
-        raw: "{}",
-        parsed: {},
-        sourceConfig: nextConfig,
-        resolved: nextConfig,
-        valid: true,
-        runtimeConfig: nextConfig,
-        config: nextConfig,
-        issues: [],
-        warnings: [],
-        legacyIssues: [],
-        hash: "hot-reload-next",
-      })) as never,
+      readSnapshot: vi.fn(async () =>
+        createValidConfigSnapshot(nextConfig, "hot-reload-next"),
+      ) as never,
       promoteSnapshot: promoteSnapshot as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          if (writeListenerRef.current === listener) {
-            writeListenerRef.current = null;
-          }
-        };
-      }) as never,
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef),
       setState,
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
       logReload,
-      channelManager: {} as never,
       activateRuntimeSecrets: activateRuntimeSecrets as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
-      reconcileTerminalSessions: vi.fn(),
       commitTerminalConfig,
-      acceptTerminalConfig: vi.fn(),
     });
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
     }
 
-    registeredWriteListener({
-      configPath: "/tmp/openclaw.json",
-      sourceConfig: nextConfig,
-      runtimeConfig: nextConfig,
-      persistedHash: "hot-reload-next",
-      revision: 1,
-      fingerprint: "runtime-hot-reload-next",
-      sourceFingerprint: "source-hot-reload-next",
-      writtenAtMs: Date.now(),
-    });
+    registeredWriteListener(
+      createConfigWriteNotification(
+        nextConfig,
+        "hot-reload-next",
+        1,
+        "runtime-hot-reload-next",
+        "source-hot-reload-next",
+      ),
+    );
     await vi.runAllTimersAsync();
     expect(await reloadOutcome).toEqual({ status: "promoted" });
 
@@ -5210,9 +4552,7 @@ describe("gateway Gmail hot reload handlers", () => {
   });
 
   it("aborts an in-flight managed Gmail restart when the reloader stops", async () => {
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     let restartSignal: AbortSignal | undefined;
     type GmailRestartOutcome = { status: "started" } | { status: "failed"; message: string };
     let settleRestart: ((outcome: GmailRestartOutcome) => void) | undefined;
@@ -5235,94 +4575,27 @@ describe("gateway Gmail hot reload handlers", () => {
     };
     const initialConfig = createGmailConfig("old@example.com");
     const nextConfig = createGmailConfig("next@example.com");
-    const readSnapshot = vi.fn(async () => ({
-      path: "/tmp/openclaw.json",
-      exists: true,
-      raw: "{}",
-      parsed: {},
-      sourceConfig: nextConfig,
-      resolved: nextConfig,
-      valid: true,
-      runtimeConfig: nextConfig,
-      config: nextConfig,
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
-      hash: "hash-next",
-    }));
+    const readSnapshot = vi.fn(async () => createValidConfigSnapshot(nextConfig, "hash-next"));
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig,
-      initialCompareConfig: initialConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
       readSnapshot: readSnapshot as never,
-      promoteSnapshot: vi.fn(async () => true) as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          if (writeListenerRef.current === listener) {
-            writeListenerRef.current = null;
-          }
-        };
-      }) as never,
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef),
       logReload,
-      channelManager: {} as never,
-      activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
-        sourceConfig: config,
-        config,
-        authStores: [],
-        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-        warnings: [],
-        webTools: {},
-      })) as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
-      reconcileTerminalSessions: vi.fn(),
-      commitTerminalConfig: vi.fn(),
-      acceptTerminalConfig: vi.fn(),
     });
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
     }
 
-    registeredWriteListener({
-      configPath: "/tmp/openclaw.json",
-      sourceConfig: nextConfig,
-      runtimeConfig: nextConfig,
-      persistedHash: "hash-next",
-      revision: 1,
-      fingerprint: "runtime-hash-next",
-      sourceFingerprint: "source-hash-next",
-      writtenAtMs: Date.now(),
-    });
+    registeredWriteListener(
+      createConfigWriteNotification(
+        nextConfig,
+        "hash-next",
+        1,
+        "runtime-hash-next",
+        "source-hash-next",
+      ),
+    );
     expect(await restartOutcome).toEqual({ status: "started" });
     expect(restartSignal?.aborted).toBe(false);
 
@@ -5333,9 +4606,7 @@ describe("gateway Gmail hot reload handlers", () => {
 
   it("keeps committed config after a Gmail watcher follow-up fails", async () => {
     vi.useFakeTimers();
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     const initialConfig = createGmailConfig("old@example.com");
     const nextConfig: OpenClawConfig = {
       ...createGmailConfig("next@example.com"),
@@ -5352,92 +4623,25 @@ describe("gateway Gmail hot reload handlers", () => {
     });
     hoisted.startGmailWatcherWithLogs.mockRejectedValueOnce(new Error("start failed"));
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig,
-      initialCompareConfig: initialConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
-      readSnapshot: vi.fn(async () => ({
-        path: "/tmp/openclaw.json",
-        exists: true,
-        raw: "{}",
-        parsed: {},
-        sourceConfig: nextConfig,
-        resolved: nextConfig,
-        valid: true,
-        runtimeConfig: nextConfig,
-        config: nextConfig,
-        issues: [],
-        warnings: [],
-        legacyIssues: [],
-        hash: "hash-next",
-      })) as never,
-      promoteSnapshot: vi.fn(async () => true) as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          if (writeListenerRef.current === listener) {
-            writeListenerRef.current = null;
-          }
-        };
-      }) as never,
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
+      readSnapshot: vi.fn(async () => createValidConfigSnapshot(nextConfig, "hash-next")) as never,
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef),
       logReload,
-      channelManager: {} as never,
-      activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
-        sourceConfig: config,
-        config,
-        authStores: [],
-        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-        warnings: [],
-        webTools: {},
-      })) as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
-      reconcileTerminalSessions: vi.fn(),
-      commitTerminalConfig: vi.fn(),
-      acceptTerminalConfig: vi.fn(),
     });
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
     }
 
-    registeredWriteListener({
-      configPath: "/tmp/openclaw.json",
-      sourceConfig: nextConfig,
-      runtimeConfig: nextConfig,
-      persistedHash: "hash-next",
-      revision: 1,
-      fingerprint: "runtime-hash-next",
-      sourceFingerprint: "source-hash-next",
-      writtenAtMs: Date.now(),
-    });
+    registeredWriteListener(
+      createConfigWriteNotification(
+        nextConfig,
+        "hash-next",
+        1,
+        "runtime-hash-next",
+        "source-hash-next",
+      ),
+    );
     await vi.runAllTimersAsync();
 
     expect(hoisted.refreshContextWindowCache).toHaveBeenCalledTimes(1);
@@ -5450,9 +4654,7 @@ describe("gateway Gmail hot reload handlers", () => {
   });
 
   it("does not start a Gmail restart after the managed reloader stops before hot reload applies", async () => {
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     let releaseSecrets: (() => void) | undefined;
     let secretsEntered: (() => void) | undefined;
     const secretsStarted = new Promise<void>((resolve) => {
@@ -5464,62 +4666,9 @@ describe("gateway Gmail hot reload handlers", () => {
     const initialConfig = createGmailConfig("old@example.com");
     const nextConfig = createGmailConfig("next@example.com");
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig,
-      initialCompareConfig: initialConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
-      readSnapshot: vi.fn(async () => ({
-        path: "/tmp/openclaw.json",
-        exists: true,
-        raw: "{}",
-        parsed: {},
-        sourceConfig: nextConfig,
-        resolved: nextConfig,
-        valid: true,
-        runtimeConfig: nextConfig,
-        config: nextConfig,
-        issues: [],
-        warnings: [],
-        legacyIssues: [],
-        hash: "hash-next",
-      })) as never,
-      promoteSnapshot: vi.fn(async () => true) as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          if (writeListenerRef.current === listener) {
-            writeListenerRef.current = null;
-          }
-        };
-      }) as never,
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      channelManager: {} as never,
+      readSnapshot: vi.fn(async () => createValidConfigSnapshot(nextConfig, "hash-next")) as never,
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef),
       activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => {
         secretsEntered?.();
         await releaseSecretsPromise;
@@ -5532,28 +4681,21 @@ describe("gateway Gmail hot reload handlers", () => {
           webTools: {},
         };
       }) as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
-      reconcileTerminalSessions: vi.fn(),
-      commitTerminalConfig: vi.fn(),
-      acceptTerminalConfig: vi.fn(),
     });
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
     }
 
-    registeredWriteListener({
-      configPath: "/tmp/openclaw.json",
-      sourceConfig: nextConfig,
-      runtimeConfig: nextConfig,
-      persistedHash: "hash-next",
-      revision: 1,
-      fingerprint: "runtime-hash-next",
-      sourceFingerprint: "source-hash-next",
-      writtenAtMs: Date.now(),
-    });
+    registeredWriteListener(
+      createConfigWriteNotification(
+        nextConfig,
+        "hash-next",
+        1,
+        "runtime-hash-next",
+        "source-hash-next",
+      ),
+    );
     await secretsStarted;
 
     const stopPromise = reloader.stop();
@@ -5650,31 +4792,9 @@ describe("gateway plugin hot reload handlers", () => {
     const stopChannel = vi.fn(async () => {});
     const logChannels = { info: vi.fn(), error: vi.fn() };
     const handlers = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
       startChannel,
       stopChannel,
-      reloadPlugins: vi.fn(async () => ({
-        restartChannels: new Set<ChannelKind>(),
-        activeChannels: new Set<ChannelKind>(),
-      })),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       logChannels,
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      createHealthMonitor: () => null,
     });
 
     try {
@@ -5770,9 +4890,7 @@ describe("gateway plugin hot reload handlers", () => {
       events.push(`cron-build:${params?.env?.[envKey]}:${targetEnv[envKey]}`);
       return rebuiltCronState;
     });
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     const reloadPlugins = vi.fn(
       async (params: {
         commitRuntime: () => Promise<void>;
@@ -5788,74 +4906,24 @@ describe("gateway plugin hot reload handlers", () => {
       },
     );
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig,
-      initialCompareConfig: initialConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
       readSnapshot: vi.fn() as never,
-      promoteSnapshot: vi.fn(async () => true) as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          writeListenerRef.current = null;
-        };
-      }) as never,
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef, false),
       startChannel: vi.fn(async () => {
         events.push(`channel:${targetEnv[envKey]}`);
       }),
-      stopChannel: vi.fn(async () => {}),
       reloadPlugins,
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      channelManager: {} as never,
-      activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
-        sourceConfig: config,
-        config,
-        authStores: [],
-        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-        warnings: [],
-        webTools: createEmptyRuntimeWebToolsMetadata(),
-      })) as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
-      reconcileTerminalSessions: vi.fn(),
-      commitTerminalConfig: vi.fn(),
-      acceptTerminalConfig: vi.fn(),
     });
     const listener = writeListenerRef.current;
     if (!listener) {
       throw new Error("Expected config write listener to be registered");
     }
 
-    listener({
-      configPath: "/tmp/openclaw.json",
-      sourceConfig: nextConfig,
-      runtimeConfig: nextConfig,
-      preparedCandidate: { runtimeConfig: nextConfig, compareConfig, runtimeEnv },
-      persistedHash: "hot-env",
-      revision: 1,
-      fingerprint: "runtime-hot-env",
-      sourceFingerprint: "source-hot-env",
-      writtenAtMs: Date.now(),
-    });
+    listener(
+      createConfigWriteNotification(nextConfig, "hot-env", 1, "runtime-hot-env", "source-hot-env", {
+        preparedCandidate: { runtimeConfig: nextConfig, compareConfig, runtimeEnv },
+      }),
+    );
     await vi.runAllTimersAsync();
 
     expect(events).toEqual([
@@ -5965,21 +5033,7 @@ describe("gateway plugin hot reload handlers", () => {
     try {
       await expect(
         handlers.applyHotReload(
-          {
-            changedPaths: ["plugins.enabled"],
-            restartGateway: false,
-            restartReasons: [],
-            hotReasons: ["plugins.enabled"],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: true,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
+          createPluginReloadPlan(),
           { plugins: { enabled: true } },
           { publish: async (commit) => await commit(), isCurrent: () => true },
         ),
@@ -6018,21 +5072,7 @@ describe("gateway plugin hot reload handlers", () => {
     try {
       await expect(
         handlers.applyHotReload(
-          {
-            changedPaths: ["plugins.enabled"],
-            restartGateway: false,
-            restartReasons: [],
-            hotReasons: ["plugins.enabled"],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: true,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
+          createPluginReloadPlan(),
           { plugins: { enabled: true } },
           { publish, isCurrent: () => true },
         ),
@@ -6162,21 +5202,7 @@ describe("gateway plugin hot reload handlers", () => {
 
     await expect(
       handlers.applyHotReload(
-        {
-          changedPaths: ["plugins.enabled"],
-          restartGateway: false,
-          restartReasons: [],
-          hotReasons: ["plugins.enabled"],
-          reloadHooks: false,
-          restartGmailWatcher: false,
-          restartCron: false,
-          restartHeartbeat: false,
-          restartHealthMonitor: false,
-          reloadPlugins: true,
-          restartChannels: new Set(),
-          disposeMcpRuntimes: false,
-          noopPaths: [],
-        },
+        createPluginReloadPlan(),
         { plugins: { enabled: true } },
         { publish, isCurrent: () => true },
       ),
@@ -6212,24 +5238,7 @@ describe("gateway plugin hot reload handlers", () => {
     );
 
     await expect(
-      handlers.applyHotReload(
-        {
-          changedPaths: ["plugins.enabled"],
-          restartGateway: false,
-          restartReasons: [],
-          hotReasons: ["plugins.enabled"],
-          reloadHooks: false,
-          restartGmailWatcher: false,
-          restartCron: false,
-          restartHeartbeat: false,
-          restartHealthMonitor: false,
-          reloadPlugins: true,
-          restartChannels: new Set(),
-          disposeMcpRuntimes: false,
-          noopPaths: [],
-        },
-        { plugins: { enabled: true } },
-      ),
+      handlers.applyHotReload(createPluginReloadPlan(), { plugins: { enabled: true } }),
     ).rejects.toThrow("config hot reload cancelled by config supersession or in-process restart");
 
     expect(events).toEqual(["stop:discord", "start:discord"]);
@@ -6274,8 +5283,6 @@ describe("gateway plugin hot reload handlers", () => {
       },
     );
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
       getState: () => ({
         hooksConfig: {} as never,
         hookClientIpConfig: {} as never,
@@ -6287,11 +5294,7 @@ describe("gateway plugin hot reload handlers", () => {
       startChannel,
       stopChannel,
       reloadPlugins,
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       logChannels,
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      createHealthMonitor: () => null,
     });
 
     const root = tryBeginGatewayRootWorkAdmission();
@@ -6299,28 +5302,11 @@ describe("gateway plugin hot reload handlers", () => {
     try {
       await expect(
         root?.run(async () => {
-          await applyHotReload(
-            {
-              changedPaths: ["plugins.enabled"],
-              restartGateway: false,
-              restartReasons: [],
-              hotReasons: ["plugins.enabled"],
-              reloadHooks: false,
-              restartGmailWatcher: false,
-              restartCron: false,
-              restartHeartbeat: false,
-              restartHealthMonitor: false,
-              reloadPlugins: true,
-              restartChannels: new Set(),
-              disposeMcpRuntimes: false,
-              noopPaths: [],
+          await applyHotReload(createPluginReloadPlan(), {
+            plugins: {
+              enabled: false,
             },
-            {
-              plugins: {
-                enabled: false,
-              },
-            },
-          );
+          });
         }),
       ).rejects.toThrow("failed to stop channels before plugin reload: discord");
     } finally {
@@ -6383,8 +5369,6 @@ describe("gateway plugin hot reload handlers", () => {
       },
     );
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
       getState: () => ({
         hooksConfig: {} as never,
         hookClientIpConfig: {} as never,
@@ -6396,36 +5380,14 @@ describe("gateway plugin hot reload handlers", () => {
       startChannel,
       stopChannel,
       reloadPlugins,
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      createHealthMonitor: () => null,
     });
 
     try {
-      await applyHotReload(
-        {
-          changedPaths: ["plugins.enabled"],
-          restartGateway: false,
-          restartReasons: [],
-          hotReasons: ["plugins.enabled"],
-          reloadHooks: false,
-          restartGmailWatcher: false,
-          restartCron: false,
-          restartHeartbeat: false,
-          restartHealthMonitor: false,
-          reloadPlugins: true,
-          restartChannels: new Set(),
-          disposeMcpRuntimes: false,
-          noopPaths: [],
+      await applyHotReload(createPluginReloadPlan(), {
+        plugins: {
+          enabled: false,
         },
-        {
-          plugins: {
-            enabled: false,
-          },
-        },
-      );
+      });
     } finally {
       if (previousSkipChannels === undefined) {
         delete process.env.OPENCLAW_SKIP_CHANNELS;
@@ -6488,8 +5450,6 @@ describe("gateway plugin hot reload handlers", () => {
       },
     );
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
       getState: () => ({
         hooksConfig: {} as never,
         hookClientIpConfig: {} as never,
@@ -6505,36 +5465,15 @@ describe("gateway plugin hot reload handlers", () => {
         reason: "crash-loop-breaker",
         message: "safe mode",
       }),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       logChannels,
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      createHealthMonitor: () => null,
     });
 
     try {
-      await applyHotReload(
-        {
-          changedPaths: ["plugins.enabled"],
-          restartGateway: false,
-          restartReasons: [],
-          hotReasons: ["plugins.enabled"],
-          reloadHooks: false,
-          restartGmailWatcher: false,
-          restartCron: false,
-          restartHeartbeat: false,
-          restartHealthMonitor: false,
-          reloadPlugins: true,
-          restartChannels: new Set(),
-          disposeMcpRuntimes: false,
-          noopPaths: [],
+      await applyHotReload(createPluginReloadPlan(), {
+        plugins: {
+          enabled: false,
         },
-        {
-          plugins: {
-            enabled: false,
-          },
-        },
-      );
+      });
     } finally {
       if (previousSkipChannels === undefined) {
         delete process.env.OPENCLAW_SKIP_CHANNELS;
@@ -6591,54 +5530,12 @@ describe("deferred channel reload abort generation", () => {
     },
   ) =>
     createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
       startChannel: channels.start,
       stopChannel: channels.stop,
-      stopPostReadySidecars: vi.fn(),
-      reloadPlugins:
-        options?.reloadPlugins ??
-        vi.fn(
-          async (): Promise<GatewayPluginReloadResult> => ({
-            restartChannels: new Set(),
-            activeChannels: new Set(),
-          }),
-        ),
+      ...(options?.reloadPlugins ? { reloadPlugins: options.reloadPlugins } : {}),
       requestRecoveryRestart: options?.requestRecoveryRestart,
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       logChannels,
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      createHealthMonitor: () => null,
     });
-
-  const createPluginReloadPlan = (): GatewayReloadPlan => ({
-    changedPaths: ["plugins.enabled"],
-    restartGateway: false,
-    restartReasons: [],
-    hotReasons: ["plugins.enabled"],
-    reloadHooks: false,
-    restartGmailWatcher: false,
-    restartCron: false,
-    restartHeartbeat: false,
-    restartHealthMonitor: false,
-    reloadPlugins: true,
-    restartChannels: new Set(),
-    disposeMcpRuntimes: false,
-    noopPaths: [],
-  });
 
   it("abortPendingChannelReloads cancels a waiting deferred channel reload", async () => {
     const logChannels = { info: vi.fn(), error: vi.fn() };
@@ -6823,9 +5720,7 @@ describe("deferred channel reload abort generation", () => {
     const registry = createTestRegistry([
       { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
     ]);
-    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
-      current: null,
-    };
+    const writeListenerRef = createConfigWriteListenerRef();
     const commitTerminalConfig = vi.fn();
     const promoteSnapshot = vi.fn(async () => true);
     const logReload = {
@@ -6835,62 +5730,12 @@ describe("deferred channel reload abort generation", () => {
     };
     pinActivePluginChannelRegistry(registry);
     const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
       initialConfig,
-      initialCompareConfig: initialConfig,
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
       readSnapshot: vi.fn() as never,
       promoteSnapshot: promoteSnapshot as never,
-      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
-        writeListenerRef.current = listener;
-        return () => {
-          if (writeListenerRef.current === listener) {
-            writeListenerRef.current = null;
-          }
-        };
-      }) as never,
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
+      subscribeToWrites: captureConfigWriteListener(writeListenerRef),
       logReload,
-      channelManager: {} as never,
-      activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
-        sourceConfig: config,
-        config,
-        authStores: [],
-        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-        warnings: [],
-        webTools: createEmptyRuntimeWebToolsMetadata(),
-      })) as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      clients: [],
-      reconcileTerminalSessions: vi.fn(),
       commitTerminalConfig,
-      acceptTerminalConfig: vi.fn(),
     });
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
@@ -6905,16 +5750,15 @@ describe("deferred channel reload abort generation", () => {
     let reloaderStopped = false;
 
     try {
-      registeredWriteListener({
-        configPath: "/tmp/openclaw.json",
-        sourceConfig: nextConfig,
-        runtimeConfig: nextConfig,
-        persistedHash: "managed-abort-next",
-        revision: 1,
-        fingerprint: "runtime-managed-abort-next",
-        sourceFingerprint: "source-managed-abort-next",
-        writtenAtMs: Date.now(),
-      });
+      registeredWriteListener(
+        createConfigWriteNotification(
+          nextConfig,
+          "managed-abort-next",
+          1,
+          "runtime-managed-abort-next",
+          "source-managed-abort-next",
+        ),
+      );
       await vi.advanceTimersByTimeAsync(10);
       abortPendingChannelReloads();
       await vi.advanceTimersByTimeAsync(500);
@@ -7005,46 +5849,13 @@ describe("deferred channel reload abort generation", () => {
       },
     );
     const { applyHotReload } = createGatewayReloadHandlers({
-      deps: {} as never,
-      broadcast: vi.fn(),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
-      setState: vi.fn(),
       startChannel: channels.start,
       stopChannel: channels.stop,
-      stopPostReadySidecars: vi.fn(),
       reloadPlugins,
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       logChannels,
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn() },
-      createHealthMonitor: () => null,
     });
 
-    const pluginReloadPlan: GatewayReloadPlan = {
-      changedPaths: ["plugins.enabled"],
-      restartGateway: false,
-      restartReasons: [],
-      hotReasons: ["plugins.enabled"],
-      reloadHooks: false,
-      restartGmailWatcher: false,
-      restartCron: false,
-      restartHeartbeat: false,
-      restartHealthMonitor: false,
-      reloadPlugins: true,
-      restartChannels: new Set(),
-      disposeMcpRuntimes: false,
-      noopPaths: [],
-    };
+    const pluginReloadPlan: GatewayReloadPlan = createPluginReloadPlan();
 
     hoisted.activeTaskBlockers.push({
       taskId: "task-blocking-reload",


### PR DESCRIPTION
## What Problem This Solves

The gateway reload-handler test file repeated the same handler defaults, managed-reloader dependency bags, restart/plugin plans, valid snapshots, write notifications, and listener lifecycle plumbing across otherwise distinct scenarios. That duplication obscured the behavior each test was actually proving.

## Why This Change Was Made

This maintainer-requested, AI-assisted test refactor keeps every scenario separate while moving equivalent setup into typed file-local builders. Caller-specific reload plugins, logging spies, health monitors, environment candidates, generation state, terminal callbacks, and listener cleanup behavior continue to override the defaults explicitly.

Intentional case restructuring:

- No test case was merged or deleted.
- No assertion was removed.
- Repeated gateway-restart and plugin-reload plan literals now use named plan builders.
- Repeated valid snapshot, write-notification, listener, handler, and reloader fixtures now use typed file-local helpers.

The test count remains 105 (delta 0). The target file falls from 7,085 to 5,896 lines (-1,189, 16.8%).

## User Impact

No runtime or user-visible behavior changes. Maintainers get a smaller reload suite whose scenario-specific state and assertions are easier to audit.

## Evidence

- Full target file: 105/105 pass.
- Adjacent reload/restart suites: 162/162 pass across config reload, plugin channel targets, hot-reload status, and restart deferral.
- Final Blacksmith Testbox changed gate: https://github.com/openclaw/openclaw/actions/runs/29994294281 (pass).
- Targeted type-aware lint and formatting: pass.
- Fresh Codex branch autoreview: clean, confidence 0.97.
- Public-model audit: PASS; no model identifier additions.
