### PR TITLE
refactor(agents): reuse code mode JSON sanitizer

### DIFF
--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -7,6 +7,7 @@ import { createRequire } from "node:module";
 import { parentPort, workerData } from "node:worker_threads";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { EvalFlags, JSException, QuickJS, type JSValueHandle } from "quickjs-wasi";
+import { toCodeModeJsonSafe as toJsonSafe } from "./code-mode-json.js";
 import type { CodeModeApiVirtualFile } from "./code-mode-namespaces.js";
 import { CODE_MODE_SWARM_CONTROLLER_SOURCE } from "./code-mode-swarm-controller-source.js";
 import type {
@@ -94,35 +95,6 @@ function errorMessage(error: unknown): string {
     return error.message || String(error);
   }
   return String(error);
-}
-
-function toJsonSafe(value: unknown): unknown {
-  if (value === undefined) {
-    return null;
-  }
-  try {
-    const serialized = JSON.stringify(value);
-    return serialized === undefined ? null : (JSON.parse(serialized) as unknown);
-  } catch {
-    if (value instanceof Error) {
-      return { name: value.name, message: value.message };
-    }
-    if (value === null) {
-      return null;
-    }
-    switch (typeof value) {
-      case "string":
-      case "number":
-      case "boolean":
-        return value;
-      case "bigint":
-      case "symbol":
-      case "function":
-        return String(value);
-      default:
-        return Object.prototype.toString.call(value);
-    }
-  }
 }
 
 const CONTROLLER_SOURCE = String.raw`


### PR DESCRIPTION
## What Problem This Solves

Removes a duplicate JSON-safety implementation from the Code Mode worker so the worker and the rest of Code Mode cannot drift onto different serialization behavior.

## Why This Change Was Made

The worker now reuses the existing canonical `toCodeModeJsonSafe` helper. This restores the shared path previously established by `2e44610ba23` after a later change reintroduced the byte-for-byte local copy.

## User Impact

No intended user-visible behavior change. The Code Mode serialization path is smaller and has one implementation to maintain.

## Evidence

- `node scripts/run-vitest.mjs src/agents/code-mode.test.ts src/agents/code-mode-swarm.test.ts` - 96 tests passed on current `main`.
- Blacksmith Testbox `tbx_01ky744wtyrrpemzretjj6gmqg` - 96 focused tests passed, full build passed, and the path-scoped `check:changed` gate passed.
- Fresh autoreview after the main rebase: clean, no actionable findings, 0.93 correctness confidence.
- `git diff --check`
