### PR TITLE
fix(sessions): preserve CLI sessions with provider overrides

### DIFF
--- a/src/config/sessions/entry-freshness.test.ts
+++ b/src/config/sessions/entry-freshness.test.ts
@@ -2,10 +2,26 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
-import { resolveSessionEntryResetFreshness } from "./entry-freshness.js";
+import { hasProviderOwnedSession, resolveSessionEntryResetFreshness } from "./entry-freshness.js";
 import { upsertSessionEntry } from "./session-accessor.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("hasProviderOwnedSession", () => {
+  it("falls back to the backend provider when a catalog provider override is active", () => {
+    expect(
+      hasProviderOwnedSession({
+        sessionId: "session-provider-owned-override",
+        updatedAt: Date.now(),
+        providerOverride: "anthropic",
+        modelProvider: "claude-cli",
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "cli-session-provider-owned-override" },
+        },
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("resolveSessionEntryResetFreshness", () => {
   let tempDirs: string[] = [];
@@ -86,6 +102,36 @@ describe("resolveSessionEntryResetFreshness", () => {
         providerOverride: "claude-cli",
         cliSessionBindings: {
           "claude-cli": { sessionId: "cli-session-provider-owned" },
+        },
+      },
+    );
+
+    const result = resolveSessionEntryResetFreshness({
+      sessionKey,
+      storePath,
+      sessionCfg: {},
+      resetType: "thread",
+      now,
+    });
+
+    expect(result.state).toBe("fresh");
+    expect(result.freshness).toMatchObject({ fresh: true });
+  });
+
+  it("keeps provider-owned sessions fresh when a catalog provider override is active", async () => {
+    const sessionKey = "agent:main:main:thread:provider-owned-override";
+    const now = new Date("2026-01-02T12:00:00Z").getTime();
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "session-provider-owned-override",
+        updatedAt: now,
+        sessionStartedAt: now - 2 * DAY_MS,
+        lastInteractionAt: now - 2 * DAY_MS,
+        providerOverride: "anthropic",
+        modelProvider: "claude-cli",
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "cli-session-provider-owned-override" },
         },
       },
     );

--- a/src/config/sessions/entry-freshness.ts
+++ b/src/config/sessions/entry-freshness.ts
@@ -46,8 +46,12 @@ type ResolvedSessionEntryResetFreshness =
     };
 
 export function hasProviderOwnedSession(entry: SessionEntry | undefined): boolean {
-  const provider = normalizeOptionalString(entry?.providerOverride ?? entry?.modelProvider);
-  return Boolean(provider && getCliSessionBinding(entry, provider));
+  const overrideProvider = normalizeOptionalString(entry?.providerOverride);
+  if (overrideProvider && getCliSessionBinding(entry, overrideProvider)) {
+    return true;
+  }
+  const modelProvider = normalizeOptionalString(entry?.modelProvider);
+  return Boolean(modelProvider && getCliSessionBinding(entry, modelProvider));
 }
 
 /** Resolves one session entry's reset freshness using the runtime lifecycle rules. */

--- a/src/cron/isolated-agent/session.provider-owned-reset.test.ts
+++ b/src/cron/isolated-agent/session.provider-owned-reset.test.ts
@@ -16,12 +16,13 @@ function providerOwnedEntry(): SessionEntry {
     lastInteractionAt: startedAt,
     model: "claude-opus-4-6",
     modelProvider: "claude-cli",
+    providerOverride: "anthropic",
     cliSessionBindings: { "claude-cli": { sessionId: "cli-conversation-xyz" } },
   };
 }
 
 describe("resolveCronSession provider-owned daily reset", () => {
-  it("keeps a provider-owned CLI session with the default reset policy", () => {
+  it("keeps a provider-owned CLI session with a catalog provider override", () => {
     const sessionKey = "agent:main:cron:daily-job";
     const entry = providerOwnedEntry();
 

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -973,7 +973,7 @@ describe("gateway agent handler", () => {
     }
   });
 
-  it("keeps a provider-owned CLI session across the daily default boundary on the gateway path", async () => {
+  it("keeps a provider-owned CLI session with a catalog override across the daily boundary", async () => {
     const now = Date.parse("2026-04-25T12:00:00.000Z");
     vi.useFakeTimers();
     vi.setSystemTime(now);
@@ -985,6 +985,7 @@ describe("gateway agent handler", () => {
         sessionStartedAt: now - 25 * 60 * 60_000,
         lastInteractionAt: now - 25 * 60 * 60_000,
         modelProvider: "claude-cli",
+        providerOverride: "anthropic",
         cliSessionBindings: { "claude-cli": { sessionId: "claude-cli-conversation-123" } },
       });
       const loaded = mocks.loadSessionEntry();


### PR DESCRIPTION
Closes #112908

## What Problem This Solves

Provider-owned CLI sessions are exempt from the implicit daily reset so the external CLI can keep its own conversation continuity. When a catalog-level `providerOverride` such as `anthropic` was present alongside the backend `modelProvider` (`claude-cli`), `hasProviderOwnedSession` checked only the override key. Since the CLI binding is stored under `claude-cli`, the exemption was missed and the session rotated at the daily boundary.

This change checks both provider identities: it accepts a binding under the override when one exists, then falls back to the backend provider. Explicitly configured reset policies remain unchanged.

## Evidence

Exact head: `fc39003ea95cbb29b3f99bb2e7c9b583026a985d`

- Focused cron behavior test: `3 passed (3)`, including the catalog override plus backend CLI binding at an expired implicit daily boundary.
- Added direct helper coverage for the provider/backend key mismatch.
- Added session-entry and gateway-path regression coverage for `providerOverride: "anthropic"` with a `claude-cli` binding.
- `oxfmt --check` passed for all four changed files.
- `oxlint` passed for all four changed files.
- `git diff --check` passed.

The focused cron proof exercises the observable outcome: the existing provider-owned CLI session ID is preserved across the implicit daily boundary. The companion configured-reset test confirms that an explicit daily reset still rotates it.