### PR TITLE
refactor(markdown): formalize channel profiles

### DIFF
--- a/extensions/clickclack/src/outbound.ts
+++ b/extensions/clickclack/src/outbound.ts
@@ -12,7 +12,11 @@ import {
   loadOutboundMediaFromUrl,
   type OutboundMediaLoadOptions,
 } from "openclaw/plugin-sdk/outbound-media";
-import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
+import {
+  type FormatCapabilityProfile,
+  renderMarkdownWithMarkers,
+  sanitizeAssistantVisibleText,
+} from "openclaw/plugin-sdk/text-chunking";
 import { resolveClickClackAccount } from "./accounts.js";
 import { createClickClackClient, type ClickClackClient } from "./http-client.js";
 import { resolveChannelId, resolveWorkspaceId } from "./resolve.js";
@@ -20,6 +24,38 @@ import { parseClickClackTarget } from "./target.js";
 import type { ClickClackMessage, ClickClackMessageProvenance, CoreConfig } from "./types.js";
 
 const CLICKCLACK_MAX_UPLOAD_BYTES = 64 * 1024 * 1024;
+
+const CLICKCLACK_FORMAT_PROFILE = {
+  mechanism: "markdown",
+  constructs: {
+    bold: "native",
+    italic: "native",
+    underline: "native",
+    strikethrough: "native",
+    spoiler: "native",
+    codeInline: "native",
+    codeBlock: "native",
+    codeLanguage: "native",
+    linkLabel: "native",
+    heading: "native",
+    bulletList: "native",
+    orderedList: "native",
+    taskList: "native",
+    table: "native",
+    blockquote: "native",
+    image: "native",
+    mention: "native",
+  },
+  chunk: { limit: 1024 * 1024, unit: "bytes" },
+} satisfies FormatCapabilityProfile;
+
+function renderClickClackMarkdown(markdown: string): string {
+  return renderMarkdownWithMarkers(
+    { text: markdown, styles: [], links: [] },
+    { styleMarkers: {}, escapeText: (text) => text },
+    CLICKCLACK_FORMAT_PROFILE,
+  );
+}
 
 async function createTargetMessage(params: {
   client: ClickClackClient;
@@ -174,7 +210,7 @@ export async function sendClickClackText(params: {
 }): Promise<string | undefined> {
   // Custom inbound replies bypass shared outbound normalization, so this private
   // sender owns ClickClack assistant-text sanitization for every delivery path.
-  const text = sanitizeAssistantVisibleText(params.text);
+  const text = renderClickClackMarkdown(sanitizeAssistantVisibleText(params.text));
   if (!text) {
     return undefined;
   }
@@ -259,7 +295,10 @@ export async function sendClickClackMedia(params: {
     });
   }
   const text =
-    sanitizeAssistantVisibleText(params.text) || mediaFilename || upload.filename || "attachment";
+    renderClickClackMarkdown(sanitizeAssistantVisibleText(params.text)) ||
+    mediaFilename ||
+    upload.filename ||
+    "attachment";
   // Upload-first ordering lets crash recovery identify the durable object before
   // it creates or repairs the corresponding message.
   const message = await createTargetMessage({

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -4,6 +4,10 @@ import {
   readProviderJsonResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
+import {
+  type FormatCapabilityProfile,
+  renderMarkdownWithMarkers,
+} from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { releaseNextcloudTalkGuardedResponse } from "./guarded-response.js";
 import { stripNextcloudTalkTargetPrefix } from "./normalize.js";
@@ -26,6 +30,38 @@ import type { CoreConfig, NextcloudTalkSendResult } from "./types.js";
 const NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES = 8 * 1024;
 const NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_CHARS = 200;
 const NEXTCLOUD_TALK_SEND_TIMEOUT_MS = 30_000;
+
+const NEXTCLOUD_TALK_FORMAT_PROFILE = {
+  mechanism: "markdown",
+  constructs: {
+    bold: "native",
+    italic: "native",
+    underline: "native",
+    strikethrough: "native",
+    spoiler: "native",
+    codeInline: "native",
+    codeBlock: "native",
+    codeLanguage: "native",
+    linkLabel: "native",
+    heading: "native",
+    bulletList: "native",
+    orderedList: "native",
+    taskList: "native",
+    table: "native",
+    blockquote: "native",
+    image: "native",
+    mention: "native",
+  },
+  chunk: { limit: 4000, unit: "chars", hardCap: 32_000 },
+} satisfies FormatCapabilityProfile;
+
+function renderNextcloudTalkMarkdown(markdown: string): string {
+  return renderMarkdownWithMarkers(
+    { text: markdown, styles: [], links: [] },
+    { styleMarkers: {}, escapeText: (text) => text },
+    NEXTCLOUD_TALK_FORMAT_PROFILE,
+  );
+}
 
 /** Collapses whitespace and caps an error-body prefix to a short, log-safe snippet. */
 function collapseErrorSnippet(text: string): string {
@@ -160,7 +196,7 @@ export async function sendMessageNextcloudTalk(
     channel: "nextcloud-talk",
     accountId: account.accountId,
   });
-  const message = convertMarkdownTables(text.trim(), tableMode);
+  const message = convertMarkdownTables(renderNextcloudTalkMarkdown(text.trim()), tableMode);
 
   const body: Record<string, unknown> = {
     message,

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -2,6 +2,7 @@
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import {
   chunkTextForOutbound,
+  type FormatCapabilityProfile,
   markdownToIR,
   type MarkdownLinkSpan,
   renderMarkdownIRChunksWithinLimit,
@@ -105,6 +106,30 @@ function buildSlackLink(link: MarkdownLinkSpan, text: string) {
 type SlackMarkdownOptions = {
   tableMode?: MarkdownTableMode;
 };
+
+const SLACK_FORMAT_PROFILE = {
+  mechanism: "markdown",
+  constructs: {
+    bold: "native",
+    italic: "native",
+    underline: "strip",
+    strikethrough: "native",
+    spoiler: "fallback",
+    codeInline: "native",
+    codeBlock: "native",
+    codeLanguage: "fallback",
+    linkLabel: "native",
+    heading: "fallback",
+    bulletList: "fallback",
+    orderedList: "fallback",
+    taskList: "fallback",
+    table: "fallback",
+    blockquote: "native",
+    image: "fallback",
+    mention: "native",
+  },
+  chunk: { limit: 4000, unit: "chars", hardCap: 40_000 },
+} satisfies FormatCapabilityProfile;
 
 type SlackCodeMarker = "`" | "```";
 const SLACK_ASSISTANT_TRANSCRIPT_PREFIX = "`Assistant:` ";
@@ -356,11 +381,11 @@ function markdownToSlackMrkdwn(markdown: string, options: SlackMarkdownOptions =
     assistantTranscriptRoleHeaders: true,
     linkify: false,
     autolink: false,
-    headingStyle: "bold",
+    headingStyle: "rich",
     blockquotePrefix: "> ",
     tableMode: options.tableMode,
   });
-  return renderMarkdownWithMarkers(ir, buildSlackRenderOptions());
+  return renderMarkdownWithMarkers(ir, buildSlackRenderOptions(), SLACK_FORMAT_PROFILE);
 }
 
 export function normalizeSlackOutboundText(markdown: string): string {
@@ -443,7 +468,7 @@ export function markdownToSlackMrkdwnChunks(
     assistantTranscriptRoleHeaders: true,
     linkify: false,
     autolink: false,
-    headingStyle: "bold",
+    headingStyle: "rich",
     blockquotePrefix: "> ",
     tableMode: options.tableMode,
   });
@@ -452,7 +477,9 @@ export function markdownToSlackMrkdwnChunks(
     ir,
     limit,
     renderChunk: (chunk) =>
-      protectSlackAssistantTranscriptRoleHeaders(renderMarkdownWithMarkers(chunk, renderOptions)),
+      protectSlackAssistantTranscriptRoleHeaders(
+        renderMarkdownWithMarkers(chunk, renderOptions, SLACK_FORMAT_PROFILE),
+      ),
     measureRendered: (rendered) => rendered.length,
   }).map(({ rendered }) => rendered);
 }


### PR DESCRIPTION
## What Problem This Solves

Slack, Nextcloud Talk, and ClickClack still encoded outbound Markdown behavior as channel-specific exceptions after the shared capability/fallback engine landed. That left their platform support implicit and kept these send paths outside the unified formatter contract.

## Why This Change Was Made

This AI-assisted refactor gives each channel an exhaustive `FormatCapabilityProfile` and routes delivery through the shared marker renderer and fallback engine. Slack now parses headings as semantic headings and lets its profile select the existing bold fallback; Nextcloud Talk and ClickClack keep receiver-owned Markdown bytes opaque so the shared all-native pass-through cannot canonicalize or rewrite authored Markdown. Transport-specific sanitization, tables, chunking, signatures, mentions, and API calls remain channel-local.

## User Impact

No user-visible output changes. Existing Slack rendering and Nextcloud Talk/ClickClack Markdown pass-through remain byte-identical, while future construct fallbacks and platform limits now have explicit channel-owned declarations.

## Evidence

- Intended output changes: none. All existing fixtures remained unchanged.
- LOC: production `+110/-8` (net `+102`), tests `+0/-0`; total `+110/-8`. This is above the wave's net-negative target because the public profile contract deliberately requires an exhaustive declaration for every construct. The added adapters replace implicit special cases with one shared renderer/fallback path; no duplicate converter or compatibility path was added.
- `node scripts/run-vitest.mjs extensions/slack/src/format.test.ts extensions/nextcloud-talk/src/send.cfg-threading.test.ts extensions/clickclack/src/outbound.test.ts` — 3 shards, 50 tests passed.
- `node scripts/check-changed.mjs -- extensions/slack/src/format.ts extensions/nextcloud-talk/src/send.ts extensions/nextcloud-talk/src/send.cfg-threading.test.ts extensions/clickclack/src/outbound.ts extensions/clickclack/src/outbound.test.ts` — passed on Blacksmith Testbox `tbx_01ky76fwzkz8h5d3853kqqhq14`; run https://github.com/openclaw/openclaw/actions/runs/29997376105. This covered formatting, Plugin SDK/API contracts, plugin boundaries, extension production/test typechecks, lint, database-first guard, and import-cycle checks.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings, overall confidence 0.90.
- `git diff --check` — passed.
