### PR TITLE
test(cron): clean per-case SQLite stores

### DIFF
--- a/src/cron/service.test-harness.test.ts
+++ b/src/cron/service.test-harness.test.ts
@@ -1,0 +1,48 @@
+// Cron service harness tests cover per-case SQLite and filesystem cleanup.
+import { describe, expect, it } from "vitest";
+import { createCronStoreHarness, writeCronStoreSnapshot } from "./service.test-harness.js";
+import { loadCronStore } from "./store.js";
+
+const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-harness-" });
+let previousStorePath: string | undefined;
+
+function testJob() {
+  return {
+    id: "job-1",
+    name: "Test job",
+    enabled: true,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    schedule: { kind: "every" as const, everyMs: 60_000 },
+    sessionTarget: "main" as const,
+    wakeMode: "next-heartbeat" as const,
+    payload: { kind: "systemEvent" as const, text: "tick" },
+    state: {},
+  };
+}
+
+describe("createCronStoreHarness", () => {
+  it("tracks stores that callers do not explicitly clean", async () => {
+    const store = await makeStorePath();
+    previousStorePath = store.storePath;
+    await writeCronStoreSnapshot({ storePath: store.storePath, jobs: [testJob()] });
+    expect((await loadCronStore(store.storePath)).jobs).toHaveLength(1);
+  });
+
+  it("clears tracked SQLite rows after each test", async () => {
+    if (!previousStorePath) {
+      throw new Error("expected previous test store path");
+    }
+    expect((await loadCronStore(previousStorePath)).jobs).toEqual([]);
+  });
+
+  it("supports explicit idempotent cleanup", async () => {
+    const store = await makeStorePath();
+    await writeCronStoreSnapshot({ storePath: store.storePath, jobs: [testJob()] });
+
+    await store.cleanup();
+    await store.cleanup();
+
+    expect((await loadCronStore(store.storePath)).jobs).toEqual([]);
+  });
+});

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -46,13 +46,13 @@ export function createCronStoreHarness(options?: { prefix?: string }) {
   }
 
   afterEach(async () => {
-    for (const [storePath, dir] of [...stores]) {
+    for (const [storePath, dir] of stores) {
       await cleanupStore(storePath, dir);
     }
   });
 
   afterAll(async () => {
-    for (const [storePath, dir] of [...stores]) {
+    for (const [storePath, dir] of stores) {
       await cleanupStore(storePath, dir);
     }
     if (!fixtureRoot) {

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -30,12 +30,31 @@ export function createNoopLogger(): NoopLogger {
 export function createCronStoreHarness(options?: { prefix?: string }) {
   let fixtureRoot = "";
   let caseId = 0;
+  const stores = new Map<string, string>();
 
   beforeAll(async () => {
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), options?.prefix ?? "openclaw-cron-"));
   });
 
+  async function cleanupStore(storePath: string, dir: string) {
+    if (!stores.has(storePath)) {
+      return;
+    }
+    await saveCronStore(storePath, { version: 1, jobs: [] });
+    await fs.rm(dir, { recursive: true, force: true });
+    stores.delete(storePath);
+  }
+
+  afterEach(async () => {
+    for (const [storePath, dir] of [...stores]) {
+      await cleanupStore(storePath, dir);
+    }
+  });
+
   afterAll(async () => {
+    for (const [storePath, dir] of [...stores]) {
+      await cleanupStore(storePath, dir);
+    }
     if (!fixtureRoot) {
       return;
     }
@@ -45,9 +64,11 @@ export function createCronStoreHarness(options?: { prefix?: string }) {
   async function makeStorePath() {
     const dir = path.join(fixtureRoot, `case-${caseId++}`);
     await fs.mkdir(dir, { recursive: true });
+    const storePath = path.join(dir, "cron", "jobs.json");
+    stores.set(storePath, dir);
     return {
-      storePath: path.join(dir, "cron", "jobs.json"),
-      cleanup: async () => {},
+      storePath,
+      cleanup: async () => await cleanupStore(storePath, dir),
     };
   }
 


### PR DESCRIPTION
## What Problem This Solves

The shared cron service test harness returns a no-op cleanup. Since cron stores are SQLite-backed by `storePath`, tests accumulate rows under unique per-case keys until the worker exits, even though the fixture directory is eventually deleted.

## Why This Change Was Made

Track every generated store in the harness. Explicit cleanup and harness `afterEach` persist an empty store to delete all rows for that key, remove the case directory, and remain idempotent. `afterAll` retries any outstanding cleanup before deleting the suite root.

A dedicated regression test proves both automatic cleanup for callers that forget to release and explicit idempotent cleanup.

## User Impact

Developers get cleaner, faster cron test workers with bounded SQLite state. Production behavior is unchanged.

## Evidence

- Blacksmith Linux Node 24:
  - new harness lifecycle tests plus four high-use consumer suites
  - 5 files / 47 tests passed
  - oxfmt check passed
- `git diff --check`: passed
- Formal Codex autoreview: clean

AI-assisted: yes.
