### PR TITLE
fix(whatsapp): render CommonMark italic correctly

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -5,7 +5,7 @@ import {
   type MessageReceiptSourceResult,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
-import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
+import type { ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-chunking";
 import {
   isReasoningReplyPayload,
@@ -27,8 +27,7 @@ import { sendWhatsAppOutboundWithRetry } from "../outbound-retry.js";
 import { buildQuotedMessageOptions, lookupInboundMessageMeta } from "../quoted-message.js";
 import { newConnectionId } from "../reconnect.js";
 import { formatError } from "../session.js";
-import { convertMarkdownTables } from "../text-runtime.js";
-import { markdownToWhatsApp } from "../text-runtime.js";
+import { markdownToWhatsAppChunks } from "../text-runtime.js";
 import { whatsappOutboundLog } from "./loggers.js";
 import { elide, markWhatsAppVisibleDeliveryError } from "./util.js";
 
@@ -131,10 +130,12 @@ export async function deliverWebReply(params: {
     normalizeWhatsAppOutboundPayload(replyResult, {
       normalizeText: normalizeWhatsAppPayloadTextPreservingIndentation,
     });
-  const convertedText = markdownToWhatsApp(
-    convertMarkdownTables(normalizedReply.text ?? "", tableMode),
+  const textChunks = markdownToWhatsAppChunks(
+    normalizedReply.text ?? "",
+    textLimit,
+    tableMode,
+    chunkMode,
   );
-  const textChunks = chunkMarkdownTextWithMode(convertedText, textLimit, chunkMode);
   const mediaList = normalizedReply.mediaUrls ?? [];
 
   const getQuote = () => {

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -142,6 +142,23 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenCalledWith("+1555", "hi", undefined, undefined);
   });
 
+  it("re-chunks after WhatsApp marker expansion", async () => {
+    const onDeliveryResult = vi.fn();
+    await sendMessageWhatsApp("+1555", Array.from({ length: 8 }, () => "`x`").join(" "), {
+      verbose: false,
+      cfg: { channels: { whatsapp: { textChunkLimit: 20 } } },
+      onDeliveryResult,
+    });
+
+    const sentText = (sendMessage.mock.calls as unknown as Array<[string, string]>).map(
+      ([, chunk]) => chunk,
+    );
+    expect(sentText.length).toBeGreaterThan(1);
+    expect(sentText.every((chunk) => chunk.length <= 20)).toBe(true);
+    expect(sentText.join("")).not.toContain("\uE000");
+    expect(onDeliveryResult).toHaveBeenCalledTimes(sentText.length);
+  });
+
   it("checks send readiness before composing or sending direct messages", async () => {
     const assertSendReady = vi.fn(async () => {
       throw new Error("WhatsApp reachout timelock is active");

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -4,13 +4,11 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { generateSecureUuid } from "openclaw/plugin-sdk/core";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { redactIdentifier } from "openclaw/plugin-sdk/logging-core";
-import {
-  convertMarkdownTables,
-  resolveMarkdownTableMode,
-} from "openclaw/plugin-sdk/markdown-table-runtime";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk/outbound-media";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { normalizePollInput, type PollInput } from "openclaw/plugin-sdk/poll-runtime";
+import { resolveChunkMode, resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { createSubsystemLogger, getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
   resolveDefaultWhatsAppAccountId,
@@ -26,7 +24,7 @@ import {
   prepareWhatsAppOutboundMedia,
   resolveAdditiveWhatsAppMediaUrls,
 } from "./outbound-media-contract.js";
-import { markdownToWhatsApp, toWhatsappJid } from "./text-runtime.js";
+import { markdownToWhatsAppChunks, toWhatsappJid } from "./text-runtime.js";
 
 const outboundLog = createSubsystemLogger("gateway/channels/whatsapp").child("outbound");
 
@@ -180,8 +178,21 @@ export async function sendMessageWhatsApp(
     channel: "whatsapp",
     accountId: resolvedAccountId ?? options.accountId,
   });
-  text = convertMarkdownTables(text ?? "", tableMode);
-  text = markdownToWhatsApp(text);
+  const accountIdForFormatting = resolvedAccountId ?? options.accountId;
+  const textLimit = Math.min(
+    resolveTextChunkLimit(cfg, "whatsapp", accountIdForFormatting, { fallbackLimit: 4_000 }),
+    4_096,
+  );
+  const textChunks = markdownToWhatsAppChunks(
+    text,
+    textLimit,
+    tableMode,
+    resolveChunkMode(cfg, "whatsapp", accountIdForFormatting),
+  );
+  text = textChunks.shift() ?? "";
+  if (!text && !hasMedia) {
+    return { messageId: "", toJid: jid };
+  }
   const redactedTo = redactIdentifier(to);
   const logger = getChildLogger({
     module: "web-outbound",
@@ -252,17 +263,22 @@ export async function sendMessageWhatsApp(
       : await active.sendMessage(to, text, mediaBuffer, mediaType);
     const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
     const sentRemoteJid = resolveActualSentRemoteJid(result, jid);
-    if (visibleTextAfterVoice) {
-      // Voice captions require a second platform send. Persist the accepted voice
-      // first so a caption failure cannot make recovery replay the voice note.
+    const trailingTextChunks = [visibleTextAfterVoice, ...textChunks].filter(
+      (chunk): chunk is string => Boolean(chunk),
+    );
+    if (trailingTextChunks.length > 0) {
+      // Persist each accepted part before the next fallible send so recovery
+      // cannot replay already-delivered media or text chunks.
       await options.onDeliveryResult?.({ messageId, toJid: sentRemoteJid });
-      const captionResult = sendOptions
-        ? await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined, sendOptions)
-        : await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined);
-      await options.onDeliveryResult?.({
-        messageId: (captionResult as { messageId?: string })?.messageId ?? "unknown",
-        toJid: resolveActualSentRemoteJid(captionResult, jid),
-      });
+      for (const trailingText of trailingTextChunks) {
+        const trailingResult = sendOptions
+          ? await active.sendMessage(to, trailingText, undefined, undefined, sendOptions)
+          : await active.sendMessage(to, trailingText, undefined, undefined);
+        await options.onDeliveryResult?.({
+          messageId: (trailingResult as { messageId?: string })?.messageId ?? "unknown",
+          toJid: resolveActualSentRemoteJid(trailingResult, jid),
+        });
+      }
     }
     const durationMs = Date.now() - startedAt;
     outboundLog.info(

--- a/extensions/whatsapp/src/targets-runtime.ts
+++ b/extensions/whatsapp/src/targets-runtime.ts
@@ -2,15 +2,55 @@
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
+import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
+import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
+import {
+  type FormatCapabilityProfile,
+  type MarkdownIR,
+  markdownToIRWithMeta,
+  renderMarkdownIRChunksWithinLimit,
+  renderMarkdownWithMarkers,
+  sliceMarkdownIR,
+} from "openclaw/plugin-sdk/text-chunking";
 import { CONFIG_DIR, resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 
-const WHATSAPP_FENCE_PLACEHOLDER = "\x00FENCE";
-const WHATSAPP_INLINE_CODE_PLACEHOLDER = "\x00CODE";
-// Terminates the numeric index in a placeholder so the restore regex cannot
-// absorb a digit from adjacent user text (e.g. `code`5) into the index.
-const WHATSAPP_PLACEHOLDER_TERMINATOR = "\x00";
+const WHATSAPP_FORMAT_CAPABILITIES = {
+  mechanism: "markdown",
+  constructs: {
+    bold: "native",
+    italic: "native",
+    underline: "strip",
+    strikethrough: "native",
+    spoiler: "fallback",
+    codeInline: "native",
+    codeBlock: "native",
+    codeLanguage: "fallback",
+    linkLabel: "fallback",
+    heading: "fallback",
+    bulletList: "native",
+    orderedList: "native",
+    taskList: "fallback",
+    table: "fallback",
+    blockquote: "native",
+    image: "fallback",
+    mention: "native",
+  },
+  chunk: { limit: 4_096, unit: "chars" },
+} satisfies FormatCapabilityProfile;
+
+const WHATSAPP_STYLE_MARKERS = {
+  bold: { open: "*", close: "*" },
+  italic: { open: "_", close: "_" },
+  strikethrough: { open: "~", close: "~" },
+  code: { open: "```", close: "```" },
+  code_block: { open: "```\n", close: "```" },
+} as const;
+
+const WHATSAPP_INDENT_GUARD = "\u2060";
+const WHATSAPP_MARKERS = ["*", "_", "~", "`"] as const;
+
+type WhatsAppEscapedMarker = { source: string; placeholder: string };
 
 export type WebChannel = "web";
 
@@ -285,44 +325,148 @@ export async function resolveJidToE164(
   }
 }
 
-export function markdownToWhatsApp(text: string): string {
-  if (!text) {
-    return text;
+function protectWhatsAppEscapedMarkers(text: string): {
+  text: string;
+  markers: WhatsAppEscapedMarker[];
+} {
+  const placeholders: string[] = [];
+  for (const [start, end] of [
+    [0xe000, 0xf8ff],
+    [0xf0000, 0xffffd],
+  ] as const) {
+    for (
+      let codePoint = start;
+      codePoint <= end && placeholders.length < WHATSAPP_MARKERS.length;
+      codePoint += 1
+    ) {
+      const candidate = String.fromCodePoint(codePoint);
+      if (!text.includes(candidate)) {
+        placeholders.push(candidate);
+      }
+    }
   }
+  if (placeholders.length < WHATSAPP_MARKERS.length) {
+    throw new Error("Unable to reserve WhatsApp formatting placeholders");
+  }
+  const markers = WHATSAPP_MARKERS.map((marker, index) => ({
+    source: `\\${marker}`,
+    placeholder: placeholders[index] ?? "",
+  }));
+  let protectedText = text;
+  for (const { source, placeholder } of markers) {
+    protectedText = protectedText.replaceAll(source, placeholder);
+  }
+  return { text: protectedText, markers };
+}
 
-  const fences: string[] = [];
-  let result = text.replace(/```[\s\S]*?```/g, (match) => {
-    fences.push(match);
-    return `${WHATSAPP_FENCE_PLACEHOLDER}${fences.length - 1}${WHATSAPP_PLACEHOLDER_TERMINATOR}`;
-  });
+function restoreWhatsAppEscapedMarkers(
+  text: string,
+  markers: readonly WhatsAppEscapedMarker[],
+): string {
+  let restored = text;
+  for (const { source, placeholder } of markers) {
+    restored = restored.replaceAll(placeholder, source);
+  }
+  return restored;
+}
 
-  const inlineCodes: string[] = [];
-  result = result.replace(/`[^`\n]+`/g, (match) => {
-    inlineCodes.push(match);
-    return `${WHATSAPP_INLINE_CODE_PLACEHOLDER}${inlineCodes.length - 1}${WHATSAPP_PLACEHOLDER_TERMINATOR}`;
-  });
-
-  // Convert combined GFM strong+emphasis before plain strong so the plain
-  // rules cannot leave literal `**` around the inner emphasis.
-  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "*_$1_*");
-  result = result.replace(/___(.+?)___/g, "*_$1_*");
-  result = result.replace(/\*\*_(.+?)_\*\*/g, "*_$1_*");
-  result = result.replace(/__\*(.+?)\*__/g, "*_$1_*");
-  result = result.replace(/_\*\*(.+?)\*\*_/g, "*_$1_*");
-  result = result.replace(/\*__(.+?)__\*/g, "*_$1_*");
-
-  result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
-  result = result.replace(/__(.+?)__/g, "*$1*");
-  result = result.replace(/~~(.+?)~~/g, "~$1~");
-
-  const terminator = escapeRegExp(WHATSAPP_PLACEHOLDER_TERMINATOR);
-  result = result.replace(
-    new RegExp(`${escapeRegExp(WHATSAPP_INLINE_CODE_PLACEHOLDER)}(\\d+)${terminator}`, "g"),
-    (_, idx) => inlineCodes[Number(idx)] ?? "",
+function renderWhatsAppMarkdownIR(
+  ir: MarkdownIR,
+  escapedMarkers: readonly WhatsAppEscapedMarker[],
+): string {
+  return renderMarkdownWithMarkers(
+    ir,
+    {
+      styleMarkers: WHATSAPP_STYLE_MARKERS,
+      escapeText: (value) => restoreWhatsAppEscapedMarkers(value, escapedMarkers),
+    },
+    WHATSAPP_FORMAT_CAPABILITIES,
   );
-  result = result.replace(
-    new RegExp(`${escapeRegExp(WHATSAPP_FENCE_PLACEHOLDER)}(\\d+)${terminator}`, "g"),
-    (_, idx) => fences[Number(idx)] ?? "",
-  );
-  return result;
+}
+
+function prepareWhatsAppMarkdown(text: string, tableMode: MarkdownTableMode) {
+  // Some outbound callers preserve leading indentation as presentation, while
+  // CommonMark consumes it as block indentation. Guard only the parse.
+  const guardedIndent = /^[\t ]/u.test(text);
+  const escaped = protectWhatsAppEscapedMarkers(text);
+  const markdown = guardedIndent ? `${WHATSAPP_INDENT_GUARD}${escaped.text}` : escaped.text;
+  const trailingWhitespace = text.match(/\s+$/u)?.[0] ?? "";
+  const { ir: parsedIr, hasTables } = markdownToIRWithMeta(markdown, {
+    linkify: false,
+    autolink: false,
+    enableSpoilers: true,
+    enableHtmlUnderline: true,
+    enableTaskLists: true,
+    headingStyle: "rich",
+    blockquotePrefix: "> ",
+    tableMode: tableMode === "block" ? "code" : tableMode,
+    preserveSourceBlockSpacing: true,
+  });
+  let ir = parsedIr;
+  if (guardedIndent && ir.text.startsWith(WHATSAPP_INDENT_GUARD)) {
+    ir = sliceMarkdownIR(ir, WHATSAPP_INDENT_GUARD.length, ir.text.length);
+  }
+  if (!hasTables && trailingWhitespace) {
+    ir.text = `${ir.text.trimEnd()}${trailingWhitespace}`;
+  }
+  return { ir, escapedMarkers: escaped.markers };
+}
+
+function splitWhatsAppIRForChunkMode(
+  ir: MarkdownIR,
+  limit: number,
+  chunkMode: ChunkMode,
+): MarkdownIR[] {
+  if (chunkMode !== "newline") {
+    return [ir];
+  }
+  const chunkTexts = chunkMarkdownTextWithMode(ir.text, limit, chunkMode);
+  const chunks: MarkdownIR[] = [];
+  let cursor = 0;
+  for (const text of chunkTexts) {
+    const start = ir.text.indexOf(text, cursor);
+    if (start < 0) {
+      return [ir];
+    }
+    const end = start + text.length;
+    chunks.push(sliceMarkdownIR(ir, start, end));
+    cursor = end;
+  }
+  return chunks;
+}
+
+export function markdownToWhatsAppChunks(
+  text: string,
+  limit: number,
+  tableMode: MarkdownTableMode = "bullets",
+  chunkMode: ChunkMode = "length",
+): string[] {
+  if (!text) {
+    return [];
+  }
+  if (!text.trim()) {
+    return chunkMarkdownTextWithMode(text, limit, chunkMode);
+  }
+  const { ir, escapedMarkers } = prepareWhatsAppMarkdown(text, tableMode);
+  const render = (chunk: MarkdownIR) => renderWhatsAppMarkdownIR(chunk, escapedMarkers);
+  const rendered = render(ir);
+  let chunks =
+    ir.styles.length === 0 && ir.links.length === 0
+      ? chunkMarkdownTextWithMode(rendered, limit, chunkMode)
+      : splitWhatsAppIRForChunkMode(ir, limit, chunkMode).flatMap((source) =>
+          renderMarkdownIRChunksWithinLimit({
+            ir: source,
+            limit,
+            renderChunk: render,
+            measureRendered: (value) => value.length,
+          }).map((chunk) => chunk.rendered),
+        );
+  if (chunkMode === "newline") {
+    chunks = chunks.map((chunk) => chunk.trimEnd()).filter(Boolean);
+  }
+  return chunks;
+}
+
+export function markdownToWhatsApp(text: string, tableMode: MarkdownTableMode = "bullets"): string {
+  return markdownToWhatsAppChunks(text, Number.POSITIVE_INFINITY, tableMode).join("");
 }

--- a/extensions/whatsapp/src/text-runtime.test.ts
+++ b/extensions/whatsapp/src/text-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   assertWebChannel,
   jidToE164,
   markdownToWhatsApp,
+  markdownToWhatsAppChunks,
   resolveEquivalentWhatsAppDirectChatJids,
   resolveJidToE164,
   toWhatsappJid,
@@ -27,57 +28,223 @@ async function withTempDir<T>(
 
 describe("markdownToWhatsApp", () => {
   it.each([
-    ["converts **bold** to *bold*", "**SOD Blast:**", "*SOD Blast:*"],
-    ["converts __bold__ to *bold*", "__important__", "*important*"],
-    ["converts ~~strikethrough~~ to ~strikethrough~", "~~deleted~~", "~deleted~"],
-    ["leaves single *italic* unchanged (already WhatsApp bold)", "*text*", "*text*"],
-    ["leaves _italic_ unchanged (already WhatsApp italic)", "_text_", "_text_"],
-    ["preserves inline code", "Use `**not bold**` here", "Use `**not bold**` here"],
-    [
-      "handles mixed formatting",
-      "**bold** and ~~strike~~ and _italic_",
-      "*bold* and ~strike~ and _italic_",
-    ],
-    ["handles multiple bold segments", "**one** then **two**", "*one* then *two*"],
-    ["returns empty string for empty input", "", ""],
-    ["returns plain text unchanged", "no formatting here", "no formatting here"],
-    ["handles bold inside a sentence", "This is **very** important", "This is *very* important"],
-    ["converts GFM ***bold italic*** to WhatsApp bold+italic", "***bi***", "*_bi_*"],
-    ["converts GFM __*bold italic*__ to WhatsApp bold+italic", "__*y*__", "*_y_*"],
-    ["converts GFM **_bold italic_** to WhatsApp bold+italic", "**_x_**", "*_x_*"],
-    ["converts GFM ___bold italic___ to WhatsApp bold+italic", "___z___", "*_z_*"],
-    ["converts GFM *__bold italic__* to WhatsApp bold+italic", "*__q__*", "*_q_*"],
-    ["converts GFM _**bold italic**_ to WhatsApp bold+italic", "_**r**_", "*_r_*"],
-    [
-      "preserves inline code containing bold-italic markers",
-      "Use `***not bold italic***` here",
-      "Use `***not bold italic***` here",
-    ],
-    // Regression: a digit immediately after an inline-code span must not be
-    // absorbed into the placeholder index (which previously dropped both).
-    ["preserves inline code immediately followed by a digit", "`a`5", "`a`5"],
-    ["preserves inline code followed by a number", "`status`200 done", "`status`200 done"],
-    ["preserves two adjacent code+digit spans", "`x`1 and `y`2", "`x`1 and `y`2"],
-    ["preserves inline code with a space before a digit", "`a` 5", "`a` 5"],
-  ] as const)("handles markdown-to-whatsapp conversion: %s", (_name, input, expected) => {
-    expect(markdownToWhatsApp(input)).toBe(expected);
+    { name: "bold", input: "**SOD Blast:**", before: "*SOD Blast:*", after: "*SOD Blast:*" },
+    { name: "alternate bold", input: "__important__", before: "*important*", after: "*important*" },
+    { name: "strikethrough", input: "~~deleted~~", before: "~deleted~", after: "~deleted~" },
+    { name: "star italic", input: "*text*", before: "*text*", after: "_text_" },
+    { name: "underscore italic", input: "_text_", before: "_text_", after: "_text_" },
+    { name: "underline fallback", input: "<u>under</u>", before: "<u>under</u>", after: "under" },
+    { name: "spoiler fallback", input: "||secret||", before: "||secret||", after: "secret" },
+    {
+      name: "inline code",
+      input: "Use `**not bold**` here",
+      before: "Use `**not bold**` here",
+      after: "Use ```**not bold**``` here",
+    },
+    {
+      name: "fenced code",
+      input: "```\nconst x = **bold**;\n```",
+      before: "```\nconst x = **bold**;\n```",
+      after: "```\nconst x = **bold**;\n```",
+    },
+    {
+      name: "fence language fallback",
+      input: "```ts\nconst x = 1;\n```",
+      before: "```ts\nconst x = 1;\n```",
+      after: "```\nconst x = 1;\n```",
+    },
+    {
+      name: "labeled link fallback",
+      input: "[docs](https://example.com)",
+      before: "[docs](https://example.com)",
+      after: "docs (https://example.com)",
+    },
+    { name: "heading fallback", input: "# Title", before: "# Title", after: "*Title*" },
+    { name: "bullet list", input: "- one\n- two", before: "- one\n- two", after: "• one\n• two" },
+    {
+      name: "ordered list",
+      input: "1. one\n2. two",
+      before: "1. one\n2. two",
+      after: "1. one\n2. two",
+    },
+    {
+      name: "task-list fallback",
+      input: "- [x] done\n- [ ] todo",
+      before: "- [x] done\n- [ ] todo",
+      after: "[x] done\n[ ] todo",
+    },
+    {
+      name: "table fallback",
+      input: "| Name | Value |\n| --- | --- |\n| A | 1 |",
+      before: "*A*\n• Value: 1",
+      after: "*A*\n• Value: 1",
+    },
+    { name: "blockquote", input: "> quote", before: "> quote", after: "> quote" },
+    {
+      name: "image fallback",
+      input: "![alt](https://example.com/a.png)",
+      before: "![alt](https://example.com/a.png)",
+      after: "alt",
+    },
+    { name: "mention", input: "Hello @alice", before: "Hello @alice", after: "Hello @alice" },
+    {
+      name: "mixed formatting",
+      input: "**bold** and ~~strike~~ and _italic_",
+      before: "*bold* and ~strike~ and _italic_",
+      after: "*bold* and ~strike~ and _italic_",
+    },
+    {
+      name: "multiple bold segments",
+      input: "**one** then **two**",
+      before: "*one* then *two*",
+      after: "*one* then *two*",
+    },
+    { name: "empty input", input: "", before: "", after: "" },
+    {
+      name: "plain text",
+      input: "no formatting here",
+      before: "no formatting here",
+      after: "no formatting here",
+    },
+    {
+      name: "inline bold",
+      input: "This is **very** important",
+      before: "This is *very* important",
+      after: "This is *very* important",
+    },
+    { name: "triple-star bold italic", input: "***bi***", before: "*_bi_*", after: "*_bi_*" },
+    { name: "underscore-star bold italic", input: "__*y*__", before: "*_y_*", after: "*_y_*" },
+    { name: "star-underscore bold italic", input: "**_x_**", before: "*_x_*", after: "*_x_*" },
+    { name: "triple-underscore bold italic", input: "___z___", before: "*_z_*", after: "*_z_*" },
+    {
+      name: "star-double-underscore bold italic",
+      input: "*__q__*",
+      before: "*_q_*",
+      after: "*_q_*",
+    },
+    {
+      name: "underscore-double-star bold italic",
+      input: "_**r**_",
+      before: "*_r_*",
+      after: "*_r_*",
+    },
+    {
+      name: "inline code containing markers",
+      input: "Use `***not bold italic***` here",
+      before: "Use `***not bold italic***` here",
+      after: "Use ```***not bold italic***``` here",
+    },
+    {
+      name: "inline code containing a backtick",
+      input: "Use ``a`b`` here",
+      before: "Use ``a`b`` here",
+      after: "Use ```a`b``` here",
+    },
+    {
+      name: "inline code followed by one digit",
+      input: "`a`5",
+      before: "`a`5",
+      after: "```a```5",
+    },
+    {
+      name: "inline code followed by a number",
+      input: "`status`200 done",
+      before: "`status`200 done",
+      after: "```status```200 done",
+    },
+    {
+      name: "two code spans followed by digits",
+      input: "`x`1 and `y`2",
+      before: "`x`1 and `y`2",
+      after: "```x```1 and ```y```2",
+    },
+    {
+      name: "inline code separated from a digit",
+      input: "`a` 5",
+      before: "`a` 5",
+      after: "```a``` 5",
+    },
+    {
+      name: "triple-delimited inline code followed by a digit",
+      input: "```code```7 done",
+      before: "```code```7 done",
+      after: "```code```7 done",
+    },
+    {
+      name: "triple-delimited inline code containing markers",
+      input: "Before ```**bold** and ~~strike~~``` after **real bold**",
+      before: "Before ```**bold** and ~~strike~~``` after *real bold*",
+      after: "Before ```**bold** and ~~strike~~``` after *real bold*",
+    },
+    {
+      name: "escaped WhatsApp markers",
+      input: "\\*literal\\* \\_name\\_ \\~gone\\~ \\`code\\`",
+      before: "\\*literal\\* \\_name\\_ \\~gone\\~ \\`code\\`",
+      after: "\\*literal\\* \\_name\\_ \\~gone\\~ \\`code\\`",
+    },
+    {
+      name: "short leading indentation",
+      input: "  indented",
+      before: "  indented",
+      after: "  indented",
+    },
+    {
+      name: "literal private-use characters",
+      input: "\uE0000\uE001 \uE0001\uE001 \uE002 \uE003",
+      before: "\uE0000\uE001 \uE0001\uE001 \uE002 \uE003",
+      after: "\uE0000\uE001 \uE0001\uE001 \uE002 \uE003",
+    },
+  ] as const)(
+    "renders $name through the WhatsApp capability profile",
+    ({ input, before, after }) => {
+      expect([before, markdownToWhatsApp(input)]).toEqual([before, after]);
+    },
+  );
+
+  it("honors each configured table mode", () => {
+    const input = "| Name | Value |\n| --- | --- |\n| A | 1 |";
+    expect({
+      off: markdownToWhatsApp(input, "off"),
+      bullets: markdownToWhatsApp(input, "bullets"),
+      code: markdownToWhatsApp(input, "code"),
+      block: markdownToWhatsApp(input, "block"),
+    }).toEqual({
+      off: input,
+      bullets: "*A*\n• Value: 1",
+      code: "```\n| Name | Value |\n| ---- | ----- |\n| A    | 1     |\n```",
+      block: "```\n| Name | Value |\n| ---- | ----- |\n| A    | 1     |\n```",
+    });
   });
 
-  it("preserves fenced code blocks", () => {
-    const input = "```\nconst x = **bold**;\n```";
-    expect(markdownToWhatsApp(input)).toBe(input);
+  it("closes and reopens formatting at chunk boundaries", () => {
+    const chunks = markdownToWhatsAppChunks(`# ${"word ".repeat(12)}`, 20);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 20)).toBe(true);
+    expect(chunks.every((chunk) => /^\*.*\*\s*$/su.test(chunk))).toBe(true);
+    expect(
+      chunks.map((chunk) => chunk.replace(/^\*/u, "").replace(/\*(\s*)$/u, "$1")).join(""),
+    ).toBe("word ".repeat(12));
   });
 
-  it("preserves a fenced code block immediately followed by a digit", () => {
-    const input = "```code```7 done";
-    expect(markdownToWhatsApp(input)).toBe(input);
+  it("keeps newline-mode paragraph packing for formatted text", () => {
+    expect(
+      markdownToWhatsAppChunks("**Alpha**\n\n**Beta**\n\n**Gamma**", 14, "bullets", "newline"),
+    ).toEqual(["*Alpha*", "*Beta*", "*Gamma*"]);
   });
 
-  it("preserves code block with formatting inside", () => {
-    const input = "Before ```**bold** and ~~strike~~``` after **real bold**";
-    expect(markdownToWhatsApp(input)).toBe(
-      "Before ```**bold** and ~~strike~~``` after *real bold*",
-    );
+  it("keeps escaped markers atomic across formatted chunk boundaries", () => {
+    const chunks = markdownToWhatsAppChunks("**aaaa\\*bbbb**", 8);
+    expect(chunks.every((chunk) => chunk.length <= 8)).toBe(true);
+    expect(chunks.join("")).toContain("\\*");
+    expect(chunks.join("")).not.toMatch(/\p{Co}/u);
+  });
+
+  it("applies the chunk limit to whitespace-only text", () => {
+    expect(markdownToWhatsAppChunks(" ".repeat(12), 5)).toEqual(["    ", "    ", "  "]);
+  });
+
+  it("does not count the parse-only indentation guard toward the chunk limit", () => {
+    expect(markdownToWhatsAppChunks(`  ${"x".repeat(8)}`, 10)).toEqual([`  ${"x".repeat(8)}`]);
   });
 });
 

--- a/extensions/whatsapp/src/text-runtime.ts
+++ b/extensions/whatsapp/src/text-runtime.ts
@@ -1,6 +1,5 @@
 // Whatsapp plugin module implements text runtime behavior.
 export {
-  convertMarkdownTables,
   sanitizeAssistantVisibleText,
   sanitizeAssistantVisibleTextWithProfile,
   stripToolCallXmlTags,
@@ -11,6 +10,7 @@ export {
   isSelfChatMode,
   jidToE164,
   markdownToWhatsApp,
+  markdownToWhatsAppChunks,
   resolveEquivalentWhatsAppDirectChatJids,
   resolveJidToE164,
   toWhatsappJid,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where CommonMark italic such as `*text*` was sent unchanged and rendered as bold in WhatsApp. The old regex converter also leaked unsupported syntax such as heading markers, labeled-link syntax, spoiler/underline markup, and fenced-code language identifiers.

## Why This Change Was Made

WhatsApp now declares a static `FormatCapabilityProfile` and uses the shared Markdown IR renderer plus fallback engine for both direct sends and auto-replies. The old regex/placeholder converter and separate table pre-pass are removed; transport-owned mentions, media envelopes, indentation, chunk modes, and provider calls remain local. Formatting-aware chunking closes and reopens markers at boundaries and re-chunks after render expansion before the provider send.

This is AI-assisted work commissioned as part of the maintainer-directed Markdown-unification wave.

## User Impact

WhatsApp users now get the intended platform dialect consistently:

- `*italic*` -> `_italic_` instead of WhatsApp bold
- `<u>under</u>` -> `under`; `||secret||` -> `secret`
- `[docs](https://example.com)` -> `docs (https://example.com)`
- `# Title` -> `*Title*`
- `- one` -> `• one`; `- [x] done` -> `[x] done`
- fenced `ts`/other language identifiers are removed while code remains monospace
- inline code uses WhatsApp triple-backtick monospace markers
- image Markdown falls back to its alt text
- configured table modes (`off`, `bullets`, `code`, `block`) still apply through the shared parse

Authored escapes, leading indentation, trailing newlines, newline-mode paragraph packing, private-use Unicode, and chunk-size limits remain preserved.

## Evidence

Golden before/after coverage enumerates every declared construct, including the italic regression, code-language fallback, links, headings, lists/tasks, tables, blockquotes, images, mentions, escapes, indentation, and chunk boundaries.

- `node scripts/run-vitest.mjs extensions/whatsapp/src/text-runtime.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts extensions/whatsapp/src/outbound-adapter.sendpayload.test.ts` — 4 files, 147 tests passed after the final rebase.
- Source-blind behavior contract — 13/13, then final 7/7 targeted rerun passed.
- `node scripts/check-changed.mjs -- extensions/whatsapp/src/targets-runtime.ts extensions/whatsapp/src/text-runtime.ts extensions/whatsapp/src/text-runtime.test.ts extensions/whatsapp/src/send.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.ts` — Blacksmith Testbox `tbx_01ky79tkrz7d0xhfc94xpqn5y4`, run https://github.com/openclaw/openclaw/actions/runs/30001121124, all selected formatting, typecheck, lint, boundary, ratchet, and import-cycle gates passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — accepted findings were fixed (IR-before-render chunking, indentation/trailing-byte preservation, escaped-marker safety, newline-mode parity, whitespace limiting, guard sizing, and direct-send re-chunking). The final repeated claim that only voice-note overflow was drained was rejected after verifying the common `trailingTextChunks` loop and the multi-provider-call regression test.
- ClawSweeper produced no `Rank-up moves`: the initial exact-head lease and one explicit re-review lease both expired with only `review started` placeholders. After backoff, the status runbook still reported zero completed reviews in the prior hour and about 2,030 pending exact reviews while repair/reconcile workflows ran. There were therefore no moves to apply; this infrastructure gap is recorded here rather than bypassed silently.
- `git diff --check origin/main...HEAD` — passed.

LOC: total `+455/-110`; production `+226/-65`; tests `+229/-45`. Production LOC grows because this channel now owns an explicit capability profile plus safe IR-aware transport chunking and byte-preservation guards, replacing the smaller but incorrect regex path and eliminating the separate table conversion path.
