### PR TITLE
fix: suppress errored assistant terminal text

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -180,6 +180,23 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "SECRET_CANARY_69737");
   });
 
+  it("suppresses streamed assistant text when the assistant errored", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["provider error details"],
+      lastAssistant: makeAssistant({
+        stopReason: "error",
+        errorMessage: "provider failed",
+        content: [{ type: "text", text: "provider error details" }],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request failed.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "provider error details");
+  });
+
   it("surfaces a terminal error after only a message-tool progress update", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -180,14 +180,18 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "SECRET_CANARY_69737");
   });
 
-  it("suppresses streamed assistant text when the assistant errored", () => {
+  it("suppresses streamed assistant text and reasoning when the assistant errored", () => {
     const payloads = buildPayloads({
       assistantTexts: ["provider error details"],
       lastAssistant: makeAssistant({
         stopReason: "error",
         errorMessage: "provider failed",
-        content: [{ type: "text", text: "provider error details" }],
+        content: [
+          { type: "thinking", thinking: "partial hidden reasoning" },
+          { type: "text", text: "provider error details" },
+        ],
       }),
+      reasoningLevel: "on",
     });
 
     expectSinglePayloadSummary(payloads, {
@@ -195,6 +199,7 @@ describe("buildEmbeddedRunPayloads", () => {
       isError: true,
     });
     expectNoPayloadTextContaining(payloads, "provider error details");
+    expectNoPayloadTextContaining(payloads, "partial hidden reasoning");
   });
 
   it("surfaces a terminal error after only a message-tool progress update", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -738,7 +738,7 @@ export function buildEmbeddedRunPayloads(params: {
     normalizedFallbackAnswerSourceText.length > 0;
   const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;
   const answerTexts =
-    suppressAssistantArtifacts || runAborted
+    suppressAssistantArtifacts || runAborted || lastAssistantNeedsErrorSurface
       ? []
       : (shouldUseCanonicalFinalAnswer
           ? [fallbackAnswerSourceText]

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -646,7 +646,7 @@ export function buildEmbeddedRunPayloads(params: {
     }
   }
   const reasoningText =
-    suppressAssistantArtifacts || runAborted
+    suppressAssistantArtifacts || runAborted || lastAssistantNeedsErrorSurface
       ? ""
       : assistantForPayload && params.reasoningLevel === "on" && params.thinkingLevel !== "off"
         ? extractAssistantThinking(assistantForPayload)

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -66,40 +66,46 @@ function attemptResult(
 }
 
 describe("prepareEmbeddedRunTerminal", () => {
-  it("does not use errored assistant text as final terminal text", async () => {
-    const { prepareEmbeddedRunTerminal } = await import("./terminal-preparation.js");
-    const assistant = assistantMessage("error");
-    const prepared = prepareEmbeddedRunTerminal({
-      runParams: {
-        sessionId: "session-1",
-        runId: "run-1",
-        workspaceDir: "/tmp/openclaw-test",
-        prompt: "hi",
-        trigger: "user",
-        timeoutMs: 60_000,
-      },
-      attempt: attemptResult({
-        lastAssistant: assistant,
-        currentAttemptAssistant: assistant,
+  it.each(["error", "aborted"] as const)(
+    "does not use %s assistant text as final terminal text",
+    async (stopReason) => {
+      const { prepareEmbeddedRunTerminal } = await import("./terminal-preparation.js");
+      const assistant = assistantMessage(stopReason);
+      const prepared = prepareEmbeddedRunTerminal({
+        runParams: {
+          sessionId: "session-1",
+          runId: "run-1",
+          workspaceDir: "/tmp/openclaw-test",
+          prompt: "hi",
+          trigger: "user",
+          timeoutMs: 60_000,
+        },
+        attempt: attemptResult({
+          lastAssistant: assistant,
+          currentAttemptAssistant: assistant,
+          currentAttemptCompletedAssistant: assistant,
+        }),
         currentAttemptCompletedAssistant: assistant,
-      }),
-      currentAttemptCompletedAssistant: assistant,
-      provider: "openai",
-      model: "gpt-5.4",
-      activeErrorContext: { provider: "openai", model: "gpt-5.4" },
-      authProfileStore: { version: 1, profiles: {} },
-      sessionIdUsed: "session-1",
-      outerContextTokenMeta: {},
-      usageAccumulator: createUsageAccumulator(),
-      contextRecoveryState: createEmbeddedRunContextRecoveryState(),
-      resolvedToolResultFormat: "markdown",
-      terminalInterrupted: false,
-      terminalTimedOut: false,
-      timedOutDuringCompaction: false,
-      timedOutDuringToolExecution: false,
-    });
+        provider: "openai",
+        model: "gpt-5.4",
+        activeErrorContext: { provider: "openai", model: "gpt-5.4" },
+        authProfileStore: { version: 1, profiles: {} },
+        sessionIdUsed: "session-1",
+        outerContextTokenMeta: {},
+        usageAccumulator: createUsageAccumulator(),
+        contextRecoveryState: createEmbeddedRunContextRecoveryState(),
+        resolvedToolResultFormat: "markdown",
+        terminalState: {
+          outcome:
+            stopReason === "aborted"
+              ? { reason: "aborted", status: "error", stopReason }
+              : { reason: "failed", status: "error", stopReason, error: "provider failed" },
+          signalOwnedInterruption: false,
+        },
+      });
 
-    expect(prepared.finalAssistantVisibleText).toBeUndefined();
-    expect(prepared.finalAssistantRawText).toBeUndefined();
-  });
+      expect(prepared.finalAssistantVisibleText).toBeUndefined();
+      expect(prepared.finalAssistantRawText).toBeUndefined();
+    },
+  );
 });

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -1,0 +1,105 @@
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it, vi } from "vitest";
+import { createUsageAccumulator } from "../usage-accumulator.js";
+import { createEmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
+import type { EmbeddedRunAttemptResult } from "./types.js";
+
+vi.mock("./payloads.js", () => ({
+  buildEmbeddedRunPayloads: () => [],
+}));
+vi.mock("./run-attempt-result.js", () => ({
+  buildTraceToolSummary: () => undefined,
+}));
+vi.mock("./tool-media-payloads.js", () => ({
+  mergeAttemptToolMediaPayloads: ({ payloads }: { payloads?: unknown[] }) => payloads,
+}));
+
+function assistantMessage(stopReason: AssistantMessage["stopReason"] = "stop"): AssistantMessage {
+  return {
+    api: "responses",
+    provider: "openai",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: "provider error details",
+        textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+      },
+    ],
+    timestamp: 0,
+    stopReason,
+    ...(stopReason === "error" ? { errorMessage: "provider failed" } : {}),
+  };
+}
+
+function attemptResult(
+  overrides: Partial<EmbeddedRunAttemptResult> = {},
+): EmbeddedRunAttemptResult {
+  const assistant = assistantMessage("error");
+  return {
+    terminal: { kind: "ok" },
+    sessionIdUsed: "session-1",
+    messagesSnapshot: [assistant],
+    assistantTexts: ["provider error details"],
+    toolMetas: [],
+    lastAssistant: assistant,
+    currentAttemptAssistant: assistant,
+    currentAttemptCompletedAssistant: assistant,
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    cloudCodeAssistFormatError: false,
+    replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+    ...overrides,
+  };
+}
+
+describe("prepareEmbeddedRunTerminal", () => {
+  it("does not use errored assistant text as final terminal text", async () => {
+    const { prepareEmbeddedRunTerminal } = await import("./terminal-preparation.js");
+    const assistant = assistantMessage("error");
+    const prepared = prepareEmbeddedRunTerminal({
+      runParams: {
+        sessionId: "session-1",
+        runId: "run-1",
+        workspaceDir: "/tmp/openclaw-test",
+        prompt: "hi",
+        trigger: "user",
+        timeoutMs: 60_000,
+      },
+      attempt: attemptResult({
+        lastAssistant: assistant,
+        currentAttemptAssistant: assistant,
+        currentAttemptCompletedAssistant: assistant,
+      }),
+      currentAttemptCompletedAssistant: assistant,
+      provider: "openai",
+      model: "gpt-5.4",
+      activeErrorContext: { provider: "openai", model: "gpt-5.4" },
+      authProfileStore: { version: 1, profiles: {} },
+      sessionIdUsed: "session-1",
+      outerContextTokenMeta: {},
+      usageAccumulator: createUsageAccumulator(),
+      contextRecoveryState: createEmbeddedRunContextRecoveryState(),
+      resolvedToolResultFormat: "markdown",
+      terminalInterrupted: false,
+      terminalTimedOut: false,
+      timedOutDuringCompaction: false,
+      timedOutDuringToolExecution: false,
+    });
+
+    expect(prepared.finalAssistantVisibleText).toBeUndefined();
+    expect(prepared.finalAssistantRawText).toBeUndefined();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -78,6 +78,9 @@ export function prepareEmbeddedRunTerminal(input: {
     model: input.model,
     assistant: terminalAssistant,
   });
+  const finalAssistantStopReason = (terminalAssistant?.stopReason ?? "").trim().toLowerCase();
+  const terminalAssistantCanOwnFinalText =
+    finalAssistantStopReason !== "error" && finalAssistantStopReason !== "aborted";
   const agentMeta: EmbeddedAgentMeta = {
     sessionId: input.sessionIdUsed,
     sessionFile: input.sessionFileUsed,
@@ -101,9 +104,12 @@ export function prepareEmbeddedRunTerminal(input: {
     .toReversed()
     .map((text) => text.trim())
     .find((text) => text.length > 0);
-  const finalAssistantVisibleText =
-    resolveFinalAssistantVisibleText(terminalAssistant) ?? attemptFinalText;
-  const finalAssistantRawText = resolveFinalAssistantRawText(terminalAssistant) ?? attemptFinalText;
+  const finalAssistantVisibleText = terminalAssistantCanOwnFinalText
+    ? (resolveFinalAssistantVisibleText(terminalAssistant) ?? attemptFinalText)
+    : undefined;
+  const finalAssistantRawText = terminalAssistantCanOwnFinalText
+    ? (resolveFinalAssistantRawText(terminalAssistant) ?? attemptFinalText)
+    : undefined;
   // A yielded attempt ends before message_end. Its aborted tool-call assistant,
   // not an earlier completed cycle, owns paused-turn classification.
   const payloadAssistant = attempt.yieldDetected
@@ -154,7 +160,6 @@ export function prepareEmbeddedRunTerminal(input: {
     toolTrustedLocalMedia: attempt.toolTrustedLocalMedia,
     sourceReplyDeliveryMode: runParams.sourceReplyDeliveryMode,
   });
-  const finalAssistantStopReason = (terminalAssistant?.stopReason ?? "").trim().toLowerCase();
   const recoveredFinalAssistantTextAfterPromptTimeout =
     timedOutDuringPrompt && ["completed", "end_turn", "stop"].includes(finalAssistantStopReason)
       ? (finalAssistantVisibleText ?? finalAssistantRawText)?.trim()


### PR DESCRIPTION
AI-assisted: yes (Codex).

## What Problem This Solves

Fixes an issue where embedded agent runs that ended with an errored or aborted assistant message could still expose that assistant text as terminal answer output.

Before this change, the errored text could be copied into final assistant metadata and streamed assistant text could still become a normal reply payload, making provider failure details look like a completed assistant response.

## Why This Change Was Made

Terminal preparation now lets only non-error, non-aborted current-attempt assistant messages own `finalAssistantVisibleText` and `finalAssistantRawText`. The payload builder also suppresses streamed assistant answer text when the terminal assistant needs error/abort surfacing, while preserving the existing clean error payload path.

## User Impact

Users and downstream run consumers no longer see errored assistant text classified or delivered as the agent's final answer after a provider failure. They get the existing concise error payload instead.

## Evidence

- RED before fix: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/terminal-preparation.test.ts` failed with `expected 'provider error details' to be undefined`.
- RED before payload fix: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts -t "suppresses streamed assistant text when the assistant errored"` failed because the payload list contained both the clean error and the streamed assistant text.
- GREEN: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts -t "suppresses streamed assistant text when the assistant errored"` passed.
- GREEN: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts` passed.
- GREEN: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/terminal-preparation.test.ts src/agents/embedded-agent-runner/run/helpers.test.ts src/agents/embedded-agent-runner/run/terminal-outcome.test.ts` passed.
- GREEN: `./node_modules/.bin/oxfmt --check src/agents/embedded-agent-runner/run/terminal-preparation.ts src/agents/embedded-agent-runner/run/terminal-preparation.test.ts src/agents/embedded-agent-runner/run/payloads.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts` passed.
- GREEN: `git diff --check` passed.
- `node scripts/check-changed.mjs -- ...` was blocked by pnpm modules purge/no TTY, not by a code failure.
