### PR TITLE
refactor(ui): split chat markdown renderer into cohesive modules

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -1075,7 +1075,6 @@ ui/src/api/types.ts
 ui/src/app/app-host.ts
 ui/src/components/browser/browser-panel.ts
 ui/src/components/config-form.node.ts
-ui/src/components/markdown.ts
 ui/src/components/terminal/terminal-panel.ts
 ui/src/e2e/chat-flow.e2e.test.ts
 ui/src/e2e/new-session-page.e2e.test.ts

--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -1,0 +1,169 @@
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import cpp from "highlight.js/lib/languages/cpp";
+import css from "highlight.js/lib/languages/css";
+import diff from "highlight.js/lib/languages/diff";
+import go from "highlight.js/lib/languages/go";
+import java from "highlight.js/lib/languages/java";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import markdown from "highlight.js/lib/languages/markdown";
+import python from "highlight.js/lib/languages/python";
+import rust from "highlight.js/lib/languages/rust";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+import { t } from "../i18n/index.ts";
+import { copyToClipboard } from "../lib/clipboard.ts";
+import type { MarkdownRenderEnv } from "./markdown-render-options.ts";
+import { escapeMarkdownHtml, isMarkdownBlockArtText } from "./markdown-text.ts";
+
+const blockArtCopyPayloadPrefix = "openclaw:block-art-code:";
+const blockArtCodeBlockCopyPayloadEncoding = "block-art-json";
+
+for (const [language, definition] of Object.entries({
+  bash,
+  cpp,
+  css,
+  diff,
+  go,
+  java,
+  javascript,
+  json,
+  markdown,
+  python,
+  rust,
+  typescript,
+  xml,
+  yaml,
+})) {
+  hljs.registerLanguage(language, definition);
+}
+hljs.registerAliases("shell", { languageName: "bash" });
+
+function shouldRenderCodeBlockCopy(env: unknown): boolean {
+  return (env as Partial<MarkdownRenderEnv> | undefined)?.codeBlockChrome !== "none";
+}
+
+function encodeBlockArtCodeBlockCopyPayload(value: string): string {
+  return `${blockArtCopyPayloadPrefix}${JSON.stringify(value)}`;
+}
+
+function decodeCodeBlockCopyPayload(value: string, encoding?: string): string {
+  if (
+    encoding !== blockArtCodeBlockCopyPayloadEncoding ||
+    !value.startsWith(blockArtCopyPayloadPrefix)
+  ) {
+    return value;
+  }
+  try {
+    const decoded = JSON.parse(value.slice(blockArtCopyPayloadPrefix.length));
+    return typeof decoded === "string" ? decoded : value;
+  } catch {
+    return value;
+  }
+}
+
+export function handleMarkdownCodeBlockCopy(event: Event): void {
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return;
+  }
+  const button = target.closest<HTMLElement>(".code-block-copy");
+  if (!button) {
+    return;
+  }
+  const code = decodeCodeBlockCopyPayload(button.dataset.code ?? "", button.dataset.codeEncoding);
+  void copyToClipboard(code).then((copied) => {
+    if (!copied) {
+      return;
+    }
+    button.classList.add("copied");
+    setTimeout(() => button.classList.remove("copied"), 1500);
+  });
+}
+
+function highlightCode(text: string, lang: string): string {
+  const language = lang.trim().toLowerCase();
+  try {
+    if (language && hljs.getLanguage(language)) {
+      return hljs.highlight(text, { language, ignoreIllegals: true }).value;
+    }
+    if (!language && text.trim()) {
+      const result = hljs.highlightAuto(text);
+      if (result.relevance >= 2) {
+        return result.value;
+      }
+    }
+  } catch {
+    // Fall back to escaped plaintext; malformed input should not break chat rendering.
+  }
+  return escapeMarkdownHtml(text);
+}
+
+/** Highlight a JSON/JSON5 snippet; output is escaped hljs markup safe for unsafeHTML in a code block. */
+export function highlightJsonHtml(text: string): string {
+  return highlightCode(text, "json");
+}
+
+function codeClassAttribute(lang: string, highlighted: string): string {
+  const classes = [
+    highlighted.includes("hljs-") ? "hljs" : "",
+    lang ? `language-${lang}` : "",
+  ].filter(Boolean);
+  return classes.length > 0 ? ` class="${escapeMarkdownHtml(classes.join(" "))}"` : "";
+}
+
+function renderCodeElement(
+  text: string,
+  lang: string,
+  options: { blockArt?: boolean } = {},
+): string {
+  if (options.blockArt || isMarkdownBlockArtText(text)) {
+    return `<pre><code class="markdown-block-art">${escapeMarkdownHtml(text)}</code></pre>`;
+  }
+  const highlighted = highlightCode(text, lang);
+  const classAttr = codeClassAttribute(lang, highlighted);
+  return `<pre><code${classAttr}>${highlighted}</code></pre>`;
+}
+
+export function renderMarkdownCodeBlock(
+  text: string,
+  lang: string,
+  env: unknown,
+  options: { blockArt?: boolean; copyText?: string } = {},
+): string {
+  const blockArt = options.blockArt || isMarkdownBlockArtText(text);
+  const codeBlock = renderCodeElement(text, lang, { blockArt });
+  if (!shouldRenderCodeBlockCopy(env)) {
+    return codeBlock;
+  }
+  const langLabel = lang ? `<span class="code-block-lang">${escapeMarkdownHtml(lang)}</span>` : "";
+  const copyText = options.copyText ?? text;
+  const copyPayload = blockArt ? encodeBlockArtCodeBlockCopyPayload(copyText) : copyText;
+  const attrSafe = escapeMarkdownHtml(copyPayload);
+  const encodingAttr = blockArt
+    ? ` data-code-encoding="${blockArtCodeBlockCopyPayloadEncoding}"`
+    : "";
+  const copyButton = `<button type="button" class="code-block-copy" data-code="${attrSafe}"${encodingAttr} aria-label="${escapeMarkdownHtml(t("common.copyCode"))}"><span class="code-block-copy__idle">${escapeMarkdownHtml(t("common.copy"))}</span><span class="code-block-copy__done">${escapeMarkdownHtml(t("common.copied"))}</span></button>`;
+  const header = `<div class="code-block-header">${langLabel}${copyButton}</div>`;
+
+  const trimmed = text.trim();
+  const isJson =
+    lang === "json" ||
+    (!lang &&
+      ((trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+        (trimmed.startsWith("[") && trimmed.endsWith("]"))));
+
+  if (isJson) {
+    const lineCount = text.split("\n").length;
+    const label = lineCount > 1 ? `JSON &middot; ${lineCount} lines` : "JSON";
+    return `<details class="json-collapse"><summary>${label}</summary><div class="code-block-wrapper">${header}${codeBlock}</div></details>`;
+  }
+
+  return `<div class="code-block-wrapper">${header}${codeBlock}</div>`;
+}
+
+export function markdownCodeBlockCopyText(content: string): string {
+  return content.endsWith("\n") ? content.slice(0, -1) : content;
+}

--- a/ui/src/components/markdown-file-links.ts
+++ b/ui/src/components/markdown-file-links.ts
@@ -1,0 +1,124 @@
+const HOST_LOCAL_FILE_HREF_RE =
+  /^(?:~\/|\/(?:Users|home|tmp|private\/tmp|var\/folders|private\/var\/folders)\/|\/[A-Za-z]:\/|[A-Za-z]:[\\/])/;
+const FILE_SEGMENT_SOURCE = "[A-Za-z0-9_.@#+-]+";
+const FILE_EXTENSION_SOURCE = "[A-Za-z0-9]{1,8}";
+const FILE_LINE_SUFFIX_SOURCE = ":\\d{1,6}(?::\\d{1,6})?";
+const FILE_NAME_SOURCE = `${FILE_SEGMENT_SOURCE}\\.${FILE_EXTENSION_SOURCE}`;
+const PREFIXED_FILE_SOURCE = `(?:~\\/|\\.\\.\\/|\\.\\/|\\/)(?:${FILE_SEGMENT_SOURCE}\\/)*${FILE_NAME_SOURCE}`;
+const UNPREFIXED_FILE_SOURCE = `${FILE_SEGMENT_SOURCE}(?:\\/${FILE_SEGMENT_SOURCE})*\\/${FILE_NAME_SOURCE}`;
+const WINDOWS_ABSOLUTE_FILE_SOURCE = `[A-Za-z]:[\\\\/](?:${FILE_SEGMENT_SOURCE}[\\\\/])*${FILE_NAME_SOURCE}`;
+const MULTI_SEGMENT_FILE_SOURCE = `(?:${PREFIXED_FILE_SOURCE}|${WINDOWS_ABSOLUTE_FILE_SOURCE}|${UNPREFIXED_FILE_SOURCE})(?:${FILE_LINE_SUFFIX_SOURCE})?`;
+const BARE_FILE_WITH_LINE_SOURCE = `${FILE_SEGMENT_SOURCE}\\.${FILE_EXTENSION_SOURCE}${FILE_LINE_SUFFIX_SOURCE}`;
+const MULTI_SEGMENT_FILE_RE = new RegExp(`^${MULTI_SEGMENT_FILE_SOURCE}$`);
+const BARE_FILE_WITH_LINE_RE = new RegExp(`^${BARE_FILE_WITH_LINE_SOURCE}$`);
+const BARE_FILENAME_RE = new RegExp(`^${FILE_SEGMENT_SOURCE}\\.(${FILE_EXTENSION_SOURCE})$`, "i");
+export const MARKDOWN_FILE_LINK_SCAN_RE = new RegExp(
+  `${MULTI_SEGMENT_FILE_SOURCE}|${BARE_FILE_WITH_LINE_SOURCE}`,
+  "g",
+);
+const FILE_LINE_SUFFIX_RE = /:(\d{1,6})(?::\d{1,6})?$/;
+const BARE_FILE_EXTENSIONS = new Set([
+  "astro",
+  "bash",
+  "c",
+  "cc",
+  "cfg",
+  "cjs",
+  "conf",
+  "cpp",
+  "cs",
+  "css",
+  "diff",
+  "fish",
+  "go",
+  "h",
+  "hpp",
+  "htm",
+  "html",
+  "ini",
+  "java",
+  "js",
+  "json",
+  "jsonc",
+  "jsx",
+  "kt",
+  "kts",
+  "less",
+  "lock",
+  "log",
+  "markdown",
+  "md",
+  "mdx",
+  "mjs",
+  "patch",
+  "plist",
+  "proto",
+  "py",
+  "rb",
+  "rs",
+  "scss",
+  "sh",
+  "sql",
+  "svelte",
+  "svg",
+  "swift",
+  "toml",
+  "ts",
+  "tsx",
+  "txt",
+  "vue",
+  "xml",
+  "yaml",
+  "yml",
+  "zsh",
+]);
+
+export function markdownFileLinkFromEvent(
+  event: Event,
+): { path: string; line: number | null } | null {
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return null;
+  }
+  const link = target.closest<HTMLAnchorElement>("a[data-file-path]");
+  const path = link?.dataset.filePath;
+  if (!path) {
+    return null;
+  }
+  const line = link.dataset.fileLine;
+  return { path, line: line ? Number.parseInt(line, 10) : null };
+}
+
+export function splitMarkdownFileLineSuffix(raw: string): { path: string; line: number | null } {
+  const match = FILE_LINE_SUFFIX_RE.exec(raw);
+  const line = match?.[1];
+  return match && line
+    ? { path: raw.slice(0, match.index), line: Number.parseInt(line, 10) }
+    : { path: raw, line: null };
+}
+
+function isAllowlistedBareFilename(raw: string): boolean {
+  if (raw.includes("/") || raw.includes("\\")) {
+    return false;
+  }
+  const match = BARE_FILENAME_RE.exec(raw);
+  return Boolean(match?.[1] && BARE_FILE_EXTENSIONS.has(match[1].toLowerCase()));
+}
+
+export function parseMarkdownFileLinkTarget(
+  raw: string,
+): { path: string; line: number | null } | null {
+  const target = raw.trim();
+  if (
+    !MULTI_SEGMENT_FILE_RE.test(target) &&
+    !BARE_FILE_WITH_LINE_RE.test(target) &&
+    !isAllowlistedBareFilename(target)
+  ) {
+    return null;
+  }
+  return splitMarkdownFileLineSuffix(target);
+}
+
+export function isHostLocalMarkdownFileHref(href: string): boolean {
+  return HOST_LOCAL_FILE_HREF_RE.test(href.trim());
+}

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -1,0 +1,429 @@
+import MarkdownIt from "markdown-it";
+import markdownItTaskLists from "markdown-it-task-lists";
+import { t } from "../i18n/index.ts";
+import {
+  installAssistantTranscriptRoleImageRenderer,
+  installAssistantTranscriptRoleMarkdown,
+} from "./markdown-assistant-transcript.ts";
+import { markdownCodeBlockCopyText, renderMarkdownCodeBlock } from "./markdown-code-blocks.ts";
+import {
+  isHostLocalMarkdownFileHref,
+  MARKDOWN_FILE_LINK_SCAN_RE,
+  parseMarkdownFileLinkTarget,
+  splitMarkdownFileLineSuffix,
+} from "./markdown-file-links.ts";
+import type { MarkdownRenderEnv } from "./markdown-render-options.ts";
+import { escapeMarkdownHtml } from "./markdown-text.ts";
+
+const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
+// CJK character ranges for URL boundary detection (RFC 3986: CJK is not valid in raw URLs).
+// CJK Unified Ideographs, CJK Symbols/Punctuation, Fullwidth Forms, Hiragana, Katakana,
+// Hangul Syllables, and CJK Compatibility Ideographs.
+const CJK_RE = new RegExp(
+  "[\\u2E80-\\u2FFF\\u3000-\\u303F\\u3040-\\u309F\\u30A0-\\u30FF\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uAC00-\\uD7AF\\uF900-\\uFAFF\\uFF01-\\uFF60]",
+);
+
+function normalizeMarkdownImageLabel(text?: string | null): string {
+  const trimmed = text?.trim();
+  return trimmed ? trimmed : "image";
+}
+
+function isFileLinkBoundaryBefore(value: string, index: number): boolean {
+  const char = value[index - 1];
+  return char === undefined || /\s/.test(char) || "([{<\"'`".includes(char);
+}
+
+function isFileLinkBoundaryAfter(value: string, index: number): boolean {
+  const char = value[index];
+  return char === undefined || /\s/.test(char) || ".,;:!?)]}>\"'".includes(char);
+}
+
+export function createMarkdownParser(): MarkdownIt {
+  const markdownParser = new MarkdownIt({
+    html: true, // Enable HTML recognition so html_block/html_inline overrides can escape it
+    breaks: true,
+    linkify: true,
+  });
+  const defaultCodeInlineRenderer = markdownParser.renderer.rules.code_inline!;
+
+  // Enable GFM strikethrough (~~text~~) to match original marked.js behavior.
+  // markdown-it uses <s> tags; we added "s" to the sanitizer allowlist.
+  markdownParser.enable("strikethrough");
+  installAssistantTranscriptRoleMarkdown(markdownParser, escapeMarkdownHtml);
+
+  // Disable fuzzy link detection to prevent bare filenames like "README.md"
+  // from being auto-linked as "http://README.md". URLs with explicit protocol
+  // (https://...) and emails are still linkified.
+  //
+  // Alternative considered: extensions/matrix/src/matrix/format.ts uses fuzzyLink
+  // with a file-extension blocklist to filter false positives at render time.
+  // We chose the www-only approach instead because:
+  // 1. Matches original marked.js GFM behavior exactly (bare domains were never linked)
+  // 2. No blocklist to maintain — new TLDs like .ai, .io, .dev would need constant updates
+  // 3. Predictable behavior — users can always use explicit https:// for any URL
+  markdownParser.linkify.set({ fuzzyLink: false });
+
+  // Re-enable www. prefix detection per GFM spec: bare URLs without protocol
+  // must start with "www." to be auto-linked. This avoids false positives on
+  // filenames while preserving expected behavior for "www.example.com".
+  // GFM spec: valid domain = alphanumeric/underscore/hyphen segments separated
+  // by periods, at least one period, no underscores in last two segments.
+  markdownParser.linkify.add("www", {
+    validate(text, pos) {
+      const tail = text.slice(pos);
+      // Match: . followed by domain and optional path, matching marked.js behavior.
+      // Stops at whitespace, < (HTML tag boundary), or CJK characters (RFC 3986:
+      // raw CJK is not valid in URLs; percent-encoded CJK like %E4%BD%A0 is fine).
+      const match = tail.match(
+        /^\.(?:[a-zA-Z0-9-]+\.?)+[^\s<\u2E80-\u2FFF\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF\uFF01-\uFF60]*/,
+      );
+      if (!match) {
+        return 0;
+      }
+      let length = match[0].length;
+
+      // Strip trailing punctuation per GFM extended autolink spec.
+      // GFM says: ?, !, ., ,, :, *, _, ~ are not part of the autolink if trailing.
+
+      // Balance checking config: closeChar -> openChar mapping.
+      // Strip trailing close chars only when unbalanced (more closes than opens).
+      // For self-matching pairs like "", open === close (strip if odd count).
+      const balancePairs: Record<string, string> = {
+        ")": "(",
+        "]": "[",
+        "}": "{",
+        '"': '"',
+        "'": "'",
+      };
+
+      // Pre-count balanced pairs to avoid O(n²) rescans.
+      // balance[closeChar] = count(open) - count(close), negative means unbalanced
+      const balance: Record<string, number> = {};
+      for (const [close, open] of Object.entries(balancePairs)) {
+        balance[close] = 0;
+        for (let index = 0; index < length; index++) {
+          const character = tail.charAt(index);
+          if (open === close) {
+            // Self-matching pair (e.g., "") — toggle between 0 and 1
+            if (character === open) {
+              balance[close] = balance[close] === 0 ? 1 : 0;
+            }
+          } else if (character === open) {
+            balance[close] = (balance[close] ?? 0) + 1;
+          } else if (character === close) {
+            balance[close] = (balance[close] ?? 0) - 1;
+          }
+        }
+      }
+
+      while (length > 0) {
+        const character = tail.charAt(length - 1);
+        // GFM trailing punctuation: ?, !, ., ,, :, *, _, ~ stripped unconditionally.
+        if (/[?!.,:*_~]/.test(character)) {
+          length--;
+          continue;
+        }
+        // GFM entity reference rule: strip trailing &entity; sequences.
+        if (character === ";") {
+          // Backward scan to find & (O(n) total, avoids string allocation)
+          let index = length - 2;
+          while (index >= 0 && /[a-zA-Z0-9]/.test(tail.charAt(index))) {
+            index--;
+          }
+          // index < length - 2 ensures at least one alphanumeric between & and ;
+          if (index >= 0 && tail.charAt(index) === "&" && index < length - 2) {
+            length = index;
+            continue;
+          }
+          // Not an entity reference, stop stripping
+          break;
+        }
+        // Handle balanced pairs — only strip close char if unbalanced.
+        const open = balancePairs[character];
+        if (open !== undefined) {
+          if (open === character) {
+            if ((balance[character] ?? 0) !== 0) {
+              balance[character] = 0;
+              length--;
+              continue;
+            }
+          } else if ((balance[character] ?? 0) < 0) {
+            balance[character] = (balance[character] ?? 0) + 1;
+            length--;
+            continue;
+          }
+        }
+        break;
+      }
+      return length;
+    },
+    normalize(match) {
+      match.url = "http://" + match.url;
+    },
+  });
+
+  // Override default link validator to allow all URLs through to renderers.
+  // marked.js does not validate URLs at all — it generates <a>/<img> tags for
+  // everything and relies on DOMPurify to strip dangerous schemes.
+  //
+  // We match this behavior exactly:
+  // - All URLs pass validation, including javascript:, vbscript:, file:, data:
+  // - Images: renderer.rules.image shows alt text for non-data-image URLs
+  // - Links: DOMPurify strips dangerous href schemes, leaving safe anchor text
+  // - Blocking at validateLink would skip token generation entirely, causing raw
+  //   markdown source to appear instead of graceful fallbacks.
+  markdownParser.validateLink = () => true;
+
+  // Trim trailing CJK characters from auto-linked URLs (RFC 3986: raw CJK is
+  // not valid in URLs). markdown-it's built-in linkify for https:// URLs may
+  // swallow adjacent CJK text into the URL. This core rule runs after linkify
+  // and splits the CJK suffix back into a plain text token.
+  markdownParser.core.ruler.after("linkify", "linkify-cjk-trim", (state) => {
+    for (const blockToken of state.tokens) {
+      if (blockToken.type !== "inline" || !blockToken.children) {
+        continue;
+      }
+      const children = blockToken.children;
+      for (let index = children.length - 1; index >= 0; index--) {
+        const token = children[index];
+        if (!token || token.type !== "link_open") {
+          continue;
+        }
+        // Only trim linkify-generated autolinks, not explicit markdown links
+        // like [OpenClaw中文](https://docs.openclaw.ai) where CJK in display
+        // text is intentional and href must not be rewritten.
+        if (token.markup !== "linkify") {
+          continue;
+        }
+        // Use the display text to find CJK boundary (href may be percent-encoded)
+        const textToken = children[index + 1];
+        if (!textToken || textToken.type !== "text") {
+          continue;
+        }
+        const displayText = textToken.content;
+        // Scan backward to find trailing CJK suffix only.
+        // Middle CJK must be preserved (e.g. https://example.com/你/test stays intact);
+        // only strip a contiguous CJK tail adjacent to non-URL text.
+        let cjkIndex = displayText.length;
+        while (cjkIndex > 0 && CJK_RE.test(displayText.charAt(cjkIndex - 1))) {
+          cjkIndex--;
+        }
+        if (cjkIndex <= 0 || cjkIndex === displayText.length) {
+          continue;
+        }
+        // Split: URL part and CJK tail from display text
+        const trimmedDisplay = displayText.slice(0, cjkIndex);
+        const cjkTail = displayText.slice(cjkIndex);
+        // Rebuild href by preserving the scheme prefix that linkify added but
+        // display text omits (e.g. "mailto:" for emails, "http://" for www links).
+        const href = token.attrGet("href") ?? "";
+        const prefixLength = href.indexOf(displayText);
+        const hrefPrefix = prefixLength > 0 ? href.slice(0, prefixLength) : "";
+        token.attrSet("href", hrefPrefix + trimmedDisplay);
+        textToken.content = trimmedDisplay;
+        // Find link_close and insert CJK text after it
+        for (let closeIndex = index + 1; closeIndex < children.length; closeIndex++) {
+          if (children[closeIndex]?.type === "link_close") {
+            const tailToken = new state.Token("text", "", 0);
+            tailToken.content = cjkTail;
+            children.splice(closeIndex + 1, 0, tailToken);
+            break;
+          }
+        }
+      }
+    }
+  });
+
+  markdownParser.core.ruler.after("linkify", "file-links", (state) => {
+    const env = state.env as Partial<MarkdownRenderEnv> | undefined;
+    if (env?.fileLinks !== true) {
+      return;
+    }
+    for (const blockToken of state.tokens) {
+      if (blockToken.type !== "inline" || !blockToken.children) {
+        continue;
+      }
+      const children = blockToken.children;
+      let linkDepth = 0;
+      for (let index = 0; index < children.length; index++) {
+        const token = children[index];
+        if (!token) {
+          continue;
+        }
+        if (token.type === "link_open") {
+          const href = token.attrGet("href");
+          if (href) {
+            let decodedHref = href;
+            try {
+              decodedHref = decodeURIComponent(href);
+            } catch {
+              // Keep the raw href when malformed percent escapes cannot be decoded.
+            }
+            if (!decodedHref.includes("://")) {
+              const target =
+                parseMarkdownFileLinkTarget(decodedHref) ??
+                (isHostLocalMarkdownFileHref(decodedHref)
+                  ? splitMarkdownFileLineSuffix(decodedHref.trim())
+                  : null);
+              if (target) {
+                token.attrs = token.attrs?.filter(([name]) => name !== "href") ?? null;
+                token.attrJoin("class", "markdown-file-link");
+                token.attrSet("data-file-path", target.path);
+                if (target.line !== null) {
+                  token.attrSet("data-file-line", String(target.line));
+                }
+              }
+            }
+          }
+          linkDepth += 1;
+          continue;
+        }
+        if (token.type === "link_close") {
+          linkDepth = Math.max(0, linkDepth - 1);
+          continue;
+        }
+        if (linkDepth > 0 || token.type !== "text") {
+          continue;
+        }
+
+        const replacements: typeof children = [];
+        let cursor = 0;
+        MARKDOWN_FILE_LINK_SCAN_RE.lastIndex = 0;
+        for (const match of token.content.matchAll(MARKDOWN_FILE_LINK_SCAN_RE)) {
+          const matchIndex = match.index;
+          const matched = match[0];
+          const matchEnd = matchIndex + matched.length;
+          if (
+            !isFileLinkBoundaryBefore(token.content, matchIndex) ||
+            !isFileLinkBoundaryAfter(token.content, matchEnd)
+          ) {
+            continue;
+          }
+          const target = parseMarkdownFileLinkTarget(matched);
+          if (!target) {
+            continue;
+          }
+          if (matchIndex > cursor) {
+            const leading = new state.Token("text", "", 0);
+            leading.content = token.content.slice(cursor, matchIndex);
+            replacements.push(leading);
+          }
+          const open = new state.Token("link_open", "a", 1);
+          open.markup = "file-link";
+          open.attrSet("class", "markdown-file-link");
+          open.attrSet("data-file-path", target.path);
+          if (target.line !== null) {
+            open.attrSet("data-file-line", String(target.line));
+          }
+          const label = new state.Token("text", "", 0);
+          label.content = matched;
+          const close = new state.Token("link_close", "a", -1);
+          close.markup = "file-link";
+          replacements.push(open, label, close);
+          cursor = matchEnd;
+        }
+        if (replacements.length === 0) {
+          continue;
+        }
+        if (cursor < token.content.length) {
+          const trailing = new state.Token("text", "", 0);
+          trailing.content = token.content.slice(cursor);
+          replacements.push(trailing);
+        }
+        children.splice(index, 1, ...replacements);
+        index += replacements.length - 1;
+      }
+    }
+  });
+
+  // Enable GFM task list checkboxes (- [x] / - [ ]).
+  // enabled: false keeps checkboxes read-only (disabled="") — task lists in
+  // chat messages are display-only, not interactive forms.
+  // label: false avoids wrapping item text in <label>, which would break
+  // accessibility when the item contains links (MDN warns against anchors inside labels).
+  markdownParser.use(markdownItTaskLists, { enabled: false, label: false });
+
+  // The plugin inserts its checkbox as the first inline child. Trust only that
+  // generated token so later user-authored HTML remains escaped.
+  markdownParser.core.ruler.after("github-task-lists", "task-list-allowlist", (state) => {
+    for (const [index, listItem] of state.tokens.entries()) {
+      if (listItem.type !== "list_item_open" || listItem.attrGet("class") !== "task-list-item") {
+        continue;
+      }
+      const checkbox = state.tokens[index + 2]?.children?.[0];
+      if (checkbox?.type === "html_inline") {
+        checkbox.meta = { taskListPlugin: true };
+      }
+    }
+  });
+
+  // Override html_block and html_inline to escape raw HTML (#13937).
+  // Exception: html_inline tokens marked by a trusted plugin (meta.taskListPlugin)
+  // are allowed through — they are generated by our own plugin pipeline, not user input,
+  // and DOMPurify provides the final safety net regardless.
+  // Renderer rules degrade to empty output on impossible token misses instead of
+  // throwing mid-render; markdown input is untrusted and the chat view must not crash.
+  markdownParser.renderer.rules.html_block = (tokens, index) => {
+    const token = tokens[index];
+    return token ? escapeMarkdownHtml(token.content) + "\n" : "";
+  };
+  markdownParser.renderer.rules.html_inline = (tokens, index) => {
+    const token = tokens[index];
+    return token?.meta?.taskListPlugin === true
+      ? token.content
+      : escapeMarkdownHtml(token?.content ?? "");
+  };
+  markdownParser.renderer.rules.code_inline = (tokens, index, options, env, self) => {
+    const rendered = defaultCodeInlineRenderer(tokens, index, options, env, self);
+    const renderEnv = env as Partial<MarkdownRenderEnv> | undefined;
+    const token = tokens[index];
+    const target =
+      token && renderEnv?.fileLinks === true ? parseMarkdownFileLinkTarget(token.content) : null;
+    if (!target) {
+      return rendered;
+    }
+    const lineAttribute =
+      target.line === null ? "" : ` data-file-line="${escapeMarkdownHtml(String(target.line))}"`;
+    return `<a class="markdown-file-link" data-file-path="${escapeMarkdownHtml(target.path)}"${lineAttribute}>${rendered}</a>`;
+  };
+
+  // Override image to only allow base64 data URIs (#15437).
+  installAssistantTranscriptRoleImageRenderer(markdownParser, {
+    escapeHtml: escapeMarkdownHtml,
+    isInlineDataImage: (src) => INLINE_DATA_IMAGE_RE.test(src),
+    normalizeLabel: normalizeMarkdownImageLabel,
+    assistantLabel: () => t("sessionsView.assistant"),
+    openImageLabel: (alt, hasAlt) =>
+      t("chat.imageLightbox.open", {
+        title: hasAlt ? alt : t("chat.imageLightbox.untitled"),
+      }),
+    interactiveImages: (env) =>
+      (env as Partial<MarkdownRenderEnv> | undefined)?.interactiveImages === true,
+  });
+
+  // Override fenced code blocks with copy button + JSON collapse
+  markdownParser.renderer.rules.fence = (tokens, index, _options, env) => {
+    const token = tokens[index];
+    if (!token) {
+      return "";
+    }
+    // token.info contains the full fence info string (e.g., "json title=foo");
+    // extract only the first whitespace-separated token as the language.
+    const language = token.info.trim().split(/\s+/)[0] || "";
+    return renderMarkdownCodeBlock(token.content, language, env, {
+      copyText: markdownCodeBlockCopyText(token.content),
+    });
+  };
+  // Override indented code blocks (code_block) with the same treatment as fence
+  markdownParser.renderer.rules.code_block = (tokens, index, _options, env) => {
+    const content = tokens[index]?.content;
+    if (content === undefined) {
+      return "";
+    }
+    return renderMarkdownCodeBlock(content, "", env, {
+      copyText: markdownCodeBlockCopyText(content),
+    });
+  };
+
+  return markdownParser;
+}

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -1,0 +1,105 @@
+import remend, { type RemendOptions } from "remend";
+
+const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
+const FENCE_CONTAINER_PREFIX_RE = /^[ \t]{0,3}(?:(?:>\s?)|(?:(?:[-+*]|\d{1,9}[.)])[ \t]+))/;
+
+function stripFenceContainerPrefixes(line: string): string {
+  let current = line;
+  for (let index = 0; index < 8; index += 1) {
+    const next = current.replace(FENCE_CONTAINER_PREFIX_RE, "");
+    if (next === current) {
+      return current;
+    }
+    current = next;
+  }
+  return current;
+}
+
+function getFenceMarker(line: string): { marker: "`" | "~"; length: number } | null {
+  const match = FENCE_OPEN_RE.exec(stripFenceContainerPrefixes(line));
+  if (!match) {
+    return null;
+  }
+  const fence = match[1];
+  if (!fence) {
+    return null;
+  }
+  const marker = fence.charAt(0) as "`" | "~";
+  return { marker, length: fence.length };
+}
+
+function isFenceClose(line: string, fence: { marker: "`" | "~"; length: number }): boolean {
+  const trimmed = stripFenceContainerPrefixes(line).trimEnd();
+  const match = FENCE_OPEN_RE.exec(trimmed);
+  if (!match) {
+    return false;
+  }
+  const markerText = match[1];
+  if (!markerText) {
+    return false;
+  }
+  const marker = markerText.charAt(0);
+  if (marker !== fence.marker || markerText.length < fence.length) {
+    return false;
+  }
+  return trimmed.slice(match[0].length).trim() === "";
+}
+
+export type StreamingMarkdownSplit = {
+  /** Offset just past the last blank line outside a code fence; the prefix is block-stable. */
+  boundary: number;
+  /** True when the text after the boundary contains a code fence that has not closed yet. */
+  tailHasOpenFence: boolean;
+};
+
+export function splitStableStreamingMarkdown(markdownLocal: string): StreamingMarkdownSplit {
+  let boundary = 0;
+  let index = 0;
+  let openFence: { marker: "`" | "~"; length: number } | null = null;
+
+  while (index < markdownLocal.length) {
+    const nextLineBreak = markdownLocal.indexOf("\n", index);
+    const lineEnd = nextLineBreak === -1 ? markdownLocal.length : nextLineBreak + 1;
+    const line = markdownLocal.slice(index, nextLineBreak === -1 ? lineEnd : nextLineBreak);
+
+    if (openFence) {
+      if (isFenceClose(line, openFence)) {
+        openFence = null;
+        boundary = lineEnd;
+      }
+      index = lineEnd;
+      continue;
+    }
+
+    const openingFence = getFenceMarker(line);
+    if (openingFence) {
+      openFence = openingFence;
+      index = lineEnd;
+      continue;
+    }
+
+    if (line.trim() === "") {
+      boundary = lineEnd;
+    }
+    index = lineEnd;
+  }
+
+  return { boundary, tailHasOpenFence: openFence !== null };
+}
+
+// Streaming-tail repair config: math is not rendered by this pipeline, so
+// completing `$$` would inject visible characters into ordinary prose.
+const streamingRemendOptions = { katex: false, linkMode: "text-only" } satisfies RemendOptions;
+
+// Renders the in-flight block live. remend closes/strips unterminated inline
+// constructs (`**bold`, half links, …) so partially streamed markup styles
+// immediately instead of flashing raw markers. Inside an open code fence the
+// tail is code, not prose: skip remend (it only understands top-level ```
+// fences) and let markdown-it auto-close the fence at end of input (CommonMark
+// allows unterminated fences), so code streams with live highlighting.
+// Invariant: the tail never contains a *closed* fence — the split boundary
+// advances past every fence close — so remend (which cannot see ~~~ fences)
+// never runs across completed fenced code.
+export function repairStreamingMarkdownTail(tail: string): string {
+  return remend(tail, streamingRemendOptions);
+}

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -45,7 +45,7 @@ function isFenceClose(line: string, fence: { marker: "`" | "~"; length: number }
   return trimmed.slice(match[0].length).trim() === "";
 }
 
-export type StreamingMarkdownSplit = {
+type StreamingMarkdownSplit = {
   /** Offset just past the last blank line outside a code fence; the prefix is block-stable. */
   boundary: number;
   /** True when the text after the boundary contains a code fence that has not closed yet. */

--- a/ui/src/components/markdown-text.ts
+++ b/ui/src/components/markdown-text.ts
@@ -1,0 +1,34 @@
+const BLOCK_ART_LINE_RE = /^[\t \u00a0▀▄█]+$/u;
+const BLOCK_ART_GLYPH_RE = /[▀▄█]/u;
+
+export function escapeMarkdownHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function normalizeMarkdownLineBreaks(value: string): string {
+  return value.replace(/\r\n?|[\u2028\u2029]/g, "\n");
+}
+
+export function isMarkdownBlockArtText(value: string): boolean {
+  const lines = normalizeMarkdownLineBreaks(value).split("\n");
+  const artLines = lines.filter((line) => line.trim().length > 0);
+  if (artLines.length < 2) {
+    return false;
+  }
+
+  // QR generators commonly use spaces plus upper/lower/full block glyphs.
+  // Require multiple glyph-only lines so ordinary prose with a stray block character stays markdown.
+  let glyphCount = 0;
+  for (const line of artLines) {
+    if (!BLOCK_ART_LINE_RE.test(line) || !BLOCK_ART_GLYPH_RE.test(line)) {
+      return false;
+    }
+    glyphCount += Array.from(line).filter((char) => BLOCK_ART_GLYPH_RE.test(char)).length;
+  }
+  return glyphCount >= 8;
+}

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -1,10 +1,7 @@
 // Control UI tests cover markdown behavior.
 import { describe, expect, it, vi } from "vitest";
-import {
-  handleMarkdownCodeBlockCopy,
-  toSanitizedMarkdownHtml,
-  toStreamingMarkdownHtml,
-} from "./markdown.ts";
+import { handleMarkdownCodeBlockCopy } from "./markdown-code-blocks.ts";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "./markdown.ts";
 
 function htmlFragment(html: string): HTMLElement {
   const container = document.createElement("div");

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -1,42 +1,26 @@
 // Control UI module implements markdown behavior.
 import DOMPurify from "dompurify";
-import hljs from "highlight.js/lib/core";
-import bash from "highlight.js/lib/languages/bash";
-import cpp from "highlight.js/lib/languages/cpp";
-import css from "highlight.js/lib/languages/css";
-import diff from "highlight.js/lib/languages/diff";
-import go from "highlight.js/lib/languages/go";
-import java from "highlight.js/lib/languages/java";
-import javascript from "highlight.js/lib/languages/javascript";
-import json from "highlight.js/lib/languages/json";
-import markdown from "highlight.js/lib/languages/markdown";
-import python from "highlight.js/lib/languages/python";
-import rust from "highlight.js/lib/languages/rust";
-import typescript from "highlight.js/lib/languages/typescript";
-import xml from "highlight.js/lib/languages/xml";
-import yaml from "highlight.js/lib/languages/yaml";
-import MarkdownIt from "markdown-it";
-import markdownItTaskLists from "markdown-it-task-lists";
-import remend, { type RemendOptions } from "remend";
 import { stripUnsupportedCitationControlMarkers } from "../../../src/shared/text/citation-control-markers.js";
 import { routeIdFromPath } from "../app-route-paths.ts";
 import { resolveControlUiBasePath } from "../app/browser.ts";
 import { i18n, t } from "../i18n/index.ts";
-import { copyToClipboard } from "../lib/clipboard.ts";
 import { truncateText } from "../lib/format.ts";
 import { normalizeLowercaseStringOrEmpty } from "../lib/string-coerce.ts";
-import {
-  installAssistantTranscriptRoleMarkdown,
-  installAssistantTranscriptRoleImageRenderer,
-  renderAssistantTranscriptPlainTextFallback,
-} from "./markdown-assistant-transcript.ts";
+import { renderAssistantTranscriptPlainTextFallback } from "./markdown-assistant-transcript.ts";
+import { renderMarkdownCodeBlock } from "./markdown-code-blocks.ts";
+import { isHostLocalMarkdownFileHref } from "./markdown-file-links.ts";
+import { createMarkdownParser } from "./markdown-parser.ts";
 import {
   normalizeMarkdownRenderOptions,
   type MarkdownRenderEnv,
   type MarkdownRenderOptions,
 } from "./markdown-render-options.ts";
-
-export type { MarkdownRenderOptions } from "./markdown-render-options.ts";
+import { repairStreamingMarkdownTail, splitStableStreamingMarkdown } from "./markdown-streaming.ts";
+import {
+  escapeMarkdownHtml,
+  isMarkdownBlockArtText,
+  normalizeMarkdownLineBreaks,
+} from "./markdown-text.ts";
 
 const allowedTags = [
   "a",
@@ -103,85 +87,6 @@ const MARKDOWN_CHAR_LIMIT = 140_000;
 const MARKDOWN_PARSE_LIMIT = 40_000;
 const MARKDOWN_CACHE_LIMIT = 200;
 const MARKDOWN_CACHE_MAX_CHARS = 50_000;
-const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
-const BLOCK_ART_LINE_RE = /^[\t \u00a0▀▄█]+$/u;
-const BLOCK_ART_GLYPH_RE = /[▀▄█]/u;
-const blockArtCopyPayloadPrefix = "openclaw:block-art-code:";
-const blockArtCodeBlockCopyPayloadEncoding = "block-art-json";
-const HOST_LOCAL_FILE_HREF_RE =
-  /^(?:~\/|\/(?:Users|home|tmp|private\/tmp|var\/folders|private\/var\/folders)\/|\/[A-Za-z]:\/|[A-Za-z]:[\\/])/;
-const FILE_SEGMENT_SOURCE = "[A-Za-z0-9_.@#+-]+";
-const FILE_EXTENSION_SOURCE = "[A-Za-z0-9]{1,8}";
-const FILE_LINE_SUFFIX_SOURCE = ":\\d{1,6}(?::\\d{1,6})?";
-const FILE_NAME_SOURCE = `${FILE_SEGMENT_SOURCE}\\.${FILE_EXTENSION_SOURCE}`;
-const PREFIXED_FILE_SOURCE = `(?:~\\/|\\.\\.\\/|\\.\\/|\\/)(?:${FILE_SEGMENT_SOURCE}\\/)*${FILE_NAME_SOURCE}`;
-const UNPREFIXED_FILE_SOURCE = `${FILE_SEGMENT_SOURCE}(?:\\/${FILE_SEGMENT_SOURCE})*\\/${FILE_NAME_SOURCE}`;
-const WINDOWS_ABSOLUTE_FILE_SOURCE = `[A-Za-z]:[\\\\/](?:${FILE_SEGMENT_SOURCE}[\\\\/])*${FILE_NAME_SOURCE}`;
-const MULTI_SEGMENT_FILE_SOURCE = `(?:${PREFIXED_FILE_SOURCE}|${WINDOWS_ABSOLUTE_FILE_SOURCE}|${UNPREFIXED_FILE_SOURCE})(?:${FILE_LINE_SUFFIX_SOURCE})?`;
-const BARE_FILE_WITH_LINE_SOURCE = `${FILE_SEGMENT_SOURCE}\\.${FILE_EXTENSION_SOURCE}${FILE_LINE_SUFFIX_SOURCE}`;
-const MULTI_SEGMENT_FILE_RE = new RegExp(`^${MULTI_SEGMENT_FILE_SOURCE}$`);
-const BARE_FILE_WITH_LINE_RE = new RegExp(`^${BARE_FILE_WITH_LINE_SOURCE}$`);
-const BARE_FILENAME_RE = new RegExp(`^${FILE_SEGMENT_SOURCE}\\.(${FILE_EXTENSION_SOURCE})$`, "i");
-const FILE_LINK_SCAN_RE = new RegExp(
-  `${MULTI_SEGMENT_FILE_SOURCE}|${BARE_FILE_WITH_LINE_SOURCE}`,
-  "g",
-);
-const FILE_LINE_SUFFIX_RE = /:(\d{1,6})(?::\d{1,6})?$/;
-const BARE_FILE_EXTENSIONS = new Set([
-  "astro",
-  "bash",
-  "c",
-  "cc",
-  "cfg",
-  "cjs",
-  "conf",
-  "cpp",
-  "cs",
-  "css",
-  "diff",
-  "fish",
-  "go",
-  "h",
-  "hpp",
-  "htm",
-  "html",
-  "ini",
-  "java",
-  "js",
-  "json",
-  "jsonc",
-  "jsx",
-  "kt",
-  "kts",
-  "less",
-  "lock",
-  "log",
-  "markdown",
-  "md",
-  "mdx",
-  "mjs",
-  "patch",
-  "plist",
-  "proto",
-  "py",
-  "rb",
-  "rs",
-  "scss",
-  "sh",
-  "sql",
-  "svelte",
-  "svg",
-  "swift",
-  "toml",
-  "ts",
-  "tsx",
-  "txt",
-  "vue",
-  "xml",
-  "yaml",
-  "yml",
-  "zsh",
-]);
 const DOCS_ORIGIN = "https://docs.openclaw.ai";
 const DOCS_ROOT_SEGMENTS = new Set([
   "agent-runtime-architecture",
@@ -408,15 +313,6 @@ const APP_RESOURCE_PATH_PREFIXES = [
 ];
 const markdownCache = new Map<string, string>();
 const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
-const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
-const FENCE_CONTAINER_PREFIX_RE = /^[ \t]{0,3}(?:(?:>\s?)|(?:(?:[-+*]|\d{1,9}[.)])[ \t]+))/;
-
-// CJK character ranges for URL boundary detection (RFC 3986: CJK is not valid in raw URLs).
-// CJK Unified Ideographs, CJK Symbols/Punctuation, Fullwidth Forms, Hiragana, Katakana,
-// Hangul Syllables, and CJK Compatibility Ideographs.
-const CJK_RE = new RegExp(
-  "[\\u2E80-\\u2FFF\\u3000-\\u303F\\u3040-\\u309F\\u30A0-\\u30FF\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uAC00-\\uD7AF\\uF900-\\uFAFF\\uFF01-\\uFF60]",
-);
 
 function getCachedMarkdown(key: string): string | null {
   const cached = markdownCache.get(key);
@@ -437,96 +333,6 @@ function setCachedMarkdown(key: string, value: string) {
   if (oldest) {
     markdownCache.delete(oldest);
   }
-}
-
-function shouldRenderCodeBlockCopy(env: unknown): boolean {
-  return (env as Partial<MarkdownRenderEnv> | undefined)?.codeBlockChrome !== "none";
-}
-
-function encodeBlockArtCodeBlockCopyPayload(value: string): string {
-  return `${blockArtCopyPayloadPrefix}${JSON.stringify(value)}`;
-}
-
-function decodeCodeBlockCopyPayload(value: string, encoding?: string): string {
-  if (
-    encoding !== blockArtCodeBlockCopyPayloadEncoding ||
-    !value.startsWith(blockArtCopyPayloadPrefix)
-  ) {
-    return value;
-  }
-  try {
-    const decoded = JSON.parse(value.slice(blockArtCopyPayloadPrefix.length));
-    return typeof decoded === "string" ? decoded : value;
-  } catch {
-    return value;
-  }
-}
-
-export function handleMarkdownCodeBlockCopy(event: Event): void {
-  const target = event.target;
-  if (!(target instanceof Element)) {
-    return;
-  }
-  const button = target.closest<HTMLElement>(".code-block-copy");
-  if (!button) {
-    return;
-  }
-  const code = decodeCodeBlockCopyPayload(button.dataset.code ?? "", button.dataset.codeEncoding);
-  void copyToClipboard(code).then((copied) => {
-    if (!copied) {
-      return;
-    }
-    button.classList.add("copied");
-    setTimeout(() => button.classList.remove("copied"), 1500);
-  });
-}
-
-export function markdownFileLinkFromEvent(
-  event: Event,
-): { path: string; line: number | null } | null {
-  const target = event.target;
-  if (!(target instanceof Element)) {
-    return null;
-  }
-  const link = target.closest<HTMLAnchorElement>("a[data-file-path]");
-  const path = link?.dataset.filePath;
-  if (!path) {
-    return null;
-  }
-  const line = link.dataset.fileLine;
-  return { path, line: line ? Number.parseInt(line, 10) : null };
-}
-
-function splitFileLineSuffix(raw: string): { path: string; line: number | null } {
-  const match = FILE_LINE_SUFFIX_RE.exec(raw);
-  const line = match?.[1];
-  return match && line
-    ? { path: raw.slice(0, match.index), line: Number.parseInt(line, 10) }
-    : { path: raw, line: null };
-}
-
-function isAllowlistedBareFilename(raw: string): boolean {
-  if (raw.includes("/") || raw.includes("\\")) {
-    return false;
-  }
-  const match = BARE_FILENAME_RE.exec(raw);
-  return Boolean(match?.[1] && BARE_FILE_EXTENSIONS.has(match[1].toLowerCase()));
-}
-
-function parseFileLinkTarget(raw: string): { path: string; line: number | null } | null {
-  const target = raw.trim();
-  if (
-    !MULTI_SEGMENT_FILE_RE.test(target) &&
-    !BARE_FILE_WITH_LINE_RE.test(target) &&
-    !isAllowlistedBareFilename(target)
-  ) {
-    return null;
-  }
-  return splitFileLineSuffix(target);
-}
-
-function isHostLocalFileHref(href: string): boolean {
-  return HOST_LOCAL_FILE_HREF_RE.test(href.trim());
 }
 
 function isControlUiRoutePath(pathname: string): boolean {
@@ -632,7 +438,7 @@ function installHooks() {
       return;
     }
 
-    if (isHostLocalFileHref(href)) {
+    if (isHostLocalMarkdownFileHref(href)) {
       node.removeAttribute("href");
       return;
     }
@@ -663,26 +469,6 @@ function installHooks() {
   });
 }
 
-// ── markdown-it instance with custom renderers ──
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-function normalizeMarkdownImageLabel(text?: string | null): string {
-  const trimmed = text?.trim();
-  return trimmed ? trimmed : "image";
-}
-
-function normalizeMarkdownLineBreaks(value: string): string {
-  return value.replace(/\r\n?|[\u2028\u2029]/g, "\n");
-}
-
 function formatTruncatedMarkdownInput(input: string): string {
   const truncated = truncateText(input, MARKDOWN_CHAR_LIMIT);
   return appendMarkdownTruncationNotice(truncated);
@@ -699,613 +485,7 @@ function appendMarkdownTruncationNotice(truncated: {
   return `${truncated.text}${notice}`;
 }
 
-export function isMarkdownBlockArtText(value: string): boolean {
-  const lines = normalizeMarkdownLineBreaks(value).split("\n");
-  const artLines = lines.filter((line) => line.trim().length > 0);
-  if (artLines.length < 2) {
-    return false;
-  }
-
-  // QR generators commonly use spaces plus upper/lower/full block glyphs.
-  // Require multiple glyph-only lines so ordinary prose with a stray block character stays markdown.
-  let glyphCount = 0;
-  for (const line of artLines) {
-    if (!BLOCK_ART_LINE_RE.test(line) || !BLOCK_ART_GLYPH_RE.test(line)) {
-      return false;
-    }
-    glyphCount += Array.from(line).filter((char) => BLOCK_ART_GLYPH_RE.test(char)).length;
-  }
-  return glyphCount >= 8;
-}
-
-function getFenceMarker(line: string): { marker: "`" | "~"; length: number } | null {
-  const match = FENCE_OPEN_RE.exec(stripFenceContainerPrefixes(line));
-  if (!match) {
-    return null;
-  }
-  const fence = match[1];
-  if (!fence) {
-    return null;
-  }
-  const marker = fence.charAt(0) as "`" | "~";
-  return { marker, length: fence.length };
-}
-
-function stripFenceContainerPrefixes(line: string): string {
-  let current = line;
-  for (let index = 0; index < 8; index += 1) {
-    const next = current.replace(FENCE_CONTAINER_PREFIX_RE, "");
-    if (next === current) {
-      return current;
-    }
-    current = next;
-  }
-  return current;
-}
-
-function isFenceClose(line: string, fence: { marker: "`" | "~"; length: number }): boolean {
-  const trimmed = stripFenceContainerPrefixes(line).trimEnd();
-  const match = FENCE_OPEN_RE.exec(trimmed);
-  if (!match) {
-    return false;
-  }
-  const markerText = match[1];
-  if (!markerText) {
-    return false;
-  }
-  const marker = markerText.charAt(0);
-  if (marker !== fence.marker || markerText.length < fence.length) {
-    return false;
-  }
-  return trimmed.slice(match[0].length).trim() === "";
-}
-
-type StreamingMarkdownSplit = {
-  /** Offset just past the last blank line outside a code fence; the prefix is block-stable. */
-  boundary: number;
-  /** True when the text after the boundary contains a code fence that has not closed yet. */
-  tailHasOpenFence: boolean;
-};
-
-function splitStableStreamingMarkdown(markdownLocal: string): StreamingMarkdownSplit {
-  let boundary = 0;
-  let index = 0;
-  let openFence: { marker: "`" | "~"; length: number } | null = null;
-
-  while (index < markdownLocal.length) {
-    const nextLineBreak = markdownLocal.indexOf("\n", index);
-    const lineEnd = nextLineBreak === -1 ? markdownLocal.length : nextLineBreak + 1;
-    const line = markdownLocal.slice(index, nextLineBreak === -1 ? lineEnd : nextLineBreak);
-
-    if (openFence) {
-      if (isFenceClose(line, openFence)) {
-        openFence = null;
-        boundary = lineEnd;
-      }
-      index = lineEnd;
-      continue;
-    }
-
-    const openingFence = getFenceMarker(line);
-    if (openingFence) {
-      openFence = openingFence;
-      index = lineEnd;
-      continue;
-    }
-
-    if (line.trim() === "") {
-      boundary = lineEnd;
-    }
-    index = lineEnd;
-  }
-
-  return { boundary, tailHasOpenFence: openFence !== null };
-}
-
-for (const [language, definition] of Object.entries({
-  bash,
-  cpp,
-  css,
-  diff,
-  go,
-  java,
-  javascript,
-  json,
-  markdown,
-  python,
-  rust,
-  typescript,
-  xml,
-  yaml,
-})) {
-  hljs.registerLanguage(language, definition);
-}
-hljs.registerAliases("shell", { languageName: "bash" });
-
-function highlightCode(text: string, lang: string): string {
-  const language = lang.trim().toLowerCase();
-  try {
-    if (language && hljs.getLanguage(language)) {
-      return hljs.highlight(text, { language, ignoreIllegals: true }).value;
-    }
-    if (!language && text.trim()) {
-      const result = hljs.highlightAuto(text);
-      if (result.relevance >= 2) {
-        return result.value;
-      }
-    }
-  } catch {
-    // Fall back to escaped plaintext; malformed input should not break chat rendering.
-  }
-  return escapeHtml(text);
-}
-
-/** Highlight a JSON/JSON5 snippet; output is escaped hljs markup safe for unsafeHTML in a code block. */
-export function highlightJsonHtml(text: string): string {
-  return highlightCode(text, "json");
-}
-
-function codeClassAttribute(lang: string, highlighted: string): string {
-  const classes = [
-    highlighted.includes("hljs-") ? "hljs" : "",
-    lang ? `language-${lang}` : "",
-  ].filter(Boolean);
-  return classes.length > 0 ? ` class="${escapeHtml(classes.join(" "))}"` : "";
-}
-
-function renderCodeElement(
-  text: string,
-  lang: string,
-  options: { blockArt?: boolean } = {},
-): string {
-  if (options.blockArt || isMarkdownBlockArtText(text)) {
-    return `<pre><code class="markdown-block-art">${escapeHtml(text)}</code></pre>`;
-  }
-  const highlighted = highlightCode(text, lang);
-  const classAttr = codeClassAttribute(lang, highlighted);
-  return `<pre><code${classAttr}>${highlighted}</code></pre>`;
-}
-
-function renderCodeBlock(
-  text: string,
-  lang: string,
-  env: unknown,
-  options: { blockArt?: boolean; copyText?: string } = {},
-): string {
-  const blockArt = options.blockArt || isMarkdownBlockArtText(text);
-  const codeBlock = renderCodeElement(text, lang, { blockArt });
-  if (!shouldRenderCodeBlockCopy(env)) {
-    return codeBlock;
-  }
-  const langLabel = lang ? `<span class="code-block-lang">${escapeHtml(lang)}</span>` : "";
-  const copyText = options.copyText ?? text;
-  const copyPayload = blockArt ? encodeBlockArtCodeBlockCopyPayload(copyText) : copyText;
-  const attrSafe = escapeHtml(copyPayload);
-  const encodingAttr = blockArt
-    ? ` data-code-encoding="${blockArtCodeBlockCopyPayloadEncoding}"`
-    : "";
-  const copyBtn = `<button type="button" class="code-block-copy" data-code="${attrSafe}"${encodingAttr} aria-label="${escapeHtml(t("common.copyCode"))}"><span class="code-block-copy__idle">${escapeHtml(t("common.copy"))}</span><span class="code-block-copy__done">${escapeHtml(t("common.copied"))}</span></button>`;
-  const header = `<div class="code-block-header">${langLabel}${copyBtn}</div>`;
-
-  const trimmed = text.trim();
-  const isJson =
-    lang === "json" ||
-    (!lang &&
-      ((trimmed.startsWith("{") && trimmed.endsWith("}")) ||
-        (trimmed.startsWith("[") && trimmed.endsWith("]"))));
-
-  if (isJson) {
-    const lineCount = text.split("\n").length;
-    const label = lineCount > 1 ? `JSON &middot; ${lineCount} lines` : "JSON";
-    return `<details class="json-collapse"><summary>${label}</summary><div class="code-block-wrapper">${header}${codeBlock}</div></details>`;
-  }
-
-  return `<div class="code-block-wrapper">${header}${codeBlock}</div>`;
-}
-
-function codeBlockCopyTextFromMarkdownToken(content: string): string {
-  return content.endsWith("\n") ? content.slice(0, -1) : content;
-}
-
-const md = new MarkdownIt({
-  html: true, // Enable HTML recognition so html_block/html_inline overrides can escape it
-  breaks: true,
-  linkify: true,
-});
-const defaultCodeInlineRenderer = md.renderer.rules.code_inline!;
-
-// Enable GFM strikethrough (~~text~~) to match original marked.js behavior.
-// markdown-it uses <s> tags; we added "s" to allowedTags for DOMPurify.
-md.enable("strikethrough");
-installAssistantTranscriptRoleMarkdown(md, escapeHtml);
-
-// Disable fuzzy link detection to prevent bare filenames like "README.md"
-// from being auto-linked as "http://README.md". URLs with explicit protocol
-// (https://...) and emails are still linkified.
-//
-// Alternative considered: extensions/matrix/src/matrix/format.ts uses fuzzyLink
-// with a file-extension blocklist to filter false positives at render time.
-// We chose the www-only approach instead because:
-// 1. Matches original marked.js GFM behavior exactly (bare domains were never linked)
-// 2. No blocklist to maintain — new TLDs like .ai, .io, .dev would need constant updates
-// 3. Predictable behavior — users can always use explicit https:// for any URL
-md.linkify.set({ fuzzyLink: false });
-
-// Re-enable www. prefix detection per GFM spec: bare URLs without protocol
-// must start with "www." to be auto-linked. This avoids false positives on
-// filenames while preserving expected behavior for "www.example.com".
-// GFM spec: valid domain = alphanumeric/underscore/hyphen segments separated
-// by periods, at least one period, no underscores in last two segments.
-md.linkify.add("www", {
-  validate(text, pos) {
-    const tail = text.slice(pos);
-    // Match: . followed by domain and optional path, matching marked.js behavior.
-    // Stops at whitespace, < (HTML tag boundary), or CJK characters (RFC 3986:
-    // raw CJK is not valid in URLs; percent-encoded CJK like %E4%BD%A0 is fine).
-    const match = tail.match(
-      /^\.(?:[a-zA-Z0-9-]+\.?)+[^\s<\u2E80-\u2FFF\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF\uFF01-\uFF60]*/,
-    );
-    if (!match) {
-      return 0;
-    }
-    let len = match[0].length;
-
-    // Strip trailing punctuation per GFM extended autolink spec.
-    // GFM says: ?, !, ., ,, :, *, _, ~ are not part of the autolink if trailing.
-
-    // Balance checking config: closeChar -> openChar mapping.
-    // Strip trailing close chars only when unbalanced (more closes than opens).
-    // For self-matching pairs like "", open === close (strip if odd count).
-    const balancePairs: Record<string, string> = {
-      ")": "(",
-      "]": "[",
-      "}": "{",
-      '"': '"',
-      "'": "'",
-    };
-
-    // Pre-count balanced pairs to avoid O(n²) rescans.
-    // balance[closeChar] = count(open) - count(close), negative means unbalanced
-    const balance: Record<string, number> = {};
-    for (const [close, open] of Object.entries(balancePairs)) {
-      balance[close] = 0;
-      for (let i = 0; i < len; i++) {
-        const c = tail.charAt(i);
-        if (open === close) {
-          // Self-matching pair (e.g., "") — toggle between 0 and 1
-          if (c === open) {
-            balance[close] = balance[close] === 0 ? 1 : 0;
-          }
-        } else if (c === open) {
-          // Distinct open/close (e.g., ())
-          balance[close] = (balance[close] ?? 0) + 1;
-        } else if (c === close) {
-          balance[close] = (balance[close] ?? 0) - 1;
-        }
-      }
-    }
-
-    while (len > 0) {
-      const ch = tail.charAt(len - 1);
-      // GFM trailing punctuation: ?, !, ., ,, :, *, _, ~ stripped unconditionally.
-      // Semicolon is handled specially below (entity reference rule).
-      if (/[?!.,:*_~]/.test(ch)) {
-        len--;
-        continue;
-      }
-      // GFM entity reference rule: strip trailing &entity; sequences.
-      // Only strip ; when preceded by &<alphanumeric>+ (e.g., &amp; &lt; &hl;).
-      if (ch === ";") {
-        // Backward scan to find & (O(n) total, avoids string allocation)
-        let j = len - 2;
-        while (j >= 0 && /[a-zA-Z0-9]/.test(tail.charAt(j))) {
-          j--;
-        }
-        // j < len - 2 ensures at least one alphanumeric between & and ;
-        if (j >= 0 && tail.charAt(j) === "&" && j < len - 2) {
-          len = j;
-          continue;
-        }
-        // Not an entity reference, stop stripping
-        break;
-      }
-      // Handle balanced pairs — only strip close char if unbalanced.
-      const open = balancePairs[ch];
-      if (open !== undefined) {
-        if (open === ch) {
-          // Self-matching: strip if odd count (unbalanced)
-          if ((balance[ch] ?? 0) !== 0) {
-            balance[ch] = 0;
-            len--;
-            continue;
-          }
-        } else if ((balance[ch] ?? 0) < 0) {
-          // Distinct pair: strip if more closes than opens
-          balance[ch] = (balance[ch] ?? 0) + 1;
-          len--;
-          continue;
-        }
-      }
-      break;
-    }
-    return len;
-  },
-  normalize(match) {
-    match.url = "http://" + match.url;
-  },
-});
-
-// Override default link validator to allow all URLs through to renderers.
-// marked.js does not validate URLs at all — it generates <a>/<img> tags for
-// everything and relies on DOMPurify to strip dangerous schemes.
-//
-// We match this behavior exactly:
-// - All URLs pass validation, including javascript:, vbscript:, file:, data:
-// - Images: renderer.rules.image shows alt text for non-data-image URLs
-// - Links: DOMPurify strips dangerous href schemes, leaving safe anchor text
-// - Blocking at validateLink would skip token generation entirely, causing raw
-//   markdown source to appear instead of graceful fallbacks.
-md.validateLink = () => true;
-
-// Trim trailing CJK characters from auto-linked URLs (RFC 3986: raw CJK is
-// not valid in URLs). markdown-it's built-in linkify for https:// URLs may
-// swallow adjacent CJK text into the URL. This core rule runs after linkify
-// and splits the CJK suffix back into a plain text token.
-md.core.ruler.after("linkify", "linkify-cjk-trim", (state) => {
-  for (const blockToken of state.tokens) {
-    if (blockToken.type !== "inline" || !blockToken.children) {
-      continue;
-    }
-    const children = blockToken.children;
-    for (let i = children.length - 1; i >= 0; i--) {
-      const token = children[i];
-      if (!token) {
-        continue;
-      }
-      if (token.type !== "link_open") {
-        continue;
-      }
-      // Only trim linkify-generated autolinks, not explicit markdown links
-      // like [OpenClaw中文](https://docs.openclaw.ai) where CJK in display
-      // text is intentional and href must not be rewritten.
-      if (token.markup !== "linkify") {
-        continue;
-      }
-      // Use the display text to find CJK boundary (href may be percent-encoded)
-      const textToken = children[i + 1];
-      if (!textToken || textToken.type !== "text") {
-        continue;
-      }
-      const displayText = textToken.content;
-      // Scan backward to find trailing CJK suffix only.
-      // Middle CJK must be preserved (e.g. https://example.com/你/test stays intact);
-      // only strip a contiguous CJK tail adjacent to non-URL text.
-      let cjkIdx = displayText.length;
-      while (cjkIdx > 0 && CJK_RE.test(displayText.charAt(cjkIdx - 1))) {
-        cjkIdx--;
-      }
-      if (cjkIdx <= 0 || cjkIdx === displayText.length) {
-        continue;
-      }
-      // Split: URL part and CJK tail from display text
-      const trimmedDisplay = displayText.slice(0, cjkIdx);
-      const cjkTail = displayText.slice(cjkIdx);
-      // Rebuild href by preserving the scheme prefix that linkify added but
-      // display text omits (e.g. "mailto:" for emails, "http://" for www links).
-      const href = token.attrGet("href") ?? "";
-      const prefixLen = href.indexOf(displayText);
-      const hrefPrefix = prefixLen > 0 ? href.slice(0, prefixLen) : "";
-      token.attrSet("href", hrefPrefix + trimmedDisplay);
-      textToken.content = trimmedDisplay;
-      // Find link_close and insert CJK text after it
-      for (let j = i + 1; j < children.length; j++) {
-        if (children[j]?.type === "link_close") {
-          const tailToken = new state.Token("text", "", 0);
-          tailToken.content = cjkTail;
-          children.splice(j + 1, 0, tailToken);
-          break;
-        }
-      }
-    }
-  }
-});
-
-function isFileLinkBoundaryBefore(value: string, index: number): boolean {
-  const char = value[index - 1];
-  return char === undefined || /\s/.test(char) || "([{<\"'`".includes(char);
-}
-
-function isFileLinkBoundaryAfter(value: string, index: number): boolean {
-  const char = value[index];
-  return char === undefined || /\s/.test(char) || ".,;:!?)]}>\"'".includes(char);
-}
-
-md.core.ruler.after("linkify", "file-links", (state) => {
-  const env = state.env as Partial<MarkdownRenderEnv> | undefined;
-  if (env?.fileLinks !== true) {
-    return;
-  }
-  for (const blockToken of state.tokens) {
-    if (blockToken.type !== "inline" || !blockToken.children) {
-      continue;
-    }
-    const children = blockToken.children;
-    let linkDepth = 0;
-    for (let index = 0; index < children.length; index += 1) {
-      const token = children[index];
-      if (!token) {
-        continue;
-      }
-      if (token.type === "link_open") {
-        const href = token.attrGet("href");
-        if (href) {
-          let decodedHref = href;
-          try {
-            decodedHref = decodeURIComponent(href);
-          } catch {
-            // Keep the raw href when malformed percent escapes cannot be decoded.
-          }
-          if (!decodedHref.includes("://")) {
-            const target =
-              parseFileLinkTarget(decodedHref) ??
-              (isHostLocalFileHref(decodedHref) ? splitFileLineSuffix(decodedHref.trim()) : null);
-            if (target) {
-              token.attrs = token.attrs?.filter(([name]) => name !== "href") ?? null;
-              token.attrJoin("class", "markdown-file-link");
-              token.attrSet("data-file-path", target.path);
-              if (target.line !== null) {
-                token.attrSet("data-file-line", String(target.line));
-              }
-            }
-          }
-        }
-        linkDepth += 1;
-        continue;
-      }
-      if (token.type === "link_close") {
-        linkDepth = Math.max(0, linkDepth - 1);
-        continue;
-      }
-      if (linkDepth > 0 || token.type !== "text") {
-        continue;
-      }
-
-      const replacements: typeof children = [];
-      let cursor = 0;
-      FILE_LINK_SCAN_RE.lastIndex = 0;
-      for (const match of token.content.matchAll(FILE_LINK_SCAN_RE)) {
-        const matchIndex = match.index;
-        const matched = match[0];
-        const matchEnd = matchIndex + matched.length;
-        if (
-          !isFileLinkBoundaryBefore(token.content, matchIndex) ||
-          !isFileLinkBoundaryAfter(token.content, matchEnd)
-        ) {
-          continue;
-        }
-        const target = parseFileLinkTarget(matched);
-        if (!target) {
-          continue;
-        }
-        if (matchIndex > cursor) {
-          const leading = new state.Token("text", "", 0);
-          leading.content = token.content.slice(cursor, matchIndex);
-          replacements.push(leading);
-        }
-        const open = new state.Token("link_open", "a", 1);
-        open.markup = "file-link";
-        open.attrSet("class", "markdown-file-link");
-        open.attrSet("data-file-path", target.path);
-        if (target.line !== null) {
-          open.attrSet("data-file-line", String(target.line));
-        }
-        const label = new state.Token("text", "", 0);
-        label.content = matched;
-        const close = new state.Token("link_close", "a", -1);
-        close.markup = "file-link";
-        replacements.push(open, label, close);
-        cursor = matchEnd;
-      }
-      if (replacements.length === 0) {
-        continue;
-      }
-      if (cursor < token.content.length) {
-        const trailing = new state.Token("text", "", 0);
-        trailing.content = token.content.slice(cursor);
-        replacements.push(trailing);
-      }
-      children.splice(index, 1, ...replacements);
-      index += replacements.length - 1;
-    }
-  }
-});
-
-// Enable GFM task list checkboxes (- [x] / - [ ]).
-// enabled: false keeps checkboxes read-only (disabled="") — task lists in
-// chat messages are display-only, not interactive forms.
-// label: false avoids wrapping item text in <label>, which would break
-// accessibility when the item contains links (MDN warns against anchors inside labels).
-md.use(markdownItTaskLists, { enabled: false, label: false });
-
-// The plugin inserts its checkbox as the first inline child. Trust only that
-// generated token so later user-authored HTML remains escaped.
-md.core.ruler.after("github-task-lists", "task-list-allowlist", (state) => {
-  for (const [index, listItem] of state.tokens.entries()) {
-    if (listItem.type !== "list_item_open" || listItem.attrGet("class") !== "task-list-item") {
-      continue;
-    }
-    const checkbox = state.tokens[index + 2]?.children?.[0];
-    if (checkbox?.type === "html_inline") {
-      checkbox.meta = { taskListPlugin: true };
-    }
-  }
-});
-
-// Override html_block and html_inline to escape raw HTML (#13937).
-// Exception: html_inline tokens marked by a trusted plugin (meta.taskListPlugin)
-// are allowed through — they are generated by our own plugin pipeline, not user input,
-// and DOMPurify provides the final safety net regardless.
-// Renderer rules degrade to empty output on impossible token misses instead of
-// throwing mid-render; markdown input is untrusted and the chat view must not crash.
-md.renderer.rules.html_block = (tokens, idx) => {
-  const token = tokens[idx];
-  return token ? escapeHtml(token.content) + "\n" : "";
-};
-md.renderer.rules.html_inline = (tokens, idx) => {
-  const token = tokens[idx];
-  return token?.meta?.taskListPlugin === true ? token.content : escapeHtml(token?.content ?? "");
-};
-md.renderer.rules.code_inline = (tokens, idx, options, env, self) => {
-  const rendered = defaultCodeInlineRenderer(tokens, idx, options, env, self);
-  const renderEnv = env as Partial<MarkdownRenderEnv> | undefined;
-  const token = tokens[idx];
-  const target = token && renderEnv?.fileLinks === true ? parseFileLinkTarget(token.content) : null;
-  if (!target) {
-    return rendered;
-  }
-  const lineAttr =
-    target.line === null ? "" : ` data-file-line="${escapeHtml(String(target.line))}"`;
-  return `<a class="markdown-file-link" data-file-path="${escapeHtml(target.path)}"${lineAttr}>${rendered}</a>`;
-};
-
-// Override image to only allow base64 data URIs (#15437).
-installAssistantTranscriptRoleImageRenderer(md, {
-  escapeHtml,
-  isInlineDataImage: (src) => INLINE_DATA_IMAGE_RE.test(src),
-  normalizeLabel: normalizeMarkdownImageLabel,
-  assistantLabel: () => t("sessionsView.assistant"),
-  openImageLabel: (alt, hasAlt) =>
-    t("chat.imageLightbox.open", {
-      title: hasAlt ? alt : t("chat.imageLightbox.untitled"),
-    }),
-  interactiveImages: (env) =>
-    (env as Partial<MarkdownRenderEnv> | undefined)?.interactiveImages === true,
-});
-
-// Override fenced code blocks with copy button + JSON collapse
-md.renderer.rules.fence = (tokens, idx, _options, env) => {
-  const token = tokens[idx];
-  if (!token) {
-    return "";
-  }
-  // token.info contains the full fence info string (e.g., "json title=foo");
-  // extract only the first whitespace-separated token as the language.
-  const lang = token.info.trim().split(/\s+/)[0] || "";
-  return renderCodeBlock(token.content, lang, env, {
-    copyText: codeBlockCopyTextFromMarkdownToken(token.content),
-  });
-};
-
-// Override indented code blocks (code_block) with the same treatment as fence
-md.renderer.rules.code_block = (tokens, idx, _options, env) => {
-  const content = tokens[idx]?.content;
-  if (content === undefined) {
-    return "";
-  }
-  return renderCodeBlock(content, "", env, {
-    copyText: codeBlockCopyTextFromMarkdownToken(content),
-  });
-};
+const markdownParser = createMarkdownParser();
 
 // Uncached render core shared by the static and streaming paths. The streaming
 // tail changes on every delta, so routing it through here (instead of the cached
@@ -1316,7 +496,7 @@ function renderSanitizedMarkdown(renderInput: string, renderOptions: MarkdownRen
   const input = appendMarkdownTruncationNotice(truncated);
   if (isMarkdownBlockArtText(truncated.text)) {
     return DOMPurify.sanitize(
-      renderCodeBlock(input, "", renderOptions, { blockArt: true }),
+      renderMarkdownCodeBlock(input, "", renderOptions, { blockArt: true }),
       sanitizeOptions,
     );
   }
@@ -1328,7 +508,7 @@ function renderSanitizedMarkdown(renderInput: string, renderOptions: MarkdownRen
   }
   let rendered: string;
   try {
-    rendered = md.render(input, renderOptions);
+    rendered = markdownParser.render(input, renderOptions);
   } catch (err) {
     // Fall back to escaped plain text when md.render() throws (#36213).
     console.warn("[markdown] md.render failed, falling back to plain text:", err);
@@ -1370,26 +550,10 @@ function toEscapedPlainTextHtml(value: string, options: MarkdownRenderEnv): stri
     normalizeMarkdownLineBreaks(value),
     options.assistantTranscriptRoleHeaders,
     () => t("sessionsView.assistant"),
-    escapeHtml,
+    escapeMarkdownHtml,
   );
 }
 
-// Streaming-tail repair config: math is not rendered by this pipeline, so
-// completing `$$` would inject visible characters into ordinary prose.
-const streamingRemendOptions = { katex: false, linkMode: "text-only" } satisfies RemendOptions;
-
-// Renders the in-flight block live. remend closes/strips unterminated inline
-// constructs (`**bold`, half links, …) so partially streamed markup styles
-// immediately instead of flashing raw markers. Inside an open code fence the
-// tail is code, not prose: skip remend (it only understands top-level ```
-// fences) and let markdown-it auto-close the fence at end of input (CommonMark
-// allows unterminated fences), so code streams with live highlighting.
-// Invariant: the tail never contains a *closed* fence — the split boundary
-// advances past every fence close — so remend (which cannot see ~~~ fences)
-// never runs across completed fenced code.
-function toStreamingTailHtml(tail: string, renderOptions: MarkdownRenderEnv): string {
-  return renderSanitizedMarkdown(remend(tail, streamingRemendOptions), renderOptions);
-}
 export function toStreamingMarkdownHtml(
   markdownLocal: string,
   options: MarkdownRenderOptions = {},
@@ -1417,7 +581,6 @@ export function toStreamingMarkdownHtml(
   }
   const tailHtml = tailHasOpenFence
     ? renderSanitizedMarkdown(streamingTail, renderOptions)
-    : toStreamingTailHtml(streamingTail, renderOptions);
+    : renderSanitizedMarkdown(repairStreamingMarkdownTail(streamingTail), renderOptions);
   return `${stableHtml}${tailHtml}`;
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -17,7 +17,7 @@ import type {
   WhatsAppStatus,
 } from "../../api/types.ts";
 import { icons } from "../../components/icons.ts";
-import { highlightJsonHtml } from "../../components/markdown.ts";
+import { highlightJsonHtml } from "../../components/markdown-code-blocks.ts";
 import "../../components/openclaw-mascot.ts";
 import {
   renderSettingsEmpty,

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -8,11 +8,8 @@ import { resolveLocalUserName } from "../../../app/user-identity.ts";
 import { renderCopyAsMarkdownButton } from "../../../components/copy-button.ts";
 import { icons, type IconName } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
-import {
-  toSanitizedMarkdownHtml,
-  toStreamingMarkdownHtml,
-  type MarkdownRenderOptions,
-} from "../../../components/markdown.ts";
+import type { MarkdownRenderOptions } from "../../../components/markdown-render-options.ts";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "../../../components/markdown.ts";
 import { t } from "../../../i18n/index.ts";
 import type { AssistantIdentity } from "../../../lib/assistant-identity.ts";
 import type { BoardProvider } from "../../../lib/board/provider.ts";

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -4,12 +4,10 @@ import { keyed } from "lit/directives/keyed.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
+import { handleMarkdownCodeBlockCopy } from "../../../components/markdown-code-blocks.ts";
+import { markdownFileLinkFromEvent } from "../../../components/markdown-file-links.ts";
 import "../../../components/web-awesome.ts";
-import {
-  handleMarkdownCodeBlockCopy,
-  markdownFileLinkFromEvent,
-  toSanitizedMarkdownHtml,
-} from "../../../components/markdown.ts";
+import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import { t } from "../../../i18n/index.ts";
 import "../../../components/tooltip.ts";
 import { extractRawText } from "../../../lib/chat/message-extract.ts";

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -20,11 +20,9 @@ import { resolveLocalUserName } from "../../../app/user-identity.ts";
 import { COPY_LABEL } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
+import { handleMarkdownCodeBlockCopy } from "../../../components/markdown-code-blocks.ts";
+import { markdownFileLinkFromEvent } from "../../../components/markdown-file-links.ts";
 import "../../../components/tooltip.ts";
-import {
-  handleMarkdownCodeBlockCopy,
-  markdownFileLinkFromEvent,
-} from "../../../components/markdown.ts";
 import { McpAppUnmountGate } from "../../../components/mcp-app-unmount.ts";
 import { i18n, t } from "../../../i18n/index.ts";
 import type { BoardProvider } from "../../../lib/board/provider.ts";

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -2,7 +2,7 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { icons, type IconName } from "../../../components/icons.ts";
-import { isMarkdownBlockArtText } from "../../../components/markdown.ts";
+import { isMarkdownBlockArtText } from "../../../components/markdown-text.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ToolCard, ToolCardOutcome } from "../../../lib/chat/chat-types.ts";

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -42,7 +42,7 @@ import {
   canonicalLobsterLook,
   renderLobsterSvg,
 } from "../../components/lobster-pet.ts";
-import { highlightJsonHtml } from "../../components/markdown.ts";
+import { highlightJsonHtml } from "../../components/markdown-code-blocks.ts";
 import {
   renderSettingsRow,
   renderSettingsSegmented,

--- a/ui/src/pages/debug/view.ts
+++ b/ui/src/pages/debug/view.ts
@@ -2,7 +2,7 @@
 import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { EventLogEntry } from "../../api/event-log.ts";
-import { highlightJsonHtml } from "../../components/markdown.ts";
+import { highlightJsonHtml } from "../../components/markdown-code-blocks.ts";
 import {
   renderSettingsEmpty,
   renderSettingsPage,


### PR DESCRIPTION
## What Problem This Solves

The chat markdown renderer had grown to 1,423 lines and required a grandfathered max-lines suppression. Because every chat message renders through this hot path, the oversized module made focused review and ownership of parsing, code-block, file-link, sanitization, and streaming behavior unnecessarily difficult.

## Why This Change Was Made

This maintainer-requested refactor moves the existing implementation into cohesive static sibling modules for code blocks/highlighting, file links, parser configuration, streaming repair, and shared text handling. It keeps synchronous rendering, module-level constants, direct free-function calls, and the existing markdown dependency chunk; there are no compatibility shims, callback bags, or new dynamic-import boundaries.

AI-assisted: implemented and reviewed with Codex.

## User Impact

None — this is a behavior-neutral split. Markdown rendering, sanitization, syntax highlighting, links, images, code-copy controls, block art, caching, and streaming output remain unchanged.

## Evidence

- Renderer and every direct importer suite: 17 files, 555 tests passed, 9 skipped on Blacksmith Testbox `tbx_01ky7bs81qmrmpkfyy8r7mwern` ([run](https://github.com/openclaw/openclaw/actions/runs/30003307928)).
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json`: passed on the same Testbox.
- `node scripts/check-changed.mjs -- <touched files>`: passed, including max-lines ratchet, formatting, UI/core typechecks, lint, i18n, and repository guards.
- Production `pnpm ui:build`: passed; startup JS is 323,411 B gzip versus the 323,435 B baseline (-24 B), with 9 startup requests. No `[INEFFECTIVE_DYNAMIC_IMPORT]` warning was emitted.
- Autoreview: clean in both uncommitted and committed branch modes; no accepted/actionable findings.
- Diff: +890/-877 (net +13 lines). All six renderer implementation files are 34–586 lines, with no max-lines suppression.
- Removed `ui/src/components/markdown.ts` from `config/max-lines-baseline.txt`.
- Test assertions were not changed; `ui/src/components/markdown.test.ts` only updates the extracted code-copy helper import.
