### PR TITLE
refactor(ui): split terminal panel into chrome renderers and a PTY controller

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -1073,7 +1073,6 @@ src/worker/worker.runtime.test.ts
 ui/src/api/gateway.node.test.ts
 ui/src/api/types.ts
 ui/src/app/app-host.ts
-ui/src/components/terminal/terminal-panel.ts
 ui/src/e2e/chat-flow.e2e.test.ts
 ui/src/e2e/new-session-page.e2e.test.ts
 ui/src/e2e/session-management.e2e.test.ts

--- a/ui/src/components/terminal/terminal-panel-chrome.ts
+++ b/ui/src/components/terminal/terminal-panel-chrome.ts
@@ -1,0 +1,98 @@
+import { html, nothing, type TemplateResult } from "lit";
+import { t } from "../../i18n/index.ts";
+import type { DockPanelSide } from "../dock-panel-layout.ts";
+import type { TerminalPanelSessionTab } from "./terminal-panel-session-types.ts";
+import { renderTerminalPanelTabs } from "./terminal-panel-tabs.ts";
+import {
+  renderTerminalPanelActions,
+  renderTerminalUploadLayer,
+  type TerminalPanelUploadController,
+} from "./terminal-panel-upload.ts";
+
+type TerminalDock = Exclude<DockPanelSide, "left">;
+
+export function renderTerminalPanelResizer(
+  fullscreen: boolean,
+  dock: TerminalDock,
+  startResize: (event: PointerEvent) => void,
+): TemplateResult | typeof nothing {
+  if (fullscreen) {
+    return nothing;
+  }
+  return html`<div
+    class="tp-resizer tp-resizer--${dock}"
+    @pointerdown=${startResize}
+    role="separator"
+    aria-label=${t("terminal.resize")}
+  ></div>`;
+}
+
+export function renderTerminalPanelToolbar(
+  fullscreen: boolean,
+  dock: TerminalDock,
+  uploadController: TerminalPanelUploadController,
+  sessionPicker: TemplateResult,
+  setDock: (dock: TerminalDock) => void,
+  hidePanel: () => void,
+): TemplateResult {
+  return renderTerminalPanelActions({
+    fullscreen,
+    dock,
+    upload: uploadController,
+    sessionPicker,
+    onDock: setDock,
+    onHide: hidePanel,
+  });
+}
+
+export function renderTerminalPanelHeader(
+  tabs: TerminalPanelSessionTab[],
+  activeId: string | null,
+  booting: boolean,
+  toolbar: TemplateResult,
+  selectTab: (id: string) => void,
+  closeTab: (id: string) => void,
+  openSession: () => void,
+): TemplateResult {
+  return html`<header class="tp-header">
+    ${renderTerminalPanelTabs({
+      tabs,
+      activeId,
+      booting,
+      onSelect: selectTab,
+      onClose: closeTab,
+      onNew: openSession,
+    })}
+    ${toolbar}
+  </header>`;
+}
+
+export function renderTerminalPanelViewport(
+  activeId: string | null,
+  connecting: boolean,
+  errorText: string | null,
+  uploadController: TerminalPanelUploadController,
+): TemplateResult {
+  return html`
+    ${errorText ? html`<div class="tp-error" role="alert">${errorText}</div>` : nothing}
+    <wa-tab-panel
+      id="terminal-tab-panel"
+      class="tp-viewport"
+      name=${activeId ?? "terminal"}
+      active
+      aria-labelledby=${activeId ? `terminal-tab-${activeId}` : nothing}
+      @dragenter=${uploadController.handleDragEnter}
+      @dragover=${uploadController.handleDragOver}
+      @dragleave=${uploadController.handleDragLeave}
+      @drop=${uploadController.handleDrop}
+    >
+      ${connecting
+        ? html`<div class="tp-connecting" role="status">
+            <span class="tp-connecting__spinner" aria-hidden="true"></span>
+            <span>${t("terminal.connecting")}</span>
+          </div>`
+        : nothing}
+      ${renderTerminalUploadLayer(uploadController)}
+    </wa-tab-panel>
+  `;
+}

--- a/ui/src/components/terminal/terminal-panel-readiness.test.ts
+++ b/ui/src/components/terminal/terminal-panel-readiness.test.ts
@@ -32,7 +32,7 @@ function createTerminalController() {
 const createTerminal = vi.fn(async () => createTerminalController());
 
 class ReadinessTestTerminalPanel extends OpenClawTerminalPanel {
-  protected override createTerminal =
+  override createTerminalController =
     createTerminal as unknown as typeof createIsolatedGhosttyTerminal;
 }
 

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -1,0 +1,691 @@
+import type { GhosttyTerminalController } from "@openclaw/libterminal/browser";
+import type { ReactiveController } from "lit";
+import { t } from "../../i18n/index.ts";
+import {
+  TerminalConnection,
+  type TerminalGatewayClient,
+  TerminalOpenTimeoutError,
+  type TerminalSessionInfo,
+} from "./terminal-connection.ts";
+import {
+  forceTerminalRender,
+  persistLiveTerminalSessions,
+  shellBasename,
+  TERMINAL_FONT_FAMILY,
+  TERMINAL_OUTPUT_ENCODER,
+  type TerminalOperation,
+  type TerminalPanelCatalogReference,
+  type TerminalPanelSessionControllerHost,
+  type TerminalPanelSessionControllerState,
+  type TerminalPanelSessionTab,
+} from "./terminal-panel-session-types.ts";
+import { loadPersistedTerminalSessionIds } from "./terminal-session-storage.ts";
+import { createTerminalStartupInput } from "./terminal-startup-input.ts";
+import { TerminalTabReadinessController } from "./terminal-tab-readiness.ts";
+import { TerminalTaskQueue } from "./terminal-task-queue.ts";
+import { terminalDynamicColors, terminalTheme } from "./terminal-theme.ts";
+
+/** Owns gateway PTY sessions and the Ghostty controllers bound to them. */
+export class TerminalPanelSessionController
+  implements ReactiveController, TerminalPanelSessionControllerState
+{
+  tabs: TerminalPanelSessionTab[] = [];
+  activeId: string | null = null;
+  booting = false;
+
+  private connection: TerminalConnection | null = null;
+  private activeClient: TerminalGatewayClient | null = null;
+  private activeAvailable = false;
+  private lifecycleGeneration = 0;
+  private lifecycleAbortController = new AbortController();
+  private lifecycleSyncToken = 0;
+  private tabSequence = 0;
+  private readonly bootQueue = new TerminalTaskQueue();
+  private readonly readiness: TerminalTabReadinessController<TerminalPanelSessionTab>;
+
+  constructor(private readonly host: TerminalPanelSessionControllerHost) {
+    host.addController(this);
+    this.readiness = new TerminalTabReadinessController<TerminalPanelSessionTab>({
+      timeoutMs: () => this.host.catalogReadyTimeoutMs,
+      isCurrent: (tab) => this.tabs.includes(tab),
+      onReady: () => {
+        this.updateControllerState("tabs", [...this.tabs]);
+        persistLiveTerminalSessions(this.tabs);
+      },
+      onTimeout: (tab) => {
+        this.host.terminalPanelErrorText = t("terminal.connectionTimedOut");
+        void this.connection?.close(tab.gatewaySessionId);
+        this.dropFailedTab(tab);
+        persistLiveTerminalSessions(this.tabs);
+      },
+    });
+  }
+
+  hostConnected(): void {}
+
+  private updateControllerState<Key extends keyof TerminalPanelSessionControllerState>(
+    key: Key,
+    value: TerminalPanelSessionControllerState[Key],
+  ): void {
+    Object.assign(this, { [key]: value });
+    this.host.requestUpdate();
+  }
+
+  connectHost(): void {
+    this.activeClient = this.host.client;
+    this.activeAvailable = this.host.available;
+  }
+
+  disconnectHost(): void {
+    this.disposeAllTabs();
+    this.activeClient = null;
+    this.activeAvailable = false;
+  }
+
+  scheduleLifecycleSync(): void {
+    const token = ++this.lifecycleSyncToken;
+    const generation = this.lifecycleGeneration;
+    // State teardown inside Lit's updated hook schedules a nested update.
+    // Defer it; token + generation reject superseded connection epochs.
+    queueMicrotask(() => {
+      if (
+        token !== this.lifecycleSyncToken ||
+        generation !== this.lifecycleGeneration ||
+        !this.host.isConnected
+      ) {
+        return;
+      }
+      this.synchronizeLifecycle();
+    });
+  }
+
+  private synchronizeLifecycle(): void {
+    const clientChanged = this.host.client !== this.activeClient;
+    const availabilityChanged = this.host.available !== this.activeAvailable;
+    if (!clientChanged && !availabilityChanged) {
+      return;
+    }
+    if (clientChanged) {
+      this.activeClient = this.host.client;
+    }
+    this.activeAvailable = this.host.available;
+    const becameUnavailable = availabilityChanged && !this.host.available;
+    if (clientChanged || becameUnavailable) {
+      this.disposeAllTabs();
+    }
+    let shouldRestore = clientChanged && this.host.available && this.host.terminalPanelOpen;
+    if (availabilityChanged) {
+      if (!this.host.available) {
+        this.host.hideTerminalPanelForUnavailableSurface();
+      } else if (this.host.restoreTerminalPanelOpenState()) {
+        shouldRestore = true;
+      }
+    }
+    if (shouldRestore) {
+      void this.restoreSessions();
+    }
+  }
+
+  async restoreSessions(): Promise<void> {
+    await this.bootQueue.enqueueSteps(
+      () => this.reattachPersistedSessions(),
+      () => this.ensureInitialSession(),
+    );
+  }
+
+  async openCatalogSession(catalog: TerminalPanelCatalogReference): Promise<void> {
+    await this.bootQueue.enqueueSteps(
+      () => this.reattachPersistedSessions(),
+      () => this.openSessionNow(catalog),
+    );
+  }
+
+  async openRequestedSession(sessionId: string): Promise<void> {
+    await this.enqueueAttachSession(sessionId, true);
+  }
+
+  private async reattachPersistedSessions(): Promise<void> {
+    const operation = this.captureTerminalOperation();
+    if (!operation || this.tabs.length > 0) {
+      return;
+    }
+    const persisted = loadPersistedTerminalSessionIds();
+    if (persisted.length === 0) {
+      return;
+    }
+    this.updateControllerState("booting", true);
+    try {
+      const connection = this.connectionFor(operation);
+      const listed = await connection.list();
+      if (!this.isTerminalOperationCurrent(operation)) {
+        return;
+      }
+      const known = new Map(listed.map((session) => [session.sessionId, session]));
+      for (const sessionId of persisted) {
+        const session = known.get(sessionId);
+        if (!session) {
+          await this.restoreExitedSession(sessionId, operation);
+        } else {
+          await this.attachSession(
+            sessionId,
+            operation,
+            session.owner?.startsWith("agent:") === true,
+            true,
+          );
+        }
+        if (!this.isTerminalOperationCurrent(operation)) {
+          return;
+        }
+      }
+    } catch {
+      if (!this.isTerminalOperationCurrent(operation)) {
+        return;
+      }
+      // terminal.list failed (older gateway, surface flapping): fall through
+      // to a fresh session below.
+    } finally {
+      if (this.isTerminalOperationCurrent(operation)) {
+        this.updateControllerState("booting", false);
+      }
+    }
+    if (!this.isTerminalOperationCurrent(operation)) {
+      return;
+    }
+    // Prune ids the gateway no longer knows (reaped or externally closed).
+    persistLiveTerminalSessions(this.tabs);
+  }
+
+  private async ensureInitialSession(): Promise<void> {
+    if (this.tabs.length === 0 && !this.booting) {
+      await this.openSessionNow();
+    }
+  }
+
+  async listSessions(): Promise<TerminalSessionInfo[] | null> {
+    const operation = this.captureTerminalOperation();
+    if (!operation) {
+      return null;
+    }
+    try {
+      const sessions = await this.connectionFor(operation).list();
+      return this.isTerminalOperationCurrent(operation) ? sessions : null;
+    } catch {
+      return this.isTerminalOperationCurrent(operation) ? [] : null;
+    }
+  }
+
+  async attachSessionById(sessionId: string, agentOwned = false): Promise<void> {
+    await this.enqueueAttachSession(sessionId, agentOwned);
+  }
+
+  private async enqueueAttachSession(sessionId: string, agentOwned: boolean): Promise<void> {
+    await this.bootQueue.enqueue(async () => {
+      const existing = this.tabs.find((tab) => tab.gatewaySessionId === sessionId);
+      if (existing) {
+        this.switchTo(existing.id);
+        return;
+      }
+      const operation = this.captureTerminalOperation();
+      if (!operation) {
+        return;
+      }
+      this.updateControllerState("booting", true);
+      this.host.terminalPanelErrorText = null;
+      try {
+        const attached = await this.attachSession(sessionId, operation, agentOwned);
+        if (!attached && this.isTerminalOperationCurrent(operation)) {
+          this.host.terminalPanelErrorText = t("terminal.attachFailed");
+        }
+      } finally {
+        if (this.isTerminalOperationCurrent(operation)) {
+          this.updateControllerState("booting", false);
+        }
+      }
+    });
+  }
+
+  /** Boots a tab with a libterminal controller, ready for an open or attach RPC. */
+  private async bootTab(
+    operation: TerminalOperation,
+    options: { awaitFirstOutput?: boolean } = {},
+  ): Promise<{
+    tab: TerminalPanelSessionTab;
+    connection: TerminalConnection;
+    cols: number;
+    rows: number;
+  }> {
+    const connection = this.connectionFor(operation);
+    // Preserve the connection so cancelled-open cleanup still closes the in-flight session.
+    const host = document.createElement("div");
+    host.className = "tp-host";
+    const id = `tab-${++this.tabSequence}`;
+    // Wait for the panel (and its .tp-viewport) to render before attaching the
+    // ghostty host, so the terminal opens into a laid-out, measurable node.
+    await this.host.updateComplete;
+    if (!this.isTerminalOperationCurrent(operation)) {
+      throw new Error("terminal operation cancelled");
+    }
+    const viewport = this.host.findTerminalPanelViewport();
+    if (!viewport) {
+      throw new Error("terminal viewport unavailable");
+    }
+    viewport.append(host);
+    const tabReference = { current: undefined as TerminalPanelSessionTab | undefined };
+    const startupInput = createTerminalStartupInput(
+      connection,
+      () => tabReference.current?.gatewaySessionId,
+    );
+    const { createTerminalDefaultColorQueryResponder } =
+      await import("@openclaw/libterminal/browser");
+    const defaultColorQueries = createTerminalDefaultColorQueryResponder({
+      getColors: () => terminalDynamicColors(this.host.themeMode),
+      reply: (data) => startupInput.onData(TERMINAL_OUTPUT_ENCODER.encode(data)),
+    });
+    let controller: GhosttyTerminalController;
+    try {
+      controller = await this.host.createTerminalController({
+        parent: host,
+        readOnly: false,
+        terminalOptions: {
+          fontSize: 13,
+          fontFamily: TERMINAL_FONT_FAMILY,
+          cursorBlink: true,
+          theme: terminalTheme(this.host.themeMode),
+          scrollback: 5000,
+        },
+        signal: operation.signal,
+        // The browser controller owns these subscriptions and their teardown.
+        onData: startupInput.onData,
+        onResize: startupInput.onResize,
+      });
+    } catch (error) {
+      host.remove();
+      throw error;
+    }
+    if (!this.isTerminalOperationCurrent(operation)) {
+      try {
+        controller.dispose();
+      } finally {
+        host.remove();
+      }
+      throw new Error("terminal operation cancelled");
+    }
+    const tab: TerminalPanelSessionTab = {
+      id,
+      sequence: this.tabSequence,
+      gatewaySessionId: "",
+      pendingInput: startupInput.buffer,
+      defaultColorQueries,
+      shellName: null,
+      shell: "",
+      agentId: null,
+      cwd: null,
+      agentOwned: false,
+      controller,
+      host,
+      status: "connecting",
+      awaitFirstOutput: options.awaitFirstOutput === true,
+      readyTimer: null,
+    };
+    tabReference.current = tab;
+    this.updateControllerState("tabs", [...this.tabs, tab]);
+    this.updateControllerState("activeId", id);
+    const { terminal } = controller;
+    return { tab, connection, cols: terminal.cols || 80, rows: terminal.rows || 24 };
+  }
+
+  /** Output/exit sink for one tab, shared by open and attach. */
+  private tabSink(tab: TerminalPanelSessionTab) {
+    return {
+      // The cancelled guard also protects the buffered-event replay inside
+      // connection.open/attach from writing to an already-disposed terminal.
+      onData: (data: string) => {
+        if (!tab.cancelled) {
+          tab.defaultColorQueries.observe(data);
+          tab.controller.write(TERMINAL_OUTPUT_ENCODER.encode(data));
+          if (data.length > 0) {
+            this.readiness.markReady(tab);
+          }
+        }
+      },
+      // A replay is authoritative. Reset parser, screen, and scrollback so a
+      // gap cannot leave stale cells or a partial escape sequence behind.
+      onReplay: (data: string, newlyObservedFrom: number) => {
+        if (!tab.cancelled) {
+          // Suppress complete historical queries, then answer only the suffix
+          // recovered after a sequence gap. A split query may cross the seam.
+          tab.defaultColorQueries.primeFromReplay(data.slice(0, newlyObservedFrom));
+          tab.defaultColorQueries.observe(data.slice(newlyObservedFrom));
+          tab.controller.terminal.reset();
+          if (data) {
+            tab.controller.write(TERMINAL_OUTPUT_ENCODER.encode(data));
+            this.readiness.markReady(tab);
+          }
+        }
+      },
+      onExit: (info: { reason?: string; exitCode: number | null; error?: string }) =>
+        this.handleExit(tab.id, info),
+    };
+  }
+
+  /** Binds a freshly opened or attached gateway session to its tab. */
+  private adoptSession(
+    tab: TerminalPanelSessionTab,
+    result: { sessionId: string; shell: string; agentId: string; cwd: string; title?: string },
+    agentOwned = false,
+  ): void {
+    tab.gatewaySessionId = result.sessionId;
+    tab.shellName = result.title ?? shellBasename(result.shell);
+    tab.shell = result.shell;
+    tab.agentId = result.agentId;
+    tab.cwd = result.cwd;
+    tab.agentOwned = agentOwned;
+    // Libterminal observes layout before the Gateway session exists. Resync the
+    // current grid now so a resize during the open/attach RPC is not lost.
+    const { cols, rows } = tab.controller.terminal;
+    void this.connection?.resize(result.sessionId, cols || 80, rows || 24);
+    for (const data of tab.pendingInput.drain()) {
+      void this.connection?.input(result.sessionId, data);
+    }
+    if (tab.status === "connecting") {
+      if (tab.awaitFirstOutput) {
+        this.readiness.arm(tab);
+      } else {
+        this.readiness.markReady(tab);
+      }
+    }
+    this.updateControllerState("tabs", [...this.tabs]);
+    persistLiveTerminalSessions(this.tabs);
+  }
+
+  /** Removes a tab whose open/attach never produced a server session. */
+  private dropFailedTab(tab: TerminalPanelSessionTab): void {
+    this.disposeTab(tab);
+    this.updateControllerState(
+      "tabs",
+      this.tabs.filter((entry) => entry.id !== tab.id),
+    );
+    if (this.activeId === tab.id) {
+      this.updateControllerState("activeId", this.tabs.at(-1)?.id ?? null);
+    }
+  }
+
+  async openSession(catalog?: TerminalPanelCatalogReference): Promise<void> {
+    await this.bootQueue.enqueue(() => this.openSessionNow(catalog));
+  }
+
+  private async openSessionNow(catalog?: TerminalPanelCatalogReference): Promise<void> {
+    const operation = this.captureTerminalOperation();
+    if (!operation) {
+      return;
+    }
+    this.updateControllerState("booting", true);
+    this.host.terminalPanelErrorText = null;
+    // Freeze the selection for this tab; later agent changes affect only new tabs.
+    const agentId = this.host.agentId?.trim() || undefined;
+    // Tracked outside the try so the catch can dispose a tab whose open failed.
+    let createdTab: TerminalPanelSessionTab | undefined;
+    try {
+      const boot = await this.bootTab(operation, { awaitFirstOutput: Boolean(catalog) });
+      createdTab = boot.tab;
+      const result = await boot.connection.open(
+        { agentId, cols: boot.cols, rows: boot.rows, ...(catalog ? { catalog } : {}) },
+        this.tabSink(boot.tab),
+      );
+      if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
+        // The tab's close button was clicked while the open RPC was in flight.
+        // The server session is live and its sink registered; close it now or
+        // it survives invisibly (eating the session cap) until disconnect.
+        void boot.connection.close(result.sessionId);
+        if (this.tabs.includes(boot.tab)) {
+          boot.tab.cancelled = "lifecycle";
+          this.dropFailedTab(boot.tab);
+        }
+        return;
+      }
+      this.adoptSession(boot.tab, result);
+      boot.tab.controller.terminal.focus();
+    } catch (error) {
+      // A failed open (e.g. terminal disabled or a sandboxed agent is refused)
+      // must not leave a phantom "live" tab with no server session. Drop it but
+      // keep the panel open so the error stays visible.
+      if (createdTab && !createdTab.gatewaySessionId && this.tabs.includes(createdTab)) {
+        this.dropFailedTab(createdTab);
+      }
+      if (!this.isTerminalOperationCurrent(operation)) {
+        return;
+      }
+      this.host.terminalPanelErrorText =
+        error instanceof TerminalOpenTimeoutError
+          ? t("terminal.connectionTimedOut")
+          : error instanceof Error
+            ? error.message
+            : String(error);
+    } finally {
+      if (this.isTerminalOperationCurrent(operation)) {
+        this.updateControllerState("booting", false);
+      }
+    }
+  }
+
+  /** Reattaches one session and reports whether adoption succeeded. */
+  private async attachSession(
+    sessionId: string,
+    operation: TerminalOperation,
+    agentOwned = false,
+    confirmGoneOnFailure = false,
+  ): Promise<boolean> {
+    let createdTab: TerminalPanelSessionTab | undefined;
+    let createdConnection: TerminalConnection | undefined;
+    try {
+      const boot = await this.bootTab(operation);
+      createdTab = boot.tab;
+      createdConnection = boot.connection;
+      const result = await boot.connection.attach(sessionId, this.tabSink(boot.tab));
+      if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
+        // A user close is deliberate; lifecycle cancellation leaves the existing
+        // server session available for the next reconnect to reattach.
+        if (boot.tab.cancelled === "close") {
+          void boot.connection.close(result.sessionId);
+        }
+        if (this.tabs.includes(boot.tab)) {
+          boot.tab.cancelled = "lifecycle";
+          this.dropFailedTab(boot.tab);
+        }
+        return false;
+      }
+      this.adoptSession(boot.tab, result, agentOwned);
+      return true;
+    } catch {
+      const sessionGone =
+        confirmGoneOnFailure && createdConnection
+          ? await this.confirmRestoredSessionGone(createdConnection, sessionId, operation)
+          : false;
+      if (createdTab && !createdTab.gatewaySessionId && this.tabs.includes(createdTab)) {
+        if (sessionGone) {
+          this.markRestoredSessionExited(createdTab, sessionId);
+        } else {
+          this.dropFailedTab(createdTab);
+        }
+      }
+      return false;
+    }
+  }
+
+  private async confirmRestoredSessionGone(
+    connection: TerminalConnection,
+    sessionId: string,
+    operation: TerminalOperation,
+  ): Promise<boolean> {
+    try {
+      const sessions = await connection.list();
+      return (
+        this.isTerminalOperationCurrent(operation) &&
+        !sessions.some((session) => session.sessionId === sessionId)
+      );
+    } catch {
+      // A failed confirmation cannot turn a transport or authorization error
+      // into an authoritative terminal exit.
+      return false;
+    }
+  }
+
+  /** Keeps a dead persisted session visible without replaying bytes from a missing PTY. */
+  private async restoreExitedSession(
+    sessionId: string,
+    operation: TerminalOperation,
+  ): Promise<void> {
+    const boot = await this.bootTab(operation);
+    if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
+      if (this.tabs.includes(boot.tab)) {
+        boot.tab.cancelled = "lifecycle";
+        this.dropFailedTab(boot.tab);
+      }
+      return;
+    }
+    this.markRestoredSessionExited(boot.tab, sessionId);
+  }
+
+  private markRestoredSessionExited(tab: TerminalPanelSessionTab, sessionId: string): void {
+    tab.gatewaySessionId = sessionId;
+    this.handleExit(tab.id, { reason: "disconnected", exitCode: null });
+  }
+
+  private handleExit(
+    tabId: string,
+    info: { reason?: string; exitCode: number | null; error?: string },
+  ): void {
+    const tab = this.tabs.find((entry) => entry.id === tabId);
+    if (!tab) {
+      return;
+    }
+    this.readiness.stop(tab);
+    tab.status = "exited";
+    tab.exitReason = info.reason;
+    tab.exitCode = info.exitCode;
+    if (info.error?.trim()) {
+      this.host.terminalPanelErrorText = info.error.trim();
+    }
+    // The connection drops its own sink on exit delivery, so no release() here —
+    // the session id may not be recorded yet when an early exit is replayed.
+    this.updateControllerState("tabs", [...this.tabs]);
+    persistLiveTerminalSessions(this.tabs);
+  }
+
+  closeTab(tabId: string): void {
+    const tab = this.tabs.find((entry) => entry.id === tabId);
+    if (!tab) {
+      return;
+    }
+    this.host.terminalPanelUploadController.cancelForTab(tab);
+    if (tab.gatewaySessionId && tab.status !== "exited") {
+      void this.connection?.close(tab.gatewaySessionId);
+    } else if (!tab.gatewaySessionId && tab.status !== "exited") {
+      // Open still in flight: no session id to close yet. Flag it so the open
+      // continuation closes the server session as soon as the RPC resolves.
+      tab.cancelled = "close";
+    }
+    this.disposeTab(tab);
+    this.updateControllerState(
+      "tabs",
+      this.tabs.filter((entry) => entry.id !== tabId),
+    );
+    if (this.activeId === tabId) {
+      this.updateControllerState("activeId", this.tabs.at(-1)?.id ?? null);
+    }
+    persistLiveTerminalSessions(this.tabs);
+    // Fullscreen documents (mobile WebViews) have no toggle to reopen a closed
+    // panel, so closing the last tab keeps the panel with an empty tab strip
+    // (the "+" button stays reachable) instead of leaving a dead blank page.
+    if (this.tabs.length === 0 && !this.host.fullscreen) {
+      this.host.closeTerminalPanel();
+    }
+  }
+
+  switchTo(tabId: string): void {
+    this.updateControllerState("activeId", tabId);
+    const tab = this.tabs.find((entry) => entry.id === tabId);
+    // Refit and repaint after the container becomes visible. A same-size tab
+    // switch otherwise leaves the newly shown canvas without dirty rows.
+    void this.host.updateComplete.then(() => {
+      if (tab) {
+        tab.controller.fit();
+        forceTerminalRender(tab.controller);
+        tab.controller.terminal.focus();
+      }
+    });
+  }
+
+  private captureTerminalOperation(): TerminalOperation | null {
+    const client = this.host.client;
+    if (!client || client !== this.activeClient || !this.host.available || !this.host.isConnected) {
+      return null;
+    }
+    return {
+      generation: this.lifecycleGeneration,
+      client,
+      signal: this.lifecycleAbortController.signal,
+    };
+  }
+
+  private isTerminalOperationCurrent(operation: TerminalOperation): boolean {
+    return (
+      this.host.isConnected &&
+      this.host.available &&
+      this.host.client === operation.client &&
+      this.activeClient === operation.client &&
+      this.lifecycleGeneration === operation.generation &&
+      !operation.signal.aborted
+    );
+  }
+
+  private connectionFor(operation: TerminalOperation): TerminalConnection {
+    if (!this.isTerminalOperationCurrent(operation)) {
+      throw new Error("terminal operation cancelled");
+    }
+    this.connection ??= new TerminalConnection(operation.client);
+    return this.connection;
+  }
+
+  private disposeTab(tab: TerminalPanelSessionTab): void {
+    this.readiness.stop(tab);
+    try {
+      tab.controller.dispose();
+    } catch {
+      // Best-effort teardown; a partially-initialized tab may throw.
+    } finally {
+      // DOM ownership is independent of controller cleanup; never strand a
+      // Ghostty canvas when dependency disposal fails partway through.
+      tab.host.remove();
+    }
+  }
+
+  private disposeAllTabs(): void {
+    this.lifecycleGeneration += 1;
+    this.lifecycleAbortController.abort();
+    this.lifecycleAbortController = new AbortController();
+    this.bootQueue.reset();
+    this.updateControllerState("booting", false);
+    this.host.terminalPanelUploadController.dispose();
+    this.host.clearTerminalPanelResizeListeners();
+    for (const tab of this.tabs) {
+      // No terminal.close here: this teardown runs for disconnects,
+      // availability loss, and element removal — exactly the sessions the
+      // persisted-id reattach flow recovers afterwards. Deliberate closes go
+      // through closeTab(); sessions nobody reattaches are bounded by the
+      // server's detach reaper.
+      // The cancelled flag covers a tab whose open RPC is still in flight; its
+      // continuation closes the fresh session instead of adopting the
+      // disposed terminal.
+      tab.cancelled = "lifecycle";
+      this.disposeTab(tab);
+    }
+    this.updateControllerState("tabs", []);
+    this.updateControllerState("activeId", null);
+    this.host.resetTerminalSessionPicker();
+    // Drop the gateway subscription with the tabs so the listener never outlives
+    // the connection (disconnect/disable/element-removal all route through here).
+    this.connection?.dispose();
+    this.connection = null;
+  }
+}

--- a/ui/src/components/terminal/terminal-panel-session-rendering.ts
+++ b/ui/src/components/terminal/terminal-panel-session-rendering.ts
@@ -1,0 +1,72 @@
+import {
+  forceTerminalRender,
+  type TerminalPanelSessionTab,
+} from "./terminal-panel-session-types.ts";
+import { terminalTheme } from "./terminal-theme.ts";
+
+export function updateTerminalSessionTheme(
+  tabs: readonly TerminalPanelSessionTab[],
+  themeMode: "dark" | "light",
+): void {
+  const theme = terminalTheme(themeMode);
+  for (const tab of tabs) {
+    // ghostty-web 0.4.0 ignores options.theme after open() (its option
+    // handler only warns), so update the renderer directly and force one
+    // full render — the frame loop repaints only dirty rows, which would
+    // leave a static screen on the old palette.
+    const term = tab.controller.terminal;
+    if (term.renderer && term.wasmTerm) {
+      term.renderer.setTheme(theme);
+      forceTerminalRender(tab.controller);
+    }
+  }
+}
+
+export function reattachTerminalSessionHosts(
+  tabs: readonly TerminalPanelSessionTab[],
+  activeId: string | null,
+  viewport: Element | null,
+): void {
+  if (!viewport) {
+    return;
+  }
+  // Hiding the panel returns `nothing`, which detaches each session's ghostty
+  // host. Re-attach live hosts whenever the viewport is rendered so a
+  // hide/show cycle keeps the terminals intact instead of blanking them.
+  for (const tab of tabs) {
+    if (tab.host.parentElement !== viewport) {
+      viewport.append(tab.host);
+    }
+  }
+  const activeTab = tabs.find((tab) => tab.id === activeId);
+  if (activeTab) {
+    activeTab.controller.fit();
+    // FitAddon skips unchanged dimensions; force dirty-row rendering to
+    // repair a canvas that was detached while the panel was hidden.
+    forceTerminalRender(activeTab.controller);
+  }
+}
+
+export function fitActiveTerminalSession(
+  tabs: readonly TerminalPanelSessionTab[],
+  activeId: string | null,
+): void {
+  tabs.find((tab) => tab.id === activeId)?.controller.fit();
+}
+
+export function fitAllTerminalSessions(tabs: readonly TerminalPanelSessionTab[]): void {
+  for (const tab of tabs) {
+    tab.controller.fit();
+  }
+}
+
+export function prepareTerminalSessionHostVisibility(
+  tabs: readonly TerminalPanelSessionTab[],
+  activeId: string | null,
+): void {
+  // Keep only the active session's host visible; ghostty renders to a canvas
+  // that must be laid out to measure correctly.
+  for (const tab of tabs) {
+    tab.host.style.display = tab.id === activeId ? "block" : "none";
+  }
+}

--- a/ui/src/components/terminal/terminal-panel-session-types.ts
+++ b/ui/src/components/terminal/terminal-panel-session-types.ts
@@ -1,0 +1,90 @@
+import type {
+  createTerminalDefaultColorQueryResponder,
+  CreateGhosttyTerminalOptions,
+  GhosttyTerminalController,
+} from "@openclaw/libterminal/browser";
+import type { ReactiveControllerHost } from "lit";
+import type { TerminalGatewayClient } from "./terminal-connection.ts";
+import type { TerminalPanelTab } from "./terminal-panel-tabs.ts";
+import type { TerminalPanelUploadController } from "./terminal-panel-upload.ts";
+import { persistTerminalSessionIds } from "./terminal-session-storage.ts";
+import type { StartupInputBuffer } from "./terminal-startup-input.ts";
+import type { TerminalTabReadinessState } from "./terminal-tab-readiness.ts";
+
+export type TerminalPanelSessionTab = TerminalPanelTab &
+  TerminalTabReadinessState & {
+    gatewaySessionId: string;
+    pendingInput: StartupInputBuffer;
+    defaultColorQueries: ReturnType<typeof createTerminalDefaultColorQueryResponder>;
+    controller: GhosttyTerminalController;
+    shell: string;
+    host: HTMLDivElement;
+    /** Why an in-flight open/attach must not adopt this disposed terminal. */
+    cancelled?: "close" | "lifecycle";
+  };
+
+export type TerminalOperation = {
+  generation: number;
+  client: TerminalGatewayClient;
+  signal: AbortSignal;
+};
+
+export type TerminalPanelCatalogReference = {
+  catalogId: string;
+  hostId: string;
+  threadId: string;
+};
+
+export type TerminalPanelSessionControllerState = {
+  tabs: TerminalPanelSessionTab[];
+  activeId: string | null;
+  booting: boolean;
+};
+
+export interface TerminalPanelSessionControllerHost extends ReactiveControllerHost {
+  readonly isConnected: boolean;
+  readonly client: TerminalGatewayClient | null;
+  readonly agentId: string | null;
+  readonly available: boolean;
+  readonly themeMode: "dark" | "light";
+  readonly fullscreen: boolean;
+  readonly terminalPanelOpen: boolean;
+  readonly catalogReadyTimeoutMs: number;
+  terminalPanelErrorText: string | null;
+  readonly terminalPanelUploadController: TerminalPanelUploadController;
+  createTerminalController(
+    options: CreateGhosttyTerminalOptions,
+  ): Promise<GhosttyTerminalController>;
+  closeTerminalPanel(): void;
+  clearTerminalPanelResizeListeners(): void;
+  findTerminalPanelViewport(): Element | null;
+  hideTerminalPanelForUnavailableSurface(): void;
+  resetTerminalSessionPicker(): void;
+  restoreTerminalPanelOpenState(): boolean;
+}
+
+export const TERMINAL_FONT_FAMILY =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Symbols Nerd Font Mono", "MesloLGLDZ Nerd Font Mono", "JetBrainsMono Nerd Font Mono", "Liberation Mono", monospace';
+export const TERMINAL_OUTPUT_ENCODER = new TextEncoder();
+
+/** Reduces a shell path to a tab label, e.g. "/bin/zsh" -> "zsh". */
+export function shellBasename(shell: string): string {
+  const base = shell.split(/[\\/]/).pop()?.trim();
+  return base && base.length > 0 ? base : "shell";
+}
+
+export function forceTerminalRender(controller: GhosttyTerminalController): void {
+  const term = controller.terminal;
+  if (term.renderer && term.wasmTerm) {
+    // An omitted opacity defaults to 1; repaint without inventing a visible scrollbar.
+    term.renderer.render(term.wasmTerm, true, term.viewportY, term, 0);
+  }
+}
+
+export function persistLiveTerminalSessions(tabs: readonly TerminalPanelSessionTab[]): void {
+  persistTerminalSessionIds(
+    tabs
+      .filter((tab) => tab.status === "live" && tab.gatewaySessionId)
+      .map((tab) => tab.gatewaySessionId),
+  );
+}

--- a/ui/src/components/terminal/terminal-panel-upload.test.ts
+++ b/ui/src/components/terminal/terminal-panel-upload.test.ts
@@ -44,7 +44,7 @@ const createGhosttyTerminalMock: CreateGhosttyTerminalMock = vi.fn();
 const TERMINAL_PANEL_ELEMENT_NAME = `test-openclaw-terminal-panel-upload-${crypto.randomUUID()}`;
 
 class TestTerminalPanel extends OpenClawTerminalPanel {
-  protected override createTerminal = createGhosttyTerminalMock as unknown as TerminalFactory;
+  override createTerminalController = createGhosttyTerminalMock as unknown as TerminalFactory;
 }
 
 customElements.define(TERMINAL_PANEL_ELEMENT_NAME, TestTerminalPanel);

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -78,7 +78,7 @@ const TERMINAL_PANEL_ELEMENT_NAME = `test-openclaw-terminal-panel-${crypto.rando
 // The full non-isolated UI suite can import the production panel before this
 // test. Override its factory instead of relying on a module mock import order.
 class TestTerminalPanel extends OpenClawTerminalPanel {
-  protected override createTerminal = createGhosttyTerminalMock as unknown as TerminalFactory;
+  override createTerminalController = createGhosttyTerminalMock as unknown as TerminalFactory;
 }
 
 customElements.define(TERMINAL_PANEL_ELEMENT_NAME, TestTerminalPanel);
@@ -1043,11 +1043,14 @@ describe("OpenClawTerminalPanel", () => {
     const dispose = vi.fn(() => {
       throw new Error("dispose failed");
     });
-    const disposeTab = (
+    const terminalSessions = (
       panel as unknown as {
-        disposeTab(tab: { controller: { dispose(): void }; host: HTMLDivElement }): void;
+        terminalSessions: {
+          disposeTab(tab: { controller: { dispose(): void }; host: HTMLDivElement }): void;
+        };
       }
-    ).disposeTab.bind(panel);
+    ).terminalSessions;
+    const disposeTab = terminalSessions.disposeTab.bind(terminalSessions);
 
     expect(() => disposeTab({ controller: { dispose }, host })).not.toThrow();
     expect(dispose).toHaveBeenCalledOnce();

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -1,7 +1,3 @@
-import type {
-  createTerminalDefaultColorQueryResponder,
-  GhosttyTerminalController,
-} from "@openclaw/libterminal/browser";
 // Dockable operator terminal panel for the Control UI shell.
 //
 // Renders a VS Code-style shell dock (bottom by default, or right) with session
@@ -19,58 +15,29 @@ import {
   TERMINAL_PANEL_TOGGLE_EVENT,
   type TerminalPanelToggleDetail,
 } from "../panel-toggle-contract.ts";
+import type { TerminalGatewayClient, TerminalSessionInfo } from "./terminal-connection.ts";
 import {
-  TerminalConnection,
-  type TerminalGatewayClient,
-  TerminalOpenTimeoutError,
-  type TerminalSessionInfo,
-} from "./terminal-connection.ts";
+  renderTerminalPanelHeader,
+  renderTerminalPanelResizer,
+  renderTerminalPanelToolbar,
+  renderTerminalPanelViewport,
+} from "./terminal-panel-chrome.ts";
+import { TerminalPanelSessionController } from "./terminal-panel-session-controller.ts";
+import {
+  fitActiveTerminalSession,
+  fitAllTerminalSessions,
+  prepareTerminalSessionHostVisibility,
+  reattachTerminalSessionHosts,
+  updateTerminalSessionTheme,
+} from "./terminal-panel-session-rendering.ts";
+import type { TerminalPanelSessionTab } from "./terminal-panel-session-types.ts";
 import { terminalPanelStyles } from "./terminal-panel-styles.ts";
-import { renderTerminalPanelTabs, type TerminalPanelTab } from "./terminal-panel-tabs.ts";
 import { terminalPanelUploadStyles } from "./terminal-panel-upload-styles.ts";
-import {
-  renderTerminalPanelActions,
-  renderTerminalUploadLayer,
-  TerminalPanelUploadController,
-} from "./terminal-panel-upload.ts";
+import { TerminalPanelUploadController } from "./terminal-panel-upload.ts";
 import { createIsolatedGhosttyTerminal } from "./terminal-runtime.ts";
 import { renderTerminalSessionPicker } from "./terminal-session-picker.ts";
-import {
-  loadPersistedTerminalSessionIds,
-  persistTerminalSessionIds,
-} from "./terminal-session-storage.ts";
-import { createTerminalStartupInput, type StartupInputBuffer } from "./terminal-startup-input.ts";
-import {
-  TerminalTabReadinessController,
-  type TerminalTabReadinessState,
-} from "./terminal-tab-readiness.ts";
-import { TerminalTaskQueue } from "./terminal-task-queue.ts";
-import { terminalDynamicColors, terminalTheme } from "./terminal-theme.ts";
 
 type TerminalDock = Exclude<DockPanelSide, "left">;
-type TerminalTabState = TerminalPanelTab &
-  TerminalTabReadinessState & {
-    gatewaySessionId: string;
-    pendingInput: StartupInputBuffer;
-    defaultColorQueries: ReturnType<typeof createTerminalDefaultColorQueryResponder>;
-    controller: GhosttyTerminalController;
-    shell: string;
-    host: HTMLDivElement;
-    /** Why an in-flight open/attach must not adopt this disposed terminal. */
-    cancelled?: "close" | "lifecycle";
-  };
-
-type TerminalOperation = {
-  generation: number;
-  client: TerminalGatewayClient;
-  signal: AbortSignal;
-};
-
-/** Reduces a shell path to a tab label, e.g. "/bin/zsh" -> "zsh". */
-function shellBasename(shell: string): string {
-  const base = shell.split(/[\\/]/).pop()?.trim();
-  return base && base.length > 0 ? base : "shell";
-}
 
 const panelLayout = createDockPanelLayout({
   storageKey: "openclaw.terminal.panel.v1",
@@ -81,18 +48,7 @@ const panelLayout = createDockPanelLayout({
   defaultHeight: 320,
   defaultWidth: 520,
 });
-const TERMINAL_FONT_FAMILY =
-  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Symbols Nerd Font Mono", "MesloLGLDZ Nerd Font Mono", "JetBrainsMono Nerd Font Mono", "Liberation Mono", monospace';
-const TERMINAL_OUTPUT_ENCODER = new TextEncoder();
 const CATALOG_TERMINAL_READY_TIMEOUT_MS = 30_000;
-
-function forceTerminalRender(controller: GhosttyTerminalController): void {
-  const term = controller.terminal;
-  if (term.renderer && term.wasmTerm) {
-    // An omitted opacity defaults to 1; repaint without inventing a visible scrollbar.
-    term.renderer.render(term.wasmTerm, true, term.viewportY, term, 0);
-  }
-}
 
 /** `<openclaw-terminal-panel>` — the dockable Control UI shell surface. */
 export class OpenClawTerminalPanel extends OpenClawLitElement {
@@ -114,51 +70,31 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
   @state() private dock: TerminalDock = "bottom";
   @state() private height = panelLayout.defaults.height;
   @state() private width = panelLayout.defaults.width;
-  @state() private tabs: TerminalTabState[] = [];
-  @state() private activeId: string | null = null;
-  @state() private booting = false;
-  @state() private errorText: string | null = null;
+  @state() terminalPanelErrorText: string | null = null;
   @state() private sessionPickerOpen = false;
   @state() private sessionPickerLoading = false;
   @state() private pickerSessions: TerminalSessionInfo[] = [];
 
-  private connection: TerminalConnection | null = null;
-  private activeClient: TerminalGatewayClient | null = null;
-  private activeAvailable = false;
-  private lifecycleGeneration = 0;
   private sessionPickerRefreshGeneration = 0;
-  private lifecycleAbortController = new AbortController();
-  private lifecycleSyncToken = 0;
   private resizeCleanup: (() => void) | null = null;
-  private tabSeq = 0;
-  private readonly upload = new TerminalPanelUploadController({
+  readonly terminalPanelUploadController = new TerminalPanelUploadController({
     activeTab: () =>
-      this.tabs.find(
-        (tab) => tab.id === this.activeId && tab.status === "live" && tab.gatewaySessionId,
+      this.terminalSessions.tabs.find(
+        (tab) =>
+          tab.id === this.terminalSessions.activeId &&
+          tab.status === "live" &&
+          tab.gatewaySessionId,
       ),
     client: () => this.client,
-    isCurrent: (tab) => this.tabs.includes(tab as TerminalTabState) && tab.status === "live",
+    isCurrent: (tab) =>
+      this.terminalSessions.tabs.includes(tab as TerminalPanelSessionTab) && tab.status === "live",
     fileInput: () => this.renderRoot.querySelector<HTMLInputElement>(".tp-file-input"),
-    setError: (message) => (this.errorText = message),
+    setError: (message) => (this.terminalPanelErrorText = message),
     requestUpdate: () => this.requestUpdate(),
   });
-  private readonly bootQueue = new TerminalTaskQueue();
-  protected createTerminal = createIsolatedGhosttyTerminal;
-  protected catalogReadyTimeoutMs = CATALOG_TERMINAL_READY_TIMEOUT_MS;
-  private readonly readiness = new TerminalTabReadinessController<TerminalTabState>({
-    timeoutMs: () => this.catalogReadyTimeoutMs,
-    isCurrent: (tab) => this.tabs.includes(tab),
-    onReady: () => {
-      this.tabs = [...this.tabs];
-      this.persistLiveSessions();
-    },
-    onTimeout: (tab) => {
-      this.errorText = t("terminal.connectionTimedOut");
-      void this.connection?.close(tab.gatewaySessionId);
-      this.dropFailedTab(tab);
-      this.persistLiveSessions();
-    },
-  });
+  createTerminalController = createIsolatedGhosttyTerminal;
+  catalogReadyTimeoutMs = CATALOG_TERMINAL_READY_TIMEOUT_MS;
+  private readonly terminalSessions = new TerminalPanelSessionController(this);
   private readonly onGlobalKeyDown = (event: KeyboardEvent) => this.handleGlobalKey(event);
   private readonly onToggleRequest = (event: Event) => this.handleToggleRequest(event);
   // Re-clamp a dock sized on a larger window so the header/resizer never end
@@ -172,13 +108,12 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     this.height = height;
     this.width = width;
     this.syncLayoutReservation();
-    this.tabs.find((tab) => tab.id === this.activeId)?.controller.fit();
+    fitActiveTerminalSession(this.terminalSessions.tabs, this.terminalSessions.activeId);
   };
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.activeClient = this.client;
-    this.activeAvailable = this.available;
+    this.terminalSessions.connectHost();
     if (!this.fullscreen) {
       const layout = panelLayout.load();
       this.dock = layout.dock;
@@ -195,7 +130,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       this.open = this.available;
     }
     if (this.open) {
-      void this.restoreSessions();
+      void this.terminalSessions.restoreSessions();
     }
   }
 
@@ -207,105 +142,24 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     // Release the content-area reservation so the shell reflows to full size.
     document.documentElement.style.setProperty("--oc-terminal-reserve-bottom", "0px");
     document.documentElement.style.setProperty("--oc-terminal-reserve-right", "0px");
-    this.disposeAllTabs();
-    this.activeClient = null;
-    this.activeAvailable = false;
+    this.terminalSessions.disconnectHost();
   }
 
   override updated(changed: Map<string, unknown>): void {
     if (changed.has("client") || changed.has("available")) {
-      this.scheduleLifecycleSync();
+      this.terminalSessions.scheduleLifecycleSync();
     }
     if (changed.has("themeMode")) {
-      const theme = terminalTheme(this.themeMode);
-      for (const tab of this.tabs) {
-        // ghostty-web 0.4.0 ignores options.theme after open() (its option
-        // handler only warns), so update the renderer directly and force one
-        // full render — the frame loop repaints only dirty rows, which would
-        // leave a static screen on the old palette.
-        const term = tab.controller.terminal;
-        if (term.renderer && term.wasmTerm) {
-          term.renderer.setTheme(theme);
-          forceTerminalRender(tab.controller);
-        }
-      }
+      updateTerminalSessionTheme(this.terminalSessions.tabs, this.themeMode);
     }
-    // Hiding the panel returns `nothing`, which detaches each session's ghostty
-    // host. Re-attach live hosts whenever the viewport is rendered so a
-    // hide/show cycle keeps the terminals intact instead of blanking them.
     if (this.open) {
-      const viewport = this.renderRoot.querySelector(".tp-viewport");
-      if (viewport) {
-        for (const tab of this.tabs) {
-          if (tab.host.parentElement !== viewport) {
-            viewport.append(tab.host);
-          }
-        }
-        const activeTab = this.tabs.find((tab) => tab.id === this.activeId);
-        if (activeTab) {
-          activeTab.controller.fit();
-          // FitAddon skips unchanged dimensions; force dirty-row rendering to
-          // repair a canvas that was detached while the panel was hidden.
-          forceTerminalRender(activeTab.controller);
-        }
-      }
+      reattachTerminalSessionHosts(
+        this.terminalSessions.tabs,
+        this.terminalSessions.activeId,
+        this.findTerminalPanelViewport(),
+      );
     }
     this.syncLayoutReservation();
-  }
-
-  private scheduleLifecycleSync(): void {
-    const token = ++this.lifecycleSyncToken;
-    const generation = this.lifecycleGeneration;
-    // State teardown inside Lit's updated hook schedules a nested update.
-    // Defer it; token + generation reject superseded connection epochs.
-    queueMicrotask(() => {
-      if (
-        token !== this.lifecycleSyncToken ||
-        generation !== this.lifecycleGeneration ||
-        !this.isConnected
-      ) {
-        return;
-      }
-      this.synchronizeLifecycle();
-    });
-  }
-
-  private synchronizeLifecycle(): void {
-    const clientChanged = this.client !== this.activeClient;
-    const availabilityChanged = this.available !== this.activeAvailable;
-    if (!clientChanged && !availabilityChanged) {
-      return;
-    }
-    if (clientChanged) {
-      this.activeClient = this.client;
-    }
-    this.activeAvailable = this.available;
-    const becameUnavailable = availabilityChanged && !this.available;
-    if (clientChanged || becameUnavailable) {
-      this.disposeAllTabs();
-    }
-    let shouldRestore = clientChanged && this.available && this.open;
-    if (availabilityChanged) {
-      if (!this.available) {
-        // The surface disappeared (gateway disconnect/disable). Tear down local
-        // tabs and the connection (disposeAllTabs drops the gateway
-        // subscription too). Server sessions survive a disconnect for the
-        // detach grace period, and their ids stay persisted, so the restore on
-        // reconnect reattaches them instead of opening fresh shells. Hide the
-        // panel WITHOUT persisting: a disconnect must not overwrite the user's
-        // open preference, or the reconnect path would never auto-reopen.
-        this.open = false;
-      } else if (!this.open && (this.fullscreen || panelLayout.load().open)) {
-        // Hello arrived after mount (or a reconnect); restore the persisted
-        // open state (fullscreen documents are always open while available)
-        // and reattach persisted sessions where possible.
-        this.open = true;
-        shouldRestore = true;
-      }
-    }
-    if (shouldRestore) {
-      void this.restoreSessions();
-    }
   }
 
   /**
@@ -333,12 +187,12 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       return;
     }
     if (this.open) {
-      this.closePanel();
+      this.closeTerminalPanel();
     } else {
       this.open = true;
       this.syncLayoutReservation();
       this.persistLayout();
-      void this.restoreSessions();
+      void this.terminalSessions.restoreSessions();
     }
   }
 
@@ -352,7 +206,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       this.dock = dock;
     }
     if (detail?.open === false) {
-      this.closePanel();
+      this.closeTerminalPanel();
       return;
     }
     if (detail?.terminalSessionId || detail?.catalog || detail?.open === true) {
@@ -363,19 +217,41 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       this.syncLayoutReservation();
       this.persistLayout();
       void (detail.terminalSessionId
-        ? this.openRequestedSession(detail.terminalSessionId)
+        ? this.terminalSessions.openRequestedSession(detail.terminalSessionId)
         : detail.catalog
-          ? this.openCatalogSession(detail.catalog)
-          : this.restoreSessions());
+          ? this.terminalSessions.openCatalogSession(detail.catalog)
+          : this.terminalSessions.restoreSessions());
       return;
     }
     this.toggle();
   }
 
-  private closePanel(): void {
+  closeTerminalPanel(): void {
     this.open = false;
     this.syncLayoutReservation();
     this.persistLayout();
+  }
+
+  get terminalPanelOpen(): boolean {
+    return this.open;
+  }
+
+  hideTerminalPanelForUnavailableSurface(): void {
+    // The surface disappeared (gateway disconnect/disable). Hide the panel
+    // WITHOUT persisting: a disconnect must not overwrite the user's open
+    // preference, or the reconnect path would never auto-reopen. Server
+    // sessions survive for the detach grace period and reattach afterwards.
+    this.open = false;
+  }
+
+  restoreTerminalPanelOpenState(): boolean {
+    if (this.open || (!this.fullscreen && !panelLayout.load().open)) {
+      return false;
+    }
+    // Hello arrived after mount (or a reconnect); fullscreen documents are
+    // always open while available, while docked panels restore user state.
+    this.open = true;
+    return true;
   }
 
   private handleGlobalKey(event: KeyboardEvent): void {
@@ -383,84 +259,6 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     if (isTerminalPanelShortcut(event)) {
       event.preventDefault();
       this.toggle();
-    }
-  }
-
-  /**
-   * Entry point whenever the panel (re)opens: reattach persisted sessions if
-   * the gateway still has them, otherwise fall back to one fresh session.
-   */
-  private async restoreSessions(): Promise<void> {
-    await this.bootQueue.enqueueSteps(
-      () => this.reattachPersistedSessions(),
-      () => this.ensureInitialSession(),
-    );
-  }
-
-  private async openCatalogSession(catalog: NonNullable<TerminalPanelToggleDetail["catalog"]>) {
-    await this.bootQueue.enqueueSteps(
-      () => this.reattachPersistedSessions(),
-      () => this.openSessionNow(catalog),
-    );
-  }
-
-  private async openRequestedSession(sessionId: string): Promise<void> {
-    await this.enqueueAttachSession(sessionId, true);
-  }
-
-  private async reattachPersistedSessions(): Promise<void> {
-    const operation = this.captureTerminalOperation();
-    if (!operation || this.tabs.length > 0) {
-      return;
-    }
-    const persisted = loadPersistedTerminalSessionIds();
-    if (persisted.length > 0) {
-      this.booting = true;
-      try {
-        const connection = this.connectionFor(operation);
-        const listed = await connection.list();
-        if (!this.isTerminalOperationCurrent(operation)) {
-          return;
-        }
-        const known = new Map(listed.map((session) => [session.sessionId, session]));
-        for (const sessionId of persisted) {
-          const session = known.get(sessionId);
-          if (!session) {
-            await this.restoreExitedSession(sessionId, operation);
-          } else {
-            await this.attachSession(
-              sessionId,
-              operation,
-              session.owner?.startsWith("agent:") === true,
-              true,
-            );
-          }
-          if (!this.isTerminalOperationCurrent(operation)) {
-            return;
-          }
-        }
-      } catch {
-        if (!this.isTerminalOperationCurrent(operation)) {
-          return;
-        }
-        // terminal.list failed (older gateway, surface flapping): fall through
-        // to a fresh session below.
-      } finally {
-        if (this.isTerminalOperationCurrent(operation)) {
-          this.booting = false;
-        }
-      }
-      if (!this.isTerminalOperationCurrent(operation)) {
-        return;
-      }
-      // Prune ids the gateway no longer knows (reaped or externally closed).
-      this.persistLiveSessions();
-    }
-  }
-
-  private async ensureInitialSession(): Promise<void> {
-    if (this.tabs.length === 0 && !this.booting) {
-      await this.openSessionNow();
     }
   }
 
@@ -472,530 +270,29 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
   }
 
   private async refreshSessionPicker(): Promise<void> {
-    const operation = this.captureTerminalOperation();
-    if (!operation) {
+    const refreshGeneration = ++this.sessionPickerRefreshGeneration;
+    this.sessionPickerLoading = true;
+    const sessions = await this.terminalSessions.listSessions();
+    if (refreshGeneration !== this.sessionPickerRefreshGeneration || sessions === null) {
       return;
     }
-    const refreshGeneration = ++this.sessionPickerRefreshGeneration;
-    const isCurrentRefresh = () =>
-      refreshGeneration === this.sessionPickerRefreshGeneration &&
-      this.isTerminalOperationCurrent(operation);
-    this.sessionPickerLoading = true;
-    try {
-      const sessions = await this.connectionFor(operation).list();
-      if (isCurrentRefresh()) {
-        this.pickerSessions = sessions;
-      }
-    } catch {
-      if (isCurrentRefresh()) {
-        this.pickerSessions = [];
-      }
-    } finally {
-      if (isCurrentRefresh()) {
-        this.sessionPickerLoading = false;
-      }
-    }
+    this.pickerSessions = sessions;
+    this.sessionPickerLoading = false;
   }
 
   private async attachPickedSession(
     sessionId: string,
-    owner: TerminalSessionInfo["owner"],
+    owner?: TerminalSessionInfo["owner"],
   ): Promise<void> {
     this.sessionPickerOpen = false;
-    await this.enqueueAttachSession(sessionId, owner?.startsWith("agent:") === true);
-  }
-
-  private async enqueueAttachSession(sessionId: string, agentOwned: boolean): Promise<void> {
-    await this.bootQueue.enqueue(async () => {
-      const existing = this.tabs.find((tab) => tab.gatewaySessionId === sessionId);
-      if (existing) {
-        this.switchTo(existing.id);
-        return;
-      }
-      const operation = this.captureTerminalOperation();
-      if (!operation) {
-        return;
-      }
-      this.booting = true;
-      this.errorText = null;
-      try {
-        const attached = await this.attachSession(sessionId, operation, agentOwned);
-        if (!attached && this.isTerminalOperationCurrent(operation)) {
-          this.errorText = t("terminal.attachFailed");
-        }
-      } finally {
-        if (this.isTerminalOperationCurrent(operation)) {
-          this.booting = false;
-        }
-      }
-    });
-  }
-
-  /** Boots a tab with a libterminal controller, ready for an open or attach RPC. */
-  private async bootTab(
-    operation: TerminalOperation,
-    options: { awaitFirstOutput?: boolean } = {},
-  ): Promise<{
-    tab: TerminalTabState;
-    connection: TerminalConnection;
-    cols: number;
-    rows: number;
-  }> {
-    const connection = this.connectionFor(operation);
-    // Preserve the connection so cancelled-open cleanup still closes the in-flight session.
-    const host = document.createElement("div");
-    host.className = "tp-host";
-    const id = `tab-${++this.tabSeq}`;
-    // Wait for the panel (and its .tp-viewport) to render before attaching the
-    // ghostty host, so the terminal opens into a laid-out, measurable node.
-    await this.updateComplete;
-    if (!this.isTerminalOperationCurrent(operation)) {
-      throw new Error("terminal operation cancelled");
-    }
-    const viewport = this.renderRoot.querySelector(".tp-viewport");
-    if (!viewport) {
-      throw new Error("terminal viewport unavailable");
-    }
-    viewport.append(host);
-    const tabRef = { current: undefined as TerminalTabState | undefined };
-    const startupInput = createTerminalStartupInput(
-      connection,
-      () => tabRef.current?.gatewaySessionId,
-    );
-    const { createTerminalDefaultColorQueryResponder } =
-      await import("@openclaw/libterminal/browser");
-    const defaultColorQueries = createTerminalDefaultColorQueryResponder({
-      getColors: () => terminalDynamicColors(this.themeMode),
-      reply: (data) => startupInput.onData(TERMINAL_OUTPUT_ENCODER.encode(data)),
-    });
-    let controller: GhosttyTerminalController;
-    try {
-      controller = await this.createTerminal({
-        parent: host,
-        readOnly: false,
-        terminalOptions: {
-          fontSize: 13,
-          fontFamily: TERMINAL_FONT_FAMILY,
-          cursorBlink: true,
-          theme: terminalTheme(this.themeMode),
-          scrollback: 5000,
-        },
-        signal: operation.signal,
-        // The browser controller owns these subscriptions and their teardown.
-        onData: startupInput.onData,
-        onResize: startupInput.onResize,
-      });
-    } catch (error) {
-      host.remove();
-      throw error;
-    }
-    if (!this.isTerminalOperationCurrent(operation)) {
-      try {
-        controller.dispose();
-      } finally {
-        host.remove();
-      }
-      throw new Error("terminal operation cancelled");
-    }
-    const tab: TerminalTabState = {
-      id,
-      sequence: this.tabSeq,
-      gatewaySessionId: "",
-      pendingInput: startupInput.buffer,
-      defaultColorQueries,
-      shellName: null,
-      shell: "",
-      agentId: null,
-      cwd: null,
-      agentOwned: false,
-      controller,
-      host,
-      status: "connecting",
-      awaitFirstOutput: options.awaitFirstOutput === true,
-      readyTimer: null,
-    };
-    tabRef.current = tab;
-    this.tabs = [...this.tabs, tab];
-    this.activeId = id;
-    const { terminal } = controller;
-    return { tab, connection, cols: terminal.cols || 80, rows: terminal.rows || 24 };
-  }
-
-  /** Output/exit sink for one tab, shared by open and attach. */
-  private tabSink(tab: TerminalTabState) {
-    return {
-      // The cancelled guard also protects the buffered-event replay inside
-      // connection.open/attach from writing to an already-disposed terminal.
-      onData: (data: string) => {
-        if (!tab.cancelled) {
-          tab.defaultColorQueries.observe(data);
-          tab.controller.write(TERMINAL_OUTPUT_ENCODER.encode(data));
-          if (data.length > 0) {
-            this.readiness.markReady(tab);
-          }
-        }
-      },
-      // A replay is authoritative. Reset parser, screen, and scrollback so a
-      // gap cannot leave stale cells or a partial escape sequence behind.
-      onReplay: (data: string, newlyObservedFrom: number) => {
-        if (!tab.cancelled) {
-          // Suppress complete historical queries, then answer only the suffix
-          // recovered after a sequence gap. A split query may cross the seam.
-          tab.defaultColorQueries.primeFromReplay(data.slice(0, newlyObservedFrom));
-          tab.defaultColorQueries.observe(data.slice(newlyObservedFrom));
-          tab.controller.terminal.reset();
-          if (data) {
-            tab.controller.write(TERMINAL_OUTPUT_ENCODER.encode(data));
-            this.readiness.markReady(tab);
-          }
-        }
-      },
-      onExit: (info: { reason?: string; exitCode: number | null; error?: string }) =>
-        this.handleExit(tab.id, info),
-    };
-  }
-
-  /** Binds a freshly opened or attached gateway session to its tab. */
-  private adoptSession(
-    tab: TerminalTabState,
-    result: { sessionId: string; shell: string; agentId: string; cwd: string; title?: string },
-    agentOwned = false,
-  ): void {
-    tab.gatewaySessionId = result.sessionId;
-    tab.shellName = result.title ?? shellBasename(result.shell);
-    tab.shell = result.shell;
-    tab.agentId = result.agentId;
-    tab.cwd = result.cwd;
-    tab.agentOwned = agentOwned;
-    // Libterminal observes layout before the Gateway session exists. Resync the
-    // current grid now so a resize during the open/attach RPC is not lost.
-    const { cols, rows } = tab.controller.terminal;
-    void this.connection?.resize(result.sessionId, cols || 80, rows || 24);
-    for (const data of tab.pendingInput.drain()) {
-      void this.connection?.input(result.sessionId, data);
-    }
-
-    if (tab.status === "connecting") {
-      if (tab.awaitFirstOutput) {
-        this.readiness.arm(tab);
-      } else {
-        this.readiness.markReady(tab);
-      }
-    }
-
-    this.tabs = [...this.tabs];
-    this.persistLiveSessions();
-  }
-
-  /** Removes a tab whose open/attach never produced a server session. */
-  private dropFailedTab(tab: TerminalTabState): void {
-    this.disposeTab(tab);
-    this.tabs = this.tabs.filter((entry) => entry.id !== tab.id);
-    if (this.activeId === tab.id) {
-      this.activeId = this.tabs.at(-1)?.id ?? null;
-    }
-  }
-
-  private async openSession(catalog?: TerminalPanelToggleDetail["catalog"]): Promise<void> {
-    await this.bootQueue.enqueue(() => this.openSessionNow(catalog));
-  }
-
-  private async openSessionNow(catalog?: TerminalPanelToggleDetail["catalog"]): Promise<void> {
-    const operation = this.captureTerminalOperation();
-    if (!operation) {
-      return;
-    }
-    this.booting = true;
-    this.errorText = null;
-    // Freeze the selection for this tab; later agent changes affect only new tabs.
-    const agentId = this.agentId?.trim() || undefined;
-    // Tracked outside the try so the catch can dispose a tab whose open failed.
-    let createdTab: TerminalTabState | undefined;
-    try {
-      const boot = await this.bootTab(operation, { awaitFirstOutput: Boolean(catalog) });
-      createdTab = boot.tab;
-      const result = await boot.connection.open(
-        { agentId, cols: boot.cols, rows: boot.rows, ...(catalog ? { catalog } : {}) },
-        this.tabSink(boot.tab),
-      );
-      if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
-        // The tab's close button was clicked while the open RPC was in flight.
-        // The server session is live and its sink registered; close it now or
-        // it survives invisibly (eating the session cap) until disconnect.
-        void boot.connection.close(result.sessionId);
-        if (this.tabs.includes(boot.tab)) {
-          boot.tab.cancelled = "lifecycle";
-          this.dropFailedTab(boot.tab);
-        }
-        return;
-      }
-      this.adoptSession(boot.tab, result);
-      boot.tab.controller.terminal.focus();
-    } catch (err) {
-      // A failed open (e.g. terminal disabled or a sandboxed agent is refused)
-      // must not leave a phantom "live" tab with no server session. Drop it but
-      // keep the panel open so the error stays visible.
-      if (createdTab && !createdTab.gatewaySessionId && this.tabs.includes(createdTab)) {
-        this.dropFailedTab(createdTab);
-      }
-      if (!this.isTerminalOperationCurrent(operation)) {
-        return;
-      }
-      this.errorText =
-        err instanceof TerminalOpenTimeoutError
-          ? t("terminal.connectionTimedOut")
-          : err instanceof Error
-            ? err.message
-            : String(err);
-    } finally {
-      if (this.isTerminalOperationCurrent(operation)) {
-        this.booting = false;
-      }
-    }
-  }
-
-  /** Reattaches one session and reports whether adoption succeeded. */
-  private async attachSession(
-    sessionId: string,
-    operation: TerminalOperation,
-    agentOwned = false,
-    confirmGoneOnFailure = false,
-  ): Promise<boolean> {
-    let createdTab: TerminalTabState | undefined;
-    let createdConnection: TerminalConnection | undefined;
-    try {
-      const boot = await this.bootTab(operation);
-      createdTab = boot.tab;
-      createdConnection = boot.connection;
-      const result = await boot.connection.attach(sessionId, this.tabSink(boot.tab));
-      if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
-        // A user close is deliberate; lifecycle cancellation leaves the existing
-        // server session available for the next reconnect to reattach.
-        if (boot.tab.cancelled === "close") {
-          void boot.connection.close(result.sessionId);
-        }
-        if (this.tabs.includes(boot.tab)) {
-          boot.tab.cancelled = "lifecycle";
-          this.dropFailedTab(boot.tab);
-        }
-        return false;
-      }
-      this.adoptSession(boot.tab, result, agentOwned);
-      return true;
-    } catch {
-      const sessionGone =
-        confirmGoneOnFailure && createdConnection
-          ? await this.confirmRestoredSessionGone(createdConnection, sessionId, operation)
-          : false;
-      if (createdTab && !createdTab.gatewaySessionId && this.tabs.includes(createdTab)) {
-        if (sessionGone) {
-          this.markRestoredSessionExited(createdTab, sessionId);
-        } else {
-          this.dropFailedTab(createdTab);
-        }
-      }
-      return false;
-    }
-  }
-
-  private async confirmRestoredSessionGone(
-    connection: TerminalConnection,
-    sessionId: string,
-    operation: TerminalOperation,
-  ): Promise<boolean> {
-    try {
-      const sessions = await connection.list();
-      return (
-        this.isTerminalOperationCurrent(operation) &&
-        !sessions.some((session) => session.sessionId === sessionId)
-      );
-    } catch {
-      // A failed confirmation cannot turn a transport or authorization error
-      // into an authoritative terminal exit.
-      return false;
-    }
-  }
-
-  /** Keeps a dead persisted session visible without replaying bytes from a missing PTY. */
-  private async restoreExitedSession(
-    sessionId: string,
-    operation: TerminalOperation,
-  ): Promise<void> {
-    const boot = await this.bootTab(operation);
-    if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
-      if (this.tabs.includes(boot.tab)) {
-        boot.tab.cancelled = "lifecycle";
-        this.dropFailedTab(boot.tab);
-      }
-      return;
-    }
-    this.markRestoredSessionExited(boot.tab, sessionId);
-  }
-
-  private markRestoredSessionExited(tab: TerminalTabState, sessionId: string): void {
-    tab.gatewaySessionId = sessionId;
-    this.handleExit(tab.id, { reason: "disconnected", exitCode: null });
-  }
-
-  private handleExit(
-    tabId: string,
-    info: { reason?: string; exitCode: number | null; error?: string },
-  ): void {
-    const tab = this.tabs.find((entry) => entry.id === tabId);
-    if (!tab) {
-      return;
-    }
-    this.readiness.stop(tab);
-    tab.status = "exited";
-    tab.exitReason = info.reason;
-    tab.exitCode = info.exitCode;
-    if (info.error?.trim()) {
-      this.errorText = info.error.trim();
-    }
-    // The connection drops its own sink on exit delivery, so no release() here —
-    // the session id may not be recorded yet when an early exit is replayed.
-    this.tabs = [...this.tabs];
-    this.persistLiveSessions();
-  }
-
-  private closeTab(tabId: string): void {
-    const tab = this.tabs.find((entry) => entry.id === tabId);
-    if (!tab) {
-      return;
-    }
-    this.upload.cancelForTab(tab);
-    if (tab.gatewaySessionId && tab.status !== "exited") {
-      void this.connection?.close(tab.gatewaySessionId);
-    } else if (!tab.gatewaySessionId && tab.status !== "exited") {
-      // Open still in flight: no session id to close yet. Flag it so the open
-      // continuation closes the server session as soon as the RPC resolves.
-      tab.cancelled = "close";
-    }
-    this.disposeTab(tab);
-    this.tabs = this.tabs.filter((entry) => entry.id !== tabId);
-    if (this.activeId === tabId) {
-      this.activeId = this.tabs.at(-1)?.id ?? null;
-    }
-    this.persistLiveSessions();
-    // Fullscreen documents (mobile WebViews) have no toggle to reopen a closed
-    // panel, so closing the last tab keeps the panel with an empty tab strip
-    // (the "+" button stays reachable) instead of leaving a dead blank page.
-    if (this.tabs.length === 0 && !this.fullscreen) {
-      this.closePanel();
-    }
-  }
-
-  private switchTo(tabId: string): void {
-    this.activeId = tabId;
-    const tab = this.tabs.find((entry) => entry.id === tabId);
-    // Refit and repaint after the container becomes visible. A same-size tab
-    // switch otherwise leaves the newly shown canvas without dirty rows.
-    void this.updateComplete.then(() => {
-      if (tab) {
-        tab.controller.fit();
-        forceTerminalRender(tab.controller);
-        tab.controller.terminal.focus();
-      }
-    });
-  }
-
-  private captureTerminalOperation(): TerminalOperation | null {
-    const client = this.client;
-    if (!client || client !== this.activeClient || !this.available || !this.isConnected) {
-      return null;
-    }
-    return {
-      generation: this.lifecycleGeneration,
-      client,
-      signal: this.lifecycleAbortController.signal,
-    };
-  }
-
-  private isTerminalOperationCurrent(operation: TerminalOperation): boolean {
-    return (
-      this.isConnected &&
-      this.available &&
-      this.client === operation.client &&
-      this.activeClient === operation.client &&
-      this.lifecycleGeneration === operation.generation &&
-      !operation.signal.aborted
-    );
-  }
-
-  private connectionFor(operation: TerminalOperation): TerminalConnection {
-    if (!this.isTerminalOperationCurrent(operation)) {
-      throw new Error("terminal operation cancelled");
-    }
-    this.connection ??= new TerminalConnection(operation.client);
-    return this.connection;
-  }
-
-  private disposeTab(tab: TerminalTabState): void {
-    this.readiness.stop(tab);
-    try {
-      tab.controller.dispose();
-    } catch {
-      // Best-effort teardown; a partially-initialized tab may throw.
-    } finally {
-      // DOM ownership is independent of controller cleanup; never strand a
-      // Ghostty canvas when dependency disposal fails partway through.
-      tab.host.remove();
-    }
-  }
-
-  private disposeAllTabs(): void {
-    this.lifecycleGeneration += 1;
-    this.lifecycleAbortController.abort();
-    this.lifecycleAbortController = new AbortController();
-    this.bootQueue.reset();
-    this.booting = false;
-    this.upload.dispose();
-    this.clearResizeListeners();
-    for (const tab of this.tabs) {
-      // No terminal.close here: this teardown runs for disconnects,
-      // availability loss, and element removal — exactly the sessions the
-      // persisted-id reattach flow recovers afterwards. Deliberate closes go
-      // through closeTab(); sessions nobody reattaches are bounded by the
-      // server's detach reaper.
-      // The cancelled flag covers a tab whose open RPC is still in flight; its
-      // continuation closes the fresh session instead of adopting the
-      // disposed terminal.
-      tab.cancelled = "lifecycle";
-      this.disposeTab(tab);
-    }
-    this.tabs = [];
-    this.activeId = null;
-    this.sessionPickerOpen = false;
-    this.sessionPickerLoading = false;
-    this.sessionPickerRefreshGeneration += 1;
-    this.pickerSessions = [];
-    // Drop the gateway subscription with the tabs so the listener never outlives
-    // the connection (disconnect/disable/element-removal all route through here).
-    this.connection?.dispose();
-    this.connection = null;
+    await this.terminalSessions.attachSessionById(sessionId, owner?.startsWith("agent:") === true);
   }
 
   private setDock(dock: TerminalDock): void {
     this.dock = dock;
     this.syncLayoutReservation();
     this.persistLayout();
-    void this.updateComplete.then(() => {
-      for (const tab of this.tabs) {
-        tab.controller.fit();
-      }
-    });
-  }
-
-  /**
-   * Records which gateway sessions this window's live tabs own so a reload or
-   * reconnect can reattach them. Intentionally NOT cleared on disconnect
-   * teardown (disposeAllTabs) — surviving ids are the reattach memory.
-   */
-  private persistLiveSessions(): void {
-    const ids = this.tabs
-      .filter((tab) => tab.status === "live" && tab.gatewaySessionId)
-      .map((tab) => tab.gatewaySessionId);
-    persistTerminalSessionIds(ids);
+    void this.updateComplete.then(() => fitAllTerminalSessions(this.terminalSessions.tabs));
   }
 
   private persistLayout(): void {
@@ -1009,7 +306,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
 
   private startResize(event: PointerEvent): void {
     event.preventDefault();
-    this.clearResizeListeners();
+    this.clearTerminalPanelResizeListeners();
     const startX = event.clientX;
     const startY = event.clientY;
     const startHeight = this.height;
@@ -1024,8 +321,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       }
       // Reflow the content reservation live so the shell tracks the drag.
       this.syncLayoutReservation();
-      const active = this.tabs.find((tab) => tab.id === this.activeId);
-      active?.controller.fit();
+      fitActiveTerminalSession(this.terminalSessions.tabs, this.terminalSessions.activeId);
     };
     const cleanup = () => {
       window.removeEventListener("pointermove", onMove);
@@ -1050,9 +346,20 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     window.addEventListener("blur", onUp);
   }
 
-  private clearResizeListeners(): void {
+  clearTerminalPanelResizeListeners(): void {
     this.resizeCleanup?.();
     this.resizeCleanup = null;
+  }
+
+  resetTerminalSessionPicker(): void {
+    this.sessionPickerOpen = false;
+    this.sessionPickerLoading = false;
+    this.sessionPickerRefreshGeneration += 1;
+    this.pickerSessions = [];
+  }
+
+  findTerminalPanelViewport(): Element | null {
+    return this.renderRoot.querySelector(".tp-viewport");
   }
 
   override render() {
@@ -1065,84 +372,65 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       : this.dock === "bottom"
         ? `height:${this.height}px;--tp-panel-height:${this.height}px`
         : `width:${this.width}px`;
-    const activeTab = this.tabs.find((tab) => tab.id === this.activeId);
+    const activeTab = this.terminalSessions.tabs.find(
+      (tab) => tab.id === this.terminalSessions.activeId,
+    );
     const connecting =
-      (this.booting && this.tabs.length === 0) || activeTab?.status === "connecting";
+      (this.terminalSessions.booting && this.terminalSessions.tabs.length === 0) ||
+      activeTab?.status === "connecting";
+    const sessionPicker = renderTerminalSessionPicker({
+      open: this.sessionPickerOpen,
+      loading: this.sessionPickerLoading,
+      sessions: this.pickerSessions,
+      currentSessionIds: new Set(
+        this.terminalSessions.tabs
+          .map((tab) => tab.gatewaySessionId)
+          .filter(
+            (sessionId): sessionId is string =>
+              typeof sessionId === "string" && sessionId.length > 0,
+          ),
+      ),
+      onToggle: () => this.toggleSessionPicker(),
+      onRefresh: () => void this.refreshSessionPicker(),
+      onAttach: (sessionId, owner) => void this.attachPickedSession(sessionId, owner),
+    });
+    const toolbar = renderTerminalPanelToolbar(
+      this.fullscreen,
+      this.dock,
+      this.terminalPanelUploadController,
+      sessionPicker,
+      (dock) => this.setDock(dock),
+      () => this.closeTerminalPanel(),
+    );
     return html`
       <section class="tp tp--${mode}" style=${style} aria-label=${t("terminal.title")}>
-        ${this.fullscreen
-          ? nothing
-          : html`<div
-              class="tp-resizer tp-resizer--${this.dock}"
-              @pointerdown=${(e: PointerEvent) => this.startResize(e)}
-              role="separator"
-              aria-label=${t("terminal.resize")}
-            ></div>`}
-        <header class="tp-header">
-          ${renderTerminalPanelTabs({
-            tabs: this.tabs,
-            activeId: this.activeId,
-            booting: this.booting,
-            onSelect: (id) => this.switchTo(id),
-            onClose: (id) => this.closeTab(id),
-            onNew: () => void this.openSession(),
-          })}
-          ${renderTerminalPanelActions({
-            fullscreen: this.fullscreen,
-            dock: this.dock,
-            upload: this.upload,
-            sessionPicker: renderTerminalSessionPicker({
-              open: this.sessionPickerOpen,
-              loading: this.sessionPickerLoading,
-              sessions: this.pickerSessions,
-              currentSessionIds: new Set(
-                this.tabs
-                  .map((tab) => tab.gatewaySessionId)
-                  .filter(
-                    (sessionId): sessionId is string =>
-                      typeof sessionId === "string" && sessionId.length > 0,
-                  ),
-              ),
-              onToggle: () => this.toggleSessionPicker(),
-              onRefresh: () => void this.refreshSessionPicker(),
-              onAttach: (sessionId, owner) => void this.attachPickedSession(sessionId, owner),
-            }),
-            onDock: (dock) => this.setDock(dock),
-            onHide: () => this.closePanel(),
-          })}
-        </header>
-        ${this.errorText
-          ? html`<div class="tp-error" role="alert">${this.errorText}</div>`
-          : nothing}
-        <wa-tab-panel
-          id="terminal-tab-panel"
-          class="tp-viewport"
-          name=${this.activeId ?? "terminal"}
-          active
-          aria-labelledby=${this.activeId ? `terminal-tab-${this.activeId}` : nothing}
-          @dragenter=${this.upload.handleDragEnter}
-          @dragover=${this.upload.handleDragOver}
-          @dragleave=${this.upload.handleDragLeave}
-          @drop=${this.upload.handleDrop}
-        >
-          ${connecting
-            ? html`<div class="tp-connecting" role="status">
-                <span class="tp-connecting__spinner" aria-hidden="true"></span>
-                <span>${t("terminal.connecting")}</span>
-              </div>`
-            : nothing}
-          ${renderTerminalUploadLayer(this.upload)}
-        </wa-tab-panel>
+        ${renderTerminalPanelResizer(this.fullscreen, this.dock, (event) =>
+          this.startResize(event),
+        )}
+        ${renderTerminalPanelHeader(
+          this.terminalSessions.tabs,
+          this.terminalSessions.activeId,
+          this.terminalSessions.booting,
+          toolbar,
+          (id) => this.terminalSessions.switchTo(id),
+          (id) => this.terminalSessions.closeTab(id),
+          () => void this.terminalSessions.openSession(),
+        )}
+        ${renderTerminalPanelViewport(
+          this.terminalSessions.activeId,
+          connecting,
+          this.terminalPanelErrorText,
+          this.terminalPanelUploadController,
+        )}
       </section>
     `;
   }
 
   override willUpdate(): void {
-    // Keep only the active session's host visible; ghostty renders to a canvas
-    // that must be laid out to measure correctly.
-    for (const tab of this.tabs) {
-      tab.host.style.display = tab.id === this.activeId ? "block" : "none";
-    }
+    prepareTerminalSessionHostVisibility(
+      this.terminalSessions.tabs,
+      this.terminalSessions.activeId,
+    );
   }
 
   static override styles = [panelTabStripStyles, terminalPanelStyles, terminalPanelUploadStyles];
@@ -1153,4 +441,3 @@ declare global {
     "openclaw-terminal-panel": OpenClawTerminalPanel;
   }
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

`ui/src/components/terminal/terminal-panel.ts` had grown to 1,156 lines and remained on the grandfathered max-lines suppression list, which made the dock chrome and gateway PTY lifecycle difficult to review independently.

## Why This Change Was Made

This behavior-neutral split moves panel chrome into free render functions and moves terminal open/attach, data/replay, readiness, resize RPC, and teardown ownership into one Lit ReactiveController with a narrow host contract. It preserves teardown ordering, deferred reconnect synchronization, resize behavior, and the existing `ghostty-web` dynamic-import boundary.

The only test-source edits are harness updates for the moved private seam: the readiness and upload subclasses now override `createTerminalController`, and the disposal test reaches `disposeTab` through the controller. Assertions are unchanged.

## User Impact

None — this is a behavior-neutral internal refactor of the existing terminal panel.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/terminal/terminal-panel.test.ts ui/src/components/terminal/terminal-panel-readiness.test.ts ui/src/components/terminal/terminal-panel-upload.test.ts` — 3 files, 32 tests passed.
- `node scripts/run-vitest.mjs ui/src/e2e/terminal-embedded.e2e.test.ts ui/src/e2e/terminal-upload.e2e.test.ts` — 2 files, 3 tests passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json` — passed.
- `node scripts/check-changed.mjs -- <9 touched files>` — passed on Blacksmith Testbox `tbx_01ky7d1a29vqqfjhp1nn2c1qmx` (types, lint, formatting, guards, max-lines ratchet).
- Production `pnpm ui:build` — passed; startup JS is 323,379 bytes gzip, 56 bytes below the 323,435-byte baseline. The terminal panel remains a separate 52.89 kB chunk, `ghostty-web` remains a separate 636.94 kB chunk, and no `[INEFFECTIVE_DYNAMIC_IMPORT]` warning was emitted.
- Autoreview: `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- `git diff --numstat`: +1,103 / -863 across 9 files.
- Removed the `terminal-panel.ts` max-lines suppression and its `config/max-lines-baseline.txt` entry. Resulting production files are all under 700 lines: panel 443, chrome 98, controller 691, session rendering 72, session types 90.
