### PR TITLE
feat: enable Teams and Zoom meeting plugins by default

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -6062,7 +6062,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Choose a plugin
   - H2: Choose a mode
   - H2: Prepare Chrome and audio
-  - H2: Enable the plugin
+  - H2: Install or disable plugins
   - H2: Verify and join
   - H2: Handle platform policy prompts
   - H2: Discord voice chat

--- a/docs/plugins/meeting-plugins.md
+++ b/docs/plugins/meeting-plugins.md
@@ -16,8 +16,8 @@ These plugins participate in meetings. They are separate from messaging channels
 | Platform        | Plugin                                      | Accepted meeting links                                                                                      | Installation                             | Participation paths                                      | Platform-specific capabilities                                                                                |
 | --------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Google Meet     | [`google-meet`](/plugins/google-meet)       | `meet.google.com/...`                                                                                       | Install from npm or ClawHub, then enable | Local Chrome, Chrome on a paired node, or Twilio dial-in | Can create meetings through the Meet API or a signed-in browser; can read supported Meet artifacts with OAuth |
-| Microsoft Teams | [`teams-meetings`](/plugins/teams-meetings) | Work links under `teams.microsoft.com/l/meetup-join/...` and consumer links under `teams.live.com/meet/...` | Included; enable it                      | Local Chrome or Chrome on a paired node                  | Guest join for work and consumer meetings                                                                     |
-| Zoom            | [`zoom-meetings`](/plugins/zoom-meetings)   | `zoom.us/j/...` and account subdomains such as `example.zoom.us/j/...`                                      | Included; enable it                      | Local Chrome or Chrome on a paired node                  | Guest join through the Zoom Web App                                                                           |
+| Microsoft Teams | [`teams-meetings`](/plugins/teams-meetings) | Work links under `teams.microsoft.com/l/meetup-join/...` and consumer links under `teams.live.com/meet/...` | Included; enabled by default             | Local Chrome or Chrome on a paired node                  | Guest join for work and consumer meetings                                                                     |
+| Zoom            | [`zoom-meetings`](/plugins/zoom-meetings)   | `zoom.us/j/...` and account subdomains such as `example.zoom.us/j/...`                                      | Included; enabled by default             | Local Chrome or Chrome on a paired node                  | Guest join through the Zoom Web App                                                                           |
 
 Choose Google Meet when you need meeting creation, Google API artifacts, or a Twilio phone path. Choose Teams or Zoom for direct browser guest participation on those platforms. The Teams and Zoom plugins do not create meetings, dial in, call the vendor API, or record meetings.
 
@@ -56,18 +56,21 @@ command -v sox
 
 The Gateway host still owns the OpenClaw agent and model credentials when Chrome runs on a paired node. Configure a realtime transcription provider and OpenClaw TTS for `agent` mode, or a realtime voice provider for `bidi` mode. The platform guides contain the provider and audio-command options.
 
-## Enable the plugin
+## Install or disable plugins
 
-Install Google Meet before enabling it. Teams meetings and Zoom are included with OpenClaw and only need to be enabled:
+Install and enable Google Meet separately. Teams meetings and Zoom are included with OpenClaw and enabled by default:
 
 ```bash
 # Google Meet only
 openclaw plugins install npm:@openclaw/google-meet
-
-# Enable only the meeting plugins you use
 openclaw plugins enable google-meet
-openclaw plugins enable teams-meetings
-openclaw plugins enable zoom-meetings
+```
+
+Disable either included plugin if you do not use it:
+
+```bash
+openclaw plugins disable teams-meetings
+openclaw plugins disable zoom-meetings
 ```
 
 Restart the Gateway if your plugin-management path does not restart it automatically. Then run the platform setup check before joining.

--- a/docs/plugins/teams-meetings.md
+++ b/docs/plugins/teams-meetings.md
@@ -19,14 +19,13 @@ system_profiler SPAudioDataType | grep -i BlackHole
 command -v sox
 ```
 
-Enable the plugin, then check setup:
+The plugin is included and enabled by default. Add an entry only to customize it, then check setup:
 
 ```json5
 {
   plugins: {
     entries: {
       "teams-meetings": {
-        enabled: true,
         config: {
           defaultMode: "agent",
           chrome: { guestName: "OpenClaw Agent" },
@@ -36,6 +35,8 @@ Enable the plugin, then check setup:
   },
 }
 ```
+
+Run `openclaw plugins disable teams-meetings` if you do not want the plugin active.
 
 ```bash
 openclaw teamsmeetings setup

--- a/docs/plugins/zoom-meetings.md
+++ b/docs/plugins/zoom-meetings.md
@@ -19,14 +19,13 @@ system_profiler SPAudioDataType | grep -i BlackHole
 command -v sox
 ```
 
-Enable the plugin, then check setup:
+The plugin is included and enabled by default. Add an entry only to customize it, then check setup:
 
 ```json5
 {
   plugins: {
     entries: {
       "zoom-meetings": {
-        enabled: true,
         config: {
           defaultMode: "agent",
           chrome: { guestName: "OpenClaw Agent" },
@@ -36,6 +35,8 @@ Enable the plugin, then check setup:
   },
 }
 ```
+
+Run `openclaw plugins disable zoom-meetings` if you do not want the plugin active.
 
 ```bash
 openclaw zoommeetings setup

--- a/extensions/teams-meetings/openclaw.plugin.json
+++ b/extensions/teams-meetings/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "Microsoft Teams meetings",
   "description": "Join Microsoft Teams meetings as a Chrome browser guest.",
   "icon": "https://cdn.simpleicons.org/microsoftteams",
-  "enabledByDefault": false,
+  "enabledByDefault": true,
   "commandAliases": [{ "name": "teamsmeetings" }],
   "activation": {
     "onStartup": true,

--- a/extensions/zoom-meetings/openclaw.plugin.json
+++ b/extensions/zoom-meetings/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "Zoom meetings",
   "description": "Join Zoom meetings as a Chrome browser guest.",
   "icon": "https://cdn.simpleicons.org/zoom",
-  "enabledByDefault": false,
+  "enabledByDefault": true,
   "commandAliases": [{ "name": "zoommeetings" }],
   "activation": {
     "onStartup": true,

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -80,6 +80,8 @@ const EXPECTED_EMPTY_CONFIG_GATEWAY_STARTUP_PLUGIN_IDS = [
   "opencode",
   "phone-control",
   "talk-voice",
+  "teams-meetings",
+  "zoom-meetings",
 ] as const;
 
 installGeneratedPluginTempRootCleanup();


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams meetings and Zoom are bundled, live-validated meeting plugins, but fresh and upgraded OpenClaw installations still leave both disabled until an operator explicitly enables them. That makes the supported meeting tools and commands unavailable by default despite their bounded guest-join behavior.

Related live-validation context: #110615 and #111048.

## Why This Change Was Made

This maintainer-directed change flips the two bundled manifests to `enabledByDefault: true`, updates the empty-config startup expectation, and updates the meeting docs to describe the new defaults and explicit opt-out commands.

Maintainer decision: Peter Steinberger explicitly approved enabling both bundled meeting plugins by default on 2026-07-23, including activation for existing installations that have no explicit plugin entries.

This is a compatibility-sensitive default change: **2 bundled plugin defaults change from disabled to enabled**. Existing installations will activate the Teams and Zoom plugin surfaces after upgrade unless explicitly disabled. The activation is safe and bounded: each plugin retains an explicit runtime `enabled` gate ([Teams config](https://github.com/openclaw/openclaw/blob/afe72db3113eb77be5464e65602e80e8f10b4669/extensions/teams-meetings/src/config.ts#L24-L25), [Zoom config](https://github.com/openclaw/openclaw/blob/afe72db3113eb77be5464e65602e80e8f10b4669/extensions/zoom-meetings/src/config.ts#L24-L25)), and the shared entry creates no meeting runtime until an operation is called and requires a meeting URL for join/test operations ([runtime gate and URL validation](https://github.com/openclaw/openclaw/blob/afe72db3113eb77be5464e65602e80e8f10b4669/src/meeting-bot/plugin-entry.ts#L151-L218)). Default activation therefore registers the plugin surfaces but does not open a browser or join a meeting without an explicit URL-bearing request.

## User Impact

Teams and Zoom meeting commands and tools are available without a separate plugin-enable step. Operators who do not use either plugin can disable it with `openclaw plugins disable teams-meetings` or `openclaw plugins disable zoom-meetings`.

Release-note context: bundled Microsoft Teams and Zoom meeting plugins are now enabled by default; existing installs activate them on upgrade, with explicit opt-out commands documented.

## Evidence

- Teams live proof: #110615 validated a `teams.live.com` consumer guest join end to end in Crabbox, including prejoin controls, lobby/admission, media permissions, in-call detection, BlackHole input/output routing, live captions, leave, and post-call state. Residual gap: work-tenant anonymous guest, sign-in/email-verification, admission, and leave-confirmation variants were not live-exercised because no authorized work-tenant fixture was available; those states remain guarded manual-action paths.
- Zoom live proof: #111048 validated Zoom's official test meeting end to end in Crabbox, including browser handoff, guest name, prejoin controls, BlackHole/SoX audio, in-call detection, live captions with real speech, leave redirect, and host-ended state. Policy-dependent lobby and CAPTCHA states were not emitted and remain documented manual-action paths.
- `node scripts/run-vitest.mjs src/plugins/bundled-plugin-metadata.test.ts` — 37/37 passed on the final rebased head.
- `node scripts/run-vitest.mjs extensions/teams-meetings/src/config.test.ts extensions/zoom-meetings/src/config.test.ts src/plugins/manifest-owner-policy.test.ts` — 14/14 passed on the final rebased head.
- `node scripts/check-changed.mjs -- <six touched files>` — passed formatting, manifest/API and plugin-boundary checks, selected typechecks, full core/extension lint, database/runtime-sidecar guards, and import-cycle checks on Blacksmith Testbox `tbx_01ky7e8gba7wx61vmsw0bwyv97`, [Actions run 30006072959](https://github.com/openclaw/openclaw/actions/runs/30006072959). The final rebase is patch-identical and the focused suites were rerun afterward.
- Real default-activation proof on Blacksmith Testbox `tbx_01ky7hta72y9n353p8hw4ybppf`, [Actions run 30010362715](https://github.com/openclaw/openclaw/actions/runs/30010362715):
  - a fresh state root with no config reported both plugins enabled in the cold registry and runtime-loaded with their tool, CLI command, and join gateway method registered;
  - an existing state root with `gateway.mode` configured but no `plugins.entries` reported the same registrations, exercising the no-entry upgrade shape;
  - browser process count remained `0 -> 0`, no meeting join operation was invoked, and the proof confirmed base defaults `false/false` versus head defaults `true/true`.
- `node scripts/generate-docs-map.mjs --check` — passed after refreshing the generated map for the changed docs heading.
- `git diff --check origin/main...HEAD` — passed.
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean on the final head, no accepted/actionable findings; patch correct at 0.97 confidence.

AI-assisted: yes. The default surface, activation owner path, live-validation history, docs, focused tests, hosted changed gate, and structured review were inspected before opening this PR.
