### PR TITLE
fix(googlechat): render outbound markdown for Chat

### DIFF
--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -9,7 +9,6 @@ import {
   defineChannelMessageAdapter,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import {
   composeAccountWarningCollectors,
   createAllowlistProviderOpenWarningCollector,
@@ -22,12 +21,10 @@ import {
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { shouldSuppressGoogleChatManualExecApprovalFollowupPayload } from "./approval-card-actions.js";
 import { formatGoogleChatAllowFromEntry } from "./channel-base.js";
 import {
   type ResolvedGoogleChatAccount,
-  chunkTextForOutbound,
   isGoogleChatUserTarget,
   missingTargetError,
   normalizeGoogleChatTarget,
@@ -36,6 +33,11 @@ import {
   resolveGoogleChatOutboundSpace,
   type OpenClawConfig,
 } from "./channel.deps.runtime.js";
+import {
+  formatGoogleChatTextChunks,
+  GOOGLE_CHAT_FORMAT_PROFILE,
+  sanitizeGoogleChatText,
+} from "./format.js";
 import { resolveGoogleChatGroupRequireMention } from "./group-policy.js";
 
 const loadGoogleChatChannelRuntime = createLazyRuntimeNamedExport(
@@ -188,14 +190,10 @@ export const googlechatPairingTextAdapter = {
 export const googlechatOutboundAdapter = {
   base: {
     deliveryMode: "direct" as const,
-    chunker: chunkTextForOutbound,
+    chunker: (text: string, limit: number) => formatGoogleChatTextChunks(text, limit),
     chunkerMode: "markdown" as const,
-    textChunkLimit: 4000,
-    // Google Chat's plain-text pass does not remove assistant scaffolding.
-    // Run the canonical delivery sanitizer first so internal tool traces are
-    // dropped before channel formatting.
-    sanitizeText: ({ text }: { text: string }) =>
-      sanitizeForPlainText(sanitizeAssistantVisibleText(text)),
+    textChunkLimit: GOOGLE_CHAT_FORMAT_PROFILE.chunk.limit,
+    sanitizeText: ({ text }: { text: string }) => sanitizeGoogleChatText(text),
     normalizePayload: ({ payload }: { payload: ReplyPayload }) =>
       shouldSuppressGoogleChatManualExecApprovalFollowupPayload(payload) ? null : payload,
     resolveTarget: ({ to }: { to?: string }) => {

--- a/extensions/googlechat/src/channel.deps.runtime.ts
+++ b/extensions/googlechat/src/channel.deps.runtime.ts
@@ -1,7 +1,6 @@
 // Googlechat plugin module implements channeleps behavior.
 export {
   buildChannelConfigSchema,
-  chunkTextForOutbound,
   DEFAULT_ACCOUNT_ID,
   GoogleChatConfigSchema,
   missingTargetError,

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -229,10 +229,12 @@ describe("googlechatPlugin outbound", () => {
     ]);
   });
 
-  it("chunks outbound text without requiring Google Chat runtime initialization", () => {
+  it("renders and chunks outbound text without requiring Google Chat runtime initialization", () => {
     const chunker = googlechatOutboundAdapter.base.chunker;
 
-    expect(chunker("alpha beta", 5)).toEqual(["alpha", "beta"]);
+    expect(chunker("**alpha** [docs](https://example.com)", 32_000)).toEqual([
+      "*alpha* <https://example.com|docs>",
+    ]);
   });
 });
 
@@ -584,5 +586,9 @@ describe("googlechatPlugin outbound sanitizeText", () => {
   it("preserves ordinary assistant prose untouched", () => {
     const text = "El pipeline tiene 3 deals abiertos por USD 12.000.";
     expect(sanitizeText({ text })).toBe(text);
+  });
+
+  it("keeps CommonMark intact until chunks reach the send boundary", () => {
+    expect(sanitizeText({ text: "**bold** and ~~gone~~" })).toBe("**bold** and ~~gone~~");
   });
 });

--- a/extensions/googlechat/src/format.test.ts
+++ b/extensions/googlechat/src/format.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatGoogleChatText,
+  formatGoogleChatTextChunks,
+  GOOGLE_CHAT_FORMAT_PROFILE,
+} from "./format.js";
+
+const DIALECT_FIXTURES = [
+  { name: "bold", input: "**bold**", before: "**bold**", after: "*bold*" },
+  { name: "italic", input: "*italic*", before: "*italic*", after: "_italic_" },
+  { name: "underline fallback", input: "<u>under</u>", before: "under", after: "under" },
+  { name: "strikethrough", input: "~~gone~~", before: "~~gone~~", after: "~gone~" },
+  { name: "spoiler fallback", input: "||secret||", before: "||secret||", after: "secret" },
+  { name: "inline code", input: "`value`", before: "`value`", after: "`value`" },
+  {
+    name: "fenced code drops language",
+    input: "```ts\nconst value = 1;\n```",
+    before: "```ts\nconst value = 1;\n```",
+    after: "```\nconst value = 1;\n```",
+  },
+  {
+    name: "labeled link",
+    input: "[docs](https://example.com)",
+    before: "[docs](https://example.com)",
+    after: "<https://example.com|docs>",
+  },
+  { name: "heading fallback", input: "## Heading", before: "## Heading", after: "*Heading*" },
+  {
+    name: "nested bullet list",
+    input: "- first\n  - second",
+    before: "- first\n  - second",
+    after: "* first\n    * second",
+  },
+  {
+    name: "ordered-list fallback",
+    input: "1. first\n2. second",
+    before: "1. first\n2. second",
+    after: "1. first\n2. second",
+  },
+  {
+    name: "task-list fallback",
+    input: "- [x] done",
+    before: "- [x] done",
+    after: "[x] done",
+  },
+  {
+    name: "table fallback",
+    input: "| Name | Value |\n| --- | --- |\n| A | 1 |",
+    before: "| Name | Value |\n| --- | --- |\n| A | 1 |",
+    after: "*A*\n• Value: 1",
+  },
+  {
+    name: "multiline blockquote",
+    input: "> first\n> second",
+    before: "> first\n> second",
+    after: "> first\n> second",
+  },
+  {
+    name: "image fallback",
+    input: "![diagram](https://example.com/diagram.png)",
+    before: "![diagram](https://example.com/diagram.png)",
+    after: "diagram",
+  },
+  {
+    name: "raw mention stripping",
+    input: "Hello <users/123456789>",
+    before: "Hello",
+    after: "Hello",
+  },
+  {
+    name: "escaped literal markup",
+    input: "\\*literal\\* and \\_plain\\_",
+    before: "\\*literal\\* and \\_plain\\_",
+    after: "＊literal＊ and ＿plain＿",
+  },
+  {
+    name: "bullet list inside blockquote",
+    input: "> - quoted item",
+    before: "> - quoted item",
+    after: "> * quoted item",
+  },
+] as const;
+
+describe("formatGoogleChatText", () => {
+  it.each(DIALECT_FIXTURES)("$name: $before -> $after", ({ input, after }) => {
+    expect(formatGoogleChatText(input)).toBe(after);
+  });
+
+  it("keeps sanitizer safety while accepting model-authored HTML", () => {
+    expect(formatGoogleChatText("<script>alert(1)</script> <b>safe</b>")).toBe("alert(1) *safe*");
+    expect(
+      formatGoogleChatText('<tool_call>{"target":"<users/1>","token":"secret"}</tool_call>'),
+    ).toBe("");
+  });
+
+  it("does not reinterpret a literal bullet as a Google Chat list", () => {
+    expect(formatGoogleChatText("• literal bullet")).toBe("• literal bullet");
+    expect(formatGoogleChatText("\\* not a list")).toBe("＊ not a list");
+    expect(formatGoogleChatText("\\- not a list")).toBe("－ not a list");
+    expect(formatGoogleChatText("snake_case and 2 * 3")).toBe("snake_case and 2 * 3");
+    expect(formatGoogleChatText("\\`one\\` and \\`two\\`")).toBe("｀one｀ and ｀two｀");
+  });
+
+  it("uses semantic list depth instead of authored indentation width", () => {
+    expect(formatGoogleChatText("- parent\n    - child")).toBe("* parent\n    * child");
+    expect(formatGoogleChatText("   - top-level")).toBe("* top-level");
+  });
+
+  it("neutralizes nested markup inside native link labels", () => {
+    expect(formatGoogleChatText("[x > y](https://example.com)")).toBe(
+      "<https://example.com|x ＞ y>",
+    );
+    expect(
+      formatGoogleChatText("[&#60;https://evil.example&#124;caption&#62;](https://outer.example)"),
+    ).toBe("<https://outer.example|＜https://evil.example｜caption＞>");
+  });
+
+  it("keeps entity-decoded mention syntax non-active", () => {
+    expect(formatGoogleChatText("&#60;users/all&#62;")).toBe("＜users/all＞");
+    expect(formatGoogleChatText("&#60;customEmojis/123&#62;")).toBe("＜customEmojis/123＞");
+  });
+
+  it("neutralizes target-only delimiter pairs left plain by CommonMark", () => {
+    expect(formatGoogleChatText("~approximate~ and snake_case_more")).toBe(
+      "～approximate～ and snake＿case＿more",
+    );
+    expect(formatGoogleChatText("&#126;entity&#126;")).toBe("～entity～");
+    expect(formatGoogleChatText("~approximate and ~~gone~~")).toBe("～approximate and ~gone~");
+  });
+
+  it("preserves linkified URLs containing delimiter characters", () => {
+    expect(formatGoogleChatText("https://example.com/a_b_c")).toBe("https://example.com/a_b_c");
+  });
+
+  it("handles newline-heavy messages without changing their content", () => {
+    const text = "a\n".repeat(16_000);
+    expect(formatGoogleChatText(text)).toBe(text.trimEnd());
+  });
+
+  it("falls back to visually equivalent plain text for unsupported code delimiters", () => {
+    expect(formatGoogleChatText("``a ` b``")).toBe("a ｀ b");
+    expect(formatGoogleChatText("````\nbefore\n```\nafter\n````")).toBe("before\n｀｀｀\nafter\n");
+  });
+
+  it("does not collide with private-use characters in authored text", () => {
+    const privateUse = Array.from({ length: 0x1900 }, (_, index) =>
+      String.fromCharCode(0xe000 + index),
+    ).join("");
+    expect(formatGoogleChatText(`${privateUse}\n- item`)).toBe(`${privateUse}\n\n* item`);
+  });
+
+  it("strips email-alias mentions unsupported by app authentication", () => {
+    expect(formatGoogleChatText("Hello <users/alice@example.com>")).toBe("Hello");
+  });
+
+  it("chunks against the rendered UTF-8 byte size", () => {
+    const input = `| ${"H".repeat(30)} | Value |\n| --- | --- |\n${Array.from(
+      { length: 8 },
+      (_, index) => `| row-${index} | ${index} |`,
+    ).join("\n")}`;
+    const chunks = formatGoogleChatTextChunks(input, 80);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => new TextEncoder().encode(chunk).byteLength <= 80)).toBe(true);
+  });
+
+  it("declares the Google Chat app-message capability profile", () => {
+    expect(GOOGLE_CHAT_FORMAT_PROFILE).toMatchObject({
+      mechanism: "markdown",
+      chunk: { limit: 32_000, unit: "bytes" },
+      constructs: {
+        bold: "native",
+        bulletList: "native",
+        heading: "fallback",
+        orderedList: "fallback",
+        table: "fallback",
+      },
+    });
+  });
+});

--- a/extensions/googlechat/src/format.test.ts
+++ b/extensions/googlechat/src/format.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from "vitest";
-import {
-  formatGoogleChatText,
-  formatGoogleChatTextChunks,
-  GOOGLE_CHAT_FORMAT_PROFILE,
-} from "./format.js";
+import { formatGoogleChatTextChunks, GOOGLE_CHAT_FORMAT_PROFILE } from "./format.js";
+
+const formatGoogleChatText = (text: string) => formatGoogleChatTextChunks(text).join("");
 
 const DIALECT_FIXTURES = [
   { name: "bold", input: "**bold**", before: "**bold**", after: "*bold*" },

--- a/extensions/googlechat/src/format.ts
+++ b/extensions/googlechat/src/format.ts
@@ -1,0 +1,339 @@
+import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  markdownToIR,
+  renderMarkdownIRChunksWithinLimit,
+  renderMarkdownWithMarkers,
+  sanitizeAssistantVisibleText,
+  type FormatCapabilityProfile,
+  type MarkdownIR,
+} from "openclaw/plugin-sdk/text-chunking";
+
+export const GOOGLE_CHAT_FORMAT_PROFILE = {
+  mechanism: "markdown",
+  constructs: {
+    bold: "native",
+    italic: "native",
+    underline: "fallback",
+    strikethrough: "native",
+    spoiler: "fallback",
+    codeInline: "native",
+    codeBlock: "native",
+    codeLanguage: "fallback",
+    linkLabel: "native",
+    heading: "fallback",
+    bulletList: "native",
+    orderedList: "fallback",
+    taskList: "fallback",
+    table: "fallback",
+    blockquote: "native",
+    image: "fallback",
+    mention: "strip",
+  },
+  chunk: { limit: 32_000, unit: "bytes" },
+} satisfies FormatCapabilityProfile;
+
+const GOOGLE_CHAT_LITERAL_FALLBACKS = new Map([
+  ["*", "＊"],
+  ["_", "＿"],
+  ["~", "～"],
+  ["`", "｀"],
+  ["<", "＜"],
+  [">", "＞"],
+  ["\\", "＼"],
+  ["-", "－"],
+  ["|", "｜"],
+]);
+
+type GoogleChatMarkers = {
+  blockquoteClose: string;
+  blockquoteOpen: string;
+  list: string;
+};
+
+function createPrivateMarkerGenerator(text: string): () => string {
+  const used = new Set<string>();
+  let candidate = 0;
+  const rangeSize = 0x1900;
+  return () => {
+    while (true) {
+      const marker = String.fromCharCode(
+        0xe000 + Math.floor(candidate / rangeSize),
+        0xe000 + (candidate % rangeSize),
+      );
+      candidate += 1;
+      if (!used.has(marker) && !text.includes(marker)) {
+        used.add(marker);
+        return marker;
+      }
+    }
+  };
+}
+
+function createGoogleChatMarkers(text: string): GoogleChatMarkers {
+  const nextMarker = createPrivateMarkerGenerator(text);
+  return {
+    list: nextMarker(),
+    blockquoteOpen: nextMarker(),
+    blockquoteClose: nextMarker(),
+  };
+}
+
+/** Removes unsafe HTML and internal scaffolding while retaining source Markdown for chunking. */
+export function sanitizeGoogleChatText(text: string): string {
+  return sanitizeForPlainText(sanitizeAssistantVisibleText(text), {
+    style: "markdown",
+  });
+}
+
+function projectDecodedGoogleChatResources(ir: MarkdownIR): MarkdownIR {
+  const characters = ir.text.split("");
+  let changed = false;
+  for (const match of ir.text.matchAll(/<(?:users|customEmojis)\/[^<>\s]+>/giu)) {
+    const start = match.index ?? 0;
+    characters[start] = "＜";
+    characters[start + match[0].length - 1] = "＞";
+    changed = true;
+  }
+  return changed ? { ...ir, text: characters.join("") } : ir;
+}
+
+function projectGoogleChatLinkLabels(ir: MarkdownIR): MarkdownIR {
+  const characters = ir.text.split("");
+  let changed = false;
+  for (const link of ir.links) {
+    const label = ir.text.slice(link.start, link.end);
+    const comparableHref = link.href.startsWith("mailto:")
+      ? link.href.slice("mailto:".length)
+      : link.href;
+    if (label === link.href || label === comparableHref) {
+      continue;
+    }
+    for (let index = link.start; index < link.end; index += 1) {
+      const character = characters[index] ?? "";
+      const fallback = GOOGLE_CHAT_LITERAL_FALLBACKS.get(character);
+      if (fallback && /[<>|*_~`]/u.test(character)) {
+        characters[index] = fallback;
+        changed = true;
+      }
+    }
+  }
+  return changed ? { ...ir, text: characters.join("") } : ir;
+}
+
+function markGoogleChatBulletLists(ir: MarkdownIR, markerToken: string): MarkdownIR {
+  let text = ir.text;
+  for (const item of ir.listItems ?? []) {
+    const marker = item.listMarker;
+    if (item.kind !== "bullet" || !marker || text.slice(marker.start, marker.end) !== "• ") {
+      continue;
+    }
+    text = `${text.slice(0, marker.start)}${markerToken}${text.slice(marker.end)}`;
+  }
+  return text === ir.text ? ir : { ...ir, text };
+}
+
+function projectUnsafeCodeFallbacks(ir: MarkdownIR): MarkdownIR {
+  let text = ir.text;
+  const styles = ir.styles.filter((span) => {
+    const content = ir.text.slice(span.start, span.end);
+    const unsafe =
+      (span.style === "code" && content.includes("`")) ||
+      (span.style === "code_block" && content.includes("```"));
+    if (unsafe) {
+      const replacement = [...content]
+        .map((character) => GOOGLE_CHAT_LITERAL_FALLBACKS.get(character) ?? character)
+        .join("");
+      text = `${text.slice(0, span.start)}${replacement}${text.slice(span.end)}`;
+    }
+    return !unsafe;
+  });
+  return styles.length === ir.styles.length ? ir : { ...ir, styles, text };
+}
+
+function projectGoogleChatPlainLiterals(ir: MarkdownIR): MarkdownIR {
+  const codeRanges = ir.styles.filter(
+    (span) => span.style === "code" || span.style === "code_block",
+  );
+  const inCode = (index: number) =>
+    codeRanges.some((span) => index >= span.start && index < span.end);
+  const inLink = (index: number) =>
+    ir.links.some((span) => index >= span.start && index < span.end);
+  const styleDelimiter = new Map([
+    ["~", "strikethrough"],
+    ["_", "italic"],
+    ["*", "bold"],
+    ["`", "code"],
+  ]);
+  const characters = ir.text.split("");
+  let lineStart = 0;
+  while (lineStart < characters.length) {
+    const nextNewline = characters.indexOf("\n", lineStart);
+    const lineEnd = nextNewline < 0 ? characters.length : nextNewline;
+    for (const delimiter of ["~", "_", "*", "`"]) {
+      const indexes: number[] = [];
+      for (let index = lineStart; index < lineEnd; index += 1) {
+        if (characters[index] === delimiter && !inCode(index) && !inLink(index)) {
+          indexes.push(index);
+        }
+      }
+      if (indexes.length === 0) {
+        continue;
+      }
+      const renderedStyle = styleDelimiter.get(delimiter);
+      const lineAddsDelimiter = ir.styles.some(
+        (span) => span.style === renderedStyle && span.start < lineEnd && span.end > lineStart,
+      );
+      if (indexes.length >= 2 || lineAddsDelimiter) {
+        for (const index of indexes) {
+          characters[index] = GOOGLE_CHAT_LITERAL_FALLBACKS.get(delimiter) ?? delimiter;
+        }
+      }
+    }
+    let firstTextIndex = lineStart;
+    while (firstTextIndex < lineEnd && characters[firstTextIndex] === " ") {
+      firstTextIndex += 1;
+    }
+    if (firstTextIndex >= lineStart && !inCode(firstTextIndex)) {
+      const character = characters[firstTextIndex];
+      const isListMarker =
+        (character === "*" || character === "-") && characters[firstTextIndex + 1] === " ";
+      if (isListMarker || character === ">") {
+        characters[firstTextIndex] = GOOGLE_CHAT_LITERAL_FALLBACKS.get(character) ?? character;
+      }
+    }
+    const line = characters.slice(lineStart, lineEnd).join("");
+    for (const match of line.matchAll(/<[^<>\n]*\|[^<>\n]*>/gu)) {
+      const open = lineStart + (match.index ?? 0);
+      const close = open + match[0].length - 1;
+      if (!inCode(open) && !inCode(close) && !inLink(open) && !inLink(close)) {
+        characters[open] = "＜";
+        characters[close] = "＞";
+      }
+    }
+    lineStart = lineEnd + 1;
+  }
+  const text = characters.join("");
+  return text === ir.text ? ir : { ...ir, text };
+}
+
+function emitGoogleChatLists(text: string, markerToken: string): string {
+  return text
+    .split("\n")
+    .map((line) => {
+      const markerIndex = line.indexOf(markerToken);
+      if (markerIndex < 0) {
+        return line;
+      }
+      const prefix = line.slice(0, markerIndex);
+      const quote = /^(?:> )*/u.exec(prefix)?.[0] ?? "";
+      const indent = prefix.slice(quote.length);
+      return `${quote}${" ".repeat(indent.length * 2)}* ${line.slice(
+        markerIndex + markerToken.length,
+      )}`;
+    })
+    .join("\n");
+}
+
+function emitGoogleChatBlockquotes(text: string, markers: GoogleChatMarkers): string {
+  let depth = 0;
+  let lineStart = true;
+  let rendered = "";
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.startsWith(markers.blockquoteOpen, index)) {
+      depth += 1;
+      index += markers.blockquoteOpen.length - 1;
+      continue;
+    }
+    if (text.startsWith(markers.blockquoteClose, index)) {
+      depth = Math.max(0, depth - 1);
+      index += markers.blockquoteClose.length - 1;
+      continue;
+    }
+    const character = text[index] ?? "";
+    if (lineStart && depth > 0) {
+      rendered += "> ".repeat(depth);
+    }
+    rendered += character;
+    lineStart = character === "\n";
+  }
+  return rendered;
+}
+
+function prepareGoogleChatIR(text: string): {
+  ir: MarkdownIR;
+  markers: GoogleChatMarkers;
+} {
+  const sanitized = sanitizeGoogleChatText(text);
+  const parsed = markdownToIR(sanitized, {
+    enableSpoilers: true,
+    enableTaskLists: true,
+    headingStyle: "rich",
+    tableMode: "bullets",
+  });
+  const ir = projectGoogleChatPlainLiterals(
+    projectGoogleChatLinkLabels(
+      projectDecodedGoogleChatResources(projectUnsafeCodeFallbacks(parsed)),
+    ),
+  );
+  const markers = createGoogleChatMarkers(ir.text);
+  return {
+    ir: markGoogleChatBulletLists(ir, markers.list),
+    markers,
+  };
+}
+
+function renderGoogleChatIR(ir: MarkdownIR, markers: GoogleChatMarkers): string {
+  const rendered = renderMarkdownWithMarkers(
+    ir,
+    {
+      styleMarkers: {
+        bold: { open: "*", close: "*" },
+        italic: { open: "_", close: "_" },
+        strikethrough: { open: "~", close: "~" },
+        code: { open: "`", close: "`" },
+        code_block: { open: "```\n", close: "```" },
+        blockquote: { open: markers.blockquoteOpen, close: markers.blockquoteClose },
+      },
+      escapeText: (value) => value,
+      buildLink: (link, value, context) => {
+        if (context.origin === "linkify") {
+          return null;
+        }
+        const href = link.href.trim();
+        const label = value.slice(link.start, link.end);
+        if (!href || !label) {
+          return null;
+        }
+        const labelHasStyles = ir.styles.some(
+          (span) => span.start < link.end && span.end > link.start,
+        );
+        return /[<>|]/u.test(href) || /[<>|*_~`]/u.test(label) || labelHasStyles
+          ? { start: link.start, end: link.end, open: "", close: ` (${href})` }
+          : { start: link.start, end: link.end, open: `<${href}|`, close: ">" };
+      },
+    },
+    GOOGLE_CHAT_FORMAT_PROFILE,
+  );
+  const blockquotes = emitGoogleChatBlockquotes(rendered, markers);
+  return emitGoogleChatLists(blockquotes, markers.list);
+}
+
+/** Renders CommonMark into byte-bounded Google Chat app-message chunks. */
+export function formatGoogleChatTextChunks(
+  text: string,
+  limit = GOOGLE_CHAT_FORMAT_PROFILE.chunk.limit,
+): string[] {
+  const prepared = prepareGoogleChatIR(text);
+  return renderMarkdownIRChunksWithinLimit({
+    ir: prepared.ir,
+    limit: Math.min(limit, GOOGLE_CHAT_FORMAT_PROFILE.chunk.limit),
+    measureRendered: (rendered) => new TextEncoder().encode(rendered).byteLength,
+    renderChunk: (chunk) => renderGoogleChatIR(chunk, prepared.markers),
+  }).map((chunk) => chunk.rendered);
+}
+
+/** Renders one uncapped CommonMark value for non-transport formatting callers. */
+export function formatGoogleChatText(text: string): string {
+  const prepared = prepareGoogleChatIR(text);
+  return renderGoogleChatIR(prepared.ir, prepared.markers);
+}

--- a/extensions/googlechat/src/format.ts
+++ b/extensions/googlechat/src/format.ts
@@ -324,10 +324,10 @@ export function formatGoogleChatTextChunks(
   limit = GOOGLE_CHAT_FORMAT_PROFILE.chunk.limit,
 ): string[] {
   const prepared = prepareGoogleChatIR(text);
-  return renderMarkdownIRChunksWithinLimit({
+  return renderMarkdownIRChunksWithinLimit<string>({
     ir: prepared.ir,
     limit: Math.min(limit, GOOGLE_CHAT_FORMAT_PROFILE.chunk.limit),
-    measureRendered: (rendered) => new TextEncoder().encode(rendered).byteLength,
+    measureRendered: (rendered: string) => new TextEncoder().encode(rendered).byteLength,
     renderChunk: (chunk) => renderGoogleChatIR(chunk, prepared.markers),
   }).map((chunk) => chunk.rendered);
 }

--- a/extensions/googlechat/src/format.ts
+++ b/extensions/googlechat/src/format.ts
@@ -140,7 +140,8 @@ function projectUnsafeCodeFallbacks(ir: MarkdownIR): MarkdownIR {
       (span.style === "code" && content.includes("`")) ||
       (span.style === "code_block" && content.includes("```"));
     if (unsafe) {
-      const replacement = [...content]
+      const replacement = content
+        .split("")
         .map((character) => GOOGLE_CHAT_LITERAL_FALLBACKS.get(character) ?? character)
         .join("");
       text = `${text.slice(0, span.start)}${replacement}${text.slice(span.end)}`;
@@ -330,10 +331,4 @@ export function formatGoogleChatTextChunks(
     measureRendered: (rendered: string) => new TextEncoder().encode(rendered).byteLength,
     renderChunk: (chunk) => renderGoogleChatIR(chunk, prepared.markers),
   }).map((chunk) => chunk.rendered);
-}
-
-/** Renders one uncapped CommonMark value for non-transport formatting callers. */
-export function formatGoogleChatText(text: string): string {
-  const prepared = prepareGoogleChatIR(text);
-  return renderGoogleChatIR(prepared.ir, prepared.markers);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google Chat users saw literal CommonMark syntax such as `**bold**`, `~~strike~~`, headings, tables, and `[label](url)` because outbound app messages only passed through the HTML/plain-text sanitizer and never had a Google Chat renderer.

## Why This Change Was Made

Google Chat now declares a `FormatCapabilityProfile` and routes outbound text through markdown-core's single parse, shared construct fallbacks, marker renderer, and rendered-size-aware chunker. The channel keeps only transport-specific emission rules: Google Chat markers, four-space list nesting, safe resource-token handling, sanitizer preservation, and the 32,000-byte app-message limit. Raw mention syntax remains stripped as before because this text renderer has no typed mention contract.

AI-assisted implementation; I reviewed the resulting code and behavior.

## User Impact

Google Chat app messages now render bold, italic, strikethrough, inline code, fenced code, links, blockquotes, and bullet lists in the platform's native dialect. Unsupported headings, ordered/task lists, tables, spoilers, images, underline, and code languages use the shared markdown-core fallbacks instead of leaking source syntax.

Intended golden byte changes:

- `**bold**` -> `*bold*`
- `*italic*` -> `_italic_`
- `~~strike~~` -> `~strike~`
- fenced code language identifiers are removed
- `[label](url)` -> `<url|label>`
- headings -> bold lines
- bullet lists -> `* ` with four spaces per semantic nesting level
- ordered lists stay numbered; task lists become `[x] item`
- tables become markdown-core's readable bullet fallback
- spoilers, images, and underline fall back to safe visible text
- multiline blockquotes prefix every quoted line
- raw mention syntax remains stripped; entity-decoded Google Chat resources are neutralized

## Evidence

- LOC: production `+342/-11`; tests `+186/-2`; total `+528/-13`. This correctness wave intentionally replaces the no-renderer path with one capability-driven renderer and exhaustive golden coverage; the markdown-unification directive prioritizes the canonical architecture over raw LOC for this channel.
- `pnpm test extensions/googlechat/src/format.test.ts extensions/googlechat/src/channel.test.ts` — 48/48 passed on Blacksmith Testbox (`tbx_01ky7grzgp702kh2paa309pf4y`, run https://github.com/openclaw/openclaw/actions/runs/30009058926).
- `pnpm check:changed` — passed on the same Testbox: formatting, extension prod/test types, lint, deadcode-sensitive boundaries, max-lines, dependency, database-first, sidecar, and import-cycle gates.
- `git diff --check` — passed.
- Structured Codex autoreview ran repeatedly. All accepted findings were fixed; the final reported media-caption concern was rejected because Google Chat declares no media capability or media sender, as verified by the existing adapter capability proof.
