### PR TITLE
refactor(browser-extension): extract config + tab-group helpers from background.js

### DIFF
--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -1,3 +1,4 @@
+import { getConfig, getCopilotConfig } from "./modules/config.js";
 import { createCopilotController } from "./modules/copilot-background.js";
 import {
   buildPageSharePayload,
@@ -19,6 +20,14 @@ import {
   reconnectDelayMs,
   toRelayTabInfo,
 } from "./modules/relay-core.js";
+import {
+  addTabToOpenClawGroup,
+  focusWindowForTab,
+  isOpenClawGroupId,
+  isTabShared,
+  listSharedTabs,
+  removeTabFromOpenClawGroup,
+} from "./modules/tab-groups.js";
 
 const BADGE = {
   off: { text: "", color: "#000000" },
@@ -84,93 +93,6 @@ function flashPageShareBadge(ok) {
     },
     ok ? 2_000 : 3_000,
   );
-}
-
-async function getConfig() {
-  const stored = await chrome.storage.local.get(["relayUrl", "token", "groupColor"]);
-  return {
-    relayUrl: typeof stored.relayUrl === "string" ? stored.relayUrl : "",
-    token: typeof stored.token === "string" ? stored.token : "",
-    groupColor: typeof stored.groupColor === "string" ? stored.groupColor : "orange",
-  };
-}
-
-async function getCopilotConfig() {
-  const config = await getConfig();
-  const stored = await chrome.storage.local.get(["gatewayUrl"]);
-  return {
-    ...config,
-    gatewayUrl: typeof stored.gatewayUrl === "string" ? stored.gatewayUrl : "",
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Tab group management (the consent boundary)
-// ---------------------------------------------------------------------------
-
-async function findOpenClawGroups() {
-  try {
-    return await chrome.tabGroups.query({ title: OPENCLAW_TAB_GROUP_TITLE });
-  } catch {
-    return [];
-  }
-}
-
-async function listSharedTabs() {
-  const groups = await findOpenClawGroups();
-  const tabs = [];
-  for (const group of groups) {
-    const groupTabs = await chrome.tabs.query({ groupId: group.id });
-    tabs.push(...groupTabs);
-  }
-  return tabs.filter((tab) => typeof tab.id === "number");
-}
-
-async function addTabToOpenClawGroup(tabId) {
-  const tab = await chrome.tabs.get(tabId);
-  const groups = await findOpenClawGroups();
-  const sameWindowGroup = groups.find((group) => group.windowId === tab.windowId);
-  if (sameWindowGroup) {
-    await chrome.tabs.group({ tabIds: [tabId], groupId: sameWindowGroup.id });
-    return;
-  }
-  const { groupColor } = await getConfig();
-  const groupId = await chrome.tabs.group({ tabIds: [tabId] });
-  await chrome.tabGroups.update(groupId, {
-    title: OPENCLAW_TAB_GROUP_TITLE,
-    color: groupColor,
-  });
-}
-
-async function focusWindowForTab(tab) {
-  if (typeof tab.windowId === "number") {
-    await chrome.windows.update(tab.windowId, { focused: true });
-  }
-}
-
-async function removeTabFromOpenClawGroup(tabId) {
-  try {
-    await chrome.tabs.ungroup([tabId]);
-  } catch {
-    // tab may already be gone
-  }
-}
-
-async function isTabShared(tabId) {
-  const shared = await listSharedTabs();
-  return shared.some((tab) => tab.id === tabId);
-}
-
-async function isOpenClawGroupId(groupId) {
-  if (!Number.isInteger(groupId) || groupId < 0) {
-    return false;
-  }
-  try {
-    const group = await chrome.tabGroups.get(groupId);
-    return group.title === OPENCLAW_TAB_GROUP_TITLE;
-  } catch {
-    return false;
-  }
 }
 
 function scheduleTabsSync() {

--- a/extensions/browser/chrome-extension/modules/config.js
+++ b/extensions/browser/chrome-extension/modules/config.js
@@ -1,0 +1,21 @@
+// Extension configuration read from chrome.storage: the relay pairing (url/token,
+// tab-group color) and the copilot gateway url. Kept in one place so the service
+// worker and the tab-group helpers share a single source of truth.
+
+export async function getConfig() {
+  const stored = await chrome.storage.local.get(["relayUrl", "token", "groupColor"]);
+  return {
+    relayUrl: typeof stored.relayUrl === "string" ? stored.relayUrl : "",
+    token: typeof stored.token === "string" ? stored.token : "",
+    groupColor: typeof stored.groupColor === "string" ? stored.groupColor : "orange",
+  };
+}
+
+export async function getCopilotConfig() {
+  const config = await getConfig();
+  const stored = await chrome.storage.local.get(["gatewayUrl"]);
+  return {
+    ...config,
+    gatewayUrl: typeof stored.gatewayUrl === "string" ? stored.gatewayUrl : "",
+  };
+}

--- a/extensions/browser/chrome-extension/modules/tab-groups.js
+++ b/extensions/browser/chrome-extension/modules/tab-groups.js
@@ -1,0 +1,71 @@
+// The OpenClaw tab group is the user-visible consent boundary: only tabs in that
+// group are reported to (and driven by) OpenClaw. These helpers own membership in
+// the group; leaving the group revokes agent access.
+
+import { getConfig } from "./config.js";
+import { OPENCLAW_TAB_GROUP_TITLE } from "./relay-core.js";
+
+export async function findOpenClawGroups() {
+  try {
+    return await chrome.tabGroups.query({ title: OPENCLAW_TAB_GROUP_TITLE });
+  } catch {
+    return [];
+  }
+}
+
+export async function listSharedTabs() {
+  const groups = await findOpenClawGroups();
+  const tabs = [];
+  for (const group of groups) {
+    const groupTabs = await chrome.tabs.query({ groupId: group.id });
+    tabs.push(...groupTabs);
+  }
+  return tabs.filter((tab) => typeof tab.id === "number");
+}
+
+export async function addTabToOpenClawGroup(tabId) {
+  const tab = await chrome.tabs.get(tabId);
+  const groups = await findOpenClawGroups();
+  const sameWindowGroup = groups.find((group) => group.windowId === tab.windowId);
+  if (sameWindowGroup) {
+    await chrome.tabs.group({ tabIds: [tabId], groupId: sameWindowGroup.id });
+    return;
+  }
+  const { groupColor } = await getConfig();
+  const groupId = await chrome.tabs.group({ tabIds: [tabId] });
+  await chrome.tabGroups.update(groupId, {
+    title: OPENCLAW_TAB_GROUP_TITLE,
+    color: groupColor,
+  });
+}
+
+export async function focusWindowForTab(tab) {
+  if (typeof tab.windowId === "number") {
+    await chrome.windows.update(tab.windowId, { focused: true });
+  }
+}
+
+export async function removeTabFromOpenClawGroup(tabId) {
+  try {
+    await chrome.tabs.ungroup([tabId]);
+  } catch {
+    // tab may already be gone
+  }
+}
+
+export async function isTabShared(tabId) {
+  const shared = await listSharedTabs();
+  return shared.some((tab) => tab.id === tabId);
+}
+
+export async function isOpenClawGroupId(groupId) {
+  if (!Number.isInteger(groupId) || groupId < 0) {
+    return false;
+  }
+  try {
+    const group = await chrome.tabGroups.get(groupId);
+    return group.title === OPENCLAW_TAB_GROUP_TITLE;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Related: #113029

## What Problem This Solves

`extensions/browser/chrome-extension/background.js` sits at the oxlint `max-lines` budget, so any behavior change to it trips the gate. This behavior-neutral refactor makes room for the accompanying relay/copilot fixes in this set (see #113029).

## Why This Change Was Made

Two cohesive, side-effect-light units are split out with no behavior change: the `chrome.storage` config reads (`getConfig`/`getCopilotConfig`) into `modules/config.js`, and the OpenClaw tab-group consent-boundary helpers (`list`/`add`/`remove`/`isTabShared`/`isOpenClawGroupId`/…) into `modules/tab-groups.js`. Definitions move verbatim and are imported back, so call sites and the copilot controller injection are unchanged. background.js drops from ~695 to ~631 code lines.

## User Impact

None — behavior-neutral refactor. It unblocks the follow-up fixes in this set.

## Evidence

- Rig-verified behavior-neutral: pairing + connect unchanged when loaded in an isolated latest-`main` test gateway (Playwright under xvfb).
- `oxfmt` clean, `oxlint` 0 errors, 47 extension tests pass (`extensions/browser/chrome-extension`).
- autoreview: `nothing_found`, high confidence, reviewed against the full files + scoped `AGENTS.md`.
