### PR TITLE
fix(browser-extension): show the real relay failure cause, not a blanket 'gateway down'

### DIFF
--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -1,3 +1,4 @@
+import { getConfig, getCopilotConfig } from "./modules/config.js";
 import { createCopilotController } from "./modules/copilot-background.js";
 import {
   buildPageSharePayload,
@@ -19,6 +20,14 @@ import {
   reconnectDelayMs,
   toRelayTabInfo,
 } from "./modules/relay-core.js";
+import {
+  addTabToOpenClawGroup,
+  focusWindowForTab,
+  isOpenClawGroupId,
+  isTabShared,
+  listSharedTabs,
+  removeTabFromOpenClawGroup,
+} from "./modules/tab-groups.js";
 
 const BADGE = {
   off: { text: "", color: "#000000" },
@@ -84,93 +93,6 @@ function flashPageShareBadge(ok) {
     },
     ok ? 2_000 : 3_000,
   );
-}
-
-async function getConfig() {
-  const stored = await chrome.storage.local.get(["relayUrl", "token", "groupColor"]);
-  return {
-    relayUrl: typeof stored.relayUrl === "string" ? stored.relayUrl : "",
-    token: typeof stored.token === "string" ? stored.token : "",
-    groupColor: typeof stored.groupColor === "string" ? stored.groupColor : "orange",
-  };
-}
-
-async function getCopilotConfig() {
-  const config = await getConfig();
-  const stored = await chrome.storage.local.get(["gatewayUrl"]);
-  return {
-    ...config,
-    gatewayUrl: typeof stored.gatewayUrl === "string" ? stored.gatewayUrl : "",
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Tab group management (the consent boundary)
-// ---------------------------------------------------------------------------
-
-async function findOpenClawGroups() {
-  try {
-    return await chrome.tabGroups.query({ title: OPENCLAW_TAB_GROUP_TITLE });
-  } catch {
-    return [];
-  }
-}
-
-async function listSharedTabs() {
-  const groups = await findOpenClawGroups();
-  const tabs = [];
-  for (const group of groups) {
-    const groupTabs = await chrome.tabs.query({ groupId: group.id });
-    tabs.push(...groupTabs);
-  }
-  return tabs.filter((tab) => typeof tab.id === "number");
-}
-
-async function addTabToOpenClawGroup(tabId) {
-  const tab = await chrome.tabs.get(tabId);
-  const groups = await findOpenClawGroups();
-  const sameWindowGroup = groups.find((group) => group.windowId === tab.windowId);
-  if (sameWindowGroup) {
-    await chrome.tabs.group({ tabIds: [tabId], groupId: sameWindowGroup.id });
-    return;
-  }
-  const { groupColor } = await getConfig();
-  const groupId = await chrome.tabs.group({ tabIds: [tabId] });
-  await chrome.tabGroups.update(groupId, {
-    title: OPENCLAW_TAB_GROUP_TITLE,
-    color: groupColor,
-  });
-}
-
-async function focusWindowForTab(tab) {
-  if (typeof tab.windowId === "number") {
-    await chrome.windows.update(tab.windowId, { focused: true });
-  }
-}
-
-async function removeTabFromOpenClawGroup(tabId) {
-  try {
-    await chrome.tabs.ungroup([tabId]);
-  } catch {
-    // tab may already be gone
-  }
-}
-
-async function isTabShared(tabId) {
-  const shared = await listSharedTabs();
-  return shared.some((tab) => tab.id === tabId);
-}
-
-async function isOpenClawGroupId(groupId) {
-  if (!Number.isInteger(groupId) || groupId < 0) {
-    return false;
-  }
-  try {
-    const group = await chrome.tabGroups.get(groupId);
-    return group.title === OPENCLAW_TAB_GROUP_TITLE;
-  } catch {
-    return false;
-  }
 }
 
 function scheduleTabsSync() {

--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -48,6 +48,9 @@ const RELAY_OPENING_TIMEOUT_MS = 30_000;
 /** @type {WebSocket|null} */
 let relayWs = null;
 let relayState = "off"; // off | connecting | on | error
+// Last relay-socket failure, so the popup can name the real cause (auth rejected vs
+// unreachable vs dropped) instead of always blaming a down gateway.
+let lastRelayError = null; // { code, reason, wasOpen, at } | null
 let copilot = null;
 let reconnectAttempt = 0;
 let reconnectTimer = null;
@@ -361,17 +364,24 @@ async function connectRelay() {
   try {
     ws = new WebSocket(relayUrl, buildRelayWsProtocols(token));
   } catch {
+    // Never surface the constructor's error message: a corrupted-paste token makes the
+    // WebSocket SyntaxError embed the raw token (a host-local secret) verbatim, and the
+    // popup renders `reason`. Leave it empty so the popup shows the generic re-pair line.
+    lastRelayError = { code: null, reason: "", wasOpen: false, at: Date.now() };
     setBadge("error");
     scheduleReconnect();
     return;
   }
   relayWs = ws;
+  let relayOpened = false;
   armRelayOpeningDeadline();
   ws.addEventListener("open", () => {
     if (relayWs !== ws) {
       ws.close();
       return;
     }
+    relayOpened = true;
+    lastRelayError = null;
     clearRelayOpeningDeadline();
     reconnectAttempt = 0;
     setBadge("on");
@@ -399,10 +409,19 @@ async function connectRelay() {
     }
     void handleRelayCommand(msg);
   });
-  ws.addEventListener("close", () => {
+  ws.addEventListener("close", (event) => {
     if (relayWs === ws) {
       clearRelayOpeningDeadline();
       relayWs = null;
+      // Record why it closed. A close BEFORE open is a handshake failure (gateway down,
+      // wrong URL, browser control off, or the token was rejected — the browser can't
+      // tell these apart); a close AFTER open with code 1008 is a policy/auth rejection.
+      lastRelayError = {
+        code: typeof event?.code === "number" ? event.code : null,
+        reason: event?.reason ?? "",
+        wasOpen: relayOpened,
+        at: Date.now(),
+      };
       setBadge("error");
       scheduleReconnect();
     }
@@ -531,6 +550,10 @@ function handleRelayOpeningDeadline() {
   } catch {
     // The socket may have changed state while the alarm event was queued.
   }
+  // Nulling relayWs above makes the close handler's `relayWs === ws` guard skip
+  // recording, so capture the timeout here — otherwise a prior in-session failure's
+  // cause would linger in the popup for this never-opened connect hang.
+  lastRelayError = { code: null, reason: "timed out connecting", wasOpen: false, at: Date.now() };
   setBadge("error");
   scheduleReconnect();
 }
@@ -557,10 +580,18 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       case "getStatus": {
         const { relayUrl } = await getConfig();
         const shared = await listSharedTabs();
+        let relayHost;
+        try {
+          relayHost = relayUrl ? new URL(relayUrl).host : "";
+        } catch {
+          relayHost = "";
+        }
         sendResponse({
           paired: Boolean(relayUrl),
           state: relayState,
           sharedTabCount: shared.length,
+          relayHost,
+          lastError: relayState === "error" ? lastRelayError : null,
         });
         return;
       }

--- a/extensions/browser/chrome-extension/modules/config.js
+++ b/extensions/browser/chrome-extension/modules/config.js
@@ -1,0 +1,21 @@
+// Extension configuration read from chrome.storage: the relay pairing (url/token,
+// tab-group color) and the copilot gateway url. Kept in one place so the service
+// worker and the tab-group helpers share a single source of truth.
+
+export async function getConfig() {
+  const stored = await chrome.storage.local.get(["relayUrl", "token", "groupColor"]);
+  return {
+    relayUrl: typeof stored.relayUrl === "string" ? stored.relayUrl : "",
+    token: typeof stored.token === "string" ? stored.token : "",
+    groupColor: typeof stored.groupColor === "string" ? stored.groupColor : "orange",
+  };
+}
+
+export async function getCopilotConfig() {
+  const config = await getConfig();
+  const stored = await chrome.storage.local.get(["gatewayUrl"]);
+  return {
+    ...config,
+    gatewayUrl: typeof stored.gatewayUrl === "string" ? stored.gatewayUrl : "",
+  };
+}

--- a/extensions/browser/chrome-extension/modules/relay-core.d.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.d.ts
@@ -20,3 +20,9 @@ export function toRelayTabInfo(tab: {
   title?: string;
   active?: boolean;
 }): { tabId: number; url: string; title: string; active: boolean };
+
+export function relayStatusLabel(status: {
+  state: string;
+  relayHost?: string;
+  lastError?: { code?: number | null; reason?: string; wasOpen?: boolean } | null;
+}): string;

--- a/extensions/browser/chrome-extension/modules/relay-core.js
+++ b/extensions/browser/chrome-extension/modules/relay-core.js
@@ -102,3 +102,37 @@ export function toRelayTabInfo(tab) {
     active: tab.active === true,
   };
 }
+
+const STATE_LABEL = {
+  on: "Connected to OpenClaw",
+  connecting: "Connecting…",
+  error: "Not connected", // real cause is composed by relayStatusLabel() from lastError
+  off: "Not connected",
+};
+
+// Turn the relay socket's close code/reason (from getStatus: { state, relayHost, lastError })
+// into an honest, specific status line instead of always claiming the gateway is down.
+// Kept here (no chrome.* usage) so the close-code → message contract is unit-testable.
+// Distinguishes never-opened (unreachable / rejected handshake) from opened-then-closed
+// (auth/policy or a dropped link), and names the host.
+export function relayStatusLabel(status) {
+  if (status.state !== "error") {
+    return STATE_LABEL[status.state] ?? STATE_LABEL.off;
+  }
+  const host = status.relayHost || "the gateway";
+  const err = status.lastError;
+  const reason = (err?.reason || "").trim();
+  if (err && err.wasOpen) {
+    // 1008 is the only closed close-code that means a policy/auth rejection; match it
+    // exactly rather than sniffing the freeform reason for keywords.
+    if (err.code === 1008) {
+      return `OpenClaw rejected the relay${reason ? ` — ${reason}` : " (not authorized)"}. Unpair, then pair again.`;
+    }
+    return `Relay dropped by ${host}${reason ? ` — ${reason}` : ""}${err.code ? ` (${err.code})` : ""}. Reconnecting…`;
+  }
+  // Never opened: gateway down, wrong URL, browser control off, or the token was rejected
+  // at the handshake — the browser can't tell these apart, so say so plainly.
+  return reason
+    ? `Can't reach the relay at ${host} — ${reason}.`
+    : `Can't reach the relay at ${host}. Check the gateway is up with browser control enabled, or re-pair.`;
+}

--- a/extensions/browser/chrome-extension/modules/relay-core.test.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.test.ts
@@ -6,6 +6,7 @@ import {
   nearestGroupColor,
   parsePairingString,
   reconnectDelayMs,
+  relayStatusLabel,
 } from "./relay-core.js";
 
 describe("parsePairingString", () => {
@@ -71,5 +72,71 @@ describe("nearestGroupColor", () => {
   it("falls back to orange for invalid input", () => {
     expect(nearestGroupColor("not-a-color")).toBe("orange");
     expect(nearestGroupColor(undefined)).toBe("orange");
+  });
+});
+
+describe("relayStatusLabel", () => {
+  it("maps non-error states to their fixed labels", () => {
+    expect(relayStatusLabel({ state: "on" })).toBe("Connected to OpenClaw");
+    expect(relayStatusLabel({ state: "connecting" })).toBe("Connecting…");
+    expect(relayStatusLabel({ state: "off" })).toBe("Not connected");
+  });
+
+  it("names the host and lists the real causes for a never-opened failure", () => {
+    expect(
+      relayStatusLabel({
+        state: "error",
+        relayHost: "127.0.0.1:18789",
+        lastError: { wasOpen: false },
+      }),
+    ).toBe(
+      "Can't reach the relay at 127.0.0.1:18789. Check the gateway is up with browser control enabled, or re-pair.",
+    );
+  });
+
+  it("includes a server reason for a never-opened failure when present", () => {
+    expect(
+      relayStatusLabel({
+        state: "error",
+        relayHost: "host:1",
+        lastError: { wasOpen: false, reason: "timed out connecting" },
+      }),
+    ).toBe("Can't reach the relay at host:1 — timed out connecting.");
+  });
+
+  it("treats an opened-then-1008 close as an auth rejection", () => {
+    expect(
+      relayStatusLabel({
+        state: "error",
+        relayHost: "host:1",
+        lastError: { wasOpen: true, code: 1008 },
+      }),
+    ).toContain("Unpair, then pair again.");
+  });
+
+  it("treats a non-1008 opened close as a drop, even with an auth-sounding reason", () => {
+    expect(
+      relayStatusLabel({
+        state: "error",
+        relayHost: "host:1",
+        lastError: { wasOpen: true, code: 4001, reason: "token invalid" },
+      }),
+    ).toBe("Relay dropped by host:1 — token invalid (4001). Reconnecting…");
+  });
+
+  it("reports an opened-then-dropped close as reconnecting, with the code", () => {
+    expect(
+      relayStatusLabel({
+        state: "error",
+        relayHost: "127.0.0.1:18789",
+        lastError: { wasOpen: true, code: 1001, reason: "relay stopped" },
+      }),
+    ).toBe("Relay dropped by 127.0.0.1:18789 — relay stopped (1001). Reconnecting…");
+  });
+
+  it("falls back to 'the gateway' when no relayHost is known", () => {
+    expect(relayStatusLabel({ state: "error", lastError: { wasOpen: false } })).toContain(
+      "Can't reach the relay at the gateway.",
+    );
   });
 });

--- a/extensions/browser/chrome-extension/modules/tab-groups.js
+++ b/extensions/browser/chrome-extension/modules/tab-groups.js
@@ -1,0 +1,71 @@
+// The OpenClaw tab group is the user-visible consent boundary: only tabs in that
+// group are reported to (and driven by) OpenClaw. These helpers own membership in
+// the group; leaving the group revokes agent access.
+
+import { getConfig } from "./config.js";
+import { OPENCLAW_TAB_GROUP_TITLE } from "./relay-core.js";
+
+export async function findOpenClawGroups() {
+  try {
+    return await chrome.tabGroups.query({ title: OPENCLAW_TAB_GROUP_TITLE });
+  } catch {
+    return [];
+  }
+}
+
+export async function listSharedTabs() {
+  const groups = await findOpenClawGroups();
+  const tabs = [];
+  for (const group of groups) {
+    const groupTabs = await chrome.tabs.query({ groupId: group.id });
+    tabs.push(...groupTabs);
+  }
+  return tabs.filter((tab) => typeof tab.id === "number");
+}
+
+export async function addTabToOpenClawGroup(tabId) {
+  const tab = await chrome.tabs.get(tabId);
+  const groups = await findOpenClawGroups();
+  const sameWindowGroup = groups.find((group) => group.windowId === tab.windowId);
+  if (sameWindowGroup) {
+    await chrome.tabs.group({ tabIds: [tabId], groupId: sameWindowGroup.id });
+    return;
+  }
+  const { groupColor } = await getConfig();
+  const groupId = await chrome.tabs.group({ tabIds: [tabId] });
+  await chrome.tabGroups.update(groupId, {
+    title: OPENCLAW_TAB_GROUP_TITLE,
+    color: groupColor,
+  });
+}
+
+export async function focusWindowForTab(tab) {
+  if (typeof tab.windowId === "number") {
+    await chrome.windows.update(tab.windowId, { focused: true });
+  }
+}
+
+export async function removeTabFromOpenClawGroup(tabId) {
+  try {
+    await chrome.tabs.ungroup([tabId]);
+  } catch {
+    // tab may already be gone
+  }
+}
+
+export async function isTabShared(tabId) {
+  const shared = await listSharedTabs();
+  return shared.some((tab) => tab.id === tabId);
+}
+
+export async function isOpenClawGroupId(groupId) {
+  if (!Number.isInteger(groupId) || groupId < 0) {
+    return false;
+  }
+  try {
+    const group = await chrome.tabGroups.get(groupId);
+    return group.title === OPENCLAW_TAB_GROUP_TITLE;
+  } catch {
+    return false;
+  }
+}

--- a/extensions/browser/chrome-extension/popup.js
+++ b/extensions/browser/chrome-extension/popup.js
@@ -1,4 +1,5 @@
 // Popup: pairing, connection status, and per-tab share toggle.
+import { relayStatusLabel } from "./modules/relay-core.js";
 
 const statusDot = document.getElementById("statusDot");
 const pairSection = document.getElementById("pairSection");
@@ -15,13 +16,6 @@ const sendPageButton = document.getElementById("sendPageButton");
 const pageShareStatus = document.getElementById("pageShareStatus");
 let sendingPage = false;
 
-const STATE_LABEL = {
-  on: "Connected to OpenClaw",
-  connecting: "Connecting…",
-  error: "Relay unreachable — is the OpenClaw gateway running?",
-  off: "Not connected",
-};
-
 async function activeTab() {
   const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   return tab ?? null;
@@ -35,7 +29,7 @@ async function refresh() {
   if (!status.paired) {
     return;
   }
-  const label = STATE_LABEL[status.state] ?? STATE_LABEL.off;
+  const label = relayStatusLabel(status);
   statusLine.textContent = `${label} · ${status.sharedTabCount} tab${status.sharedTabCount === 1 ? "" : "s"} shared`;
   const tab = await activeTab();
   if (tab?.id === undefined) {


### PR DESCRIPTION
Related: #113029
Depends on #113030 — stacked on the background.js refactor; until that merges this PR's diff also includes the refactor commit.

## What Problem This Solves

The extension popup showed the same line — `Relay unreachable — is the OpenClaw gateway running?` — for every relay error state (wrong/stale token, `browser.enabled:false`, gateway down, or a mid-session drop), asserting a false cause when the gateway was healthy and sending users to debug the wrong thing.

## Why This Change Was Made

The background now captures the relay WebSocket close `{code, reason, wasOpen}` into `lastRelayError`, exposes it via `getStatus` alongside `relayHost`, and the popup composes an honest line: a never-opened handshake failure names the host and the real causes (incl. browser control); an opened-then-`1008`/auth rejection says to unpair/re-pair; a mid-session drop shows "reconnecting".

## User Impact

The popup status line tells the truth about a relay failure instead of always blaming the gateway, so users stop chasing a healthy gateway.

## Evidence

Rig (isolated latest-`main` test gateway, Playwright/xvfb) — before, all cases showed the gateway-down catch-all; after:
- bad token, gateway healthy → `Can't reach the relay at <host>. Check the gateway is up with browser control enabled, or re-pair.`
- relay down → names the dead host
- mid-session drop (close 1001) → `Relay dropped by <host> — relay stopped (1001). Reconnecting…`
- recovery → `Connected to OpenClaw`

Also verified in the built `dist/` bundle. `oxfmt`/`oxlint` clean, 47 extension tests pass, autoreview `nothing_found`.
