### PR TITLE
fix(browser-extension): answer popup/side-panel messages even when the handler throws

### DIFF
--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -1,3 +1,4 @@
+import { getConfig, getCopilotConfig } from "./modules/config.js";
 import { createCopilotController } from "./modules/copilot-background.js";
 import {
   buildPageSharePayload,
@@ -19,6 +20,14 @@ import {
   reconnectDelayMs,
   toRelayTabInfo,
 } from "./modules/relay-core.js";
+import {
+  addTabToOpenClawGroup,
+  focusWindowForTab,
+  isOpenClawGroupId,
+  isTabShared,
+  listSharedTabs,
+  removeTabFromOpenClawGroup,
+} from "./modules/tab-groups.js";
 
 const BADGE = {
   off: { text: "", color: "#000000" },
@@ -84,93 +93,6 @@ function flashPageShareBadge(ok) {
     },
     ok ? 2_000 : 3_000,
   );
-}
-
-async function getConfig() {
-  const stored = await chrome.storage.local.get(["relayUrl", "token", "groupColor"]);
-  return {
-    relayUrl: typeof stored.relayUrl === "string" ? stored.relayUrl : "",
-    token: typeof stored.token === "string" ? stored.token : "",
-    groupColor: typeof stored.groupColor === "string" ? stored.groupColor : "orange",
-  };
-}
-
-async function getCopilotConfig() {
-  const config = await getConfig();
-  const stored = await chrome.storage.local.get(["gatewayUrl"]);
-  return {
-    ...config,
-    gatewayUrl: typeof stored.gatewayUrl === "string" ? stored.gatewayUrl : "",
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Tab group management (the consent boundary)
-// ---------------------------------------------------------------------------
-
-async function findOpenClawGroups() {
-  try {
-    return await chrome.tabGroups.query({ title: OPENCLAW_TAB_GROUP_TITLE });
-  } catch {
-    return [];
-  }
-}
-
-async function listSharedTabs() {
-  const groups = await findOpenClawGroups();
-  const tabs = [];
-  for (const group of groups) {
-    const groupTabs = await chrome.tabs.query({ groupId: group.id });
-    tabs.push(...groupTabs);
-  }
-  return tabs.filter((tab) => typeof tab.id === "number");
-}
-
-async function addTabToOpenClawGroup(tabId) {
-  const tab = await chrome.tabs.get(tabId);
-  const groups = await findOpenClawGroups();
-  const sameWindowGroup = groups.find((group) => group.windowId === tab.windowId);
-  if (sameWindowGroup) {
-    await chrome.tabs.group({ tabIds: [tabId], groupId: sameWindowGroup.id });
-    return;
-  }
-  const { groupColor } = await getConfig();
-  const groupId = await chrome.tabs.group({ tabIds: [tabId] });
-  await chrome.tabGroups.update(groupId, {
-    title: OPENCLAW_TAB_GROUP_TITLE,
-    color: groupColor,
-  });
-}
-
-async function focusWindowForTab(tab) {
-  if (typeof tab.windowId === "number") {
-    await chrome.windows.update(tab.windowId, { focused: true });
-  }
-}
-
-async function removeTabFromOpenClawGroup(tabId) {
-  try {
-    await chrome.tabs.ungroup([tabId]);
-  } catch {
-    // tab may already be gone
-  }
-}
-
-async function isTabShared(tabId) {
-  const shared = await listSharedTabs();
-  return shared.some((tab) => tab.id === tabId);
-}
-
-async function isOpenClawGroupId(groupId) {
-  if (!Number.isInteger(groupId) || groupId < 0) {
-    return false;
-  }
-  try {
-    const group = await chrome.tabGroups.get(groupId);
-    return group.title === OPENCLAW_TAB_GROUP_TITLE;
-  } catch {
-    return false;
-  }
 }
 
 function scheduleTabsSync() {

--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -553,94 +553,100 @@ function scheduleReconnect() {
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   void (async () => {
-    switch (msg?.type) {
-      case "getStatus": {
-        const { relayUrl } = await getConfig();
-        const shared = await listSharedTabs();
-        sendResponse({
-          paired: Boolean(relayUrl),
-          state: relayState,
-          sharedTabCount: shared.length,
-        });
-        return;
-      }
-      case "pair": {
-        const parsed = parsePairingString(msg.pairingString);
-        if (!parsed) {
-          sendResponse({ ok: false, error: "Invalid pairing string." });
-          return;
-        }
-        await chrome.storage.local.set({
-          relayUrl: parsed.relayUrl,
-          token: parsed.token,
-          groupColor: nearestGroupColor(msg.groupColor),
-        });
-        reconnectAttempt = 0;
-        clearRelayOpeningDeadline();
-        relayWs?.close();
-        relayWs = null;
-        await chrome.storage.local.set({ gatewayUrl: parsed.gatewayUrl ?? "" });
-        await connectRelay();
-        await copilot.refreshConfig();
-        sendResponse({ ok: true });
-        return;
-      }
-      case "unpair": {
-        await chrome.storage.local.remove(["relayUrl", "gatewayUrl", "token"]);
-        clearRelayOpeningDeadline();
-        relayWs?.close();
-        relayWs = null;
-        setBadge("off");
-        await copilot.refreshConfig();
-        sendResponse({ ok: true });
-        return;
-      }
-      case "toggleShareTab": {
-        const tabId = msg.tabId;
-        if (typeof tabId !== "number") {
-          sendResponse({ ok: false, error: "No tab." });
-          return;
-        }
-        if (await isTabShared(tabId)) {
-          await detachDebugger(tabId);
-          await removeTabFromOpenClawGroup(tabId);
-          scheduleTabsSync();
-          sendResponse({ ok: true, shared: false });
-        } else {
-          await addTabToOpenClawGroup(tabId);
-          scheduleTabsSync();
-          sendResponse({ ok: true, shared: true });
-        }
-        await copilot.onConsentChanged();
-        return;
-      }
-      case "isTabShared": {
-        sendResponse({ shared: await isTabShared(msg.tabId) });
-        return;
-      }
-      case "sendPageToOpenClaw": {
-        if (typeof msg.tabId !== "number") {
-          sendResponse({ ok: false, error: "No tab." });
-          return;
-        }
-        try {
-          await sendPageToOpenClaw(msg.tabId, msg.note);
-          sendResponse({ ok: true });
-        } catch (error) {
+    try {
+      switch (msg?.type) {
+        case "getStatus": {
+          const { relayUrl } = await getConfig();
+          const shared = await listSharedTabs();
           sendResponse({
-            ok: false,
-            error: error instanceof Error ? error.message : String(error),
+            paired: Boolean(relayUrl),
+            state: relayState,
+            sharedTabCount: shared.length,
           });
+          return;
         }
-        return;
+        case "pair": {
+          const parsed = parsePairingString(msg.pairingString);
+          if (!parsed) {
+            sendResponse({ ok: false, error: "Invalid pairing string." });
+            return;
+          }
+          await chrome.storage.local.set({
+            relayUrl: parsed.relayUrl,
+            token: parsed.token,
+            groupColor: nearestGroupColor(msg.groupColor),
+          });
+          reconnectAttempt = 0;
+          clearRelayOpeningDeadline();
+          relayWs?.close();
+          relayWs = null;
+          await chrome.storage.local.set({ gatewayUrl: parsed.gatewayUrl ?? "" });
+          await connectRelay();
+          await copilot.refreshConfig();
+          sendResponse({ ok: true });
+          return;
+        }
+        case "unpair": {
+          await chrome.storage.local.remove(["relayUrl", "gatewayUrl", "token"]);
+          clearRelayOpeningDeadline();
+          relayWs?.close();
+          relayWs = null;
+          setBadge("off");
+          await copilot.refreshConfig();
+          sendResponse({ ok: true });
+          return;
+        }
+        case "toggleShareTab": {
+          const tabId = msg.tabId;
+          if (typeof tabId !== "number") {
+            sendResponse({ ok: false, error: "No tab." });
+            return;
+          }
+          if (await isTabShared(tabId)) {
+            await detachDebugger(tabId);
+            await removeTabFromOpenClawGroup(tabId);
+            scheduleTabsSync();
+            sendResponse({ ok: true, shared: false });
+          } else {
+            await addTabToOpenClawGroup(tabId);
+            scheduleTabsSync();
+            sendResponse({ ok: true, shared: true });
+          }
+          await copilot.onConsentChanged();
+          return;
+        }
+        case "isTabShared": {
+          sendResponse({ shared: await isTabShared(msg.tabId) });
+          return;
+        }
+        case "sendPageToOpenClaw": {
+          if (typeof msg.tabId !== "number") {
+            sendResponse({ ok: false, error: "No tab." });
+            return;
+          }
+          try {
+            await sendPageToOpenClaw(msg.tabId, msg.note);
+            sendResponse({ ok: true });
+          } catch (error) {
+            sendResponse({
+              ok: false,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+          return;
+        }
+        case "prepareCopilotPanel": {
+          const options = await copilot.preparePanel(msg.tabId);
+          sendResponse({ ok: true, ...options });
+          return;
+        }
+        default:
+          sendResponse({ ok: false, error: "unknown message" });
       }
-      case "prepareCopilotPanel": {
-        const options = await copilot.preparePanel(msg.tabId);
-        sendResponse({ ok: true, ...options });
-        return;
-      }
-      default:
-        sendResponse({ ok: false, error: "unknown message" });
+    } catch (error) {
+      // Any throw in the async handler must still answer the caller; without this the
+      // popup/side-panel awaits a response that never arrives and its UI freezes.
+      sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) });
     }
   })();
   return true; // keep sendResponse alive for the async path

--- a/extensions/browser/chrome-extension/modules/config.js
+++ b/extensions/browser/chrome-extension/modules/config.js
@@ -1,0 +1,21 @@
+// Extension configuration read from chrome.storage: the relay pairing (url/token,
+// tab-group color) and the copilot gateway url. Kept in one place so the service
+// worker and the tab-group helpers share a single source of truth.
+
+export async function getConfig() {
+  const stored = await chrome.storage.local.get(["relayUrl", "token", "groupColor"]);
+  return {
+    relayUrl: typeof stored.relayUrl === "string" ? stored.relayUrl : "",
+    token: typeof stored.token === "string" ? stored.token : "",
+    groupColor: typeof stored.groupColor === "string" ? stored.groupColor : "orange",
+  };
+}
+
+export async function getCopilotConfig() {
+  const config = await getConfig();
+  const stored = await chrome.storage.local.get(["gatewayUrl"]);
+  return {
+    ...config,
+    gatewayUrl: typeof stored.gatewayUrl === "string" ? stored.gatewayUrl : "",
+  };
+}

--- a/extensions/browser/chrome-extension/modules/tab-groups.js
+++ b/extensions/browser/chrome-extension/modules/tab-groups.js
@@ -1,0 +1,71 @@
+// The OpenClaw tab group is the user-visible consent boundary: only tabs in that
+// group are reported to (and driven by) OpenClaw. These helpers own membership in
+// the group; leaving the group revokes agent access.
+
+import { getConfig } from "./config.js";
+import { OPENCLAW_TAB_GROUP_TITLE } from "./relay-core.js";
+
+export async function findOpenClawGroups() {
+  try {
+    return await chrome.tabGroups.query({ title: OPENCLAW_TAB_GROUP_TITLE });
+  } catch {
+    return [];
+  }
+}
+
+export async function listSharedTabs() {
+  const groups = await findOpenClawGroups();
+  const tabs = [];
+  for (const group of groups) {
+    const groupTabs = await chrome.tabs.query({ groupId: group.id });
+    tabs.push(...groupTabs);
+  }
+  return tabs.filter((tab) => typeof tab.id === "number");
+}
+
+export async function addTabToOpenClawGroup(tabId) {
+  const tab = await chrome.tabs.get(tabId);
+  const groups = await findOpenClawGroups();
+  const sameWindowGroup = groups.find((group) => group.windowId === tab.windowId);
+  if (sameWindowGroup) {
+    await chrome.tabs.group({ tabIds: [tabId], groupId: sameWindowGroup.id });
+    return;
+  }
+  const { groupColor } = await getConfig();
+  const groupId = await chrome.tabs.group({ tabIds: [tabId] });
+  await chrome.tabGroups.update(groupId, {
+    title: OPENCLAW_TAB_GROUP_TITLE,
+    color: groupColor,
+  });
+}
+
+export async function focusWindowForTab(tab) {
+  if (typeof tab.windowId === "number") {
+    await chrome.windows.update(tab.windowId, { focused: true });
+  }
+}
+
+export async function removeTabFromOpenClawGroup(tabId) {
+  try {
+    await chrome.tabs.ungroup([tabId]);
+  } catch {
+    // tab may already be gone
+  }
+}
+
+export async function isTabShared(tabId) {
+  const shared = await listSharedTabs();
+  return shared.some((tab) => tab.id === tabId);
+}
+
+export async function isOpenClawGroupId(groupId) {
+  if (!Number.isInteger(groupId) || groupId < 0) {
+    return false;
+  }
+  try {
+    const group = await chrome.tabGroups.get(groupId);
+    return group.title === OPENCLAW_TAB_GROUP_TITLE;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Related: #113029
Depends on #113030 — stacked on the background.js refactor.

## What Problem This Solves

Fixes an issue where the extension popup or side panel could freeze: the background `onMessage` handler ran its whole async body as a fire-and-forget IIFE with no rejection handler, then returned `true` to hold the response channel open. Any thrown error (storage, tab, debugger, or gateway call) left `sendResponse` uncalled, so the popup's awaited `sendMessage` never resolved.

## Why This Change Was Made

Wrap the handler body in a `try/catch` (the codebase idiom, and it satisfies oxlint's catch-variable rule) that always returns `{ ok: false, error }`, so a failed action surfaces instead of hanging.

## User Impact

A transient background error now shows up as an error in the popup/side panel instead of freezing it with stale controls.

## Evidence

Combined-build rig load confirms the extension initializes and serves normally with the change. `oxfmt`/`oxlint` clean, 47 extension tests pass, autoreview `nothing_found`.
