### PR TITLE
fix(browser-extension): recover the copilot composer instead of locking it on a failed or stalled send

### DIFF
--- a/extensions/browser/chrome-extension/sidepanel.js
+++ b/extensions/browser/chrome-extension/sidepanel.js
@@ -27,6 +27,24 @@ let panelState = "connecting";
 let port = null;
 let reconnectTimer = null;
 let reconnectDelayMs = 250;
+// Recover the composer if a send never gets a terminal event (gateway hang or a
+// silent drop). Idle watchdog: reset on every gateway message so long streams do
+// not trip it, but genuine silence while a send is in flight does.
+let sendIdleTimer = null;
+const SEND_IDLE_TIMEOUT_MS = 45_000;
+
+function armSendWatchdog() {
+  clearTimeout(sendIdleTimer);
+  sendIdleTimer = sending
+    ? setTimeout(() => {
+        if (!sending) {
+          return;
+        }
+        addBubble("system", "No response from the gateway — the run may have stalled.");
+        finalizeStream();
+      }, SEND_IDLE_TIMEOUT_MS)
+    : null;
+}
 
 function setComposerEnabled(enabled) {
   panelReady = enabled;
@@ -73,6 +91,8 @@ function renderHistory(history) {
 }
 
 function finalizeStream() {
+  clearTimeout(sendIdleTimer);
+  sendIdleTimer = null;
   streamingBubble?.classList.remove("streaming");
   streamingBubble = null;
   resetChatStream(stream);
@@ -161,6 +181,8 @@ function updateState(state) {
 
 function handlePortMessage(message) {
   reconnectDelayMs = 250;
+  // Any gateway message means the run is still alive; reset the send idle watchdog.
+  armSendWatchdog();
   if (message?.type === "panel.state") {
     updateState(message);
   } else if (message?.type === "panel.history") {
@@ -230,12 +252,24 @@ async function send() {
   if (!message || !panelReady || sending) {
     return;
   }
+  if (!port) {
+    addBubble("system", "Not connected to the extension background — reopen the panel.");
+    return;
+  }
   addBubble("user", message);
   input.value = "";
   input.style.height = "auto";
   sending = true;
   setComposerEnabled(true);
-  port?.postMessage({ type: "panel.send", message });
+  try {
+    port.postMessage({ type: "panel.send", message });
+  } catch {
+    // A disconnected port throws here; recover the composer instead of locking it.
+    addBubble("system", "Couldn't send — the connection dropped. Try again.");
+    finalizeStream();
+    return;
+  }
+  armSendWatchdog();
 }
 
 input.addEventListener("input", () => {


### PR DESCRIPTION
Related: #113029

## What Problem This Solves

Fixes an issue where the copilot side-panel composer could lock permanently: `send()` set `sending = true`, then called `port.postMessage` with no guard. A disconnected background port (throws or silent no-op) or a run that never emitted a terminal event left `sending` stuck true, so the input stayed disabled with no error and the panel looked dead.

## Why This Change Was Made

Reject the send with a clear message when the background port is gone, catch a `postMessage` failure and re-enable the composer, and add an idle watchdog that resets on every gateway message (so long streams don't trip it) and recovers the composer after genuine silence.

## User Impact

The copilot composer stays usable: a dropped connection or a stalled run now surfaces a message and re-enables input instead of locking it.

## Evidence

Combined-build rig load confirms no regression. `oxfmt`/`oxlint` clean, 47 extension tests pass, autoreview `nothing_found`.
