### PR TITLE
fix(browser-extension): back off copilot reconnect while waiting for device approval

### DIFF
--- a/extensions/browser/chrome-extension/modules/copilot-gateway.js
+++ b/extensions/browser/chrome-extension/modules/copilot-gateway.js
@@ -14,6 +14,7 @@ import {
   PROTOCOL_VERSION,
 } from "./copilot-runtime.js";
 import { normalizeGatewayUrl } from "./panel-core.js";
+import { reconnectDelayMs } from "./relay-core.js";
 
 const CLIENT_ID = GATEWAY_CLIENT_IDS.BROWSER_COPILOT;
 const CLIENT_MODE = GATEWAY_CLIENT_MODES.UI;
@@ -214,6 +215,11 @@ export class CopilotGatewayClient {
         if (!pairingRequired) {
           this.pairingRetries = 0;
         }
+        // Status listeners may switch Gateways immediately; reserve this scope's
+        // retry before notifying them so its count cannot leak into the next one.
+        const pairingReconnectDelayMs = pairingRequired
+          ? reconnectDelayMs(++this.pairingRetries)
+          : undefined;
         this.#emitStatus({
           state: pairingRequired ? "approval" : "error",
           label: error.message,
@@ -222,11 +228,7 @@ export class CopilotGatewayClient {
         return {
           closeCode: 4008,
           closeReason: "connect failed",
-          // Approval is a human step; back off 2s→30s while waiting instead of hammering
-          // the gateway every 2s. A successful connect (onHello) resets the delay.
-          reconnectDelayMs: pairingRequired
-            ? Math.min(2_000 * 2 ** this.pairingRetries++, 30_000)
-            : undefined,
+          reconnectDelayMs: pairingReconnectDelayMs,
           stop:
             details.code === "AUTH_DEVICE_TOKEN_MISMATCH" ||
             (details.pauseReconnect === true && !pairingRequired),

--- a/extensions/browser/chrome-extension/modules/copilot-gateway.js
+++ b/extensions/browser/chrome-extension/modules/copilot-gateway.js
@@ -125,6 +125,9 @@ export class CopilotGatewayClient {
     this.statusListeners = new Set();
     this.lifecycle = null;
     this.tokenRecovery = null;
+    // Consecutive "pairing required" failures, so we back off the reconnect while
+    // waiting for the operator to approve this device instead of retrying every 2s.
+    this.pairingRetries = 0;
   }
 
   onEvent(listener) {
@@ -149,6 +152,7 @@ export class CopilotGatewayClient {
     }
     this.stop();
     this.url = gatewayScope;
+    this.pairingRetries = 0;
     const lifecycle = new GatewayBrowserDeviceAuthLifecycle({
       loadIdentity: () => loadOrCreateCopilotIdentity(this.storage, gatewayScope),
       tokenStore: createCopilotTokenStore(this.storage, gatewayScope),
@@ -196,6 +200,7 @@ export class CopilotGatewayClient {
       onHello: (hello) => {
         this.ready = true;
         this.hello = hello;
+        this.pairingRetries = 0;
         this.#emitStatus({ state: "ready", label: "Gateway connected", hello });
       },
       onConnectFailure: (error, { plan }) => {
@@ -205,18 +210,26 @@ export class CopilotGatewayClient {
           void cleared.catch(() => undefined);
           this.tokenRecovery = { gatewayScope, protocol, cleared };
         }
+        const pairingRequired = details.code === "PAIRING_REQUIRED";
+        if (!pairingRequired) {
+          this.pairingRetries = 0;
+        }
         this.#emitStatus({
-          state: details.code === "PAIRING_REQUIRED" ? "approval" : "error",
+          state: pairingRequired ? "approval" : "error",
           label: error.message,
           requestId: typeof details.requestId === "string" ? details.requestId : undefined,
         });
         return {
           closeCode: 4008,
           closeReason: "connect failed",
-          reconnectDelayMs: details.code === "PAIRING_REQUIRED" ? 2_000 : undefined,
+          // Approval is a human step; back off 2s→30s while waiting instead of hammering
+          // the gateway every 2s. A successful connect (onHello) resets the delay.
+          reconnectDelayMs: pairingRequired
+            ? Math.min(2_000 * 2 ** this.pairingRetries++, 30_000)
+            : undefined,
           stop:
             details.code === "AUTH_DEVICE_TOKEN_MISMATCH" ||
-            (details.pauseReconnect === true && details.code !== "PAIRING_REQUIRED"),
+            (details.pauseReconnect === true && !pairingRequired),
         };
       },
       resolveClose: resolveCopilotClose,

--- a/extensions/browser/chrome-extension/modules/copilot-gateway.test.ts
+++ b/extensions/browser/chrome-extension/modules/copilot-gateway.test.ts
@@ -105,6 +105,43 @@ class FakeWebSocket {
   }
 }
 
+async function receiveGatewayConnect(index: number) {
+  const socket = FakeWebSocket.instances[index];
+  if (!socket) {
+    throw new Error(`expected Gateway socket ${index}`);
+  }
+  await vi.advanceTimersByTimeAsync(0);
+  socket.message({
+    type: "event",
+    event: "connect.challenge",
+    payload: { nonce: `pairing-nonce-${index}` },
+  });
+  await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+  const requestId = socket.sent[0]?.id;
+  if (typeof requestId !== "string") {
+    throw new Error(`expected Gateway connect request ${index}`);
+  }
+  return { socket, requestId };
+}
+
+async function rejectGatewayPairing(socket: FakeWebSocket, requestId: string) {
+  socket.message({
+    type: "res",
+    id: requestId,
+    ok: false,
+    error: {
+      code: "UNAVAILABLE",
+      message: "device approval required",
+      details: {
+        code: "PAIRING_REQUIRED",
+        requestId: `approval-${requestId}`,
+        pauseReconnect: true,
+      },
+    },
+  });
+  await vi.advanceTimersByTimeAsync(0);
+}
+
 describe("browser copilot Gateway custody", () => {
   it("scopes device identities and issued tokens to one Gateway", async () => {
     const storage = storageArea();
@@ -219,6 +256,91 @@ describe("browser copilot Gateway custody", () => {
       notify: true,
       pendingError: undefined,
     });
+  });
+
+  it("backs off pending device approvals and resets after a successful connection", async () => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("chrome", { runtime: { getManifest: () => ({ version: "test" }) } });
+    vi.stubGlobal("navigator", { language: "en", userAgent: "copilot-test" });
+    const client = new CopilotGatewayClient({
+      storage: storageArea(),
+      WebSocketImpl: FakeWebSocket as never,
+    });
+    const statuses: Array<Record<string, unknown>> = [];
+    client.onStatus((status) => statuses.push(status));
+
+    try {
+      client.start("ws://127.0.0.1:28789/");
+      const expectedDelays = [2_000, 4_000, 8_000, 16_000, 30_000, 30_000];
+      for (const [index, delay] of expectedDelays.entries()) {
+        const { socket, requestId } = await receiveGatewayConnect(index);
+        await rejectGatewayPairing(socket, requestId);
+        expect(statuses.at(-1)).toMatchObject({
+          state: "approval",
+          requestId: `approval-${requestId}`,
+        });
+        await vi.advanceTimersByTimeAsync(delay - 1);
+        expect(FakeWebSocket.instances).toHaveLength(index + 1);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(FakeWebSocket.instances).toHaveLength(index + 2);
+      }
+
+      const approved = await receiveGatewayConnect(expectedDelays.length);
+      approved.socket.message({ type: "res", id: approved.requestId, ok: true, payload: {} });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(client.ready).toBe(true);
+
+      approved.socket.close();
+      await vi.advanceTimersByTimeAsync(1_000);
+      const next = await receiveGatewayConnect(expectedDelays.length + 1);
+      await rejectGatewayPairing(next.socket, next.requestId);
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(FakeWebSocket.instances).toHaveLength(expectedDelays.length + 2);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(FakeWebSocket.instances).toHaveLength(expectedDelays.length + 3);
+    } finally {
+      client.stop();
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not leak approval retries when a status listener switches Gateways", async () => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("chrome", { runtime: { getManifest: () => ({ version: "test" }) } });
+    vi.stubGlobal("navigator", { language: "en", userAgent: "copilot-test" });
+    const client = new CopilotGatewayClient({
+      storage: storageArea(),
+      WebSocketImpl: FakeWebSocket as never,
+    });
+    let switchedGateway = false;
+    client.onStatus((status) => {
+      if (status.state === "approval" && !switchedGateway) {
+        switchedGateway = true;
+        client.start("ws://127.0.0.1:38789/");
+      }
+    });
+
+    try {
+      client.start("ws://127.0.0.1:28789/");
+      const original = await receiveGatewayConnect(0);
+      await rejectGatewayPairing(original.socket, original.requestId);
+      expect(switchedGateway).toBe(true);
+      expect(FakeWebSocket.instances).toHaveLength(2);
+
+      const replacement = await receiveGatewayConnect(1);
+      await rejectGatewayPairing(replacement.socket, replacement.requestId);
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(FakeWebSocket.instances).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(FakeWebSocket.instances).toHaveLength(3);
+    } finally {
+      client.stop();
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
   });
 
   it("clears a rejected device token before starting a fresh connection", async () => {

--- a/extensions/browser/chrome-extension/modules/copilot-gateway.test.ts
+++ b/extensions/browser/chrome-extension/modules/copilot-gateway.test.ts
@@ -114,7 +114,7 @@ async function receiveGatewayConnect(index: number) {
   socket.message({
     type: "event",
     event: "connect.challenge",
-    payload: { nonce: `pairing-nonce-${index}` },
+    payload: { nonce: `pairing-nonce-${index}`, ts: Date.now() },
   });
   await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
   const requestId = socket.sent[0]?.id;

--- a/extensions/browser/chrome-extension/sidepanel.js
+++ b/extensions/browser/chrome-extension/sidepanel.js
@@ -143,9 +143,9 @@ function updateState(state) {
       break;
     case "approval":
       setGate({
-        title: "Approve this copilot device",
+        title: "Waiting for device approval",
         detail:
-          "On the Gateway, run openclaw devices list, inspect this dedicated browser identity, then approve its current request.",
+          "This browser needs a one-time approval on the OpenClaw gateway — approve it there (openclaw devices approve, or the gateway's Devices settings). The panel connects automatically once approved.",
       });
       break;
     case "denied":

--- a/extensions/browser/chrome-extension/sidepanel.js
+++ b/extensions/browser/chrome-extension/sidepanel.js
@@ -143,9 +143,9 @@ function updateState(state) {
       break;
     case "approval":
       setGate({
-        title: "Waiting for device approval",
+        title: "Approve this copilot device",
         detail:
-          "This browser needs a one-time approval on the OpenClaw gateway — approve it there (openclaw devices approve, or the gateway's Devices settings). The panel connects automatically once approved.",
+          "On the Gateway, run openclaw devices list, inspect this dedicated browser identity, then approve its current request.",
       });
       break;
     case "denied":

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -56,6 +56,8 @@ const runRestartScript = vi.fn();
 const mockedRunDaemonInstall = vi.fn();
 const serviceReadCommand = vi.fn();
 const serviceReadRuntime = vi.fn();
+// A real worker can have the fixture PID; keep the managed gateway outside its ancestry.
+const managedGatewayPid = process.pid === 4242 ? 4243 : 4242;
 const mockGetSelfAndAncestorPidsSync = vi.fn(() => new Set<number>([process.pid]));
 const inspectPortUsage = vi.fn();
 const classifyPortListener = vi.fn();
@@ -1153,7 +1155,11 @@ describe("update-cli", () => {
       },
     });
     serviceLoaded.mockResolvedValue(true);
-    serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: managedGatewayPid,
+      state: "running",
+    });
   };
 
   const mockStoppedManagedGitGateway = () => {
@@ -1166,7 +1172,11 @@ describe("update-cli", () => {
     serviceLoaded.mockResolvedValue(false);
     serviceLoaded.mockResolvedValueOnce(true);
     serviceReadRuntime.mockResolvedValue({ status: "stopped", pid: null, state: "stopped" });
-    serviceReadRuntime.mockResolvedValueOnce({ status: "running", pid: 4242, state: "running" });
+    serviceReadRuntime.mockResolvedValueOnce({
+      status: "running",
+      pid: managedGatewayPid,
+      state: "running",
+    });
   };
 
   const expectFailedManagedGitRestart = (message: string) => {
@@ -1398,7 +1408,7 @@ describe("update-cli", () => {
     );
     serviceReadRuntime.mockResolvedValue({
       status: "running",
-      pid: 4242,
+      pid: managedGatewayPid,
       state: "running",
     });
     mockGetSelfAndAncestorPidsSync.mockReturnValue(new Set<number>([process.pid]));
@@ -1407,7 +1417,7 @@ describe("update-cli", () => {
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
-      listeners: [{ pid: 4242, command: "openclaw-gateway" }],
+      listeners: [{ pid: managedGatewayPid, command: "openclaw-gateway" }],
       hints: [],
     });
     classifyPortListener.mockReturnValue("gateway");
@@ -3684,7 +3694,7 @@ describe("update-cli", () => {
     serviceReadCommand.mockResolvedValue(null);
     serviceReadRuntime.mockResolvedValueOnce({
       status: "running",
-      pid: 4242,
+      pid: managedGatewayPid,
       state: "running",
     });
 
@@ -3705,7 +3715,9 @@ describe("update-cli", () => {
   it("refuses package updates from inside the active gateway process tree", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-update"));
     serviceLoaded.mockResolvedValue(true);
-    mockGetSelfAndAncestorPidsSync.mockReturnValue(new Set<number>([process.pid, 4242]));
+    mockGetSelfAndAncestorPidsSync.mockReturnValue(
+      new Set<number>([process.pid, managedGatewayPid]),
+    );
 
     await updateCommand({ yes: true });
 
@@ -3713,7 +3725,7 @@ describe("update-cli", () => {
     expect(errors).toContain(
       "openclaw update detected it is running inside the gateway process tree.",
     );
-    expect(errors).toContain("Gateway PID 4242 is an ancestor");
+    expect(errors).toContain(`Gateway PID ${managedGatewayPid} is an ancestor`);
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
     expect(serviceStop).not.toHaveBeenCalled();
     expect(packageInstallCommandCall()).toBeUndefined();
@@ -3724,18 +3736,21 @@ describe("update-cli", () => {
     serviceLoaded.mockResolvedValue(true);
     serviceReadRuntime.mockResolvedValue({
       status: "running",
-      pid: 4242,
+      pid: managedGatewayPid,
       state: "running",
     });
     mockGetSelfAndAncestorPidsSync.mockReturnValue(new Set<number>([process.pid]));
 
-    await runWithGatewayServiceEnv({ yes: true }, { [GATEWAY_SERVICE_RUNTIME_PID_ENV]: "4242" });
+    await runWithGatewayServiceEnv(
+      { yes: true },
+      { [GATEWAY_SERVICE_RUNTIME_PID_ENV]: String(managedGatewayPid) },
+    );
 
     const errors = getErrorOutput();
     expect(errors).toContain(
       "openclaw update detected it is running inside the gateway process tree.",
     );
-    expect(errors).toContain("Gateway PID 4242 is an ancestor");
+    expect(errors).toContain(`Gateway PID ${managedGatewayPid} is an ancestor`);
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
     expect(serviceStop).not.toHaveBeenCalled();
     expect(packageInstallCommandCall()).toBeUndefined();
@@ -4404,7 +4419,7 @@ describe("update-cli", () => {
       });
       serviceReadRuntime.mockResolvedValue(
         runtimeStatus === "running"
-          ? { status: "running", state: "running", pid: 4242 }
+          ? { status: "running", state: "running", pid: managedGatewayPid }
           : { status: "stopped", state: "stopped" },
       );
       suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
@@ -4491,7 +4506,7 @@ describe("update-cli", () => {
       portUsage: {
         port: 18789,
         status: "busy",
-        listeners: [{ pid: 4242, command: "openclaw-gateway" }],
+        listeners: [{ pid: managedGatewayPid, command: "openclaw-gateway" }],
         hints: [],
       },
       healthy: true,


### PR DESCRIPTION
Related: #113029

## What Problem This Solves

When the browser copilot gateway closes with `PAIRING_REQUIRED` (1008), the client currently reconnects every two seconds indefinitely while waiting for device approval. Synchronous approval-state listeners that switch gateways can also leak the old gateway's retry state into the new gateway, making its first approval retry wait four seconds instead of the intended two.

## Why This Change Was Made

Keep the repair in the gateway connection owner: exponentially back off pairing-required reconnects from 2 seconds up to 30 seconds, publish the retry delay before approval listeners run, and reset scoped retry state after a successful connection or gateway change. Ordinary non-pairing reconnect behavior remains unchanged.

This change does not modify the side panel, approval commands, or device-approval permissions. The original reconnect fix is by @anagnorisis2peripeteia; the maintainer follow-up removes the unrelated side-panel change and adds owner-level race coverage.

## User Impact

The browser stops hammering the gateway while approval is pending, reconnects automatically after approval, and avoids leaking an old gateway's retry state into a replacement gateway. Existing ordinary reconnect and approval-security behavior stays intact.

## Evidence

Focused owner and sibling regression suites:

```
node scripts/run-vitest.mjs extensions/browser/chrome-extension/modules/copilot-gateway.test.ts extensions/browser/chrome-extension/modules/relay-core.test.ts
```

Result: 17 tests passed across both files.

Real localhost WebSocket proof exercises 21 production client/server connections: exponential pairing delays of 2, 4, 8, 16, 30, and 30 seconds; unchanged ordinary reconnect delays; automatic post-approval connection; per-gateway retry reset; and a synchronous approval-listener gateway-switch race with a fresh two-second first retry. The branch is rebased on current `main`, preserving the current supported workflow-scanner version.

### Shared CI fixture repair included

The first hosted run also exposed an unrelated deterministic defect in the existing update CLI test fixture. The fixture hard-coded the managed gateway PID as `4242`; when a legitimate Vitest worker itself has PID `4242`, the production updater correctly recognizes the gateway as its own process and refuses to stop it. That collision produced 25 unrelated managed-service test failures in `checks-node-compact-small-6`.

The included repair changes **only** `src/cli/update-cli.test.ts`: choose a managed-gateway fixture PID distinct from the real worker PID and keep every coupled runtime, listener, ancestor, environment, and assertion value consistent. No CLI production behavior changes.

Trusted hosted Linux proof on the same immutable source and the same Blacksmith Testbox lease: [Testbox run 30745156359](https://github.com/openclaw/openclaw/actions/runs/30745156359).

- Existing fixture, ordinary worker PID: **213 update CLI tests passed**.
- Existing fixture, worker PID forced to `4242`: the original CI failure reproduced exactly — **25 failed, 188 passed**, including the same first managed-service failure.
- Repaired fixture, worker PID forced to `4242`: **213 update CLI tests passed**.
- Repaired fixture, ordinary worker PID: **213 update CLI tests passed**.
- Final browser gateway plus relay sibling suites: **17 tests passed**.

The browser pairing behavior remains the only production change; the additional file repairs the shared CI test-fixture owner rather than bypassing or weakening its real process-ancestry safety contract.