### PR TITLE
fix(webchat): strip media directives from streamed replies

### DIFF
--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -254,6 +254,41 @@ describe("createBlockReplyDeliveryHandler", () => {
     });
   });
 
+  it("strips media directives from block-streamed text while retaining structured media", async () => {
+    const enqueue = vi.fn();
+    const signalTextDelta = vi.fn(async () => {});
+    const blockReplyPipeline = {
+      enqueue,
+    } as unknown as BlockReplyPipelineLike;
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply: vi.fn(async () => {}),
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: { signalTextDelta } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline,
+      directlySentBlockKeys: new Set(),
+      directlySentBlockPayloads: [],
+    });
+
+    await handler({
+      text: "Rendered image\nMEDIA:/private/tmp/generated.png",
+      mediaUrls: ["/api/chat/media/outgoing/generated.png"],
+    });
+
+    expect(enqueue).toHaveBeenCalledWith({
+      text: "Rendered image",
+      mediaUrl: "/api/chat/media/outgoing/generated.png",
+      mediaUrls: ["/api/chat/media/outgoing/generated.png"],
+      replyToId: undefined,
+      replyToCurrent: undefined,
+      replyToTag: false,
+      audioAsVoice: false,
+    });
+    expect(signalTextDelta).toHaveBeenCalledWith("Rendered image");
+  });
+
   it("suppresses implicit current-message threading for block replies when reply threading denies it", async () => {
     const blockReplyPipeline = {
       enqueue: vi.fn(),

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -148,7 +148,6 @@ export function createBlockReplyDeliveryHandler(params: {
       silentToken: SILENT_REPLY_TOKEN,
       trimLeadingWhitespace: true,
       parseMode: "auto",
-      extractMediaDirectives: false,
     });
 
     const mediaNormalizedPayload = params.normalizeMediaPaths


### PR DESCRIPTION
Closes #113014

## What Problem This Solves

Block-streamed replies intentionally ran directive normalization with media extraction disabled. As a result, a complete `MEDIA:/absolute/path` line stayed in the text delivered to webchat even when the same payload already carried a valid structured outgoing-media URL. The UI then rendered the leaked filesystem path as an unavailable local attachment.

This change lets the existing reply-directive parser strip complete media directives before block delivery. Existing structured media remains authoritative, so the outgoing attachment is retained without exposing the source path in visible text.

## Evidence

Exact head: `2fc47d4c0d2c7362ec84a85533822e6166a84500`

Baseline proof with the same regression test on unmodified upstream code:

```text
Received text:
Rendered image
MEDIA:/private/tmp/generated.png

Test Files  1 failed (1)
Tests       1 failed | 19 skipped (20)
```

Patched exact-head proof:

```text
Test Files  1 passed (1)
Tests       20 passed (20)
```

The regression test verifies both observable outcomes:

- the block-streamed text and typing signal contain only `Rendered image`;
- the existing `/api/chat/media/outgoing/generated.png` structured attachment remains present.

Additional checks:

- `oxfmt --check` passed for both changed files.
- `oxlint` passed for both changed files.
- `git diff --check` passed.
