### PR TITLE
fix(claws): normalize cron defaults during removal

### DIFF
--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -187,7 +187,9 @@ openclaw claws add ./incident-triage.claw.json \
 `--yes` alone is insufficient. OpenClaw rebuilds the plan and rejects consent
 when the source, destination, or live configuration changed after preview. Use
 `--agent-id` or `--workspace` during both preview and apply when package
-defaults collide with local state.
+defaults collide with local state. For disposable profiles and parallel validation,
+pass an explicit `--workspace`; `OPENCLAW_STATE_DIR` relocates runtime state but
+does not change the default workspace location.
 
 Adding a Claw creates the new agent and workspace configuration, writes declared
 workspace files, installs or reuses declared skill and plugin artifacts, and

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -1,5 +1,6 @@
 import { resolveCronJobConfigRevision } from "../cron/config-revision.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
+import { applyDefaultCronToolsAllow } from "../cron/tools-allow.js";
 import type { CronJob } from "../cron/types.js";
 import {
   openOpenClawStateDatabase,
@@ -252,6 +253,9 @@ export function clawCronGatewayJobMatchesRef(
   ) {
     return false;
   }
+  const comparableLive = { ...live, payload: { ...live.payload } } as CronJob;
+  applyDefaultCronToolsAllow(expected);
+  applyDefaultCronToolsAllow(comparableLive);
   try {
     return (
       resolveCronJobConfigRevision({
@@ -260,7 +264,7 @@ export function clawCronGatewayJobMatchesRef(
         createdAtMs: live.createdAtMs,
         updatedAtMs: live.updatedAtMs,
         state: live.state,
-      }) === resolveCronJobConfigRevision(live as CronJob)
+      }) === resolveCronJobConfigRevision(comparableLive)
     );
   } catch {
     return false;

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -456,6 +456,38 @@ describe("Claw status and remove", () => {
     });
   });
 
+  it("accepts the scheduler's default tool cap when removing a Claw cron job", async () => {
+    const current = await addFixture({ withCron: true });
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    const ref = readClawCronRefs("worker", { env: current.env })[0]!;
+    const live = cronReadView("worker", ref);
+    const remove = vi.fn().mockResolvedValue({ ok: true });
+
+    const result = await applyClawRemovePlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: current.env,
+      config: current.getConfig(),
+      commitConfig: current.commitConfig,
+      cronGateway: {
+        get: async () => ({
+          ...live,
+          payload: { ...live.payload, toolsAllow: ["*"] },
+        }),
+        remove,
+      },
+    });
+
+    expect(remove).toHaveBeenCalledWith(ref.schedulerJobId);
+    expect(result).toMatchObject({
+      status: "complete",
+      agentRemoved: true,
+      cronJobs: [{ manifestId: "daily-report", action: "removed" }],
+    });
+  });
+
   it("fails removal planning when source MCP config cannot be read", async () => {
     const current = await addFixture({ withCron: true });
 


### PR DESCRIPTION
## Summary

- Treat the Gateway scheduler default `payload.toolsAllow: ["*"]` as equivalent to an omitted tool cap when comparing Claw-owned cron jobs during removal.
- Preserve compare-before-remove protection for explicit cron changes.
- Clarify explicit workspace selection for disposable Claw profiles.

## Validation

- `node scripts/run-vitest.mjs src/claws/lifecycle-state.test.ts src/claws/cron.test.ts` (32 passed)
- `pnpm exec oxfmt --check src/claws/cron.ts src/claws/lifecycle-state.test.ts docs/cli/claws.md`
- `pnpm exec oxlint --deny-warnings src/claws/cron.ts src/claws/lifecycle-state.test.ts`
- `git diff --check`
- `codex review --uncommitted` (clean; no accepted/actionable findings)

## Real behavior proof

Behavior or issue addressed:
An unchanged cron job installed by a Claw was retained during `claws remove` because the Gateway persisted its default `toolsAllow: ["*"]`, which the Claw manifest omitted.

Real environment tested:
Ubuntu 24.04 under WSL2, OpenClaw source checkout at upstream main `f3b4f9cfa208aff19dc98b8a2e8e8658195adf7d`, isolated state/config/workspace, and a real local Gateway scheduler on port 19321.

Exact steps or command run after this patch:

1. Applied a local CLAW.md package declaring one agent, one MCP server, and one isolated cron job.
2. Confirmed the Gateway persisted the cron payload with `toolsAllow: ["*"]`.
3. Previewed removal and applied it with the exact returned `planIntegrity` digest.
4. Queried cron inventory, Claw status, config, and workspace state.

Evidence after fix:
`claws remove` returned `status: "complete"`, `agentRemoved: true`, and `cronJobs: [{ manifestId: "validation-check", action: "removed" }]`. The follow-up cron query returned `[]`; Claw status reported `claws: 0`, `cronRefs: 0`, and `mcpServerRefs: 0`; the agent/MCP config entries and workspace were absent.

Observed result after fix:
The real Gateway-owned cron job was removed before agent cleanup, and retry from the prior truthful partial state converged to a complete removal.

What was not tested:
No skill or plugin package installation was included in this focused removal proof; those paths were outside this cron normalization change.