### PR TITLE
fix: webchat MEDIA leak and large-video aspect ratio

### DIFF
--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -323,7 +323,7 @@ describe("createBlockReplyDeliveryHandler", () => {
     expect(normalized.payload.mediaUrls).toEqual([]);
   });
 
-  it("leaves media-looking text alone when media directive parsing is disabled", () => {
+  it("strips MEDIA directives from visible text when attachment extraction is disabled", () => {
     const normalized = normalizeReplyPayloadDirectives({
       payload: { text: "Result\nMEDIA: ./image.png" },
       trimLeadingWhitespace: true,
@@ -331,7 +331,8 @@ describe("createBlockReplyDeliveryHandler", () => {
       extractMediaDirectives: false,
     });
 
-    expect(normalized.payload.text).toBe("Result\nMEDIA: ./image.png");
+    // Block streaming disables mid-stream attach, but the directive must not leak as text.
+    expect(normalized.payload.text).toBe("Result");
     expect(normalized.payload.mediaUrl).toBeUndefined();
     expect(normalized.payload.mediaUrls).toBeUndefined();
   });

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -30,7 +30,9 @@ export function normalizeReplyPayloadDirectives(params: {
     parseMode === "always" ||
     (parseMode === "auto" &&
       (sourceText.includes("[[") ||
-        (params.extractMediaDirectives !== false && /media:/i.test(sourceText)) ||
+        // Always parse MEDIA: so block streaming can strip the directive from visible
+        // text even when extractMediaDirectives is false (no mid-stream attach).
+        /media:/i.test(sourceText) ||
         (params.extractMarkdownImages === true && /!\[[^\]]*]\(/.test(sourceText)) ||
         sourceText.includes(silentToken)));
 

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -143,6 +143,35 @@ describe("splitMediaFromOutput", () => {
     ]);
   });
 
+  it("strips MEDIA lines from visible text when attachment extraction is disabled", () => {
+    expectParsedMediaOutputCase(
+      "Caption\nMEDIA:./screenshot.png\nDone",
+      {
+        text: "Caption\nDone",
+        mediaUrls: undefined,
+      },
+      { extractMediaDirectives: false },
+    );
+  });
+
+  it("strips mixed valid/invalid MEDIA leftovers when extraction is disabled", () => {
+    expectParsedMediaOutputCase(
+      "Caption\nMEDIA:./ok.png leftover-words\nDone",
+      {
+        text: "Caption\nDone",
+        mediaUrls: undefined,
+      },
+      { extractMediaDirectives: false },
+    );
+  });
+
+  it("still extracts MEDIA attachments when extraction remains enabled", () => {
+    expectParsedMediaOutputCase("Caption\nMEDIA:./screenshot.png\nDone", {
+      text: "Caption\nDone",
+      mediaUrls: ["./screenshot.png"],
+    });
+  });
+
   const extractMarkdownImages = { extractMarkdownImages: true } as const;
 
   it("keeps markdown image urls as text by default", () => {

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -500,7 +500,9 @@ export function splitMediaFromOutput(
   }
   const extractMarkdownImages = options.extractMarkdownImages === true;
   const extractMediaDirectives = options.extractMediaDirectives !== false;
-  const mayContainMediaToken = extractMediaDirectives && /media:/i.test(trimmedRaw);
+  // Always detect MEDIA: lines so block-streaming (extractMediaDirectives:false) can
+  // still strip the directive from visible text without attaching mid-stream.
+  const mayContainMediaToken = /media:/i.test(trimmedRaw);
   const mayContainMarkdownImage = extractMarkdownImages && /!\[[^\]]*]\(/.test(trimmedRaw);
   const mayContainAudioTag = trimmedRaw.includes("[[");
   if (!mayContainMediaToken && !mayContainMarkdownImage && !mayContainAudioTag) {
@@ -542,7 +544,7 @@ export function splitMediaFromOutput(
     }
 
     const trimmedStart = line.trimStart();
-    if (!extractMediaDirectives || !trimmedStart.toUpperCase().startsWith("MEDIA:")) {
+    if (!trimmedStart.toUpperCase().startsWith("MEDIA:")) {
       const markdownImageResult = extractMarkdownImages
         ? collectMarkdownImageSegments({ line, media })
         : { lineSegments: [], foundMedia: false };
@@ -593,7 +595,11 @@ export function splitMediaFromOutput(
       for (const part of parts) {
         const candidate = normalizeMediaSource(cleanCandidate(part));
         if (isValidMedia(candidate, unwrapped ? { allowSpaces: true } : undefined)) {
-          media.push(candidate);
+          // Collect attachments only when extraction is enabled; always mark handled so
+          // the directive line is stripped from visible text during block streaming.
+          if (extractMediaDirectives) {
+            media.push(candidate);
+          }
           hasValidMedia = true;
           foundMediaToken = true;
           validCount += 1;
@@ -615,7 +621,9 @@ export function splitMediaFromOutput(
         // A single valid split plus invalid leftovers can be one local path containing spaces.
         const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
         if (isValidMedia(fallback, { allowSpaces: true })) {
-          media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
+          if (extractMediaDirectives) {
+            media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
+          }
           hasValidMedia = true;
           foundMediaToken = true;
           validCount = 1;
@@ -626,7 +634,9 @@ export function splitMediaFromOutput(
       if (!hasValidMedia && !unwrapped && /\s/.test(payloadValue)) {
         const spacedFallback = normalizeMediaSource(cleanCandidate(payloadValue));
         if (isValidMedia(spacedFallback, { allowSpaces: true, allowBareFilename: true })) {
-          media.splice(mediaStartIndex, media.length - mediaStartIndex, spacedFallback);
+          if (extractMediaDirectives) {
+            media.splice(mediaStartIndex, media.length - mediaStartIndex, spacedFallback);
+          }
           hasValidMedia = true;
           foundMediaToken = true;
           validCount = 1;
@@ -637,7 +647,9 @@ export function splitMediaFromOutput(
       if (!hasValidMedia) {
         const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
         if (isValidMedia(fallback, { allowSpaces: true, allowBareFilename: true })) {
-          media.push(fallback);
+          if (extractMediaDirectives) {
+            media.push(fallback);
+          }
           hasValidMedia = true;
           foundMediaToken = true;
           invalidParts.length = 0;
@@ -650,11 +662,15 @@ export function splitMediaFromOutput(
           lineSegments.push({ type: "text", text: beforeText });
         }
         pieces.length = 0;
-        for (const url of media.slice(mediaStartIndex, mediaStartIndex + validCount)) {
-          lineSegments.push({ type: "media", url });
-        }
-        if (invalidParts.length > 0) {
-          pieces.push(invalidParts.join(" "));
+        if (extractMediaDirectives) {
+          for (const url of media.slice(mediaStartIndex, mediaStartIndex + validCount)) {
+            lineSegments.push({ type: "media", url });
+          }
+          // Keep invalid leftovers visible only when attaching; strip-only mode drops
+          // the whole MEDIA directive from streamed text.
+          if (invalidParts.length > 0) {
+            pieces.push(invalidParts.join(" "));
+          }
         }
       } else if (looksLikeLocalPath) {
         // Strip MEDIA: lines with local paths even when invalid (e.g. absolute paths

--- a/src/media/video-dimensions.test.ts
+++ b/src/media/video-dimensions.test.ts
@@ -1,43 +1,81 @@
 // Video dimension tests cover ffprobe parsing and fallback behavior.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { probeVideoDimensions } from "./video-dimensions.js";
 
-const { runFfprobe } = vi.hoisted(() => ({
+const { runFfprobe, withTempWorkspace, resolvePreferredOpenClawTmpDir } = vi.hoisted(() => ({
   runFfprobe: vi.fn(),
+  withTempWorkspace: vi.fn(),
+  resolvePreferredOpenClawTmpDir: vi.fn(),
 }));
 
 vi.mock("./ffmpeg-exec.js", () => ({
   runFfprobe,
 }));
 
+vi.mock("../infra/private-temp-workspace.js", () => ({
+  withTempWorkspace,
+}));
+
+vi.mock("../infra/tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir,
+}));
+
+beforeEach(() => {
+  resolvePreferredOpenClawTmpDir.mockReturnValue("/tmp/openclaw");
+  withTempWorkspace.mockImplementation(async (_opts, run) => {
+    const workspace = {
+      write: vi.fn(async (name: string) => `/tmp/openclaw/ws/${name}`),
+    };
+    return await run(workspace);
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("probeVideoDimensions", () => {
-  it("probes video dimensions through ffprobe stdin", async () => {
+  it("writes buffer to seekable temp file then probes path", async () => {
     const buffer = Buffer.from("video");
+    const write = vi.fn(async (name: string) => `/tmp/openclaw/ws/${name}`);
+    withTempWorkspace.mockImplementationOnce(async (_opts, run) => await run({ write }));
     runFfprobe.mockResolvedValueOnce(JSON.stringify({ streams: [{ width: 720, height: 1280 }] }));
 
     await expect(probeVideoDimensions(buffer)).resolves.toEqual({ width: 720, height: 1280 });
 
-    expect(runFfprobe).toHaveBeenCalledWith(
-      [
-        "-v",
-        "error",
-        "-select_streams",
-        "v:0",
-        "-show_entries",
-        "stream=width,height",
-        "-of",
-        "json",
-        "pipe:0",
-      ],
-      { input: buffer },
+    expect(write).toHaveBeenCalledWith("video.bin", buffer);
+    expect(withTempWorkspace).toHaveBeenCalledWith(
+      {
+        rootDir: "/tmp/openclaw",
+        prefix: "openclaw-ffprobe-",
+      },
+      expect.any(Function),
     );
+    expect(runFfprobe).toHaveBeenCalledWith([
+      "-v",
+      "error",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=width,height",
+      "-of",
+      "json",
+      "/tmp/openclaw/ws/video.bin",
+    ]);
   });
 
   it("falls back when ffprobe fails or returns malformed output", async () => {
+    const buffer = Buffer.from("video");
+
     runFfprobe.mockRejectedValueOnce(new Error("missing ffprobe"));
-    await expect(probeVideoDimensions(Buffer.from("video"))).resolves.toBeUndefined();
+    await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
 
     runFfprobe.mockResolvedValueOnce("{");
+    await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+  });
+
+  it("falls back when the temp workspace write rejects", async () => {
+    withTempWorkspace.mockRejectedValueOnce(new Error("disk full"));
     await expect(probeVideoDimensions(Buffer.from("video"))).resolves.toBeUndefined();
   });
 });

--- a/src/media/video-dimensions.ts
+++ b/src/media/video-dimensions.ts
@@ -1,4 +1,6 @@
 // Video dimension helpers read video dimensions through ffprobe.
+import { withTempWorkspace } from "../infra/private-temp-workspace.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfprobe } from "./ffmpeg-exec.js";
 
 /** Positive video dimensions reported by ffprobe for the first video stream. */
@@ -36,24 +38,35 @@ function parseFfprobeVideoDimensions(stdout: string): VideoDimensions | undefine
   return width && height ? { width, height } : undefined;
 }
 
-/** Probes a video buffer through ffprobe stdin and treats probe failures as unknown dimensions. */
+/**
+ * Probes video dimensions via a seekable temp file. Pipe:0 probing fails for
+ * large MP4s because ffprobe needs to seek the MOOV atom (often at the end for
+ * faststart files), which is impossible over a non-seekable stdin pipe.
+ * Temp-file probing resolves dimensions reliably for any buffer size.
+ */
 export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensions | undefined> {
   try {
-    const stdout = await runFfprobe(
-      [
-        "-v",
-        "error",
-        "-select_streams",
-        "v:0",
-        "-show_entries",
-        "stream=width,height",
-        "-of",
-        "json",
-        "pipe:0",
-      ],
-      { input: buffer },
+    return await withTempWorkspace(
+      {
+        rootDir: resolvePreferredOpenClawTmpDir(),
+        prefix: "openclaw-ffprobe-",
+      },
+      async (workspace) => {
+        const tempPath = await workspace.write("video.bin", buffer);
+        const stdout = await runFfprobe([
+          "-v",
+          "error",
+          "-select_streams",
+          "v:0",
+          "-show_entries",
+          "stream=width,height",
+          "-of",
+          "json",
+          tempPath,
+        ]);
+        return parseFfprobeVideoDimensions(stdout);
+      },
     );
-    return parseFfprobeVideoDimensions(stdout);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
Related: #113014, #97826

## What Problem This Solves

Fixes two high-impact bugs:

1. Webchat/block-streamed replies leak raw `MEDIA:/path` lines into visible text ("Outside allowed folders").
2. Large Telegram videos omit width/height because ffprobe stdin probing fails on non-seekable pipes, so playback stretches.

## Why This Change Was Made

- Always strip `MEDIA:` directives from visible text during block streaming while still deferring attachment extraction to the final pass.
- Probe video dimensions via a seekable temp workspace instead of `pipe:0`.

## User Impact

- Webchat image replies no longer show broken local-path chips for stripped MEDIA directives.
- Large videos keep correct aspect ratio when dimensions can be probed.

## Evidence

Focused tests (Node 24.15):
- `node scripts/run-vitest.mjs src/media/parse.test.ts src/media/video-dimensions.test.ts src/auto-reply/reply/reply-delivery.test.ts`
- Autoreview (claude-fable-5): clean / `patch is correct`

AI-assisted.