### PR TITLE
fix(hooks): prevent Codex relay resource exhaustion

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -100,6 +100,8 @@ const rootEntries = [
   "openclaw.mjs!",
   "src/index.ts!",
   "src/entry.ts!",
+  // Built as a standalone hook subprocess entry and invoked by generated path.
+  "src/native-hook-relay-entry.ts!",
   "src/cli/daemon-cli.ts!",
   "src/agents/code-mode.worker.ts!",
   // Worker-thread and script entrypoints import contracts that production Knip cannot trace.

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -76,6 +76,7 @@ const rawSqliteAllowPathGroups = {
     "src/state/openclaw-agent-db-readonly.ts",
     "src/state/openclaw-state-db-readonly.ts",
   ],
+  "latency-critical read-only native hook relay bootstrap": ["src/native-hook-relay-entry.ts"],
   "read-only schema preflight and integrity verification access": [
     "src/state/openclaw-database-preflight.ts",
     "src/state/openclaw-database-verify.worker.ts",

--- a/src/agents/harness/native-hook-relay-admission.test.ts
+++ b/src/agents/harness/native-hook-relay-admission.test.ts
@@ -85,6 +85,42 @@ describe("NativeHookRelayAdmissionController", () => {
     await first;
   });
 
+  it("propagates abort to active work and drains the next queued operation", async () => {
+    const controller = new NativeHookRelayAdmissionController({
+      maxActive: 1,
+      maxQueued: 1,
+    });
+    const abortController = new AbortController();
+    const started = deferred();
+    const active = controller.run(
+      async (signal) => {
+        started.resolve();
+        await new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(new NativeHookRelayAdmissionCancelledError()),
+            { once: true },
+          );
+        });
+      },
+      { signal: abortController.signal },
+    );
+    const queued = controller.run(async () => "drained");
+
+    await started.promise;
+    expect(controller.snapshot()).toMatchObject({ active: 1, queued: 1 });
+    abortController.abort();
+    await expect(active).rejects.toBeInstanceOf(NativeHookRelayAdmissionCancelledError);
+    await expect(queued).resolves.toBe("drained");
+    expect(controller.snapshot()).toMatchObject({
+      active: 0,
+      queued: 0,
+      accepted: 2,
+      completed: 2,
+      cancelled: 1,
+    });
+  });
+
   it("rejects queued and future operations after close", async () => {
     const controller = new NativeHookRelayAdmissionController({
       maxActive: 1,
@@ -129,5 +165,73 @@ describe("NativeHookRelayAdmissionController", () => {
     expect(operation).toHaveBeenCalledOnce();
     release.resolve();
     await expect(Promise.all([first, duplicate])).resolves.toEqual([undefined, undefined]);
+  });
+
+  it("keeps coalesced work alive until its final connected waiter leaves", async () => {
+    const controller = new NativeHookRelayAdmissionController({
+      maxActive: 1,
+      maxQueued: 0,
+    });
+    const release = deferred();
+    const started = deferred();
+    const sharedAborted = vi.fn();
+    const operation = vi.fn(async (signal?: AbortSignal) => {
+      signal?.addEventListener("abort", sharedAborted, { once: true });
+      started.resolve();
+      await release.promise;
+      return "allowed";
+    });
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+    const first = controller.run(operation, {
+      key: "permission:call-1",
+      signal: firstAbort.signal,
+    });
+    const second = controller.run(operation, {
+      key: "permission:call-1",
+      signal: secondAbort.signal,
+    });
+
+    await started.promise;
+    firstAbort.abort();
+    await expect(first).rejects.toBeInstanceOf(NativeHookRelayAdmissionCancelledError);
+    expect(sharedAborted).not.toHaveBeenCalled();
+    release.resolve();
+    await expect(second).resolves.toBe("allowed");
+    expect(sharedAborted).not.toHaveBeenCalled();
+  });
+
+  it("aborts coalesced work after its final connected waiter leaves", async () => {
+    const controller = new NativeHookRelayAdmissionController({
+      maxActive: 1,
+      maxQueued: 0,
+    });
+    const started = deferred();
+    const abortController = new AbortController();
+    const active = controller.run(
+      async (signal?: AbortSignal) => {
+        started.resolve();
+        await new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(new NativeHookRelayAdmissionCancelledError()),
+            { once: true },
+          );
+        });
+      },
+      {
+        key: "permission:call-1",
+        signal: abortController.signal,
+      },
+    );
+
+    await started.promise;
+    abortController.abort();
+    await expect(active).rejects.toBeInstanceOf(NativeHookRelayAdmissionCancelledError);
+    expect(controller.snapshot()).toMatchObject({
+      active: 0,
+      completed: 1,
+      cancelled: 1,
+    });
   });
 });

--- a/src/agents/harness/native-hook-relay-admission.test.ts
+++ b/src/agents/harness/native-hook-relay-admission.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  NativeHookRelayAdmissionCancelledError,
+  NativeHookRelayAdmissionClosedError,
+  NativeHookRelayAdmissionController,
+  NativeHookRelayAdmissionOverloadedError,
+} from "./native-hook-relay-admission.js";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+describe("NativeHookRelayAdmissionController", () => {
+  it("runs four active operations, queues 32 in FIFO order, and rejects the next request", async () => {
+    const controller = new NativeHookRelayAdmissionController();
+    const releases = Array.from({ length: 36 }, deferred);
+    const started: number[] = [];
+    const operations = releases.map((release, index) =>
+      controller.run(async () => {
+        started.push(index);
+        await release.promise;
+        return index;
+      }),
+    );
+
+    await Promise.resolve();
+    expect(started).toEqual([0, 1, 2, 3]);
+    expect(controller.snapshot()).toMatchObject({
+      active: 4,
+      queued: 32,
+      accepted: 36,
+      rejected: 0,
+      peakActive: 4,
+      peakQueued: 32,
+    });
+    await expect(controller.run(async () => 36)).rejects.toBeInstanceOf(
+      NativeHookRelayAdmissionOverloadedError,
+    );
+
+    for (let index = 0; index < releases.length; index += 1) {
+      releases[index]?.resolve();
+      await operations[index];
+    }
+    expect(started).toEqual(Array.from({ length: 36 }, (_, index) => index));
+    expect(controller.snapshot()).toEqual({
+      active: 0,
+      queued: 0,
+      accepted: 36,
+      completed: 36,
+      rejected: 1,
+      cancelled: 0,
+      coalesced: 0,
+      peakActive: 4,
+      peakQueued: 32,
+    });
+  });
+
+  it("removes an aborted queued operation without consuming an execution slot", async () => {
+    const controller = new NativeHookRelayAdmissionController({
+      maxActive: 1,
+      maxQueued: 1,
+    });
+    const active = deferred();
+    const first = controller.run(() => active.promise);
+    const abortController = new AbortController();
+    const queued = controller.run(async () => undefined, {
+      signal: abortController.signal,
+    });
+
+    abortController.abort();
+    await expect(queued).rejects.toBeInstanceOf(NativeHookRelayAdmissionCancelledError);
+    expect(controller.snapshot()).toMatchObject({
+      active: 1,
+      queued: 0,
+      cancelled: 1,
+    });
+    active.resolve();
+    await first;
+  });
+
+  it("rejects queued and future operations after close", async () => {
+    const controller = new NativeHookRelayAdmissionController({
+      maxActive: 1,
+      maxQueued: 1,
+    });
+    const active = deferred();
+    const first = controller.run(() => active.promise);
+    const queued = controller.run(async () => undefined);
+
+    controller.close();
+    await expect(queued).rejects.toBeInstanceOf(NativeHookRelayAdmissionClosedError);
+    await expect(controller.run(async () => undefined)).rejects.toBeInstanceOf(
+      NativeHookRelayAdmissionClosedError,
+    );
+    active.resolve();
+    await first;
+  });
+
+  it("rejects a zero active limit rather than creating an undrainable queue", () => {
+    expect(() => new NativeHookRelayAdmissionController({ maxActive: 0, maxQueued: 1 })).toThrow(
+      "maxActive must be a safe integer greater than or equal to 1",
+    );
+  });
+
+  it("coalesces an exact in-flight key without consuming active or queued capacity", async () => {
+    const controller = new NativeHookRelayAdmissionController({
+      maxActive: 1,
+      maxQueued: 0,
+    });
+    const release = deferred();
+    const operation = vi.fn(() => release.promise);
+    const first = controller.run(operation, { key: "permission:call-1" });
+    const duplicate = controller.run(operation, { key: "permission:call-1" });
+
+    await Promise.resolve();
+    expect(controller.snapshot()).toMatchObject({
+      active: 1,
+      queued: 0,
+      accepted: 1,
+      coalesced: 1,
+    });
+    expect(operation).toHaveBeenCalledOnce();
+    release.resolve();
+    await expect(Promise.all([first, duplicate])).resolves.toEqual([undefined, undefined]);
+  });
+});

--- a/src/agents/harness/native-hook-relay-admission.test.ts
+++ b/src/agents/harness/native-hook-relay-admission.test.ts
@@ -234,4 +234,45 @@ describe("NativeHookRelayAdmissionController", () => {
       cancelled: 1,
     });
   });
+
+  it("allows an immediate retry after the final connected waiter leaves", async () => {
+    const controller = new NativeHookRelayAdmissionController({
+      maxActive: 1,
+      maxQueued: 0,
+    });
+    const started = deferred();
+    const abortController = new AbortController();
+    const firstOperation = vi.fn(async (signal?: AbortSignal) => {
+      started.resolve();
+      await new Promise<void>((_resolve, reject) => {
+        signal?.addEventListener(
+          "abort",
+          () => reject(new NativeHookRelayAdmissionCancelledError()),
+          { once: true },
+        );
+      });
+    });
+    const first = controller.run(firstOperation, {
+      key: "permission:call-1",
+      signal: abortController.signal,
+    });
+
+    await started.promise;
+    abortController.abort();
+    await expect(first).rejects.toBeInstanceOf(NativeHookRelayAdmissionCancelledError);
+
+    const retryOperation = vi.fn(async () => "allowed");
+    await expect(controller.run(retryOperation, { key: "permission:call-1" })).resolves.toBe(
+      "allowed",
+    );
+    expect(firstOperation).toHaveBeenCalledOnce();
+    expect(retryOperation).toHaveBeenCalledOnce();
+    expect(controller.snapshot()).toMatchObject({
+      active: 0,
+      accepted: 2,
+      completed: 2,
+      cancelled: 1,
+      coalesced: 0,
+    });
+  });
 });

--- a/src/agents/harness/native-hook-relay-admission.ts
+++ b/src/agents/harness/native-hook-relay-admission.ts
@@ -1,0 +1,248 @@
+const DEFAULT_MAX_ACTIVE = 4;
+const DEFAULT_MAX_QUEUED = 32;
+
+export type NativeHookRelayAdmissionSnapshot = {
+  active: number;
+  queued: number;
+  accepted: number;
+  completed: number;
+  rejected: number;
+  cancelled: number;
+  coalesced: number;
+  peakActive: number;
+  peakQueued: number;
+};
+
+type QueuedAdmission<T> = {
+  operation: () => Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  abort?: () => void;
+};
+
+export class NativeHookRelayAdmissionOverloadedError extends Error {
+  constructor() {
+    super("native hook relay overloaded");
+    this.name = "NativeHookRelayAdmissionOverloadedError";
+  }
+}
+
+export class NativeHookRelayAdmissionClosedError extends Error {
+  constructor() {
+    super("native hook relay admission closed");
+    this.name = "NativeHookRelayAdmissionClosedError";
+  }
+}
+
+export class NativeHookRelayAdmissionCancelledError extends Error {
+  constructor() {
+    super("native hook relay admission cancelled");
+    this.name = "NativeHookRelayAdmissionCancelledError";
+  }
+}
+
+export function isNativeHookRelayAdmissionOverloadedError(
+  error: unknown,
+): error is NativeHookRelayAdmissionOverloadedError {
+  return (
+    error instanceof NativeHookRelayAdmissionOverloadedError ||
+    (error instanceof Error && error.message === "native hook relay overloaded")
+  );
+}
+
+/**
+ * Bounds policy work for one native relay. Active operations and queued waiters
+ * are both hard-capped; queued work starts in arrival order.
+ */
+export class NativeHookRelayAdmissionController {
+  readonly maxActive: number;
+  readonly maxQueued: number;
+
+  private active = 0;
+  private closed = false;
+  private queue: QueuedAdmission<unknown>[] = [];
+  private inFlight = new Map<string, Promise<unknown>>();
+  private accepted = 0;
+  private completed = 0;
+  private rejected = 0;
+  private cancelled = 0;
+  private coalesced = 0;
+  private peakActive = 0;
+  private peakQueued = 0;
+
+  constructor(options: { maxActive?: number; maxQueued?: number } = {}) {
+    this.maxActive = normalizeLimit(options.maxActive, DEFAULT_MAX_ACTIVE, "maxActive", 1);
+    this.maxQueued = normalizeLimit(options.maxQueued, DEFAULT_MAX_QUEUED, "maxQueued", 0);
+  }
+
+  run<T>(
+    operation: () => Promise<T>,
+    options: { signal?: AbortSignal; key?: string } = {},
+  ): Promise<T> {
+    if (this.closed) {
+      return Promise.reject(new NativeHookRelayAdmissionClosedError());
+    }
+    if (options.signal?.aborted) {
+      this.cancelled += 1;
+      return Promise.reject(new NativeHookRelayAdmissionCancelledError());
+    }
+    const key = options.key?.trim();
+    if (key) {
+      const existing = this.inFlight.get(key) as Promise<T> | undefined;
+      if (existing) {
+        this.coalesced += 1;
+        return this.waitForShared(existing, options.signal);
+      }
+      const promise = this.runUnique(operation, options);
+      this.inFlight.set(key, promise);
+      const clear = () => {
+        if (this.inFlight.get(key) === promise) {
+          this.inFlight.delete(key);
+        }
+      };
+      void promise.then(clear, clear);
+      return promise;
+    }
+    return this.runUnique(operation, options);
+  }
+
+  private runUnique<T>(operation: () => Promise<T>, options: { signal?: AbortSignal }): Promise<T> {
+    if (this.active < this.maxActive) {
+      this.accepted += 1;
+      return this.start(operation);
+    }
+    if (this.queue.length >= this.maxQueued) {
+      this.rejected += 1;
+      return Promise.reject(new NativeHookRelayAdmissionOverloadedError());
+    }
+    this.accepted += 1;
+    return new Promise<T>((resolve, reject) => {
+      const queued: QueuedAdmission<T> = {
+        operation,
+        resolve,
+        reject,
+        ...(options.signal ? { signal: options.signal } : {}),
+      };
+      this.queue.push(queued as QueuedAdmission<unknown>);
+      this.peakQueued = Math.max(this.peakQueued, this.queue.length);
+      if (options.signal) {
+        queued.abort = () => {
+          const index = this.queue.indexOf(queued as QueuedAdmission<unknown>);
+          if (index < 0) {
+            return;
+          }
+          this.queue.splice(index, 1);
+          this.cancelled += 1;
+          reject(new NativeHookRelayAdmissionCancelledError());
+        };
+        options.signal.addEventListener("abort", queued.abort, { once: true });
+        if (options.signal.aborted) {
+          queued.abort();
+        }
+      }
+    });
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    const queued = this.queue.splice(0);
+    for (const entry of queued) {
+      this.detachAbort(entry);
+      entry.reject(new NativeHookRelayAdmissionClosedError());
+    }
+  }
+
+  snapshot(): NativeHookRelayAdmissionSnapshot {
+    return {
+      active: this.active,
+      queued: this.queue.length,
+      accepted: this.accepted,
+      completed: this.completed,
+      rejected: this.rejected,
+      cancelled: this.cancelled,
+      peakActive: this.peakActive,
+      peakQueued: this.peakQueued,
+      coalesced: this.coalesced,
+    };
+  }
+
+  private start<T>(operation: () => Promise<T>): Promise<T> {
+    this.active += 1;
+    this.peakActive = Math.max(this.peakActive, this.active);
+    return Promise.resolve()
+      .then(operation)
+      .finally(() => {
+        this.active -= 1;
+        this.completed += 1;
+        this.drain();
+      });
+  }
+
+  private drain(): void {
+    while (!this.closed && this.active < this.maxActive && this.queue.length > 0) {
+      const entry = this.queue.shift();
+      if (!entry) {
+        return;
+      }
+      this.detachAbort(entry);
+      if (entry.signal?.aborted) {
+        this.cancelled += 1;
+        entry.reject(new NativeHookRelayAdmissionCancelledError());
+        continue;
+      }
+      void this.start(entry.operation).then(entry.resolve, entry.reject);
+    }
+  }
+
+  private detachAbort(entry: QueuedAdmission<unknown>): void {
+    if (entry.signal && entry.abort) {
+      entry.signal.removeEventListener("abort", entry.abort);
+    }
+  }
+
+  private waitForShared<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+    if (!signal) {
+      return promise;
+    }
+    return new Promise<T>((resolve, reject) => {
+      const abort = () => {
+        cleanup();
+        this.cancelled += 1;
+        reject(new NativeHookRelayAdmissionCancelledError());
+      };
+      const cleanup = () => signal.removeEventListener("abort", abort);
+      signal.addEventListener("abort", abort, { once: true });
+      if (signal.aborted) {
+        abort();
+        return;
+      }
+      promise.then(
+        (value) => {
+          cleanup();
+          resolve(value);
+        },
+        (error: unknown) => {
+          cleanup();
+          reject(error);
+        },
+      );
+    });
+  }
+}
+
+function normalizeLimit(
+  value: number | undefined,
+  fallback: number,
+  name: string,
+  minimum: number,
+): number {
+  const selected = value ?? fallback;
+  if (!Number.isSafeInteger(selected) || selected < minimum) {
+    throw new Error(`${name} must be a safe integer greater than or equal to ${minimum}`);
+  }
+  return selected;
+}

--- a/src/agents/harness/native-hook-relay-admission.ts
+++ b/src/agents/harness/native-hook-relay-admission.ts
@@ -14,11 +14,17 @@ export type NativeHookRelayAdmissionSnapshot = {
 };
 
 type QueuedAdmission<T> = {
-  operation: () => Promise<T>;
+  operation: (signal?: AbortSignal) => Promise<T>;
   resolve: (value: T | PromiseLike<T>) => void;
   reject: (error: Error) => void;
   signal?: AbortSignal;
   abort?: () => void;
+};
+
+type SharedAdmission<T> = {
+  abortController: AbortController;
+  promise: Promise<T>;
+  waiters: number;
 };
 
 export class NativeHookRelayAdmissionOverloadedError extends Error {
@@ -62,7 +68,7 @@ export class NativeHookRelayAdmissionController {
   private active = 0;
   private closed = false;
   private queue: QueuedAdmission<unknown>[] = [];
-  private inFlight = new Map<string, Promise<unknown>>();
+  private inFlight = new Map<string, SharedAdmission<unknown>>();
   private accepted = 0;
   private completed = 0;
   private rejected = 0;
@@ -77,7 +83,7 @@ export class NativeHookRelayAdmissionController {
   }
 
   run<T>(
-    operation: () => Promise<T>,
+    operation: (signal?: AbortSignal) => Promise<T>,
     options: { signal?: AbortSignal; key?: string } = {},
   ): Promise<T> {
     if (this.closed) {
@@ -89,28 +95,33 @@ export class NativeHookRelayAdmissionController {
     }
     const key = options.key?.trim();
     if (key) {
-      const existing = this.inFlight.get(key) as Promise<T> | undefined;
+      const existing = this.inFlight.get(key) as SharedAdmission<T> | undefined;
       if (existing) {
         this.coalesced += 1;
-        return this.waitForShared(existing, options.signal);
+        return this.waitForShared(key, existing, options.signal);
       }
-      const promise = this.runUnique(operation, options);
-      this.inFlight.set(key, promise);
+      const abortController = new AbortController();
+      const promise = this.runUnique(operation, { signal: abortController.signal });
+      const shared: SharedAdmission<T> = { abortController, promise, waiters: 0 };
+      this.inFlight.set(key, shared);
       const clear = () => {
-        if (this.inFlight.get(key) === promise) {
+        if (this.inFlight.get(key) === shared) {
           this.inFlight.delete(key);
         }
       };
       void promise.then(clear, clear);
-      return promise;
+      return this.waitForShared(key, shared, options.signal);
     }
     return this.runUnique(operation, options);
   }
 
-  private runUnique<T>(operation: () => Promise<T>, options: { signal?: AbortSignal }): Promise<T> {
+  private runUnique<T>(
+    operation: (signal?: AbortSignal) => Promise<T>,
+    options: { signal?: AbortSignal },
+  ): Promise<T> {
     if (this.active < this.maxActive) {
       this.accepted += 1;
-      return this.start(operation);
+      return this.start(operation, options.signal);
     }
     if (this.queue.length >= this.maxQueued) {
       this.rejected += 1;
@@ -133,7 +144,9 @@ export class NativeHookRelayAdmissionController {
             return;
           }
           this.queue.splice(index, 1);
-          this.cancelled += 1;
+          if (!(options.signal?.reason instanceof NativeHookRelayAdmissionCancelledError)) {
+            this.cancelled += 1;
+          }
           reject(new NativeHookRelayAdmissionCancelledError());
         };
         options.signal.addEventListener("abort", queued.abort, { once: true });
@@ -170,12 +183,32 @@ export class NativeHookRelayAdmissionController {
     };
   }
 
-  private start<T>(operation: () => Promise<T>): Promise<T> {
+  private start<T>(
+    operation: (signal?: AbortSignal) => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
     this.active += 1;
     this.peakActive = Math.max(this.peakActive, this.active);
+    let observedAbort = false;
+    const onAbort = () => {
+      if (!observedAbort) {
+        observedAbort = true;
+        if (!(signal?.reason instanceof NativeHookRelayAdmissionCancelledError)) {
+          this.cancelled += 1;
+        }
+      }
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
     return Promise.resolve()
-      .then(operation)
+      .then(() => operation(signal))
+      .catch((error: unknown) => {
+        if (signal?.aborted) {
+          throw new NativeHookRelayAdmissionCancelledError();
+        }
+        throw error;
+      })
       .finally(() => {
+        signal?.removeEventListener("abort", onAbort);
         this.active -= 1;
         this.completed += 1;
         this.drain();
@@ -194,7 +227,7 @@ export class NativeHookRelayAdmissionController {
         entry.reject(new NativeHookRelayAdmissionCancelledError());
         continue;
       }
-      void this.start(entry.operation).then(entry.resolve, entry.reject);
+      void this.start(entry.operation, entry.signal).then(entry.resolve, entry.reject);
     }
   }
 
@@ -204,33 +237,37 @@ export class NativeHookRelayAdmissionController {
     }
   }
 
-  private waitForShared<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
-    if (!signal) {
-      return promise;
-    }
-    return new Promise<T>((resolve, reject) => {
-      const abort = () => {
-        cleanup();
-        this.cancelled += 1;
-        reject(new NativeHookRelayAdmissionCancelledError());
-      };
-      const cleanup = () => signal.removeEventListener("abort", abort);
-      signal.addEventListener("abort", abort, { once: true });
-      if (signal.aborted) {
-        abort();
-        return;
+  private async waitForShared<T>(
+    key: string,
+    shared: SharedAdmission<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    shared.waiters += 1;
+    let abort: (() => void) | undefined;
+    try {
+      if (!signal) {
+        return await shared.promise;
       }
-      promise.then(
-        (value) => {
-          cleanup();
-          resolve(value);
-        },
-        (error: unknown) => {
-          cleanup();
-          reject(error);
-        },
-      );
-    });
+      const abortPromise = new Promise<never>((_, reject) => {
+        abort = () => {
+          this.cancelled += 1;
+          reject(new NativeHookRelayAdmissionCancelledError());
+        };
+        signal.addEventListener("abort", abort, { once: true });
+        if (signal.aborted) {
+          abort();
+        }
+      });
+      return await Promise.race([shared.promise, abortPromise]);
+    } finally {
+      if (abort) {
+        signal?.removeEventListener("abort", abort);
+      }
+      shared.waiters -= 1;
+      if (shared.waiters === 0 && this.inFlight.get(key) === shared) {
+        shared.abortController.abort(new NativeHookRelayAdmissionCancelledError());
+      }
+    }
   }
 }
 

--- a/src/agents/harness/native-hook-relay-admission.ts
+++ b/src/agents/harness/native-hook-relay-admission.ts
@@ -265,6 +265,8 @@ export class NativeHookRelayAdmissionController {
       }
       shared.waiters -= 1;
       if (shared.waiters === 0 && this.inFlight.get(key) === shared) {
+        // Make the key reusable before abort rejection can reach the final waiter.
+        this.inFlight.delete(key);
         shared.abortController.abort(new NativeHookRelayAdmissionCancelledError());
       }
     }

--- a/src/agents/harness/native-hook-relay-admission.ts
+++ b/src/agents/harness/native-hook-relay-admission.ts
@@ -1,7 +1,7 @@
 const DEFAULT_MAX_ACTIVE = 4;
 const DEFAULT_MAX_QUEUED = 32;
 
-export type NativeHookRelayAdmissionSnapshot = {
+type NativeHookRelayAdmissionSnapshot = {
   active: number;
   queued: number;
   accepted: number;

--- a/src/agents/harness/native-hook-relay-bridge.ts
+++ b/src/agents/harness/native-hook-relay-bridge.ts
@@ -7,6 +7,12 @@ import {
 } from "node:http";
 import { toErrorObject } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  isNativeHookRelayAdmissionOverloadedError,
+  NativeHookRelayAdmissionCancelledError,
+  NativeHookRelayAdmissionClosedError,
+  NativeHookRelayAdmissionOverloadedError,
+} from "./native-hook-relay-admission.js";
 import { DEFAULT_RELAY_TIMEOUT_MS } from "./native-hook-relay-command.js";
 import { nativeHookRelayState } from "./native-hook-relay-state.js";
 import {
@@ -42,7 +48,7 @@ export const NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR =
   "native hook relay bridge stale registration";
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
 
-const { relays, relayBridges } = nativeHookRelayState;
+const { relays, relayBridges, admissions } = nativeHookRelayState;
 
 type InvokeNativeHookRelay = (
   params: InvokeNativeHookRelayParams,
@@ -215,46 +221,87 @@ async function handleNativeHookRelayBridgeRequest(
   res: ServerResponse,
   auth: NativeHookRelayBridgeRequestAuth,
 ): Promise<void> {
+  if (req.method !== "POST" || req.url !== "/invoke") {
+    writeNativeHookRelayBridgeJson(res, 404, { ok: false, error: "not found" });
+    return;
+  }
+  if (req.headers.authorization !== `Bearer ${auth.token}`) {
+    writeNativeHookRelayBridgeJson(res, 403, { ok: false, error: "forbidden" });
+    return;
+  }
+  if (!isCurrentNativeHookRelayBridgeRequest(auth)) {
+    writeNativeHookRelayBridgeJson(res, 410, {
+      ok: false,
+      error: NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
+    });
+    return;
+  }
+  const admission = admissions.get(auth.relayId);
+  if (!admission) {
+    writeNativeHookRelayBridgeJson(res, 410, {
+      ok: false,
+      error: NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
+    });
+    return;
+  }
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  req.once("aborted", abort);
+  res.once("close", abort);
   try {
-    if (req.method !== "POST" || req.url !== "/invoke") {
-      writeNativeHookRelayBridgeJson(res, 404, { ok: false, error: "not found" });
-      return;
-    }
-    if (req.headers.authorization !== `Bearer ${auth.token}`) {
-      writeNativeHookRelayBridgeJson(res, 403, { ok: false, error: "forbidden" });
-      return;
-    }
-    if (!isCurrentNativeHookRelayBridgeRequest(auth)) {
-      writeNativeHookRelayBridgeJson(res, 410, {
-        ok: false,
-        error: NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
-      });
-      return;
-    }
-    const body = await readNativeHookRelayBridgeBody(req);
-    const payload = readNativeHookRelayBridgePayload(JSON.parse(body));
-    if (payload.provider !== auth.provider || payload.relayId !== auth.relayId) {
-      writeNativeHookRelayBridgeJson(res, 403, {
-        ok: false,
-        error: "native hook relay bridge target mismatch",
-      });
-      return;
-    }
-    if (!isCurrentNativeHookRelayBridgeRequest(auth)) {
-      writeNativeHookRelayBridgeJson(res, 410, {
-        ok: false,
-        error: NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
-      });
-      return;
-    }
-    const result = await auth.invokeRelay({ ...payload, requireGeneration: true });
+    const result = await admission.run(
+      async (signal) => {
+        if (!isCurrentNativeHookRelayBridgeRequest(auth)) {
+          throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
+        }
+        const body = await readNativeHookRelayBridgeBody(req);
+        const payload = readNativeHookRelayBridgePayload(JSON.parse(body));
+        if (payload.provider !== auth.provider || payload.relayId !== auth.relayId) {
+          throw new Error("native hook relay bridge target mismatch");
+        }
+        if (!isCurrentNativeHookRelayBridgeRequest(auth)) {
+          throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
+        }
+        return auth.invokeRelay({
+          ...payload,
+          requireGeneration: true,
+          admissionReserved: true,
+          ...(signal ? { admissionSignal: signal } : {}),
+        });
+      },
+      { signal: controller.signal },
+    );
     writeNativeHookRelayBridgeJson(res, 200, { ok: true, result });
   } catch (error) {
-    writeNativeHookRelayBridgeJson(
-      res,
-      isNativeHookRelayBridgeStaleRegistrationError(error) ? 410 : 500,
-      { ok: false, error: error instanceof Error ? error.message : String(error) },
-    );
+    if (error instanceof NativeHookRelayAdmissionCancelledError) {
+      return;
+    }
+    if (isNativeHookRelayAdmissionOverloadedError(error)) {
+      log.warn("native hook relay bridge rejected overloaded invocation", {
+        relayId: auth.relayId,
+        ...admission.snapshot(),
+      });
+      writeNativeHookRelayBridgeJson(res, 429, {
+        ok: false,
+        code: "overloaded",
+        error: "native hook relay overloaded",
+      });
+      return;
+    }
+    const stale =
+      isNativeHookRelayBridgeStaleRegistrationError(error) ||
+      error instanceof NativeHookRelayAdmissionClosedError;
+    writeNativeHookRelayBridgeJson(res, stale ? 410 : 500, {
+      ok: false,
+      error: stale
+        ? NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR
+        : error instanceof Error
+          ? error.message
+          : String(error),
+    });
+  } finally {
+    req.off("aborted", abort);
+    res.off("close", abort);
   }
 }
 
@@ -296,6 +343,9 @@ function writeNativeHookRelayBridgeJson(
   statusCode: number,
   payload: unknown,
 ): void {
+  if (res.destroyed || res.writableEnded) {
+    return;
+  }
   const body = JSON.stringify(payload);
   res.writeHead(statusCode, {
     "content-type": "application/json",
@@ -434,9 +484,13 @@ function postNativeHookRelayBridgeRecord(params: {
           try {
             const parsed = JSON.parse(responseText) as
               | { ok: true; result: NativeHookRelayProcessResponse }
-              | { ok: false; error?: string };
+              | { ok: false; code?: string; error?: string };
             if (parsed.ok) {
               resolveOnce(parsed.result);
+              return;
+            }
+            if (parsed.code === "overloaded") {
+              rejectOnce(new NativeHookRelayAdmissionOverloadedError());
               return;
             }
             rejectOnce(new Error(parsed.error || "native hook relay bridge failed"));

--- a/src/agents/harness/native-hook-relay-codec.ts
+++ b/src/agents/harness/native-hook-relay-codec.ts
@@ -1,5 +1,10 @@
 import { stableStringify } from "../stable-stringify.js";
 import { normalizeToolName } from "../tool-policy.js";
+import {
+  renderCodexNativeHookNoopResponse,
+  renderCodexNativeHookPermissionResponse,
+  renderCodexNativeHookPreToolUseBlockResponse,
+} from "./native-hook-relay-response.js";
 import type {
   JsonValue,
   NativeHookRelayInvocation,
@@ -27,22 +32,9 @@ const nativeHookRelayProviderAdapters: Record<
     normalizeMetadata: normalizeCodexHookMetadata,
     readToolInput: readCodexToolInput,
     readToolResponse: readCodexToolResponse,
-    renderNoopResponse: () => {
-      // Codex treats empty stdout plus exit 0 as no decision/no additional context.
-      return { stdout: "", stderr: "", exitCode: 0 };
-    },
-    renderPreToolUseBlockResponse: (reason, failureDisposition) => ({
-      stdout: `${JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-          permissionDecision: "deny",
-          permissionDecisionReason: reason,
-        },
-      })}\n`,
-      stderr: "",
-      exitCode: 0,
-      ...(failureDisposition ? { failureDisposition } : {}),
-    }),
+    renderNoopResponse: () => renderCodexNativeHookNoopResponse(),
+    renderPreToolUseBlockResponse: (reason, failureDisposition) =>
+      renderCodexNativeHookPreToolUseBlockResponse(reason, failureDisposition),
     renderBeforeAgentFinalizeReviseResponse: (reason) => ({
       stdout: `${JSON.stringify({
         decision: "block",
@@ -59,22 +51,8 @@ const nativeHookRelayProviderAdapters: Record<
       stderr: "",
       exitCode: 0,
     }),
-    renderPermissionDecisionResponse: (decision, message) => ({
-      stdout: `${JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PermissionRequest",
-          decision:
-            decision === "allow"
-              ? { behavior: "allow" }
-              : {
-                  behavior: "deny",
-                  message: message?.trim() || "Denied by OpenClaw",
-                },
-        },
-      })}\n`,
-      stderr: "",
-      exitCode: 0,
-    }),
+    renderPermissionDecisionResponse: (decision, message) =>
+      renderCodexNativeHookPermissionResponse(decision, message),
   },
 };
 

--- a/src/agents/harness/native-hook-relay-command.ts
+++ b/src/agents/harness/native-hook-relay-command.ts
@@ -9,6 +9,7 @@ import {
 } from "./native-hook-relay-utils.js";
 
 export const DEFAULT_RELAY_TIMEOUT_MS = 5_000;
+const NATIVE_HOOK_RELAY_MAX_OLD_SPACE_MIB = 64;
 
 function resolveNativeHookRelayNicePrefix(value: number | false | undefined): string[] {
   if (process.platform === "win32" || value === false || value === undefined) {
@@ -54,6 +55,7 @@ export function buildNativeHookRelayCommandWithStateDatabase(params: {
   provider: NativeHookRelayProvider;
   relayId: string;
   stateDbPath?: string;
+  stateSchemaVersion?: number;
   generation?: string;
   event: NativeHookRelayEvent;
   preToolUseUnavailable?: "noop";
@@ -63,22 +65,35 @@ export function buildNativeHookRelayCommandWithStateDatabase(params: {
   nodeExecutable?: string;
 }): string {
   const timeoutMs = normalizePositiveInteger(params.timeoutMs, DEFAULT_RELAY_TIMEOUT_MS);
-  const executable = params.executable ?? resolveOpenClawCliExecutable();
-  const argv =
-    executable === "openclaw"
+  const cliPathOverride = process.env.OPENCLAW_CLI_PATH?.trim();
+  const fastExecutable =
+    params.executable === undefined && !cliPathOverride && params.stateDbPath
+      ? resolveOpenClawNativeHookRelayExecutable()
+      : undefined;
+  const executable = fastExecutable ?? params.executable ?? resolveOpenClawCliExecutable();
+  const argv = fastExecutable
+    ? [
+        params.nodeExecutable ?? process.execPath,
+        `--max-old-space-size=${NATIVE_HOOK_RELAY_MAX_OLD_SPACE_MIB}`,
+        "--disable-warning=ExperimentalWarning",
+        fastExecutable,
+      ]
+    : executable === "openclaw"
       ? ["openclaw"]
       : [params.nodeExecutable ?? process.execPath, executable];
   const nicePrefix = resolveNativeHookRelayNicePrefix(params.nice);
   const command = shellQuoteArgs([
     ...nicePrefix,
     ...argv,
-    "hooks",
-    "relay",
+    ...(fastExecutable ? [] : ["hooks", "relay"]),
     "--provider",
     params.provider,
     "--relay-id",
     params.relayId,
     ...(params.stateDbPath ? ["--state-db", params.stateDbPath] : []),
+    ...(fastExecutable && params.stateSchemaVersion !== undefined
+      ? ["--state-schema-version", String(params.stateSchemaVersion)]
+      : []),
     ...(params.generation ? ["--generation", params.generation] : []),
     "--event",
     params.event,
@@ -91,6 +106,19 @@ export function buildNativeHookRelayCommandWithStateDatabase(params: {
   // Codex kills the shell process when a hook times out. Replace that shell so
   // the timeout targets this relay instead of leaving its Node child behind.
   return process.platform === "win32" ? command : `exec ${command}`;
+}
+
+function resolveOpenClawNativeHookRelayExecutable(): string | undefined {
+  const packageRoot = resolveOpenClawPackageRootSync({
+    moduleUrl: import.meta.url,
+    argv1: process.argv[1],
+    cwd: process.cwd(),
+  });
+  if (!packageRoot) {
+    return undefined;
+  }
+  const candidate = path.join(packageRoot, "dist", "native-hook-relay-entry.js");
+  return existsSync(candidate) ? candidate : undefined;
 }
 
 function resolveOpenClawCliExecutable(): string {

--- a/src/agents/harness/native-hook-relay-events.ts
+++ b/src/agents/harness/native-hook-relay-events.ts
@@ -64,6 +64,7 @@ export async function processNativeHookRelayInvocation(params: {
   registration: NativeHookRelayRegistration;
   invocation: NativeHookRelayInvocation;
   adapter: NativeHookRelayProviderAdapter;
+  signal?: AbortSignal;
 }): Promise<NativeHookRelayProcessResponse> {
   if (params.invocation.event === "pre_tool_use") {
     return runNativeHookRelayPreToolUse(params);
@@ -81,6 +82,7 @@ async function runNativeHookRelayPreToolUse(params: {
   registration: NativeHookRelayRegistration;
   invocation: NativeHookRelayInvocation;
   adapter: NativeHookRelayProviderAdapter;
+  signal?: AbortSignal;
 }): Promise<NativeHookRelayProcessResponse> {
   const toolName = normalizeNativeHookToolName(params.invocation.toolName);
   const toolInput = params.adapter.readToolInput(params.invocation.rawPayload);
@@ -91,7 +93,7 @@ async function runNativeHookRelayPreToolUse(params: {
     params: toolInput,
     ...(params.invocation.toolUseId ? { toolCallId: params.invocation.toolUseId } : {}),
     ...(approvalMode === "report" ? { approvalMode: "defer" } : {}),
-    signal: params.registration.signal,
+    signal: params.signal,
     ctx: {
       ...(params.registration.agentId ? { agentId: params.registration.agentId } : {}),
       sessionId: params.registration.sessionId,
@@ -143,7 +145,9 @@ async function runNativeHookRelayPostToolUse(params: {
   registration: NativeHookRelayRegistration;
   invocation: NativeHookRelayInvocation;
   adapter: NativeHookRelayProviderAdapter;
+  signal?: AbortSignal;
 }): Promise<NativeHookRelayProcessResponse> {
+  params.signal?.throwIfAborted();
   const toolName = normalizeNativeHookToolName(params.invocation.toolName);
   const toolCallId =
     params.invocation.toolUseId ?? `${params.invocation.event}:${params.invocation.receivedAt}`;
@@ -180,6 +184,7 @@ async function runNativeHookRelayPostToolUse(params: {
     startArgs,
     result,
   });
+  params.signal?.throwIfAborted();
   return params.adapter.renderNoopResponse(params.invocation.event);
 }
 
@@ -187,7 +192,9 @@ async function runNativeHookRelayBeforeAgentFinalize(params: {
   registration: NativeHookRelayRegistration;
   invocation: NativeHookRelayInvocation;
   adapter: NativeHookRelayProviderAdapter;
+  signal?: AbortSignal;
 }): Promise<NativeHookRelayProcessResponse> {
+  params.signal?.throwIfAborted();
   const outcome = await runAgentHarnessBeforeAgentFinalizeHook({
     event: {
       runId: params.registration.runId,
@@ -215,6 +222,7 @@ async function runNativeHookRelayBeforeAgentFinalize(params: {
       ...(params.invocation.model ? { modelId: params.invocation.model } : {}),
     },
   });
+  params.signal?.throwIfAborted();
   if (outcome.action === "revise") {
     return params.adapter.renderBeforeAgentFinalizeReviseResponse(outcome.reason);
   }

--- a/src/agents/harness/native-hook-relay-permissions.ts
+++ b/src/agents/harness/native-hook-relay-permissions.ts
@@ -26,6 +26,7 @@ import type {
   NativeHookRelayPermissionApprovalRequest,
   NativeHookRelayPermissionApprovalRequester,
   NativeHookRelayPermissionApprovalResult,
+  NativeHookRelayPendingPermissionApproval,
   NativeHookRelayPreToolUseApproval,
   NativeHookRelayProcessResponse,
   NativeHookRelayProvider,
@@ -169,6 +170,7 @@ export async function runNativeHookRelayPermissionRequest(params: {
   registration: NativeHookRelayRegistration;
   invocation: NativeHookRelayInvocation;
   adapter: NativeHookRelayProviderAdapter;
+  signal?: AbortSignal;
 }): Promise<NativeHookRelayProcessResponse> {
   const request: NativeHookRelayPermissionApprovalRequest = {
     provider: params.registration.provider,
@@ -181,7 +183,7 @@ export async function runNativeHookRelayPermissionRequest(params: {
     ...(params.invocation.cwd ? { cwd: params.invocation.cwd } : {}),
     ...(params.invocation.model ? { model: params.invocation.model } : {}),
     toolInput: params.adapter.readToolInput(params.invocation.rawPayload),
-    ...(params.registration.signal ? { signal: params.registration.signal } : {}),
+    ...(params.signal ? { signal: params.signal } : {}),
   };
   const approvalKey = nativeHookRelayPermissionApprovalKey({
     registration: params.registration,
@@ -194,14 +196,18 @@ export async function runNativeHookRelayPermissionRequest(params: {
   if (hasNativeHookRelayPermissionAllowAlways(allowAlwaysKey)) {
     return params.adapter.renderPermissionDecisionResponse("allow");
   }
-  const pendingApproval = pendingPermissionApprovals.get(approvalKey);
   try {
-    const decision = await (pendingApproval ??
-      startNativeHookRelayPermissionApprovalWithBudget({
-        registration: params.registration,
-        approvalKey,
-        request,
-      }));
+    const decision = await waitForNativeHookRelayPermissionApproval({
+      approvalKey,
+      pendingApproval:
+        pendingPermissionApprovals.get(approvalKey) ??
+        startNativeHookRelayPermissionApprovalWithBudget({
+          registration: params.registration,
+          approvalKey,
+          request,
+        }),
+      signal: params.signal,
+    });
     if (decision === "allow") {
       return params.adapter.renderPermissionDecisionResponse("allow");
     }
@@ -222,25 +228,96 @@ export async function runNativeHookRelayPermissionRequest(params: {
   return params.adapter.renderNoopResponse(params.invocation.event);
 }
 
-async function startNativeHookRelayPermissionApprovalWithBudget(params: {
+export function buildNativeHookRelayPermissionAdmissionKey(params: {
+  registration: NativeHookRelayRegistration;
+  invocation: NativeHookRelayInvocation;
+  adapter: NativeHookRelayProviderAdapter;
+}): string {
+  const request: NativeHookRelayPermissionApprovalRequest = {
+    provider: params.registration.provider,
+    ...(params.registration.agentId ? { agentId: params.registration.agentId } : {}),
+    sessionId: params.registration.sessionId,
+    ...(params.registration.sessionKey ? { sessionKey: params.registration.sessionKey } : {}),
+    runId: params.registration.runId,
+    toolName: normalizeNativeHookToolName(params.invocation.toolName),
+    ...(params.invocation.toolUseId ? { toolCallId: params.invocation.toolUseId } : {}),
+    ...(params.invocation.cwd ? { cwd: params.invocation.cwd } : {}),
+    ...(params.invocation.model ? { model: params.invocation.model } : {}),
+    toolInput: params.adapter.readToolInput(params.invocation.rawPayload),
+  };
+  return nativeHookRelayPermissionApprovalKey({
+    registration: params.registration,
+    request,
+  });
+}
+
+function startNativeHookRelayPermissionApprovalWithBudget(params: {
   registration: NativeHookRelayRegistration;
   approvalKey: string;
   request: NativeHookRelayPermissionApprovalRequest;
-}): Promise<NativeHookRelayPermissionApprovalResult> {
+}): NativeHookRelayPendingPermissionApproval {
+  const abortController = new AbortController();
   if (!consumeNativeHookRelayPermissionBudget(params.registration.relayId)) {
     log.warn(
       `native hook permission approval rate limit exceeded; deferring to provider approval path: relay=${params.registration.relayId} run=${params.registration.runId}`,
     );
-    return "defer";
+    return { abortController, promise: Promise.resolve("defer"), waiters: 0 };
   }
+  const signal = params.registration.signal
+    ? AbortSignal.any([abortController.signal, params.registration.signal])
+    : abortController.signal;
+  const pendingApproval: NativeHookRelayPendingPermissionApproval = {
+    abortController,
+    promise: Promise.resolve("defer"),
+    waiters: 0,
+  };
   const approval: Promise<NativeHookRelayPermissionApprovalResult> =
-    nativeHookRelayPermissionApprovalRequester(params.request).finally(() => {
-      if (pendingPermissionApprovals.get(params.approvalKey) === approval) {
+    nativeHookRelayPermissionApprovalRequester({ ...params.request, signal }).finally(() => {
+      if (pendingPermissionApprovals.get(params.approvalKey) === pendingApproval) {
         pendingPermissionApprovals.delete(params.approvalKey);
       }
     });
-  pendingPermissionApprovals.set(params.approvalKey, approval);
-  return approval;
+  pendingApproval.promise = approval;
+  pendingPermissionApprovals.set(params.approvalKey, pendingApproval);
+  return pendingApproval;
+}
+
+async function waitForNativeHookRelayPermissionApproval(params: {
+  approvalKey: string;
+  pendingApproval: NativeHookRelayPendingPermissionApproval;
+  signal?: AbortSignal;
+}): Promise<NativeHookRelayPermissionApprovalResult> {
+  const { pendingApproval } = params;
+  pendingApproval.waiters += 1;
+  let onAbort: (() => void) | undefined;
+  try {
+    if (!params.signal) {
+      return await pendingApproval.promise;
+    }
+    const abortPromise = new Promise<never>((_resolve, reject) => {
+      if (params.signal?.aborted) {
+        reject(toErrorObject(params.signal.reason, "Non-Error rejection"));
+        return;
+      }
+      onAbort = () => reject(toErrorObject(params.signal?.reason, "Non-Error rejection"));
+      params.signal?.addEventListener("abort", onAbort, { once: true });
+    });
+    return await Promise.race([pendingApproval.promise, abortPromise]);
+  } finally {
+    if (onAbort) {
+      params.signal?.removeEventListener("abort", onAbort);
+    }
+    pendingApproval.waiters -= 1;
+    if (
+      pendingApproval.waiters === 0 &&
+      pendingPermissionApprovals.get(params.approvalKey) === pendingApproval
+    ) {
+      pendingPermissionApprovals.delete(params.approvalKey);
+      pendingApproval.abortController.abort(
+        new Error("native hook relay permission approval has no connected waiters"),
+      );
+    }
+  }
 }
 
 function nativeHookRelayPermissionApprovalKey(params: {

--- a/src/agents/harness/native-hook-relay-response.ts
+++ b/src/agents/harness/native-hook-relay-response.ts
@@ -1,0 +1,72 @@
+export type NativeHookRelayResponseEvent =
+  | "pre_tool_use"
+  | "post_tool_use"
+  | "permission_request"
+  | "before_agent_finalize";
+
+export type NativeHookRelayWireResponse = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  failureDisposition?: "failed" | "cancelled" | "timed_out";
+};
+
+export function renderCodexNativeHookNoopResponse(): NativeHookRelayWireResponse {
+  return { stdout: "", stderr: "", exitCode: 0 };
+}
+
+export function renderCodexNativeHookPreToolUseBlockResponse(
+  reason: string,
+  failureDisposition?: NativeHookRelayWireResponse["failureDisposition"],
+): NativeHookRelayWireResponse {
+  return {
+    stdout: `${JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    })}\n`,
+    stderr: "",
+    exitCode: 0,
+    ...(failureDisposition ? { failureDisposition } : {}),
+  };
+}
+
+export function renderCodexNativeHookPermissionResponse(
+  decision: "allow" | "deny",
+  message?: string,
+): NativeHookRelayWireResponse {
+  return {
+    stdout: `${JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision:
+          decision === "allow"
+            ? { behavior: "allow" }
+            : {
+                behavior: "deny",
+                message: message?.trim() || "Denied by OpenClaw",
+              },
+      },
+    })}\n`,
+    stderr: "",
+    exitCode: 0,
+  };
+}
+
+export function renderCodexNativeHookUnavailableResponse(params: {
+  event: NativeHookRelayResponseEvent;
+  preToolUseUnavailable?: "noop";
+  message: string;
+}): NativeHookRelayWireResponse {
+  if (params.event === "pre_tool_use") {
+    return params.preToolUseUnavailable === "noop"
+      ? renderCodexNativeHookNoopResponse()
+      : renderCodexNativeHookPreToolUseBlockResponse(params.message);
+  }
+  if (params.event === "permission_request") {
+    return renderCodexNativeHookPermissionResponse("deny", params.message);
+  }
+  return renderCodexNativeHookNoopResponse();
+}

--- a/src/agents/harness/native-hook-relay-state.ts
+++ b/src/agents/harness/native-hook-relay-state.ts
@@ -9,6 +9,7 @@ function getNativeHookRelaySharedState(): NativeHookRelaySharedState {
   globalRecord[NATIVE_HOOK_RELAY_STATE_SYMBOL] ??= {
     relays: new Map(),
     relayBridges: new Map(),
+    admissions: new Map(),
     invocations: [],
     pendingPermissionApprovals: new Map(),
     pendingPreToolUseApprovals: new Map(),

--- a/src/agents/harness/native-hook-relay-types.ts
+++ b/src/agents/harness/native-hook-relay-types.ts
@@ -5,6 +5,7 @@ import type {
   BeforeToolCallFailureDisposition,
   DeferredPluginToolApproval,
 } from "../agent-tools.before-tool-call.js";
+import type { NativeHookRelayAdmissionController } from "./native-hook-relay-admission.js";
 
 export type JsonValue =
   | null
@@ -128,6 +129,8 @@ export type InvokeNativeHookRelayParams = {
   event: unknown;
   rawPayload: unknown;
   requireGeneration?: boolean;
+  admissionReserved?: boolean;
+  admissionSignal?: AbortSignal;
 };
 
 export type InvokeNativeHookRelayBridgeParams = InvokeNativeHookRelayParams & {
@@ -175,6 +178,11 @@ export type NativeHookRelayPermissionApprovalResult =
   | NativeHookRelayPermissionDecision
   | "allow-always"
   | "defer";
+export type NativeHookRelayPendingPermissionApproval = {
+  abortController: AbortController;
+  promise: Promise<NativeHookRelayPermissionApprovalResult>;
+  waiters: number;
+};
 
 export type ActiveNativeHookRelayRegistration = NativeHookRelayRegistration & {
   generation: string;
@@ -232,8 +240,9 @@ export type NativeHookRelayBridgeRegistration = {
 export type NativeHookRelaySharedState = {
   relays: Map<string, ActiveNativeHookRelayRegistration>;
   relayBridges: Map<string, NativeHookRelayBridgeRegistration>;
+  admissions: Map<string, NativeHookRelayAdmissionController>;
   invocations: NativeHookRelayInvocation[];
-  pendingPermissionApprovals: Map<string, Promise<NativeHookRelayPermissionApprovalResult>>;
+  pendingPermissionApprovals: Map<string, NativeHookRelayPendingPermissionApproval>;
   pendingPreToolUseApprovals: Map<string, NativeHookRelayPreToolUseApproval>;
   permissionApprovalWindows: Map<string, number[]>;
   permissionAllowAlwaysApprovals: Map<string, { expiresAtMs: number }>;

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -36,6 +36,7 @@ const NATIVE_HOOK_RELAY_EXEC_PREFIX = process.platform === "win32" ? "" : "exec 
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
   resetGlobalHookRunner();
   setActivePluginRegistry(createEmptyPluginRegistry());
@@ -3229,6 +3230,171 @@ describe("native hook relay registry", () => {
     ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
   });
 
+  it("releases an active PermissionRequest admission when its hook process disconnects", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+    const approvalStarted = deferredForNativeHookRelayTests();
+    const abortController = new AbortController();
+    testing.setNativeHookRelayPermissionApprovalRequesterForTests(
+      vi.fn(
+        (request) =>
+          new Promise<"allow">((_resolve, reject) => {
+            approvalStarted.resolve();
+            request.signal?.addEventListener(
+              "abort",
+              () => reject(new Error("hook process disconnected")),
+              { once: true },
+            );
+          }),
+      ),
+    );
+    const pending = invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "permission_request",
+      admissionSignal: abortController.signal,
+      rawPayload: {
+        hook_event_name: "PermissionRequest",
+        tool_name: "Bash",
+        tool_use_id: "disconnected-call",
+        tool_input: { command: "git push" },
+      },
+    });
+
+    await approvalStarted.promise;
+    expect(
+      getNativeHookRelaySharedStateForTests().admissions.get(relay.relayId)?.snapshot(),
+    ).toMatchObject({ active: 1, queued: 0 });
+    abortController.abort();
+    await expect(pending).rejects.toThrow("native hook relay admission cancelled");
+    expect(
+      getNativeHookRelaySharedStateForTests().admissions.get(relay.relayId)?.snapshot(),
+    ).toMatchObject({ active: 0, queued: 0, completed: 1, cancelled: 1 });
+
+    testing.setNativeHookRelayPermissionApprovalRequesterForTests(
+      vi.fn(async () => "allow" as const),
+    );
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          tool_name: "Bash",
+          tool_use_id: "successor-call",
+          tool_input: { command: "git status" },
+        },
+      }),
+    ).resolves.toMatchObject({ exitCode: 0 });
+    expect(
+      getNativeHookRelaySharedStateForTests().admissions.get(relay.relayId)?.snapshot(),
+    ).toMatchObject({ active: 0, completed: 2, rejected: 0 });
+  });
+
+  it("keeps a shared PermissionRequest approval alive for a connected duplicate", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+    const approvalStarted = deferredForNativeHookRelayTests();
+    let resolveDecision: ((decision: "allow") => void) | undefined;
+    const approvalRequester = vi.fn(
+      (request: { signal?: AbortSignal }) =>
+        new Promise<"allow">((resolve, reject) => {
+          resolveDecision = resolve;
+          request.signal?.addEventListener(
+            "abort",
+            () => reject(new Error("shared approval aborted")),
+            { once: true },
+          );
+          approvalStarted.resolve();
+        }),
+    );
+    testing.setNativeHookRelayPermissionApprovalRequesterForTests(approvalRequester);
+    const firstAbort = new AbortController();
+    const payload = {
+      hook_event_name: "PermissionRequest",
+      tool_name: "Bash",
+      tool_use_id: "shared-call",
+      tool_input: { command: "git push" },
+    };
+    const first = invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "permission_request",
+      admissionSignal: firstAbort.signal,
+      rawPayload: payload,
+    });
+    const second = invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "permission_request",
+      rawPayload: payload,
+    });
+
+    await approvalStarted.promise;
+    firstAbort.abort();
+    await expect(first).rejects.toThrow("native hook relay admission cancelled");
+    expect(approvalRequester).toHaveBeenCalledOnce();
+    expect(approvalRequester.mock.calls[0]?.[0].signal?.aborted).toBe(false);
+    resolveDecision?.("allow");
+    await expect(second).resolves.toMatchObject({ exitCode: 0 });
+    expect(getNativeHookRelaySharedStateForTests().pendingPermissionApprovals.size).toBe(0);
+  });
+
+  it("removes queued and active admission work when the relay registration stops", async () => {
+    const registrationAbort = new AbortController();
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+      signal: registrationAbort.signal,
+    });
+    const approvalRequester = vi.fn(
+      (request: { signal?: AbortSignal }) =>
+        new Promise<"allow">((_resolve, reject) => {
+          request.signal?.addEventListener(
+            "abort",
+            () => reject(new Error("relay registration stopped")),
+            { once: true },
+          );
+        }),
+    );
+    testing.setNativeHookRelayPermissionApprovalRequesterForTests(approvalRequester);
+    const invocations = Array.from({ length: 5 }, (_, index) =>
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          tool_name: "Bash",
+          tool_use_id: `registration-stop-${index}`,
+          tool_input: { command: `command-${index}` },
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        getNativeHookRelaySharedStateForTests().admissions.get(relay.relayId)?.snapshot(),
+      ).toMatchObject({ active: 4, queued: 1 });
+    });
+    registrationAbort.abort();
+    const settled = await Promise.allSettled(invocations);
+    expect(settled.every((result) => result.status === "rejected")).toBe(true);
+    await vi.waitFor(() => {
+      expect(
+        getNativeHookRelaySharedStateForTests().admissions.get(relay.relayId)?.snapshot(),
+      ).toMatchObject({ active: 0, queued: 0, completed: 4, cancelled: 5 });
+    });
+  });
+
   it("deduplicates pending PermissionRequest approvals by relay, run, and tool call", async () => {
     const relay = registerNativeHookRelay({
       provider: "codex",
@@ -3680,6 +3846,22 @@ describe("native hook relay command builder", () => {
         ? "openclaw hooks relay --provider codex --relay-id relay-1 --event post_tool_use --timeout 5000"
         : "exec nice -n 10 openclaw hooks relay --provider codex --relay-id relay-1 --event post_tool_use --timeout 5000",
     );
+  });
+
+  it("honors OPENCLAW_CLI_PATH instead of silently selecting the packaged fast entry", () => {
+    const cliPath = path.resolve("openclaw.mjs");
+    vi.stubEnv("OPENCLAW_CLI_PATH", cliPath);
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["post_tool_use"],
+    });
+
+    const command = relay.commandForEvent("post_tool_use");
+    expect(command).toContain(`${process.execPath} ${cliPath} hooks relay`);
+    expect(command).not.toContain("native-hook-relay-entry");
+    expect(command).not.toContain("--state-schema-version");
   });
 
   it("includes explicit unavailable noop mode only for PreToolUse", () => {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -3166,21 +3166,36 @@ describe("native hook relay registry", () => {
     expect(approvalRequester).toHaveBeenCalledTimes(1);
     resolveDecision?.("allow");
     const responses = await Promise.all([first, second]);
+    const settledDuplicate = await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "permission_request",
+      rawPayload: payload,
+    });
 
-    expect(responses.map((response) => JSON.parse(response.stdout))).toEqual([
-      {
-        hookSpecificOutput: {
-          hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+    expect(approvalRequester).toHaveBeenCalledTimes(1);
+    expect([...responses, settledDuplicate].map((response) => JSON.parse(response.stdout))).toEqual(
+      [
+        {
+          hookSpecificOutput: {
+            hookEventName: "PermissionRequest",
+            decision: { behavior: "allow" },
+          },
         },
-      },
-      {
-        hookSpecificOutput: {
-          hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+        {
+          hookSpecificOutput: {
+            hookEventName: "PermissionRequest",
+            decision: { behavior: "allow" },
+          },
         },
-      },
-    ]);
+        {
+          hookSpecificOutput: {
+            hookEventName: "PermissionRequest",
+            decision: { behavior: "allow" },
+          },
+        },
+      ],
+    );
   });
 
   it("keeps replacement pending PermissionRequest approvals when stale approvals settle", async () => {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -126,6 +126,17 @@ function nativeHookRelayStateDbArgForTests(): string {
   return `--state-db ${resolveOpenClawStateSqlitePath()}`;
 }
 
+function deferredForNativeHookRelayTests(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 function openDeferredNativeHookRelayBridgeRequest(
   record: Pick<NativeHookRelayBridgeRecord, "hostname" | "port" | "token">,
   payload: Record<string, unknown>,
@@ -201,6 +212,20 @@ type NativeHookRelaySharedStateForTests = {
   pendingPermissionApprovals: Map<string, unknown>;
   permissionApprovalWindows: Map<string, unknown[]>;
   permissionAllowAlwaysApprovals: Map<string, unknown>;
+  admissions: Map<
+    string,
+    {
+      snapshot: () => {
+        active: number;
+        queued: number;
+        accepted: number;
+        completed: number;
+        rejected: number;
+        peakActive: number;
+        peakQueued: number;
+      };
+    }
+  >;
 };
 
 function getNativeHookRelaySharedStateForTests(): NativeHookRelaySharedStateForTests {
@@ -768,6 +793,80 @@ describe("native hook relay registry", () => {
       relayId: relay.relayId,
       event: "pre_tool_use",
       runId: "run-1",
+    });
+  });
+
+  it("enforces four active and 32 queued bridge requests with deterministic overload", async () => {
+    const release = deferredForNativeHookRelayTests();
+    const beforeAgentFinalize = vi.fn(async () => {
+      await release.promise;
+      return { action: "continue" as const };
+    });
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "before_agent_finalize", handler: beforeAgentFinalize },
+      ]),
+    );
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-bounded-bridge-admission",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["before_agent_finalize"],
+    });
+    const record = await waitForNativeHookRelayBridgeRecord(relay.relayId);
+    const requests = Array.from({ length: 37 }, (_, index) =>
+      openDeferredNativeHookRelayBridgeRequest(record, {
+        provider: "codex",
+        relayId: relay.relayId,
+        generation: relay.generation,
+        event: "before_agent_finalize",
+        rawPayload: {
+          hook_event_name: "Stop",
+          turn_id: `bounded-admission-${index}`,
+          stop_hook_active: false,
+        },
+      }),
+    );
+    try {
+      await Promise.all(requests.map((request) => request.connected));
+      for (const request of requests) {
+        request.sendBody();
+      }
+      await vi.waitFor(() => expect(beforeAgentFinalize).toHaveBeenCalledTimes(4));
+
+      const admission = getNativeHookRelaySharedStateForTests().admissions.get(relay.relayId);
+      expect(admission?.snapshot()).toMatchObject({
+        active: 4,
+        queued: 32,
+        accepted: 36,
+        rejected: 1,
+        peakActive: 4,
+        peakQueued: 32,
+      });
+      await expect(requests[36]?.response).resolves.toMatchObject({
+        ok: false,
+        code: "overloaded",
+        error: "native hook relay overloaded",
+      });
+    } finally {
+      release.resolve();
+    }
+
+    const accepted = await Promise.all(requests.slice(0, 36).map((request) => request.response));
+    expect(accepted).toHaveLength(36);
+    expect(accepted.every((response) => response.ok === true)).toBe(true);
+    expect(beforeAgentFinalize).toHaveBeenCalledTimes(36);
+    expect(
+      getNativeHookRelaySharedStateForTests().admissions.get(relay.relayId)?.snapshot(),
+    ).toMatchObject({
+      active: 0,
+      queued: 0,
+      accepted: 36,
+      completed: 36,
+      rejected: 1,
+      peakActive: 4,
+      peakQueued: 32,
     });
   });
 

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -3285,8 +3285,8 @@ describe("native hook relay registry", () => {
         rawPayload: {
           hook_event_name: "PermissionRequest",
           tool_name: "Bash",
-          tool_use_id: "successor-call",
-          tool_input: { command: "git status" },
+          tool_use_id: "disconnected-call",
+          tool_input: { command: "git push" },
         },
       }),
     ).resolves.toMatchObject({ exitCode: 0 });
@@ -3395,7 +3395,7 @@ describe("native hook relay registry", () => {
     });
   });
 
-  it("deduplicates pending PermissionRequest approvals by relay, run, and tool call", async () => {
+  it("deduplicates only pending PermissionRequest approvals by relay, run, and tool call", async () => {
     const relay = registerNativeHookRelay({
       provider: "codex",
       sessionId: "session-1",
@@ -3438,7 +3438,7 @@ describe("native hook relay registry", () => {
       rawPayload: payload,
     });
 
-    expect(approvalRequester).toHaveBeenCalledTimes(1);
+    expect(approvalRequester).toHaveBeenCalledTimes(2);
     expect([...responses, settledDuplicate].map((response) => JSON.parse(response.stdout))).toEqual(
       [
         {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -4,11 +4,16 @@
 import { randomUUID } from "node:crypto";
 import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import type {
   BeforeToolCallFailureDisposition,
   requestDeferredPluginToolApproval,
 } from "../agent-tools.before-tool-call.js";
+import {
+  isNativeHookRelayAdmissionOverloadedError,
+  NativeHookRelayAdmissionController,
+} from "./native-hook-relay-admission.js";
 import {
   clearNativeHookRelayBridgesForTests,
   NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
@@ -36,6 +41,7 @@ import {
 } from "./native-hook-relay-events.js";
 import {
   clearNativeHookRelayPermissionsForTests,
+  buildNativeHookRelayPermissionAdmissionKey,
   formatPermissionApprovalDescriptionForTests as formatPermissionApprovalDescriptionForTestsImpl,
   permissionRequestContentFingerprintForTests as permissionRequestContentFingerprintForTestsImpl,
   permissionRequestToolInputKeyFingerprintForTests as permissionRequestToolInputKeyFingerprintForTestsImpl,
@@ -46,6 +52,7 @@ import {
   setNativeHookRelayDeferredToolApprovalRequesterForTests as setNativeHookRelayDeferredToolApprovalRequesterForTestsImpl,
   setNativeHookRelayPermissionApprovalRequesterForTests as setNativeHookRelayPermissionApprovalRequesterForTestsImpl,
 } from "./native-hook-relay-permissions.js";
+import { renderCodexNativeHookUnavailableResponse } from "./native-hook-relay-response.js";
 import { nativeHookRelayState } from "./native-hook-relay-state.js";
 import type {
   ActiveNativeHookRelayRegistration,
@@ -129,7 +136,7 @@ const DEFAULT_RELAY_TTL_MS = 30 * 60 * 1000;
 const MAX_NATIVE_HOOK_RELAY_INVOCATIONS = 200;
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
 
-const { relays, relayBridges, invocations } = nativeHookRelayState;
+const { relays, relayBridges, admissions, invocations } = nativeHookRelayState;
 
 function resolveNativeHookRelayExpiresAtMs(ttlMs: number | undefined): number | undefined {
   return resolveExpiresAtMsFromDurationMs(normalizePositiveInteger(ttlMs, DEFAULT_RELAY_TTL_MS));
@@ -153,6 +160,7 @@ export function registerNativeHookRelay(
   unregisterNativeHookRelay(relayId, undefined, {
     deferBridgeRecordRemovalMs: NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
   });
+  admissions.set(relayId, new NativeHookRelayAdmissionController());
   const registration: ActiveNativeHookRelayRegistration = {
     relayId,
     provider: params.provider,
@@ -184,6 +192,7 @@ export function registerNativeHookRelay(
         provider: params.provider,
         relayId,
         stateDbPath,
+        stateSchemaVersion: OPENCLAW_STATE_SCHEMA_VERSION,
         generation: registration.generation,
         event,
         preToolUseUnavailable:
@@ -239,6 +248,13 @@ function unregisterNativeHookRelay(
 ): void {
   if (expectedRegistration && relays.get(relayId) !== expectedRegistration) {
     return;
+  }
+  const admission = admissions.get(relayId);
+  if (admission) {
+    const snapshot = admission.snapshot();
+    admission.close();
+    admissions.delete(relayId);
+    log.debug("native hook relay admission summary", { relayId, ...snapshot });
   }
   unregisterNativeHookRelayBridge(relayId, options);
   relays.delete(relayId);
@@ -307,31 +323,77 @@ export async function invokeNativeHookRelay(
     throw new Error("native hook relay payload must be JSON-compatible");
   }
 
+  const adapter = getNativeHookRelayProviderAdapter(provider);
   const normalized = normalizeNativeHookInvocation({
     registration,
     event,
     rawPayload: params.rawPayload,
   });
-  recordNativeHookRelayInvocation(normalized);
-  const startedAt = Date.now();
-  const response = await processNativeHookRelayInvocation({
-    registration,
-    invocation: normalized,
-    adapter: getNativeHookRelayProviderAdapter(provider),
-  });
-  if (
-    normalized.toolUseId &&
-    response.failureDisposition &&
-    readNativeHookRelayApprovalMode(normalized.rawPayload) !== "report"
-  ) {
-    projectNativeHookRelayPreToolUseFailure(registration, {
-      toolName: normalizeNativeHookToolName(normalized.toolName),
-      toolCallId: normalized.toolUseId,
-      disposition: response.failureDisposition,
-      durationMs: Date.now() - startedAt,
+  const admissionKey =
+    event === "permission_request"
+      ? `permission:${buildNativeHookRelayPermissionAdmissionKey({
+          registration,
+          invocation: normalized,
+          adapter,
+        })}`
+      : undefined;
+  const directSignal =
+    params.admissionSignal && registration.signal
+      ? AbortSignal.any([params.admissionSignal, registration.signal])
+      : (params.admissionSignal ?? registration.signal);
+  const execute = async (operationSignal: AbortSignal | undefined = directSignal) => {
+    const signal =
+      operationSignal && registration.signal && operationSignal !== registration.signal
+        ? AbortSignal.any([operationSignal, registration.signal])
+        : (operationSignal ?? registration.signal);
+    signal?.throwIfAborted();
+    recordNativeHookRelayInvocation(normalized);
+    const startedAt = Date.now();
+    const response = await processNativeHookRelayInvocation({
+      registration,
+      invocation: normalized,
+      adapter,
+      signal,
+    });
+    signal?.throwIfAborted();
+    if (
+      normalized.toolUseId &&
+      response.failureDisposition &&
+      readNativeHookRelayApprovalMode(normalized.rawPayload) !== "report"
+    ) {
+      projectNativeHookRelayPreToolUseFailure(registration, {
+        toolName: normalizeNativeHookToolName(normalized.toolName),
+        toolCallId: normalized.toolUseId,
+        disposition: response.failureDisposition,
+        durationMs: Date.now() - startedAt,
+      });
+    }
+    return response;
+  };
+  const admission = admissions.get(relayId);
+  if (params.admissionReserved || !admission) {
+    return execute(directSignal);
+  }
+  try {
+    return await admission.run(execute, {
+      ...(directSignal ? { signal: directSignal } : {}),
+      ...(admissionKey ? { key: admissionKey } : {}),
+    });
+  } catch (error) {
+    if (!isNativeHookRelayAdmissionOverloadedError(error)) {
+      throw error;
+    }
+    log.warn("native hook relay admission rejected overloaded invocation", {
+      relayId,
+      runId: registration.runId,
+      event,
+      ...admission.snapshot(),
+    });
+    return renderCodexNativeHookUnavailableResponse({
+      event,
+      message: "Native hook relay overloaded",
     });
   }
-  return response;
 }
 
 function projectNativeHookRelayPreToolUseFailure(
@@ -401,23 +463,14 @@ export function renderNativeHookRelayUnavailableResponse(params: {
   preToolUseUnavailable?: unknown;
   message?: string;
 }): NativeHookRelayProcessResponse {
-  const provider = readNativeHookRelayProvider(params.provider);
+  readNativeHookRelayProvider(params.provider);
   const event = readNativeHookRelayEvent(params.event);
-  const adapter = getNativeHookRelayProviderAdapter(provider);
   const message = params.message?.trim() || "Native hook relay unavailable";
-  if (event === "pre_tool_use") {
-    // The standalone CLI cannot reconstruct the originating registration after
-    // relay lookup fails, so unavailable PreToolUse must fail closed unless the
-    // generated command explicitly recorded that no before-tool policy existed.
-    if (params.preToolUseUnavailable === "noop") {
-      return adapter.renderNoopResponse(event);
-    }
-    return adapter.renderPreToolUseBlockResponse(message);
-  }
-  if (event === "permission_request") {
-    return adapter.renderPermissionDecisionResponse("deny", message);
-  }
-  return adapter.renderNoopResponse(event);
+  return renderCodexNativeHookUnavailableResponse({
+    event,
+    ...(params.preToolUseUnavailable === "noop" ? { preToolUseUnavailable: "noop" } : {}),
+    message,
+  });
 }
 
 function recordNativeHookRelayInvocation(invocation: NativeHookRelayInvocation): void {
@@ -473,6 +526,10 @@ function normalizeAllowedEvents(
 export const testing = {
   clearNativeHookRelaysForTests(): void {
     clearNativeHookRelayBridgesForTests();
+    for (const admission of admissions.values()) {
+      admission.close();
+    }
+    admissions.clear();
     relays.clear();
     invocations.length = 0;
     clearNativeHookRelayPermissionsForTests();

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -1,6 +1,7 @@
 // Native hook relay CLI tests cover relay command registration and runtime delegation.
 import { PassThrough, Readable, Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
+import { NativeHookRelayAdmissionOverloadedError } from "../agents/harness/native-hook-relay-admission.js";
 import { runNativeHookRelayCli } from "./native-hook-relay-cli.js";
 
 function createReadableTextStream(text: string): NodeJS.ReadableStream {
@@ -615,6 +616,40 @@ describe("native hook relay CLI", () => {
     expect(exitCode).toBe(0);
     expect(stdout.text()).toBe("");
     expect(stderr.text()).toContain("native hook relay unavailable");
+  });
+
+  it("does not bypass deterministic overload through the gateway fallback", async () => {
+    const callGateway = vi.fn();
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      {
+        provider: "codex",
+        relayId: "relay-1",
+        generation: "generation-1",
+        event: "permission_request",
+      },
+      {
+        stdin: createReadableTextStream("{}"),
+        stdout,
+        stderr,
+        invokeBridge: vi.fn(async () => {
+          throw new NativeHookRelayAdmissionOverloadedError();
+        }) as never,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.text())).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: { behavior: "deny", message: "Native hook relay overloaded" },
+      },
+    });
+    expect(stderr.text()).toContain("native hook relay unavailable");
+    expect(callGateway).not.toHaveBeenCalled();
   });
 });
 

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -1,3 +1,4 @@
+import { isNativeHookRelayAdmissionOverloadedError } from "../agents/harness/native-hook-relay-admission.js";
 // CLI adapter for invoking native provider hooks through direct relay or gateway fallback.
 import {
   invokeNativeHookRelayBridge,
@@ -120,6 +121,17 @@ export async function runNativeHookRelayCli(
       if (isNativeHookRelayBridgeStaleRegistrationError(error)) {
         writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
         return writeNativeHookRelayUnavailableResponse({ stdout, stderr, opts, provider, event });
+      }
+      if (isNativeHookRelayAdmissionOverloadedError(error)) {
+        writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
+        return writeNativeHookRelayUnavailableResponse({
+          stdout,
+          stderr,
+          opts,
+          provider,
+          event,
+          message: "Native hook relay overloaded",
+        });
       }
       // Fall through to the gateway path for embedded/local gateway cases and
       // older registrations that predate the direct relay bridge.

--- a/src/native-hook-relay-entry.test.ts
+++ b/src/native-hook-relay-entry.test.ts
@@ -295,6 +295,37 @@ describe("native hook relay minimal entry", () => {
     expect(fallback).toHaveBeenCalledOnce();
   });
 
+  it("bounds an oversized bridge response before using the full fallback", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end("x".repeat(5 * 1024 * 1024 + 1));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("oversized-response test bridge did not expose a TCP port");
+    }
+    const fallback = vi.fn(async () => 6);
+    try {
+      await expect(
+        runNativeHookRelayEntry(options(), {
+          stdin: readable("{}"),
+          readRecord: () => ({ ...record, port: address.port }),
+          fallback,
+        }),
+      ).resolves.toBe(6);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+
+    expect(fallback).toHaveBeenCalledOnce();
+  });
+
   it("rejects oversized input before locator access or fallback", async () => {
     const stderr = writable();
     const readRecord = vi.fn();

--- a/src/native-hook-relay-entry.test.ts
+++ b/src/native-hook-relay-entry.test.ts
@@ -1,0 +1,341 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { PassThrough, Readable, Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseNativeHookRelayEntryArgs,
+  runNativeHookRelayEntry,
+  type FastRelayOptions,
+} from "./native-hook-relay-entry.js";
+
+function options(overrides: Partial<FastRelayOptions> = {}): FastRelayOptions {
+  return {
+    provider: "codex",
+    relayId: "relay-1",
+    stateDb: "/tmp/openclaw.sqlite",
+    stateSchemaVersion: 5,
+    generation: "generation-1",
+    event: "pre_tool_use",
+    timeoutMs: 5_000,
+    ...overrides,
+  };
+}
+
+function readable(text: string): NodeJS.ReadableStream {
+  return Readable.from([text]);
+}
+
+function writable(): NodeJS.WritableStream & { text: () => string } {
+  const chunks: Buffer[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+      callback();
+    },
+  });
+  return Object.assign(stream, {
+    text: () => Buffer.concat(chunks).toString("utf8"),
+  });
+}
+
+const record = {
+  relayId: "relay-1",
+  pid: 42,
+  hostname: "127.0.0.1" as const,
+  port: 19_999,
+  token: "opaque-token",
+  expiresAtMs: Number.MAX_SAFE_INTEGER,
+};
+
+describe("native hook relay minimal entry", () => {
+  it("parses the generated command contract without importing the full CLI", () => {
+    expect(
+      parseNativeHookRelayEntryArgs([
+        "--provider",
+        "codex",
+        "--relay-id",
+        "relay-1",
+        "--state-db",
+        "/tmp/openclaw.sqlite",
+        "--state-schema-version",
+        "5",
+        "--generation",
+        "generation-1",
+        "--event",
+        "post_tool_use",
+        "--timeout",
+        "4321",
+      ]),
+    ).toEqual(options({ event: "post_tool_use", timeoutMs: 4_321 }));
+  });
+
+  it("forwards JSON to the bridge and preserves its response byte-for-byte", async () => {
+    const stdout = writable();
+    const stderr = writable();
+    const post = vi.fn(async (_params: { body: string }) => ({
+      stdout: "exact-out\n",
+      stderr: "exact-err\n",
+      exitCode: 7,
+    }));
+    const fallback = vi.fn();
+
+    await expect(
+      runNativeHookRelayEntry(options(), {
+        stdin: readable('{"tool_name":"Bash"}'),
+        stdout,
+        stderr,
+        readRecord: () => record,
+        post,
+        fallback,
+      }),
+    ).resolves.toBe(7);
+
+    expect(stdout.text()).toBe("exact-out\n");
+    expect(stderr.text()).toBe("exact-err\n");
+    expect(JSON.parse(post.mock.calls[0]?.[0].body as string)).toEqual({
+      provider: "codex",
+      relayId: "relay-1",
+      generation: "generation-1",
+      event: "pre_tool_use",
+      rawPayload: { tool_name: "Bash" },
+    });
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("reads the real SQLite locator and invokes a loopback bridge end to end", async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-native-hook-entry-"));
+    const stateDb = path.join(tempDir, "state.sqlite");
+    const token = "integration-token";
+    let receivedAuthorization = "";
+    let receivedBody = "";
+    const server = createServer((request, response) => {
+      receivedAuthorization = String(request.headers.authorization ?? "");
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        receivedBody += chunk;
+      });
+      request.on("end", () => {
+        const body = JSON.stringify({
+          ok: true,
+          result: { stdout: "integrated\n", stderr: "", exitCode: 0 },
+        });
+        response.writeHead(200, {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+        });
+        response.end(body);
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("test bridge did not expose a TCP port");
+    }
+    const db = new DatabaseSync(stateDb);
+    try {
+      db.exec(`
+        PRAGMA user_version = 5;
+        CREATE TABLE native_hook_relay_bridges (
+          relay_id TEXT NOT NULL PRIMARY KEY,
+          pid INTEGER NOT NULL,
+          hostname TEXT NOT NULL,
+          port INTEGER NOT NULL,
+          token TEXT NOT NULL,
+          expires_at_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL
+        ) STRICT;
+      `);
+      db.prepare(
+        `INSERT INTO native_hook_relay_bridges
+          (relay_id, pid, hostname, port, token, expires_at_ms, updated_at_ms)
+          VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "relay-1",
+        process.pid,
+        "127.0.0.1",
+        address.port,
+        token,
+        Date.now() + 60_000,
+        Date.now(),
+      );
+    } finally {
+      db.close();
+    }
+
+    const stdout = writable();
+    try {
+      await expect(
+        runNativeHookRelayEntry(options({ stateDb }), {
+          stdin: readable('{"tool_name":"Bash"}'),
+          stdout,
+        }),
+      ).resolves.toBe(0);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+
+    expect(stdout.text()).toBe("integrated\n");
+    expect(receivedAuthorization).toBe(`Bearer ${token}`);
+    expect(JSON.parse(receivedBody)).toMatchObject({
+      relayId: "relay-1",
+      event: "pre_tool_use",
+      rawPayload: { tool_name: "Bash" },
+    });
+  });
+
+  it("renders overload locally and never bypasses admission through fallback", async () => {
+    const stdout = writable();
+    const stderr = writable();
+    const fallback = vi.fn();
+
+    await expect(
+      runNativeHookRelayEntry(options({ event: "permission_request" }), {
+        stdin: readable("{}"),
+        stdout,
+        stderr,
+        readRecord: () => record,
+        post: async () => {
+          throw Object.assign(new Error("native hook relay overloaded"), {
+            code: "overloaded",
+          });
+        },
+        fallback,
+      }),
+    ).resolves.toBe(0);
+
+    expect(JSON.parse(stdout.text())).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: { behavior: "deny", message: "Native hook relay overloaded" },
+      },
+    });
+    expect(stderr.text()).toContain("native hook relay unavailable");
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("re-reads the locator during replacement and accepts the successor", async () => {
+    let now = 0;
+    const post = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("stale"), { code: "stale" }))
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+    const fallback = vi.fn();
+
+    await expect(
+      runNativeHookRelayEntry(options(), {
+        stdin: readable("{}"),
+        readRecord: () => record,
+        post,
+        fallback,
+        now: () => now,
+        sleep: async (ms) => {
+          now += ms;
+        },
+      }),
+    ).resolves.toBe(0);
+
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing locator", Object.assign(new Error("missing"), { code: "ENOENT" })],
+    ["refused bridge", Object.assign(new Error("refused"), { code: "ECONNREFUSED" })],
+    ["unsafe database", new Error("unsupported OpenClaw state database schema")],
+  ])("uses the full same-process fallback for %s", async (_label, failure) => {
+    let now = 0;
+    const fallback = vi.fn(async () => 9);
+
+    await expect(
+      runNativeHookRelayEntry(options(), {
+        stdin: readable('{"x":1}'),
+        readRecord: () => {
+          throw failure;
+        },
+        fallback,
+        now: () => now,
+        sleep: async () => {
+          now += 100;
+        },
+      }),
+    ).resolves.toBe(9);
+
+    expect(fallback).toHaveBeenCalledWith(
+      expect.objectContaining({ relayId: "relay-1" }),
+      '{"x":1}',
+      expect.any(Object),
+      expect.any(Number),
+    );
+  });
+
+  it("falls back instead of contacting an expired bridge record", async () => {
+    const post = vi.fn();
+    const fallback = vi.fn(async () => 8);
+
+    await expect(
+      runNativeHookRelayEntry(options(), {
+        stdin: readable("{}"),
+        readRecord: () => ({ ...record, expiresAtMs: 999 }),
+        post,
+        fallback,
+        now: () => 1_000,
+      }),
+    ).resolves.toBe(8);
+
+    expect(post).not.toHaveBeenCalled();
+    expect(fallback).toHaveBeenCalledOnce();
+  });
+
+  it("rejects oversized input before locator access or fallback", async () => {
+    const stderr = writable();
+    const readRecord = vi.fn();
+    const fallback = vi.fn();
+
+    await expect(
+      runNativeHookRelayEntry(options({ event: "post_tool_use" }), {
+        stdin: readable("x".repeat(1024 * 1024 + 1)),
+        stderr,
+        readRecord,
+        fallback,
+      }),
+    ).resolves.toBe(1);
+
+    expect(stderr.text()).toContain("native hook input exceeds");
+    expect(readRecord).not.toHaveBeenCalled();
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("bounds held-open stdin and returns the event-specific timeout response", async () => {
+    const stdin = new PassThrough();
+    stdin.write("{}");
+    const stdout = writable();
+    const stderr = writable();
+
+    await expect(
+      runNativeHookRelayEntry(options({ timeoutMs: 20 }), {
+        stdin,
+        stdout,
+        stderr,
+      }),
+    ).resolves.toBe(0);
+
+    expect(JSON.parse(stdout.text())).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay timed out",
+      },
+    });
+    expect(stderr.text()).toContain("native hook relay timed out");
+    expect(stdin.destroyed).toBe(true);
+  });
+});

--- a/src/native-hook-relay-entry.test.ts
+++ b/src/native-hook-relay-entry.test.ts
@@ -112,7 +112,7 @@ describe("native hook relay minimal entry", () => {
     let receivedAuthorization = "";
     let receivedBody = "";
     const server = createServer((request, response) => {
-      receivedAuthorization = String(request.headers.authorization ?? "");
+      receivedAuthorization = request.headers.authorization ?? "";
       request.setEncoding("utf8");
       request.on("data", (chunk) => {
         receivedBody += chunk;

--- a/src/native-hook-relay-entry.ts
+++ b/src/native-hook-relay-entry.ts
@@ -329,7 +329,7 @@ function postFastRelay(params: {
               reject(new Error(parsed.error ?? "native hook relay bridge failed"));
             }
           } catch (error) {
-            reject(error);
+            reject(error instanceof Error ? error : new Error(String(error)));
           }
         });
       },

--- a/src/native-hook-relay-entry.ts
+++ b/src/native-hook-relay-entry.ts
@@ -1,0 +1,505 @@
+#!/usr/bin/env node
+// Minimal native-hook transport. Policy remains in the long-lived Gateway.
+import { request as httpRequest } from "node:http";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { Readable } from "node:stream";
+import { pathToFileURL } from "node:url";
+import {
+  renderCodexNativeHookUnavailableResponse,
+  type NativeHookRelayResponseEvent,
+  type NativeHookRelayWireResponse,
+} from "./agents/harness/native-hook-relay-response.js";
+
+const MAX_STDIN_BYTES = 1024 * 1024;
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const REGISTRATION_RETRY_MS = 100;
+const STALE_RETRY_MS = 250;
+const SQLITE_BUSY_TIMEOUT_MS = 5_000;
+const EVENTS = new Set<NativeHookRelayResponseEvent>([
+  "pre_tool_use",
+  "post_tool_use",
+  "permission_request",
+  "before_agent_finalize",
+]);
+
+export type FastRelayOptions = {
+  provider: string;
+  relayId: string;
+  stateDb: string;
+  stateSchemaVersion: number;
+  generation?: string;
+  event: NativeHookRelayResponseEvent;
+  preToolUseUnavailable?: "noop";
+  timeoutMs: number;
+};
+
+type FastRelayRecord = {
+  relayId: string;
+  pid: number;
+  hostname: "127.0.0.1";
+  port: number;
+  token: string;
+  expiresAtMs: number;
+};
+
+export type FastRelayDeps = {
+  stdin?: NodeJS.ReadableStream;
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+  now?: () => number;
+  readRecord?: (options: FastRelayOptions) => FastRelayRecord;
+  post?: (params: {
+    record: FastRelayRecord;
+    body: string;
+    timeoutMs: number;
+    signal: AbortSignal;
+  }) => Promise<NativeHookRelayWireResponse>;
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+  fallback?: (
+    options: FastRelayOptions,
+    rawInput: string,
+    streams: { stdout: NodeJS.WritableStream; stderr: NodeJS.WritableStream },
+    timeoutMs: number,
+  ) => Promise<number>;
+};
+
+class FastRelayError extends Error {
+  constructor(
+    readonly code: "overloaded" | "stale",
+    errorMessage: string,
+  ) {
+    super(errorMessage);
+    this.name = "FastRelayError";
+  }
+}
+
+type Deadline = {
+  expiresAtMs: number;
+  signal: AbortSignal;
+  timeoutMs: number;
+  dispose: () => void;
+};
+
+export function parseNativeHookRelayEntryArgs(argv: string[]): FastRelayOptions {
+  const values = new Map<string, string>();
+  const allowed = new Set([
+    "--provider",
+    "--relay-id",
+    "--state-db",
+    "--state-schema-version",
+    "--generation",
+    "--event",
+    "--pre-tool-use-unavailable",
+    "--timeout",
+  ]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag || !allowed.has(flag) || value === undefined || value.startsWith("--")) {
+      throw new Error(`invalid native hook relay argument: ${flag ?? "<missing>"}`);
+    }
+    if (values.has(flag)) {
+      throw new Error(`duplicate native hook relay argument: ${flag}`);
+    }
+    values.set(flag, value);
+  }
+  const provider = required(values, "--provider");
+  if (provider !== "codex") {
+    throw new Error(`unsupported native hook relay provider: ${provider}`);
+  }
+  const event = required(values, "--event");
+  if (!EVENTS.has(event as NativeHookRelayResponseEvent)) {
+    throw new Error(`unsupported native hook relay event: ${event}`);
+  }
+  const stateSchemaVersion = positiveInteger(
+    required(values, "--state-schema-version"),
+    "state schema version",
+  );
+  const timeoutMs = positiveInteger(
+    values.get("--timeout") ?? String(DEFAULT_TIMEOUT_MS),
+    "timeout",
+  );
+  const preToolUseUnavailable = values.get("--pre-tool-use-unavailable");
+  if (preToolUseUnavailable !== undefined && preToolUseUnavailable !== "noop") {
+    throw new Error(`unsupported pre-tool-use unavailable behavior: ${preToolUseUnavailable}`);
+  }
+  return {
+    provider,
+    relayId: required(values, "--relay-id"),
+    stateDb: required(values, "--state-db"),
+    stateSchemaVersion,
+    ...(values.get("--generation") ? { generation: values.get("--generation") } : {}),
+    event: event as NativeHookRelayResponseEvent,
+    ...(preToolUseUnavailable ? { preToolUseUnavailable } : {}),
+    timeoutMs,
+  };
+}
+
+export async function runNativeHookRelayEntry(
+  options: FastRelayOptions,
+  deps: FastRelayDeps = {},
+): Promise<number> {
+  const stdin = deps.stdin ?? process.stdin;
+  const stdout = deps.stdout ?? process.stdout;
+  const stderr = deps.stderr ?? process.stderr;
+  const now = deps.now ?? Date.now;
+  const deadline = createDeadline(options.timeoutMs, now);
+  let rawInput: string;
+  try {
+    rawInput = await readBoundedInput(stdin, deadline, now);
+  } catch (error) {
+    if (deadline.signal.aborted) {
+      return writeUnavailable(options, stdout, stderr, "Native hook relay timed out", error);
+    }
+    write(stderr, `failed to read native hook input: ${message(error)}\n`);
+    deadline.dispose();
+    return 1;
+  }
+
+  try {
+    const rawPayload = rawInput.trim() ? JSON.parse(rawInput) : null;
+    const body = JSON.stringify({
+      provider: options.provider,
+      relayId: options.relayId,
+      generation: options.generation,
+      event: options.event,
+      rawPayload,
+    });
+    const response = await invokeFastRelay(options, body, deadline, now, deps);
+    write(stdout, response.stdout);
+    write(stderr, response.stderr);
+    return response.exitCode;
+  } catch (error) {
+    if (deadline.signal.aborted) {
+      return writeUnavailable(options, stdout, stderr, "Native hook relay timed out", error);
+    }
+    if (isFastRelayError(error, "overloaded") || isFastRelayError(error, "stale")) {
+      const unavailable = isFastRelayError(error, "overloaded")
+        ? "Native hook relay overloaded"
+        : "Native hook relay unavailable";
+      return writeUnavailable(options, stdout, stderr, unavailable, error);
+    }
+    try {
+      const remainingMs = remaining(deadline, now);
+      const fallback = deps.fallback ?? runFullRelayFallback;
+      return await fallback(options, rawInput, { stdout, stderr }, remainingMs);
+    } catch (fallbackError) {
+      const unavailable = deadline.signal.aborted
+        ? "Native hook relay timed out"
+        : "Native hook relay unavailable";
+      return writeUnavailable(options, stdout, stderr, unavailable, fallbackError);
+    }
+  } finally {
+    deadline.dispose();
+  }
+}
+
+async function invokeFastRelay(
+  options: FastRelayOptions,
+  body: string,
+  deadline: Deadline,
+  now: () => number,
+  deps: FastRelayDeps,
+): Promise<NativeHookRelayWireResponse> {
+  const startedAt = now();
+  for (;;) {
+    try {
+      const record = (deps.readRecord ?? readFastRelayRecord)(options);
+      if (now() > record.expiresAtMs) {
+        throw new Error("native hook relay bridge expired");
+      }
+      return await (deps.post ?? postFastRelay)({
+        record,
+        body,
+        timeoutMs: remaining(deadline, now),
+        signal: deadline.signal,
+      });
+    } catch (error) {
+      if (isFastRelayError(error, "overloaded")) {
+        throw error;
+      }
+      const elapsedMs = now() - startedAt;
+      const retryable = isRetryable(error);
+      const stale = isFastRelayError(error, "stale");
+      if (
+        (!retryable || elapsedMs >= REGISTRATION_RETRY_MS) &&
+        (!stale || elapsedMs >= STALE_RETRY_MS)
+      ) {
+        throw error;
+      }
+      await (deps.sleep ?? delay)(Math.min(10, remaining(deadline, now)), deadline.signal);
+    }
+  }
+}
+
+function readFastRelayRecord(options: FastRelayOptions): FastRelayRecord {
+  const db = new DatabaseSync(path.resolve(options.stateDb), {
+    readOnly: true,
+  });
+  try {
+    db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
+    const versionRow = db.prepare("PRAGMA user_version").get() as
+      | { user_version?: unknown }
+      | undefined;
+    const version = versionRow?.user_version;
+    if (typeof version !== "number" || version > options.stateSchemaVersion) {
+      throw new Error("unsupported OpenClaw state database schema");
+    }
+    const row = db
+      .prepare(
+        "SELECT relay_id, pid, hostname, port, token, expires_at_ms FROM native_hook_relay_bridges WHERE relay_id = ?",
+      )
+      .get(options.relayId) as Record<string, unknown> | undefined;
+    if (
+      row?.relay_id !== options.relayId ||
+      !Number.isSafeInteger(row.pid) ||
+      row.hostname !== "127.0.0.1" ||
+      !Number.isSafeInteger(row.port) ||
+      Number(row.port) <= 0 ||
+      Number(row.port) > 65_535 ||
+      typeof row.token !== "string" ||
+      row.token.length === 0 ||
+      !Number.isSafeInteger(row.expires_at_ms)
+    ) {
+      throw Object.assign(new Error("native hook relay bridge not found"), {
+        code: "ENOENT",
+      });
+    }
+    return {
+      relayId: options.relayId,
+      pid: Number(row.pid),
+      hostname: row.hostname,
+      port: Number(row.port),
+      token: row.token,
+      expiresAtMs: Number(row.expires_at_ms),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function postFastRelay(params: {
+  record: FastRelayRecord;
+  body: string;
+  timeoutMs: number;
+  signal: AbortSignal;
+}): Promise<NativeHookRelayWireResponse> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        hostname: params.record.hostname,
+        port: params.record.port,
+        path: "/invoke",
+        method: "POST",
+        signal: params.signal,
+        timeout: params.timeoutMs,
+        headers: {
+          authorization: `Bearer ${params.record.token}`,
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(params.body),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        let total = 0;
+        res.on("data", (chunk) => {
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          total += buffer.byteLength;
+          if (total > MAX_RESPONSE_BYTES) {
+            res.destroy(new Error("native hook relay bridge response too large"));
+            return;
+          }
+          chunks.push(buffer);
+        });
+        res.on("error", reject);
+        res.on("end", () => {
+          try {
+            const parsed = JSON.parse(Buffer.concat(chunks, total).toString("utf8")) as
+              | { ok: true; result: NativeHookRelayWireResponse }
+              | { ok: false; code?: string; error?: string };
+            if (parsed.ok) {
+              resolve(parsed.result);
+            } else if (parsed.code === "overloaded") {
+              reject(new FastRelayError("overloaded", "native hook relay overloaded"));
+            } else if (res.statusCode === 410) {
+              reject(new FastRelayError("stale", parsed.error ?? "native hook relay stale"));
+            } else {
+              reject(new Error(parsed.error ?? "native hook relay bridge failed"));
+            }
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+    req.on("timeout", () => req.destroy(new Error("native hook relay bridge timed out")));
+    req.on("error", reject);
+    req.end(params.body);
+  });
+}
+
+async function runFullRelayFallback(
+  options: FastRelayOptions,
+  rawInput: string,
+  streams: { stdout: NodeJS.WritableStream; stderr: NodeJS.WritableStream },
+  timeoutMs: number,
+): Promise<number> {
+  const startedAt = Date.now();
+  const { runNativeHookRelayCli } = await import("./cli/native-hook-relay-cli.js");
+  const remainingMs = Math.max(1, timeoutMs - (Date.now() - startedAt));
+  return runNativeHookRelayCli(
+    {
+      provider: options.provider,
+      relayId: options.relayId,
+      stateDb: options.stateDb,
+      ...(options.generation ? { generation: options.generation } : {}),
+      event: options.event,
+      ...(options.preToolUseUnavailable
+        ? { preToolUseUnavailable: options.preToolUseUnavailable }
+        : {}),
+      timeout: String(remainingMs),
+    },
+    { stdin: Readable.from([rawInput]), ...streams },
+  );
+}
+
+async function readBoundedInput(
+  stream: NodeJS.ReadableStream,
+  deadline: Deadline,
+  now: () => number,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const abort = () => {
+    const destroy = (stream as NodeJS.ReadableStream & { destroy?: (error?: Error) => void })
+      .destroy;
+    destroy?.call(stream, new Error(`native hook relay timed out after ${deadline.timeoutMs}ms`));
+  };
+  deadline.signal.addEventListener("abort", abort, { once: true });
+  try {
+    for await (const chunk of stream) {
+      remaining(deadline, now);
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buffer.byteLength;
+      if (total > MAX_STDIN_BYTES) {
+        throw new Error(`native hook input exceeds ${MAX_STDIN_BYTES} bytes`);
+      }
+      chunks.push(buffer);
+    }
+    remaining(deadline, now);
+    return Buffer.concat(chunks, total).toString("utf8");
+  } finally {
+    deadline.signal.removeEventListener("abort", abort);
+  }
+}
+
+function createDeadline(timeoutMs: number, now: () => number): Deadline {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  timer.unref?.();
+  return {
+    expiresAtMs: now() + timeoutMs,
+    signal: controller.signal,
+    timeoutMs,
+    dispose: () => clearTimeout(timer),
+  };
+}
+
+function remaining(deadline: Deadline, now: () => number): number {
+  const value = deadline.expiresAtMs - now();
+  if (value <= 0 || deadline.signal.aborted) {
+    throw new Error(`native hook relay timed out after ${deadline.timeoutMs}ms`);
+  }
+  return Math.max(1, value);
+}
+
+function isRetryable(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOENT" || code === "ECONNREFUSED" || code === "EAGAIN";
+}
+
+function isFastRelayError(error: unknown, code: FastRelayError["code"]): error is FastRelayError {
+  return (
+    (error instanceof FastRelayError && error.code === code) ||
+    (error instanceof Error && (error as Error & { code?: unknown }).code === code)
+  );
+}
+
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", abort);
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const abort = () => {
+      clearTimeout(timer);
+      cleanup();
+      reject(new Error("native hook relay timed out"));
+    };
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function writeUnavailable(
+  options: FastRelayOptions,
+  stdout: NodeJS.WritableStream,
+  stderr: NodeJS.WritableStream,
+  unavailable: string,
+  error: unknown,
+): number {
+  const prefix =
+    unavailable === "Native hook relay timed out"
+      ? "native hook relay timed out"
+      : "native hook relay unavailable";
+  write(stderr, `${prefix}: ${message(error)}\n`);
+  const response = renderCodexNativeHookUnavailableResponse({
+    event: options.event,
+    ...(options.preToolUseUnavailable
+      ? { preToolUseUnavailable: options.preToolUseUnavailable }
+      : {}),
+    message: unavailable,
+  });
+  write(stdout, response.stdout);
+  write(stderr, response.stderr);
+  return response.exitCode;
+}
+
+function required(values: Map<string, string>, flag: string): string {
+  const value = values.get(flag)?.trim();
+  if (!value) {
+    throw new Error(`missing required native hook relay argument: ${flag}`);
+  }
+  return value;
+}
+
+function positiveInteger(value: string, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+  return parsed;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function write(stream: NodeJS.WritableStream, value: string | undefined): void {
+  if (value) {
+    stream.write(value);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    process.exitCode = await runNativeHookRelayEntry(
+      parseNativeHookRelayEntryArgs(process.argv.slice(2)),
+    );
+  } catch (error) {
+    process.stderr.write(`invalid native hook relay options: ${message(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/src/native-hook-relay-entry.ts
+++ b/src/native-hook-relay-entry.ts
@@ -2,7 +2,6 @@
 // Minimal native-hook transport. Policy remains in the long-lived Gateway.
 import { request as httpRequest } from "node:http";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import {
@@ -10,6 +9,7 @@ import {
   type NativeHookRelayResponseEvent,
   type NativeHookRelayWireResponse,
 } from "./agents/harness/native-hook-relay-response.js";
+import { openNodeSqliteDatabase } from "./infra/node-sqlite.js";
 
 const MAX_STDIN_BYTES = 1024 * 1024;
 const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
@@ -235,7 +235,7 @@ async function invokeFastRelay(
 }
 
 function readFastRelayRecord(options: FastRelayOptions): FastRelayRecord {
-  const db = new DatabaseSync(path.resolve(options.stateDb), {
+  const db = openNodeSqliteDatabase(path.resolve(options.stateDb), {
     readOnly: true,
   });
   try {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -264,6 +264,8 @@ function buildCoreDistEntries(): Record<string, string> {
   return {
     index: "src/index.ts",
     entry: "src/entry.ts",
+    "native-hook-relay-entry": "src/native-hook-relay-entry.ts",
+    "cli/native-hook-relay-cli": "src/cli/native-hook-relay-cli.ts",
     // Ensure this module is bundled as an entry so legacy CLI shims can resolve its exports.
     "cli/daemon-cli": "src/cli/daemon-cli.ts",
     // Keep long-lived lazy runtime boundaries on stable filenames so rebuilt


### PR DESCRIPTION
Related: #111879

## What Problem This Solves

Fixes an issue where users running Codex-backed agents can exhaust Gateway memory and process
budgets when concurrent native hooks each launch the full OpenClaw CLI. A single agent run can
therefore make health checks and channel polling unresponsive even when agent concurrency is set
to one.

## Why This Change Was Made

This change adds a narrow, Node-core-only relay entry for the normal bridge path while retaining the
full CLI for explicit overrides and exceptional fallback. Per-relay admission limits policy work to
four active and 32 queued invocations, coalesces exact duplicate permission requests, returns a
deterministic overload response, and propagates disconnect or relay-shutdown cancellation through
two-phase approval RPCs. The transport continues to obtain every policy decision from the existing
Gateway authority; it does not move, cache, or reinterpret policy in the client.

## User Impact

Codex hook traffic uses substantially less CPU, memory, and wall time, and one busy run can no
longer create an unbounded set of policy workers. Existing full-CLI behavior remains available
through `OPENCLAW_CLI_PATH`, and exceptional bridge failures retain the established event-specific
fallback behavior.

## Evidence

- `pnpm build` passed on both the predecessor evidence head and the current corrected head.

- The predecessor 210-test focused suite passed across the relay, admission, bridge-entry, and
  related projects. The current corrected head `de08b1d9` passed 112 focused tests on a fresh ARM64
  VISION target, including the immediate-retry regression for final-waiter cancellation.

- Type-aware `oxlint`, `tsgo:core`, `tsgo:test:src`, formatting, and `git diff --check` passed on the
  predecessor. Targeted `oxlint`, `oxfmt --check`, and `git diff --check` passed for the corrective
  commit.

- The repository `autoreview` skill completed with TruffleHog clean and no accepted/actionable
  findings after three review-discovered cancellation defects were repaired.

- A hermetic randomized, counterbalanced N=6 benchmark on predecessor evidence head `76658ba8`
  produced 48/48 byte-equivalent allow/deny pairs across `PreToolUse`, `PostToolUse`,
  `PermissionRequest`, and `Stop`/before-finalize. On that controlled normal-path workload, mean
  wall time fell 98.67%, mean CPU time fell 99.02%, and mean peak RSS fell 87.96% on ULTRON. These
  are transport-path benchmark results, not production-wide performance claims.

- The same randomized protocol was rerun on a fresh VISION target at current exact head `de08b1d9`.
  All 48 allow/deny pairs remained byte-equivalent; mean wall time fell 98.13%, mean CPU time fell
  98.50%, and mean peak RSS fell 86.46%. The built fast entry was 12,162 bytes with SHA-256
  `ea4604b15f5b8e8a343595073acc0dcc8d0abf2573f23286ee9d2ffd3f5c2de2`.

- The admission tests prove four active plus 32 FIFO-queued operations, deterministic rejection of
  the 37th unique request, bounded history and decision caches, disconnect cancellation, duplicate
  waiter isolation, immediate same-key reuse after the final waiter leaves, and active/queued
  cleanup when a relay registration stops.

- Upstream CI's previously failing relay shard, `checks-node-compact-large-4`, passes at current
  head. One different current-base secrets test in `checks-node-compact-small-11` timed out after
  120 seconds; the contributor head does not contain that test and this PR does not touch
  `src/secrets`. Fork contributors cannot rerun failed upstream Actions jobs, so maintainer rerun or
  adjudication remains necessary.

This PR is AI-assisted. I reviewed the implementation, understand the authority and fallback
boundaries, and used the repository's required structured review workflow.
