### PR TITLE
fix(elevenlabs): route TTS and voice egress through the trusted env proxy

### DIFF
--- a/extensions/elevenlabs/elevenlabs.proxy.test.ts
+++ b/extensions/elevenlabs/elevenlabs.proxy.test.ts
@@ -1,0 +1,105 @@
+// Elevenlabs proxy tests cover the trusted-env-proxy egress mode across the TTS
+// synth/stream endpoints and voice discovery, so voice features keep working in
+// HTTP-proxy-required environments where direct egress is blocked.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: async (params: {
+    url: string;
+    init?: RequestInit;
+    timeoutMs?: number;
+  }): Promise<{ response: Response; release: () => Promise<void> }> => {
+    fetchWithSsrFGuardMock(params);
+    return {
+      response: await globalThis.fetch(params.url, params.init),
+      release: vi.fn(async () => {}),
+    };
+  },
+  ssrfPolicyFromHttpBaseUrlAllowedHostname: () => undefined,
+}));
+
+vi.mock("./config-api.js", () => ({
+  resolveElevenLabsApiKeyWithProfileFallback: () => null,
+}));
+
+import { buildElevenLabsSpeechProvider } from "./speech-provider.js";
+import { elevenLabsTTS, elevenLabsTTSStream } from "./tts.js";
+
+const originalFetch = globalThis.fetch;
+
+function createTtsRequest() {
+  return {
+    text: "hello",
+    apiKey: "xi-test",
+    baseUrl: "https://api.elevenlabs.io",
+    voiceId: "pMsXgVXv3BLzUgSXRplE",
+    modelId: "eleven_multilingual_v2",
+    outputFormat: "mp3_44100_128",
+    voiceSettings: {
+      stability: 0.5,
+      similarityBoost: 0.75,
+      style: 0,
+      useSpeakerBoost: true,
+      speed: 1,
+    },
+    timeoutMs: 5_000,
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  fetchWithSsrFGuardMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("elevenlabs trusted-env-proxy egress mode", () => {
+  it("routes buffered TTS synthesis through the trusted env proxy", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(Buffer.from("mp3")),
+    ) as unknown as typeof fetch;
+
+    await elevenLabsTTS(createTtsRequest());
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "trusted_env_proxy",
+        url: "https://api.elevenlabs.io/v1/text-to-speech/pMsXgVXv3BLzUgSXRplE?output_format=mp3_44100_128",
+      }),
+    );
+  });
+
+  it("routes streamed TTS synthesis through the trusted env proxy", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(new Uint8Array([1, 2, 3])),
+    ) as unknown as typeof fetch;
+
+    const { release } = await elevenLabsTTSStream(createTtsRequest());
+    await release();
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "trusted_env_proxy",
+        url: "https://api.elevenlabs.io/v1/text-to-speech/pMsXgVXv3BLzUgSXRplE/stream?output_format=mp3_44100_128",
+      }),
+    );
+  });
+
+  it("routes voice discovery through the trusted env proxy", async () => {
+    globalThis.fetch = vi.fn(async () => Response.json({ voices: [] })) as unknown as typeof fetch;
+    const provider = buildElevenLabsSpeechProvider();
+
+    await provider.listVoices?.({
+      providerConfig: { apiKey: "xi-test" },
+      timeoutMs: 30_000,
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "trusted_env_proxy",
+        url: "https://api.elevenlabs.io/v1/voices",
+      }),
+    );
+  });
+});

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -1,5 +1,6 @@
 // Elevenlabs provider module implements model/runtime integration.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { parseStrictFiniteNumber, parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
   assertOkOrThrowProviderError,
@@ -370,17 +371,19 @@ async function listElevenLabsVoices(params: {
   timeoutMs?: number;
 }): Promise<SpeechVoiceOption[]> {
   const normalizedBaseUrl = normalizeElevenLabsBaseUrl(params.baseUrl);
-  const { response, release } = await fetchWithSsrFGuard({
-    url: `${normalizedBaseUrl}/v1/voices`,
-    init: {
-      headers: {
-        "xi-api-key": params.apiKey,
+  const { response, release } = await fetchWithSsrFGuard(
+    withTrustedEnvProxyGuardedFetchMode({
+      url: `${normalizedBaseUrl}/v1/voices`,
+      init: {
+        headers: {
+          "xi-api-key": params.apiKey,
+        },
       },
-    },
-    timeoutMs: params.timeoutMs,
-    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(normalizedBaseUrl),
-    auditContext: "elevenlabs.voices",
-  });
+      timeoutMs: params.timeoutMs,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(normalizedBaseUrl),
+      auditContext: "elevenlabs.voices",
+    }),
+  );
   try {
     await assertOkOrThrowProviderError(response, "ElevenLabs voices API error");
     const json = await readProviderJsonResponse<{

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -1,4 +1,5 @@
 // Elevenlabs plugin module implements tts behavior.
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { MAX_AUDIO_BYTES } from "openclaw/plugin-sdk/media-runtime";
 import {
   assertOkOrThrowProviderError,
@@ -213,21 +214,23 @@ export async function elevenLabsTTS(params: ElevenLabsTtsRequestParams): Promise
     stream: false,
   });
 
-  const { response, release } = await fetchWithSsrFGuard({
-    url: url.toString(),
-    init: {
-      method: "POST",
-      headers: {
-        "xi-api-key": apiKey,
-        "Content-Type": "application/json",
-        ...(acceptHeader ? { Accept: acceptHeader } : {}),
+  const { response, release } = await fetchWithSsrFGuard(
+    withTrustedEnvProxyGuardedFetchMode({
+      url: url.toString(),
+      init: {
+        method: "POST",
+        headers: {
+          "xi-api-key": apiKey,
+          "Content-Type": "application/json",
+          ...(acceptHeader ? { Accept: acceptHeader } : {}),
+        },
+        body,
       },
-      body,
-    },
-    timeoutMs,
-    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(normalizedBaseUrl),
-    auditContext: "elevenlabs.tts",
-  });
+      timeoutMs,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(normalizedBaseUrl),
+      auditContext: "elevenlabs.tts",
+    }),
+  );
   try {
     await assertOkOrThrowProviderError(response, "ElevenLabs API error");
 
@@ -247,21 +250,23 @@ export async function elevenLabsTTSStream(params: ElevenLabsTtsRequestParams): P
     stream: true,
   });
 
-  const { response, release } = await fetchWithSsrFGuard({
-    url: url.toString(),
-    init: {
-      method: "POST",
-      headers: {
-        "xi-api-key": apiKey,
-        "Content-Type": "application/json",
-        ...(acceptHeader ? { Accept: acceptHeader } : {}),
+  const { response, release } = await fetchWithSsrFGuard(
+    withTrustedEnvProxyGuardedFetchMode({
+      url: url.toString(),
+      init: {
+        method: "POST",
+        headers: {
+          "xi-api-key": apiKey,
+          "Content-Type": "application/json",
+          ...(acceptHeader ? { Accept: acceptHeader } : {}),
+        },
+        body,
       },
-      body,
-    },
-    timeoutMs,
-    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(normalizedBaseUrl),
-    auditContext: "elevenlabs.tts.stream",
-  });
+      timeoutMs,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(normalizedBaseUrl),
+      auditContext: "elevenlabs.tts.stream",
+    }),
+  );
   let handedOff = false;
   try {
     await assertOkOrThrowProviderError(response, "ElevenLabs API error");


### PR DESCRIPTION
## What Problem This Solves

Users whose outbound HTTPS access requires an HTTP(S) proxy cannot use ElevenLabs voice features: listing voices and text-to-speech synthesis both fail because their guarded requests never use trusted-env-proxy mode, so a proxy-required network blocks the direct egress.

The three ElevenLabs egress sites that call `fetchWithSsrFGuard(...)` directly pass no proxy preset:

- `extensions/elevenlabs/tts.ts` — `elevenLabsTTS` (buffered synth) and `elevenLabsTTSStream` (streamed synth)
- `extensions/elevenlabs/speech-provider.ts` — `listElevenLabsVoices` (`GET /v1/voices`, reached via the speech provider's `listVoices`)

The plugin's speech-to-text path (`media-understanding-provider.ts`) is unaffected: it goes through the shared `postTranscriptionRequest` transport, which already auto-upgrades to trusted-env-proxy mode when eligible. Only the three direct `fetchWithSsrFGuard` calls miss that upgrade, so voice listing and TTS silently break behind a proxy even with valid credentials and a reachable proxy.

## Why This Change Was Made

Each of the three direct guarded requests now wraps its options with OpenClaw's existing `withTrustedEnvProxyGuardedFetchMode(...)` preset (from `openclaw/plugin-sdk/fetch-runtime`), the same preset the sibling provider model-discovery fixes use. The preset only adds `mode: "trusted_env_proxy"`. The hostname allowlist stays enforced; as designed for this mode, hostname resolution moves to the eligible HTTP CONNECT proxy instead of client-side pinned DNS (see the `shouldAutoUpgradeToTrustedEnvProxy` rationale in `src/media-understanding/shared.ts`). The timeout, request body/headers, audit context, and response `release()` are unchanged.

Scope is limited to these three direct `fetchWithSsrFGuard` sites in the ElevenLabs plugin. `realtime-transcription-provider.ts` (a separate WebSocket path) and `media-understanding-provider.ts` issue no direct `fetchWithSsrFGuard` call, so they are untouched.

## User Impact

**Before:** For users behind an eligible HTTP(S) proxy, ElevenLabs voice discovery and TTS (buffered and streamed) failed before reaching the API: client-side DNS resolution failed, so no HTTP request was issued and the proxy was never asked to open a tunnel. Authentication was never attempted. (The captures use a placeholder key, so they show the failure landing earlier than auth rather than exercising a valid credential.)

**After:** The three guarded requests use trusted-env-proxy mode, so the guard routes them through an eligible configured HTTP(S) proxy and they reach the ElevenLabs API in proxy-required environments instead of failing before egress.

This is a tradeoff, not a pure win, and it is the part that needs an owner decision. The preset itself adds nothing but the mode — `withTrustedEnvProxyGuardedFetchMode` is `{ ...params, mode: TRUSTED_ENV_PROXY }` (`src/infra/net/fetch-guard.ts`) — but the two halves of the guard are affected differently and the difference is the decision.

What is kept: the hostname allowlist. On this path the guard still calls `assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl)` before dispatching, so a request to a host outside the policy is refused exactly as before.

What is given up: client-side DNS pinning. In trusted-env-proxy mode the guard deliberately skips local DNS resolution, so there is no resolved address for it to check or pin — the proxy resolves the hostname and opens the connection. The IP-level half of the pinned path therefore does not run for these three requests, and an eligible configured proxy becomes part of the trust boundary for them. It engages only when the operator has configured a proxy the guard deems eligible, and it is the same mode seven adapters already ship on — `chutes`, `clawrouter`, `deepinfra`, `huggingface`, `openai`, `slack`, `vercel-ai-gateway` — which is precedent for the shape, not by itself a justification for this adapter.

The allowlist here is derived from the configured base URL (`ssrfPolicyFromHttpBaseUrlAllowedHostname(normalizedBaseUrl)`), so it tracks whatever host the operator sets rather than being pinned to the default. The captures below exercise the default `api.elevenlabs.io` only. The decision for a maintainer is therefore whether proxy-side resolution is acceptable for operator-configured ElevenLabs hosts in general, not just for the one this proof covers. `NO_PROXY` matches and the no-proxy-configured case are honored, so users without an eligible proxy are unaffected — the request options are otherwise identical.

## Real behavior proof

Behavior addressed: on a network where outbound access requires an HTTP(S) proxy, ElevenLabs voice listing and both TTS modes never reach the API — their guarded requests take the strict pinned-DNS path, which resolves the target hostname on the client and connects directly, so the configured proxy is never used.

Real environment tested: Linux x86_64, Node v24.18.0, undici 8.9.0, the real `https://api.elevenlabs.io` endpoint over TLS, and a real local HTTP `CONNECT` proxy on `127.0.0.1:18080` that resolves the target itself and tunnels raw bytes. The three call sites are driven through their real exported production functions (`buildElevenLabsSpeechProvider().listVoices`, `elevenLabsTTS`, `elevenLabsTTSStream`) by a standalone script — no test runner, no mocked fetch, no `fetchImpl` override, no dependency injection. That statement describes this real-behavior harness only; the focused suite listed under Evidence is an ordinary vitest file and does mock at the guard boundary, as unit tests there normally do. The proxy-required network is produced by entering a user + mount namespace (`unshare -rm`) and bind-mounting a dead `/etc/resolv.conf` over the real one: inside it no hostname can be resolved, so client-side pinned DNS cannot egress, while the proxy — running outside the namespace, with working DNS — stays reachable at `127.0.0.1`.

Exact steps or command run after this patch: a runner script drives each scenario — it checks the two changed files out at the scenario's SHA (base or head) inside the PR head worktree, starts the proxy, then runs the harness, which reports the SHA and a hash of each changed file so every result line identifies the code that produced it. Abridged, one scenario is:

```
node connect-proxy.mjs 18080 proxy.jsonl &                     # real CONNECT proxy
git checkout <base|head> -- extensions/elevenlabs/tts.ts \
                            extensions/elevenlabs/speech-provider.ts
unshare -rm bash -c 'mount --bind dead-resolv.conf /etc/resolv.conf &&
  HTTPS_PROXY=http://127.0.0.1:18080 tsx harness.mts'          # 3 real production calls
```

Before evidence — a base-file variant, not a base-commit build: the run happens in the head
worktree with only `extensions/elevenlabs/tts.ts` and `extensions/elevenlabs/speech-provider.ts`
checked out at base `90beb639e7e`, everything else on the head tree. The `sources` hashes below
are the first 12 hex characters of `sha256` over each file's bytes, so they identify which variant
of those two files each run actually loaded:

```
{"scenario":"S1-before-proxy-required","codeSha":"90beb639e7e","env":{"HTTPS_PROXY":"http://127.0.0.1:18080","NO_PROXY":null},"sources":{"extensions/elevenlabs/tts.ts":"09863c8f2047","extensions/elevenlabs/speech-provider.ts":"ee92ad12f3f1"}}
{"scenario":"S1-before-proxy-required","path":"listVoices GET /v1/voices","class":"transport_error","code":"EAI_AGAIN","detail":"getaddrinfo EAI_AGAIN api.elevenlabs.io"}
{"scenario":"S1-before-proxy-required","path":"elevenLabsTTS POST /v1/text-to-speech/{id}","class":"transport_error","code":"EAI_AGAIN","detail":"getaddrinfo EAI_AGAIN api.elevenlabs.io"}
{"scenario":"S1-before-proxy-required","path":"elevenLabsTTSStream POST /v1/text-to-speech/{id}/stream","class":"transport_error","code":"EAI_AGAIN","detail":"getaddrinfo EAI_AGAIN api.elevenlabs.io"}

proxy log for this run:
{"event":"proxy_listening","address":"127.0.0.1:18080","at":"2026-08-12T06:29:33.323Z"}
(no CONNECT request — the proxy was configured but never contacted)
```

Evidence after fix (head `ea15af62f97`, same harness, same proxy, same namespace):

```
{"scenario":"S2-after-proxy-required","codeSha":"ea15af62f97","env":{"HTTPS_PROXY":"http://127.0.0.1:18080","NO_PROXY":null},"sources":{"extensions/elevenlabs/tts.ts":"e22fb72a9269","extensions/elevenlabs/speech-provider.ts":"add92acdf8b3"}}
{"scenario":"S2-after-proxy-required","path":"listVoices GET /v1/voices","class":"http_status","status":401,"detail":"ElevenLabs voices API error (401): Invalid API key [type=authentication_error, code=unauthorized]"}
{"scenario":"S2-after-proxy-required","path":"elevenLabsTTS POST /v1/text-to-speech/{id}","class":"http_status","status":401,"detail":"ElevenLabs API error (401): Invalid API key [type=authentication_error, code=unauthorized]"}
{"scenario":"S2-after-proxy-required","path":"elevenLabsTTSStream POST /v1/text-to-speech/{id}/stream","class":"http_status","status":401,"detail":"ElevenLabs API error (401): Invalid API key [type=authentication_error, code=unauthorized]"}

proxy log for this run:
{"event":"proxy_listening","address":"127.0.0.1:18080","at":"2026-08-12T06:29:39.481Z"}
{"event":"connect_request","target":"api.elevenlabs.io:443","at":"2026-08-12T06:29:41.513Z"}
{"event":"connect_request","target":"api.elevenlabs.io:443","at":"2026-08-12T06:29:41.865Z"}
{"event":"connect_closed","target":"api.elevenlabs.io:443","startedAt":"2026-08-12T06:29:41.513Z","endedAt":"2026-08-12T06:29:41.903Z","bytesClientToTarget":1958,"bytesTargetToClient":5951,"reason":"client_close"}
{"event":"connect_request","target":"api.elevenlabs.io:443","at":"2026-08-12T06:29:42.133Z"}
{"event":"connect_closed","target":"api.elevenlabs.io:443","startedAt":"2026-08-12T06:29:41.865Z","endedAt":"2026-08-12T06:29:42.162Z","bytesClientToTarget":2269,"bytesTargetToClient":6040,"reason":"client_close"}
{"event":"connect_closed","target":"api.elevenlabs.io:443","startedAt":"2026-08-12T06:29:42.133Z","endedAt":"2026-08-12T06:29:42.418Z","bytesClientToTarget":2276,"bytesTargetToClient":6005,"reason":"client_close"}
```

Three further runs with the same rig cover the paths this change must not disturb. S3 (pre-fix code, ordinary network) shows the defect is specific to proxy-required networks; S4 (post-fix code, ordinary network) shows the preset does not force proxying when none is configured; S5 (post-fix code, proxy configured but `NO_PROXY` matching) shows `NO_PROXY` still wins and the request falls back to the direct path — which the dead resolver then blocks, so no request reaches the proxy. Raw output of the three runs:

```
{"scenario":"S3-before-ordinary-net","codeSha":"90beb639e7e","env":{"HTTPS_PROXY":null,"NO_PROXY":null},"sources":{"extensions/elevenlabs/tts.ts":"09863c8f2047","extensions/elevenlabs/speech-provider.ts":"ee92ad12f3f1"}}
{"scenario":"S3-before-ordinary-net","path":"listVoices GET /v1/voices","class":"http_status","status":401,"detail":"ElevenLabs voices API error (401): Invalid API key [type=authentication_error, code=unauthorized]"}
{"scenario":"S3-before-ordinary-net","path":"elevenLabsTTS POST /v1/text-to-speech/{id}","class":"http_status","status":401,"detail":"ElevenLabs API error (401): Invalid API key [type=authentication_error, code=unauthorized]"}
{"scenario":"S3-before-ordinary-net","path":"elevenLabsTTSStream POST /v1/text-to-speech/{id}/stream","class":"http_status","status":401,"detail":"ElevenLabs API error (401): Invalid API key [type=authentication_error, code=unauthorized]"}

proxy log for this run:
{"event":"proxy_listening","address":"127.0.0.1:18080","at":"2026-08-12T06:29:43.503Z"}
(no CONNECT request)

{"scenario":"S4-after-ordinary-net","codeSha":"ea15af62f97","env":{"HTTPS_PROXY":null,"NO_PROXY":null},"sources":{"extensions/elevenlabs/tts.ts":"e22fb72a9269","extensions/elevenlabs/speech-provider.ts":"add92acdf8b3"}}
{"scenario":"S4-after-ordinary-net","path":"listVoices GET /v1/voices","class":"http_status","status":401,"detail":"ElevenLabs voices API error (401): Invalid API key [type=authentication_error, code=unauthorized]"}
{"scenario":"S4-after-ordinary-net","path":"elevenLabsTTS POST /v1/text-to-speech/{id}","class":"http_status","status":401,"detail":"ElevenLabs API error (401): Invalid API key [type=authentication_error, code=unauthorized]"}
{"scenario":"S4-after-ordinary-net","path":"elevenLabsTTSStream POST /v1/text-to-speech/{id}/stream","class":"http_status","status":401,"detail":"ElevenLabs API error (401): Invalid API key [type=authentication_error, code=unauthorized]"}

proxy log for this run:
{"event":"proxy_listening","address":"127.0.0.1:18080","at":"2026-08-12T06:29:50.471Z"}
(no CONNECT request)

{"scenario":"S5-after-no-proxy-honored","codeSha":"ea15af62f97","env":{"HTTPS_PROXY":"http://127.0.0.1:18080","NO_PROXY":"api.elevenlabs.io"},"sources":{"extensions/elevenlabs/tts.ts":"e22fb72a9269","extensions/elevenlabs/speech-provider.ts":"add92acdf8b3"}}
{"scenario":"S5-after-no-proxy-honored","path":"listVoices GET /v1/voices","class":"transport_error","code":"EAI_AGAIN","detail":"getaddrinfo EAI_AGAIN api.elevenlabs.io"}
{"scenario":"S5-after-no-proxy-honored","path":"elevenLabsTTS POST /v1/text-to-speech/{id}","class":"transport_error","code":"EAI_AGAIN","detail":"getaddrinfo EAI_AGAIN api.elevenlabs.io"}
{"scenario":"S5-after-no-proxy-honored","path":"elevenLabsTTSStream POST /v1/text-to-speech/{id}/stream","class":"transport_error","code":"EAI_AGAIN","detail":"getaddrinfo EAI_AGAIN api.elevenlabs.io"}

proxy log for this run:
{"event":"proxy_listening","address":"127.0.0.1:18080","at":"2026-08-12T06:29:54.557Z"}
(no CONNECT request)
```

Observed result after fix: in a proxy-required environment the three requests change from "client-side DNS resolution fails with `getaddrinfo EAI_AGAIN`, no HTTP request is issued, and no CONNECT reaches the proxy" (those proxy logs contain their `proxy_listening` line and nothing else) to three real `CONNECT api.elevenlabs.io:443` tunnels carrying real TLS bytes, with ElevenLabs itself answering each request. With no proxy configured, and with `NO_PROXY` matching, the behavior is the previous direct-egress behavior.

What was not tested: synthesis of actual audio — this run used a placeholder API key, so the after-fix success criterion is "the request traversed the proxy and the ElevenLabs API answered" (HTTP 401 from the real service), not "audio was returned"; a proxy appliance with proxy authentication or TLS interception; the plugin's speech-to-text path (untouched here — it already auto-upgrades through `postTranscriptionRequest`); Windows and macOS.

Proof limitations or environment constraints: the proxy under test is an HTTP `CONNECT` proxy reached over plain HTTP at `http://127.0.0.1:18080`; an HTTPS proxy endpoint (TLS between client and proxy) was not exercised, so "HTTP(S) proxy" above describes the supported configuration surface rather than what these captures cover. the proxy-required network is emulated by removing DNS resolution inside a user + mount namespace, which is what makes the strict pinned-DNS path fail; a network that permits DNS but blocks direct TCP egress was not exercised separately (in that shape the pre-fix failure surfaces as a connect timeout/refusal rather than `EAI_AGAIN`, but the routing difference proven here is the same). The proxy is a minimal local `CONNECT` tunnel written for this run, not a production proxy product. The before/after runs are the PR head worktree with the two changed files checked out at the base and head SHAs respectively — that is the application-source difference this comparison switches. The guard and dispatcher
implementations are untouched by this PR; what changes is the mode value they receive, which is
what selects the env-proxy dispatcher instead of the pinned-DNS one, and each result line carries the SHA and the file hashes it ran with. Everything on the client side of the tunnel — the three exported entry points, the SSRF guard, the undici dispatcher selection — is unmodified production code.

## Evidence

- Exact head (abbreviated SHAs): `ea15af62f97` = `ea15af62f970fae5fb66e20ed91164e5dfb7fa28`, on branch `fix/elevenlabs-trusted-env-proxy`, rebased onto `upstream/main` `90beb639e7e` = `90beb639e7e8c0e03fc5ce9b48f3c089a6d827bd`. Every `codeSha` in the captures above is one of these two.
- Changed: `extensions/elevenlabs/tts.ts` (2 sites), `extensions/elevenlabs/speech-provider.ts` (1 site), new `extensions/elevenlabs/elevenlabs.proxy.test.ts` (+105)
- Supplemental to the real-behavior run above, the focused suite `extensions/elevenlabs/elevenlabs.proxy.test.ts` (3 tests) locks the regression: each asserts the guarded request for its endpoint (`/v1/text-to-speech/{voice}`, `/v1/text-to-speech/{voice}/stream`, `/v1/voices`) carries `mode: "trusted_env_proxy"`. Verified red before the wrap (no `mode` → all 3 fail) and green after.
- Regression: existing `extensions/elevenlabs/speech-provider.test.ts` (10) + `extensions/elevenlabs/tts.test.ts` (16) pass unchanged. Across the three suites that is 3 new + 26 existing = 29, 0 failed, on the rebased head.

### Branch state

This is a revision of the PR as originally submitted, not a new change. The branch was ~20 days
behind and has been rebased onto `main` `90beb639e7e`; the net diff is still the same three files
listed above. Because the rebase moves the base the proof was pinned to, the whole five-scenario
matrix was re-run on the rebased head — every capture, `codeSha` and file-content hash in the
Evidence section comes from that run, not from the original submission.

The net diff on this head is still only those three files: two call sites in
`extensions/elevenlabs/tts.ts`, one in `extensions/elevenlabs/speech-provider.ts`, and the new
`extensions/elevenlabs/elevenlabs.proxy.test.ts`. Nothing from the rebase appears in it.

