### PR TITLE
test(outbound): close queue SQLite fixtures

### DIFF
--- a/src/infra/outbound/delivery-queue.test-helpers.test.ts
+++ b/src/infra/outbound/delivery-queue.test-helpers.test.ts
@@ -1,0 +1,26 @@
+// Delivery queue helper tests cover shared SQLite and temp-directory cleanup.
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  isOpenClawStateDatabaseOpen,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { installDeliveryQueueTmpDirHooks } from "./delivery-queue.test-helpers.js";
+
+const fixture = installDeliveryQueueTmpDirHooks();
+let previousTmpDir = "";
+
+describe("installDeliveryQueueTmpDirHooks", () => {
+  it("tracks an open per-case state database", () => {
+    previousTmpDir = fixture.tmpDir();
+    openOpenClawStateDatabase({ env: { ...process.env, OPENCLAW_STATE_DIR: previousTmpDir } });
+
+    expect(isOpenClawStateDatabaseOpen()).toBe(true);
+    expect(fs.existsSync(previousTmpDir)).toBe(true);
+  });
+
+  it("closes handles and removes the previous case directory", () => {
+    expect(isOpenClawStateDatabaseOpen()).toBe(false);
+    expect(fs.existsSync(previousTmpDir)).toBe(false);
+  });
+});

--- a/src/infra/outbound/delivery-queue.test-helpers.ts
+++ b/src/infra/outbound/delivery-queue.test-helpers.ts
@@ -2,8 +2,11 @@
 // stubs for queue/recovery tests.
 import fs from "node:fs";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, vi } from "vitest";
-import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
 import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
 import type { DeliverFn, RecoveryLogger } from "./delivery-queue.js";
 
@@ -22,7 +25,16 @@ export function installDeliveryQueueTmpDirHooks(): { readonly tmpDir: () => stri
     fs.mkdirSync(tmpDir, { recursive: true });
   });
 
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = "";
+    }
+  });
+
   afterAll(() => {
+    closeOpenClawStateDatabaseForTest();
     if (!fixtureRoot) {
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

Delivery-queue tests create a fresh state directory per case, but cached shared SQLite handles and WAL maintenance remain open until worker exit. The suite root is then deleted while those resources are still owned by the process.

## Why This Change Was Made

Close all cached shared-state database handles before deleting each case directory, and defensively close again before suite-root cleanup. A regression test proves one case can open the state DB and the next case starts with no open handle and no prior directory.

## User Impact

Developers get deterministic outbound queue teardown without lingering SQLite/WAL resources. Production behavior is unchanged.

## Evidence

- Blacksmith Linux Node 24 before final rebase:
  - all five current helper consumers plus lifecycle regression
  - 6 files / 104 tests passed
  - oxfmt check passed
- Formal Codex autoreview: clean
- `git diff --check`: passed
- Post-rebase Blacksmith dispatch was unavailable (HTTP 502); exact-head CI is the authoritative post-rebase proof.

AI-assisted: yes.
