### PR TITLE
fix(hooks): bound native hook relay latency

### DIFF
--- a/src/agents/harness/native-hook-relay-bridge-client.ts
+++ b/src/agents/harness/native-hook-relay-bridge-client.ts
@@ -1,0 +1,209 @@
+import { request as httpRequest } from "node:http";
+import { toErrorObject } from "../../infra/errors.js";
+import { readNativeHookRelayBridgeRecord } from "./native-hook-relay-store.js";
+import {
+  readNativeHookRelayEvent,
+  readNativeHookRelayProvider,
+  type NativeHookRelayProcessResponse,
+} from "./native-hook-relay-wire.js";
+
+const DEFAULT_RELAY_TIMEOUT_MS = 5_000;
+const MAX_NATIVE_HOOK_BRIDGE_RESPONSE_BYTES = 5_000_000;
+const NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS = 25;
+const NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS = 250;
+export const NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR =
+  "native hook relay bridge stale registration";
+
+type InvokeNativeHookRelayBridgeParams = {
+  provider: unknown;
+  relayId: unknown;
+  generation?: unknown;
+  event: unknown;
+  rawPayload: unknown;
+  registrationTimeoutMs?: number;
+  stateDbPath?: string;
+  timeoutMs?: number;
+};
+
+export async function invokeNativeHookRelayBridge(
+  params: InvokeNativeHookRelayBridgeParams,
+): Promise<NativeHookRelayProcessResponse> {
+  const provider = readNativeHookRelayProvider(params.provider);
+  const relayId = readNonEmptyString(params.relayId, "relayId");
+  const event = readNativeHookRelayEvent(params.event);
+  const timeoutMs = normalizePositiveInteger(params.timeoutMs, DEFAULT_RELAY_TIMEOUT_MS);
+  const registrationTimeoutMs = normalizePositiveInteger(params.registrationTimeoutMs, timeoutMs);
+  const startedAt = Date.now();
+  let lastError: unknown = new Error("native hook relay bridge not found");
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const record = readNativeHookRelayBridgeRecord({
+        relayId,
+        stateDbPath: params.stateDbPath,
+      });
+      if (!record) {
+        throw new Error("native hook relay bridge not found");
+      }
+      if (Date.now() > record.expiresAtMs) {
+        throw new Error("native hook relay bridge expired");
+      }
+      return await postNativeHookRelayBridgeRecord({
+        record,
+        timeoutMs: Math.max(1, timeoutMs - (Date.now() - startedAt)),
+        payload: {
+          provider,
+          relayId,
+          event,
+          generation: params.generation,
+          rawPayload: params.rawPayload,
+        },
+      });
+    } catch (error) {
+      lastError = error;
+      if (
+        error instanceof Error &&
+        error.message === "native hook relay bridge not found" &&
+        Date.now() - startedAt >= registrationTimeoutMs
+      ) {
+        break;
+      }
+      if (
+        !isRetryableNativeHookRelayBridgeLookupError({
+          error,
+          elapsedMs: Date.now() - startedAt,
+        })
+      ) {
+        break;
+      }
+      await delay(
+        Math.min(NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS, timeoutMs - (Date.now() - startedAt)),
+      );
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+export function isNativeHookRelayBridgeStaleRegistrationError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message === NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR
+  );
+}
+
+export function isRetryableNativeHookRelayBridgeLookupError(params: {
+  error: unknown;
+  elapsedMs: number;
+}): boolean {
+  return (
+    isRetryableNativeHookRelayBridgeError(params.error) ||
+    (params.elapsedMs < NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS &&
+      isNativeHookRelayBridgeStaleRegistrationError(params.error))
+  );
+}
+
+function postNativeHookRelayBridgeRecord(params: {
+  record: {
+    hostname: "127.0.0.1";
+    port: number;
+    token: string;
+  };
+  timeoutMs: number;
+  payload: unknown;
+}): Promise<NativeHookRelayProcessResponse> {
+  const body = JSON.stringify(params.payload);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const resolveOnce = (value: NativeHookRelayProcessResponse) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+    const rejectOnce = (error: unknown) => {
+      if (!settled) {
+        settled = true;
+        reject(toErrorObject(error, "Non-Error rejection"));
+      }
+    };
+    const req = httpRequest(
+      {
+        hostname: params.record.hostname,
+        method: "POST",
+        path: "/invoke",
+        port: params.record.port,
+        timeout: params.timeoutMs,
+        headers: {
+          authorization: `Bearer ${params.record.token}`,
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let responseText = "";
+        let responseBytes = 0;
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          const chunkText = typeof chunk === "string" ? chunk : String(chunk);
+          responseBytes += Buffer.byteLength(chunkText);
+          if (responseBytes > MAX_NATIVE_HOOK_BRIDGE_RESPONSE_BYTES) {
+            rejectOnce(new Error("native hook relay bridge response too large"));
+            res.destroy();
+            return;
+          }
+          responseText += chunkText;
+        });
+        res.on("error", rejectOnce);
+        res.on("end", () => {
+          if (settled) {
+            return;
+          }
+          try {
+            const parsed = JSON.parse(responseText) as
+              | { ok: true; result: NativeHookRelayProcessResponse }
+              | { ok: false; error?: string };
+            if (parsed.ok) {
+              resolveOnce(parsed.result);
+              return;
+            }
+            rejectOnce(new Error(parsed.error || "native hook relay bridge failed"));
+          } catch (error) {
+            rejectOnce(error);
+          }
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error("native hook relay bridge timed out"));
+    });
+    req.on("error", rejectOnce);
+    req.end(body);
+  });
+}
+
+function isRetryableNativeHookRelayBridgeError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    code === "ENOENT" ||
+    code === "ECONNREFUSED" ||
+    code === "EAGAIN" ||
+    (error instanceof Error && error.message === "native hook relay bridge not found")
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, Math.max(0, ms));
+  });
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+function readNonEmptyString(value: unknown, name: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${name} must be non-empty string`);
+  }
+  return value.trim();
+}

--- a/src/agents/harness/native-hook-relay-wire.ts
+++ b/src/agents/harness/native-hook-relay-wire.ts
@@ -1,0 +1,77 @@
+import type { BeforeToolCallFailureDisposition } from "../agent-tools.before-tool-call.js";
+
+export const NATIVE_HOOK_RELAY_EVENTS = [
+  "pre_tool_use",
+  "post_tool_use",
+  "permission_request",
+  "before_agent_finalize",
+] as const;
+
+export const NATIVE_HOOK_RELAY_PROVIDERS = ["codex"] as const;
+
+export type NativeHookRelayEvent = (typeof NATIVE_HOOK_RELAY_EVENTS)[number];
+export type NativeHookRelayProvider = (typeof NATIVE_HOOK_RELAY_PROVIDERS)[number];
+
+export type NativeHookRelayProcessResponse = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  failureDisposition?: Exclude<BeforeToolCallFailureDisposition, "blocked">;
+};
+
+export function readNativeHookRelayProvider(value: unknown): NativeHookRelayProvider {
+  if (typeof value === "string" && NATIVE_HOOK_RELAY_PROVIDERS.includes(value as never)) {
+    return value as NativeHookRelayProvider;
+  }
+  throw new Error("unsupported native hook relay provider");
+}
+
+export function readNativeHookRelayEvent(value: unknown): NativeHookRelayEvent {
+  if (typeof value === "string" && NATIVE_HOOK_RELAY_EVENTS.includes(value as never)) {
+    return value as NativeHookRelayEvent;
+  }
+  throw new Error("unsupported native hook relay event");
+}
+
+export function renderNativeHookRelayUnavailableResponse(params: {
+  provider: unknown;
+  event: unknown;
+  preToolUseUnavailable?: unknown;
+  message?: string;
+}): NativeHookRelayProcessResponse {
+  readNativeHookRelayProvider(params.provider);
+  const event = readNativeHookRelayEvent(params.event);
+  const message = params.message?.trim() || "Native hook relay unavailable";
+  if (event === "pre_tool_use") {
+    if (params.preToolUseUnavailable === "noop") {
+      return { stdout: "", stderr: "", exitCode: 0 };
+    }
+    return {
+      stdout: `${JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: message,
+        },
+      })}\n`,
+      stderr: "",
+      exitCode: 0,
+    };
+  }
+  if (event === "permission_request") {
+    return {
+      stdout: `${JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PermissionRequest",
+          decision: {
+            behavior: "deny",
+            message,
+          },
+        },
+      })}\n`,
+      stderr: "",
+      exitCode: 0,
+    };
+  }
+  return { stdout: "", stderr: "", exitCode: 0 };
+}

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -3538,6 +3538,25 @@ describe("native hook relay registry", () => {
 });
 
 describe("native hook relay command builder", () => {
+  it("prefers the built relay entry over launcher scripts", async () => {
+    const packageRoot = await fs.mkdtemp(path.join(tmpdir(), "openclaw-hook-relay-root-"));
+    try {
+      await fs.mkdir(path.join(packageRoot, "dist"), { recursive: true });
+      await fs.mkdir(path.join(packageRoot, "scripts"), { recursive: true });
+      await Promise.all([
+        fs.writeFile(path.join(packageRoot, "dist", "entry.js"), ""),
+        fs.writeFile(path.join(packageRoot, "openclaw.mjs"), ""),
+        fs.writeFile(path.join(packageRoot, "scripts", "run-node.mjs"), ""),
+      ]);
+
+      expect(testing.resolvePackageRootHookRelayExecutableForTests(packageRoot)).toBe(
+        path.join(packageRoot, "dist", "entry.js"),
+      );
+    } finally {
+      await fs.rm(packageRoot, { recursive: true, force: true });
+    }
+  });
+
   it("uses the Codex hook relay command shape", () => {
     expect(
       buildNativeHookRelayCommand({

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -3,13 +3,7 @@
  */
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import {
-  createServer,
-  request as httpRequest,
-  type IncomingMessage,
-  type Server,
-  type ServerResponse,
-} from "node:http";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import path from "node:path";
 import {
   asDateTimestampMs,
@@ -43,6 +37,12 @@ import { callGatewayTool } from "../tools/gateway.js";
 import { runAgentHarnessAfterToolCallHook } from "./hook-helpers.js";
 import { runAgentHarnessBeforeAgentFinalizeHook } from "./lifecycle-hook-helpers.js";
 import {
+  invokeNativeHookRelayBridge,
+  isNativeHookRelayBridgeStaleRegistrationError,
+  isRetryableNativeHookRelayBridgeLookupError,
+  NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
+} from "./native-hook-relay-bridge-client.js";
+import {
   clearNativeHookRelayBridgeRecordsForTests,
   deleteNativeHookRelayBridgeRecordIfOwned,
   pruneNativeHookRelayBridgeRecords,
@@ -51,21 +51,29 @@ import {
   writeNativeHookRelayBridgeRecord,
   type NativeHookRelayBridgeRecord,
 } from "./native-hook-relay-store.js";
+import {
+  NATIVE_HOOK_RELAY_EVENTS,
+  readNativeHookRelayEvent,
+  readNativeHookRelayProvider,
+  renderNativeHookRelayUnavailableResponse,
+  type NativeHookRelayEvent,
+  type NativeHookRelayProcessResponse,
+  type NativeHookRelayProvider,
+} from "./native-hook-relay-wire.js";
 import { createAgentToolResultMiddlewareRunner } from "./tool-result-middleware.js";
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
 
-const NATIVE_HOOK_RELAY_EVENTS = [
-  "pre_tool_use",
-  "post_tool_use",
-  "permission_request",
-  "before_agent_finalize",
-] as const;
-
-const NATIVE_HOOK_RELAY_PROVIDERS = ["codex"] as const;
-
-export type NativeHookRelayEvent = (typeof NATIVE_HOOK_RELAY_EVENTS)[number];
-export type NativeHookRelayProvider = (typeof NATIVE_HOOK_RELAY_PROVIDERS)[number];
+export type {
+  NativeHookRelayEvent,
+  NativeHookRelayProcessResponse,
+  NativeHookRelayProvider,
+} from "./native-hook-relay-wire.js";
+export {
+  invokeNativeHookRelayBridge,
+  isNativeHookRelayBridgeStaleRegistrationError,
+  renderNativeHookRelayUnavailableResponse,
+};
 
 type NativeHookRelayInvocation = {
   provider: NativeHookRelayProvider;
@@ -87,13 +95,6 @@ type NativeHookRelayInvocation = {
   toolUseId?: string;
   rawPayload: JsonValue;
   receivedAt: string;
-};
-
-export type NativeHookRelayProcessResponse = {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-  failureDisposition?: Exclude<BeforeToolCallFailureDisposition, "blocked">;
 };
 
 type NativeHookRelayRegistration = {
@@ -171,12 +172,6 @@ type InvokeNativeHookRelayParams = {
   requireGeneration?: boolean;
 };
 
-type InvokeNativeHookRelayBridgeParams = InvokeNativeHookRelayParams & {
-  registrationTimeoutMs?: number;
-  stateDbPath?: string;
-  timeoutMs?: number;
-};
-
 type NativeHookRelayInvocationMetadata = Partial<
   Pick<
     NativeHookRelayInvocation,
@@ -232,11 +227,7 @@ const MAX_PERMISSION_APPROVALS_PER_WINDOW = 12;
 const PERMISSION_APPROVAL_WINDOW_MS = 60_000;
 const MAX_PERMISSION_ALLOW_ALWAYS_ENTRIES = 512;
 const MAX_NATIVE_HOOK_BRIDGE_BODY_BYTES = 5_000_000;
-const MAX_NATIVE_HOOK_BRIDGE_RESPONSE_BYTES = 5_000_000;
-const NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS = 25;
 const NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS = 250;
-const NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR =
-  "native hook relay bridge stale registration";
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
 
 function resolveNativeHookRelayExpiresAtMs(ttlMs: number | undefined): number | undefined {
@@ -861,89 +852,6 @@ async function resolveNativeHookRelayPreToolUseApproval(
   };
 }
 
-export async function invokeNativeHookRelayBridge(
-  params: InvokeNativeHookRelayBridgeParams,
-): Promise<NativeHookRelayProcessResponse> {
-  const provider = readNativeHookRelayProvider(params.provider);
-  const relayId = readNonEmptyString(params.relayId, "relayId");
-  const event = readNativeHookRelayEvent(params.event);
-  const timeoutMs = normalizePositiveInteger(params.timeoutMs, DEFAULT_RELAY_TIMEOUT_MS);
-  const registrationTimeoutMs = normalizePositiveInteger(params.registrationTimeoutMs, timeoutMs);
-  const startedAt = Date.now();
-  let lastError: unknown = new Error("native hook relay bridge not found");
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      const record = readNativeHookRelayBridgeRecord(relayId, params.stateDbPath);
-      if (Date.now() > record.expiresAtMs) {
-        throw new Error("native hook relay bridge expired");
-      }
-      return await invokeNativeHookRelayBridgeRecord({
-        record,
-        timeoutMs: Math.max(1, timeoutMs - (Date.now() - startedAt)),
-        payload: {
-          provider,
-          relayId,
-          event,
-          generation: params.generation,
-          rawPayload: params.rawPayload,
-        },
-      });
-    } catch (error) {
-      lastError = error;
-      if (
-        error instanceof Error &&
-        error.message === "native hook relay bridge not found" &&
-        Date.now() - startedAt >= registrationTimeoutMs
-      ) {
-        break;
-      }
-      if (
-        !isRetryableNativeHookRelayBridgeLookupError({
-          error,
-          elapsedMs: Date.now() - startedAt,
-        })
-      ) {
-        break;
-      }
-      await delay(
-        Math.min(NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS, timeoutMs - (Date.now() - startedAt)),
-      );
-    }
-  }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
-}
-
-export function renderNativeHookRelayUnavailableResponse(params: {
-  provider: unknown;
-  event: unknown;
-  preToolUseUnavailable?: unknown;
-  message?: string;
-}): NativeHookRelayProcessResponse {
-  const provider = readNativeHookRelayProvider(params.provider);
-  const event = readNativeHookRelayEvent(params.event);
-  const adapter = getNativeHookRelayProviderAdapter(provider);
-  const message = params.message?.trim() || "Native hook relay unavailable";
-  if (event === "pre_tool_use") {
-    // The standalone CLI cannot reconstruct the originating registration after
-    // relay lookup fails, so unavailable PreToolUse must fail closed unless the
-    // generated command explicitly recorded that no before-tool policy existed.
-    if (params.preToolUseUnavailable === "noop") {
-      return adapter.renderNoopResponse(event);
-    }
-    return adapter.renderPreToolUseBlockResponse(message);
-  }
-  if (event === "permission_request") {
-    return adapter.renderPermissionDecisionResponse("deny", message);
-  }
-  return adapter.renderNoopResponse(event);
-}
-
-export function isNativeHookRelayBridgeStaleRegistrationError(error: unknown): boolean {
-  return (
-    error instanceof Error && error.message === NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR
-  );
-}
-
 function recordNativeHookRelayInvocation(invocation: NativeHookRelayInvocation): void {
   invocations.push({
     ...invocation,
@@ -1273,17 +1181,6 @@ function writeNativeHookRelayBridgeJson(
   res.end(body);
 }
 
-function readNativeHookRelayBridgeRecord(
-  relayId: string,
-  stateDbPath?: string,
-): NativeHookRelayBridgeRecord {
-  const record = readNativeHookRelayBridgeRecordIfExists(relayId, stateDbPath);
-  if (!record) {
-    throw new Error("native hook relay bridge not found");
-  }
-  return record;
-}
-
 function readNativeHookRelayBridgeRecordIfExists(
   relayId: string,
   stateDbPath?: string,
@@ -1294,116 +1191,6 @@ function readNativeHookRelayBridgeRecordIfExists(
     log.debug("failed to read native hook relay bridge record", { error, relayId });
   }
   return undefined;
-}
-
-async function invokeNativeHookRelayBridgeRecord(params: {
-  record: NativeHookRelayBridgeRecord;
-  timeoutMs: number;
-  payload: InvokeNativeHookRelayParams;
-}): Promise<NativeHookRelayProcessResponse> {
-  return postNativeHookRelayBridgeRecord(params);
-}
-
-function postNativeHookRelayBridgeRecord(params: {
-  record: NativeHookRelayBridgeRecord;
-  timeoutMs: number;
-  payload: InvokeNativeHookRelayParams;
-}): Promise<NativeHookRelayProcessResponse> {
-  const body = JSON.stringify(params.payload);
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const resolveOnce = (value: NativeHookRelayProcessResponse) => {
-      if (!settled) {
-        settled = true;
-        resolve(value);
-      }
-    };
-    const rejectOnce = (error: unknown) => {
-      if (!settled) {
-        settled = true;
-        reject(toErrorObject(error, "Non-Error rejection"));
-      }
-    };
-    const req = httpRequest(
-      {
-        hostname: params.record.hostname,
-        method: "POST",
-        path: "/invoke",
-        port: params.record.port,
-        timeout: params.timeoutMs,
-        headers: {
-          authorization: `Bearer ${params.record.token}`,
-          "content-type": "application/json",
-          "content-length": Buffer.byteLength(body),
-        },
-      },
-      (res) => {
-        let responseText = "";
-        let responseBytes = 0;
-        res.setEncoding("utf8");
-        res.on("data", (chunk) => {
-          const chunkText = typeof chunk === "string" ? chunk : String(chunk);
-          responseBytes += Buffer.byteLength(chunkText);
-          if (responseBytes > MAX_NATIVE_HOOK_BRIDGE_RESPONSE_BYTES) {
-            rejectOnce(new Error("native hook relay bridge response too large"));
-            res.destroy();
-            return;
-          }
-          responseText += chunkText;
-        });
-        res.on("error", rejectOnce);
-        res.on("end", () => {
-          if (settled) {
-            return;
-          }
-          try {
-            const parsed = JSON.parse(responseText) as
-              | { ok: true; result: NativeHookRelayProcessResponse }
-              | { ok: false; error?: string };
-            if (parsed.ok) {
-              resolveOnce(parsed.result);
-              return;
-            }
-            rejectOnce(new Error(parsed.error || "native hook relay bridge failed"));
-          } catch (error) {
-            rejectOnce(error);
-          }
-        });
-      },
-    );
-    req.on("timeout", () => {
-      req.destroy(new Error("native hook relay bridge timed out"));
-    });
-    req.on("error", rejectOnce);
-    req.end(body);
-  });
-}
-
-function isRetryableNativeHookRelayBridgeError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException).code;
-  return (
-    code === "ENOENT" ||
-    code === "ECONNREFUSED" ||
-    code === "EAGAIN" ||
-    (error instanceof Error && error.message === "native hook relay bridge not found")
-  );
-}
-
-function isRetryableNativeHookRelayBridgeLookupError(params: {
-  error: unknown;
-  elapsedMs: number;
-}): boolean {
-  return (
-    isRetryableNativeHookRelayBridgeError(params.error) ||
-    (params.elapsedMs < NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS &&
-      isNativeHookRelayBridgeStaleRegistrationError(params.error))
-  );
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, Math.max(0, ms));
-  });
 }
 
 async function processNativeHookRelayInvocation(params: {
@@ -2238,14 +2025,9 @@ function resolveOpenClawCliExecutable(): string {
     cwd: process.cwd(),
   });
   if (packageRoot) {
-    for (const candidate of [
-      path.join(packageRoot, "openclaw.mjs"),
-      path.join(packageRoot, "dist", "entry.js"),
-      path.join(packageRoot, "scripts", "run-node.mjs"),
-    ]) {
-      if (existsSync(candidate)) {
-        return candidate;
-      }
+    const executable = resolvePackageRootHookRelayExecutable(packageRoot);
+    if (executable) {
+      return executable;
     }
   }
   const argvEntry = process.argv[1];
@@ -2256,6 +2038,22 @@ function resolveOpenClawCliExecutable(): string {
     }
   }
   throw new Error("Cannot resolve OpenClaw CLI executable path for native hook relay");
+}
+
+function resolvePackageRootHookRelayExecutable(packageRoot: string): string | undefined {
+  // Codex kills a timed-out command process directly. Prefer the built entry
+  // so that process is the relay itself, not a launcher parent that can leave
+  // the relay alive after the timeout.
+  for (const candidate of [
+    path.join(packageRoot, "dist", "entry.js"),
+    path.join(packageRoot, "openclaw.mjs"),
+    path.join(packageRoot, "scripts", "run-node.mjs"),
+  ]) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
 }
 
 function normalizeAllowedEvents(
@@ -2291,25 +2089,6 @@ function shellQuoteArg(value: string, platform: NodeJS.Platform): string {
     return `"${value.replaceAll('"', '\\"')}"`;
   }
   return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
-function readNativeHookRelayProvider(value: unknown): NativeHookRelayProvider {
-  if (value === "codex") {
-    return value;
-  }
-  throw new Error("unsupported native hook relay provider");
-}
-
-function readNativeHookRelayEvent(value: unknown): NativeHookRelayEvent {
-  if (
-    value === "pre_tool_use" ||
-    value === "post_tool_use" ||
-    value === "permission_request" ||
-    value === "before_agent_finalize"
-  ) {
-    return value;
-  }
-  throw new Error("unsupported native hook relay event");
 }
 
 function readNonEmptyString(value: unknown, name: string): string {
@@ -2444,6 +2223,9 @@ export const testing = {
   getNativeHookRelayBridgeRecordForTests(relayId: string): Record<string, unknown> | undefined {
     const record = readNativeHookRelayBridgeRecordIfExists(relayId);
     return record ? { ...record } : undefined;
+  },
+  resolvePackageRootHookRelayExecutableForTests(packageRoot: string): string | undefined {
+    return resolvePackageRootHookRelayExecutable(packageRoot);
   },
   isNativeHookRelayBridgeLookupRetryableForTests(error: unknown, elapsedMs = 0): boolean {
     return isRetryableNativeHookRelayBridgeLookupError({ error, elapsedMs });

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -2,10 +2,11 @@
 import {
   invokeNativeHookRelayBridge,
   isNativeHookRelayBridgeStaleRegistrationError,
+} from "../agents/harness/native-hook-relay-bridge-client.js";
+import {
   renderNativeHookRelayUnavailableResponse,
   type NativeHookRelayProcessResponse,
-} from "../agents/harness/native-hook-relay.js";
-import { callGateway } from "../gateway/call.js";
+} from "../agents/harness/native-hook-relay-wire.js";
 import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
 import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
@@ -28,7 +29,7 @@ type NativeHookRelayCliDeps = {
   stdout?: NodeJS.WritableStream;
   stderr?: NodeJS.WritableStream;
   invokeBridge?: typeof invokeNativeHookRelayBridge;
-  callGateway?: typeof callGateway;
+  callGateway?: typeof import("../gateway/call.js").callGateway;
 };
 
 type NativeHookRelayDeadline = {
@@ -54,7 +55,6 @@ export async function runNativeHookRelayCli(
   const stdout = deps.stdout ?? process.stdout;
   const stderr = deps.stderr ?? process.stderr;
   const invokeBridge = deps.invokeBridge ?? invokeNativeHookRelayBridge;
-  const callGatewayFn = deps.callGateway ?? callGateway;
   const provider = readRequiredOption(opts.provider, "provider");
   const relayId = readRequiredOption(opts.relayId, "relay-id");
   const generation = opts.generation?.trim() || undefined;
@@ -126,6 +126,7 @@ export async function runNativeHookRelayCli(
     }
 
     try {
+      const callGatewayFn = deps.callGateway ?? (await import("../gateway/call.js")).callGateway;
       const response = await withNativeHookRelayDeadline(
         deadline,
         callGatewayFn<NativeHookRelayProcessResponse>({

--- a/src/entry.native-hook-relay-fast-path.test.ts
+++ b/src/entry.native-hook-relay-fast-path.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { tryHandleNativeHookRelayFastPath } from "./entry.native-hook-relay-fast-path.js";
+
+describe("native hook relay entry fast path", () => {
+  it("parses and dispatches the internal relay without CLI bootstrap", async () => {
+    const runRelay = vi.fn(async () => 0);
+    const setExitCode = vi.fn();
+
+    await expect(
+      tryHandleNativeHookRelayFastPath(
+        [
+          "node",
+          "entry.js",
+          "hooks",
+          "relay",
+          "--provider",
+          "codex",
+          "--relay-id=relay-1",
+          "--state-db",
+          "/tmp/openclaw.sqlite",
+          "--generation",
+          "generation-1",
+          "--event",
+          "pre_tool_use",
+          "--pre-tool-use-unavailable",
+          "noop",
+          "--timeout",
+          "2000",
+        ],
+        { runRelay, setExitCode },
+      ),
+    ).resolves.toBe(true);
+
+    expect(runRelay).toHaveBeenCalledWith({
+      provider: "codex",
+      relayId: "relay-1",
+      stateDb: "/tmp/openclaw.sqlite",
+      generation: "generation-1",
+      event: "pre_tool_use",
+      preToolUseUnavailable: "noop",
+      timeout: "2000",
+    });
+    expect(setExitCode).toHaveBeenCalledWith(0);
+  });
+
+  it("does not intercept other commands", async () => {
+    const runRelay = vi.fn();
+
+    await expect(
+      tryHandleNativeHookRelayFastPath(["node", "entry.js", "hooks", "list"], { runRelay }),
+    ).resolves.toBe(false);
+
+    expect(runRelay).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Commander for malformed relay options", async () => {
+    const runRelay = vi.fn();
+
+    await expect(
+      tryHandleNativeHookRelayFastPath(
+        ["node", "entry.js", "hooks", "relay", "--provider", "--event", "pre_tool_use"],
+        { runRelay },
+      ),
+    ).resolves.toBe(false);
+
+    expect(runRelay).not.toHaveBeenCalled();
+  });
+});

--- a/src/entry.native-hook-relay-fast-path.ts
+++ b/src/entry.native-hook-relay-fast-path.ts
@@ -1,0 +1,98 @@
+import { getCommandPathWithRootOptions } from "./cli/argv.js";
+import type {
+  NativeHookRelayCliOptions,
+  runNativeHookRelayCli as RunNativeHookRelayCli,
+} from "./cli/native-hook-relay-cli.js";
+
+type NativeHookRelayFastPathDeps = {
+  runRelay?: typeof RunNativeHookRelayCli;
+  setExitCode?: (exitCode: number) => void;
+};
+
+const RELAY_OPTION_KEYS: Record<string, keyof NativeHookRelayCliOptions> = {
+  "--provider": "provider",
+  "--relay-id": "relayId",
+  "--state-db": "stateDb",
+  "--generation": "generation",
+  "--event": "event",
+  "--pre-tool-use-unavailable": "preToolUseUnavailable",
+  "--timeout": "timeout",
+};
+
+/** Handle the internal native relay before the full CLI/plugin graph is imported. */
+export async function tryHandleNativeHookRelayFastPath(
+  argv: string[],
+  deps: NativeHookRelayFastPathDeps = {},
+): Promise<boolean> {
+  const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
+  if (primary !== "hooks" || secondary !== "relay") {
+    return false;
+  }
+
+  const relayIndex = findRelayCommandIndex(argv);
+  if (relayIndex === -1) {
+    return false;
+  }
+
+  const options = parseRelayOptions(argv.slice(relayIndex + 1));
+  if (!options) {
+    return false;
+  }
+
+  const runRelay =
+    deps.runRelay ?? (await import("./cli/native-hook-relay-cli.js")).runNativeHookRelayCli;
+  const exitCode = await runRelay(options);
+  if (deps.setExitCode) {
+    deps.setExitCode(exitCode);
+  } else {
+    await exitAfterNativeHookRelayOutput(exitCode);
+  }
+  return true;
+}
+
+async function exitAfterNativeHookRelayOutput(exitCode: number): Promise<never> {
+  await Promise.all(
+    [process.stdout, process.stderr].map(
+      (stream) =>
+        new Promise<void>((resolve) => {
+          stream.write("", "utf8", () => resolve());
+        }),
+    ),
+  );
+  process.exit(exitCode);
+}
+
+function findRelayCommandIndex(argv: string[]): number {
+  for (let index = 2; index < argv.length - 1; index += 1) {
+    if (argv[index] === "hooks" && argv[index + 1] === "relay") {
+      return index + 1;
+    }
+  }
+  return -1;
+}
+
+function parseRelayOptions(args: string[]): NativeHookRelayCliOptions | null {
+  const options: NativeHookRelayCliOptions = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (!token) {
+      return null;
+    }
+    const equalsIndex = token.indexOf("=");
+    const flag = equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+    const inlineValue = equalsIndex === -1 ? undefined : token.slice(equalsIndex + 1);
+    const key = RELAY_OPTION_KEYS[flag];
+    if (!key) {
+      return null;
+    }
+    const value = inlineValue ?? args[index + 1];
+    if (value === undefined || (!inlineValue && value.startsWith("--"))) {
+      return null;
+    }
+    Object.assign(options, { [key]: value });
+    if (inlineValue === undefined) {
+      index += 1;
+    }
+  }
+  return options;
+}

--- a/src/entry.process-title.test.ts
+++ b/src/entry.process-title.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveEntryProcessTitle } from "./entry.process-title.js";
+
+describe("resolveEntryProcessTitle", () => {
+  it("marks native hook relays before CLI bootstrap", () => {
+    expect(
+      resolveEntryProcessTitle([
+        "/usr/bin/node",
+        "/opt/openclaw/dist/entry.js",
+        "hooks",
+        "relay",
+        "--provider",
+        "codex",
+      ]),
+    ).toBe("openclaw-hooks");
+  });
+
+  it("recognizes hook relays after root options", () => {
+    expect(
+      resolveEntryProcessTitle([
+        "/usr/bin/node",
+        "/opt/openclaw/dist/entry.js",
+        "--profile",
+        "work",
+        "hooks",
+        "relay",
+      ]),
+    ).toBe("openclaw-hooks");
+  });
+
+  it("keeps other hook commands on the normal CLI title", () => {
+    expect(
+      resolveEntryProcessTitle(["/usr/bin/node", "/opt/openclaw/dist/entry.js", "hooks", "list"]),
+    ).toBe("openclaw");
+  });
+});

--- a/src/entry.process-title.ts
+++ b/src/entry.process-title.ts
@@ -1,0 +1,7 @@
+import { getCommandPathWithRootOptions } from "./cli/argv.js";
+
+/** Resolve the process title before command bootstrap can open runtime state. */
+export function resolveEntryProcessTitle(argv: string[]): "openclaw" | "openclaw-hooks" {
+  const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
+  return primary === "hooks" && secondary === "relay" ? "openclaw-hooks" : "openclaw";
+}

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -18,6 +18,8 @@ import {
   resolveEntryInstallRoot,
   respawnWithoutOpenClawCompileCacheIfNeeded,
 } from "./entry.compile-cache.js";
+import { tryHandleNativeHookRelayFastPath } from "./entry.native-hook-relay-fast-path.js";
+import { resolveEntryProcessTitle } from "./entry.process-title.js";
 import { buildCliRespawnPlan, runCliRespawnPlan } from "./entry.respawn.js";
 import { tryHandleRootVersionFastPath } from "./entry.version-fast-path.js";
 import { normalizeEnv } from "./infra/env.js";
@@ -65,7 +67,10 @@ if (
     installRoot,
   });
   if (!waitingForCompileCacheRespawn) {
-    process.title = "openclaw";
+    // Native relays open agent state during CLI bootstrap, before Commander
+    // can assign its command-specific title. Mark them at the entry boundary
+    // so their bounded integrity gate applies to the first database open.
+    process.title = resolveEntryProcessTitle(process.argv);
     ensureOpenClawExecMarkerOnProcess();
     installProcessWarningFilter();
     normalizeEnv();
@@ -126,7 +131,8 @@ if (
       }
       gatewayEntryStartupTrace.mark("argv");
 
-      if (!tryHandleRootVersionFastPath(process.argv)) {
+      const handledNativeHookRelay = await tryHandleNativeHookRelayFastPath(process.argv);
+      if (!handledNativeHookRelay && !tryHandleRootVersionFastPath(process.argv)) {
         await runMainOrRootHelp(process.argv);
       }
     }

--- a/src/infra/sqlite-integrity.ts
+++ b/src/infra/sqlite-integrity.ts
@@ -45,6 +45,13 @@ export function assertSqliteIntegrity(
   return { integrityCheck };
 }
 
+/** Require bounded structural and referential checks for latency-sensitive processes. */
+export function assertSqliteFastIntegrity(database: DatabaseSync, databaseLabel: string): "ok" {
+  const quickCheck = runSqliteCheck(database, databaseLabel, "quick_check");
+  runSqliteForeignKeyCheck(database, databaseLabel);
+  return quickCheck;
+}
+
 /** Require table and associated index consistency before trusting indexed reads. */
 export function assertSqliteTableIntegrity(
   database: DatabaseSync,

--- a/src/infra/sqlite-integrity.ts
+++ b/src/infra/sqlite-integrity.ts
@@ -4,7 +4,7 @@ type SqliteIntegrityChecks = {
   integrityCheck: "ok";
 };
 
-type SqliteCheckPragma = "integrity_check";
+type SqliteCheckPragma = "integrity_check" | "quick_check";
 type SqliteForeignKeyViolation = {
   fkid: bigint;
   parent: string;


### PR DESCRIPTION
Forward-ports the native hook relay fast path onto current upstream main.\n\n- avoids worker-side repeated full runtime startup\n- keeps native relay bridge calls bounded to a 5s timeout and capped response size\n- preserves current upstream bounded database-open safeguards\n- adds fast-path and process-title coverage\n\nValidation: focused relay tests, core typecheck, formatting, and gateway CPU scenario sweep.