### PR TITLE
test(ios): isolate TLS pin clearing

### DIFF
--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -556,23 +556,6 @@ import Testing
         #expect(controller.pendingTrustPrompt == nil)
     }
 
-    @Test @MainActor func `clear all TLS fingerprints removes stored pins`() {
-        let stableID1 = "test|\(UUID().uuidString)"
-        let stableID2 = "test|\(UUID().uuidString)"
-        defer { GatewayTLSStore.clearAllFingerprints() }
-
-        GatewayTLSStore.saveFingerprint("11", stableID: stableID1)
-        GatewayTLSStore.saveFingerprint("22", stableID: stableID2)
-
-        #expect(GatewayTLSStore.loadFingerprint(stableID: stableID1) == "11")
-        #expect(GatewayTLSStore.loadFingerprint(stableID: stableID2) == "22")
-
-        GatewayTLSStore.clearAllFingerprints()
-
-        #expect(GatewayTLSStore.loadFingerprint(stableID: stableID1) == nil)
-        #expect(GatewayTLSStore.loadFingerprint(stableID: stableID2) == nil)
-    }
-
     @Test func `TLS fingerprints preserve exact unicode gateway owners`() {
         let suffix = UUID().uuidString
         let composedOwner = "gateway-\u{00E9}-\(suffix)"

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
@@ -366,11 +366,15 @@ public enum GatewayTLSStore {
 
     @discardableResult
     public static func clearAllFingerprints() -> Bool {
+        self.clearAllFingerprints(clearLegacy: { self.clearAllLegacyFingerprints() })
+    }
+
+    static func clearAllFingerprints(clearLegacy: () -> Void) -> Bool {
         let removedKeychain = self.keychainOperations.delete([
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.keychainService,
         ] as CFDictionary)
-        self.clearAllLegacyFingerprints()
+        clearLegacy()
         let removed = removedKeychain == errSecSuccess || removedKeychain == errSecItemNotFound
         if removed {
             self.firstUseClaims.clearAll()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayTLSPinningTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayTLSPinningTests.swift
@@ -389,4 +389,17 @@ struct GatewayTLSPinningTests {
             required: true,
             systemTrustOk: false) == .reject(.untrustedCertificate))
     }
+
+    @Test func `clear all fingerprints removes every canonical pin without live storage`() {
+        self.withFakeKeychain { _ in
+            GatewayTLSStore.saveFingerprint("11", stableID: "gateway-1")
+            GatewayTLSStore.saveFingerprint("22", stableID: "gateway-2")
+            var clearedLegacy = false
+
+            #expect(GatewayTLSStore.clearAllFingerprints(clearLegacy: { clearedLegacy = true }))
+            #expect(clearedLegacy)
+            #expect(GatewayTLSStore.loadFingerprint(stableID: "gateway-1") == nil)
+            #expect(GatewayTLSStore.loadFingerprint(stableID: "gateway-2") == nil)
+        }
+    }
 }


### PR DESCRIPTION
## What Problem This Solves

An iOS security test called `GatewayTLSStore.clearAllFingerprints()` against the live `ai.openclaw.tls-pinning` Keychain service. Because the production operation intentionally has no account filter, the test could delete every operator TLS pin on the machine, and its `defer` repeated the broad deletion.

## Why This Change Was Made

The destructive iOS test is removed. Clear-all coverage now lives with `GatewayTLSStore` in the shared OpenClawKit suite, using the existing TaskLocal fake Keychain. A small internal overload injects legacy cleanup so the test also avoids touching the real `ai.openclaw.shared` UserDefaults suite.

The public clear-all API and full-onboarding-reset behavior are unchanged: production still removes all canonical pins, legacy pins, and in-memory first-use claims.

## User Impact

Running iOS/OpenClawKit tests no longer erases operator TLS pins or legacy TLS preferences. Production onboarding reset behavior is unchanged.

## Evidence

- Before the production seam: `swift test --package-path apps/shared/OpenClawKit --filter GatewayTLSPinningTests --parallel` failed to compile the moved test because the isolated legacy-cleanup overload did not exist.
- After the production seam: the same command passed 20/20 `GatewayTLSPinningTests`; the moved clear-all case used only fake Keychain and an injected legacy closure.
- `node scripts/check-changed.mjs` passed remotely on Blacksmith Testbox `tbx_01kzk9xnrm17kw3jpbg9vnfcbb` in 2m40s. Run: https://github.com/openclaw/openclaw/actions/runs/31314826250
- Exact-head native CI is green: https://github.com/openclaw/openclaw/actions/runs/31315015583 (`macos-swift`, iOS Debug/Release builds, focused simulator lifecycle tests, screenshot capture, and Android/shared-kit build).
- Repo-configured SwiftFormat lint passed 0/3 files: `swiftformat --lint --config config/swiftformat ...`.
- `git diff --check` passed.
- Fresh Codex-backed autoreview passed with no accepted or actionable findings.
- Production delta: +5/-1. Test delta: +13/-17.

### ClawSweeper rank-up moves

- Applied: refreshed the patch on current main without changing production clear-all semantics.
- Applied: exact-head macOS Swift, iOS, and shared-kit native validation completed successfully.
