### PR TITLE
test(sessions): close SQLite fixtures before cleanup

### DIFF
--- a/src/config/sessions/ambient-transcript-watermark.test.ts
+++ b/src/config/sessions/ambient-transcript-watermark.test.ts
@@ -1,13 +1,17 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   readAmbientTranscriptWatermark,
   resolveAmbientTranscriptWatermarkKey,
   updateAmbientTranscriptWatermark,
 } from "./ambient-transcript-watermark.js";
 import { loadSessionEntry, replaceSessionEntry } from "./session-accessor.js";
+
+const tempDirs: string[] = [];
 
 describe("ambient transcript watermark", () => {
   let tempDir: string;
@@ -20,12 +24,14 @@ describe("ambient transcript watermark", () => {
   });
 
   beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ambient-watermark-"));
+    tempDir = makeTempDir(tempDirs, "openclaw-ambient-watermark-");
     storePath = path.join(tempDir, "sessions.json");
   });
 
   afterEach(() => {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    cleanupTempDirs(tempDirs);
   });
 
   it("stamps and resolves the watermark for the current session id only", async () => {

--- a/src/config/sessions/entry-freshness.test.ts
+++ b/src/config/sessions/entry-freshness.test.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { resolveSessionEntryResetFreshness } from "./entry-freshness.js";
 import { appendTranscriptEvent, upsertSessionEntry } from "./session-accessor.js";
 
@@ -18,6 +20,8 @@ describe("resolveSessionEntryResetFreshness", () => {
   });
 
   afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     cleanupTempDirs(tempDirs);
   });
 

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../../test/helpers/promise.js";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import {
   onInternalSessionTranscriptUpdate,
@@ -17,6 +17,10 @@ import {
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
 } from "../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  isOpenClawStateDatabaseOpen,
+} from "../../state/openclaw-state-db.js";
 import { appendSqliteTrajectoryRuntimeEvents } from "../../trajectory/runtime-store.sqlite.js";
 import type { TrajectoryEvent } from "../../trajectory/types.js";
 import {
@@ -88,6 +92,7 @@ import { withOwnedSessionTranscriptWrites } from "./transcript-write-context.js"
 import type { InternalSessionEntry, SessionEntry } from "./types.js";
 
 const cleanupArchivedSessionTranscriptsMock = vi.hoisted(() => vi.fn(async () => {}));
+const tempDirs: string[] = [];
 
 vi.mock("../../gateway/session-archive.runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../gateway/session-archive.runtime.js")>();
@@ -127,6 +132,8 @@ describe("session accessor seam", () => {
   let tempDir: string;
   let storePath: string;
   let transcriptPath: string;
+  let cleanupProbeDatabasePath = "";
+  let cleanupProbeRoot = "";
 
   function loadMainInitializationSnapshot(sessionKey: string) {
     return loadReplySessionInitializationSnapshot({ agentId: "main", sessionKey, storePath });
@@ -134,13 +141,38 @@ describe("session accessor seam", () => {
 
   beforeEach(() => {
     cleanupArchivedSessionTranscriptsMock.mockReset();
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-accessor-"));
+    tempDir = makeTempDir(tempDirs, "openclaw-session-accessor-");
     storePath = path.join(tempDir, "sessions.json");
     transcriptPath = path.join(tempDir, "session.jsonl");
   });
 
   afterEach(() => {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    cleanupTempDirs(tempDirs);
+  });
+
+  describe.sequential("session database teardown boundary", () => {
+    it("opens cached agent and shared-state handles", async () => {
+      await replaceSessionEntry(
+        { agentId: "main", sessionKey: "agent:main:cleanup-probe", storePath },
+        { sessionId: "cleanup-probe", updatedAt: 1 },
+      );
+      cleanupProbeDatabasePath = expectDefined(
+        resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+        "cleanup probe database path",
+      );
+      cleanupProbeRoot = tempDir;
+
+      expect(isOpenClawAgentDatabaseOpen(cleanupProbeDatabasePath)).toBe(true);
+      expect(isOpenClawStateDatabaseOpen()).toBe(true);
+    });
+
+    it("releases both cache owners before the next test", () => {
+      expect(isOpenClawAgentDatabaseOpen(cleanupProbeDatabasePath)).toBe(false);
+      expect(isOpenClawStateDatabaseOpen()).toBe(false);
+      expect(fs.existsSync(cleanupProbeRoot)).toBe(false);
+    });
   });
 
   it("exposes the canonical SQLite session lifecycle owners", () => {

--- a/src/config/sessions/session-registry-maintenance.test.ts
+++ b/src/config/sessions/session-registry-maintenance.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { readSessionArchiveContentSync } from "./archive-compression.js";
 import { isRetainedSessionTranscriptArchiveName } from "./artifacts.js";
@@ -24,6 +26,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
   await fixtureSuite.cleanup();
 });
 

--- a/src/test-utils/fixture-suite.ts
+++ b/src/test-utils/fixture-suite.ts
@@ -1,25 +1,23 @@
 // Loads fixture suites from disk for parametrized tests.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 /** Creates a temp fixture root with deterministic per-case subdirectories. */
 export function createFixtureSuite(rootPrefix: string) {
   let fixtureRoot = "";
   let fixtureCount = 0;
+  const fixtureRoots = new Set<string>();
 
   return {
     async setup(): Promise<void> {
-      // Canonicalize: macOS tmpdir sits behind a symlink (/var -> /private/var)
-      // and production realpaths state/session paths, so symlinked roots break
-      // path-equality assertions.
-      fixtureRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), rootPrefix)));
+      fixtureRoot = makeTempDir(fixtureRoots, rootPrefix);
     },
     async cleanup(): Promise<void> {
       if (!fixtureRoot) {
         return;
       }
-      await fs.rm(fixtureRoot, { recursive: true, force: true });
+      cleanupTempDirs(fixtureRoots);
       fixtureRoot = "";
     },
     async createCaseDir(prefix: string): Promise<string> {


### PR DESCRIPTION
## What Problem This Solves

Session tests removed fixture roots while process-cached agent and shared-state SQLite handles could still own files below those roots. The leaked owners contaminate later tests and can make Windows directory removal fail with `EBUSY`.

The three surviving original suites remain repaired. The stale fourth original target was deleted from `main` and stays omitted. A current-main sibling in the entry-freshness suite is repaired under the same invariant.

## Why This Change Was Made

Every affected teardown now closes cached agent databases first, closes the shared-state database second, and only then removes tracked fixture roots. The order is required because closing an agent database releases its durable lease through a shared-state write transaction; closing shared state first would let the agent close reopen it.

Temporary roots are registered by their producers and removed through the canonical `cleanupTempDirs` helper, matching #113342. `createFixtureSuite` now owns that policy for all of its consumers instead of maintaining a second removal implementation.

The sequential regression opens the real agent and shared-state cache owners, then proves the next test observes both owners closed and the prior root removed.

## User Impact

Developers and CI workers get deterministic SQLite fixture teardown without stale cached handles. Production behavior and persisted schemas are unchanged.

The PR is currently blocked from landing because current `main` fails the core-test typecheck in an unrelated file: `src/sessions/user-turn-transcript.test.ts:548` references an undefined `createTempDir`. This PR does not touch that file, and no gate is bypassed.

## Evidence

- Regression before the ordered close (`node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts -- -t 'session database teardown boundary'`):
  - `Test Files 1 failed`
  - `Tests 1 failed | 1 passed | 105 skipped`
  - the next test observed the prior agent cache handle still open
  - `[vitest] FAILED (exit 1)`
- Regression after the repair (same command):
  - `Test Files 1 passed`
  - `Tests 2 passed | 105 skipped`
  - `[test] passed 1 Vitest shard in 4.23s`
- Affected and producer-sibling suites:
  - `node scripts/run-vitest.mjs src/config/sessions/ambient-transcript-watermark.test.ts src/config/sessions/entry-freshness.test.ts src/config/sessions/session-accessor.test.ts src/config/sessions/session-registry-maintenance.test.ts src/config/sessions/store.pruning.test.ts`
  - `Test Files 5 passed`
  - `Tests 176 passed`
  - `[test] passed 1 Vitest shard in 32.20s`
- Changed-file gate (`node scripts/check-changed.mjs`):
  - Blacksmith Testbox `tbx_01kzkav12v0k8g6tt67j85ge96`
  - https://github.com/openclaw/openclaw/actions/runs/31315504772
  - formatting, boundaries, dependency checks, dead-code checks, production typecheck, and temp-root checks passed
  - core-test typecheck failed only at `src/sessions/user-turn-transcript.test.ts:548:19` with `TS2304: Cannot find name 'createTempDir'`
  - `[check:changed] FAILED (exit 1)`; landing intentionally stopped under the red-main rule
- `git diff --check`: passed.
- Codex autoreview on head `1bd736ac6065`: clean after one round; no accepted/actionable findings, confidence 0.99.
- ClawSweeper rank-up moves applied: current-main reconstruction contains only the surviving original targets, the deleted target remains omitted, and focused before/after proof is recorded above.

AI-assisted: yes.
