### PR TITLE
fix(anthropic): keep adopted Claude CLI chats working after first turn

### DIFF
--- a/extensions/anthropic/session-catalog-history.test.ts
+++ b/extensions/anthropic/session-catalog-history.test.ts
@@ -75,4 +75,40 @@ describe("importClaudeHistory", () => {
     expect(assistantRow).toBeDefined();
     expect(assistantRow?.["__openclaw"]).toBeUndefined();
   });
+
+  it("omits empty native reasoning records instead of rendering a placeholder", async () => {
+    appended.length = 0;
+    await importClaudeHistory({
+      items: [
+        { type: "reasoning", content: [{ type: "thinking", thinking: "" }], uuid: "r-1" },
+        { type: "assistantMessage", text: "AUTH_OK", uuid: "a-1" },
+      ],
+      threadId: "thread-1",
+      sessionFile: "/tmp/unused.jsonl",
+      sessionId: "session-1",
+      sessionKey: "agent:main:catalog-adopt",
+      agentId: "main",
+      config: {} as OpenClawConfig,
+    });
+
+    expect(appended).toHaveLength(1);
+    expect(JSON.stringify(appended)).toContain("AUTH_OK");
+    expect(JSON.stringify(appended)).not.toContain("Unsupported Claude transcript item");
+  });
+
+  it("retains the placeholder for unsupported non-reasoning records", async () => {
+    appended.length = 0;
+    await importClaudeHistory({
+      items: [{ type: "toolCall", content: [{ type: "tool_use" }], uuid: "t-1" }],
+      threadId: "thread-1",
+      sessionFile: "/tmp/unused.jsonl",
+      sessionId: "session-1",
+      sessionKey: "agent:main:catalog-adopt",
+      agentId: "main",
+      config: {} as OpenClawConfig,
+    });
+
+    expect(appended).toHaveLength(1);
+    expect(JSON.stringify(appended)).toContain("Unsupported Claude transcript item");
+  });
 });

--- a/extensions/anthropic/session-catalog-history.ts
+++ b/extensions/anthropic/session-catalog-history.ts
@@ -7,10 +7,14 @@ import type { ClaudeTranscriptItem } from "./session-catalog-transcript.js";
 function importedClaudeMessage(
   item: ClaudeTranscriptItem,
   fallbackTimestamp: number,
-): AgentMessage {
+): AgentMessage | undefined {
   const parsedTimestamp = item.timestamp ? Date.parse(item.timestamp) : Number.NaN;
   const timestamp = Number.isFinite(parsedTimestamp) ? parsedTimestamp : fallbackTimestamp;
-  const text = item.text?.trim() || "[Unsupported Claude transcript item]";
+  const importedText = item.text?.trim();
+  if (!importedText && item.type === "reasoning") {
+    return undefined;
+  }
+  const text = importedText || "[Unsupported Claude transcript item]";
   if (item.type === "userMessage") {
     // Imported native rows are not OpenClaw-authored; mirrorOrigin excludes them
     // from self-echo provenance so a repeated native prompt stays observable.
@@ -61,9 +65,13 @@ export async function importClaudeHistory(params: {
   const items = params.items.toReversed();
   await withSessionTranscriptWriteLock(params, async (transcript) => {
     for (const [index, item] of items.entries()) {
+      const imported = importedClaudeMessage(item, Date.now() + index);
+      if (!imported) {
+        continue;
+      }
       // The idempotency key rides on the message so recovery re-imports dedupe.
       const message = {
-        ...(importedClaudeMessage(item, Date.now() + index) as unknown as Record<string, unknown>),
+        ...(imported as unknown as Record<string, unknown>),
         idempotencyKey: `claude-catalog:${params.threadId}:${item.uuid ?? index}`,
       } as unknown as AgentMessage;
       await transcript.appendMessage({

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1288,6 +1288,42 @@ describe("createModelSelectionState respects session model override", () => {
     });
   });
 
+  it("keeps ordinary provider overrides off the CLI setup-registry path", async () => {
+    const resolvePluginSetupCliBackend = vi.fn(() => undefined);
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [],
+      resolvePluginSetupCliBackend,
+    });
+    const cfg = {
+      agents: {
+        defaults: {
+          models: { "custom-provider/custom-model": {} },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:custom-provider";
+    const sessionEntry = makeEntry({
+      providerOverride: "custom-provider",
+      modelOverride: "custom-model",
+    });
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultProvider: "custom-provider",
+      defaultModel: "custom-model",
+      provider: "custom-provider",
+      model: "custom-model",
+      hasModelDirective: false,
+    });
+
+    expect(state).toMatchObject({ provider: "custom-provider", model: "custom-model" });
+    expect(resolvePluginSetupCliBackend).not.toHaveBeenCalled();
+  });
+
   it("adopts a concurrent valid model while repairing a stale override", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-repair-race-"));
     const storePath = path.join(tempRoot, "sessions.json");

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import {
   MODEL_CONTEXT_TOKEN_CACHE,
   providerContextTokenCacheKey,
@@ -116,6 +117,7 @@ vi.mock("../../agents/auth-profiles/order.js", () => ({
 
 afterEach(() => {
   MODEL_CONTEXT_TOKEN_CACHE.clear();
+  cliBackendsTesting.resetDepsForTest();
   vi.mocked(loadManifestModelCatalog).mockReset();
   vi.mocked(loadManifestModelCatalog).mockReturnValue([]);
   authProfileStoreMock.reset();
@@ -1214,6 +1216,74 @@ describe("createModelSelectionState respects session model override", () => {
       providerOverride: "openai",
       modelOverride: "gpt-4o-mini",
       modelOverrideSource: "user",
+      modelSelectionLocked: true,
+    });
+  });
+
+  it("preserves a locked CLI runtime alias when its canonical model is allowed", async () => {
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [],
+      resolvePluginSetupCliBackend: ({ backend }) =>
+        backend === "claude-cli"
+          ? ({
+              pluginId: "anthropic",
+              backend: {
+                id: "claude-cli",
+                modelProvider: "anthropic",
+                config: { command: "claude" },
+                bundleMcp: false,
+              },
+            } as never)
+          : undefined,
+    });
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.6-sol" },
+          models: {
+            "openai/gpt-5.6-sol": {},
+            "anthropic/claude-opus-4-8": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:plugin:anthropic:catalog-adopt:claude:test";
+    const sessionEntry = makeEntry({
+      providerOverride: "claude-cli",
+      modelOverride: "claude-opus-4-8",
+      modelSelectionLocked: true,
+      pluginOwnerId: "anthropic",
+      cliSessionBindings: {
+        "claude-cli": {
+          sessionId: "native-claude-session",
+          forceReuse: true,
+          forkNextResume: true,
+        },
+      },
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.6-sol",
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+      hasModelDirective: false,
+    });
+
+    expect(state).toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      resetModelOverride: false,
+    });
+    expect(sessionStore[sessionKey]).toMatchObject({
+      providerOverride: "claude-cli",
+      modelOverride: "claude-opus-4-8",
       modelSelectionLocked: true,
     });
   });

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -7,7 +7,6 @@ import {
 } from "../../agents/agent-scope.js";
 import { isStoredCredentialCompatibleWithAuthProvider } from "../../agents/auth-profiles/order.js";
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
-import { resolveCliRuntimeCanonicalProvider } from "../../agents/cli-backends.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
@@ -51,6 +50,7 @@ export {
 } from "./model-selection-directive.js";
 import {
   isStaleHeartbeatAutoFallbackOverride,
+  normalizeStoredRuntimeModelRef,
   resolveStoredModelOverride,
 } from "./stored-model-override.js";
 
@@ -123,28 +123,8 @@ const modelCatalogRuntimeLoader = createLazyImportLoader(
 const sessionPersistenceRuntimeLoader = createLazyImportLoader(
   () => import("./session-entry-persistence.js"),
 );
-function normalizeRuntimeModelRef(
-  provider: string,
-  model: string,
-  cfg?: OpenClawConfig,
-  sessionEntry?: SessionEntry,
-) {
-  const normalized = normalizeModelRef(provider, model, RUNTIME_MODEL_VISIBILITY_NORMALIZATION);
-  // Only CLI-bound sessions can persist a runtime id in providerOverride. Keep
-  // ordinary provider overrides on the static model-selection path instead of
-  // loading the CLI setup registry for every reply.
-  const hasCliSessionBinding = Object.keys(sessionEntry?.cliSessionBindings ?? {}).some(
-    (runtime) => normalizeProviderId(runtime) === normalized.provider,
-  );
-  const canonicalProvider =
-    cfg && hasCliSessionBinding
-      ? resolveCliRuntimeCanonicalProvider({
-          runtime: normalized.provider,
-          config: cfg,
-          includeSetupRegistry: true,
-        })
-      : undefined;
-  return canonicalProvider ? { ...normalized, provider: canonicalProvider } : normalized;
+function normalizeRuntimeModelRef(provider: string, model: string) {
+  return normalizeModelRef(provider, model, RUNTIME_MODEL_VISIBILITY_NORMALIZATION);
 }
 
 function loadPreparedModelCatalogRuntime() {
@@ -361,7 +341,7 @@ export async function createModelSelectionState(params: {
     directStoredOverride &&
     !hasOneTurnModelOverride
   ) {
-    const normalizedOverride = normalizeRuntimeModelRef(
+    const normalizedOverride = normalizeStoredRuntimeModelRef(
       directStoredOverride.provider,
       directStoredOverride.model,
       cfg,
@@ -452,7 +432,7 @@ export async function createModelSelectionState(params: {
     (resetModelOverride && staleDirectStoredOverride && storedOverride?.source === "session");
 
   if (storedOverride?.model && !skipStoredOverride) {
-    const normalizedStoredOverride = normalizeRuntimeModelRef(
+    const normalizedStoredOverride = normalizeStoredRuntimeModelRef(
       storedOverride.provider || defaultProvider,
       storedOverride.model,
       cfg,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -123,15 +123,27 @@ const modelCatalogRuntimeLoader = createLazyImportLoader(
 const sessionPersistenceRuntimeLoader = createLazyImportLoader(
   () => import("./session-entry-persistence.js"),
 );
-function normalizeRuntimeModelRef(provider: string, model: string, cfg?: OpenClawConfig) {
+function normalizeRuntimeModelRef(
+  provider: string,
+  model: string,
+  cfg?: OpenClawConfig,
+  sessionEntry?: SessionEntry,
+) {
   const normalized = normalizeModelRef(provider, model, RUNTIME_MODEL_VISIBILITY_NORMALIZATION);
-  const canonicalProvider = cfg
-    ? resolveCliRuntimeCanonicalProvider({
-        runtime: normalized.provider,
-        config: cfg,
-        includeSetupRegistry: true,
-      })
-    : undefined;
+  // Only CLI-bound sessions can persist a runtime id in providerOverride. Keep
+  // ordinary provider overrides on the static model-selection path instead of
+  // loading the CLI setup registry for every reply.
+  const hasCliSessionBinding = Object.keys(sessionEntry?.cliSessionBindings ?? {}).some(
+    (runtime) => normalizeProviderId(runtime) === normalized.provider,
+  );
+  const canonicalProvider =
+    cfg && hasCliSessionBinding
+      ? resolveCliRuntimeCanonicalProvider({
+          runtime: normalized.provider,
+          config: cfg,
+          includeSetupRegistry: true,
+        })
+      : undefined;
   return canonicalProvider ? { ...normalized, provider: canonicalProvider } : normalized;
 }
 
@@ -353,6 +365,7 @@ export async function createModelSelectionState(params: {
       directStoredOverride.provider,
       directStoredOverride.model,
       cfg,
+      sessionEntry,
     );
     const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
     const overrideAllowed = visibilityPolicy.allowsKey(key);
@@ -443,6 +456,7 @@ export async function createModelSelectionState(params: {
       storedOverride.provider || defaultProvider,
       storedOverride.model,
       cfg,
+      sessionEntry,
     );
     const key = modelKey(normalizedStoredOverride.provider, normalizedStoredOverride.model);
     if (visibilityPolicy.allowsKey(key)) {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -7,6 +7,7 @@ import {
 } from "../../agents/agent-scope.js";
 import { isStoredCredentialCompatibleWithAuthProvider } from "../../agents/auth-profiles/order.js";
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
+import { resolveCliRuntimeCanonicalProvider } from "../../agents/cli-backends.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
@@ -122,8 +123,16 @@ const modelCatalogRuntimeLoader = createLazyImportLoader(
 const sessionPersistenceRuntimeLoader = createLazyImportLoader(
   () => import("./session-entry-persistence.js"),
 );
-function normalizeRuntimeModelRef(provider: string, model: string) {
-  return normalizeModelRef(provider, model, RUNTIME_MODEL_VISIBILITY_NORMALIZATION);
+function normalizeRuntimeModelRef(provider: string, model: string, cfg?: OpenClawConfig) {
+  const normalized = normalizeModelRef(provider, model, RUNTIME_MODEL_VISIBILITY_NORMALIZATION);
+  const canonicalProvider = cfg
+    ? resolveCliRuntimeCanonicalProvider({
+        runtime: normalized.provider,
+        config: cfg,
+        includeSetupRegistry: true,
+      })
+    : undefined;
+  return canonicalProvider ? { ...normalized, provider: canonicalProvider } : normalized;
 }
 
 function loadPreparedModelCatalogRuntime() {
@@ -343,6 +352,7 @@ export async function createModelSelectionState(params: {
     const normalizedOverride = normalizeRuntimeModelRef(
       directStoredOverride.provider,
       directStoredOverride.model,
+      cfg,
     );
     const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
     const overrideAllowed = visibilityPolicy.allowsKey(key);
@@ -432,6 +442,7 @@ export async function createModelSelectionState(params: {
     const normalizedStoredOverride = normalizeRuntimeModelRef(
       storedOverride.provider || defaultProvider,
       storedOverride.model,
+      cfg,
     );
     const key = modelKey(normalizedStoredOverride.provider, normalizedStoredOverride.model);
     if (visibilityPolicy.allowsKey(key)) {

--- a/src/auto-reply/reply/stored-model-override.ts
+++ b/src/auto-reply/reply/stored-model-override.ts
@@ -1,14 +1,17 @@
 // Persists and resolves per-session model override choices.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hasSessionAutoModelFallbackProvenance } from "../../agents/agent-scope.js";
+import { resolveCliRuntimeCanonicalProvider } from "../../agents/cli-backends.js";
 import {
   modelKey,
   normalizeModelRef,
   normalizeStoredOverrideModel,
   resolvePersistedOverrideModelRef,
 } from "../../agents/model-selection.js";
+import { RUNTIME_MODEL_VISIBILITY_NORMALIZATION } from "../../agents/model-visibility-policy.js";
 import { resolveSessionParentSessionKey } from "../../channels/plugins/session-conversation.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 /** Model override loaded from the current session or its parent session. */
 export type StoredModelOverride = {
@@ -16,6 +19,27 @@ export type StoredModelOverride = {
   model: string;
   source: "session" | "parent";
 };
+
+/** Normalizes a stored model ref, resolving runtime aliases only for CLI-bound sessions. */
+export function normalizeStoredRuntimeModelRef(
+  provider: string,
+  model: string,
+  cfg?: OpenClawConfig,
+  sessionEntry?: SessionEntry,
+) {
+  const normalized = normalizeModelRef(provider, model, RUNTIME_MODEL_VISIBILITY_NORMALIZATION);
+  const hasCliSessionBinding =
+    sessionEntry?.cliSessionBindings?.[normalized.provider] !== undefined;
+  const canonicalProvider =
+    cfg && hasCliSessionBinding
+      ? resolveCliRuntimeCanonicalProvider({
+          runtime: normalized.provider,
+          config: cfg,
+          includeSetupRegistry: true,
+        })
+      : undefined;
+  return canonicalProvider ? { ...normalized, provider: canonicalProvider } : normalized;
+}
 
 function resolveParentSessionKeyCandidate(params: {
   sessionKey?: string;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users continuing an adopted Claude Code chat could receive `Model selection is locked for this session.` after the first turn, even though they had not changed the model. Imported Claude history could also render empty signed reasoning records as `[Unsupported Claude transcript item]`.

## Why This Change Was Made

For CLI-bound sessions, canonicalize the stored runtime alias to its provider before model-visibility checks while preserving the locked persisted runtime binding. Ordinary provider overrides stay on the static path and do not load the CLI/plugin setup registry. During Claude history import, omit only empty reasoning records; unsupported non-reasoning records retain the existing fallback so unexpected data is not silently discarded.

## User Impact

Adopted Claude Code chats can continue across multiple turns on the same locked CLI session, and new imports no longer display placeholder prose for empty reasoning metadata.

## Evidence

- Reproduced the locked-session failure before patching and verified that it was gateway-injected before Claude model contact.
- Live Control UI `chat.send` proof on the repaired runtime persisted two consecutive responses from `claude-cli` / `claude-opus-4-8` on the same locked OpenClaw and native Claude sessions.
- Blacksmith Testbox: 67/67 model-selection tests and 4/4 Claude history-import tests passed on `a74c710bd390` ([run](https://github.com/openclaw/openclaw/actions/runs/30023668310)).
- Delegated `pnpm check:changed`: passed in 9m32s after the sync cache conservatively widened the gate beyond this four-file patch.
- The first PR CI run exposed an adjacent plugin-runtime test failure caused by an unnecessary setup-registry lookup for ordinary provider overrides. The repaired head passes that exact shard (8/8) plus the focused model-selection/history/override suite (73/73).
- Structured autoreview: initial full diff clean at 0.99 confidence; adjacent CI repair clean at 0.98 confidence.
- Source-blind exact-head validation on an isolated packaged OCM runtime: two nonce-distinct turns on the same locked adopted session both persisted exact replies from `claude-cli` / `claude-opus-4-8`, with no lock error or new unsupported placeholder in the recent history window. `/healthz` was live; full clone readiness was limited only by an intentionally uncopied Telegram credential.
- The current published head is patch-identical by `git range-diff` after rebasing onto the latest canonical `main`.
