### PR TITLE
fix(line): keep replies deliverable when action data or button URLs exceed LINE's size caps

### DIFF
--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -5,12 +5,13 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 export type Action = messagingApi.Action;
 const LINE_ACTION_LABEL_LIMIT = 20;
 const LINE_ACTION_DATA_LIMIT = 300;
+const LINE_ACTION_URI_LIMIT = 1000;
 
 export function truncateLineActionLabel(label: string, limit = LINE_ACTION_LABEL_LIMIT): string {
   return truncateUtf16Safe(label, limit);
 }
 
-function truncateLineActionData(data: string): string {
+export function truncateLineActionData(data: string): string {
   return truncateUtf16Safe(data, LINE_ACTION_DATA_LIMIT);
 }
 
@@ -32,7 +33,7 @@ export function uriAction(label: string, uri: string): Action {
   return {
     type: "uri",
     label: truncateLineActionLabel(label),
-    uri,
+    uri: truncateUtf16Safe(uri, LINE_ACTION_URI_LIMIT),
   };
 }
 

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -55,22 +55,18 @@ export function uriAction(label: string, uri: string): Action {
  * Create a postback action (sends data to webhook when tapped)
  */
 export function postbackAction(label: string, data: string, displayText?: string): Action {
+  const boundedData = truncateLineActionData(data);
+  if (boundedData !== data) {
+    // Callback data is opaque and echoed back by LINE. Never dispatch a value
+    // whose identity changed merely to satisfy the transport cap.
+    return unavailableAction("Action", "callback data exceeds LINE's limit.");
+  }
   return {
     type: "postback",
     label: truncateLineActionLabel(label),
-    data: truncateLineActionData(data),
+    data: boundedData,
     displayText: displayText === undefined ? undefined : truncateLineActionData(displayText),
   };
-}
-
-export function postbackOrUnavailableAction(label: string, data: string): Action {
-  const action = postbackAction(label, data);
-  if (action.type === "postback" && action.data === data) {
-    return action;
-  }
-  // Never expose the generic postback truncation for opaque card callbacks;
-  // a visible unavailable action is safer than dispatching altered data.
-  return unavailableAction("Action", "callback data exceeds LINE's limit.");
 }
 
 /**
@@ -86,10 +82,14 @@ export function datetimePickerAction(
     min?: string;
   },
 ): Action {
+  const boundedData = truncateLineActionData(data);
+  if (boundedData !== data) {
+    return unavailableAction("Action", "callback data exceeds LINE's limit.");
+  }
   return {
     type: "datetimepicker",
     label: truncateLineActionLabel(label),
-    data: truncateLineActionData(data),
+    data: boundedData,
     mode,
     initial: options?.initial,
     max: options?.max,

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -39,10 +39,7 @@ function unavailableAction(kind: "Action" | "Link", reason: string): Action {
   };
 }
 
-export function normalizeLineAction(
-  action: Action,
-  labelLimit = LINE_ACTION_LABEL_LIMIT,
-): Action {
+export function normalizeLineAction(action: Action, labelLimit = LINE_ACTION_LABEL_LIMIT): Action {
   const label =
     action.label === undefined ? undefined : truncateLineActionLabel(action.label, labelLimit);
 
@@ -61,8 +58,7 @@ export function normalizeLineAction(
   }
 
   if (action.type === "postback") {
-    const data =
-      action.data === undefined ? undefined : truncateLineActionData(action.data);
+    const data = action.data === undefined ? undefined : truncateLineActionData(action.data);
     if (data !== action.data) {
       // Callback data is opaque and echoed back by LINE. Never dispatch a value
       // whose identity changed merely to satisfy the transport cap.
@@ -88,8 +84,7 @@ export function normalizeLineAction(
   }
 
   if (action.type === "datetimepicker") {
-    const data =
-      action.data === undefined ? undefined : truncateLineActionData(action.data);
+    const data = action.data === undefined ? undefined : truncateLineActionData(action.data);
     if (data !== action.data) {
       return unavailableAction("Action", "callback data exceeds LINE's limit.");
     }
@@ -109,8 +104,7 @@ export function normalizeLineAction(
 
   if (action.type === "clipboard") {
     if (
-      truncateUtf16Safe(action.clipboardText, LINE_CLIPBOARD_TEXT_LIMIT) !==
-      action.clipboardText
+      truncateUtf16Safe(action.clipboardText, LINE_CLIPBOARD_TEXT_LIMIT) !== action.clipboardText
     ) {
       return unavailableAction("Action", "clipboard text exceeds LINE's limit.");
     }
@@ -118,8 +112,7 @@ export function normalizeLineAction(
   }
 
   if (action.type === "richmenuswitch") {
-    const data =
-      action.data === undefined ? undefined : truncateLineActionData(action.data);
+    const data = action.data === undefined ? undefined : truncateLineActionData(action.data);
     const aliasTooLong =
       action.richMenuAliasId !== undefined &&
       truncateUtf16Safe(action.richMenuAliasId, LINE_RICH_MENU_ALIAS_LIMIT) !==

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -15,11 +15,12 @@ function truncateLineActionText(text: string, limit: number): string {
   let result = "";
   let count = 0;
   for (const { segment } of graphemeSegmenter.segment(text)) {
-    if (count >= limit) {
+    const codePointCount = [...segment].length;
+    if (count + codePointCount > limit) {
       break;
     }
     result += segment;
-    count += 1;
+    count += codePointCount;
   }
   return result;
 }

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -217,7 +217,8 @@ function normalizeImagemapVideo(video: ImagemapVideo): {
   const label =
     externalLink.label === undefined
       ? undefined
-      : truncateLineActionLabel(externalLink.label, LINE_IMAGEMAP_EXTERNAL_LINK_LABEL_LIMIT);
+      : truncateUtf16Safe(externalLink.label, LINE_IMAGEMAP_EXTERNAL_LINK_LABEL_LIMIT) ||
+        (externalLink.label ? "…" : "");
   if (
     externalLink.linkUri !== undefined &&
     truncateUtf16Safe(externalLink.linkUri, LINE_ACTION_URI_LIMIT) !== externalLink.linkUri

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -3,6 +3,7 @@ import type { messagingApi } from "@line/bot-sdk";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export type Action = messagingApi.Action;
+type Message = messagingApi.Message;
 const LINE_ACTION_LABEL_LIMIT = 20;
 const LINE_ACTION_DATA_LIMIT = 300;
 const LINE_ACTION_URI_LIMIT = 1000;
@@ -37,6 +38,87 @@ function unavailableAction(kind: "Action" | "Link", reason: string): Action {
     label: "Unavailable",
     text: `${kind} unavailable: ${reason}`,
   };
+}
+
+const actionTypes = new Set([
+  "camera",
+  "cameraRoll",
+  "clipboard",
+  "datetimepicker",
+  "location",
+  "message",
+  "postback",
+  "richmenuswitch",
+  "uri",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isLineAction(value: unknown): value is Action {
+  return isRecord(value) && typeof value.type === "string" && actionTypes.has(value.type);
+}
+
+function normalizeNestedActions(value: unknown, labelLimit: number): unknown {
+  if (Array.isArray(value)) {
+    const normalized: unknown[] = [];
+    for (const item of value) {
+      normalized.push(normalizeNestedActions(item, labelLimit));
+    }
+    return normalized;
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const normalized: Record<string, unknown> = { ...value };
+  for (const [key, nested] of Object.entries(value)) {
+    if ((key === "action" || key === "defaultAction") && isLineAction(nested)) {
+      const action = normalizeLineAction(nested, labelLimit);
+      if (value.type === "video" && action.type !== "uri") {
+        // LINE accepts only URI actions on Flex video components. Dropping an
+        // unusable optional tap target keeps the video itself deliverable.
+        delete normalized[key];
+      } else {
+        normalized[key] = action;
+      }
+    } else if (key === "actions" && Array.isArray(nested)) {
+      normalized[key] = nested.map((action) =>
+        isLineAction(action) ? normalizeLineAction(action, labelLimit) : action,
+      );
+    } else {
+      normalized[key] = normalizeNestedActions(nested, labelLimit);
+    }
+  }
+  return normalized;
+}
+
+export function normalizeLineMessageActions(message: Message): Message {
+  let normalized: Message;
+  if (message.type === "flex") {
+    normalized = {
+      ...message,
+      contents: normalizeNestedActions(message.contents, 40) as messagingApi.FlexContainer,
+    };
+  } else if (message.type === "template") {
+    const labelLimit = message.template.type === "image_carousel" ? 12 : 20;
+    normalized = {
+      ...message,
+      template: normalizeNestedActions(message.template, labelLimit) as messagingApi.Template,
+    };
+  } else {
+    normalized = { ...message };
+  }
+
+  if (message.quickReply) {
+    normalized = {
+      ...normalized,
+      quickReply: normalizeNestedActions(message.quickReply, 20) as messagingApi.QuickReply,
+    };
+  }
+
+  return normalized;
 }
 
 export function normalizeLineAction(action: Action, labelLimit = LINE_ACTION_LABEL_LIMIT): Action {

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -5,6 +5,7 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 export type Action = messagingApi.Action;
 type Message = messagingApi.Message;
 type ImagemapAction = messagingApi.ImagemapAction;
+type ImagemapVideo = messagingApi.ImagemapVideo;
 const LINE_ACTION_LABEL_LIMIT = 20;
 const LINE_ACTION_DATA_LIMIT = 300;
 const LINE_ACTION_URI_LIMIT = 1000;
@@ -12,6 +13,8 @@ const LINE_CLIPBOARD_TEXT_LIMIT = 1000;
 const LINE_RICH_MENU_ALIAS_LIMIT = 32;
 const LINE_IMAGEMAP_ACTION_LABEL_LIMIT = 100;
 const LINE_IMAGEMAP_MESSAGE_TEXT_LIMIT = 400;
+const LINE_IMAGEMAP_EXTERNAL_LINK_LABEL_LIMIT = 30;
+const LINE_IMAGEMAP_ACTION_LIMIT = 50;
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 function truncateLineActionText(text: string, limit: number): string {
@@ -29,7 +32,8 @@ function truncateLineActionText(text: string, limit: number): string {
 }
 
 export function truncateLineActionLabel(label: string, limit = LINE_ACTION_LABEL_LIMIT): string {
-  return truncateLineActionText(label, limit);
+  const truncated = truncateLineActionText(label, limit);
+  return truncated || (label ? "…" : "");
 }
 
 function truncateLineActionData(data: string): string {
@@ -201,6 +205,36 @@ function normalizeImagemapAction(action: ImagemapAction): ImagemapAction {
   return { ...action, label };
 }
 
+function normalizeImagemapVideo(video: ImagemapVideo): {
+  video: ImagemapVideo;
+  fallbackAction?: ImagemapAction;
+} {
+  const externalLink = video.externalLink;
+  if (!externalLink) {
+    return { video };
+  }
+
+  const label =
+    externalLink.label === undefined
+      ? undefined
+      : truncateLineActionLabel(externalLink.label, LINE_IMAGEMAP_EXTERNAL_LINK_LABEL_LIMIT);
+  if (
+    externalLink.linkUri !== undefined &&
+    truncateUtf16Safe(externalLink.linkUri, LINE_ACTION_URI_LIMIT) !== externalLink.linkUri
+  ) {
+    const normalizedVideo = { ...video };
+    delete normalizedVideo.externalLink;
+    return {
+      video: normalizedVideo,
+      fallbackAction:
+        video.area === undefined
+          ? undefined
+          : unavailableImagemapAction("Link", "URL exceeds LINE's limit.", video.area),
+    };
+  }
+  return { video: { ...video, externalLink: { ...externalLink, label } } };
+}
+
 export function normalizeLineMessageActions(message: Message): Message {
   let normalized: Message;
   if (message.type === "flex") {
@@ -215,9 +249,17 @@ export function normalizeLineMessageActions(message: Message): Message {
       template: normalizeNestedActions(message.template, labelLimit) as messagingApi.Template,
     };
   } else if (message.type === "imagemap") {
+    const actions = message.actions.map(normalizeImagemapAction);
+    const videoResult = message.video ? normalizeImagemapVideo(message.video) : undefined;
+    if (videoResult?.fallbackAction) {
+      if (actions.length < LINE_IMAGEMAP_ACTION_LIMIT) {
+        actions.push(videoResult.fallbackAction);
+      }
+    }
     normalized = {
       ...message,
-      actions: message.actions.map(normalizeImagemapAction),
+      actions,
+      video: videoResult?.video,
     };
   } else {
     normalized = { ...message };

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -32,12 +32,19 @@ function truncateLineActionData(data: string): string {
   return truncateUtf16Safe(data, LINE_ACTION_DATA_LIMIT);
 }
 
+const unavailableActionMarker = Symbol("lineUnavailableAction");
+type UnavailableAction = Extract<Action, { type: "message" }> & {
+  [unavailableActionMarker]: true;
+};
+
 function unavailableAction(kind: "Action" | "Link", reason: string): Action {
-  return {
+  const action = {
     type: "message",
     label: "Unavailable",
     text: `${kind} unavailable: ${reason}`,
-  };
+  } satisfies Action;
+  Object.defineProperty(action, unavailableActionMarker, { value: true });
+  return action;
 }
 
 const actionTypes = new Set([
@@ -60,11 +67,15 @@ function isLineAction(value: unknown): value is Action {
   return isRecord(value) && typeof value.type === "string" && actionTypes.has(value.type);
 }
 
-function normalizeNestedActions(value: unknown, labelLimit: number): unknown {
+function isUnavailableAction(action: Action): action is UnavailableAction {
+  return (action as Partial<UnavailableAction>)[unavailableActionMarker] === true;
+}
+
+function normalizeNestedActions(value: unknown, labelLimit: number, warnings?: string[]): unknown {
   if (Array.isArray(value)) {
     const normalized: unknown[] = [];
     for (const item of value) {
-      normalized.push(normalizeNestedActions(item, labelLimit));
+      normalized.push(normalizeNestedActions(item, labelLimit, warnings));
     }
     return normalized;
   }
@@ -72,42 +83,78 @@ function normalizeNestedActions(value: unknown, labelLimit: number): unknown {
     return value;
   }
 
-  if (value.type === "video" && isLineAction(value.action)) {
-    const action = normalizeLineAction(value.action, labelLimit);
-    if (action.type !== "uri") {
-      // Flex video accepts only URI actions. Replace the video with its visual
-      // fallback and an explicit warning instead of dropping the tap target.
-      const contents: unknown[] = [];
-      if (isRecord(value.altContent)) {
-        contents.push(normalizeNestedActions(value.altContent, labelLimit));
-      }
-      contents.push({
-        type: "text",
-        text:
-          action.type === "message" && action.text
-            ? action.text
-            : "Action unavailable in this video.",
-        wrap: true,
-        size: "sm",
-        color: "#666666",
-      });
-      return { type: "box", layout: "vertical", contents };
-    }
-  }
-
   const normalized: Record<string, unknown> = { ...value };
   for (const [key, nested] of Object.entries(value)) {
     if ((key === "action" || key === "defaultAction") && isLineAction(nested)) {
-      normalized[key] = normalizeLineAction(nested, labelLimit);
+      const action = normalizeLineAction(nested, labelLimit);
+      if (
+        warnings &&
+        key === "action" &&
+        ((value.type === "video" && action.type !== "uri") ||
+          (value.type !== "button" && isUnavailableAction(action)))
+      ) {
+        delete normalized[key];
+        warnings.push(
+          isUnavailableAction(action)
+            ? (action.text ?? "Action unavailable.")
+            : "Action unavailable in this video.",
+        );
+      } else {
+        normalized[key] = action;
+      }
     } else if (key === "actions" && Array.isArray(nested)) {
       normalized[key] = nested.map((action) =>
         isLineAction(action) ? normalizeLineAction(action, labelLimit) : action,
       );
     } else {
-      normalized[key] = normalizeNestedActions(nested, labelLimit);
+      normalized[key] = normalizeNestedActions(nested, labelLimit, warnings);
     }
   }
   return normalized;
+}
+
+function normalizeFlexBubbleActions(value: unknown): unknown {
+  if (!isRecord(value) || value.type !== "bubble") {
+    return normalizeNestedActions(value, 40);
+  }
+
+  const warnings: string[] = [];
+  const normalized = normalizeNestedActions(value, 40, warnings);
+  if (!isRecord(normalized) || warnings.length === 0) {
+    return normalized;
+  }
+
+  const warning = {
+    type: "text",
+    text: [...new Set(warnings)].join("\n"),
+    wrap: true,
+    size: "sm",
+    color: "#B45309",
+    margin: "md",
+  };
+  const body = normalized.body;
+  if (isRecord(body) && Array.isArray(body.contents)) {
+    normalized.body = { ...body, contents: [...body.contents, warning] };
+  } else {
+    normalized.body = { type: "box", layout: "vertical", contents: [warning] };
+  }
+  return normalized;
+}
+
+function normalizeFlexContainerActions(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  if (value.type === "bubble") {
+    return normalizeFlexBubbleActions(value);
+  }
+  if (value.type === "carousel" && Array.isArray(value.contents)) {
+    return {
+      ...value,
+      contents: value.contents.map((bubble) => normalizeFlexBubbleActions(bubble)),
+    };
+  }
+  return normalizeNestedActions(value, 40);
 }
 
 export function normalizeLineMessageActions(message: Message): Message {
@@ -115,7 +162,7 @@ export function normalizeLineMessageActions(message: Message): Message {
   if (message.type === "flex") {
     normalized = {
       ...message,
-      contents: normalizeNestedActions(message.contents, 40) as messagingApi.FlexContainer,
+      contents: normalizeFlexContainerActions(message.contents) as messagingApi.FlexContainer,
     };
   } else if (message.type === "template") {
     const labelLimit = message.template.type === "image_carousel" ? 12 : 20;
@@ -138,6 +185,9 @@ export function normalizeLineMessageActions(message: Message): Message {
 }
 
 export function normalizeLineAction(action: Action, labelLimit = LINE_ACTION_LABEL_LIMIT): Action {
+  if (isUnavailableAction(action)) {
+    return action;
+  }
   const label =
     action.label === undefined ? undefined : truncateLineActionLabel(action.label, labelLimit);
 

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -11,8 +11,33 @@ export function truncateLineActionLabel(label: string, limit = LINE_ACTION_LABEL
   return truncateUtf16Safe(label, limit);
 }
 
-export function truncateLineActionData(data: string): string {
+function truncateLineActionData(data: string): string {
   return truncateUtf16Safe(data, LINE_ACTION_DATA_LIMIT);
+}
+
+function truncateLineActionUri(uri: string): string {
+  let candidate = truncateUtf16Safe(uri, LINE_ACTION_URI_LIMIT);
+  if (candidate === uri) {
+    return candidate;
+  }
+
+  try {
+    decodeURI(uri);
+  } catch {
+    return candidate;
+  }
+
+  // LINE requires UTF-8 percent-encoded URIs. Retreat from the size boundary
+  // until truncation no longer leaves a partial encoded code point.
+  while (candidate) {
+    try {
+      decodeURI(candidate);
+      return candidate;
+    } catch {
+      candidate = truncateUtf16Safe(candidate, candidate.length - 1);
+    }
+  }
+  return candidate;
 }
 
 /**
@@ -33,7 +58,7 @@ export function uriAction(label: string, uri: string): Action {
   return {
     type: "uri",
     label: truncateLineActionLabel(label),
-    uri: truncateUtf16Safe(uri, LINE_ACTION_URI_LIMIT),
+    uri: truncateLineActionUri(uri),
   };
 }
 

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -15,29 +15,13 @@ function truncateLineActionData(data: string): string {
   return truncateUtf16Safe(data, LINE_ACTION_DATA_LIMIT);
 }
 
-function truncateLineActionUri(uri: string): string {
-  let candidate = truncateUtf16Safe(uri, LINE_ACTION_URI_LIMIT);
-  if (candidate === uri) {
-    return candidate;
-  }
-
-  try {
-    decodeURI(uri);
-  } catch {
-    return candidate;
-  }
-
-  // LINE requires UTF-8 percent-encoded URIs. Retreat from the size boundary
-  // until truncation no longer leaves a partial encoded code point.
-  while (candidate) {
-    try {
-      decodeURI(candidate);
-      return candidate;
-    } catch {
-      candidate = truncateUtf16Safe(candidate, candidate.length - 1);
-    }
-  }
-  return candidate;
+function unavailableAction(kind: "Action" | "Link", reason: string): Action {
+  const label = `${kind} unavailable`;
+  return {
+    type: "message",
+    label,
+    text: `${label}: ${reason}`,
+  };
 }
 
 /**
@@ -55,10 +39,15 @@ export function messageAction(label: string, text?: string): Action {
  * Create a URI action (opens a URL when tapped)
  */
 export function uriAction(label: string, uri: string): Action {
+  // Opaque URLs may be signed or tokenized; changing their tail can navigate to
+  // the wrong destination. Keep the card deliverable with a visible fallback.
+  if (truncateUtf16Safe(uri, LINE_ACTION_URI_LIMIT) !== uri) {
+    return unavailableAction("Link", "URL exceeds LINE's limit.");
+  }
   return {
     type: "uri",
     label: truncateLineActionLabel(label),
-    uri: truncateLineActionUri(uri),
+    uri,
   };
 }
 
@@ -72,6 +61,16 @@ export function postbackAction(label: string, data: string, displayText?: string
     data: truncateLineActionData(data),
     displayText: displayText === undefined ? undefined : truncateLineActionData(displayText),
   };
+}
+
+export function postbackOrUnavailableAction(label: string, data: string): Action {
+  const action = postbackAction(label, data);
+  if (action.type === "postback" && action.data === data) {
+    return action;
+  }
+  // Never expose the generic postback truncation for opaque card callbacks;
+  // a visible unavailable action is safer than dispatching altered data.
+  return unavailableAction("Action", "callback data exceeds LINE's limit.");
 }
 
 /**

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -21,7 +21,7 @@ function truncateLineActionText(text: string, limit: number): string {
   let result = "";
   let count = 0;
   for (const { segment } of graphemeSegmenter.segment(text)) {
-    const codePointCount = [...segment].length;
+    const codePointCount = Array.from(segment).length;
     if (count + codePointCount > limit) {
       break;
     }

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -4,11 +4,14 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export type Action = messagingApi.Action;
 type Message = messagingApi.Message;
+type ImagemapAction = messagingApi.ImagemapAction;
 const LINE_ACTION_LABEL_LIMIT = 20;
 const LINE_ACTION_DATA_LIMIT = 300;
 const LINE_ACTION_URI_LIMIT = 1000;
 const LINE_CLIPBOARD_TEXT_LIMIT = 1000;
 const LINE_RICH_MENU_ALIAS_LIMIT = 32;
+const LINE_IMAGEMAP_ACTION_LABEL_LIMIT = 100;
+const LINE_IMAGEMAP_MESSAGE_TEXT_LIMIT = 400;
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 function truncateLineActionText(text: string, limit: number): string {
@@ -158,6 +161,46 @@ function normalizeFlexContainerActions(value: unknown): unknown {
   return normalizeNestedActions(value, 40);
 }
 
+function unavailableImagemapAction(
+  kind: "Action" | "Link",
+  reason: string,
+  area: ImagemapAction["area"],
+): ImagemapAction {
+  return {
+    type: "message",
+    label: "Unavailable",
+    text: `${kind} unavailable: ${reason}`,
+    area,
+  };
+}
+
+function normalizeImagemapAction(action: ImagemapAction): ImagemapAction {
+  const label =
+    action.label === undefined
+      ? undefined
+      : truncateLineActionText(action.label, LINE_IMAGEMAP_ACTION_LABEL_LIMIT);
+
+  if (action.type === "uri") {
+    if (truncateUtf16Safe(action.linkUri, LINE_ACTION_URI_LIMIT) !== action.linkUri) {
+      return unavailableImagemapAction("Link", "URL exceeds LINE's limit.", action.area);
+    }
+    return { ...action, label };
+  }
+
+  if (action.type === "message") {
+    const text = truncateLineActionText(action.text, LINE_IMAGEMAP_MESSAGE_TEXT_LIMIT);
+    if (text !== action.text) {
+      return unavailableImagemapAction("Action", "message text exceeds LINE's limit.", action.area);
+    }
+    return { ...action, label, text };
+  }
+
+  if (truncateUtf16Safe(action.clipboardText, LINE_CLIPBOARD_TEXT_LIMIT) !== action.clipboardText) {
+    return unavailableImagemapAction("Action", "clipboard text exceeds LINE's limit.", action.area);
+  }
+  return { ...action, label };
+}
+
 export function normalizeLineMessageActions(message: Message): Message {
   let normalized: Message;
   if (message.type === "flex") {
@@ -170,6 +213,11 @@ export function normalizeLineMessageActions(message: Message): Message {
     normalized = {
       ...message,
       template: normalizeNestedActions(message.template, labelLimit) as messagingApi.Template,
+    };
+  } else if (message.type === "imagemap") {
+    normalized = {
+      ...message,
+      actions: message.actions.map(normalizeImagemapAction),
     };
   } else {
     normalized = { ...message };

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -16,11 +16,10 @@ function truncateLineActionData(data: string): string {
 }
 
 function unavailableAction(kind: "Action" | "Link", reason: string): Action {
-  const label = `${kind} unavailable`;
   return {
     type: "message",
-    label,
-    text: `${label}: ${reason}`,
+    label: "Unavailable",
+    text: `${kind} unavailable: ${reason}`,
   };
 }
 

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -6,9 +6,25 @@ export type Action = messagingApi.Action;
 const LINE_ACTION_LABEL_LIMIT = 20;
 const LINE_ACTION_DATA_LIMIT = 300;
 const LINE_ACTION_URI_LIMIT = 1000;
+const LINE_CLIPBOARD_TEXT_LIMIT = 1000;
+const LINE_RICH_MENU_ALIAS_LIMIT = 32;
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function truncateLineActionText(text: string, limit: number): string {
+  let result = "";
+  let count = 0;
+  for (const { segment } of graphemeSegmenter.segment(text)) {
+    if (count >= limit) {
+      break;
+    }
+    result += segment;
+    count += 1;
+  }
+  return result;
+}
 
 export function truncateLineActionLabel(label: string, limit = LINE_ACTION_LABEL_LIMIT): string {
-  return truncateUtf16Safe(label, limit);
+  return truncateLineActionText(label, limit);
 }
 
 function truncateLineActionData(data: string): string {
@@ -23,49 +39,132 @@ function unavailableAction(kind: "Action" | "Link", reason: string): Action {
   };
 }
 
+export function normalizeLineAction(
+  action: Action,
+  labelLimit = LINE_ACTION_LABEL_LIMIT,
+): Action {
+  const label =
+    action.label === undefined ? undefined : truncateLineActionLabel(action.label, labelLimit);
+
+  if (action.type === "uri") {
+    const uriTooLong =
+      action.uri !== undefined &&
+      truncateUtf16Safe(action.uri, LINE_ACTION_URI_LIMIT) !== action.uri;
+    const desktopUri = action.altUri?.desktop;
+    const desktopUriTooLong =
+      desktopUri !== undefined &&
+      truncateUtf16Safe(desktopUri, LINE_ACTION_URI_LIMIT) !== desktopUri;
+    if (uriTooLong || desktopUriTooLong) {
+      return unavailableAction("Link", "URL exceeds LINE's limit.");
+    }
+    return { ...action, label };
+  }
+
+  if (action.type === "postback") {
+    const data =
+      action.data === undefined ? undefined : truncateLineActionData(action.data);
+    if (data !== action.data) {
+      // Callback data is opaque and echoed back by LINE. Never dispatch a value
+      // whose identity changed merely to satisfy the transport cap.
+      return unavailableAction("Action", "callback data exceeds LINE's limit.");
+    }
+    return {
+      ...action,
+      label,
+      data,
+      displayText:
+        action.displayText === undefined
+          ? undefined
+          : truncateLineActionText(action.displayText, LINE_ACTION_DATA_LIMIT),
+      text:
+        action.text === undefined
+          ? undefined
+          : truncateLineActionText(action.text, LINE_ACTION_DATA_LIMIT),
+      fillInText:
+        action.fillInText === undefined
+          ? undefined
+          : truncateLineActionText(action.fillInText, LINE_ACTION_DATA_LIMIT),
+    };
+  }
+
+  if (action.type === "datetimepicker") {
+    const data =
+      action.data === undefined ? undefined : truncateLineActionData(action.data);
+    if (data !== action.data) {
+      return unavailableAction("Action", "callback data exceeds LINE's limit.");
+    }
+    return { ...action, label, data };
+  }
+
+  if (action.type === "message") {
+    return {
+      ...action,
+      label,
+      text:
+        action.text === undefined
+          ? undefined
+          : truncateLineActionText(action.text, LINE_ACTION_DATA_LIMIT),
+    };
+  }
+
+  if (action.type === "clipboard") {
+    if (
+      truncateUtf16Safe(action.clipboardText, LINE_CLIPBOARD_TEXT_LIMIT) !==
+      action.clipboardText
+    ) {
+      return unavailableAction("Action", "clipboard text exceeds LINE's limit.");
+    }
+    return { ...action, label };
+  }
+
+  if (action.type === "richmenuswitch") {
+    const data =
+      action.data === undefined ? undefined : truncateLineActionData(action.data);
+    const aliasTooLong =
+      action.richMenuAliasId !== undefined &&
+      truncateUtf16Safe(action.richMenuAliasId, LINE_RICH_MENU_ALIAS_LIMIT) !==
+        action.richMenuAliasId;
+    if (data !== action.data || aliasTooLong) {
+      return unavailableAction("Action", "rich menu data exceeds LINE's limit.");
+    }
+    return { ...action, label, data };
+  }
+
+  return action.label === label ? action : { ...action, label };
+}
+
 /**
  * Create a message action (sends text when tapped)
  */
 export function messageAction(label: string, text?: string): Action {
-  return {
+  return normalizeLineAction({
     type: "message",
-    label: truncateLineActionLabel(label),
+    label,
     text: text ?? label,
-  };
+  });
 }
 
 /**
  * Create a URI action (opens a URL when tapped)
  */
 export function uriAction(label: string, uri: string): Action {
-  // Opaque URLs may be signed or tokenized; changing their tail can navigate to
-  // the wrong destination. Keep the card deliverable with a visible fallback.
-  if (truncateUtf16Safe(uri, LINE_ACTION_URI_LIMIT) !== uri) {
-    return unavailableAction("Link", "URL exceeds LINE's limit.");
-  }
-  return {
+  return normalizeLineAction({
     type: "uri",
-    label: truncateLineActionLabel(label),
+    label,
     uri,
-  };
+  });
 }
 
 /**
  * Create a postback action (sends data to webhook when tapped)
  */
 export function postbackAction(label: string, data: string, displayText?: string): Action {
-  const boundedData = truncateLineActionData(data);
-  if (boundedData !== data) {
-    // Callback data is opaque and echoed back by LINE. Never dispatch a value
-    // whose identity changed merely to satisfy the transport cap.
-    return unavailableAction("Action", "callback data exceeds LINE's limit.");
-  }
-  return {
+  return normalizeLineAction({
     type: "postback",
-    label: truncateLineActionLabel(label),
-    data: boundedData,
-    displayText: displayText === undefined ? undefined : truncateLineActionData(displayText),
-  };
+    label,
+    data,
+    displayText,
+  });
 }
 
 /**
@@ -81,17 +180,13 @@ export function datetimePickerAction(
     min?: string;
   },
 ): Action {
-  const boundedData = truncateLineActionData(data);
-  if (boundedData !== data) {
-    return unavailableAction("Action", "callback data exceeds LINE's limit.");
-  }
-  return {
+  return normalizeLineAction({
     type: "datetimepicker",
-    label: truncateLineActionLabel(label),
-    data: boundedData,
+    label,
+    data,
     mode,
     initial: options?.initial,
     max: options?.max,
     min: options?.min,
-  };
+  });
 }

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -72,17 +72,33 @@ function normalizeNestedActions(value: unknown, labelLimit: number): unknown {
     return value;
   }
 
+  if (value.type === "video" && isLineAction(value.action)) {
+    const action = normalizeLineAction(value.action, labelLimit);
+    if (action.type !== "uri") {
+      // Flex video accepts only URI actions. Replace the video with its visual
+      // fallback and an explicit warning instead of dropping the tap target.
+      const contents: unknown[] = [];
+      if (isRecord(value.altContent)) {
+        contents.push(normalizeNestedActions(value.altContent, labelLimit));
+      }
+      contents.push({
+        type: "text",
+        text:
+          action.type === "message" && action.text
+            ? action.text
+            : "Action unavailable in this video.",
+        wrap: true,
+        size: "sm",
+        color: "#666666",
+      });
+      return { type: "box", layout: "vertical", contents };
+    }
+  }
+
   const normalized: Record<string, unknown> = { ...value };
   for (const [key, nested] of Object.entries(value)) {
     if ((key === "action" || key === "defaultAction") && isLineAction(nested)) {
-      const action = normalizeLineAction(nested, labelLimit);
-      if (value.type === "video" && action.type !== "uri") {
-        // LINE accepts only URI actions on Flex video components. Dropping an
-        // unusable optional tap target keeps the video itself deliverable.
-        delete normalized[key];
-      } else {
-        normalized[key] = action;
-      }
+      normalized[key] = normalizeLineAction(nested, labelLimit);
     } else if (key === "actions" && Array.isArray(nested)) {
       normalized[key] = nested.map((action) =>
         isLineAction(action) ? normalizeLineAction(action, labelLimit) : action,

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -146,6 +146,17 @@ export function normalizeLineAction(action: Action, labelLimit = LINE_ACTION_LAB
       // whose identity changed merely to satisfy the transport cap.
       return unavailableAction("Action", "callback data exceeds LINE's limit.");
     }
+    const text =
+      action.text === undefined
+        ? undefined
+        : truncateLineActionText(action.text, LINE_ACTION_DATA_LIMIT);
+    const fillInText =
+      action.fillInText === undefined
+        ? undefined
+        : truncateLineActionText(action.fillInText, LINE_ACTION_DATA_LIMIT);
+    if (text !== action.text || fillInText !== action.fillInText) {
+      return unavailableAction("Action", "message text exceeds LINE's limit.");
+    }
     return {
       ...action,
       label,
@@ -154,14 +165,8 @@ export function normalizeLineAction(action: Action, labelLimit = LINE_ACTION_LAB
         action.displayText === undefined
           ? undefined
           : truncateLineActionText(action.displayText, LINE_ACTION_DATA_LIMIT),
-      text:
-        action.text === undefined
-          ? undefined
-          : truncateLineActionText(action.text, LINE_ACTION_DATA_LIMIT),
-      fillInText:
-        action.fillInText === undefined
-          ? undefined
-          : truncateLineActionText(action.fillInText, LINE_ACTION_DATA_LIMIT),
+      text,
+      fillInText,
     };
   }
 
@@ -174,13 +179,17 @@ export function normalizeLineAction(action: Action, labelLimit = LINE_ACTION_LAB
   }
 
   if (action.type === "message") {
+    const text =
+      action.text === undefined
+        ? undefined
+        : truncateLineActionText(action.text, LINE_ACTION_DATA_LIMIT);
+    if (text !== action.text) {
+      return unavailableAction("Action", "message text exceeds LINE's limit.");
+    }
     return {
       ...action,
       label,
-      text:
-        action.text === undefined
-          ? undefined
-          : truncateLineActionText(action.text, LINE_ACTION_DATA_LIMIT),
+      text,
     };
   }
 

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -192,7 +192,7 @@ function normalizeImagemapAction(action: ImagemapAction): ImagemapAction {
   }
 
   if (action.type === "message") {
-    const text = truncateLineActionText(action.text, LINE_IMAGEMAP_MESSAGE_TEXT_LIMIT);
+    const text = truncateUtf16Safe(action.text, LINE_IMAGEMAP_MESSAGE_TEXT_LIMIT);
     if (text !== action.text) {
       return unavailableImagemapAction("Action", "message text exceeds LINE's limit.", action.area);
     }
@@ -253,6 +253,8 @@ export function normalizeLineMessageActions(message: Message): Message {
     const actions = message.actions.map(normalizeImagemapAction);
     const videoResult = message.video ? normalizeImagemapVideo(message.video) : undefined;
     if (videoResult?.fallbackAction) {
+      // At LINE's 50-action cap, silently drop the invalid video link so its
+      // warning never displaces a valid action.
       if (actions.length < LINE_IMAGEMAP_ACTION_LIMIT) {
         actions.push(videoResult.fallbackAction);
       }

--- a/extensions/line/src/flex-templates/basic-cards.ts
+++ b/extensions/line/src/flex-templates/basic-cards.ts
@@ -1,6 +1,6 @@
+import { normalizeLineAction } from "../actions.js";
 // Line plugin module implements basic cards behavior.
 import { attachFooterText } from "./common.js";
-import { normalizeLineAction } from "../actions.js";
 import type {
   Action,
   CardAction,
@@ -150,7 +150,7 @@ export function createListCard(title: string, items: ListItem[]): FlexBubble {
     };
 
     if (item.action) {
-      itemBox.action = item.action;
+      itemBox.action = normalizeLineAction(item.action, 40);
     }
 
     return itemBox;
@@ -210,8 +210,7 @@ export function createImageCard(
       size: "full",
       aspectRatio: options?.aspectRatio ?? "20:13",
       aspectMode: options?.aspectMode ?? "cover",
-      action:
-        options?.action === undefined ? undefined : normalizeLineAction(options.action, 40),
+      action: options?.action === undefined ? undefined : normalizeLineAction(options.action, 40),
     } as FlexImage,
     body: {
       type: "box",

--- a/extensions/line/src/flex-templates/basic-cards.ts
+++ b/extensions/line/src/flex-templates/basic-cards.ts
@@ -1,5 +1,6 @@
 // Line plugin module implements basic cards behavior.
 import { attachFooterText } from "./common.js";
+import { normalizeLineAction } from "../actions.js";
 import type {
   Action,
   CardAction,
@@ -209,7 +210,8 @@ export function createImageCard(
       size: "full",
       aspectRatio: options?.aspectRatio ?? "20:13",
       aspectMode: options?.aspectMode ?? "cover",
-      action: options?.action,
+      action:
+        options?.action === undefined ? undefined : normalizeLineAction(options.action, 40),
     } as FlexImage,
     body: {
       type: "box",
@@ -284,7 +286,7 @@ export function createActionCard(
         (action, index) =>
           ({
             type: "button",
-            action: action.action,
+            action: normalizeLineAction(action.action, 40),
             style: index === 0 ? "primary" : "secondary",
             margin: index > 0 ? "sm" : undefined,
           }) as FlexButton,

--- a/extensions/line/src/flex-templates/media-control-cards.ts
+++ b/extensions/line/src/flex-templates/media-control-cards.ts
@@ -1,5 +1,5 @@
 // Line plugin module implements media control cards behavior.
-import { truncateLineActionLabel } from "../actions.js";
+import { truncateLineActionData, truncateLineActionLabel } from "../actions.js";
 import type {
   FlexBox,
   FlexBubble,
@@ -161,7 +161,7 @@ export function createMediaPlayerCard(params: {
           action: {
             type: "postback",
             label: "⏮",
-            data: controls.previous.data,
+            data: truncateLineActionData(controls.previous.data),
           },
           style: "secondary",
           flex: 1,
@@ -175,7 +175,7 @@ export function createMediaPlayerCard(params: {
           action: {
             type: "postback",
             label: "▶",
-            data: controls.play.data,
+            data: truncateLineActionData(controls.play.data),
           },
           style: isPlaying ? "secondary" : "primary",
           flex: 1,
@@ -190,7 +190,7 @@ export function createMediaPlayerCard(params: {
           action: {
             type: "postback",
             label: "⏸",
-            data: controls.pause.data,
+            data: truncateLineActionData(controls.pause.data),
           },
           style: isPlaying ? "primary" : "secondary",
           flex: 1,
@@ -205,7 +205,7 @@ export function createMediaPlayerCard(params: {
           action: {
             type: "postback",
             label: "⏭",
-            data: controls.next.data,
+            data: truncateLineActionData(controls.next.data),
           },
           style: "secondary",
           flex: 1,
@@ -235,7 +235,7 @@ export function createMediaPlayerCard(params: {
               action: {
                 type: "postback",
                 label: truncateLineActionLabel(action.label, 15),
-                data: action.data,
+                data: truncateLineActionData(action.data),
               },
               style: "secondary",
               flex: 1,
@@ -315,7 +315,7 @@ export function createAppleTvRemoteCard(params: {
     action: {
       type: "postback",
       label,
-      data,
+      data: truncateLineActionData(data),
     },
     style,
     height: "sm",
@@ -519,7 +519,7 @@ export function createDeviceControlCard(params: {
           action: {
             type: "postback",
             label: truncateLineActionLabel(buttonLabel, 18),
-            data: ctrl.data,
+            data: truncateLineActionData(ctrl.data),
           },
           style: ctrl.style ?? "secondary",
           flex: 1,

--- a/extensions/line/src/flex-templates/media-control-cards.ts
+++ b/extensions/line/src/flex-templates/media-control-cards.ts
@@ -1,5 +1,5 @@
 // Line plugin module implements media control cards behavior.
-import { postbackOrUnavailableAction, truncateLineActionLabel } from "../actions.js";
+import { postbackAction, truncateLineActionLabel } from "../actions.js";
 import type {
   FlexBox,
   FlexBubble,
@@ -158,7 +158,7 @@ export function createMediaPlayerCard(params: {
       if (controls.previous) {
         controlButtons.push({
           type: "button",
-          action: postbackOrUnavailableAction("⏮", controls.previous.data),
+          action: postbackAction("⏮", controls.previous.data),
           style: "secondary",
           flex: 1,
           height: "sm",
@@ -168,7 +168,7 @@ export function createMediaPlayerCard(params: {
       if (controls.play) {
         controlButtons.push({
           type: "button",
-          action: postbackOrUnavailableAction("▶", controls.play.data),
+          action: postbackAction("▶", controls.play.data),
           style: isPlaying ? "secondary" : "primary",
           flex: 1,
           height: "sm",
@@ -179,7 +179,7 @@ export function createMediaPlayerCard(params: {
       if (controls.pause) {
         controlButtons.push({
           type: "button",
-          action: postbackOrUnavailableAction("⏸", controls.pause.data),
+          action: postbackAction("⏸", controls.pause.data),
           style: isPlaying ? "primary" : "secondary",
           flex: 1,
           height: "sm",
@@ -190,7 +190,7 @@ export function createMediaPlayerCard(params: {
       if (controls.next) {
         controlButtons.push({
           type: "button",
-          action: postbackOrUnavailableAction("⏭", controls.next.data),
+          action: postbackAction("⏭", controls.next.data),
           style: "secondary",
           flex: 1,
           height: "sm",
@@ -216,10 +216,7 @@ export function createMediaPlayerCard(params: {
           (action, index) =>
             ({
               type: "button",
-              action: postbackOrUnavailableAction(
-                truncateLineActionLabel(action.label, 15),
-                action.data,
-              ),
+              action: postbackAction(truncateLineActionLabel(action.label, 15), action.data),
               style: "secondary",
               flex: 1,
               height: "sm",
@@ -295,7 +292,7 @@ export function createAppleTvRemoteCard(params: {
     style: "primary" | "secondary" = "secondary",
   ): FlexButton => ({
     type: "button",
-    action: postbackOrUnavailableAction(label, data),
+    action: postbackAction(label, data),
     style,
     height: "sm",
     flex: 1,
@@ -495,7 +492,7 @@ export function createDeviceControlCard(params: {
 
         rowButtons.push({
           type: "button",
-          action: postbackOrUnavailableAction(truncateLineActionLabel(buttonLabel, 18), ctrl.data),
+          action: postbackAction(truncateLineActionLabel(buttonLabel, 18), ctrl.data),
           style: ctrl.style ?? "secondary",
           flex: 1,
           height: "sm",

--- a/extensions/line/src/flex-templates/media-control-cards.ts
+++ b/extensions/line/src/flex-templates/media-control-cards.ts
@@ -1,5 +1,5 @@
 // Line plugin module implements media control cards behavior.
-import { truncateLineActionData, truncateLineActionLabel } from "../actions.js";
+import { postbackAction, truncateLineActionLabel } from "../actions.js";
 import type {
   FlexBox,
   FlexBubble,
@@ -158,11 +158,7 @@ export function createMediaPlayerCard(params: {
       if (controls.previous) {
         controlButtons.push({
           type: "button",
-          action: {
-            type: "postback",
-            label: "⏮",
-            data: truncateLineActionData(controls.previous.data),
-          },
+          action: postbackAction("⏮", controls.previous.data),
           style: "secondary",
           flex: 1,
           height: "sm",
@@ -172,11 +168,7 @@ export function createMediaPlayerCard(params: {
       if (controls.play) {
         controlButtons.push({
           type: "button",
-          action: {
-            type: "postback",
-            label: "▶",
-            data: truncateLineActionData(controls.play.data),
-          },
+          action: postbackAction("▶", controls.play.data),
           style: isPlaying ? "secondary" : "primary",
           flex: 1,
           height: "sm",
@@ -187,11 +179,7 @@ export function createMediaPlayerCard(params: {
       if (controls.pause) {
         controlButtons.push({
           type: "button",
-          action: {
-            type: "postback",
-            label: "⏸",
-            data: truncateLineActionData(controls.pause.data),
-          },
+          action: postbackAction("⏸", controls.pause.data),
           style: isPlaying ? "primary" : "secondary",
           flex: 1,
           height: "sm",
@@ -202,11 +190,7 @@ export function createMediaPlayerCard(params: {
       if (controls.next) {
         controlButtons.push({
           type: "button",
-          action: {
-            type: "postback",
-            label: "⏭",
-            data: truncateLineActionData(controls.next.data),
-          },
+          action: postbackAction("⏭", controls.next.data),
           style: "secondary",
           flex: 1,
           height: "sm",
@@ -232,11 +216,7 @@ export function createMediaPlayerCard(params: {
           (action, index) =>
             ({
               type: "button",
-              action: {
-                type: "postback",
-                label: truncateLineActionLabel(action.label, 15),
-                data: truncateLineActionData(action.data),
-              },
+              action: postbackAction(truncateLineActionLabel(action.label, 15), action.data),
               style: "secondary",
               flex: 1,
               height: "sm",
@@ -312,11 +292,7 @@ export function createAppleTvRemoteCard(params: {
     style: "primary" | "secondary" = "secondary",
   ): FlexButton => ({
     type: "button",
-    action: {
-      type: "postback",
-      label,
-      data: truncateLineActionData(data),
-    },
+    action: postbackAction(label, data),
     style,
     height: "sm",
     flex: 1,
@@ -516,11 +492,7 @@ export function createDeviceControlCard(params: {
 
         rowButtons.push({
           type: "button",
-          action: {
-            type: "postback",
-            label: truncateLineActionLabel(buttonLabel, 18),
-            data: truncateLineActionData(ctrl.data),
-          },
+          action: postbackAction(truncateLineActionLabel(buttonLabel, 18), ctrl.data),
           style: ctrl.style ?? "secondary",
           flex: 1,
           height: "sm",

--- a/extensions/line/src/flex-templates/media-control-cards.ts
+++ b/extensions/line/src/flex-templates/media-control-cards.ts
@@ -1,5 +1,5 @@
 // Line plugin module implements media control cards behavior.
-import { postbackAction, truncateLineActionLabel } from "../actions.js";
+import { postbackOrUnavailableAction, truncateLineActionLabel } from "../actions.js";
 import type {
   FlexBox,
   FlexBubble,
@@ -158,7 +158,7 @@ export function createMediaPlayerCard(params: {
       if (controls.previous) {
         controlButtons.push({
           type: "button",
-          action: postbackAction("⏮", controls.previous.data),
+          action: postbackOrUnavailableAction("⏮", controls.previous.data),
           style: "secondary",
           flex: 1,
           height: "sm",
@@ -168,7 +168,7 @@ export function createMediaPlayerCard(params: {
       if (controls.play) {
         controlButtons.push({
           type: "button",
-          action: postbackAction("▶", controls.play.data),
+          action: postbackOrUnavailableAction("▶", controls.play.data),
           style: isPlaying ? "secondary" : "primary",
           flex: 1,
           height: "sm",
@@ -179,7 +179,7 @@ export function createMediaPlayerCard(params: {
       if (controls.pause) {
         controlButtons.push({
           type: "button",
-          action: postbackAction("⏸", controls.pause.data),
+          action: postbackOrUnavailableAction("⏸", controls.pause.data),
           style: isPlaying ? "primary" : "secondary",
           flex: 1,
           height: "sm",
@@ -190,7 +190,7 @@ export function createMediaPlayerCard(params: {
       if (controls.next) {
         controlButtons.push({
           type: "button",
-          action: postbackAction("⏭", controls.next.data),
+          action: postbackOrUnavailableAction("⏭", controls.next.data),
           style: "secondary",
           flex: 1,
           height: "sm",
@@ -216,7 +216,10 @@ export function createMediaPlayerCard(params: {
           (action, index) =>
             ({
               type: "button",
-              action: postbackAction(truncateLineActionLabel(action.label, 15), action.data),
+              action: postbackOrUnavailableAction(
+                truncateLineActionLabel(action.label, 15),
+                action.data,
+              ),
               style: "secondary",
               flex: 1,
               height: "sm",
@@ -292,7 +295,7 @@ export function createAppleTvRemoteCard(params: {
     style: "primary" | "secondary" = "secondary",
   ): FlexButton => ({
     type: "button",
-    action: postbackAction(label, data),
+    action: postbackOrUnavailableAction(label, data),
     style,
     height: "sm",
     flex: 1,
@@ -492,7 +495,7 @@ export function createDeviceControlCard(params: {
 
         rowButtons.push({
           type: "button",
-          action: postbackAction(truncateLineActionLabel(buttonLabel, 18), ctrl.data),
+          action: postbackOrUnavailableAction(truncateLineActionLabel(buttonLabel, 18), ctrl.data),
           style: ctrl.style ?? "secondary",
           flex: 1,
           height: "sm",

--- a/extensions/line/src/flex-templates/schedule-cards.ts
+++ b/extensions/line/src/flex-templates/schedule-cards.ts
@@ -1,4 +1,5 @@
 // Line plugin module implements schedule cards behavior.
+import { normalizeLineAction } from "../actions.js";
 import { attachFooterText } from "./common.js";
 import type { Action, FlexBox, FlexBubble, FlexComponent, FlexText } from "./types.js";
 
@@ -333,7 +334,7 @@ export function createEventCard(params: {
       contents: bodyContents,
       paddingAll: "xl",
       backgroundColor: "#FFFFFF",
-      action,
+      action: action === undefined ? undefined : normalizeLineAction(action, 40),
     },
   };
 }

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -5,6 +5,7 @@ import { datetimePickerAction, messageAction, postbackAction, uriAction } from "
 import { registerLineCardCommand } from "./card-command.js";
 import {
   createActionCard,
+  createAppleTvRemoteCard,
   createCarousel,
   createDeviceControlCard,
   createEventCard,
@@ -14,6 +15,7 @@ import {
   createMediaPlayerCard,
 } from "./flex-templates.js";
 import {
+  buildTemplateMessageFromPayload,
   createConfirmTemplate,
   createButtonTemplate,
   createTemplateCarousel,
@@ -477,6 +479,108 @@ describe("action label/data surrogate-safe truncation", () => {
 
     expect(extraAction?.label).toBe("x".repeat(14));
     expect(loneHighSurrogate.test(extraAction?.label ?? "")).toBe(false);
+  });
+
+  it("uriAction truncates uri on surrogate boundaries", () => {
+    // 999 code units + 😀 = 1001; the 1000-unit slice cuts the emoji.
+    const uri = `https://e.example/?q=${"u".repeat(978)}😀`;
+    const action = uriAction("Open", uri) as { uri: string };
+
+    expect(action.uri).toBe(`https://e.example/?q=${"u".repeat(978)}`);
+    expect(loneHighSurrogate.test(action.uri)).toBe(false);
+  });
+
+  it("buttons template payload uri actions truncate past the 1000-unit cap", () => {
+    const template = buildTemplateMessageFromPayload({
+      type: "buttons",
+      text: "Pick",
+      actions: [{ type: "uri", label: "Open", uri: `https://e.example/?q=${"u".repeat(1200)}` }],
+    });
+
+    const buttonsTemplate = expectDefined(template, "buttons template message").template as {
+      actions: Array<{ uri?: string }>;
+    };
+    const uriTemplateAction = expectDefined(
+      buttonsTemplate.actions[0],
+      "buttons template uri action",
+    );
+    expect(uriTemplateAction.uri).toHaveLength(1000);
+  });
+
+  it("media control postback data truncates on surrogate boundaries", () => {
+    // 299 code units + 😀 = 301; the 300-unit slice cuts the emoji.
+    const overlongData = `${"d".repeat(299)}😀`;
+    const card = createMediaPlayerCard({
+      title: "Track",
+      controls: {
+        previous: { data: overlongData },
+        play: { data: overlongData },
+        pause: { data: overlongData },
+        next: { data: overlongData },
+      },
+      extraActions: [{ label: "Extra", data: overlongData }],
+    });
+    const footer = card.footer as {
+      contents: Array<{ contents?: Array<{ action?: { data?: string } }> }>;
+    };
+    const datas = footer.contents
+      .flatMap((content) => content.contents ?? [])
+      .flatMap((button) => (button.action?.data ? [button.action.data] : []));
+
+    expect(datas).toHaveLength(5);
+    for (const data of datas) {
+      expect(data).toBe("d".repeat(299));
+      expect(loneHighSurrogate.test(data)).toBe(false);
+    }
+  });
+
+  it("device control postback data truncates on surrogate boundaries", () => {
+    const card = createDeviceControlCard({
+      deviceName: "Device",
+      controls: [{ label: "On", data: `${"d".repeat(299)}😀` }],
+    });
+    const footer = card.footer as {
+      contents: Array<{ contents: Array<{ action?: { data: string } }> }>;
+    };
+    const action = footer.contents
+      .flatMap((row) => row.contents)
+      .find((button) => button.action)?.action;
+
+    expect(action?.data).toBe("d".repeat(299));
+    expect(loneHighSurrogate.test(action?.data ?? "")).toBe(false);
+  });
+
+  it("apple tv remote postback data truncates on surrogate boundaries", () => {
+    const overlongData = `${"d".repeat(299)}😀`;
+    const card = createAppleTvRemoteCard({
+      deviceName: "TV",
+      actionData: {
+        up: overlongData,
+        down: overlongData,
+        left: overlongData,
+        right: overlongData,
+        select: overlongData,
+        menu: overlongData,
+        home: overlongData,
+        play: overlongData,
+        pause: overlongData,
+        volumeUp: overlongData,
+        volumeDown: overlongData,
+        mute: overlongData,
+      },
+    });
+    const body = card.body as {
+      contents: Array<{ contents?: Array<{ action?: { data?: string } }> }>;
+    };
+    const datas = body.contents
+      .flatMap((row) => row.contents ?? [])
+      .flatMap((button) => (button.action?.data ? [button.action.data] : []));
+
+    expect(datas).toHaveLength(12);
+    for (const data of datas) {
+      expect(data).toBe("d".repeat(299));
+      expect(loneHighSurrogate.test(data)).toBe(false);
+    }
   });
 });
 

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -481,18 +481,21 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(loneHighSurrogate.test(extraAction?.label ?? "")).toBe(false);
   });
 
-  it("uriAction truncates without splitting surrogates or percent-encoded code points", () => {
-    // 999 code units + 😀 = 1001; the 1000-unit slice cuts the emoji.
-    const uri = `https://e.example/?q=${"u".repeat(978)}😀`;
-    const action = uriAction("Open", uri) as { uri: string };
-    // The raw 1000-unit boundary ends in "%A", halfway through an encoded euro sign.
-    const encodedUri = `https://example.com/?q=${"a".repeat(969)}%E2%82%AC`;
-    const encodedAction = uriAction("Open", encodedUri) as { uri: string };
+  it("uriAction visibly disables overlong links instead of changing their destination", () => {
+    const validUri = `https://e.example/?q=${"u".repeat(978)}`;
+    const validAction = uriAction("Open", validUri) as { type: string; uri?: string };
+    const overlongAction = uriAction("Open", `${validUri}😀`) as {
+      type: string;
+      label?: string;
+      text?: string;
+    };
 
-    expect(action.uri).toBe(`https://e.example/?q=${"u".repeat(978)}`);
-    expect(loneHighSurrogate.test(action.uri)).toBe(false);
-    expect(encodedAction.uri).toBe(`https://example.com/?q=${"a".repeat(969)}`);
-    expect(() => decodeURI(encodedAction.uri)).not.toThrow();
+    expect(validAction).toMatchObject({ type: "uri", uri: validUri });
+    expect(overlongAction).toEqual({
+      type: "message",
+      label: "Link unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+    });
   });
 
   it("buttons template payload uri actions truncate past the 1000-unit cap", () => {
@@ -503,16 +506,20 @@ describe("action label/data surrogate-safe truncation", () => {
     });
 
     const buttonsTemplate = expectDefined(template, "buttons template message").template as {
-      actions: Array<{ uri?: string }>;
+      actions: Array<{ type: string; label?: string; text?: string }>;
     };
     const uriTemplateAction = expectDefined(
       buttonsTemplate.actions[0],
       "buttons template uri action",
     );
-    expect(uriTemplateAction.uri).toHaveLength(1000);
+    expect(uriTemplateAction).toEqual({
+      type: "message",
+      label: "Link unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+    });
   });
 
-  it("media control postback data truncates on surrogate boundaries", () => {
+  it("media control cards visibly disable overlong opaque callbacks", () => {
     // 299 code units + 😀 = 301; the 300-unit slice cuts the emoji.
     const overlongData = `${"d".repeat(299)}😀`;
     const card = createMediaPlayerCard({
@@ -526,36 +533,50 @@ describe("action label/data surrogate-safe truncation", () => {
       extraActions: [{ label: "Extra", data: overlongData }],
     });
     const footer = card.footer as {
-      contents: Array<{ contents?: Array<{ action?: { data?: string } }> }>;
+      contents: Array<{
+        contents?: Array<{
+          action?: { type: string; data?: string; label?: string; text?: string };
+        }>;
+      }>;
     };
-    const datas = footer.contents
+    const actions = footer.contents
       .flatMap((content) => content.contents ?? [])
-      .flatMap((button) => (button.action?.data ? [button.action.data] : []));
+      .flatMap((button) => (button.action ? [button.action] : []));
 
-    expect(datas).toHaveLength(5);
-    for (const data of datas) {
-      expect(data).toBe("d".repeat(299));
-      expect(loneHighSurrogate.test(data)).toBe(false);
+    expect(actions).toHaveLength(5);
+    for (const action of actions) {
+      expect(action).toEqual({
+        type: "message",
+        label: "Action unavailable",
+        text: "Action unavailable: callback data exceeds LINE's limit.",
+      });
     }
   });
 
-  it("device control postback data truncates on surrogate boundaries", () => {
+  it("device controls visibly disable overlong opaque callbacks", () => {
     const card = createDeviceControlCard({
       deviceName: "Device",
       controls: [{ label: "On", data: `${"d".repeat(299)}😀` }],
     });
     const footer = card.footer as {
-      contents: Array<{ contents: Array<{ action?: { data: string } }> }>;
+      contents: Array<{
+        contents: Array<{
+          action?: { type: string; data?: string; label?: string; text?: string };
+        }>;
+      }>;
     };
     const action = footer.contents
       .flatMap((row) => row.contents)
       .find((button) => button.action)?.action;
 
-    expect(action?.data).toBe("d".repeat(299));
-    expect(loneHighSurrogate.test(action?.data ?? "")).toBe(false);
+    expect(action).toEqual({
+      type: "message",
+      label: "Action unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
+    });
   });
 
-  it("apple tv remote postback data truncates on surrogate boundaries", () => {
+  it("Apple TV controls visibly disable overlong opaque callbacks", () => {
     const overlongData = `${"d".repeat(299)}😀`;
     const card = createAppleTvRemoteCard({
       deviceName: "TV",
@@ -575,16 +596,23 @@ describe("action label/data surrogate-safe truncation", () => {
       },
     });
     const body = card.body as {
-      contents: Array<{ contents?: Array<{ action?: { data?: string } }> }>;
+      contents: Array<{
+        contents?: Array<{
+          action?: { type: string; data?: string; label?: string; text?: string };
+        }>;
+      }>;
     };
-    const datas = body.contents
+    const actions = body.contents
       .flatMap((row) => row.contents ?? [])
-      .flatMap((button) => (button.action?.data ? [button.action.data] : []));
+      .flatMap((button) => (button.action ? [button.action] : []));
 
-    expect(datas).toHaveLength(12);
-    for (const data of datas) {
-      expect(data).toBe("d".repeat(299));
-      expect(loneHighSurrogate.test(data)).toBe(false);
+    expect(actions).toHaveLength(12);
+    for (const action of actions) {
+      expect(action).toEqual({
+        type: "message",
+        label: "Action unavailable",
+        text: "Action unavailable: callback data exceeds LINE's limit.",
+      });
     }
   });
 });

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -699,9 +699,7 @@ describe("action label/data surrogate-safe truncation", () => {
       text: "Link unavailable: URL exceeds LINE's limit.",
     });
 
-    const card = createActionCard("Title", "Body", [
-      { label: "Open", action: oversizedPostback },
-    ]);
+    const card = createActionCard("Title", "Body", [{ label: "Open", action: oversizedPostback }]);
     const button = (card.footer as { contents: Array<{ action: Action }> }).contents[0];
     expect(button?.action).toEqual({
       type: "message",
@@ -716,6 +714,28 @@ describe("action label/data surrogate-safe truncation", () => {
     const labeledButton = (labeledCard.footer as { contents: Array<{ action: Action }> })
       .contents[0];
     expect(labeledButton?.action.label).toBe(validLongLabel);
+
+    const list = createListCard("List", [{ title: "Item", action: oversizedPostback }]);
+    const listBody = (list.body as { contents: unknown[] }).contents;
+    const listBox = listBody[2] as {
+      contents: Array<{ action?: Action }>;
+    };
+    expect(listBox.contents[0]?.action).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
+    });
+
+    const event = createEventCard({
+      title: "Event",
+      date: "Today",
+      action: oversizedUri,
+    });
+    expect((event.body as { action?: Action }).action).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+    });
   });
 
   it("media control cards visibly disable overlong opaque callbacks", () => {

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -651,18 +651,40 @@ describe("action label/data surrogate-safe truncation", () => {
       label: "Open",
       data: "action=open",
       displayText: "d".repeat(301),
-      text: "t".repeat(301),
-      fillInText: "f".repeat(301),
     });
     expect(postback).toMatchObject({
       displayText: "d".repeat(300),
-      text: "t".repeat(300),
-      fillInText: "f".repeat(300),
     });
 
+    expect(normalizeLineAction({ type: "message", label: "Open", text: "x".repeat(301) })).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Action unavailable: message text exceeds LINE's limit.",
+    });
     expect(
-      normalizeLineAction({ type: "message", label: "Open", text: "x".repeat(301) }),
-    ).toMatchObject({ text: "x".repeat(300) });
+      normalizeLineAction({
+        type: "postback",
+        label: "Open",
+        data: "action=open",
+        fillInText: "x".repeat(301),
+      }),
+    ).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Action unavailable: message text exceeds LINE's limit.",
+    });
+    expect(
+      normalizeLineAction({
+        type: "postback",
+        label: "Open",
+        data: "action=open",
+        text: "x".repeat(301),
+      }),
+    ).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Action unavailable: message text exceeds LINE's limit.",
+    });
     const emojiText = "😀".repeat(300);
     expect(messageAction("Open", emojiText)).toMatchObject({ text: emojiText });
     expect(

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -234,6 +234,27 @@ describe("carousel column limits", () => {
     expect(template.altText).toBe("x".repeat(399));
     expect(loneHighSurrogate.test(template.altText)).toBe(false);
   });
+
+  it("keeps unavailable action labels within the image-carousel cap", () => {
+    const template = createImageCarousel([
+      createImageCarouselColumn(
+        "https://example.com/0.jpg",
+        uriAction("Open", `https://example.com/?q=${"x".repeat(1200)}`),
+      ),
+    ]);
+    const column = (
+      template.template as {
+        columns: Array<{ action: { label?: string; text?: string; type: string } }>;
+      }
+    ).columns[0];
+
+    expect(column?.action).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+    });
+    expect(column?.action.label).toHaveLength(11);
+  });
 });
 
 describe("createProductCarousel", () => {
@@ -386,7 +407,7 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(exact.data).toBe(exactData);
     expect(unavailable).toEqual({
       type: "message",
-      label: "Action unavailable",
+      label: "Unavailable",
       text: "Action unavailable: callback data exceeds LINE's limit.",
     });
   });
@@ -417,7 +438,7 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(exact.data).toBe(exactData);
     expect(unavailable).toEqual({
       type: "message",
-      label: "Action unavailable",
+      label: "Unavailable",
       text: "Action unavailable: callback data exceeds LINE's limit.",
     });
   });
@@ -454,7 +475,7 @@ describe("action label/data surrogate-safe truncation", () => {
 
     expect(action).toEqual({
       type: "message",
-      label: "Action unavailable",
+      label: "Unavailable",
       text: "Action unavailable: callback data exceeds LINE's limit.",
     });
   });
@@ -512,7 +533,7 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(validAction).toMatchObject({ type: "uri", uri: validUri });
     expect(overlongAction).toEqual({
       type: "message",
-      label: "Link unavailable",
+      label: "Unavailable",
       text: "Link unavailable: URL exceeds LINE's limit.",
     });
   });
@@ -533,7 +554,7 @@ describe("action label/data surrogate-safe truncation", () => {
     );
     expect(uriTemplateAction).toEqual({
       type: "message",
-      label: "Link unavailable",
+      label: "Unavailable",
       text: "Link unavailable: URL exceeds LINE's limit.",
     });
   });
@@ -550,7 +571,7 @@ describe("action label/data surrogate-safe truncation", () => {
 
     expect(buttonsTemplate.actions[0]).toEqual({
       type: "message",
-      label: "Action unavailable",
+      label: "Unavailable",
       text: "Action unavailable: callback data exceeds LINE's limit.",
     });
   });
@@ -582,7 +603,7 @@ describe("action label/data surrogate-safe truncation", () => {
     for (const action of actions) {
       expect(action).toEqual({
         type: "message",
-        label: "Action unavailable",
+        label: "Unavailable",
         text: "Action unavailable: callback data exceeds LINE's limit.",
       });
     }
@@ -606,7 +627,7 @@ describe("action label/data surrogate-safe truncation", () => {
 
     expect(action).toEqual({
       type: "message",
-      label: "Action unavailable",
+      label: "Unavailable",
       text: "Action unavailable: callback data exceeds LINE's limit.",
     });
   });
@@ -645,7 +666,7 @@ describe("action label/data surrogate-safe truncation", () => {
     for (const action of actions) {
       expect(action).toEqual({
         type: "message",
-        label: "Action unavailable",
+        label: "Unavailable",
         text: "Action unavailable: callback data exceeds LINE's limit.",
       });
     }

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -373,13 +373,17 @@ describe("action label/data surrogate-safe truncation", () => {
   });
 
   it("postbackAction truncates labels but visibly disables overlong callback data", () => {
-    // 299 ASCII chars + 😀 = 301 code units; the 300-unit slice cuts the emoji.
-    const data = `${"d".repeat(299)}😀`;
+    const exactData = `${"d".repeat(298)}😀`;
+    const overlongData = `${"d".repeat(299)}😀`;
     const action = postbackAction(labelWithEmoji, "data") as { label: string };
-    const unavailable = postbackAction("Label", data);
+    const exact = postbackAction("Label", exactData) as { data: string };
+    const unavailable = postbackAction("Label", overlongData);
 
+    expect(exactData).toHaveLength(300);
+    expect(overlongData).toHaveLength(301);
     expect(action.label).toBe("1234567890123456789");
     expect(loneHighSurrogate.test(action.label)).toBe(false);
+    expect(exact.data).toBe(exactData);
     expect(unavailable).toEqual({
       type: "message",
       label: "Action unavailable",
@@ -400,12 +404,17 @@ describe("action label/data surrogate-safe truncation", () => {
   });
 
   it("datetimePickerAction truncates labels but visibly disables overlong callback data", () => {
-    const data = `${"d".repeat(299)}😀`;
+    const exactData = `${"d".repeat(298)}😀`;
+    const overlongData = `${"d".repeat(299)}😀`;
     const action = datetimePickerAction(labelWithEmoji, "data", "datetime") as { label: string };
-    const unavailable = datetimePickerAction("Pick", data, "datetime");
+    const exact = datetimePickerAction("Pick", exactData, "datetime") as { data: string };
+    const unavailable = datetimePickerAction("Pick", overlongData, "datetime");
 
+    expect(exactData).toHaveLength(300);
+    expect(overlongData).toHaveLength(301);
     expect(action.label).toBe("1234567890123456789");
     expect(loneHighSurrogate.test(action.label)).toBe(false);
+    expect(exact.data).toBe(exactData);
     expect(unavailable).toEqual({
       type: "message",
       label: "Action unavailable",
@@ -491,14 +500,15 @@ describe("action label/data surrogate-safe truncation", () => {
   });
 
   it("uriAction visibly disables overlong links instead of changing their destination", () => {
-    const validUri = `https://e.example/?q=${"u".repeat(978)}`;
+    const validUri = `https://e.example/?q=${"u".repeat(979)}`;
     const validAction = uriAction("Open", validUri) as { type: string; uri?: string };
-    const overlongAction = uriAction("Open", `${validUri}😀`) as {
+    const overlongAction = uriAction("Open", `${validUri}u`) as {
       type: string;
       label?: string;
       text?: string;
     };
 
+    expect(validUri).toHaveLength(1000);
     expect(validAction).toMatchObject({ type: "uri", uri: validUri });
     expect(overlongAction).toEqual({
       type: "message",
@@ -546,7 +556,6 @@ describe("action label/data surrogate-safe truncation", () => {
   });
 
   it("media control cards visibly disable overlong opaque callbacks", () => {
-    // 299 code units + 😀 = 301; the 300-unit slice cuts the emoji.
     const overlongData = `${"d".repeat(299)}😀`;
     const card = createMediaPlayerCard({
       title: "Track",

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -690,6 +690,7 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(messageAction("Open", emojiText)).toMatchObject({ text: emojiText });
     const familyEmoji = "👨‍👩‍👧‍👦";
     expect(truncateLineActionLabel(familyEmoji.repeat(3))).toBe(familyEmoji.repeat(2));
+    expect(truncateLineActionLabel(`👩${"‍👩".repeat(10)}`)).toBe("…");
     expect(messageAction("Open", familyEmoji.repeat(43))).toEqual({
       type: "message",
       label: "Unavailable",

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -372,18 +372,19 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(loneHighSurrogate.test(action.label)).toBe(false);
   });
 
-  it("postbackAction truncates label and data on surrogate boundaries", () => {
+  it("postbackAction truncates labels but visibly disables overlong callback data", () => {
     // 299 ASCII chars + 😀 = 301 code units; the 300-unit slice cuts the emoji.
     const data = `${"d".repeat(299)}😀`;
-    const action = postbackAction(labelWithEmoji, data) as {
-      label: string;
-      data: string;
-    };
+    const action = postbackAction(labelWithEmoji, "data") as { label: string };
+    const unavailable = postbackAction("Label", data);
 
     expect(action.label).toBe("1234567890123456789");
     expect(loneHighSurrogate.test(action.label)).toBe(false);
-    expect(action.data).toBe("d".repeat(299));
-    expect(loneHighSurrogate.test(action.data)).toBe(false);
+    expect(unavailable).toEqual({
+      type: "message",
+      label: "Action unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
+    });
   });
 
   it("postbackAction truncates displayText on surrogate boundaries but keeps undefined", () => {
@@ -398,20 +399,21 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(withoutDisplay.displayText).toBeUndefined();
   });
 
-  it("datetimePickerAction truncates label and data on surrogate boundaries", () => {
+  it("datetimePickerAction truncates labels but visibly disables overlong callback data", () => {
     const data = `${"d".repeat(299)}😀`;
-    const action = datetimePickerAction(labelWithEmoji, data, "datetime") as {
-      label: string;
-      data: string;
-    };
+    const action = datetimePickerAction(labelWithEmoji, "data", "datetime") as { label: string };
+    const unavailable = datetimePickerAction("Pick", data, "datetime");
 
     expect(action.label).toBe("1234567890123456789");
     expect(loneHighSurrogate.test(action.label)).toBe(false);
-    expect(action.data).toBe("d".repeat(299));
-    expect(loneHighSurrogate.test(action.data)).toBe(false);
+    expect(unavailable).toEqual({
+      type: "message",
+      label: "Action unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
+    });
   });
 
-  it("/card action command uses surrogate-safe labels and postback data", async () => {
+  it("/card action command visibly disables overlong callback data", async () => {
     const registerCommand = (command: unknown) => {
       const { handler } = command as {
         handler: (ctx: { args: string; channel: string }) => Promise<unknown>;
@@ -425,7 +427,13 @@ describe("action label/data surrogate-safe truncation", () => {
       channelData: {
         line: {
           flexMessage: {
-            contents: { footer: { contents: Array<{ action: { label: string; data: string } }> } };
+            contents: {
+              footer: {
+                contents: Array<{
+                  action: { type: string; label: string; text?: string };
+                }>;
+              };
+            };
           };
         };
       };
@@ -435,10 +443,11 @@ describe("action label/data surrogate-safe truncation", () => {
       "LINE flex-message footer action",
     ).action;
 
-    expect(action.label).toBe("1234567890123456789");
-    expect(loneHighSurrogate.test(action.label)).toBe(false);
-    expect(action.data).toBe(`k=${"d".repeat(297)}`);
-    expect(loneHighSurrogate.test(action.data)).toBe(false);
+    expect(action).toEqual({
+      type: "message",
+      label: "Action unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
+    });
   });
 
   it("/card receipt altText truncates on a surrogate boundary", async () => {
@@ -498,7 +507,7 @@ describe("action label/data surrogate-safe truncation", () => {
     });
   });
 
-  it("buttons template payload uri actions truncate past the 1000-unit cap", () => {
+  it("buttons template payload visibly disables URIs past the 1000-unit cap", () => {
     const template = buildTemplateMessageFromPayload({
       type: "buttons",
       text: "Pick",
@@ -516,6 +525,23 @@ describe("action label/data surrogate-safe truncation", () => {
       type: "message",
       label: "Link unavailable",
       text: "Link unavailable: URL exceeds LINE's limit.",
+    });
+  });
+
+  it("buttons template payload visibly disables overlong postback data", () => {
+    const template = buildTemplateMessageFromPayload({
+      type: "buttons",
+      text: "Pick",
+      actions: [{ type: "postback", label: "Open", data: `action=open&token=${"x".repeat(300)}` }],
+    });
+    const buttonsTemplate = expectDefined(template, "buttons template message").template as {
+      actions: Array<{ type: string; label?: string; text?: string }>;
+    };
+
+    expect(buttonsTemplate.actions[0]).toEqual({
+      type: "message",
+      label: "Action unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
     });
   });
 

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -6,6 +6,7 @@ import {
   messageAction,
   normalizeLineAction,
   postbackAction,
+  truncateLineActionLabel,
   uriAction,
   type Action,
 } from "./actions.js";
@@ -687,6 +688,16 @@ describe("action label/data surrogate-safe truncation", () => {
     });
     const emojiText = "😀".repeat(300);
     expect(messageAction("Open", emojiText)).toMatchObject({ text: emojiText });
+    const familyEmoji = "👨‍👩‍👧‍👦";
+    expect(truncateLineActionLabel(familyEmoji.repeat(3))).toBe(familyEmoji.repeat(2));
+    expect(messageAction("Open", familyEmoji.repeat(43))).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Action unavailable: message text exceeds LINE's limit.",
+    });
+    expect(messageAction("Open", familyEmoji.repeat(42))).toMatchObject({
+      text: familyEmoji.repeat(42),
+    });
     expect(
       normalizeLineAction({
         type: "clipboard",

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -481,13 +481,18 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(loneHighSurrogate.test(extraAction?.label ?? "")).toBe(false);
   });
 
-  it("uriAction truncates uri on surrogate boundaries", () => {
+  it("uriAction truncates without splitting surrogates or percent-encoded code points", () => {
     // 999 code units + 😀 = 1001; the 1000-unit slice cuts the emoji.
     const uri = `https://e.example/?q=${"u".repeat(978)}😀`;
     const action = uriAction("Open", uri) as { uri: string };
+    // The raw 1000-unit boundary ends in "%A", halfway through an encoded euro sign.
+    const encodedUri = `https://example.com/?q=${"a".repeat(969)}%E2%82%AC`;
+    const encodedAction = uriAction("Open", encodedUri) as { uri: string };
 
     expect(action.uri).toBe(`https://e.example/?q=${"u".repeat(978)}`);
     expect(loneHighSurrogate.test(action.uri)).toBe(false);
+    expect(encodedAction.uri).toBe(`https://example.com/?q=${"a".repeat(969)}`);
+    expect(() => decodeURI(encodedAction.uri)).not.toThrow();
   });
 
   it("buttons template payload uri actions truncate past the 1000-unit cap", () => {

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -1,7 +1,14 @@
 // Line tests cover message cards plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
-import { datetimePickerAction, messageAction, postbackAction, uriAction } from "./actions.js";
+import {
+  datetimePickerAction,
+  messageAction,
+  normalizeLineAction,
+  postbackAction,
+  uriAction,
+  type Action,
+} from "./actions.js";
 import { registerLineCardCommand } from "./card-command.js";
 import {
   createActionCard,
@@ -376,7 +383,7 @@ describe("action label/data surrogate-safe truncation", () => {
   it("messageAction drops a half emoji instead of leaving a lone surrogate", () => {
     const action = messageAction(labelWithEmoji) as { label: string };
 
-    expect(action.label).toBe("1234567890123456789");
+    expect(action.label).toBe(labelWithEmoji);
     expect(loneHighSurrogate.test(action.label)).toBe(false);
   });
 
@@ -389,11 +396,11 @@ describe("action label/data surrogate-safe truncation", () => {
   it("uriAction drops a half emoji instead of leaving a lone surrogate", () => {
     const action = uriAction(labelWithEmoji, "https://example.com") as { label: string };
 
-    expect(action.label).toBe("1234567890123456789");
+    expect(action.label).toBe(labelWithEmoji);
     expect(loneHighSurrogate.test(action.label)).toBe(false);
   });
 
-  it("postbackAction truncates labels but visibly disables overlong callback data", () => {
+  it("postbackAction preserves valid grapheme labels but disables overlong callback data", () => {
     const exactData = `${"d".repeat(298)}😀`;
     const overlongData = `${"d".repeat(299)}😀`;
     const action = postbackAction(labelWithEmoji, "data") as { label: string };
@@ -402,7 +409,7 @@ describe("action label/data surrogate-safe truncation", () => {
 
     expect(exactData).toHaveLength(300);
     expect(overlongData).toHaveLength(301);
-    expect(action.label).toBe("1234567890123456789");
+    expect(action.label).toBe(labelWithEmoji);
     expect(loneHighSurrogate.test(action.label)).toBe(false);
     expect(exact.data).toBe(exactData);
     expect(unavailable).toEqual({
@@ -412,19 +419,19 @@ describe("action label/data surrogate-safe truncation", () => {
     });
   });
 
-  it("postbackAction truncates displayText on surrogate boundaries but keeps undefined", () => {
-    const displayText = `${"t".repeat(299)}😀`;
+  it("postbackAction truncates displayText by grapheme cluster but keeps undefined", () => {
+    const displayText = `${"t".repeat(300)}😀`;
     const withDisplay = postbackAction("Label", "data", displayText) as {
       displayText?: string;
     };
     const withoutDisplay = postbackAction("Label", "data") as { displayText?: string };
 
-    expect(withDisplay.displayText).toBe("t".repeat(299));
+    expect(withDisplay.displayText).toBe("t".repeat(300));
     expect(loneHighSurrogate.test(withDisplay.displayText ?? "")).toBe(false);
     expect(withoutDisplay.displayText).toBeUndefined();
   });
 
-  it("datetimePickerAction truncates labels but visibly disables overlong callback data", () => {
+  it("datetimePickerAction preserves valid grapheme labels but disables overlong callback data", () => {
     const exactData = `${"d".repeat(298)}😀`;
     const overlongData = `${"d".repeat(299)}😀`;
     const action = datetimePickerAction(labelWithEmoji, "data", "datetime") as { label: string };
@@ -433,7 +440,7 @@ describe("action label/data surrogate-safe truncation", () => {
 
     expect(exactData).toHaveLength(300);
     expect(overlongData).toHaveLength(301);
-    expect(action.label).toBe("1234567890123456789");
+    expect(action.label).toBe(labelWithEmoji);
     expect(loneHighSurrogate.test(action.label)).toBe(false);
     expect(exact.data).toBe(exactData);
     expect(unavailable).toEqual({
@@ -501,7 +508,7 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(loneHighSurrogate.test(altText)).toBe(false);
   });
 
-  it("media control postback labels truncate on surrogate boundaries", () => {
+  it("media control postback labels count grapheme clusters", () => {
     const card = createMediaPlayerCard({
       title: "Track",
       controls: {
@@ -516,7 +523,7 @@ describe("action label/data surrogate-safe truncation", () => {
       .flatMap((content) => content.contents ?? [])
       .find((button) => button.action?.data === "extra")?.action;
 
-    expect(extraAction?.label).toBe("x".repeat(14));
+    expect(extraAction?.label).toBe(`${"x".repeat(14)}😀`);
     expect(loneHighSurrogate.test(extraAction?.label ?? "")).toBe(false);
   });
 
@@ -574,6 +581,141 @@ describe("action label/data surrogate-safe truncation", () => {
       label: "Unavailable",
       text: "Action unavailable: callback data exceeds LINE's limit.",
     });
+  });
+
+  it("normalizes raw actions at exported template builder boundaries", () => {
+    const oversizedPostback: Action = {
+      type: "postback",
+      label: "Open",
+      data: "x".repeat(301),
+    };
+    const oversizedUri: Action = {
+      type: "uri",
+      label: "Open",
+      uri: `https://e.example/?q=${"x".repeat(1200)}`,
+    };
+    const unavailableAction = {
+      type: "message",
+      label: "Unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
+    };
+    const unavailableLink = {
+      type: "message",
+      label: "Unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+    };
+
+    const buttons = createButtonTemplate(undefined, "Pick", [oversizedPostback], {
+      defaultAction: oversizedUri,
+    }).template as {
+      actions: Action[];
+      defaultAction?: Action;
+    };
+    expect(buttons.actions).toEqual([unavailableAction]);
+    expect(buttons.defaultAction).toEqual(unavailableLink);
+
+    const carousel = createTemplateCarousel([
+      {
+        text: "Pick",
+        actions: [oversizedPostback],
+        defaultAction: oversizedUri,
+      },
+    ]).template as {
+      columns: Array<{ actions: Action[]; defaultAction?: Action }>;
+    };
+    expect(carousel.columns[0]?.actions).toEqual([unavailableAction]);
+    expect(carousel.columns[0]?.defaultAction).toEqual(unavailableLink);
+
+    const imageCarousel = createImageCarousel([
+      { imageUrl: "https://e.example/image.jpg", action: oversizedPostback },
+    ]).template as { columns: Array<{ action: Action }> };
+    expect(imageCarousel.columns[0]?.action).toEqual(unavailableAction);
+  });
+
+  it("normalizes every length-constrained raw action field", () => {
+    expect(
+      normalizeLineAction({
+        type: "uri",
+        label: "Open",
+        uri: "https://e.example",
+        altUri: { desktop: `https://e.example/?q=${"x".repeat(1200)}` },
+      }),
+    ).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+    });
+
+    const postback = normalizeLineAction({
+      type: "postback",
+      label: "Open",
+      data: "action=open",
+      displayText: "d".repeat(301),
+      text: "t".repeat(301),
+      fillInText: "f".repeat(301),
+    });
+    expect(postback).toMatchObject({
+      displayText: "d".repeat(300),
+      text: "t".repeat(300),
+      fillInText: "f".repeat(300),
+    });
+
+    expect(
+      normalizeLineAction({ type: "message", label: "Open", text: "x".repeat(301) }),
+    ).toMatchObject({ text: "x".repeat(300) });
+    const emojiText = "😀".repeat(300);
+    expect(messageAction("Open", emojiText)).toMatchObject({ text: emojiText });
+    expect(
+      normalizeLineAction({
+        type: "clipboard",
+        label: "Copy",
+        clipboardText: "x".repeat(1001),
+      }),
+    ).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Action unavailable: clipboard text exceeds LINE's limit.",
+    });
+  });
+
+  it("normalizes raw actions at exported flex builder boundaries", () => {
+    const oversizedUri: Action = {
+      type: "uri",
+      label: "Open",
+      uri: `https://e.example/?q=${"x".repeat(1200)}`,
+    };
+    const oversizedPostback: Action = {
+      type: "postback",
+      label: "Open",
+      data: "x".repeat(301),
+    };
+
+    const image = createImageCard("https://e.example/image.jpg", "Image", undefined, {
+      action: oversizedUri,
+    });
+    expect((image.hero as { action?: Action }).action).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+    });
+
+    const card = createActionCard("Title", "Body", [
+      { label: "Open", action: oversizedPostback },
+    ]);
+    const button = (card.footer as { contents: Array<{ action: Action }> }).contents[0];
+    expect(button?.action).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
+    });
+
+    const validLongLabel = "x".repeat(40);
+    const labeledCard = createActionCard("Title", "Body", [
+      { label: validLongLabel, action: { type: "message", label: validLongLabel, text: "Open" } },
+    ]);
+    const labeledButton = (labeledCard.footer as { contents: Array<{ action: Action }> })
+      .contents[0];
+    expect(labeledButton?.action.label).toBe(validLongLabel);
   });
 
   it("media control cards visibly disable overlong opaque callbacks", () => {

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -450,6 +450,30 @@ describe("parseLineDirectives", () => {
     });
   });
 
+  describe("overlong action payloads", () => {
+    it("caps device control postback data despite an overlong device name", () => {
+      // The device slug is embedded in every control's postback data; an unbounded
+      // name pushes the data past LINE's 300-unit action cap and the whole flex
+      // message would come back HTTP 400.
+      const longName = "Very Long Device Name ".repeat(30);
+      const result = parseLineDirectives({
+        text: `[[device: ${longName} | Streaming Box | Playing | Play/Pause:toggle]]`,
+      });
+      const flexMessage = requireFlexMessage(getLineData(result).flexMessage, "long device name");
+      const footer = flexMessage.contents?.footer as {
+        contents?: Array<{ contents?: Array<{ action?: { data?: string } }> }>;
+      };
+      const datas = (footer?.contents ?? [])
+        .flatMap((row) => row.contents ?? [])
+        .flatMap((button) => (button.action?.data ? [button.action.data] : []));
+
+      expect(datas.length).toBeGreaterThan(0);
+      for (const data of datas) {
+        expect(data.length).toBeLessThanOrEqual(300);
+      }
+    });
+  });
+
   describe("appletv_remote", () => {
     it("parses appletv remote variants", () => {
       const cases = [

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -471,7 +471,7 @@ describe("parseLineDirectives", () => {
       expect(flexMessage.altText).toContain("living_room");
       expect(action).toEqual({
         type: "message",
-        label: "Action unavailable",
+        label: "Unavailable",
         text: "Action unavailable: callback data exceeds LINE's limit.",
       });
     });

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -461,15 +461,25 @@ describe("parseLineDirectives", () => {
       });
       const flexMessage = requireFlexMessage(getLineData(result).flexMessage, "long device name");
       const footer = flexMessage.contents?.footer as {
-        contents?: Array<{ contents?: Array<{ action?: { data?: string } }> }>;
+        contents?: Array<{
+          contents?: Array<{ action?: { data?: string; label?: string } }>;
+        }>;
       };
-      const datas = (footer?.contents ?? [])
+      const actions = (footer?.contents ?? [])
         .flatMap((row) => row.contents ?? [])
-        .flatMap((button) => (button.action?.data ? [button.action.data] : []));
+        .flatMap((button) => (button.action?.data ? [button.action] : []));
 
-      expect(datas.length).toBeGreaterThan(0);
-      for (const data of datas) {
-        expect(data.length).toBeLessThanOrEqual(300);
+      expect(flexMessage.altText).toContain("Very Long Device Name");
+      expect(actions.length).toBeGreaterThan(0);
+      for (const action of actions) {
+        if (!action.data) {
+          throw new Error("expected device callback data");
+        }
+        const params = new URLSearchParams(action.data);
+        expect(action.label).toBe("Play/Pause");
+        expect(action.data.length).toBeLessThanOrEqual(300);
+        expect(params.get("line.action")).toBe("toggle");
+        expect(params.get("line.device")).toBeTruthy();
       }
     });
   });

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -451,36 +451,29 @@ describe("parseLineDirectives", () => {
   });
 
   describe("overlong action payloads", () => {
-    it("caps device control postback data despite an overlong device name", () => {
-      // The device slug is embedded in every control's postback data; an unbounded
-      // name pushes the data past LINE's 300-unit action cap and the whole flex
-      // message would come back HTTP 400.
-      const longName = "Very Long Device Name ".repeat(30);
+    it("keeps the card visible but disables a callback that cannot round-trip", () => {
+      const deviceName = `${"a".repeat(280)}_living_room`;
       const result = parseLineDirectives({
-        text: `[[device: ${longName} | Streaming Box | Playing | Play/Pause:toggle]]`,
+        text: `[[device: ${deviceName} | Streaming Box | Playing | Play/Pause:toggle]]`,
       });
       const flexMessage = requireFlexMessage(getLineData(result).flexMessage, "long device name");
       const footer = flexMessage.contents?.footer as {
         contents?: Array<{
-          contents?: Array<{ action?: { data?: string; label?: string } }>;
+          contents?: Array<{
+            action?: { type?: string; data?: string; label?: string; text?: string };
+          }>;
         }>;
       };
-      const actions = (footer?.contents ?? [])
+      const action = (footer?.contents ?? [])
         .flatMap((row) => row.contents ?? [])
-        .flatMap((button) => (button.action?.data ? [button.action] : []));
+        .find((button) => button.action)?.action;
 
-      expect(flexMessage.altText).toContain("Very Long Device Name");
-      expect(actions.length).toBeGreaterThan(0);
-      for (const action of actions) {
-        if (!action.data) {
-          throw new Error("expected device callback data");
-        }
-        const params = new URLSearchParams(action.data);
-        expect(action.label).toBe("Play/Pause");
-        expect(action.data.length).toBeLessThanOrEqual(300);
-        expect(params.get("line.action")).toBe("toggle");
-        expect(params.get("line.device")).toBeTruthy();
-      }
+      expect(flexMessage.altText).toContain("living_room");
+      expect(action).toEqual({
+        type: "message",
+        label: "Action unavailable",
+        text: "Action unavailable: callback data exceeds LINE's limit.",
+      });
     });
   });
 

--- a/extensions/line/src/rich-menu.test.ts
+++ b/extensions/line/src/rich-menu.test.ts
@@ -104,7 +104,7 @@ describe("postbackAction", () => {
     const unavailable = postbackAction("Test", "x".repeat(400));
     expect(unavailable).toEqual({
       type: "message",
-      label: "Action unavailable",
+      label: "Unavailable",
       text: "Action unavailable: callback data exceeds LINE's limit.",
     });
 

--- a/extensions/line/src/rich-menu.test.ts
+++ b/extensions/line/src/rich-menu.test.ts
@@ -100,9 +100,13 @@ describe("postbackAction", () => {
     expect((action as { displayText: string }).displayText).toBe("Selected item 1");
   });
 
-  it("applies postback payload truncation and displayText behavior", () => {
-    const truncatedData = postbackAction("Test", "x".repeat(400));
-    expect((truncatedData as { data: string }).data.length).toBe(300);
+  it("visibly disables overlong postback data and truncates displayText", () => {
+    const unavailable = postbackAction("Test", "x".repeat(400));
+    expect(unavailable).toEqual({
+      type: "message",
+      label: "Action unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
+    });
 
     const truncatedDisplay = postbackAction("Test", "data", "y".repeat(400));
     expect((truncatedDisplay as { displayText: string }).displayText?.length).toBe(300);

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -188,7 +188,17 @@ describe("LINE send helpers", () => {
       contents: {
         type: "bubble",
         action: oversizedPostback,
-        hero: { type: "video", url: "https://e.example/video.mp4", action: oversizedUri },
+        hero: {
+          type: "video",
+          url: "https://e.example/video.mp4",
+          previewUrl: "https://e.example/preview.jpg",
+          altContent: {
+            type: "image",
+            url: "https://e.example/preview.jpg",
+            size: "full",
+          },
+          action: oversizedUri,
+        },
         body: {
           type: "box",
           layout: "vertical",
@@ -214,7 +224,7 @@ describe("LINE send helpers", () => {
 
     const contents = pushed.messages[0]?.contents as {
       action: unknown;
-      hero: { action: unknown };
+      hero: { type: string; contents: Array<{ type: string; text?: string }> };
       body: { action: unknown; contents: Array<{ action: unknown }> };
     };
     const unavailableAction = {
@@ -228,7 +238,24 @@ describe("LINE send helpers", () => {
       text: "Link unavailable: URL exceeds LINE's limit.",
     };
     expect(contents.action).toEqual(unavailableAction);
-    expect(contents.hero.action).toBeUndefined();
+    expect(contents.hero).toEqual({
+      type: "box",
+      layout: "vertical",
+      contents: [
+        {
+          type: "image",
+          url: "https://e.example/preview.jpg",
+          size: "full",
+        },
+        {
+          type: "text",
+          text: "Link unavailable: URL exceeds LINE's limit.",
+          wrap: true,
+          size: "sm",
+          color: "#666666",
+        },
+      ],
+    });
     expect(contents.body.action).toEqual(unavailableAction);
     expect(contents.body.contents[0]?.action).toEqual(unavailableLink);
     expect(contents.body.contents[1]?.action).toEqual(unavailableAction);

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -262,6 +262,44 @@ describe("LINE send helpers", () => {
     expect(message.contents.action).toBe(oversizedPostback);
   });
 
+  it("normalizes raw imagemap actions at both outbound API boundaries", async () => {
+    const area = { x: 0, y: 0, width: 520, height: 1040 };
+    const message = {
+      type: "imagemap",
+      baseUrl: "https://e.example/imagemap",
+      altText: "Map",
+      baseSize: { width: 1040, height: 1040 },
+      actions: [
+        {
+          type: "uri",
+          label: "Open",
+          linkUri: `https://e.example/?q=${"x".repeat(1200)}`,
+          area,
+        },
+      ],
+    };
+
+    await sendModule.pushMessagesLine("U123", [message] as never, { cfg: LINE_TEST_CFG });
+    await sendModule.replyMessageLine("reply-token", [message] as never, { cfg: LINE_TEST_CFG });
+
+    const pushed = pushMessageMock.mock.calls[0]?.[0] as {
+      messages: Array<{ actions: unknown[] }>;
+    };
+    const replied = replyMessageMock.mock.calls[0]?.[0] as {
+      messages: Array<{ actions: unknown[] }>;
+    };
+    expect(pushed.messages[0]?.actions).toEqual(replied.messages[0]?.actions);
+    expect(pushed.messages[0]?.actions).toEqual([
+      {
+        type: "message",
+        label: "Unavailable",
+        text: "Link unavailable: URL exceeds LINE's limit.",
+        area,
+      },
+    ]);
+    expect(message.actions[0]?.type).toBe("uri");
+  });
+
   it("pushes images via normalized LINE target", async () => {
     const result = await sendModule.pushImageMessage(
       "line:user:U123",

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -206,6 +206,11 @@ describe("LINE send helpers", () => {
           contents: [
             { type: "text", text: "Open", action: oversizedUri },
             { type: "button", action: oversizedPostback },
+            {
+              type: "text",
+              text: "Still works",
+              action: { type: "message", label: "Unavailable", text: "keep" },
+            },
           ],
         },
       },
@@ -223,42 +228,37 @@ describe("LINE send helpers", () => {
     expect(pushed.messages[0]?.contents).toEqual(replied.messages[0]?.contents);
 
     const contents = pushed.messages[0]?.contents as {
-      action: unknown;
-      hero: { type: string; contents: Array<{ type: string; text?: string }> };
-      body: { action: unknown; contents: Array<{ action: unknown }> };
+      action?: unknown;
+      hero: { type: string; action?: unknown };
+      body: { action?: unknown; contents: Array<{ action?: unknown; text?: string }> };
     };
     const unavailableAction = {
       type: "message",
       label: "Unavailable",
       text: "Action unavailable: callback data exceeds LINE's limit.",
     };
-    const unavailableLink = {
+    expect(contents.action).toBeUndefined();
+    expect(contents.hero).toEqual({
+      type: "video",
+      url: "https://e.example/video.mp4",
+      previewUrl: "https://e.example/preview.jpg",
+      altContent: {
+        type: "image",
+        url: "https://e.example/preview.jpg",
+        size: "full",
+      },
+    });
+    expect(contents.body.action).toBeUndefined();
+    expect(contents.body.contents[0]?.action).toBeUndefined();
+    expect(contents.body.contents[1]?.action).toEqual(unavailableAction);
+    expect(contents.body.contents[2]?.action).toEqual({
       type: "message",
       label: "Unavailable",
-      text: "Link unavailable: URL exceeds LINE's limit.",
-    };
-    expect(contents.action).toEqual(unavailableAction);
-    expect(contents.hero).toEqual({
-      type: "box",
-      layout: "vertical",
-      contents: [
-        {
-          type: "image",
-          url: "https://e.example/preview.jpg",
-          size: "full",
-        },
-        {
-          type: "text",
-          text: "Link unavailable: URL exceeds LINE's limit.",
-          wrap: true,
-          size: "sm",
-          color: "#666666",
-        },
-      ],
+      text: "keep",
     });
-    expect(contents.body.action).toEqual(unavailableAction);
-    expect(contents.body.contents[0]?.action).toEqual(unavailableLink);
-    expect(contents.body.contents[1]?.action).toEqual(unavailableAction);
+    expect(contents.body.contents.slice(3).map((item) => item.text)).toEqual([
+      "Action unavailable: callback data exceeds LINE's limit.\nLink unavailable: URL exceeds LINE's limit.",
+    ]);
     expect(message.contents.action).toBe(oversizedPostback);
   });
 

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -175,6 +175,66 @@ describe("LINE send helpers", () => {
     expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(item?.action.label ?? "")).toBe(false);
   });
 
+  it("normalizes raw Flex actions at both outbound API boundaries", async () => {
+    const oversizedPostback = { type: "postback", label: "Open", data: "x".repeat(301) };
+    const oversizedUri = {
+      type: "uri",
+      label: "Open",
+      uri: `https://e.example/?q=${"x".repeat(1200)}`,
+    };
+    const message = {
+      type: "flex",
+      altText: "Raw Flex",
+      contents: {
+        type: "bubble",
+        action: oversizedPostback,
+        hero: { type: "video", url: "https://e.example/video.mp4", action: oversizedUri },
+        body: {
+          type: "box",
+          layout: "vertical",
+          action: oversizedPostback,
+          contents: [
+            { type: "text", text: "Open", action: oversizedUri },
+            { type: "button", action: oversizedPostback },
+          ],
+        },
+      },
+    };
+
+    await sendModule.pushMessagesLine("U123", [message] as never, { cfg: LINE_TEST_CFG });
+    await sendModule.replyMessageLine("reply-token", [message] as never, { cfg: LINE_TEST_CFG });
+
+    const pushed = pushMessageMock.mock.calls[0]?.[0] as {
+      messages: Array<{ contents: Record<string, unknown> }>;
+    };
+    const replied = replyMessageMock.mock.calls[0]?.[0] as {
+      messages: Array<{ contents: Record<string, unknown> }>;
+    };
+    expect(pushed.messages[0]?.contents).toEqual(replied.messages[0]?.contents);
+
+    const contents = pushed.messages[0]?.contents as {
+      action: unknown;
+      hero: { action: unknown };
+      body: { action: unknown; contents: Array<{ action: unknown }> };
+    };
+    const unavailableAction = {
+      type: "message",
+      label: "Unavailable",
+      text: "Action unavailable: callback data exceeds LINE's limit.",
+    };
+    const unavailableLink = {
+      type: "message",
+      label: "Unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+    };
+    expect(contents.action).toEqual(unavailableAction);
+    expect(contents.hero.action).toBeUndefined();
+    expect(contents.body.action).toEqual(unavailableAction);
+    expect(contents.body.contents[0]?.action).toEqual(unavailableLink);
+    expect(contents.body.contents[1]?.action).toEqual(unavailableAction);
+    expect(message.contents.action).toBe(oversizedPostback);
+  });
+
   it("pushes images via normalized LINE target", async () => {
     const result = await sendModule.pushImageMessage(
       "line:user:U123",

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -264,6 +264,7 @@ describe("LINE send helpers", () => {
 
   it("normalizes raw imagemap actions at both outbound API boundaries", async () => {
     const area = { x: 0, y: 0, width: 520, height: 1040 };
+    const videoArea = { x: 520, y: 0, width: 520, height: 1040 };
     const message = {
       type: "imagemap",
       baseUrl: "https://e.example/imagemap",
@@ -276,27 +277,50 @@ describe("LINE send helpers", () => {
           linkUri: `https://e.example/?q=${"x".repeat(1200)}`,
           area,
         },
+        ...Array.from({ length: 49 }, (_, index) => ({
+          type: "message",
+          label: `Item ${index}`,
+          text: `item-${index}`,
+          area,
+        })),
       ],
+      video: {
+        originalContentUrl: "https://e.example/video.mp4",
+        previewImageUrl: "https://e.example/preview.jpg",
+        area: videoArea,
+        externalLink: {
+          linkUri: `https://e.example/video?q=${"x".repeat(1200)}`,
+          label: "Open video",
+        },
+      },
     };
 
     await sendModule.pushMessagesLine("U123", [message] as never, { cfg: LINE_TEST_CFG });
     await sendModule.replyMessageLine("reply-token", [message] as never, { cfg: LINE_TEST_CFG });
 
     const pushed = pushMessageMock.mock.calls[0]?.[0] as {
-      messages: Array<{ actions: unknown[] }>;
+      messages: Array<{ actions: unknown[]; video?: { externalLink?: unknown } }>;
     };
     const replied = replyMessageMock.mock.calls[0]?.[0] as {
       messages: Array<{ actions: unknown[] }>;
     };
     expect(pushed.messages[0]?.actions).toEqual(replied.messages[0]?.actions);
-    expect(pushed.messages[0]?.actions).toEqual([
-      {
-        type: "message",
-        label: "Unavailable",
-        text: "Link unavailable: URL exceeds LINE's limit.",
-        area,
-      },
-    ]);
+    expect(pushed.messages[0]?.actions).toHaveLength(50);
+    expect(pushed.messages[0]?.actions[0]).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+      area,
+    });
+    expect(pushed.messages[0]?.actions[1]).toMatchObject({
+      type: "message",
+      text: "item-0",
+    });
+    expect(pushed.messages[0]?.actions[49]).toMatchObject({
+      type: "message",
+      text: "item-48",
+    });
+    expect(pushed.messages[0]?.video?.externalLink).toBeUndefined();
     expect(message.actions[0]?.type).toBe("uri");
   });
 

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -165,12 +165,12 @@ describe("LINE send helpers", () => {
     expect(quickReply.items).toHaveLength(13);
   });
 
-  it("truncates quick reply labels without leaving lone surrogates", () => {
+  it("counts quick reply labels in grapheme clusters", () => {
     const label = "1234567890123456789😀";
     const quickReply = sendModule.createQuickReplyItems([label]);
     const item = quickReply.items?.[0] as { action: { label: string; text: string } } | undefined;
 
-    expect(item?.action.label).toBe("1234567890123456789");
+    expect(item?.action.label).toBe(label);
     expect(item?.action.text).toBe(label);
     expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(item?.action.label ?? "")).toBe(false);
   });

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -324,6 +324,32 @@ describe("LINE send helpers", () => {
     expect(message.actions[0]?.type).toBe("uri");
   });
 
+  it("counts imagemap video-link labels in UTF-16 units", async () => {
+    const message = {
+      type: "imagemap",
+      baseUrl: "https://e.example/imagemap",
+      altText: "Map",
+      baseSize: { width: 1040, height: 1040 },
+      actions: [],
+      video: {
+        originalContentUrl: "https://e.example/video.mp4",
+        previewImageUrl: "https://e.example/preview.jpg",
+        area: { x: 0, y: 0, width: 1040, height: 1040 },
+        externalLink: {
+          linkUri: "https://e.example/video",
+          label: "😀".repeat(16),
+        },
+      },
+    };
+
+    await sendModule.pushMessagesLine("U123", [message] as never, { cfg: LINE_TEST_CFG });
+
+    const pushed = pushMessageMock.mock.calls[0]?.[0] as {
+      messages: Array<{ video: { externalLink: { label: string } } }>;
+    };
+    expect(pushed.messages[0]?.video.externalLink.label).toBe("😀".repeat(15));
+  });
+
   it("pushes images via normalized LINE target", async () => {
     const result = await sendModule.pushImageMessage(
       "line:user:U123",

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -324,6 +324,41 @@ describe("LINE send helpers", () => {
     expect(message.actions[0]?.type).toBe("uri");
   });
 
+  it("counts imagemap message text in UTF-16 units at both outbound API boundaries", async () => {
+    const area = { x: 0, y: 0, width: 1040, height: 1040 };
+    const exactText = "😀".repeat(200);
+    const message = {
+      type: "imagemap",
+      baseUrl: "https://e.example/imagemap",
+      altText: "Map",
+      baseSize: { width: 1040, height: 1040 },
+      actions: [
+        { type: "message", label: "Exact", text: exactText, area },
+        { type: "message", label: "Too long", text: `${exactText}😀`, area },
+      ],
+    };
+
+    await sendModule.pushMessagesLine("U123", [message] as never, { cfg: LINE_TEST_CFG });
+    await sendModule.replyMessageLine("reply-token", [message] as never, { cfg: LINE_TEST_CFG });
+
+    const pushed = pushMessageMock.mock.calls[0]?.[0] as {
+      messages: Array<{ actions: unknown[] }>;
+    };
+    const replied = replyMessageMock.mock.calls[0]?.[0] as {
+      messages: Array<{ actions: unknown[] }>;
+    };
+    expect(pushed.messages[0]?.actions).toEqual(replied.messages[0]?.actions);
+    expect(pushed.messages[0]?.actions).toEqual([
+      { type: "message", label: "Exact", text: exactText, area },
+      {
+        type: "message",
+        label: "Unavailable",
+        text: "Action unavailable: message text exceeds LINE's limit.",
+        area,
+      },
+    ]);
+  });
+
   it("counts imagemap video-link labels in UTF-16 units", async () => {
     const message = {
       type: "imagemap",

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -7,7 +7,7 @@ import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime"
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveLineAccount } from "./accounts.js";
-import { messageAction } from "./actions.js";
+import { messageAction, normalizeLineMessageActions } from "./actions.js";
 import { resolveLineChannelAccessToken } from "./channel-access-token.js";
 import { validateLineMediaUrl } from "./outbound-media.js";
 import { createLineSendReceipt } from "./send-receipt.js";
@@ -241,9 +241,10 @@ async function pushLineMessages(
   }
 
   const { account, client, chatId } = createLinePushContext(to, opts);
+  const normalizedMessages = messages.map(normalizeLineMessageActions);
   const pushRequest = client.pushMessage({
     to: chatId,
-    messages,
+    messages: normalizedMessages,
   });
 
   if (behavior.errorContext) {
@@ -283,10 +284,11 @@ async function replyLineMessages(
   behavior: LineReplyBehavior = {},
 ): Promise<void> {
   const { account, client } = createLineMessagingClient(opts);
+  const normalizedMessages = messages.map(normalizeLineMessageActions);
 
   await client.replyMessage({
     replyToken,
-    messages,
+    messages: normalizedMessages,
   });
 
   recordLineOutboundActivity(account.accountId);

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -1,6 +1,12 @@
 // Line plugin module implements template messages behavior.
 import type { messagingApi } from "@line/bot-sdk";
-import { messageAction, postbackAction, uriAction, type Action } from "./actions.js";
+import {
+  messageAction,
+  normalizeLineAction,
+  postbackAction,
+  uriAction,
+  type Action,
+} from "./actions.js";
 import type { LineTemplateMessagePayload } from "./types.js";
 
 type TemplateMessage = messagingApi.TemplateMessage;
@@ -92,7 +98,7 @@ export function createConfirmTemplate(
   const template: ConfirmTemplate = {
     type: "confirm",
     text: truncateTemplateText(text, 240), // LINE limit
-    actions: [confirmAction, cancelAction],
+    actions: [normalizeLineAction(confirmAction), normalizeLineAction(cancelAction)],
   };
 
   return {
@@ -128,12 +134,15 @@ export function createButtonTemplate(
     type: "buttons",
     ...(normalizedTitle ? { title: truncateTemplateText(normalizedTitle, 40) } : {}), // LINE limit
     text: truncateTemplateText(text, textLimit),
-    actions: actions.slice(0, 4), // LINE limit: max 4 actions
+    actions: actions.slice(0, 4).map((action) => normalizeLineAction(action)), // LINE limit: max 4 actions
     thumbnailImageUrl: options?.thumbnailImageUrl,
     imageAspectRatio: options?.imageAspectRatio ?? "rectangle",
     imageSize: options?.imageSize ?? "cover",
     imageBackgroundColor: options?.imageBackgroundColor,
-    defaultAction: options?.defaultAction,
+    defaultAction:
+      options?.defaultAction === undefined
+        ? undefined
+        : normalizeLineAction(options.defaultAction),
   };
 
   return {
@@ -158,7 +167,14 @@ export function createTemplateCarousel(
 ): TemplateMessage {
   const template: CarouselTemplate = {
     type: "carousel",
-    columns: columns.slice(0, 10), // LINE limit: max 10 columns
+    columns: columns.slice(0, 10).map((column) => ({
+      ...column,
+      actions: column.actions.map((action) => normalizeLineAction(action)),
+      defaultAction:
+        column.defaultAction === undefined
+          ? undefined
+          : normalizeLineAction(column.defaultAction),
+    })), // LINE limit: max 10 columns
     imageAspectRatio: options?.imageAspectRatio ?? "rectangle",
     imageSize: options?.imageSize ?? "cover",
   };
@@ -189,10 +205,13 @@ export function createCarouselColumn(params: {
   return {
     title: truncateOptionalTemplateText(params.title, 40),
     text: truncateTemplateText(params.text, textLimit),
-    actions: params.actions.slice(0, 3), // LINE limit: max 3 actions per column
+    actions: params.actions.slice(0, 3).map((action) => normalizeLineAction(action)), // LINE limit: max 3 actions per column
     thumbnailImageUrl: params.thumbnailImageUrl,
     imageBackgroundColor: params.imageBackgroundColor,
-    defaultAction: params.defaultAction,
+    defaultAction:
+      params.defaultAction === undefined
+        ? undefined
+        : normalizeLineAction(params.defaultAction),
   };
 }
 
@@ -205,7 +224,10 @@ export function createImageCarousel(
 ): TemplateMessage {
   const template: ImageCarouselTemplate = {
     type: "image_carousel",
-    columns: columns.slice(0, 10), // LINE limit: max 10 columns
+    columns: columns.slice(0, 10).map((column) => ({
+      ...column,
+      action: normalizeLineAction(column.action, 12),
+    })), // LINE limit: max 10 columns
   };
 
   return {
@@ -221,7 +243,7 @@ export function createImageCarousel(
 export function createImageCarouselColumn(imageUrl: string, action: Action): ImageCarouselColumn {
   return {
     imageUrl,
-    action,
+    action: normalizeLineAction(action, 12),
   };
 }
 

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -140,9 +140,7 @@ export function createButtonTemplate(
     imageSize: options?.imageSize ?? "cover",
     imageBackgroundColor: options?.imageBackgroundColor,
     defaultAction:
-      options?.defaultAction === undefined
-        ? undefined
-        : normalizeLineAction(options.defaultAction),
+      options?.defaultAction === undefined ? undefined : normalizeLineAction(options.defaultAction),
   };
 
   return {
@@ -171,9 +169,7 @@ export function createTemplateCarousel(
       ...column,
       actions: column.actions.map((action) => normalizeLineAction(action)),
       defaultAction:
-        column.defaultAction === undefined
-          ? undefined
-          : normalizeLineAction(column.defaultAction),
+        column.defaultAction === undefined ? undefined : normalizeLineAction(column.defaultAction),
     })), // LINE limit: max 10 columns
     imageAspectRatio: options?.imageAspectRatio ?? "rectangle",
     imageSize: options?.imageSize ?? "cover",
@@ -209,9 +205,7 @@ export function createCarouselColumn(params: {
     thumbnailImageUrl: params.thumbnailImageUrl,
     imageBackgroundColor: params.imageBackgroundColor,
     defaultAction:
-      params.defaultAction === undefined
-        ? undefined
-        : normalizeLineAction(params.defaultAction),
+      params.defaultAction === undefined ? undefined : normalizeLineAction(params.defaultAction),
   };
 }
 

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -86,6 +86,22 @@ function formatProductCarouselText(description: string, price?: string): string 
   return descriptionText ? `${descriptionText}\n${priceText}` : priceText;
 }
 
+function normalizeCarouselColumnActions(column: CarouselColumn): CarouselColumn {
+  return {
+    ...column,
+    actions: column.actions.map((action) => normalizeLineAction(action)),
+    defaultAction:
+      column.defaultAction === undefined ? undefined : normalizeLineAction(column.defaultAction),
+  };
+}
+
+function normalizeImageCarouselColumnAction(column: ImageCarouselColumn): ImageCarouselColumn {
+  return {
+    ...column,
+    action: normalizeLineAction(column.action, 12),
+  };
+}
+
 /**
  * Create a confirm template (yes/no style dialog)
  */
@@ -165,12 +181,7 @@ export function createTemplateCarousel(
 ): TemplateMessage {
   const template: CarouselTemplate = {
     type: "carousel",
-    columns: columns.slice(0, 10).map((column) => ({
-      ...column,
-      actions: column.actions.map((action) => normalizeLineAction(action)),
-      defaultAction:
-        column.defaultAction === undefined ? undefined : normalizeLineAction(column.defaultAction),
-    })), // LINE limit: max 10 columns
+    columns: columns.slice(0, 10).map(normalizeCarouselColumnActions), // LINE limit: max 10 columns
     imageAspectRatio: options?.imageAspectRatio ?? "rectangle",
     imageSize: options?.imageSize ?? "cover",
   };
@@ -218,10 +229,7 @@ export function createImageCarousel(
 ): TemplateMessage {
   const template: ImageCarouselTemplate = {
     type: "image_carousel",
-    columns: columns.slice(0, 10).map((column) => ({
-      ...column,
-      action: normalizeLineAction(column.action, 12),
-    })), // LINE limit: max 10 columns
+    columns: columns.slice(0, 10).map(normalizeImageCarouselColumnAction), // LINE limit: max 10 columns
   };
 
   return {


### PR DESCRIPTION
Closes #113079

## What Problem This Solves

LINE rejects an entire reply when action callback data or a URI exceeds the provider cap. This can make device, media-player, Apple TV, template, Flex, or imagemap replies disappear with HTTP 400.

## Current Fix Shape

The branch treats callback data and URLs as opaque identities: it never truncates them into a different callback or destination. Oversized actions become bounded `Unavailable` message actions. Flex non-button surfaces remove the unusable tap target and render a visible warning in the owning bubble; valid video content remains intact. The same normalization runs at both LINE push and reply boundaries, so raw `channelData.line.flexMessage` payloads cannot bypass the transport limits.

At LINE's 50-action imagemap maximum, an invalid oversized `video.externalLink` is removed silently. The implementation preserves all 50 valid actions rather than sacrificing a working action to add a warning. Below the cap, the invalid link is replaced by a visible unavailable action when its area is available.

Ordinary action labels and visible action text follow the contributor's exact provider validation: 300 single-code-point emoji pass, 43 family-ZWJ graphemes (301 code points) fail, and 42 (294 code points) pass. Cuts stay on grapheme boundaries. Opaque callback data and URLs retain the conservative transport-safe checks. Imagemap message text follows LINE's default UTF-16-unit counting contract.

## Evidence

The original defect reproduces on current `origin/main` at `e71e4ac83eb25cf842892387869c278b78aec043`: the real LINE directive transform emits a 690-code-point postback payload, and `uriAction` emits a 1223-code-point URI, exceeding LINE's documented 300 and 1000 limits.

Focused proof on Blacksmith Testbox passed 114/114 tests across:

- `extensions/line/src/message-cards.test.ts`
- `extensions/line/src/reply-payload-transform.test.ts`
- `extensions/line/src/rich-menu.test.ts`
- `extensions/line/src/send.test.ts`

Run: https://github.com/openclaw/openclaw/actions/runs/30234544093

The tests cover push and reply normalization, raw Flex actions, template actions, image carousels, media/device/Apple TV controls, imagemap actions, the 50-action cap policy, Unicode boundaries, callback identity preservation, imagemap UTF-16 text limits, and visible Flex degradation. Targeted `oxfmt --check` and `git diff --check` also pass.

## Live LINE Proof Gap

No approved LINE channel token is available to the maintainer worker. The earlier HTTP 200 validation evidence belongs to a superseded truncation implementation, not this exact fallback/warning head. This PR therefore does **not** claim current-head live LINE validate or push coverage; the closest available proof is the provider-contract inspection plus the exact outbound-payload tests above.
