### PR TITLE
feat(chat): show live run telemetry across clients

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -41747,7 +41747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 90,
+      "line": 99,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",
@@ -41755,7 +41755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 235,
+      "line": 244,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift",
       "source": "Gateway changed before the thread operation started.",
       "surface": "apple",
@@ -41763,7 +41763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1245,
+      "line": 1225,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -579,7 +579,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 476,
+      "line": 477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -587,7 +587,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 612,
+      "line": 613,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -595,7 +595,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 626,
+      "line": 627,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -731,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -739,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 184,
+      "line": 185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -747,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 186,
+      "line": 187,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -755,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 188,
+      "line": 189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -763,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 190,
+      "line": 191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -771,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 287,
+      "line": 288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Device approved.",
       "surface": "android",
@@ -779,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 288,
+      "line": 289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pairing request rejected.",
       "surface": "android",
@@ -787,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 289,
+      "line": 290,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Paired device removed.",
       "surface": "android",
@@ -795,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 350,
+      "line": 351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -803,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 350,
+      "line": 351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -811,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 351,
+      "line": 352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -819,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 351,
+      "line": 352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -827,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 352,
+      "line": 353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -835,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 352,
+      "line": 353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -843,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 359,
+      "line": 360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -851,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 360,
+      "line": 361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -859,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 368,
+      "line": 369,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -867,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 550,
+      "line": 551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -875,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 551,
+      "line": 552,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -883,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 553,
+      "line": 554,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -891,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 561,
+      "line": 562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2293,
+      "line": 2294,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2323,
+      "line": 2324,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2323,
+      "line": 2324,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2336,
+      "line": 2337,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2367,
+      "line": 2368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2367,
+      "line": 2368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2389,
+      "line": 2390,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2395,
+      "line": 2396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2410,
+      "line": 2411,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2625,
+      "line": 2626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2636,
+      "line": 2637,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2657,
+      "line": 2658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2668,
+      "line": 2669,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3763,
+      "line": 3766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3791,
+      "line": 3794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3800,
+      "line": 3803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4511,
+      "line": 4514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4515,
+      "line": 4518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4519,
+      "line": 4522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4569,
+      "line": 4572,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4773,
+      "line": 4776,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5580,
+      "line": 5583,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5611,
+      "line": 5614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5613,
+      "line": 5616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5629,
+      "line": 5632,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5716,
+      "line": 5719,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5802,
+      "line": 5805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5812,
+      "line": 5815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5816,
+      "line": 5819,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5828,
+      "line": 5831,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5859,
+      "line": 5862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5876,
+      "line": 5879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5885,
+      "line": 5888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5897,
+      "line": 5900,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5944,
+      "line": 5947,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6056,
+      "line": 6059,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6071,
+      "line": 6074,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6091,
+      "line": 6094,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6095,
+      "line": 6098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6110,
+      "line": 6113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6110,
+      "line": 6113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6128,
+      "line": 6131,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6174,
+      "line": 6177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6187,
+      "line": 6190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6220,
+      "line": 6223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6236,
+      "line": 6239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6252,
+      "line": 6255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6268,
+      "line": 6271,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6358,
+      "line": 6361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6365,
+      "line": 6368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6405,
+      "line": 6408,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6445,
+      "line": 6448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6465,
+      "line": 6468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6517,
+      "line": 6520,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6537,
+      "line": 6540,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6542,
+      "line": 6545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6732,
+      "line": 6735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not verify the device pairing change. Refresh and try again.",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6814,
+      "line": 6817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6844,
+      "line": 6847,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7494,
+      "line": 7497,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7512,
+      "line": 7515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7527,
+      "line": 7530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8010,
+      "line": 8013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8019,
+      "line": 8022,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8020,
+      "line": 8023,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8028,
+      "line": 8031,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8029,
+      "line": 8032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8030,
+      "line": 8033,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8031,
+      "line": 8034,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8047,
+      "line": 8050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8064,
+      "line": 8067,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8072,
+      "line": 8075,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8073,
+      "line": 8076,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8075,
+      "line": 8078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8079,
+      "line": 8082,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8082,
+      "line": 8085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8087,
+      "line": 8090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8088,
+      "line": 8091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8090,
+      "line": 8093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8094,
+      "line": 8097,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8097,
+      "line": 8100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8102,
+      "line": 8105,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1555,7 +1555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8103,
+      "line": 8106,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1563,7 +1563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8105,
+      "line": 8108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1571,7 +1571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8109,
+      "line": 8112,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1579,7 +1579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8112,
+      "line": 8115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1587,7 +1587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8144,
+      "line": 8147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1595,7 +1595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8159,
+      "line": 8162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1603,7 +1603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8160,
+      "line": 8163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1611,7 +1611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8161,
+      "line": 8164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1619,7 +1619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8816,
+      "line": 8819,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1825,
+      "line": 1838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Wait for the current response to finish before starting a new chat.",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1958,
+      "line": 1971,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update model.",
       "surface": "android",
@@ -1811,7 +1811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2023,
+      "line": 2036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update thinking level.",
       "surface": "android",
@@ -1819,7 +1819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2536,
+      "line": 2550,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed before the run started; try again.",
       "surface": "android",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4232,
+      "line": 4412,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not stage an attachment for sending.",
       "surface": "android",
@@ -1835,7 +1835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4265,
+      "line": 4445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first.",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4271,
+      "line": 4451,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Attachments are too large to queue for one message; remove some and try again.",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4277,
+      "line": 4457,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline attachment storage is full; delete queued items first.",
       "surface": "android",
@@ -1859,7 +1859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4282,
+      "line": 4462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Gateway health not OK; cannot send",
       "surface": "android",
@@ -1867,7 +1867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4289,
+      "line": 4469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not queue message for later delivery.",
       "surface": "android",
@@ -1875,7 +1875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5190,
+      "line": 5375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed",
       "surface": "android",
@@ -1883,7 +1883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5421,
+      "line": 5679,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Event stream interrupted; try refreshing.",
       "surface": "android",
@@ -1891,7 +1891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5562,
+      "line": 5826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out waiting for a reply; try again or refresh.",
       "surface": "android",
@@ -1899,7 +1899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5770,
+      "line": 6043,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out confirming the sent message; refresh to check delivery.",
       "surface": "android",
@@ -12395,7 +12395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 407,
+      "line": 409,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Working",
       "surface": "android",
@@ -12403,7 +12403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 417,
+      "line": 423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "· $phrase",
       "surface": "android",
@@ -12411,7 +12411,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 434,
+      "line": 440,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Tools",
       "surface": "android",
@@ -12419,7 +12419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 437,
+      "line": 443,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
@@ -12427,7 +12427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 441,
+      "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
@@ -12435,7 +12435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 458,
+      "line": 464,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
@@ -12443,7 +12443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 479,
+      "line": 485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Queued — sends when reconnected",
       "surface": "android",
@@ -12451,7 +12451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 480,
+      "line": 486,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Sending…",
       "surface": "android",
@@ -12459,7 +12459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 481,
+      "line": 487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Sent — confirming delivery…",
       "surface": "android",
@@ -12467,7 +12467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 489,
+      "line": 495,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Session branch changed; review and retry this message.",
       "surface": "android",
@@ -12475,7 +12475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 493,
+      "line": 499,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Failed — $it",
       "surface": "android",
@@ -12483,7 +12483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 494,
+      "line": 500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Failed",
       "surface": "android",
@@ -12491,7 +12491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 498,
+      "line": 504,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "user",
       "surface": "android",
@@ -12499,7 +12499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 506,
+      "line": 512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "📎 ${attachment.fileName}",
       "surface": "android",
@@ -12507,7 +12507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 522,
+      "line": 528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Retry",
       "surface": "android",
@@ -12515,7 +12515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 527,
+      "line": 533,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Delete",
       "surface": "android",
@@ -12523,7 +12523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 558,
+      "line": 564,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "assistant",
       "surface": "android",
@@ -12531,7 +12531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 559,
+      "line": 565,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12539,7 +12539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 595,
+      "line": 601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "You",
       "surface": "android",
@@ -12547,7 +12547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 596,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
@@ -12555,7 +12555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 597,
+      "line": 603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12563,7 +12563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 609,
+      "line": 615,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Attachment",
       "surface": "android",
@@ -12571,7 +12571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 611,
+      "line": 617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",
@@ -12579,7 +12579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 653,
+      "line": 659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Image unavailable · Tap to retry",
       "surface": "android",
@@ -12587,7 +12587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 661,
+      "line": 667,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Loading image…",
       "surface": "android",
@@ -12595,7 +12595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 699,
+      "line": 705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Open image preview",
       "surface": "android",
@@ -12603,7 +12603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 717,
+      "line": 723,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Image preview",
       "surface": "android",
@@ -12611,7 +12611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 731,
+      "line": 737,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Close image preview",
       "surface": "android",
@@ -12691,7 +12691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 396,
+      "line": 397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Model",
       "surface": "android",
@@ -12699,7 +12699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 519,
+      "line": 520,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Some shared images were omitted or could not be added.",
       "surface": "android",
@@ -12707,7 +12707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 673,
+      "line": 674,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -12715,7 +12715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1012,
+      "line": 1016,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -12723,7 +12723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1099,
+      "line": 1103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -12731,7 +12731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1100,
+      "line": 1104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -12739,7 +12739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1101,
+      "line": 1105,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -12747,7 +12747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1114,
+      "line": 1118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -12755,7 +12755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1119,
+      "line": 1123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -12763,7 +12763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1138,
+      "line": 1142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dashboard",
       "surface": "android",
@@ -12771,7 +12771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1146,
+      "line": 1150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -12779,7 +12779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1167,
+      "line": 1171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -12787,7 +12787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1346,
+      "line": 1360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages to recover",
       "surface": "android",
@@ -12795,7 +12795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1348,
+      "line": 1362,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
       "surface": "android",
@@ -12803,7 +12803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1387,
+      "line": 1405,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading thread",
       "surface": "android",
@@ -12811,7 +12811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1420,
+      "line": 1438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -12819,7 +12819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1499,
+      "line": 1512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -12827,7 +12827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1503,
+      "line": 1516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -12835,7 +12835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1505,
+      "line": 1518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -12843,7 +12843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1507,
+      "line": 1520,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -12851,7 +12851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1530,
+      "line": 1543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -12859,7 +12859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1531,
+      "line": 1544,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -12867,7 +12867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1590,
+      "line": 1603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -12875,7 +12875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1591,
+      "line": 1604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent threads and next steps.",
       "surface": "android",
@@ -12883,7 +12883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1592,
+      "line": 1605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
       "surface": "android",
@@ -12891,7 +12891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1596,
+      "line": 1609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -12899,7 +12899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1597,
+      "line": 1610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -12907,7 +12907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1598,
+      "line": 1611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -12915,7 +12915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1602,
+      "line": 1615,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -12923,7 +12923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1603,
+      "line": 1616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -12931,7 +12931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1604,
+      "line": 1617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -12939,7 +12939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1686,
+      "line": 1699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12947,7 +12947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1687,
+      "line": 1700,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -12955,7 +12955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1688,
+      "line": 1701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -12963,7 +12963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1689,
+      "line": 1702,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12971,7 +12971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1716,
+      "line": 1729,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Image",
       "surface": "android",
@@ -12979,7 +12979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1732,
+      "line": 1745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Additional images hidden: ${omittedImageCount}",
       "surface": "android",
@@ -12987,7 +12987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1787,
+      "line": 1800,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12995,7 +12995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1787,
+      "line": 1800,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -13003,7 +13003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1818,
+      "line": 1831,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close",
       "surface": "android",
@@ -13011,7 +13011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1818,
+      "line": 1831,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -13019,7 +13019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1848,
+      "line": 1861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -13027,7 +13027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1850,
+      "line": 1863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -13035,7 +13035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1853,
+      "line": 1866,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -13043,7 +13043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1919,
+      "line": 1932,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$completedCount/${steps.size}",
       "surface": "android",
@@ -13051,7 +13051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1926,
+      "line": 1939,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Collapse plan checklist",
       "surface": "android",
@@ -13059,7 +13059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1926,
+      "line": 1939,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Expand plan checklist",
       "surface": "android",
@@ -13067,7 +13067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2058,
+      "line": 2071,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dismiss shared-image warning",
       "surface": "android",
@@ -13075,7 +13075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2161,
+      "line": 2174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -13083,7 +13083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2248,
+      "line": 2261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Switch branch",
       "surface": "android",
@@ -13091,7 +13091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2272,
+      "line": 2285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Untitled branch",
       "surface": "android",
@@ -13099,7 +13099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2287,
+      "line": 2300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current branch",
       "surface": "android",
@@ -13107,7 +13107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2299,
+      "line": 2312,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages: $count",
       "surface": "android",
@@ -13115,7 +13115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2307,
+      "line": 2320,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$count · $updated",
       "surface": "android",
@@ -13123,7 +13123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2336,
+      "line": 2349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -13131,7 +13131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2402,
+      "line": 2415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -13139,7 +13139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2402,
+      "line": 2415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -13147,7 +13147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2419,
+      "line": 2432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -13155,7 +13155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2461,
+      "line": 2474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Command",
       "surface": "android",
@@ -13163,7 +13163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2481,
+      "line": 2494,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -13171,7 +13171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2527,
+      "line": 2540,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -13179,7 +13179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2527,
+      "line": 2540,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -13187,7 +13187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2592,
+      "line": 2605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -13195,7 +13195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2597,
+      "line": 2610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attachment",
       "surface": "android",
@@ -13203,7 +13203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2628,
+      "line": 2641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -13211,7 +13211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2657,
+      "line": 2670,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -13219,7 +13219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2657,
+      "line": 2670,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -13227,7 +13227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2742,
+      "line": 2755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -13235,7 +13235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2751,
+      "line": 2764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -13243,7 +13243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2763,
+      "line": 2776,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -13251,7 +13251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2772,
+      "line": 2785,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -13259,7 +13259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2773,
+      "line": 2786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -13267,7 +13267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2780,
+      "line": 2793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -13275,7 +13275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2839,
+      "line": 2852,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -13283,7 +13283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2850,
+      "line": 2863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -13291,7 +13291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2851,
+      "line": 2864,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -13299,7 +13299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2852,
+      "line": 2865,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -13307,7 +13307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2871,
+      "line": 2884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -13315,7 +13315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2872,
+      "line": 2885,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -13323,7 +13323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2873,
+      "line": 2886,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -13331,7 +13331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2912,
+      "line": 2925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -13339,7 +13339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2913,
+      "line": 2926,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -13347,7 +13347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2914,
+      "line": 2927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -13355,7 +13355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2915,
+      "line": 2928,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -13363,7 +13363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2916,
+      "line": 2929,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -13371,7 +13371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2917,
+      "line": 2930,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -13379,7 +13379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2918,
+      "line": 2931,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -13387,7 +13387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2919,
+      "line": 2932,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",
@@ -13435,23 +13435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 227,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
-      "source": "1 token",
-      "surface": "android",
-      "id": "native.android.c2dc3a65302976c0"
-    },
-    {
-      "kind": "ui-call",
-      "line": 229,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
-      "source": "$count tokens",
-      "surface": "android",
-      "id": "native.android.e7059e3a756908c4"
-    },
-    {
-      "kind": "ui-call",
-      "line": 239,
+      "line": 230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "Done in $duration",
       "surface": "android",
@@ -13459,7 +13443,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 271,
+      "line": 246,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
+      "source": "1 token",
+      "surface": "android",
+      "id": "native.android.c2dc3a65302976c0"
+    },
+    {
+      "kind": "ui-call",
+      "line": 248,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
+      "source": "$count tokens",
+      "surface": "android",
+      "id": "native.android.e7059e3a756908c4"
+    },
+    {
+      "kind": "ui-call",
+      "line": 273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "${decimal(count / 1_000_000.0)}M",
       "surface": "android",
@@ -13467,7 +13467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 278,
+      "line": 280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "${thousands}k",
       "surface": "android",
@@ -13475,7 +13475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 358,
+      "line": 387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${days}d",
       "surface": "android",
@@ -13483,7 +13483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 362,
+      "line": 391,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -13491,7 +13491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 366,
+      "line": 395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -13499,7 +13499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 370,
+      "line": 399,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${seconds}s",
       "surface": "android",
@@ -13507,7 +13507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 405,
+      "line": 440,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Shelling",
       "surface": "android",
@@ -13515,7 +13515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 406,
+      "line": 441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Scuttling",
       "surface": "android",
@@ -13523,7 +13523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 407,
+      "line": 442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Clawing",
       "surface": "android",
@@ -13531,7 +13531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 408,
+      "line": 443,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Pinching",
       "surface": "android",
@@ -13539,7 +13539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 409,
+      "line": 444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Molting",
       "surface": "android",
@@ -13547,7 +13547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 410,
+      "line": 445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Bubbling",
       "surface": "android",
@@ -13555,7 +13555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 411,
+      "line": 446,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Tiding",
       "surface": "android",
@@ -13563,7 +13563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 412,
+      "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Reefing",
       "surface": "android",
@@ -13571,7 +13571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 413,
+      "line": 448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Cracking",
       "surface": "android",
@@ -13579,7 +13579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 414,
+      "line": 449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Sifting",
       "surface": "android",
@@ -13587,7 +13587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 415,
+      "line": 450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Brining",
       "surface": "android",
@@ -13595,7 +13595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 416,
+      "line": 451,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Nautiling",
       "surface": "android",
@@ -13603,7 +13603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 417,
+      "line": 452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Krilling",
       "surface": "android",
@@ -13611,7 +13611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 418,
+      "line": 453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Barnacling",
       "surface": "android",
@@ -13619,7 +13619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 419,
+      "line": 454,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Lobstering",
       "surface": "android",
@@ -13627,7 +13627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 420,
+      "line": 455,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Tidepooling",
       "surface": "android",
@@ -13635,7 +13635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 421,
+      "line": 456,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Pearling",
       "surface": "android",
@@ -13643,7 +13643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 422,
+      "line": 457,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Snapping",
       "surface": "android",
@@ -13651,7 +13651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 423,
+      "line": 458,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Surfacing",
       "surface": "android",
@@ -40323,7 +40323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 749,
+      "line": 752,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -40331,7 +40331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 783,
+      "line": 791,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -40339,7 +40339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 786,
+      "line": 794,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -40347,7 +40347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 794,
+      "line": 802,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -40355,7 +40355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 795,
+      "line": 803,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -41539,7 +41539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 578,
+      "line": 579,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -41547,7 +41547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 592,
+      "line": 593,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -41555,7 +41555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 628,
+      "line": 629,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -41563,7 +41563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 631,
+      "line": 632,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -41571,7 +41571,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 728,
+      "line": 729,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -41579,7 +41579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 748,
+      "line": 749,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -41587,7 +41587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1164,
+      "line": 1166,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -41595,7 +41595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1187,
+      "line": 1189,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
@@ -41603,7 +41603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1206,
+      "line": 1208,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Rewind to Here",
       "surface": "apple",
@@ -41611,7 +41611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1226,
+      "line": 1228,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Fork from Here",
       "surface": "apple",
@@ -41619,7 +41619,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1252,
+      "line": 1254,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -41627,7 +41627,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1262,
+      "line": 1264,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -41635,7 +41635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1264,
+      "line": 1266,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -41643,7 +41643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1330,
+      "line": 1332,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -41651,7 +41651,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1410,
+      "line": 1412,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -41715,7 +41715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 74,
+      "line": 76,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "\\(invocation) ",
       "surface": "apple",
@@ -41723,7 +41723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 332,
+      "line": 334,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "See attached.",
       "surface": "apple",
@@ -41731,7 +41731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 742,
+      "line": 744,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -41739,7 +41739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 742,
+      "line": 744,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -41763,7 +41763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1231,
+      "line": 1245,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -42275,7 +42275,15 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 135,
+      "line": 118,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "1 second",
+      "surface": "apple",
+      "id": "native.apple.286932b5ea17b3f8"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 153,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Done in %@",
       "surface": "apple",
@@ -42283,7 +42291,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 145,
+      "line": 163,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "1 token",
       "surface": "apple",
@@ -42291,7 +42299,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 148,
+      "line": 166,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "%@ tokens",
       "surface": "apple",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app
 
 import ai.openclaw.app.chat.BackgroundTask
+import ai.openclaw.app.chat.ChatActiveRunPresentation
 import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.ChatMessage
@@ -651,6 +652,8 @@ class MainViewModel private constructor(
   val chatSessionBranchesLoading: StateFlow<Boolean> = runtimeState(initial = false) { it.chatSessionBranchesLoading }
   val chatSessionBranchSwitching: StateFlow<Boolean> = runtimeState(initial = false) { it.chatSessionBranchSwitching }
   val pendingRunCount: StateFlow<Int> = runtimeState(initial = 0) { it.pendingRunCount }
+  internal val chatSelectedActiveRunPresentation: StateFlow<ChatActiveRunPresentation> =
+    runtimeState(initial = ChatActiveRunPresentation()) { it.chatSelectedActiveRunPresentation }
   val chatCommands: StateFlow<List<ChatCommandEntry>> = runtimeState(initial = emptyList<ChatCommandEntry>()) { it.chatCommands }
   val chatOutboxItems: StateFlow<List<ChatOutboxItem>> = runtimeState(initial = emptyList()) { it.chatOutboxItems }
   val chatOutboxPresentationRestored: StateFlow<Boolean> = runtimeState(initial = false) { it.chatOutboxPresentationRestored }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2,6 +2,7 @@ package ai.openclaw.app
 
 import ai.openclaw.app.chat.AndroidClientDatabases
 import ai.openclaw.app.chat.BackgroundTask
+import ai.openclaw.app.chat.ChatActiveRunPresentation
 import ai.openclaw.app.chat.ChatCacheScope
 import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatCommandOutbox
@@ -2787,6 +2788,8 @@ class NodeRuntime private constructor(
   val chatSessionBranchesLoading: StateFlow<Boolean> = chat.sessionBranchesLoading
   val chatSessionBranchSwitching: StateFlow<Boolean> = chat.sessionBranchSwitching
   val pendingRunCount: StateFlow<Int> = chat.pendingRunCount
+  internal val chatSelectedActiveRunPresentation: StateFlow<ChatActiveRunPresentation> =
+    chat.selectedActiveRunPresentation
   val chatCommands: StateFlow<List<ChatCommandEntry>> = chat.commands
   val chatOutboxItems: StateFlow<List<ChatOutboxItem>> = chat.outboxItems
   val chatOutboxPresentationRestored: StateFlow<Boolean> = chat.outboxPresentationRestored

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -282,6 +282,10 @@ class ChatController internal constructor(
   private val _pendingRunCount = MutableStateFlow(0)
   val pendingRunCount: StateFlow<Int> = _pendingRunCount.asStateFlow()
 
+  private val selectedActiveRunPresentationState = MutableStateFlow(ChatActiveRunPresentation())
+  internal val selectedActiveRunPresentation: StateFlow<ChatActiveRunPresentation> =
+    selectedActiveRunPresentationState.asStateFlow()
+
   private val _streamingAssistantText = MutableStateFlow<String?>(null)
   val streamingAssistantText: StateFlow<String?> = _streamingAssistantText.asStateFlow()
 
@@ -383,7 +387,15 @@ class ChatController internal constructor(
       ?: error("Gateway returned no background task")
   }
 
+  private data class LiveRunTelemetryState(
+    val highestSequence: Long,
+    val outputTokens: Long? = null,
+    val terminal: Boolean = false,
+  )
+
   private val pendingRuns = mutableSetOf<String>()
+  private val liveRunTelemetryLock = Any()
+  private val liveRunTelemetryByRunId = mutableMapOf<String, LiveRunTelemetryState>()
   private val disconnectedPendingRunIds = mutableSetOf<String>()
   private val timedOutRunIds = ConcurrentHashMap.newKeySet<String>()
   private val terminalWithoutReplyRunIds = ConcurrentHashMap.newKeySet<String>()
@@ -650,6 +662,7 @@ class ChatController internal constructor(
       )
       clearLiveHistoryMarker()
       _sessions.value = emptyList()
+      publishRunPresentation()
       clearQuestions()
       applyThinkingMetadata(null)
       sessionsListArchived = false
@@ -2473,6 +2486,7 @@ class ChatController internal constructor(
     if (ownsCapturedUi()) projectRunToCurrentOwner()
 
     fun settleProjectedRun(settledRunId: String) {
+      retireRunTelemetry(settledRunId)
       clearPendingRun(settledRunId)
       removeOptimisticMessage(settledRunId)
       unresolvedRepliesByRunId.remove(settledRunId)
@@ -2614,6 +2628,160 @@ class ChatController internal constructor(
       mainSessionKey = appliedMainSessionKey,
     )
 
+  private fun currentSelectedSession(): ChatSessionEntry? = _sessions.value.firstOrNull { it.key == _sessionKey.value }
+
+  private fun advertisedRunIds(session: ChatSessionEntry? = currentSelectedSession()): List<String> =
+    session
+      ?.activeRunIds
+      .orEmpty()
+      .mapNotNull { it.trim().takeIf(String::isNotEmpty) }
+      .distinct()
+
+  private fun publishRunPresentation() {
+    val localRunIds = synchronized(pendingRuns) { pendingRuns.toSet() }
+    val session = currentSelectedSession()
+    val rawAdvertisedRunIds = advertisedRunIds(session)
+    val telemetry = synchronized(liveRunTelemetryLock) { liveRunTelemetryByRunId.toMap() }
+    val liveLocalRunIds = localRunIds.filterTo(mutableSetOf()) { telemetry[it]?.terminal != true }
+    val liveAdvertisedRunIds = rawAdvertisedRunIds.filter { telemetry[it]?.terminal != true }
+    val selectedRunId =
+      resolvePreferredActiveRunId(
+        localRunIds = liveLocalRunIds,
+        advertisedRunIds = liveAdvertisedRunIds,
+      )
+    val hasUnknownAdvertisedRun =
+      session?.hasActiveRun == true &&
+        (rawAdvertisedRunIds.isEmpty() || liveAdvertisedRunIds.isNotEmpty())
+    val activeCount =
+      resolveSelectedActiveRunCount(
+        localRunIds = liveLocalRunIds,
+        advertisedRunIds = liveAdvertisedRunIds,
+        hasAdvertisedRun = hasUnknownAdvertisedRun,
+      )
+    val clockKey =
+      when {
+        selectedRunId != null && selectedRunId in liveLocalRunIds ->
+          pendingRunProjectionsByRunId[selectedRunId]?.optimisticMessage?.id
+            ?: optimisticMessagesByRunId[selectedRunId]?.id
+            ?: unresolvedRepliesByRunId[selectedRunId]?.id
+            ?: selectedRunId
+        selectedRunId != null -> selectedRunId
+        activeCount > 0 -> session?.startedAt?.let { "${_sessionKey.value}:active:$it" } ?: "${_sessionKey.value}:active"
+        else -> null
+      }
+    _pendingRunCount.value = localRunIds.size
+    selectedActiveRunPresentationState.value =
+      ChatActiveRunPresentation(
+        count = activeCount,
+        runId = selectedRunId,
+        clockKey = clockKey,
+        outputTokens = selectedRunId?.let { telemetry[it]?.outputTokens },
+      )
+  }
+
+  private fun pruneRunTelemetryToAuthoritativeOwnership() {
+    val session = currentSelectedSession() ?: return
+    if (!session.hasActiveRunMetadata) return
+    val localRunIds = synchronized(pendingRuns) { pendingRuns.toSet() }
+    val authoritativeRunIds = advertisedRunIds(session).toSet()
+    synchronized(liveRunTelemetryLock) {
+      liveRunTelemetryByRunId.keys.removeAll { it !in localRunIds && it !in authoritativeRunIds }
+    }
+  }
+
+  private fun clearUnownedNonterminalTelemetry(runId: String) {
+    val advertised = runId in advertisedRunIds()
+    synchronized(liveRunTelemetryLock) {
+      if (!advertised && liveRunTelemetryByRunId[runId]?.terminal != true) {
+        liveRunTelemetryByRunId.remove(runId)
+      }
+    }
+  }
+
+  private fun clearAllRunTelemetry() {
+    synchronized(liveRunTelemetryLock) { liveRunTelemetryByRunId.clear() }
+  }
+
+  private fun recordLiveRunUsage(
+    runId: String,
+    sequence: Long,
+    outputTokens: Long,
+  ): Boolean =
+    synchronized(liveRunTelemetryLock) {
+      val current = liveRunTelemetryByRunId[runId]
+      if (current?.terminal == true || sequence <= (current?.highestSequence ?: 0L)) {
+        return@synchronized false
+      }
+      val nextOutputTokens = maxOf(outputTokens, current?.outputTokens ?: 0L)
+      liveRunTelemetryByRunId[runId] =
+        LiveRunTelemetryState(
+          highestSequence = sequence,
+          outputTokens = nextOutputTokens,
+        )
+      nextOutputTokens != current?.outputTokens
+    }
+
+  private fun applyLiveRunLifecycle(
+    runId: String,
+    sequence: Long,
+    terminal: Boolean,
+  ): Boolean =
+    synchronized(liveRunTelemetryLock) {
+      val current = liveRunTelemetryByRunId[runId]
+      if (current?.terminal == true || sequence <= (current?.highestSequence ?: 0L)) {
+        return@synchronized false
+      }
+      liveRunTelemetryByRunId[runId] =
+        LiveRunTelemetryState(
+          highestSequence = sequence,
+          outputTokens = current?.outputTokens,
+          terminal = terminal,
+        )
+      true
+    }
+
+  private fun retireRunTelemetry(runId: String) {
+    synchronized(liveRunTelemetryLock) {
+      val current = liveRunTelemetryByRunId[runId]
+      liveRunTelemetryByRunId[runId] =
+        LiveRunTelemetryState(
+          highestSequence = current?.highestSequence ?: 0L,
+          outputTokens = current?.outputTokens,
+          terminal = true,
+        )
+    }
+  }
+
+  private fun invalidateIncompleteRunTelemetry() {
+    synchronized(liveRunTelemetryLock) {
+      liveRunTelemetryByRunId.toMap().forEach { (runId, state) ->
+        if (!state.terminal && state.outputTokens != null) {
+          liveRunTelemetryByRunId[runId] = state.copy(outputTokens = null)
+        }
+      }
+    }
+  }
+
+  private fun transferRunTelemetry(
+    oldRunId: String,
+    newRunId: String,
+  ) {
+    synchronized(liveRunTelemetryLock) {
+      val old = liveRunTelemetryByRunId.remove(oldRunId) ?: return@synchronized
+      val existing = liveRunTelemetryByRunId[newRunId]
+      liveRunTelemetryByRunId[newRunId] =
+        if (existing == null) {
+          old
+        } else {
+          LiveRunTelemetryState(
+            highestSequence = maxOf(old.highestSequence, existing.highestSequence),
+            outputTokens = listOfNotNull(old.outputTokens, existing.outputTokens).maxOrNull(),
+            terminal = old.terminal || existing.terminal,
+          )
+        }
+    }
+  }
+
   private fun projectPendingRun(projection: PendingRunProjection) {
     if (projection.owner != currentChatComposerRoutingOwner()) {
       unprojectPendingRun(projection.runId)
@@ -2632,15 +2800,13 @@ class ChatController internal constructor(
       _messages.value = _messages.value + optimisticMessage
     }
     armPendingRunTimeout(runId)
-    synchronized(pendingRuns) {
-      pendingRuns.add(runId)
-      _pendingRunCount.value = pendingRuns.size
-    }
+    synchronized(pendingRuns) { pendingRuns.add(runId) }
     updateErrorText(null)
     _streamingAssistantText.value = null
     pendingToolCallsById.clear()
     publishPendingToolCalls()
     clearPlanSteps()
+    publishRunPresentation()
   }
 
   /** Hides another owner's live run without discarding the ownership needed to restore it. */
@@ -2651,10 +2817,11 @@ class ChatController internal constructor(
     synchronized(pendingRuns) {
       disconnectedPendingRunIds.remove(runId)
       pendingRuns.remove(runId)
-      _pendingRunCount.value = pendingRuns.size
     }
+    clearUnownedNonterminalTelemetry(runId)
     clearTransientRunUiIfIdle()
     if (pendingRunProjectionsByRunId.containsKey(runId)) armPendingRunProjectionDeadline(runId)
+    publishRunPresentation()
   }
 
   /** Bounds hidden run ownership when its terminal event is lost before the owner is revisited. */
@@ -2780,6 +2947,14 @@ class ChatController internal constructor(
       unknownOutcomeRunIds.contains(runId) ||
       unresolvedRepliesByRunId.containsKey(runId)
 
+  private fun locallyOwnedRunIds(): Set<String> =
+    buildSet {
+      addAll(synchronized(pendingRuns) { pendingRuns.toSet() })
+      addAll(pendingRunProjectionsByRunId.keys)
+      addAll(unknownOutcomeRunIds)
+      addAll(unresolvedRepliesByRunId.keys)
+    }
+
   private fun sameOutboxSession(
     left: String,
     right: String,
@@ -2880,10 +3055,11 @@ class ChatController internal constructor(
         }
       }
       "seqGap" -> {
-        // Missed events may include deltas or the terminal state of a pending run;
-        // retain local ownership until the recovery snapshot can reconcile it.
+        // Missed events can hide terminal state or usage for any active run.
+        // Keep ownership, discard incomplete telemetry, and recover from snapshots.
         resetSwarmProgress()
         if (isSwarmEnabled()) refreshSwarmSessions()
+        invalidateIncompleteRunTelemetry()
         clearLiveRunUi()
         refreshQuestions()
         refreshHistoryForRecovery()
@@ -3336,10 +3512,10 @@ class ChatController internal constructor(
         val restored = disconnectedPendingRunIds.toSet()
         pendingRuns.addAll(restored)
         disconnectedPendingRunIds.clear()
-        _pendingRunCount.value = pendingRuns.size
         restored
       }
     restoredRunIds.forEach(::armPendingRunTimeout)
+    publishRunPresentation()
     val runIdsToReconcile =
       synchronized(pendingRuns) {
         pendingRuns + optimisticMessagesByRunId.keys + unresolvedRepliesByRunId.keys
@@ -3498,7 +3674,7 @@ class ChatController internal constructor(
           }
         latestAppliedHistoryRequest = requestSequence
         if (updateSessionInfo) {
-          updateSessionFromHistory(history)
+          updateSessionFromHistory(history, publishRunState = false)
           if (requestModelSelectionGeneration == modelSelectionGeneration.get()) {
             _selectedModelRef.value = history.sessionInfo?.providerQualifiedModelRef()
           }
@@ -3518,7 +3694,7 @@ class ChatController internal constructor(
             .filterNot { runId ->
               unknownOutcomeRunIds.contains(runId) && unresolvedRepliesByRunId.containsKey(runId)
             }.filterNotTo(mutableSetOf()) { optimisticMessagesByRunId.containsKey(it) }
-            .forEach(::clearPendingRun)
+            .forEach { clearPendingRun(it, publishRunState = false) }
         }
         if (snapshotRunId != null) {
           runIdsToReconcile
@@ -3526,7 +3702,7 @@ class ChatController internal constructor(
               it != snapshotRunId &&
                 !optimisticMessagesByRunId.containsKey(it) &&
                 !unresolvedRepliesByRunId.containsKey(it)
-            }.forEach(::clearPendingRun)
+            }.forEach { clearPendingRun(it, publishRunState = false) }
         }
         val nextMessages = mergeOptimisticMessages(incoming = history.messages, optimistic = optimisticMessagesByRunId.values)
         _messagesFromCache.value = false
@@ -3557,13 +3733,14 @@ class ChatController internal constructor(
           runIdsToReconcile
             .filterNot { runId ->
               unknownOutcomeRunIds.contains(runId) && unresolvedRepliesByRunId.containsKey(runId)
-            }.forEach(::clearPendingRun)
+            }.forEach { clearPendingRun(it, publishRunState = false) }
         }
         clearTransientRunUiIfIdle(preservePlan = true)
         // All live history paths (bootstrap, reconnect recovery, cache-first
         // replace) adopt the gateway's in-flight run snapshot so restored
         // runs keep their pending state and streaming text.
         adoptInFlightRun(history, runIdsOwnedAfterRequest)
+        publishRunPresentation()
         history.thinkingLevel
           ?.trim()
           ?.takeIf { it.isNotEmpty() }
@@ -3858,6 +4035,8 @@ class ChatController internal constructor(
         ) {
           continue
         }
+        pruneRunTelemetryToAuthoritativeOwnership()
+        publishRunPresentation()
         unreadPatchSessionKey?.let { trackedKey ->
           acknowledgeUnreadIfNeeded(
             key = trackedKey,
@@ -5160,7 +5339,10 @@ class ChatController internal constructor(
           }
           return
         }
-        if (runId != null) lastHandledTerminalRunId = runId
+        if (runId != null) {
+          lastHandledTerminalRunId = runId
+          retireRunTelemetry(runId)
+        }
         if (wasTimedOut) {
           val hasNewerRun =
             synchronized(pendingRuns) { pendingRuns.isNotEmpty() } || unresolvedRepliesByRunId.isNotEmpty()
@@ -5175,11 +5357,13 @@ class ChatController internal constructor(
               },
             )
           }
+          publishRunPresentation()
           refreshCurrentHistoryBestEffort(updateSessionInfo = true)
           return
         }
         if (runId != null && !isPending) {
           if (resolvesWithoutReply) terminalWithoutReplyRunIds.add(runId)
+          publishRunPresentation()
           refreshCurrentHistoryBestEffort(
             runIdsToReconcile = setOf(runId),
             updateSessionInfo = true,
@@ -5189,17 +5373,20 @@ class ChatController internal constructor(
         if (state == "error") {
           updateLocalizedErrorText(payload["errorMessage"].asStringOrNull()?.let(::verbatimText) ?: nativeText("Chat failed"))
         }
+        val terminalRunIds =
+          runId?.let(::setOf)
+            ?: (synchronized(pendingRuns) { pendingRuns.toSet() } + unresolvedRepliesByRunId.keys)
         if (runId != null) {
           clearPendingRun(runId)
           if (resolvesWithoutReply) {
             terminalWithoutReplyRunIds.add(runId)
           }
         } else {
-          clearPendingRuns(clearOptimisticMessages = false)
+          terminalRunIds.forEach(::retireRunTelemetry)
+          clearPendingRuns(clearOptimisticMessages = false, clearRunTelemetry = false)
         }
         clearLiveRunUi()
         clearPlanStepsFor(runId)
-        val terminalRunIds = runId?.let(::setOf) ?: unresolvedRepliesByRunId.keys.toSet()
         refreshCurrentHistoryBestEffort(
           runIdsToReconcile = terminalRunIds,
           updateSessionInfo = true,
@@ -5347,10 +5534,31 @@ class ChatController internal constructor(
     }
     if (eventOwner != visibleOwner) return
     val ownedEntry = reconcileSessionObserverProjectionOwner(entry, eventOwner)
+    val phase = payload["phase"].asStringOrNull()
+    val terminalRunId =
+      payload["runId"]
+        .asStringOrNull()
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+        ?.takeIf { phase == "end" || phase == "error" }
+    val terminalWasLocal = terminalRunId?.let(::isLocallyOwnedRun) == true
+    val terminalWasAdvertised = terminalRunId?.let { it in advertisedRunIds() } == true
+    val settlesSelectedRun = terminalRunId != null && (terminalWasLocal || terminalWasAdvertised)
     upsertSessionEntry(
       entry = if (ownedEntry.ownerAgentId == eventOwner) ownedEntry else ownedEntry.copy(ownerAgentId = eventOwner),
       clearedFields = parseExplicitSessionClears(eventObject),
+      publishRunState = !settlesSelectedRun,
     )
+    if (!settlesSelectedRun) return
+    val settledRunId = terminalRunId
+    if (!entry.hasActiveRunMetadata) retireRunTelemetry(settledRunId)
+    if (terminalWasLocal) {
+      clearPendingRun(settledRunId)
+      clearPlanStepsFor(settledRunId)
+      clearTransientRunUiIfIdle()
+    } else {
+      publishRunPresentation()
+    }
   }
 
   private fun eventSessionObject(payload: JsonObject): JsonObject? = payload["session"].asObjectOrNull() ?: payload.takeIf { it["key"].asStringOrNull() != null }
@@ -5363,24 +5571,73 @@ class ChatController internal constructor(
       if (obj["category"] is JsonNull) add("category")
     }
 
+  private fun isLocallyOwnedRun(runId: String): Boolean = synchronized(pendingRuns) { runId in pendingRuns } || unresolvedRepliesByRunId.containsKey(runId)
+
+  private fun ownsLiveRunTelemetry(runId: String): Boolean = isLocallyOwnedRun(runId) || runId in advertisedRunIds()
+
+  private fun parseAgentEventSequence(payload: JsonObject): Long? {
+    val raw = payload["seq"] as? JsonPrimitive ?: return null
+    if (raw.isString) return null
+    return raw.asLongOrNull()?.takeIf { it > 0L }
+  }
+
+  private fun parsePositiveOutputTokens(data: JsonObject?): Long? {
+    val raw = data?.get("outputTokens") as? JsonPrimitive ?: return null
+    if (raw.isString) return null
+    return raw.asLongOrNull()?.takeIf { it > 0L }
+  }
+
   private fun handleAgentEvent(payloadJson: String) {
     val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return
     val sessionKey = payload["sessionKey"].asStringOrNull()?.trim()
     if (!sessionKey.isNullOrEmpty() && sessionKey != _sessionKey.value) return
-    val runId = payload["runId"].asStringOrNull()
+    val runId = payload["runId"].asStringOrNull()?.trim()?.takeIf(String::isNotEmpty)
     val projection = runId?.let(pendingRunProjectionsByRunId::get)
     if (projection != null && projection.owner != currentChatComposerRoutingOwner()) return
-    if (
-      runId != null &&
-      synchronized(pendingRuns) { runId !in pendingRuns } &&
-      !unresolvedRepliesByRunId.containsKey(runId)
-    ) {
-      return
-    }
 
     val stream = payload["stream"].asStringOrNull()
     val data = payload["data"].asObjectOrNull()
+    if (stream == "usage") {
+      val usageRunId = runId?.takeIf(::ownsLiveRunTelemetry) ?: return
+      val sequence = parseAgentEventSequence(payload) ?: return
+      val outputTokens = parsePositiveOutputTokens(data) ?: return
+      if (recordLiveRunUsage(usageRunId, sequence, outputTokens)) publishRunPresentation()
+      return
+    }
+    if (stream == "lifecycle") {
+      val phase = data?.get("phase").asStringOrNull()
+      val isTerminal = phase == "end" || phase == "error"
+      if (runId != null && !ownsLiveRunTelemetry(runId)) return
+      if (runId == null && !isTerminal) return
+      val lifecycleRunId = runId ?: locallyOwnedRunIds().singleOrNull() ?: return
+      val sequence = parseAgentEventSequence(payload)
+      when (phase) {
+        "start" -> {
+          val orderedSequence = sequence ?: return
+          if (applyLiveRunLifecycle(lifecycleRunId, orderedSequence, terminal = false)) publishRunPresentation()
+        }
+        "end", "error" -> {
+          val accepted =
+            if (sequence == null) {
+              retireRunTelemetry(lifecycleRunId)
+              true
+            } else {
+              applyLiveRunLifecycle(lifecycleRunId, sequence, terminal = true)
+            }
+          if (!accepted) return
+          if (isLocallyOwnedRun(lifecycleRunId)) {
+            clearPendingRun(lifecycleRunId)
+            clearPlanStepsFor(lifecycleRunId)
+            clearTransientRunUiIfIdle()
+          } else {
+            publishRunPresentation()
+          }
+        }
+      }
+      return
+    }
 
+    if (runId != null && !isLocallyOwnedRun(runId)) return
     when (stream) {
       "assistant" -> {
         val text = data?.get("text")?.asStringOrNull()
@@ -5419,9 +5676,16 @@ class ChatController internal constructor(
       }
       "error" -> {
         updateLocalizedErrorText(nativeText("Event stream interrupted; try refreshing."))
-        clearPendingRuns()
-        clearLiveRunUi()
-        clearPlanSteps()
+        if (runId == null) {
+          clearPendingRuns()
+        } else {
+          clearPendingRun(runId)
+          clearPlanStepsFor(runId)
+          clearTransientRunUiIfIdle()
+        }
+        pendingToolCallsById.clear()
+        publishPendingToolCalls()
+        _streamingAssistantText.value = null
       }
     }
   }
@@ -5494,7 +5758,6 @@ class ChatController internal constructor(
       if (pendingRuns.isNotEmpty() && runId !in pendingRuns) return
       if (pendingRuns.isEmpty() && unresolvedRepliesByRunId.isNotEmpty() && !unresolvedRepliesByRunId.containsKey(runId)) return
       pendingRuns.add(runId)
-      _pendingRunCount.value = pendingRuns.size
     }
     armPendingRunTimeout(runId)
     if (run.text.isNotEmpty()) {
@@ -5584,15 +5847,19 @@ class ChatController internal constructor(
     publishOutbox()
   }
 
-  private fun clearPendingRun(runId: String) {
+  private fun clearPendingRun(
+    runId: String,
+    publishRunState: Boolean = true,
+  ) {
     pendingRunProjectionsByRunId.remove(runId)
     pendingRunTimeoutJobs.remove(runId)?.cancel()
     unknownOutcomeRunIds.remove(runId)
     synchronized(pendingRuns) {
       disconnectedPendingRunIds.remove(runId)
       pendingRuns.remove(runId)
-      _pendingRunCount.value = pendingRuns.size
     }
+    clearUnownedNonterminalTelemetry(runId)
+    if (publishRunState) publishRunPresentation()
   }
 
   private fun clearTransientRunUiIfIdle(preservePlan: Boolean = false) {
@@ -5604,6 +5871,7 @@ class ChatController internal constructor(
   private fun clearPendingRuns(
     clearOptimisticMessages: Boolean = true,
     preserveDisconnectedOwnership: Boolean = false,
+    clearRunTelemetry: Boolean = true,
   ) {
     for ((_, job) in pendingRunTimeoutJobs) {
       job.cancel()
@@ -5624,11 +5892,12 @@ class ChatController internal constructor(
         disconnectedPendingRunIds.clear()
       }
       pendingRuns.clear()
-      _pendingRunCount.value = 0
     }
+    if (clearRunTelemetry) clearAllRunTelemetry()
     pendingRunProjectionsByRunId.keys
       .filterNot { runId -> synchronized(pendingRuns) { runId in pendingRuns } }
       .forEach(::armPendingRunProjectionDeadline)
+    publishRunPresentation()
   }
 
   private fun removeOptimisticMessage(runId: String) {
@@ -5641,6 +5910,7 @@ class ChatController internal constructor(
     newRunId: String,
     fallbackMessage: ChatMessage,
     messageIdempotencyKey: String? = fallbackMessage.idempotencyKey,
+    publishRunState: Boolean = true,
   ) {
     if (oldRunId == newRunId) return
     val pendingProjection = pendingRunProjectionsByRunId.remove(oldRunId)
@@ -5649,6 +5919,7 @@ class ChatController internal constructor(
     val wasPending = synchronized(pendingRuns) { oldRunId in pendingRuns }
     val terminalWithoutReply = terminalWithoutReplyRunIds.remove(oldRunId)
     unknownOutcomeRunIds.remove(oldRunId)
+    pendingRunTimeoutJobs.remove(oldRunId)?.cancel()
     val original = optimistic ?: unresolved ?: fallbackMessage
     // Run ownership can change independently of the client key persisted on the
     // user row. Only history proof may replace that transcript identity.
@@ -5657,15 +5928,14 @@ class ChatController internal constructor(
     if (unresolved != null) unresolvedRepliesByRunId[newRunId] = rekeyed
     if (terminalWithoutReply) terminalWithoutReplyRunIds.add(newRunId)
     _messages.value = _messages.value.map { if (it.id == original.id) rekeyed else it }
-    clearPendingRun(oldRunId)
     val wasProjected = optimistic != null || unresolved != null || wasPending
-    if (wasProjected) {
-      synchronized(pendingRuns) {
-        pendingRuns.add(newRunId)
-        _pendingRunCount.value = pendingRuns.size
-      }
-      armPendingRunTimeout(newRunId)
+    synchronized(pendingRuns) {
+      disconnectedPendingRunIds.remove(oldRunId)
+      pendingRuns.remove(oldRunId)
+      if (wasProjected) pendingRuns.add(newRunId)
     }
+    transferRunTelemetry(oldRunId, newRunId)
+    if (wasProjected) armPendingRunTimeout(newRunId)
     if (pendingProjection != null) {
       pendingRunProjectionsByRunId[newRunId] =
         pendingProjection.copy(
@@ -5674,6 +5944,7 @@ class ChatController internal constructor(
         )
       if (!wasProjected) armPendingRunProjectionDeadline(newRunId)
     }
+    if (publishRunState) publishRunPresentation()
   }
 
   private fun transferLostAckOwnershipFromHistory(history: ChatHistory) {
@@ -5704,6 +5975,7 @@ class ChatController internal constructor(
         newRunId = snapshotRunId,
         fallbackMessage = optimistic,
         messageIdempotencyKey = persistedUser.idempotencyKey,
+        publishRunState = false,
       )
     }
   }
@@ -6168,15 +6440,23 @@ class ChatController internal constructor(
     }
   }
 
-  private fun updateSessionFromHistory(history: ChatHistory) {
+  private fun updateSessionFromHistory(
+    history: ChatHistory,
+    publishRunState: Boolean = true,
+  ) {
     val info = history.sessionInfo ?: return
-    upsertSessionEntry(info, preserveExistingContextUsageWithoutTotal = true)
+    upsertSessionEntry(
+      info,
+      preserveExistingContextUsageWithoutTotal = true,
+      publishRunState = publishRunState,
+    )
   }
 
   private fun upsertSessionEntry(
     entry: ChatSessionEntry,
     preserveExistingContextUsageWithoutTotal: Boolean = false,
     clearedFields: Set<String> = emptySet(),
+    publishRunState: Boolean = true,
   ) {
     val current = _sessions.value
     val index = current.indexOfFirst { it.key == entry.key }
@@ -6204,6 +6484,8 @@ class ChatController internal constructor(
       }
     if (applied.key == _sessionKey.value) {
       applyThinkingMetadata(applied)
+      pruneRunTelemetryToAuthoritativeOwnership()
+      if (publishRunState) publishRunPresentation()
     }
     acknowledgeUnreadIfNeeded(applied.key, applied, requireActive = true)
   }
@@ -6755,6 +7037,27 @@ private fun JsonElement?.asBooleanOrNull(): Boolean? =
     is JsonPrimitive -> content.toBooleanStrictOrNull()
     else -> null
   }
+
+internal fun resolvePreferredActiveRunId(
+  localRunIds: Collection<String>,
+  advertisedRunIds: List<String>,
+): String? =
+  advertisedRunIds.firstOrNull(localRunIds::contains)
+    ?: localRunIds.minOrNull()
+    ?: advertisedRunIds.firstOrNull()
+
+internal fun resolveSelectedActiveRunCount(
+  localRunIds: Collection<String>,
+  advertisedRunIds: Collection<String>,
+  hasAdvertisedRun: Boolean,
+): Int =
+  maxOf(
+    buildSet {
+      addAll(localRunIds)
+      addAll(advertisedRunIds)
+    }.size,
+    if (hasAdvertisedRun) 1 else 0,
+  )
 
 internal fun mergeChatSessionEntry(
   existing: ChatSessionEntry,

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -3060,6 +3060,7 @@ class ChatController internal constructor(
         resetSwarmProgress()
         if (isSwarmEnabled()) refreshSwarmSessions()
         invalidateIncompleteRunTelemetry()
+        publishRunPresentation()
         clearLiveRunUi()
         refreshQuestions()
         refreshHistoryForRecovery()

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -182,6 +182,13 @@ internal val defaultChatThinkingLevelSelection =
     isGatewayProvided = false,
   )
 
+internal data class ChatActiveRunPresentation(
+  val count: Int = 0,
+  val runId: String? = null,
+  val clockKey: String? = null,
+  val outputTokens: Long? = null,
+)
+
 /**
  * Stable session selector row; [key] is the gateway session key used in chat requests.
  */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -396,9 +396,11 @@ private fun linkPreviewDomain(url: String): String =
 fun ChatTypingIndicatorBubble(
   runKey: String,
   observedAtElapsedMs: Long,
+  outputTokens: Long? = null,
 ) {
   val elapsedMs = rememberWorkingElapsedMs(observedAtElapsedMs)
   val phrase = workingPhraseText(seed = runKey, elapsedMs = elapsedMs)
+  val tokens = outputTokens?.let { localizedChatOutputTokens(it) }
   ChatBubbleContainer(
     style = bubbleStyle("assistant"),
     roleLabel = roleLabel("assistant"),
@@ -414,6 +416,10 @@ fun ChatTypingIndicatorBubble(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
       ) {
         Text(formatLocalizedChatDurationCompact(elapsedMs), style = mobileCallout, color = mobileTextSecondary)
+        tokens?.let {
+          Text(nativeStringResource("·"), style = mobileCallout, color = mobileTextSecondary)
+          Text(it, style = mobileCallout, color = mobileTextSecondary)
+        }
         phrase?.let { Text(nativeStringResource("· \$phrase", it), style = mobileCallout, color = mobileTextSecondary) }
       }
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -254,6 +254,7 @@ fun ChatScreen(
   val historyLoading by viewModel.chatHistoryLoading.collectAsState()
   val errorText by viewModel.chatError.collectAsState()
   val pendingRunCount by viewModel.pendingRunCount.collectAsState()
+  val selectedActiveRun by viewModel.chatSelectedActiveRunPresentation.collectAsState()
   val healthOk by viewModel.chatHealthOk.collectAsState()
   val gatewayConnectionDisplay by viewModel.gatewayConnectionDisplay.collectAsState()
   val activeGatewayStableId by viewModel.activeGatewayStableId.collectAsState()
@@ -681,7 +682,10 @@ fun ChatScreen(
       messages = messages,
       transcriptAnchor = transcriptAnchor,
       historyLoading = historyLoading,
-      pendingRunCount = pendingRunCount,
+      activeRunCount = selectedActiveRun.count,
+      activeRunId = selectedActiveRun.runId,
+      activeRunClockKey = selectedActiveRun.clockKey,
+      activeRunOutputTokens = selectedActiveRun.outputTokens,
       pendingToolCalls = pendingToolCalls,
       questions = questionsForSession(questions, sessionKey, mainSessionKey, activeAgentId),
       streamingAssistantText = streamingAssistantText,
@@ -1237,7 +1241,10 @@ private fun ChatMessageList(
   messages: List<ChatMessage>,
   transcriptAnchor: ChatTranscriptAnchorState?,
   historyLoading: Boolean,
-  pendingRunCount: Int,
+  activeRunCount: Int,
+  activeRunId: String?,
+  activeRunClockKey: String?,
+  activeRunOutputTokens: Long?,
   pendingToolCalls: List<ChatPendingToolCall>,
   questions: List<ChatQuestionPrompt>,
   streamingAssistantText: String?,
@@ -1261,10 +1268,10 @@ private fun ChatMessageList(
   modifier: Modifier = Modifier,
 ) {
   val baseTimeline =
-    remember(messages, pendingRunCount, pendingToolCalls, questions, streamingAssistantText, outboxItems, recoveryOutboxItems) {
+    remember(messages, activeRunCount, pendingToolCalls, questions, streamingAssistantText, outboxItems, recoveryOutboxItems) {
       buildChatTimeline(
         messages = messages,
-        pendingRunCount = pendingRunCount,
+        pendingRunCount = activeRunCount,
         pendingToolCalls = pendingToolCalls,
         streamingAssistantText = streamingAssistantText,
         outboxItems = outboxItems,
@@ -1272,9 +1279,16 @@ private fun ChatMessageList(
         questions = questions,
       )
     }
-  val indicatorVisible = pendingRunCount > 0
+  val indicatorVisible = activeRunCount > 0
   val workingRunTracker = remember(sessionKey) { ChatWorkingRunTracker(sessionKey) }
-  val workingRun = workingRunTracker.resolve(indicatorVisible, session, SystemClock.elapsedRealtime())
+  val workingRun =
+    workingRunTracker.resolve(
+      indicatorVisible = indicatorVisible,
+      clockKey = activeRunClockKey,
+      authoritativeRunId = activeRunId,
+      nowElapsedMs = SystemClock.elapsedRealtime(),
+      outputTokens = activeRunOutputTokens,
+    )
   val turnRecapResolver = remember { TurnRecapResolver() }
   val turnRecap =
     turnRecapResolver.resolve(
@@ -1375,7 +1389,11 @@ private fun ChatMessageList(
           ChatTimelineItem.Thinking -> {
             val run = workingRun
             if (run != null) {
-              ChatTypingIndicatorBubble(runKey = run.key, observedAtElapsedMs = run.observedAtElapsedMs)
+              ChatTypingIndicatorBubble(
+                runKey = run.clockKey,
+                observedAtElapsedMs = run.observedAtElapsedMs,
+                outputTokens = run.outputTokens,
+              )
             }
           }
         }
@@ -1429,10 +1447,10 @@ private fun ChatMessageList(
 }
 
 internal data class ChatWorkingRun(
-  val key: String,
+  val clockKey: String,
   val observedAtElapsedMs: Long,
   val authoritativeRunId: String?,
-  val authoritativeStartedAtMs: Long?,
+  val outputTokens: Long?,
 )
 
 internal class ChatWorkingRunTracker(
@@ -1442,35 +1460,30 @@ internal class ChatWorkingRunTracker(
 
   fun resolve(
     indicatorVisible: Boolean,
-    session: ChatSessionEntry?,
+    clockKey: String?,
+    authoritativeRunId: String?,
     nowElapsedMs: Long,
+    outputTokens: Long?,
   ): ChatWorkingRun? {
     if (!indicatorVisible) {
       current = null
       return null
     }
-    val runId = session?.activeRunIds?.lastOrNull()
-    val startedAt = session?.startedAt?.takeIf { session.endedAt == null }
+    val resolvedClockKey = clockKey ?: "$sessionKey:active"
     val previous = current
-    val replacementByRunId = previous?.authoritativeRunId != null && runId != null && previous.authoritativeRunId != runId
-    val replacementByStart =
-      previous?.authoritativeStartedAtMs != null && startedAt != null && previous.authoritativeStartedAtMs != startedAt
-    val replacement = replacementByRunId || replacementByStart
-    if (previous == null || replacement) {
+    if (previous == null || previous.clockKey != resolvedClockKey) {
       return ChatWorkingRun(
-        key = runId ?: "$sessionKey:${startedAt ?: nowElapsedMs}",
+        clockKey = resolvedClockKey,
         observedAtElapsedMs = nowElapsedMs,
-        authoritativeRunId = runId,
-        authoritativeStartedAtMs = startedAt,
+        authoritativeRunId = authoritativeRunId,
+        outputTokens = outputTokens,
       ).also { current = it }
     }
-    val adoptsRunId = previous.authoritativeRunId == null && runId != null
-    val adoptsStartedAt = previous.authoritativeStartedAtMs == null && startedAt != null
-    if (adoptsRunId || adoptsStartedAt) {
+    if (previous.authoritativeRunId != authoritativeRunId || previous.outputTokens != outputTokens) {
       current =
         previous.copy(
-          authoritativeRunId = runId ?: previous.authoritativeRunId,
-          authoritativeStartedAtMs = startedAt ?: previous.authoritativeStartedAtMs,
+          authoritativeRunId = authoritativeRunId,
+          outputTokens = outputTokens,
         )
     }
     return current

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt
@@ -218,17 +218,8 @@ internal class TurnRecapResolver(
 
 @Composable
 internal fun ChatTurnRecapRow(recap: TurnRecap) {
-  val duration = formatLocalizedChatDurationCompact(recap.runtimeMs.coerceAtLeast(1_000L))
-  val locale = LocalConfiguration.current.locales[0]
-  val tokens =
-    recap.outputTokens?.let { count ->
-      val format = turnRecapTokenFormat(count, locale)
-      if (format.singular) {
-        nativeStringResource("1 token")
-      } else {
-        nativeStringResource("\$count tokens", format.count)
-      }
-    }
+  val duration = formatLocalizedChatDurationFull(recap.runtimeMs.coerceAtLeast(1_000L))
+  val tokens = recap.outputTokens?.let { localizedChatOutputTokens(it) }
   Row(
     modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 4.dp),
     verticalAlignment = Alignment.CenterVertically,
@@ -244,6 +235,17 @@ internal fun ChatTurnRecapRow(recap: TurnRecap) {
       Text(text = nativeStringResource("·"), style = ClawTheme.type.caption, color = ClawTheme.colors.textSubtle)
       Text(text = it, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
     }
+  }
+}
+
+@Composable
+internal fun localizedChatOutputTokens(count: Long): String {
+  val locale = LocalConfiguration.current.locales[0]
+  val format = turnRecapTokenFormat(count, locale)
+  return if (format.singular) {
+    nativeStringResource("1 token")
+  } else {
+    nativeStringResource("\$count tokens", format.count)
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt
@@ -403,8 +403,7 @@ internal fun formatLocalizedChatDurationCompact(durationMs: Long): String =
 
 @Composable
 internal fun formatLocalizedChatDurationFull(durationMs: Long): String {
-  val configuration = LocalConfiguration.current
-  val locale = configuration.locales.get(0) ?: Locale.getDefault()
+  val locale = LocalConfiguration.current.locales.get(0) ?: Locale.ROOT
   return remember(durationMs, locale) { formatChatDurationFull(durationMs, locale) }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt
@@ -3,6 +3,9 @@ package ai.openclaw.app.ui.chat
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.i18n.nativeStringResource
 import ai.openclaw.app.ui.rememberSystemAnimationsEnabled
+import android.icu.text.MeasureFormat
+import android.icu.util.Measure
+import android.icu.util.MeasureUnit
 import android.os.SystemClock
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.foundation.Canvas
@@ -25,10 +28,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.PathParser
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
+import java.util.Locale
 import kotlin.math.roundToLong
 import kotlin.random.Random
 
@@ -315,29 +320,32 @@ internal enum class ChatDurationUnit {
   Second,
 }
 
+private val chatDurationUnits =
+  listOf(
+    86_400L to ChatDurationUnit.Day,
+    3_600L to ChatDurationUnit.Hour,
+    60L to ChatDurationUnit.Minute,
+    1L to ChatDurationUnit.Second,
+  )
+
+private fun chatDurationParts(durationMs: Long): List<Pair<Long, ChatDurationUnit>> {
+  var remaining = (durationMs.coerceAtLeast(1_000L) / 1_000.0).roundToLong().coerceAtLeast(1L)
+  return buildList {
+    for ((seconds, unit) in chatDurationUnits) {
+      if (size == 2) break
+      val count = remaining / seconds
+      if (count > 0L) {
+        add(count to unit)
+        remaining %= seconds
+      }
+    }
+  }
+}
+
 internal fun formatChatDurationCompact(
   durationMs: Long,
   formatPart: (Long, ChatDurationUnit) -> String = ::formatEnglishChatDurationPart,
-): String {
-  var remaining = (durationMs.coerceAtLeast(1_000L) / 1_000.0).roundToLong().coerceAtLeast(1L)
-  val units =
-    listOf(
-      86_400L to ChatDurationUnit.Day,
-      3_600L to ChatDurationUnit.Hour,
-      60L to ChatDurationUnit.Minute,
-      1L to ChatDurationUnit.Second,
-    )
-  val parts = mutableListOf<String>()
-  units.forEach { (seconds, unit) ->
-    if (parts.size == 2) return@forEach
-    val count = remaining / seconds
-    if (count > 0L) {
-      parts += formatPart(count, unit)
-      remaining %= seconds
-    }
-  }
-  return parts.joinToString(" ")
-}
+): String = chatDurationParts(durationMs).joinToString(" ") { (count, unit) -> formatPart(count, unit) }
 
 private fun formatEnglishChatDurationPart(
   count: Long,
@@ -349,6 +357,27 @@ private fun formatEnglishChatDurationPart(
     ChatDurationUnit.Minute -> "${count}m"
     ChatDurationUnit.Second -> "${count}s"
   }
+
+internal fun formatChatDurationFull(
+  durationMs: Long,
+  locale: Locale,
+): String {
+  val formatter = MeasureFormat.getInstance(locale, MeasureFormat.FormatWidth.WIDE)
+  val measures =
+    chatDurationParts(durationMs)
+      .map { (count, unit) ->
+        Measure(
+          count,
+          when (unit) {
+            ChatDurationUnit.Day -> MeasureUnit.DAY
+            ChatDurationUnit.Hour -> MeasureUnit.HOUR
+            ChatDurationUnit.Minute -> MeasureUnit.MINUTE
+            ChatDurationUnit.Second -> MeasureUnit.SECOND
+          },
+        )
+      }.toTypedArray()
+  return formatter.formatMeasures(*measures)
+}
 
 internal fun formatLocalizedChatDurationCompact(durationMs: Long): String =
   formatChatDurationCompact(durationMs) { count, unit ->
@@ -371,6 +400,13 @@ internal fun formatLocalizedChatDurationCompact(durationMs: Long): String =
       }
     }
   }
+
+@Composable
+internal fun formatLocalizedChatDurationFull(durationMs: Long): String {
+  val configuration = LocalConfiguration.current
+  val locale = configuration.locales.get(0) ?: Locale.getDefault()
+  return remember(durationMs, locale) { formatChatDurationFull(durationMs, locale) }
+}
 
 internal fun workingPhraseIndex(
   seed: String,

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionPolicyTest.kt
@@ -209,4 +209,43 @@ class ChatControllerSessionPolicyTest {
     assertEquals(null, merged.runtimeMs)
     assertEquals(null, merged.outputTokens)
   }
+
+  @Test
+  fun activeRunSelectionPrefersAdvertisedOverlapThenDeterministicLocalThenAdvertised() {
+    assertEquals(
+      "local-b",
+      resolvePreferredActiveRunId(
+        localRunIds = listOf("local-a", "local-b"),
+        advertisedRunIds = listOf("server", "local-b", "local-a"),
+      ),
+    )
+    assertEquals(
+      "local-a",
+      resolvePreferredActiveRunId(
+        localRunIds = listOf("local-b", "local-a"),
+        advertisedRunIds = listOf("server"),
+      ),
+    )
+    assertEquals("server", resolvePreferredActiveRunId(emptyList(), listOf("server", "later")))
+  }
+
+  @Test
+  fun activeRunCountIncludesBooleanFallbackWithoutAnId() {
+    assertEquals(
+      1,
+      resolveSelectedActiveRunCount(
+        localRunIds = emptyList(),
+        advertisedRunIds = emptyList(),
+        hasAdvertisedRun = true,
+      ),
+    )
+    assertEquals(
+      3,
+      resolveSelectedActiveRunCount(
+        localRunIds = listOf("local", "overlap"),
+        advertisedRunIds = listOf("overlap", "server"),
+        hasAdvertisedRun = true,
+      ),
+    )
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerUsageStreamTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerUsageStreamTest.kt
@@ -1,0 +1,227 @@
+package ai.openclaw.app.chat
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatControllerUsageStreamTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private data class StartedRun(
+    val controller: ChatController,
+    val gateway: ScriptedGateway,
+    val runId: String,
+  )
+
+  private suspend fun TestScope.startRun(): StartedRun {
+    val gateway = ScriptedGateway(json)
+    gateway.respondChatSend(status = "started")
+    gateway.respondWith("question.list", """{"questions":[]}""")
+    val controller = ChatController(scope = backgroundScope, json = json, requestGateway = gateway::request)
+    controller.handleGatewayEvent("health", null)
+    assertTrue(controller.sendMessageAwaitAcceptance("count this", "off", emptyList()))
+    return StartedRun(controller, gateway, requireNotNull(gateway.lastRunId))
+  }
+
+  private fun usagePayload(
+    runId: String,
+    sequence: Long,
+    outputTokens: String,
+  ): String = """{"sessionKey":"main","runId":"$runId","seq":$sequence,"ts":10,"stream":"usage","data":{"outputTokens":$outputTokens}}"""
+
+  private fun lifecyclePayload(
+    runId: String,
+    sequence: Long,
+    phase: String,
+  ): String = """{"sessionKey":"main","runId":"$runId","seq":$sequence,"ts":11,"stream":"lifecycle","data":{"phase":"$phase"}}"""
+
+  private fun advertise(vararg runIds: String): String = """{"reason":"patch","session":{"key":"main","agentId":"main","hasActiveRun":${runIds.isNotEmpty()},"activeRunIds":[${runIds.joinToString(",") { "\"$it\"" }}]}}"""
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun usageRequiresOwnershipAndKeepsHighestSequenceAndCumulativeMaximum() =
+    runTest {
+      val (controller, _, runId) = startRun()
+
+      controller.handleGatewayEvent("agent", usagePayload(runId, 2L, "12"))
+      controller.handleGatewayEvent("agent", usagePayload(runId, 1L, "90"))
+      controller.handleGatewayEvent("agent", usagePayload(runId, 3L, "8"))
+      controller.handleGatewayEvent("agent", usagePayload(runId, 4L, "0"))
+      controller.handleGatewayEvent("agent", usagePayload("foreign", 5L, "99"))
+
+      assertEquals(12L, controller.selectedActiveRunPresentation.value.outputTokens)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun unsequencedTerminalWithoutRunIdSettlesSoleLocalRun() =
+    runTest {
+      val (controller, _, _) = startRun()
+
+      controller.handleGatewayEvent(
+        "agent",
+        """{"sessionKey":"main","stream":"lifecycle","data":{"phase":"end"}}""",
+      )
+
+      assertEquals(0, controller.pendingRunCount.value)
+      assertEquals(0, controller.selectedActiveRunPresentation.value.count)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun unsequencedForeignTerminalDoesNotSettleSoleLocalRun() =
+    runTest {
+      val (controller, _, localRunId) = startRun()
+
+      controller.handleGatewayEvent(
+        "agent",
+        """{"sessionKey":"main","runId":"foreign-run","stream":"lifecycle","data":{"phase":"end"}}""",
+      )
+
+      assertEquals(1, controller.pendingRunCount.value)
+      assertEquals(localRunId, controller.selectedActiveRunPresentation.value.runId)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun activeBooleanWithoutRunIdUsesStableSessionFallback() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val controller = ChatController(scope = backgroundScope, json = json, requestGateway = gateway::request)
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"patch","session":{"key":"main","agentId":"main","hasActiveRun":true,"activeRunIds":[]}}""",
+      )
+
+      val presentation = controller.selectedActiveRunPresentation.value
+      assertEquals(1, presentation.count)
+      assertNull(presentation.runId)
+      assertEquals("main:active", presentation.clockKey)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun idlessReplacementRunGetsANewStartedAtClockKey() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val controller = ChatController(scope = backgroundScope, json = json, requestGateway = gateway::request)
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"patch","session":{"key":"main","agentId":"main","status":"running","hasActiveRun":true,"activeRunIds":[],"startedAt":100}}""",
+      )
+      val firstClockKey = controller.selectedActiveRunPresentation.value.clockKey
+
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"patch","session":{"key":"main","agentId":"main","status":"running","hasActiveRun":true,"activeRunIds":[],"startedAt":200}}""",
+      )
+
+      assertEquals("main:active:100", firstClockKey)
+      assertEquals("main:active:200", controller.selectedActiveRunPresentation.value.clockKey)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun terminalTombstoneIgnoresLaterStartAndUsageUntilOwnershipRemoval() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val controller = ChatController(scope = backgroundScope, json = json, requestGateway = gateway::request)
+      controller.handleGatewayEvent("sessions.changed", advertise("server-run"))
+      controller.handleGatewayEvent("agent", usagePayload("server-run", 1L, "20"))
+      controller.handleGatewayEvent(
+        "agent",
+        """{"sessionKey":"main","runId":"server-run","seq":2,"ts":10,"stream":"assistant","data":{"text":"foreign"}}""",
+      )
+      assertNull(controller.streamingAssistantText.value)
+      controller.handleGatewayEvent("agent", lifecyclePayload("server-run", 2L, "end"))
+      controller.handleGatewayEvent("agent", lifecyclePayload("server-run", 3L, "start"))
+      controller.handleGatewayEvent("agent", usagePayload("server-run", 4L, "40"))
+
+      assertEquals(0, controller.selectedActiveRunPresentation.value.count)
+      assertNull(controller.selectedActiveRunPresentation.value.outputTokens)
+
+      controller.handleGatewayEvent("sessions.changed", advertise())
+      controller.handleGatewayEvent("sessions.changed", advertise("server-run"))
+      controller.handleGatewayEvent("agent", usagePayload("server-run", 1L, "40"))
+
+      assertEquals(1, controller.selectedActiveRunPresentation.value.count)
+      assertEquals(40L, controller.selectedActiveRunPresentation.value.outputTokens)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun sequenceGapForConcurrentAdvertisedRunPreservesLocalPendingOwnership() =
+    runTest {
+      val (controller, gateway, localRunId) = startRun()
+      controller.handleGatewayEvent("sessions.changed", advertise("server-run"))
+      controller.handleGatewayEvent("agent", usagePayload(localRunId, 1L, "15"))
+      controller.handleGatewayEvent(
+        "agent",
+        """{"sessionKey":"main","runId":"$localRunId","seq":2,"ts":10,"stream":"assistant","data":{"text":"partial"}}""",
+      )
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-1",
+          messages = emptyList(),
+          inFlightRun = "server-run" to "",
+        ),
+      )
+
+      controller.handleGatewayEvent("seqGap", null)
+      runCurrent()
+
+      assertEquals(1, controller.pendingRunCount.value)
+      assertEquals(localRunId, controller.selectedActiveRunPresentation.value.runId)
+      assertNull(controller.selectedActiveRunPresentation.value.outputTokens)
+      assertNull(controller.streamingAssistantText.value)
+      assertTrue(gateway.callCount("chat.history") > 0)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun ackRekeyPreservesOptimisticClockIdentity() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("question.list", """{"questions":[]}""")
+      val requestSeen = CompletableDeferred<String>()
+      val releaseAck = CompletableDeferred<Unit>()
+      gateway.respond("chat.send") { paramsJson ->
+        val clientRunId =
+          json
+            .parseToJsonElement(requireNotNull(paramsJson))
+            .jsonObject["idempotencyKey"]!!
+            .jsonPrimitive
+            .content
+        requestSeen.complete(clientRunId)
+        releaseAck.await()
+        """{"runId":"server-run","status":"started"}"""
+      }
+      val controller = ChatController(scope = backgroundScope, json = json, requestGateway = gateway::request)
+      controller.handleGatewayEvent("health", null)
+      val send = async { controller.sendMessageAwaitAcceptance("hello", "off", emptyList()) }
+      val clientRunId = requestSeen.await()
+      runCurrent()
+      val before = controller.selectedActiveRunPresentation.value
+
+      releaseAck.complete(Unit)
+      assertTrue(send.await())
+      val after = controller.selectedActiveRunPresentation.value
+
+      assertEquals(clientRunId, before.runId)
+      assertEquals("server-run", after.runId)
+      assertNotNull(before.clockKey)
+      assertEquals(before.clockKey, after.clockKey)
+    }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerUsageStreamTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerUsageStreamTest.kt
@@ -180,6 +180,7 @@ class ChatControllerUsageStreamTest {
       )
 
       controller.handleGatewayEvent("seqGap", null)
+      assertNull(controller.selectedActiveRunPresentation.value.outputTokens)
       runCurrent()
 
       assertEquals(1, controller.pendingRunCount.value)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatDurationFormatterRobolectricTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatDurationFormatterRobolectricTest.kt
@@ -1,0 +1,23 @@
+package ai.openclaw.app.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ChatDurationFormatterRobolectricTest {
+  @Test
+  fun fullDurationUsesLocalizedHumanReadableWording() {
+    assertEquals("4 hours, 2 minutes", formatChatDurationFull(14_520_000L, Locale.US))
+
+    val german = formatChatDurationFull(14_520_000L, Locale.GERMAN)
+    assertTrue(german.contains("4"))
+    assertTrue(german.contains("2"))
+    assertTrue(german != "4h 2m")
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatWorkingIndicatorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatWorkingIndicatorTest.kt
@@ -1,6 +1,5 @@
 package ai.openclaw.app.ui.chat
 
-import ai.openclaw.app.chat.ChatSessionEntry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -112,70 +111,50 @@ class ChatWorkingIndicatorTest {
   }
 
   @Test
-  fun provisionalRunAdoptsAuthoritativeIdentityWithoutChangingLocalStart() {
+  fun ackRekeyKeepsOptimisticClockAndLocalStart() {
     val tracker = ChatWorkingRunTracker("agent:main:main")
-    val provisional = requireNotNull(tracker.resolve(indicatorVisible = true, session = null, nowElapsedMs = 5_000L))
-
+    val provisional =
+      requireNotNull(
+        tracker.resolve(
+          indicatorVisible = true,
+          clockKey = "message-1",
+          authoritativeRunId = "client-run",
+          nowElapsedMs = 5_000L,
+          outputTokens = null,
+        ),
+      )
     val authoritative =
       requireNotNull(
         tracker.resolve(
           indicatorVisible = true,
-          session =
-            ChatSessionEntry(
-              key = "agent:main:main",
-              updatedAtMs = 6_000L,
-              status = "running",
-              startedAt = 4_000L,
-              activeRunIds = listOf("run-1"),
-            ),
-          nowElapsedMs = 6_000L,
+          clockKey = "message-1",
+          authoritativeRunId = "server-run",
+          nowElapsedMs = 8_000L,
+          outputTokens = 40L,
         ),
       )
 
-    assertEquals(provisional.key, authoritative.key)
+    assertEquals(provisional.clockKey, authoritative.clockKey)
     assertEquals(5_000L, authoritative.observedAtElapsedMs)
-    assertEquals("run-1", authoritative.authoritativeRunId)
-    assertEquals(4_000L, authoritative.authoritativeStartedAtMs)
+    assertEquals("server-run", authoritative.authoritativeRunId)
+    assertEquals(40L, authoritative.outputTokens)
   }
 
   @Test
-  fun authoritativeReplacementGetsANewRunIdentity() {
+  fun serverRunReplacementGetsANewClock() {
     val tracker = ChatWorkingRunTracker("agent:main:main")
     val first =
       requireNotNull(
-        tracker.resolve(
-          indicatorVisible = true,
-          session =
-            ChatSessionEntry(
-              key = "agent:main:main",
-              updatedAtMs = 1L,
-              status = "running",
-              startedAt = 1_000L,
-              activeRunIds = listOf("run-1"),
-            ),
-          nowElapsedMs = 7_000L,
-        ),
+        tracker.resolve(true, "run-1", "run-1", 7_000L, null),
       )
     val replacement =
       requireNotNull(
-        tracker.resolve(
-          indicatorVisible = true,
-          session =
-            ChatSessionEntry(
-              key = "agent:main:main",
-              updatedAtMs = 2L,
-              status = "running",
-              startedAt = 2_000L,
-              activeRunIds = listOf("run-2"),
-            ),
-          nowElapsedMs = 9_000L,
-        ),
+        tracker.resolve(true, "run-2", "run-2", 9_000L, null),
       )
 
-    assertEquals("run-1", first.key)
-    assertEquals("run-2", replacement.key)
+    assertEquals("run-1", first.clockKey)
+    assertEquals("run-2", replacement.clockKey)
     assertEquals(9_000L, replacement.observedAtElapsedMs)
-    assertEquals(2_000L, replacement.authoritativeStartedAtMs)
   }
 
   private fun assertPose(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -722,6 +722,7 @@ struct ChatTypingIndicatorBubble: View {
     let showsAssistantAvatar: Bool
     let isClean: Bool
     let runIdentity: String
+    let outputTokens: Int?
 
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
@@ -734,7 +735,9 @@ struct ChatTypingIndicatorBubble: View {
             }
 
             HStack(spacing: 9) {
-                ChatWorkingIndicatorContent(runIdentity: self.runIdentity)
+                ChatWorkingIndicatorContent(
+                    runIdentity: self.runIdentity,
+                    outputTokens: self.outputTokens)
                     .id(self.runIdentity)
             }
             .padding(.vertical, self.isClean ? 5 : (self.style == .standard ? 10 : 9))
@@ -754,16 +757,21 @@ struct ChatTypingIndicatorBubble: View {
 private struct ChatWorkingIndicatorContent: View {
     @State private var startedAt: Date
     let seed: String
+    let outputTokens: Int?
 
-    init(runIdentity: String) {
+    init(runIdentity: String, outputTokens: Int?) {
         _startedAt = State(initialValue: Date())
         self.seed = runIdentity
+        self.outputTokens = outputTokens
     }
 
     var body: some View {
         HStack(spacing: 9) {
             ChatWorkingClawView(seed: self.seed)
-            ChatWorkingStatusText(startedAt: self.startedAt, seed: self.seed)
+            ChatWorkingStatusText(
+                startedAt: self.startedAt,
+                seed: self.seed,
+                outputTokens: self.outputTokens)
         }
     }
 }
@@ -868,7 +876,8 @@ extension ChatTypingIndicatorBubble: @MainActor Equatable {
             lhs.assistantAvatarText == rhs.assistantAvatarText &&
             lhs.showsAssistantAvatar == rhs.showsAssistantAvatar &&
             lhs.isClean == rhs.isClean &&
-            lhs.runIdentity == rhs.runIdentity
+            lhs.runIdentity == rhs.runIdentity &&
+            lhs.outputTokens == rhs.outputTokens
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -34,6 +34,9 @@ public struct OpenClawChatSessionsChangedEvent: Codable, Sendable, Equatable {
     public let parentSessionKey: String?
     public let spawnedBy: String?
     public let reason: String
+    public let phase: String?
+    public let runId: String?
+    public let session: OpenClawChatSessionEntry?
     public let updatedAt: Double?
     public let lastReadAt: Double?
     public let agentStatus: OpenClawChatSessionAgentStatus?
@@ -59,6 +62,9 @@ public struct OpenClawChatSessionsChangedEvent: Codable, Sendable, Equatable {
         parentSessionKey: String? = nil,
         spawnedBy: String? = nil,
         reason: String = "",
+        phase: String? = nil,
+        runId: String? = nil,
+        session: OpenClawChatSessionEntry? = nil,
         updatedAt: Double? = nil,
         lastReadAt: Double? = nil,
         agentStatus: OpenClawChatSessionAgentStatus? = nil,
@@ -83,6 +89,9 @@ public struct OpenClawChatSessionsChangedEvent: Codable, Sendable, Equatable {
         self.parentSessionKey = parentSessionKey
         self.spawnedBy = spawnedBy
         self.reason = reason
+        self.phase = phase
+        self.runId = runId
+        self.session = session
         self.updatedAt = updatedAt
         self.lastReadAt = lastReadAt
         self.agentStatus = agentStatus
@@ -105,6 +114,7 @@ public struct OpenClawChatSessionsChangedEvent: Codable, Sendable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.session = try container.decodeIfPresent(OpenClawChatSessionEntry.self, forKey: .session)
         let nested = try? container.nestedContainer(keyedBy: CodingKeys.self, forKey: .session)
 
         func decode<T: Decodable>(_ type: T.Type, forKey key: CodingKeys) throws -> T? {
@@ -127,6 +137,8 @@ public struct OpenClawChatSessionsChangedEvent: Codable, Sendable, Equatable {
         self.parentSessionKey = try decode(String.self, forKey: .parentSessionKey)
         self.spawnedBy = try decode(String.self, forKey: .spawnedBy)
         self.reason = try decode(String.self, forKey: .reason) ?? ""
+        self.phase = try decode(String.self, forKey: .phase)
+        self.runId = try decode(String.self, forKey: .runId)
         self.updatedAt = try decode(Double.self, forKey: .updatedAt)
         self.lastReadAt = try decode(Double.self, forKey: .lastReadAt)
         self.agentStatus = try decode(OpenClawChatSessionAgentStatus.self, forKey: .agentStatus)
@@ -154,6 +166,9 @@ public struct OpenClawChatSessionsChangedEvent: Codable, Sendable, Equatable {
         try container.encodeIfPresent(self.parentSessionKey, forKey: .parentSessionKey)
         try container.encodeIfPresent(self.spawnedBy, forKey: .spawnedBy)
         try container.encodeIfPresent(self.reason, forKey: .reason)
+        try container.encodeIfPresent(self.phase, forKey: .phase)
+        try container.encodeIfPresent(self.runId, forKey: .runId)
+        try container.encodeIfPresent(self.session, forKey: .session)
         try container.encodeIfPresent(self.updatedAt, forKey: .updatedAt)
         try container.encodeIfPresent(self.lastReadAt, forKey: .lastReadAt)
         try container.encodeIfPresent(self.agentStatus, forKey: .agentStatus)
@@ -178,6 +193,8 @@ public struct OpenClawChatSessionsChangedEvent: Codable, Sendable, Equatable {
         case parentSessionKey
         case spawnedBy
         case reason
+        case phase
+        case runId
         case updatedAt
         case lastReadAt
         case agentStatus

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -492,7 +492,8 @@ public struct OpenClawChatView: View {
                 assistantAvatarTint: self.assistantAvatarTint,
                 showsAssistantAvatar: self.showsAssistantAvatars,
                 isClean: self.composerChrome == .clean,
-                runIdentity: self.viewModel.workingIndicatorIdentity)
+                runIdentity: self.viewModel.workingIndicatorIdentity,
+                outputTokens: self.viewModel.liveRunOutputTokens)
                 .equatable()
         }
 
@@ -787,7 +788,8 @@ public struct OpenClawChatView: View {
     }
 
     private var showsWorkingIndicator: Bool {
-        self.viewModel.hasBlockingRunActivity && !self.hasVisibleStreamingAssistantText
+        self.viewModel.hasBlockingRunActivity &&
+            (!self.hasVisibleStreamingAssistantText || self.viewModel.liveUsageRunID != nil)
     }
 
     private var turnRecapObservation: ChatTurnRecapObservation {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -26,6 +26,11 @@ public enum OpenClawChatOutboxMessageState: Equatable, Sendable {
 /// strictly in createdAt order when health recovers. A gateway ACK only moves
 /// a row to awaiting-confirmation; canonical history owns durable completion.
 extension OpenClawChatViewModel {
+    /// True when this view model owns a gateway-scoped durable text outbox.
+    public var supportsOfflineTextOutbox: Bool {
+        self.outbox != nil
+    }
+
     struct OutboxDeliveryTarget: Hashable {
         let presentationSessionKey: String
         let deliverySessionKey: String

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+RunSnapshot.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+RunSnapshot.swift
@@ -12,10 +12,16 @@ extension OpenClawChatViewModel {
             return
         }
         self.latestAppliedRunSnapshotRequestID = request.id
+        if let activeRunIDs = payload.sessionInfo?.activeRunIds {
+            self.updateActiveSessionRunIDs(activeRunIDs)
+        } else if payload.sessionInfo?.hasActiveRun == false {
+            self.updateActiveSessionRunIDs([])
+        }
         // Plan reconciliation shares run adoption: rejected history cannot clobber newer live state.
         // A missing plan is version-skew unknown; replacement or explicit terminal evidence clears it.
         guard let snapshot = payload.inFlightRun,
-              let runId = Self.normalizedRunID(snapshot.runId)
+              let runId = Self.normalizedRunID(snapshot.runId),
+              self.liveRunStateByRunID[runId]?.terminal != true
         else {
             guard let retainedRunId = self.planRunId else { return }
             let activeRunIds = payload.sessionInfo?.activeRunIds
@@ -46,8 +52,10 @@ extension OpenClawChatViewModel {
     }
 
     private func adoptRunState(runId: String, bufferedText: String, preservePlan: Bool) {
-        let canonicalPendingRuns = Set([runId])
-        let replacedRun = self.pendingRuns != canonicalPendingRuns
+        // A terminal ID stays retired until an authoritative session snapshot
+        // explicitly removes it; late deltas/history cannot resurrect the run.
+        guard self.liveRunStateByRunID[runId]?.terminal != true else { return }
+        let replacedRun = self.pendingRuns.count != 1 || !self.pendingRuns.contains(runId)
         if replacedRun {
             // Gateway snapshots and live deltas are canonical for this session.
             // Replace stale local ownership so only that run consumes later events.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
@@ -25,13 +25,15 @@ extension OpenClawChatViewModel {
     }
 
     var hasBlockingRunActivity: Bool {
-        pendingRunCount > 0 || hasActiveSessionRunWithoutChatSnapshot || isSwitchingSessionBranch
+        pendingRunCount > 0 || self.hasAdvertisedLiveRun ||
+            hasActiveSessionRunWithoutChatSnapshot || isSwitchingSessionBranch
     }
 
     var workingIndicatorIdentity: String {
-        ChatWorkingIdentity.resolve(
+        let selectedRunIDs = self.liveUsageRunID.map { Set([$0]) } ?? []
+        return ChatWorkingIdentity.resolve(
             sessionKey: sessionKey,
-            pendingRunIDs: pendingRuns,
+            pendingRunIDs: selectedRunIDs,
             localUserMessageIDsByRunID: pendingLocalUserEchoMessageIDsByRunID,
             fallbackGeneration: runOwnershipGeneration)
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -6,6 +6,15 @@ private let chatSessionActionsLogger = Logger(
     category: "OpenClawChat")
 
 extension OpenClawChatViewModel {
+    struct SessionBranchSwitchActivity: Equatable {
+        let session: SessionSnapshot
+        let generation: UInt64
+    }
+
+    var isSwitchingSessionBranch: Bool {
+        self.sessionBranchSwitchActivity != nil
+    }
+
     private enum SessionBranchesRefreshPurpose {
         case readOnly
         case reconcile

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -34,6 +34,126 @@ extension OpenClawChatViewModel {
             })
     }
 
+    static func preferredLiveUsageRunID(
+        localRunIDs: Set<String>,
+        sessionActiveRunIDs: [String]) -> String?
+    {
+        sessionActiveRunIDs.first(where: localRunIDs.contains) ??
+            localRunIDs.min() ??
+            sessionActiveRunIDs.first
+    }
+
+    var liveLocalRunIDs: Set<String> {
+        Set(self.pendingRuns.filter { self.liveRunStateByRunID[$0]?.terminal != true })
+    }
+
+    var liveAdvertisedRunIDs: [String] {
+        self.activeSessionRunIDs.filter { self.liveRunStateByRunID[$0]?.terminal != true }
+    }
+
+    var liveUsageRunID: String? {
+        Self.preferredLiveUsageRunID(
+            localRunIDs: self.liveLocalRunIDs,
+            sessionActiveRunIDs: self.liveAdvertisedRunIDs)
+    }
+
+    var liveRunOutputTokens: Int? {
+        self.liveUsageRunID.flatMap { self.liveRunStateByRunID[$0]?.outputTokens }
+    }
+
+    var hasAdvertisedLiveRun: Bool {
+        !self.liveAdvertisedRunIDs.isEmpty
+    }
+
+    func updateActiveSessionRunIDs(_ runIDs: [String]?) {
+        guard let runIDs else { return }
+        var seen = Set<String>()
+        let normalized = runIDs.compactMap { runID -> String? in
+            guard let runID = Self.normalizedRunID(runID),
+                  seen.insert(runID).inserted
+            else {
+                return nil
+            }
+            return runID
+        }
+        let authoritativeRunIDs = Set(normalized)
+        let removedStates = self.liveRunStateByRunID.filter { !authoritativeRunIDs.contains($0.key) }
+        for (runID, state) in removedStates where state.terminal || !self.pendingRuns.contains(runID) {
+            // Explicit absence releases a terminal tombstone, but the sequence
+            // stays monotonic if the gateway later reuses the same run ID.
+            self.liveRunStateByRunID[runID] = ChatLiveRunState(
+                sequence: state.sequence,
+                outputTokens: nil,
+                terminal: false)
+        }
+        guard normalized != self.activeSessionRunIDs else { return }
+        self.activeSessionRunIDs = normalized
+        self.markTimelineChanged()
+    }
+
+    func syncActiveSessionRunIDsFromCurrentSession() {
+        guard let session = self.currentSessionEntry() else {
+            self.updateActiveSessionRunIDs([])
+            return
+        }
+        if let activeRunIDs = session.activeRunIds {
+            self.updateActiveSessionRunIDs(activeRunIDs)
+        } else if session.hasActiveRun == false {
+            self.updateActiveSessionRunIDs([])
+        }
+    }
+
+    func ownsLiveTelemetryRun(_ runID: String) -> Bool {
+        self.liveRunStateByRunID[runID]?.terminal != true &&
+            (self.pendingRuns.contains(runID) || self.activeSessionRunIDs.contains(runID))
+    }
+
+    @discardableResult
+    func applyLiveRunUsage(runID: String, sequence: Int, outputTokens: Int) -> Bool {
+        guard sequence > 0, outputTokens > 0, self.ownsLiveTelemetryRun(runID) else { return false }
+        let previous = self.liveRunStateByRunID[runID]
+        guard sequence > (previous?.sequence ?? 0), previous?.terminal != true else { return false }
+        self.liveRunStateByRunID[runID] = ChatLiveRunState(
+            sequence: sequence,
+            outputTokens: max(outputTokens, previous?.outputTokens ?? 0),
+            terminal: false)
+        return true
+    }
+
+    @discardableResult
+    func applyLiveRunLifecycle(runID: String, sequence: Int, terminal: Bool) -> Bool {
+        guard sequence > 0, self.ownsLiveTelemetryRun(runID) else { return false }
+        let previous = self.liveRunStateByRunID[runID]
+        guard sequence > (previous?.sequence ?? 0), previous?.terminal != true else { return false }
+        self.liveRunStateByRunID[runID] = ChatLiveRunState(
+            sequence: sequence,
+            outputTokens: previous?.outputTokens,
+            terminal: terminal)
+        return true
+    }
+
+    func retireTerminalRun(_ runID: String?) {
+        guard let runID = Self.normalizedRunID(runID) else { return }
+        let previous = self.liveRunStateByRunID[runID]
+        self.liveRunStateByRunID[runID] = ChatLiveRunState(
+            sequence: previous?.sequence ?? 0,
+            outputTokens: previous?.outputTokens,
+            terminal: true)
+    }
+
+    func clearLiveRunState(for runID: String) {
+        self.liveRunStateByRunID[runID] = nil
+    }
+
+    func invalidateIncompleteLiveRunUsage() {
+        for (runID, state) in self.liveRunStateByRunID where !state.terminal && state.outputTokens != nil {
+            self.liveRunStateByRunID[runID] = ChatLiveRunState(
+                sequence: state.sequence,
+                outputTokens: nil,
+                terminal: false)
+        }
+    }
+
     /// Session mutations and their ordering use the routed gateway identity,
     /// never a presentation alias such as `main`.
     func sessionMutationIdentity(for key: String, listedKey: String? = nil) -> String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+struct ChatLiveRunState: Equatable, Sendable {
+    let sequence: Int
+    let outputTokens: Int?
+    let terminal: Bool
+}
+
 extension OpenClawChatViewModel {
     nonisolated static func chatContextUsageFraction(for session: OpenClawChatSessionEntry?) -> Double? {
         guard session?.totalTokensFresh != false,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TranscriptCache.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TranscriptCache.swift
@@ -20,6 +20,25 @@ extension OpenClawChatViewModel {
         markTimelineChanged()
     }
 
+    nonisolated static func durableSessionCacheProjection(
+        _ session: OpenClawChatSessionEntry) -> OpenClawChatSessionEntry
+    {
+        var projected = session
+        let wasActive =
+            projected.hasActiveRun == true ||
+            projected.activeRunIds?.isEmpty == false ||
+            projected.hasActiveSubagentRun == true ||
+            projected.status?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "running"
+        projected.hasActiveRun = nil
+        projected.activeRunIds = nil
+        projected.hasActiveSubagentRun = nil
+        if wasActive {
+            projected.startedAt = nil
+            projected.status = nil
+        }
+        return projected
+    }
+
     func persistTranscriptToCache(
         session: SessionSnapshot,
         messages: [OpenClawChatMessage],
@@ -66,10 +85,11 @@ extension OpenClawChatViewModel {
 
     func persistSessionsToCache(_ sessions: [OpenClawChatSessionEntry]) {
         guard let transcriptCache else { return }
+        let durableSessions = sessions.map(Self.durableSessionCacheProjection)
         let previous = pendingCacheWriteTask
         pendingCacheWriteTask = Task.detached {
             await previous?.value
-            await transcriptCache.storeSessions(sessions)
+            await transcriptCache.storeSessions(durableSessions)
         }
     }
 
@@ -94,7 +114,8 @@ extension OpenClawChatViewModel {
                 else {
                     return
                 }
-                let organized = OpenClawChatSessionListOrganizer.organize(cached)
+                let durableSessions = cached.map(Self.durableSessionCacheProjection)
+                let organized = OpenClawChatSessionListOrganizer.organize(durableSessions)
                 let scoped = ChatSessionSidebarModel.clearingForeignGlobalObserverDigest(
                     in: organized,
                     activeAgentId: self.activeAgentId)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -34,57 +34,7 @@ extension OpenClawChatViewModel {
             let context = self.currentSessionSnapshot()
             Task { await self.pollHealthIfNeeded(force: false, sessionSnapshot: context) }
         case let .sessionsChanged(change):
-            // Broad subscribers see every agent's canonical global row. Gate
-            // ownership before the shared-key projection can replace local state.
-            guard ChatSessionSidebarModel.sessionMatchesActiveAgent(
-                sessionKey: change.sessionKey,
-                agentId: change.agentId,
-                activeAgentId: self.activeAgentId)
-            else { return }
-            let swarmEvent = self.observeSwarmEvent(change)
-            let ownedSwarmActivityNote = swarmEvent && SelfContainedSwarmHelpers.isActivityNote(change)
-            self.applySessionChangeProjection(change, ownedSwarmActivityNote: ownedSwarmActivityNote)
-            // Group-catalog mutations from any client arrive as reason "groups"
-            // (mirrors web ui/src/lib/sessions); bump the revision so views keyed
-            // on it refetch. Rename/delete also rewrite member sessions' category
-            // values, so refresh sessions too or inspectors keep stale placement.
-            if change.reason == "groups" {
-                self.sessionGroupsRevision += 1
-                let context = self.currentSessionSnapshot()
-                Task { await self.fetchSessions(limit: 50, sessionSnapshot: context) }
-                return
-            }
-            if change.reason == "rewind" || change.reason == "branch-switch" {
-                guard let sessionKey = change.sessionKey,
-                      self.matchesCurrentSessionKey(
-                          incoming: sessionKey,
-                          agentId: change.agentId,
-                          current: self.sessionKey)
-                else { return }
-                self.replyTarget = nil
-                self.runMessageScopesByRunID.removeAll()
-                self.provisionalFinalMessagesByID.removeAll()
-                let context = self.beginHistoryRequest()
-                if change.reason == "branch-switch" {
-                    let switchActivity = self.beginSessionBranchSwitchActivity(for: context.session)
-                    Task {
-                        defer { self.endSessionBranchSwitchActivity(switchActivity) }
-                        await self.reconcileSessionBranchChange(
-                            switchActivity,
-                            confirmFromBranchRefresh: true)
-                    }
-                    return
-                }
-                Task {
-                    await self.refreshHistoryAfterRun(historyRequest: context)
-                    guard self.isCurrentSession(context.session) else { return }
-                    await self.refreshSessionBranches(confirmingBranchChange: true)
-                }
-                return
-            }
-            guard change.reason == "patch" || change.reason == "command-metadata" else { return }
-            let context = self.currentSessionSnapshot()
-            Task { await self.fetchSessions(limit: 50, sessionSnapshot: context) }
+            self.handleSessionsChangedEvent(change)
         case let .sessionObserver(digest):
             self.sessions = ChatSessionSidebarModel.applying(
                 observerDigest: digest,
@@ -114,6 +64,7 @@ extension OpenClawChatViewModel {
             self.invalidateHistorySnapshots()
             self.invalidateRunSnapshots()
             self.clearPendingRuns(reason: nil)
+            self.invalidateIncompleteLiveRunUsage()
             self.pendingToolCallsById = [:]
             self.updateStreamingAssistantText(nil)
             self.clearPlan()
@@ -142,6 +93,279 @@ extension OpenClawChatViewModel {
             let context = self.currentSessionSnapshot()
             Task { await self.fetchSessions(limit: 50, sessionSnapshot: context) }
         }
+    }
+
+    private enum LifecycleSessionMergeResult: Equatable {
+        case merged
+        case unavailable
+        case rejected
+    }
+
+    private func handleSessionsChangedEvent(_ change: OpenClawChatSessionsChangedEvent) {
+        // Broad subscribers see every agent's canonical global row. Gate
+        // ownership before the shared-key projection can replace local state.
+        let eventSessionKey = change.sessionKey ?? change.session?.key
+        guard ChatSessionSidebarModel.sessionMatchesActiveAgent(
+            sessionKey: eventSessionKey,
+            agentId: change.agentId,
+            activeAgentId: self.activeAgentId)
+        else { return }
+        let swarmEvent = self.observeSwarmEvent(change)
+        let ownedSwarmActivityNote = swarmEvent && SelfContainedSwarmHelpers.isActivityNote(change)
+
+        if let phase = change.phase?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           phase == "start" || phase == "end" || phase == "error"
+        {
+            self.handleLifecycleSessionChange(change, phase: phase)
+            return
+        }
+
+        self.applySessionChangeProjection(change, ownedSwarmActivityNote: ownedSwarmActivityNote)
+        // Group-catalog mutations from any client arrive as reason "groups"
+        // (mirrors web ui/src/lib/sessions); bump the revision so views keyed
+        // on it refetch. Rename/delete also rewrite member sessions' category.
+        if change.reason == "groups" {
+            self.sessionGroupsRevision += 1
+            self.requestSessionsRefresh()
+            return
+        }
+        if change.reason == "rewind" || change.reason == "branch-switch" {
+            guard let sessionKey = change.sessionKey,
+                  self.matchesCurrentSessionKey(
+                      incoming: sessionKey,
+                      agentId: change.agentId,
+                      current: self.sessionKey)
+            else { return }
+            self.replyTarget = nil
+            self.runMessageScopesByRunID.removeAll()
+            self.provisionalFinalMessagesByID.removeAll()
+            let context = self.beginHistoryRequest()
+            if change.reason == "branch-switch" {
+                let switchActivity = self.beginSessionBranchSwitchActivity(for: context.session)
+                Task {
+                    defer { self.endSessionBranchSwitchActivity(switchActivity) }
+                    await self.reconcileSessionBranchChange(
+                        switchActivity,
+                        confirmFromBranchRefresh: true)
+                }
+                return
+            }
+            Task {
+                await self.refreshHistoryAfterRun(historyRequest: context)
+                guard self.isCurrentSession(context.session) else { return }
+                await self.refreshSessionBranches(confirmingBranchChange: true)
+            }
+            return
+        }
+        guard change.reason == "patch" || change.reason == "command-metadata" else { return }
+        self.requestSessionsRefresh()
+    }
+
+    private func handleLifecycleSessionChange(
+        _ change: OpenClawChatSessionsChangedEvent,
+        phase: String)
+    {
+        let eventSessionKey = change.sessionKey ?? change.session?.key
+        let changesCurrentSession = eventSessionKey.map {
+            self.matchesCurrentSessionKey(
+                incoming: $0,
+                agentId: change.agentId,
+                current: self.sessionKey)
+        } ?? false
+        let isTerminal = phase == "end" || phase == "error"
+        let runID = isTerminal
+            ? self.terminalRunID(
+                explicitRunID: change.runId,
+                sessionKey: eventSessionKey,
+                agentID: change.agentId,
+                includeAdvertisedRuns: true)
+            : Self.normalizedRunID(change.runId)
+        let ownsCurrentRun = changesCurrentSession && runID.map {
+            self.pendingRuns.contains($0) || self.ownsLiveTelemetryRun($0)
+        } == true
+
+        if isTerminal, ownsCurrentRun, let runID {
+            let wasSelectedRun = self.liveUsageRunID == runID
+            if self.pendingRuns.contains(runID) {
+                self.retirePendingRun(
+                    runID,
+                    hapticEvent: phase == "error" ? .runFailed : .runCompleted)
+            } else {
+                self.retireTerminalRun(runID)
+            }
+            if wasSelectedRun {
+                self.pendingToolCallsById = [:]
+                self.updateStreamingAssistantText(nil)
+                self.clearPlan(for: runID)
+            }
+            if self.liveUsageRunID == nil {
+                self.updateActiveSessionRunWithoutChatSnapshot(false)
+            }
+        }
+
+        let mergeResult: LifecycleSessionMergeResult
+        if change.session != nil {
+            mergeResult = self.mergeLifecycleSessionSnapshot(change, phase: phase, runID: runID)
+        } else {
+            if let projected = ChatSessionSidebarModel.applying(
+                sessionChange: change,
+                to: self.sessions,
+                activeAgentId: self.activeAgentId)
+            {
+                self.sessions = projected
+            }
+            mergeResult = .unavailable
+        }
+
+        if mergeResult != .merged {
+            self.requestSessionsRefresh()
+        }
+    }
+
+    private func mergeLifecycleSessionSnapshot(
+        _ change: OpenClawChatSessionsChangedEvent,
+        phase: String,
+        runID: String?) -> LifecycleSessionMergeResult
+    {
+        guard let snapshot = change.session else { return .unavailable }
+        if let eventKey = change.sessionKey,
+           snapshot.key != eventKey,
+           !self.matchesCurrentSessionKey(
+               incoming: snapshot.key,
+               agentId: change.agentId,
+               current: eventKey)
+        {
+            return .rejected
+        }
+
+        let exactIndex = self.sessions.firstIndex(where: { $0.key == snapshot.key })
+        let eventKeyIndex = change.sessionKey.flatMap { key in
+            self.sessions.firstIndex(where: { $0.key == key })
+        }
+        let aliasIndex = self.sessions.firstIndex(where: { session in
+            self.matchesCurrentSessionKey(
+                incoming: snapshot.key,
+                agentId: change.agentId,
+                current: session.key)
+        })
+        guard let index = exactIndex ?? eventKeyIndex ?? aliasIndex else { return .unavailable }
+
+        let existing = self.sessions[index]
+        let isTerminal = phase == "end" || phase == "error"
+        if phase == "start" {
+            guard let snapshotUpdatedAt = snapshot.updatedAt else { return .unavailable }
+            if let existingUpdatedAt = existing.updatedAt, snapshotUpdatedAt <= existingUpdatedAt {
+                return .rejected
+            }
+        } else if let snapshotUpdatedAt = snapshot.updatedAt,
+                  let existingUpdatedAt = existing.updatedAt,
+                  snapshotUpdatedAt < existingUpdatedAt
+        {
+            return .rejected
+        }
+
+        let existingActiveRunIDs = existing.activeRunIds?.compactMap { Self.normalizedRunID($0) } ?? []
+        if isTerminal, let runID {
+            if !existingActiveRunIDs.isEmpty {
+                guard existingActiveRunIDs == [runID] else { return .rejected }
+            } else if existing.hasActiveRun == true {
+                return .rejected
+            }
+        }
+
+        // Lifecycle snapshots intentionally omit catalog metadata. Merge only
+        // run-owned fields so a sparse terminal row cannot erase sidebar state.
+        var merged = existing
+        if let updatedAt = snapshot.updatedAt {
+            merged.updatedAt = updatedAt
+        }
+        if let status = snapshot.status {
+            merged.status = status
+        }
+        if phase == "start" || phase == "end" {
+            merged.lastRunError = snapshot.lastRunError
+        } else if let lastRunError = snapshot.lastRunError {
+            merged.lastRunError = lastRunError
+        }
+        if let hasActiveRun = snapshot.hasActiveRun {
+            merged.hasActiveRun = hasActiveRun
+        }
+        if let activeRunIDs = snapshot.activeRunIds {
+            merged.activeRunIds = activeRunIDs
+        } else if phase == "start", let runID {
+            var activeRunIDs = existingActiveRunIDs
+            if !activeRunIDs.contains(runID) {
+                activeRunIDs.append(runID)
+            }
+            merged.activeRunIds = activeRunIDs
+            merged.hasActiveRun = true
+        } else if isTerminal, let runID {
+            merged.activeRunIds = existingActiveRunIDs.filter { $0 != runID }
+            merged.hasActiveRun = merged.activeRunIds?.isEmpty == false
+        }
+
+        switch phase {
+        case "start":
+            merged.startedAt = snapshot.startedAt ?? existing.startedAt
+            merged.endedAt = nil
+            merged.runtimeMs = nil
+            merged.outputTokens = nil
+        case "end", "error":
+            merged.startedAt = snapshot.startedAt ?? existing.startedAt
+            merged.endedAt = snapshot.endedAt ?? existing.endedAt
+            merged.runtimeMs = snapshot.runtimeMs ?? existing.runtimeMs
+            merged.outputTokens = snapshot.outputTokens ?? existing.outputTokens
+        default:
+            if let startedAt = snapshot.startedAt {
+                merged.startedAt = startedAt
+            }
+            if let endedAt = snapshot.endedAt {
+                merged.endedAt = endedAt
+            }
+            if let runtimeMs = snapshot.runtimeMs {
+                merged.runtimeMs = runtimeMs
+            }
+            if let outputTokens = snapshot.outputTokens {
+                merged.outputTokens = outputTokens
+            }
+        }
+
+        var updated = self.sessions
+        updated[index] = merged
+        self.sessions = OpenClawChatSessionListOrganizer.organize(updated)
+        self.persistSessionsToCache(self.sessions)
+        return .merged
+    }
+
+    private func terminalRunID(
+        explicitRunID: String?,
+        sessionKey: String?,
+        agentID: String?,
+        includeAdvertisedRuns: Bool) -> String?
+    {
+        if let explicitRunID = Self.normalizedRunID(explicitRunID) {
+            return explicitRunID
+        }
+        if sessionKey == nil {
+            return self.pendingRuns.count == 1 ? self.pendingRuns.first : nil
+        }
+        guard let sessionKey,
+              self.matchesCurrentSessionKey(
+                  incoming: sessionKey,
+                  agentId: agentID,
+                  current: self.sessionKey)
+        else {
+            return nil
+        }
+        let ownedRunIDs = includeAdvertisedRuns
+            ? self.pendingRuns.union(Set(self.liveAdvertisedRunIDs))
+            : self.pendingRuns
+        return ownedRunIDs.count == 1 ? ownedRunIDs.first : nil
+    }
+
+    private func requestSessionsRefresh() {
+        let context = self.currentSessionSnapshot()
+        Task { await self.fetchSessions(limit: 50, sessionSnapshot: context) }
     }
 
     private func handleSessionMessageEvent(_ payload: OpenClawSessionMessageEventPayload) {
@@ -184,91 +408,93 @@ extension OpenClawChatViewModel {
     }
 
     private func handleChatEvent(_ chat: OpenClawChatEventPayload) {
-        let isOurRun = chat.runId.flatMap { self.pendingRuns.contains($0) } ?? false
-        if let runId = chat.runId {
+        let explicitRunID = Self.normalizedRunID(chat.runId)
+        let isOurRun = explicitRunID.map { self.pendingRuns.contains($0) } ?? false
+        if let runID = explicitRunID {
             self.logDiagnostic(
                 "chat.ui event chat state=\(chat.state ?? "unknown") "
-                    + "runId=\(runId) ours=\(isOurRun) pending=\(self.pendingRunCount)")
+                    + "runId=\(runID) ours=\(isOurRun) pending=\(self.pendingRunCount)")
         }
 
         // Gateway may publish canonical session keys (for example "agent:main:main")
         // even when this view currently uses an alias key (for example "main").
         // Never drop events for our own pending run on key mismatch, or the UI can stay
         // stuck at "thinking" until the user reopens and forces a history reload.
-        if let sessionKey = chat.sessionKey,
-           !self.matchesCurrentSessionKey(
-               incoming: sessionKey,
-               agentId: chat.agentId,
-               current: self.sessionKey),
-           !isOurRun
-        {
+        let matchesCurrentSession = chat.sessionKey.map {
+            self.matchesCurrentSessionKey(
+                incoming: $0,
+                agentId: chat.agentId,
+                current: self.sessionKey)
+        } ?? true
+        if !matchesCurrentSession, !isOurRun {
             return
         }
-        if chat.state == "delta",
-           let runId = Self.normalizedRunID(chat.runId)
-        {
-            guard self.pendingRuns.isEmpty || self.pendingRuns.contains(runId) else {
-                return
-            }
+        if chat.state == "delta", let runID = explicitRunID {
+            guard self.pendingRuns.isEmpty || self.pendingRuns.contains(runID) else { return }
             self.invalidateRunSnapshots()
             self.adoptRun(
-                runId: runId,
+                runId: runID,
                 bufferedText: OpenClawChatEventText.assistantText(from: chat) ?? "")
             return
         }
-        if chat.state == "final" || chat.state == "aborted" || chat.state == "error" {
+
+        let isTerminal = chat.state == "final" || chat.state == "aborted" || chat.state == "error"
+        let terminalRunID = isTerminal
+            ? self.terminalRunID(
+                explicitRunID: explicitRunID,
+                sessionKey: chat.sessionKey,
+                agentID: chat.agentId,
+                includeAdvertisedRuns: false)
+            : nil
+        let ownsTerminalRun = terminalRunID.map { self.pendingRuns.contains($0) } == true
+        let settlesAdvertisedRun = matchesCurrentSession && explicitRunID.map {
+            self.activeSessionRunIDs.contains($0)
+        } == true
+        if isTerminal {
             self.invalidateHistorySnapshots()
-            if isOurRun || self.pendingRuns.isEmpty {
+            if settlesAdvertisedRun, !ownsTerminalRun {
+                self.retireTerminalRun(explicitRunID)
+            }
+            if ownsTerminalRun || self.pendingRuns.isEmpty {
                 self.updateActiveSessionRunWithoutChatSnapshot(false)
             }
         }
         self.invalidateRunSnapshots()
-        if !isOurRun {
-            // Keep multiple clients in sync: if another client finishes a run for our session, refresh history.
-            switch chat.state {
-            case "final", "aborted", "error":
-                // An older external turn must not erase the stream or tools
-                // owned by the run this client is still actively following.
-                if self.pendingRuns.isEmpty {
+
+        guard isOurRun || ownsTerminalRun else {
+            // Another client's completion refreshes durable history, but cannot
+            // erase singleton activity owned by this client's selected run.
+            if isTerminal {
+                if self.liveLocalRunIDs.isEmpty {
                     self.updateStreamingAssistantText(nil)
                     self.pendingToolCallsById = [:]
                 }
-                if let runId = chat.runId {
-                    self.clearPlan(for: runId)
+                if let explicitRunID {
+                    self.clearPlan(for: explicitRunID)
                 }
                 self.appendFinalChatMessageIfPresent(chat)
                 let context = self.beginHistoryRequest()
                 Task { await self.refreshHistoryAfterRun(historyRequest: context) }
-            default:
-                break
             }
             return
         }
 
-        switch chat.state {
-        case "final", "aborted", "error":
-            if chat.state == "error" {
-                self.errorText = chat.errorMessage ?? "Chat failed"
-            }
-            let hapticEvent: OpenClawChatHaptics.Event? = switch chat.state {
-            case "final": .runCompleted
-            case "error": .runFailed
-            default: nil
-            }
-            if let runId = chat.runId {
-                self.clearPendingRun(runId, hapticEvent: hapticEvent)
-            } else if self.pendingRuns.count <= 1 {
-                self.clearPendingRuns(reason: nil, hapticEvent: hapticEvent)
-            }
-            self.pendingToolCallsById = [:]
-            self.updateStreamingAssistantText(nil)
-            self.appendFinalChatMessageIfPresent(chat)
-            let context = self.beginHistoryRequest()
-            self.applyDeferredExternalStateIfReady()
-            Task { await self.refreshHistoryAfterRun(historyRequest: context) }
-        default:
-            break
+        guard isTerminal, let terminalRunID else { return }
+        if chat.state == "error" {
+            self.errorText = chat.errorMessage ?? "Chat failed"
         }
+        let hapticEvent: OpenClawChatHaptics.Event? = switch chat.state {
+        case "final": .runCompleted
+        case "error": .runFailed
+        default: nil
+        }
+        self.retirePendingRun(terminalRunID, hapticEvent: hapticEvent)
+        self.pendingToolCallsById = [:]
+        self.updateStreamingAssistantText(nil)
+        self.appendFinalChatMessageIfPresent(chat)
+        let context = self.beginHistoryRequest()
+        self.applyDeferredExternalStateIfReady()
+        Task { await self.refreshHistoryAfterRun(historyRequest: context) }
     }
 
     private func appendFinalChatMessageIfPresent(_ chat: OpenClawChatEventPayload) {
@@ -351,11 +577,26 @@ extension OpenClawChatViewModel {
     }
 
     private func handleAgentEvent(_ evt: OpenClawAgentEventPayload) {
-        let isPendingRun = self.pendingRuns.contains(evt.runId)
-        let isLegacySessionStream = self.pendingRuns.isEmpty && self.sessionId == evt.runId
-        if !isPendingRun, !isLegacySessionStream {
+        if evt.stream == "usage" {
+            self.handleAgentUsageEvent(evt)
             return
         }
+
+        let isPendingRun = self.pendingRuns.contains(evt.runId)
+        let isAdvertisedRun = self.activeSessionRunIDs.contains(evt.runId)
+        let isLegacySessionStream = self.pendingRuns.isEmpty && self.sessionId == evt.runId
+        if evt.stream == "lifecycle" {
+            guard isPendingRun || isAdvertisedRun || isLegacySessionStream else { return }
+            self.handleAgentLifecycleEvent(
+                evt,
+                isPendingRun: isPendingRun,
+                isSelectedRun: self.liveUsageRunID == evt.runId,
+                isLegacySessionStream: isLegacySessionStream)
+            return
+        }
+
+        let isSelectedPendingRun = isPendingRun && self.liveUsageRunID == evt.runId
+        guard isSelectedPendingRun || isLegacySessionStream else { return }
         self.invalidateRunSnapshots()
         self.logDiagnostic(
             "chat.ui event agent stream=\(evt.stream) "
@@ -367,8 +608,6 @@ extension OpenClawChatViewModel {
                 self.updateActiveSessionRunWithoutChatSnapshot(false)
                 self.updateStreamingAssistantText(text)
             }
-        case "lifecycle":
-            self.handleAgentLifecycleEvent(evt, isPendingRun: isPendingRun)
         case "plan":
             guard Self.lowercasedAgentEventString(evt.data["phase"]) == "update" else { return }
             self.applyPlanSnapshot(runId: evt.runId, data: evt.data)
@@ -393,7 +632,24 @@ extension OpenClawChatViewModel {
         }
     }
 
-    private func handleAgentLifecycleEvent(_ evt: OpenClawAgentEventPayload, isPendingRun: Bool) {
+    private func handleAgentUsageEvent(_ evt: OpenClawAgentEventPayload) {
+        guard let sequence = evt.seq,
+              let outputTokens = evt.data["outputTokens"]?.value as? Int
+        else {
+            return
+        }
+        self.applyLiveRunUsage(
+            runID: evt.runId,
+            sequence: sequence,
+            outputTokens: outputTokens)
+    }
+
+    private func handleAgentLifecycleEvent(
+        _ evt: OpenClawAgentEventPayload,
+        isPendingRun: Bool,
+        isSelectedRun: Bool,
+        isLegacySessionStream: Bool)
+    {
         let phase = Self.lowercasedAgentEventString(evt.data["phase"])
         let status = Self.lowercasedAgentEventString(evt.data["status"])
         let aborted = Self.agentEventBool(evt.data["aborted"])
@@ -405,18 +661,37 @@ extension OpenClawChatViewModel {
             status == "complete" || status == "completed"
         let isTerminalPhase = phase == "end" || phase == "complete" || phase == "completed"
 
+        if phase == "start" {
+            guard let sequence = evt.seq else { return }
+            _ = self.applyLiveRunLifecycle(runID: evt.runId, sequence: sequence, terminal: false)
+            return
+        }
         guard isTerminalPhase || isFailure || aborted || isSuccessfulStatus else { return }
+        let acceptedLifecycle = if isLegacySessionStream {
+            true
+        } else if let sequence = evt.seq {
+            self.applyLiveRunLifecycle(runID: evt.runId, sequence: sequence, terminal: true)
+        } else {
+            isPendingRun || isSelectedRun
+        }
+        guard acceptedLifecycle else { return }
 
         self.invalidateHistorySnapshots()
-        self.updateActiveSessionRunWithoutChatSnapshot(false)
-
-        if isFailure || aborted {
-            self.errorText = Self.agentLifecycleErrorMessage(evt, aborted: aborted)
-        }
         if isPendingRun {
-            self.clearPendingRun(
+            self.retirePendingRun(
                 evt.runId,
                 hapticEvent: isFailure || aborted ? .runFailed : .runCompleted)
+        } else if evt.seq == nil {
+            self.retireTerminalRun(evt.runId)
+        }
+        guard isSelectedRun || isLegacySessionStream else {
+            self.requestSessionsRefresh()
+            return
+        }
+
+        self.updateActiveSessionRunWithoutChatSnapshot(false)
+        if isFailure || aborted {
+            self.errorText = Self.agentLifecycleErrorMessage(evt, aborted: aborted)
         }
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
@@ -458,7 +733,7 @@ extension OpenClawChatViewModel {
     }
 
     func finishPendingRunAfterTerminalOkSendAck(_ response: OpenClawChatSendResponse) {
-        self.clearPendingRun(response.runId, hapticEvent: .runCompleted)
+        self.retirePendingRun(response.runId, hapticEvent: .runCompleted)
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
         self.logDiagnostic(
@@ -473,7 +748,7 @@ extension OpenClawChatViewModel {
             self.pendingToolCallsById = [:]
             self.updateStreamingAssistantText(nil)
             self.errorText = "Chat failed before the run started; try again."
-            self.clearPendingRun(response.runId, hapticEvent: .runFailed)
+            self.retirePendingRun(response.runId, hapticEvent: .runFailed)
             self.logDiagnostic(
                 "chat.ui send terminal ack sessionKey=\(self.sessionKey) "
                     + "runId=\(response.runId) status=timeout")
@@ -483,7 +758,7 @@ extension OpenClawChatViewModel {
             self.pendingToolCallsById = [:]
             self.updateStreamingAssistantText(nil)
             self.errorText = "Chat failed before the run started; try again."
-            self.clearPendingRun(response.runId, hapticEvent: .runFailed)
+            self.retirePendingRun(response.runId, hapticEvent: .runFailed)
             self.logDiagnostic(
                 "chat.ui send terminal ack sessionKey=\(self.sessionKey) "
                     + "runId=\(response.runId) status=error")
@@ -531,7 +806,7 @@ extension OpenClawChatViewModel {
                 return false
             }
             self.errorText = message
-            self.clearPendingRun(runId, hapticEvent: .runFailed)
+            self.retirePendingRun(runId, hapticEvent: .runFailed)
             self.pendingToolCallsById = [:]
             self.updateStreamingAssistantText(nil)
             return false
@@ -582,7 +857,7 @@ extension OpenClawChatViewModel {
             self.errorText = message
             hapticEvent = .runFailed
         }
-        self.clearPendingRun(runId, hapticEvent: hapticEvent)
+        self.retirePendingRun(runId, hapticEvent: hapticEvent)
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
     }
@@ -600,7 +875,7 @@ extension OpenClawChatViewModel {
     @discardableResult
     func clearPendingRunIfAssistantMessagePresent(runId: String, after timestamp: Double) -> Bool {
         guard let hapticEvent = assistantHapticEvent(after: timestamp) else { return false }
-        self.clearPendingRun(runId, hapticEvent: hapticEvent)
+        self.retirePendingRun(runId, hapticEvent: hapticEvent)
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
         return true
@@ -1051,6 +1326,22 @@ extension OpenClawChatViewModel {
         _ runId: String,
         hapticEvent: OpenClawChatHaptics.Event? = nil)
     {
+        self.clearLiveRunState(for: runId)
+        self.removePendingRun(runId, hapticEvent: hapticEvent)
+    }
+
+    func retirePendingRun(
+        _ runId: String,
+        hapticEvent: OpenClawChatHaptics.Event? = nil)
+    {
+        self.retireTerminalRun(runId)
+        self.removePendingRun(runId, hapticEvent: hapticEvent)
+    }
+
+    private func removePendingRun(
+        _ runId: String,
+        hapticEvent: OpenClawChatHaptics.Event?)
+    {
         let wasPending = self.pendingRuns.contains(runId)
         self.pendingRuns.remove(runId)
         self.clearPlan(for: runId)
@@ -1076,6 +1367,7 @@ extension OpenClawChatViewModel {
         let runIds = Array(pendingRuns)
         for runId in self.pendingRuns {
             self.pendingRunOwnerTasks[runId]?.cancel()
+            self.clearLiveRunState(for: runId)
         }
         self.pendingRunOwnerTasks.removeAll()
         self.pendingRunOwnerArmIDs.removeAll()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -228,30 +228,67 @@ extension OpenClawChatViewModel {
         runID: String?) -> LifecycleSessionMergeResult
     {
         guard let snapshot = change.session else { return .unavailable }
-        if let eventKey = change.sessionKey,
-           snapshot.key != eventKey,
-           !self.matchesCurrentSessionKey(
-               incoming: snapshot.key,
-               agentId: change.agentId,
-               current: eventKey)
+        guard self.lifecycleSnapshotMatchesEvent(snapshot, change: change) else { return .rejected }
+        guard let index = self.lifecycleSessionIndex(snapshot, change: change) else { return .unavailable }
+
+        let existing = self.sessions[index]
+        if let rejection = Self.lifecycleSnapshotRejection(
+            snapshot: snapshot,
+            existing: existing,
+            phase: phase,
+            runID: runID)
         {
-            return .rejected
+            return rejection
         }
 
-        let exactIndex = self.sessions.firstIndex(where: { $0.key == snapshot.key })
-        let eventKeyIndex = change.sessionKey.flatMap { key in
-            self.sessions.firstIndex(where: { $0.key == key })
+        var updated = self.sessions
+        updated[index] = Self.mergedLifecycleSession(
+            existing: existing,
+            snapshot: snapshot,
+            phase: phase,
+            runID: runID)
+        self.sessions = OpenClawChatSessionListOrganizer.organize(updated)
+        self.persistSessionsToCache(self.sessions)
+        return .merged
+    }
+
+    private func lifecycleSnapshotMatchesEvent(
+        _ snapshot: OpenClawChatSessionEntry,
+        change: OpenClawChatSessionsChangedEvent) -> Bool
+    {
+        guard let eventKey = change.sessionKey, snapshot.key != eventKey else { return true }
+        return self.matchesCurrentSessionKey(
+            incoming: snapshot.key,
+            agentId: change.agentId,
+            current: eventKey)
+    }
+
+    private func lifecycleSessionIndex(
+        _ snapshot: OpenClawChatSessionEntry,
+        change: OpenClawChatSessionsChangedEvent) -> Int?
+    {
+        if let exactIndex = self.sessions.firstIndex(where: { $0.key == snapshot.key }) {
+            return exactIndex
         }
-        let aliasIndex = self.sessions.firstIndex(where: { session in
+        if let eventKey = change.sessionKey,
+           let eventKeyIndex = self.sessions.firstIndex(where: { $0.key == eventKey })
+        {
+            return eventKeyIndex
+        }
+        return self.sessions.firstIndex(where: { session in
             self.matchesCurrentSessionKey(
                 incoming: snapshot.key,
                 agentId: change.agentId,
                 current: session.key)
         })
-        guard let index = exactIndex ?? eventKeyIndex ?? aliasIndex else { return .unavailable }
+    }
 
-        let existing = self.sessions[index]
-        let isTerminal = phase == "end" || phase == "error"
+    private static func lifecycleSnapshotRejection(
+        snapshot: OpenClawChatSessionEntry,
+        existing: OpenClawChatSessionEntry,
+        phase: String,
+        runID: String?) -> LifecycleSessionMergeResult?
+    {
         if phase == "start" {
             guard let snapshotUpdatedAt = snapshot.updatedAt else { return .unavailable }
             if let existingUpdatedAt = existing.updatedAt, snapshotUpdatedAt <= existingUpdatedAt {
@@ -264,40 +301,38 @@ extension OpenClawChatViewModel {
             return .rejected
         }
 
-        let existingActiveRunIDs = existing.activeRunIds?.compactMap { Self.normalizedRunID($0) } ?? []
-        if isTerminal, let runID {
-            if !existingActiveRunIDs.isEmpty {
-                guard existingActiveRunIDs == [runID] else { return .rejected }
-            } else if existing.hasActiveRun == true {
-                return .rejected
-            }
+        guard phase == "end" || phase == "error", let runID else { return nil }
+        let activeRunIDs = existing.activeRunIds?.compactMap { Self.normalizedRunID($0) } ?? []
+        if !activeRunIDs.isEmpty {
+            return activeRunIDs == [runID] ? nil : .rejected
         }
+        return existing.hasActiveRun == true ? .rejected : nil
+    }
 
-        // Lifecycle snapshots intentionally omit catalog metadata. Merge only
-        // run-owned fields so a sparse terminal row cannot erase sidebar state.
+    private static func mergedLifecycleSession(
+        existing: OpenClawChatSessionEntry,
+        snapshot: OpenClawChatSessionEntry,
+        phase: String,
+        runID: String?) -> OpenClawChatSessionEntry
+    {
+        let isTerminal = phase == "end" || phase == "error"
+        let existingActiveRunIDs = existing.activeRunIds?.compactMap { Self.normalizedRunID($0) } ?? []
         var merged = existing
-        if let updatedAt = snapshot.updatedAt {
-            merged.updatedAt = updatedAt
-        }
-        if let status = snapshot.status {
-            merged.status = status
-        }
+        merged.updatedAt = snapshot.updatedAt ?? existing.updatedAt
+        merged.status = snapshot.status ?? existing.status
+        merged.hasActiveRun = snapshot.hasActiveRun ?? existing.hasActiveRun
         if phase == "start" || phase == "end" {
             merged.lastRunError = snapshot.lastRunError
-        } else if let lastRunError = snapshot.lastRunError {
-            merged.lastRunError = lastRunError
+        } else {
+            merged.lastRunError = snapshot.lastRunError ?? existing.lastRunError
         }
-        if let hasActiveRun = snapshot.hasActiveRun {
-            merged.hasActiveRun = hasActiveRun
-        }
+
         if let activeRunIDs = snapshot.activeRunIds {
             merged.activeRunIds = activeRunIDs
         } else if phase == "start", let runID {
-            var activeRunIDs = existingActiveRunIDs
-            if !activeRunIDs.contains(runID) {
-                activeRunIDs.append(runID)
-            }
-            merged.activeRunIds = activeRunIDs
+            merged.activeRunIds = existingActiveRunIDs.contains(runID)
+                ? existingActiveRunIDs
+                : existingActiveRunIDs + [runID]
             merged.hasActiveRun = true
         } else if isTerminal, let runID {
             merged.activeRunIds = existingActiveRunIDs.filter { $0 != runID }
@@ -316,25 +351,12 @@ extension OpenClawChatViewModel {
             merged.runtimeMs = snapshot.runtimeMs ?? existing.runtimeMs
             merged.outputTokens = snapshot.outputTokens ?? existing.outputTokens
         default:
-            if let startedAt = snapshot.startedAt {
-                merged.startedAt = startedAt
-            }
-            if let endedAt = snapshot.endedAt {
-                merged.endedAt = endedAt
-            }
-            if let runtimeMs = snapshot.runtimeMs {
-                merged.runtimeMs = runtimeMs
-            }
-            if let outputTokens = snapshot.outputTokens {
-                merged.outputTokens = outputTokens
-            }
+            merged.startedAt = snapshot.startedAt ?? existing.startedAt
+            merged.endedAt = snapshot.endedAt ?? existing.endedAt
+            merged.runtimeMs = snapshot.runtimeMs ?? existing.runtimeMs
+            merged.outputTokens = snapshot.outputTokens ?? existing.outputTokens
         }
-
-        var updated = self.sessions
-        updated[index] = merged
-        self.sessions = OpenClawChatSessionListOrganizer.organize(updated)
-        self.persistSessionsToCache(self.sessions)
-        return .merged
+        return merged
     }
 
     private func terminalRunID(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -472,12 +472,15 @@ extension OpenClawChatViewModel {
         let settlesAdvertisedRun = matchesCurrentSession && explicitRunID.map {
             self.activeSessionRunIDs.contains($0)
         } == true
+        let settlesBooleanOnlyRun =
+            matchesCurrentSession && explicitRunID == nil && self.pendingRuns.isEmpty &&
+            self.activeSessionRunIDs.isEmpty && self.hasActiveSessionRunWithoutChatSnapshot
         if isTerminal {
             self.invalidateHistorySnapshots()
             if settlesAdvertisedRun, !ownsTerminalRun {
                 self.retireTerminalRun(explicitRunID)
             }
-            if ownsTerminalRun || self.pendingRuns.isEmpty {
+            if ownsTerminalRun || settlesBooleanOnlyRun {
                 self.updateActiveSessionRunWithoutChatSnapshot(false)
             }
         }
@@ -612,6 +615,7 @@ extension OpenClawChatViewModel {
             self.handleAgentLifecycleEvent(
                 evt,
                 isPendingRun: isPendingRun,
+                isAdvertisedRun: isAdvertisedRun,
                 isSelectedRun: self.liveUsageRunID == evt.runId,
                 isLegacySessionStream: isLegacySessionStream)
             return
@@ -669,6 +673,7 @@ extension OpenClawChatViewModel {
     private func handleAgentLifecycleEvent(
         _ evt: OpenClawAgentEventPayload,
         isPendingRun: Bool,
+        isAdvertisedRun: Bool,
         isSelectedRun: Bool,
         isLegacySessionStream: Bool)
     {
@@ -694,7 +699,7 @@ extension OpenClawChatViewModel {
         } else if let sequence = evt.seq {
             self.applyLiveRunLifecycle(runID: evt.runId, sequence: sequence, terminal: true)
         } else {
-            isPendingRun || isSelectedRun
+            isPendingRun || isAdvertisedRun || isSelectedRun
         }
         guard acceptedLifecycle else { return }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -6,6 +6,12 @@ import OSLog
 // Module-internal: ChatViewModel extension files share this logger.
 let chatUILogger = Logger(subsystem: "ai.openclaw", category: "OpenClawChatUI")
 
+struct ChatLiveRunState: Equatable, Sendable {
+    let sequence: Int
+    let outputTokens: Int?
+    let terminal: Bool
+}
+
 @MainActor
 @Observable
 public final class OpenClawChatViewModel {
@@ -111,9 +117,14 @@ public final class OpenClawChatViewModel {
     var questionRefreshRetryTask: Task<Void, Never>?
     var questionRefreshRetryDelaysMs: [Int64] = [1000, 2000, 4000]
     var hasActiveSessionRunWithoutChatSnapshot = false
+    var activeSessionRunIDs: [String] = []
+    var liveRunStateByRunID: [String: ChatLiveRunState] = [:]
 
     public private(set) var sessionKey: String {
-        didSet { syncContextUsageFraction() }
+        didSet {
+            syncContextUsageFraction()
+            syncActiveSessionRunIDsFromCurrentSession()
+        }
     }
 
     public internal(set) var sessionId: String?
@@ -127,7 +138,10 @@ public final class OpenClawChatViewModel {
     private(set) var timelineRevision: UInt64 = 0
     /// Setter is module-internal for the transcript-cache extension only.
     public internal(set) var sessions: [OpenClawChatSessionEntry] = [] {
-        didSet { syncContextUsageFraction() }
+        didSet {
+            syncContextUsageFraction()
+            syncActiveSessionRunIDsFromCurrentSession()
+        }
     }
 
     public internal(set) var swarmSessions: [OpenClawChatSessionEntry] = []
@@ -1286,6 +1300,8 @@ extension OpenClawChatViewModel {
         self.updateStreamingAssistantText(nil)
         clearPlan()
         self.updateActiveSessionRunWithoutChatSnapshot(false)
+        self.activeSessionRunIDs = []
+        self.liveRunStateByRunID.removeAll()
         resetSlashCommandCatalog()
         self.sessionBranches = []
         self.isLoadingSessionBranches = false

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -6,12 +6,6 @@ import OSLog
 // Module-internal: ChatViewModel extension files share this logger.
 let chatUILogger = Logger(subsystem: "ai.openclaw", category: "OpenClawChatUI")
 
-struct ChatLiveRunState: Equatable, Sendable {
-    let sequence: Int
-    let outputTokens: Int?
-    let terminal: Bool
-}
-
 @MainActor
 @Observable
 public final class OpenClawChatViewModel {
@@ -90,23 +84,9 @@ public final class OpenClawChatViewModel {
     public internal(set) var isLoadingSessionBranches = false
     @ObservationIgnored
     var sessionBranchesRefreshGeneration: UInt64 = 0
-    struct SessionBranchSwitchActivity: Equatable {
-        let session: SessionSnapshot
-        let generation: UInt64
-    }
-
     var sessionBranchSwitchActivity: SessionBranchSwitchActivity?
     @ObservationIgnored
     var nextSessionBranchSwitchGeneration: UInt64 = 0
-
-    var isSwitchingSessionBranch: Bool {
-        self.sessionBranchSwitchActivity != nil
-    }
-
-    /// True when this view model owns a gateway-scoped durable text outbox.
-    public var supportsOfflineTextOutbox: Bool {
-        self.outbox != nil
-    }
 
     public private(set) var pendingRunCount: Int = 0
     public internal(set) var questionCards: [OpenClawQuestionCardModel] = []

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingClawView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingClawView.swift
@@ -402,6 +402,7 @@ struct ChatWorkingStatusText: View {
 
     let startedAt: Date
     let seed: String
+    let outputTokens: Int?
 
     var body: some View {
         Group {
@@ -423,6 +424,14 @@ struct ChatWorkingStatusText: View {
             Text(duration)
                 .font(OpenClawChatTypography.captionSemiBold)
                 .monospacedDigit()
+            if let tokensText = ChatTurnRecapText.tokens(self.outputTokens) {
+                Text("·")
+                    .font(OpenClawChatTypography.caption)
+                    .accessibilityHidden(true)
+                Text(tokensText)
+                    .font(OpenClawChatTypography.caption)
+                    .monospacedDigit()
+            }
             if let index = ChatWorkingPhrase.index(
                 seed: self.seed,
                 elapsedMilliseconds: elapsedMilliseconds)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
@@ -81,19 +81,18 @@ enum ChatWorkingPhrase {
 }
 
 enum ChatWorkingDurationFormatter {
+    private static let compactUnits = [
+        (suffix: "d", seconds: 86400),
+        (suffix: "h", seconds: 3600),
+        (suffix: "m", seconds: 60),
+        (suffix: "s", seconds: 1),
+    ]
+
     static func compact(milliseconds: Double) -> String {
-        let finiteMilliseconds = milliseconds.isFinite ? milliseconds : 1000
-        let roundedSeconds = (max(1000, finiteMilliseconds) / 1000).rounded()
-        let totalSeconds = max(1, Int(min(roundedSeconds, Double(Int.max / 2))))
-        let units = [
-            (suffix: "d", seconds: 86400),
-            (suffix: "h", seconds: 3600),
-            (suffix: "m", seconds: 60),
-            (suffix: "s", seconds: 1),
-        ]
+        let totalSeconds = self.totalSeconds(milliseconds: milliseconds)
         var remainder = totalSeconds
         var parts: [String] = []
-        for unit in units {
+        for unit in self.compactUnits {
             let value = remainder / unit.seconds
             remainder %= unit.seconds
             if value > 0 {
@@ -104,6 +103,25 @@ enum ChatWorkingDurationFormatter {
             }
         }
         return parts.joined(separator: " ")
+    }
+
+    static func full(milliseconds: Double, locale: Locale = .current) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour, .minute, .second]
+        formatter.unitsStyle = .full
+        formatter.maximumUnitCount = 2
+        formatter.zeroFormattingBehavior = .dropAll
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = locale
+        formatter.calendar = calendar
+        return formatter.string(from: TimeInterval(self.totalSeconds(milliseconds: milliseconds))) ??
+            String(localized: "1 second", locale: locale)
+    }
+
+    private static func totalSeconds(milliseconds: Double) -> Int {
+        let finiteMilliseconds = milliseconds.isFinite ? milliseconds : 1000
+        let roundedSeconds = (max(1000, finiteMilliseconds) / 1000).rounded()
+        return max(1, Int(min(roundedSeconds, Double(Int.max / 2))))
     }
 }
 
@@ -134,7 +152,7 @@ enum ChatTurnRecapText {
         String(
             format: String(localized: "Done in %@", locale: locale),
             locale: locale,
-            ChatWorkingDurationFormatter.compact(milliseconds: runtimeMs))
+            ChatWorkingDurationFormatter.full(milliseconds: runtimeMs, locale: locale))
     }
 
     static func tokens(_ outputTokens: Int?, locale: Locale = .current) -> String? {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
@@ -455,6 +455,38 @@ struct ChatGatewayPayloadCodecTests {
         #expect(note.kind == "phase")
         #expect(note.text == "Research")
 
+        let lifecycleChanged = EventFrame(
+            type: "event",
+            event: "sessions.changed",
+            payload: AnyCodable([
+                "sessionKey": AnyCodable("agent:main:main"),
+                "phase": AnyCodable("end"),
+                "runId": AnyCodable("run-1"),
+                "session": AnyCodable([
+                    "key": AnyCodable("agent:main:main"),
+                    "updatedAt": AnyCodable(30000),
+                    "status": AnyCodable("done"),
+                    "hasActiveRun": AnyCodable(false),
+                    "runtimeMs": AnyCodable(30000),
+                    "outputTokens": AnyCodable(42),
+                    "activeRunIds": AnyCodable([]),
+                ]),
+            ]))
+        guard case let .sessionsChanged(lifecycle) = OpenClawChatGatewayPayloadCodec.event(
+            from: lifecycleChanged)
+        else {
+            Issue.record("expected lifecycle sessionsChanged")
+            return
+        }
+        #expect(lifecycle.reason.isEmpty)
+        #expect(lifecycle.phase == "end")
+        #expect(lifecycle.runId == "run-1")
+        #expect(lifecycle.session?.key == "agent:main:main")
+        #expect(lifecycle.session?.status == "done")
+        #expect(lifecycle.session?.runtimeMs == 30000)
+        #expect(lifecycle.session?.outputTokens == 42)
+        #expect(lifecycle.session?.activeRunIds == [])
+
         let chat = EventFrame(
             type: "event",
             event: "chat",

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -87,6 +87,54 @@ private func historyPayload(
         inFlightRun: inFlightRun)
 }
 
+private func usageEvent(runId: String, outputTokens: Int, seq: Int) -> OpenClawAgentEventPayload {
+    OpenClawAgentEventPayload(
+        runId: runId,
+        seq: seq,
+        stream: "usage",
+        ts: seq,
+        data: ["outputTokens": AnyCodable(outputTokens)])
+}
+
+private func lifecycleSessionEntry(
+    key: String,
+    updatedAt: Double,
+    status: String,
+    hasActiveRun: Bool,
+    activeRunIds: [String],
+    startedAt: Double? = nil,
+    endedAt: Double? = nil,
+    runtimeMs: Double? = nil,
+    outputTokens: Int? = nil) -> OpenClawChatSessionEntry
+{
+    OpenClawChatSessionEntry(
+        key: key,
+        kind: nil,
+        displayName: nil,
+        surface: nil,
+        subject: nil,
+        room: nil,
+        space: nil,
+        updatedAt: updatedAt,
+        sessionId: nil,
+        systemSent: nil,
+        abortedLastRun: nil,
+        thinkingLevel: nil,
+        verboseLevel: nil,
+        inputTokens: nil,
+        outputTokens: outputTokens,
+        totalTokens: nil,
+        modelProvider: nil,
+        model: nil,
+        contextTokens: nil,
+        status: status,
+        hasActiveRun: hasActiveRun,
+        activeRunIds: activeRunIds,
+        startedAt: startedAt,
+        endedAt: endedAt,
+        runtimeMs: runtimeMs)
+}
+
 private func sessionEntry(
     key: String,
     updatedAt: Double,
@@ -1928,6 +1976,232 @@ struct ChatViewModelTests {
         #expect(fraction(total: 25, fresh: false, context: 100) == nil)
         #expect(fraction(total: 150, context: 100) == 1)
         #expect(fraction(total: 25, fresh: nil, context: 100) == 0.25)
+    }
+
+    @Test @MainActor func `live usage is ordered monotonic and telemetry-only for advertised runs`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        var session = sessionEntry(key: "main", updatedAt: 1)
+        session.hasActiveRun = true
+        session.activeRunIds = ["remote-z", "remote-a"]
+        viewModel.sessions = [session]
+        viewModel.pendingRuns.insert("local-run")
+
+        viewModel.handleTransportEvent(.agent(usageEvent(
+            runId: "remote-a",
+            outputTokens: 0,
+            seq: 1)))
+        #expect(viewModel.liveRunStateByRunID["remote-a"] == nil)
+        viewModel.handleTransportEvent(.agent(usageEvent(
+            runId: "remote-z",
+            outputTokens: 12,
+            seq: 1)))
+        viewModel.handleTransportEvent(.agent(usageEvent(
+            runId: "local-run",
+            outputTokens: 4,
+            seq: 1)))
+        #expect(viewModel.liveUsageRunID == "local-run")
+        #expect(viewModel.liveRunOutputTokens == 4)
+
+        viewModel.handleTransportEvent(.agent(usageEvent(
+            runId: "local-run",
+            outputTokens: 3,
+            seq: 2)))
+        viewModel.handleTransportEvent(.agent(usageEvent(
+            runId: "local-run",
+            outputTokens: 9,
+            seq: 1)))
+        #expect(viewModel.liveRunOutputTokens == 4)
+
+        viewModel.handleTransportEvent(.agent(OpenClawAgentEventPayload(
+            runId: "remote-z",
+            seq: 2,
+            stream: "assistant",
+            ts: 2,
+            data: ["text": AnyCodable("must stay remote")])))
+        viewModel.handleTransportEvent(.agent(OpenClawAgentEventPayload(
+            runId: "remote-z",
+            seq: 3,
+            stream: "tool",
+            ts: 3,
+            data: [
+                "phase": AnyCodable("start"),
+                "name": AnyCodable("demo"),
+                "toolCallId": AnyCodable("remote-tool"),
+            ])))
+        #expect(viewModel.streamingAssistantText == nil)
+        #expect(viewModel.pendingToolCalls.isEmpty)
+    }
+
+    @Test @MainActor func `sequence gap invalidates incomplete advertised usage`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        var running = sessionEntry(key: "main", updatedAt: 1)
+        running.hasActiveRun = true
+        running.activeRunIds = ["remote-run"]
+        viewModel.sessions = [running]
+        viewModel.handleTransportEvent(.agent(usageEvent(
+            runId: "remote-run",
+            outputTokens: 12,
+            seq: 1)))
+        #expect(viewModel.liveRunOutputTokens == 12)
+
+        viewModel.handleTransportEvent(.seqGap)
+
+        #expect(viewModel.liveRunStateByRunID["remote-run"]?.sequence == 1)
+        #expect(viewModel.liveRunOutputTokens == nil)
+    }
+
+    @Test @MainActor func `session switch clears advertised runs when the row is missing`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        var running = sessionEntry(key: "main", updatedAt: 1)
+        running.hasActiveRun = true
+        running.activeRunIds = ["remote-run"]
+        viewModel.sessions = [running]
+        #expect(viewModel.activeSessionRunIDs == ["remote-run"])
+
+        viewModel.switchSession(to: "missing")
+
+        #expect(viewModel.activeSessionRunIDs.isEmpty)
+        #expect(!viewModel.hasAdvertisedLiveRun)
+    }
+
+    @Test @MainActor func `remote lifecycle merges terminal recap metadata`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        var running = sessionEntry(key: "main", updatedAt: 1)
+        running.status = "running"
+        running.lastRunError = "previous failure"
+        running.hasActiveRun = true
+        running.activeRunIds = ["remote-run"]
+        viewModel.sessions = [running]
+        viewModel.handleTransportEvent(.agent(usageEvent(
+            runId: "remote-run",
+            outputTokens: 8,
+            seq: 1)))
+
+        viewModel.handleTransportEvent(.sessionsChanged(.init(
+            sessionKey: "main",
+            phase: "end",
+            runId: "remote-run",
+            session: lifecycleSessionEntry(
+                key: "main",
+                updatedAt: 2,
+                status: "done",
+                hasActiveRun: false,
+                activeRunIds: [],
+                endedAt: 2000,
+                runtimeMs: 1000,
+                outputTokens: 42))))
+
+        let merged = viewModel.currentSessionEntry()
+        #expect(merged?.status == "done")
+        #expect(merged?.lastRunError == nil)
+        #expect(merged?.endedAt == 2000)
+        #expect(merged?.runtimeMs == 1000)
+        #expect(merged?.outputTokens == 42)
+        #expect(merged?.activeRunIds == [])
+        #expect(viewModel.liveRunOutputTokens == nil)
+        #expect(!viewModel.hasBlockingRunActivity)
+    }
+
+    @Test @MainActor func `terminal lifecycle retires matching pending run despite stale snapshot`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        var running = sessionEntry(key: "main", updatedAt: 20)
+        running.status = "running"
+        running.hasActiveRun = true
+        running.activeRunIds = ["run-a", "run-b"]
+        viewModel.sessions = [running]
+        viewModel.pendingRuns = ["run-a", "run-b"]
+        viewModel.handleTransportEvent(.agent(usageEvent(
+            runId: "run-a",
+            outputTokens: 5,
+            seq: 1)))
+
+        viewModel.handleTransportEvent(.sessionsChanged(.init(
+            sessionKey: "main",
+            phase: "end",
+            runId: "run-a",
+            session: lifecycleSessionEntry(
+                key: "main",
+                updatedAt: 10,
+                status: "done",
+                hasActiveRun: false,
+                activeRunIds: [],
+                endedAt: 10,
+                runtimeMs: 5,
+                outputTokens: 5))))
+
+        #expect(viewModel.pendingRuns == ["run-b"])
+        #expect(viewModel.liveRunStateByRunID["run-a"]?.terminal == true)
+        #expect(viewModel.currentSessionEntry()?.updatedAt == 20)
+        #expect(viewModel.activeSessionRunIDs == ["run-a", "run-b"])
+        #expect(viewModel.liveUsageRunID == "run-b")
+    }
+
+    @Test @MainActor func `unsequenced lifecycle terminal retires a pending run`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        viewModel.pendingRuns.insert("legacy-run")
+
+        viewModel.handleTransportEvent(.agent(OpenClawAgentEventPayload(
+            runId: "legacy-run",
+            seq: nil,
+            stream: "lifecycle",
+            ts: 1,
+            data: ["phase": AnyCodable("end")])))
+
+        #expect(viewModel.pendingRuns.isEmpty)
+        #expect(viewModel.liveRunStateByRunID["legacy-run"]?.terminal == true)
+    }
+
+    @Test @MainActor func `advertised terminal chat retires the run without clearing local work`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        var running = sessionEntry(key: "main", updatedAt: 1)
+        running.hasActiveRun = true
+        running.activeRunIds = ["remote-run"]
+        viewModel.sessions = [running]
+
+        viewModel.handleTransportEvent(.chat(OpenClawChatEventPayload(
+            runId: "remote-run",
+            sessionKey: "main",
+            state: "final",
+            message: nil,
+            errorMessage: nil)))
+
+        #expect(viewModel.liveRunStateByRunID["remote-run"]?.terminal == true)
+        #expect(!viewModel.hasBlockingRunActivity)
+    }
+
+    @Test @MainActor func `terminal chat without run ID requires one current local owner`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        viewModel.pendingRuns = ["run-a", "run-b"]
+        let terminal = OpenClawChatEventPayload(
+            runId: nil,
+            sessionKey: nil,
+            state: "final",
+            message: nil,
+            errorMessage: nil)
+
+        viewModel.handleTransportEvent(.chat(terminal))
+        #expect(viewModel.pendingRuns == ["run-a", "run-b"])
+
+        viewModel.clearPendingRun("run-b")
+        viewModel.handleTransportEvent(.chat(terminal))
+        #expect(viewModel.pendingRuns.isEmpty)
+        #expect(viewModel.liveRunStateByRunID["run-a"]?.terminal == true)
     }
 
     @Test @MainActor func `event listener does not retain discarded view model`() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -2163,6 +2163,27 @@ struct ChatViewModelTests {
         #expect(viewModel.liveRunStateByRunID["legacy-run"]?.terminal == true)
     }
 
+    @Test @MainActor func `unsequenced lifecycle terminal retires a nonselected advertised run`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        var running = sessionEntry(key: "main", updatedAt: 1)
+        running.hasActiveRun = true
+        running.activeRunIds = ["remote-a", "remote-b"]
+        viewModel.sessions = [running]
+        #expect(viewModel.liveUsageRunID == "remote-a")
+
+        viewModel.handleTransportEvent(.agent(OpenClawAgentEventPayload(
+            runId: "remote-b",
+            seq: nil,
+            stream: "lifecycle",
+            ts: 1,
+            data: ["phase": AnyCodable("end")])))
+
+        #expect(viewModel.liveRunStateByRunID["remote-b"]?.terminal == true)
+        #expect(viewModel.liveUsageRunID == "remote-a")
+    }
+
     @Test @MainActor func `advertised terminal chat retires the run without clearing local work`() {
         let viewModel = OpenClawChatViewModel(
             sessionKey: "main",
@@ -2180,6 +2201,23 @@ struct ChatViewModelTests {
             errorMessage: nil)))
 
         #expect(viewModel.liveRunStateByRunID["remote-run"]?.terminal == true)
+        #expect(!viewModel.hasBlockingRunActivity)
+    }
+
+    @Test @MainActor func `idless terminal chat clears boolean-only current activity`() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: TestChatTransport(historyResponses: []))
+        viewModel.updateActiveSessionRunWithoutChatSnapshot(true)
+        #expect(viewModel.hasBlockingRunActivity)
+
+        viewModel.handleTransportEvent(.chat(OpenClawChatEventPayload(
+            runId: nil,
+            sessionKey: "main",
+            state: "final",
+            message: nil,
+            errorMessage: nil)))
+
         #expect(!viewModel.hasBlockingRunActivity)
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTranscriptCacheTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTranscriptCacheTests.swift
@@ -414,6 +414,35 @@ struct ChatViewModelTranscriptCacheTests {
 
         #expect(await MainActor.run { vm.sessions[0].key == "global" })
         #expect(await MainActor.run { vm.sessions[0].observerDigest == nil })
+    @Test func `session cache strips active markers and preserves terminal recap`() {
+        var active = cachedSessionEntry(key: "active", updatedAt: 2000)
+        active.status = "running"
+        active.hasActiveRun = true
+        active.activeRunIds = ["run-active"]
+        active.hasActiveSubagentRun = true
+        active.startedAt = 1000
+        active.endedAt = 2000
+        active.runtimeMs = 1000
+        active.outputTokens = 42
+
+        let projected = OpenClawChatViewModel.durableSessionCacheProjection(active)
+        #expect(projected.status == nil)
+        #expect(projected.hasActiveRun == nil)
+        #expect(projected.activeRunIds == nil)
+        #expect(projected.hasActiveSubagentRun == nil)
+        #expect(projected.startedAt == nil)
+        #expect(projected.endedAt == 2000)
+        #expect(projected.runtimeMs == 1000)
+        #expect(projected.outputTokens == 42)
+
+        var terminal = active
+        terminal.status = "done"
+        terminal.hasActiveRun = false
+        terminal.activeRunIds = []
+        terminal.hasActiveSubagentRun = false
+        let terminalProjection = OpenClawChatViewModel.durableSessionCacheProjection(terminal)
+        #expect(terminalProjection.status == "done")
+        #expect(terminalProjection.startedAt == 1000)
     }
 
     @Test func `empty live history wins over cached transcript`() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTranscriptCacheTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTranscriptCacheTests.swift
@@ -414,6 +414,8 @@ struct ChatViewModelTranscriptCacheTests {
 
         #expect(await MainActor.run { vm.sessions[0].key == "global" })
         #expect(await MainActor.run { vm.sessions[0].observerDigest == nil })
+    }
+
     @Test func `session cache strips active markers and preserves terminal recap`() {
         var active = cachedSessionEntry(key: "active", updatedAt: 2000)
         active.status = "running"

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
@@ -177,13 +177,21 @@ struct ChatWorkingProgressTests {
         #expect(!ChatWorkingDurationFormatter.compact(milliseconds: 1e30).isEmpty)
     }
 
+    @Test func `recap duration uses localized full wording with two units`() {
+        let locale = Locale(identifier: "en_US")
+        #expect(ChatWorkingDurationFormatter.full(milliseconds: 30000, locale: locale) == "30 seconds")
+        #expect(ChatWorkingDurationFormatter.full(
+            milliseconds: 14_520_000,
+            locale: locale) == "4 hours, 2 minutes")
+    }
+
     @Test func `recap token text distinguishes unknown zero one and many`() {
         let locale = Locale(identifier: "en_US")
         #expect(ChatTurnRecapText.tokens(nil, locale: locale) == nil)
         #expect(ChatTurnRecapText.tokens(0, locale: locale) == "0 tokens")
         #expect(ChatTurnRecapText.tokens(1, locale: locale) == "1 token")
         #expect(ChatTurnRecapText.tokens(485, locale: locale) == "485 tokens")
-        #expect(ChatTurnRecapText.done(runtimeMs: 51000, locale: locale) == "Done in 51s")
+        #expect(ChatTurnRecapText.done(runtimeMs: 51000, locale: locale) == "Done in 51 seconds")
     }
 
     @Test func `recap resolves on a fresh terminal then sticks`() {

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -408,9 +408,9 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
         sessionKey: "main",
         state: "delta",
       });
-      // Streaming content replaces the spark as the working signal.
+      // The working row stays attached with elapsed/token telemetry throughout streaming.
       await expect.poll(() => page.getByText("Working on it.").first().isVisible()).toBe(true);
-      await expect.poll(() => spark.count()).toBe(0);
+      await expect.poll(() => spark.isVisible()).toBe(true);
       await expect.poll(() => announcement.textContent()).toContain("Rosita is responding");
       const [activeSettingsBox, activeSplitViewBox, activeModelBox, activeChatContentBox] =
         await Promise.all([

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -221,7 +221,7 @@ suite.define(() => {
     },
   );
 
-  it("keeps the pending working row stable through acknowledgement and streaming", async () => {
+  it("keeps the pending telemetry row stable through acknowledgement and streaming", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -340,6 +340,20 @@ suite.define(() => {
       expect(Math.max(...tops) - Math.min(...tops)).toBeLessThan(1);
       expect(Math.max(...heights) - Math.min(...heights)).toBeLessThan(1);
 
+      await gateway.emitGatewayEvent("agent", {
+        data: { outputTokens: 2_400 },
+        runId,
+        seq: 1,
+        sessionKey: "main",
+        stream: "usage",
+        ts: Date.now(),
+      });
+      await expect
+        .poll(async () =>
+          (await page.locator(".chat-working-indicator__tokens").textContent())?.trim(),
+        )
+        .toBe("2.4k output tokens");
+
       const response = "The streamed response is now visible.";
       await gateway.emitGatewayEvent("chat", {
         deltaText: response,
@@ -354,11 +368,12 @@ suite.define(() => {
       });
 
       await page.getByText(response).waitFor({ timeout: 10_000 });
-      await page.locator(".chat-reading-indicator").waitFor({ state: "detached", timeout: 10_000 });
+      await indicator.waitFor({ timeout: 10_000 });
       const streamingLayout = await pendingRow.evaluate(
         (row, visibleResponse) => ({
           connected: row.isConnected,
           hasResponse: row.textContent?.includes(visibleResponse) ?? false,
+          hasTokens: row.textContent?.includes("2.4k output tokens") ?? false,
           key: row.getAttribute("data-virtual-row-key"),
         }),
         response,
@@ -366,6 +381,7 @@ suite.define(() => {
       expect(streamingLayout).toEqual({
         connected: true,
         hasResponse: true,
+        hasTokens: true,
         key: pendingLayout.key,
       });
     } finally {

--- a/ui/src/pages/chat/chat-progress.test.ts
+++ b/ui/src/pages/chat/chat-progress.test.ts
@@ -131,10 +131,17 @@ describe("resolveTurnRecap", () => {
 
   it("hides the recap as soon as the next run's indicator appears", () => {
     resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
-    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).not.toBeNull();
-    // Next turn: indicator visible again — recap gone, new baseline captured.
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 51_000, 485))).toEqual({
+      runtimeMs: 51_000,
+      outputTokens: 485,
+    });
+    // Next turn: indicator visible again — recap gone before its terminal row changes.
     expect(resolveTurnRecap(SESSION, true, doneRow(RUN_ENDED_AT))).toBeNull();
     expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).toBeNull();
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 1_000, 2_000, 12))).toEqual({
+      runtimeMs: 2_000,
+      outputTokens: 12,
+    });
   });
 
   it("stays quiet for failed runs but ignores stale failed rows", () => {

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -70,8 +70,6 @@ export type BuildChatItemsProps = {
   persistCommentary?: boolean;
   /** True while the agent is visibly working (isChatRunWorking). */
   runWorking?: boolean;
-  /** Keeps the status row visible while a running tool is parked for approval. */
-  waitingApproval?: boolean;
   /** True while the current session has an abortable live run. */
   runActive?: boolean;
   planStatus?: PlanStatus | null;
@@ -480,65 +478,48 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     toolStreamPredecessors,
   );
 
-  // Working spark contract: whenever the agent works with nothing visibly
-  // streaming (pre-first-token, or a queued send in flight), the thread shows
-  // the reading indicator where the reply will materialize. Streaming text
-  // and running tool rows take over as the signal once content flows.
-  // A visible running tool row already signals active work, so the spark is
-  // suppressed rather than stacked under it; hidden tool calls keep the spark.
-  const hasVisibleRunningTool =
-    props.showToolCalls &&
-    tools.some((message) => {
-      const record = asRecord(message);
-      return (
-        record?.["__openclawToolStreamLive"] === true &&
-        record["__openclawToolStreamResultReceived"] !== true
-      );
-    });
-  // The initial-load skeleton owns the empty thread; a background reload with
-  // content still visible keeps the spark (it is the only working signal).
-  const initialHistoryLoad = props.loading === true && items.length === 0;
-  const hasPendingResponse =
-    props.stream === null &&
-    ((props.runWorking === true &&
-      (props.waitingApproval === true || !hasVisibleRunningTool) &&
-      !initialHistoryLoad) ||
-      queuedSends.some(
-        (item) => item.sendState === "sending" && shouldRenderQueuedSendInThread(item),
-      ));
-  if (props.runWorking !== true && props.stream === null && !hasPendingResponse) {
+  // The active claw is telemetry, not a placeholder: it stays through visible
+  // assistant text and tool cards until the run settles. The initial-load
+  // skeleton still owns an otherwise empty thread, but not an active stream.
+  const initialHistoryLoad = props.stream === null && props.loading === true && items.length === 0;
+  // A non-null empty stream is the acknowledgement bridge before runWorking
+  // catches up.
+  const hasEmptyLiveStream = props.stream !== null && props.stream.trim().length === 0;
+  const showWorkingIndicator =
+    (props.runWorking === true && !initialHistoryLoad) ||
+    hasEmptyLiveStream ||
+    queuedSends.some(
+      (item) => item.sendState === "sending" && shouldRenderQueuedSendInThread(item),
+    );
+  if (props.runWorking !== true && props.stream === null && !showWorkingIndicator) {
     clearWorkingProgress(props.sessionKey);
   }
+  let progress: ReturnType<typeof resolveWorkingProgress> | null = null;
   const resolveProgress = () =>
-    resolveWorkingProgress(
+    (progress ??= resolveWorkingProgress(
       props.sessionKey,
       props.runId ?? null,
       props.streamStartedAt,
       queuedSends,
       segments,
       tools,
-    );
-  if (hasPendingResponse) {
-    const progress = resolveProgress();
-    items.push({ kind: "reading-indicator", ...progress });
-  } else if (props.stream !== null) {
+    ));
+  if (props.stream !== null) {
     const text = sanitizeStreamText(props.stream);
     const visibleText = trimAccumulatedStreamPrefix(text, previousAccumulatedStreamText);
-    if (visibleText.length > 0) {
-      if (!stripHeartbeatTokenForDisplay(visibleText).shouldSkip) {
-        const progress = resolveProgress();
-        items.push({
-          kind: "stream",
-          key: progress.key,
-          text: visibleText,
-          startedAt: timestampAfterVisibleItems(items, props.streamStartedAt ?? Date.now()),
-          isStreaming: true,
-        });
-      }
-    } else if (props.stream.trim().length === 0) {
-      const progress = resolveProgress();
-      items.push({ kind: "reading-indicator", ...progress });
+    if (visibleText.length > 0 && !stripHeartbeatTokenForDisplay(visibleText).shouldSkip) {
+      const liveProgress = resolveProgress();
+      items.push({
+        kind: "stream",
+        key: liveProgress.key,
+        text: visibleText,
+        startedAt: timestampAfterVisibleItems(items, props.streamStartedAt ?? Date.now()),
+        isStreaming: true,
+      });
     }
+  }
+  if (showWorkingIndicator) {
+    items.push({ kind: "reading-indicator", ...resolveProgress() });
   }
   if (props.runActive === true && props.planStatus && props.planStatus.steps.length > 0) {
     items.push({ kind: "plan", key: `plan:${props.sessionKey}:active` });

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1216,13 +1216,21 @@ describe("buildCachedChatItems working spark", () => {
       streamingItems.find((item) => item.kind === "stream" && item.isStreaming),
       "visible live stream",
     );
+    const streamingIndicator = expectDefined(
+      streamingItems.find((item) => item.kind === "reading-indicator"),
+      "streaming working indicator",
+    );
     const streamingRun = expectDefined(
       coalesceStreamRuns(streamingItems).find((item) => item.kind === "stream-run"),
       "streaming run",
     );
 
     expect(visibleStream.key).toBe(pendingIndicator.key);
-    expect(streamingRun.key).toBe(pendingRun.key);
+    expect(streamingIndicator.key).toBe(pendingIndicator.key);
+    expect(streamingRun).toMatchObject({
+      key: pendingRun.key,
+      parts: [{ kind: "stream" }, { kind: "reading-indicator" }],
+    });
 
     const nextRunIndicator = expectDefined(
       readingIndicator({
@@ -1305,21 +1313,24 @@ describe("buildCachedChatItems working spark", () => {
     expect(hasReadingIndicator({ runWorking: true, loading: true })).toBe(false);
   });
 
-  it("does not stack the spark under a visible running tool row", () => {
-    expect(hasReadingIndicator({ runWorking: true, toolMessages: [liveTool(false)] })).toBe(false);
+  it("keeps the non-null empty-stream fallback during initial history loading", () => {
+    expect(hasReadingIndicator({ stream: "", loading: true })).toBe(true);
   });
 
-  it("keeps the approval status row beside a visible running tool", () => {
-    expect(
-      hasReadingIndicator({
-        runWorking: true,
-        waitingApproval: true,
-        toolMessages: [liveTool(false)],
-      }),
-    ).toBe(true);
+  it("does not suppress active telemetry once a live stream exists", () => {
+    const items = buildCachedChatItems(
+      createProps({ runWorking: true, loading: true, stream: "The reply has started." }),
+    );
+
+    expect(items.filter((item) => item.kind === "stream")).toHaveLength(1);
+    expect(items.filter((item) => item.kind === "reading-indicator")).toHaveLength(1);
   });
 
-  it("returns the spark once the running tool resolves", () => {
+  it("keeps the telemetry row beside a visible running tool", () => {
+    expect(hasReadingIndicator({ runWorking: true, toolMessages: [liveTool(false)] })).toBe(true);
+  });
+
+  it("keeps the telemetry row once the running tool resolves", () => {
     expect(hasReadingIndicator({ runWorking: true, toolMessages: [liveTool(true)] })).toBe(true);
   });
 

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -229,7 +229,6 @@ function sameChatItemsStructuralInput(
     previous.showToolCalls === next.showToolCalls &&
     previous.persistCommentary === next.persistCommentary &&
     previous.runWorking === next.runWorking &&
-    previous.waitingApproval === next.waitingApproval &&
     previous.runActive === next.runActive &&
     previous.questionPrompts === next.questionPrompts &&
     Boolean(previous.planStatus?.steps.length) === Boolean(next.planStatus?.steps.length) &&

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1610,7 +1610,7 @@ describe("grouped chat rendering", () => {
     expect(container.querySelectorAll(".chat-group.assistant")).toHaveLength(1);
     expect(container.querySelector(".chat-working-indicator")).toBeNull();
     expect(container.querySelector(".chat-turn-recap--continuation")?.textContent).toContain(
-      "Done in 5s",
+      "Done in 5 seconds",
     );
     expect(container.querySelector(".chat-tasks-status__claw")).toBeNull();
   });

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -14,6 +14,7 @@ import {
   renderMessageGroup,
   renderStreamGroup,
 } from "./chat-message.ts";
+import { renderTurnRecapRow } from "./chat-working-indicator.ts";
 
 const localStorageValues = new Map<string, string>();
 const renderMarkdownHtml = markdown.toSanitizedMarkdownHtml;
@@ -1637,6 +1638,31 @@ describe("grouped chat rendering", () => {
     ).toBeNull();
   });
 
+  it("formats terminal recap durations with full localized units", () => {
+    const cases = [
+      { runtimeMs: 3_600_000, expected: "Done in 1 hour" },
+      { runtimeMs: 10 * 60_000, expected: "Done in 10 minutes" },
+      { runtimeMs: 30_000, expected: "Done in 30 seconds" },
+      { runtimeMs: 86_400_000, expected: "Done in 1 day" },
+      {
+        runtimeMs: 4 * 3_600_000 + 2 * 60_000,
+        expected: "Done in 4 hours, 2 minutes",
+      },
+    ];
+
+    for (const { runtimeMs, expected } of cases) {
+      const container = document.createElement("div");
+      render(renderTurnRecapRow({ runtimeMs, outputTokens: null }), container);
+      expect(container.querySelector(".chat-turn-recap")?.textContent?.trim()).toBe(expected);
+    }
+
+    const withTokens = document.createElement("div");
+    render(renderTurnRecapRow({ runtimeMs: 30_000, outputTokens: 2_400 }), withTokens);
+    expect(
+      withTokens.querySelector(".chat-turn-recap")?.textContent?.replace(/\s+/g, " ").trim(),
+    ).toBe("Done in 30 seconds · 2.4k tokens");
+  });
+
   it("shows live output usage beside elapsed time", () => {
     const container = document.createElement("div");
 
@@ -1714,7 +1740,9 @@ describe("grouped chat rendering", () => {
     const group = container.querySelector(".chat-group.assistant");
     expect(group?.classList.contains("chat-group--working")).toBe(false);
     expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(1);
-    expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
+    expect(container.querySelectorAll(".chat-group-footer")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-working-indicator")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
   });
 
   it("seeds at most one stable claw surprise per reading-indicator key", () => {

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1357,12 +1357,9 @@ function latestTranscriptAnnouncement(
   return null;
 }
 
-function chatRenderItemGuardDependencies(
-  item: ChatRenderItem,
-  runOutputTokens: number | null | undefined,
-): readonly unknown[] {
+function chatRenderItemGuardDependencies(item: ChatRenderItem): readonly unknown[] {
   if (item.kind === "stream-run") {
-    return [item.key, ...item.parts, runOutputTokens];
+    return [item.key, ...item.parts];
   }
   if (item.kind === "work-group") {
     return [item.key, item.durationMs, item.hasError, ...item.groups];

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1357,9 +1357,12 @@ function latestTranscriptAnnouncement(
   return null;
 }
 
-function chatRenderItemGuardDependencies(item: ChatRenderItem): readonly unknown[] {
+function chatRenderItemGuardDependencies(
+  item: ChatRenderItem,
+  runOutputTokens: number | null | undefined,
+): readonly unknown[] {
   if (item.kind === "stream-run") {
-    return [item.key, ...item.parts];
+    return [item.key, ...item.parts, runOutputTokens];
   }
   if (item.kind === "work-group") {
     return [item.key, item.durationMs, item.hasError, ...item.groups];
@@ -1453,7 +1456,6 @@ function renderChatThreadContents(
     showToolCalls: props.showToolCalls,
     persistCommentary: props.persistCommentary,
     runWorking: Boolean(props.runWorking),
-    waitingApproval: Boolean(props.waitingApproval),
     runActive: Boolean(props.runActive),
     planStatus: props.planStatus,
     questionPrompts: props.questionPrompts,

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -2,9 +2,9 @@ import { html, nothing } from "lit";
 import "../../../components/elapsed-time.ts";
 import { icons } from "../../../components/icons.ts";
 import "../../../components/working-phrase.ts";
-import { t } from "../../../i18n/index.ts";
+import { i18n, t } from "../../../i18n/index.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
-import { formatCompactTokenCount, formatDurationCompact } from "../../../lib/format.ts";
+import { formatCompactTokenCount } from "../../../lib/format.ts";
 import type { TurnRecap } from "../chat-progress.ts";
 import type { ChatRunStartupPhase } from "../chat-run-startup.ts";
 import { selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
@@ -16,9 +16,39 @@ const STARTUP_STATUS_LABEL_KEYS = {
   preparing_context: "chat.startupStatus.preparingContext",
   starting_model: "chat.startupStatus.startingModel",
 } as const satisfies Record<ChatRunStartupPhase, Parameters<typeof t>[0]>;
+const TURN_RECAP_DURATION_UNITS = [
+  { seconds: 86_400, unit: "day" },
+  { seconds: 3_600, unit: "hour" },
+  { seconds: 60, unit: "minute" },
+  { seconds: 1, unit: "second" },
+] as const;
 
 function startupStatusLabel(phase: ChatRunStartupPhase): string {
   return t(STARTUP_STATUS_LABEL_KEYS[phase]);
+}
+
+function formatTurnRecapDuration(ms: number): string {
+  let remainingSeconds = Math.max(1, Math.round(ms / 1_000));
+  const locale = i18n.getLocale();
+  const parts: string[] = [];
+  for (const { seconds, unit } of TURN_RECAP_DURATION_UNITS) {
+    const value = Math.floor(remainingSeconds / seconds);
+    if (value === 0) {
+      continue;
+    }
+    parts.push(
+      new Intl.NumberFormat(locale, {
+        style: "unit",
+        unit,
+        unitDisplay: "long",
+      }).format(value),
+    );
+    remainingSeconds -= value * seconds;
+    if (parts.length === 2) {
+      break;
+    }
+  }
+  return new Intl.ListFormat(locale, { style: "long", type: "unit" }).format(parts);
 }
 
 function renderLiveOutputTokens(outputTokens: number | null | undefined) {
@@ -104,9 +134,8 @@ export function renderTurnRecapRow(
   options: { presentation?: "standalone" | "continuation" } = {},
 ) {
   const continuation = options.presentation === "continuation";
-  // Sub-second turns still read "1s"; the clamp also keeps the type a string.
-  const clampedMs = Math.max(1_000, recap.runtimeMs);
-  const duration = formatDurationCompact(clampedMs, { spaced: true }) ?? "1s";
+  // Sub-second turns still read as one second; terminal recaps favor full words.
+  const duration = formatTurnRecapDuration(recap.runtimeMs);
   // 0 is a valid count (command-only turns); only null means "unknown".
   const tokens =
     typeof recap.outputTokens === "number"


### PR DESCRIPTION
Closes #113082

## What Problem This Solves

Long-running chat turns expose inconsistent progress across OpenClaw clients. Active elapsed time and cumulative output-token usage can disappear after assistant text or tool activity becomes visible, and native clients do not project restored/concurrent runs consistently. Once a turn completes, useful duration and token context also vanishes immediately.

## Why This Change Was Made

This change gives Control UI, the shared iOS/macOS chat UI, and Android one lifecycle: an active working-claw row remains visible with elapsed time and cumulative output tokens throughout streaming text and tool activity; terminal completion replaces it with a localized chilled-claw duration/token recap; the next turn clears that recap immediately.

Run ownership stays client-local where appropriate, while restored and concurrent runs reconcile through authoritative active-run IDs plus per-run sequence ordering. The implementation preserves existing session observer, composer blocking, cache, legacy terminal-event, and claw-stance behavior. No protocol, config, or storage schema change is introduced.

AI-assisted implementation. I reviewed the final code and understand the ownership, compatibility, and recovery paths.

## User Impact

Users can see that a turn is still progressing, how long it has been running, and how many output tokens it has generated without switching surfaces. After completion, the last turn's duration and token count remain visible until the next turn starts. The behavior is consistent across Control UI, iOS/macOS, and Android.

## Evidence

### Control UI

- Focused unit coverage: 466 tests passed across chat progress, thread derivation, message rendering, and chat view.
- Focused mocked-browser scenario passed and verifies that token-only events repaint immediately, the telemetry row remains attached to streamed assistant output, and the final row contains elapsed time plus `2.4k output tokens`.
- `pnpm format:check` passed for all touched UI files.
- `pnpm tsgo:ui` and `pnpm tsgo:test:ui` passed.

Sanitized mocked before/after screenshots were captured and manually verified. Attachment is pending because the approved R2 uploader was unavailable and the browser upload step was denied.

### Android

- `:app:ktlintCheck` passed.
- Focused Play debug unit lane passed for live usage/lifecycle ordering, concurrent ownership, sequence gaps, ACK rekey clock stability, id-less replacement runs, localized duration formatting, working indicator behavior, session selection policy, and next-turn recap clearing.
- The lane compiled the Play debug app and test sources successfully.

### Shared iOS/macOS chat UI

- Focused Swift package build and 36 tests passed across transport decoding, live usage ordering, restored/advertised runs, legacy unsequenced terminals, terminal reconciliation, session-switch cleanup, cache projection, localized duration wording, and next-turn recap clearing.
- SwiftFormat lint passed for all touched Swift files.

### Review and remote proof

- Final Codex autoreview on the rebased branch: clean, no accepted/actionable findings.
- - Blacksmith Testbox: `tbx_01kya5dc2bsjwbf98snyx2m3d0`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30097499950
- Final head: `cf3fd1cf134d92`

### Known proof gap

No physical iOS or Android device was connected, so native visual screenshot proof was not available. Native UI behavior is covered by compiled focused tests; the source-blind browser proof covers the Control UI behavior contract.
