### PR TITLE
fix(cron): claim benign same-generation session updates

### DIFF
--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -486,6 +486,45 @@ describe("createPersistCronSessionEntry", () => {
     });
   });
 
+  it("does not claim the same lifecycle revision after the session id rotates", async () => {
+    const sessionKey = "agent:main:session";
+    const initialRevision = "initial-revision";
+    const runRevision = crypto.randomUUID();
+    const initialSessionEntry = makeSessionEntry({
+      sessionId: "initial-session-id",
+      lifecycleRevision: initialRevision,
+    });
+    const cronSession = {
+      ...makeCronSession(
+        makeSessionEntry({
+          sessionId: "initial-session-id",
+          lifecycleRevision: runRevision,
+        }),
+      ),
+      initialSessionEntry,
+      lifecycleRevision: runRevision,
+    } as MutableCronSession;
+    const rotatedEntry = makeSessionEntry({
+      sessionId: "rotated-session-id",
+      lifecycleRevision: initialRevision,
+      updatedAt: 2000,
+    });
+    const persistedStore: Record<string, SessionEntry> = {
+      [sessionKey]: rotatedEntry,
+    };
+    const persist = createPersistCronSessionEntry({
+      cronSession,
+      agentSessionKey: sessionKey,
+      persistSessionEntry: makeGuardedPersistSessionEntry(persistedStore),
+    });
+
+    await expect(persist()).rejects.toBeInstanceOf(CronSessionLifecycleClaimError);
+
+    expect(persistedStore[sessionKey]).toBe(rotatedEntry);
+    expect(cronSession.store[sessionKey]).toBeUndefined();
+    expect(cronSession.sessionEntry.sessionId).toBe("initial-session-id");
+  });
+
   it("claims an initial row after a concurrent pin and rename", async () => {
     const sessionKey = "agent:main:session";
     const lifecycleRevision = crypto.randomUUID();

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -434,6 +434,58 @@ describe("createPersistCronSessionEntry", () => {
     expect(persistedStore[sessionKey]).toStrictEqual(nextSession.sessionEntry);
   });
 
+  it("claims an initial row after a benign concurrent same-generation field write", async () => {
+    // Repro for the session-store claim race: under a large, busy store a
+    // concurrent writer advances an ownership field (delivery/token/status) on
+    // the row WITHOUT minting a new lifecycle generation, between resolve and
+    // this run's first persist. The row still carries the run's resolved
+    // lifecycle revision, so no competing run has claimed it. The guard must
+    // merge-and-claim, not throw CronSessionLifecycleClaimError.
+    const sessionKey = "agent:main:session";
+    const initialRevision = "initial-revision";
+    const runRevision = crypto.randomUUID();
+    const initialSessionEntry = makeSessionEntry({
+      lifecycleRevision: initialRevision,
+      status: "running",
+      totalTokens: 10,
+    });
+    const cronSession = {
+      ...makeCronSession(
+        makeSessionEntry({
+          lifecycleRevision: runRevision,
+          status: "done",
+          totalTokens: 42,
+        }),
+      ),
+      initialSessionEntry,
+      lifecycleRevision: runRevision,
+    } as MutableCronSession;
+    const persistedStore: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        ...initialSessionEntry,
+        // Concurrent benign update: same lifecycle generation, drifted fields.
+        totalTokens: 25,
+        lastInteractionAt: 2000,
+        updatedAt: 2000,
+      },
+    };
+    const persist = createPersistCronSessionEntry({
+      cronSession,
+      agentSessionKey: sessionKey,
+      persistSessionEntry: makeGuardedPersistSessionEntry(persistedStore),
+    });
+
+    await expect(persist()).resolves.toBeUndefined();
+
+    // The run claims (its revision wins) while the concurrent update survives.
+    expect(persistedStore[sessionKey]).toMatchObject({
+      lifecycleRevision: runRevision,
+      status: "done",
+      totalTokens: 25,
+      lastInteractionAt: 2000,
+    });
+  });
+
   it("claims an initial row after a concurrent pin and rename", async () => {
     const sessionKey = "agent:main:session";
     const lifecycleRevision = crypto.randomUUID();

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -140,8 +140,19 @@ export function createPersistCronSessionEntry(params: {
             projectCronOwnershipFields(currentEntry),
             projectCronOwnershipFields(params.cronSession.initialSessionEntry),
           );
+        // Same-generation continuation: the row still carries the lifecycle
+        // revision this run resolved from, so no competing run has claimed it
+        // since. Benign concurrent field writes (delivery, token, status) then
+        // merge into the claim instead of aborting it. Exact ownership-field
+        // equality alone spuriously rejected these on large, busy stores where
+        // such an update lands between resolve and this first persist.
+        const initialLifecycleRevision = params.cronSession.initialSessionEntry?.lifecycleRevision;
+        const currentContinuesInitialGeneration =
+          initialLifecycleRevision !== undefined &&
+          currentEntry?.lifecycleRevision === initialLifecycleRevision;
         const canClaimInitialRevision = params.cronSession.initialSessionEntry
-          ? !currentRevisionActive && initialEntryMatchesOwnershipFields
+          ? !currentRevisionActive &&
+            (initialEntryMatchesOwnershipFields || currentContinuesInitialGeneration)
           : currentEntry === undefined;
         // Concurrent persistent runs can resolve the same initial row. Once one
         // revision claims it, older owners must not reclaim it and delete newer state.

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -146,10 +146,14 @@ export function createPersistCronSessionEntry(params: {
         // merge into the claim instead of aborting it. Exact ownership-field
         // equality alone spuriously rejected these on large, busy stores where
         // such an update lands between resolve and this first persist.
-        const initialLifecycleRevision = params.cronSession.initialSessionEntry?.lifecycleRevision;
+        const initialEntry = params.cronSession.initialSessionEntry;
+        const initialLifecycleRevision = initialEntry?.lifecycleRevision;
         const currentContinuesInitialGeneration =
+          currentEntry !== undefined &&
+          initialEntry !== undefined &&
           initialLifecycleRevision !== undefined &&
-          currentEntry?.lifecycleRevision === initialLifecycleRevision;
+          currentEntry.lifecycleRevision === initialLifecycleRevision &&
+          currentEntry.sessionId === initialEntry.sessionId;
         const canClaimInitialRevision = params.cronSession.initialSessionEntry
           ? !currentRevisionActive &&
             (initialEntryMatchesOwnershipFields || currentContinuesInitialGeneration)


### PR DESCRIPTION
Closes #113085

## What Problem This Solves

Fixes an issue where isolated cron runs and `sessions_spawn` subagents can fail their first session claim when a benign concurrent write lands between session resolution and persistence. Large JSON session stores widen that window, causing repeated `CronSessionLifecycleClaimError` failures even though no competing run claimed the row.

## Why This Change Was Made

The claim guard now accepts a same-generation continuation when the freshest row still has both:

- the lifecycle revision captured by the run's initial snapshot; and
- the same session ID as that snapshot.

Concurrent token, delivery, status, pin, label, or timestamp changes are then reconciled by the existing `mergeSessionSnapshotChanges` path instead of aborting the run.

The session-ID requirement is the maintainer safety repair. The snapshot projector intentionally returns no patch across a session rotation; allowing the claim on lifecycle revision alone could resolve successfully while silently adopting a foreign session row.

## User Impact

Benign writes no longer prevent isolated cron/subagent runs from starting under busy or large session stores. Genuine conflicts remain fail-closed:

- another lifecycle revision claimed the row;
- the current revision is actively admitted; or
- the session ID rotated since resolution.

## Evidence

Focused proof after the final commit:

```text
Blacksmith Testbox: tbx_01ky8g4pwenvvvczr5xa1xbhez
Test Files  2 passed (2)
Tests       34 passed (34)
```

https://github.com/openclaw/openclaw/actions/runs/30048597136

The regressions prove:

- same-session/same-generation token and status drift merges, and the run claims its new revision;
- same revision with a rotated session ID throws `CronSessionLifecycleClaimError`;
- the rotated persisted row and the run's live/session-store state remain untouched.

Additional proof:

- Earlier Testbox `tbx_01ky8g004zm75xpabwex9xm3bk` passed the same 34 tests.
- Fresh Codex autoreview against `origin/main`: clean, no accepted/actionable findings.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30048771513

AI-assisted: contributor fix repaired and verified by maintainers.
