### PR TITLE
docs(subagents): clarify requester ownership after spawn

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -112,6 +112,13 @@ agent decides whether a user-facing update is needed.
     - OpenClaw hides `runtime: "acp"` until ACP is enabled, the requester is not sandboxed, and a backend plugin such as `acpx` is loaded. `runtime: "acp"` expects an external ACP harness id, or an `agents.entries.*` entry with `runtime.type="acp"`; use the default sub-agent runtime for normal OpenClaw config agents from `agents_list`.
 
   </Accordion>
+  <Accordion title="Requester ownership">
+    - After `sessions_spawn`, the **requester** owns the user-facing reply path. Native children do not get the message tool by default; they return evidence to the requester.
+    - Treat the completion handoff `Result` as evidence to verify (claimed paths, status, follow-ups) before deciding the original task is done or telling the user it is done.
+    - If the turn needs child output, call `sessions_yield` after spawning. Do not poll `/subagents list`, `sessions_list`, `sessions_history`, or sleep-loops waiting for completion.
+    - Keep the spawn `task` aligned with the full user intent the requester will review. Avoid shrinking the child to a fragment and inventing the rest in the parent without evidence from the Result or transcript.
+    - Prefer `/subagents info`, announce stats, or `sessions_history` for inspection. Raw transcript fields may be SQLite session markers, not JSONL filesystem paths.
+  </Accordion>
 </AccordionGroup>
 
 ## Context modes

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -118,6 +118,7 @@ agent decides whether a user-facing update is needed.
     - If the turn needs child output, call `sessions_yield` after spawning. Do not poll `/subagents list`, `sessions_list`, `sessions_history`, or sleep-loops waiting for completion.
     - Keep the spawn `task` aligned with the full user intent the requester will review. Avoid shrinking the child to a fragment and inventing the rest in the parent without evidence from the Result or transcript.
     - Prefer `/subagents info`, announce stats, or `sessions_history` for inspection. Raw transcript fields may be SQLite session markers, not JSONL filesystem paths.
+
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a documentation gap where Spawn behavior already describes push-based completion, yield, and “no message tool for children”, but does not state the requester ownership rules in one place. Operators and agents can still treat child completion as user delivery, shrink spawn tasks, or invent parent-side work without Result evidence.

Affected surface: `docs/tools/subagents.md` orchestration guidance.

## Why This Change Was Made

Add a short **Requester ownership** accordion under Spawn behavior that restates the intended model: requester owns user-facing replies; Result is evidence to verify; yield instead of polling; keep spawn task aligned with full user intent; prefer `/subagents info` / history over assuming raw transcript fields are JSONL paths.

## User Impact

Clearer parent/requester guidance for sub-agent workflows. No runtime behavior change.

## Evidence

Docs-only change to `docs/tools/subagents.md`. Placement is after the existing Spawn behavior accordions and before Context modes, intentionally away from the `sessions_yield` / Active Subagents paragraph so it stays parallel with open PR #112623.

## Test plan
- [ ] Docs preview: Requester ownership accordion renders under Spawn behavior
- [ ] Confirm no conflict with #112623 Recently Completed edits

Made with [Cursor](https://cursor.com)