### PR TITLE
docs(gateway): document crash-loop safe mode channel recovery

### DIFF
--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -152,6 +152,14 @@ Full troubleshooting: [QQ Bot troubleshooting](/channels/qqbot#troubleshooting)
 
 Full setup and config: [Matrix](/channels/matrix)
 
+## Gateway up but channel never connects
+
+If the gateway process is healthy but a channel stays stopped after repeated
+unclean boots, the [crash-loop breaker](/gateway/restart-recovery#safety-valves-and-observability)
+may be suppressing channel auto-start. Use
+`openclaw gateway call channels.start --params '{"channel":"<id>"}'` to
+override, or wait for the unclean-boot window to drain.
+
 ## Related
 
 - [Pairing](/channels/pairing)

--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -158,7 +158,8 @@ If the gateway process is healthy but a channel stays stopped after repeated
 unclean boots, the [crash-loop breaker](/gateway/restart-recovery#safety-valves-and-observability)
 may be suppressing channel auto-start. Use
 `openclaw gateway call channels.start --params '{"channel":"<id>"}'` to
-override, or wait for the unclean-boot window to drain.
+override, or wait for the unclean-boot window to drain and then restart the
+gateway.
 
 ## Related
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1020,6 +1020,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: QQ Bot failure signatures
   - H2: Matrix
   - H3: Matrix failure signatures
+  - H2: Gateway up but channel never connects
   - H2: Related
 
 ## channels/twitch.md

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -284,7 +284,7 @@ Do not also let `openclaw doctor --fix` install a user-level gateway service for
   </Tab>
 </Tabs>
 
-Invalid configuration errors exit with code `78`. Linux systemd units use `RestartPreventExitStatus=78` to stop relaunching until the config is fixed. launchd and Windows Task Scheduler do not have an equivalent per-exit-code stop rule, so the Gateway also persists rapid unclean boot history and suppresses channel/provider account auto-start after repeated startup failures. In that safe mode the control plane still starts for inspection and repair, config hot reloads and `secrets.reload` refuse automatic channel restarts, and an explicit operator `channels.start` request can override the suppression.
+Invalid configuration errors exit with code `78`. Linux systemd units use `RestartPreventExitStatus=78` to stop relaunching until the config is fixed. launchd and Windows Task Scheduler do not have an equivalent per-exit-code stop rule, so the Gateway also persists rapid unclean boot history and suppresses channel/provider account auto-start after repeated startup failures. In that safe mode the control plane still starts for inspection and repair, config hot reloads and `secrets.reload` refuse automatic channel restarts, and an explicit operator `channels.start` request can override the suppression. Step-by-step recovery lives in [Restart recovery](/gateway/restart-recovery#safety-valves-and-observability).
 
 ## Dev profile quick path
 

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -172,6 +172,40 @@ restart handling continues.
 - **Crash-loop breaker:** 3 unclean boots within 5 minutes trip a breaker that
   suppresses auto-start side services on the next boot, so a crashing gateway
   does not amplify itself. It recovers once the unclean-boot window drains.
+
+  When the breaker is tripped, the **control plane still starts**, but channel
+  plugins (and other auto-started side services) stay down until an operator
+  overrides or the unclean-boot window drains. Gateway logs look like:
+  `channel autostart suppressed by crash-loop breaker; refusing automatic
+start for <channel>… Use channels.start to override.`
+
+  Operator recovery SOP:
+
+  1. Confirm the gateway process is up (`openclaw gateway status` / LaunchAgent
+     or systemd unit still running). A “channel disconnected” symptom often
+     means suppressed autostart, not a dead gateway.
+  2. Inspect channel state: `openclaw channels status` (add `--probe` when
+     useful). Look for stopped / not connected accounts while the gateway
+     itself is healthy.
+  3. Fix the root cause of the unclean boots (bad config, plugin crash on
+     start, missing secrets) before forcing channels back up.
+  4. Manually start a channel while suppression is active:
+
+     ```bash
+     openclaw gateway call channels.start --params '{"channel":"<id>"}'
+     # optional: {"channel":"<id>","accountId":"<account>"}
+     ```
+
+     `channels.start` is a **manual** override; it does not disable the
+     breaker for other channels.
+
+  5. Or wait for the unclean-boot window to drain — the gateway logs when
+     channel auto-start is restored, and subsequent boots start channels
+     normally again.
+
+  See also [Gateway](/gateway) (safe mode paragraph) for the same control-plane
+  vs channel-autostart split.
+
 - **Main-session attempt budget:** three charged automatic dispatch attempts
   per interrupted cycle; exhaustion tombstones that session until it is
   inspected and replaced.

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -175,8 +175,10 @@ restart handling continues.
   drains.
 
   When the breaker is tripped, the **control plane still starts**, but channel
-  plugins (and other auto-started side services) stay down until an operator
-  overrides or the unclean-boot window drains. Gateway logs look like:
+  plugins (and other auto-started side services) stay down for the current boot
+  unless an operator manually overrides the suppression. Automatic startup
+  resumes on a later boot after the unclean-boot window drains. Gateway logs
+  look like:
   `channel autostart suppressed by crash-loop breaker; refusing automatic
 start for <channel>… Use channels.start to override.`
 

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -171,7 +171,8 @@ restart handling continues.
 
 - **Crash-loop breaker:** 3 unclean boots within 5 minutes trip a breaker that
   suppresses auto-start side services on the next boot, so a crashing gateway
-  does not amplify itself. It recovers once the unclean-boot window drains.
+  does not amplify itself. A later boot recovers once the unclean-boot window
+  drains.
 
   When the breaker is tripped, the **control plane still starts**, but channel
   plugins (and other auto-started side services) stay down until an operator
@@ -199,9 +200,8 @@ start for <channel>… Use channels.start to override.`
      `channels.start` is a **manual** override; it does not disable the
      breaker for other channels.
 
-  5. Or wait for the unclean-boot window to drain — the gateway logs when
-     channel auto-start is restored, and subsequent boots start channels
-     normally again.
+  5. Or wait for the unclean-boot window to drain, then restart the gateway.
+     The next boot logs whether channel auto-start is restored.
 
   See also [Gateway](/gateway) (safe mode paragraph) for the same control-plane
   vs channel-autostart split.


### PR DESCRIPTION
## What Problem This Solves

Resolves an operational gap where the crash-loop breaker correctly suppresses channel auto-start after repeated unclean boots, but operators see “channel disconnected” while the gateway control plane is still healthy and lack a step-by-step recovery path. The override (`channels.start`) already exists; it was easy to miss.

Affected surface: gateway restart / channel troubleshooting docs.

## Why This Change Was Made

Expand the crash-loop breaker note in `docs/gateway/restart-recovery.md` into an operator SOP (confirm gateway up → inspect channels → fix root cause → `openclaw gateway call channels.start` or wait for window drain). Cross-link from `docs/gateway/index.md` and add a short pointer in `docs/channels/troubleshooting.md`.

## User Impact

Operators can recover suppressed channels without restarting the whole gateway or mistaking safe mode for a dead process. No runtime behavior change; breaker semantics unchanged.

## Evidence

Docs-only. Verified against current code paths:
- `inspectGatewayCrashLoopBreaker` / suppression in gateway boot
- `startChannelInternal` refuses non-manual starts while suppressed
- `channels.start` RPC uses `{ manual: true }` override

## Test plan
- [ ] Docs preview: SOP renders under Safety valves in restart-recovery
- [ ] Cross-links resolve to restart-recovery anchor
- [ ] Confirm no suggestion to weaken the breaker

Made with [Cursor](https://cursor.com)