### PR TITLE
fix(arcee): make OpenRouter onboarding runnable

### DIFF
--- a/docs/providers/arcee.md
+++ b/docs/providers/arcee.md
@@ -66,13 +66,11 @@ openclaw gateway restart
         {
           agents: {
             defaults: {
-              model: { primary: "arcee/trinity-large-thinking" },
+              model: { primary: "openrouter/arcee-ai/trinity-large-thinking" },
             },
           },
         }
         ```
-
-        The same model refs work for both direct and OpenRouter setups.
       </Step>
     </Steps>
 
@@ -115,7 +113,10 @@ The onboarding preset sets `arcee/trinity-large-thinking` as the default model.
 
 ## OpenRouter catalog
 
-OpenRouter onboarding exposes `arcee/trinity-large-preview` and `arcee/trinity-large-thinking`. OpenClaw keeps those provider-qualified model refs in config and sends OpenRouter's canonical `arcee-ai/*` runtime ids. Trinity Mini is no longer served by OpenRouter; use the direct Arcee API for that model.
+OpenRouter onboarding exposes `openrouter/arcee-ai/trinity-large-preview` and
+`openrouter/arcee-ai/trinity-large-thinking`. These refs keep the model route
+and the stored `openrouter` credential under the same provider owner. Trinity
+Mini is no longer served by OpenRouter; use the direct Arcee API for that model.
 
 ## Supported features
 
@@ -134,9 +135,8 @@ OpenRouter onboarding exposes `arcee/trinity-large-preview` and `arcee/trinity-l
   </Accordion>
 
   <Accordion title="OpenRouter routing">
-    OpenRouter uses the same `arcee/trinity-large-thinking` OpenClaw model ref.
-    OpenClaw routes it with the canonical `arcee-ai/trinity-large-thinking`
-    OpenRouter runtime id. See the
+    OpenRouter uses the `openrouter/arcee-ai/trinity-large-thinking` model ref.
+    See the
     [OpenRouter provider docs](/providers/openrouter) for OpenRouter-specific
     configuration details.
   </Accordion>

--- a/docs/providers/arcee.md
+++ b/docs/providers/arcee.md
@@ -118,6 +118,10 @@ OpenRouter onboarding exposes `openrouter/arcee-ai/trinity-large-preview` and
 and the stored `openrouter` credential under the same provider owner. Trinity
 Mini is no longer served by OpenRouter; use the direct Arcee API for that model.
 
+If an older OpenClaw release created an `arcee/...` OpenRouter route, run
+`openclaw doctor --fix` once after upgrading. Doctor moves the catalog and model
+references to the canonical `openrouter/arcee-ai/...` route.
+
 ## Supported features
 
 | Feature                                       | Supported                                    |

--- a/extensions/arcee/doctor-contract-api.test.ts
+++ b/extensions/arcee/doctor-contract-api.test.ts
@@ -3,9 +3,25 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract-api.js";
 
+type ModelDefinition = NonNullable<
+  NonNullable<OpenClawConfig["models"]>["providers"]
+>[string]["models"][number];
+
+function modelDefinition(id: string, name: string): ModelDefinition {
+  return {
+    id,
+    name,
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 131_072,
+    maxTokens: 8_192,
+  };
+}
+
 const legacyCatalog = [
-  { id: "arcee-ai/trinity-large-preview", name: "Trinity Large Preview" },
-  { id: "arcee-ai/trinity-large-thinking", name: "Trinity Large Thinking" },
+  modelDefinition("arcee-ai/trinity-large-preview", "Trinity Large Preview"),
+  modelDefinition("arcee-ai/trinity-large-thinking", "Trinity Large Thinking"),
 ];
 
 function shippedOpenRouterConfig(): OpenClawConfig {
@@ -86,8 +102,8 @@ describe("Arcee doctor contract", () => {
       baseUrl: "https://openrouter-proxy.example.test/v1",
       api: "openai-responses",
       models: [
-        { id: "arcee-ai/trinity-large-thinking", name: "Operator override" },
-        { id: "other/model", name: "Other model" },
+        modelDefinition("arcee-ai/trinity-large-thinking", "Operator override"),
+        modelDefinition("other/model", "Other model"),
       ],
     };
 
@@ -111,7 +127,7 @@ describe("Arcee doctor contract", () => {
           arcee: {
             baseUrl: "https://api.arcee.ai/api/v1",
             api: "openai-completions",
-            models: [{ id: "trinity-large-thinking", name: "Trinity Large Thinking" }],
+            models: [modelDefinition("trinity-large-thinking", "Trinity Large Thinking")],
           },
         },
       },

--- a/extensions/arcee/doctor-contract-api.test.ts
+++ b/extensions/arcee/doctor-contract-api.test.ts
@@ -1,0 +1,122 @@
+// Arcee tests cover upgrade repair for the shipped OpenRouter onboarding shape.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract-api.js";
+
+const legacyCatalog = [
+  { id: "arcee-ai/trinity-large-preview", name: "Trinity Large Preview" },
+  { id: "arcee-ai/trinity-large-thinking", name: "Trinity Large Thinking" },
+];
+
+function shippedOpenRouterConfig(): OpenClawConfig {
+  return {
+    auth: {
+      profiles: {
+        "openrouter:default": { provider: "openrouter", mode: "api_key" },
+      },
+    },
+    agents: {
+      defaults: {
+        model: {
+          primary: "arcee/trinity-large-thinking",
+          fallbacks: ["arcee/trinity-large-preview", "openai/gpt-5.5"],
+        },
+        models: {
+          "arcee/trinity-large-thinking": { alias: "Arcee AI (OpenRouter)" },
+          "openai/gpt-5.5": { alias: "Primary fallback" },
+        },
+      },
+    },
+    models: {
+      mode: "merge",
+      providers: {
+        arcee: {
+          baseUrl: "https://openrouter.ai/api/v1",
+          api: "openai-completions",
+          models: legacyCatalog,
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("Arcee doctor contract", () => {
+  it("detects only OpenRouter-backed Arcee provider catalogs", () => {
+    const rule = legacyConfigRules[0];
+    expect(rule?.match?.({ baseUrl: "https://openrouter.ai/api/v1" })).toBe(true);
+    expect(rule?.match?.({ baseUrl: "https://api.arcee.ai/api/v1" })).toBe(false);
+    expect(rule?.message).toContain("openclaw doctor --fix");
+  });
+
+  it("migrates the shipped catalog, default, fallbacks, and alias to OpenRouter ownership", () => {
+    const config = shippedOpenRouterConfig();
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([
+      "Moved the OpenRouter-backed Arcee catalog from models.providers.arcee to models.providers.openrouter and repaired its model references.",
+    ]);
+    expect(result.config.models?.providers?.arcee).toBeUndefined();
+    expect(result.config.models?.providers?.openrouter).toMatchObject({
+      baseUrl: "https://openrouter.ai/api/v1",
+      api: "openai-completions",
+      models: legacyCatalog,
+    });
+    expect(result.config.agents?.defaults?.model).toEqual({
+      primary: "openrouter/arcee-ai/trinity-large-thinking",
+      fallbacks: ["openrouter/arcee-ai/trinity-large-preview", "openai/gpt-5.5"],
+    });
+    expect(result.config.agents?.defaults?.models).toEqual({
+      "openrouter/arcee-ai/trinity-large-thinking": { alias: "Arcee AI (OpenRouter)" },
+      "openai/gpt-5.5": { alias: "Primary fallback" },
+    });
+    expect(result.config.auth).toEqual(config.auth);
+    expect(config.models?.providers?.arcee).toBeDefined();
+    expect(normalizeCompatibilityConfig({ cfg: result.config })).toEqual({
+      config: result.config,
+      changes: [],
+    });
+  });
+
+  it("merges catalog rows into an existing OpenRouter provider without overwriting it", () => {
+    const config = shippedOpenRouterConfig();
+    if (!config.models?.providers) {
+      throw new Error("expected provider config");
+    }
+    config.models.providers.openrouter = {
+      baseUrl: "https://openrouter-proxy.example.test/v1",
+      api: "openai-responses",
+      models: [
+        { id: "arcee-ai/trinity-large-thinking", name: "Operator override" },
+        { id: "other/model", name: "Other model" },
+      ],
+    };
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.config.models?.providers?.openrouter).toMatchObject({
+      baseUrl: "https://openrouter-proxy.example.test/v1",
+      api: "openai-responses",
+      models: [
+        { id: "arcee-ai/trinity-large-thinking", name: "Operator override" },
+        { id: "other/model", name: "Other model" },
+        { id: "arcee-ai/trinity-large-preview", name: "Trinity Large Preview" },
+      ],
+    });
+  });
+
+  it("leaves direct Arcee configuration unchanged", () => {
+    const config = {
+      models: {
+        providers: {
+          arcee: {
+            baseUrl: "https://api.arcee.ai/api/v1",
+            api: "openai-completions",
+            models: [{ id: "trinity-large-thinking", name: "Trinity Large Thinking" }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(normalizeCompatibilityConfig({ cfg: config })).toEqual({ config, changes: [] });
+  });
+});

--- a/extensions/arcee/doctor-contract-api.ts
+++ b/extensions/arcee/doctor-contract-api.ts
@@ -1,0 +1,176 @@
+// Arcee doctor contract repairs the shipped OpenRouter onboarding shape. Older
+// releases stored an OpenRouter catalog under `models.providers.arcee`, so the
+// runtime could not use the accompanying `openrouter:default` credential.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+
+const LEGACY_PROVIDER_PATH = "models.providers.arcee";
+const CANONICAL_PROVIDER_PATH = "models.providers.openrouter";
+const CANONICAL_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+const MODEL_REF_MIGRATIONS = new Map([
+  ["arcee/trinity-large-preview", "openrouter/arcee-ai/trinity-large-preview"],
+  ["arcee/trinity-large-thinking", "openrouter/arcee-ai/trinity-large-thinking"],
+]);
+
+function isOpenRouterBaseUrl(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+  try {
+    return new URL(value).hostname.toLowerCase() === "openrouter.ai";
+  } catch {
+    return false;
+  }
+}
+
+function isLegacyOpenRouterProvider(value: unknown): boolean {
+  return isOpenRouterBaseUrl(asObjectRecord(value)?.baseUrl);
+}
+
+export const legacyConfigRules = [
+  {
+    path: ["models", "providers", "arcee"],
+    message: `${LEGACY_PROVIDER_PATH} owns an OpenRouter catalog but cannot use OpenRouter credentials; run "openclaw doctor --fix" to move it to ${CANONICAL_PROVIDER_PATH}.`,
+    match: isLegacyOpenRouterProvider,
+  },
+];
+
+function mergeCatalogModels(current: unknown, legacy: unknown): unknown {
+  if (!Array.isArray(current)) {
+    return Array.isArray(legacy) ? legacy : current;
+  }
+  if (!Array.isArray(legacy)) {
+    return current;
+  }
+
+  const seenIds = new Set(
+    current
+      .map((model) => asObjectRecord(model)?.id)
+      .filter((id): id is string => typeof id === "string"),
+  );
+  const missingLegacyModels = legacy.filter((model) => {
+    const id = asObjectRecord(model)?.id;
+    return typeof id !== "string" || !seenIds.has(id);
+  });
+  return missingLegacyModels.length > 0 ? [...current, ...missingLegacyModels] : current;
+}
+
+function buildCanonicalOpenRouterProvider(params: {
+  current: Record<string, unknown> | null | undefined;
+  legacy: Record<string, unknown>;
+}): Record<string, unknown> {
+  if (!params.current) {
+    return {
+      ...params.legacy,
+      baseUrl: CANONICAL_OPENROUTER_BASE_URL,
+    };
+  }
+  return {
+    ...params.current,
+    models: mergeCatalogModels(params.current.models, params.legacy.models),
+  };
+}
+
+function migrateModelRef(value: unknown): unknown {
+  return typeof value === "string" ? (MODEL_REF_MIGRATIONS.get(value) ?? value) : value;
+}
+
+function migrateModelSelection(value: unknown): unknown {
+  if (typeof value === "string") {
+    return migrateModelRef(value);
+  }
+  const selection = asObjectRecord(value);
+  if (!selection) {
+    return value;
+  }
+
+  const primary = migrateModelRef(selection.primary);
+  const fallbacks = Array.isArray(selection.fallbacks)
+    ? selection.fallbacks.map(migrateModelRef)
+    : selection.fallbacks;
+  if (primary === selection.primary && fallbacks === selection.fallbacks) {
+    return value;
+  }
+  return {
+    ...selection,
+    ...(primary !== undefined ? { primary } : {}),
+    ...(fallbacks !== undefined ? { fallbacks } : {}),
+  };
+}
+
+function migrateAgentModelMap(value: unknown): unknown {
+  const models = asObjectRecord(value);
+  if (!models) {
+    return value;
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [modelRef, modelConfig] of Object.entries(models)) {
+    const canonicalRef = migrateModelRef(modelRef);
+    if (typeof canonicalRef !== "string" || canonicalRef === modelRef) {
+      if (!Object.hasOwn(next, modelRef)) {
+        next[modelRef] = modelConfig;
+      }
+      continue;
+    }
+    const existing = asObjectRecord(next[canonicalRef] ?? models[canonicalRef]);
+    const legacy = asObjectRecord(modelConfig);
+    next[canonicalRef] =
+      legacy && existing ? { ...legacy, ...existing } : (existing ?? modelConfig);
+    changed = true;
+  }
+  return changed ? next : value;
+}
+
+export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  const models = asObjectRecord(cfg.models);
+  const providers = asObjectRecord(models?.providers);
+  const legacyProvider = asObjectRecord(providers?.arcee);
+  if (!legacyProvider || !isLegacyOpenRouterProvider(legacyProvider)) {
+    return { config: cfg, changes: [] };
+  }
+
+  const currentOpenRouter = asObjectRecord(providers?.openrouter);
+  const nextProviders = { ...providers };
+  delete nextProviders.arcee;
+  nextProviders.openrouter = buildCanonicalOpenRouterProvider({
+    current: currentOpenRouter,
+    legacy: legacyProvider,
+  });
+
+  const agents = asObjectRecord(cfg.agents);
+  const defaults = asObjectRecord(agents?.defaults);
+  const nextDefaults = defaults
+    ? {
+        ...defaults,
+        model: migrateModelSelection(defaults.model),
+        models: migrateAgentModelMap(defaults.models),
+      }
+    : defaults;
+
+  return {
+    config: {
+      ...cfg,
+      models: {
+        ...models,
+        providers: nextProviders,
+      } as OpenClawConfig["models"],
+      ...(agents
+        ? {
+            agents: {
+              ...agents,
+              ...(nextDefaults ? { defaults: nextDefaults } : {}),
+            } as OpenClawConfig["agents"],
+          }
+        : {}),
+    },
+    changes: [
+      `Moved the OpenRouter-backed Arcee catalog from ${LEGACY_PROVIDER_PATH} to ${CANONICAL_PROVIDER_PATH} and repaired its model references.`,
+    ],
+  };
+}

--- a/extensions/arcee/index.test.ts
+++ b/extensions/arcee/index.test.ts
@@ -64,13 +64,17 @@ describe("arcee provider plugin", () => {
     const openRouterProfile = config?.auth?.profiles?.["openrouter:default"];
     expect(openRouterProfile?.provider).toBe("openrouter");
     expect(openRouterProfile?.mode).toBe("api_key");
-    const arceeConfig = config?.models?.providers?.arcee;
-    expect(arceeConfig?.baseUrl).toBe("https://openrouter.ai/api/v1");
-    expect(arceeConfig?.api).toBe("openai-completions");
-    expect(config?.models?.providers?.arcee?.models?.map((model) => model.id)).toEqual([
+    const openRouterConfig = config?.models?.providers?.openrouter;
+    expect(openRouterConfig?.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(openRouterConfig?.api).toBe("openai-completions");
+    expect(config?.models?.providers?.openrouter?.models?.map((model) => model.id)).toEqual([
       "arcee-ai/trinity-large-preview",
       "arcee-ai/trinity-large-thinking",
     ]);
+    expect(config?.models?.providers?.arcee).toBeUndefined();
+    expect(config?.agents?.defaults?.model).toEqual({
+      primary: "openrouter/arcee-ai/trinity-large-thinking",
+    });
   });
 
   it("keeps direct Arcee auth env candidates separate from OpenRouter", () => {

--- a/extensions/arcee/onboard.ts
+++ b/extensions/arcee/onboard.ts
@@ -13,7 +13,7 @@ import {
 /** Default Arcee model ref for direct API setup. */
 export const ARCEE_DEFAULT_MODEL_REF = "arcee/trinity-large-thinking";
 /** Default Arcee model ref for OpenRouter setup. */
-export const ARCEE_OPENROUTER_DEFAULT_MODEL_REF = "arcee/trinity-large-thinking";
+export const ARCEE_OPENROUTER_DEFAULT_MODEL_REF = "openrouter/arcee-ai/trinity-large-thinking";
 
 /** Apply direct Arcee provider defaults to config. */
 export const { applyConfig: applyArceeConfig } = createModelCatalogPresetAppliers<[]>({
@@ -31,7 +31,7 @@ export const { applyConfig: applyArceeConfig } = createModelCatalogPresetApplier
 export const { applyConfig: applyArceeOpenRouterConfig } = createModelCatalogPresetAppliers<[]>({
   primaryModelRef: ARCEE_OPENROUTER_DEFAULT_MODEL_REF,
   resolveParams: () => ({
-    providerId: "arcee",
+    providerId: "openrouter",
     api: "openai-completions",
     baseUrl: OPENROUTER_BASE_URL,
     catalogModels: buildArceeOpenRouterCatalogModels(),


### PR DESCRIPTION
Closes #112747

AI-assisted: implemented and verified with Codex.

## What Problem This Solves

Arcee setup through OpenRouter should keep provider configuration, model references, and the stored OpenRouter credential under the same provider owner. The original July onboarding preset wrote an `arcee/...` route while storing the credential as `openrouter:default`, causing the first agent request to fail. Current main also has legacy auth-alias support; this PR makes new OpenRouter setup canonical and repairs previously persisted configuration.

The previous PR head had two compatibility defects: Doctor removed the old provider without migrating every agent model scope, and re-onboarding overwrote an existing shared OpenRouter endpoint/API mode.

## Why This Change Was Made

- New OpenRouter-backed Arcee setup selects `openrouter/arcee-ai/trinity-large-thinking` and owns its provider configuration under `models.providers.openrouter`.
- Doctor migrates defaults, keyed agent entries, legacy agent lists, primary/fallback references, model aliases, nested subagent/heartbeat/compaction/media selections, and explicit model-policy references before removing the old OpenRouter-backed Arcee catalog.
- Existing canonical model settings win on collisions. Migration is immutable and idempotent; direct Arcee configuration is unchanged.
- Both registered onboarding and the public catalog helper preserve an existing OpenRouter `baseUrl` and `api`, seeding defaults only when absent.
- Integration with current main preserves connection-only setup in merge mode and catalog seeding in replace mode, plus the eager public catalog helper. The Doctor repair is declared in the plugin manifest and uses the current lightweight migration SDK.

## User Impact

Fresh OpenRouter setup has matching credential and model ownership. Existing installations retain their proxy transport and authored model settings. Older OpenRouter-backed Arcee configuration can be repaired with `openclaw doctor --fix`; direct Arcee setup is unaffected.

## Evidence

### Current repair and upstream integration — 2026-09-17

Head: `54ab6358560c4f59a59b06bc820d335a5b08623d`. Rebased onto `9ace0a571f4151cd1f47eb8aaa7b8cc987c45cee` to resolve the actual merge conflicts; no unrelated main changes were reverted.

- Before the fix: five new regression cases failed and twelve tests passed on the old PR base. Failures covered defaults/entries/legacy-list migration and custom OpenRouter transport with and without an explicit API mode.
- Final current-main proof with Node 24.20.0 and pinned pnpm 12.4.0:
  - `node scripts/run-vitest.mjs run extensions/arcee/doctor-contract-api.test.ts extensions/arcee/index.test.ts` — **39 passed**.
  - `node scripts/run-vitest.mjs run src/plugins/doctor-contract-declarations.test.ts -t 'matches every resolvable artifact'` — **1 passed**, 1 unrelated state-migration case deselected.
  - Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Registered interactive/non-interactive setup, credential isolation, merge/replace behavior, public helper behavior, migration scope completeness, input preservation, and idempotence are covered.
- [GitHub checks](https://github.com/openclaw/openclaw/pull/113097/checks) report the hosted CI status for the current head; the earlier head's green CI is not reused as current-head proof.
- No fresh paid model request or operator-Gateway deployment was performed for this repair. The historical live inference proof below belongs only to its explicitly identified earlier head.

### Historical live inference proof — original PR head

Performed on 2026-07-31 from PR head `f8ac6b1ce06ded770ee5325191fbfca274600bab` with a newly issued real OpenRouter credential. Private credential material was removed and never printed.

```text
$ openclaw --version
OpenClaw 2026.7.2 (f8ac6b1)

$ openclaw onboard --non-interactive --auth-choice arceeai-openrouter ... --json
Updated config: /tmp/openclaw-pr113097-live-state/openclaw.json
Workspace OK: /tmp/openclaw-pr113097-live-state/workspace
Sessions OK: /tmp/openclaw-pr113097-live-state/agents/main/sessions
{
  "ok": true,
  "mode": "local",
  "authChoice": "arceeai-openrouter",
  "installDaemon": false,
  "skipHealth": true
}

$ jq <redacted config assertions>
{
  "defaultModel": "openrouter/arcee-ai/trinity-large-thinking",
  "providerOwners": ["openrouter"],
  "modelIds": [
    "arcee-ai/trinity-large-preview",
    "arcee-ai/trinity-large-thinking"
  ],
  "legacyProviderPresent": false,
  "authProfile": {
    "provider": "openrouter",
    "mode": "api_key"
  }
}

$ openclaw agent --local --agent main --message "Reply with exactly: ARCEE_OPENROUTER_OK" --json
[model-fetch] start provider=openrouter api=openai-completions model=arcee-ai/trinity-large-thinking url=https://openrouter.ai/api/v1/chat/completions
[model-fetch] response provider=openrouter api=openai-completions model=arcee-ai/trinity-large-thinking status=200
{
  "text": "ARCEE_OPENROUTER_OK",
  "provider": "openrouter",
  "model": "arcee-ai/trinity-large-thinking",
  "executionTrace": {
    "result": "success",
    "fallbackUsed": false
  },
  "requestShaping": {
    "authMode": "auth-profile"
  }
}
```

## Security

Only synthetic regression fixtures are added. No API key, OAuth code, verifier, live configuration, or auth-profile contents are included. No production configuration, Gateway restart, or deployment was performed.
