### PR TITLE
fix(codex): stop runaway tool retry loops

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -304,6 +304,16 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     terminalState.explicitCancellationReason ??= reason;
     runAbortController.abort(reason);
   };
+  const abortForAttemptFailure = (reason: unknown) => {
+    if (terminalState.terminalOutcomeFrozen) {
+      return;
+    }
+    // Internal safety failures must stop the provider turn without being
+    // misreported as a user cancellation by the outer reply operation.
+    terminalState.explicitCancellationObserved = true;
+    terminalState.explicitCancellationReason ??= reason;
+    runAbortController.abort(reason);
+  };
   const abortFromUpstream = () => {
     abortExplicitly(params.abortSignal?.reason ?? "upstream_abort");
   };
@@ -399,6 +409,7 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     runAbortController,
     terminalState,
     abortExplicitly,
+    abortForAttemptFailure,
     abortFromUpstream,
     resolveReviewerPolicyContext,
     resolveRuntimeOptionsForCurrentBinding,

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -35,6 +35,7 @@ import {
 } from "./run-attempt-state.js";
 import type { prepareCodexAttemptTurnRequest } from "./run-attempt-turn-request.js";
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
+import { formatCodexRunSafetyAlert } from "./run-safety.js";
 import { captureCodexSettledTurnFinalizationContext } from "./settled-turn-context.js";
 import { settleCodexSourceReplyFinality } from "./source-reply-finality.js";
 import { normalizeCodexTrajectoryError, recordCodexTrajectoryCompletion } from "./trajectory.js";
@@ -54,7 +55,13 @@ export async function finalizeCodexAttempt(
   requestRuntime: Awaited<ReturnType<typeof prepareCodexAttemptTurnRequest>>,
   activeTurn: CodexAttemptActiveTurn,
 ): Promise<EmbeddedRunAttemptResult> {
-  const { prompt, state: resourceState, trajectoryRecorder, markTrajectoryEndRecorded } = resources;
+  const {
+    prompt,
+    state: resourceState,
+    trajectoryRecorder,
+    markTrajectoryEndRecorded,
+    runSafety,
+  } = resources;
   const { context, systemPromptReport } = prompt;
   const { runtime, attemptTools, activeTranscriptTarget, historyState, hookContext } = context;
   const { hookContextWindowFields, hookRunner, promptState } = context;
@@ -146,18 +153,32 @@ export async function finalizeCodexAttempt(
   const result = activeProjector.buildResult(toolBridge.telemetry, {
     yieldDetected: toolState.yieldDetected,
   });
+  const runSafetyTrip = runSafety.readTrip();
+  const runSafetyPromptError = runSafetyTrip
+    ? new Error(
+        formatCodexRunSafetyAlert({
+          objective: "complete the current Codex turn",
+          trip: runSafetyTrip,
+        }),
+      )
+    : undefined;
   const effectiveTimedOut = state.timedOut && !recoveredTurnWatchTimeout;
   const effectiveTurnCompletionIdleTimedOut =
     state.turnCompletionIdleTimedOut && !recoveredTurnWatchTimeout;
   const isFinalAborted = () =>
-    result.aborted ||
-    terminalState.explicitCancellationObserved ||
-    (runAbortController.signal.aborted && !state.clientClosedAbort && !recoveredTurnWatchTimeout);
+    runSafetyTrip
+      ? false
+      : result.aborted ||
+        terminalState.explicitCancellationObserved ||
+        (runAbortController.signal.aborted &&
+          !state.clientClosedAbort &&
+          !recoveredTurnWatchTimeout);
   const clientClosedPromptErrorForFinal =
     state.clientClosedPromptError && hasRecoverableCompletedAssistant
       ? undefined
       : state.clientClosedPromptError;
   let finalPromptError =
+    runSafetyPromptError ??
     clientClosedPromptErrorForFinal ??
     (effectiveTurnCompletionIdleTimedOut
       ? state.turnCompletionIdleTimeoutMessage
@@ -226,7 +247,9 @@ export async function finalizeCodexAttempt(
     });
   }
   const finalPromptErrorSource =
-    effectiveTimedOut || clientClosedPromptErrorForFinal ? "prompt" : result.promptErrorSource;
+    runSafetyTrip || effectiveTimedOut || clientClosedPromptErrorForFinal
+      ? "prompt"
+      : result.promptErrorSource;
   const codexAppServerFailureKind = clientClosedPromptErrorForFinal
     ? "client_closed_before_turn_completed"
     : effectiveTurnCompletionIdleTimedOut

--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -4,6 +4,7 @@ import {
   isTerminalCodexTurnNotificationForTurn,
 } from "./attempt-notification-state.js";
 import {
+  codexExecutionToolName,
   describeNotificationActivity,
   isAssistantCompletionReleaseNotification,
   isRawFunctionToolOutputCompletionNotification,
@@ -11,7 +12,7 @@ import {
   readRawResponseToolCallId,
 } from "./attempt-notifications.js";
 import { readCodexTurnCompletedNotification } from "./protocol-validators.js";
-import type { CodexServerNotification } from "./protocol.js";
+import type { CodexServerNotification, CodexThreadItem } from "./protocol.js";
 import type { CodexAttemptLifecycleController } from "./run-attempt-lifecycle-controller.js";
 import type { CodexAttemptResources } from "./run-attempt-resources.js";
 import {
@@ -27,7 +28,13 @@ export function createCodexAttemptNotificationController(
   turnRuntime: CodexAttemptTurnState,
   lifecycle: CodexAttemptLifecycleController,
 ) {
-  const { prompt, state: resourceState, projectorRef, registerNativeSubagentMonitor } = resources;
+  const {
+    prompt,
+    state: resourceState,
+    projectorRef,
+    registerNativeSubagentMonitor,
+    runSafety,
+  } = resources;
   const { context, turnState } = prompt;
   const { attemptTools, runtime } = context;
   const { connection } = runtime;
@@ -236,6 +243,21 @@ export function createCodexAttemptNotificationController(
         allocateCodexToolOutcomeOrdinal?.(modelToolCallId);
       }
       const nativeItem = readCodexNotificationItem(notification.params);
+      if (
+        nativeItem &&
+        (notification.method === "item/started" || notification.method === "item/completed")
+      ) {
+        const toolAttempt = readCodexRunSafetyToolAttempt(nativeItem);
+        if (toolAttempt) {
+          runSafety.recordToolCall(toolAttempt);
+          if (notification.method === "item/completed") {
+            const outcome = readCodexRunSafetyToolOutcome(nativeItem);
+            if (outcome) {
+              runSafety.recordToolOutcome({ ...toolAttempt, ...outcome });
+            }
+          }
+        }
+      }
       if (nativeItem?.type === "webSearch") {
         projector.recordNativeToolOutcome(nativeItem);
       }
@@ -276,3 +298,79 @@ export function createCodexAttemptNotificationController(
 export type CodexAttemptNotificationController = ReturnType<
   typeof createCodexAttemptNotificationController
 >;
+
+function readCodexRunSafetyToolAttempt(item: CodexThreadItem) {
+  const toolName = codexExecutionToolName(item) ?? readAdditionalCodexToolName(item);
+  if (!toolName) {
+    return undefined;
+  }
+  const args =
+    item.type === "commandExecution"
+      ? { command: item.command }
+      : item.type === "fileChange"
+        ? { changes: item.changes }
+        : item.type === "webSearch"
+          ? { query: item.query }
+          : item.type === "collabAgentToolCall"
+            ? {
+                tool: item.tool,
+                prompt: item.prompt,
+                model: item.model,
+                receiverThreadIds: item.receiverThreadIds,
+              }
+            : item.type === "sleep"
+              ? { durationMs: item.durationMs }
+              : item.arguments;
+  return {
+    toolName,
+    toolCallId: item.id,
+    ...(args !== undefined ? { arguments: args } : {}),
+  };
+}
+
+function readAdditionalCodexToolName(item: CodexThreadItem): string | undefined {
+  switch (item.type) {
+    case "collabAgentToolCall":
+      return typeof item.tool === "string" && item.tool ? item.tool : "collaboration";
+    case "imageGeneration":
+      return "image_generation";
+    case "imageView":
+      return "view_image";
+    case "sleep":
+      return "clock.sleep";
+    default:
+      return undefined;
+  }
+}
+
+function readCodexRunSafetyToolOutcome(item: CodexThreadItem) {
+  const status = item.status?.trim().toLowerCase();
+  if (status === "completed" || status === "succeeded" || status === "success") {
+    return { success: true as const };
+  }
+  if (status !== "failed" && status !== "error" && status !== "declined") {
+    return undefined;
+  }
+  return {
+    success: false as const,
+    error:
+      item.aggregatedOutput?.trim() ||
+      safeCodexRunSafetyValue(item.error) ||
+      safeCodexRunSafetyValue(item.result) ||
+      status,
+  };
+}
+
+function safeCodexRunSafetyValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return `[unserializable ${typeof value}]`;
+  }
+}

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -17,7 +17,13 @@ import {
 } from "./native-hook-relay.js";
 import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js";
 import type { CodexSandboxPolicy, CodexTurnEnvironmentParams } from "./protocol.js";
+import { emitCodexAppServerEvent } from "./run-attempt-lifecycle.js";
 import type { CodexAttemptPrompt } from "./run-attempt-prompt.js";
+import {
+  createCodexRunSafetyController,
+  formatCodexRunSafetyAlert,
+  formatCodexRunSafetyCheckpoint,
+} from "./run-safety.js";
 import { releaseCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
 import {
@@ -42,6 +48,7 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
     sandbox,
     options,
     nativeHookRelayEvents,
+    abortForAttemptFailure,
   } = connection;
   const { toolBridge } = attemptTools;
   const hostTrajectoryRecorder = (
@@ -86,6 +93,68 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
   };
   const pendingNativePreToolUseFailures: CodexNativePreToolUseFailure[] = [];
   const projectorRef: { current?: CodexAppServerEventProjector } = {};
+  const runSafetyObjective = "complete the current Codex turn";
+  const deliverRunSafetyUpdate = (text: string, isError: boolean) => {
+    try {
+      void Promise.resolve(
+        params.onToolResult?.({
+          text,
+          ...(isError ? { isError: true } : {}),
+          channelData: { openclawProgressKind: "codex-run-safety" },
+        }),
+      ).catch((error: unknown) => {
+        embeddedAgentLog.debug("codex app-server run-safety delivery failed", { error });
+      });
+    } catch (error) {
+      embeddedAgentLog.debug("codex app-server run-safety delivery threw", { error });
+    }
+  };
+  const runSafety = createCodexRunSafetyController({
+    onWarning: (checkpoint) => {
+      embeddedAgentLog.warn("codex app-server tool-call checkpoint reached", {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        ...checkpoint,
+      });
+      void emitCodexAppServerEvent(params, {
+        stream: "item",
+        data: {
+          kind: "status",
+          title: "Tool-call safety",
+          phase: "warning",
+          objective: runSafetyObjective,
+          ...checkpoint,
+        },
+      });
+      deliverRunSafetyUpdate(formatCodexRunSafetyCheckpoint(checkpoint), false);
+    },
+    onTrip: (trip) => {
+      const { kind: safetyKind, ...tripDetails } = trip;
+      embeddedAgentLog.error("codex app-server stopped a runaway tool loop", {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        ...trip,
+      });
+      void emitCodexAppServerEvent(params, {
+        stream: "item",
+        data: {
+          kind: "status",
+          title: "Tool-call safety",
+          phase: "stopped",
+          objective: runSafetyObjective,
+          safetyKind,
+          ...tripDetails,
+        },
+      });
+      deliverRunSafetyUpdate(
+        formatCodexRunSafetyAlert({ objective: runSafetyObjective, trip }),
+        true,
+      );
+      abortForAttemptFailure(`codex_run_safety:${trip.kind}`);
+    },
+  });
   const emitNativePreToolUseFailure = (failure: CodexNativePreToolUseFailure) => {
     emitCodexNativePreToolUseFailureDiagnostic({
       agentId: sessionAgentId,
@@ -218,6 +287,7 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
       loopDetectionPreToolUseRelay: appServer.loopDetectionPreToolUseRelay,
       signal: runAbortController.signal,
       onPreToolUseFailure: (failure) => {
+        runSafety.recordNativePreToolUseFailure(failure);
         const projector = projectorRef.current;
         if (projector) {
           projector.recordNativeToolPreToolUseFailure(failure);
@@ -245,6 +315,7 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
   return {
     prompt,
     trajectoryRecorder,
+    runSafety,
     state,
     projectorRef,
     pendingNativePreToolUseFailures,

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -38,7 +38,7 @@ export function createCodexAttemptServerRequestController(
   turnRuntime: CodexAttemptTurnState,
   lifecycle: CodexAttemptLifecycleController,
 ) {
-  const { prompt, state: resourceState, projectorRef, trajectoryRecorder } = resources;
+  const { prompt, state: resourceState, projectorRef, trajectoryRecorder, runSafety } = resources;
   const { context } = prompt;
   const { runtime, attemptTools } = context;
   const { connection } = runtime;
@@ -135,6 +135,22 @@ export function createCodexAttemptServerRequestController(
       const call = readCodexDynamicToolCallParams(request.params);
       if (!call || call.threadId !== resourceState.thread.threadId || call.turnId !== turnId) {
         return undefined;
+      }
+      const canExecuteToolCall = runSafety.recordToolCall({
+        toolName: call.tool,
+        toolCallId: call.callId,
+        arguments: call.arguments,
+      });
+      if (!canExecuteToolCall) {
+        return {
+          success: false,
+          contentItems: [
+            {
+              type: "inputText",
+              text: "OpenClaw stopped this turn after reaching a tool-loop safety limit.",
+            },
+          ],
+        } as JsonValue;
       }
       const replayedExecution = openClawDynamicToolExecutions.get(call);
       if (replayedExecution) {
@@ -236,6 +252,15 @@ export function createCodexAttemptServerRequestController(
         );
         const response = await execution;
         const protocolResponse = toCodexDynamicToolProtocolResponse(response);
+        runSafety.recordToolOutcome({
+          toolName: call.tool,
+          toolCallId: call.callId,
+          arguments: call.arguments,
+          success: protocolResponse.success,
+          ...(!protocolResponse.success
+            ? { error: safeCodexRunSafetyValue(protocolResponse.contentItems) }
+            : {}),
+        });
         if (!protocolResponse.success && toolCallOrdinal !== undefined) {
           suppressedDynamicToolOutcomeOrdinals.add(toolCallOrdinal);
           params.onToolOutcome?.({
@@ -305,6 +330,13 @@ export function createCodexAttemptServerRequestController(
         }
         return protocolResponse as JsonValue;
       } catch (error) {
+        runSafety.recordToolOutcome({
+          toolName: call.tool,
+          toolCallId: call.callId,
+          arguments: call.arguments,
+          success: false,
+          error: error instanceof Error ? error.message : safeCodexRunSafetyValue(error),
+        });
         pendingOpenClawDynamicToolCompletionIds.delete(call.callId);
         if (
           !terminalDiagnosticObserved &&
@@ -353,4 +385,15 @@ export function createCodexAttemptServerRequestController(
     }
   };
   return { handleServerRequest };
+}
+
+function safeCodexRunSafetyValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -58,6 +58,73 @@ function activeDiagnosticToolKeys(events: DiagnosticEventPayload[]): Set<string>
 setupRunAttemptTestHooks();
 
 describe("runCodexAppServerAttempt dynamic tools", () => {
+  it("warns at 25 dynamic calls and stops before executing call 50", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session-tool-limit.jsonl"),
+      path.join(tempDir, "workspace-tool-limit"),
+    );
+    const onRunAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
+    params.onAgentEvent = onRunAgentEvent;
+    params.onToolResult = onToolResult;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    const responses = [];
+    for (let index = 1; index <= 50; index += 1) {
+      responses.push(
+        await harness.handleServerRequest({
+          id: `request-${index}`,
+          method: "item/tool/call",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: `call-${index}`,
+            namespace: null,
+            tool: `unknown_tool_${index}`,
+            arguments: {},
+          },
+        }),
+      );
+    }
+
+    const result = await run;
+    const safetyEvents = onRunAgentEvent.mock.calls.map(
+      ([event]) => event as { data?: Record<string, unknown>; stream?: string },
+    );
+    const warning = safetyEvents.find((event) => event.data?.phase === "warning");
+    const stopped = safetyEvents.find((event) => event.data?.phase === "stopped");
+
+    expect(responses[48]).toMatchObject({
+      success: false,
+      contentItems: [{ text: "Unknown OpenClaw tool: unknown_tool_49" }],
+    });
+    // Aborting the turn releases its request route before the blocked response
+    // can be returned to Codex, so the 50th call has no executable result.
+    expect(responses[49]).toBeUndefined();
+    expect(warning).toMatchObject({
+      stream: "item",
+      data: { phase: "warning", toolCallCount: 25 },
+    });
+    expect(stopped).toMatchObject({
+      stream: "item",
+      data: {
+        phase: "stopped",
+        safetyKind: "tool_call_limit",
+        attempts: 50,
+        toolCallCount: 50,
+      },
+    });
+    expect(result.aborted).toBe(false);
+    expect(result.promptError).toBeInstanceOf(Error);
+    expect(
+      onToolResult.mock.calls.some(
+        ([payload]) => (payload as { text?: string }).text?.includes("used 25 tool calls") === true,
+      ),
+    ).toBe(true);
+  });
+
   it.each(["cancelled", "timed_out"] as const)(
     "preserves the %s terminal reason in trusted tool diagnostics",
     async (terminalReason) => {

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -905,4 +905,101 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
+
+  it("stops after the second matching tool failure and preserves prior successful work", async () => {
+    const sessionFile = path.join(tempDir, "session-run-safety.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-run-safety");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    const onRunAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
+    params.onAgentEvent = onRunAgentEvent;
+    params.onToolResult = onToolResult;
+
+    const run = runCodexAppServerAttempt(params, {
+      nativeHookRelay: { enabled: true },
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "successful-command",
+          type: "commandExecution",
+          command: "git status -sb",
+          status: "inProgress",
+        },
+      },
+    });
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "successful-command",
+          type: "commandExecution",
+          command: "git status -sb",
+          status: "completed",
+          aggregatedOutput: "clean",
+        },
+      },
+    });
+
+    const sendGoalFailure = async (id: string, status: string) =>
+      await harness.handleServerRequest({
+        id: `request-${id}`,
+        method: "item/tool/call",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: id,
+          namespace: null,
+          tool: "update_goal",
+          arguments: { status },
+        },
+      });
+    await sendGoalFailure("goal-failure-1", "blocked");
+    await sendGoalFailure("goal-failure-2", " BLOCKED ");
+
+    const result = await run;
+    const safetyEvent = onRunAgentEvent.mock.calls
+      .map(([event]) => event as { data?: Record<string, unknown>; stream?: string })
+      .find((event) => event.data?.phase === "stopped");
+    const failureBrief = onToolResult.mock.calls
+      .map(([payload]) => payload as { isError?: boolean; text?: string })
+      .find((payload) => payload.isError === true);
+
+    expect(result.aborted).toBe(false);
+    expect(result.promptError).toBeInstanceOf(Error);
+    expect((result.promptError as Error).message).toContain("Unknown OpenClaw tool: update_goal");
+    expect(safetyEvent).toMatchObject({
+      stream: "item",
+      data: {
+        phase: "stopped",
+        safetyKind: "identical_failure",
+        attempts: 2,
+        toolCallCount: 3,
+        toolName: "update_goal",
+        lastSuccessfulStep: "bash",
+      },
+    });
+    expect(failureBrief?.text).toContain("Failed operation: update_goal");
+    expect(failureBrief?.text).toContain("Attempts: 2");
+    expect(failureBrief?.text).toContain("Last successful step: bash");
+    expect(
+      harness.request.mock.calls.filter(([method]) => method === "turn/interrupt"),
+    ).toHaveLength(1);
+    expect(
+      onRunAgentEvent.mock.calls.some(
+        ([event]) =>
+          (event as { stream?: string; data?: { name?: string; phase?: string } }).stream ===
+            "tool" &&
+          (event as { data?: { name?: string; phase?: string } }).data?.name === "bash" &&
+          (event as { data?: { name?: string; phase?: string } }).data?.phase === "result",
+      ),
+    ).toBe(true);
+  });
 });

--- a/extensions/codex/src/app-server/run-safety.test.ts
+++ b/extensions/codex/src/app-server/run-safety.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCodexRunSafetyController, formatCodexRunSafetyAlert } from "./run-safety.js";
+
+describe("Codex run safety", () => {
+  it("recreates the relay failure and stops before a third attempt", () => {
+    const onTrip = vi.fn();
+    const safety = createCodexRunSafetyController({
+      onWarning: vi.fn(),
+      onTrip,
+    });
+
+    safety.recordToolOutcome({
+      toolName: "bash",
+      toolCallId: "successful-call",
+      arguments: { command: "git status -sb" },
+      success: true,
+    });
+    safety.recordToolOutcome({
+      toolName: " UPDATE_GOAL ",
+      toolCallId: "call-1",
+      arguments: { status: "BLOCKED", nested: { reason: " Relay down " } },
+      success: false,
+      error: " Native hook relay unavailable ",
+    });
+    safety.recordToolOutcome({
+      toolName: "update_goal",
+      toolCallId: "call-2",
+      arguments: { nested: { reason: "relay   down" }, status: "blocked" },
+      success: false,
+      error: "native hook   relay UNAVAILABLE",
+    });
+    safety.recordToolOutcome({
+      toolName: "update_goal",
+      toolCallId: "call-3",
+      arguments: { status: "blocked" },
+      success: false,
+      error: "Native hook relay unavailable",
+    });
+
+    expect(onTrip).toHaveBeenCalledTimes(1);
+    expect(safety.readTrip()).toMatchObject({
+      kind: "identical_failure",
+      attempts: 2,
+      toolCallCount: 3,
+      toolName: "update_goal",
+      error: "native hook relay UNAVAILABLE",
+      lastSuccessfulStep: "bash",
+    });
+  });
+
+  it("does not combine different operations or errors", () => {
+    const onTrip = vi.fn();
+    const safety = createCodexRunSafetyController({
+      onWarning: vi.fn(),
+      onTrip,
+    });
+
+    safety.recordToolOutcome({
+      toolName: "update_goal",
+      toolCallId: "call-1",
+      arguments: { status: "blocked" },
+      success: false,
+      error: "relay unavailable",
+    });
+    safety.recordToolOutcome({
+      toolName: "update_goal",
+      toolCallId: "call-2",
+      arguments: { status: "complete" },
+      success: false,
+      error: "relay unavailable",
+    });
+    safety.recordToolOutcome({
+      toolName: "update_goal",
+      toolCallId: "call-3",
+      arguments: { status: "blocked" },
+      success: false,
+      error: "permission denied",
+    });
+
+    expect(onTrip).not.toHaveBeenCalled();
+  });
+
+  it("clears matching failure history after a successful operation", () => {
+    const onTrip = vi.fn();
+    const safety = createCodexRunSafetyController({
+      onWarning: vi.fn(),
+      onTrip,
+    });
+    const operation = {
+      toolName: "update_goal",
+      arguments: { status: "blocked" },
+    };
+
+    safety.recordToolOutcome({
+      ...operation,
+      toolCallId: "call-1",
+      success: false,
+      error: "relay unavailable",
+    });
+    safety.recordToolOutcome({ ...operation, toolCallId: "call-2", success: true });
+    safety.recordToolOutcome({
+      ...operation,
+      toolCallId: "call-3",
+      success: false,
+      error: "relay unavailable",
+    });
+
+    expect(onTrip).not.toHaveBeenCalled();
+  });
+
+  it("warns at 25 tool calls and blocks the 50th call", () => {
+    const onWarning = vi.fn();
+    const onTrip = vi.fn();
+    const safety = createCodexRunSafetyController({ onWarning, onTrip });
+
+    for (let index = 1; index <= 49; index += 1) {
+      expect(
+        safety.recordToolCall({
+          toolName: `tool-${index}`,
+          toolCallId: `call-${index}`,
+        }),
+      ).toBe(true);
+    }
+    expect(onWarning).toHaveBeenCalledOnce();
+    expect(onWarning).toHaveBeenCalledWith({ toolCallCount: 25 });
+    expect(
+      safety.recordToolCall({
+        toolName: "tool-50",
+        toolCallId: "call-50",
+      }),
+    ).toBe(false);
+    expect(
+      safety.recordToolCall({
+        toolName: "tool-51",
+        toolCallId: "call-51",
+      }),
+    ).toBe(false);
+
+    expect(onTrip).toHaveBeenCalledOnce();
+    expect(safety.readTrip()).toMatchObject({
+      kind: "tool_call_limit",
+      attempts: 50,
+      toolCallCount: 50,
+    });
+  });
+
+  it("formats a complete redacted failure brief", () => {
+    const safety = createCodexRunSafetyController({
+      onWarning: vi.fn(),
+      onTrip: vi.fn(),
+    });
+    safety.recordToolOutcome({
+      toolName: "update_goal",
+      toolCallId: "call-1",
+      arguments: { status: "blocked" },
+      success: false,
+      error: "Native hook relay unavailable token=secret-value",
+    });
+    safety.recordToolOutcome({
+      toolName: "update_goal",
+      toolCallId: "call-2",
+      arguments: { status: "blocked" },
+      success: false,
+      error: "Native hook relay unavailable token=secret-value",
+    });
+
+    const text = formatCodexRunSafetyAlert({
+      objective: "complete the current Codex turn",
+      trip: safety.readTrip()!,
+    });
+    expect(text).toContain("Objective: complete the current Codex turn");
+    expect(text).toContain("Attempts: 2");
+    expect(text).toContain("Total tool calls: 2");
+    expect(text).toContain("Possible partial writes or duplicates:");
+    expect(text).toContain("Recommended recovery:");
+    expect(text).toContain("Needed from you:");
+    expect(text).not.toContain("secret-value");
+  });
+});

--- a/extensions/codex/src/app-server/run-safety.ts
+++ b/extensions/codex/src/app-server/run-safety.ts
@@ -1,0 +1,243 @@
+import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import type { CodexNativePreToolUseFailure } from "./native-hook-relay.js";
+
+const CODEX_RUN_TOOL_CALL_WARNING_THRESHOLD = 25;
+const CODEX_RUN_TOOL_CALL_HARD_LIMIT = 50;
+const CODEX_RUN_IDENTICAL_FAILURE_LIMIT = 2;
+
+const CODEX_RUN_SAFETY_PREVIEW_CHARS = 500;
+
+type CodexRunSafetyToolAttempt = {
+  toolName: string;
+  toolCallId?: string;
+  arguments?: unknown;
+};
+
+type CodexRunSafetyTrip = {
+  kind: "identical_failure" | "tool_call_limit";
+  attempts: number;
+  toolCallCount: number;
+  toolName?: string;
+  error: string;
+  lastSuccessfulStep?: string;
+  currentState: string;
+  possiblePartialWrites: string;
+  likelyCause: string;
+  recommendedRecovery: string;
+  decisionNeeded: string;
+};
+
+type CodexRunSafetyCheckpoint = {
+  toolCallCount: number;
+  lastSuccessfulStep?: string;
+};
+
+type CodexRunSafetyController = {
+  recordToolCall: (attempt: CodexRunSafetyToolAttempt) => boolean;
+  recordToolOutcome: (
+    attempt: CodexRunSafetyToolAttempt & { success: boolean; error?: string },
+  ) => void;
+  recordNativePreToolUseFailure: (failure: CodexNativePreToolUseFailure) => void;
+  readTrip: () => CodexRunSafetyTrip | undefined;
+};
+
+export function createCodexRunSafetyController(params: {
+  onWarning: (checkpoint: CodexRunSafetyCheckpoint) => void;
+  onTrip: (trip: CodexRunSafetyTrip) => void;
+  warningThreshold?: number;
+  hardLimit?: number;
+  identicalFailureLimit?: number;
+}): CodexRunSafetyController {
+  const warningThreshold = params.warningThreshold ?? CODEX_RUN_TOOL_CALL_WARNING_THRESHOLD;
+  const hardLimit = params.hardLimit ?? CODEX_RUN_TOOL_CALL_HARD_LIMIT;
+  const identicalFailureLimit = params.identicalFailureLimit ?? CODEX_RUN_IDENTICAL_FAILURE_LIMIT;
+  const observedToolCallIds = new Set<string>();
+  const observedToolOutcomeIds = new Set<string>();
+  const failureCounts = new Map<string, number>();
+  const failureKeysByOperation = new Map<string, Set<string>>();
+  let anonymousToolCallCount = 0;
+  let toolCallCount = 0;
+  let warned = false;
+  let trip: CodexRunSafetyTrip | undefined;
+  let lastSuccessfulStep: string | undefined;
+
+  const tripOnce = (nextTrip: CodexRunSafetyTrip) => {
+    if (trip) {
+      return;
+    }
+    trip = nextTrip;
+    params.onTrip(nextTrip);
+  };
+
+  const recordToolCall: CodexRunSafetyController["recordToolCall"] = (attempt) => {
+    if (trip) {
+      return false;
+    }
+    const identity = attempt.toolCallId ?? `anonymous:${++anonymousToolCallCount}`;
+    if (observedToolCallIds.has(identity)) {
+      return true;
+    }
+    observedToolCallIds.add(identity);
+    toolCallCount += 1;
+    if (!warned && toolCallCount >= warningThreshold) {
+      warned = true;
+      params.onWarning({ toolCallCount, lastSuccessfulStep });
+    }
+    if (toolCallCount >= hardLimit) {
+      tripOnce({
+        kind: "tool_call_limit",
+        attempts: toolCallCount,
+        toolCallCount,
+        toolName: safePreview(attempt.toolName),
+        error: `hard tool-call limit reached (${hardLimit})`,
+        lastSuccessfulStep,
+        currentState: "the turn was interrupted before another tool could run",
+        possiblePartialWrites:
+          "Earlier tool calls remain committed; the blocked call was not executed by OpenClaw",
+        likelyCause: "the turn reached its configured tool-call safety ceiling",
+        recommendedRecovery:
+          "review the completed work and start a new bounded turn only if more tool calls are required",
+        decisionNeeded: "explicitly continue from the checkpoint or choose a narrower next step",
+      });
+    }
+    return !trip;
+  };
+
+  const recordToolOutcome: CodexRunSafetyController["recordToolOutcome"] = (attempt) => {
+    if (trip) {
+      return;
+    }
+    recordToolCall(attempt);
+    if (trip) {
+      return;
+    }
+    const outcomeIdentity = attempt.toolCallId ?? `anonymous-outcome:${++anonymousToolCallCount}`;
+    if (observedToolOutcomeIds.has(outcomeIdentity)) {
+      return;
+    }
+    observedToolOutcomeIds.add(outcomeIdentity);
+    const operationKey = buildOperationKey(attempt);
+    if (attempt.success) {
+      lastSuccessfulStep = safePreview(attempt.toolName);
+      for (const failureKey of failureKeysByOperation.get(operationKey) ?? []) {
+        failureCounts.delete(failureKey);
+      }
+      failureKeysByOperation.delete(operationKey);
+      return;
+    }
+    const rawError = attempt.error?.trim() || "tool call failed";
+    const failureKey = `${operationKey}\u0000${normalizeMaterialValue(rawError)}`;
+    const attempts = (failureCounts.get(failureKey) ?? 0) + 1;
+    failureCounts.set(failureKey, attempts);
+    const operationFailureKeys = failureKeysByOperation.get(operationKey) ?? new Set<string>();
+    operationFailureKeys.add(failureKey);
+    failureKeysByOperation.set(operationKey, operationFailureKeys);
+    if (attempts >= identicalFailureLimit) {
+      tripOnce({
+        kind: "identical_failure",
+        attempts,
+        toolCallCount,
+        toolName: safePreview(attempt.toolName),
+        error: safePreview(rawError),
+        lastSuccessfulStep,
+        currentState: "the turn was interrupted after the repeated failure",
+        possiblePartialWrites:
+          "The failed operation may have partially written state; completed earlier calls were not rolled back",
+        likelyCause:
+          "the same tool, materially equivalent arguments, and materially equivalent error repeated without a successful matching operation",
+        recommendedRecovery:
+          "verify the failed dependency and current external state before choosing a different operation",
+        decisionNeeded:
+          "restore the dependency, provide missing access or information, or explicitly choose another recovery path",
+      });
+    }
+  };
+
+  return {
+    recordToolCall,
+    recordToolOutcome,
+    recordNativePreToolUseFailure(failure) {
+      recordToolOutcome({
+        toolName: failure.toolName,
+        toolCallId: failure.toolCallId,
+        success: false,
+        error: failure.disposition,
+      });
+    },
+    readTrip: () => trip,
+  };
+}
+
+export function formatCodexRunSafetyAlert(params: {
+  objective: string;
+  trip: CodexRunSafetyTrip;
+}): string {
+  const { trip } = params;
+  return [
+    "OpenClaw stopped this turn to prevent a runaway tool loop.",
+    `Objective: ${params.objective}`,
+    `Failed operation: ${trip.toolName ?? "next tool call"}`,
+    `Error: ${trip.error}`,
+    `Attempts: ${trip.attempts}`,
+    `Total tool calls: ${trip.toolCallCount}`,
+    `Last successful step: ${trip.lastSuccessfulStep ?? "none recorded"}`,
+    `Current state: ${trip.currentState}`,
+    `Possible partial writes or duplicates: ${trip.possiblePartialWrites}`,
+    `Likely cause: ${trip.likelyCause}`,
+    `Recommended recovery: ${trip.recommendedRecovery}`,
+    `Needed from you: ${trip.decisionNeeded}`,
+  ].join("\n");
+}
+
+export function formatCodexRunSafetyCheckpoint(checkpoint: CodexRunSafetyCheckpoint): string {
+  return [
+    `OpenClaw checkpoint: this turn has used ${checkpoint.toolCallCount} tool calls.`,
+    `Last successful step: ${checkpoint.lastSuccessfulStep ?? "none recorded"}.`,
+    `The turn will stop at ${CODEX_RUN_TOOL_CALL_HARD_LIMIT}; checkpoint progress before continuing.`,
+  ].join("\n");
+}
+
+function buildOperationKey(attempt: CodexRunSafetyToolAttempt): string {
+  return [
+    normalizeMaterialValue(attempt.toolName),
+    normalizeMaterialValue(attempt.arguments ?? null),
+  ].join("\u0000");
+}
+
+function normalizeMaterialValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim().toLowerCase().replace(/\s+/gu, " ");
+  }
+  if (Array.isArray(value)) {
+    return JSON.stringify(value.map((entry) => normalizeMaterialJson(entry)));
+  }
+  if (value && typeof value === "object") {
+    return JSON.stringify(normalizeMaterialJson(value));
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeMaterialJson(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value.trim().toLowerCase().replace(/\s+/gu, " ");
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeMaterialJson(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, normalizeMaterialJson(entry)]),
+  );
+}
+
+function safePreview(value: string): string {
+  return truncateUtf16Safe(
+    redactSensitiveText(value).replace(/\s+/gu, " ").trim(),
+    CODEX_RUN_SAFETY_PREVIEW_CHARS,
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex-backed OpenClaw turns could repeatedly retry materially identical failed tool operations, replaying an expanding context without an execution-layer stop.

## Why This Change Was Made

Adds a per-turn safety controller in the Codex app-server execution path. It warns at 25 tool calls, stops at 50, and interrupts a turn after two failures with normalized-equivalent tool names, arguments, and errors. The terminal failure brief reports the last successful step and recovery state without rolling back earlier successful work.

## User Impact

Runaway Codex tool loops now stop automatically and surface a structured failure brief. Normal turns below the thresholds are unchanged.

## Evidence

- 34 focused tests pass across the controller, dynamic-tool path, and native-hook relay path.
- Mocked relay-unavailable regression stops after the second matching failure and interrupts the turn before another model retry.
- Warning is emitted at call 25; call 50 triggers the hard stop.
- Codex extension TypeScript check passes.
- `git diff --check` passes.

No production runtime was modified while preparing this change.