### PR TITLE
test(telegram): deduplicate bot creation scenarios

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -116,6 +116,181 @@ const TELEGRAM_TEST_TIMINGS = {
   mediaGroupFlushMs: 20,
   textFragmentGapMs: 30,
 } as const;
+const INBOUND_DEBOUNCE_MS = 4321;
+
+type TelegramMessageHandler = (ctx: TelegramMiddlewareTestContext) => Promise<void>;
+type MessagePolicyCase = {
+  name: string;
+  config: Record<string, unknown>;
+  message: Record<string, unknown>;
+  expectedReplyCount: number;
+};
+
+function makeMessagePolicyCase(params: {
+  name: string;
+  telegram: Record<string, unknown>;
+  expectedReplyCount: number;
+  kind?: "private" | "group";
+  rootConfig?: Record<string, unknown>;
+  message?: Record<string, unknown>;
+}): MessagePolicyCase {
+  const isGroup = params.kind !== "private";
+  return {
+    name: params.name,
+    config: { ...params.rootConfig, channels: { telegram: params.telegram } },
+    message: {
+      chat: isGroup
+        ? { id: -100123456789, type: "group", title: "Test Group" }
+        : { id: 123456789, type: "private" },
+      from: { id: 123456789, username: "testuser" },
+      text: "hello",
+      date: 1736380800,
+      ...params.message,
+    },
+    expectedReplyCount: params.expectedReplyCount,
+  };
+}
+
+function makePrivateTextContext(params: {
+  text: string;
+  messageId?: number;
+  updateId?: number;
+  date?: number;
+  chatId?: number;
+  from?: Record<string, unknown>;
+  message?: Record<string, unknown>;
+  downloadable?: boolean;
+}): TelegramMiddlewareTestContext {
+  const from = params.from ?? { id: 42, first_name: "Ada" };
+  return {
+    ...(params.updateId === undefined ? {} : { update: { update_id: params.updateId } }),
+    message: {
+      chat: { id: params.chatId ?? 7, type: "private" },
+      text: params.text,
+      date: params.date ?? 1736380800,
+      ...(params.messageId === undefined ? {} : { message_id: params.messageId }),
+      from,
+      ...params.message,
+    },
+    me: { username: "openclaw_bot" },
+    getFile: params.downloadable
+      ? async () => ({ download: async () => new Uint8Array() })
+      : async () => ({}),
+  };
+}
+
+function makeCallbackRetryContext(params: {
+  updateId?: number;
+  id: string;
+  data: string;
+  messageId: number;
+  text?: string;
+  message?: Record<string, unknown>;
+  from?: Record<string, unknown>;
+  downloadable?: boolean;
+}): TelegramMiddlewareTestContext {
+  return {
+    ...(params.updateId === undefined ? {} : { update: { update_id: params.updateId } }),
+    callbackQuery: {
+      id: params.id,
+      data: params.data,
+      from: params.from ?? { id: 9, first_name: "Ada", username: "ada_bot" },
+      message: {
+        chat: { id: 1234, type: "private" },
+        date: 1736380800,
+        message_id: params.messageId,
+        ...(params.text === undefined ? {} : { text: params.text }),
+        ...params.message,
+      },
+    },
+    me: { username: "openclaw_bot" },
+    getFile:
+      params.downloadable === false
+        ? async () => ({})
+        : async () => ({ download: async () => new Uint8Array() }),
+  };
+}
+
+function configureOpenDm(
+  params: {
+    debounceMs?: number;
+    timezone?: "envelopeTimezone" | "userTimezone";
+  } = {},
+): void {
+  loadConfig.mockReturnValue({
+    agents: params.timezone
+      ? { defaults: { [params.timezone]: params.timezone === "userTimezone" ? "UTC" : "utc" } }
+      : undefined,
+    messages: params.debounceMs ? { inbound: { debounceMs: params.debounceMs } } : undefined,
+    channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+  });
+}
+
+function getTelegramHandler(name: "message" | "callback_query"): TelegramMessageHandler {
+  return requireValue(getOnHandler(name) as TelegramMessageHandler | undefined, `${name} handler`);
+}
+
+const getMessageHandler = () => getTelegramHandler("message");
+const getCallbackHandler = () => getTelegramHandler("callback_query");
+
+function takeLatestTimerCallback(delayMs: number): () => void {
+  const setTimeoutMock = vi.mocked(globalThis.setTimeout);
+  const callIndex = setTimeoutMock.mock.calls.findLastIndex((call) => call[1] === delayMs);
+  expect(callIndex).toBeGreaterThanOrEqual(0);
+  clearTimeout(setTimeoutMock.mock.results[callIndex]?.value as ReturnType<typeof setTimeout>);
+  return requireValue(
+    setTimeoutMock.mock.calls[callIndex]?.[0] as (() => void) | undefined,
+    `timer callback for ${delayMs}ms`,
+  );
+}
+
+async function dispatchPrivateText(
+  messageHandler: TelegramMessageHandler,
+  params: Parameters<typeof makePrivateTextContext>[0],
+): Promise<void> {
+  await runTelegramMiddlewareChain({
+    ctx: makePrivateTextContext(params),
+    finalHandler: messageHandler,
+  });
+}
+
+async function dispatchSpooledPrivateText(
+  messageHandler: TelegramMessageHandler,
+  params: Parameters<typeof makePrivateTextContext>[0] & {
+    updateId: number;
+    replayUpdate?: "id" | "full";
+  },
+) {
+  const ctx = makePrivateTextContext(params);
+  const replayUpdate =
+    params.replayUpdate === "full" ? { ...ctx.update, message: ctx.message } : (ctx.update ?? {});
+  return await runWithTelegramSpooledReplayUpdate(replayUpdate, async () => {
+    await runTelegramMiddlewareChain({ ctx, finalHandler: messageHandler });
+  });
+}
+
+function setupUpdateOffsetTracker(params: {
+  lastUpdateId: number;
+  onUpdateId?: ReturnType<typeof vi.fn>;
+  runtime?: TelegramBotOptions["runtime"];
+}) {
+  sequentializeSpy.mockImplementationOnce(
+    () => async (_ctx: unknown, next: () => Promise<void>) => {
+      await next();
+    },
+  );
+  const onUpdateId = params.onUpdateId ?? vi.fn();
+  createTelegramBot({
+    token: "tok",
+    runtime: params.runtime,
+    updateOffset: { lastUpdateId: params.lastUpdateId, onUpdateId },
+  });
+  return {
+    onUpdateId,
+    run: (ctx: Record<string, unknown>, finalNext: () => Promise<void>) =>
+      runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, async () => finalNext()),
+  };
+}
 
 async function runTelegramMiddlewareChain(params: {
   ctx: TelegramMiddlewareTestContext;
@@ -694,44 +869,8 @@ describe("createTelegramBot", () => {
   });
 
   it("preserves same-chat reply order when a debounced run is still active", async () => {
-    const DEBOUNCE_MS = 4321;
-    loadConfig.mockReturnValue({
-      agents: {
-        defaults: {
-          envelopeTimezone: "utc",
-        },
-      },
-      messages: {
-        inbound: {
-          debounceMs: DEBOUNCE_MS,
-        },
-      },
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
-
-    sequentializeSpy.mockImplementationOnce(() => {
-      const lanes = new Map<string, Promise<void>>();
-      return async (ctx: Record<string, unknown>, next: () => Promise<void>) => {
-        const key = harness.sequentializeKey?.(ctx) ?? "default";
-        const previous = lanes.get(key) ?? Promise.resolve();
-        const current = previous.then(async () => {
-          await next();
-        });
-        lanes.set(
-          key,
-          current.catch(() => undefined),
-        );
-        try {
-          await current;
-        } finally {
-          if (lanes.get(key) === current) {
-            lanes.delete(key);
-          }
-        }
-      };
-    });
+    configureOpenDm({ debounceMs: INBOUND_DEBOUNCE_MS, timezone: "envelopeTimezone" });
+    installPerKeySequentializer();
 
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const startedBodies: string[] = [];
@@ -750,42 +889,13 @@ describe("createTelegramBot", () => {
       return { text: `reply:${body}` };
     });
 
-    const runMiddlewareChain = (ctx: Record<string, unknown>) =>
-      runTelegramTestMiddlewareChain(
-        middlewareUseSpy,
-        ctx,
-        getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>,
-      );
-
-    const extractLatestDebounceFlush = () => {
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
-        (call) => call[1] === DEBOUNCE_MS,
-      );
-      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-      clearTimeout(
-        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
-      );
-      return setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
-    };
-
     try {
       createTelegramBot({ token: "tok" });
+      const messageHandler = getMessageHandler();
 
-      await runMiddlewareChain({
-        update: { update_id: 101 },
-        message: {
-          chat: { id: 7, type: "private" },
-          text: "first",
-          date: 1736380800,
-          message_id: 101,
-          from: { id: 42, first_name: "Ada" },
-        },
-        me: { username: "openclaw_bot" },
-        getFile: async () => ({}),
-      });
+      await dispatchPrivateText(messageHandler, { updateId: 101, messageId: 101, text: "first" });
 
-      const flushFirst = extractLatestDebounceFlush();
-      flushFirst?.();
+      takeLatestTimerCallback(INBOUND_DEBOUNCE_MS)();
 
       await vi.waitFor(
         () => {
@@ -795,21 +905,14 @@ describe("createTelegramBot", () => {
         { interval: 1, timeout: 500 },
       );
 
-      await runMiddlewareChain({
-        update: { update_id: 102 },
-        message: {
-          chat: { id: 7, type: "private" },
-          text: "second",
-          date: 1736380801,
-          message_id: 102,
-          from: { id: 42, first_name: "Ada" },
-        },
-        me: { username: "openclaw_bot" },
-        getFile: async () => ({}),
+      await dispatchPrivateText(messageHandler, {
+        updateId: 102,
+        messageId: 102,
+        text: "second",
+        date: 1736380801,
       });
 
-      const flushSecond = extractLatestDebounceFlush();
-      flushSecond?.();
+      takeLatestTimerCallback(INBOUND_DEBOUNCE_MS)();
       await Promise.resolve();
 
       expect(startedBodies).toHaveLength(1);
@@ -841,22 +944,7 @@ describe("createTelegramBot", () => {
   it.each(["stop", "/stop@openclaw_bot"] as const)(
     "lets %s bypass and cancel pending same-chat inbound debounce",
     async (stopText) => {
-      const DEBOUNCE_MS = 4321;
-      loadConfig.mockReturnValue({
-        agents: {
-          defaults: {
-            userTimezone: "UTC",
-          },
-        },
-        messages: {
-          inbound: {
-            debounceMs: DEBOUNCE_MS,
-          },
-        },
-        channels: {
-          telegram: { dmPolicy: "open", allowFrom: ["*"] },
-        },
-      });
+      configureOpenDm({ debounceMs: INBOUND_DEBOUNCE_MS, timezone: "userTimezone" });
 
       installPerKeySequentializer();
 
@@ -869,85 +957,30 @@ describe("createTelegramBot", () => {
         return { text: `reply:${body}` };
       });
 
-      const extractLatestDebounceFlush = () => {
-        const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
-          (call) => call[1] === DEBOUNCE_MS,
-        );
-        expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-        clearTimeout(
-          setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
-        );
-        return setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
-      };
-
       try {
         createTelegramBot({ token: "tok" });
-        const messageHandler = getOnHandler("message") as (
-          ctx: TelegramMiddlewareTestContext,
-        ) => Promise<void>;
-
-        await runTelegramMiddlewareChain({
-          ctx: {
-            update: { update_id: 101 },
-            message: {
-              chat: { id: 7, type: "private" },
-              text: "first",
-              date: 1736380800,
-              message_id: 101,
-              from: { id: 42, first_name: "Ada" },
-            },
-            me: { username: "openclaw_bot" },
-            getFile: async () => ({}),
-          },
-          finalHandler: messageHandler,
-        });
-
-        const flushFirst = extractLatestDebounceFlush();
-
-        await runTelegramMiddlewareChain({
-          ctx: {
-            update: { update_id: 102 },
-            message: {
-              chat: { id: 7, type: "private" },
-              text: stopText,
-              date: 1736380801,
-              message_id: 102,
-              from: { id: 42, first_name: "Ada" },
-            },
-            me: { username: "openclaw_bot" },
-            getFile: async () => ({}),
-          },
-          finalHandler: messageHandler,
+        const messageHandler = getMessageHandler();
+        await dispatchPrivateText(messageHandler, { updateId: 101, messageId: 101, text: "first" });
+        const flushFirst = takeLatestTimerCallback(INBOUND_DEBOUNCE_MS);
+        await dispatchPrivateText(messageHandler, {
+          updateId: 102,
+          messageId: 102,
+          text: stopText,
+          date: 1736380801,
         });
 
         expect(startedBodies).toHaveLength(1);
         expect(startedBodies[0]).toContain("stop");
 
-        flushFirst?.();
+        flushFirst();
         await Promise.resolve();
         expect(startedBodies).toHaveLength(1);
         expect(sendMessageSpy.mock.calls.map((call) => String(call[1])).join("\n")).not.toContain(
           "reply:first",
         );
 
-        await runTelegramMiddlewareChain({
-          ctx: {
-            update: { update_id: 103 },
-            message: {
-              chat: { id: 7, type: "private" },
-              text: "first",
-              date: 1736380800,
-              message_id: 101,
-              from: { id: 42, first_name: "Ada" },
-            },
-            me: { username: "openclaw_bot" },
-            getFile: async () => ({}),
-          },
-          finalHandler: messageHandler,
-        });
-
-        const flushReplay = extractLatestDebounceFlush();
-        flushReplay?.();
+        await dispatchPrivateText(messageHandler, { updateId: 103, messageId: 101, text: "first" });
+        takeLatestTimerCallback(INBOUND_DEBOUNCE_MS)();
         await vi.waitFor(
           () => {
             expect(startedBodies).toHaveLength(2);
@@ -962,48 +995,18 @@ describe("createTelegramBot", () => {
   );
 
   it("settles spooled replay participants when stop cancels pending inbound debounce", async () => {
-    const DEBOUNCE_MS = 4321;
-    loadConfig.mockReturnValue({
-      agents: {
-        defaults: {
-          userTimezone: "UTC",
-        },
-      },
-      messages: {
-        inbound: {
-          debounceMs: DEBOUNCE_MS,
-        },
-      },
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm({ debounceMs: INBOUND_DEBOUNCE_MS, timezone: "userTimezone" });
 
     installPerKeySequentializer();
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
     try {
       createTelegramBot({ token: "tok" });
-      const messageHandler = getOnHandler("message") as (
-        ctx: TelegramMiddlewareTestContext,
-      ) => Promise<void>;
-      const firstUpdate = { update_id: 201 };
-      const replay = await runWithTelegramSpooledReplayUpdate(firstUpdate, async () => {
-        await runTelegramMiddlewareChain({
-          ctx: {
-            update: firstUpdate,
-            message: {
-              chat: { id: 7, type: "private" },
-              text: "first",
-              date: 1736380800,
-              message_id: 201,
-              from: { id: 42, first_name: "Ada" },
-            },
-            me: { username: "openclaw_bot" },
-            getFile: async () => ({}),
-          },
-          finalHandler: messageHandler,
-        });
+      const messageHandler = getMessageHandler();
+      const replay = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 201,
+        messageId: 201,
+        text: "first",
       });
 
       const deferredWork = replay.deferredWork;
@@ -1011,70 +1014,31 @@ describe("createTelegramBot", () => {
       if (!deferredWork) {
         throw new Error("Expected spooled replay deferred work");
       }
-      await runTelegramMiddlewareChain({
-        ctx: {
-          update: { update_id: 202 },
-          message: {
-            chat: { id: 7, type: "private" },
-            text: "stop",
-            date: 1736380801,
-            message_id: 202,
-            from: { id: 42, first_name: "Ada" },
-          },
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({}),
-        },
-        finalHandler: messageHandler,
+      await dispatchPrivateText(messageHandler, {
+        updateId: 202,
+        messageId: 202,
+        text: "stop",
+        date: 1736380801,
       });
 
       await expect(deferredWork.task).resolves.toEqual({ kind: "skipped" });
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
-        (call) => call[1] === DEBOUNCE_MS,
-      );
-      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-      clearTimeout(
-        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
-      );
+      takeLatestTimerCallback(INBOUND_DEBOUNCE_MS);
     } finally {
       setTimeoutSpy.mockRestore();
     }
   });
 
   it("settles spooled replay participants when stop cancels pending text fragments", async () => {
-    loadConfig.mockReturnValue({
-      agents: {
-        defaults: {
-          envelopeTimezone: "utc",
-        },
-      },
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm({ timezone: "envelopeTimezone" });
 
     installPerKeySequentializer();
 
     createTelegramBot({ token: "tok" });
-    const messageHandler = getOnHandler("message") as (
-      ctx: TelegramMiddlewareTestContext,
-    ) => Promise<void>;
-    const firstUpdate = { update_id: 211 };
-    const replay = await runWithTelegramSpooledReplayUpdate(firstUpdate, async () => {
-      await runTelegramMiddlewareChain({
-        ctx: {
-          update: firstUpdate,
-          message: {
-            chat: { id: 7, type: "private" },
-            text: "A".repeat(4050),
-            date: 1736380800,
-            message_id: 211,
-            from: { id: 42, first_name: "Ada" },
-          },
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({}),
-        },
-        finalHandler: messageHandler,
-      });
+    const messageHandler = getMessageHandler();
+    const replay = await dispatchSpooledPrivateText(messageHandler, {
+      updateId: 211,
+      messageId: 211,
+      text: "A".repeat(4050),
     });
 
     const deferredWork = replay.deferredWork;
@@ -1082,36 +1046,18 @@ describe("createTelegramBot", () => {
     if (!deferredWork) {
       throw new Error("Expected spooled replay deferred work");
     }
-    await runTelegramMiddlewareChain({
-      ctx: {
-        update: { update_id: 212 },
-        message: {
-          chat: { id: 7, type: "private" },
-          text: "stop",
-          date: 1736380801,
-          message_id: 212,
-          from: { id: 42, first_name: "Ada" },
-        },
-        me: { username: "openclaw_bot" },
-        getFile: async () => ({}),
-      },
-      finalHandler: messageHandler,
+    await dispatchPrivateText(messageHandler, {
+      updateId: 212,
+      messageId: 212,
+      text: "stop",
+      date: 1736380801,
     });
 
     await expect(deferredWork.task).resolves.toEqual({ kind: "skipped" });
   });
 
   it("keeps forced text-fragment flush settlement isolated from the triggering replay", async () => {
-    loadConfig.mockReturnValue({
-      agents: {
-        defaults: {
-          envelopeTimezone: "utc",
-        },
-      },
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm({ timezone: "envelopeTimezone" });
 
     installPerKeySequentializer();
     const secondDispatchError = new Error("triggering replay failed before adoption");
@@ -1120,49 +1066,26 @@ describe("createTelegramBot", () => {
       .mockRejectedValueOnce(secondDispatchError);
 
     createTelegramBot({ token: "tok" });
-    const messageHandler = getOnHandler("message") as (
-      ctx: TelegramMiddlewareTestContext,
-    ) => Promise<void>;
-    const dispatchSpooledMessage = async (params: {
-      updateId: number;
-      messageId: number;
-      text: string;
-    }) => {
-      const message = {
-        chat: { id: 7, type: "private" as const },
-        text: params.text,
-        date: 1736380800 + params.updateId,
-        message_id: params.messageId,
-        from: { id: 42, first_name: "Ada" },
-      };
-      const update = { update_id: params.updateId, message };
-      return await runWithTelegramSpooledReplayUpdate(update, async () => {
-        await runTelegramMiddlewareChain({
-          ctx: {
-            update,
-            message,
-            me: { username: "openclaw_bot" },
-            getFile: async () => ({}),
-          },
-          finalHandler: messageHandler,
-        });
-      });
-    };
+    const messageHandler = getMessageHandler();
 
-    const bufferedReplay = await dispatchSpooledMessage({
+    const bufferedReplay = await dispatchSpooledPrivateText(messageHandler, {
       updateId: 213,
       messageId: 213,
       text: "A".repeat(4050),
+      date: 1736381013,
+      replayUpdate: "full",
     });
     const bufferedParticipant = requireValue(
       bufferedReplay.deferredWork,
       "buffered replay participant",
     );
 
-    const triggeringReplay = await dispatchSpooledMessage({
+    const triggeringReplay = await dispatchSpooledPrivateText(messageHandler, {
       updateId: 214,
       messageId: 215,
       text: "B",
+      date: 1736381014,
+      replayUpdate: "full",
     });
     const triggeringParticipant = requireValue(
       triggeringReplay.deferredWork,
@@ -1179,22 +1102,7 @@ describe("createTelegramBot", () => {
   });
 
   it("retries deferred adoption after durable commit fails without settling buffered participants", async () => {
-    const DEBOUNCE_MS = 4321;
-    loadConfig.mockReturnValue({
-      agents: {
-        defaults: {
-          envelopeTimezone: "utc",
-        },
-      },
-      messages: {
-        inbound: {
-          debounceMs: DEBOUNCE_MS,
-        },
-      },
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm({ debounceMs: INBOUND_DEBOUNCE_MS, timezone: "envelopeTimezone" });
 
     installPerKeySequentializer();
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
@@ -1211,32 +1119,20 @@ describe("createTelegramBot", () => {
 
     try {
       createTelegramBot({ token: "tok" });
-      const messageHandler = getOnHandler("message") as (
-        ctx: TelegramMiddlewareTestContext,
-      ) => Promise<void>;
-      const dispatchSpooledMessage = async (updateId: number, text: string) => {
-        const update = { update_id: updateId };
-        return await runWithTelegramSpooledReplayUpdate(update, async () => {
-          await runTelegramMiddlewareChain({
-            ctx: {
-              update,
-              message: {
-                chat: { id: 7, type: "private" },
-                text,
-                date: 1736380800 + updateId,
-                message_id: updateId,
-                from: { id: 42, first_name: "Ada" },
-              },
-              me: { username: "openclaw_bot" },
-              getFile: async () => ({}),
-            },
-            finalHandler: messageHandler,
-          });
-        });
-      };
+      const messageHandler = getMessageHandler();
 
-      const firstReplay = await dispatchSpooledMessage(221, "first buffered message");
-      const secondReplay = await dispatchSpooledMessage(222, "second buffered message");
+      const firstReplay = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 221,
+        messageId: 221,
+        text: "first buffered message",
+        date: 1736381021,
+      });
+      const secondReplay = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 222,
+        messageId: 222,
+        text: "second buffered message",
+        date: 1736381022,
+      });
       const firstParticipant = requireValue(
         firstReplay.deferredWork,
         "first buffered replay participant",
@@ -1254,15 +1150,7 @@ describe("createTelegramBot", () => {
         secondSettled = true;
       });
 
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
-        (call) => call[1] === DEBOUNCE_MS,
-      );
-      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-      clearTimeout(
-        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
-      );
-      const flush = setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
-      flush?.();
+      takeLatestTimerCallback(INBOUND_DEBOUNCE_MS)();
       await vi.waitFor(() => {
         expect(queuedLifecycle?.onAdopted).toEqual(expect.any(Function));
       });
@@ -1286,22 +1174,7 @@ describe("createTelegramBot", () => {
   });
 
   it("serializes timeout settlement behind an in-flight durable adoption commit", async () => {
-    const DEBOUNCE_MS = 4321;
-    loadConfig.mockReturnValue({
-      agents: {
-        defaults: {
-          envelopeTimezone: "utc",
-        },
-      },
-      messages: {
-        inbound: {
-          debounceMs: DEBOUNCE_MS,
-        },
-      },
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm({ debounceMs: INBOUND_DEBOUNCE_MS, timezone: "envelopeTimezone" });
 
     installPerKeySequentializer();
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
@@ -1341,32 +1214,20 @@ describe("createTelegramBot", () => {
 
     try {
       createTelegramBot({ token: "tok" });
-      const messageHandler = getOnHandler("message") as (
-        ctx: TelegramMiddlewareTestContext,
-      ) => Promise<void>;
-      const dispatchSpooledMessage = async (updateId: number, text: string) => {
-        const update = { update_id: updateId };
-        return await runWithTelegramSpooledReplayUpdate(update, async () => {
-          await runTelegramMiddlewareChain({
-            ctx: {
-              update,
-              message: {
-                chat: { id: 7, type: "private" },
-                text,
-                date: 1736380800 + updateId,
-                message_id: updateId,
-                from: { id: 42, first_name: "Ada" },
-              },
-              me: { username: "openclaw_bot" },
-              getFile: async () => ({}),
-            },
-            finalHandler: messageHandler,
-          });
-        });
-      };
+      const messageHandler = getMessageHandler();
 
-      const firstReplay = await dispatchSpooledMessage(225, "first buffered message");
-      const secondReplay = await dispatchSpooledMessage(226, "second buffered message");
+      const firstReplay = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 225,
+        messageId: 225,
+        text: "first buffered message",
+        date: 1736381025,
+      });
+      const secondReplay = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 226,
+        messageId: 226,
+        text: "second buffered message",
+        date: 1736381026,
+      });
       const firstParticipant = requireValue(
         firstReplay.deferredWork,
         "first buffered replay participant",
@@ -1376,15 +1237,7 @@ describe("createTelegramBot", () => {
         "second buffered replay participant",
       );
 
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
-        (call) => call[1] === DEBOUNCE_MS,
-      );
-      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-      clearTimeout(
-        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
-      );
-      const flush = setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
-      flush?.();
+      takeLatestTimerCallback(INBOUND_DEBOUNCE_MS)();
       await vi.waitFor(() => {
         expect(runQueuedTurn).toEqual(expect.any(Function));
       });
@@ -1421,22 +1274,7 @@ describe("createTelegramBot", () => {
   });
 
   it("blocks buffered adoption after an exposed replay participant times out", async () => {
-    const DEBOUNCE_MS = 4321;
-    loadConfig.mockReturnValue({
-      agents: {
-        defaults: {
-          envelopeTimezone: "utc",
-        },
-      },
-      messages: {
-        inbound: {
-          debounceMs: DEBOUNCE_MS,
-        },
-      },
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm({ debounceMs: INBOUND_DEBOUNCE_MS, timezone: "envelopeTimezone" });
 
     installPerKeySequentializer();
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
@@ -1452,32 +1290,20 @@ describe("createTelegramBot", () => {
 
     try {
       createTelegramBot({ token: "tok" });
-      const messageHandler = getOnHandler("message") as (
-        ctx: TelegramMiddlewareTestContext,
-      ) => Promise<void>;
-      const dispatchSpooledMessage = async (updateId: number, text: string) => {
-        const update = { update_id: updateId };
-        return await runWithTelegramSpooledReplayUpdate(update, async () => {
-          await runTelegramMiddlewareChain({
-            ctx: {
-              update,
-              message: {
-                chat: { id: 7, type: "private" },
-                text,
-                date: 1736380800 + updateId,
-                message_id: updateId,
-                from: { id: 42, first_name: "Ada" },
-              },
-              me: { username: "openclaw_bot" },
-              getFile: async () => ({}),
-            },
-            finalHandler: messageHandler,
-          });
-        });
-      };
+      const messageHandler = getMessageHandler();
 
-      const firstReplay = await dispatchSpooledMessage(223, "first buffered message");
-      const secondReplay = await dispatchSpooledMessage(224, "second buffered message");
+      const firstReplay = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 223,
+        messageId: 223,
+        text: "first buffered message",
+        date: 1736381023,
+      });
+      const secondReplay = await dispatchSpooledPrivateText(messageHandler, {
+        updateId: 224,
+        messageId: 224,
+        text: "second buffered message",
+        date: 1736381024,
+      });
       const firstParticipant = requireValue(
         firstReplay.deferredWork,
         "first buffered replay participant",
@@ -1487,15 +1313,7 @@ describe("createTelegramBot", () => {
         "second buffered replay participant",
       );
 
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
-        (call) => call[1] === DEBOUNCE_MS,
-      );
-      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-      clearTimeout(
-        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
-      );
-      const flush = setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
-      flush?.();
+      takeLatestTimerCallback(INBOUND_DEBOUNCE_MS)();
       await vi.waitFor(() => {
         expect(queuedLifecycle?.onAdopted).toEqual(expect.any(Function));
       });
@@ -1519,41 +1337,28 @@ describe("createTelegramBot", () => {
   });
 
   it("preserves structured origin for a single forwarded debounce entry", async () => {
-    loadConfig.mockReturnValue({
-      agents: { defaults: { envelopeTimezone: "utc" } },
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-    });
+    configureOpenDm({ timezone: "envelopeTimezone" });
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
     try {
       createTelegramBot({ token: "tok" });
-      const messageHandler = getOnHandler("message") as (
-        ctx: TelegramMiddlewareTestContext,
-      ) => Promise<void>;
-      await messageHandler({
-        message: {
-          chat: { id: 7, type: "private" },
+      const messageHandler = getMessageHandler();
+      await messageHandler(
+        makePrivateTextContext({
           text: "single forwarded note",
+          messageId: 121,
           date: 1736380921,
-          message_id: 121,
-          from: { id: 42, first_name: "Ada" },
-          forward_origin: {
-            type: "hidden_user",
-            date: 621,
-            sender_user_name: "Original A",
+          message: {
+            forward_origin: {
+              type: "hidden_user",
+              date: 621,
+              sender_user_name: "Original A",
+            },
           },
-        },
-        me: { username: "openclaw_bot" },
-        getFile: async () => ({}),
-      });
-
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 80);
-      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-      clearTimeout(
-        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
+        }),
       );
-      const flush = setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
-      flush?.();
+
+      takeLatestTimerCallback(80)();
 
       await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
       const payload = requireValue(replySpy.mock.calls[0]?.[0], "single forwarded payload");
@@ -1565,47 +1370,34 @@ describe("createTelegramBot", () => {
   });
 
   it("preserves distinct origins for forwarded messages in one debounce batch", async () => {
-    loadConfig.mockReturnValue({
-      agents: { defaults: { envelopeTimezone: "utc" } },
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-    });
+    configureOpenDm({ timezone: "envelopeTimezone" });
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
     try {
       createTelegramBot({ token: "tok" });
-      const messageHandler = getOnHandler("message") as (
-        ctx: TelegramMiddlewareTestContext,
-      ) => Promise<void>;
+      const messageHandler = getMessageHandler();
 
       for (const [messageId, text, origin] of [
         [121, "first forwarded note", "Original A"],
         [122, "second forwarded note", "Original B"],
       ] as const) {
-        await messageHandler({
-          message: {
-            chat: { id: 7, type: "private" },
+        await messageHandler(
+          makePrivateTextContext({
             text,
             date: 1736380800 + messageId,
-            message_id: messageId,
-            from: { id: 42, first_name: "Ada" },
-            forward_origin: {
-              type: "hidden_user",
-              date: 500 + messageId,
-              sender_user_name: origin,
+            messageId,
+            message: {
+              forward_origin: {
+                type: "hidden_user",
+                date: 500 + messageId,
+                sender_user_name: origin,
+              },
             },
-          },
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({}),
-        });
+          }),
+        );
       }
 
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 80);
-      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-      clearTimeout(
-        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
-      );
-      const flush = setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
-      flush?.();
+      takeLatestTimerCallback(80)();
 
       await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
       const payload = requireValue(replySpy.mock.calls[0]?.[0], "forwarded batch payload");
@@ -1626,22 +1418,7 @@ describe("createTelegramBot", () => {
   });
 
   it("lets stop cancel pending same-chat forwarded debounce", async () => {
-    const DEBOUNCE_MS = 4321;
-    loadConfig.mockReturnValue({
-      agents: {
-        defaults: {
-          envelopeTimezone: "utc",
-        },
-      },
-      messages: {
-        inbound: {
-          debounceMs: DEBOUNCE_MS,
-        },
-      },
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm({ debounceMs: INBOUND_DEBOUNCE_MS, timezone: "envelopeTimezone" });
 
     installPerKeySequentializer();
 
@@ -1654,60 +1431,31 @@ describe("createTelegramBot", () => {
       return { text: `reply:${body}` };
     });
 
-    const extractLatestForwardDebounceFlush = () => {
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 80);
-      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-      clearTimeout(
-        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
-      );
-      return setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
-    };
-
     try {
       createTelegramBot({ token: "tok" });
-      const messageHandler = getOnHandler("message") as (
-        ctx: TelegramMiddlewareTestContext,
-      ) => Promise<void>;
-
-      await runTelegramMiddlewareChain({
-        ctx: {
-          update: { update_id: 121 },
-          message: {
-            chat: { id: 7, type: "private" },
-            text: "forwarded first",
-            date: 1736380800,
-            message_id: 121,
-            from: { id: 42, first_name: "Ada" },
-            forward_date: 1736380700,
-          },
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({}),
+      const messageHandler = getMessageHandler();
+      await dispatchPrivateText(messageHandler, {
+        updateId: 121,
+        messageId: 121,
+        text: "forwarded first",
+        message: {
+          forward_date: 1736380700,
         },
-        finalHandler: messageHandler,
       });
 
-      const flushForward = extractLatestForwardDebounceFlush();
+      const flushForward = takeLatestTimerCallback(80);
 
-      await runTelegramMiddlewareChain({
-        ctx: {
-          update: { update_id: 122 },
-          message: {
-            chat: { id: 7, type: "private" },
-            text: "stop",
-            date: 1736380801,
-            message_id: 122,
-            from: { id: 42, first_name: "Ada" },
-          },
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({}),
-        },
-        finalHandler: messageHandler,
+      await dispatchPrivateText(messageHandler, {
+        updateId: 122,
+        messageId: 122,
+        text: "stop",
+        date: 1736380801,
       });
 
       expect(startedBodies).toHaveLength(1);
       expect(startedBodies[0]).toContain("stop");
 
-      flushForward?.();
+      flushForward();
       await Promise.resolve();
       expect(startedBodies).toHaveLength(1);
       expect(sendMessageSpy.mock.calls.map((call) => String(call[1])).join("\n")).not.toContain(
@@ -1719,7 +1467,6 @@ describe("createTelegramBot", () => {
   });
 
   it("does not let unauthorized group stop cancel pending same-sender inbound debounce", async () => {
-    const DEBOUNCE_MS = 4321;
     loadConfig.mockReturnValue({
       agents: {
         defaults: {
@@ -1728,7 +1475,7 @@ describe("createTelegramBot", () => {
       },
       messages: {
         inbound: {
-          debounceMs: DEBOUNCE_MS,
+          debounceMs: INBOUND_DEBOUNCE_MS,
         },
       },
       channels: {
@@ -1751,22 +1498,9 @@ describe("createTelegramBot", () => {
       return { text: `reply:${body}` };
     });
 
-    const extractLatestDebounceFlush = () => {
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
-        (call) => call[1] === DEBOUNCE_MS,
-      );
-      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
-      clearTimeout(
-        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
-      );
-      return setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
-    };
-
     try {
       createTelegramBot({ token: "tok" });
-      const messageHandler = getOnHandler("message") as (
-        ctx: TelegramMiddlewareTestContext,
-      ) => Promise<void>;
+      const messageHandler = getMessageHandler();
 
       await runTelegramMiddlewareChain({
         ctx: {
@@ -1784,7 +1518,7 @@ describe("createTelegramBot", () => {
         finalHandler: messageHandler,
       });
 
-      const flushFirst = extractLatestDebounceFlush();
+      const flushFirst = takeLatestTimerCallback(INBOUND_DEBOUNCE_MS);
 
       await runTelegramMiddlewareChain({
         ctx: {
@@ -1802,7 +1536,7 @@ describe("createTelegramBot", () => {
         finalHandler: messageHandler,
       });
 
-      flushFirst?.();
+      flushFirst();
       await vi.waitFor(() => {
         expect(startedBodies.some((body) => body.includes("first"))).toBe(true);
       });
@@ -1813,27 +1547,10 @@ describe("createTelegramBot", () => {
 
   it("routes generic callback_query payloads as callback_data messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
+    const callbackHandler = getCallbackHandler();
+    await callbackHandler(
+      makeCallbackRetryContext({ id: "cbq-1", data: "cmd:option_a", messageId: 10 }),
     );
-
-    await callbackHandler({
-      callbackQuery: {
-        id: "cbq-1",
-        data: "cmd:option_a",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
@@ -1857,31 +1574,20 @@ describe("createTelegramBot", () => {
     ).toEqual({ ok: true });
 
     createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
-    );
-
-    await callbackHandler({
-      callbackQuery: {
+    const callbackHandler = getCallbackHandler();
+    await callbackHandler(
+      makeCallbackRetryContext({
         id: "cbq-plugin-1",
         data: "code-agent:approve-123",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        messageId: 10,
+        text: "Approve this code-agent action?",
         message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
           reply_markup: {
             inline_keyboard: [[{ text: "Approve", callback_data: "code-agent:approve-123" }]],
           },
-          text: "Approve this code-agent action?",
         },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+      }),
+    );
 
     expect(pluginHandler).toHaveBeenCalledTimes(1);
     expect(replySpy).not.toHaveBeenCalled();
@@ -1893,27 +1599,10 @@ describe("createTelegramBot", () => {
 
   it("preserves raw slash callback_query payloads as command text", async () => {
     createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
+    const callbackHandler = getCallbackHandler();
+    await callbackHandler(
+      makeCallbackRetryContext({ id: "cbq-slash-1", data: "/fast status", messageId: 10 }),
     );
-
-    await callbackHandler({
-      callbackQuery: {
-        id: "cbq-slash-1",
-        data: "/fast status",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
@@ -1975,27 +1664,14 @@ describe("createTelegramBot", () => {
 
   it("does not route opaque callback_query payloads as synthetic commands", async () => {
     createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
-    );
-
-    await callbackHandler({
-      callbackQuery: {
+    const callbackHandler = getCallbackHandler();
+    await callbackHandler(
+      makeCallbackRetryContext({
         id: "cbq-opaque-1",
         data: buildTelegramOpaqueCallbackData("/codex permissions yolo"),
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+        messageId: 10,
+      }),
+    );
 
     expect(replySpy).not.toHaveBeenCalled();
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-opaque-1");
@@ -2003,31 +1679,20 @@ describe("createTelegramBot", () => {
 
   it("toggles OC_MULTI buttons without routing through the generic callback message path", async () => {
     createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
-    );
-
-    await callbackHandler({
-      callbackQuery: {
+    const callbackHandler = getCallbackHandler();
+    await callbackHandler(
+      makeCallbackRetryContext({
         id: "cbq-multi-toggle-1",
         data: "OC_MULTI|toggle|env|prod",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        messageId: 10,
         message: {
           business_connection_id: "biz-multi-1",
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
           reply_markup: {
             inline_keyboard: [[{ text: "Prod", callback_data: "OC_MULTI|toggle|env|prod" }]],
           },
         },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+      }),
+    );
 
     expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
       business_connection_id: "biz-multi-1",
@@ -2041,22 +1706,13 @@ describe("createTelegramBot", () => {
 
   it("submits OC_MULTI selections as a synthetic inbound message", async () => {
     createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
-    );
-
-    await callbackHandler({
-      callbackQuery: {
+    const callbackHandler = getCallbackHandler();
+    await callbackHandler(
+      makeCallbackRetryContext({
         id: "cbq-multi-submit-1",
         data: "OC_MULTI|submit",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        messageId: 10,
         message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
           reply_markup: {
             inline_keyboard: [
               [{ text: "✅ Prod", callback_data: "OC_MULTI|toggle|env|prod" }],
@@ -2064,10 +1720,8 @@ describe("createTelegramBot", () => {
             ],
           },
         },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+      }),
+    );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     expect(requireValue(replySpy.mock.calls.at(0), "replySpy call")[0].Body).toContain(
@@ -2077,30 +1731,19 @@ describe("createTelegramBot", () => {
 
   it("submits OC_SELECT values as a synthetic inbound message and clears buttons", async () => {
     createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
-    );
-
-    await callbackHandler({
-      callbackQuery: {
+    const callbackHandler = getCallbackHandler();
+    await callbackHandler(
+      makeCallbackRetryContext({
         id: "cbq-select-1",
         data: "OC_SELECT|env|canary",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        messageId: 10,
         message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
           reply_markup: {
             inline_keyboard: [[{ text: "Canary", callback_data: "OC_SELECT|env|canary" }]],
           },
         },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+      }),
+    );
 
     expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
       reply_markup: { inline_keyboard: [] },
@@ -2123,24 +1766,10 @@ describe("createTelegramBot", () => {
     });
 
     createTelegramBot({ token: "tok" });
-    const callbackHandler = getOnHandler("callback_query") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await callbackHandler({
-      callbackQuery: {
-        id: "cbq-native-1",
-        data: "tgcmd:/fast status",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+    const callbackHandler = getCallbackHandler();
+    await callbackHandler(
+      makeCallbackRetryContext({ id: "cbq-native-1", data: "tgcmd:/fast status", messageId: 10 }),
+    );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
@@ -2171,25 +1800,12 @@ describe("createTelegramBot", () => {
     }));
 
     createTelegramBot({ token: "tok" });
-    const callbackHandler = getOnHandler("callback_query") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
+    const callbackHandler = getCallbackHandler();
 
     const sendModelCallback = async (id: number) => {
-      await callbackHandler({
-        callbackQuery: {
-          id: `cbq-model-${id}`,
-          data: "mdl_prov",
-          from: { id: 9, first_name: "Ada", username: "ada_bot" },
-          message: {
-            chat: { id: 1234, type: "private" },
-            date: 1736380800 + id,
-            message_id: id,
-          },
-        },
-        me: { username: "openclaw_bot" },
-        getFile: async () => ({ download: async () => new Uint8Array() }),
-      });
+      await callbackHandler(
+        makeCallbackRetryContext({ id: `cbq-model-${id}`, data: "mdl_prov", messageId: id }),
+      );
     };
 
     buildModelsProviderDataMock.mockClear();
@@ -2206,23 +1822,20 @@ describe("createTelegramBot", () => {
       createTelegramBot({ token: "tok" });
       const messageRegistration = onSpy.mock.calls.find(([event]) => event === "message");
       expect(messageRegistration?.[1]).toBeTypeOf("function");
-      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-
-      const message = {
-        chat: { id: 1234, type: "private" },
-        text: "hello world",
-        date: 1736380800, // 2025-01-09T00:00:00Z
-        from: {
-          first_name: "Ada",
-          last_name: "Lovelace",
-          username: "ada_bot",
-        },
-      };
-      await handler({
-        message,
-        me: { username: "openclaw_bot" },
-        getFile: async () => ({ download: async () => new Uint8Array() }),
-      });
+      const handler = getMessageHandler();
+      await handler(
+        makePrivateTextContext({
+          chatId: 1234,
+          text: "hello world",
+          date: 1736380800, // 2025-01-09T00:00:00Z
+          from: {
+            first_name: "Ada",
+            last_name: "Lovelace",
+            username: "ada_bot",
+          },
+          downloadable: true,
+        }),
+      );
 
       expect(replySpy).toHaveBeenCalledTimes(1);
       const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
@@ -2275,19 +1888,17 @@ describe("createTelegramBot", () => {
       });
 
       createTelegramBot({ token: "tok" });
-      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      const handler = getMessageHandler();
       const senderId = Number(`${Date.now()}${index}`.slice(-9));
       for (const text of testCase.messages) {
-        await handler({
-          message: {
-            chat: { id: 1234, type: "private" },
+        await handler(
+          makePrivateTextContext({
+            chatId: 1234,
             text,
-            date: 1736380800,
             from: { id: senderId, username: "random" },
-          },
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({ download: async () => new Uint8Array() }),
-        });
+            downloadable: true,
+          }),
+        );
       }
 
       expect(replySpy, testCase.name).not.toHaveBeenCalled();
@@ -2315,19 +1926,16 @@ describe("createTelegramBot", () => {
     replySpy.mockClear();
 
     createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-
-    await handler({
-      message: {
-        chat: { id: 1234, type: "private" },
+    const handler = getMessageHandler();
+    await handler(
+      makePrivateTextContext({
+        chatId: 1234,
         text: "hello",
-        message_id: 9,
-        date: 1736380800,
+        messageId: 9,
         from: { id: 123456789, username: "testuser" },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+        downloadable: true,
+      }),
+    );
 
     expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
     expect(replySpy).not.toHaveBeenCalled();
@@ -2404,30 +2012,27 @@ describe("createTelegramBot", () => {
     replySpy.mockClear();
 
     createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-
-    const firstMessage = {
-      chat: { id: 1234, type: "private" },
-      text: "hello",
-      date: 1736380800,
-      message_id: 10,
-      from: { id: 123456789, username: "testuser" },
-    };
-    await handler({
-      message: firstMessage,
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
-    await handler({
-      message: {
-        ...firstMessage,
+    const handler = getMessageHandler();
+    const sender = { id: 123456789, username: "testuser" };
+    await handler(
+      makePrivateTextContext({
+        chatId: 1234,
+        text: "hello",
+        messageId: 10,
+        from: sender,
+        downloadable: true,
+      }),
+    );
+    await handler(
+      makePrivateTextContext({
+        chatId: 1234,
         text: "still there?",
+        messageId: 11,
         date: 1736380801,
-        message_id: 11,
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+        from: sender,
+        downloadable: true,
+      }),
+    );
 
     expect(readChannelAllowFromStore).toHaveBeenCalledTimes(2);
     expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
@@ -2467,9 +2072,7 @@ describe("createTelegramBot", () => {
   });
 
   it("does not require the pairing allowlist store for open private messages", async () => {
-    loadConfig.mockReturnValue({
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-    });
+    configureOpenDm();
     readChannelAllowFromStore.mockRejectedValueOnce(new Error("store temporarily unavailable"));
     upsertChannelPairingRequest.mockClear();
     sendMessageSpy.mockClear();
@@ -3028,9 +2631,7 @@ describe("createTelegramBot", () => {
   });
 
   it("dedupes a replayed Telegram message after handler recreation", async () => {
-    loadConfig.mockReturnValue({
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-    });
+    configureOpenDm();
 
     const replayedCtx = () => ({
       update: { update_id: 8488601 },
@@ -3061,9 +2662,7 @@ describe("createTelegramBot", () => {
   });
 
   it("dedupes a replayed Telegram message after handler recreation while dispatch is pending", async () => {
-    loadConfig.mockReturnValue({
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-    });
+    configureOpenDm();
 
     const firstDispatchStarted = createDeferred();
     const finishFirstDispatch = createDeferred();
@@ -3107,9 +2706,7 @@ describe("createTelegramBot", () => {
   });
 
   it("retries a spooled message after dispatch fails before turn adoption", async () => {
-    loadConfig.mockReturnValue({
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-    });
+    configureOpenDm();
     const dispatchError = new Error("failed before turn adoption");
     replySpy.mockRejectedValueOnce(dispatchError).mockResolvedValueOnce({ text: "recovered" });
 
@@ -3164,28 +2761,10 @@ describe("createTelegramBot", () => {
   });
 
   it("persists update offsets after successful dispatch completion", async () => {
-    // For this test we need sequentialize(...) to behave like a normal middleware and call next().
-    sequentializeSpy.mockImplementationOnce(
-      () => async (_ctx: unknown, next: () => Promise<void>) => {
-        await next();
-      },
-    );
-
-    const onUpdateId = vi.fn();
-    loadConfig.mockReturnValue({
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    configureOpenDm();
+    const { onUpdateId, run: runMiddlewareChain } = setupUpdateOffsetTracker({
+      lastUpdateId: 100,
     });
-
-    createTelegramBot({
-      token: "tok",
-      updateOffset: {
-        lastUpdateId: 100,
-        onUpdateId,
-      },
-    });
-
-    const runMiddlewareChain = (ctx: Record<string, unknown>, finalNext: () => Promise<void>) =>
-      runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, async () => finalNext());
 
     let releaseUpdate101: (() => void) | undefined;
     const update101Gate = new Promise<void>((resolve) => {
@@ -3210,12 +2789,6 @@ describe("createTelegramBot", () => {
     expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([102]);
   });
   it("logs and swallows update watermark persistence failures", async () => {
-    sequentializeSpy.mockImplementationOnce(
-      () => async (_ctx: unknown, next: () => Promise<void>) => {
-        await next();
-      },
-    );
-
     const onUpdateId = vi.fn().mockRejectedValueOnce(new Error("disk boom"));
     const runtime = {
       log: vi.fn(),
@@ -3225,17 +2798,11 @@ describe("createTelegramBot", () => {
       exit: vi.fn(),
     };
 
-    createTelegramBot({
-      token: "tok",
+    const { run: runMiddlewareChain } = setupUpdateOffsetTracker({
+      lastUpdateId: 13_099,
+      onUpdateId,
       runtime,
-      updateOffset: {
-        lastUpdateId: 13_099,
-        onUpdateId,
-      },
     });
-
-    const runMiddlewareChain = (ctx: Record<string, unknown>, finalNext: () => Promise<void>) =>
-      runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, async () => finalNext());
 
     const unhandled: unknown[] = [];
     const onUnhandledRejection = (reason: unknown) => {
@@ -3254,24 +2821,9 @@ describe("createTelegramBot", () => {
   });
 
   it("keeps failed updates unpersisted while preserving same-process retries", async () => {
-    sequentializeSpy.mockImplementationOnce(
-      () => async (_ctx: unknown, next: () => Promise<void>) => {
-        await next();
-      },
-    );
-
-    const onUpdateId = vi.fn();
-
-    createTelegramBot({
-      token: "tok",
-      updateOffset: {
-        lastUpdateId: 200,
-        onUpdateId,
-      },
+    const { onUpdateId, run: runMiddlewareChain } = setupUpdateOffsetTracker({
+      lastUpdateId: 200,
     });
-
-    const runMiddlewareChain = (ctx: Record<string, unknown>, finalNext: () => Promise<void>) =>
-      runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, async () => finalNext());
 
     await expect(
       runMiddlewareChain({ update: { update_id: 201 } }, async () => {
@@ -3297,24 +2849,9 @@ describe("createTelegramBot", () => {
   });
 
   it("persists recorded dispatch failures during normal polling", async () => {
-    sequentializeSpy.mockImplementationOnce(
-      () => async (_ctx: unknown, next: () => Promise<void>) => {
-        await next();
-      },
-    );
-
-    const onUpdateId = vi.fn();
-
-    createTelegramBot({
-      token: "tok",
-      updateOffset: {
-        lastUpdateId: 500,
-        onUpdateId,
-      },
+    const { onUpdateId, run: runMiddlewareChain } = setupUpdateOffsetTracker({
+      lastUpdateId: 500,
     });
-
-    const runMiddlewareChain = (ctx: Record<string, unknown>, finalNext: () => Promise<void>) =>
-      runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, async () => finalNext());
 
     const dispatchError = new Error("dispatch exploded");
     await runMiddlewareChain({ update: { update_id: 501 } }, async () => {
@@ -3332,24 +2869,9 @@ describe("createTelegramBot", () => {
   });
 
   it("rejects recorded dispatch failures during isolated spool replay", async () => {
-    sequentializeSpy.mockImplementationOnce(
-      () => async (_ctx: unknown, next: () => Promise<void>) => {
-        await next();
-      },
-    );
-
-    const onUpdateId = vi.fn();
-
-    createTelegramBot({
-      token: "tok",
-      updateOffset: {
-        lastUpdateId: 600,
-        onUpdateId,
-      },
+    const { onUpdateId, run: runMiddlewareChain } = setupUpdateOffsetTracker({
+      lastUpdateId: 600,
     });
-
-    const runMiddlewareChain = (ctx: Record<string, unknown>, finalNext: () => Promise<void>) =>
-      runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, async () => finalNext());
 
     const update = { update_id: 601 };
     const dispatchError = new Error("dispatch exploded");
@@ -3371,24 +2893,9 @@ describe("createTelegramBot", () => {
   });
 
   it("keeps deferred spooled failures retryable in the same bot tracker", async () => {
-    sequentializeSpy.mockImplementationOnce(
-      () => async (_ctx: unknown, next: () => Promise<void>) => {
-        await next();
-      },
-    );
-
-    const onUpdateId = vi.fn();
-
-    createTelegramBot({
-      token: "tok",
-      updateOffset: {
-        lastUpdateId: 700,
-        onUpdateId,
-      },
+    const { onUpdateId, run: runMiddlewareChain } = setupUpdateOffsetTracker({
+      lastUpdateId: 700,
     });
-
-    const runMiddlewareChain = (ctx: Record<string, unknown>, finalNext: () => Promise<void>) =>
-      runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, async () => finalNext());
 
     const update = { update_id: 701 };
     const replay = await runWithTelegramSpooledReplayUpdate(update, async () => {
@@ -3426,24 +2933,9 @@ describe("createTelegramBot", () => {
   });
 
   it("skips replayed update ids even when the semantic update key differs", async () => {
-    sequentializeSpy.mockImplementationOnce(
-      () => async (_ctx: unknown, next: () => Promise<void>) => {
-        await next();
-      },
-    );
-
-    const onUpdateId = vi.fn();
-
-    createTelegramBot({
-      token: "tok",
-      updateOffset: {
-        lastUpdateId: 300,
-        onUpdateId,
-      },
+    const { onUpdateId, run: runMiddlewareChain } = setupUpdateOffsetTracker({
+      lastUpdateId: 300,
     });
-
-    const runMiddlewareChain = (ctx: Record<string, unknown>, finalNext: () => Promise<void>) =>
-      runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, async () => finalNext());
 
     const handler = vi.fn();
     await runMiddlewareChain(
@@ -3477,269 +2969,122 @@ describe("createTelegramBot", () => {
     expect(replayHandler).not.toHaveBeenCalled();
   });
   it("allows distinct callback_query ids without update_id", async () => {
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm();
 
     createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("callback_query") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      callbackQuery: {
-        id: "cb-1",
-        data: "ping",
-        from: { id: 789, username: "testuser" },
-        message: {
-          chat: { id: 123, type: "private" },
-          date: 1736380800,
-          message_id: 9001,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({}),
-    });
-
-    await handler({
-      callbackQuery: {
-        id: "cb-2",
-        data: "ping",
-        from: { id: 789, username: "testuser" },
-        message: {
-          chat: { id: 123, type: "private" },
-          date: 1736380800,
-          message_id: 9001,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({}),
-    });
+    const handler = getCallbackHandler();
+    for (const id of ["cb-1", "cb-2"]) {
+      await handler(
+        makeCallbackRetryContext({
+          id,
+          data: "ping",
+          messageId: 9001,
+          from: { id: 789, username: "testuser" },
+          message: { chat: { id: 123, type: "private" } },
+          downloadable: false,
+        }),
+      );
+    }
 
     expect(replySpy).toHaveBeenCalledTimes(2);
   });
 
-  const groupPolicyCases: Array<{
-    name: string;
-    config: Record<string, unknown>;
-    message: Record<string, unknown>;
-    expectedReplyCount: number;
-  }> = [
-    {
+  const accessGroup = (member: string) => ({
+    accessGroups: {
+      operators: { type: "message.senders", members: { telegram: [member] } },
+    },
+  });
+  const groupPolicyCases: MessagePolicyCase[] = [
+    makeMessagePolicyCase({
       name: "blocks all group messages when groupPolicy is 'disabled'",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "disabled",
-            allowFrom: ["123456789"],
-          },
-        },
-      },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 123456789, username: "testuser" },
-        text: "@openclaw_bot hello",
-        date: 1736380800,
-      },
+      telegram: { groupPolicy: "disabled", allowFrom: ["123456789"] },
+      message: { text: "@openclaw_bot hello" },
       expectedReplyCount: 0,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "blocks group messages from senders not in allowFrom when groupPolicy is 'allowlist'",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            allowFrom: ["123456789"],
-          },
-        },
-      },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 999999, username: "notallowed" },
-        text: "@openclaw_bot hello",
-        date: 1736380800,
-      },
+      telegram: { groupPolicy: "allowlist", allowFrom: ["123456789"] },
+      message: { from: { id: 999999, username: "notallowed" }, text: "@openclaw_bot hello" },
       expectedReplyCount: 0,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "allows group messages from senders in allowFrom (by ID) when groupPolicy is 'allowlist'",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            allowFrom: ["123456789"],
-            groups: { "*": { requireMention: false } },
-          },
-        },
-      },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 123456789, username: "testuser" },
-        text: "hello",
-        date: 1736380800,
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["123456789"],
+        groups: { "*": { requireMention: false } },
       },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "allows group messages from sender access groups in groupAllowFrom",
-      config: {
-        accessGroups: {
-          operators: {
-            type: "message.senders",
-            members: { telegram: ["123456789"] },
-          },
-        },
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            groupAllowFrom: ["accessGroup:operators"],
-            groups: { "*": { requireMention: false } },
-          },
-        },
-      },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 123456789, username: "testuser" },
-        text: "hello",
-        date: 1736380800,
+      rootConfig: accessGroup("123456789"),
+      telegram: {
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["accessGroup:operators"],
+        groups: { "*": { requireMention: false } },
       },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "blocks explicitly configured group when groupAllowFrom access group does not match sender",
-      config: {
-        accessGroups: {
-          operators: {
-            type: "message.senders",
-            members: { telegram: ["111111111"] },
-          },
-        },
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            groupAllowFrom: ["accessGroup:operators"],
-            groups: { "-100123456789": { requireMention: false } },
-          },
-        },
-      },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 123456789, username: "testuser" },
-        text: "hello",
-        date: 1736380800,
+      rootConfig: accessGroup("111111111"),
+      telegram: {
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["accessGroup:operators"],
+        groups: { "-100123456789": { requireMention: false } },
       },
       expectedReplyCount: 0,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "allows group messages from sender access groups in per-group allowFrom",
-      config: {
-        accessGroups: {
-          operators: {
-            type: "message.senders",
-            members: { telegram: ["123456789"] },
+      rootConfig: accessGroup("123456789"),
+      telegram: {
+        groupPolicy: "open",
+        groups: {
+          "-100123456789": {
+            allowFrom: ["accessGroup:operators"],
+            requireMention: false,
           },
         },
-        channels: {
-          telegram: {
-            groupPolicy: "open",
-            groups: {
-              "-100123456789": {
-                allowFrom: ["accessGroup:operators"],
-                requireMention: false,
-              },
-            },
-          },
-        },
-      },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 123456789, username: "testuser" },
-        text: "hello",
-        date: 1736380800,
       },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "blocks group messages when allowFrom is configured with @username entries (numeric IDs required)",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            allowFrom: ["@testuser"],
-            groups: { "*": { requireMention: false } },
-          },
-        },
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["@testuser"],
+        groups: { "*": { requireMention: false } },
       },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 12345, username: "testuser" },
-        text: "hello",
-        date: 1736380800,
-      },
+      message: { from: { id: 12345, username: "testuser" } },
       expectedReplyCount: 0,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "allows group messages from tg:-prefixed allowFrom entries case-insensitively",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            allowFrom: ["TG:77112533"],
-            groups: { "*": { requireMention: false } },
-          },
-        },
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["TG:77112533"],
+        groups: { "*": { requireMention: false } },
       },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 77112533, username: "mneves" },
-        text: "hello",
-        date: 1736380800,
-      },
+      message: { from: { id: 77112533, username: "mneves" } },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "blocks group messages when per-group allowFrom override is explicitly empty",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "open",
-            groups: {
-              "-100123456789": {
-                allowFrom: [],
-                requireMention: false,
-              },
-            },
-          },
-        },
+      telegram: {
+        groupPolicy: "open",
+        groups: { "-100123456789": { allowFrom: [], requireMention: false } },
       },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 999999, username: "random" },
-        text: "hello",
-        date: 1736380800,
-      },
+      message: { from: { id: 999999, username: "random" } },
       expectedReplyCount: 0,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "allows all group messages when groupPolicy is 'open'",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "open",
-            groups: { "*": { requireMention: false } },
-          },
-        },
-      },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 999999, username: "random" },
-        text: "hello",
-        date: 1736380800,
-      },
+      telegram: { groupPolicy: "open", groups: { "*": { requireMention: false } } },
+      message: { from: { id: 999999, username: "random" } },
       expectedReplyCount: 1,
-    },
+    }),
   ];
 
   it("applies groupPolicy cases", async () => {
@@ -3781,19 +3126,16 @@ describe("createTelegramBot", () => {
     loadConfig.mockReturnValue(config);
 
     createTelegramBot({ token: "tok", accountId: "opie" });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-
-    await handler({
-      message: {
-        chat: { id: 123, type: "private" },
+    const handler = getMessageHandler();
+    await handler(
+      makePrivateTextContext({
+        chatId: 123,
         from: { id: 999, username: "testuser" },
         text: "hello",
-        date: 1736380800,
-        message_id: 42,
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+        messageId: 42,
+        downloadable: true,
+      }),
+    );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
@@ -3834,20 +3176,19 @@ describe("createTelegramBot", () => {
     loadConfig.mockImplementation(() => configForAgent(boundAgentId));
 
     createTelegramBot({ token: "tok", accountId: "opie" });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+    const handler = getMessageHandler();
 
     const sendDm = async (messageId: number, text: string) => {
-      await handler({
-        message: {
-          chat: { id: 123, type: "private" },
+      await handler(
+        makePrivateTextContext({
+          chatId: 123,
           from: { id: 999, username: "testuser" },
           text,
           date: 1736380800 + messageId,
-          message_id: messageId,
-        },
-        me: { username: "openclaw_bot" },
-        getFile: async () => ({ download: async () => new Uint8Array() }),
-      });
+          messageId,
+          downloadable: true,
+        }),
+      );
     };
 
     await sendDm(42, "hello one");
@@ -3955,19 +3296,16 @@ describe("createTelegramBot", () => {
     });
 
     createTelegramBot({ token: "tok", accountId: "opie" });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-
-    await handler({
-      message: {
-        chat: { id: 123, type: "private" },
+    const handler = getMessageHandler();
+    await handler(
+      makePrivateTextContext({
+        chatId: 123,
         from: { id: 999, username: "testuser" },
         text: "hello",
-        date: 1736380800,
-        message_id: 42,
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+        messageId: 42,
+        downloadable: true,
+      }),
+    );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = requireValue(replySpy.mock.calls.at(0), "reply call")[0];
@@ -4039,117 +3377,91 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 
-  it("lets topic mention overrides fall back from wildcard group config", () => {
+  it.each([
+    {
+      name: "lets topic mention overrides fall back from wildcard group config",
+      groupPolicy: "open",
+      groups: {
+        "*": { requireMention: true },
+        "-1001234567890": { requireMention: true, topics: { "99": { requireMention: false } } },
+      },
+      topicId: 99,
+      expectedGroup: { requireMention: true },
+      expectedTopic: { requireMention: false },
+    },
+    {
+      name: "lets topic configs inherit group allowlist and requireMention",
+      groupPolicy: "allowlist",
+      groups: {
+        "-1001234567890": {
+          requireMention: false,
+          allowFrom: ["123456789"],
+          topics: { "99": {} },
+        },
+      },
+      topicId: 99,
+      expectedGroup: { requireMention: false, allowFrom: ["123456789"] },
+      expectedTopic: {},
+    },
+    {
+      name: "uses topics.* as the default config for unmatched forum topics",
+      groupPolicy: "allowlist",
+      groups: {
+        "-1001234567890": {
+          allowFrom: ["999999999"],
+          topics: { "*": { allowFrom: ["123456789"], agentId: "zu" } },
+        },
+      },
+      topicId: 77,
+      expectedGroup: { allowFrom: ["999999999"] },
+      expectedTopic: { allowFrom: ["123456789"], agentId: "zu" },
+    },
+    {
+      name: "prefers exact topic config over topics.* fallback",
+      groupPolicy: "allowlist",
+      groups: {
+        "-1001234567890": {
+          topics: {
+            "*": { allowFrom: ["123456789"], agentId: "zu" },
+            "77": { allowFrom: ["555555555"], agentId: "main" },
+          },
+        },
+      },
+      topicId: 77,
+      expectedGroup: undefined,
+      expectedTopic: { allowFrom: ["555555555"], agentId: "main" },
+    },
+    {
+      name: "inherits topics.* fields that exact topic config does not override",
+      groupPolicy: "allowlist",
+      groups: {
+        "-1001234567890": {
+          topics: {
+            "*": { allowFrom: ["123456789"], requireMention: false },
+            "77": { agentId: "main" },
+          },
+        },
+      },
+      topicId: 77,
+      expectedGroup: undefined,
+      expectedTopic: { allowFrom: ["123456789"], requireMention: false, agentId: "main" },
+    },
+  ] satisfies Array<
+    Record<string, unknown> & {
+      groupPolicy: "open" | "allowlist";
+      groups: Record<string, TelegramGroupConfig>;
+    }
+  >)("$name", ({ groupPolicy, groups, topicId, expectedGroup, expectedTopic }) => {
     const { groupConfig, topicConfig } = resolveTelegramScopedGroupConfig(
-      {
-        groupPolicy: "open",
-        groups: {
-          "*": { requireMention: true },
-          "-1001234567890": {
-            requireMention: true,
-            topics: {
-              "99": { requireMention: false },
-            },
-          },
-        },
-      },
+      { groupPolicy, groups },
       -1001234567890,
-      99,
+      topicId,
     );
 
-    const group = groupConfig as TelegramGroupConfig | undefined;
-    expect(group?.requireMention).toBe(true);
-    expect(topicConfig?.requireMention).toBe(false);
-  });
-
-  it("lets topic configs inherit group allowlist and requireMention", () => {
-    const { groupConfig, topicConfig } = resolveTelegramScopedGroupConfig(
-      {
-        groupPolicy: "allowlist",
-        groups: {
-          "-1001234567890": {
-            requireMention: false,
-            allowFrom: ["123456789"],
-            topics: {
-              "99": {},
-            },
-          },
-        },
-      },
-      -1001234567890,
-      99,
-    );
-
-    const group = groupConfig as TelegramGroupConfig | undefined;
-    expect(group?.requireMention).toBe(false);
-    expect(group?.allowFrom).toEqual(["123456789"]);
-    expect(topicConfig).toEqual({});
-  });
-
-  it("uses topics.* as the default config for unmatched forum topics", () => {
-    const { groupConfig, topicConfig } = resolveTelegramScopedGroupConfig(
-      {
-        groupPolicy: "allowlist",
-        groups: {
-          "-1001234567890": {
-            allowFrom: ["999999999"],
-            topics: {
-              "*": { allowFrom: ["123456789"], agentId: "zu" },
-            },
-          },
-        },
-      },
-      -1001234567890,
-      77,
-    );
-
-    const group = groupConfig as TelegramGroupConfig | undefined;
-    expect(group?.allowFrom).toEqual(["999999999"]);
-    expect(topicConfig).toEqual({ allowFrom: ["123456789"], agentId: "zu" });
-  });
-
-  it("prefers exact topic config over topics.* fallback", () => {
-    const { topicConfig } = resolveTelegramScopedGroupConfig(
-      {
-        groupPolicy: "allowlist",
-        groups: {
-          "-1001234567890": {
-            topics: {
-              "*": { allowFrom: ["123456789"], agentId: "zu" },
-              "77": { allowFrom: ["555555555"], agentId: "main" },
-            },
-          },
-        },
-      },
-      -1001234567890,
-      77,
-    );
-
-    expect(topicConfig).toEqual({ allowFrom: ["555555555"], agentId: "main" });
-  });
-
-  it("inherits topics.* fields that exact topic config does not override", () => {
-    const { topicConfig } = resolveTelegramScopedGroupConfig(
-      {
-        groupPolicy: "allowlist",
-        groups: {
-          "-1001234567890": {
-            topics: {
-              "*": { allowFrom: ["123456789"], requireMention: false },
-              "77": { agentId: "main" },
-            },
-          },
-        },
-      },
-      -1001234567890,
-      77,
-    );
-
-    expect(topicConfig).toEqual({
-      allowFrom: ["123456789"],
-      requireMention: false,
-      agentId: "main",
-    });
+    if (expectedGroup) {
+      expect(groupConfig as TelegramGroupConfig | undefined).toMatchObject(expectedGroup);
+    }
+    expect(topicConfig).toEqual(expectedTopic);
   });
 
   it.each([
@@ -4272,7 +3584,7 @@ describe("createTelegramBot", () => {
     setMessageReactionSpy.mockClear();
     setMyCommandsSpy.mockClear();
   }
-  function getMessageHandler(botRequireMention?: boolean) {
+  function createMessageHandler(botRequireMention?: boolean) {
     createTelegramBot({
       token: "tok",
       ...(typeof botRequireMention === "boolean" ? { requireMention: botRequireMention } : {}),
@@ -4284,7 +3596,7 @@ describe("createTelegramBot", () => {
     me?: Record<string, unknown>;
     botRequireMention?: boolean;
   }) {
-    const handler = getMessageHandler(params.botRequireMention);
+    const handler = createMessageHandler(params.botRequireMention);
     await handler({
       message: params.message,
       me: params.me ?? { username: "openclaw_bot" },
@@ -4675,33 +3987,18 @@ describe("createTelegramBot", () => {
       authorized: true,
     });
   });
-  it("resolves topic-scoped forum metadata", () => {
-    const threadSpec = resolveTelegramThreadSpec({
-      isGroup: true,
-      isForum: true,
-      messageThreadId: 99,
-    });
-    const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
-    const route = resolveTelegramConversationRoute({
-      cfg: {},
-      accountId: "default",
-      chatId: -1001234567890,
-      isGroup: true,
-      resolvedThreadId,
-    });
-
-    expect(route.route.sessionKey).toContain("telegram:group:-1001234567890:topic:99");
-    expect(buildTelegramGroupFrom(-1001234567890, resolvedThreadId)).toBe(
-      "telegram:group:-1001234567890:topic:99",
-    );
-    expect(buildTypingThreadParams(resolvedThreadId)).toEqual({ message_thread_id: 99 });
-  });
-
-  it("resolves General topic forum metadata and typing fallback", () => {
-    const threadSpec = resolveTelegramThreadSpec({
-      isGroup: true,
-      isForum: true,
+  it.each([
+    { name: "resolves topic-scoped forum metadata", messageThreadId: 99, expectedTopicId: 99 },
+    {
+      name: "resolves General topic forum metadata and typing fallback",
       messageThreadId: undefined,
+      expectedTopicId: 1,
+    },
+  ] as const)("$name", ({ messageThreadId, expectedTopicId }) => {
+    const threadSpec = resolveTelegramThreadSpec({
+      isGroup: true,
+      isForum: true,
+      messageThreadId,
     });
     const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
     const route = resolveTelegramConversationRoute({
@@ -4712,11 +4009,12 @@ describe("createTelegramBot", () => {
       resolvedThreadId,
     });
 
-    expect(route.route.sessionKey).toContain("telegram:group:-1001234567890:topic:1");
-    expect(buildTelegramGroupFrom(-1001234567890, resolvedThreadId)).toBe(
-      "telegram:group:-1001234567890:topic:1",
-    );
-    expect(buildTypingThreadParams(resolvedThreadId)).toEqual({ message_thread_id: 1 });
+    const expectedGroupFrom = `telegram:group:-1001234567890:topic:${expectedTopicId}`;
+    expect(route.route.sessionKey).toContain(expectedGroupFrom);
+    expect(buildTelegramGroupFrom(-1001234567890, resolvedThreadId)).toBe(expectedGroupFrom);
+    expect(buildTypingThreadParams(resolvedThreadId)).toEqual({
+      message_thread_id: expectedTopicId,
+    });
   });
 
   it("routes General-topic forum metadata via getChat when Telegram omits forum metadata", async () => {
@@ -4776,140 +4074,56 @@ describe("createTelegramBot", () => {
     ).toEqual({ message_thread_id: 99 });
   });
 
-  const allowFromEdgeCases: Array<{
-    name: string;
-    config: Record<string, unknown>;
-    message: Record<string, unknown>;
-    expectedReplyCount: number;
-  }> = [
-    {
+  const allowFromEdgeCases: MessagePolicyCase[] = [
+    makeMessagePolicyCase({
       name: "allows direct messages regardless of groupPolicy",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "disabled",
-            allowFrom: ["123456789"],
-          },
-        },
-      },
-      message: {
-        chat: { id: 123456789, type: "private" },
-        from: { id: 123456789, username: "testuser" },
-        text: "hello",
-        date: 1736380800,
-      },
+      kind: "private",
+      telegram: { groupPolicy: "disabled", allowFrom: ["123456789"] },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "allows direct messages with tg/Telegram-prefixed allowFrom entries",
-      config: {
-        channels: {
-          telegram: {
-            allowFrom: ["  TG:123456789  "],
-          },
-        },
-      },
-      message: {
-        chat: { id: 123456789, type: "private" },
-        from: { id: 123456789, username: "testuser" },
-        text: "hello",
-        date: 1736380800,
-      },
+      kind: "private",
+      telegram: { allowFrom: ["  TG:123456789  "] },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "allows direct messages from sender access groups in allowFrom",
-      config: {
-        accessGroups: {
-          operators: {
-            type: "message.senders",
-            members: { telegram: ["123456789"] },
-          },
-        },
-        channels: {
-          telegram: {
-            dmPolicy: "allowlist",
-            allowFrom: ["accessGroup:operators"],
-          },
-        },
-      },
-      message: {
-        chat: { id: 123456789, type: "private" },
-        from: { id: 123456789, username: "testuser" },
-        text: "hello",
-        date: 1736380800,
-      },
+      kind: "private",
+      rootConfig: accessGroup("123456789"),
+      telegram: { dmPolicy: "allowlist", allowFrom: ["accessGroup:operators"] },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "matches direct message allowFrom against sender user id when chat id differs",
-      config: {
-        channels: {
-          telegram: {
-            allowFrom: ["123456789"],
-          },
-        },
-      },
-      message: {
-        chat: { id: 777777777, type: "private" },
-        from: { id: 123456789, username: "testuser" },
-        text: "hello",
-        date: 1736380800,
-      },
+      kind: "private",
+      telegram: { allowFrom: ["123456789"] },
+      message: { chat: { id: 777777777, type: "private" } },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "falls back to direct message chat id when sender user id is missing",
-      config: {
-        channels: {
-          telegram: {
-            allowFrom: ["123456789"],
-          },
-        },
-      },
-      message: {
-        chat: { id: 123456789, type: "private" },
-        text: "hello",
-        date: 1736380800,
-      },
+      kind: "private",
+      telegram: { allowFrom: ["123456789"] },
+      message: { from: undefined },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "allows group messages with wildcard in allowFrom when groupPolicy is 'allowlist'",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            allowFrom: ["*"],
-            groups: { "*": { requireMention: false } },
-          },
-        },
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["*"],
+        groups: { "*": { requireMention: false } },
       },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 999999, username: "random" },
-        text: "hello",
-        date: 1736380800,
-      },
+      message: { from: { id: 999999, username: "random" } },
       expectedReplyCount: 1,
-    },
-    {
+    }),
+    makeMessagePolicyCase({
       name: "blocks group messages with no sender ID when groupPolicy is 'allowlist'",
-      config: {
-        channels: {
-          telegram: {
-            groupPolicy: "allowlist",
-            allowFrom: ["123456789"],
-          },
-        },
-      },
-      message: {
-        chat: { id: -100123456789, type: "group", title: "Test Group" },
-        text: "hello",
-        date: 1736380800,
-      },
+      telegram: { groupPolicy: "allowlist", allowFrom: ["123456789"] },
+      message: { from: undefined },
       expectedReplyCount: 0,
-    },
+    }),
   ];
 
   it("applies allowFrom edge cases", async () => {
@@ -4930,17 +4144,16 @@ describe("createTelegramBot", () => {
     replySpy.mockResolvedValue({ text: "a".repeat(TELEGRAM_RICH_TEXT_LIMIT + 1024) });
 
     createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-    await handler({
-      message: {
-        chat: { id: 5, type: "private" },
+    const handler = getMessageHandler();
+    await handler(
+      makePrivateTextContext({
+        chatId: 5,
         text: "hi",
-        date: 1736380800,
-        message_id: 101,
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+        messageId: 101,
+        message: { from: undefined },
+        downloadable: true,
+      }),
+    );
 
     expect(sendMessageSpy.mock.calls.length).toBeGreaterThan(1);
     for (const call of sendMessageSpy.mock.calls) {
@@ -4958,16 +4171,15 @@ describe("createTelegramBot", () => {
     });
 
     createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-    await handler({
-      message: {
-        chat: { id: 5, type: "private" },
+    const handler = getMessageHandler();
+    await handler(
+      makePrivateTextContext({
+        chatId: 5,
         text: "hi",
-        date: 1736380800,
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+        message: { from: undefined },
+        downloadable: true,
+      }),
+    );
 
     expect(sendMessageSpy).toHaveBeenCalledTimes(1);
     expect(requireValue(sendMessageSpy.mock.calls.at(0), "sendMessageSpy call")[1]).toBe(
@@ -4979,23 +4191,18 @@ describe("createTelegramBot", () => {
     const codexRateLimitText =
       "⚠️ You've reached your Codex subscription usage limit. Next reset in 42 minutes (2026-05-04T21:34:00.000Z). Run /codex account for current usage details.";
     replySpy.mockResolvedValue({ text: codexRateLimitText });
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm();
 
     createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-    await handler({
-      message: {
-        chat: { id: 5, type: "private" },
+    const handler = getMessageHandler();
+    await handler(
+      makePrivateTextContext({
+        chatId: 5,
         text: "hi",
-        date: 1736380800,
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+        message: { from: undefined },
+        downloadable: true,
+      }),
+    );
 
     expect(sendMessageSpy).toHaveBeenCalledTimes(1);
     expect(String(requireValue(sendMessageSpy.mock.calls.at(0), "sendMessageSpy call")[0])).toBe(
@@ -5309,11 +4516,7 @@ describe("createTelegramBot", () => {
     onSpy.mockReset();
     replySpy.mockReset();
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
+    configureOpenDm();
 
     createTelegramBot({ token: "tok" });
     const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
@@ -5486,21 +4689,12 @@ describe("createTelegramBot", () => {
     const runMiddlewareChain = (ctx: Record<string, unknown>) =>
       runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, callbackHandler);
 
-    const ctx = {
-      update: { update_id: 666 },
-      callbackQuery: {
-        id: "cbq-model-retry-1",
-        data: "mdl_prov",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 18,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      updateId: 666,
+      id: "cbq-model-retry-1",
+      data: "mdl_prov",
+      messageId: 18,
+    });
 
     buildModelsProviderDataMock.mockImplementationOnce(async () => {
       throw new Error("providers boom");
@@ -5529,21 +4723,12 @@ describe("createTelegramBot", () => {
     const runMiddlewareChain = (ctx: Record<string, unknown>) =>
       runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, callbackHandler);
 
-    const ctx = {
-      update: { update_id: 777 },
-      callbackQuery: {
-        id: "cbq-commands-retry-1",
-        data: "commands_page_2:main",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 19,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      updateId: 777,
+      id: "cbq-commands-retry-1",
+      data: "commands_page_2:main",
+      messageId: 19,
+    });
 
     editMessageTextSpy.mockImplementationOnce(async () => {
       throw new Error("edit boom");
@@ -5572,21 +4757,12 @@ describe("createTelegramBot", () => {
     });
 
     const callbackHandler = getOnHandler("callback_query");
-    const ctx = {
-      update: { update_id: 777 },
-      callbackQuery: {
-        id: "cbq-commands-permanent-edit-1",
-        data: "commands_page_2:main",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 20,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      updateId: 777,
+      id: "cbq-commands-permanent-edit-1",
+      data: "commands_page_2:main",
+      messageId: 20,
+    });
 
     editMessageTextSpy.mockRejectedValueOnce(
       new Error("400: Bad Request: message can't be edited"),
@@ -5614,21 +4790,12 @@ describe("createTelegramBot", () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = getOnHandler("callback_query");
 
-    const ctx = {
-      update: { update_id: 778 },
-      callbackQuery: {
-        id: "cbq-commands-non-telegram-edit-1",
-        data: "commands_page_2:main",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 21,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      updateId: 778,
+      id: "cbq-commands-non-telegram-edit-1",
+      data: "commands_page_2:main",
+      messageId: 21,
+    });
 
     editMessageTextSpy.mockRejectedValueOnce(new Error("message can't be edited"));
 
@@ -5656,21 +4823,12 @@ describe("createTelegramBot", () => {
     const runMiddlewareChain = (ctx: Record<string, unknown>) =>
       runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, callbackHandler);
 
-    const ctx = {
-      update: { update_id: 778 },
-      callbackQuery: {
-        id: "cbq-commands-retry-2",
-        data: "commands_page_2:main",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 21,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      updateId: 778,
+      id: "cbq-commands-retry-2",
+      data: "commands_page_2:main",
+      messageId: 21,
+    });
 
     listSkillCommandsMock.mockImplementationOnce(() => {
       throw new Error("commands boom");
@@ -5692,22 +4850,13 @@ describe("createTelegramBot", () => {
     const resolvePluginBindingApprovalSpy = vi.mocked(resolvePluginConversationBindingApproval);
     resolvePluginBindingApprovalSpy.mockRejectedValueOnce(new Error("binding boom"));
 
-    const ctx = {
-      update: { update_id: 888 },
-      callbackQuery: {
-        id: "cbq-plugin-binding-retry-1",
-        data: buildPluginBindingApprovalCustomId("binding-1", "allow-once"),
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 20,
-          text: "Plugin approval required.",
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      updateId: 888,
+      id: "cbq-plugin-binding-retry-1",
+      data: buildPluginBindingApprovalCustomId("binding-1", "allow-once"),
+      messageId: 20,
+      text: "Plugin approval required.",
+    });
 
     try {
       await expect(runMiddlewareChain(ctx)).rejects.toThrow("binding boom");
@@ -5742,22 +4891,13 @@ describe("createTelegramBot", () => {
 
     resolveExecApprovalSpy.mockRejectedValueOnce(new Error("approval boom"));
 
-    const ctx = {
-      update: { update_id: 8895 },
-      callbackQuery: {
-        id: "cbq-approval-retry-1",
-        data: "/approve 138e9b8c allow-once",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 231,
-          text: "Approval required.",
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      updateId: 8895,
+      id: "cbq-approval-retry-1",
+      data: "/approve 138e9b8c allow-once",
+      messageId: 231,
+      text: "Approval required.",
+    });
 
     await expect(runMiddlewareChain(ctx)).rejects.toThrow("approval boom");
     await runMiddlewareChain(ctx);
@@ -5779,21 +4919,12 @@ describe("createTelegramBot", () => {
     const runMiddlewareChain = (ctx: Record<string, unknown>) =>
       runTelegramTestMiddlewareChain(middlewareUseSpy, ctx, callbackHandler);
 
-    const ctx = {
-      update: { update_id: 889 },
-      callbackQuery: {
-        id: "cbq-model-provider-retry-1",
-        data: "mdl_prov",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 23,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      updateId: 889,
+      id: "cbq-model-provider-retry-1",
+      data: "mdl_prov",
+      messageId: 23,
+    });
 
     editMessageTextSpy.mockImplementationOnce(async () => {
       throw new Error("edit boom");
@@ -5824,21 +4955,12 @@ describe("createTelegramBot", () => {
     const patchSessionEntrySpy = vi.spyOn(sessionStoreRuntime, "patchSessionEntry");
     patchSessionEntrySpy.mockRejectedValueOnce(new Error("session store boom"));
 
-    const ctx = {
-      update: { update_id: 890 },
-      callbackQuery: {
-        id: "cbq-model-select-retry-1",
-        data: "mdl_sel_openai/gpt-5.4",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 24,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      updateId: 890,
+      id: "cbq-model-select-retry-1",
+      data: "mdl_sel_openai/gpt-5.4",
+      messageId: 24,
+    });
 
     try {
       await expect(runMiddlewareChain(ctx)).rejects.toThrow("session store boom");
@@ -5873,20 +4995,11 @@ describe("createTelegramBot", () => {
         await params.update(entry, { existingEntry: entry });
         return entry;
       });
-    const ctx = {
-      callbackQuery: {
-        id: "cbq-model-select-locked-1",
-        data: "mdl_sel_openai/gpt-5.4",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 25,
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const ctx = makeCallbackRetryContext({
+      id: "cbq-model-select-locked-1",
+      data: "mdl_sel_openai/gpt-5.4",
+      messageId: 25,
+    });
 
     try {
       await expect(callbackHandler(ctx)).resolves.toBeUndefined();

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -262,8 +262,9 @@ async function dispatchSpooledPrivateText(
   },
 ) {
   const ctx = makePrivateTextContext(params);
+  const update = ctx.update ?? {};
   const replayUpdate =
-    params.replayUpdate === "full" ? { ...ctx.update, message: ctx.message } : (ctx.update ?? {});
+    params.replayUpdate === "full" ? Object.assign({}, update, { message: ctx.message }) : update;
   return await runWithTelegramSpooledReplayUpdate(replayUpdate, async () => {
     await runTelegramMiddlewareChain({ ctx, finalHandler: messageHandler });
   });
@@ -271,7 +272,7 @@ async function dispatchSpooledPrivateText(
 
 function setupUpdateOffsetTracker(params: {
   lastUpdateId: number;
-  onUpdateId?: ReturnType<typeof vi.fn>;
+  onUpdateId?: ReturnType<typeof vi.fn<(updateId: number) => void | Promise<void>>>;
   runtime?: TelegramBotOptions["runtime"];
 }) {
   sequentializeSpy.mockImplementationOnce(
@@ -279,7 +280,7 @@ function setupUpdateOffsetTracker(params: {
       await next();
     },
   );
-  const onUpdateId = params.onUpdateId ?? vi.fn();
+  const onUpdateId = params.onUpdateId ?? vi.fn<(updateId: number) => void | Promise<void>>();
   createTelegramBot({
     token: "tok",
     runtime: params.runtime,
@@ -2786,7 +2787,7 @@ describe("createTelegramBot", () => {
     releaseUpdate101?.();
     await p101;
 
-    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([102]);
+    expect(onUpdateId.mock.calls.map((call) => call[0])).toEqual([102]);
   });
   it("logs and swallows update watermark persistence failures", async () => {
     const onUpdateId = vi.fn().mockRejectedValueOnce(new Error("disk boom"));
@@ -2845,7 +2846,7 @@ describe("createTelegramBot", () => {
 
     await flushTelegramTestMicrotasks();
     expect(retryHandler).toHaveBeenCalledTimes(1);
-    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([202]);
+    expect(onUpdateId.mock.calls.map((call) => call[0])).toEqual([202]);
   });
 
   it("persists recorded dispatch failures during normal polling", async () => {
@@ -2861,11 +2862,11 @@ describe("createTelegramBot", () => {
       });
     });
     await flushTelegramTestMicrotasks();
-    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([501]);
+    expect(onUpdateId.mock.calls.map((call) => call[0])).toEqual([501]);
 
     await runMiddlewareChain({ update: { update_id: 502 } }, async () => {});
     await flushTelegramTestMicrotasks();
-    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([501, 502]);
+    expect(onUpdateId.mock.calls.map((call) => call[0])).toEqual([501, 502]);
   });
 
   it("rejects recorded dispatch failures during isolated spool replay", async () => {
@@ -2929,7 +2930,7 @@ describe("createTelegramBot", () => {
     });
     await flushTelegramTestMicrotasks();
     expect(retried).toBe(true);
-    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([701]);
+    expect(onUpdateId.mock.calls.map((call) => call[0])).toEqual([701]);
   });
 
   it("skips replayed update ids even when the semantic update key differs", async () => {
@@ -3384,7 +3385,7 @@ describe("createTelegramBot", () => {
       groups: {
         "*": { requireMention: true },
         "-1001234567890": { requireMention: true, topics: { "99": { requireMention: false } } },
-      },
+      } as Record<string, TelegramGroupConfig>,
       topicId: 99,
       expectedGroup: { requireMention: true },
       expectedTopic: { requireMention: false },
@@ -3398,7 +3399,7 @@ describe("createTelegramBot", () => {
           allowFrom: ["123456789"],
           topics: { "99": {} },
         },
-      },
+      } as Record<string, TelegramGroupConfig>,
       topicId: 99,
       expectedGroup: { requireMention: false, allowFrom: ["123456789"] },
       expectedTopic: {},
@@ -3411,7 +3412,7 @@ describe("createTelegramBot", () => {
           allowFrom: ["999999999"],
           topics: { "*": { allowFrom: ["123456789"], agentId: "zu" } },
         },
-      },
+      } as Record<string, TelegramGroupConfig>,
       topicId: 77,
       expectedGroup: { allowFrom: ["999999999"] },
       expectedTopic: { allowFrom: ["123456789"], agentId: "zu" },
@@ -3426,7 +3427,7 @@ describe("createTelegramBot", () => {
             "77": { allowFrom: ["555555555"], agentId: "main" },
           },
         },
-      },
+      } as Record<string, TelegramGroupConfig>,
       topicId: 77,
       expectedGroup: undefined,
       expectedTopic: { allowFrom: ["555555555"], agentId: "main" },
@@ -3441,7 +3442,7 @@ describe("createTelegramBot", () => {
             "77": { agentId: "main" },
           },
         },
-      },
+      } as Record<string, TelegramGroupConfig>,
       topicId: 77,
       expectedGroup: undefined,
       expectedTopic: { allowFrom: ["123456789"], requireMention: false, agentId: "main" },


### PR DESCRIPTION
## What Problem This Solves

The Telegram bot-construction suite repeated private-message contexts, debounce/replay setup, callback envelopes, update-offset trackers, and policy fixtures across a 5,903-line file. That duplication made the channel invariants harder to audit than the scenario-specific assertions.

## Why This Change Was Made

This maintainer-requested test-only refactor adds typed file-local builders and tables without changing Telegram runtime code, transport behavior, or API assertions.

Merged/table-driven cases:

- Scoped topic config: wildcard-group mention fallback; topic inheritance of group allowlist/mention policy; `topics.*` default for unmatched topic 77; exact topic 77 precedence; exact-agent plus wildcard allowlist/mention inheritance.
- Forum metadata: explicit topic 99 and omitted-thread General topic 1, each retaining session-key, group-from, and typing-thread assertions.
- Group-policy matrix: disabled policy; unmatched allowlist sender; numeric allowlist match; matching/mismatching group access groups; per-group access-group match; username-only rejection; case-insensitive `TG:` match; explicit empty per-group override; open policy.
- Allow-from matrix: DM despite disabled group policy; trimmed `TG:` DM match; DM access-group match; sender-ID-over-chat-ID match; chat-ID fallback without sender; wildcard group match; no-sender group rejection.

Replay/adoption lifecycle cases and callback retry cases remain separate because their ordering, settlement, owner, and failure postconditions differ. The test count remains 125 (delta 0).

## User Impact

No runtime or user-visible behavior changes. Maintainers get a 15.01% smaller Telegram bot suite with the same reliability, authorization, callback, topic, and replay coverage.

## Evidence

- Target file: 5,903 -> 5,017 lines (-886, 15.01%).
- PR numstat: +765/-1,651 in one test file.
- Fresh jscpd 5-line/30-token scan: 2,359 duplicated source lines (39.97%) -> 1,080 (21.53%).
- Full target suite: 125/125 pass.
- Targeted extension lint, formatting, and `git diff --check`: pass.
- Fresh Codex autoreview: full-diff pass clean at 0.93 after its readonly-tuple finding; post-CI type-fix pass clean at 0.96.
- Full test-type lane: pass on Blacksmith Testbox `tbx_01ky7yp0rjfsvy3ctbn3yrysqa` (https://github.com/openclaw/openclaw/actions/runs/30027485613).
- Public-model audit: PASS; the only model identifier in changed lines is an unchanged existing fixture moved into a shared callback context.
- No `CHANGELOG.md`, docs-map input, production code, or Telegram API-shape change.
