### PR TITLE
fix(agents): resolve trusted shell snapshot home

### DIFF
--- a/src/agents/shell-snapshot.test.ts
+++ b/src/agents/shell-snapshot.test.ts
@@ -333,10 +333,12 @@ describe("exec shell snapshots", () => {
       return;
     }
 
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-blank-home-"));
+    const homeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-blank-home-"));
+    const home = path.join(homeRoot, " trusted home ");
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-blank-state-"));
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-blank-cwd-"));
-    tempDirs.push(home, stateDir, cwd);
+    fs.mkdirSync(home);
+    tempDirs.push(homeRoot, stateDir, cwd);
     setSnapshotStateForTest(stateDir, { home });
     fs.writeFileSync(path.join(home, ".bashrc"), 'export PNPM_HOME="/rc-home"\n');
 
@@ -366,8 +368,8 @@ describe("exec shell snapshots", () => {
 
     await expect(runWithCapturedPnpmHome()).resolves.toBe("/rc-home");
 
-    // A blank trusted HOME must fall back to USERPROFILE; resolving to "" would
-    // change the snapshot identity and drop the previously captured rc values.
+    // A blank trusted HOME must fall back to USERPROFILE without trimming a
+    // valid path; resolving to "" changes the identity and drops the rc values.
     setTestEnvValue("HOME", "");
     setTestEnvValue("USERPROFILE", home);
     await expect(runWithCapturedPnpmHome()).resolves.toBe("/rc-home");

--- a/src/agents/shell-snapshot.test.ts
+++ b/src/agents/shell-snapshot.test.ts
@@ -375,6 +375,43 @@ describe("exec shell snapshots", () => {
     await expect(runWithCapturedPnpmHome()).resolves.toBe("/rc-home");
   });
 
+  it("uses the OS account home when trusted home variables are blank", async () => {
+    const bash = resolveBashForTest();
+    if (!bash) {
+      return;
+    }
+
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-account-home-"));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-account-state-"));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-account-cwd-"));
+    tempDirs.push(home, stateDir, cwd);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("HOME", "");
+    setTestEnvValue("USERPROFILE", "   ");
+    const userInfo = os.userInfo();
+    vi.spyOn(os, "userInfo").mockReturnValue({ ...userInfo, homedir: home });
+    fs.writeFileSync(path.join(home, ".bashrc"), 'export PNPM_HOME="/account-home"\n');
+
+    const shellArgs = getPosixShellArgs(bash);
+    const env = { ...process.env, HOME: home, OPENCLAW_STATE_DIR: stateDir };
+    const wrapped = await maybeWrapCommandWithShellSnapshot({
+      command: 'printf "%s" "$PNPM_HOME"',
+      shell: bash,
+      shellArgs,
+      cwd,
+      env,
+    });
+    const result = spawnSync(bash, [...shellArgs, wrapped], {
+      cwd,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("/account-home");
+  });
+
   it("preserves per-call env outside the snapshot allowlist", async () => {
     const bash = resolveBashForTest();
     if (!bash) {

--- a/src/agents/shell-snapshot.test.ts
+++ b/src/agents/shell-snapshot.test.ts
@@ -72,6 +72,7 @@ describe("exec shell snapshots", () => {
   beforeEach(() => {
     envSnapshot = captureEnv([
       "HOME",
+      "USERPROFILE",
       "OPENCLAW_STATE_DIR",
       "OPENCLAW_EXEC_SHELL_SNAPSHOT",
       "PNPM_HOME",
@@ -367,13 +368,9 @@ describe("exec shell snapshots", () => {
 
     // A blank trusted HOME must fall back to USERPROFILE; resolving to "" would
     // change the snapshot identity and drop the previously captured rc values.
-    process.env.HOME = "";
-    process.env.USERPROFILE = home;
-    try {
-      await expect(runWithCapturedPnpmHome()).resolves.toBe("/rc-home");
-    } finally {
-      delete process.env.USERPROFILE;
-    }
+    setTestEnvValue("HOME", "");
+    setTestEnvValue("USERPROFILE", home);
+    await expect(runWithCapturedPnpmHome()).resolves.toBe("/rc-home");
   });
 
   it("preserves per-call env outside the snapshot allowlist", async () => {

--- a/src/agents/shell-snapshot.test.ts
+++ b/src/agents/shell-snapshot.test.ts
@@ -326,6 +326,56 @@ describe("exec shell snapshots", () => {
     await expect(runWithPnpmHome("/second")).resolves.toBe("/second");
   });
 
+  it("treats a blank trusted HOME as unset when resolving the snapshot home", async () => {
+    const bash = resolveBashForTest();
+    if (!bash) {
+      return;
+    }
+
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-blank-home-"));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-blank-state-"));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-blank-cwd-"));
+    tempDirs.push(home, stateDir, cwd);
+    setSnapshotStateForTest(stateDir, { home });
+    fs.writeFileSync(path.join(home, ".bashrc"), 'export PNPM_HOME="/rc-home"\n');
+
+    const shellArgs = getPosixShellArgs(bash);
+    const runWithCapturedPnpmHome = async (): Promise<string> => {
+      const env = {
+        ...process.env,
+        HOME: home,
+        OPENCLAW_STATE_DIR: stateDir,
+      };
+      const wrapped = await maybeWrapCommandWithShellSnapshot({
+        command: 'printf "%s" "$PNPM_HOME"',
+        shell: bash,
+        shellArgs,
+        cwd,
+        env,
+      });
+      const result = spawnSync(bash, [...shellArgs, wrapped], {
+        cwd,
+        env,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      expect(result.status).toBe(0);
+      return result.stdout;
+    };
+
+    await expect(runWithCapturedPnpmHome()).resolves.toBe("/rc-home");
+
+    // A blank trusted HOME must fall back to USERPROFILE; resolving to "" would
+    // change the snapshot identity and drop the previously captured rc values.
+    process.env.HOME = "";
+    process.env.USERPROFILE = home;
+    try {
+      await expect(runWithCapturedPnpmHome()).resolves.toBe("/rc-home");
+    } finally {
+      delete process.env.USERPROFILE;
+    }
+  });
+
   it("preserves per-call env outside the snapshot allowlist", async () => {
     const bash = resolveBashForTest();
     if (!bash) {

--- a/src/agents/shell-snapshot.ts
+++ b/src/agents/shell-snapshot.ts
@@ -9,6 +9,7 @@ import { statSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStateDir } from "../config/paths.js";
 import { killProcessTree } from "../process/kill-tree.js";
 
@@ -177,7 +178,11 @@ function buildStartupSignature(shell: string): Array<[string, number, number] | 
 }
 
 function getTrustedShellHome(): string {
-  return process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
+  return (
+    normalizeOptionalString(process.env.HOME) ??
+    normalizeOptionalString(process.env.USERPROFILE) ??
+    os.homedir()
+  );
 }
 
 async function createShellSnapshot(

--- a/src/agents/shell-snapshot.ts
+++ b/src/agents/shell-snapshot.ts
@@ -181,11 +181,16 @@ function readNonBlankPathEnv(value: string | undefined): string | undefined {
 }
 
 function getTrustedShellHome(): string {
-  return (
-    readNonBlankPathEnv(process.env.HOME) ??
-    readNonBlankPathEnv(process.env.USERPROFILE) ??
-    os.homedir()
-  );
+  const configuredHome =
+    readNonBlankPathEnv(process.env.HOME) ?? readNonBlankPathEnv(process.env.USERPROFILE);
+  if (configuredHome) {
+    return configuredHome;
+  }
+  const accountHome = readNonBlankPathEnv(os.userInfo().homedir);
+  if (!accountHome) {
+    throw new Error("Unable to resolve the current user's home directory");
+  }
+  return accountHome;
 }
 
 async function createShellSnapshot(
@@ -314,6 +319,7 @@ function buildTrustedSnapshotCaptureEnv(
   runtimeEnv: Record<string, string | undefined>,
 ): Record<string, string | undefined> {
   const env = buildSnapshotCaptureEnv(process.env);
+  env.HOME = getTrustedShellHome();
   // OPENCLAW_SHELL is injected by the exec runtime, so startup files can keep
   // their documented exec-specific branches without trusting model input.
   if (runtimeEnv.OPENCLAW_SHELL === "exec") {

--- a/src/agents/shell-snapshot.ts
+++ b/src/agents/shell-snapshot.ts
@@ -9,7 +9,6 @@ import { statSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStateDir } from "../config/paths.js";
 import { killProcessTree } from "../process/kill-tree.js";
 
@@ -177,10 +176,14 @@ function buildStartupSignature(shell: string): Array<[string, number, number] | 
   });
 }
 
+function readNonBlankPathEnv(value: string | undefined): string | undefined {
+  return value?.trim() ? value : undefined;
+}
+
 function getTrustedShellHome(): string {
   return (
-    normalizeOptionalString(process.env.HOME) ??
-    normalizeOptionalString(process.env.USERPROFILE) ??
+    readNonBlankPathEnv(process.env.HOME) ??
+    readNonBlankPathEnv(process.env.USERPROFILE) ??
     os.homedir()
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a defined-but-blank `HOME` breaks exec shell snapshots. The empty value previously shadowed both `USERPROFILE` and the OS account home, so snapshot identity and startup-file signatures used an empty/CWD-relative path. Recapture could then miss the real `.bashrc` and drop shell-derived exports from exec commands.

## Why This Change Was Made

Shell snapshots now resolve one trusted home consistently for the cache key, startup-file signature, validation, and capture shell:

1. Use nonblank `HOME` unchanged.
2. Otherwise use nonblank `USERPROFILE` unchanged.
3. Otherwise use `os.userInfo().homedir`, which comes from the OS account record rather than rereading the same blank environment variable.

Blank and whitespace-only values are treated as absent, but valid path values are not trimmed. The resolved trusted home is explicitly injected into the snapshot capture environment, so first capture and refresh use the same startup files as the cache identity.

## User Impact

Minimal containers and CI images with `HOME=""` retain a stable shell snapshot and continue loading the user's startup environment. Valid home paths containing leading or trailing spaces remain unchanged. If no trusted home can be resolved, snapshot wrapping falls back to the existing best-effort behavior and the approved command runs unchanged.

## Evidence

Focused proof after the final rebase:

```text
Blacksmith Testbox: tbx_01ky8e34z32kq64jqw846zc756
Test Files  2 passed (2)
Tests       16 passed (16)
```

https://github.com/openclaw/openclaw/actions/runs/30046338411

The regressions prove:

- `HOME=""` falls back to a nonblank `USERPROFILE`.
- Pre-existing `USERPROFILE` is restored after the test.
- A valid home path containing surrounding spaces is preserved byte-for-byte.
- Blank `HOME` and blank `USERPROFILE` fall back to the OS account home on first capture, and the real `.bashrc` export is captured.

Additional proof:

- Earlier Testbox `tbx_01ky8dtxx5xrdrzbymp3ra24pa` passed the same 16 tests.
- Fresh Codex autoreview against `origin/main`: clean, no accepted/actionable findings.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30046567892

AI-assisted: contributor fix repaired and verified by maintainers.
