### PR TITLE
fix(release): use candidate pnpm for Telegram QA

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -437,6 +437,7 @@ jobs:
       - name: Install candidate dependencies without runner credentials
         id: install_candidate
         shell: bash
+        working-directory: .candidate
         run: |
           set -euo pipefail
           candidate_home="${RUNNER_TEMP}/openclaw-telegram-candidate-home"
@@ -449,7 +450,7 @@ jobs:
             NPM_CONFIG_USERCONFIG=/dev/null \
             PATH="$PATH" \
             RUNNER_TEMP="$RUNNER_TEMP" \
-            pnpm --dir .candidate install \
+            pnpm install \
               --store-dir "$RUNNER_TEMP/openclaw-telegram-candidate-pnpm-store" \
               --prefer-offline \
               --frozen-lockfile \
@@ -462,6 +463,7 @@ jobs:
       - name: Build candidate runtime without runner credentials
         id: build_candidate
         shell: bash
+        working-directory: .candidate
         run: |
           set -euo pipefail
           candidate_home="${RUNNER_TEMP}/openclaw-telegram-candidate-home"
@@ -475,7 +477,7 @@ jobs:
             OPENCLAW_BUILD_PRIVATE_QA=1 \
             PATH="$PATH" \
             RUNNER_TEMP="$RUNNER_TEMP" \
-            pnpm --dir .candidate exec node scripts/build-all.mjs qaRuntime
+            pnpm exec node scripts/build-all.mjs qaRuntime
 
       - name: Move built candidate outside trusted workspace
         id: move_candidate

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -25,6 +25,7 @@ type WorkflowJob = {
     run?: string;
     uses?: string;
     with?: Record<string, unknown>;
+    "working-directory"?: string;
   }>;
   uses?: string;
   with?: Record<string, unknown>;
@@ -457,6 +458,22 @@ describe("release Telegram QA workflow", () => {
         }
       }
     }
+  });
+
+  it("resolves pnpm from the candidate package-manager pin", () => {
+    const buildJob = workflowJob("build_candidate");
+    const installStep = workflowStep(
+      buildJob,
+      "Install candidate dependencies without runner credentials",
+    );
+    const buildStep = workflowStep(buildJob, "Build candidate runtime without runner credentials");
+
+    expect(installStep["working-directory"]).toBe(".candidate");
+    expect(installStep.run).toContain("pnpm install");
+    expect(installStep.run).not.toContain("pnpm --dir .candidate");
+    expect(buildStep["working-directory"]).toBe(".candidate");
+    expect(buildStep.run).toContain("pnpm exec node scripts/build-all.mjs qaRuntime");
+    expect(buildStep.run).not.toContain("pnpm --dir .candidate");
   });
 
   it("allows the tracked-file index to exceed Node's default child-process buffer", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could not build a frozen release candidate when current `main` used a newer pnpm version. The trusted Telegram QA bootstrap invoked pnpm from its own checkout, so Corepack selected the main pin and the candidate install failed before QA ran.

## Why This Change Was Made

Run both candidate dependency installation and candidate build steps with `.candidate` as their working directory. Corepack then selects the candidate's own immutable `packageManager` pin while the existing secretless environment and trusted-workflow boundary remain unchanged.

## User Impact

Release operators can validate supported frozen candidates across pnpm version changes on `main`; Telegram release QA no longer fails before exercising the candidate.

## Evidence

- Failure: Full Release Validation https://github.com/openclaw/openclaw/actions/runs/30026416415 traced through Release Checks https://github.com/openclaw/openclaw/actions/runs/30027218021 to the secretless candidate build https://github.com/openclaw/openclaw/actions/runs/30027268800/job/89274816416, where main pnpm `11.15.1` rejected candidate pin `11.2.2`.
- Blacksmith Testbox https://github.com/openclaw/openclaw/actions/runs/30028021579: a synthetic `11.15.1` bootstrap root with an `11.2.2` `.candidate` resolved `root_pnpm=11.15.1 candidate_pnpm=11.2.2` when each command ran from its owning directory.
- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- `node scripts/run-vitest.mjs test/scripts/openclaw-release-telegram-qa-workflow.test.ts` (22 passed, 2 skipped)
- Autoreview: clean, no accepted/actionable findings (0.97 confidence).

AI-assisted: implemented and verified with Codex; maintainer understands the change and proof.
