### PR TITLE
refactor(telegram): deduplicate polling session tests

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1,4 +1,3 @@
-// Telegram tests cover polling session plugin behavior.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -130,6 +129,14 @@ async function claimSpooledUpdate(update: TelegramSpooledUpdate) {
   });
 }
 
+async function claimSpooledUpdateById(spoolDir: string, updateId: number) {
+  const update = expectDefined(
+    (await listTelegramSpooledUpdates({ spoolDir })).find((entry) => entry.updateId === updateId),
+    `spooled update ${updateId}`,
+  );
+  return expectDefined(await claimSpooledUpdate(update), `claimed update ${updateId}`);
+}
+
 async function createTelegramMessageDispatchReplayForgetError(): Promise<unknown> {
   type ReplayGuard = Parameters<typeof commitTelegramMessageDispatchReplay>[0]["guard"];
   type ReplayClaim = import("openclaw/plugin-sdk/persistent-dedupe").ChannelReplayClaimHandle;
@@ -159,6 +166,18 @@ async function createTelegramMessageDispatchReplayForgetError(): Promise<unknown
     return error;
   }
   throw new Error("expected Telegram dispatch rollback failure");
+}
+
+function collectDeferredParticipant(
+  participants: TelegramSpooledReplayDeferredParticipant[],
+  key: string,
+): TelegramSpooledReplayDeferredParticipant {
+  const participant = expectDefined(
+    createTelegramSpooledReplayDeferredParticipant(key),
+    "spooled replay participant",
+  );
+  participants.push(participant);
+  return participant;
 }
 
 type TelegramApiMiddleware = (
@@ -191,11 +210,18 @@ type WorkerPollErrorListener = (message: {
   finishedAt: number;
 }) => void;
 type WorkerMessageListener = (message: TelegramIngressWorkerMessage) => void;
+type TestWorkerMessage =
+  | TelegramIngressWorkerMessage
+  | { type: "poll-success"; finishedAt: number; count: number }
+  | { type: "poll-error"; finishedAt: number; message: string };
 type AsyncVoidFn = () => Promise<void>;
 type MockCallSource = { mock: { calls: Array<Array<unknown>> } };
 type TelegramPollingTestDatabase = Pick<
   OpenClawStateKyselyDatabaseForTests,
   "channel_ingress_events"
+>;
+type IsolatedIngressOptions = NonNullable<
+  ConstructorParameters<typeof TelegramPollingSession>[0]["isolatedIngress"]
 >;
 
 const POLLING_TEST_WATCHDOG_INTERVAL_MS = 30_000;
@@ -266,6 +292,23 @@ function makeBot() {
       config: { use: vi.fn() },
     },
     stop: vi.fn(async () => undefined),
+  };
+}
+
+function makeIsolatedBot(params?: {
+  deleteWebhook?: () => Promise<boolean>;
+  handleUpdate?: (update: { update_id?: number }) => Promise<unknown>;
+  init?: AsyncVoidFn;
+  stop?: AsyncVoidFn;
+}) {
+  return {
+    api: {
+      deleteWebhook: vi.fn(params?.deleteWebhook ?? (async () => true)),
+      config: { use: vi.fn() },
+    },
+    init: vi.fn(params?.init ?? (async () => undefined)),
+    handleUpdate: vi.fn(params?.handleUpdate ?? (async () => undefined)),
+    stop: vi.fn(params?.stop ?? (async () => undefined)),
   };
 }
 
@@ -408,12 +451,24 @@ function mockRestartAfterPollingError(error: unknown, abort: AbortController) {
   });
 }
 
-function createPollingSessionWithTransportRestart(params: {
-  abortSignal: AbortSignal;
-  telegramTransport: ReturnType<typeof makeTelegramTransport>;
-  createTelegramTransport: () => ReturnType<typeof makeTelegramTransport>;
-}) {
-  return createPollingSession(params);
+async function runTransportRestart(error: Error, recoverable = true) {
+  const abort = new AbortController();
+  const log = vi.fn();
+  const firstTransport = makeTelegramTransport();
+  const secondTransport = makeTelegramTransport();
+  const createTelegramTransport = vi.fn(() => secondTransport);
+  createTelegramBotMock.mockReturnValueOnce(makeBot()).mockReturnValueOnce(makeBot());
+  isRecoverableTelegramNetworkErrorMock.mockReturnValue(recoverable);
+  mockRestartAfterPollingError(error, abort);
+
+  const session = createPollingSession({
+    abortSignal: abort.signal,
+    log,
+    telegramTransport: firstTransport,
+    createTelegramTransport,
+  });
+  await session.runUntilAbort();
+  return { createTelegramTransport, firstTransport, log, secondTransport };
 }
 
 function createPollingSession(params: {
@@ -497,7 +552,7 @@ type TestTelegramUpdate = {
   update_id: number;
   message: {
     text: string;
-    chat: { id: number; type: "private" | "supergroup" };
+    chat: { id: number; type: "private" | "supergroup"; is_forum?: boolean };
     message_thread_id?: number;
     is_topic_message?: boolean;
   };
@@ -520,9 +575,15 @@ function directUpdate(updateId: number, chatId: number, text: string): TestTeleg
     update_id: updateId,
     message: {
       text,
-      chat: { id: chatId, type: "private" },
+      chat: { id: chatId, type: chatId < 0 ? "supergroup" : "private" },
     },
   };
+}
+
+function forumUpdate(updateId: number, text: string) {
+  const update = topicUpdate(updateId, 5907, text);
+  update.message.chat.is_forum = true;
+  return update;
 }
 
 async function waitForAbortSignal(signal: AbortSignal): Promise<void> {
@@ -677,11 +738,12 @@ function createIdleIngressWorker() {
   const workerDone = new Promise<void>((resolve) => {
     stopWorker = resolve;
   });
+  const workerStop = vi.fn(async () => {
+    stopWorker?.();
+  });
   const createWorker = vi.fn(() => ({
     onMessage: vi.fn(() => () => undefined),
-    stop: vi.fn(async () => {
-      stopWorker?.();
-    }),
+    stop: workerStop,
     task: vi.fn(async () => {
       await workerDone;
     }),
@@ -689,38 +751,67 @@ function createIdleIngressWorker() {
   return {
     createWorker,
     stop: () => stopWorker?.(),
+    workerStop,
+  };
+}
+
+function createListeningIngressWorker() {
+  let listener: WorkerMessageListener | undefined;
+  const idle = createIdleIngressWorker();
+  const ackSpooledUpdate = vi.fn();
+  const createWorker = vi.fn(() => {
+    const worker = idle.createWorker();
+    return {
+      ...worker,
+      ackSpooledUpdate,
+      onMessage: vi.fn((nextListener: WorkerMessageListener) => {
+        listener = nextListener;
+        return () => undefined;
+      }),
+    };
+  });
+  return {
+    ackSpooledUpdate,
+    createWorker,
+    emit: (message: TestWorkerMessage) => listener?.(message as TelegramIngressWorkerMessage),
+    hasListener: () => listener !== undefined,
+    stop: idle.stop,
+    workerStop: idle.workerStop,
   };
 }
 
 function startIsolatedIngressSession(params: {
   abort: AbortController;
-  spoolDir: string;
+  spoolDir?: string;
   handleUpdate: (update: { update_id?: number }) => Promise<void>;
+  createWorker?: IsolatedIngressOptions["createWorker"];
   drainIntervalMs?: number;
+  getLastUpdateId?: () => number | null;
+  init?: AsyncVoidFn;
   log?: (message: string) => void;
   stop?: () => Promise<void>;
   spooledUpdateHandlerTimeoutMs?: number;
   spooledUpdateHandlerAbortGraceMs?: number;
+  stallThresholdMs?: number;
 }) {
-  const worker = createIdleIngressWorker();
-  const bot = {
-    api: {
-      deleteWebhook: vi.fn(async () => true),
-      config: { use: vi.fn() },
-    },
-    init: vi.fn(async () => undefined),
-    handleUpdate: vi.fn(params.handleUpdate),
-    stop: vi.fn(params.stop ?? (async () => undefined)),
-  };
+  const idleWorker = createIdleIngressWorker();
+  const createWorker = params.createWorker ?? idleWorker.createWorker;
+  const bot = makeIsolatedBot({
+    handleUpdate: params.handleUpdate,
+    init: params.init,
+    stop: params.stop,
+  });
   createTelegramBotMock.mockReturnValueOnce(bot);
   const session = createPollingSession({
     abortSignal: params.abort.signal,
+    getLastUpdateId: params.getLastUpdateId,
     log: params.log,
+    stallThresholdMs: params.stallThresholdMs,
     isolatedIngress: {
       enabled: true,
-      spoolDir: params.spoolDir,
-      createWorker: worker.createWorker,
+      createWorker,
       drainIntervalMs: params.drainIntervalMs ?? 10,
+      ...(params.spoolDir ? { spoolDir: params.spoolDir } : {}),
       ...(params.spooledUpdateHandlerTimeoutMs !== undefined
         ? { spooledUpdateHandlerTimeoutMs: params.spooledUpdateHandlerTimeoutMs }
         : {}),
@@ -730,10 +821,9 @@ function startIsolatedIngressSession(params: {
     },
   });
   return {
-    bot,
-    createWorker: worker.createWorker,
+    createWorker,
     runPromise: session.runUntilAbort(),
-    stopWorker: worker.stop,
+    stopWorker: idleWorker.stop,
   };
 }
 
@@ -948,57 +1038,37 @@ describe("TelegramPollingSession", () => {
   });
 
   it("initializes the main-thread bot before draining isolated ingress spool", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    const handleUpdate = vi.fn(async () => undefined);
-    const init = vi.fn(async () => undefined);
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init,
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    await writeTelegramSpooledUpdate({
-      spoolDir: tempDir,
-      update: { update_id: 42, message: { text: "hello" } },
-    });
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn(() => () => undefined),
-      stop: vi.fn(async () => undefined),
-      task: vi.fn(async () => {
-        await waitForAbortSignal(abort.signal);
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 10,
-        },
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const handleUpdate = vi.fn(async () => undefined);
+      const init = vi.fn(async () => undefined);
+      await writeTelegramSpooledUpdate({
+        spoolDir: tempDir,
+        update: { update_id: 42, message: { text: "hello" } },
       });
 
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
-      await waitForTelegramTestState(async () =>
-        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
-      );
-      await waitForTelegramTestState(async () =>
-        expect(
-          await listTelegramSpooledUpdateClaims({
-            spoolDir: tempDir,
-          }),
-        ).toEqual([]),
-      );
-      abort.abort();
-      await runPromise;
+      const { createWorker, runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        init,
+      });
+      try {
+        await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
+        await waitForTelegramTestState(async () =>
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+        );
+        await waitForTelegramTestState(async () =>
+          expect(
+            await listTelegramSpooledUpdateClaims({
+              spoolDir: tempDir,
+            }),
+          ).toEqual([]),
+        );
+      } finally {
+        abort.abort();
+        await runPromise;
+      }
 
       expect(createWorker).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1014,342 +1084,209 @@ describe("TelegramPollingSession", () => {
       });
       expect(init).toHaveBeenCalledBefore(handleUpdate);
       expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } });
-    } finally {
-      abort.abort();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("writes isolated worker updates through the main runtime queue", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    const handleUpdate = vi.fn(async () => undefined);
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    let onMessage: WorkerMessageListener | undefined;
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const handleUpdate = vi.fn(async () => undefined);
+      const worker = createListeningIngressWorker();
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: worker.createWorker,
+      });
+      try {
+        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
+        worker.emit({
+          type: "update",
+          requestId: "write-1",
+          update: { update_id: 42, message: { text: "hello" } },
+          queued: 1,
+        });
+        await waitForTelegramTestState(() =>
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("write-1", {
+            ok: true,
+            updateId: 42,
+          }),
+        );
+        await waitForTelegramTestState(() =>
+          expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } }),
+        );
+        await waitForTelegramTestState(async () =>
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+        );
+      } finally {
+        abort.abort();
+        await runPromise;
+      }
     });
-    const ackSpooledUpdate = vi.fn();
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn((listener: WorkerMessageListener) => {
-        onMessage = listener;
-        return () => undefined;
-      }),
-      ackSpooledUpdate,
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 10,
-        },
-      });
-
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(onMessage).toBeDefined());
-      onMessage?.({
-        type: "update",
-        requestId: "write-1",
-        update: { update_id: 42, message: { text: "hello" } },
-        queued: 1,
-      });
-
-      await waitForTelegramTestState(() =>
-        expect(ackSpooledUpdate).toHaveBeenCalledWith("write-1", { ok: true, updateId: 42 }),
-      );
-      await waitForTelegramTestState(() =>
-        expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } }),
-      );
-      await waitForTelegramTestState(async () =>
-        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
-      );
-      abort.abort();
-      await runPromise;
-    } finally {
-      abort.abort();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
   });
 
   it("drains worker-spooled updates without waiting for the next drain interval", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    const handleUpdate = vi.fn(async () => {
-      abort.abort();
-    });
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    let onMessage: WorkerMessageListener | undefined;
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const ackSpooledUpdate = vi.fn();
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn((listener: WorkerMessageListener) => {
-        onMessage = listener;
-        return () => undefined;
-      }),
-      ackSpooledUpdate,
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 60_000,
-        },
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const handleUpdate = vi.fn(async () => abort.abort());
+      const worker = createListeningIngressWorker();
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: worker.createWorker,
+        drainIntervalMs: 60_000,
       });
-
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(onMessage).toBeDefined());
-      onMessage?.({
-        type: "update",
-        requestId: "write-1",
-        update: { update_id: 42, message: { text: "hello" } },
-        queued: 1,
-      });
-
-      await waitForTelegramTestState(() =>
-        expect(ackSpooledUpdate).toHaveBeenCalledWith("write-1", { ok: true, updateId: 42 }),
-      );
-      onMessage?.({ type: "spooled", updateId: 42, queued: 1 });
-      await waitForTelegramTestState(() =>
-        expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } }),
-      );
-      await waitForTelegramTestState(async () =>
-        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
-      );
-      abort.abort();
-      stopWorker?.();
-      await runPromise;
-    } finally {
-      abort.abort();
-      stopWorker?.();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+      try {
+        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
+        worker.emit({
+          type: "update",
+          requestId: "write-1",
+          update: { update_id: 42, message: { text: "hello" } },
+          queued: 1,
+        });
+        await waitForTelegramTestState(() =>
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("write-1", {
+            ok: true,
+            updateId: 42,
+          }),
+        );
+        worker.emit({ type: "spooled", updateId: 42, queued: 1 });
+        await waitForTelegramTestState(() =>
+          expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } }),
+        );
+        await waitForTelegramTestState(async () =>
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+        );
+      } finally {
+        abort.abort();
+        await runPromise;
+      }
+    });
   });
 
   it("drains worker-spooled updates that arrive during an active drain", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    let releaseFirstClaim: (() => void) | undefined;
-    let firstClaimStarted: (() => void) | undefined;
-    const firstClaimGate = new Promise<void>((resolve) => {
-      releaseFirstClaim = resolve;
-    });
-    const firstClaimStartedPromise = new Promise<void>((resolve) => {
-      firstClaimStarted = resolve;
-    });
-    let blockedFirstClaim = false;
-    setTelegramRuntime({
-      state: {
-        resolveStateDir: () => tempDir,
-        openChannelIngressQueue: (
-          options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
-        ) => {
-          const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
-          return {
-            ...queue,
-            claimNext: async (...args: Parameters<typeof queue.claimNext>) => {
-              if (!blockedFirstClaim) {
-                blockedFirstClaim = true;
-                firstClaimStarted?.();
-                await firstClaimGate;
-              }
-              return queue.claimNext(...args);
-            },
-          };
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      let releaseFirstClaim: (() => void) | undefined;
+      let firstClaimStarted: (() => void) | undefined;
+      const firstClaimGate = new Promise<void>((resolve) => {
+        releaseFirstClaim = resolve;
+      });
+      const firstClaimStartedPromise = new Promise<void>((resolve) => {
+        firstClaimStarted = resolve;
+      });
+      let blockedFirstClaim = false;
+      setTelegramRuntime({
+        state: {
+          resolveStateDir: () => tempDir,
+          openChannelIngressQueue: (
+            options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
+          ) => {
+            const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
+            return {
+              ...queue,
+              claimNext: async (...args: Parameters<typeof queue.claimNext>) => {
+                if (!blockedFirstClaim) {
+                  blockedFirstClaim = true;
+                  firstClaimStarted?.();
+                  await firstClaimGate;
+                }
+                return queue.claimNext(...args);
+              },
+            };
+          },
         },
-      },
-    } as TelegramRuntime);
+      } as TelegramRuntime);
 
-    await writeTelegramSpooledUpdate({
-      spoolDir: tempDir,
-      update: { update_id: 1, message: { text: "pre-seeded" } },
-    });
+      await writeTelegramSpooledUpdate({
+        spoolDir: tempDir,
+        update: { update_id: 1, message: { text: "pre-seeded" } },
+      });
+      const handleUpdate = vi.fn(async () => undefined);
+      const worker = createListeningIngressWorker();
 
-    const handleUpdate = vi.fn(async () => undefined);
-
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    let onMessage: WorkerMessageListener | undefined;
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const ackSpooledUpdate = vi.fn();
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn((listener: WorkerMessageListener) => {
-        onMessage = listener;
-        return () => undefined;
-      }),
-      ackSpooledUpdate,
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 60_000,
-        },
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: worker.createWorker,
+        drainIntervalMs: 60_000,
       });
 
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(onMessage).toBeDefined());
-      await firstClaimStartedPromise;
+      try {
+        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
+        await firstClaimStartedPromise;
+        worker.emit({
+          type: "update",
+          requestId: "write-2",
+          update: { update_id: 2, message: { text: "during-drain" } },
+          queued: 1,
+        });
+        await waitForTelegramTestState(() =>
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("write-2", {
+            ok: true,
+            updateId: 2,
+          }),
+        );
+        worker.emit({ type: "spooled", updateId: 2, queued: 1 });
+        releaseFirstClaim?.();
+        releaseFirstClaim = undefined;
 
-      onMessage?.({
-        type: "update",
-        requestId: "write-2",
-        update: { update_id: 2, message: { text: "during-drain" } },
-        queued: 1,
-      });
-
-      await waitForTelegramTestState(() =>
-        expect(ackSpooledUpdate).toHaveBeenCalledWith("write-2", { ok: true, updateId: 2 }),
-      );
-      onMessage?.({ type: "spooled", updateId: 2, queued: 1 });
-      releaseFirstClaim?.();
-      releaseFirstClaim = undefined;
-
-      await waitForTelegramTestState(() =>
-        expect(handleUpdate).toHaveBeenCalledWith({
-          update_id: 1,
-          message: { text: "pre-seeded" },
-        }),
-      );
-      await waitForTelegramTestState(() =>
-        expect(handleUpdate).toHaveBeenCalledWith({
-          update_id: 2,
-          message: { text: "during-drain" },
-        }),
-      );
-      await waitForTelegramTestState(async () =>
-        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
-      );
-      abort.abort();
-      stopWorker?.();
-      await runPromise;
-    } finally {
-      releaseFirstClaim?.();
-      abort.abort();
-      stopWorker?.();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+        await waitForTelegramTestState(() =>
+          expect(handleUpdate).toHaveBeenCalledWith({
+            update_id: 1,
+            message: { text: "pre-seeded" },
+          }),
+        );
+        await waitForTelegramTestState(() =>
+          expect(handleUpdate).toHaveBeenCalledWith({
+            update_id: 2,
+            message: { text: "during-drain" },
+          }),
+        );
+        await waitForTelegramTestState(async () =>
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+        );
+      } finally {
+        releaseFirstClaim?.();
+        abort.abort();
+        await runPromise;
+      }
+    });
   });
 
   it("drains existing isolated ingress spool entries below the persisted offset", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    const handleUpdate = vi.fn(async () => undefined);
-    createTelegramBotMock.mockReturnValueOnce({
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    });
-    await writeTelegramSpooledUpdate({
-      spoolDir: tempDir,
-      update: { update_id: 42, message: { text: "pre-upgrade pending" } },
-    });
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn(() => () => undefined),
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        getLastUpdateId: () => 42,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 10,
-        },
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const handleUpdate = vi.fn(async () => undefined);
+      await writeTelegramSpooledUpdate({
+        spoolDir: tempDir,
+        update: { update_id: 42, message: { text: "pre-upgrade pending" } },
       });
 
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
-      await waitForTelegramTestState(async () =>
-        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
-      );
-      await waitForTelegramTestState(async () =>
-        expect(
-          await listTelegramSpooledUpdateClaims({
-            spoolDir: tempDir,
-          }),
-        ).toEqual([]),
-      );
-      abort.abort();
-      await runPromise;
+      const { createWorker, runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        getLastUpdateId: () => 42,
+      });
+      try {
+        await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
+        await waitForTelegramTestState(async () =>
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+        );
+        await waitForTelegramTestState(async () =>
+          expect(
+            await listTelegramSpooledUpdateClaims({
+              spoolDir: tempDir,
+            }),
+          ).toEqual([]),
+        );
+      } finally {
+        abort.abort();
+        await runPromise;
+      }
 
       expect(createWorker).toHaveBeenCalledWith(expect.objectContaining({ initialUpdateId: 42 }));
       expect(mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset).toEqual({
@@ -1361,61 +1298,23 @@ describe("TelegramPollingSession", () => {
         update_id: 42,
         message: { text: "pre-upgrade pending" },
       });
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("drains Telegram delivery queue after isolated ingress reports poll success", async () => {
     const abort = new AbortController();
     const init = vi.fn(async () => undefined);
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
+    const worker = createListeningIngressWorker();
+    const { runPromise } = startIsolatedIngressSession({
+      abort,
+      handleUpdate: async () => undefined,
       init,
-      handleUpdate: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    let onMessage:
-      | ((
-          message:
-            | { type: "poll-success"; finishedAt: number; count: number }
-            | { type: "poll-error"; finishedAt: number; message: string },
-        ) => void)
-      | undefined;
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn((handler) => {
-        onMessage = handler;
-        return () => undefined;
-      }),
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    const session = createPollingSession({
-      abortSignal: abort.signal,
-      isolatedIngress: {
-        enabled: true,
-        createWorker,
-        drainIntervalMs: 10,
-      },
+      createWorker: worker.createWorker,
     });
 
-    const runPromise = session.runUntilAbort();
     await waitForTelegramTestState(() => expect(init).toHaveBeenCalledTimes(1));
-    onMessage?.({ type: "poll-success", finishedAt: 10_000, count: 0 });
-    onMessage?.({ type: "poll-success", finishedAt: 10_001, count: 0 });
+    worker.emit({ type: "poll-success", finishedAt: 10_000, count: 0 });
+    worker.emit({ type: "poll-success", finishedAt: 10_001, count: 0 });
 
     await waitForTelegramTestState(() =>
       expect(drainPendingDeliveriesMock).toHaveBeenCalledTimes(1),
@@ -1423,15 +1322,15 @@ describe("TelegramPollingSession", () => {
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 0);
     });
-    onMessage?.({ type: "poll-success", finishedAt: 15_000, count: 0 });
+    worker.emit({ type: "poll-success", finishedAt: 15_000, count: 0 });
     await waitForTelegramTestState(() =>
       expect(drainPendingDeliveriesMock).toHaveBeenCalledTimes(2),
     );
-    onMessage?.({ type: "poll-error", finishedAt: 15_001, message: "offline" });
+    worker.emit({ type: "poll-error", finishedAt: 15_001, message: "offline" });
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 0);
     });
-    onMessage?.({ type: "poll-success", finishedAt: 15_002, count: 0 });
+    worker.emit({ type: "poll-success", finishedAt: 15_002, count: 0 });
     await waitForTelegramTestState(() =>
       expect(drainPendingDeliveriesMock).toHaveBeenCalledTimes(3),
     );
@@ -1443,16 +1342,7 @@ describe("TelegramPollingSession", () => {
   it("resets restart backoff after isolated ingress reports poll success", async () => {
     const abort = new AbortController();
     const init = vi.fn(async () => undefined);
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init,
-      handleUpdate: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValue(bot);
+    createTelegramBotMock.mockReturnValue(makeIsolatedBot({ init }));
     sleepWithAbortMock.mockImplementation(async () => {
       if (sleepWithAbortMock.mock.calls.length >= 2) {
         abort.abort();
@@ -1500,16 +1390,7 @@ describe("TelegramPollingSession", () => {
   it("restarts isolated ingress when worker liveness stalls", async () => {
     const abort = new AbortController();
     const log = vi.fn();
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValue(bot);
+    createTelegramBotMock.mockReturnValue(makeIsolatedBot());
 
     let firstWorkerDone: (() => void) | undefined;
     const firstWorkerTask = new Promise<void>((resolve) => {
@@ -1572,16 +1453,7 @@ describe("TelegramPollingSession", () => {
   it("applies stop-timeout cooldown to isolated ingress forced restarts", async () => {
     const abort = new AbortController();
     const log = vi.fn();
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValue(bot);
+    createTelegramBotMock.mockReturnValue(makeIsolatedBot());
     computeBackoffMock.mockImplementation((policy: { initialMs: number }, attempt: number) => {
       if (policy.initialMs === 120_000) {
         return attempt * 100_000;
@@ -1667,65 +1539,31 @@ describe("TelegramPollingSession", () => {
   it("keeps isolated ingress alive when spooled messages show worker activity", async () => {
     const abort = new AbortController();
     const log = vi.fn();
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValue(bot);
-
-    let onMessage: WorkerMessageListener | undefined;
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const workerStop = vi.fn(async () => {
-      stopWorker?.();
-    });
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn((handler: WorkerMessageListener) => {
-        onMessage = handler;
-        return () => undefined;
-      }),
-      stop: workerStop,
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
+    const worker = createListeningIngressWorker();
     const watchdogHarness = installPollingStallWatchdogHarness([0]);
-    const session = createPollingSession({
-      abortSignal: abort.signal,
+    const { runPromise } = startIsolatedIngressSession({
+      abort,
+      handleUpdate: async () => undefined,
       log,
       stallThresholdMs: 30_000,
-      isolatedIngress: {
-        enabled: true,
-        createWorker,
-        drainIntervalMs: 500,
-      },
+      createWorker: worker.createWorker,
+      drainIntervalMs: 500,
     });
 
     try {
-      const runPromise = session.runUntilAbort();
       const watchdog = await watchdogHarness.waitForWatchdog();
-      onMessage?.({ type: "poll-start", offset: null, startedAt: 0 });
+      worker.emit({ type: "poll-start", offset: null, startedAt: 0 });
       watchdogHarness.setNow(31_000);
-      onMessage?.({ type: "spooled", updateId: 42, queued: 1 });
+      worker.emit({ type: "spooled", updateId: 42, queued: 1 });
       watchdogHarness.setNow(45_000);
       watchdog?.();
 
-      expect(workerStop).not.toHaveBeenCalled();
+      expect(worker.workerStop).not.toHaveBeenCalled();
       expectLogExcludes(log, "Polling stall detected");
-
-      abort.abort();
-      stopWorker?.();
-      await runPromise;
     } finally {
       watchdogHarness.restore();
       abort.abort();
+      await runPromise;
     }
   });
 
@@ -1866,13 +1704,7 @@ describe("TelegramPollingSession", () => {
         drainIntervalMs: 10,
         handleUpdate: async (update) => {
           events.push(`topic10:${update.update_id}`);
-          const participant = createTelegramSpooledReplayDeferredParticipant(
-            `test-buffer:${update.update_id}`,
-          );
-          if (!participant) {
-            throw new Error("expected spooled replay participant");
-          }
-          participants.push(participant);
+          collectDeferredParticipant(participants, `test-buffer:${update.update_id}`);
         },
       });
 
@@ -1913,13 +1745,7 @@ describe("TelegramPollingSession", () => {
         abort,
         spoolDir: tempDir,
         handleUpdate: async (update) => {
-          const participant = createTelegramSpooledReplayDeferredParticipant(
-            `test-buffer:${update.update_id}`,
-          );
-          if (!participant) {
-            throw new Error("expected spooled replay participant");
-          }
-          participants.push(participant);
+          collectDeferredParticipant(participants, `test-buffer:${update.update_id}`);
         },
       });
 
@@ -1960,13 +1786,7 @@ describe("TelegramPollingSession", () => {
         spoolDir: tempDir,
         drainIntervalMs: 10,
         handleUpdate: async (update) => {
-          const participant = createTelegramSpooledReplayDeferredParticipant(
-            `test-buffer:${update.update_id}`,
-          );
-          if (!participant) {
-            throw new Error("expected spooled replay participant");
-          }
-          participants.push(participant);
+          collectDeferredParticipant(participants, `test-buffer:${update.update_id}`);
         },
       });
 
@@ -2012,13 +1832,7 @@ describe("TelegramPollingSession", () => {
           attempts += 1;
           if (attempts === 1) {
             events.push(`dispatch:${update.update_id}`);
-            const participant = createTelegramSpooledReplayDeferredParticipant(
-              `test-buffer:${update.update_id}`,
-            );
-            if (!participant) {
-              throw new Error("expected spooled replay participant");
-            }
-            participants.push(participant);
+            collectDeferredParticipant(participants, `test-buffer:${update.update_id}`);
             return;
           }
           events.push(`duplicate-skip:${update.update_id}`);
@@ -2060,13 +1874,7 @@ describe("TelegramPollingSession", () => {
         drainIntervalMs: 10,
         spooledUpdateHandlerTimeoutMs: 20,
         handleUpdate: async (update) => {
-          const participant = createTelegramSpooledReplayDeferredParticipant(
-            `test-buffer:${update.update_id}`,
-          );
-          if (!participant) {
-            throw new Error("expected spooled replay participant");
-          }
-          participants.push(participant);
+          collectDeferredParticipant(participants, `test-buffer:${update.update_id}`);
         },
       });
 
@@ -2101,13 +1909,10 @@ describe("TelegramPollingSession", () => {
         drainIntervalMs: 10,
         spooledUpdateHandlerTimeoutMs: 80,
         handleUpdate: async (update) => {
-          const participant = createTelegramSpooledReplayDeferredParticipant(
+          const participant = collectDeferredParticipant(
+            participants,
             `test-adopt:${update.update_id}`,
           );
-          if (!participant) {
-            throw new Error("expected spooled replay participant");
-          }
-          participants.push(participant);
           // Return immediately (deferred registered). Adoption settles the
           // spool row; the agent turn would continue under run lifecycle.
           queueMicrotask(() => {
@@ -2150,13 +1955,7 @@ describe("TelegramPollingSession", () => {
           spoolDir: tempDir,
           drainIntervalMs: 10,
           handleUpdate: async (update) => {
-            const participant = createTelegramSpooledReplayDeferredParticipant(
-              `test-pre-crash:${update.update_id}`,
-            );
-            if (!participant) {
-              throw new Error("expected spooled replay participant");
-            }
-            participants.push(participant);
+            collectDeferredParticipant(participants, `test-pre-crash:${update.update_id}`);
             // Never adopt: process dies with claim held.
           },
         });
@@ -2199,13 +1998,10 @@ describe("TelegramPollingSession", () => {
         spoolDir: tempDir,
         drainIntervalMs: 10,
         handleUpdate: async (update) => {
-          const participant = createTelegramSpooledReplayDeferredParticipant(
+          const participant = collectDeferredParticipant(
+            participants,
             `test-post-crash:${update.update_id}`,
           );
-          if (!participant) {
-            throw new Error("expected spooled replay participant");
-          }
-          participants.push(participant);
           participant.settle({ kind: "completed" });
           // Turn would continue under run lifecycle; process crash after this is fine.
         },
@@ -2281,13 +2077,10 @@ describe("TelegramPollingSession", () => {
         handleUpdate: async (update) => {
           events.push(`dispatch:${update.update_id}`);
           if (update.update_id === 42) {
-            const participant = createTelegramSpooledReplayDeferredParticipant(
+            const participant = collectDeferredParticipant(
+              participants,
               `test-lane:${update.update_id}`,
             );
-            if (!participant) {
-              throw new Error("expected spooled replay participant");
-            }
-            participants.push(participant);
             // Adopt immediately so the lane frees while a long turn would
             // continue under run lifecycle (not retested here).
             participant.settle({ kind: "completed" });
@@ -2498,11 +2291,26 @@ describe("TelegramPollingSession", () => {
     });
   }
 
-  it("dead-letters wrapped missing harness failures", async () => {
+  it.each([
+    {
+      name: "dead-letters wrapped missing harness failures",
+      text: "wrapped missing harness",
+      wrap: (cause: Error) => new Error("Agent turn failed", { cause }),
+    },
+    {
+      name: "dead-letters grammY BotError-wrapped missing harness failures",
+      text: "bot error wrapped missing harness",
+      wrap: (cause: Error) =>
+        Object.assign(new Error("Error in middleware: Agent turn failed"), {
+          name: "BotError",
+          error: new Error("Agent turn failed", { cause }),
+        }),
+    },
+  ])("$name", async ({ text, wrap }) => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
       const log = vi.fn();
-      await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "wrapped missing harness")]);
+      await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, text)]);
 
       const { runPromise, stopWorker } = startIsolatedIngressSession({
         abort,
@@ -2513,46 +2321,7 @@ describe("TelegramPollingSession", () => {
           const cause = new Error(
             'Requested agent harness "missing-harness-85470" is not registered.',
           );
-          const err = new Error("Agent turn failed", { cause });
-          throw err;
-        },
-      });
-
-      await waitForTelegramTestState(async () =>
-        expect(await failedUpdateIds(tempDir)).toEqual([42]),
-      );
-      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
-      expectLogIncludes(log, "spooled update 42 failed with non-retryable missing-agent-harness");
-      expectLogExcludes(log, "spooled update 42 failed; keeping for retry");
-      abort.abort();
-      stopWorker();
-      await runPromise;
-    });
-  });
-
-  it("dead-letters grammY BotError-wrapped missing harness failures", async () => {
-    await withTempSpool(async (tempDir) => {
-      const abort = new AbortController();
-      const log = vi.fn();
-      await writeSpooledTestUpdates(tempDir, [
-        topicUpdate(42, 10, "bot error wrapped missing harness"),
-      ]);
-
-      const { runPromise, stopWorker } = startIsolatedIngressSession({
-        abort,
-        spoolDir: tempDir,
-        log,
-        drainIntervalMs: 10,
-        handleUpdate: async () => {
-          const cause = new Error(
-            'Requested agent harness "missing-harness-85470" is not registered.',
-          );
-          const middlewareError = new Error("Agent turn failed", { cause });
-          const botError = Object.assign(new Error("Error in middleware: Agent turn failed"), {
-            name: "BotError",
-            error: middlewareError,
-          });
-          throw botError;
+          throw wrap(cause);
         },
       });
 
@@ -2577,13 +2346,7 @@ describe("TelegramPollingSession", () => {
         topicUpdate(43, 10, "later topic 10 turn"),
         topicUpdate(44, 11, "topic 11 turn"),
       ]);
-      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
-        (update) => update.updateId === 42,
-      );
-      if (!interrupted) {
-        throw new Error("Expected interrupted update");
-      }
-      await claimSpooledUpdate(interrupted);
+      await claimSpooledUpdateById(tempDir, 42);
 
       const { runPromise, stopWorker } = startIsolatedIngressSession({
         abort,
@@ -2630,13 +2393,7 @@ describe("TelegramPollingSession", () => {
         topicUpdate(42, 10, "interrupted topic 10 turn"),
         topicUpdate(43, 10, "later topic 10 turn"),
       ]);
-      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
-        (update) => update.updateId === 42,
-      );
-      if (!interrupted) {
-        throw new Error("Expected interrupted update");
-      }
-      await claimSpooledUpdate(interrupted);
+      await claimSpooledUpdateById(tempDir, 42);
 
       await runPromise;
       expect(events).toEqual(["handled:40", "handled:42"]);
@@ -2652,16 +2409,7 @@ describe("TelegramPollingSession", () => {
         interruptedUpdate,
         topicUpdate(43, 10, "later topic 10 turn"),
       ]);
-      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
-        (update) => update.updateId === 42,
-      );
-      if (!interrupted) {
-        throw new Error("Expected interrupted update");
-      }
-      const claimed = await claimSpooledUpdate(interrupted);
-      if (!claimed) {
-        throw new Error("Expected claimed update");
-      }
+      await claimSpooledUpdateById(tempDir, 42);
       const liveOwnerPid = process.ppid > 0 ? process.ppid : 1;
       await adoptClaimOwner({
         spoolDir: tempDir,
@@ -2699,16 +2447,7 @@ describe("TelegramPollingSession", () => {
         topicUpdate(42, 10, "wedged topic 10 turn"),
         topicUpdate(43, 10, "later topic 10 turn"),
       ]);
-      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
-        (update) => update.updateId === 42,
-      );
-      if (!interrupted) {
-        throw new Error("Expected interrupted update");
-      }
-      const claimed = await claimSpooledUpdate(interrupted);
-      if (!claimed) {
-        throw new Error("Expected claimed update");
-      }
+      await claimSpooledUpdateById(tempDir, 42);
       await adoptClaimOwner({
         spoolDir: tempDir,
         updateId: 42,
@@ -2743,16 +2482,7 @@ describe("TelegramPollingSession", () => {
         topicUpdate(42, 10, "tid-reuse wedged turn"),
         topicUpdate(43, 10, "later same-lane turn"),
       ]);
-      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
-        (update) => update.updateId === 42,
-      );
-      if (!interrupted) {
-        throw new Error("Expected interrupted update");
-      }
-      const claimed = await claimSpooledUpdate(interrupted);
-      if (!claimed) {
-        throw new Error("Expected claimed update");
-      }
+      await claimSpooledUpdateById(tempDir, 42);
       // Old owner PID 9 is gone; a thread of this process now occupies numeric id 9.
       await adoptClaimOwner({
         spoolDir: tempDir,
@@ -2807,16 +2537,7 @@ describe("TelegramPollingSession", () => {
         topicUpdate(42, 10, "adopted before crash"),
         topicUpdate(43, 10, "later same-lane turn"),
       ]);
-      const adopted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
-        (update) => update.updateId === 42,
-      );
-      if (!adopted) {
-        throw new Error("Expected adopted update");
-      }
-      const claimed = await claimSpooledUpdate(adopted);
-      if (!claimed) {
-        throw new Error("Expected claimed update");
-      }
+      await claimSpooledUpdateById(tempDir, 42);
       await adoptClaimOwner({
         spoolDir: tempDir,
         updateId: 42,
@@ -2866,16 +2587,7 @@ describe("TelegramPollingSession", () => {
         topicUpdate(42, 10, "expired foreign claim"),
         topicUpdate(43, 10, "later topic 10 turn"),
       ]);
-      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
-        (update) => update.updateId === 42,
-      );
-      if (!interrupted) {
-        throw new Error("Expected interrupted update");
-      }
-      const claimed = await claimSpooledUpdate(interrupted);
-      if (!claimed) {
-        throw new Error("Expected claimed update");
-      }
+      await claimSpooledUpdateById(tempDir, 42);
       await adoptClaimOwner({
         spoolDir: tempDir,
         updateId: 42,
@@ -2963,15 +2675,7 @@ describe("TelegramPollingSession", () => {
     const handleUpdate = vi.fn(async () => {
       await turnDone;
     });
-    createTelegramBotMock.mockImplementation(() => ({
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    }));
+    createTelegramBotMock.mockImplementation(() => makeIsolatedBot({ handleUpdate }));
     await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "lone active topic turn")]);
     const createWorker = vi.fn(() => {
       let stopWorker: (() => void) | undefined;
@@ -3040,480 +2744,188 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("lets isolated ingress drain interleave different Telegram topic lanes", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    const events: string[] = [];
-    let releaseTopicTenTurn: (() => void) | undefined;
-    const topicTenTurnDone = new Promise<void>((resolve) => {
-      releaseTopicTenTurn = resolve;
-    });
-    const handleUpdate = vi.fn(async (update: { update_id?: number }) => {
-      if (update.update_id === 42) {
-        events.push("topic10:start");
-        await topicTenTurnDone;
-        events.push("topic10:end");
-        return;
-      }
-      if (update.update_id === 43) {
-        events.push("topic11");
-        return;
-      }
-      if (update.update_id === 44) {
-        events.push("topic10:second");
-      }
-    });
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    for (const { updateId, threadId, text } of [
-      { updateId: 42, threadId: 10, text: "long topic 10 turn" },
-      { updateId: 43, threadId: 11, text: "topic 11 turn" },
-      { updateId: 44, threadId: 10, text: "second topic 10 turn" },
-    ]) {
-      await writeTelegramSpooledUpdate({
+  it.each([
+    {
+      name: "lets isolated ingress drain interleave different Telegram topic lanes",
+      updates: [
+        topicUpdate(42, 10, "long topic 10 turn"),
+        topicUpdate(43, 11, "topic 11 turn"),
+        topicUpdate(44, 10, "second topic 10 turn"),
+      ],
+      labels: ["topic10:start", "topic11", "topic10:end", "topic10:second"],
+    },
+    {
+      name: "lets isolated ingress drain interleave different Telegram chats",
+      updates: [
+        directUpdate(42, -100, "long first chat turn"),
+        directUpdate(43, 854067528, "second chat turn"),
+        directUpdate(44, -100, "second first chat turn"),
+      ],
+      labels: ["chatA:start", "chatB", "chatA:end", "chatA:second"],
+    },
+  ])("$name", async ({ updates, labels }) => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const events: string[] = [];
+      let releaseFirstLane: (() => void) | undefined;
+      const firstLaneDone = new Promise<void>((resolve) => {
+        releaseFirstLane = resolve;
+      });
+      await writeSpooledTestUpdates(tempDir, updates);
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
         spoolDir: tempDir,
-        update: {
-          update_id: updateId,
-          message: {
-            text,
-            message_thread_id: threadId,
-            is_topic_message: true,
-            chat: { id: -100, type: "supergroup" },
-          },
-        },
-      });
-    }
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn(() => () => undefined),
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 10,
+        handleUpdate: async (update) => {
+          if (update.update_id === 42) {
+            events.push(labels[0]);
+            await firstLaneDone;
+            events.push(labels[2]);
+          } else if (update.update_id === 43) {
+            events.push(labels[1]);
+          } else if (update.update_id === 44) {
+            events.push(labels[3]);
+          }
         },
       });
 
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(events).toEqual(["topic10:start", "topic11"]));
-      expect(
-        (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map((update) => update.updateId),
-      ).toEqual([44]);
-
-      releaseTopicTenTurn?.();
-      await waitForTelegramTestState(() =>
-        expect(events).toEqual(["topic10:start", "topic11", "topic10:end", "topic10:second"]),
-      );
-      await waitForTelegramTestState(async () =>
-        expect(
-          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
-            (update) => update.updateId,
-          ),
-        ).toEqual([]),
-      );
-      abort.abort();
-      await runPromise;
-    } finally {
-      releaseTopicTenTurn?.();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("lets isolated ingress drain interleave different Telegram chats", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    const events: string[] = [];
-    let releaseFirstChatTurn: (() => void) | undefined;
-    const firstChatTurnDone = new Promise<void>((resolve) => {
-      releaseFirstChatTurn = resolve;
-    });
-    const handleUpdate = vi.fn(async (update: { update_id?: number }) => {
-      if (update.update_id === 42) {
-        events.push("chatA:start");
-        await firstChatTurnDone;
-        events.push("chatA:end");
-        return;
-      }
-      if (update.update_id === 43) {
-        events.push("chatB");
-        return;
-      }
-      if (update.update_id === 44) {
-        events.push("chatA:second");
+      try {
+        await waitForTelegramTestState(() => expect(events).toEqual(labels.slice(0, 2)));
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([44]);
+        releaseFirstLane?.();
+        await waitForTelegramTestState(() => expect(events).toEqual(labels));
+        await waitForTelegramTestState(async () =>
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+        );
+      } finally {
+        releaseFirstLane?.();
+        abort.abort();
+        stopWorker();
+        await runPromise;
       }
     });
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    for (const { updateId, chatId, text } of [
-      { updateId: 42, chatId: -100, text: "long first chat turn" },
-      { updateId: 43, chatId: 854067528, text: "second chat turn" },
-      { updateId: 44, chatId: -100, text: "second first chat turn" },
-    ]) {
-      await writeTelegramSpooledUpdate({
-        spoolDir: tempDir,
-        update: {
-          update_id: updateId,
-          message: {
-            text,
-            chat: { id: chatId, type: chatId < 0 ? "supergroup" : "private" },
-          },
-        },
-      });
-    }
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn(() => () => undefined),
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 10,
-        },
-      });
-
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(events).toEqual(["chatA:start", "chatB"]));
-      expect(
-        (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map((update) => update.updateId),
-      ).toEqual([44]);
-
-      releaseFirstChatTurn?.();
-      await waitForTelegramTestState(() =>
-        expect(events).toEqual(["chatA:start", "chatB", "chatA:end", "chatA:second"]),
-      );
-      await waitForTelegramTestState(async () =>
-        expect(
-          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
-            (update) => update.updateId,
-          ),
-        ).toEqual([]),
-      );
-      abort.abort();
-      await runPromise;
-    } finally {
-      releaseFirstChatTurn?.();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
   });
 
   it("lets isolated ingress control updates bypass an active spooled turn", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    const events: string[] = [];
-    let releaseRegularTurn: (() => void) | undefined;
-    const regularTurnDone = new Promise<void>((resolve) => {
-      releaseRegularTurn = resolve;
-    });
-    const handleUpdate = vi.fn(async (update: { update_id?: number }) => {
-      if (update.update_id === 42) {
-        events.push("regular:start");
-        await regularTurnDone;
-        events.push("regular:end");
-        return;
-      }
-      if (update.update_id === 43) {
-        events.push("status");
-      }
-      if (update.update_id === 44) {
-        events.push("stop");
-      }
-    });
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    await writeTelegramSpooledUpdate({
-      spoolDir: tempDir,
-      update: {
-        update_id: 42,
-        message: {
-          text: "summarize this",
-          chat: { id: -100, type: "supergroup", is_forum: true },
-          is_topic_message: true,
-          message_thread_id: 5907,
-        },
-      },
-    });
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn(() => () => undefined),
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 10,
-        },
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const events: string[] = [];
+      let releaseRegularTurn: (() => void) | undefined;
+      const regularTurnDone = new Promise<void>((resolve) => {
+        releaseRegularTurn = resolve;
       });
-
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(events).toEqual(["regular:start"]));
-      await writeTelegramSpooledUpdate({
+      await writeSpooledTestUpdates(tempDir, [forumUpdate(42, "summarize this")]);
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
         spoolDir: tempDir,
-        update: {
-          update_id: 43,
-          message: {
-            text: "/status",
-            chat: { id: -100, type: "supergroup", is_forum: true },
-            is_topic_message: true,
-            message_thread_id: 5907,
-          },
-        },
-      });
-      await writeTelegramSpooledUpdate({
-        spoolDir: tempDir,
-        update: {
-          update_id: 44,
-          message: {
-            text: "/stop@vacs_tars_bot",
-            chat: { id: -100, type: "supergroup", is_forum: true },
-            is_topic_message: true,
-            message_thread_id: 5907,
-          },
+        handleUpdate: async (update) => {
+          if (update.update_id === 42) {
+            events.push("regular:start");
+            await regularTurnDone;
+            events.push("regular:end");
+          } else if (update.update_id === 43) {
+            events.push("status");
+          } else if (update.update_id === 44) {
+            events.push("stop");
+          }
         },
       });
 
-      await waitForTelegramTestState(() =>
-        expect(events).toEqual(["regular:start", "status", "stop"]),
-      );
-      expect(
-        (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map((update) => update.updateId),
-      ).toEqual([]);
-
-      releaseRegularTurn?.();
-      await waitForTelegramTestState(async () =>
-        expect(
-          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
-            (update) => update.updateId,
-          ),
-        ).toEqual([]),
-      );
-      abort.abort();
-      await runPromise;
-    } finally {
-      releaseRegularTurn?.();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+      try {
+        await waitForTelegramTestState(() => expect(events).toEqual(["regular:start"]));
+        await writeSpooledTestUpdates(tempDir, [
+          forumUpdate(43, "/status"),
+          forumUpdate(44, "/stop@vacs_tars_bot"),
+        ]);
+        await waitForTelegramTestState(() =>
+          expect(events).toEqual(["regular:start", "status", "stop"]),
+        );
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+        releaseRegularTurn?.();
+        await waitForTelegramTestState(async () =>
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+        );
+      } finally {
+        releaseRegularTurn?.();
+        abort.abort();
+        stopWorker();
+        await runPromise;
+      }
+    });
   });
 
   it("preserves spool order when a control update is already queued after a regular turn", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    const events: string[] = [];
-    let releaseRegularTurn: (() => void) | undefined;
-    const regularTurnDone = new Promise<void>((resolve) => {
-      releaseRegularTurn = resolve;
-    });
-    const handleUpdate = vi.fn(async (update: { update_id?: number }) => {
-      if (update.update_id === 42) {
-        events.push("regular:start");
-        await regularTurnDone;
-        events.push("regular:end");
-        return;
-      }
-      if (update.update_id === 43) {
-        events.push("status");
-      }
-    });
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    await writeTelegramSpooledUpdate({
-      spoolDir: tempDir,
-      update: {
-        update_id: 42,
-        message: { text: "summarize this", chat: { id: -100, type: "supergroup" } },
-      },
-    });
-    await writeTelegramSpooledUpdate({
-      spoolDir: tempDir,
-      update: {
-        update_id: 43,
-        message: { text: "/status", chat: { id: -100, type: "supergroup" } },
-      },
-    });
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn(() => () => undefined),
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 10,
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const events: string[] = [];
+      let releaseRegularTurn: (() => void) | undefined;
+      const regularTurnDone = new Promise<void>((resolve) => {
+        releaseRegularTurn = resolve;
+      });
+      await writeSpooledTestUpdates(tempDir, [
+        directUpdate(42, -100, "summarize this"),
+        directUpdate(43, -100, "/status"),
+      ]);
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate: async (update) => {
+          if (update.update_id === 42) {
+            events.push("regular:start");
+            await regularTurnDone;
+            events.push("regular:end");
+          } else if (update.update_id === 43) {
+            events.push("status");
+          }
         },
       });
 
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(events).toEqual(["regular:start", "status"]));
-
-      releaseRegularTurn?.();
-      await waitForTelegramTestState(async () =>
-        expect(
-          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
-            (update) => update.updateId,
-          ),
-        ).toEqual([]),
-      );
-      abort.abort();
-      await runPromise;
-    } finally {
-      releaseRegularTurn?.();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+      try {
+        await waitForTelegramTestState(() => expect(events).toEqual(["regular:start", "status"]));
+        releaseRegularTurn?.();
+        await waitForTelegramTestState(async () =>
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+        );
+      } finally {
+        releaseRegularTurn?.();
+        abort.abort();
+        stopWorker();
+        await runPromise;
+      }
+    });
   });
 
   it("waits for active spooled handlers before stopping the bot", async () => {
-    const abort = new AbortController();
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
-    const events: string[] = [];
-    let releaseRegularTurn: (() => void) | undefined;
-    const regularTurnDone = new Promise<void>((resolve) => {
-      releaseRegularTurn = resolve;
-    });
-    const handleUpdate = vi.fn(async () => {
-      events.push("regular:start");
-      await regularTurnDone;
-      events.push("regular:end");
-    });
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => {
-        events.push("bot:stop");
-      }),
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot);
-    await writeTelegramSpooledUpdate({
-      spoolDir: tempDir,
-      update: {
-        update_id: 42,
-        message: { text: "summarize this", chat: { id: -100, type: "supergroup" } },
-      },
-    });
-    let stopWorker: (() => void) | undefined;
-    const workerDone = new Promise<void>((resolve) => {
-      stopWorker = resolve;
-    });
-    const createWorker = vi.fn(() => ({
-      onMessage: vi.fn(() => () => undefined),
-      stop: vi.fn(async () => {
-        stopWorker?.();
-      }),
-      task: vi.fn(async () => {
-        await workerDone;
-      }),
-    }));
-
-    try {
-      const session = createPollingSession({
-        abortSignal: abort.signal,
-        isolatedIngress: {
-          enabled: true,
-          spoolDir: tempDir,
-          createWorker,
-          drainIntervalMs: 10,
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const events: string[] = [];
+      let releaseRegularTurn: (() => void) | undefined;
+      const regularTurnDone = new Promise<void>((resolve) => {
+        releaseRegularTurn = resolve;
+      });
+      await writeSpooledTestUpdates(tempDir, [directUpdate(42, -100, "summarize this")]);
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate: async () => {
+          events.push("regular:start");
+          await regularTurnDone;
+          events.push("regular:end");
+        },
+        stop: async () => {
+          events.push("bot:stop");
         },
       });
 
-      const runPromise = session.runUntilAbort();
-      await waitForTelegramTestState(() => expect(events).toEqual(["regular:start"]));
-      abort.abort();
-      releaseRegularTurn?.();
-      await runPromise;
-
-      expect(events).toEqual(["regular:start", "regular:end", "bot:stop"]);
-    } finally {
-      releaseRegularTurn?.();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+      try {
+        await waitForTelegramTestState(() => expect(events).toEqual(["regular:start"]));
+        abort.abort();
+        releaseRegularTurn?.();
+        await runPromise;
+        expect(events).toEqual(["regular:start", "regular:end", "bot:stop"]);
+      } finally {
+        releaseRegularTurn?.();
+      }
+    });
   });
 
   it("recovers orphaned spooled claims across isolated ingress restarts", async () => {
@@ -3528,15 +2940,7 @@ describe("TelegramPollingSession", () => {
     const handleUpdate = vi.fn(async () => {
       await regularTurnDone;
     });
-    createTelegramBotMock.mockImplementation(() => ({
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    }));
+    createTelegramBotMock.mockImplementation(() => makeIsolatedBot({ handleUpdate }));
     await writeTelegramSpooledUpdate({
       spoolDir: tempDir,
       update: {
@@ -3586,11 +2990,7 @@ describe("TelegramPollingSession", () => {
       releaseRegularTurn?.();
       await vi.advanceTimersByTimeAsync(1_000);
       await waitForTelegramTestState(async () =>
-        expect(
-          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
-            (update) => update.updateId,
-          ),
-        ).toEqual([]),
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
       );
       abort.abort();
       await vi.advanceTimersByTimeAsync(20_000);
@@ -3608,15 +3008,7 @@ describe("TelegramPollingSession", () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
     const log = vi.fn();
     const setStatus = vi.fn();
-    createTelegramBotMock.mockImplementation(() => ({
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-    }));
+    createTelegramBotMock.mockImplementation(() => makeIsolatedBot());
 
     let workerTaskCalls = 0;
     const createWorker = vi.fn(() => {
@@ -3931,15 +3323,7 @@ describe("TelegramPollingSession", () => {
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
     const log = vi.fn();
-    createTelegramBotMock.mockImplementation(() => ({
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-    }));
+    createTelegramBotMock.mockImplementation(() => makeIsolatedBot());
 
     let rejectWorker: ((err: Error) => void) | undefined;
     const workerDone = new Promise<void>((_resolve, reject) => {
@@ -3988,15 +3372,7 @@ describe("TelegramPollingSession", () => {
     const log = vi.fn();
     const setStatus = vi.fn();
     isRecoverableTelegramNetworkErrorMock.mockReturnValue(false);
-    createTelegramBotMock.mockImplementation(() => ({
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-    }));
+    createTelegramBotMock.mockImplementation(() => makeIsolatedBot());
 
     let listener: WorkerPollErrorListener | undefined;
     const createWorker = vi.fn(() => ({
@@ -4053,15 +3429,7 @@ describe("TelegramPollingSession", () => {
     // must restart the cycle before that classifier is consulted.
     isRecoverableTelegramNetworkErrorMock.mockReturnValue(false);
     const deleteWebhook = vi.fn(async () => true);
-    createTelegramBotMock.mockImplementation(() => ({
-      api: {
-        deleteWebhook,
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined),
-    }));
+    createTelegramBotMock.mockImplementation(() => makeIsolatedBot({ deleteWebhook }));
     const transport1 = makeTelegramTransport();
     const transport2 = makeTelegramTransport();
     const createTelegramTransport = vi
@@ -4140,15 +3508,7 @@ describe("TelegramPollingSession", () => {
     const handleUpdate = vi.fn(async () => {
       await regularTurnDone;
     });
-    createTelegramBotMock.mockImplementation(() => ({
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        config: { use: vi.fn() },
-      },
-      init: vi.fn(async () => undefined),
-      handleUpdate,
-      stop: vi.fn(async () => undefined),
-    }));
+    createTelegramBotMock.mockImplementation(() => makeIsolatedBot({ handleUpdate }));
     await writeTelegramSpooledUpdate({
       spoolDir: tempDir,
       update: {
@@ -4207,11 +3567,7 @@ describe("TelegramPollingSession", () => {
       releaseRegularTurn?.();
       await vi.advanceTimersByTimeAsync(1_000);
       await waitForTelegramTestState(async () =>
-        expect(
-          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
-            (update) => update.updateId,
-          ),
-        ).toEqual([]),
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
       );
       secondAbort.abort();
       await vi.advanceTimersByTimeAsync(20_000);
@@ -4292,25 +3648,26 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("forces a restart when polling stalls without getUpdates activity", async () => {
+  it.each([
+    {
+      name: "forces a restart when polling stalls without getUpdates activity",
+      reportsRunning: true,
+      detailedAssertions: true,
+      clock: [0, 0, 0, 0, 0],
+    },
+    {
+      name: "forces a restart when the runner task is pending but reports not running",
+      reportsRunning: false,
+      detailedAssertions: false,
+      clock: [0, 0],
+    },
+  ])("$name", async ({ reportsRunning, detailedAssertions, clock }) => {
     const abort = new AbortController();
     const botStop = vi.fn(async () => undefined);
-    const secondBotStop = vi.fn(async () => undefined);
+    const firstBot = makeBot();
+    firstBot.stop = botStop;
+    createTelegramBotMock.mockReturnValueOnce(firstBot).mockReturnValueOnce(makeBot());
     const firstRunnerStop = vi.fn(async () => undefined);
-    const secondRunnerStop = vi.fn(async () => undefined);
-    const bot = {
-      api: {
-        deleteWebhook: vi.fn(async () => true),
-        getUpdates: vi.fn(async () => []),
-        config: { use: vi.fn() },
-      },
-      stop: botStop,
-    };
-    createTelegramBotMock.mockReturnValueOnce(bot).mockReturnValueOnce({
-      ...bot,
-      stop: secondBotStop,
-    });
-
     let firstTaskResolve: (() => void) | undefined;
     const firstTask = new Promise<void>((resolve) => {
       firstTaskResolve = resolve;
@@ -4318,55 +3675,39 @@ describe("TelegramPollingSession", () => {
     let cycle = 0;
     runMock.mockImplementation(() => {
       cycle += 1;
-      if (cycle === 1) {
-        return {
-          task: () => firstTask,
-          stop: async () => {
-            await firstRunnerStop();
-            firstTaskResolve?.();
-          },
-          isRunning: () => true,
-        };
-      }
-      return {
-        task: async () => {
-          abort.abort();
-        },
-        stop: secondRunnerStop,
-        isRunning: () => false,
-      };
+      return cycle === 1
+        ? {
+            task: () => firstTask,
+            stop: async () => {
+              await firstRunnerStop();
+              firstTaskResolve?.();
+            },
+            isRunning: () => reportsRunning,
+          }
+        : {
+            task: async () => abort.abort(),
+            stop: vi.fn(async () => undefined),
+            isRunning: () => false,
+          };
     });
-
-    const watchdogHarness = installPollingStallWatchdogHarness([0, 0, 0, 0, 0]);
-
+    const watchdogHarness = installPollingStallWatchdogHarness(clock);
     const log = vi.fn();
-    const session = new TelegramPollingSession({
-      token: "tok",
-      config: {},
-      accountId: "default",
-      runtime: undefined,
-      proxyFetch: undefined,
-      abortSignal: abort.signal,
-      runnerOptions: {},
-      getLastUpdateId: () => null,
-      persistUpdateId: async () => undefined,
-      log,
-      telegramTransport: undefined,
-    });
 
     try {
-      const runPromise = session.runUntilAbort();
+      const runPromise = createPollingSession({ abortSignal: abort.signal, log }).runUntilAbort();
       const watchdog = await watchdogHarness.waitForWatchdog();
       watchdogHarness.setNow(150_001);
-      watchdog?.();
+      watchdog();
       await runPromise;
 
       expect(runMock).toHaveBeenCalledTimes(2);
       expect(firstRunnerStop).toHaveBeenCalledTimes(1);
-      expect(botStop).toHaveBeenCalledTimes(1);
       expectLogIncludes(log, "Polling stall detected");
-      expectLogIncludes(log, "polling stall detected");
-      expectLogExcludes(log, "Polling runner stop timed out");
+      if (detailedAssertions) {
+        expect(botStop).toHaveBeenCalledTimes(1);
+        expectLogIncludes(log, "polling stall detected");
+        expectLogExcludes(log, "Polling runner stop timed out");
+      }
     } finally {
       watchdogHarness.restore();
     }
@@ -4401,61 +3742,6 @@ describe("TelegramPollingSession", () => {
       ([policy]) => (policy as { initialMs: number }).initialMs === 120_000,
     );
     expect(stopCooldownCalls.map((call) => call[1])).toEqual([1, 2]);
-  });
-
-  it("forces a restart when the runner task is pending but reports not running", async () => {
-    const abort = new AbortController();
-    const firstRunnerStop = vi.fn(async () => undefined);
-    const secondRunnerStop = vi.fn(async () => undefined);
-    createTelegramBotMock.mockReturnValue(makeBot());
-
-    let firstTaskResolve: (() => void) | undefined;
-    const firstTask = new Promise<void>((resolve) => {
-      firstTaskResolve = resolve;
-    });
-    let cycle = 0;
-    runMock.mockImplementation(() => {
-      cycle += 1;
-      if (cycle === 1) {
-        return {
-          task: () => firstTask,
-          stop: async () => {
-            await firstRunnerStop();
-            firstTaskResolve?.();
-          },
-          isRunning: () => false,
-        };
-      }
-      return {
-        task: async () => {
-          abort.abort();
-        },
-        stop: secondRunnerStop,
-        isRunning: () => false,
-      };
-    });
-
-    const watchdogHarness = installPollingStallWatchdogHarness();
-
-    const log = vi.fn();
-    const session = createPollingSession({
-      abortSignal: abort.signal,
-      log,
-    });
-
-    try {
-      const runPromise = session.runUntilAbort();
-      const watchdog = await watchdogHarness.waitForWatchdog();
-      watchdogHarness.setNow(150_001);
-      watchdog?.();
-      await runPromise;
-
-      expect(runMock).toHaveBeenCalledTimes(2);
-      expect(firstRunnerStop).toHaveBeenCalledTimes(1);
-      expectLogIncludes(log, "Polling stall detected");
-    } finally {
-      watchdogHarness.restore();
-    }
   });
 
   it("honors a custom polling stall threshold", async () => {
@@ -4566,25 +3852,62 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("rebuilds the transport after a recoverable polling error", async () => {
-    const abort = new AbortController();
-    const recoverableError = new Error("recoverable polling error");
-    const transport1 = makeTelegramTransport();
-    const transport2 = makeTelegramTransport();
-    const createTelegramTransport = vi.fn(() => transport2);
-    createTelegramBotMock.mockReturnValueOnce(makeBot()).mockReturnValueOnce(makeBot());
-    mockRestartAfterPollingError(recoverableError, abort);
-
-    const session = createPollingSessionWithTransportRestart({
-      abortSignal: abort.signal,
-      telegramTransport: transport1,
-      createTelegramTransport,
-    });
-
-    await session.runUntilAbort();
-
-    expectTelegramBotTransportSequence(transport1, transport2);
-    expect(createTelegramTransport).toHaveBeenCalledTimes(1);
+  it.each([
+    {
+      name: "rebuilds the transport after a recoverable polling error",
+      error: new Error("recoverable polling error"),
+      recoverable: true,
+      verify: ({
+        createTelegramTransport,
+        firstTransport,
+        secondTransport,
+      }: Awaited<ReturnType<typeof runTransportRestart>>) => {
+        expectTelegramBotTransportSequence(firstTransport, secondTransport);
+        expect(createTelegramTransport).toHaveBeenCalledTimes(1);
+      },
+    },
+    {
+      name: "rebuilds the transport after a getUpdates conflict to force a fresh TCP socket",
+      error: Object.assign(new Error("Conflict: terminated by other getUpdates request"), {
+        error_code: 409,
+        method: "getUpdates",
+      }),
+      recoverable: false,
+      verify: ({
+        createTelegramTransport,
+        firstTransport,
+        secondTransport,
+      }: Awaited<ReturnType<typeof runTransportRestart>>) => {
+        expect(createTelegramTransport).toHaveBeenCalledTimes(1);
+        expectTelegramBotTransportSequence(firstTransport, secondTransport);
+        // A 409 rebuild closes the stale socket; session disposal closes its replacement.
+        expect(firstTransport.close).toHaveBeenCalledTimes(1);
+        expect(secondTransport.close).toHaveBeenCalledTimes(1);
+      },
+    },
+    {
+      name: "logs polling cycle start after a transport rebuild",
+      error: new Error("recoverable polling error"),
+      recoverable: true,
+      verify: ({ log }: Awaited<ReturnType<typeof runTransportRestart>>) => {
+        expectLogIncludes(log, "rebuilding transport for next polling cycle");
+        expectLogIncludes(log, "polling cycle started");
+      },
+    },
+    {
+      name: "closes the stale transport when a rebuild replaces it",
+      error: new Error("recoverable polling error"),
+      recoverable: true,
+      verify: ({
+        firstTransport,
+        secondTransport,
+      }: Awaited<ReturnType<typeof runTransportRestart>>) => {
+        expect(firstTransport.close).toHaveBeenCalled();
+        expect(secondTransport.close).toHaveBeenCalled();
+      },
+    },
+  ])("$name", async ({ error, recoverable, verify }) => {
+    verify(await runTransportRestart(error, recoverable));
   });
 
   it("starts polling when webhook cleanup times out during startup", async () => {
@@ -4940,45 +4263,6 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("rebuilds the transport after a getUpdates conflict to force a fresh TCP socket", async () => {
-    // Regression for #69787: Telegram-side session termination returns 409
-    // and the previous behavior retried on the same HTTP keep-alive socket,
-    // which Telegram repeatedly terminated as the "old" session — producing
-    // a sustained low-rate 409 loop. The polling session must now mark the
-    // transport dirty on 409 so the next cycle uses a fresh connection.
-    const abort = new AbortController();
-    const conflictError = Object.assign(
-      new Error("Conflict: terminated by other getUpdates request"),
-      {
-        error_code: 409,
-        method: "getUpdates",
-      },
-    );
-    const transport1 = makeTelegramTransport();
-    const transport2 = makeTelegramTransport();
-    const createTelegramTransport = vi
-      .fn<() => ReturnType<typeof makeTelegramTransport>>()
-      .mockReturnValueOnce(transport2);
-    createTelegramBotMock.mockReturnValueOnce(makeBot()).mockReturnValueOnce(makeBot());
-    isRecoverableTelegramNetworkErrorMock.mockReturnValue(false);
-    mockRestartAfterPollingError(conflictError, abort);
-
-    const session = createPollingSessionWithTransportRestart({
-      abortSignal: abort.signal,
-      telegramTransport: transport1,
-      createTelegramTransport,
-    });
-
-    await session.runUntilAbort();
-
-    expect(createTelegramTransport).toHaveBeenCalledTimes(1);
-    expectTelegramBotTransportSequence(transport1, transport2);
-    // The stale transport is closed by the dirty-rebuild; the new transport
-    // is closed when dispose() fires on session exit.
-    expect(transport1.close).toHaveBeenCalledTimes(1);
-    expect(transport2.close).toHaveBeenCalledTimes(1);
-  });
-
   it("logs an actionable duplicate-poller hint for getUpdates conflicts", async () => {
     const abort = new AbortController();
     const log = vi.fn();
@@ -5012,31 +4296,6 @@ describe("TelegramPollingSession", () => {
     ).toBe(true);
   });
 
-  it("logs polling cycle start after a transport rebuild", async () => {
-    const abort = new AbortController();
-    const log = vi.fn();
-    const recoverableError = new Error("recoverable polling error");
-    const transport1 = makeTelegramTransport();
-    const transport2 = makeTelegramTransport();
-    const createTelegramTransport = vi
-      .fn<() => ReturnType<typeof makeTelegramTransport>>()
-      .mockReturnValueOnce(transport2);
-    createTelegramBotMock.mockReturnValueOnce(makeBot()).mockReturnValueOnce(makeBot());
-    mockRestartAfterPollingError(recoverableError, abort);
-
-    const session = createPollingSession({
-      abortSignal: abort.signal,
-      log,
-      telegramTransport: transport1,
-      createTelegramTransport,
-    });
-
-    await session.runUntilAbort();
-
-    expectLogIncludes(log, "rebuilding transport for next polling cycle");
-    expectLogIncludes(log, "polling cycle started");
-  });
-
   it("closes the transport once when runUntilAbort exits normally", async () => {
     const abort = new AbortController();
     const transport = makeTelegramTransport();
@@ -5057,31 +4316,6 @@ describe("TelegramPollingSession", () => {
     await session.runUntilAbort();
 
     expect(transport.close).toHaveBeenCalledTimes(1);
-  });
-
-  it("closes the stale transport when a rebuild replaces it", async () => {
-    const abort = new AbortController();
-    const recoverableError = new Error("recoverable polling error");
-    const transport1 = makeTelegramTransport();
-    const transport2 = makeTelegramTransport();
-    const createTelegramTransport = vi
-      .fn<() => ReturnType<typeof makeTelegramTransport>>()
-      .mockReturnValueOnce(transport2);
-    createTelegramBotMock.mockReturnValueOnce(makeBot()).mockReturnValueOnce(makeBot());
-    mockRestartAfterPollingError(recoverableError, abort);
-
-    const session = createPollingSessionWithTransportRestart({
-      abortSignal: abort.signal,
-      telegramTransport: transport1,
-      createTelegramTransport,
-    });
-
-    await session.runUntilAbort();
-
-    // Dirty-rebuild closes transport1 (fire-and-forget via #closeTransportAsync).
-    // dispose() closes transport2 since it becomes the held transport after the rebuild.
-    expect(transport1.close).toHaveBeenCalled();
-    expect(transport2.close).toHaveBeenCalled();
   });
 });
 

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -2752,7 +2752,7 @@ describe("TelegramPollingSession", () => {
         topicUpdate(43, 11, "topic 11 turn"),
         topicUpdate(44, 10, "second topic 10 turn"),
       ],
-      labels: ["topic10:start", "topic11", "topic10:end", "topic10:second"],
+      labels: ["topic10:start", "topic11", "topic10:end", "topic10:second"] as const,
     },
     {
       name: "lets isolated ingress drain interleave different Telegram chats",
@@ -2761,7 +2761,7 @@ describe("TelegramPollingSession", () => {
         directUpdate(43, 854067528, "second chat turn"),
         directUpdate(44, -100, "second first chat turn"),
       ],
-      labels: ["chatA:start", "chatB", "chatA:end", "chatA:second"],
+      labels: ["chatA:start", "chatB", "chatA:end", "chatA:second"] as const,
     },
   ])("$name", async ({ updates, labels }) => {
     await withTempSpool(async (tempDir) => {


### PR DESCRIPTION
## What Problem This Solves

The Telegram polling-session test suite repeated large worker, bot, spool, restart, and timeout harnesses across behaviorally distinct cases. The duplication made the 5,101-line file harder to review and maintain.

## Why This Change Was Made

This consolidates repeated test-only setup into typed helpers and tables while preserving all 75 registered cases and their distinct assertions. The file is now 4,335 lines (`+649/-1,415`, net `-766`), meeting the 15% reduction floor without changing production code.

Merged table-driven cases:

- Missing-harness dead-lettering: ordinary wrapped failure; grammY `BotError`-wrapped failure.
- Isolated-ingress lane interleaving: different Telegram topic lanes; different Telegram chats.
- Polling-stall restart: runner reports running without activity; pending runner task reports not running.
- Transport rebuild: recoverable polling error; `getUpdates` 409 conflict with fresh-socket close assertions; post-rebuild cycle-start logging; stale/replacement transport closure.

## User Impact

No user-visible behavior changes. This is a test-only maintainability refactor.

## Evidence

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts` — 75/75 passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/polling-session.test.ts` — passed.
- `./node_modules/.bin/oxfmt --check extensions/telegram/src/polling-session.test.ts` — passed.
- `git diff --check` — passed.
- Fresh jscpd 5-line/30-token scan: 2,008 duplicated lines (39.37%) -> 1,020 (23.53%).
- Fresh post-fix Codex autoreview: no accepted/actionable findings, 0.96 confidence.
- Test-count delta: 0 (75 before, 75 after).
