### PR TITLE
docs(showcase): add VibeKit (phone-native app builder built on OpenClaw)

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -413,6 +413,12 @@ Packaging, deployment, and integrations that make OpenClaw easier to run and ext
 
 <CardGroup cols={2}>
 
+<Card title="VibeKit phone-native app builder" icon="mobile" href="https://vibekit.bot">
+  **@609NFT** • `mobile` `hosting` `app-builder`
+
+Every app gets its own persistent OpenClaw agent that builds, hosts, and keeps improving it over time (Postgres database and a live domain included), driven entirely from your phone or a CLI. On iOS: [App Store](https://apps.apple.com/us/app/vibekit-ai-app-builder/id6760206636).
+</Card>
+
 <Card title="Home Assistant add-on" icon="home" href="https://github.com/ngutman/openclaw-ha-addon">
   **@ngutman** • `homeassistant` `docker` `raspberry-pi`
 


### PR DESCRIPTION
Adds **VibeKit** to the *Infrastructure and deployment* section of the community showcase.

- Site: https://vibekit.bot
- iOS: https://apps.apple.com/us/app/vibekit-ai-app-builder/id6760206636

## What Problem This Solves

The *Infrastructure and deployment* section collects ways to run and extend OpenClaw, but every entry in it today assumes a desktop or server operator: Docker packaging, Home Assistant, Raspberry Pi, CLI wrappers. Nothing in the showcase demonstrates OpenClaw driving real work from a phone, so a reader asking "can agents run somewhere other than my terminal?" has no reference implementation to look at.

VibeKit is that reference: every app gets its own persistent OpenClaw agent that builds it, hosts it, and keeps improving it over time (Postgres database and live domain included), operated entirely from iOS or a CLI. Listing it gives the section a mobile-first deployment example alongside the existing server-side ones.

Scope note: this is a docs-only showcase addition. It changes no runtime code, config, or workflow paths.

## Evidence

Verified 2026-07-30:

- **Both links resolve.** `curl` against https://vibekit.bot returns HTTP 200. The App Store listing returns HTTP 200; I have also updated the href in this PR to the canonical slug (`vibekit-ai-app-builder`), since the previously submitted one served a 301 redirect.
- **The diff is additive and format-matched.** `+6/-0` in `docs/start/showcase.md`: a single `<Card>` added inside the existing `<CardGroup cols={2}>`, following the same shape as its sibling cards in that group (`title` / `icon` / `href`, then `**@handle**` with backticked tags, then a one-line description). No existing lines are modified, so the surrounding page cannot regress.
- **This is a real OpenClaw deployment, not a drive-by listing.** VibeKit runs OpenClaw gateways in production, and the compaction fix I upstreamed in #112416 (merged 2026-07-25) came out of operating that deployment.
- **Coverage limits, stated plainly.** There is no runtime behavior to exercise here, so I ran no functional tests. For a docs card the meaningful validation is that it renders in the existing card group and that its links resolve, both covered above.

Happy to move this to Discord or X instead if the maintainers would rather curate the showcase that way. I opened a PR because I already contribute here and the card matched the existing format; I also posted it in the community Discord #showcase channel per the page's stated route.
