### PR TITLE
refactor(signal): adopt formatting capability profile

### DIFF
--- a/extensions/signal/src/format.ts
+++ b/extensions/signal/src/format.ts
@@ -1,7 +1,7 @@
-// Signal helper module supports format behavior.
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  type FormatCapabilityProfile,
   markdownToIR,
   type MarkdownIR,
   renderMarkdownWithAttributedRanges,
@@ -34,50 +34,75 @@ const SIGNAL_STYLE_MAP = {
   spoiler: "SPOILER",
 } as const;
 
-function normalizeUrlForComparison(url: string): string {
-  let normalized = normalizeLowercaseStringOrEmpty(url);
-  // Strip protocol
-  normalized = normalized.replace(/^https?:\/\//, "");
-  // Strip www. prefix
-  normalized = normalized.replace(/^www\./, "");
-  // Strip trailing slashes
-  normalized = normalized.replace(/\/+$/, "");
-  return normalized;
+const SIGNAL_FORMAT_PROFILE = {
+  mechanism: "ranges",
+  constructs: {
+    bold: "native",
+    italic: "native",
+    underline: "strip",
+    strikethrough: "native",
+    spoiler: "native",
+    codeInline: "native",
+    codeBlock: "native",
+    codeLanguage: "fallback",
+    linkLabel: "fallback",
+    heading: "fallback",
+    bulletList: "fallback",
+    orderedList: "fallback",
+    taskList: "fallback",
+    table: "fallback",
+    blockquote: "fallback",
+    image: "fallback",
+    mention: "strip",
+  },
+  // Signal clients switch beyond 2 KiB bytes; byte-aware chunking remains an open question.
+  chunk: { limit: 4_000, unit: "chars" },
+} satisfies FormatCapabilityProfile;
+
+function stripEquivalentSignalLinks(ir: MarkdownIR): MarkdownIR {
+  const normalize = (value: string) =>
+    normalizeLowercaseStringOrEmpty(value)
+      .replace(/^(?:https?:\/\/)?(?:www\.)?/, "")
+      .replace(/\/+$/, "");
+  // Core owns link suffixes; Signal retains its established normalized-URL de-duplication.
+  return {
+    ...ir,
+    links: ir.links.filter((link) => {
+      const label = ir.text.slice(link.start, link.end).trim();
+      return normalize(label) !== normalize(link.href.trim().replace(/^mailto:/, ""));
+    }),
+  };
 }
 
 function renderSignalText(ir: MarkdownIR): SignalFormattedText {
-  const rendered = renderMarkdownWithAttributedRanges(ir, {
-    styleMap: SIGNAL_STYLE_MAP,
-    annotationStyleMap: { assistant_transcript_role: "MONOSPACE" },
-    trimEnd: true,
-    renderLink: (link, text) => {
-      const href = link.href.trim();
-      const trimmedLabel = text.slice(link.start, link.end).trim();
-      if (!href || !trimmedLabel) {
-        return href;
-      }
-      const comparableHref = href.startsWith("mailto:") ? href.slice("mailto:".length) : href;
-      return normalizeUrlForComparison(trimmedLabel) === normalizeUrlForComparison(comparableHref)
-        ? ""
-        : ` (${href})`;
+  const rendered = renderMarkdownWithAttributedRanges(
+    stripEquivalentSignalLinks(ir),
+    {
+      styleMap: SIGNAL_STYLE_MAP,
+      annotationStyleMap: { assistant_transcript_role: "MONOSPACE" },
+      trimEnd: true,
     },
-  });
+    SIGNAL_FORMAT_PROFILE,
+  );
   return { text: rendered.text, styles: rendered.ranges };
+}
+
+function markdownToSignalIR(markdown: string, options: SignalMarkdownOptions): MarkdownIR {
+  return markdownToIR(markdown ?? "", {
+    assistantTranscriptRoleHeaders: true,
+    linkify: true,
+    enableSpoilers: true,
+    headingStyle: "rich",
+    blockquotePrefix: "> ",
+    tableMode: options.tableMode,
+  });
 }
 
 export function markdownToSignalText(
   markdown: string,
   options: SignalMarkdownOptions = {},
 ): SignalFormattedText {
-  const ir = markdownToIR(markdown ?? "", {
-    assistantTranscriptRoleHeaders: true,
-    linkify: true,
-    enableSpoilers: true,
-    headingStyle: "bold",
-    blockquotePrefix: "> ",
-    tableMode: options.tableMode,
-  });
-  return renderSignalText(ir);
+  return renderSignalText(markdownToSignalIR(markdown, options));
 }
 
 export function markdownToSignalTextChunks(
@@ -85,14 +110,7 @@ export function markdownToSignalTextChunks(
   limit: number,
   options: SignalMarkdownOptions = {},
 ): SignalFormattedText[] {
-  const ir = markdownToIR(markdown ?? "", {
-    assistantTranscriptRoleHeaders: true,
-    linkify: true,
-    enableSpoilers: true,
-    headingStyle: "bold",
-    blockquotePrefix: "> ",
-    tableMode: options.tableMode,
-  });
+  const ir = markdownToSignalIR(markdown, options);
   return renderMarkdownIRChunksWithinLimit({
     ir,
     limit,


### PR DESCRIPTION
## What Problem This Solves

Signal still encoded heading and link fallback decisions inside its attributed-text formatter even though markdown-core now owns those policies through `FormatCapabilityProfile`. That left Signal with a second fallback path that could drift from the unified outbound formatting pipeline.

## Why This Change Was Made

This AI-assisted refactor declares Signal's range-formatting capabilities and passes the profile through the shared attributed renderer. Markdown-core now owns heading-to-bold and `label (url)` fallback insertion; Signal retains only its established normalized-URL de-duplication rule. The profile deliberately records the current 4,000-character chunk contract and documents Signal clients' 2 KiB byte threshold as a separate open question, without changing chunking in this PR.

## User Impact

No user-visible output changes. Existing Signal text, UTF-16 style ranges, normalized URL handling, and chunk behavior remain byte-identical.

## Evidence

- Intended before -> after output changes: none. Existing golden fixtures for nested link/style ranges, CJK plus emoji offsets, headings, spoilers, code, lists, and normalized-equivalent URLs remain unchanged.
- `node scripts/run-vitest.mjs extensions/signal/src/format.test.ts extensions/signal/src/format.chunking.test.ts` -> 2 files passed, 43 tests passed after the final rebase.
- `node scripts/check-changed.mjs -- extensions/signal/src/format.ts` -> passed on Blacksmith Testbox `tbx_01ky81vmk22ze27syrg4h7qcgg`; formatting, extension prod/test types, lint, ratchets, boundaries, and import cycles were clean. Run: https://github.com/openclaw/openclaw/actions/runs/30031451223
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` -> clean; no accepted/actionable findings.
- Numstat: production `+58/-40` (net `+18`); tests `+0/-0`; total `+58/-40`. The required 18-construct profile and byte-compatible URL de-duplication account for the positive line delta, while heading and link-suffix fallback execution now have one shared owner instead of channel-local implementations.
