### PR TITLE
fix(cli): backport macOS system CA trust

### DIFF
--- a/src/cli/one-shot-exit.test.ts
+++ b/src/cli/one-shot-exit.test.ts
@@ -65,7 +65,9 @@ describe("one-shot CLI exit", () => {
       markers: {},
     });
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     expect(exit).not.toHaveBeenCalled();
 
     finishRun?.();
@@ -88,7 +90,9 @@ describe("one-shot CLI exit", () => {
           throw new Error("command failed");
         },
         onError: async () => {
-          await new Promise<void>((resolve) => setImmediate(resolve));
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
           order.push("reported");
           process.exitCode = 6;
         },

--- a/src/cli/one-shot-exit.test.ts
+++ b/src/cli/one-shot-exit.test.ts
@@ -1,11 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defaultRuntime } from "../runtime.js";
-import {
-  flushExitAfterOneShotOutput,
-  requestExitAfterOneShotOutput,
-  requestExitAfterSystemCaCliCompletion,
-  runCliWithExitFinalization,
-} from "./one-shot-exit.js";
+import { requestExitAfterOneShotOutput, runCliWithExitFinalization } from "./one-shot-exit.js";
+
+const successfulRun = async () => {};
+const ignoreError = () => {};
 
 describe("one-shot CLI exit", () => {
   afterEach(() => {
@@ -19,35 +17,46 @@ describe("one-shot CLI exit", () => {
     ["NODE_OPTIONS", { NODE_OPTIONS: "'--use-system-ca'" }, []],
     ["underscored NODE_OPTIONS", { NODE_OPTIONS: "--use_system_ca" }, []],
   ] as const)(
-    "requests a post-teardown exit for macOS system CA from %s",
+    "exits after macOS system CA command completion from %s",
     async (_label, env, execArgv) => {
+      const previousExitCode = process.exitCode;
       const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
-
-      expect(
-        requestExitAfterSystemCaCliCompletion(defaultRuntime, {
+      try {
+        process.exitCode = 3;
+        await runCliWithExitFinalization({
+          run: successfulRun,
+          onError: ignoreError,
           env: env as NodeJS.ProcessEnv,
           execArgv,
           platform: "darwin",
-          exitCode: 3,
-        }),
-      ).toBe(true);
-      flushExitAfterOneShotOutput(defaultRuntime, {} as NodeJS.ProcessEnv, {});
-
-      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(3));
+          markers: {},
+        });
+        await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(3));
+      } finally {
+        process.exitCode = previousExitCode;
+      }
     },
   );
 
   it.each([
     ["non-macOS", "linux" as const, { NODE_USE_SYSTEM_CA: "1" }, []],
     ["system CA disabled", "darwin" as const, { NODE_USE_SYSTEM_CA: "0" }, []],
-  ])("does not request a completion exit when %s", (_label, platform, env, execArgv) => {
-    expect(
-      requestExitAfterSystemCaCliCompletion(defaultRuntime, {
-        env: env as NodeJS.ProcessEnv,
-        execArgv: execArgv as string[],
-        platform,
-      }),
-    ).toBe(false);
+  ])("does not exit after completion when %s", async (_label, platform, env, execArgv) => {
+    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+
+    await runCliWithExitFinalization({
+      run: successfulRun,
+      onError: ignoreError,
+      env: env as NodeJS.ProcessEnv,
+      execArgv: execArgv as string[],
+      platform,
+      markers: {},
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(exit).not.toHaveBeenCalled();
   });
 
   it("does not finalize a long-lived command until its run promise settles", async () => {
@@ -58,7 +67,7 @@ describe("one-shot CLI exit", () => {
         await new Promise<void>((resolve) => {
           finishRun = resolve;
         }),
-      onError: vi.fn(),
+      onError: ignoreError,
       env: { NODE_USE_SYSTEM_CA: "1" },
       execArgv: [],
       platform: "darwin",
@@ -75,7 +84,7 @@ describe("one-shot CLI exit", () => {
     await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
   });
 
-  it("reports failures and sets their status before draining the system CA exit", async () => {
+  it("reports failures and replaces a pending successful exit before draining", async () => {
     const previousExitCode = process.exitCode;
     const order: string[] = [];
     const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
@@ -109,20 +118,20 @@ describe("one-shot CLI exit", () => {
     }
   });
 
-  it("resolves the process exit code after a system CA completion request", async () => {
+  it("normalizes a Node integer-string process exit code", async () => {
     const previousExitCode = process.exitCode;
     const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
 
     try {
-      process.exitCode = undefined;
-      requestExitAfterSystemCaCliCompletion(defaultRuntime, {
+      process.exitCode = "9";
+      await runCliWithExitFinalization({
+        run: successfulRun,
+        onError: ignoreError,
         env: { NODE_USE_SYSTEM_CA: "1" },
         execArgv: [],
         platform: "darwin",
+        markers: {},
       });
-      flushExitAfterOneShotOutput(defaultRuntime, {} as NodeJS.ProcessEnv, {});
-      process.exitCode = "9";
-
       await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(9));
     } finally {
       process.exitCode = previousExitCode;
@@ -133,39 +142,51 @@ describe("one-shot CLI exit", () => {
     const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
 
     requestExitAfterOneShotOutput(defaultRuntime, 7);
-    requestExitAfterSystemCaCliCompletion(defaultRuntime, {
+    await runCliWithExitFinalization({
+      run: successfulRun,
+      onError: ignoreError,
       env: { NODE_USE_SYSTEM_CA: "1" },
       execArgv: [],
       platform: "darwin",
-      exitCode: 0,
+      markers: {},
     });
-    flushExitAfterOneShotOutput(defaultRuntime, {} as NodeJS.ProcessEnv, {});
 
     await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(7));
   });
 
-  it("defers the requested exit code until the top-level flush", async () => {
+  it("defers a requested exit until the outer finalizer", async () => {
     const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
 
     expect(requestExitAfterOneShotOutput(defaultRuntime, 2)).toBe(true);
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
-
     expect(exit).not.toHaveBeenCalled();
-    flushExitAfterOneShotOutput(defaultRuntime, {} as NodeJS.ProcessEnv, {});
+
+    await runCliWithExitFinalization({
+      run: successfulRun,
+      onError: ignoreError,
+      env: {},
+      execArgv: [],
+      platform: "linux",
+      markers: {},
+    });
     await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(2));
   });
 
   it("does not request exits for embedded custom runtimes", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
     expect(requestExitAfterOneShotOutput(runtime)).toBe(false);
-    flushExitAfterOneShotOutput(runtime, {} as NodeJS.ProcessEnv, {});
+    await runCliWithExitFinalization({
+      run: successfulRun,
+      onError: ignoreError,
+      runtime,
+      env: { NODE_USE_SYSTEM_CA: "1" },
+      execArgv: [],
+      platform: "darwin",
+      markers: {},
+    });
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
@@ -178,14 +199,25 @@ describe("one-shot CLI exit", () => {
     const inheritedTestEnv = { VITEST: "1", VITEST_WORKER_ID: "1" } as NodeJS.ProcessEnv;
 
     requestExitAfterOneShotOutput(defaultRuntime);
-    flushExitAfterOneShotOutput(defaultRuntime, inheritedTestEnv, { tinypoolState: {} });
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
+    await runCliWithExitFinalization({
+      run: successfulRun,
+      onError: ignoreError,
+      env: inheritedTestEnv,
+      execArgv: [],
+      platform: "linux",
+      markers: { tinypoolState: {} },
     });
     expect(exit).not.toHaveBeenCalled();
 
     requestExitAfterOneShotOutput(defaultRuntime);
-    flushExitAfterOneShotOutput(defaultRuntime, inheritedTestEnv, {});
+    await runCliWithExitFinalization({
+      run: successfulRun,
+      onError: ignoreError,
+      env: inheritedTestEnv,
+      execArgv: [],
+      platform: "linux",
+      markers: {},
+    });
     await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
   });
 
@@ -196,24 +228,25 @@ describe("one-shot CLI exit", () => {
 
     let flushStdout: (() => void) | undefined;
     let flushStderr: (() => void) | undefined;
-    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(((
-      ...args: unknown[]
-    ) => {
+    vi.spyOn(process.stdout, "write").mockImplementation(((...args: unknown[]) => {
       flushStdout = args.find((arg): arg is () => void => typeof arg === "function");
       return true;
     }) as typeof process.stdout.write);
-    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(((
-      ...args: unknown[]
-    ) => {
+    vi.spyOn(process.stderr, "write").mockImplementation(((...args: unknown[]) => {
       flushStderr = args.find((arg): arg is () => void => typeof arg === "function");
       return true;
     }) as typeof process.stderr.write);
 
     requestExitAfterOneShotOutput(defaultRuntime);
-    flushExitAfterOneShotOutput(defaultRuntime, {} as NodeJS.ProcessEnv, {});
+    await runCliWithExitFinalization({
+      run: successfulRun,
+      onError: ignoreError,
+      env: {},
+      execArgv: [],
+      platform: "linux",
+      markers: {},
+    });
 
-    expect(stdoutWrite).toHaveBeenCalledOnce();
-    expect(stderrWrite).toHaveBeenCalledOnce();
     expect(exit).not.toHaveBeenCalled();
     flushStdout?.();
     expect(exit).not.toHaveBeenCalled();

--- a/src/cli/one-shot-exit.test.ts
+++ b/src/cli/one-shot-exit.test.ts
@@ -1,10 +1,143 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defaultRuntime } from "../runtime.js";
-import { flushExitAfterOneShotOutput, requestExitAfterOneShotOutput } from "./one-shot-exit.js";
+import {
+  flushExitAfterOneShotOutput,
+  requestExitAfterOneShotOutput,
+  requestExitAfterSystemCaCliCompletion,
+  runCliWithExitFinalization,
+} from "./one-shot-exit.js";
 
 describe("one-shot CLI exit", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["NODE_USE_SYSTEM_CA", { NODE_USE_SYSTEM_CA: "1" }, []],
+    ["execArgv", {}, ["--use-system-ca"]],
+    ["underscored execArgv", {}, ["--use_system_ca"]],
+    ["NODE_OPTIONS", { NODE_OPTIONS: "'--use-system-ca'" }, []],
+    ["underscored NODE_OPTIONS", { NODE_OPTIONS: "--use_system_ca" }, []],
+  ] as const)(
+    "requests a post-teardown exit for macOS system CA from %s",
+    async (_label, env, execArgv) => {
+      const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+
+      expect(
+        requestExitAfterSystemCaCliCompletion(defaultRuntime, {
+          env: env as NodeJS.ProcessEnv,
+          execArgv,
+          platform: "darwin",
+          exitCode: 3,
+        }),
+      ).toBe(true);
+      flushExitAfterOneShotOutput(defaultRuntime, {} as NodeJS.ProcessEnv, {});
+
+      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(3));
+    },
+  );
+
+  it.each([
+    ["non-macOS", "linux" as const, { NODE_USE_SYSTEM_CA: "1" }, []],
+    ["system CA disabled", "darwin" as const, { NODE_USE_SYSTEM_CA: "0" }, []],
+  ])("does not request a completion exit when %s", (_label, platform, env, execArgv) => {
+    expect(
+      requestExitAfterSystemCaCliCompletion(defaultRuntime, {
+        env: env as NodeJS.ProcessEnv,
+        execArgv: execArgv as string[],
+        platform,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not finalize a long-lived command until its run promise settles", async () => {
+    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+    let finishRun: (() => void) | undefined;
+    const runPromise = runCliWithExitFinalization({
+      run: async () =>
+        await new Promise<void>((resolve) => {
+          finishRun = resolve;
+        }),
+      onError: vi.fn(),
+      env: { NODE_USE_SYSTEM_CA: "1" },
+      execArgv: [],
+      platform: "darwin",
+      markers: {},
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(exit).not.toHaveBeenCalled();
+
+    finishRun?.();
+    await runPromise;
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+  });
+
+  it("reports failures and sets their status before draining the system CA exit", async () => {
+    const previousExitCode = process.exitCode;
+    const order: string[] = [];
+    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
+      order.push(`exit:${String(code)}`);
+    });
+
+    try {
+      process.exitCode = undefined;
+      requestExitAfterOneShotOutput(defaultRuntime, 0);
+      await runCliWithExitFinalization({
+        run: async () => {
+          throw new Error("command failed");
+        },
+        onError: async () => {
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          order.push("reported");
+          process.exitCode = 6;
+        },
+        env: { NODE_USE_SYSTEM_CA: "1" },
+        execArgv: [],
+        platform: "darwin",
+        markers: {},
+      });
+
+      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(6));
+      expect(order).toEqual(["reported", "exit:6"]);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("resolves the process exit code after a system CA completion request", async () => {
+    const previousExitCode = process.exitCode;
+    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+
+    try {
+      process.exitCode = undefined;
+      requestExitAfterSystemCaCliCompletion(defaultRuntime, {
+        env: { NODE_USE_SYSTEM_CA: "1" },
+        execArgv: [],
+        platform: "darwin",
+      });
+      flushExitAfterOneShotOutput(defaultRuntime, {} as NodeJS.ProcessEnv, {});
+      process.exitCode = "9";
+
+      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(9));
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("preserves a command-specific exit code when system CA completion also requests exit", async () => {
+    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+
+    requestExitAfterOneShotOutput(defaultRuntime, 7);
+    requestExitAfterSystemCaCliCompletion(defaultRuntime, {
+      env: { NODE_USE_SYSTEM_CA: "1" },
+      execArgv: [],
+      platform: "darwin",
+      exitCode: 0,
+    });
+    flushExitAfterOneShotOutput(defaultRuntime, {} as NodeJS.ProcessEnv, {});
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(7));
   });
 
   it("defers the requested exit code until the top-level flush", async () => {

--- a/src/cli/one-shot-exit.ts
+++ b/src/cli/one-shot-exit.ts
@@ -1,12 +1,14 @@
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 
-type VitestWorkerMarkers = {
+export type VitestWorkerMarkers = {
   tinypoolState?: unknown;
   vitestWorker?: unknown;
 };
 
-let requestedExitCode: number | undefined;
+const SYSTEM_CA_FLAG = "--use-system-ca";
+
+let requestedExitCode: number | "process" | undefined;
 
 function resolveVitestWorkerMarkers(): VitestWorkerMarkers {
   const processMarkers = process as NodeJS.Process & Record<string, unknown>;
@@ -15,6 +17,34 @@ function resolveVitestWorkerMarkers(): VitestWorkerMarkers {
     tinypoolState: processMarkers["__tinypool_state__"],
     vitestWorker: globalMarkers["__vitest_worker__"],
   };
+}
+
+function hasNodeRuntimeOption(
+  option: string,
+  env: NodeJS.ProcessEnv,
+  execArgv: readonly string[],
+): boolean {
+  const normalize = (value: string) => value.replaceAll("_", "-");
+  if (execArgv.some((arg) => normalize(arg) === option)) {
+    return true;
+  }
+  return (env.NODE_OPTIONS ?? "").split(/\s+/u).some((token) => {
+    const quote = token[0];
+    const unquoted =
+      (quote === '"' || quote === "'") && token.at(-1) === quote ? token.slice(1, -1) : token;
+    return normalize(unquoted) === option;
+  });
+}
+
+function resolveProcessExitCode(fallback = 0): number {
+  const value = process.exitCode;
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? value : fallback;
+  }
+  if (typeof value === "string" && /^-?\d+$/u.test(value.trim())) {
+    return Number.parseInt(value, 10);
+  }
+  return fallback;
 }
 
 function isVitestWorker(
@@ -29,6 +59,54 @@ function isVitestWorker(
   return (
     hasVitestEnv && (markers.tinypoolState !== undefined || markers.vitestWorker !== undefined)
   );
+}
+
+export function requestExitAfterSystemCaCliCompletion(
+  runtime: RuntimeEnv = defaultRuntime,
+  params: {
+    env?: NodeJS.ProcessEnv;
+    execArgv?: readonly string[];
+    platform?: NodeJS.Platform;
+    exitCode?: number;
+  } = {},
+): boolean {
+  const env = params.env ?? process.env;
+  const execArgv = params.execArgv ?? process.execArgv;
+  const platform = params.platform ?? process.platform;
+  const usesSystemCa =
+    env.NODE_USE_SYSTEM_CA === "1" || hasNodeRuntimeOption(SYSTEM_CA_FLAG, env, execArgv);
+  if (platform !== "darwin" || !usesSystemCa || runtime !== defaultRuntime) {
+    return false;
+  }
+  if (requestedExitCode === undefined) {
+    requestedExitCode = params.exitCode ?? "process";
+  }
+  return true;
+}
+
+export async function runCliWithExitFinalization(params: {
+  run: () => Promise<void>;
+  onError: (error: unknown) => void | Promise<void>;
+  runtime?: RuntimeEnv;
+  env?: NodeJS.ProcessEnv;
+  execArgv?: readonly string[];
+  platform?: NodeJS.Platform;
+  markers?: VitestWorkerMarkers;
+}): Promise<void> {
+  const runtime = params.runtime ?? defaultRuntime;
+  try {
+    await params.run();
+  } catch (error) {
+    await params.onError(error);
+    requestExitAfterOneShotOutput(runtime, resolveProcessExitCode(1));
+  } finally {
+    requestExitAfterSystemCaCliCompletion(runtime, {
+      env: params.env,
+      execArgv: params.execArgv,
+      platform: params.platform,
+    });
+    flushExitAfterOneShotOutput(runtime, params.env, params.markers);
+  }
 }
 
 export function requestExitAfterOneShotOutput(
@@ -47,13 +125,14 @@ export function flushExitAfterOneShotOutput(
   env: NodeJS.ProcessEnv = process.env,
   markers: VitestWorkerMarkers = resolveVitestWorkerMarkers(),
 ): void {
-  const exitCode = requestedExitCode;
+  const requestedCode = requestedExitCode;
   requestedExitCode = undefined;
-  if (exitCode === undefined || runtime !== defaultRuntime || isVitestWorker(env, markers)) {
+  if (requestedCode === undefined || runtime !== defaultRuntime || isVitestWorker(env, markers)) {
     return;
   }
 
-  const exit = () => runtime.exit(exitCode);
+  const exit = () =>
+    runtime.exit(requestedCode === "process" ? resolveProcessExitCode() : requestedCode);
   let pendingStreams = 2;
 
   const drain = (stream: NodeJS.WriteStream) => {

--- a/src/cli/one-shot-exit.ts
+++ b/src/cli/one-shot-exit.ts
@@ -1,7 +1,7 @@
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 
-export type VitestWorkerMarkers = {
+type VitestWorkerMarkers = {
   tinypoolState?: unknown;
   vitestWorker?: unknown;
 };
@@ -61,7 +61,7 @@ function isVitestWorker(
   );
 }
 
-export function requestExitAfterSystemCaCliCompletion(
+function requestExitAfterSystemCaCliCompletion(
   runtime: RuntimeEnv = defaultRuntime,
   params: {
     env?: NodeJS.ProcessEnv;
@@ -120,7 +120,7 @@ export function requestExitAfterOneShotOutput(
   return true;
 }
 
-export function flushExitAfterOneShotOutput(
+function flushExitAfterOneShotOutput(
   runtime: RuntimeEnv = defaultRuntime,
   env: NodeJS.ProcessEnv = process.env,
   markers: VitestWorkerMarkers = resolveVitestWorkerMarkers(),

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -487,7 +487,7 @@ describe("runCli exit behavior", () => {
     expect(disposeRegisteredAgentHarnessesMock).toHaveBeenCalledTimes(1);
   });
 
-  it("flushes requested one-shot exits after asynchronous teardown", async () => {
+  it("completes asynchronous teardown before returning to the outer entrypoint", async () => {
     const order: string[] = [];
     listRegisteredAgentHarnessesMock.mockReturnValueOnce([{ harness: { id: "copilot" } }]);
     disposeRegisteredAgentHarnessesMock.mockImplementationOnce(async () => {
@@ -497,14 +497,12 @@ describe("runCli exit behavior", () => {
     closeActiveMemorySearchManagersMock.mockImplementationOnce(async () => {
       order.push("memory");
     });
-    flushExitAfterOneShotOutputMock.mockImplementationOnce(() => {
-      order.push("exit");
-    });
     tryRouteCliMock.mockResolvedValueOnce(true);
 
     await runCli(["node", "openclaw", "models", "status", "--probe"]);
 
-    expect(order).toEqual(["harnesses", "memory", "exit"]);
+    expect(order).toEqual(["harnesses", "memory"]);
+    expect(flushExitAfterOneShotOutputMock).not.toHaveBeenCalled();
   });
 
   it("shows the standard spinner while loading the full CLI", async () => {
@@ -3789,7 +3787,7 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "openclaw", "security", "--help"]);
 
     expect(requestExitAfterOneShotOutputMock).toHaveBeenCalledOnce();
-    expect(flushExitAfterOneShotOutputMock).toHaveBeenCalledOnce();
+    expect(flushExitAfterOneShotOutputMock).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(0);
     process.exitCode = exitCode;
   });
@@ -3805,7 +3803,7 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "openclaw", "memory", "--help"]);
 
     expect(requestExitAfterOneShotOutputMock).toHaveBeenCalledOnce();
-    expect(flushExitAfterOneShotOutputMock).toHaveBeenCalledOnce();
+    expect(flushExitAfterOneShotOutputMock).not.toHaveBeenCalled();
   });
 
   it("loads the real primary command before rendering command help", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -35,7 +35,7 @@ import {
   resolveGatewayRunPreBootstrapOptions,
 } from "./gateway-run-argv.js";
 import { hasJsonOutputFlag, withConsoleLogsRoutedToStderrForJson } from "./json-output-mode.js";
-import { flushExitAfterOneShotOutput, requestExitAfterOneShotOutput } from "./one-shot-exit.js";
+import { requestExitAfterOneShotOutput } from "./one-shot-exit.js";
 import { tryOutputPrecomputedCommandHelp } from "./precomputed-help.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { formatCliCommandSuggestions } from "./program/command-suggestions.js";
@@ -1116,7 +1116,6 @@ export async function runCli(argv: string[] = process.argv) {
     });
   }
 
-  let flushedHelpExit = false;
   try {
     if (shouldUseRootHelpFastPath(normalizedArgv)) {
       const { loadRootHelpRenderOptionsForConfigSensitivePlugins } =
@@ -1420,10 +1419,9 @@ export async function runCli(argv: string[] = process.argv) {
       }
       if (completedHelpOrVersion) {
         // Lazy command-group registrars can import native/runtime resources solely to
-        // render complete help. Exit after Commander has rendered and streams flush.
+        // render complete help. Request an exit now; the top-level finally flushes it
+        // after shared async teardown completes.
         requestExitAfterOneShotOutput();
-        flushExitAfterOneShotOutput();
-        flushedHelpExit = true;
       }
     } finally {
       stopStartupProgress();
@@ -1434,9 +1432,6 @@ export async function runCli(argv: string[] = process.argv) {
     await disposeCliAgentHarnesses();
     await closeCliMemoryManagers();
     pauseNonTtyStdinForCliExit();
-    if (!flushedHelpExit) {
-      flushExitAfterOneShotOutput();
-    }
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -5,8 +5,6 @@ import { describe, expect, it, vi } from "vitest";
 import { buildCliRespawnPlan, runCliRespawnPlan } from "./entry.respawn.js";
 
 const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
-const BUNDLED_CA_FLAG = "--use-bundled-ca";
-const OPENSSL_CA_FLAG = "--use-openssl-ca";
 const OPENCLAW_NODE_EXTRA_CA_CERTS_READY = "OPENCLAW_NODE_EXTRA_CA_CERTS_READY";
 const OPENCLAW_NODE_OPTIONS_READY = "OPENCLAW_NODE_OPTIONS_READY";
 
@@ -103,7 +101,7 @@ describe("buildCliRespawnPlan", () => {
     expect(respawnPlan.detachForProcessTree).toBe(false);
   });
 
-  it("uses bundled public roots for one-shot macOS commands", () => {
+  it("preserves macOS system CA trust through one-shot warning respawns", () => {
     const plan = buildCliRespawnPlan({
       argv: ["node", "openclaw", "cron", "list", "--json"],
       env: { NODE_USE_SYSTEM_CA: "1" },
@@ -115,13 +113,12 @@ describe("buildCliRespawnPlan", () => {
     const respawnPlan = expectCliRespawnPlan(plan);
     expect(respawnPlan.argv).toEqual([
       EXPERIMENTAL_WARNING_FLAG,
-      BUNDLED_CA_FLAG,
       "openclaw",
       "cron",
       "list",
       "--json",
     ]);
-    expect(respawnPlan.env.NODE_USE_SYSTEM_CA).toBe("0");
+    expect(respawnPlan.env.NODE_USE_SYSTEM_CA).toBe("1");
   });
 
   it.each([
@@ -139,58 +136,15 @@ describe("buildCliRespawnPlan", () => {
     ).toBeNull();
   });
 
-  it.each([
-    ["the command line", ["--use-system-ca"], undefined],
-    ["NODE_OPTIONS", [], "--use-system-ca"],
-    ["quoted NODE_OPTIONS", [], '"--use-system-ca"'],
-    ["single-quoted NODE_OPTIONS", [], "'--use-system-ca'"],
-  ] as const)(
-    "keeps an explicit macOS system CA runtime flag from %s",
-    (_label, execArgv, nodeOptions) => {
-      const plan = buildCliRespawnPlan({
-        argv: ["node", "openclaw", "cron", "list", "--json"],
-        env: { NODE_OPTIONS: nodeOptions, NODE_USE_SYSTEM_CA: "1" },
-        execArgv: [...execArgv],
-        autoNodeExtraCaCerts: undefined,
-        platform: "darwin",
-      });
-
-      const respawnPlan = expectCliRespawnPlan(plan);
-      expect(respawnPlan.argv).not.toContain(OPENSSL_CA_FLAG);
-      expect(respawnPlan.env.NODE_USE_SYSTEM_CA).toBe("1");
-    },
-  );
-
-  it.each([
-    ["the command line", [BUNDLED_CA_FLAG], undefined],
-    ["NODE_OPTIONS", [], BUNDLED_CA_FLAG],
-    ["quoted NODE_OPTIONS", [], `"${BUNDLED_CA_FLAG}"`],
-  ] as const)(
-    "preserves an explicit bundled CA selection from %s",
-    (_label, execArgv, nodeOptions) => {
-      const plan = buildCliRespawnPlan({
-        argv: ["node", "openclaw", "cron", "list", "--json"],
-        env: { NODE_OPTIONS: nodeOptions, NODE_USE_SYSTEM_CA: "1" },
-        execArgv: [...execArgv],
-        autoNodeExtraCaCerts: undefined,
-        platform: "darwin",
-      });
-
-      const respawnPlan = expectCliRespawnPlan(plan);
-      expect(respawnPlan.argv).not.toContain(OPENSSL_CA_FLAG);
-      expect(respawnPlan.env.NODE_USE_SYSTEM_CA).toBe("0");
-    },
-  );
-
-  it("does not respawn again after selecting bundled public roots", () => {
+  it("does not respawn one-shot commands only to change CA trust", () => {
     expect(
       buildCliRespawnPlan({
         argv: ["node", "openclaw", "cron", "list", "--json"],
         env: {
-          NODE_USE_SYSTEM_CA: "0",
+          NODE_USE_SYSTEM_CA: "1",
           [OPENCLAW_NODE_OPTIONS_READY]: "1",
         },
-        execArgv: [BUNDLED_CA_FLAG, EXPERIMENTAL_WARNING_FLAG],
+        execArgv: [EXPERIMENTAL_WARNING_FLAG],
         autoNodeExtraCaCerts: undefined,
         platform: "darwin",
       }),

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -16,9 +16,6 @@ import {
 } from "./process/respawn-child-runner.js";
 
 const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
-const BUNDLED_CA_FLAG = "--use-bundled-ca";
-const OPENSSL_CA_FLAG = "--use-openssl-ca";
-const SYSTEM_CA_FLAG = "--use-system-ca";
 const OPENCLAW_NODE_OPTIONS_READY = "OPENCLAW_NODE_OPTIONS_READY";
 const OPENCLAW_NODE_EXTRA_CA_CERTS_READY = "OPENCLAW_NODE_EXTRA_CA_CERTS_READY";
 const WINDOWS_STACK_SIZE_FLAG = "--stack-size=8192";
@@ -63,28 +60,6 @@ function hasExperimentalWarningSuppressed(
     return true;
   }
   return execArgv.some((arg) => arg === EXPERIMENTAL_WARNING_FLAG || arg === "--no-warnings");
-}
-
-function hasNodeRuntimeOption(params: {
-  env: NodeJS.ProcessEnv;
-  execArgv: string[];
-  option: string;
-}): boolean {
-  const nodeOptions = (params.env.NODE_OPTIONS ?? "").split(/\s+/u);
-  return (
-    params.execArgv.includes(params.option) ||
-    nodeOptions.some((token) => {
-      if (token === params.option) {
-        return true;
-      }
-      const quote = token[0];
-      return (
-        (quote === '"' || quote === "'") &&
-        token.at(-1) === quote &&
-        token.slice(1, -1) === params.option
-      );
-    })
-  );
 }
 
 function hasStackSizeConfigured(execArgv: string[]): boolean {
@@ -142,23 +117,6 @@ export function buildCliRespawnPlan(
       env: childEnv,
       detachForProcessTree: false,
     };
-  }
-
-  if (
-    platform === "darwin" &&
-    env.NODE_USE_SYSTEM_CA === "1" &&
-    !isTerminalInteractiveRespawnArgv(argv) &&
-    !hasNodeRuntimeOption({ env, execArgv, option: SYSTEM_CA_FLAG }) &&
-    !hasNodeRuntimeOption({ env, execArgv, option: OPENSSL_CA_FLAG })
-  ) {
-    // Node loads the macOS Keychain off-thread on the first TLS import, then joins
-    // that worker during shutdown. One-shot CLIs use Node's bundled public roots;
-    // an explicit --use-system-ca remains the opt-in for Keychain-only trust.
-    childEnv.NODE_USE_SYSTEM_CA = "0";
-    if (!hasNodeRuntimeOption({ env, execArgv, option: BUNDLED_CA_FLAG })) {
-      childExecArgv.unshift(BUNDLED_CA_FLAG);
-    }
-    needsRespawn = true;
   }
 
   const autoNodeExtraCaCerts =

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -5,6 +5,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { isRootHelpInvocation } from "./cli/argv.js";
 import { parseCliContainerArgs, resolveCliContainerTarget } from "./cli/container-target.js";
+import { runCliWithExitFinalization } from "./cli/one-shot-exit.js";
 import {
   tryOutputPrecomputedCommandHelp,
   type PrecomputedCommandHelpDeps,
@@ -200,27 +201,30 @@ export async function tryHandlePrecomputedCommandHelpFastPath(
 }
 
 async function runMainOrRootHelp(argv: string[]): Promise<void> {
-  if (await tryHandleRootHelpFastPath(argv)) {
-    return;
-  }
-  if (await tryHandlePrecomputedCommandHelpFastPath(argv)) {
-    return;
-  }
-  try {
-    const { runCli } = await gatewayEntryStartupTrace.measure(
-      "run-main-import",
-      () => import("./cli/run-main.js"),
-    );
-    await runCli(argv);
-  } catch (error) {
-    const { formatCliFailureLines } = await import("./cli/failure-output.js");
-    for (const line of formatCliFailureLines({
-      title: "Could not start the CLI.",
-      error,
-      argv,
-    })) {
-      console.error(line);
-    }
-    process.exit(1);
-  }
+  await runCliWithExitFinalization({
+    run: async () => {
+      if (await tryHandleRootHelpFastPath(argv)) {
+        return;
+      }
+      if (await tryHandlePrecomputedCommandHelpFastPath(argv)) {
+        return;
+      }
+      const { runCli } = await gatewayEntryStartupTrace.measure(
+        "run-main-import",
+        () => import("./cli/run-main.js"),
+      );
+      await runCli(argv);
+    },
+    onError: async (error) => {
+      const { formatCliFailureLines } = await import("./cli/failure-output.js");
+      for (const line of formatCliFailureLines({
+        title: "Could not start the CLI.",
+        error,
+        argv,
+      })) {
+        console.error(line);
+      }
+      process.exitCode = 1;
+    },
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { formatCliFailureLines } from "./cli/failure-output.js";
+import { runCliWithExitFinalization } from "./cli/one-shot-exit.js";
 import { formatUncaughtError } from "./infra/errors.js";
 import { runFatalErrorHooks } from "./infra/fatal-error-hooks.js";
 import { isMainModule } from "./infra/is-main.js";
@@ -117,18 +118,21 @@ if (isMain) {
     process.exit(1);
   });
 
-  void runLegacyCliEntry(process.argv).catch((err: unknown) => {
-    for (const line of formatCliFailureLines({
-      title: "The CLI command failed.",
-      error: err,
-      argv: process.argv,
-    })) {
-      console.error(line);
-    }
-    for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
-      console.error("[openclaw]", message);
-    }
-    restoreTerminalState("legacy cli failure", { resumeStdinIfPaused: false });
-    process.exit(1);
+  void runCliWithExitFinalization({
+    run: async () => await runLegacyCliEntry(process.argv),
+    onError: (err) => {
+      for (const line of formatCliFailureLines({
+        title: "The CLI command failed.",
+        error: err,
+        argv: process.argv,
+      })) {
+        console.error(line);
+      }
+      for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
+        console.error("[openclaw]", message);
+      }
+      restoreTerminalState("legacy cli failure", { resumeStdinIfPaused: false });
+      process.exitCode = 1;
+    },
   });
 }


### PR DESCRIPTION
Backport of #113112 to `release/2026.7.2`.
Related: #113108, #110341, #112868

## What Problem This Solves

The release branch contains the macOS one-shot shutdown workaround that disables system/Keychain CA trust. Public roots work after #112868, but enterprise and Keychain-only private roots are still removed despite `NODE_USE_SYSTEM_CA=1`.

## Why This Change Was Made

This applies the reviewed mainline lifecycle fix without changing release identity or unrelated release code. Node CA policy is preserved; explicit drained exit happens only after command completion, error reporting, shared teardown, and stream flush.

## User Impact

The `2026.7.2` release can retain macOS system CA trust and still exit one-shot commands promptly. Extended stable `2026.6.33` never received the regression and requires no backport.

## Evidence

- Cherry-picked the three reviewed commits from #113112 without conflict.
- Focused release-branch suite: 253/253 tests passed.
- `pnpm deadcode:full` passed.
- Main PR exact-head CI, Testbox changed gates, real macOS Keychain proof, and repository-native prepare/merge gates were green.

AI-assisted: yes. This is a mechanical backport of the landed fix.
