### PR TITLE
test(discord): restore authorized voice fixture coverage

### DIFF
--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -4942,6 +4942,7 @@ describe("DiscordVoiceManager", () => {
     const manager = createManager(
       {
         groupPolicy: "open",
+        allowFrom: ["discord:u-guest"],
         voice: {
           model: "openai/gpt-5.4-mini",
         },
@@ -4966,7 +4967,11 @@ describe("DiscordVoiceManager", () => {
     } as never);
 
     const client = createClientWithMember("u-guest", "Guest", "4321");
-    const manager = createManager({ groupPolicy: "open" }, client, {});
+    const manager = createManager(
+      { groupPolicy: "open", allowFrom: ["discord:u-guest"] },
+      client,
+      {},
+    );
     await processVoiceSegment(manager, "u-guest");
 
     const commandArgs = lastAgentCommandArgs() as
@@ -4989,7 +4994,11 @@ describe("DiscordVoiceManager", () => {
       text: `hello from voice\n\n${"x".repeat(700)}`,
     });
     const client = createClientWithMember("u-debug", "Debug", "0001", "Debug Speaker");
-    const manager = createManager({ groupPolicy: "open" }, client, {});
+    const manager = createManager(
+      { groupPolicy: "open", allowFrom: ["discord:u-debug"] },
+      client,
+      {},
+    );
 
     await processVoiceSegment(manager, "u-debug");
 
@@ -5018,7 +5027,11 @@ describe("DiscordVoiceManager", () => {
     } as never);
 
     const client = createClientWithMember("u-guest", "Guest", "4321");
-    const manager = createManager({ groupPolicy: "open" }, client, {});
+    const manager = createManager(
+      { groupPolicy: "open", allowFrom: ["discord:u-guest"] },
+      client,
+      {},
+    );
     await processVoiceSegment(manager, "u-guest");
 
     expect(lastTtsStreamArgs().channel).toBe("discord");
@@ -5040,6 +5053,7 @@ describe("DiscordVoiceManager", () => {
     const manager = createManager(
       {
         groupPolicy: "open",
+        allowFrom: ["discord:u-guest"],
         guilds: {
           g1: {
             channels: {
@@ -5076,6 +5090,7 @@ describe("DiscordVoiceManager", () => {
     const manager = createManager(
       {
         groupPolicy: "open",
+        allowFrom: ["discord:u-owner"],
         guilds: {
           g1: {
             channels: {


### PR DESCRIPTION
## What Problem This Solves

Resolves a test-fixture regression where six Discord voice end-to-end scenarios stopped exercising their intended post-authorization behavior after #111527 removed `commands.useAccessGroups`. The scenarios used unlisted guest speakers, so production correctly rejected them before STT.

## Why This Change Was Made

Each affected scenario now explicitly lists its synthetic speaker in `allowFrom`. This keeps production authorization strict and restores coverage of the model override, voice output policy, transcript logging, streaming TTS, per-channel prompt, and participant-roster paths.

## User Impact

No runtime behavior changes. The Discord voice regression suite once again covers these six authorized paths.

## Evidence

Node 24.18.0, exact head `8121d3732e3a915c98fc85d4d23f132b05f6bd53`:

- Before: `manager.e2e.test.ts` reported 6 failures and 150 passes; each failure logged `segment unauthorized` before STT.
- After: `node scripts/run-vitest.mjs extensions/discord/src/voice/manager.e2e.test.ts` — 156/156 passed.
- `oxfmt --check extensions/discord/src/voice/manager.e2e.test.ts` — passed.
- `git diff --check` — passed.
- Codex autoreview — clean, no accepted/actionable findings.

Overlap check: #110004 also touches `manager.e2e.test.ts`, but only in the separate PCM-cap capture-lifecycle block around line 6157. This authorization-fixture repair is independent and should merge without semantic overlap.

Follow-up coverage gap: the compact full-Node plan explicitly excludes `*.e2e.test.ts` in `scripts/lib/ci-node-test-plan.mjs:416` and `scripts/lib/ci-node-test-plan.mjs:1364`, which allowed this fixture drift to escape the normal compact plan. This PR deliberately does not change the CI plan; that should be handled separately.
