### PR TITLE
fix: ClawHub plugin installs do not count as installs

### DIFF
--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -12,6 +12,8 @@ type UnknownMock = Mock<(...args: unknown[]) => unknown>;
 type AsyncUnknownMock = Mock<(...args: unknown[]) => Promise<unknown>>;
 type LoadConfigFn = (typeof import("../config/config.js"))["loadConfig"];
 type ParseClawHubPluginSpecFn = (typeof import("../infra/clawhub.js"))["parseClawHubPluginSpec"];
+type ReportClawHubPluginInstallTelemetryFn =
+  (typeof import("../infra/clawhub.js"))["reportClawHubPluginInstallTelemetry"];
 type InstallPluginFromMarketplaceFn =
   (typeof import("../plugins/marketplace.js"))["installPluginFromMarketplace"];
 type InstallPluginFromGitSpecFn =
@@ -112,6 +114,8 @@ export const installPluginFromNpmPackArchive: AsyncUnknownMock = vi.fn();
 export const installPluginFromPath: AsyncUnknownMock = vi.fn();
 export const installPluginFromClawHub: AsyncUnknownMock = vi.fn();
 export const parseClawHubPluginSpec: Mock<ParseClawHubPluginSpecFn> = vi.fn();
+export const reportClawHubPluginInstallTelemetry: Mock<ReportClawHubPluginInstallTelemetryFn> =
+  vi.fn(async () => undefined);
 export const findBundledPluginSourceMock: UnknownMock = vi.fn();
 export const installHooksFromNpmSpec: AsyncUnknownMock = vi.fn();
 export const installHooksFromPath: AsyncUnknownMock = vi.fn();
@@ -703,6 +707,18 @@ vi.mock("../infra/clawhub.js", () => ({
       parseClawHubPluginSpec,
       ...args,
     )) as (typeof import("../infra/clawhub.js"))["parseClawHubPluginSpec"],
+  reportClawHubPluginInstallTelemetry: ((
+    ...args: Parameters<
+      (typeof import("../infra/clawhub.js"))["reportClawHubPluginInstallTelemetry"]
+    >
+  ) =>
+    invokeMock<
+      Parameters<(typeof import("../infra/clawhub.js"))["reportClawHubPluginInstallTelemetry"]>,
+      ReturnType<(typeof import("../infra/clawhub.js"))["reportClawHubPluginInstallTelemetry"]>
+    >(
+      reportClawHubPluginInstallTelemetry,
+      ...args,
+    )) as (typeof import("../infra/clawhub.js"))["reportClawHubPluginInstallTelemetry"],
 }));
 
 const { registerPluginsCli } = await import("./plugins-cli.js");
@@ -758,6 +774,8 @@ export function resetPluginsCliTestState() {
   installPluginFromPath.mockReset();
   installPluginFromClawHub.mockReset();
   parseClawHubPluginSpec.mockReset();
+  reportClawHubPluginInstallTelemetry.mockReset();
+  reportClawHubPluginInstallTelemetry.mockResolvedValue(undefined);
   findBundledPluginSourceMock.mockReset();
   installHooksFromNpmSpec.mockReset();
   installHooksFromPath.mockReset();

--- a/src/cli/plugins-cli.clawhub-install.e2e.test.ts
+++ b/src/cli/plugins-cli.clawhub-install.e2e.test.ts
@@ -1,0 +1,313 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import JSZip from "jszip";
+import { describe, expect, it } from "vitest";
+import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
+
+const PACKAGE_NAME = "@openclaw/telemetry-demo";
+const PACKAGE_VERSION = "1.0.0";
+const PLUGIN_ID = "telemetry-demo";
+const ENCODED_PACKAGE_NAME = encodeURIComponent(PACKAGE_NAME);
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function spawnOpenClaw(
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", "src/entry.ts", ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+async function buildPluginZip(): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file(
+    "package/package.json",
+    JSON.stringify({
+      name: PACKAGE_NAME,
+      version: PACKAGE_VERSION,
+      type: "module",
+      openclaw: { extensions: ["./dist/index.js"] },
+    }),
+  );
+  zip.file(
+    "package/openclaw.plugin.json",
+    JSON.stringify({
+      id: PLUGIN_ID,
+      configSchema: { type: "object", properties: {} },
+    }),
+  );
+  zip.file("package/dist/index.js", "export default function register() {}\n");
+  return await zip.generateAsync({ type: "nodebuffer" });
+}
+
+type TestServerOptions = {
+  artifactSha256?: string;
+  telemetryStatus?: number;
+};
+
+async function startClawHubServer(options: TestServerOptions = {}) {
+  const archive = await buildPluginZip();
+  const artifactSha256 =
+    options.artifactSha256 ?? createHash("sha256").update(archive).digest("hex");
+  const telemetryBodies: unknown[] = [];
+  const requestLog: string[] = [];
+
+  async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    requestLog.push(`${req.method ?? "GET"} ${url.pathname}`);
+    const packagePath = `/api/v1/packages/${ENCODED_PACKAGE_NAME}`;
+
+    if (req.method === "GET" && url.pathname === packagePath) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          package: {
+            name: PACKAGE_NAME,
+            displayName: "Telemetry Demo",
+            family: "code-plugin",
+            runtimeId: PLUGIN_ID,
+            channel: "community",
+            isOfficial: false,
+            latestVersion: PACKAGE_VERSION,
+            tags: { latest: PACKAGE_VERSION },
+            compatibility: {},
+          },
+          owner: { handle: "openclaw" },
+        }),
+      );
+      return;
+    }
+
+    if (
+      req.method === "GET" &&
+      url.pathname === `${packagePath}/versions/${PACKAGE_VERSION}/artifact`
+    ) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          package: {
+            name: PACKAGE_NAME,
+            displayName: "Telemetry Demo",
+            family: "code-plugin",
+          },
+          version: {
+            version: PACKAGE_VERSION,
+            createdAt: 1,
+            changelog: "Initial release",
+            sha256hash: artifactSha256,
+            compatibility: {},
+          },
+        }),
+      );
+      return;
+    }
+
+    if (
+      req.method === "GET" &&
+      url.pathname === `${packagePath}/versions/${PACKAGE_VERSION}/security`
+    ) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          package: {
+            name: PACKAGE_NAME,
+            displayName: "Telemetry Demo",
+            family: "code-plugin",
+          },
+          release: { version: PACKAGE_VERSION },
+          trust: {
+            scanStatus: "clean",
+            moderationState: null,
+            blockedFromDownload: false,
+            reasons: [],
+            pending: false,
+            stale: false,
+          },
+        }),
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === `${packagePath}/download`) {
+      res.writeHead(200, { "Content-Type": "application/zip" });
+      res.end(archive);
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/cli/telemetry/install") {
+      telemetryBodies.push(JSON.parse(await readRequestBody(req)) as unknown);
+      const status = options.telemetryStatus ?? 200;
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(status === 200 ? JSON.stringify({ ok: true }) : JSON.stringify({ error: "down" }));
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("not found");
+  }
+
+  const server = createServer((req, res) => {
+    void handleRequest(req, res).catch((error: unknown) => {
+      res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  return {
+    registry: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    requestLog,
+    telemetryBodies,
+    close: async () => {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+function buildEnv(stateDir: string, registry: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+    OPENCLAW_CLAWHUB_URL: registry,
+    CLAWHUB_TOKEN: "test-token",
+    CLAWHUB_DISABLE_TELEMETRY: "",
+    CLAWDHUB_DISABLE_TELEMETRY: "",
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+  };
+}
+
+async function readPersistedInstallRecord(stateDir: string) {
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  process.env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");
+  try {
+    const records = await loadInstalledPluginIndexInstallRecords();
+    return records[PLUGIN_ID];
+  } finally {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    if (previousConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+    }
+  }
+}
+
+describe("openclaw plugins install ClawHub E2E", () => {
+  it("reports successful installs and repeat updates after persisting the install record", async () => {
+    const testServer = await startClawHubServer();
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-telemetry-e2e-"));
+    try {
+      const env = buildEnv(stateDir, testServer.registry);
+      const first = await spawnOpenClaw(
+        ["plugins", "install", `clawhub:${PACKAGE_NAME}@${PACKAGE_VERSION}`],
+        { cwd: process.cwd(), env },
+      );
+      expect(first.status, first.stderr || first.stdout).toBe(0);
+
+      const record = await readPersistedInstallRecord(stateDir);
+      expect(record).toMatchObject({
+        source: "clawhub",
+        clawhubPackage: PACKAGE_NAME,
+        version: PACKAGE_VERSION,
+      });
+      expect(testServer.telemetryBodies).toEqual([
+        {
+          event: "plugin_install",
+          packageName: PACKAGE_NAME,
+          version: PACKAGE_VERSION,
+        },
+      ]);
+
+      const repeat = await spawnOpenClaw(
+        ["plugins", "install", `clawhub:${PACKAGE_NAME}@${PACKAGE_VERSION}`, "--force"],
+        { cwd: process.cwd(), env },
+      );
+      expect(repeat.status, repeat.stderr || repeat.stdout).toBe(0);
+      expect(testServer.telemetryBodies).toHaveLength(2);
+      expect(testServer.telemetryBodies[1]).toEqual(testServer.telemetryBodies[0]);
+    } finally {
+      await testServer.close();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it("does not report success when plugin installation fails", async () => {
+    const testServer = await startClawHubServer({ artifactSha256: "0".repeat(64) });
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-telemetry-fail-"));
+    try {
+      const result = await spawnOpenClaw(
+        ["plugins", "install", `clawhub:${PACKAGE_NAME}@${PACKAGE_VERSION}`],
+        { cwd: process.cwd(), env: buildEnv(stateDir, testServer.registry) },
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(testServer.telemetryBodies).toEqual([]);
+      await expect(readPersistedInstallRecord(stateDir)).resolves.toBeUndefined();
+    } finally {
+      await testServer.close();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("keeps a valid local install successful when telemetry is unavailable", async () => {
+    const testServer = await startClawHubServer({ telemetryStatus: 503 });
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-telemetry-down-"));
+    try {
+      const result = await spawnOpenClaw(
+        ["plugins", "install", `clawhub:${PACKAGE_NAME}@${PACKAGE_VERSION}`],
+        { cwd: process.cwd(), env: buildEnv(stateDir, testServer.registry) },
+      );
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      await expect(readPersistedInstallRecord(stateDir)).resolves.toMatchObject({
+        source: "clawhub",
+        clawhubPackage: PACKAGE_NAME,
+        version: PACKAGE_VERSION,
+      });
+      expect(testServer.telemetryBodies).toHaveLength(1);
+    } finally {
+      await testServer.close();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -31,6 +31,7 @@ import {
   readConfigFileSnapshotForWrite,
   parseClawHubPluginSpec,
   promptYesNo,
+  reportClawHubPluginInstallTelemetry,
   recordHookInstall,
   recordPluginInstall,
   resetPluginsCliTestState,
@@ -1661,7 +1662,37 @@ describe("plugins cli install", () => {
     expect(readConfigFileSnapshotForWrite).toHaveBeenCalledTimes(2);
     expect(writeConfigFile).toHaveBeenCalledWith(enabledCfg);
     expect(runtimeLogsContain("Installed plugin: demo")).toBe(true);
+    expect(reportClawHubPluginInstallTelemetry).toHaveBeenCalledWith({
+      baseUrl: "https://clawhub.ai",
+      packageName: "demo",
+      version: "1.2.3",
+    });
     expect(installPluginFromNpmSpec).not.toHaveBeenCalled();
+  });
+
+  it("does not report a ClawHub install when durable persistence fails", async () => {
+    loadConfig.mockReturnValue(createEmptyPluginConfig());
+    parseClawHubPluginSpec.mockReturnValue({ name: "demo" });
+    installPluginFromClawHub.mockResolvedValue(
+      createClawHubInstallResult({
+        pluginId: "demo",
+        packageName: "demo",
+        version: "1.2.3",
+        channel: "official",
+      }),
+    );
+    enablePluginInConfig.mockReturnValue({ config: createEnabledPluginConfig("demo") });
+    applyExclusiveSlotSelection.mockReturnValue({
+      config: createEnabledPluginConfig("demo"),
+      warnings: [],
+    });
+    writeConfigFile.mockRejectedValueOnce(new Error("persistence failed"));
+
+    await expect(runPluginsCommand(["plugins", "install", "clawhub:demo"])).rejects.toThrow(
+      "persistence failed",
+    );
+
+    expect(reportClawHubPluginInstallTelemetry).not.toHaveBeenCalled();
   });
 
   it("passes ClawHub risk acknowledgement to explicit ClawHub installs", async () => {

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -13,7 +13,7 @@ import {
   type InstallHooksResult,
 } from "../hooks/install.js";
 import { resolveArchiveKind } from "../infra/archive.js";
-import { parseClawHubPluginSpec } from "../infra/clawhub.js";
+import { parseClawHubPluginSpec, reportClawHubPluginInstallTelemetry } from "../infra/clawhub.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { installBundledPluginSource } from "../plugins/bundled-install.js";
 import { findBundledPluginSource } from "../plugins/bundled-sources.js";
@@ -1274,6 +1274,11 @@ async function runPluginInstallCommandUnlocked(params: RunPluginInstallCommandPa
           version: result.clawhub.version,
         });
       }
+      await reportClawHubPluginInstallTelemetry({
+        baseUrl: result.clawhub.clawhubUrl,
+        packageName: result.clawhub.clawhubPackage,
+        version: result.clawhub.version,
+      }).catch(() => undefined);
     };
     if (params.clawManaged) {
       return await installFromClawHub();

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -22,6 +22,7 @@ import {
   normalizeClawHubSha256Integrity,
   normalizeClawHubSha256Hex,
   parseClawHubPluginSpec,
+  reportClawHubPluginInstallTelemetry,
   reportClawHubSkillInstallTelemetry,
   resolveLatestVersionFromPackage,
   satisfiesGatewayMinimum,
@@ -427,6 +428,43 @@ describe("clawhub helpers", () => {
     await reportClawHubSkillInstallTelemetry({
       token: "token-123",
       slug: "calendar",
+      fetchImpl,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("sends canonical plugin install telemetry", async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      if (typeof init?.body !== "string") {
+        throw new Error("Expected JSON request body");
+      }
+      requestBody = JSON.parse(init.body) as unknown;
+      return new Response(null, { status: 200 });
+    });
+
+    await reportClawHubPluginInstallTelemetry({
+      token: "token-123",
+      packageName: "@openclaw/voice-call",
+      version: "2026.7.23",
+      fetchImpl,
+    });
+
+    expect(requestBody).toEqual({
+      event: "plugin_install",
+      packageName: "@openclaw/voice-call",
+      version: "2026.7.23",
+    });
+  });
+
+  it("applies the install telemetry opt-out to plugin reports", async () => {
+    process.env.CLAWHUB_DISABLE_TELEMETRY = "true";
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await reportClawHubPluginInstallTelemetry({
+      token: "token-123",
+      packageName: "@openclaw/voice-call",
       fetchImpl,
     });
 

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -1631,6 +1631,41 @@ export async function reportClawHubSkillInstallTelemetry(params: {
   }
 }
 
+export async function reportClawHubPluginInstallTelemetry(params: {
+  baseUrl?: string;
+  token?: string;
+  packageName: string;
+  version?: string | null;
+  timeoutMs?: number;
+  fetchImpl?: FetchLike;
+}): Promise<void> {
+  const token = normalizeOptionalString(params.token) ?? (await resolveClawHubAuthToken());
+  if (!token || isClawHubTelemetryDisabled()) {
+    return;
+  }
+  const packageName = normalizeOptionalString(params.packageName);
+  if (!packageName) {
+    return;
+  }
+
+  const { response, url, hasToken } = await clawhubRequest({
+    baseUrl: params.baseUrl,
+    path: "/api/cli/telemetry/install",
+    method: "POST",
+    token,
+    timeoutMs: params.timeoutMs,
+    fetchImpl: params.fetchImpl,
+    json: {
+      event: "plugin_install",
+      packageName,
+      version: params.version ?? undefined,
+    },
+  });
+  if (!response.ok) {
+    throw await buildClawHubError(response, url, hasToken, params.timeoutMs);
+  }
+}
+
 function isClawHubTelemetryDisabled(): boolean {
   const raw =
     normalizeOptionalString(process.env.CLAWHUB_DISABLE_TELEMETRY) ??


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users completing `openclaw plugins install clawhub:<package>` would only produce ClawHub download telemetry, so the successful plugin installation was absent from package install counts.

## Why This Change Was Made

After the plugin archive is installed and OpenClaw has persisted its durable install record, the CLI sends authenticated best-effort `plugin_install` telemetry with the canonical ClawHub package name and installed version. Failed installs do not report success, telemetry opt-out is preserved, and telemetry failures cannot turn a valid local install into a failure.

Merged backend contract: https://github.com/openclaw/clawhub/pull/3242

## User Impact

Successful authenticated ClawHub plugin installs can now be counted accurately. Reinstalls and updates report again so ClawHub can refresh the recorded version, while backend user/package dedupe prevents count inflation.

## Evidence

- `pnpm exec vitest run src/infra/clawhub.test.ts src/cli/plugins-cli.install.test.ts` (264 passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/cli/plugins-cli.clawhub-install.e2e.test.ts` (3 passed, real CLI subprocess installs against a test HTTP server)
- Changed-file formatting and type-aware oxlint passed locally.
- `$autoreview` completed clean with no accepted/actionable findings.
- Rebased onto current `main` at `913a6a83c54`; the exact rebased candidate passed the focused unit and E2E commands above.
