### PR TITLE
fix(system-agent): avoid TUI startup catalog preparation

### DIFF
--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -8,10 +8,6 @@ import type { SystemAgentOverview } from "./overview.js";
 import { createSystemAgentVerifiedInferenceTestFixture } from "./system-agent.test-helpers.js";
 import { runSystemAgentTui, type SystemAgentTuiOptions } from "./tui-backend.js";
 
-vi.mock("../agents/prepared-model-catalog.js", () => ({
-  loadPreparedModelCatalog: vi.fn(async () => []),
-}));
-
 vi.mock("../plugins/providers.js", () => ({
   resolveOwningPluginIdsForModelRefs: vi.fn(() => []),
   resolveOwningPluginIdsForProviderRef: vi.fn(() => []),
@@ -20,6 +16,7 @@ vi.mock("../plugins/providers.js", () => ({
 vi.mock("../agents/prepared-model-catalog.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../agents/prepared-model-catalog.js")>()),
   // These tests exercise the TUI boundary, not filesystem-backed catalog discovery.
+  getPreparedModelCatalogSnapshot: vi.fn(() => undefined),
   loadPreparedModelCatalog: vi.fn(async () => []),
 }));
 

--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -1,5 +1,6 @@
 // OpenClaw TUI backend tests cover rescue status integration with the TUI backend.
 import { describe, expect, it, vi } from "vitest";
+import * as preparedModelCatalog from "../agents/prepared-model-catalog.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
@@ -156,6 +157,39 @@ describe("runSystemAgentTui", () => {
       throw new Error("expected openclaw TUI backend");
     }
   }, 240_000);
+
+  it("opens the verified setup shell without preparing an unpublished model catalog", async () => {
+    const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
+    const catalogPreparation = vi.mocked(preparedModelCatalog.loadPreparedModelCatalog);
+    const publishedSnapshot = vi
+      .spyOn(preparedModelCatalog, "getPreparedModelCatalogSnapshot")
+      .mockReturnValue(undefined);
+    const runTui = vi.fn(async () => ({ exitReason: "exit" as const }));
+
+    catalogPreparation.mockClear();
+    catalogPreparation.mockRejectedValueOnce(new Error("catalog preparation must not block setup"));
+
+    try {
+      await runSystemAgentTui({ ...verified, runTui }, createRuntime());
+
+      expect(publishedSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({ config: verifiedConfig, readOnly: true }),
+      );
+      expect(catalogPreparation).not.toHaveBeenCalled();
+      expect(runTui).toHaveBeenCalledOnce();
+      expect(runTui).toHaveBeenCalledWith(
+        expect.objectContaining({
+          local: true,
+          session: "agent:openclaw:main",
+          title: "openclaw setup",
+        }),
+      );
+    } finally {
+      publishedSnapshot.mockRestore();
+      catalogPreparation.mockReset();
+      catalogPreparation.mockResolvedValue([]);
+    }
+  });
 
   it("reports the verified model without its auth profile and the effective thinking level", async () => {
     const config = {

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -503,18 +503,18 @@ async function requireTuiVerifiedInference(
   try {
     const route = await resolveSystemAgentVerifiedInferenceRoute(binding, opts.deps);
     if (route) {
-      const [{ loadPreparedModelCatalog }, { resolveThinkingDefault }] = await Promise.all([
+      const [{ getPreparedModelCatalogSnapshot }, { resolveThinkingDefault }] = await Promise.all([
         import("../agents/prepared-model-catalog.js"),
         import("../agents/model-thinking-default.js"),
       ]);
       // Catalog metadata improves the label but must not become a new startup
       // dependency after this exact inference route has already been verified.
-      const catalog = await loadPreparedModelCatalog({
+      const catalog = getPreparedModelCatalogSnapshot({
         config: route.runConfig,
         agentId: route.agentId,
         agentDir: route.agentDir,
         readOnly: true,
-      }).catch(() => undefined);
+      })?.entries;
       const model = splitModelRef(route.modelLabel);
       return {
         model: model.model,


### PR DESCRIPTION
## What Problem This Solves

PR https://github.com/openclaw/openclaw/pull/108287 is blocked by a recurring `checks-node-compact-large-5` timeout in `src/system-agent/tui-backend.test.ts` at `runs OpenClaw inside the shared TUI shell`. The failure repeats after the unrelated release-maintainer regression was removed from main, so this is now the active upstream blocker for GitLab work item https://gitlab.com/xrow-public/helm-openclaw/-/work_items/47.

The TUI route has already been verified before `requireTuiVerifiedInference` runs. Loading the prepared model catalog again during TUI startup can add filesystem-backed catalog discovery work to this hot path. The startup path only needs catalog metadata for thinking-default resolution, so this changes it to read the existing prepared catalog snapshot instead of loading/preparing the catalog again.

## Evidence

- Failure inspected: https://github.com/openclaw/openclaw/actions/runs/30012122947/job/89222800187
- Failing check: `checks-node-compact-large-5`
- Failing test: `src/system-agent/tui-backend.test.ts > runSystemAgentTui > runs OpenClaw inside the shared TUI shell` timed out after 120000ms.
- Local static validation passed: `git diff --check upstream/main...HEAD`.

I could not run the focused Vitest test locally because this isolated workspace volume is full and package installation hit `ERR_PNPM_ENOSPC`; CI should provide the meaningful validation for this branch.

Related blocker: https://gitlab.com/xrow-public/helm-openclaw/-/work_items/47
