### PR TITLE
fix(discord): announce visible text when subagent/ingress fails

### DIFF
--- a/extensions/discord/src/failure-announce.ts
+++ b/extensions/discord/src/failure-announce.ts
@@ -1,0 +1,171 @@
+// Discord plugin module sends concise user-visible failure notes.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createReusableDiscordReplyReference } from "./reply-reference.js";
+import { sendMessageDiscord } from "./send.js";
+
+const ANNOUNCED_FAILURE_TTL_MS = 60 * 60_000;
+const MAX_ANNOUNCED_FAILURES = 4_096;
+
+const announcedFailures = new Map<string, number>();
+
+type DiscordFailureLogger = {
+  debug?: (message: string) => void;
+};
+
+type DiscordFailureOutcome = "error" | "timeout" | "killed" | "unknown";
+
+function pruneAnnouncedFailures(now: number) {
+  for (const [key, expiresAt] of announcedFailures) {
+    if (expiresAt > now) {
+      continue;
+    }
+    announcedFailures.delete(key);
+  }
+  while (announcedFailures.size >= MAX_ANNOUNCED_FAILURES) {
+    const oldest = announcedFailures.keys().next().value;
+    if (!oldest) {
+      break;
+    }
+    announcedFailures.delete(oldest);
+  }
+}
+
+function markAnnounced(key: string): boolean {
+  const now = Date.now();
+  pruneAnnouncedFailures(now);
+  if (announcedFailures.has(key)) {
+    return false;
+  }
+  announcedFailures.set(key, now + ANNOUNCED_FAILURE_TTL_MS);
+  return true;
+}
+
+function normalizeFailureOutcome(outcome: string): DiscordFailureOutcome {
+  return outcome === "timeout" || outcome === "killed" || outcome === "unknown"
+    ? outcome
+    : "error";
+}
+
+function formatFailureNextStep(outcome: DiscordFailureOutcome): string {
+  if (outcome === "timeout") {
+    return "Gateway was busy -- try again in a minute.";
+  }
+  return "Please retry the request.";
+}
+
+function logAnnounceFailure(
+  logger: DiscordFailureLogger | undefined,
+  action: string,
+  error: unknown,
+) {
+  const message = error instanceof Error ? error.message : String(error);
+  logger?.debug?.(`discord failure announce ${action} failed: ${message}`);
+}
+
+async function sendDedupedDiscordFailureNote(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+  channelId: string;
+  messageId: string;
+  dedupeKey: string;
+  text: string;
+  logger?: DiscordFailureLogger;
+}) {
+  const channelId = params.channelId.trim();
+  const messageId = params.messageId.trim();
+  if (!channelId || !messageId || !markAnnounced(params.dedupeKey)) {
+    return false;
+  }
+  try {
+    await sendMessageDiscord(`channel:${channelId}`, params.text, {
+      cfg: params.cfg,
+      accountId: params.accountId,
+      reply: createReusableDiscordReplyReference(messageId),
+    });
+    return true;
+  } catch (error) {
+    logAnnounceFailure(params.logger, "send", error);
+    return false;
+  }
+}
+
+export function formatDiscordSubagentFailureText(params: {
+  outcome: string;
+  agentId?: string;
+  runId?: string;
+}) {
+  const outcome = normalizeFailureOutcome(params.outcome);
+  const agentId = params.agentId?.trim();
+  const runId = params.runId?.trim();
+  const workerLabel = agentId
+    ? `Sub-agent worker ${agentId}`
+    : runId
+      ? `A sub-agent worker (${runId})`
+      : "A sub-agent worker";
+  return [`${workerLabel} failed.`, `Outcome: ${outcome}.`, formatFailureNextStep(outcome)].join(
+    "\n",
+  );
+}
+
+export async function sendDiscordSubagentFailureAnnounce(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+  channelId: string;
+  messageId: string;
+  runId: string;
+  outcome: string;
+  agentId?: string;
+  logger?: DiscordFailureLogger;
+}) {
+  const outcome = normalizeFailureOutcome(params.outcome);
+  return await sendDedupedDiscordFailureNote({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    channelId: params.channelId,
+    messageId: params.messageId,
+    dedupeKey: [
+      "subagent",
+      params.accountId ?? "",
+      params.channelId,
+      params.messageId,
+      params.runId,
+    ].join(":"),
+    text: formatDiscordSubagentFailureText({
+      outcome,
+      agentId: params.agentId,
+      runId: params.runId,
+    }),
+    logger: params.logger,
+  });
+}
+
+export function formatDiscordHandlerTimeoutFailureText() {
+  return [
+    "Discord gateway was busy and timed out before handling this message.",
+    "Please retry the request in a minute.",
+  ].join("\n");
+}
+
+export async function sendDiscordHandlerTimeoutFailureAnnounce(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+  channelId: string;
+  messageId: string;
+  logger?: DiscordFailureLogger;
+}) {
+  return await sendDedupedDiscordFailureNote({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    channelId: params.channelId,
+    messageId: params.messageId,
+    dedupeKey: ["handler-timeout", params.accountId ?? "", params.channelId, params.messageId].join(
+      ":",
+    ),
+    text: formatDiscordHandlerTimeoutFailureText(),
+    logger: params.logger,
+  });
+}
+
+export function resetDiscordFailureAnnounceForTest() {
+  announcedFailures.clear();
+}

--- a/extensions/discord/src/monitor/ingress.test.ts
+++ b/extensions/discord/src/monitor/ingress.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { APIMessage } from "discord-api-types/v10";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -12,10 +13,28 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDiscordIngressMonitor, type DiscordIngressLifecycle } from "./ingress.js";
 
+const sendMessageDiscordMock = vi.hoisted(() =>
+  vi.fn(async (_to: string, _text: string, _opts: unknown) => ({
+    ok: true,
+    messageId: "timeout-note",
+    channelId: "channel-1",
+  })),
+);
+
+vi.mock("../send.js", () => ({ sendMessageDiscord: sendMessageDiscordMock }));
+
 type DiscordIngressPayload = {
   version: 1;
   receivedAt: number;
   rawMessage: APIMessage;
+};
+
+const TEST_CFG: OpenClawConfig = {
+  channels: {
+    discord: {
+      token: "test-token",
+    },
+  },
 };
 
 function createRawMessage(id: string, channelId = "channel-1"): APIMessage {
@@ -86,6 +105,8 @@ async function stopAll(monitors: DiscordIngressMonitor[]): Promise<void> {
 describe("Discord durable ingress", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
+    sendMessageDiscordMock.mockReset();
+    vi.useRealTimers();
   });
 
   it("does not normalize or dispatch before the durable append completes", async () => {
@@ -249,6 +270,46 @@ describe("Discord durable ingress", () => {
           const verdict = await queue.enqueue("1005", payloadFor(rawMessage));
           expect(verdict.kind).toBe("failed");
         });
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("sends a visible reply when handler adoption times out", async () => {
+    vi.useFakeTimers();
+    sendMessageDiscordMock.mockResolvedValue({
+      ok: true,
+      messageId: "timeout-note",
+      channelId: "channel-timeout",
+    });
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async () => ({ kind: "deferred" as const }));
+      const monitor = createDiscordIngressMonitor({
+        accountId: "default",
+        client: {} as never,
+        cfg: TEST_CFG,
+        runtime: runtime(),
+        queue,
+        dispatch,
+      });
+      monitor.start();
+      try {
+        await monitor.accept(createRawMessage("timeout-1", "channel-timeout"));
+        await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+        await vi.waitFor(() => expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1));
+        expect(sendMessageDiscordMock).toHaveBeenCalledWith(
+          "channel:channel-timeout",
+          "Discord gateway was busy and timed out before handling this message.\nPlease retry the request in a minute.",
+          expect.objectContaining({
+            cfg: TEST_CFG,
+            accountId: "default",
+            reply: { messageId: "timeout-1", scope: "all" },
+          }),
+        );
       } finally {
         await monitor.stop();
       }

--- a/extensions/discord/src/monitor/ingress.ts
+++ b/extensions/discord/src/monitor/ingress.ts
@@ -1,5 +1,6 @@
 // Discord plugin module owns raw gateway-message durable ingress and replay draining.
 import { GatewayDispatchEvents, type APIMessage } from "discord-api-types/v10";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   createChannelIngressMonitor,
   type ChannelIngressQueue,
@@ -9,6 +10,7 @@ import {
 import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { Client } from "../internal/discord.js";
 import { mapGatewayDispatchData } from "../internal/gateway-dispatch.js";
+import { sendDiscordHandlerTimeoutFailureAnnounce } from "../failure-announce.js";
 import { getDiscordRuntime } from "../runtime.js";
 import type { DiscordMessageEvent } from "./listeners.js";
 
@@ -114,6 +116,7 @@ function isDiscordAuthenticationFailure(error: unknown): boolean {
 export function createDiscordIngressMonitor(params: {
   accountId: string;
   client: Client;
+  cfg?: OpenClawConfig;
   runtime: Pick<RuntimeEnv, "error" | "log">;
   dispatch: DiscordIngressDispatch;
   queue?: ChannelIngressQueue<DiscordIngressPayload>;
@@ -173,6 +176,21 @@ export function createDiscordIngressMonitor(params: {
         return null;
       },
       onLog: (message) => params.runtime.error?.(danger(`discord ingress: ${message}`)),
+      onHandlerTimeout: async (claim) => {
+        const rawMessage = claim.payload.rawMessage;
+        if (!params.cfg || !rawMessage.channel_id || !rawMessage.id) {
+          return;
+        }
+        await sendDiscordHandlerTimeoutFailureAnnounce({
+          cfg: params.cfg,
+          accountId: params.accountId,
+          channelId: rawMessage.channel_id,
+          messageId: rawMessage.id,
+          logger: {
+            debug: (message) => params.runtime.log?.(message),
+          },
+        });
+      },
     },
     onError: (error) =>
       params.runtime.error?.(danger(`discord ingress drain failed: ${errorText(error)}`)),

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -18,6 +18,7 @@ export function createDiscordMessageHandler(
   const ingress = createIngressMonitor({
     accountId: params.accountId,
     client: params.client,
+    cfg: params.cfg,
     runtime: params.runtime,
     dispatch: (event, lifecycle) =>
       dispatcher(event, params.client, {

--- a/extensions/discord/src/subagent-progress.test.ts
+++ b/extensions/discord/src/subagent-progress.test.ts
@@ -5,8 +5,14 @@ import {
   handleDiscordSubagentProgress,
   recoverDiscordSubagentProgress,
 } from "./subagent-progress.js";
+import { resetDiscordFailureAnnounceForTest } from "./failure-announce.js";
 
 const sendMocks = vi.hoisted(() => ({
+  message: vi.fn(async (_to: string, _text: string, _opts: unknown) => ({
+    ok: true,
+    messageId: "failure-note",
+    channelId: "123",
+  })),
   react: vi.fn(async (_channelId: string, _messageId: string, _emoji: string, _opts: unknown) => ({
     ok: true,
   })),
@@ -26,6 +32,7 @@ vi.mock("./send.reactions.js", () => ({
   removeReactionDiscord: sendMocks.remove,
 }));
 vi.mock("./send.typing.js", () => ({ sendTypingDiscord: sendMocks.typing }));
+vi.mock("./send.js", () => ({ sendMessageDiscord: sendMocks.message }));
 
 type StoredProgressRunBase = {
   key: string;
@@ -117,10 +124,14 @@ describe("Discord subagent progress", () => {
     sendMocks.react.mockReset().mockResolvedValue({ ok: true });
     sendMocks.remove.mockReset().mockResolvedValue({ ok: true });
     sendMocks.typing.mockReset().mockResolvedValue({ ok: true, channelId: "123" });
+    sendMocks.message
+      .mockReset()
+      .mockResolvedValue({ ok: true, messageId: "failure-note", channelId: "123" });
   });
 
   afterEach(() => {
     resetDiscordSubagentProgressForTest();
+    resetDiscordFailureAnnounceForTest();
     vi.useRealTimers();
   });
 
@@ -165,10 +176,43 @@ describe("Discord subagent progress", () => {
       phase: "ended",
       runId: "run-error",
       outcome: "error",
+      agentId: "worker-1",
     });
 
     expect(sendMocks.remove).toHaveBeenCalledWith("123", "456", "1️⃣", expect.any(Object));
     expect(sendMocks.react).toHaveBeenLastCalledWith("123", "456", "🔴", expect.any(Object));
+    expect(sendMocks.message).toHaveBeenCalledWith(
+      "channel:123",
+      "Sub-agent worker worker-1 failed.\nOutcome: error.\nPlease retry the request.",
+      expect.objectContaining({
+        cfg: api.config,
+        accountId: "default",
+        reply: { messageId: "456", scope: "all" },
+      }),
+    );
+    const failureReactionCall = sendMocks.react.mock.calls.findIndex((call) => call[2] === "🔴");
+    expect(sendMocks.message.mock.invocationCallOrder[0]).toBeGreaterThan(
+      sendMocks.react.mock.invocationCallOrder[failureReactionCall] ?? 0,
+    );
+  });
+
+  it("deduplicates subagent failure notes for the same source message and run", async () => {
+    await handleDiscordSubagentProgress(api, started("run-dedupe"));
+    await handleDiscordSubagentProgress(api, {
+      phase: "ended",
+      runId: "run-dedupe",
+      outcome: "timeout",
+    });
+    await handleDiscordSubagentProgress(api, {
+      phase: "ended",
+      runId: "run-dedupe",
+      outcome: "timeout",
+    });
+
+    expect(sendMocks.message).toHaveBeenCalledTimes(1);
+    expect(sendMocks.message.mock.calls[0]?.[1]).toContain(
+      "Gateway was busy -- try again in a minute.",
+    );
   });
 
   it("clears a count reaction whose successful add response was lost", async () => {

--- a/extensions/discord/src/subagent-progress.ts
+++ b/extensions/discord/src/subagent-progress.ts
@@ -1,5 +1,6 @@
 // Discord plugin module maps portable subagent progress onto source-message feedback.
 import { resolveDiscordAccount } from "./accounts.js";
+import { sendDiscordSubagentFailureAnnounce } from "./failure-announce.js";
 import { reactMessageDiscord, removeReactionDiscord } from "./send.reactions.js";
 import { sendTypingDiscord } from "./send.typing.js";
 import {
@@ -44,12 +45,16 @@ type SubagentProgressEvent =
   | {
       phase: "started";
       runId: string;
+      agentId?: string;
+      childSessionKey?: string;
       requester?: DiscordProgressRequester;
     }
   | {
       phase: "ended";
       runId: string;
       outcome: SubagentProgressOutcome;
+      agentId?: string;
+      childSessionKey?: string;
       requester?: Extract<SubagentProgressEvent, { phase: "started" }>["requester"];
     };
 
@@ -73,7 +78,7 @@ const terminalRetryAttempts = new Map<string, number>();
 const startupRecoveryRetries = new Map<ProgressApi, StartupRecovery>();
 
 function isSubagentProgressEnabled(account: ReturnType<typeof resolveDiscordAccount>): boolean {
-  return Boolean(process.env.VITEST) && account.enabled && account.config.subagentProgress === true;
+  return account.enabled && account.config.subagentProgress === true;
 }
 
 function clearTerminalRetry(runId: string) {
@@ -220,6 +225,38 @@ async function sendTyping(api: ProgressApi, tracker: ProgressTracker) {
   }
 }
 
+function resolveFailureAgentId(event?: Partial<SubagentProgressEvent>): string | undefined {
+  const explicit = event?.agentId?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const childSessionKey = event?.childSessionKey?.trim();
+  const match = childSessionKey?.match(/^agent:([^:]+)/);
+  return match?.[1];
+}
+
+async function announceSubagentFailure(
+  api: ProgressApi,
+  tracker: ProgressTracker,
+  runId: string,
+  outcome: SubagentProgressOutcome,
+  event?: Partial<SubagentProgressEvent>,
+) {
+  if (outcome === "ok") {
+    return;
+  }
+  await sendDiscordSubagentFailureAnnounce({
+    cfg: api.config,
+    accountId: tracker.accountId,
+    channelId: tracker.channelId,
+    messageId: tracker.messageId,
+    runId,
+    outcome,
+    agentId: resolveFailureAgentId(event),
+    logger: api.logger,
+  });
+}
+
 function startTyping(api: ProgressApi, tracker: ProgressTracker) {
   tracker.typingExpiresAt = Date.now() + TYPING_TTL_MS;
   void sendTyping(api, tracker);
@@ -312,6 +349,11 @@ async function handleStarted(
           !reactionsEnabled ||
           (countsCleared && (await setReaction(api, tracker, FAILURE_EMOJI)));
         if (countsCleared && failurePresented) {
+          await Promise.all(
+            failedCleanupRuns.map((cleanup) =>
+              announceSubagentFailure(api, tracker, cleanup.runId, cleanup.value.outcome),
+            ),
+          );
           for (const cleanup of restored.cleanupRuns) {
             markRunTerminal(cleanup.runId, cleanup.value.outcome);
           }
@@ -386,6 +428,7 @@ async function handleStarted(
         !tracker.reactionsEnabled ||
         (await setReaction(api, tracker, FAILURE_EMOJI));
       if (failurePresented) {
+        await announceSubagentFailure(api, tracker, runId, endedOutcome, event);
         await consumeProgressRun(api, runId);
       } else {
         scheduleTerminalLookupRetry(
@@ -412,9 +455,10 @@ async function handleStarted(
 async function reconcilePersistedTracker(
   api: ProgressApi,
   persisted: PersistedProgressRun,
-  outcome: Extract<SubagentProgressEvent, { phase: "ended" }>["outcome"],
-  endingRunId: string,
+  event: Extract<SubagentProgressEvent, { phase: "ended" }>,
 ): Promise<PersistedReconciliationResult> {
+  const endingRunId = event.runId.trim();
+  const outcome = event.outcome;
   const store = getProgressStore(api);
   let activeRunIds: string[] = [];
   if (store) {
@@ -470,6 +514,7 @@ async function reconcilePersistedTracker(
   if (!reactionsCleared || !countPresented || !outcomePresented) {
     return { ok: false };
   }
+  await announceSubagentFailure(api, tracker, endingRunId, outcome, event);
   return {
     ok: true,
     activeRunIds,
@@ -579,7 +624,7 @@ async function handleEnded(
     }
     if (!tracker) {
       const reconciliation = owned
-        ? await reconcilePersistedTracker(api, owned, outcome, runId)
+        ? await reconcilePersistedTracker(api, owned, retryEvent)
         : { ok: false as const };
       if (reconciliation.ok && owned) {
         const consumed = await consumeProgressRun(api, runId);
@@ -616,13 +661,16 @@ async function handleEnded(
     const countReconciled = tracker.reactionsEnabled
       ? await updateRunningReaction(api, tracker)
       : owned
-        ? (await reconcilePersistedTracker(api, owned, outcome, runId)).ok
+        ? (await reconcilePersistedTracker(api, owned, retryEvent)).ok
         : true;
     const outcomePresented =
       outcome === "ok" ||
       !tracker.reactionsEnabled ||
       (countReconciled && (await setReaction(api, tracker, FAILURE_EMOJI)));
     const reconciled = countReconciled && outcomePresented;
+    if (reconciled) {
+      await announceSubagentFailure(api, tracker, runId, outcome, retryEvent);
+    }
     if (reconciled && owned) {
       const consumed = await consumeProgressRun(api, runId);
       if (!consumed) {

--- a/src/agents/spawn-pipeline.ts
+++ b/src/agents/spawn-pipeline.ts
@@ -82,6 +82,7 @@ export async function runSpawnPipeline<TState>(params: {
           phase: "started",
           runId,
           childSessionKey: registration.childSessionKey,
+          agentId: registration.agentId,
           requester: params.progressOrigin,
         },
         {

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -167,6 +167,7 @@ export async function emitSubagentProgressEndedHook(entry: SubagentRunRecord): P
         phase: "ended",
         runId: entry.runId,
         childSessionKey: entry.childSessionKey,
+        agentId: entry.agentId,
         outcome,
         requester: entry.progressOrigin,
       },

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1678,6 +1678,7 @@ export async function spawnSubagentDirect(
               phase: "started",
               runId: hookRunId,
               childSessionKey,
+              agentId: targetAgentId,
               requester: progressOrigin,
             },
             {

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -327,10 +327,12 @@ describe("channel ingress drain", () => {
       });
       await queue.enqueue("evt-stall", { text: "x" }, { laneKey: "l1" });
 
+      const onHandlerTimeout = vi.fn();
       const drain = createChannelIngressDrain<Payload>({
         queue,
         now: () => clock,
         adoptionStallTimeoutMs: 5_000,
+        onHandlerTimeout,
         dispatchClaimedEvent: async () => {
           // Never adopt, never return — stall until watchdog.
           await new Promise(() => {});
@@ -348,6 +350,10 @@ describe("channel ingress drain", () => {
       if (reenqueue.kind === "failed") {
         expect(reenqueue.record.reason).toBe("handler-timeout");
       }
+      expect(onHandlerTimeout).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "evt-stall", payload: { text: "x" } }),
+        expect.objectContaining({ ageMs: 5_000, laneKey: "l1" }),
+      );
       drain.dispose();
     });
   });

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -117,6 +117,10 @@ export type CreateChannelIngressDrainOptions<
   now?: () => number;
   formatError?: (err: unknown) => string;
   onLog?: (message: string) => void;
+  onHandlerTimeout?: (
+    claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
+    details: { message: string; ageMs: number; laneKey: string },
+  ) => Promise<void> | void;
   abortSignal?: AbortSignal;
   orderBy?: "received" | "id";
   scanLimit?: number;
@@ -477,6 +481,17 @@ export function createChannelIngressDrain<
       } catch {
         // AbortController.abort is not fallible in practice.
       }
+      void Promise.resolve(
+        options.onHandlerTimeout?.(state.claim, {
+          message,
+          ageMs,
+          laneKey: state.laneKey,
+        }),
+      ).catch((error: unknown) => {
+        log(
+          `ingress drain: handler-timeout callback failed for event ${displayId}: ${formatError(error)}`,
+        );
+      });
       // Same bounded-retry/hold-ownership policy as tombstone: a fail write
       // error must not falsely settle (would stop heartbeat and wedge recovery).
       void state

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -861,12 +861,14 @@ export type PluginHookSubagentProgressEvent =
       phase: "started";
       runId: string;
       childSessionKey: string;
+      agentId?: string;
       requester?: PluginHookSubagentRequester;
     }
   | {
       phase: "ended";
       runId: string;
       childSessionKey: string;
+      agentId?: string;
       outcome: "ok" | "error" | "timeout" | "killed" | "unknown";
       requester?: PluginHookSubagentRequester;
     };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord users would only see a 🔴 reaction (and sometimes 👀) when a sub-agent failed or when Discord ingress hit handler-timeout, with no visible text explaining what happened or what to do next — especially when the parent agent turn could not speak.

## Why This Change Was Made

When Discord sets the subagent-failed reaction or dead-letters an ingress event for claim→adoption stall (`handler-timeout`), OpenClaw now also posts a short, deduped reply on the source message. Subagent progress reactions are no longer gated to Vitest-only environments when `channels.discord.subagentProgress` is enabled.

## User Impact

On failure, users get a concise note such as which worker failed / outcome / retry guidance, or that the gateway timed out before handling the message — instead of reaction-only silence.

## Evidence

- Unit coverage in `extensions/discord/src/subagent-progress.test.ts` (deduped failure notes)
- Unit coverage in `extensions/discord/src/monitor/ingress.test.ts` (handler-timeout reply)
- Ingress drain callback wired in `src/channels/message/ingress-drain.ts`