### PR TITLE
refactor(imessage): unify outbound markdown ranges

### DIFF
--- a/extensions/imessage/src/markdown-format.test.ts
+++ b/extensions/imessage/src/markdown-format.test.ts
@@ -1,100 +1,176 @@
 // Imessage tests cover markdown format plugin behavior.
 import { describe, expect, it } from "vitest";
-import { extractMarkdownFormatRuns } from "./markdown-format.js";
+import { extractMarkdownFormatRuns, IMESSAGE_FORMAT_PROFILE } from "./markdown-format.js";
+
+const MIGRATION_GOLDENS = [
+  {
+    name: "CommonMark alternate bold replaces the legacy underline dialect",
+    input: "__x__",
+    before: { text: "x", ranges: [{ start: 0, length: 1, styles: ["underline"] }] },
+    after: { text: "x", ranges: [{ start: 0, length: 1, styles: ["bold"] }] },
+  },
+  {
+    name: "authored HTML u is the underline source",
+    input: "<u>x</u>",
+    before: { text: "<u>x</u>", ranges: [] },
+    after: { text: "x", ranges: [{ start: 0, length: 1, styles: ["underline"] }] },
+  },
+  {
+    name: "authored HTML ins is the underline source",
+    input: "<ins>x</ins>",
+    before: { text: "<ins>x</ins>", ranges: [] },
+    after: { text: "x", ranges: [{ start: 0, length: 1, styles: ["underline"] }] },
+  },
+  {
+    name: "inline code protects markdown-looking content and keeps its backticks",
+    input: "`*x*`",
+    before: { text: "`x`", ranges: [{ start: 1, length: 1, styles: ["italic"] }] },
+    after: { text: "`*x*`", ranges: [] },
+  },
+  {
+    name: "intraword underscore stays literal",
+    input: "snake_case",
+    before: { text: "snake_case", ranges: [] },
+    after: { text: "snake_case", ranges: [] },
+  },
+  {
+    name: "Python dunder identifier stays literal",
+    input: "def __init__(self):",
+    before: { text: "def __init__(self):", ranges: [] },
+    after: { text: "def __init__(self):", ranges: [] },
+  },
+] as const;
 
 describe("extractMarkdownFormatRuns", () => {
-  it("returns the text unchanged when there is no markdown", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("plain text reply");
-    expect(text).toBe("plain text reply");
-    expect(ranges).toStrictEqual([]);
+  it.each(MIGRATION_GOLDENS)("$name: $before -> $after", ({ input, after }) => {
+    expect(extractMarkdownFormatRuns(input)).toEqual(after);
   });
 
-  it("extracts a bold span", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("**bold** text");
-    expect(text).toBe("bold text");
-    expect(ranges).toEqual([{ start: 0, length: 4, styles: ["bold"] }]);
+  it("returns plain text unchanged", () => {
+    expect(extractMarkdownFormatRuns("plain text reply")).toEqual({
+      text: "plain text reply",
+      ranges: [],
+    });
   });
 
-  it("extracts mixed bold and italic", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("**hi** and *there*");
-    expect(text).toBe("hi and there");
-    expect(ranges).toEqual([
-      { start: 0, length: 2, styles: ["bold"] },
-      { start: 7, length: 5, styles: ["italic"] },
-    ]);
+  it("renders mixed, nested, and repeated native styles in UTF-16 coordinates", () => {
+    expect(extractMarkdownFormatRuns("😀 **bold _and italic_** ~~gone~~")).toEqual({
+      text: "😀 bold and italic gone",
+      ranges: [
+        { start: 3, length: 15, styles: ["bold"] },
+        { start: 8, length: 10, styles: ["italic"] },
+        { start: 19, length: 4, styles: ["strikethrough"] },
+      ],
+    });
   });
 
-  it("extracts underline and strikethrough", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("__under__ and ~~strike~~");
-    expect(text).toBe("under and strike");
-    expect(ranges).toEqual([
-      { start: 0, length: 5, styles: ["underline"] },
-      { start: 10, length: 6, styles: ["strikethrough"] },
-    ]);
+  it("keeps literal markers that CommonMark does not treat as emphasis", () => {
+    expect(extractMarkdownFormatRuns("price * quantity and **  **")).toEqual({
+      text: "price * quantity and **  **",
+      ranges: [],
+    });
   });
 
-  it("respects word boundaries on single-underscore italics", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("snake_case_var ok");
-    expect(text).toBe("snake_case_var ok");
-    expect(ranges).toStrictEqual([]);
+  it("preserves CommonMark flanking around protected inline code", () => {
+    expect(extractMarkdownFormatRuns("`code`_italic_ __Important__ (read this)")).toEqual({
+      text: "`code`italic Important (read this)",
+      ranges: [
+        { start: 6, length: 6, styles: ["italic"] },
+        { start: 13, length: 9, styles: ["bold"] },
+      ],
+    });
   });
 
-  it("treats single-underscore as italic when surrounded by whitespace", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("a _word_ b");
-    expect(text).toBe("a word b");
-    expect(ranges).toEqual([{ start: 2, length: 4, styles: ["italic"] }]);
+  it("restores inline code containing bare carriage returns without leaking masks", () => {
+    expect(extractMarkdownFormatRuns("`*x*\rmore`")).toEqual({
+      text: "`*x* more`",
+      ranges: [],
+    });
   });
 
-  it("does not treat empty marker pairs as formatting", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("**  ** literal");
-    expect(text).toBe("**  ** literal");
-    expect(ranges).toStrictEqual([]);
+  it("preserves multi-backtick inline code delimiters and contents", () => {
+    expect(extractMarkdownFormatRuns("Use ``a`*b*`` here")).toEqual({
+      text: "Use ``a`*b*`` here",
+      ranges: [],
+    });
   });
 
-  it("leaves a lone asterisk alone", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("price * quantity");
-    expect(text).toBe("price * quantity");
-    expect(ranges).toStrictEqual([]);
+  it("separates code content that touches a backtick delimiter", () => {
+    expect(extractMarkdownFormatRuns("`` ` ``")).toEqual({
+      text: "`` ` ``",
+      ranges: [],
+    });
   });
 
-  it("computes ranges in output coordinates, not input", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("a **b** c **d** e");
-    expect(text).toBe("a b c d e");
-    expect(ranges).toEqual([
-      { start: 2, length: 1, styles: ["bold"] },
-      { start: 6, length: 1, styles: ["bold"] },
-    ]);
+  it("does not cross-protect backticks inside indented code blocks", () => {
+    expect(extractMarkdownFormatRuns("    `abc`")).toEqual({
+      text: "`abc`\n",
+      ranges: [],
+    });
   });
 
-  it("parses ***triple-marker*** as bold + italic over the same span", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("***hi***");
-    expect(text).toBe("hi");
-    // Compound marker emits both styles over the same span.
-    expect(ranges).toEqual([
-      { start: 0, length: 2, styles: ["bold"] },
-      { start: 0, length: 2, styles: ["italic"] },
-    ]);
+  it("does not escape dunders inside fenced code blocks", () => {
+    expect(extractMarkdownFormatRuns("```python\nobj.__class__\n```")).toEqual({
+      text: "obj.__class__\n",
+      ranges: [],
+    });
   });
 
-  it("parses **bold _and underline_ together** as nested ranges", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("**bold _and underline_ together**");
-    expect(text).toBe("bold and underline together");
-    // Inner italic-via-_ at offset 5, length 13; outer bold over the full span.
-    expect(ranges).toEqual([
-      { start: 5, length: 13, styles: ["italic"] },
-      { start: 0, length: 27, styles: ["bold"] },
-    ]);
+  it("keeps Python dunder method declarations literal", () => {
+    expect(extractMarkdownFormatRuns("def __str__(self):")).toEqual({
+      text: "def __str__(self):",
+      ranges: [],
+    });
   });
 
-  it("respects word boundaries on double-underscore underline", () => {
-    const { text, ranges } = extractMarkdownFormatRuns("def __init__(self):");
-    expect(text).toBe("def __init__(self):");
-    expect(ranges).toStrictEqual([]);
+  it("keeps standalone lowercase dunder calls literal", () => {
+    expect(extractMarkdownFormatRuns("Call __init__() and __str__(obj)")).toEqual({
+      text: "Call __init__() and __str__(obj)",
+      ranges: [],
+    });
   });
 
-  it("does not leak literal asterisks from triple markers when intent is unclear", () => {
-    // `***bold***` should never produce a bare `*` in the output text.
-    const { text } = extractMarkdownFormatRuns("hello ***world***");
-    expect(text).not.toMatch(/\*/);
+  it("keeps qualified and indexed dunder identifiers literal", () => {
+    expect(extractMarkdownFormatRuns("obj.__class__ print(__name__) __dict__['key']")).toEqual({
+      text: "obj.__class__ print(__name__) __dict__['key']",
+      ranges: [],
+    });
+  });
+
+  it("does not confuse ordinary parenthesized CommonMark bold with an identifier", () => {
+    expect(extractMarkdownFormatRuns("(__warning__)")).toEqual({
+      text: "(warning)",
+      ranges: [{ start: 1, length: 7, styles: ["bold"] }],
+    });
+  });
+
+  it("does not confuse an earlier matching bold span with a protected dunder", () => {
+    expect(extractMarkdownFormatRuns("**init**() then __init__()")).toEqual({
+      text: "init() then __init__()",
+      ranges: [{ start: 0, length: 4, styles: ["bold"] }],
+    });
+  });
+
+  it("searches past unrelated declarations for the matching dunder range", () => {
+    expect(extractMarkdownFormatRuns("def init():\ndef __init__(self):")).toEqual({
+      text: "def init():\ndef __init__(self):",
+      ranges: [],
+    });
+  });
+
+  it("declares the native four-style attributed capability profile", () => {
+    expect(IMESSAGE_FORMAT_PROFILE).toMatchObject({
+      mechanism: "ranges",
+      chunk: { limit: 4_000, unit: "utf16" },
+      constructs: {
+        bold: "native",
+        italic: "native",
+        underline: "native",
+        strikethrough: "native",
+        codeInline: "fallback",
+        linkLabel: "fallback",
+        heading: "fallback",
+      },
+    });
   });
 });

--- a/extensions/imessage/src/markdown-format.test.ts
+++ b/extensions/imessage/src/markdown-format.test.ts
@@ -1,6 +1,6 @@
 // Imessage tests cover markdown format plugin behavior.
 import { describe, expect, it } from "vitest";
-import { extractMarkdownFormatRuns, IMESSAGE_FORMAT_PROFILE } from "./markdown-format.js";
+import { extractMarkdownFormatRuns } from "./markdown-format.js";
 
 const MIGRATION_GOLDENS = [
   {
@@ -155,22 +155,6 @@ describe("extractMarkdownFormatRuns", () => {
     expect(extractMarkdownFormatRuns("def init():\ndef __init__(self):")).toEqual({
       text: "def init():\ndef __init__(self):",
       ranges: [],
-    });
-  });
-
-  it("declares the native four-style attributed capability profile", () => {
-    expect(IMESSAGE_FORMAT_PROFILE).toMatchObject({
-      mechanism: "ranges",
-      chunk: { limit: 4_000, unit: "utf16" },
-      constructs: {
-        bold: "native",
-        italic: "native",
-        underline: "native",
-        strikethrough: "native",
-        codeInline: "fallback",
-        linkLabel: "fallback",
-        heading: "fallback",
-      },
     });
   });
 });

--- a/extensions/imessage/src/markdown-format.ts
+++ b/extensions/imessage/src/markdown-format.ts
@@ -12,7 +12,7 @@ type IMessageFormatRange = {
   styles: IMessageFormatStyle[];
 };
 
-export const IMESSAGE_FORMAT_PROFILE = {
+const IMESSAGE_FORMAT_PROFILE = {
   mechanism: "ranges",
   constructs: {
     bold: "native",

--- a/extensions/imessage/src/markdown-format.ts
+++ b/extensions/imessage/src/markdown-format.ts
@@ -1,33 +1,8 @@
-/**
- * Convert markdown bold/italic/underline/strikethrough markers in agent text
- * into typed-run formatting ranges that the imsg bridge's `sendMessage`
- * action understands. Returns the marker-stripped text plus an array of
- * ranges keyed by their start in the OUTPUT string.
- *
- * macOS 15+ recipients render typed runs natively; macOS 14 falls back to
- * client-side markdown rendering, so passing both raw markdown and ranges
- * would double up — callers should send the stripped `text` only.
- *
- * Supported markers:
- *  - `**bold**`
- *  - `*italic*` / `_italic_` (single-underscore enforces word boundaries)
- *  - `__underline__` (double-underscore also enforces word boundaries so
- *    Python identifiers like `__init__` are not mangled)
- *  - `~~strikethrough~~`
- *
- * Nesting:
- *  - `***bold-italic***` is parsed as `**` containing `*italic*`, yielding
- *    two ranges over the same span (one bold, one italic).
- *  - Other nested combinations (`**bold _underline_**`, etc.) are
- *    similarly parsed by recursing into the inner text of every marker
- *    pair we consume.
- *
- * Out of scope: escaped markers (`\*literal\*`), code spans (` `code` `),
- * and combining-character edge cases. The receiver's iMessage style
- * vocabulary covers only bold/italic/underline/strikethrough — there is
- * nowhere to render anything fancier, and over-eager parsing would mangle
- * plain-text emoji/punctuation that happens to look like markdown.
- */
+import {
+  type FormatCapabilityProfile,
+  markdownToIR,
+  renderMarkdownWithAttributedRanges,
+} from "openclaw/plugin-sdk/text-chunking";
 
 type IMessageFormatStyle = "bold" | "italic" | "underline" | "strikethrough";
 
@@ -37,118 +12,182 @@ type IMessageFormatRange = {
   styles: IMessageFormatStyle[];
 };
 
-type Marker = {
-  marker: string;
-  styles: IMessageFormatStyle[];
-  /**
-   * When true, the marker only counts when both ends sit on a word
-   * boundary. Single-underscore italics need this so `snake_case_var` is
-   * left literal, and double-underscore underline needs it so Python
-   * dunder names like `__init__` are not turned into underline.
-   */
-  requireWordBoundary: boolean;
-};
+export const IMESSAGE_FORMAT_PROFILE = {
+  mechanism: "ranges",
+  constructs: {
+    bold: "native",
+    italic: "native",
+    underline: "native",
+    strikethrough: "native",
+    spoiler: "strip",
+    codeInline: "fallback",
+    codeBlock: "fallback",
+    codeLanguage: "strip",
+    linkLabel: "fallback",
+    heading: "fallback",
+    bulletList: "fallback",
+    orderedList: "fallback",
+    taskList: "fallback",
+    table: "fallback",
+    blockquote: "fallback",
+    image: "fallback",
+    mention: "strip",
+  },
+  chunk: { limit: 4_000, unit: "utf16" },
+} satisfies FormatCapabilityProfile;
 
-// Order matters: longer/compound markers are tried first.
-//  - `***...***` is bold+italic over the inner span.
-//  - `___...___` is underline+italic.
-//  - `~~`, `**`, `__` cover their own styles.
-//  - `*` / `_` italic match last (with `_` enforcing word boundaries).
-const MARKERS: readonly Marker[] = [
-  { marker: "***", styles: ["bold", "italic"], requireWordBoundary: false },
-  { marker: "___", styles: ["underline", "italic"], requireWordBoundary: true },
-  { marker: "~~", styles: ["strikethrough"], requireWordBoundary: false },
-  { marker: "**", styles: ["bold"], requireWordBoundary: false },
-  { marker: "__", styles: ["underline"], requireWordBoundary: true },
-  { marker: "*", styles: ["italic"], requireWordBoundary: false },
-  { marker: "_", styles: ["italic"], requireWordBoundary: true },
-];
+const IMESSAGE_CODE_PROFILE = {
+  ...IMESSAGE_FORMAT_PROFILE,
+  constructs: { ...IMESSAGE_FORMAT_PROFILE.constructs, codeInline: "native" },
+} satisfies FormatCapabilityProfile;
 
-function tryConsumeMarker(
-  input: string,
-  i: number,
-  m: Marker,
-): { close: number; inner: string } | null {
-  if (!input.startsWith(m.marker, i)) {
-    return null;
-  }
-  // For single-char markers, reject when the next char is the same so we
-  // don't consume the leading half of a longer marker (e.g. `*` matching
-  // the first asterisk of `**bold**`).
-  if (m.marker.length === 1 && input[i + 1] === m.marker) {
-    return null;
-  }
-  // For 2-char markers, reject when there's a third repeat — that's the
-  // longer compound marker (`***`, `___`) which should match first.
-  if (m.marker.length === 2 && input[i + 2] === m.marker[0]) {
-    return null;
-  }
-  // For underscore markers we use a stricter rule than CommonMark: the
-  // OUTSIDE of each marker must be whitespace, start-of-string, or
-  // end-of-string. That keeps `def __init__(self)` literal (`(` after the
-  // close is neither whitespace nor end-of-string) while `__under__ and`
-  // still parses cleanly. Asterisk markers don't need this because they
-  // don't appear inside identifiers.
-  const isAtBoundary = (ch: string | undefined): boolean => ch === undefined || /\s/.test(ch);
-  if (m.requireWordBoundary && i > 0 && !isAtBoundary(input[i - 1])) {
-    return null;
-  }
-  const startInner = i + m.marker.length;
-  const close = input.indexOf(m.marker, startInner);
-  if (close === -1 || close === startInner) {
-    return null;
-  }
-  if (m.requireWordBoundary && !isAtBoundary(input[close + m.marker.length])) {
-    return null;
-  }
-  const inner = input.slice(startInner, close);
-  if (!inner.trim()) {
-    return null;
-  }
-  return { close, inner };
+const IMESSAGE_STYLE_MAP = {
+  bold: "bold",
+  italic: "italic",
+  underline: "underline",
+  strikethrough: "strikethrough",
+} as const;
+
+function codeDelimiter(content: string): string {
+  const longestRun = Math.max(0, ...[...content.matchAll(/`+/gu)].map((match) => match[0].length));
+  return "`".repeat(longestRun + 1);
 }
 
-function parseInternal(input: string, baseOffset: number, sink: IMessageFormatRange[]): string {
-  let out = "";
-  let i = 0;
-  while (i < input.length) {
-    let consumed = false;
-    for (const m of MARKERS) {
-      const hit = tryConsumeMarker(input, i, m);
-      if (!hit) {
-        continue;
-      }
-      // Recurse on the inner span so nested markers compose. The inner
-      // ranges are emitted with offsets relative to the new base.
-      const innerOffset = baseOffset + out.length;
-      const innerStripped = parseInternal(hit.inner, innerOffset, sink);
-      // Compound markers (`***`, `___`) emit multiple styles over the same
-      // span — push them in order so callers see e.g. italic before bold.
-      for (const style of m.styles) {
-        sink.push({
-          start: innerOffset,
-          length: innerStripped.length,
-          styles: [style],
-        });
-      }
-      out += innerStripped;
-      i = hit.close + m.marker.length;
-      consumed = true;
-      break;
+type TextEdit = { start: number; end: number; text: string };
+type DunderProtection = { token: string; identifier: string };
+
+function protectDunderIdentifiers(input: string): {
+  markdown: string;
+  protections: DunderProtection[];
+} {
+  const protections: DunderProtection[] = [];
+  let markdown = "";
+  let cursor = 0;
+  for (const match of input.matchAll(/__[\p{L}_][\p{L}\p{N}_]*__/gu)) {
+    const identifier = match[0];
+    const start = match.index ?? 0;
+    const end = start + identifier.length;
+    const before = input[start - 1];
+    const beforeBefore = input[start - 2];
+    const after = input[end];
+    const member = before === ".";
+    const call = after === "(";
+    const functionArgument = before === "(" && /[\p{L}\p{N}_]/u.test(beforeBefore ?? "");
+    const index = after === "[";
+    if (!member && !call && !functionArgument && !index) {
+      continue;
     }
-    if (!consumed) {
-      out += input[i];
-      i += 1;
+    let token = `OCdunder${protections.length}token`;
+    while (input.includes(token)) {
+      token += "x";
     }
+    markdown += input.slice(cursor, start) + token;
+    protections.push({ token, identifier });
+    cursor = end;
   }
-  return out;
+  return { markdown: markdown + input.slice(cursor), protections };
+}
+
+function applyTextEdits(text: string, edits: TextEdit[]) {
+  const ordered = edits.toSorted((left, right) => left.start - right.start);
+  let rendered = "";
+  let cursor = 0;
+  for (const edit of ordered) {
+    rendered += text.slice(cursor, edit.start) + edit.text;
+    cursor = edit.end;
+  }
+  rendered += text.slice(cursor);
+  return {
+    text: rendered,
+    mapOffset: (offset: number) =>
+      offset +
+      ordered.reduce(
+        (delta, edit) =>
+          delta + (edit.end <= offset ? edit.text.length - edit.end + edit.start : 0),
+        0,
+      ),
+  };
+}
+
+function restoreDunderIdentifiers(
+  text: string,
+  ranges: IMessageFormatRange[],
+  codeRanges: Array<{ start: number; length: number }>,
+  protections: DunderProtection[],
+) {
+  const edits = protections.flatMap((protection) => {
+    const start = text.indexOf(protection.token);
+    return start === -1
+      ? []
+      : [{ start, end: start + protection.token.length, text: protection.identifier }];
+  });
+  const edited = applyTextEdits(text, edits);
+  const mapRange = <T extends { start: number; length: number }>(range: T): T => ({
+    ...range,
+    start: edited.mapOffset(range.start),
+    length: edited.mapOffset(range.start + range.length) - edited.mapOffset(range.start),
+  });
+  return {
+    text: edited.text,
+    ranges: ranges.map(mapRange),
+    codeRanges: codeRanges.map(mapRange),
+  };
+}
+
+function restoreCodeMarkers(
+  text: string,
+  ranges: Array<{ start: number; length: number; styles: IMessageFormatStyle[] }>,
+  codeRanges: Array<{ start: number; length: number }>,
+): { text: string; ranges: IMessageFormatRange[] } {
+  const edits = codeRanges.map((range) => {
+    const end = range.start + range.length;
+    const content = text.slice(range.start, end);
+    const marker = codeDelimiter(content);
+    const padding = content.startsWith("`") || content.endsWith("`") ? " " : "";
+    return { start: range.start, end, text: `${marker}${padding}${content}${padding}${marker}` };
+  });
+  const edited = applyTextEdits(text, edits);
+  return {
+    text: edited.text,
+    ranges: ranges.map((range) => ({
+      ...range,
+      start: edited.mapOffset(range.start),
+      length: edited.mapOffset(range.start + range.length) - edited.mapOffset(range.start),
+    })),
+  };
 }
 
 export function extractMarkdownFormatRuns(input: string): {
   text: string;
   ranges: IMessageFormatRange[];
 } {
-  const ranges: IMessageFormatRange[] = [];
-  const text = parseInternal(input, 0, ranges);
-  return { text, ranges };
+  const protectedDunders = protectDunderIdentifiers(input);
+  const ir = markdownToIR(protectedDunders.markdown, {
+    autolink: false,
+    enableHtmlUnderline: true,
+    headingStyle: "rich",
+    linkify: false,
+    preserveSourceBlockSpacing: true,
+  });
+  const rendered = renderMarkdownWithAttributedRanges(
+    ir,
+    { styleMap: IMESSAGE_STYLE_MAP },
+    IMESSAGE_FORMAT_PROFILE,
+  );
+  const code = renderMarkdownWithAttributedRanges(
+    ir,
+    { styleMap: { code: "code" } },
+    IMESSAGE_CODE_PROFILE,
+  );
+  const dunders = restoreDunderIdentifiers(
+    rendered.text,
+    rendered.ranges.map(({ start, length, style }) => ({
+      start,
+      length,
+      styles: [style],
+    })),
+    code.ranges,
+    protectedDunders.protections,
+  );
+  return restoreCodeMarkers(dunders.text, dunders.ranges, dunders.codeRanges);
 }

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -769,9 +769,8 @@ export async function sendMessageIMessage(
     throw new Error("iMessage send requires text or media");
   }
   // Extract markdown bold/italic/underline/strikethrough into typed-run
-  // ranges that the imsg bridge applies via attributedBody. macOS 15+
-  // recipients render the runs natively; earlier macOS recipients still
-  // see the marker-stripped text without literal asterisks.
+  // ranges that the imsg bridge applies via attributedBody. The sender needs
+  // macOS 15+; pre-Sequoia recipients see the same marker-stripped plain text.
   const formatted = message.trim()
     ? extractMarkdownFormatRuns(message)
     : { text: message, ranges: [] };


### PR DESCRIPTION
## What Problem This Solves

Resolves inconsistent iMessage outbound formatting caused by a channel-local marker parser. The old path treated double underscores as underline instead of CommonMark bold, styled markdown-looking text inside inline code, and could mangle identifier-shaped underscore text.

## Why This Change Was Made

iMessage now declares a private ranges-based `FormatCapabilityProfile` and uses the shared CommonMark IR, fallback engine, and attributed-range driver. The iMessage-specific layer only maps the bridge's four native styles, restores literal inline-code delimiters from parser-derived code ranges, and preserves syntactically code-like dunder identifiers without changing ordinary CommonMark bold.

The macOS gate comment now reflects the platform contract: the sending Mac needs macOS 15+ for typed runs, while pre-Sequoia recipients see plain text rather than client-side Markdown.

## User Impact

- `__x__` is emitted as bold instead of underline.
- Underline is emitted only from authored `<u>` or `<ins>` HTML.
- Markdown-looking text inside inline code stays literal and keeps safe backtick delimiters.
- `snake_case` and Python-style `__init__` identifiers remain literal in their covered code contexts.
- Range offsets remain UTF-16-correct for emoji and nested styles.

## Evidence

Golden before -> after fixtures cover every authorized output change:

- `__x__`: underline range -> bold range.
- `<u>x</u>` and `<ins>x</ins>`: literal tags -> underline range.
- `` `*x*` ``: italicized inner text -> literal code with no style range and retained backticks.
- `snake_case` and `def __init__(self):`: literal before and after.

Validation:

- `node scripts/run-vitest.mjs extensions/imessage/src/markdown-format.test.ts` — 21 tests passed after the dead-code fix.
- `node scripts/run-vitest.mjs extensions/imessage` — 47 files / 801 tests passed on the rebased implementation commit.
- `node scripts/check-changed.mjs -- extensions/imessage/src/markdown-format.ts extensions/imessage/src/markdown-format.test.ts extensions/imessage/src/send.ts` — passed on Blacksmith Testbox `tbx_01ky87yvavhvpymh8x13rkxqty`; Actions run https://github.com/openclaw/openclaw/actions/runs/30039010783.
- Exact-head hosted CI — green on `dfb6938c2621465cb7d54dbd022d458ba67032d1`; run https://github.com/openclaw/openclaw/actions/runs/30040281112.
- Source-blind module API contract — all bold, underline, inline-code, identifier, nested-style, plain-text, and emoji UTF-16 clauses passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean on the implementation and on the follow-up dead-code fix; no accepted/actionable findings.
- `git diff --check origin/main...HEAD` — passed.

The first hosted CI run found that the profile constant was exported only for its test. The follow-up makes it private and removes that non-production export; a direct Testbox reproduction confirmed this was the only dead-code finding.

### ClawSweeper rank-up moves

- Real macOS 15+ bridge send: skipped. The maintainer-commissioned batch explicitly authorizes the visible formatting changes and specifies focused iMessage fixtures as proof. A live send would require an approved external recipient/destination that is not part of this task. The owner accepts the remaining bridge-integration uncertainty based on the upstream imsg contract, source-blind API proof, full extension suite, Testbox, and exact-head CI.
- Refresh against moving `main`: the branch was rebased onto fresh `origin/main` before final proof and remains mergeable. Repository policy says not to chase moving main after one clean rebase plus green exact-head gates; `scripts/pr prepare-run` will still prove the current merge result.

Numstat:

- Production: +172 / -134, net +38.
- Tests: +129 / -69, net +60.
- Total: +301 / -203, net +98.

This wave explicitly prioritizes correctness and a single shared formatting architecture over raw LOC. The old recursive marker parser is deleted; the production growth is the parser-derived literal-code and identifier projection needed to avoid unintended byte changes, while the test growth is the before/after golden and adversarial boundary matrix.

AI-assisted: yes. I reviewed the implementation, ran the source-blind behavior contract, and completed the repository autoreview gate. No agent transcript is attached because none was explicitly approved for publication.
