### PR TITLE
fix(ci): rebuild stale sticky dependency snapshots

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -387,6 +387,12 @@ runs:
         append_pnpm_option_arg PNPM_CONFIG_NETWORK_CONCURRENCY network-concurrency
         append_pnpm_option_arg PNPM_CONFIG_STORE_DIR store-dir
         append_pnpm_option_arg PNPM_CONFIG_VIRTUAL_STORE_DIR virtual-store-dir
+        if [ "$STICKY_DISK" = "true" ] && [ "$STICKY_WRITER" = "true" ] &&
+          [ "$sticky_snapshot_matches" != "true" ]; then
+          # A mounted stale tree can make a normal frozen install report "Already up to date".
+          # Only the canonical writer may rebuild the shared modules directory in place.
+          install_args+=(--force)
+        fi
         run_pnpm_install() {
           if [ "$STICKY_DISK" = "true" ]; then
             # Pnpm can keep retrying optional platform tarballs after the

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2161,6 +2161,14 @@ describe("ci workflow guards", () => {
     );
     expect(installStep.run).toContain("timeout --signal=TERM --kill-after=15s 4m");
     expect(installStep.run).toContain('pnpm "${install_args[@]}" --config.fetch-retries=0');
+    const forceStickyWriterInstall =
+      'if [ "$STICKY_DISK" = "true" ] && [ "$STICKY_WRITER" = "true" ] &&\n' +
+      '  [ "$sticky_snapshot_matches" != "true" ]; then';
+    expect(installStep.run).toContain(forceStickyWriterInstall);
+    expect(installStep.run).toContain("install_args+=(--force)");
+    expect(installStep.run.indexOf(forceStickyWriterInstall)).toBeLessThan(
+      installStep.run.indexOf("run_pnpm_install()"),
+    );
     expect(installStep.run).toContain("install_attempts=2");
     expect(installStep.run).toContain("install_attempts=3");
     expect(installStep.run).toContain(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `main` CI could remain red after dependency updates because the canonical sticky-disk writer detected a stale dependency fingerprint but a normal frozen `pnpm install` reported `Already up to date` and left the mounted `node_modules` tree unchanged.

The importer validator correctly refused to publish the stale snapshot after resolving UI `marked@18.0.5` while the lockfile required `marked@18.0.6`.

Failing run: https://github.com/openclaw/openclaw/actions/runs/30029395390

## Why This Change Was Made

When the trusted sticky writer has no content-validated snapshot, its existing bounded frozen install now adds pnpm's supported `--force` option. This forces pnpm to rebuild the mounted modules directory before the existing importer capture and validation steps publish a new fingerprint.

The force path is restricted to the canonical writer. Read-only consumers still detach to runner-local storage, and valid content-matching snapshots still skip installation entirely.

## User Impact

There is no shipped product behavior change. Maintainers get self-healing dependency snapshots after manifest or lockfile updates instead of repeated preflight failures that block all downstream CI lanes.

## Evidence

- Repeated current-main failures showed the same stale-tree mismatch after `pnpm install` reported `Already up to date`.
- Upstream pnpm 11 source documents `--force` as forcing dependency reinstall and recreating an incompatible modules directory; it remains inside the existing frozen-lockfile, timeout, retry, capture, and importer-validation flow.
- `test/scripts/ci-workflow-guards.test.ts`: 90 tests passed on Blacksmith Testbox after the change and again after rebasing.
- `pnpm check:changed -- .github/actions/setup-node-env/action.yml test/scripts/ci-workflow-guards.test.ts`: passed on Blacksmith Testbox, including formatting, test-root typecheck, script declarations, dependency guards, and script lint.
- `git diff --check`: passed.
- Rebased patch identity verified with `git patch-id --stable`.
- Codex autoreview (`--mode uncommitted`): clean, no accepted/actionable findings.

The final integration proof must occur on the first post-merge `main` push because only canonical `refs/heads/main` runs are authorized to publish the shared sticky snapshot.

AI-assisted: Claude Code investigated and implemented the repair with independent Codex autoreview. The failure logs, pnpm source contract, workflow boundaries, and test evidence were manually verified.
