### PR TITLE
fix(state): v13 agent databases fail to open on supported Node versions

### DIFF
--- a/src/state/openclaw-agent-db-session-nodes-migration.ts
+++ b/src/state/openclaw-agent-db-session-nodes-migration.ts
@@ -139,11 +139,14 @@ function migrateSessionWindows(db: DatabaseSync): void {
   }
   const entryColumns = readSqliteTableColumns(db, "session_entries");
   const routeColumns = readSqliteTableColumns(db, "session_routes");
+  // Keep owner preference local to each scalar query: supported SQLite 3.51
+  // cannot resolve an outer column reference from a correlated ORDER BY.
   const entryOwner = entryColumns
     ? `(SELECT se.session_key
         FROM session_entries AS se
+        INNER JOIN session_windows AS owner_window ON owner_window.session_id = se.session_id
         WHERE se.session_id = session_windows.session_id
-        ORDER BY CASE WHEN se.session_key = session_windows.session_key THEN 0 ELSE 1 END,
+        ORDER BY CASE WHEN se.session_key = owner_window.session_key THEN 0 ELSE 1 END,
                  se.updated_at DESC,
                  se.session_key ASC
         LIMIT 1)`
@@ -151,8 +154,9 @@ function migrateSessionWindows(db: DatabaseSync): void {
   const routeOwner = routeColumns
     ? `(SELECT sr.session_key
         FROM session_routes AS sr
+        INNER JOIN session_windows AS owner_window ON owner_window.session_id = sr.session_id
         WHERE sr.session_id = session_windows.session_id
-        ORDER BY CASE WHEN sr.session_key = session_windows.session_key THEN 0 ELSE 1 END,
+        ORDER BY CASE WHEN sr.session_key = owner_window.session_key THEN 0 ELSE 1 END,
                  sr.updated_at DESC,
                  sr.session_key ASC
         LIMIT 1)`
@@ -160,8 +164,9 @@ function migrateSessionWindows(db: DatabaseSync): void {
   const currentEntryJson = entryColumns
     ? `(SELECT se.entry_json
         FROM session_entries AS se
+        INNER JOIN session_windows AS owner_window ON owner_window.session_id = se.session_id
         WHERE se.session_id = session_windows.session_id
-        ORDER BY CASE WHEN se.session_key = session_windows.session_key THEN 0 ELSE 1 END,
+        ORDER BY CASE WHEN se.session_key = owner_window.session_key THEN 0 ELSE 1 END,
                  se.updated_at DESC,
                  se.session_key ASC
         LIMIT 1)`

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -947,6 +947,12 @@ describe("openclaw agent database", () => {
         '{"sessionId":"window-created-by","updatedAt":60,"createdBy":{"id":"legacy-human","label":"Legacy"}}',
         60,
         NULL
+      ), (
+        'agent:worker-1:newer-alias',
+        'window-current',
+        '{"sessionId":"window-current","updatedAt":100,"previousSessionId":"wrong-window"}',
+        100,
+        NULL
       );
       INSERT INTO transcript_events (session_id, seq, event_json, created_at)
       VALUES


### PR DESCRIPTION
Related: #113071

## What Problem This Solves

Fixes an issue where users upgrading an existing agent database from schema v13 to v14 could not start OpenClaw on supported Node 22.22.3 or Node 24.15.0 runtimes. Their embedded SQLite 3.51.3 rejected the session-window migration with `no such column: session_windows.session_key`.

## Why This Change Was Made

The migration now joins each legacy window owner inside its scalar lookup instead of referencing the outer window from `ORDER BY`, which is only accepted by newer SQLite releases. This preserves exact-key preference, latest-update fallback ordering, and entry JSON selection without changing the schema or runtime contract.

The existing migration fixture now includes a newer competing alias to prove that the original window key and matching entry JSON still win.

## User Impact

Operators can upgrade schema-v13 agent databases on every currently supported Node line without a gateway startup failure. Fresh databases and databases already on schema v14 are unchanged.

This PR was AI-assisted and reviewed with the repository's structured autoreview workflow.

## Evidence

### Crabbox gateway behavior proof

Crabbox ran exact PR head `30213cd3779744cfed3446b38a42dedee9f2500f` on Node 24.15.0 with SQLite 3.51.3. The isolated proof built the branch, created a synthetic v13 agent database, started the built gateway, and invoked the production `sessions.patch` RPC that opens and migrates the writable agent database.

The authoritative Crabbox command result was:

```json
{
  "provider": "blacksmith-testbox",
  "leaseId": "tbx_01ky8f5fakwt724eb1hvkzdtaz",
  "commandMs": 74199,
  "totalMs": 74214,
  "exitCode": 0,
  "runStatus": "succeeded"
}
```

The Blacksmith Actions lifecycle run is not used as proof because it tracks Testbox provisioning and keepalive. Stopping the retained Testbox after the command completed marks that lifecycle run as cancelled.

<details>
<summary>Observed before/after state</summary>

```json
{
  "exactHead": "30213cd3779744cfed3446b38a42dedee9f2500f",
  "node": "v24.15.0",
  "before": {
    "userVersion": 13,
    "sqliteVersion": "3.51.3",
    "canonicalEntry": {
      "sessionKey": "agent:main:crabbox-v14-proof",
      "sessionId": "window-current",
      "updatedAt": 40,
      "label": "Crabbox proof",
      "previousSessionId": "window-old"
    },
    "newerCompetingAlias": {
      "sessionKey": "agent:main:crabbox-newer-alias",
      "sessionId": "window-current",
      "updatedAt": 100,
      "label": "Wrong alias",
      "previousSessionId": "wrong-window"
    }
  },
  "behavior": {
    "gatewayStarted": true,
    "gatewayHealthExit": 0,
    "gatewaySessionsPatchExit": 0,
    "sessionsCommandExit": 0,
    "sessionsCommandDatabasePathMatched": true
  },
  "after": {
    "userVersion": 14,
    "schemaVersion": 14,
    "integrityCheck": "ok",
    "canonicalNode": {
      "sessionKey": "agent:main:crabbox-v14-proof",
      "currentSessionId": "window-current",
      "label": "Crabbox proof patched"
    },
    "currentWindow": {
      "sessionId": "window-current",
      "sessionKey": "agent:main:crabbox-v14-proof",
      "previousSessionId": "window-old"
    }
  }
}
```

</details>

### Automated checks

- Before the fix, the focused v13 migration test failed on Node 24.15.0 / SQLite 3.51.3 with `no such column: session_windows.session_key`.
- Node 24.15.0: full `src/state/openclaw-agent-db.test.ts`, 59 passed and 1 skipped.
- Node 22.22.3 / SQLite 3.51.3: focused v13 migration test passed.
- Node 24.18.0 / SQLite 3.53.1: focused v13 migration test passed.
- `oxfmt --check` passed for both changed files.
- `git diff --check` passed.
- Structured Codex autoreview reported no accepted or actionable findings.
- Local `tsgo` was attempted but the shared dependency checkout lacks the unrelated `libphonenumber-js/min` module; no dependencies were changed or reinstalled.
