### PR TITLE
fix(gateway): keep Control UI questions working after upgrades

### DIFF
--- a/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
+++ b/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
@@ -256,6 +256,7 @@ describe("trusted-proxy browser device auto-approval", () => {
     const paired = await getPairedDevice(identity.deviceId);
     expect(paired?.approvedScopes).toEqual([
       "operator.approvals",
+      "operator.questions",
       "operator.read",
       "operator.write",
     ]);

--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -56,6 +56,7 @@ const DEFAULT_TRUSTED_PROXY_DEVICE_AUTO_APPROVE_SCOPES = [
   "operator.read",
   "operator.write",
   "operator.approvals",
+  "operator.questions",
 ] as const;
 
 function resolveTrustedProxyDeviceAutoApproveScopes(params: {
@@ -70,7 +71,13 @@ function resolveTrustedProxyDeviceAutoApproveScopes(params: {
     return configuredScopes;
   }
   const configured = new Set(configuredScopes);
-  return normalizeSortedUniqueTrimmedStringList(params.requestedScopes).filter((scope) =>
+  const requestedScopes = normalizeSortedUniqueTrimmedStringList(params.requestedScopes);
+  // Trusted-proxy Control UI tabs can remain open across upgrades. Grant newly
+  // required default UI scopes without widening an explicitly configured cap.
+  if (params.configuredScopes === undefined) {
+    requestedScopes.push("operator.questions");
+  }
+  return normalizeSortedUniqueTrimmedStringList(requestedScopes).filter((scope) =>
     configured.has(scope),
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where already-open Control UI tabs behind trusted-proxy authentication lose access to the questions API after upgrading to a gateway that requires `operator.questions`. The stale tab reconnects and is auto-approved with only `operator.approvals`, `operator.read`, and `operator.write`, so `question.list` fails continuously and the authenticated team UI appears broken.

## Why This Change Was Made

Trusted-proxy Control UI auto-approval now includes `operator.questions` in its bounded default scope set and supplies that newly required default when an older client reconnects with the pre-questions scope list. Explicit `gateway.auth.trustedProxy.deviceAutoApprove.scopes` configuration remains authoritative and continues to cap the approved intersection.

## User Impact

Control UI tabs that remain open across gateway upgrades can reconnect and use question cards without clearing browser state or manually re-pairing. Custom trusted-proxy scope caps are unchanged.

## Evidence

- Live production reproduction on `team.openclaw.ai`: the connected `openclaw-control-ui` device repeatedly received `missing scope: operator.questions` from `question.list`; removing and automatically re-pairing the same browser key reproduced the old three-scope token.
- Source/bundle verification showed current Control UI requests `operator.questions`, while the server's trusted-proxy default auto-approval set omitted it.
- `node scripts/run-vitest.mjs src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts` — 11 tests passed.
- `oxfmt` and `git diff --check` passed.
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings.

AI-assisted.
