### PR TITLE
fix(ci): rebuild sticky modules before snapshot refresh

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -389,8 +389,9 @@ runs:
         append_pnpm_option_arg PNPM_CONFIG_VIRTUAL_STORE_DIR virtual-store-dir
         if [ "$STICKY_DISK" = "true" ] && [ "$STICKY_WRITER" = "true" ] &&
           [ "$sticky_snapshot_matches" != "true" ]; then
-          # A mounted stale tree can make a normal frozen install report "Already up to date".
-          # Only the canonical writer may rebuild the shared modules directory in place.
+          # Pnpm can trust stale hidden install metadata even with --force. Clear only
+          # the writer-owned modules tree; the warmed store remains on the sticky disk.
+          find "$GITHUB_WORKSPACE/node_modules" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
           install_args+=(--force)
         fi
         run_pnpm_install() {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2165,8 +2165,14 @@ describe("ci workflow guards", () => {
       'if [ "$STICKY_DISK" = "true" ] && [ "$STICKY_WRITER" = "true" ] &&\n' +
       '  [ "$sticky_snapshot_matches" != "true" ]; then';
     expect(installStep.run).toContain(forceStickyWriterInstall);
+    const clearStickyModules =
+      'find "$GITHUB_WORKSPACE/node_modules" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +';
+    expect(installStep.run).toContain(clearStickyModules);
     expect(installStep.run).toContain("install_args+=(--force)");
     expect(installStep.run.indexOf(forceStickyWriterInstall)).toBeLessThan(
+      installStep.run.indexOf(clearStickyModules),
+    );
+    expect(installStep.run.indexOf(clearStickyModules)).toBeLessThan(
       installStep.run.indexOf("run_pnpm_install()"),
     );
     expect(installStep.run).toContain("install_attempts=2");


### PR DESCRIPTION
Related: #113142

## What Problem This Solves

Fixes the remaining `main` preflight failure after PR #113142. The canonical sticky writer did pass pnpm `--force`, but pnpm still trusted stale hidden install metadata, reported `Already up to date`, and left UI resolving `marked@18.0.5` instead of the lockfile-required `18.0.6`.

Post-merge failure proof: https://github.com/openclaw/openclaw/actions/runs/30044378343

## Why This Change Was Made

When the trusted writer has no content-validated snapshot, it now clears only the contents beneath the mounted writer-owned `node_modules` directory before the existing forced frozen install. The sticky mount itself and the separate warmed pnpm store remain intact.

Read-only consumers and validated snapshots remain unchanged. Importer validation and fingerprint publication still occur only after a successful install.

## User Impact

There is no shipped product behavior change. Maintainers get a real clean relink when sticky install metadata and filesystem links disagree, allowing `main` CI to recover after dependency updates.

## Evidence

- PR #113142 canonical proof confirmed `--force` ran but pnpm still exited in 351 ms with `Already up to date` and the same importer mismatch.
- CI workflow guard suite: 90 tests passed on Blacksmith Testbox before and after rebase.
- Changed-file gates passed on Blacksmith Testbox, including formatting, test-root typecheck, script declarations, dependency guards, and script lint.
- `git diff --check` passed.
- Rebased patch identity verified with `git patch-id --stable`.
- Codex autoreview: clean, no accepted/actionable findings.

The final integration proof remains the first post-merge canonical-main writer run.

AI-assisted: Claude Code implemented and verified the follow-up with independent Codex autoreview.
