### PR TITLE
feat(telegram): render rich Markdown lists natively

### DIFF
--- a/extensions/telegram/src/rich-block-model.ts
+++ b/extensions/telegram/src/rich-block-model.ts
@@ -1,6 +1,6 @@
 // Bot API 10.2 rich block/RichText model: types, size accounting, and the
 // plain-text projection shared by the emitter, splitter, and fallback paths.
-export type TelegramRichBlocksDegradationReason = "table-ascii";
+export type TelegramRichBlocksDegradationReason = "list-limit" | "table-ascii";
 
 export type RichText =
   | string
@@ -235,6 +235,108 @@ export function countInputRichBlockChars(block: InputRichBlock): number {
   }
 }
 
+/** Bot API block budget, including nested blocks, list items, and table rows. */
+export function countInputRichBlocks(blocks: readonly InputRichBlock[]): number {
+  return blocks.reduce((total, block) => {
+    switch (block.type) {
+      case "blockquote":
+      case "details":
+      case "collage":
+      case "slideshow":
+        return total + 1 + countInputRichBlocks(block.blocks);
+      case "list":
+        return (
+          total +
+          1 +
+          block.items.reduce((items, item) => items + 1 + countInputRichBlocks(item.blocks), 0)
+        );
+      case "table":
+        return total + 1 + block.cells.length;
+      default:
+        return total + 1;
+    }
+  }, 0);
+}
+
+function maxRichTextNesting(text: RichText): number {
+  if (typeof text === "string") {
+    return 0;
+  }
+  if (Array.isArray(text)) {
+    return Math.max(0, ...text.map(maxRichTextNesting));
+  }
+  if (text.type === "mathematical_expression" || text.type === "custom_emoji") {
+    return 0;
+  }
+  return 1 + maxRichTextNesting(text.text);
+}
+
+function maxCaptionNesting(caption: RichBlockCaption | undefined): number {
+  return caption
+    ? Math.max(
+        maxRichTextNesting(caption.text),
+        caption.credit ? maxRichTextNesting(caption.credit) : 0,
+      )
+    : 0;
+}
+
+/** Maximum nested block/formatting edges in a rich-message tree. */
+export function maxInputRichBlockNesting(blocks: readonly InputRichBlock[]): number {
+  const blockDepth = (block: InputRichBlock): number => {
+    switch (block.type) {
+      case "paragraph":
+      case "heading":
+      case "footer":
+        return maxRichTextNesting(block.text);
+      case "pullquote":
+        return Math.max(
+          maxRichTextNesting(block.text),
+          block.credit ? maxRichTextNesting(block.credit) : 0,
+        );
+      case "blockquote":
+        return Math.max(
+          1 + maxInputRichBlockNesting(block.blocks),
+          block.credit ? 1 + maxRichTextNesting(block.credit) : 0,
+        );
+      case "details":
+        return Math.max(
+          1 + maxInputRichBlockNesting(block.blocks),
+          1 + maxRichTextNesting(block.summary),
+        );
+      case "collage":
+      case "slideshow":
+        return Math.max(
+          1 + maxInputRichBlockNesting(block.blocks),
+          1 + maxCaptionNesting(block.caption),
+        );
+      case "list":
+        return 1 + Math.max(0, ...block.items.map((item) => maxInputRichBlockNesting(item.blocks)));
+      case "table":
+        return (
+          1 +
+          Math.max(
+            maxRichTextNesting(block.caption ?? ""),
+            ...block.cells.flatMap((row) => row.map((cell) => maxRichTextNesting(cell.text ?? ""))),
+          )
+        );
+      case "photo":
+      case "video":
+      case "audio":
+      case "animation":
+      case "voice_note":
+      case "map":
+        return block.caption ? 1 + maxCaptionNesting(block.caption) : 0;
+      case "pre":
+        // This wire model intentionally narrows pre text to a plain string;
+        // draft-only thinking blocks are not part of InputRichBlock.
+        return 0;
+      default:
+        return 0;
+    }
+  };
+  return Math.max(0, ...blocks.map(blockDepth));
+}
+
 /** Media elements per block, for the wire's 50-media message cap. */
 export function countInputRichBlockMedia(block: InputRichBlock): number {
   switch (block.type) {
@@ -286,7 +388,10 @@ function captionToPlainText(caption: RichBlockCaption | undefined): string {
   return `${richTextToPlainString(caption.text)}${credit}`.trim();
 }
 
-export function inputRichBlocksToPlainText(blocks: readonly InputRichBlock[]): string {
+function inputRichBlocksToPlainTextAtDepth(
+  blocks: readonly InputRichBlock[],
+  listDepth: number,
+): string {
   const parts: string[] = [];
   const push = (value: string) => {
     if (value) {
@@ -314,30 +419,31 @@ export function inputRichBlocksToPlainText(blocks: readonly InputRichBlock[]): s
         );
         break;
       case "blockquote":
-        push(inputRichBlocksToPlainText(block.blocks));
+        push(inputRichBlocksToPlainTextAtDepth(block.blocks, listDepth));
         if (block.credit) {
           push(`— ${richTextToPlainString(block.credit)}`);
         }
         break;
       case "collage":
       case "slideshow":
-        push(inputRichBlocksToPlainText(block.blocks));
+        push(inputRichBlocksToPlainTextAtDepth(block.blocks, listDepth));
         push(captionToPlainText(block.caption));
         break;
       case "details":
         push(richTextToPlainString(block.summary));
-        push(inputRichBlocksToPlainText(block.blocks));
+        push(inputRichBlocksToPlainTextAtDepth(block.blocks, listDepth));
         break;
       case "list":
         for (const item of block.items) {
-          const marker = item.has_checkbox
+          const markerText = item.has_checkbox
             ? item.is_checked
               ? "[x] "
               : "[ ] "
             : item.value !== undefined
               ? `${item.value}. `
               : "• ";
-          push(`${marker}${inputRichBlocksToPlainText(item.blocks)}`);
+          const marker = `${"  ".repeat(listDepth)}${markerText}`;
+          push(`${marker}${inputRichBlocksToPlainTextAtDepth(item.blocks, listDepth + 1)}`);
         }
         break;
       case "table":
@@ -376,6 +482,10 @@ export function inputRichBlocksToPlainText(blocks: readonly InputRichBlock[]): s
     }
   }
   return parts.join("\n");
+}
+
+export function inputRichBlocksToPlainText(blocks: readonly InputRichBlock[]): string {
+  return inputRichBlocksToPlainTextAtDepth(blocks, 0);
 }
 
 export function boldRichText(text: string): RichText {

--- a/extensions/telegram/src/rich-blocks-list.ts
+++ b/extensions/telegram/src/rich-blocks-list.ts
@@ -1,0 +1,81 @@
+import type { MarkdownIR } from "openclaw/plugin-sdk/text-chunking";
+import type { InputRichBlock, InputRichBlockListItem } from "./rich-block-model.js";
+
+type MarkdownRichListItemSource = {
+  kind: "bullet" | "ordered";
+  start: number;
+  end: number;
+  contentStart: number;
+  task: boolean;
+  checked: boolean;
+  value?: number;
+};
+
+export type MarkdownRichListSource = {
+  start: number;
+  end: number;
+  items: MarkdownRichListItemSource[];
+};
+
+/** Groups exact parser-owned item spans by list identity without reparsing Markdown. */
+export function collectMarkdownRichListSources(ir: MarkdownIR): MarkdownRichListSource[] {
+  const byListId = new Map<number, MarkdownRichListItemSource[]>();
+  for (const item of ir.listItems ?? []) {
+    if (
+      !item.listMarker ||
+      item.listId === undefined ||
+      item.start === undefined ||
+      item.end === undefined
+    ) {
+      continue;
+    }
+    const markerText = ir.text.slice(item.listMarker.start, item.listMarker.end);
+    const taskText = item.taskMarker
+      ? ir.text.slice(item.taskMarker.start, item.taskMarker.end)
+      : "";
+    const value = item.kind === "ordered" ? Number.parseInt(markerText, 10) : undefined;
+    const source = {
+      kind: item.kind,
+      start: item.start,
+      end: item.end,
+      contentStart: item.taskMarker?.end ?? item.listMarker.end,
+      task: item.task === true,
+      checked: /^\[[xX]\]/u.test(taskText),
+      ...(value !== undefined && Number.isFinite(value) ? { value } : {}),
+    } satisfies MarkdownRichListItemSource;
+    const list = byListId.get(item.listId) ?? [];
+    list.push(source);
+    byListId.set(item.listId, list);
+  }
+  return [...byListId.values()].map((items) => {
+    items.sort((left, right) => left.start - right.start);
+    return {
+      start: Math.min(...items.map((item) => item.start)),
+      end: Math.max(...items.map((item) => item.end)),
+      items,
+    };
+  });
+}
+
+type RenderRange = (start: number, end: number) => InputRichBlock[];
+
+/** Renders one parser list; nested containers arrive through renderRange. */
+export function renderMarkdownRichListSource(
+  source: MarkdownRichListSource,
+  renderRange: RenderRange,
+): InputRichBlock[] | undefined {
+  const kind = source.items[0]?.kind;
+  if (!kind || source.items.some((item) => item.kind !== kind)) {
+    return undefined;
+  }
+  const items: InputRichBlockListItem[] = source.items.map((item) => {
+    const blocks = renderRange(item.contentStart, item.end);
+    return {
+      blocks: blocks.length > 0 ? blocks : [{ type: "paragraph", text: "" }],
+      ...(item.task ? { has_checkbox: true as const } : {}),
+      ...(item.checked ? { is_checked: true as const } : {}),
+      ...(kind === "ordered" && item.value !== undefined ? { value: item.value } : {}),
+    };
+  });
+  return [{ type: "list", items }];
+}

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -1,5 +1,6 @@
 // Telegram rich-blocks unit tests for Bot API 10.2 InputRichBlock emission.
 import { describe, expect, it } from "vitest";
+import { markdownToTelegramHtml } from "./format.js";
 import {
   countInputRichBlockChars,
   inputRichBlocksToPlainText,
@@ -48,6 +49,227 @@ function hasStyle(text: RichText, style: string): boolean {
 }
 
 describe("markdownToTelegramRichBlocks", () => {
+  it.each([
+    {
+      name: "bullet items",
+      markdown: "- alpha\n- beta",
+      before: "• alpha\n• beta",
+      after: {
+        type: "list" as const,
+        items: [
+          { blocks: [{ type: "paragraph" as const, text: "alpha" }] },
+          { blocks: [{ type: "paragraph" as const, text: "beta" }] },
+        ],
+      },
+    },
+    {
+      name: "ordered start values",
+      markdown: "4. fourth\n5. fifth",
+      before: "4. fourth\n5. fifth",
+      after: {
+        type: "list" as const,
+        items: [
+          { blocks: [{ type: "paragraph" as const, text: "fourth" }], value: 4 },
+          { blocks: [{ type: "paragraph" as const, text: "fifth" }], value: 5 },
+        ],
+      },
+    },
+    {
+      name: "task checkboxes",
+      markdown: "- [ ] todo\n- [x] done",
+      before: "• [ ] todo\n• [x] done",
+      after: {
+        type: "list" as const,
+        items: [
+          {
+            blocks: [{ type: "paragraph" as const, text: "todo" }],
+            has_checkbox: true as const,
+          },
+          {
+            blocks: [{ type: "paragraph" as const, text: "done" }],
+            has_checkbox: true as const,
+            is_checked: true as const,
+          },
+        ],
+      },
+    },
+    {
+      name: "mixed nesting",
+      markdown: "- parent\n  1. child\n  2. sibling\n- next",
+      before: "• parent\n  1. child\n  2. sibling\n• next",
+      after: {
+        type: "list" as const,
+        items: [
+          {
+            blocks: [
+              { type: "paragraph" as const, text: "parent" },
+              {
+                type: "list" as const,
+                items: [
+                  { blocks: [{ type: "paragraph" as const, text: "child" }], value: 1 },
+                  { blocks: [{ type: "paragraph" as const, text: "sibling" }], value: 2 },
+                ],
+              },
+            ],
+          },
+          { blocks: [{ type: "paragraph" as const, text: "next" }] },
+        ],
+      },
+    },
+  ])("maps $name from flattened text to native blocks", ({ markdown, before, after }) => {
+    const rendered = markdownToTelegramRichBlocks(markdown);
+    expect(rendered.blocks).toEqual([after]);
+    expect(rendered.plainText).toBe(before);
+  });
+
+  it("keeps the classic sendMessage list path byte-identical", () => {
+    expect(markdownToTelegramHtml("- [ ] todo\n- [x] done\n\n4. fourth\n5. fifth")).toBe(
+      "• [ ] todo\n• [x] done\n\n4. fourth\n5. fifth",
+    );
+  });
+
+  it("keeps list boundaries separate from following paragraphs", () => {
+    const rendered = markdownToTelegramRichBlocks("- one\n- two\n\nafter");
+    expect(rendered.blocks.map((block) => block.type)).toEqual(["list", "paragraph"]);
+    expect(rendered.blocks[1]).toEqual({ type: "paragraph", text: "after" });
+  });
+
+  it("uses parser-owned boundaries before a following heading", () => {
+    const rendered = markdownToTelegramRichBlocks("- one\n# Heading");
+    expect(rendered.blocks.map((block) => block.type)).toEqual(["list", "heading"]);
+  });
+
+  it("keeps loose continuation paragraphs inside their native list item", () => {
+    const rendered = markdownToTelegramRichBlocks("- first\n\n  continuation\n- next");
+    expect(rendered.blocks).toHaveLength(1);
+    const list = rendered.blocks[0];
+    if (list?.type !== "list") {
+      expect(list?.type).toBe("list");
+      return;
+    }
+    expect(list.items[0]?.blocks.map((block) => block.type)).toEqual(["paragraph", "paragraph"]);
+    expect(rendered.plainText).toBe("• first\ncontinuation\n• next");
+  });
+
+  it("returns parent continuation content after a nested list", () => {
+    const rendered = markdownToTelegramRichBlocks("- parent\n  - child\n\n  continuation");
+    const outer = rendered.blocks[0];
+    if (outer?.type !== "list") {
+      expect(outer?.type).toBe("list");
+      return;
+    }
+    expect(outer.items[0]?.blocks.map((block) => block.type)).toEqual([
+      "paragraph",
+      "list",
+      "paragraph",
+    ]);
+    const nested = outer.items[0]?.blocks[1];
+    expect(nested?.type).toBe("list");
+    expect(inputRichBlocksToPlainText(nested?.type === "list" ? [nested] : [])).not.toContain(
+      "continuation",
+    );
+  });
+
+  it("preserves a blockquote around a nested list", () => {
+    const rendered = markdownToTelegramRichBlocks("- outer\n  > - inner");
+    const outer = rendered.blocks[0];
+    if (outer?.type !== "list") {
+      expect(outer?.type).toBe("list");
+      return;
+    }
+    const quote = outer.items[0]?.blocks.find((block) => block.type === "blockquote");
+    expect(quote?.type).toBe("blockquote");
+    if (quote?.type === "blockquote") {
+      expect(quote.blocks[0]?.type).toBe("list");
+    }
+  });
+
+  it("keeps distinct same-kind child lists separated by parent content", () => {
+    const rendered = markdownToTelegramRichBlocks(
+      "- outer\n  - first\n\n  parent text\n\n  - second",
+    );
+    const outer = rendered.blocks[0];
+    if (outer?.type !== "list") {
+      expect(outer?.type).toBe("list");
+      return;
+    }
+    expect(outer.items[0]?.blocks.map((block) => block.type)).toEqual([
+      "paragraph",
+      "list",
+      "paragraph",
+      "list",
+    ]);
+  });
+
+  it("nests Markdown lists inside blockquotes", () => {
+    const rendered = markdownToTelegramRichBlocks("> - parent\n>   - child");
+    expect(rendered.blocks).toHaveLength(1);
+    const quote = rendered.blocks[0];
+    expect(quote?.type).toBe("blockquote");
+    if (quote?.type !== "blockquote") {
+      return;
+    }
+    expect(quote.blocks[0]?.type).toBe("list");
+    expect(rendered.plainText).toBe("• parent\n  • child");
+  });
+
+  it("keeps rich inline formatting inside native list items", () => {
+    const rendered = markdownToTelegramRichBlocks("- **bold** and [docs](https://example.com)");
+    const list = rendered.blocks[0];
+    if (list?.type !== "list") {
+      expect(list?.type).toBe("list");
+      return;
+    }
+    const paragraph = list.items[0]?.blocks[0];
+    if (paragraph?.type !== "paragraph") {
+      expect(paragraph?.type).toBe("paragraph");
+      return;
+    }
+    expect(hasStyle(paragraph.text, "bold")).toBe(true);
+    expect(collectUrls(paragraph.text)).toEqual(["https://example.com"]);
+  });
+
+  it("degrades native lists when their nested block count would exceed 500", () => {
+    const markdown = Array.from({ length: 251 }, (_, index) => `- item ${index + 1}`).join("\n");
+    const rendered = markdownToTelegramRichBlocks(markdown);
+    expect(rendered.degradationReasons).toEqual(["list-limit"]);
+    expect(rendered.blocks).toHaveLength(1);
+    expect(rendered.blocks[0]?.type).toBe("paragraph");
+    expect(rendered.plainText).toContain("• item 251");
+  });
+
+  it("degrades lists when surrounding blocks push the message over 500 blocks", () => {
+    const list = Array.from({ length: 200 }, (_, index) => `- item ${index + 1}`).join("\n");
+    const paragraphs = Array.from({ length: 100 }, (_, index) => `paragraph ${index + 1}`).join(
+      "\n\n",
+    );
+    const rendered = markdownToTelegramRichBlocks(`${list}\n\n${paragraphs}`);
+    expect(rendered.degradationReasons).toEqual(["list-limit"]);
+    expect(rendered.blocks.every((block) => block.type !== "list")).toBe(true);
+    expect(rendered.plainText).toContain("paragraph 100");
+  });
+
+  it("degrades native lists beyond 16 nesting levels", () => {
+    const markdown = Array.from(
+      { length: 17 },
+      (_, index) => `${"  ".repeat(index)}- level ${index + 1}`,
+    ).join("\n");
+    const rendered = markdownToTelegramRichBlocks(markdown);
+    expect(rendered.degradationReasons).toEqual(["list-limit"]);
+    expect(rendered.blocks.every((block) => block.type !== "list")).toBe(true);
+    expect(rendered.plainText).toContain("level 17");
+  });
+
+  it("includes surrounding blockquotes in the 16-level nesting budget", () => {
+    const markdown = Array.from(
+      { length: 16 },
+      (_, index) => `> ${"  ".repeat(index)}- level ${index + 1}`,
+    ).join("\n");
+    const rendered = markdownToTelegramRichBlocks(markdown);
+    expect(rendered.degradationReasons).toEqual(["list-limit"]);
+    expect(JSON.stringify(rendered.blocks)).not.toContain('"type":"list"');
+  });
+
   it("nests inline styles and links", () => {
     const { blocks } = markdownToTelegramRichBlocks(
       "**bold _italic_** and [docs](https://example.com) ~~strike~~ ||spoiler|| `code`",

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -1,6 +1,7 @@
 // Markdown → Bot API 10.2 InputRichBlock[] for Telegram rich messages.
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import {
+  type FormatCapabilityProfile,
   isAutoLinkedFileRef,
   markdownToIRWithMeta,
   renderMarkdownWithMarkers,
@@ -12,7 +13,9 @@ import {
   type MarkdownTableMeta,
 } from "openclaw/plugin-sdk/text-chunking";
 import {
+  countInputRichBlocks,
   inputRichBlocksToPlainText,
+  maxInputRichBlockNesting,
   normalizeRichText,
   type InputRichBlock,
   type InputRichBlockParagraph,
@@ -22,8 +25,37 @@ import {
 } from "./rich-block-model.js";
 import { findTelegramHtmlIslands } from "./rich-blocks-html-map.js";
 import { parseInlineHtmlIslands } from "./rich-blocks-html.js";
+import {
+  collectMarkdownRichListSources,
+  renderMarkdownRichListSource,
+  type MarkdownRichListSource,
+} from "./rich-blocks-list.js";
 
 const TELEGRAM_RICH_TEXT_TABLE_COLUMN_LIMIT = 20;
+
+const TELEGRAM_RICH_FORMAT_PROFILE = {
+  mechanism: "blocks",
+  constructs: {
+    bold: "native",
+    italic: "native",
+    underline: "native",
+    strikethrough: "native",
+    spoiler: "native",
+    codeInline: "native",
+    codeBlock: "native",
+    codeLanguage: "native",
+    linkLabel: "native",
+    heading: "native",
+    bulletList: "native",
+    orderedList: "native",
+    taskList: "native",
+    table: "native",
+    blockquote: "native",
+    image: "native",
+    mention: "native",
+  },
+  chunk: { limit: 32_768, unit: "chars" },
+} satisfies FormatCapabilityProfile;
 
 const INLINE_STYLE_RANK: Record<string, number> = {
   spoiler: 0,
@@ -41,6 +73,7 @@ type StructuralSegment =
   | { kind: "heading"; start: number; end: number; size: 1 | 2 | 3 | 4 | 5 | 6 }
   | { kind: "code_block"; start: number; end: number; language?: string }
   | { kind: "blockquote"; start: number; end: number }
+  | { kind: "list"; start: number; end: number; source: MarkdownRichListSource }
   | { kind: "table"; start: number; end: number; table: MarkdownTableMeta };
 
 function isTelegramRichLinkHref(href: string): boolean {
@@ -111,17 +144,21 @@ function collectTelegramLinkActions(
   ir: MarkdownIR,
 ): Array<{ start: number; end: number; action: TelegramLinkAction }> {
   const links: Array<{ start: number; end: number; action: TelegramLinkAction }> = [];
-  renderMarkdownWithMarkers(ir, {
-    styleMarkers: {},
-    escapeText: (text) => text,
-    buildLink: (link, source, context) => {
-      const action = resolveTelegramLinkAction(link, source, context);
-      if (action) {
-        links.push({ start: link.start, end: link.end, action });
-      }
-      return null;
+  renderMarkdownWithMarkers(
+    ir,
+    {
+      styleMarkers: {},
+      escapeText: (text) => text,
+      buildLink: (link, source, context) => {
+        const action = resolveTelegramLinkAction(link, source, context);
+        if (action) {
+          links.push({ start: link.start, end: link.end, action });
+        }
+        return null;
+      },
     },
-  });
+    TELEGRAM_RICH_FORMAT_PROFILE,
+  );
   return links;
 }
 
@@ -495,9 +532,19 @@ function collectStructuralSegments(
     const offset = Math.max(0, Math.min(table.placeholderOffset, ir.text.length));
     segments.push({ kind: "table", start: offset, end: offset, table });
   }
+  for (const source of collectMarkdownRichListSources(ir)) {
+    segments.push({ kind: "list", start: source.start, end: source.end, source });
+  }
   // Containers sort before their children (start asc, end desc) so emitSegments
   // can consume contained segments recursively instead of double-emitting them.
-  return segments.toSorted((left, right) => left.start - right.start || right.end - left.end);
+  const containerRank = (segment: StructuralSegment) =>
+    segment.kind === "blockquote" ? 0 : segment.kind === "list" ? 1 : 2;
+  return segments.toSorted(
+    (left, right) =>
+      left.start - right.start ||
+      right.end - left.end ||
+      containerRank(left) - containerRank(right),
+  );
 }
 
 function emitSegments(
@@ -549,6 +596,32 @@ function emitSegments(
         }
         break;
       }
+      case "list": {
+        const rendered = renderMarkdownRichListSource(segment.source, (start, end) =>
+          emitSegments(
+            ir,
+            children.filter((child) => child.start >= start && child.end <= end),
+            start,
+            end,
+            degradationReasons,
+          ),
+        );
+        if (rendered) {
+          blocks.push(...rendered);
+        } else {
+          degradationReasons.add("list-limit");
+          blocks.push(
+            ...emitSegments(
+              ir,
+              children.filter((child) => child.kind !== "list"),
+              segment.start,
+              segment.end,
+              degradationReasons,
+            ),
+          );
+        }
+        break;
+      }
       case "table": {
         const rendered = renderTableBlock(segment.table);
         if (rendered.degradation) {
@@ -576,32 +649,46 @@ export function markdownToTelegramRichBlocks(
   degradationReasons: readonly TelegramRichBlocksDegradationReason[];
 } {
   const tableMode = options.tableMode ?? "block";
-  // Markdown-native lists stay IR-flattened and `---` keeps the IR's ─── text
-  // (the old rich path did the same); native list/media/details/math blocks
-  // come from the documented HTML-island contract (rich-blocks-html.ts), which
-  // the agent system prompt advertises when rich messages are enabled.
+  // The shared parse carries list markers into native blocks; `---` keeps the
+  // IR's ─── text, while media/details/math stay HTML-island contracts.
   const { ir, tables } = markdownToIRWithMeta(markdown ?? "", {
     assistantTranscriptRoleHeaders: true,
     linkify: options.skipEntityDetection !== true,
     enableSpoilers: true,
+    enableTaskLists: true,
     headingStyle: "rich",
     blockquotePrefix: "",
     tableMode,
   });
 
-  const degradationReasons = new Set<TelegramRichBlocksDegradationReason>();
+  let degradationReasons = new Set<TelegramRichBlocksDegradationReason>();
   const segments = collectStructuralSegments(ir, tables);
-  const blocks = emitSegments(ir, segments, 0, ir.text.length, degradationReasons);
+  const hasMarkdownLists = segments.some((segment) => segment.kind === "list");
+  const flattenedSegments = segments.filter((segment) => segment.kind !== "list");
+  let blocks = emitSegments(ir, segments, 0, ir.text.length, degradationReasons);
+  if (
+    hasMarkdownLists &&
+    (countInputRichBlocks(blocks) > 500 || maxInputRichBlockNesting(blocks) > 16)
+  ) {
+    degradationReasons = new Set<TelegramRichBlocksDegradationReason>();
+    degradationReasons.add("list-limit");
+    blocks = emitSegments(ir, flattenedSegments, 0, ir.text.length, degradationReasons);
+  }
 
   if (blocks.length === 0 && ir.text.trim()) {
     blocks.push({ type: "paragraph", text: ir.text });
   }
 
+  // Plain recovery remains byte-compatible with the pre-native-list path.
+  const plainBlocks = hasMarkdownLists
+    ? emitSegments(ir, flattenedSegments, 0, ir.text.length, new Set())
+    : blocks;
+
   return {
     blocks,
     // Tables are zero-width placeholders in ir.text; project the blocks so the
     // plain fallback keeps table content instead of silently dropping it.
-    plainText: inputRichBlocksToPlainText(blocks),
+    plainText: inputRichBlocksToPlainText(plainBlocks),
     degradationReasons: [...degradationReasons],
   };
 }

--- a/packages/markdown-core/src/ir.nested-lists.test.ts
+++ b/packages/markdown-core/src/ir.nested-lists.test.ts
@@ -41,6 +41,26 @@ import { describe, it, expect } from "vitest";
 import { markdownToIR } from "./ir.js";
 
 describe("Nested Lists - 2 Level Nesting", () => {
+  it("records parser-owned item spans and list ancestry", () => {
+    const result = markdownToIR("- parent\n  - child\n- next\n# Heading");
+    const items = [...(result.listItems ?? [])].toSorted(
+      (left, right) => (left.listMarker?.start ?? 0) - (right.listMarker?.start ?? 0),
+    );
+    const [parent, child, next] = items;
+    expect(items).toHaveLength(3);
+    expect(parent).toMatchObject({ depth: 0, start: 0 });
+    expect(child).toMatchObject({ depth: 1, parentListId: parent?.listId });
+    expect(next?.listId).toBe(parent?.listId);
+    expect(result.text.slice(parent?.start, parent?.end)).toContain("child");
+    expect(result.text.slice(next?.start, next?.end)).not.toContain("Heading");
+  });
+
+  it("keeps loose continuation paragraphs inside the item span", () => {
+    const result = markdownToIR("- first\n\n  continuation\n- next");
+    const first = result.listItems?.find((item) => item.listMarker?.start === 0);
+    expect(result.text.slice(first?.start, first?.end)).toContain("continuation");
+  });
+
   it("renders bullet items nested inside bullet items with proper indentation", () => {
     const input = `- Item 1
   - Nested 1.1

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -43,6 +43,8 @@ type ListState = {
   type: "bullet" | "ordered";
   index: number;
   openLevel: number;
+  id: number;
+  parentId?: number;
 };
 
 type LinkState = {
@@ -80,6 +82,12 @@ type MarkdownListItemMarker = {
   listMarker?: { start: number; end: number };
   task?: true;
   taskMarker?: { start: number; end: number };
+  /** Parser-owned identity and rendered span for block-native list emitters. */
+  listId?: number;
+  parentListId?: number;
+  depth?: number;
+  start?: number;
+  end?: number;
 };
 
 export type MarkdownIR = {
@@ -150,6 +158,7 @@ type RenderState = RenderTarget & {
   headingLineEnd: number | undefined;
   listItems: MarkdownListItemMarker[];
   openListItems: MarkdownListItemMarker[];
+  nextListId: number;
 };
 
 export type MarkdownParseOptions = {
@@ -477,14 +486,19 @@ function appendListPrefix(state: RenderState, isTask: boolean): MarkdownListItem
     return undefined;
   }
   top.index += 1;
+  const itemStart = state.text.length;
   const indent = "  ".repeat(Math.max(0, stack.length - 1));
   const prefix = top.type === "ordered" ? `${top.index}. ` : "• ";
   state.text += indent;
-  const start = state.text.length;
+  const markerStart = state.text.length;
   state.text += prefix;
   return {
     kind: top.type,
-    listMarker: { start, end: state.text.length },
+    listMarker: { start: markerStart, end: state.text.length },
+    listId: top.id,
+    ...(top.parentId !== undefined ? { parentListId: top.parentId } : {}),
+    depth: stack.length - 1,
+    start: itemStart,
     ...(isTask ? { task: true as const } : {}),
   };
 }
@@ -988,7 +1002,15 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         if (state.env.listStack.length > 0) {
           appendNestedListSeparator(state);
         }
-        state.env.listStack.push({ type: "bullet", index: 0, openLevel: token.level ?? 0 });
+        state.env.listStack.push({
+          type: "bullet",
+          index: 0,
+          openLevel: token.level ?? 0,
+          id: state.nextListId++,
+          ...(state.env.listStack.at(-1)?.id !== undefined
+            ? { parentId: state.env.listStack.at(-1)?.id }
+            : {}),
+        });
         break;
       case "bullet_list_close":
         state.env.listStack.pop();
@@ -1006,6 +1028,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
           type: "ordered",
           index: start - 1,
           openLevel: token.level ?? 0,
+          id: state.nextListId++,
+          ...(state.env.listStack.at(-1)?.id !== undefined
+            ? { parentId: state.env.listStack.at(-1)?.id }
+            : {}),
         });
         break;
       }
@@ -1033,6 +1059,11 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
             ...(item.listMarker ? { listMarker: item.listMarker } : {}),
             ...(item.task ? { task: true } : {}),
             ...(item.taskMarker ? { taskMarker: item.taskMarker } : {}),
+            ...(item.listId !== undefined ? { listId: item.listId } : {}),
+            ...(item.parentListId !== undefined ? { parentListId: item.parentListId } : {}),
+            ...(item.depth !== undefined ? { depth: item.depth } : {}),
+            ...(item.start !== undefined ? { start: item.start } : {}),
+            end: state.text.length,
           });
         }
         // Avoid double newlines (nested list's last item already added newline)
@@ -1174,6 +1205,11 @@ export function sliceMarkdownIR(ir: MarkdownIR, start: number, end: number): Mar
             ...(listMarker ? { listMarker } : {}),
             ...(item.task ? { task: true as const } : {}),
             ...(taskMarker ? { taskMarker } : {}),
+            ...(item.listId !== undefined ? { listId: item.listId } : {}),
+            ...(item.parentListId !== undefined ? { parentListId: item.parentListId } : {}),
+            ...(item.depth !== undefined ? { depth: item.depth } : {}),
+            ...(item.start !== undefined ? { start: Math.max(item.start, start) - start } : {}),
+            ...(item.end !== undefined ? { end: Math.min(item.end, end) - start } : {}),
           },
         ]
       : [];
@@ -1226,6 +1262,7 @@ export function markdownToIRWithMeta(
     headingLineEnd: undefined,
     listItems: [],
     openListItems: [],
+    nextListId: 0,
   };
 
   renderTokens(tokens as MarkdownToken[], state);
@@ -1260,6 +1297,11 @@ export function markdownToIRWithMeta(
             ...(listMarker ? { listMarker } : {}),
             ...(item.task ? { task: true as const } : {}),
             ...(taskMarker ? { taskMarker } : {}),
+            ...(item.listId !== undefined ? { listId: item.listId } : {}),
+            ...(item.parentListId !== undefined ? { parentListId: item.parentListId } : {}),
+            ...(item.depth !== undefined ? { depth: item.depth } : {}),
+            ...(item.start !== undefined ? { start: Math.min(item.start, finalLength) } : {}),
+            ...(item.end !== undefined ? { end: Math.min(item.end, finalLength) } : {}),
           },
         ]
       : [];


### PR DESCRIPTION
## What Problem This Solves

Telegram rich-message accounts currently receive Markdown lists as one flattened paragraph, even though the Bot API supports native bullet, ordered, nested, and checkbox list blocks. This loses native list semantics and task state on the rich path.

## Why This Change Was Made

The Telegram rich renderer now declares its block capability profile, consumes the shared Markdown IR, and emits `InputRichBlockList` / `InputRichBlockListItem` structures. Markdown-core carries parser-owned list IDs, ancestry, and exact item spans so the channel does not reparse Markdown or infer boundaries from whitespace; the existing structural segment emitter remains responsible for blockquotes, headings, code, tables, and intervening paragraphs.

The renderer preserves ordered values and maps `- [ ]` / `- [x]` to `has_checkbox` / `is_checked`. It counts the complete rich block tree against Telegram's 500-block and 16-level limits and restores the previous flattened representation when native lists would exceed either limit. Classic `sendMessage` rendering and plain recovery remain byte-identical.

Telegram contracts: https://core.telegram.org/bots/api#inputrichblocklistitem and https://core.telegram.org/bots/api#rich-message-limits.

AI-assisted implementation; the final staged bundle passed the repository's Codex autoreview gate.

## User Impact

Users with Telegram rich messages enabled now see native bullets, numbering, nesting, and task checkboxes. Oversized or over-deep list documents remain readable through the established flattened form instead of being rejected by Telegram. Accounts on the classic send path see no output change.

## Evidence

- LOC: production `+348/-28`, tests `+242/-0`; total `+590/-28` (net `+562`). The accepted markdown-unification tradeoff adds one parser metadata seam and one Telegram-owned 81-line emitter, replacing unsafe channel-side boundary inference with parser-owned spans.
- Golden before -> after fixtures:
  - bullet lines: flattened `• alpha` / `• beta` paragraph -> one native list with two item blocks;
  - ordered list starting at 4 -> native item values `4`, `5`;
  - `- [ ]` / `- [x]` -> native checkbox flags, while plain recovery retains the prior bullet/task bytes;
  - mixed nested bullet/ordered lists -> nested list blocks with preserved values;
  - parent continuation after a child list, list-in-blockquote, and two same-kind child lists separated by parent text retain their parser-owned container hierarchy;
  - 499 counted blocks and 16 top-level list levels remain native; 501 blocks, 17 levels, and 16 levels inside a blockquote degrade with `list-limit`.
- `node scripts/run-vitest.mjs packages/markdown-core/src/ir.nested-lists.test.ts packages/markdown-core/src/construct-fallbacks.test.ts extensions/telegram/src/rich-blocks.test.ts extensions/telegram/src/rich-blocks-html.test.ts extensions/telegram/src/rich-plain-fallback.test.ts` — 2 shards, 5 files, 158 tests passed on rebased head.
- `node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot/delivery.test.ts` — 3 files, 337 tests passed.
- `node scripts/check-changed.mjs -- packages/markdown-core/src/ir.ts packages/markdown-core/src/ir.nested-lists.test.ts extensions/telegram/src/rich-block-model.ts extensions/telegram/src/rich-blocks-list.ts extensions/telegram/src/rich-blocks.test.ts extensions/telegram/src/rich-blocks.ts` — full core + extension type/lint/boundary/cycle gate passed on Blacksmith Testbox `tbx_01ky8cw8190179p60qj9hpz2dr`, run https://github.com/openclaw/openclaw/actions/runs/30044934643; the subsequent rebase was conflict-free and patch-identical.
- Final rebased-head extension gate: `node scripts/check-changed.mjs -- extensions/telegram/src/rich-block-model.ts extensions/telegram/src/rich-blocks-list.ts extensions/telegram/src/rich-blocks.test.ts extensions/telegram/src/rich-blocks.ts` — passed on Blacksmith Testbox `tbx_01ky8fzp1h6r9gmcxq96gmn5c8`, run https://github.com/openclaw/openclaw/actions/runs/30048425564.
- Source-blind generated-payload validation passed bullets, ordered start 7, task state, nested lists, 499/501 blocks, 16/17 levels, and 16 levels inside a blockquote.
- Final `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings (overall correct, confidence 0.88). Earlier accepted findings drove the parser-owned span refactor and full-tree limit accounting.
- `git diff --check origin/main...HEAD` — passed.
- Live Telegram rich-send proof gap: this worktree has no Telegram or Convex QA credential variables, and the existing secret-bearing Telegram QA adapter hard-codes classic delivery with no rich-block assertion. Adding a temporary QA scenario/config change would cross this batch's channel surface and would not be final-head proof. The PR therefore relies on golden fixtures, rich-block model tests, delivery-funnel tests, and the official Bot API contract; no screenshot was uploaded.
- ClawSweeper rank-up move disposition: the requested real rich-message send is not applied for the same concrete environment/QA-boundary reason above. The maintainer-authored batch contract explicitly permits stating this gap and relying on golden fixtures plus rich-block model tests when live proof is genuinely infeasible. Residual risk is accepted for this opt-in rich-message surface; the first contradictory live report should be treated as a channel regression.
