### PR TITLE
fix(mcp): keep servers whose tool schemas omit a root type

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -56,6 +56,7 @@ import {
   type McpServerConnectionResolved,
 } from "./mcp-connection-resolver.js";
 import { createMcpJsonSchemaValidator } from "./mcp-json-schema-validator.js";
+import { listToolsTolerant } from "./mcp-list-tools-tolerant.js";
 import { sanitizeMcpMetadataText } from "./mcp-metadata.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
@@ -171,7 +172,7 @@ async function listAllTools(client: Client, timeoutMs: number) {
   let cursor: string | undefined;
   do {
     const params = cursor ? { cursor } : undefined;
-    const page = await client.listTools(params, { timeout: timeoutMs });
+    const page = await listToolsTolerant(client, params, { timeout: timeoutMs });
     tools.push(...page.tools);
     cursor = page.nextCursor;
   } while (cursor);
@@ -1051,7 +1052,7 @@ export function createSessionMcpRuntime(params: {
       const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(serverName, session, async () =>
         runMcpRequest(session, async (signal) =>
-          session.client.listTools(requestParams, { timeout: session.requestTimeoutMs, signal }),
+          listToolsTolerant(session.client, requestParams, { timeout: session.requestTimeoutMs, signal }),
         ),
       );
     },

--- a/src/agents/mcp-list-tools-tolerant.test.ts
+++ b/src/agents/mcp-list-tools-tolerant.test.ts
@@ -1,0 +1,172 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema, type Tool } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+import { listToolsTolerant } from "./mcp-list-tools-tolerant.js";
+
+// A root-level `oneOf` is legal JSON Schema 2020-12 and describes an object, but
+// carries no top-level "type" -- the shape the SDK's ToolSchema rejects (#112667).
+const ONE_OF_TOOL = {
+  name: "finlynq_query",
+  description: "Look a security up by symbol or by ISIN",
+  inputSchema: {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    oneOf: [
+      { type: "object", properties: { symbol: { type: "string" } }, required: ["symbol"] },
+      { type: "object", properties: { isin: { type: "string" } }, required: ["isin"] },
+    ],
+  },
+} as unknown as Tool;
+
+const CONFORMING_TOOL = {
+  name: "finlynq_ping",
+  description: "Health check",
+  inputSchema: { type: "object", properties: {}, additionalProperties: false },
+} as unknown as Tool;
+
+async function connectClient(
+  handler: (params: { cursor?: string }) => Promise<{ tools: Tool[]; nextCursor?: string }>,
+) {
+  const server = new Server({ name: "finlynq", version: "1.0.0" }, { capabilities: { tools: {} } });
+  server.setRequestHandler(ListToolsRequestSchema, async (request) =>
+    handler({ cursor: request.params?.cursor }),
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "openclaw-test", version: "1.0.0" }, { capabilities: {} });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return {
+    client,
+    async close() {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("listToolsTolerant (#112667)", () => {
+  it("loads a server whose tool inputSchema is a root-level oneOf", async () => {
+    const { client, close } = await connectClient(async () => ({ tools: [ONE_OF_TOOL] }));
+    try {
+      // The SDK's own strict schema is what fails today -- this is the bug.
+      await expect(client.listTools()).rejects.toThrow();
+
+      const page = await listToolsTolerant(client);
+      expect(page.tools.map((tool) => tool.name)).toEqual(["finlynq_query"]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("keeps the conforming tools on a server that also advertises a oneOf tool", async () => {
+    const { client, close } = await connectClient(async () => ({
+      tools: [ONE_OF_TOOL, CONFORMING_TOOL],
+    }));
+    try {
+      const page = await listToolsTolerant(client);
+      expect(page.tools.map((tool) => tool.name)).toEqual(["finlynq_query", "finlynq_ping"]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("passes the advertised schema through verbatim", async () => {
+    const { client, close } = await connectClient(async () => ({ tools: [ONE_OF_TOOL] }));
+    try {
+      const page = await listToolsTolerant(client);
+      expect(page.tools[0]?.inputSchema).toEqual(ONE_OF_TOOL.inputSchema);
+      expect(page.tools[0]?.description).toBe("Look a security up by symbol or by ISIN");
+    } finally {
+      await close();
+    }
+  });
+
+  it("leaves a conforming server on the strict SDK path (one request, no retry)", async () => {
+    let requests = 0;
+    const { client, close } = await connectClient(async () => {
+      requests += 1;
+      return { tools: [CONFORMING_TOOL] };
+    });
+    try {
+      const page = await listToolsTolerant(client);
+      expect(page.tools.map((tool) => tool.name)).toEqual(["finlynq_ping"]);
+      expect(requests).toBe(1);
+    } finally {
+      await close();
+    }
+  });
+
+  it("forwards the cursor and returns nextCursor", async () => {
+    const seen: Array<string | undefined> = [];
+    const { client, close } = await connectClient(async ({ cursor }) => {
+      seen.push(cursor);
+      return cursor ? { tools: [CONFORMING_TOOL] } : { tools: [ONE_OF_TOOL], nextCursor: "page-2" };
+    });
+    try {
+      const first = await listToolsTolerant(client);
+      expect(first.nextCursor).toBe("page-2");
+      const second = await listToolsTolerant(client, { cursor: first.nextCursor });
+      expect(second.tools.map((tool) => tool.name)).toEqual(["finlynq_ping"]);
+      // The relaxed retry re-issues the same page, so the first cursor appears twice.
+      expect(seen).toEqual([undefined, undefined, "page-2"]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("still rejects a tool schema that declares a non-object type", async () => {
+    const arrayTool = {
+      name: "finlynq_batch",
+      inputSchema: { type: "array", items: { type: "number" } },
+    } as unknown as Tool;
+    const { client, close } = await connectClient(async () => ({ tools: [arrayTool] }));
+    try {
+      // Not a missing root type -- a wrong one. The server stays rejected, with the
+      // same diagnostic the strict schema produces today.
+      await expect(listToolsTolerant(client)).rejects.toThrow(/Invalid input: expected/);
+    } finally {
+      await close();
+    }
+  });
+
+  it("does not retry a response that is malformed beyond the schema type", async () => {
+    let requests = 0;
+    const { client, close } = await connectClient(async () => {
+      requests += 1;
+      // Not a schema with an unstated type -- not a schema object at all.
+      return { tools: [{ name: "finlynq_broken", inputSchema: [] } as unknown as Tool] };
+    });
+    try {
+      await expect(listToolsTolerant(client)).rejects.toThrow(/Invalid input/);
+      // One request: a server answering differently on a retry must not be able to
+      // turn a rejected catalog into an accepted one.
+      expect(requests).toBe(1);
+    } finally {
+      await close();
+    }
+  });
+
+  it("rethrows server-side failures instead of retrying them", async () => {
+    const { client, close } = await connectClient(async () => {
+      throw new Error("tools/list exploded");
+    });
+    try {
+      await expect(listToolsTolerant(client)).rejects.toThrow(/exploded/);
+    } finally {
+      await close();
+    }
+  });
+
+  it("rethrows when the client cannot issue a raw request", async () => {
+    const validationError = Object.assign(new Error("bad tool schema"), {
+      issues: [{ path: ["tools", 0, "inputSchema", "type"] }],
+    });
+    const client = {
+      listTools: async () => {
+        throw validationError;
+      },
+    };
+    await expect(listToolsTolerant(client)).rejects.toBe(validationError);
+  });
+});

--- a/src/agents/mcp-list-tools-tolerant.test.ts
+++ b/src/agents/mcp-list-tools-tolerant.test.ts
@@ -59,6 +59,33 @@ describe("listToolsTolerant (#112667)", () => {
     }
   });
 
+  it("rejects an untyped tool schema that is not provably object-only (#113162 review)", async () => {
+    const NON_OBJECT_TOOL = {
+      name: "ambiguous",
+      inputSchema: { oneOf: [{ type: "string" }, { type: "number" }] },
+    } as unknown as Tool;
+    const { client, close } = await connectClient(async () => ({ tools: [NON_OBJECT_TOOL] }));
+    try {
+      await expect(listToolsTolerant(client)).rejects.toThrow(/Invalid input|expected/);
+    } finally {
+      await close();
+    }
+  });
+
+  it("accepts an untyped tool schema with object-only keywords (#113162 review)", async () => {
+    const PROPS_TOOL = {
+      name: "props_tool",
+      inputSchema: { properties: { symbol: { type: "string" } }, required: ["symbol"] },
+    } as unknown as Tool;
+    const { client, close } = await connectClient(async () => ({ tools: [PROPS_TOOL] }));
+    try {
+      const page = await listToolsTolerant(client);
+      expect(page.tools.map((tool) => tool.name)).toEqual(["props_tool"]);
+    } finally {
+      await close();
+    }
+  });
+
   it("keeps the conforming tools on a server that also advertises a oneOf tool", async () => {
     const { client, close } = await connectClient(async () => ({
       tools: [ONE_OF_TOOL, CONFORMING_TOOL],

--- a/src/agents/mcp-list-tools-tolerant.ts
+++ b/src/agents/mcp-list-tools-tolerant.ts
@@ -3,18 +3,50 @@ import { z } from "zod";
 
 // The SDK's ToolSchema requires `inputSchema.type` to be the literal "object", so
 // a server that describes its object argument some other legal way -- a root-level
-// `oneOf`/`anyOf`/`$ref`, ordinary in JSON Schema 2020-12 -- fails client-side
-// result validation and takes every other tool on that server down with it. This
-// mirrors ListToolsResultSchema but only drops the requirement that the type be
-// stated at the root: a schema that declares some other type (`array`, `string`)
-// is still not a tool argument object, and is still rejected.
+// `oneOf`/`anyOf`/`allOf` of objects, ordinary in JSON Schema 2020-12 -- fails
+// client-side result validation and takes every other tool on that server down with
+// it. We relax that ONE requirement, but only for schemas that still PROVABLY
+// describe an object: a stated non-object type, or an untyped schema with no object
+// evidence (so it could permit an array/string/any), stays rejected -- preserving
+// the MCP contract that tool arguments are objects.
 
-const UntypedObjectJsonSchema = z.looseObject({ type: z.literal("object").optional() });
+/** True when `schema` provably describes an object argument (see the note above). */
+function describesObjectArguments(schema: unknown): boolean {
+  if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
+    return false;
+  }
+  const s = schema as Record<string, unknown>;
+  if (s.type === "object") {
+    return true;
+  }
+  if (typeof s.type === "string") {
+    return false; // a stated non-object type is not a tool argument object
+  }
+  if (Array.isArray(s.type)) {
+    return s.type.length > 0 && s.type.every((entry) => entry === "object");
+  }
+  if ("properties" in s || "required" in s || "additionalProperties" in s) {
+    return true;
+  }
+  for (const key of ["oneOf", "anyOf", "allOf"] as const) {
+    const branches = s[key];
+    if (
+      Array.isArray(branches) &&
+      branches.length > 0 &&
+      branches.every(describesObjectArguments)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const ObjectArgumentJsonSchema = z.custom<Record<string, unknown>>(describesObjectArguments);
 
 const RelaxedToolSchema = z.looseObject({
   name: z.string(),
-  inputSchema: UntypedObjectJsonSchema.optional(),
-  outputSchema: UntypedObjectJsonSchema.optional(),
+  inputSchema: ObjectArgumentJsonSchema.optional(),
+  outputSchema: ObjectArgumentJsonSchema.optional(),
 });
 
 export const RelaxedListToolsResultSchema = z.looseObject({

--- a/src/agents/mcp-list-tools-tolerant.ts
+++ b/src/agents/mcp-list-tools-tolerant.ts
@@ -1,0 +1,93 @@
+/** Tolerant `tools/list` result parsing for schemas the MCP SDK rejects outright. */
+import { z } from "zod";
+
+// The SDK's ToolSchema requires `inputSchema.type` to be the literal "object", so
+// a server that describes its object argument some other legal way -- a root-level
+// `oneOf`/`anyOf`/`$ref`, ordinary in JSON Schema 2020-12 -- fails client-side
+// result validation and takes every other tool on that server down with it. This
+// mirrors ListToolsResultSchema but only drops the requirement that the type be
+// stated at the root: a schema that declares some other type (`array`, `string`)
+// is still not a tool argument object, and is still rejected.
+
+const UntypedObjectJsonSchema = z.looseObject({ type: z.literal("object").optional() });
+
+const RelaxedToolSchema = z.looseObject({
+  name: z.string(),
+  inputSchema: UntypedObjectJsonSchema.optional(),
+  outputSchema: UntypedObjectJsonSchema.optional(),
+});
+
+export const RelaxedListToolsResultSchema = z.looseObject({
+  tools: z.array(RelaxedToolSchema),
+  nextCursor: z.string().optional(),
+});
+
+type ListToolsParams = { cursor?: string } | undefined;
+type ListToolsRequestOptions = { timeout?: number; signal?: AbortSignal } | undefined;
+
+type ListToolsRequester = (
+  request: { method: "tools/list"; params: ListToolsParams },
+  resultSchema: typeof RelaxedListToolsResultSchema,
+  options: ListToolsRequestOptions,
+) => Promise<unknown>;
+
+type ListToolsCapableClient<TPage> = {
+  listTools(params?: { cursor?: string }, options?: { timeout?: number; signal?: AbortSignal }): Promise<TPage>;
+};
+
+/**
+ * True when the sole complaint about the response is the declared type of a tool
+ * schema -- `tools[n].inputSchema.type` or `tools[n].outputSchema.type`. Anything
+ * else (a transport error, a missing name, a schema that is not an object at all)
+ * is a real failure and keeps its existing handling, retry-free.
+ */
+function isToolSchemaTypeOnlyFailure(error: unknown): boolean {
+  const issues = (error as { issues?: unknown } | null | undefined)?.issues;
+  if (!Array.isArray(issues) || issues.length === 0) {
+    return false;
+  }
+  return issues.every((issue) => {
+    const path = (issue as { path?: unknown })?.path;
+    return (
+      Array.isArray(path) &&
+      path.length === 4 &&
+      path[0] === "tools" &&
+      (path[2] === "inputSchema" || path[2] === "outputSchema") &&
+      path[3] === "type"
+    );
+  });
+}
+
+/**
+ * Lists one page of tools through the SDK client, retrying with a relaxed result
+ * schema when -- and only when -- a tool schema's declared type is the single thing
+ * the SDK objected to. Conforming servers stay on the SDK path untouched, including
+ * its output-schema caching; the retry costs one extra request on a page that has
+ * already failed, and is skipped for clients that cannot issue a raw request.
+ */
+export async function listToolsTolerant<TPage>(
+  client: ListToolsCapableClient<TPage>,
+  params?: { cursor?: string },
+  options?: { timeout?: number; signal?: AbortSignal },
+): Promise<TPage> {
+  try {
+    return await client.listTools(params, options);
+  } catch (error) {
+    const request = (client as { request?: unknown }).request;
+    if (!isToolSchemaTypeOnlyFailure(error) || typeof request !== "function") {
+      throw error;
+    }
+    try {
+      return (await (request as ListToolsRequester).call(
+        client,
+        { method: "tools/list", params },
+        RelaxedListToolsResultSchema,
+        options,
+      )) as TPage;
+    } catch {
+      // The relaxed schema rejected it too, so the response is malformed beyond a
+      // missing root type. Report the original failure -- it is the precise one.
+      throw error;
+    }
+  }
+}

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -9,6 +9,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { NodePluginToolDescriptor } from "../../packages/gateway-protocol/src/schema/nodes.js";
 import { matchesMcpToolFilterPattern } from "../agents/agent-bundle-mcp-filter.js";
 import { createMcpJsonSchemaValidator } from "../agents/mcp-json-schema-validator.js";
+import { listToolsTolerant } from "../agents/mcp-list-tools-tolerant.js";
 import { sanitizeMcpMetadataText } from "../agents/mcp-metadata.js";
 import { resolveMcpRequestTimeoutMs } from "../agents/mcp-transport-config.js";
 import { resolveMcpTransport } from "../agents/mcp-transport.js";
@@ -265,7 +266,7 @@ async function listAllTools(
   let cursor: string | undefined;
   do {
     const page = await withAbort(
-      client.listTools(cursor ? { cursor } : undefined, { timeout: timeoutMs }),
+      listToolsTolerant(client, cursor ? { cursor } : undefined, { timeout: timeoutMs }),
       signal,
     );
     tools.push(...page.tools);


### PR DESCRIPTION
## What Problem This Solves

An MCP server that advertises a tool whose `inputSchema` states its shape with a root-level `oneOf` — legal JSON Schema 2020-12, and the schema still describes an object — is rejected by OpenClaw before any of its tools load:

```
Invalid input: expected "object"   (path: tools[0].inputSchema.type)
```

**Every** tool on that server disappears, not just the one with the composed schema.

Closes #112667.

## Why This Change Was Made

The rejection is client-side, and it is not OpenClaw's own normalization: `normalizeInputSchema` (`src/node-host/mcp.ts`) passes any object through unchanged. It comes from `@modelcontextprotocol/sdk`'s own `ToolSchema`, which pins the schema type to a literal:

```ts
// @modelcontextprotocol/sdk 1.29.0, src/types.ts:1391
inputSchema: z.object({ type: z.literal("object"), ... })
```

`client.listTools()` parses the `tools/list` response with `ListToolsResultSchema`, which embeds that. So the HTTP call succeeds, the server returns a valid tool list, and the SDK's Zod pass throws — the whole catalog is lost. Bumping the SDK is not a fix: 1.29.0 is the latest stable, and the same literal is present.

I reproduced it end-to-end against a real `Client`/`Server` pair over `InMemoryTransport`, which yields the exact error text and path from the issue.

The fix adds `listToolsTolerant` (`src/agents/mcp-list-tools-tolerant.ts`) and routes the three `tools/list` call sites through it (`node-host/mcp.ts` `listAllTools`, `agent-bundle-mcp-runtime.ts` `listAllTools`, and the runtime's `listTools` passthrough). It calls `client.listTools` exactly as before, and retries the page with a relaxed result schema **only when a tool schema's declared type is the single thing the SDK objected to** — every issue in the Zod error is at `tools[n].inputSchema.type` or `tools[n].outputSchema.type`.

That narrowness is the point:

- **A schema declaring a different type is still rejected.** The relaxed schema drops the requirement that the type be stated at the root, not the requirement that it be an object; `{ "type": "array" }` fails both, and the original diagnostic is what gets reported.
- **Any other malformation takes the existing path, with no retry** — a missing `name`, an `inputSchema` that is not an object at all, a transport error. This matters: a server can answer a retry differently, and a re-request must never be able to turn a rejected catalog into an accepted one.
- **Conforming servers never leave the SDK path**, so its tool-metadata caching (output-schema validators, task-support flags) is untouched. Verified by request count in a test.

## User Impact

MCP servers that use composed (`oneOf`/`anyOf`/`$ref`) tool schemas load, with all their tools, instead of failing wholesale. Servers that already worked behave identically, request-for-request.

## Evidence

- New suite `src/agents/mcp-list-tools-tolerant.test.ts` — **9 tests** driving a real SDK `Client` against a real SDK `Server` over `InMemoryTransport` (no hand-rolled fake, so the SDK's own validation is what runs): a `oneOf` tool loads (and plain `client.listTools()` is asserted to reject it — the bug); conforming tools on the same server survive; the schema passes through verbatim; a conforming server takes one request and no retry; cursor/`nextCursor` round-trip; a non-object type is still rejected; a response malformed beyond the type is not retried; server-side errors and clients without a raw-request method rethrow.
- Fail→pass verified by reducing the helper to a plain `client.listTools` passthrough: **8 of 18** fail (2 project configs), all pass with the fix. The three control tests pass in both directions.
- Regression: `agent-bundle-mcp-runtime` + `node-host/mcp` + `agent-bundle-mcp-tools.materialize` + `agent-bundle-mcp-harness` + `agent-bundle-mcp-tools.request-boundary` + `plugin-tools-mcp-client` + `mcp-json-schema-validator` — **205 tests pass**. `oxlint` clean, `oxfmt` clean, `tsc` clean on the touched files.

An earlier, blunter version of this patch relaxed the schema unconditionally and broke two of those tests — the invalid-tool-schema diagnostic and the overlapping-catalog-generation test, the latter because the retry consumed a second, different response from a stateful server. Both failures drove the narrowing above; both tests pass unchanged now.

**Note for maintainers:** downstream is already comfortable with composed schemas — `mcp-json-schema-validator` handles `oneOf`/`anyOf`/`allOf` explicitly, and `normalizeInputSchema` passes objects through — so the loaded tool reaches the provider intact. Whether a given model provider then accepts a root-level `oneOf` as a function parameter schema is a separate question I did not try to solve here; the scope of this change is that one such tool must not take its whole server down. Happy to add a normalization step (wrapping a composed root into an object schema) if you'd prefer that too — hence draft.


---

## Real-behavior proof (on current `main`)

A **real** MCP SDK `Client` talking to a **real** `Server` (over `InMemoryTransport`) that advertises two tools — one whose `inputSchema` is a root-level `oneOf` (legal JSON Schema 2020-12, no top-level `type`), plus a conforming tool. Base: `upstream/main` @ `ab04b2103e8` vs this branch:

```
raw  client.listTools()   (the path node-host/mcp.ts uses today):
    THREW  ZodError: Invalid input: expected "object" at tools.0.inputSchema.type
    -> the whole tools/list is rejected; ALL tools on the server are lost.

     listToolsTolerant()  (this branch):
    OK     tools = ["finlynq_query", "finlynq_ping"]
    -> the oneOf tool AND the conforming tool are both recovered.
```

The thrown error is verbatim the one from the issue report. The tolerant path only engages when every Zod issue is at `tools[n].inputSchema/outputSchema.type`, so conforming servers never leave the SDK's own validated path.


---

## Review response (2026-07-24)

- **[P1] Narrowed to provably-object-only schemas.** The relaxed schema previously accepted *any* untyped root schema; it now accepts an untyped schema only when it provably describes an object — `oneOf`/`anyOf`/`allOf` whose branches are all objects, or object-only keywords (`properties`/`required`/`additionalProperties`). A stated non-object type, or an untyped schema that could permit an array/string/any, stays rejected, preserving the MCP object-argument contract. New reject/accept regression tests added (11 tests green).
- **[P1] SDK metadata caching + interoperability policy — flagged for a maintainer.** The relaxed request still bypasses the SDK's private tool-metadata cache, and whether OpenClaw *should* accept root-`type`-omitting schemas at all is genuinely an interoperability-policy call. Rather than silently work around either, I'm surfacing both as maintainer/SDK-direction items — happy to implement whichever boundary you prefer (accept-and-cache, or reject-and-pursue-upstream).
