### PR TITLE
fix(ui): managed image replies render once under base paths

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -331,7 +331,7 @@ export async function finalizeCodexAttempt(
     threadId: resourceState.thread.threadId,
     turnId: activeTurnId,
   });
-  const { assistantTranscriptOwned } = mirrorOutcome;
+  const { assistantTranscriptOwned, assistantTranscriptIdempotencyKey } = mirrorOutcome;
   const shouldCaptureSettledTurnFinalizationContext =
     turnSucceeded &&
     result.assistantTexts.every((text) => !text.trim()) &&
@@ -521,6 +521,7 @@ export async function finalizeCodexAttempt(
     ...(codexAppServerFailure ? { codexAppServerFailure } : {}),
     ...(promptTimeoutOutcome ? { promptTimeoutOutcome } : {}),
     ...(assistantTranscriptOwned ? { assistantTranscriptOwned: true } : {}),
+    ...(assistantTranscriptIdempotencyKey ? { assistantTranscriptIdempotencyKey } : {}),
     ...(settledTurnFinalizationContext ? { settledTurnFinalizationContext } : {}),
     ...(resourceState.runtimeArtifact ? { runtimeArtifact: resourceState.runtimeArtifact } : {}),
     ...(!finalAborted && !effectiveTimedOut && !finalPromptError && preparedAuthBinding

--- a/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
@@ -124,7 +124,9 @@ describe("runCodexSettledTurnFinalization", () => {
           assistantMirrorIdentitiesOwned: ["settled-finalizer:run-1"],
           messagesPresent: [
             attachCodexMirrorAttestation(
-              assistant,
+              Object.assign({}, assistant, {
+                idempotencyKey: "codex-settled-finalizer:run-1:assistant",
+              }),
               fingerprintCodexMirrorSourceMessage(assistant as never),
             ),
           ],
@@ -181,6 +183,7 @@ describe("runCodexSettledTurnFinalization", () => {
     );
     expect(result).toMatchObject({
       assistantTranscriptOwned: true,
+      assistantTranscriptIdempotencyKey: "codex-settled-finalizer:run-1:assistant",
       usage: { input: 5, output: 4, cacheRead: 2, cacheWrite: 1, total: 12 },
       assistant: {
         role: "assistant",

--- a/extensions/codex/src/app-server/settled-turn-finalizer.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.ts
@@ -94,9 +94,17 @@ export async function runCodexSettledTurnFinalization(
     throw new Error("Codex settled-turn final answer transcript attestation mismatch");
   }
   const persistedAssistant = persistedMessage;
+  const persistedAssistantRecord = persistedAssistant as unknown as {
+    idempotencyKey?: unknown;
+  };
+  const assistantTranscriptIdempotencyKey =
+    typeof persistedAssistantRecord.idempotencyKey === "string"
+      ? persistedAssistantRecord.idempotencyKey.trim()
+      : "";
   return {
     assistant: persistedAssistant,
     assistantTranscriptOwned: true,
+    ...(assistantTranscriptIdempotencyKey ? { assistantTranscriptIdempotencyKey } : {}),
     ...(bounded.usage ? { usage: bounded.usage } : {}),
   };
 }

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -1202,6 +1202,9 @@ describe("mirrorCodexAppServerTranscript", () => {
     });
 
     expect(mirrorOutcome.assistantTranscriptOwned).toBe(true);
+    expect(mirrorOutcome.assistantTranscriptIdempotencyKey).toBe(
+      "codex-app-server:thread-1:turn-1:assistant",
+    );
     expect(mirrorOutcome.mirroredMessages).toMatchObject([
       { role: "assistant", content: [{ type: "text", text: "[redacted by hook]" }] },
     ]);

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -339,6 +339,7 @@ async function mirrorBestEffort(params: {
   turnId: string;
 }): Promise<{
   assistantTranscriptOwned: boolean;
+  assistantTranscriptIdempotencyKey?: string;
   mirroredMessages: MirroredAgentMessage[];
 }> {
   try {
@@ -387,10 +388,18 @@ async function mirrorBestEffort(params: {
         readCodexMirrorSourceFingerprint(message) === expectedFingerprints.get(identity)
       );
     });
+    const assistantMirrorIdentity = `${params.turnId}:assistant`;
+    const assistantTranscriptOwned =
+      mirrorResult.assistantMirrorIdentitiesOwned.includes(assistantMirrorIdentity);
+    const assistantTranscriptMessage = assistantTranscriptOwned
+      ? mirroredMessages.find((message) => readMirrorIdentity(message) === assistantMirrorIdentity)
+      : undefined;
+    const assistantTranscriptIdempotencyKey = normalizeOptionalString(
+      (assistantTranscriptMessage as { idempotencyKey?: unknown } | undefined)?.idempotencyKey,
+    );
     return {
-      assistantTranscriptOwned: mirrorResult.assistantMirrorIdentitiesOwned.includes(
-        `${params.turnId}:assistant`,
-      ),
+      assistantTranscriptOwned,
+      ...(assistantTranscriptIdempotencyKey ? { assistantTranscriptIdempotencyKey } : {}),
       mirroredMessages,
     };
   } catch (error) {

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -119,11 +119,13 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Already persisted."],
       assistantTranscriptOwned: true,
+      assistantTranscriptIdempotencyKey: "runtime-owned-assistant",
     });
 
     expect(payloads).toHaveLength(1);
     expect(getReplyPayloadMetadata(payloads[0] as object)).toMatchObject({
       assistantTranscriptOwned: true,
+      assistantTranscriptIdempotencyKey: "runtime-owned-assistant",
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -517,6 +517,7 @@ export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
   assistantMessageIndex?: number;
   assistantTranscriptOwned?: boolean;
+  assistantTranscriptIdempotencyKey?: string;
   toolMetas: ToolMetaEntry[];
   lastAssistant: AssistantMessage | undefined;
   currentAssistant?: AssistantMessage | null;
@@ -891,6 +892,11 @@ export function buildEmbeddedRunPayloads(params: {
             ? { assistantMessageIndex: params.assistantMessageIndex }
             : {}),
           ...(params.assistantTranscriptOwned === true ? { assistantTranscriptOwned: true } : {}),
+          ...(params.assistantTranscriptIdempotencyKey
+            ? {
+                assistantTranscriptIdempotencyKey: params.assistantTranscriptIdempotencyKey,
+              }
+            : {}),
         });
       }
       if (item.replyToId) {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -234,6 +234,7 @@ function buildSettledTurnFinalizationAttemptResult(input: {
     messagesSnapshot: [...settledAttempt.messagesSnapshot, result.assistant],
     assistantTexts: [text],
     assistantTranscriptOwned: result.assistantTranscriptOwned,
+    assistantTranscriptIdempotencyKey: result.assistantTranscriptIdempotencyKey,
     lastAssistantTextMessageIndex: result.assistantMessageIndex,
     lastAssistant: result.assistant,
     currentAttemptAssistant: result.assistant,

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -105,6 +105,7 @@ export function prepareEmbeddedRunTerminal(input: {
     assistantTexts: attempt.assistantTexts,
     assistantMessageIndex: attempt.lastAssistantTextMessageIndex,
     assistantTranscriptOwned: attempt.assistantTranscriptOwned,
+    assistantTranscriptIdempotencyKey: attempt.assistantTranscriptIdempotencyKey,
     toolMetas: attempt.toolMetas,
     lastAssistant: payloadAssistant,
     currentAssistant: attempt.yieldDetected ? null : (payloadAssistant ?? null),

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -172,6 +172,8 @@ export type EmbeddedRunAttemptResult = {
   aborted: boolean;
   /** True when the runtime made the authoritative final-assistant transcript decision. */
   assistantTranscriptOwned?: boolean;
+  /** Exact idempotency key for the runtime-owned final-assistant transcript row. */
+  assistantTranscriptIdempotencyKey?: string;
   /** True when the abort originated from the caller-provided abortSignal. */
   externalAbort: boolean;
   timedOut: boolean;

--- a/src/agents/harness/settled-turn-finalization-result.ts
+++ b/src/agents/harness/settled-turn-finalization-result.ts
@@ -9,6 +9,7 @@ const ALLOWED_SETTLED_FINALIZATION_RESULT_KEYS = new Set([
   "assistant",
   "usage",
   "assistantTranscriptOwned",
+  "assistantTranscriptIdempotencyKey",
   "assistantMessageIndex",
   "diagnosticTrace",
 ]);
@@ -128,7 +129,12 @@ export function projectSettledTurnFinalizationAttemptResult(
     assistant,
     ...(result.attemptUsage ? { usage: result.attemptUsage } : {}),
     ...(result.assistantTranscriptOwned
-      ? { assistantTranscriptOwned: true }
+      ? {
+          assistantTranscriptOwned: true,
+          ...(result.assistantTranscriptIdempotencyKey
+            ? { assistantTranscriptIdempotencyKey: result.assistantTranscriptIdempotencyKey }
+            : {}),
+        }
       : result.lastAssistantTextMessageIndex !== undefined
         ? { assistantMessageIndex: result.lastAssistantTextMessageIndex }
         : {}),

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -66,6 +66,8 @@ export type AgentHarnessSettledTurnFinalizationResult = {
   usage?: import("../usage.js").NormalizedUsage;
   /** True when the harness already persisted the assistant into the application transcript. */
   assistantTranscriptOwned?: boolean;
+  /** Exact idempotency key for the harness-owned assistant transcript row. */
+  assistantTranscriptIdempotencyKey?: string;
   /** Assistant stream generation index used to correlate final reply delivery. */
   assistantMessageIndex?: number;
   diagnosticTrace?: import("../../infra/diagnostic-trace-context.js").DiagnosticTraceContext;

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -217,6 +217,8 @@ export type ReplyPayloadMetadata = {
   assistantMessageIndex?: number;
   /** The runtime owns the transcript decision for this assistant payload. */
   assistantTranscriptOwned?: boolean;
+  /** Exact key for replacing a runtime-owned assistant row after media materialization. */
+  assistantTranscriptIdempotencyKey?: string;
   /** Foreground freshness prevented a visible final after transcript persistence. */
   foregroundDeliverySuppression?: {
     reason: "stale-foreground";

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -28,7 +28,12 @@ import {
 import { isSourceReplyTranscriptMirrorPayload } from "./chat-broadcast.js";
 import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
 import type { PreparedChatSendSession } from "./chat-send-session.js";
-import { appendAssistantTranscriptMessage } from "./chat-transcript-persistence.js";
+import {
+  appendAssistantTranscriptMessage,
+  assistantTranscriptScope,
+  publishAssistantTranscriptRewrite,
+  rewriteAssistantTranscriptMessageByIdempotencyKey,
+} from "./chat-transcript-persistence.js";
 import {
   buildTtsSupplementTranscriptMarker,
   stripVisibleTextFromTtsSupplement,
@@ -168,6 +173,44 @@ export function createChatSendReplyDispatch(params: {
       extractAssistantDisplayTextFromContent(assistantContent) ??
       buildTranscriptReplyText([transcriptPayload]);
     if (!transcriptReply && !persistedAssistantContent?.length && !assistantContent?.length) {
+      return;
+    }
+    const payloadMetadata = getReplyPayloadMetadata(payload);
+    const ownedTranscriptIdempotencyKey =
+      payloadMetadata?.assistantTranscriptOwned === true
+        ? payloadMetadata.assistantTranscriptIdempotencyKey?.trim()
+        : undefined;
+    const transcriptScope = assistantTranscriptScope({
+      sessionKey,
+      sessionId,
+      storePath: latestStorePath,
+      agentId,
+    });
+    if (ownedTranscriptIdempotencyKey && transcriptScope) {
+      // The harness row is the canonical final assistant. Replace that exact
+      // identity so media materialization cannot append a parallel reply.
+      const rewritten = await rewriteAssistantTranscriptMessageByIdempotencyKey({
+        content: persistedContentForAppend,
+        idempotencyKey: ownedTranscriptIdempotencyKey,
+        scope: transcriptScope,
+      });
+      if (rewritten) {
+        await publishAssistantTranscriptRewrite({
+          scope: transcriptScope,
+          rewritten: [rewritten],
+        });
+        if (assistantContent?.length) {
+          await attachManagedOutgoingImagesToMessage({
+            messageId: rewritten.messageId,
+            blocks: assistantContent,
+          });
+        }
+        appendedWebchatAgentMedia = true;
+        return;
+      }
+      logGateway.warn(
+        "webchat runtime-owned assistant media rewrite skipped: transcript identity not found",
+      );
       return;
     }
     const appended = await appendAssistantTranscriptMessage({

--- a/src/gateway/server-methods/chat-transcript-persistence.ts
+++ b/src/gateway/server-methods/chat-transcript-persistence.ts
@@ -335,6 +335,36 @@ export async function rewriteSourceReplyTranscriptMirrors(params: {
   });
 }
 
+export async function rewriteAssistantTranscriptMessageByIdempotencyKey(params: {
+  content: AssistantDisplayContentBlock[];
+  idempotencyKey: string;
+  scope: SessionTranscriptWriteScope;
+}): Promise<{ messageId: string } | null> {
+  const idempotencyKey = params.idempotencyKey.trim();
+  if (!idempotencyKey || params.content.length === 0) {
+    return null;
+  }
+  return await withTranscriptWriteLock(params.scope, async (transcript) => {
+    const events = await transcript.readEvents();
+    const target = findAssistantTranscriptMessageByIdempotencyKeyInEvents(events, idempotencyKey);
+    if (!target) {
+      return null;
+    }
+    const rewrittenEvents = events.map((event) =>
+      transcriptEventId(event) === target.messageId
+        ? Object.assign({}, event as Record<string, unknown>, {
+            message: {
+              ...target.message,
+              content: params.content,
+            },
+          })
+        : event,
+    );
+    await transcript.replaceEvents(rewrittenEvents);
+    return { messageId: target.messageId };
+  });
+}
+
 export async function publishAssistantTranscriptRewrite(params: {
   scope: SessionTranscriptWriteScope;
   rewritten: readonly { messageId: string }[];

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1745,6 +1745,68 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
   });
 
+  it("replaces a runtime-owned media reply instead of appending a duplicate assistant", async () => {
+    await withTranscriptFixtureState("openclaw-chat-send-owned-media-", async (fixtureDir) => {
+      const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+      const savedImagePath = path.join(fixtureDir, "reply.png");
+      fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+      mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+      await appendSourceReplyMirrorEntry({
+        idempotencyKey: "older-distinct-assistant",
+        text: "A distinct earlier reply.",
+        provider: "openai",
+        model: "codex",
+      });
+      await appendSourceReplyMirrorEntry({
+        idempotencyKey: "runtime-owned-assistant",
+        text: `Dinner options\nMEDIA:${mediaUrl}`,
+        provider: "openai",
+        model: "codex",
+      });
+      mockState.triggerAgentRunStart = true;
+      mockState.dispatchedReplies = [
+        {
+          kind: "final",
+          payload: setReplyPayloadMetadata(
+            {
+              text: "Dinner options",
+              mediaUrl,
+              mediaUrls: [mediaUrl],
+            },
+            {
+              assistantTranscriptOwned: true,
+              assistantTranscriptIdempotencyKey: "runtime-owned-assistant",
+            },
+          ),
+        },
+      ];
+      const respond = vi.fn();
+      const context = createChatContext();
+
+      await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-owned-media",
+        expectBroadcast: false,
+        waitFor: "dedupe",
+      });
+
+      const messages = await readActiveAssistantTranscriptMessages();
+      expect(messages).toHaveLength(2);
+      expect(messages.map((message) => message.idempotencyKey)).toEqual([
+        "older-distinct-assistant",
+        "runtime-owned-assistant",
+      ]);
+      const rewritten = messages[1];
+      const content = Array.isArray(rewritten?.content)
+        ? (rewritten.content as Array<Record<string, unknown>>)
+        : [];
+      expect(content[0]).toEqual({ type: "text", text: "Dinner options" });
+      expect(content.filter((block) => block.type === "image")).toHaveLength(1);
+      expect(JSON.stringify(messages)).not.toContain(":assistant-media");
+    });
+  });
+
   it("persists auto-TTS final media as audio-only so webchat does not duplicate assistant text", async () => {
     const transcriptDir = await createTranscriptFixture("openclaw-chat-send-agent-tts-final-");
     const audioPath = path.join(transcriptDir, "tts.mp3");

--- a/ui/src/e2e/managed-media-base-path.e2e.test.ts
+++ b/ui/src/e2e/managed-media-base-path.e2e.test.ts
@@ -1,0 +1,102 @@
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { chromium } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const proofDir = process.env.OPENCLAW_MEDIA_PROOF_DIR?.trim() || null;
+
+let server: ControlUiE2eServer;
+
+describe("Control UI managed media under a UI base path", () => {
+  beforeAll(async () => {
+    server = await startControlUiE2eServer();
+    if (proofDir) {
+      await mkdir(proofDir, { recursive: true });
+    }
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("keeps origin-root managed-media APIs outside the UI base path", async () => {
+    const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+    const browser = await chromium.launch({ executablePath });
+    const context = await browser.newContext({
+      ...(proofDir ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 800 } } } : {}),
+      serviceWorkers: "block",
+      viewport: { width: 1280, height: 800 },
+    });
+    const page = await context.newPage();
+    const mediaPath =
+      "/api/chat/media/outgoing/agent%3Amain%3Amain/00000000-0000-4000-8000-000000000001/full";
+    const imageBytes = await readFile(
+      path.join(process.cwd(), "docs/assets/openclaw-banner-dark.png"),
+    );
+    const requests: Array<{ contentType: string; path: string }> = [];
+
+    await page.route("**/api/chat/media/outgoing/**", async (route) => {
+      const requestPath = new URL(route.request().url()).pathname;
+      if (requestPath === mediaPath) {
+        requests.push({ contentType: "image/png", path: requestPath });
+        await route.fulfill({ body: imageBytes, contentType: "image/png", status: 200 });
+        return;
+      }
+      requests.push({ contentType: "text/html", path: requestPath });
+      await route.fulfill({
+        body: "<!doctype html><title>OpenClaw</title>",
+        contentType: "text/html",
+        status: 200,
+      });
+    });
+
+    const gateway = await installMockGateway(page, {
+      basePath: "/rosita",
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Managed attachment proof" },
+            { type: "image", url: mediaPath, alt: "Managed proof image" },
+          ],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Distinct second reply" }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    try {
+      // The Vite harness mounts at `/`; bootstrap models the reverse proxy
+      // prefix that Gateway strips before serving the Control UI.
+      await page.goto(`${server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const image = page.getByAltText("Managed proof image");
+      await image.waitFor({ state: "attached", timeout: 10_000 });
+      await expect.poll(() => requests.length).toBeGreaterThan(0);
+      if (proofDir) {
+        await page.screenshot({ path: path.join(proofDir, "state.png"), fullPage: true });
+      }
+
+      const naturalWidth = await image.evaluate((node) =>
+        node instanceof HTMLImageElement ? node.naturalWidth : 0,
+      );
+      expect(requests).toEqual([{ contentType: "image/png", path: mediaPath }]);
+      expect(naturalWidth).toBeGreaterThan(0);
+      expect(await page.getByText("Managed attachment proof", { exact: true }).count()).toBe(1);
+      expect(await page.getByText("Distinct second reply", { exact: true }).count()).toBe(1);
+    } finally {
+      await context.close();
+      await browser.close();
+    }
+  });
+});

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -3578,6 +3578,7 @@ describe("grouped chat rendering", () => {
       {
         showToolCalls: false,
         assistantAttachmentAuthToken: "test-auth-token",
+        basePath: "/rosita",
         onOpenImage,
       },
     );

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -2008,22 +2008,12 @@ function resolveManagedOutgoingImageRequesterSessionKey(source: string): string 
   }
 }
 
-function buildManagedOutgoingImageFetchUrl(source: string, basePath?: string): string {
-  if (!source.startsWith("/")) {
-    return source;
-  }
-  const normalizedBasePath =
-    basePath && basePath !== "/" ? (basePath.endsWith("/") ? basePath.slice(0, -1) : basePath) : "";
-  return `${normalizedBasePath}${source}`;
-}
-
 function resolveManagedOutgoingImageBlobUrlCacheKey(
   source: string,
   opts?: ImageRenderOptions,
 ): string {
   const authToken = opts?.authToken?.trim() ?? "";
-  const fetchUrl = buildManagedOutgoingImageFetchUrl(source, opts?.basePath);
-  return `${fetchUrl}::${authToken}`;
+  return `${source}::${authToken}`;
 }
 
 function readManagedOutgoingImageBlobUrl(
@@ -2038,7 +2028,6 @@ async function resolveManagedOutgoingImageBlobUrl(
   opts?: ImageRenderOptions,
 ): Promise<string | null> {
   const authToken = opts?.authToken?.trim() ?? "";
-  const fetchUrl = buildManagedOutgoingImageFetchUrl(source, opts?.basePath);
   const cacheKey = resolveManagedOutgoingImageBlobUrlCacheKey(source, opts);
   const cached = readManagedImageBlobUrl(cacheKey);
   if (cached) {
@@ -2065,7 +2054,9 @@ async function resolveManagedOutgoingImageBlobUrl(
         );
       }, MANAGED_OUTGOING_IMAGE_FETCH_TIMEOUT_MS);
       try {
-        const res = await fetch(fetchUrl, {
+        // Managed media is a Gateway API at the origin root. Rebasing it under
+        // the Control UI mount path serves the HTML shell instead of image bytes.
+        const res = await fetch(source, {
           method: "GET",
           headers,
           credentials: "same-origin",


### PR DESCRIPTION
Closes #113161

Related prior art: #75727

AI-assisted: yes. I understand the change and verified the full ownership path.

## What Problem This Solves

Fixes an issue where users viewing managed assistant images in a Control UI mounted below a base path would get a missing preview, and a Codex-managed media answer could appear as both a raw and managed assistant reply.

## Why This Change Was Made

Managed outgoing media URLs remain origin-root Gateway API paths instead of being rebased under the Control UI mount. For Codex runtime-owned replies, the harness now carries the exact mirrored transcript idempotency key through finalization so Gateway replaces only that canonical assistant row with managed content rather than appending a parallel row.

The identity-based rewrite preserves the existing transcript event/message ID and neighboring assistant entries. Other harnesses without an attested transcript identity retain the existing append path.

Direct Codex contract check: app-server item completion is the authoritative item/result state, while turn completion is the final turn status ([Codex app-server protocol](https://github.com/openai/codex/blob/5b402270f926cd1f9288c24cddd27410400cabe6/codex-rs/app-server/README.md#L1237-L1272)). That matches the existing OpenClaw Codex projector’s item-owned assistant lifecycle and makes the mirror idempotency key the durable reconciliation identity.

## User Impact

Managed images render normally when Control UI is served under a path such as `/rosita`, and one Codex media answer remains one logical assistant reply. Distinct neighboring assistant replies are not deduplicated.

## Evidence

- Base `8a2b2b35f50`: deterministic Chromium requested `/rosita/api/chat/media/outgoing/...`, received `text/html`, and attached no image ([red Testbox run](https://github.com/openclaw/openclaw/actions/runs/30045159115)).
- Exact head `afaddab0a90`: Chromium requested only `/api/chat/media/outgoing/...`, received `image/png`, decoded a non-zero image width, showed the managed reply once, and preserved a distinct second reply.
- Sanitized before/after contact sheets use the same deterministic fixture and 1280x800 viewport; no private session data is included.

Before (base; image absent):

![Before: managed image missing under the Control UI base path](https://gist.githubusercontent.com/fuller-stack-dev/2f68793f4d3ff411a34f1f9cb4d05dd2/raw/1c1bf0089b69554f9f5e69762f87f04077d3b5d2/before-contact-sheet.png)

After (exact head; image decoded and replies remain distinct):

![After: managed image rendered once with a distinct second reply](https://gist.githubusercontent.com/fuller-stack-dev/2f68793f4d3ff411a34f1f9cb4d05dd2/raw/1c1bf0089b69554f9f5e69762f87f04077d3b5d2/after-contact-sheet.png)

Raw recordings: [base reproduction](https://gist.githubusercontent.com/fuller-stack-dev/2f68793f4d3ff411a34f1f9cb4d05dd2/raw/1c1bf0089b69554f9f5e69762f87f04077d3b5d2/before-reproduction.mp4) · [exact-head fix](https://gist.githubusercontent.com/fuller-stack-dev/2f68793f4d3ff411a34f1f9cb4d05dd2/raw/1c1bf0089b69554f9f5e69762f87f04077d3b5d2/after-fix.mp4) · [manifest and checksums](https://gist.github.com/fuller-stack-dev/2f68793f4d3ff411a34f1f9cb4d05dd2)

- Focused Blacksmith proof: 379 assertions plus the Control UI E2E passed ([run](https://github.com/openclaw/openclaw/actions/runs/30046901367)).
- Exact-head focused proof after rebasing to `bd48b7b26bb`:
  - `src/agents/embedded-agent-runner/run/payloads.test.ts`: 54 passed
  - `src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts`: 10 passed
  - `src/gateway/server-methods/chat.directive-tags.test.ts`: 157 passed
  - `ui/src/e2e/managed-media-base-path.e2e.test.ts`: 1 passed
- Changed-surface type/lint/build command returned 0 on Blacksmith Testbox. The external portal finalization timed out afterward, so this PR does not claim that wrapper run as a GitHub check.
- `$behavior-validator`: 4 contract clauses passed; 0 failed/blocked. Anti-cheat route returned HTML for any incorrectly prefixed request, decoded dimensions proved real image bytes, and the distinct second reply guarded against broad content dedupe.
- `$autoreview`: clean, no accepted/actionable findings; overall correctness 0.94.
- `git diff --check`: passed.
