### PR TITLE
fix(text): close a code span only with an equal backtick run

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -852,6 +852,18 @@ describe("stripMinimaxToolCallXml", () => {
 });
 
 describe("sanitizeAssistantVisibleText", () => {
+  it.each([
+    { name: "closing run shorter", input: "before ```<think>private</think>`` after" },
+    { name: "closing run longer", input: "before ``<think>private</think>``` after" },
+  ])("strips reasoning tags wrapped in unequal backtick runs ($name)", ({ input }) => {
+    expect(sanitizeAssistantVisibleText(input)).not.toContain("<think>");
+  });
+
+  it("still preserves a reasoning tag inside a real code span", () => {
+    const input = "before ``<think>private</think>`` after";
+    expect(sanitizeAssistantVisibleText(input)).toContain("<think>");
+  });
+
   it("strips minimax, tool XML, downgraded tool markers, and think tags in one pass", () => {
     const input = [
       '<invoke name="read">payload</invoke></minimax:tool_call>',

--- a/src/shared/text/code-regions.test.ts
+++ b/src/shared/text/code-regions.test.ts
@@ -19,6 +19,48 @@ describe("shared/text/code-regions", () => {
     expect(isInsideCode(params.positionSelector(text, regionEnd), regions)).toBe(params.expected);
   }
 
+  describe("unequal backtick runs (#113148)", () => {
+    it.each([
+      {
+        name: "does not open a code span when the closing run is shorter",
+        text: "before ```<think>private</think>`` after",
+        expectedSlices: [],
+      },
+      {
+        name: "does not open a code span when the closing run is longer",
+        text: "before ``<think>private</think>``` after",
+        expectedSlices: [],
+      },
+      {
+        name: "does not open a code span from a lone run",
+        text: "a ``` b",
+        expectedSlices: [],
+      },
+      {
+        name: "still pairs runs of equal length",
+        text: "before ``code`` after",
+        expectedSlices: ["``code``"],
+      },
+      {
+        name: "pairs the first run of matching length, skipping shorter ones between",
+        text: "``a`b``c",
+        expectedSlices: ["``a`b``"],
+      },
+      {
+        name: "resumes scanning after a closed span",
+        text: "`one` and ``two``",
+        expectedSlices: ["`one`", "``two``"],
+      },
+      {
+        name: "leaves an unmatched run before a valid span as literal text",
+        text: "``` then `real` tail",
+        expectedSlices: ["`real`"],
+      },
+    ] as const)("$name", ({ text, expectedSlices }) => {
+      expectCodeRegionSlices(text, expectedSlices);
+    });
+  });
+
   it.each([
     {
       name: "finds fenced and inline code regions without double-counting inline code inside fences",

--- a/src/shared/text/code-regions.ts
+++ b/src/shared/text/code-regions.ts
@@ -5,6 +5,46 @@ export interface CodeRegion {
   end: number;
 }
 
+/**
+ * Finds inline code spans. Markdown closes a code span only with a backtick run of
+ * the same length as the one that opened it, so a run of three followed by a run
+ * of two spans nothing. Pairing unequal runs would let arbitrary text pose as a
+ * literal code example and slip past the sanitizers that skip code regions.
+ */
+function findInlineCodeSpans(text: string): CodeRegion[] {
+  const runs: CodeRegion[] = [];
+  for (const match of text.matchAll(/`+/g)) {
+    const start = match.index ?? 0;
+    runs.push({ start, end: start + match[0].length });
+  }
+
+  const spans: CodeRegion[] = [];
+  let openIndex = 0;
+  while (openIndex < runs.length) {
+    const open = expectDefined(runs[openIndex], "code regions backtick run");
+    const width = open.end - open.start;
+    let closeIndex = openIndex + 1;
+    while (closeIndex < runs.length) {
+      const candidate = expectDefined(runs[closeIndex], "code regions backtick run");
+      if (candidate.end - candidate.start === width) {
+        break;
+      }
+      closeIndex += 1;
+    }
+    if (closeIndex >= runs.length) {
+      // Nothing closes this run, so it is literal text -- keep looking from the next.
+      openIndex += 1;
+      continue;
+    }
+    spans.push({
+      start: open.start,
+      end: expectDefined(runs[closeIndex], "code regions backtick run").end,
+    });
+    openIndex = closeIndex + 1;
+  }
+  return spans;
+}
+
 /** Finds fenced and inline Markdown code regions so text sanitizers can avoid examples. */
 export function findCodeRegions(text: string): CodeRegion[] {
   const regions: CodeRegion[] = [];
@@ -19,13 +59,10 @@ export function findCodeRegions(text: string): CodeRegion[] {
     });
   }
 
-  const inlineRe = /`+[^`]+`+/g;
-  for (const match of text.matchAll(inlineRe)) {
-    const start = match.index ?? 0;
-    const end = start + match[0].length;
-    const insideFenced = regions.some((r) => start >= r.start && end <= r.end);
+  for (const span of findInlineCodeSpans(text)) {
+    const insideFenced = regions.some((r) => span.start >= r.start && span.end <= r.end);
     if (!insideFenced) {
-      regions.push({ start, end });
+      regions.push(span);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

`findCodeRegions` treats mismatched backtick runs as an inline code span, so text wrapped that way is classified as a literal code example. Every sanitizer that skips code regions then skips it too — and reasoning tags survive into visible assistant output:

```ts
sanitizeAssistantVisibleText("before ```<think>private</think>`` after");
// still contains "<think>private</think>"
```

Closes #113148.

## Why This Change Was Made

The inline matcher pairs a run of any length with a run of any other length:

```ts
const inlineRe = /`+[^`]+`+/g;
```

Markdown does not work that way: a code span is closed only by a backtick run of **the same length** as the one that opened it. A three-backtick run followed by a two-backtick run opens nothing, and the text between them is ordinary prose that sanitizers must process.

Because `findCodeRegions` is what `reasoning-tags.ts` and `assistant-visible-text.ts` consult before stripping, the loose rule is a sanitization bypass rather than a cosmetic parsing issue: wrapping hidden reasoning in unequal backtick runs is enough to get it in front of the user.

The fix scans maximal backtick runs and pairs equal-length ones, which is both the Markdown rule and strictly narrower than what was there:

- An unmatched run is left as the literal text it is, and scanning resumes from the following run — so `` ``` then `real` tail `` still finds `` `real` ``.
- Runs of a *different* length between an opening and closing pair are content, not delimiters: `` ``a`b`` `` is one span, exactly as Markdown renders it.
- Fenced regions are untouched, as is the existing "don't double-count inline code inside a fence" behavior.

## User Impact

Reasoning tags (and any other scaffolding the sanitizers remove) can no longer be smuggled past them with mismatched backticks. Genuine code examples — including reasoning tags a user legitimately quotes inside a properly delimited span — are preserved exactly as before.

## Evidence

- `src/shared/text/code-regions.test.ts` — **7 new cases** in an `unequal backtick runs (#113148)` block: closing run shorter, closing run longer, a lone run, equal runs still pairing, a shorter run *between* a matching pair staying content, scanning resuming after a closed span, and an unmatched run before a valid span.
- `src/shared/text/assistant-visible-text.test.ts` — **3 new cases** at the sanitizer level: both mismatch directions no longer leak `<think>`, plus the control that a reasoning tag inside a **real** (equal-run) code span is still preserved. That control is the point — the fix must not work by simply detecting fewer code regions.
- Fail→pass verified by reverting only `code-regions.ts`: **6 of 129** fail, all pass with the fix.
- Regression: all of `src/shared/` plus the other `findCodeRegions`/`isInsideCode` consumers (`plugin-sdk/text-chunking`, `channels/progress-draft-status-text`, `agents/embedded-agent-subscribe`, `assistant-phase-text`, `embedded-agent-utils`) — **698 + 56 tests pass**, no existing expectation changed. `oxlint` and `oxfmt` clean.

**Note for maintainers:** I kept the change to the inline-span rule and deliberately did not touch the fenced-region regex, so the blast radius stays inside one helper. CommonMark has further refinements this still does not implement (stripping one leading/trailing space from span contents, backslash escapes), but those affect rendering rather than which offsets count as code — happy to go further if you want `findCodeRegions` to be fully CommonMark-accurate, hence draft.


---

## Real-behavior proof (on current `main`)

The actual delivery sanitizer `sanitizeAssistantVisibleText` — the function that decides what reaches the user. `leaks` = hidden reasoning survived into visible output. Base: `upstream/main` @ `ab04b2103e8` vs this branch:

````
input: before ```<think>private</think>`` after   (3-then-2 backticks, UNEQUAL)
  upstream/main : leaks=true     <- reasoning leaks to the user
  this branch   : leaks=false

input: before ``<think>private</think>``` after   (2-then-3 backticks)
  upstream/main : leaks=true
  this branch   : leaks=false

input: before ``<think>private</think>`` after    (EQUAL runs = a real inline-code span)
  upstream/main : leaks=true
  this branch   : leaks=true    <- legitimately preserved (a genuine code example)
````

The equal-run control is the key: the fix closes the sanitization bypass **without** breaking genuine inline-code examples — it isn't just "detect fewer code regions."
