### PR TITLE
fix(ci): allow sticky writer rebuild to finish

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -387,15 +387,22 @@ runs:
         append_pnpm_option_arg PNPM_CONFIG_NETWORK_CONCURRENCY network-concurrency
         append_pnpm_option_arg PNPM_CONFIG_STORE_DIR store-dir
         append_pnpm_option_arg PNPM_CONFIG_VIRTUAL_STORE_DIR virtual-store-dir
+        sticky_writer_rebuild="false"
         if [ "$STICKY_DISK" = "true" ] && [ "$STICKY_WRITER" = "true" ] &&
           [ "$sticky_snapshot_matches" != "true" ]; then
           # Pnpm can trust stale hidden install metadata even with --force. Clear only
           # the writer-owned modules tree; the warmed store remains on the sticky disk.
           find "$GITHUB_WORKSPACE/node_modules" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
           install_args+=(--force)
+          sticky_writer_rebuild="true"
         fi
         run_pnpm_install() {
-          if [ "$STICKY_DISK" = "true" ]; then
+          if [ "$sticky_writer_rebuild" = "true" ]; then
+            # A full relink exceeds the ordinary retry cap; restarting discards
+            # several minutes of progress even when the warmed store is healthy.
+            timeout --signal=TERM --kill-after=15s 15m \
+              pnpm "${install_args[@]}" --config.fetch-retries=0
+          elif [ "$STICKY_DISK" = "true" ]; then
             # Pnpm can keep retrying optional platform tarballs after the
             # required tree is linked. Retry the whole frozen transaction from
             # its warmed store instead of letting minute backoffs outlive this cap.
@@ -425,7 +432,9 @@ runs:
             rm -f "$sticky_marker"
           fi
           install_attempts=2
-          if [ "$STICKY_DISK" = "true" ]; then
+          if [ "$sticky_writer_rebuild" = "true" ]; then
+            install_attempts=1
+          elif [ "$STICKY_DISK" = "true" ]; then
             install_attempts=3
           fi
           install_status=1

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -55,6 +55,8 @@ const repositoryScriptEntries = [
   "scripts/e2e/lib/upgrade-survivor/probe-gateway.mjs!",
   "scripts/embedded-run-abort-leak.ts!",
   "scripts/fixtures/packed-plugin-sdk-type-smoke.ts!",
+  "scripts/ios-release-cut.ts!",
+  "scripts/ios-release-plan.ts!",
   "scripts/ios-release-signing.mjs!",
   "scripts/lib/docker-plugin-selection.mjs!",
   "scripts/lib/openclaw-test-state.mjs!",

--- a/scripts/lib/ios-release-plan.ts
+++ b/scripts/lib/ios-release-plan.ts
@@ -27,13 +27,13 @@ const RELEASED_APP_STORE_VERSION_STATES = new Set([
   "DEVELOPER_REMOVED_FROM_SALE",
 ]);
 
-export type IosRemoteAppStoreVersion = {
+type IosRemoteAppStoreVersion = {
   id: string;
   state: string;
   versionString: string;
 };
 
-export type IosRemoteBuildUpload = {
+type IosRemoteBuildUpload = {
   buildNumber: string;
   shortVersion: string;
   state: string;

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2160,6 +2160,7 @@ describe("ci workflow guards", () => {
       "Sticky dependency snapshot matches the install fingerprint and importer contents; skipping pnpm install",
     );
     expect(installStep.run).toContain("timeout --signal=TERM --kill-after=15s 4m");
+    expect(installStep.run).toContain("timeout --signal=TERM --kill-after=15s 15m");
     expect(installStep.run).toContain('pnpm "${install_args[@]}" --config.fetch-retries=0');
     const forceStickyWriterInstall =
       'if [ "$STICKY_DISK" = "true" ] && [ "$STICKY_WRITER" = "true" ] &&\n' +
@@ -2169,6 +2170,9 @@ describe("ci workflow guards", () => {
       'find "$GITHUB_WORKSPACE/node_modules" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +';
     expect(installStep.run).toContain(clearStickyModules);
     expect(installStep.run).toContain("install_args+=(--force)");
+    expect(installStep.run).toContain('sticky_writer_rebuild="true"');
+    expect(installStep.run).toContain('if [ "$sticky_writer_rebuild" = "true" ]; then');
+    expect(installStep.run).toContain("install_attempts=1");
     expect(installStep.run.indexOf(forceStickyWriterInstall)).toBeLessThan(
       installStep.run.indexOf(clearStickyModules),
     );

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2848,7 +2848,10 @@ describe("scripts/test-projects changed-target routing", () => {
       {
         config: "test/vitest/vitest.unit-fast-isolated.config.ts",
         forwardedArgs: [],
-        includePatterns: ["test/scripts/android-version.test.ts"],
+        includePatterns: [
+          "test/scripts/android-version.test.ts",
+          "test/scripts/ios-release-plan.test.ts",
+        ],
         watchMode: false,
       },
       {
@@ -3006,7 +3009,10 @@ describe("scripts/test-projects changed-target routing", () => {
       {
         config: "test/vitest/vitest.unit-fast-isolated.config.ts",
         forwardedArgs: [],
-        includePatterns: ["test/scripts/android-version.test.ts"],
+        includePatterns: [
+          "test/scripts/android-version.test.ts",
+          "test/scripts/ios-release-plan.test.ts",
+        ],
         watchMode: false,
       },
       {


### PR DESCRIPTION
Related: #113142
Related: #113155

## What Problem This Solves

Fixes the remaining canonical sticky-writer failure after the clean rebuild began working. The full 1,428-package relink exceeded the ordinary four-minute install cap; each retry was killed after substantial progress and restarted from zero.

Proof: https://github.com/openclaw/openclaw/actions/runs/30051616053

## Why This Change Was Made

Only the trusted clean-writer rebuild now receives one bounded 15-minute install attempt. Ordinary sticky installs retain the existing four-minute, three-attempt policy. Validation and snapshot publication remain fail-closed after install completion.

## User Impact

No shipped product behavior changes. Main CI can finish the one-time clean relink instead of repeatedly discarding progress.

## Evidence

- Canonical logs show attempt 1 reached 1,135/1,428 links and attempt 2 reached 1,042 before each four-minute timeout.
- Workflow guard suite passed all 90 tests on Testbox.
- Changed-file gates passed on Testbox, including format, typecheck, declarations, dependency guards, and lint.
- Rebased patch identity matched and focused tests passed again.
- Codex autoreview: clean.

Final proof is the first post-merge canonical writer run.
