### PR TITLE
fix(googlechat): honor lowercase no_proxy when NO_PROXY is blank

### DIFF
--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -248,6 +248,37 @@ describe("googlechat google auth runtime", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it("falls back to lowercase no_proxy when uppercase NO_PROXY is blank", async () => {
+    const release = vi.fn();
+    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: new Response("ok", { status: 200 }),
+      release,
+    });
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("no_proxy", "oauth2.googleapis.com");
+    vi.stubEnv("HTTPS_PROXY", "http://env-proxy.example:8080");
+
+    const guardedFetch = await createGoogleAuthTransportFetch();
+    const response = await guardedFetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+    } as RequestInit);
+
+    expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledWith({
+      auditContext: "googlechat.auth.google-auth",
+      dispatcherPolicy: undefined,
+      init: {
+        method: "POST",
+      },
+      policy: {
+        hostnameAllowlist: ["accounts.google.com", "googleapis.com"],
+      },
+      timeoutMs: 30_000,
+      url: "https://oauth2.googleapis.com/token",
+    });
+    await expect(response.text()).resolves.toBe("ok");
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("releases guarded auth fetch resources even when callers do not consume the body", async () => {
     const release = vi.fn();
     mocks.fetchWithSsrFGuard.mockResolvedValueOnce({

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -148,7 +148,10 @@ function resolveGoogleAuthEnvProxyUrl(protocol: "http" | "https"): string | unde
 
 function collectGoogleAuthNoProxyRules(noProxy: ProxyRule[] = []): ProxyRule[] {
   const rules = [...noProxy];
-  const envRules = (process.env.NO_PROXY ?? process.env.no_proxy)?.split(",") ?? [];
+  const noProxyEnv =
+    normalizeGoogleAuthProxyEnvValue(process.env.NO_PROXY) ??
+    normalizeGoogleAuthProxyEnvValue(process.env.no_proxy);
+  const envRules = noProxyEnv?.split(",") ?? [];
   for (const rule of envRules) {
     const trimmed = rule.trim();
     if (trimmed.length > 0) {


### PR DESCRIPTION
## Summary

Google Chat auth no longer lets a blank uppercase `NO_PROXY` discard the lowercase `no_proxy` bypass list when routing Google auth requests through a proxy.

## What Problem This Solves

When `NO_PROXY=""` is present in the environment (a common leftover of `export NO_PROXY=` in shell profiles and CI templates) while `no_proxy` carries the actual bypass rules, the Google auth transport drops every bypass rule: hosts that must be reached directly are instead routed through the configured proxy. In proxy-restricted networks this breaks Google auth token fetches (the proxy either cannot reach or is not allowed to tunnel those endpoints), and it silently changes the routing the operator asked for.

**Code evidence**: in `extensions/googlechat/src/google-auth.runtime.ts`, `collectGoogleAuthNoProxyRules` reads `(process.env.NO_PROXY ?? process.env.no_proxy)?.split(",")`. `??` only falls through on `null`/`undefined`, so a blank `NO_PROXY` shadows the lowercase list and yields zero rules. The same file already normalizes the proxy URLs themselves with `normalizeGoogleAuthProxyEnvValue` (blank → fall through to the next candidate); the `NO_PROXY` read was the one place that missed that treatment.

## Root Cause

- Introduced by commit `6d6845ea9d2` ("fix(googlechat): harden google auth transport (#69812)", 2026-04-21), which added the env `NO_PROXY` collection with a raw `??` read.
- Violated invariant: uppercase/lowercase env pairs follow "blank means unset" semantics in this file — `normalizeGoogleAuthProxyEnvValue` returns `null` for blank values so `??` chains fall through correctly. The `NO_PROXY` read bypassed that helper, so "present but blank" was treated as authoritative.
- Trigger condition: `NO_PROXY` set to an empty/whitespace value + `no_proxy` carrying bypass rules + a proxy configured (explicit init proxy/agent or `HTTPS_PROXY`).
- Note: `src/infra/net/proxy-env.ts` intentionally gives lowercase `no_proxy` precedence to match undici; that is a separate, deliberate behavior and not related to this defect.

## Why This Fix

- Reuse the file's existing `normalizeGoogleAuthProxyEnvValue` for both `NO_PROXY` and `no_proxy`, so a blank uppercase value falls through to the lowercase one — exactly the semantics already used for `HTTP_PROXY`/`http_proxy` and `HTTPS_PROXY`/`https_proxy` in the same file.
- Two-line behavioral change confined to rule collection; rule parsing, explicit-proxy mTLS handling, and the guard policy are untouched.
- Alternatives considered: normalizing only the uppercase read (rejected: would leave `no_proxy` blank-vs-unset inconsistent with the file's own convention); delegating to the guard's env handling (rejected: the explicit-proxy path relies solely on this function, so the fix belongs here).

## User Impact

- Before: with `NO_PROXY=""` and `no_proxy=oauth2.googleapis.com`, a Google auth token request with a configured proxy is routed through the proxy instead of directly — the auth flow fails in proxy-restricted networks.
- After: the lowercase bypass rules survive the blank uppercase variable, and the request goes direct as configured.

## Evidence

- TDD red: the new regression test failed on unmodified code — the guarded fetch received an `env-proxy`/`explicit-proxy` dispatcher policy instead of the direct/bypassed one.
- Real behavior before (unmodified code): driving the real `getGoogleAuthTransport` fetch with an explicit proxy and `NO_PROXY=""` + `no_proxy=oauth2.googleapis.com`, a CONNECT-counting local proxy logged `CONNECT oauth2.googleapis.com:443` — the request was wrongly routed to the proxy.
- Real behavior after (fixed code): the same setup produced 0 CONNECTs — the explicit proxy was bypassed (the direct attempt then fails in this sandbox, which is expected; the routing decision is the signal).
- Focused green: `node scripts/test-projects.mjs extensions/googlechat/src/google-auth.runtime.test.ts` — 19 tests passed.
- `oxfmt --check` on the changed files passed; `git diff --check` clean.

## Real Behavior Proof

The proof drives the real `getGoogleAuthTransport()` fetch implementation with an explicit proxy in the request init (the google-auth-library agent path) and observes routing with a local CONNECT-counting proxy.

### Before (on main)

```bash
$ NO_PROXY="" no_proxy=oauth2.googleapis.com node --import tsx proof.mjs
fake proxy listening on http://127.0.0.1:<port>
proxy received CONNECT: oauth2.googleapis.com:443
proxy CONNECT count: 1
FAIL: token request was routed to the explicit proxy (lowercase no_proxy rules lost)
```

### After (with fix)

```bash
$ NO_PROXY="" no_proxy=oauth2.googleapis.com node --import tsx proof.mjs
fake proxy listening on http://127.0.0.1:<port>
proxy CONNECT count: 0
PASS: token request bypassed the explicit proxy (lowercase no_proxy honored)
```

## Tests and Validation

- New regression test `falls back to lowercase no_proxy when uppercase NO_PROXY is blank` in `extensions/googlechat/src/google-auth.runtime.test.ts`: with `NO_PROXY=""`, `no_proxy=oauth2.googleapis.com`, and `HTTPS_PROXY` set, asserts the token fetch resolves to the direct (bypassed) dispatcher policy.
- `node scripts/test-projects.mjs extensions/googlechat/src/google-auth.runtime.test.ts` — 1 file, 19 tests passed.
- `oxfmt --check extensions/googlechat/src/google-auth.runtime.ts extensions/googlechat/src/google-auth.runtime.test.ts` passed.
- Manual verification: proxy-routing before/after runs above.
