### PR TITLE
fix(state): add PRAGMA busy_timeout to repairOpenClawStateDatabaseSchema

### DIFF
--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -146,6 +146,7 @@ export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabase
   ensureOpenClawStatePermissions(pathname, env);
   const sqlite = requireNodeSqlite();
   const db = new sqlite.DatabaseSync(pathname);
+  db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
   try {
     assertSqliteIntegrity(db, pathname);
     assertSupportedSchemaVersion(db, pathname);


### PR DESCRIPTION
## What Problem This Solves

Fixes issue #113139:  opens a new  connection without setting , causing  errors under high concurrent write contention (agent heartbeats, concurrent writes).

## Why This Change Was Made

The function creates a new connection at line 148 and immediately performs operations (, , ) that can fail with  before the transaction starts. The transaction itself has the timeout via , but the pre-transaction operations had no protection.

## User Impact

- Schema repair now waits up to 5s (configurable via ) for locks to clear
- Prevents manual intervention when repair fails under concurrent load
- Consistent behavior with all other database connections in the codebase

## Evidence

- All 92 tests in  pass
- All 234 tests in  pass
- Follows existing pattern used at lines 331, 404 in same file and 60+ other locations
- Adds 1 line: 

Fixes #113139