### PR TITLE
fix(ios): prevent release screenshots from stalling in Settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3228,11 +3228,11 @@ jobs:
         run: pnpm ios:build
 
       - name: Capture iOS release screenshots
-        if: ${{ github.event_name == 'workflow_dispatch' && env.HISTORICAL_TARGET != 'true' }}
+        if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && env.HISTORICAL_TARGET != 'true' }}
         run: pnpm ios:screenshots
 
       - name: Upload iOS release screenshot evidence
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && env.HISTORICAL_TARGET != 'true' }}
+        if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && env.HISTORICAL_TARGET != 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ios-release-screenshots-${{ needs.preflight.outputs.checkout_revision }}

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -21107,7 +21107,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 261,
+      "line": 264,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -21115,7 +21115,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 283,
+      "line": 286,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
@@ -21123,7 +21123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 287,
+      "line": 290,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
@@ -21131,7 +21131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 295,
+      "line": 298,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
@@ -21139,7 +21139,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 299,
+      "line": 302,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -21147,7 +21147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 308,
+      "line": 311,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -21155,7 +21155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 317,
+      "line": 320,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Forget %@?",
       "surface": "apple",
@@ -21163,7 +21163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 318,
+      "line": 321,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "gateway",
       "surface": "apple",
@@ -21171,7 +21171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 331,
+      "line": 334,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Forget Gateway",
       "surface": "apple",
@@ -21179,7 +21179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 337,
+      "line": 340,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -21187,7 +21187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 345,
+      "line": 348,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This removes saved credentials, device access, TLS trust, and cached chats for this gateway.",
       "surface": "apple",
@@ -21195,7 +21195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 399,
+      "line": 402,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
@@ -21203,7 +21203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 413,
+      "line": 416,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
@@ -21211,7 +21211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 421,
+      "line": 424,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",
@@ -24459,7 +24459,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1437,
+      "line": 1443,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at %1$@:%2$@. Verify Tailscale Serve is enabled and publishes this Gateway.",
       "surface": "apple",
@@ -24467,7 +24467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1446,
+      "line": 1452,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at %1$@:%2$@. Check Tailscale or LAN.",
       "surface": "apple",
@@ -24475,7 +24475,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1452,
+      "line": 1458,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "TLS fingerprint verification timed out for %1$@:%2$@. Secure endpoint was reached, but TLS did not finish in time.",
       "surface": "apple",
@@ -24483,7 +24483,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1460,
+      "line": 1466,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "No secure gateway endpoint was detected at %1$@:%2$@. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "apple",
@@ -24491,7 +24491,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1470,
+      "line": 1476,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Could not read the TLS certificate from %1$@:%2$@.",
       "surface": "apple",
@@ -25155,7 +25155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 43,
+      "line": 52,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Off",
       "surface": "apple",
@@ -25163,7 +25163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 45,
+      "line": 54,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "While Using",
       "surface": "apple",
@@ -25171,7 +25171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 47,
+      "line": 56,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always",
       "surface": "apple",
@@ -25179,7 +25179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 59,
+      "line": 68,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. Location Services are off in iOS Settings.",
       "surface": "apple",
@@ -25187,7 +25187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 61,
+      "line": 70,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. iOS currently allows Always.",
       "surface": "apple",
@@ -25195,7 +25195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 63,
+      "line": 72,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. iOS currently allows While Using.",
       "surface": "apple",
@@ -25203,7 +25203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 65,
+      "line": 74,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled.",
       "surface": "apple",
@@ -25211,7 +25211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 67,
+      "line": 76,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location Services are off in iOS Settings.",
       "surface": "apple",
@@ -25219,7 +25219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 71,
+      "line": 80,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed. Precise Location is on.",
       "surface": "apple",
@@ -25227,7 +25227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 75,
+      "line": 84,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed. Precise Location is off.",
       "surface": "apple",
@@ -25235,7 +25235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 79,
+      "line": 88,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed.",
       "surface": "apple",
@@ -25243,7 +25243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 81,
+      "line": 90,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed. Precise Location is on.",
       "surface": "apple",
@@ -25251,7 +25251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 83,
+      "line": 92,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed. Precise Location is off.",
       "surface": "apple",
@@ -25259,7 +25259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 85,
+      "line": 94,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed.",
       "surface": "apple",
@@ -25267,7 +25267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 87,
+      "line": 96,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app. Precise Location is on.",
       "surface": "apple",
@@ -25275,7 +25275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 89,
+      "line": 98,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app. Precise Location is off.",
       "surface": "apple",
@@ -25283,7 +25283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 91,
+      "line": 100,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app.",
       "surface": "apple",
@@ -25291,7 +25291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 93,
+      "line": 102,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location permission is denied in iOS Settings.",
       "surface": "apple",
@@ -25299,7 +25299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 95,
+      "line": 104,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location permission is restricted on this device.",
       "surface": "apple",
@@ -25307,7 +25307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 97,
+      "line": 106,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Choose a location mode to request iOS permission.",
       "surface": "apple",
@@ -25315,7 +25315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 99,
+      "line": 108,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "OpenClaw cannot determine the current iOS location permission.",
       "surface": "apple",
@@ -25387,7 +25387,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4304,
+      "line": 4307,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -25395,7 +25395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4305,
+      "line": 4308,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -25403,7 +25403,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 5020,
+      "line": 5023,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -25411,7 +25411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 5021,
+      "line": 5024,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -25419,7 +25419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5376,
+      "line": 5379,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -25427,7 +25427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5376,
+      "line": 5379,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -25435,7 +25435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6546,
+      "line": 6549,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -25443,7 +25443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6745,
+      "line": 6748,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -25451,7 +25451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6745,
+      "line": 6748,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -25459,7 +25459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 9154,
+      "line": 9157,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -25467,7 +25467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 9154,
+      "line": 9157,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -25475,7 +25475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 9160,
+      "line": 9163,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -25483,7 +25483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 9161,
+      "line": 9164,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -25491,7 +25491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10498,
+      "line": 10501,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -193,6 +193,9 @@ struct SettingsProTab: View {
                     self.refreshNotificationSettings()
                 }
             }
+            .onChange(of: self.appModel.locationAuthorizationSnapshot) { _, _ in
+                self.refreshLocationPermissionSummary()
+            }
             .onChange(of: self.locationModeRaw) { _, newValue in
                 self.handleLocationModeChange(newValue)
             }

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -241,25 +241,25 @@ extension SettingsProTab {
 
     func refreshLocationPermissionSummary(desiredMode modeOverride: OpenClawLocationMode? = nil) {
         let mode = modeOverride ?? OpenClawLocationMode(rawValue: self.locationModeRaw) ?? .off
-        let manager = CLLocationManager()
+        let authorization = self.appModel.locationAuthorizationSnapshot
         self.locationPermissionRefreshID &+= 1
         let refreshID = self.locationPermissionRefreshID
         let currentSummary = self.locationPermissionSummary
         self.locationPermissionSummary = LocationPermissionSummary(
             desiredMode: mode,
             locationServicesEnabled: currentSummary.locationServicesEnabled,
-            authorizationStatus: manager.authorizationStatus,
-            accuracyAuthorization: manager.accuracyAuthorization)
+            authorizationStatus: authorization.authorizationStatus,
+            accuracyAuthorization: authorization.accuracyAuthorization)
         Task {
             let locationServicesEnabled = await Self.locationServicesEnabled()
             guard refreshID == self.locationPermissionRefreshID else { return }
-            let latestManager = CLLocationManager()
+            let latestAuthorization = self.appModel.locationAuthorizationSnapshot
             let latestMode = modeOverride ?? OpenClawLocationMode(rawValue: self.locationModeRaw) ?? .off
             self.locationPermissionSummary = LocationPermissionSummary(
                 desiredMode: latestMode,
                 locationServicesEnabled: locationServicesEnabled,
-                authorizationStatus: latestManager.authorizationStatus,
-                accuracyAuthorization: latestManager.accuracyAuthorization)
+                authorizationStatus: latestAuthorization.authorizationStatus,
+                accuracyAuthorization: latestAuthorization.accuracyAuthorization)
         }
     }
 
@@ -704,12 +704,12 @@ extension SettingsProTab {
         guard let mode = self.pendingLocationMode else { return }
         Task {
             let locationServicesEnabled = await Self.locationServicesEnabled()
-            let manager = CLLocationManager()
+            let authorization = self.appModel.locationAuthorizationSnapshot
             let summary = LocationPermissionSummary(
                 desiredMode: mode,
                 locationServicesEnabled: locationServicesEnabled,
-                authorizationStatus: manager.authorizationStatus,
-                accuracyAuthorization: manager.accuracyAuthorization)
+                authorizationStatus: authorization.authorizationStatus,
+                accuracyAuthorization: authorization.accuracyAuthorization)
             self.locationPermissionSummary = summary
             let unavailableStatus = self.locationSettingsPresentation(selectedMode: mode).statusText
             self.pendingLocationMode = nil

--- a/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
@@ -212,7 +212,7 @@ extension GatewayConnectionController {
         permissions["camera"] = AVCaptureDevice.authorizationStatus(for: .video) == .authorized
         permissions["microphone"] = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         permissions["speechRecognition"] = SFSpeechRecognizer.authorizationStatus() == .authorized
-        let locationStatus = CLLocationManager().authorizationStatus
+        let locationStatus = self.locationAuthorizationSnapshot.authorizationStatus
         let locationServicesEnabled = await Self.locationServicesEnabled()
         permissions["location"] = Self.isLocationAvailable(
             servicesEnabled: locationServicesEnabled,

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -164,6 +164,12 @@ final class GatewayConnectionController {
         }
     }
 
+    /// Registration consumes the app-owned permission snapshot; constructing a location
+    /// manager on this hot path can synchronously block the main thread on Core Location.
+    var locationAuthorizationSnapshot: LocationAuthorizationSnapshot {
+        self.appModel?.locationAuthorizationSnapshot ?? .undetermined
+    }
+
     func setDiscoveryDebugLoggingEnabled(_ enabled: Bool) {
         self.discovery.setDebugLoggingEnabled(enabled)
     }

--- a/apps/ios/Sources/Location/LocationPermissionSummary.swift
+++ b/apps/ios/Sources/Location/LocationPermissionSummary.swift
@@ -2,6 +2,15 @@ import CoreLocation
 import Foundation
 import OpenClawKit
 
+struct LocationAuthorizationSnapshot: Equatable, Sendable {
+    var authorizationStatus: CLAuthorizationStatus
+    var accuracyAuthorization: CLAccuracyAuthorization
+
+    static let undetermined = LocationAuthorizationSnapshot(
+        authorizationStatus: .notDetermined,
+        accuracyAuthorization: .fullAccuracy)
+}
+
 struct LocationPermissionSummary: Equatable {
     var desiredMode: OpenClawLocationMode
     var locationServicesEnabled: Bool

--- a/apps/ios/Sources/Location/LocationService.swift
+++ b/apps/ios/Sources/Location/LocationService.swift
@@ -16,7 +16,8 @@ final class LocationService: NSObject, CLLocationManagerDelegate, ConcurrentLoca
     private var authContinuation: CheckedContinuation<CLAuthorizationStatus, Never>?
     private var locationContinuation: CheckedContinuation<CLLocation, Swift.Error>?
     var locationRequestContinuations: [UUID: CheckedContinuation<CLLocation, Swift.Error>] = [:]
-    private var authorizationChangeHandler: (@MainActor @Sendable (CLAuthorizationStatus) -> Void)?
+    private var cachedAuthorizationSnapshot = LocationAuthorizationSnapshot.undetermined
+    private var authorizationChangeHandler: (@MainActor @Sendable (LocationAuthorizationSnapshot) -> Void)?
     private var significantLocationCallback: (@Sendable (CLLocation) -> Void)?
     private var isMonitoringSignificantChanges = false
 
@@ -36,10 +37,22 @@ final class LocationService: NSObject, CLLocationManagerDelegate, ConcurrentLoca
         self.configureLocationManager()
     }
 
+    func authorizationStatus() -> CLAuthorizationStatus {
+        self.cachedAuthorizationSnapshot.authorizationStatus
+    }
+
+    func accuracyAuthorization() -> CLAccuracyAuthorization {
+        self.cachedAuthorizationSnapshot.accuracyAuthorization
+    }
+
+    func authorizationSnapshot() -> LocationAuthorizationSnapshot {
+        self.cachedAuthorizationSnapshot
+    }
+
     func ensureAuthorization(mode: OpenClawLocationMode) async -> CLAuthorizationStatus {
         guard CLLocationManager.locationServicesEnabled() else { return .denied }
 
-        let status = self.manager.authorizationStatus
+        let status = self.authorizationStatus()
         if status == .notDetermined {
             let updated = await self.requestAuthorization(requiresDeterminedStatus: true) {
                 self.manager.requestWhenInUseAuthorization()
@@ -48,7 +61,7 @@ final class LocationService: NSObject, CLLocationManagerDelegate, ConcurrentLoca
         }
 
         if mode == .always {
-            let current = self.manager.authorizationStatus
+            let current = self.authorizationStatus()
             if current == .authorizedWhenInUse {
                 return await self.requestAuthorization(requiresDeterminedStatus: false) {
                     self.manager.requestAlwaysAuthorization()
@@ -57,7 +70,7 @@ final class LocationService: NSObject, CLLocationManagerDelegate, ConcurrentLoca
             return current
         }
 
-        return self.manager.authorizationStatus
+        return self.authorizationStatus()
     }
 
     func currentLocation(
@@ -105,7 +118,7 @@ final class LocationService: NSObject, CLLocationManagerDelegate, ConcurrentLoca
                         continue
                     }
                     guard observedPrompt || clock.now >= noPromptDeadline else { continue }
-                    let status = self.manager.authorizationStatus
+                    let status = self.authorizationStatus()
                     if Self.shouldCompleteAuthorizationWait(
                         status: status,
                         requiresDeterminedStatus: requiresDeterminedStatus)
@@ -171,7 +184,7 @@ final class LocationService: NSObject, CLLocationManagerDelegate, ConcurrentLoca
     }
 
     func setAuthorizationChangeHandler(
-        _ handler: @escaping @MainActor @Sendable (CLAuthorizationStatus) -> Void)
+        _ handler: @escaping @MainActor @Sendable (LocationAuthorizationSnapshot) -> Void)
     {
         self.authorizationChangeHandler = handler
     }
@@ -183,11 +196,16 @@ final class LocationService: NSObject, CLLocationManagerDelegate, ConcurrentLoca
     }
 
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        let status = manager.authorizationStatus
+        // Apple guarantees this callback for the initial state and every authorization
+        // change. Cache both values here so UI construction never performs synchronous XPC.
+        let snapshot = LocationAuthorizationSnapshot(
+            authorizationStatus: manager.authorizationStatus,
+            accuracyAuthorization: manager.accuracyAuthorization)
         Task { @MainActor in
-            self.authorizationChangeHandler?(status)
+            self.cachedAuthorizationSnapshot = snapshot
+            self.authorizationChangeHandler?(snapshot)
             guard let waitID = self.authWaitID else { return }
-            self.finishAuthorizationWait(waitID: waitID, status: status)
+            self.finishAuthorizationWait(waitID: waitID, status: snapshot.authorizationStatus)
         }
     }
 

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -548,6 +548,7 @@ final class NodeAppModel {
     let voiceWake = VoiceWakeManager()
     let voiceNoteRecorder: OpenClawVoiceNoteRecorder
     let talkMode: TalkModeManager
+    private(set) var locationAuthorizationSnapshot = LocationAuthorizationSnapshot.undetermined
     private let locationService: any LocationServicing
     private let deviceStatusService: any DeviceStatusServicing
     private let photosService: any PhotosServicing
@@ -990,6 +991,7 @@ final class NodeAppModel {
             rawValue: UserDefaults.standard.string(forKey: Self.preferredCameraFacingKey))
         self.screenRecorder = screenRecorder
         self.locationService = locationService
+        self.locationAuthorizationSnapshot = locationService.authorizationSnapshot()
         self.notificationCenter = notificationCenter
         self.deviceStatusService = deviceStatusService
         self.photosService = photosService
@@ -1089,11 +1091,12 @@ final class NodeAppModel {
         refreshLastShareEventFromRelay()
         let talkEnabled = UserDefaults.standard.bool(forKey: "talk.enabled")
         self.setTalkEnabled(talkEnabled)
-        self.locationService.setAuthorizationChangeHandler { [weak self] status in
+        self.locationService.setAuthorizationChangeHandler { [weak self] snapshot in
             guard let self else { return }
+            self.locationAuthorizationSnapshot = snapshot
             self.reconcileSignificantLocationMonitoring(
                 mode: self.locationMode(),
-                authorizationStatus: status)
+                authorizationStatus: snapshot.authorizationStatus)
         }
 
         // Wire up deep links from canvas taps

--- a/apps/ios/Sources/Permissions/DevicePermissions.swift
+++ b/apps/ios/Sources/Permissions/DevicePermissions.swift
@@ -173,6 +173,12 @@ final class DevicePermissionsModel {
     /// Owns its manager so authorization callbacks resolve without the app-wide service.
     private let locationService = LocationService()
 
+    init() {
+        self.locationService.setAuthorizationChangeHandler { [weak self] snapshot in
+            self?.grants[.location] = DevicePermissionStatusMap.location(snapshot.authorizationStatus)
+        }
+    }
+
     func grant(for kind: DevicePermissionKind) -> DevicePermissionGrant {
         self.grants[kind] ?? .notRequested
     }
@@ -185,7 +191,7 @@ final class DevicePermissionsModel {
             .contacts: DevicePermissionStatusMap.contacts(CNContactStore.authorizationStatus(for: .contacts)),
             .calendar: DevicePermissionStatusMap.eventKitRead(EKEventStore.authorizationStatus(for: .event)),
             .reminders: DevicePermissionStatusMap.eventKitRead(EKEventStore.authorizationStatus(for: .reminder)),
-            .location: DevicePermissionStatusMap.location(self.locationService.locationManager.authorizationStatus),
+            .location: DevicePermissionStatusMap.location(self.locationService.authorizationStatus()),
         ]
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         next[.notifications] = DevicePermissionStatusMap.notifications(settings.authorizationStatus)

--- a/apps/ios/Sources/Services/NodeServiceProtocols.swift
+++ b/apps/ios/Sources/Services/NodeServiceProtocols.swift
@@ -29,6 +29,7 @@ protocol ScreenRecordingServicing: Sendable {
 protocol LocationServicing: Sendable {
     func authorizationStatus() -> CLAuthorizationStatus
     func accuracyAuthorization() -> CLAccuracyAuthorization
+    func authorizationSnapshot() -> LocationAuthorizationSnapshot
     func ensureAuthorization(mode: OpenClawLocationMode) async -> CLAuthorizationStatus
     func currentLocation(
         params: OpenClawLocationGetParams,
@@ -37,9 +38,17 @@ protocol LocationServicing: Sendable {
         timeoutMs: Int?) async throws -> CLLocation
     func setBackgroundLocationUpdatesEnabled(_ enabled: Bool)
     func setAuthorizationChangeHandler(
-        _ handler: @escaping @MainActor @Sendable (CLAuthorizationStatus) -> Void)
+        _ handler: @escaping @MainActor @Sendable (LocationAuthorizationSnapshot) -> Void)
     func startMonitoringSignificantLocationChanges(onUpdate: @escaping @Sendable (CLLocation) -> Void)
     func stopMonitoringSignificantLocationChanges()
+}
+
+extension LocationServicing {
+    func authorizationSnapshot() -> LocationAuthorizationSnapshot {
+        LocationAuthorizationSnapshot(
+            authorizationStatus: self.authorizationStatus(),
+            accuracyAuthorization: self.accuracyAuthorization())
+    }
 }
 
 @MainActor

--- a/apps/ios/Tests/LocationPermissionSummaryTests.swift
+++ b/apps/ios/Tests/LocationPermissionSummaryTests.swift
@@ -327,18 +327,42 @@ import Testing
         #expect(locationService.startMonitoringCallCount == 2)
         #expect(locationService.stopMonitoringCallCount == 1)
     }
+
+    @MainActor @Test func `node model publishes cached location authorization changes`() {
+        let locationService = MockLocationService(
+            authorizationStatus: .authorizedWhenInUse,
+            accuracyAuthorization: .reducedAccuracy)
+        let appModel = NodeAppModel(locationService: locationService)
+
+        #expect(appModel.locationAuthorizationSnapshot == LocationAuthorizationSnapshot(
+            authorizationStatus: .authorizedWhenInUse,
+            accuracyAuthorization: .reducedAccuracy))
+
+        locationService.simulateAuthorizationChange(
+            .authorizedAlways,
+            accuracyAuthorization: .fullAccuracy)
+
+        #expect(appModel.locationAuthorizationSnapshot == LocationAuthorizationSnapshot(
+            authorizationStatus: .authorizedAlways,
+            accuracyAuthorization: .fullAccuracy))
+    }
 }
 
 @MainActor
 private final class MockLocationService: LocationServicing, @unchecked Sendable {
     private var status: CLAuthorizationStatus
-    private var authorizationChangeHandler: (@MainActor @Sendable (CLAuthorizationStatus) -> Void)?
+    private var accuracy: CLAccuracyAuthorization
+    private var authorizationChangeHandler: (@MainActor @Sendable (LocationAuthorizationSnapshot) -> Void)?
     var backgroundUpdatesEnabled: Bool?
     var startMonitoringCallCount = 0
     var stopMonitoringCallCount = 0
 
-    init(authorizationStatus: CLAuthorizationStatus) {
+    init(
+        authorizationStatus: CLAuthorizationStatus,
+        accuracyAuthorization: CLAccuracyAuthorization = .fullAccuracy)
+    {
         self.status = authorizationStatus
+        self.accuracy = accuracyAuthorization
     }
 
     func authorizationStatus() -> CLAuthorizationStatus {
@@ -346,7 +370,7 @@ private final class MockLocationService: LocationServicing, @unchecked Sendable 
     }
 
     func accuracyAuthorization() -> CLAccuracyAuthorization {
-        .fullAccuracy
+        self.accuracy
     }
 
     func ensureAuthorization(mode: OpenClawLocationMode) async -> CLAuthorizationStatus {
@@ -372,7 +396,7 @@ private final class MockLocationService: LocationServicing, @unchecked Sendable 
     }
 
     func setAuthorizationChangeHandler(
-        _ handler: @escaping @MainActor @Sendable (CLAuthorizationStatus) -> Void)
+        _ handler: @escaping @MainActor @Sendable (LocationAuthorizationSnapshot) -> Void)
     {
         self.authorizationChangeHandler = handler
     }
@@ -386,8 +410,12 @@ private final class MockLocationService: LocationServicing, @unchecked Sendable 
         self.stopMonitoringCallCount += 1
     }
 
-    func simulateAuthorizationChange(_ status: CLAuthorizationStatus) {
+    func simulateAuthorizationChange(
+        _ status: CLAuthorizationStatus,
+        accuracyAuthorization: CLAccuracyAuthorization = .fullAccuracy)
+    {
         self.status = status
-        self.authorizationChangeHandler?(status)
+        self.accuracy = accuracyAuthorization
+        self.authorizationChangeHandler?(self.authorizationSnapshot())
     }
 }

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -60,21 +60,10 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.launchApp(for: Self.agentScreenshotTarget)
 
         XCTAssertTrue(self.app?.buttons["agent-status-filter-menu"].waitForExistence(timeout: 8) == true)
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure(
-            "Agents-to-Settings navigation can wedge XCTest quiescence; keep it separate from release capture.",
-            options: options)
-        {
-            do {
-                try self.selectSidebarDestination("Settings")
-            } catch {
-                XCTFail("Agents-to-Settings navigation setup failed: \(error)")
-            }
-            XCTAssertTrue(
-                self.app?.descendants(matching: .any)["settings-system-agent-row"]
-                    .waitForExistence(timeout: 8) == true)
-        }
+        try self.selectSidebarDestination("Settings")
+        XCTAssertTrue(
+            self.app?.descendants(matching: .any)["settings-system-agent-row"]
+                .waitForExistence(timeout: 8) == true)
     }
 
     func testAutomationManagementScreenshot() {

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -9,15 +9,23 @@ final class OpenClawSnapshotUITests: XCTestCase {
         let name: String
     }
 
-    private static let screenshotTargets = [
-        ScreenshotTarget(initialTab: "control", initialDestination: "overview", name: "01-control-connected"),
-        ScreenshotTarget(initialTab: "chat", initialDestination: "chat", name: "02-chat-connected"),
-        ScreenshotTarget(initialTab: "agent", initialDestination: "agents", name: "03-agent-connected"),
-        ScreenshotTarget(initialTab: "settings", initialDestination: "settings", name: "04-settings-connected"),
-    ]
+    private static let controlScreenshotTarget = ScreenshotTarget(
+        initialTab: "control",
+        initialDestination: "overview",
+        name: "01-control-connected")
+    private static let chatScreenshotTarget = ScreenshotTarget(
+        initialTab: "chat",
+        initialDestination: "chat",
+        name: "02-chat-connected")
+    private static let agentScreenshotTarget = ScreenshotTarget(
+        initialTab: "agent",
+        initialDestination: "agents",
+        name: "03-agent-connected")
+    private static let settingsScreenshotTarget = ScreenshotTarget(
+        initialTab: "settings",
+        initialDestination: "settings",
+        name: "04-settings-connected")
     private static let appReadinessAccessibilityIdentifier = "RootTabs.Ready"
-    private static let releaseScreenshotLaunchArguments = ["-sidebar.pinnedPages", "overview,agents"]
-    private static let screenshotLaunchRetryThreshold: TimeInterval = 30
 
     private var app: XCUIApplication?
 
@@ -31,19 +39,41 @@ final class OpenClawSnapshotUITests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testConnectedGatewayTabs() throws {
-        let initialTarget = try XCTUnwrap(Self.screenshotTargets.first)
-        self.launchApp(
-            for: initialTarget,
-            additionalArguments: Self.releaseScreenshotLaunchArguments)
+    func testReleaseControlScreenshot() {
+        self.captureReleaseScreenshot(Self.controlScreenshotTarget)
+    }
 
-        for (index, target) in Self.screenshotTargets.enumerated() {
-            if index > 0 {
-                try self.selectReleaseScreenshotDestination(target)
+    func testReleaseChatScreenshot() {
+        self.captureReleaseScreenshot(Self.chatScreenshotTarget)
+    }
+
+    func testReleaseAgentScreenshot() {
+        self.captureReleaseScreenshot(Self.agentScreenshotTarget)
+    }
+
+    func testReleaseSettingsScreenshot() {
+        self.captureReleaseScreenshot(Self.settingsScreenshotTarget)
+    }
+
+    func testAgentsNavigateToSettingsThroughSidebar() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone sidebar navigation only")
+        self.launchApp(for: Self.agentScreenshotTarget)
+
+        XCTAssertTrue(self.app?.buttons["agent-status-filter-menu"].waitForExistence(timeout: 8) == true)
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure(
+            "Agents-to-Settings navigation can wedge XCTest quiescence; keep it separate from release capture.",
+            options: options)
+        {
+            do {
+                try self.selectSidebarDestination("Settings")
+            } catch {
+                XCTFail("Agents-to-Settings navigation setup failed: \(error)")
             }
-            self.waitForReleaseScreenshotTarget(target)
-            snapshot(target.name, timeWaitingForIdle: 5)
-            self.attachScreenshot(named: target.name)
+            XCTAssertTrue(
+                self.app?.descendants(matching: .any)["settings-system-agent-row"]
+                    .waitForExistence(timeout: 8) == true)
         }
     }
 
@@ -929,40 +959,12 @@ final class OpenClawSnapshotUITests: XCTestCase {
     {
         self.terminateCurrentApp()
 
-        var app = self.configuredApp(
+        let app = self.configuredApp(
             for: target,
             appearance: appearance,
             screenshotMode: screenshotMode,
             additionalArguments: additionalArguments)
-        let launchDuration = self.launchDuration(app)
-        if screenshotMode,
-           launchDuration >= Self.screenshotLaunchRetryThreshold || app.state != .runningForeground
-        {
-            // A slow XCUIApplication launch can return with the scene inactive and its
-            // accessibility tree wedged. Recover before making any element query.
-            self.attachStalledLaunchScreenshot(duration: launchDuration)
-            app.terminate()
-            guard app.wait(for: .notRunning, timeout: 5) else {
-                self.app = app
-                XCTFail("OpenClaw did not terminate after a stalled screenshot launch")
-                return
-            }
-
-            app = self.configuredApp(
-                for: target,
-                appearance: appearance,
-                screenshotMode: screenshotMode,
-                additionalArguments: additionalArguments)
-            let retryDuration = self.launchDuration(app)
-            guard retryDuration < Self.screenshotLaunchRetryThreshold,
-                  app.state == .runningForeground
-            else {
-                self.app = app
-                XCTFail("Screenshot app launch stalled again after one recovery attempt")
-                return
-            }
-        }
-
+        app.launch()
         self.app = app
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 8))
         let readiness = app.descendants(matching: .any)[Self.appReadinessAccessibilityIdentifier]
@@ -999,19 +1001,11 @@ final class OpenClawSnapshotUITests: XCTestCase {
         return app
     }
 
-    private func launchDuration(_ app: XCUIApplication) -> TimeInterval {
-        let startedAt = Date()
-        app.launch()
-        return Date().timeIntervalSince(startedAt)
-    }
-
-    private func attachStalledLaunchScreenshot(duration: TimeInterval) {
-        XCTContext.runActivity(named: "Recover stalled screenshot launch") { activity in
-            let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
-            attachment.name = "stalled-screenshot-launch-\(Int(duration.rounded()))s"
-            attachment.lifetime = .keepAlways
-            activity.add(attachment)
-        }
+    private func captureReleaseScreenshot(_ target: ScreenshotTarget) {
+        self.launchApp(for: target)
+        self.waitForReleaseScreenshotTarget(target)
+        snapshot(target.name, timeWaitingForIdle: 5)
+        self.attachScreenshot(named: target.name)
     }
 
     private func waitForReleaseScreenshotTarget(_ target: ScreenshotTarget) {
@@ -1032,60 +1026,6 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(
             anchor.waitForExistence(timeout: 8),
             "Screenshot target \(target.name) did not render its readiness anchor")
-    }
-
-    private func selectReleaseScreenshotDestination(
-        _ target: ScreenshotTarget,
-        file: StaticString = #filePath,
-        line: UInt = #line) throws
-    {
-        let app = try XCTUnwrap(self.app, file: file, line: line)
-        let destination = target.initialDestination
-        let destinationButton = app.buttons["RootTabs.Sidebar.Destination.\(destination)"]
-        let showSidebar = app.buttons["RootTabs.Sidebar.Show"]
-        let hideSidebar = app.buttons["RootTabs.Sidebar.Hide"]
-        if showSidebar.isHittable {
-            showSidebar.tap()
-            self.waitForHittable(true, of: hideSidebar)
-        } else if !destinationButton.isHittable {
-            XCTAssertTrue(showSidebar.waitForExistence(timeout: 5), file: file, line: line)
-            XCTAssertTrue(showSidebar.isHittable, file: file, line: line)
-            showSidebar.tap()
-            self.waitForHittable(true, of: hideSidebar)
-        }
-
-        XCTAssertTrue(destinationButton.waitForExistence(timeout: 5), file: file, line: line)
-        XCTAssertTrue(destinationButton.isHittable, file: file, line: line)
-        let transitionStartedAt = Date()
-        destinationButton.tap()
-        let transitionDuration = Date().timeIntervalSince(transitionStartedAt)
-        let readiness = app.descendants(matching: .any)[Self.appReadinessAccessibilityIdentifier]
-        let reachedDestination = transitionDuration < Self.screenshotLaunchRetryThreshold &&
-            app.state == .runningForeground &&
-            self.element(readiness, hasValue: "ready:\(destination)", timeout: 8)
-        if !reachedDestination {
-            // XCTest can spend its full idle timeout after a synthesized navigation
-            // event. Relaunch only the affected destination, before another AX query.
-            self.attachStalledTransitionScreenshot(target: target, duration: transitionDuration)
-            self.launchApp(for: target, additionalArguments: Self.releaseScreenshotLaunchArguments)
-            return
-        }
-
-        // Drawer layouts collapse after selection. Split layouts do not, so close
-        // them explicitly to keep every App Store capture sidebar-free.
-        if hideSidebar.isHittable {
-            hideSidebar.tap()
-        }
-        self.waitForHittable(true, of: showSidebar)
-    }
-
-    private func attachStalledTransitionScreenshot(target: ScreenshotTarget, duration: TimeInterval) {
-        XCTContext.runActivity(named: "Recover stalled screenshot transition") { activity in
-            let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
-            attachment.name = "stalled-\(target.initialDestination)-transition-\(Int(duration.rounded()))s"
-            attachment.lifetime = .keepAlways
-            activity.add(attachment)
-        }
     }
 
     private func terminateCurrentApp(

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -39,12 +39,20 @@ REQUIRED_SCREENSHOT_FAMILIES = {
   "iPhone" => /iPhone/,
   "13-inch iPad" => /iPad (Air|Pro) 13-inch/
 }.freeze
-REQUIRED_IOS_SCREENSHOT_NAMES = [
-  "01-control-connected",
-  "02-chat-connected",
-  "03-agent-connected",
-  "04-settings-connected"
+RELEASE_IOS_SCREENSHOT_TESTS = [
+  { test: "testReleaseControlScreenshot", name: "01-control-connected" },
+  { test: "testReleaseChatScreenshot", name: "02-chat-connected" },
+  { test: "testReleaseAgentScreenshot", name: "03-agent-connected" },
+  { test: "testReleaseSettingsScreenshot", name: "04-settings-connected" }
 ].freeze
+REQUIRED_IOS_SCREENSHOT_NAMES = RELEASE_IOS_SCREENSHOT_TESTS.map { |entry| entry.fetch(:name) }.freeze
+IOS_SCREENSHOT_TEST_TIMEOUT_SECONDS = 180
+IOS_SCREENSHOT_XCARGS = [
+  "-allowProvisioningUpdates",
+  "-test-timeouts-enabled YES",
+  "-default-test-execution-time-allowance #{IOS_SCREENSHOT_TEST_TIMEOUT_SECONDS}",
+  "-maximum-test-execution-time-allowance #{IOS_SCREENSHOT_TEST_TIMEOUT_SECONDS}"
+].join(" ").freeze
 PNG_SIGNATURE = "\x89PNG\r\n\x1A\n".b.freeze
 PUBLIC_METADATA_FILENAMES = [
   "description.txt",
@@ -1611,6 +1619,88 @@ rescue JSON::ParserError, KeyError => e
   UI.user_error!("Invalid screenshot test result summary for #{device}: #{e.message}")
 end
 
+def archive_snapshot_test_result!(result_bundle_path:, archive_directory:, device:, screenshot_name:, attempt:)
+  return unless File.directory?(result_bundle_path)
+
+  archive_path = File.join(
+    archive_directory,
+    "#{device}-#{screenshot_name}-attempt-#{attempt}.xcresult"
+  )
+  FileUtils.rm_rf(archive_path)
+  FileUtils.mv(result_bundle_path, archive_path)
+end
+
+def capture_release_ios_screenshot!(
+  project:,
+  device:,
+  screenshot:,
+  output_directory:,
+  result_bundle_path:,
+  result_bundle_archive_directory:,
+  derived_data_path:,
+  clear_previous_screenshots:
+)
+  test_name = screenshot.fetch(:test)
+  screenshot_name = screenshot.fetch(:name)
+  expected_screenshot_path = File.join(output_directory, "en-US", "#{device}-#{screenshot_name}.png")
+
+  1.upto(2) do |attempt|
+    FileUtils.rm_f(expected_screenshot_path)
+    FileUtils.rm_rf(result_bundle_path)
+    begin
+      # Keep retry ownership outside Snapshot. Every action call creates a new
+      # xcodebuild/TestManager session and reboots the selected simulator.
+      capture_ios_screenshots(
+        project: project,
+        scheme: "OpenClawUITests",
+        configuration: "Debug",
+        devices: [device],
+        languages: ["en-US"],
+        only_testing: ["OpenClawUITests/OpenClawSnapshotUITests/#{test_name}"],
+        launch_arguments: ["--openclaw-screenshot-mode"],
+        output_directory: output_directory,
+        clear_previous_screenshots: clear_previous_screenshots && attempt == 1,
+        derived_data_path: derived_data_path,
+        test_without_building: true,
+        result_bundle: true,
+        number_of_retries: 0,
+        stop_after_first_error: true,
+        reinstall_app: true,
+        concurrent_simulators: false,
+        override_status_bar: true,
+        override_status_bar_arguments: SNAPSHOT_STATUS_BAR_ARGUMENTS,
+        skip_open_summary: true,
+        xcargs: IOS_SCREENSHOT_XCARGS
+      )
+      verify_snapshot_test_result!(result_bundle_path, "#{device} #{screenshot_name} attempt #{attempt}")
+    rescue StandardError => error
+      archive_snapshot_test_result!(
+        result_bundle_path: result_bundle_path,
+        archive_directory: result_bundle_archive_directory,
+        device: device,
+        screenshot_name: screenshot_name,
+        attempt: attempt
+      )
+      raise if attempt == 2
+
+      UI.important(
+        "Screenshot #{screenshot_name} failed on #{device}; " \
+          "retrying once in a fresh simulator session (#{error.message})."
+      )
+      next
+    end
+
+    archive_snapshot_test_result!(
+      result_bundle_path: result_bundle_path,
+      archive_directory: result_bundle_archive_directory,
+      device: device,
+      screenshot_name: screenshot_name,
+      attempt: attempt
+    )
+    return
+  end
+end
+
 def build_app_store_release(context)
   version = context[:version]
   project_path = File.join(ios_root, "OpenClaw.xcodeproj")
@@ -2040,34 +2130,34 @@ platform :ios do
     FileUtils.mkdir_p(result_bundle_archive_directory)
     FileUtils.rm_rf(derived_data_path)
     devices = snapshot_devices
-    devices.each_with_index do |device, index|
-      capture_ios_screenshots(
-        project: File.join(ios_root, "OpenClaw.xcodeproj"),
-        scheme: "OpenClawUITests",
-        configuration: "Debug",
-        devices: [device],
-        languages: ["en-US"],
-        # App Store capture is isolated from functional UI checks; this lane only
-        # needs the deterministic four-screenshot release flow.
-        only_testing: ["OpenClawUITests/OpenClawSnapshotUITests/testConnectedGatewayTabs"],
-        launch_arguments: ["--openclaw-screenshot-mode"],
-        output_directory: output_directory,
-        clear_previous_screenshots: index.zero?,
-        derived_data_path: derived_data_path,
-        result_bundle: true,
-        number_of_retries: 0,
-        stop_after_first_error: true,
-        reinstall_app: true,
-        concurrent_simulators: false,
-        override_status_bar: true,
-        override_status_bar_arguments: SNAPSHOT_STATUS_BAR_ARGUMENTS,
-        skip_open_summary: true,
-        xcargs: "-allowProvisioningUpdates"
-      )
-      verify_snapshot_test_result!(result_bundle_path, device)
-      archived_result_bundle_path = File.join(result_bundle_archive_directory, "#{device}.xcresult")
-      FileUtils.rm_rf(archived_result_bundle_path)
-      FileUtils.mv(result_bundle_path, archived_result_bundle_path)
+    project = File.join(ios_root, "OpenClaw.xcodeproj")
+    run_tests(
+      project: project,
+      scheme: "OpenClawUITests",
+      configuration: "Debug",
+      devices: [devices.first],
+      derived_data_path: derived_data_path,
+      build_for_testing: true,
+      clean: true,
+      number_of_retries: 0,
+      xcargs: "-allowProvisioningUpdates"
+    )
+
+    capture_index = 0
+    devices.each do |device|
+      RELEASE_IOS_SCREENSHOT_TESTS.each do |screenshot|
+        capture_release_ios_screenshot!(
+          project: project,
+          device: device,
+          screenshot: screenshot,
+          output_directory: output_directory,
+          result_bundle_path: result_bundle_path,
+          result_bundle_archive_directory: result_bundle_archive_directory,
+          derived_data_path: derived_data_path,
+          clear_previous_screenshots: capture_index.zero?
+        )
+        capture_index += 1
+      end
     end
     verify_release_ios_screenshot_manifest!(
       output_directory: output_directory,

--- a/test/scripts/ios-release-fastlane-gates.test.ts
+++ b/test/scripts/ios-release-fastlane-gates.test.ts
@@ -14,7 +14,6 @@ const snapshotUITestPath = path.join(
   "UITests",
   "OpenClawSnapshotUITests.swift",
 );
-const rootSidebarPath = path.join(process.cwd(), "apps", "ios", "Sources", "RootSidebar.swift");
 const rootTabsPath = path.join(process.cwd(), "apps", "ios", "Sources", "RootTabs.swift");
 const ciWorkflowPath = path.join(process.cwd(), ".github", "workflows", "ci.yml");
 
@@ -220,27 +219,33 @@ describe("iOS Fastlane release upload gates", () => {
   it("fails from authoritative Xcode results and keeps successful bundles outside screenshots", () => {
     const fastfile = readFastfile();
     const screenshots = laneBody(fastfile, "screenshots");
+    const capture = functionBody(fastfile, "capture_release_ios_screenshot!");
+    const archive = functionBody(fastfile, "archive_snapshot_test_result!");
     const verifier = functionBody(fastfile, "verify_snapshot_test_result!");
 
     expect(screenshots).toContain("devices = snapshot_devices");
-    expect(screenshots).toContain("devices.each_with_index");
+    expect(screenshots).toContain("build_for_testing: true");
+    expect(screenshots).toContain("RELEASE_IOS_SCREENSHOT_TESTS.each");
+    expect(screenshots).toContain("capture_release_ios_screenshot!(");
+    expect(capture).toContain("1.upto(2)");
     expect(screenshots).toContain(
-      'only_testing: ["OpenClawUITests/OpenClawSnapshotUITests/testConnectedGatewayTabs"]',
+      "result_bundle_archive_directory: result_bundle_archive_directory",
     );
-    expect(screenshots).toContain("result_bundle: true");
-    expect(screenshots).toContain("number_of_retries: 0");
-    expect(screenshots).toContain("stop_after_first_error: true");
+    expect(capture).toContain(
+      'only_testing: ["OpenClawUITests/OpenClawSnapshotUITests/#{test_name}"]',
+    );
+    expect(capture).toContain("test_without_building: true");
+    expect(capture).toContain("result_bundle: true");
+    expect(capture).toContain("number_of_retries: 0");
+    expect(capture).toContain("stop_after_first_error: true");
+    expect(capture).toContain("retrying once in a fresh simulator session");
+    expect(capture).toContain("verify_snapshot_test_result!");
+    expect(archive).toContain('"#{device}-#{screenshot_name}-attempt-#{attempt}.xcresult"');
     expect(screenshots).toContain("verify_release_ios_screenshot_manifest!(");
-    expect(screenshots).toContain("verify_snapshot_test_result!(result_bundle_path, device)");
     expect(screenshots).toContain(
       'result_bundle_archive_directory = File.join(ios_root, "build", "SnapshotTestResults")',
     );
-    expect(screenshots.indexOf("verify_snapshot_test_result!")).toBeLessThan(
-      screenshots.indexOf("FileUtils.mv(result_bundle_path, archived_result_bundle_path)"),
-    );
-    expect(
-      screenshots.indexOf("FileUtils.mv(result_bundle_path, archived_result_bundle_path)"),
-    ).toBeLessThan(
+    expect(screenshots.indexOf("capture_release_ios_screenshot!")).toBeLessThan(
       screenshots.indexOf('FileUtils.rm_rf(File.join(output_directory, "test_output"))'),
     );
     expect(verifier).toContain('"xcresulttool"');
@@ -248,29 +253,38 @@ describe("iOS Fastlane release upload gates", () => {
     expect(verifier).toContain("UI.test_failure!");
   });
 
-  it("captures all release screens from one app launch with targeted launch recovery", () => {
+  it("captures each release screen from an independent direct launch", () => {
     const snapshotUITest = readFileSync(snapshotUITestPath, "utf8");
-    const releaseTest = swiftFunctionBody(snapshotUITest, "testConnectedGatewayTabs");
+    const releaseTests = [
+      ["testReleaseControlScreenshot", "controlScreenshotTarget"],
+      ["testReleaseChatScreenshot", "chatScreenshotTarget"],
+      ["testReleaseAgentScreenshot", "agentScreenshotTarget"],
+      ["testReleaseSettingsScreenshot", "settingsScreenshotTarget"],
+    ] as const;
+    const captureHelper = swiftFunctionBody(snapshotUITest, "captureReleaseScreenshot");
     const launchHelper = swiftFunctionBody(snapshotUITest, "launchApp");
-    const rootSidebar = readFileSync(rootSidebarPath, "utf8");
+    const navigationTest = swiftFunctionBody(
+      snapshotUITest,
+      "testAgentsNavigateToSettingsThroughSidebar",
+    );
     const rootTabs = readFileSync(rootTabsPath, "utf8");
 
-    expect(releaseTest.match(/self\.launchApp\(/g)).toHaveLength(1);
-    expect(snapshotUITest).toContain(
-      'releaseScreenshotLaunchArguments = ["-sidebar.pinnedPages", "overview,agents"]',
-    );
-    expect(releaseTest).toContain("selectReleaseScreenshotDestination");
-    expect(releaseTest).toContain("waitForReleaseScreenshotTarget");
-    expect(launchHelper).toContain("screenshotLaunchRetryThreshold");
-    expect(launchHelper).toContain("Recover before making any element query");
-    expect(launchHelper).toContain("app.wait(for: .notRunning, timeout: 5)");
-    expect(snapshotUITest).toContain("Recover stalled screenshot transition");
-    expect(snapshotUITest).toContain("self.launchApp(for: target");
+    for (const [testName, targetName] of releaseTests) {
+      const releaseTest = swiftFunctionBody(snapshotUITest, testName);
+      expect(releaseTest).toContain(`self.captureReleaseScreenshot(Self.${targetName})`);
+    }
+    expect(captureHelper.match(/self\.launchApp\(/g)).toHaveLength(1);
+    expect(captureHelper).toContain("waitForReleaseScreenshotTarget");
+    expect(launchHelper).toContain("app.launch()");
+    expect(snapshotUITest).not.toContain("screenshotLaunchRetryThreshold");
+    expect(snapshotUITest).not.toContain("selectReleaseScreenshotDestination");
+    expect(navigationTest).toContain("self.launchApp(for: Self.agentScreenshotTarget)");
+    expect(navigationTest).toContain('self.selectSidebarDestination("Settings")');
+    expect(navigationTest).toContain('"settings-system-agent-row"');
+    expect(navigationTest).toContain("XCTExpectedFailure.Options()");
+    expect(navigationTest).toContain("options.isStrict = false");
     expect(rootTabs).toContain("self.scenePhase == .active");
     expect(rootTabs).toContain("self.selectedSidebarDestination.rawValue");
-    expect(rootSidebar).toContain('"RootTabs.Sidebar.Destination.chat"');
-    expect(rootSidebar).toContain('"RootTabs.Sidebar.Destination.settings"');
-    expect(rootSidebar).toContain('"RootTabs.Sidebar.Destination.\\(destination.rawValue)"');
   });
 
   it("requires the exact nonempty PNG manifest before Watch capture", () => {
@@ -284,7 +298,7 @@ describe("iOS Fastlane release upload gates", () => {
     expect(verifier).toContain("File.size?(path)");
     expect(verifier).toContain("PNG_SIGNATURE");
     expect(screenshots.indexOf("verify_release_ios_screenshot_manifest!")).toBeGreaterThan(
-      screenshots.indexOf("devices.each_with_index"),
+      screenshots.indexOf("RELEASE_IOS_SCREENSHOT_TESTS.each"),
     );
     expect(screenshots.indexOf("verify_release_ios_screenshot_manifest!")).toBeLessThan(
       screenshots.indexOf("watch_screenshot("),
@@ -300,6 +314,7 @@ describe("iOS Fastlane release upload gates", () => {
     expect(iosJob).toContain("timeout-minutes: 75");
     expect(iosJob).toContain("Capture iOS release screenshots");
     expect(iosJob).toContain("github.event_name == 'workflow_dispatch'");
+    expect(iosJob).toContain("github.event_name == 'pull_request'");
     expect(iosJob).toContain("run: pnpm ios:screenshots");
     expect(iosJob).toContain("Upload iOS release screenshot evidence");
     expect(iosJob).toContain("apps/ios/build/SnapshotTestResults/*.xcresult");

--- a/test/scripts/ios-release-fastlane-gates.test.ts
+++ b/test/scripts/ios-release-fastlane-gates.test.ts
@@ -281,8 +281,8 @@ describe("iOS Fastlane release upload gates", () => {
     expect(navigationTest).toContain("self.launchApp(for: Self.agentScreenshotTarget)");
     expect(navigationTest).toContain('self.selectSidebarDestination("Settings")');
     expect(navigationTest).toContain('"settings-system-agent-row"');
-    expect(navigationTest).toContain("XCTExpectedFailure.Options()");
-    expect(navigationTest).toContain("options.isStrict = false");
+    expect(navigationTest).not.toContain("XCTExpectFailure");
+    expect(navigationTest).not.toContain("XCTExpectedFailure");
     expect(rootTabs).toContain("self.scenePhase == .active");
     expect(rootTabs).toContain("self.selectedSidebarDestination.rawValue");
   });


### PR DESCRIPTION
Closes #113186

AI-assisted with Codex. I understand and reviewed the implementation.

## What Problem This Solves

Fixes an issue where iOS release operators capturing App Store screenshots would encounter 60–140+ second XCTest quiescence stalls, intermittent failures, and expensive retries when the release flow navigated from Agents to Settings.

## Why This Change Was Made

The release lane now builds once and captures each required screen in an independent, bounded UI-test session, retaining per-attempt result bundles and retrying one failed capture once with a fresh simulator session. The underlying Settings defect is removed by making the app-owned Core Location service cache authorization state from its documented delegate callback; Settings, gateway capability registration, and device permissions consume that snapshot instead of synchronously querying Core Location during UI construction.

The Agents → Settings UI test remains separate from release capture and is strict, so a recurrence fails directly instead of wedging every App Store screenshot or being hidden as an expected failure.

## User Impact

iOS release screenshot generation is deterministic and bounded, and opening Settings no longer blocks the main thread while Core Location answers a synchronous authorization query.

## Evidence

- Focused Swift unit tests: 27 passed, 0 failed.
  - `LocationPermissionSummaryTests`
  - `DevicePermissionsTests`
- Strict `testAgentsNavigateToSettingsThroughSidebar`: passed, then passed three additional fresh-launch repetitions.
- Direct `testReleaseSettingsScreenshot`: passed in 13.1 seconds.
- The repaired Agents → Settings transition reached post-event quiescence in about 1.2 seconds, versus the observed 60–140+ second stalls.
- Fastlane release-gate tests: 20 passed.
- Remote `pnpm check:changed` on Blacksmith Testbox: passed.
- SwiftFormat, SwiftLint, `git diff --check`, and Xcode build-phase checks: passed.
- Fresh pre-commit autoreview: no accepted/actionable findings.
