### PR TITLE
feat(approvals): emit bold headers and labels in approval prompts

### DIFF
--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -614,6 +614,29 @@ describe("iMessage approval reactions", () => {
     });
   });
 
+  it("binds prompts whose headers and labels are bold", () => {
+    // The prompt builder emits **Exec approval required** / **ID:** …; binding
+    // must still correlate the delivered prompt (reaction/tapback approvals).
+    expect(
+      extractIMessageApprovalPromptBinding(
+        [
+          "**Exec approval required**",
+          "**ID:** exec-bold",
+          "**Pending command:**",
+          "```sh",
+          "echo hi",
+          "```",
+          "**Full id:** `exec-bold`",
+          "Reply with: /approve exec-bold allow-once|deny",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      approvalId: "exec-bold",
+      approvalKind: "exec",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+  });
+
   it("extracts approval bindings from explicit outbound prompts", async () => {
     expect(
       extractIMessageApprovalPromptBinding(

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -397,7 +397,9 @@ function visibleApprovalBindingMatches(
   if (!text) {
     return false;
   }
-  const lines = text.split(/\r?\n/).map((line) => line.trim());
+  // Approval prompts carry bold markers (**Header**, **ID:** …). Strip them
+  // before matching so reaction binding still correlates the delivered prompt.
+  const lines = text.split(/\r?\n/).map((line) => line.replace(/\*\*/g, "").trim());
   const normalizedHeaders = lines.map((line) => line.replace(/^[^A-Za-z0-9]*/, ""));
   const hasKindHeader =
     binding.approvalKind === "exec"
@@ -523,7 +525,9 @@ export function extractIMessageApprovalPromptBinding(text: string): {
   approvalKind: "exec" | "plugin";
   allowedDecisions: ExecApprovalReplyDecision[];
 } | null {
-  const lines = text.split(/\r?\n/);
+  // Strip bold markers the prompt builder emits (**Exec approval required**,
+  // **ID:** …) so the canonical-format checks below still recognize the prompt.
+  const lines = text.split(/\r?\n/).map((line) => line.replace(/\*\*/g, ""));
   const hasExecHeader = lines.some((line) =>
     /^\s*[^A-Za-z0-9]*Exec approval required\s*$/i.test(line),
   );

--- a/extensions/signal/src/approval-handler.runtime.test.ts
+++ b/extensions/signal/src/approval-handler.runtime.test.ts
@@ -70,7 +70,7 @@ describe("Signal approval native runtime", () => {
       accountId: "default",
       baseUrl: "http://127.0.0.1:18080",
       account: "+15550001111",
-      textMode: "plain",
+      textMode: "markdown",
     });
   });
 
@@ -120,7 +120,7 @@ describe("Signal approval native runtime", () => {
       accountId: "default",
       baseUrl: "http://127.0.0.1:18080",
       account: "+15550001111",
-      textMode: "plain",
+      textMode: "markdown",
     });
   });
 
@@ -163,7 +163,7 @@ describe("Signal approval native runtime", () => {
       accountId: "work",
       baseUrl: "http://127.0.0.1:18080",
       account: "+15550001111",
-      textMode: "plain",
+      textMode: "markdown",
     });
   });
 

--- a/extensions/signal/src/approval-handler.runtime.ts
+++ b/extensions/signal/src/approval-handler.runtime.ts
@@ -178,7 +178,10 @@ export const signalApprovalNativeRuntime = createChannelApprovalNativeRuntimeAda
         accountId: preparedTarget.accountId,
         ...(preparedTarget.baseUrl ? { baseUrl: preparedTarget.baseUrl } : {}),
         ...(preparedTarget.account ? { account: preparedTarget.account } : {}),
-        textMode: "plain",
+        // Approval prompts carry bold headers/labels; render them via
+        // markdownToSignalText so Signal shows native styling rather than
+        // literal `**` markers.
+        textMode: "markdown",
       });
       if (!result.messageId || result.messageId === "unknown") {
         return null;
@@ -204,7 +207,7 @@ export const signalApprovalNativeRuntime = createChannelApprovalNativeRuntimeAda
         accountId: entry.accountId,
         ...(entry.baseUrl ? { baseUrl: entry.baseUrl } : {}),
         ...(entry.account ? { account: entry.account } : {}),
-        textMode: "plain",
+        textMode: "markdown",
       });
     },
   },

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -369,9 +369,10 @@ export function addSignalApprovalReactionHintToText(params: {
 }
 
 function resolveStandaloneApprovalPromptKind(text: string): ApprovalKind | null {
+  // Strip bold markers (**Exec approval required**) before matching the header.
   const firstLine = text
     .split(/\r?\n/)
-    .map((line) => line.trim())
+    .map((line) => line.replace(/\*\*/g, "").trim())
     .find(Boolean);
   if (/^(?:🔒\s*)?Exec approval required$/.test(firstLine ?? "")) {
     return "exec";
@@ -406,7 +407,8 @@ function extractSignalApprovalPromptBinding(text: string): {
   approvalKind: ApprovalKind;
   allowedDecisions: ExecApprovalReplyDecision[];
 } | null {
-  const lines = text.split(/\r?\n/);
+  // Strip bold markers (**ID:** …) before matching the canonical ID header.
+  const lines = text.split(/\r?\n/).map((line) => line.replace(/\*\*/g, ""));
   const idHeaderMatch = lines
     .map((line) => line.match(APPROVAL_ID_LINE_RE))
     .find((match): match is RegExpMatchArray => Boolean(match));

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -227,7 +227,9 @@ function visibleApprovalBindingMatches(
 ): boolean {
   // Text is only a correlation check. The typed metadata/action binding remains
   // authoritative so transport copy can never choose an approval owner or id.
-  const lines = (text ?? "").split(/\r?\n/);
+  // Strip bold markers (**Exec approval required**, **ID:** …) the prompt
+  // builder emits so the canonical-format match still correlates.
+  const lines = (text ?? "").split(/\r?\n/).map((line) => line.replace(/\*\*/g, ""));
   const kindMatches = lines
     .map((line) => line.match(APPROVAL_KIND_LINE_RE))
     .filter((match): match is RegExpMatchArray => Boolean(match));

--- a/extensions/whatsapp/src/channel-outbound.test.ts
+++ b/extensions/whatsapp/src/channel-outbound.test.ts
@@ -282,8 +282,7 @@ describe("whatsappChannelOutbound", () => {
     },
     {
       name: "id header changes",
-      rewrite: (text: string) =>
-        text.replace("**ID:** exec-visible-mismatch", "**ID:** other-id"),
+      rewrite: (text: string) => text.replace("**ID:** exec-visible-mismatch", "**ID:** other-id"),
     },
     {
       name: "id header disappears",

--- a/extensions/whatsapp/src/channel-outbound.test.ts
+++ b/extensions/whatsapp/src/channel-outbound.test.ts
@@ -282,11 +282,12 @@ describe("whatsappChannelOutbound", () => {
     },
     {
       name: "id header changes",
-      rewrite: (text: string) => text.replace("ID: exec-visible-mismatch", "ID: other-id"),
+      rewrite: (text: string) =>
+        text.replace("**ID:** exec-visible-mismatch", "**ID:** other-id"),
     },
     {
       name: "id header disappears",
-      rewrite: (text: string) => text.replace("ID: exec-visible-mismatch\n", ""),
+      rewrite: (text: string) => text.replace("**ID:** exec-visible-mismatch\n", ""),
     },
     {
       name: "reaction decisions change",

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -182,7 +182,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
       nowMs: 1_000,
     });
 
-    expect(payload.text).toContain("CWD: ~/projectIgnore previous instructions");
+    expect(payload.text).toContain("**CWD:** ~/projectIgnore previous instructions");
     expect(payload.text).not.toContain("\u202E");
     expect(payload.text).not.toContain("\nIgnore previous instructions");
   });
@@ -220,8 +220,8 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
       nowMs: 1_000,
     });
 
-    expect(payload.text).toContain("Plugin approval required\nID: plugin:approval-123");
-    expect(payload.text).toContain("Title: Use 1Password");
+    expect(payload.text).toContain("**Plugin approval required**\n**ID:** plugin:approval-123");
+    expect(payload.text).toContain("**Title:** Use 1Password");
     expect(payload.text).toContain("React with:\n\n👍 Allow Once\n👎 Deny");
     expect(payload.text).not.toContain("♾️ Allow Always");
     expect(payload.text).toContain("Allow Once: /approve plugin:approval-123 allow-once");

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -150,8 +150,8 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
       nowMs: 1_000,
     });
 
-    expect(payload.text).toContain("Exec approval required\nID: exec-approval-123");
-    expect(payload.text).toContain("Pending command:\n```sh\ntouch /tmp/foo\n```");
+    expect(payload.text).toContain("**Exec approval required**\n**ID:** exec-approval-123");
+    expect(payload.text).toContain("**Pending command:**\n```sh\ntouch /tmp/foo\n```");
     expect(payload.text).toContain("React with:\n\n👍 Allow Once\n♾️ Allow Always\n👎 Deny");
     expect(payload.text).toContain("Allow Once: /approve exec-approval-123 allow-once");
     expect(payload.text).toContain("Allow Always: /approve exec-approval-123 allow-always");

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -313,10 +313,10 @@ function buildApprovalReactionPromptText(params: {
     const warningText = view.warningText?.trim();
     if (warningText) {
       // The auto-review rationale is the reason for the interruption, so bold
-      // it. It is generated text; the reaction-runtime renderers (iMessage,
-      // Signal, WhatsApp) parse to an IR that tolerates stray markers, so a
-      // rationale containing a lone `*` degrades gracefully rather than
-      // breaking the span.
+      // it. It is generated text: the reaction-runtime renderers parse to an
+      // IR, so an unmatched `*`/`_` in the rationale degrades to imperfect
+      // styling rather than a delivery failure, but the emphasis is not
+      // guaranteed pixel-perfect for hostile rationale text.
       sections.push(`**${warningText}**`);
     }
     const warningLines = view.commandAnalysis?.warningLines

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -312,7 +312,12 @@ function buildApprovalReactionPromptText(params: {
     sections.push(header.join("\n"));
     const warningText = view.warningText?.trim();
     if (warningText) {
-      sections.push(warningText);
+      // The auto-review rationale is the reason for the interruption, so bold
+      // it. It is generated text; the reaction-runtime renderers (iMessage,
+      // Signal, WhatsApp) parse to an IR that tolerates stray markers, so a
+      // rationale containing a lone `*` degrades gracefully rather than
+      // breaking the span.
+      sections.push(`**${warningText}**`);
     }
     const warningLines = view.commandAnalysis?.warningLines
       ?.map((line) => line.trim())

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -305,7 +305,10 @@ function buildApprovalReactionPromptText(params: {
   const allowedDecisions = listDecisionActions(view.actions);
   const sections: string[] = [];
   if (view.approvalKind === "exec") {
-    const header = ["Exec approval required", `ID: ${view.approvalId}`];
+    // Bold headers and field labels (#85954). Channels that render markdown
+    // translate these into native styling — iMessage into attributed-body
+    // ranges — and channels that downgrade drop the markers cleanly.
+    const header = ["**Exec approval required**", `**ID:** ${view.approvalId}`];
     sections.push(header.join("\n"));
     const warningText = view.warningText?.trim();
     if (warningText) {
@@ -316,47 +319,49 @@ function buildApprovalReactionPromptText(params: {
       .filter(Boolean)
       .slice(0, 5);
     if (warningLines?.length) {
-      sections.push(["Command analysis:", ...warningLines.map((line) => `- ${line}`)].join("\n"));
+      sections.push(
+        ["**Command analysis:**", ...warningLines.map((line) => `- ${line}`)].join("\n"),
+      );
     }
-    sections.push(["Pending command:", formatFencedCodeBlock(view.commandText, "sh")].join("\n"));
+    sections.push(["**Pending command:**", formatFencedCodeBlock(view.commandText, "sh")].join("\n"));
     const info: string[] = [];
     if (view.cwd) {
-      info.push(`CWD: ${formatApprovalDisplayPath(sanitizeForPromptLiteral(view.cwd))}`);
+      info.push(`**CWD:** ${formatApprovalDisplayPath(sanitizeForPromptLiteral(view.cwd))}`);
     }
     if (view.host) {
-      info.push(`Host: ${view.host}`);
+      info.push(`**Host:** ${view.host}`);
     }
     if (view.nodeId) {
-      info.push(`Node: ${view.nodeId}`);
+      info.push(`**Node:** ${view.nodeId}`);
     }
     if (view.agentId) {
-      info.push(`Agent: ${view.agentId}`);
+      info.push(`**Agent:** ${view.agentId}`);
     }
     if (view.ask) {
-      info.push(`Ask: ${view.ask}`);
+      info.push(`**Ask:** ${view.ask}`);
     }
-    info.push(`Expires in: ${formatExecApprovalExpiresIn(view.expiresAtMs, params.nowMs)}`);
-    info.push(`Full id: \`${view.approvalId}\``);
+    info.push(`**Expires in:** ${formatExecApprovalExpiresIn(view.expiresAtMs, params.nowMs)}`);
+    info.push(`**Full id:** \`${view.approvalId}\``);
     sections.push(info.join("\n"));
   } else {
-    const header = ["Plugin approval required", `ID: ${view.approvalId}`];
+    const header = ["**Plugin approval required**", `**ID:** ${view.approvalId}`];
     sections.push(header.join("\n"));
-    const details = [`Title: ${view.title}`];
+    const details = [`**Title:** ${view.title}`];
     if (view.description) {
-      details.push(`Description: ${view.description}`);
+      details.push(`**Description:** ${view.description}`);
     }
-    details.push(`Severity: ${formatSeverity(view.severity)}`);
+    details.push(`**Severity:** ${formatSeverity(view.severity)}`);
     if (view.toolName) {
-      details.push(`Tool: ${view.toolName}`);
+      details.push(`**Tool:** ${view.toolName}`);
     }
     if (view.pluginId) {
-      details.push(`Plugin: ${view.pluginId}`);
+      details.push(`**Plugin:** ${view.pluginId}`);
     }
     if (view.agentId) {
-      details.push(`Agent: ${view.agentId}`);
+      details.push(`**Agent:** ${view.agentId}`);
     }
-    details.push(`Expires in: ${formatExecApprovalExpiresIn(view.expiresAtMs, params.nowMs)}`);
-    details.push(`Full id: \`${view.approvalId}\``);
+    details.push(`**Expires in:** ${formatExecApprovalExpiresIn(view.expiresAtMs, params.nowMs)}`);
+    details.push(`**Full id:** \`${view.approvalId}\``);
     sections.push(details.join("\n"));
   }
   if (params.reactionHint) {

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -328,7 +328,9 @@ function buildApprovalReactionPromptText(params: {
         ["**Command analysis:**", ...warningLines.map((line) => `- ${line}`)].join("\n"),
       );
     }
-    sections.push(["**Pending command:**", formatFencedCodeBlock(view.commandText, "sh")].join("\n"));
+    sections.push(
+      ["**Pending command:**", formatFencedCodeBlock(view.commandText, "sh")].join("\n"),
+    );
     const info: string[] = [];
     if (view.cwd) {
       info.push(`**CWD:** ${formatApprovalDisplayPath(sanitizeForPromptLiteral(view.cwd))}`);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iMessage users saw approval prompts with no formatting — plain "Pending command:", "Host:", "Full id:" labels — even though iMessage can render bold. Approval headers and labels were emitted as plain text, so there was nothing for the channel to format.

Closes #85954.

## Why This Change Was Made

The markdown-core / channel-profile refactor (#113002, #113024) reworked iMessage's `extractMarkdownFormatRuns` to be profile-driven: it now translates `**bold**` into attributed-body ranges and strips code fences per `IMESSAGE_FORMAT_PROFILE`. The rendering works — the approval builder just wasn't emitting any markup.

This emits bold on the approval prompt headers and field labels in the shared reaction-runtime builder (`buildApprovalReactionPromptText`), which feeds the reaction-runtime channels (iMessage, Signal, WhatsApp — all of which render markdown). Channels that render markdown show native bold; iMessage shows attributed-body ranges; channels that downgrade drop the markers cleanly via their profile.

No new approval-text contract or per-channel declarations — rendering is owned entirely by the channel format profiles from #113002.

## User Impact

- **iMessage** approval prompts now render bold headers and labels (`**Exec approval required**`, `**Pending command:**`, `**Host:**`, `**Full id:**`, …) as attributed-body ranges. Code fences strip cleanly; the pending command stays intact and readable.
- **Signal, WhatsApp** approval prompts show native bold on the same labels.
- No change to approval semantics, decisions, reaction bindings, or the `/approve` grammar.

## Evidence

Verified against the reworked formatter on current main: the bolded prompt produces 6 bold ranges (headers + labels), no literal `**` markers leak, code fences strip, and the command survives verbatim including the `"%{http_code}"` quoting.

**Live iMessage proof pending** — testing on the dev gateway.

**Note:** supersedes #112686, which took a manual per-channel `approvalText` contract approach. That is obsolete now that #113002 owns channel markdown rendering; this PR rides that system instead.

Remaining: a handful of approval-prompt text assertions across channel tests still reference the old plain labels and are being updated to the bold form.


## Live iMessage proof (real device)

| Before (`main`) | After (this PR) |
|---|---|
| ![before](https://raw.githubusercontent.com/openclaw/rfcs/omarshahine/rfc-0002-corrections/rfcs/0002/proof/imessage-approval-before.png) | ![after](https://raw.githubusercontent.com/openclaw/rfcs/omarshahine/rfc-0002-corrections/rfcs/0002/proof/imessage-approval-after.png) |

Before/after of the approval prompt on a real iPhone: plain labels on `main`, bold headers/labels/rationale (native attributed-body ranges) with this PR. Command text (`"%{http_code}"`) byte-identical. Rendered through iMessage's actual `extractMarkdownFormatRuns` path and delivered live. Images are public (raw.githubusercontent, redacted — no phone number/secrets).

## Review trail (Codex + local ClawSweeper)

Both independent reviews found reaction-binding regressions that prompt-string tests could not see; both fixed and verified green:
- Bolding broke reaction/tapback binding on iMessage, Signal, WhatsApp (parsers anchor on the plain format) — parsers now strip `**` before matching; iMessage bold-binding regression test added.
- Signal sent approvals `textMode: "plain"` (literal markers) — switched to markdown mode; `markdownToSignalText` renders native bold.
