### PR TITLE
fix(doctor): honor configured plugin load paths

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.health.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.health.ts
@@ -283,17 +283,13 @@ export async function detectConfiguredPluginInstallHealthIssues(params: {
     ) {
       continue;
     }
+    const hasRecord = Object.hasOwn(records, candidate.pluginId);
     const hasUsableRecord =
-      Object.hasOwn(records, candidate.pluginId) &&
-      !isInstalledRecordMissingOnDisk(records[candidate.pluginId], env);
+      hasRecord && !isInstalledRecordMissingOnDisk(records[candidate.pluginId], env);
     if (
       !shouldReplaceBrokenOfficialInstall &&
-      knownIds.has(candidate.pluginId) &&
-      hasUsableRecord
+      (hasUsableRecord || (knownIds.has(candidate.pluginId) && !hasRecord))
     ) {
-      continue;
-    }
-    if (!shouldReplaceBrokenOfficialInstall && hasUsableRecord) {
       continue;
     }
     const installSpec = resolveCandidateInstallSpec({

--- a/src/commands/doctor/shared/missing-configured-plugin-install.load-path.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.load-path.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearCurrentPluginMetadataSnapshot } from "../../../plugins/current-plugin-metadata-state.js";
+import { loadManifestMetadataSnapshot } from "../../../plugins/manifest-contract-eligibility.js";
+import {
+  detectConfiguredPluginInstallHealthIssues,
+  repairMissingConfiguredPluginInstalls,
+} from "./missing-configured-plugin-install.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  clearCurrentPluginMetadataSnapshot();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeProviderPlugin(rootDir: string): void {
+  fs.mkdirSync(path.join(rootDir, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(rootDir, "dist", "index.js"), "export default {};\n", "utf8");
+  fs.writeFileSync(
+    path.join(rootDir, "package.json"),
+    JSON.stringify({
+      name: "@openclaw/kilocode-provider",
+      version: "2026.7.1",
+      openclaw: {
+        extensions: ["./index.ts"],
+        runtimeExtensions: ["./dist/index.js"],
+      },
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "kilocode",
+      enabledByDefault: true,
+      providers: ["kilocode"],
+      configSchema: { type: "object", properties: {} },
+    }),
+    "utf8",
+  );
+}
+
+describe("configured plugin install health for explicit load paths", () => {
+  it("does not install a provider plugin already present at a configured load path", async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-load-path-provider-"));
+    tempDirs.push(rootDir);
+    const pluginDir = path.join(rootDir, "kilocode-provider");
+    writeProviderPlugin(pluginDir);
+
+    const cfg = {
+      plugins: {
+        load: { paths: [pluginDir] },
+      },
+    };
+    const env = {
+      KILOCODE_API_KEY: "test-key",
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(rootDir, "bundled"),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: path.join(rootDir, "state"),
+      VITEST: "true",
+    };
+    const snapshot = loadManifestMetadataSnapshot({ config: cfg, env });
+    expect(snapshot.plugins.map((plugin) => plugin.id)).toContain("kilocode");
+
+    const issues = await detectConfiguredPluginInstallHealthIssues({
+      cfg,
+      env,
+    });
+    expect(issues).toStrictEqual([]);
+
+    const repair = await repairMissingConfiguredPluginInstalls({ cfg, env });
+    expect(repair).toMatchObject({
+      changes: [],
+      records: {},
+      warnings: [],
+    });
+  });
+});

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -378,17 +378,13 @@ async function repairMissingPluginInstalls(params: {
     ) {
       continue;
     }
+    const hasRecord = Object.hasOwn(nextRecords, candidate.pluginId);
     const hasUsableRecord =
-      Object.hasOwn(nextRecords, candidate.pluginId) &&
-      !isInstalledRecordMissingOnDisk(nextRecords[candidate.pluginId], env);
+      hasRecord && !isInstalledRecordMissingOnDisk(nextRecords[candidate.pluginId], env);
     if (
       !shouldReplaceBrokenOfficialInstall &&
-      knownIds.has(candidate.pluginId) &&
-      hasUsableRecord
+      (hasUsableRecord || (knownIds.has(candidate.pluginId) && !hasRecord))
     ) {
-      continue;
-    }
-    if (!shouldReplaceBrokenOfficialInstall && hasUsableRecord) {
       continue;
     }
     const removalPath = shouldReplaceBrokenOfficialInstall


### PR DESCRIPTION
## Summary

- treat plugins discovered through `plugins.load.paths` as present when no managed install record exists
- keep missing or broken managed install records on the existing repair path
- add a focused integration test covering both health detection and repair

## Verification

- `node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/commands/doctor/shared/missing-configured-plugin-install.load-path.test.ts` — 85 tests passed across 2 shards
- `./node_modules/.bin/oxfmt --check src/commands/doctor/shared/missing-configured-plugin-install.health.ts src/commands/doctor/shared/missing-configured-plugin-install.repair.ts src/commands/doctor/shared/missing-configured-plugin-install.load-path.test.ts` — passed
- `git diff --check` — passed
- `corepack pnpm build` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output --codex-bin /Applications/ChatGPT.app/Contents/Resources/codex` — clean, no accepted/actionable findings; overall correctness 0.90

## Real behavior proof

**Behavior addressed:** Gateway startup no longer tries to reinstall a configured provider plugin that is already discoverable through `plugins.load.paths` but has no managed install record.

**Real environment tested:** Built exact commit `58bdb576cb5a26a0a51e442e29232b897b45297a` on macOS arm64, using the published npm tarball `@openclaw/kilocode-provider@2026.7.1`, a fresh isolated OpenClaw state/config, and an intentionally unwritable npm cache.

**Exact steps or command run after this patch:** Ran `corepack pnpm build`; unpacked `@openclaw/kilocode-provider@2026.7.1` into a temporary plugin directory; configured only `plugins.load.paths` for that directory; started the built Gateway with isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`, a fake KiloCode key, and an unwritable `NPM_CONFIG_CACHE`; queried `/healthz`, `/readyz`, and `gateway call plugins.list --json`; then checked the config and Gateway log for a managed install record, redundant install attempt, `npm view` failure, or `EACCES`.

**Evidence after fix:** `/healthz` returned `{"ok":true,"status":"live"}`; `/readyz` returned `{"ready":true,"failing":[]}`; live `plugins.list` reported `{"id":"kilocode","packageName":"@openclaw/kilocode-provider","version":"2026.7.1","origin":"config","installed":true,"enabled":true,"state":"enabled","category":"provider","removable":false}`.

**Observed result after fix:** The exact-commit Gateway reached ready state with the load-path plugin enabled, left the managed install record absent, and emitted no redundant plugin-install attempt, `npm view` failure, or `EACCES` even though npm cache access was denied.

**What was not tested:** No real Kilo API request was made because the proof uses a fake key and this plugin does not activate on startup. The exact Docker image was not exercised; the built Gateway startup path and published plugin payload were exercised directly.

Closes #113143
