### PR TITLE
fix(ios): release upload no longer rejects its planned build

### DIFF
--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -1433,19 +1433,6 @@ def resolve_release_build_number(api_key:, short_version:, explicit_build_number
   next_build.to_s
 end
 
-def verify_app_store_binary!(api_key:, ipa_path:)
-  deliver(
-    api_key: api_key,
-    app_identifier: APP_STORE_APP_IDENTIFIER,
-    ipa: ipa_path,
-    platform: "ios",
-    verify_only: true,
-    skip_metadata: true,
-    skip_screenshots: true,
-    submit_for_review: false
-  )
-end
-
 def release_build_number_needs_app_store_connect_auth?(explicit_build_number: nil)
   explicit = explicit_build_number.to_s.strip
   !env_present?(explicit)
@@ -1984,9 +1971,9 @@ platform :ios do
     end
     verify_apple_release_source!(release_sha)
     build = build_app_store_release(context)
-    verify_app_store_binary!(api_key: context[:api_key], ipa_path: build[:ipa_path])
     # Release operations have one active uploader by policy. This final read
-    # catches human state changes; it is not a cross-uploader lock.
+    # catches human state changes before the first App Store mutation; it is
+    # not a cross-uploader lock.
     resolve_ios_release_plan!(
       release_version: context[:version],
       app_store_revision: context[:app_store_revision],

--- a/test/scripts/ios-release-fastlane-gates.test.ts
+++ b/test/scripts/ios-release-fastlane-gates.test.ts
@@ -178,15 +178,20 @@ describe("iOS Fastlane release upload gates", () => {
     expect(uploadCall).toBeGreaterThan(validationCall);
   });
 
-  it("validates with Apple and rechecks the plan before the first remote mutation", () => {
-    const releaseUpload = laneBody(readFastfile(), "release_upload");
-    const binaryValidation = releaseUpload.indexOf("verify_app_store_binary!");
+  it("rechecks the plan after local validation and before the first App Store mutation", () => {
+    const fastfile = readFastfile();
+    const releaseUpload = laneBody(fastfile, "release_upload");
+    const build = releaseUpload.indexOf("build = build_app_store_release(context)");
     const planRecheck = releaseUpload.lastIndexOf("resolve_ios_release_plan!");
     const metadata = releaseUpload.indexOf("\n    metadata(");
+    const upload = releaseUpload.indexOf("upload_to_testflight(");
 
-    expect(binaryValidation).toBeGreaterThanOrEqual(0);
-    expect(planRecheck).toBeGreaterThan(binaryValidation);
+    expect(fastfile).not.toContain("def verify_app_store_binary!");
+    expect(releaseUpload).not.toContain("verify_only: true");
+    expect(build).toBeGreaterThanOrEqual(0);
+    expect(planRecheck).toBeGreaterThan(build);
     expect(metadata).toBeGreaterThan(planRecheck);
+    expect(upload).toBeGreaterThan(planRecheck);
   });
 
   it("waits for Apple build processing without submitting to TestFlight review", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iOS release operators would complete signing, screenshots, archive export, local IPA validation, and Apple package verification, then have the release abort because that verification consumed the planned App Store build number.

## Why This Change Was Made

The release pipeline now relies on its existing local IPA validation before the final deterministic plan recheck, and uses the single TestFlight upload as the only Apple binary upload/validation attempt. The final plan recheck remains before App Store metadata or binary mutations so human state changes are still caught.

## User Impact

Maintainers can run `pnpm ios:release:upload` without the pipeline invalidating its own selected build number. Failed or consumed Apple upload attempts remain visible to the planner and continue to advance the next build number deterministically.

## Evidence

- Observed failure: Apple package verification succeeded for App Store version `2026.7.21` build `1`; the immediately following deterministic recheck then resolved build `2` and rejected explicit build `1`.
- `node scripts/run-vitest.mjs test/scripts/ios-release-plan.test.ts test/scripts/ios-release-fastlane-gates.test.ts` — 41 tests passed across 2 shards.
- `git diff --check` — passed.
- Fresh pre-commit autoreview — clean, no accepted/actionable findings.
- GitHub CI settled on `c09c1ca5216` with 75 passing and 20 intentionally skipped checks; no failures or cancellations.
