### PR TITLE
fix(text): skip unequal backtick runs when detecting inline code regions (#113148) [AI-assisted]

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -970,6 +970,12 @@ describe("sanitizeAssistantVisibleText", () => {
       "Before <think>literal tag text after",
     );
   });
+
+  it("does not preserve reasoning tags inside unequal backtick runs", () => {
+    expect(sanitizeAssistantVisibleText("before ```<think>private</think>`` after")).not.toContain(
+      "<think>",
+    );
+  });
 });
 
 describe("sanitizeAssistantVisibleTextWithProfile", () => {

--- a/src/shared/text/code-regions.test.ts
+++ b/src/shared/text/code-regions.test.ts
@@ -37,6 +37,11 @@ describe("shared/text/code-regions", () => {
       text: ["```ts", "const a = 1;", "```", "after `inline` tail"].join("\n"),
       expectedSlices: ["```ts\nconst a = 1;\n```", "`inline`"],
     },
+    {
+      name: "does not treat unequal backtick runs as an inline-code region",
+      text: "before ```<think>private</think>`` after",
+      expectedSlices: [],
+    },
   ] as const)("$name", ({ text, expectedSlices }) => {
     expectCodeRegionSlices(text, expectedSlices);
   });

--- a/src/shared/text/code-regions.ts
+++ b/src/shared/text/code-regions.ts
@@ -23,6 +23,13 @@ export function findCodeRegions(text: string): CodeRegion[] {
   for (const match of text.matchAll(inlineRe)) {
     const start = match.index ?? 0;
     const end = start + match[0].length;
+    // Per CommonMark 0.31.2, opening and closing backtick runs must have
+    // equal length. Skip mismatched runs — they are not valid code spans.
+    const openingLen = (match[0].match(/^`+/) || [""])[0].length;
+    const closingLen = (match[0].match(/`+$/) || [""])[0].length;
+    if (openingLen !== closingLen) {
+      continue;
+    }
     const insideFenced = regions.some((r) => start >= r.start && end <= r.end);
     if (!insideFenced) {
       regions.push({ start, end });


### PR DESCRIPTION
## What Problem This Solves

`findCodeRegions` classifies unequal opening and closing backtick runs as an inline-code region, allowing enclosed reasoning tags to bypass `sanitizeAssistantVisibleText`. For input `` "before ```<think>private</think>`` after" ``, `findCodeRegions` returns ``["```<think>private</think>``"]`` as a code region, and `<think>` is preserved in the sanitized output.

Per CommonMark 0.31.2 §6.1 (Code Spans), opening and closing backtick strings must have equal length to form a valid inline code span.

## Why This Change Was Made

Rather than rewriting the `inlineRe` regex (which would risk breaking existing matching behavior), the fix adds a length check after each potential match. If `openingLen !== closingLen`, the run is not a valid code span and is skipped. This is a minimal, targeted fix with no impact on valid code spans.

## User Impact

- **Before:** `` "before ```<think>private</think>`` after" `` → `<think>` preserved, reasoning tag leaks into visible text
- **After:** `` "before ```<think>private</think>`` after" `` → `<think>` stripped, text sanitized correctly

No impact on valid code spans (matching backtick counts continue to work as before).

Fixes #113148

## Evidence

### Real terminal output — inline Node.js verification

Extracted the exact `findCodeRegions` + `sanitizeAssistantVisibleText` logic and exercised the bug scenario:

```
=== Behavior Proof: findCodeRegions with unequal-backtick fix ===

Input:    "before ```<think>private</think>`` after"
Regions:  [] (no code region)
Status:   PASS

Input:    "before ``code`` after"
Regions:  ["``code``"] (equal backticks, control)
Status:   PASS - valid code span preserved

=== sanitizeAssistantVisibleText ===

Input:    "before ```<think>private</think>`` after"
Output:   "before ````` after" (no `<think>`)
Status:   PASS - <think> stripped, reasoning tag does not leak
```

### Unit tests

- 2 new test cases in `code-regions.test.ts` (unequal backtick detection) and `assistant-visible-text.test.ts` (sanitize path)
- All 181 tests pass: `pnpm dlx vitest run src/shared/text/` — 3 test files, 181 tests, all green
- All existing code-region and assistant-visible-text tests continue to pass

### AI-assisted

This PR was written with AI assistance (Hermes Agent). I have reviewed and understand every line of the change. Key design decisions were verified against CommonMark 0.31.2 spec.
