### PR TITLE
fix(sessions): move legacy boot session repair to doctor check

### DIFF
--- a/src/commands/doctor-session-legacy-boot.test.ts
+++ b/src/commands/doctor-session-legacy-boot.test.ts
@@ -26,7 +26,7 @@ vi.mock("../utils.js", () => ({
 const { detectLegacyBootSessionEntries, repairLegacyBootSessionEntries } =
   await import("./doctor-session-legacy-boot.js");
 
-function makeEntry(overrides?: { lifecycleRevision?: string }) {
+function makeEntry(overrides?: { lifecycleRevision?: string; createdAt?: number }) {
   return {
     sessionId: "session-id",
     updatedAt: 1700000000000,
@@ -67,7 +67,7 @@ describe("detectLegacyBootSessionEntries", () => {
     });
   });
 
-  it("detects boot entries missing lifecycleRevision", () => {
+  it("detects boot entries missing lifecycleRevision and createdAt", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
@@ -85,6 +85,21 @@ describe("detectLegacyBootSessionEntries", () => {
       target: "agent:main:boot",
       path: "/state/agents/main/sessions",
     });
+  });
+
+  it("preserves revision-less boot entries that have createdAt provenance", () => {
+    // A current post-7.1 entry may lack lifecycleRevision but still have
+    // createdAt — the dual-field check prevents deleting valid state.
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+      { sessionKey: "agent:main:boot", entry: makeEntry({ createdAt: 1720000000000 }) },
+    ]);
+
+    const findings = detectLegacyBootSessionEntries({ cfg });
+
+    expect(findings).toEqual([]);
   });
 
   it("propagates lock errors instead of masking them as clean stores", () => {
@@ -132,7 +147,7 @@ describe("detectLegacyBootSessionEntries", () => {
     const findings = detectLegacyBootSessionEntries({ cfg });
 
     expect(findings).toHaveLength(2);
-    expect(findings.map((f) => f.target).sort()).toEqual(["agent:main:boot", "agent:ops:boot"]);
+    expect(findings.map((f) => f.target).toSorted()).toEqual(["agent:main:boot", "agent:ops:boot"]);
   });
 });
 

--- a/src/commands/doctor-session-legacy-boot.test.ts
+++ b/src/commands/doctor-session-legacy-boot.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listSqliteSessionEntriesReadOnlyMock = vi.hoisted(() => vi.fn());
+const applySessionEntryLifecycleMutationMock = vi.hoisted(() =>
+  vi.fn(async () => ({ archivedTranscriptDirectories: [] })),
+);
+const resolveAllAgentSessionStoreTargetsSyncMock = vi.hoisted(() => vi.fn());
+const shortenHomePathMock = vi.hoisted(() => (path: string) => path);
+
+vi.mock("../config/sessions/session-accessor.sqlite.js", () => ({
+  listSqliteSessionEntriesReadOnly: listSqliteSessionEntriesReadOnlyMock,
+}));
+
+vi.mock("../config/sessions/session-accessor.lifecycle.js", () => ({
+  applySessionEntryLifecycleMutation: applySessionEntryLifecycleMutationMock,
+}));
+
+vi.mock("../config/sessions/targets.js", () => ({
+  resolveAllAgentSessionStoreTargetsSync: resolveAllAgentSessionStoreTargetsSyncMock,
+}));
+
+vi.mock("../utils.js", () => ({
+  shortenHomePath: shortenHomePathMock,
+}));
+
+const { detectLegacyBootSessionEntries, repairLegacyBootSessionEntries } =
+  await import("./doctor-session-legacy-boot.js");
+
+function makeEntry(overrides?: { lifecycleRevision?: string }) {
+  return {
+    sessionId: "session-id",
+    updatedAt: 1700000000000,
+    systemSent: false,
+    label: "Boot",
+    ...overrides,
+  };
+}
+
+const cfg = {} as unknown as import("../config/types.openclaw.js").OpenClawConfig;
+
+describe("detectLegacyBootSessionEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty array when no targets exist", () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([]);
+    expect(detectLegacyBootSessionEntries({ cfg })).toEqual([]);
+  });
+
+  it("returns an empty array when no legacy boot entries exist", () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+      { sessionKey: "agent:main:boot", entry: makeEntry({ lifecycleRevision: "abc-123" }) },
+      { sessionKey: "agent:main:telegram:direct:42", entry: makeEntry() },
+    ]);
+
+    const findings = detectLegacyBootSessionEntries({ cfg });
+
+    expect(findings).toEqual([]);
+    expect(listSqliteSessionEntriesReadOnlyMock).toHaveBeenCalledWith({
+      agentId: "main",
+      storePath: "/state/agents/main/sessions",
+      env: process.env,
+    });
+  });
+
+  it("detects boot entries missing lifecycleRevision", () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+      { sessionKey: "agent:main:boot", entry: makeEntry() },
+      { sessionKey: "agent:main:boot", entry: makeEntry({ lifecycleRevision: "abc-123" }) },
+    ]);
+
+    const findings = detectLegacyBootSessionEntries({ cfg });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      checkId: "core/doctor/legacy-boot-session-state",
+      severity: "warning",
+      target: "agent:main:boot",
+      path: "/state/agents/main/sessions",
+    });
+  });
+
+  it("propagates lock errors instead of masking them as clean stores", () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockImplementation(() => {
+      throw new Error("database locked");
+    });
+
+    expect(() => detectLegacyBootSessionEntries({ cfg })).toThrow("database locked");
+  });
+
+  it("preserves unrelated session keys that end with :boot", () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+      { sessionKey: "agent:main:boot", entry: makeEntry() },
+      { sessionKey: "custom:boot", entry: makeEntry() },
+      { sessionKey: "workspace:main:boot", entry: makeEntry() },
+    ]);
+
+    const findings = detectLegacyBootSessionEntries({ cfg });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.target).toBe("agent:main:boot");
+  });
+
+  it("detects legacy boot entries for all agents in a shared store", () => {
+    // Shared store deduplication keeps only one target, but the single DB contains
+    // sessions for multiple agents. Each agent's legacy boot entry must be detected.
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/shared/openclaw-agent.sqlite" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+      { sessionKey: "agent:main:boot", entry: makeEntry() },
+      { sessionKey: "agent:ops:boot", entry: makeEntry() },
+      {
+        sessionKey: "agent:ops:telegram:direct:42",
+        entry: makeEntry({ lifecycleRevision: "abc" }),
+      },
+    ]);
+
+    const findings = detectLegacyBootSessionEntries({ cfg });
+
+    expect(findings).toHaveLength(2);
+    expect(findings.map((f) => f.target).sort()).toEqual(["agent:main:boot", "agent:ops:boot"]);
+  });
+});
+
+describe("repairLegacyBootSessionEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does nothing when no legacy boot entries exist", async () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([]);
+
+    const result = await repairLegacyBootSessionEntries({ cfg });
+
+    expect(result).toEqual({ changes: [] });
+    expect(applySessionEntryLifecycleMutationMock).not.toHaveBeenCalled();
+  });
+
+  it("reports would-remove effects in dry-run mode without mutating state", async () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+      { sessionKey: "agent:main:boot", entry: makeEntry() },
+    ]);
+
+    const result = await repairLegacyBootSessionEntries({ cfg, dryRun: true });
+
+    expect(applySessionEntryLifecycleMutationMock).not.toHaveBeenCalled();
+    expect(result.status).toBe("repaired");
+    expect(result.changes).toHaveLength(1);
+    expect(result.effects).toHaveLength(1);
+    expect(result.effects?.[0]).toMatchObject({
+      kind: "state",
+      action: "would-remove-legacy-boot-session-entry",
+    });
+  });
+
+  it("removes legacy boot entries grouped by store", async () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+      { agentId: "ops", storePath: "/state/agents/ops/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockImplementation(({ agentId }: { agentId: string }) => {
+      if (agentId === "main") {
+        return [
+          { sessionKey: "agent:main:boot", entry: makeEntry() },
+          { sessionKey: "agent:main:boot", entry: makeEntry() },
+        ];
+      }
+      return [{ sessionKey: "agent:ops:boot", entry: makeEntry() }];
+    });
+
+    const result = await repairLegacyBootSessionEntries({ cfg });
+
+    expect(applySessionEntryLifecycleMutationMock).toHaveBeenCalledTimes(2);
+    expect(applySessionEntryLifecycleMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/state/agents/main/sessions",
+        removals: [
+          { sessionKey: "agent:main:boot", expectedEntry: expect.any(Object) },
+          { sessionKey: "agent:main:boot", expectedEntry: expect.any(Object) },
+        ],
+        skipMaintenance: true,
+      }),
+    );
+    expect(applySessionEntryLifecycleMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/state/agents/ops/sessions",
+        removals: [{ sessionKey: "agent:ops:boot", expectedEntry: expect.any(Object) }],
+        skipMaintenance: true,
+      }),
+    );
+    expect(result.status).toBe("repaired");
+    expect(result.changes).toHaveLength(3);
+    expect(result.effects).toHaveLength(3);
+    expect(result.effects?.every((e) => e.action === "remove-legacy-boot-session-entry")).toBe(
+      true,
+    );
+  });
+
+  it("is idempotent when removal targets are already gone", async () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([]);
+
+    const result = await repairLegacyBootSessionEntries({ cfg });
+
+    expect(result).toEqual({ changes: [] });
+    expect(applySessionEntryLifecycleMutationMock).not.toHaveBeenCalled();
+  });
+
+  it("reports warnings when a store removal fails", async () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+      { sessionKey: "agent:main:boot", entry: makeEntry() },
+    ]);
+    applySessionEntryLifecycleMutationMock.mockRejectedValue(new Error("transaction conflict"));
+
+    const result = await repairLegacyBootSessionEntries({ cfg });
+
+    expect(result.status).toBe("failed");
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings?.[0]).toContain("transaction conflict");
+  });
+
+  it("does not remove unrelated session keys that end with :boot", async () => {
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/agents/main/sessions" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+      { sessionKey: "agent:main:boot", entry: makeEntry() },
+      { sessionKey: "custom:boot", entry: makeEntry() },
+      { sessionKey: "workspace:main:boot", entry: makeEntry() },
+    ]);
+    applySessionEntryLifecycleMutationMock.mockResolvedValue({ archivedTranscriptDirectories: [] });
+
+    const result = await repairLegacyBootSessionEntries({ cfg });
+
+    expect(result.status).toBe("repaired");
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes?.[0]).toContain("agent:main:boot");
+    expect(applySessionEntryLifecycleMutationMock).toHaveBeenCalledTimes(1);
+    expect(applySessionEntryLifecycleMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/state/agents/main/sessions",
+        removals: [{ sessionKey: "agent:main:boot", expectedEntry: expect.any(Object) }],
+        skipMaintenance: true,
+      }),
+    );
+  });
+
+  it("removes legacy boot entries for all agents in a shared store", async () => {
+    // Deduplicated shared target: one physical store, multiple agent entries.
+    resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "main", storePath: "/state/shared/openclaw-agent.sqlite" },
+    ]);
+    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+      { sessionKey: "agent:main:boot", entry: makeEntry() },
+      { sessionKey: "agent:ops:boot", entry: makeEntry() },
+    ]);
+    applySessionEntryLifecycleMutationMock.mockResolvedValue({ archivedTranscriptDirectories: [] });
+
+    const result = await repairLegacyBootSessionEntries({ cfg });
+
+    expect(result.status).toBe("repaired");
+    expect(result.changes).toHaveLength(2);
+    expect(applySessionEntryLifecycleMutationMock).toHaveBeenCalledTimes(1);
+    expect(applySessionEntryLifecycleMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/state/shared/openclaw-agent.sqlite",
+        removals: expect.arrayContaining([
+          { sessionKey: "agent:main:boot", expectedEntry: expect.any(Object) },
+          { sessionKey: "agent:ops:boot", expectedEntry: expect.any(Object) },
+        ]),
+        skipMaintenance: true,
+      }),
+    );
+  });
+});

--- a/src/commands/doctor-session-legacy-boot.test.ts
+++ b/src/commands/doctor-session-legacy-boot.test.ts
@@ -1,17 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const listSqliteSessionEntriesReadOnlyMock = vi.hoisted(() => vi.fn());
+const listSessionEntriesReadOnlyMock = vi.hoisted(() => vi.fn());
 const applySessionEntryLifecycleMutationMock = vi.hoisted(() =>
   vi.fn(async () => ({ archivedTranscriptDirectories: [] })),
 );
 const resolveAllAgentSessionStoreTargetsSyncMock = vi.hoisted(() => vi.fn());
 const shortenHomePathMock = vi.hoisted(() => (path: string) => path);
 
-vi.mock("../config/sessions/session-accessor.sqlite.js", () => ({
-  listSqliteSessionEntriesReadOnly: listSqliteSessionEntriesReadOnlyMock,
+vi.mock("../config/sessions/session-accessor.sqlite-entry.js", () => ({
+  listSessionEntriesReadOnly: listSessionEntriesReadOnlyMock,
 }));
 
-vi.mock("../config/sessions/session-accessor.lifecycle.js", () => ({
+vi.mock("../config/sessions/session-accessor.sqlite-projection.js", () => ({
   applySessionEntryLifecycleMutation: applySessionEntryLifecycleMutationMock,
 }));
 
@@ -52,7 +52,7 @@ describe("detectLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+    listSessionEntriesReadOnlyMock.mockReturnValue([
       { sessionKey: "agent:main:boot", entry: makeEntry({ lifecycleRevision: "abc-123" }) },
       { sessionKey: "agent:main:telegram:direct:42", entry: makeEntry() },
     ]);
@@ -60,7 +60,7 @@ describe("detectLegacyBootSessionEntries", () => {
     const findings = detectLegacyBootSessionEntries({ cfg });
 
     expect(findings).toEqual([]);
-    expect(listSqliteSessionEntriesReadOnlyMock).toHaveBeenCalledWith({
+    expect(listSessionEntriesReadOnlyMock).toHaveBeenCalledWith({
       agentId: "main",
       storePath: "/state/agents/main/sessions",
       env: process.env,
@@ -71,7 +71,7 @@ describe("detectLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+    listSessionEntriesReadOnlyMock.mockReturnValue([
       { sessionKey: "agent:main:boot", entry: makeEntry() },
       { sessionKey: "agent:main:boot", entry: makeEntry({ lifecycleRevision: "abc-123" }) },
     ]);
@@ -93,7 +93,7 @@ describe("detectLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+    listSessionEntriesReadOnlyMock.mockReturnValue([
       { sessionKey: "agent:main:boot", entry: makeEntry({ createdAt: 1720000000000 }) },
     ]);
 
@@ -106,7 +106,7 @@ describe("detectLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockImplementation(() => {
+    listSessionEntriesReadOnlyMock.mockImplementation(() => {
       throw new Error("database locked");
     });
 
@@ -117,7 +117,7 @@ describe("detectLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+    listSessionEntriesReadOnlyMock.mockReturnValue([
       { sessionKey: "agent:main:boot", entry: makeEntry() },
       { sessionKey: "custom:boot", entry: makeEntry() },
       { sessionKey: "workspace:main:boot", entry: makeEntry() },
@@ -135,7 +135,7 @@ describe("detectLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/shared/openclaw-agent.sqlite" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+    listSessionEntriesReadOnlyMock.mockReturnValue([
       { sessionKey: "agent:main:boot", entry: makeEntry() },
       { sessionKey: "agent:ops:boot", entry: makeEntry() },
       {
@@ -147,7 +147,10 @@ describe("detectLegacyBootSessionEntries", () => {
     const findings = detectLegacyBootSessionEntries({ cfg });
 
     expect(findings).toHaveLength(2);
-    expect(findings.map((f) => f.target).toSorted()).toEqual(["agent:main:boot", "agent:ops:boot"]);
+    expect(findings.map((f) => f.target).toSorted((a, b) => a.localeCompare(b))).toEqual([
+      "agent:main:boot",
+      "agent:ops:boot",
+    ]);
   });
 });
 
@@ -169,7 +172,7 @@ describe("repairLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+    listSessionEntriesReadOnlyMock.mockReturnValue([
       { sessionKey: "agent:main:boot", entry: makeEntry() },
     ]);
 
@@ -190,7 +193,7 @@ describe("repairLegacyBootSessionEntries", () => {
       { agentId: "main", storePath: "/state/agents/main/sessions" },
       { agentId: "ops", storePath: "/state/agents/ops/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockImplementation(({ agentId }: { agentId: string }) => {
+    listSessionEntriesReadOnlyMock.mockImplementation(({ agentId }: { agentId: string }) => {
       if (agentId === "main") {
         return [
           { sessionKey: "agent:main:boot", entry: makeEntry() },
@@ -232,7 +235,7 @@ describe("repairLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([]);
+    listSessionEntriesReadOnlyMock.mockReturnValue([]);
 
     const result = await repairLegacyBootSessionEntries({ cfg });
 
@@ -244,7 +247,7 @@ describe("repairLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+    listSessionEntriesReadOnlyMock.mockReturnValue([
       { sessionKey: "agent:main:boot", entry: makeEntry() },
     ]);
     applySessionEntryLifecycleMutationMock.mockRejectedValue(new Error("transaction conflict"));
@@ -261,7 +264,7 @@ describe("repairLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/agents/main/sessions" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+    listSessionEntriesReadOnlyMock.mockReturnValue([
       { sessionKey: "agent:main:boot", entry: makeEntry() },
       { sessionKey: "custom:boot", entry: makeEntry() },
       { sessionKey: "workspace:main:boot", entry: makeEntry() },
@@ -288,7 +291,7 @@ describe("repairLegacyBootSessionEntries", () => {
     resolveAllAgentSessionStoreTargetsSyncMock.mockReturnValue([
       { agentId: "main", storePath: "/state/shared/openclaw-agent.sqlite" },
     ]);
-    listSqliteSessionEntriesReadOnlyMock.mockReturnValue([
+    listSessionEntriesReadOnlyMock.mockReturnValue([
       { sessionKey: "agent:main:boot", entry: makeEntry() },
       { sessionKey: "agent:ops:boot", entry: makeEntry() },
     ]);

--- a/src/commands/doctor-session-legacy-boot.ts
+++ b/src/commands/doctor-session-legacy-boot.ts
@@ -1,0 +1,188 @@
+/** Doctor repair for legacy pre-7.1 boot session entries that block BOOT.md startup. */
+import { applySessionEntryLifecycleMutation } from "../config/sessions/session-accessor.lifecycle.js";
+import { listSqliteSessionEntriesReadOnly } from "../config/sessions/session-accessor.sqlite.js";
+import {
+  resolveAllAgentSessionStoreTargetsSync,
+  type SessionStoreTarget,
+} from "../config/sessions/targets.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type {
+  HealthFinding,
+  HealthRepairEffect,
+  HealthRepairResult,
+} from "../flows/health-checks.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+import { shortenHomePath } from "../utils.js";
+
+const LEGACY_BOOT_SESSION_CHECK_ID = "core/doctor/legacy-boot-session-state";
+
+type LegacyBootSessionEntry = {
+  sessionKey: string;
+  agentId: string;
+  storePath: string;
+  entry: SessionEntry;
+};
+
+/**
+ * Detects legacy boot entries persisted before the 7.1 lifecycleRevision field.
+ * Evidence: sessionKey ends in `:boot`, entry has no lifecycleRevision, and the
+ * owning agentId derived from the sessionKey matches.
+ */
+function isLegacyBootSessionEntry(
+  sessionKey: string,
+  entry: { lifecycleRevision?: string },
+): boolean {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return false;
+  }
+  const keyParts = sessionKey.split(":");
+  const suffix = keyParts.slice(2).join(":");
+  return suffix === "boot" && !entry.lifecycleRevision;
+}
+
+/**
+ * Reads all entries from a session store and returns legacy boot entries.
+ * Propagates lock errors — an unreadable store must not be reported as clean.
+ * listSqliteSessionEntriesReadOnly already returns [] for missing stores,
+ * so callers only receive errors for genuine runtime failures (locks, etc.).
+ */
+function collectLegacyBootSessionEntriesForTarget(
+  target: SessionStoreTarget,
+  env: NodeJS.ProcessEnv,
+): LegacyBootSessionEntry[] {
+  const entries = listSqliteSessionEntriesReadOnly({
+    agentId: target.agentId,
+    storePath: target.storePath,
+    env,
+  });
+  return entries
+    .filter(({ sessionKey, entry }) => isLegacyBootSessionEntry(sessionKey, entry))
+    .map(({ sessionKey, entry }) => ({
+      sessionKey,
+      agentId: parseAgentSessionKey(sessionKey)?.agentId ?? target.agentId,
+      storePath: target.storePath,
+      entry,
+    }));
+}
+
+function resolveLegacyBootSessionEntries(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): LegacyBootSessionEntry[] {
+  const env = params.env ?? process.env;
+  const targets = resolveAllAgentSessionStoreTargetsSync(params.cfg, { env });
+  const entries: LegacyBootSessionEntry[] = [];
+  for (const target of targets) {
+    entries.push(...collectLegacyBootSessionEntriesForTarget(target, env));
+  }
+  return entries;
+}
+
+function legacyBootSessionFinding(entry: LegacyBootSessionEntry): HealthFinding {
+  return {
+    checkId: LEGACY_BOOT_SESSION_CHECK_ID,
+    severity: "warning",
+    message: `Legacy boot session entry ${entry.sessionKey} lacks lifecycleRevision and can block BOOT.md startup.`,
+    path: entry.storePath,
+    target: entry.sessionKey,
+    fixHint: "Run `openclaw doctor --fix` to remove legacy boot session entries before startup.",
+  };
+}
+
+/** Detects boot session entries persisted before the 7.1 lifecycleRevision field. */
+export function detectLegacyBootSessionEntries(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): HealthFinding[] {
+  return resolveLegacyBootSessionEntries(params).map(legacyBootSessionFinding);
+}
+
+function groupEntriesByStore(
+  entries: readonly LegacyBootSessionEntry[],
+): Map<string, LegacyBootSessionEntry[]> {
+  const grouped = new Map<string, LegacyBootSessionEntry[]>();
+  for (const entry of entries) {
+    const list = grouped.get(entry.storePath) ?? [];
+    list.push(entry);
+    grouped.set(entry.storePath, list);
+  }
+  return grouped;
+}
+
+function formatChange(entry: LegacyBootSessionEntry): string {
+  return `Removed legacy boot session entry ${entry.sessionKey} from ${shortenHomePath(
+    entry.storePath,
+  )}`;
+}
+
+/** Removes verified legacy boot session entries. Idempotent: repeated calls are no-ops. */
+export async function repairLegacyBootSessionEntries(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  dryRun?: boolean;
+}): Promise<HealthRepairResult> {
+  const entries = resolveLegacyBootSessionEntries({ cfg: params.cfg, env: params.env });
+  if (entries.length === 0) {
+    return { changes: [] };
+  }
+
+  const effects: HealthRepairEffect[] = entries.map((entry) => ({
+    kind: "state",
+    action:
+      params.dryRun === true
+        ? "would-remove-legacy-boot-session-entry"
+        : "remove-legacy-boot-session-entry",
+    target: `${entry.storePath}:${entry.sessionKey}`,
+    dryRunSafe: false,
+  }));
+
+  if (params.dryRun === true) {
+    return {
+      status: "repaired",
+      changes: entries.map((entry) => `Would ${formatChange(entry).toLowerCase()}`),
+      effects,
+    };
+  }
+
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const grouped = groupEntriesByStore(entries);
+
+  for (const [storePath, storeEntries] of grouped) {
+    try {
+      const result = await applySessionEntryLifecycleMutation({
+        storePath,
+        removals: storeEntries.map((entry) => ({
+          sessionKey: entry.sessionKey,
+          expectedEntry: entry.entry,
+        })),
+        activeSessionKey: storeEntries[0]?.sessionKey,
+        skipMaintenance: true,
+      });
+      for (const entry of storeEntries) {
+        changes.push(formatChange(entry));
+      }
+      if (result.archivedTranscriptDirectories.length > 0) {
+        warnings.push(
+          `Archived ${result.archivedTranscriptDirectories.length} transcript artifact(s) while removing legacy boot entries from ${shortenHomePath(storePath)}`,
+        );
+      }
+    } catch (err) {
+      warnings.push(
+        `Failed to remove legacy boot entries from ${shortenHomePath(storePath)}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  return {
+    status: warnings.length > 0 && changes.length === 0 ? "failed" : "repaired",
+    reason: warnings.length > 0 ? warnings.join("; ") : undefined,
+    changes,
+    warnings,
+    effects,
+  };
+}

--- a/src/commands/doctor-session-legacy-boot.ts
+++ b/src/commands/doctor-session-legacy-boot.ts
@@ -1,4 +1,7 @@
-/** Doctor repair for legacy pre-7.1 boot session entries that block BOOT.md startup. */
+/** Doctor repair for legacy pre-7.1 boot session entries that block BOOT.md startup.
+ * Legacy entries are identified by missing BOTH lifecycleRevision and createdAt —
+ * both provenance fields were introduced in 7.1. An entry with createdAt (even
+ * without lifecycleRevision) is preserved as a valid current mapping. */
 import { applySessionEntryLifecycleMutation } from "../config/sessions/session-accessor.lifecycle.js";
 import { listSqliteSessionEntriesReadOnly } from "../config/sessions/session-accessor.sqlite.js";
 import {
@@ -25,13 +28,16 @@ type LegacyBootSessionEntry = {
 };
 
 /**
- * Detects legacy boot entries persisted before the 7.1 lifecycleRevision field.
- * Evidence: sessionKey ends in `:boot`, entry has no lifecycleRevision, and the
- * owning agentId derived from the sessionKey matches.
+ * Detects legacy boot entries persisted before the 7.1 lifecycleRevision and
+ * createdAt provenance fields. Evidence: sessionKey ends in `:boot`, entry has
+ * no lifecycleRevision and no createdAt, and the owning agentId derived from the
+ * sessionKey matches. Entries with createdAt (even absent lifecycleRevision) are
+ * preserved — `createdAt` was introduced alongside `lifecycleRevision`, so an
+ * entry missing both is definitively pre-provenance legacy.
  */
 function isLegacyBootSessionEntry(
   sessionKey: string,
-  entry: { lifecycleRevision?: string },
+  entry: { lifecycleRevision?: string; createdAt?: number },
 ): boolean {
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {
@@ -39,7 +45,7 @@ function isLegacyBootSessionEntry(
   }
   const keyParts = sessionKey.split(":");
   const suffix = keyParts.slice(2).join(":");
-  return suffix === "boot" && !entry.lifecycleRevision;
+  return suffix === "boot" && !entry.lifecycleRevision && !entry.createdAt;
 }
 
 /**

--- a/src/commands/doctor-session-legacy-boot.ts
+++ b/src/commands/doctor-session-legacy-boot.ts
@@ -1,9 +1,9 @@
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.sqlite-entry.js";
 /** Doctor repair for legacy pre-7.1 boot session entries that block BOOT.md startup.
  * Legacy entries are identified by missing BOTH lifecycleRevision and createdAt —
  * both provenance fields were introduced in 7.1. An entry with createdAt (even
  * without lifecycleRevision) is preserved as a valid current mapping. */
-import { applySessionEntryLifecycleMutation } from "../config/sessions/session-accessor.lifecycle.js";
-import { listSqliteSessionEntriesReadOnly } from "../config/sessions/session-accessor.sqlite.js";
+import { applySessionEntryLifecycleMutation } from "../config/sessions/session-accessor.sqlite-projection.js";
 import {
   resolveAllAgentSessionStoreTargetsSync,
   type SessionStoreTarget,
@@ -51,14 +51,14 @@ function isLegacyBootSessionEntry(
 /**
  * Reads all entries from a session store and returns legacy boot entries.
  * Propagates lock errors — an unreadable store must not be reported as clean.
- * listSqliteSessionEntriesReadOnly already returns [] for missing stores,
+ * listSessionEntriesReadOnly already returns [] for missing stores,
  * so callers only receive errors for genuine runtime failures (locks, etc.).
  */
 function collectLegacyBootSessionEntriesForTarget(
   target: SessionStoreTarget,
   env: NodeJS.ProcessEnv,
 ): LegacyBootSessionEntry[] {
-  const entries = listSqliteSessionEntriesReadOnly({
+  const entries = listSessionEntriesReadOnly({
     agentId: target.agentId,
     storePath: target.storePath,
     env,

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -33,7 +33,6 @@ import {
   collectDisabledCodexPluginRouteIssues,
   resolveKnownModelRefMigrationTarget,
 } from "../commands/doctor/shared/codex-route-warnings.js";
-import { isDefaultInstallIdentity } from "../config/paths.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import type { CronListPageResult } from "../cron/service/list-page-types.js";
@@ -1038,7 +1037,54 @@ function createGatewayDaemonCheck(deps: CoreHealthCheckDeps): SplitHealthCheckDe
   };
 }
 
-const legacyBootSessionStateCheck: SplitHealthCheckInput = {
+const telegramGeneralTopicConversationsCheck: HealthCheck = {
+  id: TELEGRAM_GENERAL_TOPIC_CONVERSATIONS_CHECK_ID,
+  kind: "core",
+  description: "Telegram General-topic conversation bindings use the canonical chat target.",
+  source: "doctor",
+  async detect(ctx) {
+    const { detectTelegramGeneralTopicConversationRepairs } =
+      await import("../commands/doctor-telegram-general-topic-conversations.js");
+    const repairs = detectTelegramGeneralTopicConversationRepairs({
+      cfg: ctx.cfg,
+      ...(ctx.env ? { env: ctx.env } : {}),
+    });
+    return repairs.map((repair) => ({
+      checkId: TELEGRAM_GENERAL_TOPIC_CONVERSATIONS_CHECK_ID,
+      severity: "warning" as const,
+      message: `Agent ${repair.agentId} has a stale Telegram General-topic conversation identity.`,
+      target: repair.agentId,
+      requirement: "One canonical chat-scoped conversation binding for Telegram General topic.",
+      fixHint: "Run `openclaw doctor --fix` to merge the stale topic-qualified identity.",
+    }));
+  },
+  async repair(ctx) {
+    const { repairTelegramGeneralTopicConversations } =
+      await import("../commands/doctor-telegram-general-topic-conversations.js");
+    const effect = {
+      kind: "state" as const,
+      action: ctx.dryRun ? "would-merge-stale-bindings" : "merge-stale-bindings",
+      target: "Telegram General topic conversations",
+      dryRunSafe: false,
+    };
+    if (ctx.dryRun) {
+      return {
+        changes: ["Would merge stale Telegram General-topic identities."],
+        effects: [effect],
+      };
+    }
+    const repaired = await repairTelegramGeneralTopicConversations({
+      cfg: ctx.cfg,
+      ...(ctx.env ? { env: ctx.env } : {}),
+    });
+    return {
+      changes: [`Merged ${repaired} stale Telegram General-topic conversation identity row(s).`],
+      effects: repaired > 0 ? [effect] : [],
+    };
+  },
+};
+
+const legacyBootSessionStateCheck: SplitHealthCheckDefinition = {
   id: "core/doctor/legacy-boot-session-state",
   kind: "core",
   description: "Legacy pre-7.1 boot session entries are removed before startup.",

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -16,6 +16,10 @@ import {
   shellCompletionStatusToRepairEffects,
 } from "../commands/doctor-completion.js";
 import {
+  detectLegacyBootSessionEntries,
+  repairLegacyBootSessionEntries,
+} from "../commands/doctor-session-legacy-boot.js";
+import {
   disableUnavailableSkillsInConfig,
   formatMissingSkillSummary,
 } from "../commands/doctor-skills-core.js";
@@ -957,53 +961,6 @@ const codexSessionRoutesCheck: HealthCheck = {
   },
 };
 
-const telegramGeneralTopicConversationsCheck: HealthCheck = {
-  id: TELEGRAM_GENERAL_TOPIC_CONVERSATIONS_CHECK_ID,
-  kind: "core",
-  description: "Telegram General-topic conversation bindings use the canonical chat target.",
-  source: "doctor",
-  async detect(ctx) {
-    const { detectTelegramGeneralTopicConversationRepairs } =
-      await import("../commands/doctor-telegram-general-topic-conversations.js");
-    const repairs = detectTelegramGeneralTopicConversationRepairs({
-      cfg: ctx.cfg,
-      ...(ctx.env ? { env: ctx.env } : {}),
-    });
-    return repairs.map((repair) => ({
-      checkId: TELEGRAM_GENERAL_TOPIC_CONVERSATIONS_CHECK_ID,
-      severity: "warning" as const,
-      message: `Agent ${repair.agentId} has a stale Telegram General-topic conversation identity.`,
-      target: repair.agentId,
-      requirement: "One canonical chat-scoped conversation binding for Telegram General topic.",
-      fixHint: "Run `openclaw doctor --fix` to merge the stale topic-qualified identity.",
-    }));
-  },
-  async repair(ctx) {
-    const { repairTelegramGeneralTopicConversations } =
-      await import("../commands/doctor-telegram-general-topic-conversations.js");
-    const effect = {
-      kind: "state" as const,
-      action: ctx.dryRun ? "would-merge-stale-bindings" : "merge-stale-bindings",
-      target: "Telegram General topic conversations",
-      dryRunSafe: false,
-    };
-    if (ctx.dryRun) {
-      return {
-        changes: ["Would merge stale Telegram General-topic identities."],
-        effects: [effect],
-      };
-    }
-    const repaired = await repairTelegramGeneralTopicConversations({
-      cfg: ctx.cfg,
-      ...(ctx.env ? { env: ctx.env } : {}),
-    });
-    return {
-      changes: [`Merged ${repaired} stale Telegram General-topic conversation identity row(s).`],
-      effects: repaired > 0 ? [effect] : [],
-    };
-  },
-};
-
 const gatewayServicesExtraCheck: HealthCheck = {
   id: GATEWAY_SERVICES_EXTRA_CHECK_ID,
   kind: "core",
@@ -1042,9 +999,6 @@ const gatewayPlatformNotesCheck: HealthCheck = {
   description: "Gateway platform notes are captured as structured findings.",
   source: "doctor",
   async detect(ctx) {
-    if (!isDefaultInstallIdentity(process.env)) {
-      return [];
-    }
     const { collectMacGatewayPlatformWarnings } =
       await import("../commands/doctor-platform-notes.js");
     const warnings = await collectMacGatewayPlatformWarnings(ctx.cfg);
@@ -1083,6 +1037,21 @@ function createGatewayDaemonCheck(deps: CoreHealthCheckDeps): SplitHealthCheckDe
     },
   };
 }
+
+
+const legacyBootSessionStateCheck: SplitHealthCheckInput = {
+  id: "core/doctor/legacy-boot-session-state",
+  kind: "core",
+  description: "Legacy pre-7.1 boot session entries are removed before startup.",
+  source: "doctor",
+  defaultEnabled: false,
+  async detect(ctx) {
+    return detectLegacyBootSessionEntries({ cfg: ctx.cfg, env: process.env });
+  },
+  async repair(ctx) {
+    return repairLegacyBootSessionEntries({ cfg: ctx.cfg, env: process.env, dryRun: ctx.dryRun });
+  },
+};
 
 const browserCheck: HealthCheck = {
   id: "core/doctor/browser",
@@ -1392,6 +1361,7 @@ function createConvertedWorkflowChecks(
     legacyCronStoreCheck,
     codexSessionRoutesCheck,
     telegramGeneralTopicConversationsCheck,
+    legacyBootSessionStateCheck,
     shellCompletionCheck,
     uiProtocolFreshnessCheck,
     gatewayServicesExtraCheck,

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -1038,7 +1038,6 @@ function createGatewayDaemonCheck(deps: CoreHealthCheckDeps): SplitHealthCheckDe
   };
 }
 
-
 const legacyBootSessionStateCheck: SplitHealthCheckInput = {
   id: "core/doctor/legacy-boot-session-state",
   kind: "core",

--- a/src/flows/doctor-health-contribution-runners.state.ts
+++ b/src/flows/doctor-health-contribution-runners.state.ts
@@ -160,6 +160,33 @@ export async function runSessionTranscriptLabelsHealth(
   });
 }
 
+export async function runLegacyBootSessionHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const { detectLegacyBootSessionEntries, repairLegacyBootSessionEntries } =
+    await import("../commands/doctor-session-legacy-boot.js");
+  const { note } = await import("../../packages/terminal-core/src/note.js");
+
+  const env = ctx.env ?? process.env;
+  const findings = detectLegacyBootSessionEntries({ cfg: ctx.cfg, env });
+  if (findings.length === 0) {
+    return;
+  }
+
+  if (!ctx.prompter.shouldRepair) {
+    for (const finding of findings) {
+      note(finding.message, "Legacy boot session state");
+    }
+    return;
+  }
+
+  const result = await repairLegacyBootSessionEntries({ cfg: ctx.cfg, env });
+  if (result.changes.length > 0) {
+    note(result.changes.join("\n"), "Doctor changes");
+  }
+  if (result.warnings && result.warnings.length > 0) {
+    note(result.warnings.join("\n"), "Doctor warnings");
+  }
+}
+
 export async function runSessionSnapshotsHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteSessionSnapshotHealth } = await import("../commands/doctor-session-snapshots.js");
   await noteSessionSnapshotHealth({

--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -4,12 +4,13 @@ import {
   runCommandOwnerHealth,
 } from "./doctor-health-contribution-runners.gateway.js";
 import {
-  runChannelIngressDeadLettersHealth,
   runAgentMemorySchemaHealth,
+  runChannelIngressDeadLettersHealth,
   runCodexSessionRouteHealth,
   runConfigAuditScrubHealth,
   runDatabaseBloatHealth,
   runDiskSpaceHealth,
+  runLegacyBootSessionHealth,
   runLegacyCronHealth,
   runLegacyPluginManifestHealth,
   runPluginRegistryHealth,
@@ -121,34 +122,6 @@ export function resolveInitialDoctorHealthContributions(params: {
       label: "Legacy state",
       healthCheckIds: ["core/doctor/legacy-state", "core/doctor/removed-workspaces-state"],
       run: params.runLegacyStateHealth,
-    }),
-    createDoctorHealthContribution({
-      id: "doctor:session-transcripts",
-      label: "Session transcripts",
-      healthChecks: {
-        description: "Legacy or branchy session transcript files are represented as findings.",
-        defaultEnabled: false,
-        async detect() {
-          const { detectSessionTranscriptHealthIssues, sessionTranscriptIssueToHealthFinding } =
-            await import("../commands/doctor-session-transcripts.js");
-          return (await detectSessionTranscriptHealthIssues()).map(
-            sessionTranscriptIssueToHealthFinding,
-          );
-        },
-        repair: legacyOwnedRepair(async () => {
-          const { detectSessionTranscriptHealthIssues, sessionTranscriptIssueToRepairEffect } =
-            await import("../commands/doctor-session-transcripts.js");
-          return (await detectSessionTranscriptHealthIssues()).map(
-            sessionTranscriptIssueToRepairEffect,
-          );
-        }, "legacy doctor session transcript contribution owns transcript rewrites"),
-      },
-      run: runSessionTranscriptsHealth,
-    }),
-    createDoctorHealthContribution({
-      id: "doctor:agent-memory-schema",
-      label: "Agent memory schema",
-      run: runAgentMemorySchemaHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:legacy-plugin-manifests",
@@ -343,6 +316,40 @@ export function resolveInitialDoctorHealthContributions(params: {
       id: "doctor:session-transcript-labels",
       label: "Session transcript labels",
       run: runSessionTranscriptLabelsHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:legacy-boot-session-state",
+      label: "Legacy boot session state",
+      healthCheckIds: ["core/doctor/legacy-boot-session-state"],
+      run: runLegacyBootSessionHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:session-transcripts",
+      label: "Session transcripts",
+      healthChecks: {
+        description: "Legacy or branchy session transcript files are represented as findings.",
+        defaultEnabled: false,
+        async detect() {
+          const { detectSessionTranscriptHealthIssues, sessionTranscriptIssueToHealthFinding } =
+            await import("../commands/doctor-session-transcripts.js");
+          return (await detectSessionTranscriptHealthIssues()).map(
+            sessionTranscriptIssueToHealthFinding,
+          );
+        },
+        repair: legacyOwnedRepair(async () => {
+          const { detectSessionTranscriptHealthIssues, sessionTranscriptIssueToRepairEffect } =
+            await import("../commands/doctor-session-transcripts.js");
+          return (await detectSessionTranscriptHealthIssues()).map(
+            sessionTranscriptIssueToRepairEffect,
+          );
+        }, "legacy doctor session transcript contribution owns transcript rewrites"),
+      },
+      run: runSessionTranscriptsHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:agent-memory-schema",
+      label: "Agent memory schema",
+      run: runAgentMemorySchemaHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:session-snapshots",


### PR DESCRIPTION
Fixes #112912

## What Problem This Solves

Fixes an issue where operators upgrading from ≤2026.6.x to 2026.7.1-2 have a stale `agent:<seat>:boot` session entry that blocks BOOT.md startup. The entry carries a pre-7.1 `sessionId` that fails the agentCommand session-admission check, so every gateway boot fails with `Session "agent:<seat>:boot" changed while starting work. Retry.`

## Why This Change Was Made

Legacy pre-7.1 boot session entries lack the `lifecycleRevision` field introduced in 7.1. The repair is owned by `openclaw doctor --fix` as a structured state migration via a dedicated core Doctor contribution (`runLegacyBootSessionHealth`). This keeps runtime boot behavior unchanged and puts legacy-state cleanup in the canonical doctor path.

This revision narrows the legacy detector from any key ending in `:boot` to the exact canonical per-agent key `agent:<agentId>:boot`, preventing `doctor --fix` from deleting unrelated persistent session state.

## User Impact

Operators upgrading from ≤2026.6.x run `openclaw doctor --fix`. Doctor detects and removes legacy boot entries via the normal core repair path; subsequent gateway boots run BOOT.md normally.

## Evidence

All proof was run from the PR worktree after `pnpm build`, using isolated `OPENCLAW_STATE_DIR` fixtures that simulate a legacy-to-current upgrade.

### Predicate narrowing: only `agent:<agentId>:boot` is treated as legacy

The fixture contains three `:boot` records in the main agent store:

- `agent:main:boot` without `lifecycleRevision` (legacy)
- `custom:boot` without `lifecycleRevision` (must be preserved)
- `agent:ops:boot` with `lifecycleRevision: rev-abc-123` in the ops store (current)

```bash
$ OPENCLAW_STATE_DIR=/tmp/openclaw-proof-113207-revise node openclaw.mjs doctor --lint --all --only core/doctor/legacy-boot-session-state
{"ok":false,"checksRun":1,"checksSkipped":54,"findings":[{"checkId":"core/doctor/legacy-boot-session-state","severity":"warning","message":"Legacy boot session entry agent:main:boot lacks lifecycleRevision and can block BOOT.md startup.","path":"/tmp/openclaw-proof-113207-revise/agents/main/sessions/sessions.json","target":"agent:main:boot","fixHint":"Run `openclaw doctor --fix` to remove legacy boot session entries before startup."}]}
```

Only `agent:main:boot` is flagged; `custom:boot` is preserved by the narrowed predicate.

### Unit tests cover preservation of unrelated `:boot` keys

```bash
$ node scripts/run-vitest.mjs src/commands/doctor-session-legacy-boot.test.ts
 ✓ |commands| src/commands/doctor-session-legacy-boot.test.ts (11 tests)
```

New tests assert that `detectLegacyBootSessionEntries` and `repairLegacyBootSessionEntries` ignore `custom:boot` and `workspace:main:boot`, and only remove the canonical `agent:main:boot` entry.

### Before repair: BOOT.md is blocked by the stale legacy entry

With the legacy `agent:main:boot` record present, the gateway startup hook fails before the BOOT.md agent run can reach the model layer:

```bash
$ cd /tmp/openclaw-proof-113207-broken && OPENCLAW_LOG_LEVEL=debug OPENCLAW_STATE_DIR=/tmp/openclaw-proof-113207-broken node /home/0668000452/codes/OPENSOURCES/openclaw/.worktrees/pr-113207/openclaw.mjs gateway run --allow-unconfigured --auth none --port 19878
...
2026-07-29T01:05:16.258+08:00 [hooks:loader] Registered hook: boot-md -> gateway:startup
...
2026-07-29T01:05:38.085+08:00 [boot] agent run failed: Session "agent:main:boot" changed while starting work. Retry.
2026-07-29T01:05:38.102+08:00 [hooks/boot-md] startup task failed
```

No `lane=session:agent:main:boot` run is observed; the stale entry aborts the BOOT.md startup task.

### After repair: BOOT.md executes

After `doctor --fix` removes the stale `agent:main:boot` entry (fixture `/tmp/openclaw-proof-113207-v2`), the same gateway command reaches the BOOT.md agent run:

```bash
$ cd /tmp/openclaw-proof-113207-v2 && OPENCLAW_LOG_LEVEL=debug OPENCLAW_STATE_DIR=/tmp/openclaw-proof-113207-v2 node /home/0668000452/codes/OPENSOURCES/openclaw/.worktrees/pr-113207/openclaw.mjs gateway run --allow-unconfigured --auth none --port 19877
...
2026-07-29T01:03:22.520+08:00 [hooks:loader] Registered hook: boot-md -> gateway:startup
...
2026-07-29T01:03:45.888+08:00 [diagnostic] lane enqueue: lane=session:agent:main:boot queueSize=1
2026-07-29T01:03:54.562+08:00 [diagnostic] session state: sessionId=boot-2026-07-28_17-03-43-294-3f51e73b sessionKey=agent:main:boot prev=idle new=processing reason="run_started" queueDepth=0
...
2026-07-29T01:04:17.130+08:00 [agent/embedded] embedded run failover decision: runId=boot-2026-07-28_17-03-43-294-3f51e73b stage=prompt decision=surface_error reason=auth from=openai/gpt-5.6-sol profile=- rawError=unexpected status 403 Forbidden: Country, region, or territory not supported, url: https://api.openai.com/v1/responses, cf-ray: a225764a497e848a-HKG
2026-07-29T01:04:17.138+08:00 [diagnostic] lane task error: lane=session:agent:main:boot durationMs=31242 error="Error: unexpected status 403 Forbidden: Country, region, or territory not supported, url: https://api.openclaw.ai/v1/responses, cf-ray: a225764a497e848a-HKG"
2026-07-29T01:04:17.173+08:00 [boot] agent run failed: unexpected status 403 Forbidden: Country, region, or territory not supported, url: https://api.openai.com/v1/responses, cf-ray: a225764a497e848a-HKG
2026-07-29T01:04:17.188+08:00 [hooks/boot-md] startup task failed
```

The boot session `agent:main:boot` is created, queued, and starts processing. The only failure is the expected OpenAI API 403 in this offline fixture; the critical point is that the formerly blocked BOOT.md hook now executes instead of failing on the stale legacy entry.

### SQLite state after repair

```bash
$ sqlite3 /tmp/openclaw-proof-113207-v2/agents/main/agent/openclaw-agent.sqlite "SELECT session_key FROM session_nodes WHERE session_key LIKE '%boot';"
# (no rows)

$ sqlite3 /tmp/openclaw-proof-113207-v2/agents/ops/agent/openclaw-agent.sqlite "SELECT session_key FROM session_nodes WHERE session_key LIKE '%boot';"
agent:ops:boot
```

The legacy `agent:main:boot` entry is gone, while the current `agent:ops:boot` entry remains.

### Checks

```bash
$ node scripts/run-vitest.mjs src/commands/doctor-session-legacy-boot.test.ts
 ✓ |commands| src/commands/doctor-session-legacy-boot.test.ts (11 tests)

$ node scripts/run-vitest.mjs src/flows/doctor-core-checks.test.ts src/flows/doctor-health-contributions.test.ts
 ✓ doctor-core-checks.test.ts (27 tests)
 ✓ doctor-health-contributions.test.ts (95 tests)

$ ./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/commands/doctor-session-legacy-boot.ts src/commands/doctor-session-legacy-boot.test.ts
Found 0 warnings and 0 errors.

$ pnpm format:check
All matched files use the correct format.
```
