### PR TITLE
fix(clawhub): SSRF-guard untrusted skill archive download URLs

### DIFF
--- a/src/infra/clawhub-retry.ts
+++ b/src/infra/clawhub-retry.ts
@@ -12,6 +12,7 @@ type ClawHubResponseHandle = {
 type ClawHubRetryOptions<T extends ClawHubResponseHandle> = {
   disposeRetry: (result: T) => Promise<void>;
   retryRateLimit?: boolean;
+  isRetryableError?: (error: unknown) => boolean;
   sleep?: (ms: number) => Promise<void>;
 };
 
@@ -62,6 +63,8 @@ export async function retryClawHubRead<T extends ClawHubResponseHandle>(
         minDelayMs: 0,
         maxDelayMs: CLAWHUB_MAX_RETRY_AFTER_MS,
         delayMs: ({ attempt }) => CLAWHUB_RETRY_DELAYS_MS[attempt - 1] ?? 0,
+        shouldRetry: (error) =>
+          error instanceof RetryableClawHubResponse || (options.isRetryableError?.(error) ?? true),
         retryAfterMs: (error) =>
           error instanceof RetryableClawHubResponse
             ? parseRetryAfterMs(error.result.response.headers)

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -1,6 +1,8 @@
 // Covers ClawHub metadata and artifact fetch helpers.
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
@@ -152,7 +154,7 @@ const oversizedArchiveCases: Array<{
       downloadClawHubSkillArchiveUrl({
         baseUrl: "https://clawhub.ai",
         url: "https://downloads.example.com/skill.zip",
-        fetchImpl: async () => response,
+        fetchImpl: vi.fn(async () => response),
       }),
     expectedResource: "skill archive download at /skill.zip",
   },
@@ -1643,14 +1645,14 @@ describe("clawhub helpers", () => {
     const archive = await downloadClawHubSkillArchiveUrl({
       baseUrl: "https://clawhub.ai",
       url: "https://codeload.github.com/NVIDIA/skills/zip/abcdef",
-      fetchImpl: async (input, init) => {
+      fetchImpl: vi.fn(async (input, init) => {
         requestedUrl = input instanceof Request ? input.url : String(input);
         requestedInit = init;
         return new Response(new Uint8Array([7, 8, 9]), {
           status: 200,
           headers: { "content-type": "application/zip" },
         });
-      },
+      }),
     });
 
     try {
@@ -1661,6 +1663,61 @@ describe("clawhub helpers", () => {
       const archiveDir = path.dirname(archive.archivePath);
       await archive.cleanup();
       await expectPathMissing(archiveDir);
+    }
+  });
+
+  it("blocks off-registry resolver archive URLs that target internal addresses", async () => {
+    const payload = Buffer.from([1, 2, 3, 4]);
+    let hits = 0;
+    const server = createServer((_request, response) => {
+      hits += 1;
+      response.writeHead(200, { "content-type": "application/zip" });
+      response.end(payload);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const port = (server.address() as AddressInfo).port;
+    try {
+      await expect(
+        downloadClawHubSkillArchiveUrl({
+          baseUrl: "https://clawhub.ai",
+          url: `http://127.0.0.1:${port}/skill.zip`,
+        }),
+      ).rejects.toThrow();
+      expect(hits).toBe(0);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("still downloads archive URLs served from the configured registry origin", async () => {
+    const payload = Buffer.from([9, 8, 7, 6]);
+    let hits = 0;
+    const server = createServer((_request, response) => {
+      hits += 1;
+      response.writeHead(200, { "content-type": "application/zip" });
+      response.end(payload);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const port = (server.address() as AddressInfo).port;
+    const registry = `http://127.0.0.1:${port}`;
+    const archive = await downloadClawHubSkillArchiveUrl({
+      baseUrl: registry,
+      url: `${registry}/skill.zip`,
+    });
+    try {
+      expect(hits).toBe(1);
+      await expect(fs.readFile(archive.archivePath)).resolves.toEqual(payload);
+    } finally {
+      await archive.cleanup();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
     }
   });
 });

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -1720,5 +1720,40 @@ describe("clawhub helpers", () => {
       });
     }
   });
+
+  it("retries transient 5xx responses when downloading off-registry archive URLs", async () => {
+    const payload = Buffer.from([4, 4, 2]);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(new Uint8Array(), { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(payload, { status: 200, headers: { "content-type": "application/zip" } }),
+      );
+    const archive = await downloadClawHubSkillArchiveUrl({
+      baseUrl: "https://clawhub.ai",
+      url: "https://downloads.example.com/skill.zip",
+      fetchImpl,
+    });
+    try {
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      await expect(fs.readFile(archive.archivePath)).resolves.toEqual(payload);
+    } finally {
+      await archive.cleanup();
+    }
+  });
+
+  it("does not retry off-registry archive URLs rejected by the SSRF guard", async () => {
+    vi.useFakeTimers();
+    try {
+      await expect(
+        downloadClawHubSkillArchiveUrl({
+          baseUrl: "https://clawhub.ai",
+          url: "http://127.0.0.1:1/skill.zip",
+        }),
+      ).rejects.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -1693,6 +1693,95 @@ describe("clawhub helpers", () => {
     }
   });
 
+  it("blocks off-registry resolver archive URLs that target internal addresses even with a configured token", async () => {
+    process.env.CLAWHUB_TOKEN = "env-token-123";
+    const payload = Buffer.from([1, 2, 3, 4]);
+    let hits = 0;
+    let sawAuthorization = false;
+    const server = createServer((request, response) => {
+      hits += 1;
+      sawAuthorization = sawAuthorization || Boolean(request.headers.authorization);
+      response.writeHead(200, { "content-type": "application/zip" });
+      response.end(payload);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const port = (server.address() as AddressInfo).port;
+    try {
+      await expect(
+        downloadClawHubSkillArchiveUrl({
+          baseUrl: "https://clawhub.ai",
+          url: `http://127.0.0.1:${port}/skill.zip`,
+          token: "explicit-token-456",
+        }),
+      ).rejects.toThrow();
+      expect(hits).toBe(0);
+      expect(sawAuthorization).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("does not send a configured ClawHub token to off-registry resolver archive URLs", async () => {
+    process.env.CLAWHUB_TOKEN = "env-token-123";
+    let requestedUrl = "";
+    let requestedInit: RequestInit | undefined;
+
+    const archive = await downloadClawHubSkillArchiveUrl({
+      baseUrl: "https://clawhub.ai",
+      url: "https://downloads.example.com/skill.zip",
+      token: "explicit-token-456",
+      fetchImpl: vi.fn(async (input, init) => {
+        requestedUrl = input instanceof Request ? input.url : String(input);
+        requestedInit = init;
+        return new Response(new Uint8Array([5, 6]), {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        });
+      }),
+    });
+
+    try {
+      expect(requestedUrl).toBe("https://downloads.example.com/skill.zip");
+      expect(new Headers(requestedInit?.headers).get("Authorization")).toBeNull();
+      await expect(fs.readFile(archive.archivePath)).resolves.toEqual(Buffer.from([5, 6]));
+    } finally {
+      await archive.cleanup();
+    }
+  });
+
+  it("still sends the configured token for archive URLs served from the registry origin", async () => {
+    let requestedUrl = "";
+    let requestedInit: RequestInit | undefined;
+
+    const archive = await downloadClawHubSkillArchiveUrl({
+      baseUrl: "https://clawhub.ai",
+      url: "https://clawhub.ai/api/v1/download?slug=weather",
+      token: "explicit-token-456",
+      fetchImpl: vi.fn(async (input, init) => {
+        requestedUrl = input instanceof Request ? input.url : String(input);
+        requestedInit = init;
+        return new Response(new Uint8Array([3, 3]), {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        });
+      }),
+    });
+
+    try {
+      expect(requestedUrl).toBe("https://clawhub.ai/api/v1/download?slug=weather");
+      expect(new Headers(requestedInit?.headers).get("Authorization")).toBe(
+        "Bearer explicit-token-456",
+      );
+      await expect(fs.readFile(archive.archivePath)).resolves.toEqual(Buffer.from([3, 3]));
+    } finally {
+      await archive.cleanup();
+    }
+  });
+
   it("still downloads archive URLs served from the configured registry origin", async () => {
     const payload = Buffer.from([9, 8, 7, 6]);
     let hits = 0;

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -15,6 +15,7 @@ import { retryClawHubRead } from "./clawhub-retry.js";
 import { sha256Base64, sha256Hex as digestSha256Hex } from "./crypto-digest.js";
 import { readResponseTextSnippet, readResponseWithLimit } from "./http-body.js";
 import { fetchWithSsrFGuard } from "./net/fetch-guard.js";
+import { SsrFBlockedError } from "./net/ssrf.js";
 import { parseRegistryNpmSpec } from "./npm-registry-spec.js";
 import {
   parseStrictNonNegativeInteger,
@@ -1625,12 +1626,23 @@ async function downloadUntrustedClawHubSkillArchiveUrl(params: {
   timeoutMs?: number;
   fetchImpl?: FetchLike;
 }): Promise<ClawHubDownloadResult> {
-  const { response, finalUrl, release } = await fetchWithSsrFGuard({
-    url: params.url,
-    timeoutMs: resolveClawHubRequestTimeoutMs(params.timeoutMs),
-    ...(params.fetchImpl ? { fetchImpl: params.fetchImpl } : {}),
-    auditContext: "clawhub-skill-archive-download",
-  });
+  const timeoutMs = resolveClawHubRequestTimeoutMs(params.timeoutMs);
+  const { response, finalUrl, release } = await retryClawHubRead(
+    async () =>
+      await fetchWithSsrFGuard({
+        url: params.url,
+        timeoutMs,
+        ...(params.fetchImpl ? { fetchImpl: params.fetchImpl } : {}),
+        auditContext: "clawhub-skill-archive-download",
+      }),
+    {
+      isRetryableError: (error) => !(error instanceof SsrFBlockedError),
+      disposeRetry: async (result) => {
+        await result.response.body?.cancel().catch(() => undefined);
+        await result.release();
+      },
+    },
+  );
   try {
     const finalRequestUrl = new URL(finalUrl);
     if (!response.ok) {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -1582,8 +1582,7 @@ export async function downloadClawHubSkillArchiveUrl(params: {
   const explicitToken = normalizeOptionalString(params.token);
   const requestUrl = new URL(params.url, `${normalizeBaseUrl(params.baseUrl)}/`);
   const registryOrigin = new URL(`${normalizeBaseUrl(params.baseUrl)}/`).origin;
-  const skipAuth = explicitToken == null && requestUrl.origin !== registryOrigin;
-  if (skipAuth) {
+  if (requestUrl.origin !== registryOrigin) {
     return await downloadUntrustedClawHubSkillArchiveUrl({
       url: requestUrl.href,
       timeoutMs: params.timeoutMs,
@@ -1596,7 +1595,7 @@ export async function downloadClawHubSkillArchiveUrl(params: {
     token: explicitToken,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
-    skipAuth,
+    skipAuth: false,
   });
   if (!response.ok) {
     throw await buildClawHubError(response, url, hasToken, params.timeoutMs);

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -14,6 +14,7 @@ import { hasValidIsoCalendarComponents } from "../shared/iso-time.js";
 import { retryClawHubRead } from "./clawhub-retry.js";
 import { sha256Base64, sha256Hex as digestSha256Hex } from "./crypto-digest.js";
 import { readResponseTextSnippet, readResponseWithLimit } from "./http-body.js";
+import { fetchWithSsrFGuard } from "./net/fetch-guard.js";
 import { parseRegistryNpmSpec } from "./npm-registry-spec.js";
 import {
   parseStrictNonNegativeInteger,
@@ -1581,6 +1582,13 @@ export async function downloadClawHubSkillArchiveUrl(params: {
   const requestUrl = new URL(params.url, `${normalizeBaseUrl(params.baseUrl)}/`);
   const registryOrigin = new URL(`${normalizeBaseUrl(params.baseUrl)}/`).origin;
   const skipAuth = explicitToken == null && requestUrl.origin !== registryOrigin;
+  if (skipAuth) {
+    return await downloadUntrustedClawHubSkillArchiveUrl({
+      url: requestUrl.href,
+      timeoutMs: params.timeoutMs,
+      fetchImpl: params.fetchImpl,
+    });
+  }
   const { response, url, hasToken } = await clawhubRequest({
     baseUrl: params.baseUrl,
     url: params.url,
@@ -1610,6 +1618,45 @@ export async function downloadClawHubSkillArchiveUrl(params: {
     artifact: "archive",
     cleanup: target.cleanup,
   };
+}
+
+async function downloadUntrustedClawHubSkillArchiveUrl(params: {
+  url: string;
+  timeoutMs?: number;
+  fetchImpl?: FetchLike;
+}): Promise<ClawHubDownloadResult> {
+  const { response, finalUrl, release } = await fetchWithSsrFGuard({
+    url: params.url,
+    timeoutMs: resolveClawHubRequestTimeoutMs(params.timeoutMs),
+    ...(params.fetchImpl ? { fetchImpl: params.fetchImpl } : {}),
+    auditContext: "clawhub-skill-archive-download",
+  });
+  try {
+    const finalRequestUrl = new URL(finalUrl);
+    if (!response.ok) {
+      throw await buildClawHubError(response, finalRequestUrl, false, params.timeoutMs);
+    }
+    const bytes = await readClawHubResponseBytes({
+      response,
+      timeoutMs: params.timeoutMs,
+      resourceLabel: `skill archive download at ${finalRequestUrl.pathname}`,
+    });
+    const sha256Hex = formatSha256Hex(bytes);
+    const target = await createTempDownloadTarget({
+      prefix: "openclaw-clawhub-skill",
+      fileName: "skill.zip",
+    });
+    await fs.writeFile(target.path, bytes);
+    return {
+      archivePath: target.path,
+      integrity: formatSha256Integrity(bytes),
+      sha256Hex,
+      artifact: "archive",
+      cleanup: target.cleanup,
+    };
+  } finally {
+    await release();
+  }
 }
 
 export async function downloadClawHubGitHubSkillArchive(params: {


### PR DESCRIPTION
Related: #54135

## What Problem This Solves

Fixes an issue where a victim running `openclaw skills install <slug>` (or the gateway `skills.install` RPC) can be driven to make server-side requests to internal, loopback, link-local, or cloud-metadata addresses chosen by a malicious ClawHub-published skill.

When a skill is installed without an explicit `--version`, OpenClaw asks the ClawHub registry to resolve the latest install and then downloads the archive from the `downloadUrl` returned in that registry JSON. That URL is untrusted registry-controlled input, but the download went straight to the raw global `fetch()` with no host or IP allowlist. A published skill can set `downloadUrl` to `http://169.254.169.254/latest/meta-data/...` or any internal service, and the install path fetches it server-side.

Every other remote artifact path in the codebase already routes untrusted download URLs through the shared `fetchWithSsrFGuard`, including the sibling skill-download helper (`src/skills/lifecycle/install-download.ts`) and the plugin marketplace (`src/plugins/marketplace.ts`). This ClawHub skill-install path was the outlier.

## Why This Change Was Made

`downloadClawHubSkillArchiveUrl` in `src/infra/clawhub.ts` now decides trust purely from the archive origin: any archive URL whose origin differs from the configured registry origin is untrusted registry-controlled input and goes through `fetchWithSsrFGuard`, the same guard the sibling surfaces use, so blocked hostnames and private, loopback, link-local, and cloud-metadata IPs are rejected before any connection is made. Redirects are re-checked per hop by the guard. Downloads served from the configured registry origin itself (the operator-trusted host, which also carries auth) keep the existing authenticated request path and are unchanged.

The first revision of this PR made that branch depend on whether an explicit ClawHub token was passed, which left the hole open in the configured-token case: an off-origin registry-supplied URL still took the old raw `clawhubRequest` path, bypassing the guard and additionally sending `Authorization: Bearer <operator token>` to the attacker-chosen host. Auth configuration is not a trust signal, so the condition is now origin-only and the token can never reach an off-registry origin.

The GitHub source-archive sibling (`downloadClawHubGitHubSkillArchive`) is not affected: its host is pinned to `codeload.github.com` (or the operator `CLAWHUB_GITHUB_CODELOAD_BASE_URL`) and the repo and commit are URL-encoded per path segment, so registry input cannot redirect it to an internal address.

The guarded download is wrapped in the same `retryClawHubRead` flow the previous `clawhubRequest` GET path used, so the bounded transient-read behavior is preserved: a public archive host that briefly returns a 5xx or drops a transport connection is still retried and disposed between attempts. `retryClawHubRead` gained an optional non-retryable predicate so the deterministic SSRF policy rejection fails closed immediately instead of being retried, while transport failures and retryable 5xx statuses keep retrying as before.

## User Impact

Installing a ClawHub skill can no longer be abused to make OpenClaw reach internal or cloud-metadata endpoints on the host's behalf, and a configured ClawHub token is no longer sent to registry-chosen off-origin hosts. Legitimate installs from public download URLs and from a configured registry origin continue to work exactly as before. Operators who point a self-hosted registry's archive URLs at private infrastructure would need those URLs served from the registry origin (the trusted, authenticated path), consistent with how the marketplace and skill-download siblings already behave.

## Evidence

Behavior addressed: `openclaw skills install <slug>` with no `--version` downloaded the ClawHub-supplied `downloadUrl` through raw `fetch()`, letting a malicious skill drive a server-side request to an internal address.

Real environment tested: drove the real production `downloadClawHubSkillArchiveUrl` from `src/infra/clawhub.ts` against a live loopback HTTP server standing in for an internal service, with `baseUrl` set to the public registry `https://clawhub.ai` and the registry-supplied archive URL pointing at `http://127.0.0.1:<port>/skill.zip`. Same driver and identical inputs on pristine `origin/main` (edc344834b) and on the patched tree. The real production runtime, the real `fetchWithSsrFGuard`, and the real on-disk archive write all stayed live; nothing was mocked.

Exact steps or command run after this patch: started a loopback server on `127.0.0.1`, then called `downloadClawHubSkillArchiveUrl({ baseUrl: "https://clawhub.ai", url: "http://127.0.0.1:<port>/skill.zip" })` and recorded whether it connected and how many requests the loopback server received.

Evidence after fix:
```
# BEFORE (pristine origin/main edc344834b)
registry base: https://clawhub.ai
attacker-controlled archive downloadUrl: http://127.0.0.1:33543/skill.zip
RESULT: connected to internal address, archive written to /tmp/openclaw/openclaw-clawhub-skill-iMLMwE/skill.zip
internal server request count: 1

# AFTER (this patch, identical inputs)
registry base: https://clawhub.ai
attacker-controlled archive downloadUrl: http://127.0.0.1:34625/skill.zip
[security] blocked URL fetch (clawhub-skill-archive-download) targetOrigin=http://127.0.0.1:34625 reason=Blocked hostname or private/internal/special-use IP address
RESULT: request rejected before connecting: Blocked hostname or private/internal/special-use IP address
internal server request count: 0
```

Observed result after fix: the registry-supplied internal URL is refused before any connection, and the loopback server receives zero requests, whereas the unpatched runtime connected to it and wrote the archive.

### Configured-token branch (the security-critical case)

The same real driver, with an operator ClawHub token configured, comparing the first revision of this PR (head 6f2ef42ff0, guard present but gated on auth) against the current head. The loopback server records both its request count and any `Authorization` header it receives, so a leaked bearer token is visible in the output. Token value redacted in the printed line; the real header value was sent by the real runtime.

```
# BEFORE (PR head 6f2ef42ff0, guard gated on explicitToken == null)
registry base: https://clawhub.ai
operator ClawHub token configured: yes
attacker-controlled archive downloadUrl: http://127.0.0.1:35679/skill.zip
RESULT: connected to internal address, archive written to /tmp/openclaw/openclaw-clawhub-skill-ePCJ0R/skill.zip
internal server request count: 1
Authorization header received by internal server: Bearer <operator token leaked>

# AFTER (origin-only trust boundary, identical inputs)
registry base: https://clawhub.ai
operator ClawHub token configured: yes
attacker-controlled archive downloadUrl: http://127.0.0.1:40957/skill.zip
[security] blocked URL fetch (clawhub-skill-archive-download) targetOrigin=http://127.0.0.1:40957 reason=Blocked hostname or private/internal/special-use IP address
RESULT: request rejected before connecting: Blocked hostname or private/internal/special-use IP address
internal server request count: 0
Authorization header received by internal server: none
```

Observed result: with a token configured, the internal server is never contacted and never receives the operator's bearer token. The earlier revision both connected to it and handed it the token.

### Preserved transient-retry behavior

Driving the same real `downloadClawHubSkillArchiveUrl` against a public off-registry host (`https://example.com/skill.zip`, resolved and policy-checked live by the real guard) with the HTTP layer returning `503` then `200`, comparing the pre-retry commit against this patch:

```
# BEFORE retry preservation (guarded, single attempt)
off-registry public host https://example.com/skill.zip through the guard, HTTP layer returns 503 then 200
RESULT: failed after 1 guarded requests: ClawHub /skill.zip failed (503): temporarily unavailable

# AFTER (guarded + retryClawHubRead, identical inputs)
off-registry public host https://example.com/skill.zip through the guard, HTTP layer returns 503 then 200
RESULT: succeeded after 2 guarded requests, archive written
```

The real production runtime, real DNS resolution, real SSRF policy check, and real bounded retry all stayed live; only the HTTP response bytes were substituted. A deterministic SSRF policy rejection still fails closed on the first attempt with no retry delay.

What was not tested: no live ClawHub registry or live cloud-metadata endpoint was contacted; the internal target was a local loopback server. Full `pnpm build` was not run since no packaging, dynamic-import, or published-surface boundaries changed.

## Verification

- `node scripts/run-vitest.mjs src/infra/clawhub.test.ts src/infra/clawhub-retry.test.ts`: 101 passed, 2 skipped. `blocks off-registry resolver archive URLs that target internal addresses` fails on pristine `origin/main` (the download connects) and passes with this patch. Three cases cover the configured-token branch: `blocks off-registry resolver archive URLs that target internal addresses even with a configured token` fails on head 6f2ef42ff0 (the loopback archive is written to disk) and asserts the internal server sees zero requests and no `Authorization` header; `does not send a configured ClawHub token to off-registry resolver archive URLs` fails on that head with `expected 'Bearer explicit-token-456' to be null`; `still sends the configured token for archive URLs served from the registry origin` proves the trusted same-origin authenticated path is preserved. `still downloads archive URLs served from the configured registry origin` covers the unauthenticated same-origin path, and `retries transient 5xx responses when downloading off-registry archive URLs` plus `does not retry off-registry archive URLs rejected by the SSRF guard` cover the preserved bounded retry and the fail-closed SSRF rejection.
- `node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts` (the calling install/update surface): 77 passed.
- `oxlint` and `oxfmt --check` on `src/infra/clawhub.ts`, `src/infra/clawhub.test.ts`, and `src/infra/clawhub-retry.ts`: clean.
- `tsgo -p tsconfig.core.json`: no errors in the changed files. The lane reports pre-existing `@types/node` `AbortSignal` and `undici-types` `Response` naming errors in `packages/retry`, `src/auto-reply/reply/*`, and `src/media-understanding/audio.test-helpers.ts` that reproduce unchanged with this patch stashed, so they are not from this change.
- Note: PR #109092 is an in-flight refactor of the request-deadline handling in this same function; it keeps the raw `fetch()` transport and does not add an SSRF guard, so it overlaps textually but is a distinct concern. Whichever lands second needs a trivial rebase.
