### PR TITLE
fix(agents): restore update_plan opt-in and stop plan-only churn

### DIFF
--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -23,7 +23,7 @@ Local onboarding defaults new local configs to `tools.profile: "coding"` when un
 | Profile     | Includes                                                                                                                                                                                                                                                |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `minimal`   | `session_status` only                                                                                                                                                                                                                                   |
-| `coding`    | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `cron`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `ask_user`, `skill_workshop`, `image`, `image_generate`, `music_generate`, `video_generate`                |
+| `coding`    | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `cron`, `get_goal`, `create_goal`, `update_goal`, `ask_user`, `skill_workshop`, `image`, `image_generate`, `music_generate`, `video_generate`                               |
 | `messaging` | `group:messaging`, `sessions`, `sessions_list`, `sessions_history`, `sessions_search`, `conversations_list`, `conversations_send`, `conversations_turn`, `sessions_send`, `sessions_spawn`, `sessions_yield`, `subagents`, `session_status`, `ask_user` |
 | `full`      | No restriction (same as unset)                                                                                                                                                                                                                          |
 
@@ -421,7 +421,9 @@ Experimental built-in tool flags. Default off unless a strict-agentic GPT-5 auto
 
 - `planTool`: enables the structured `update_plan` tool for non-trivial multi-step work tracking.
 - Default: `false` unless `agents.defaults.embeddedAgent.executionContract` (or a per-agent override) is set to `"strict-agentic"` for an `openai` provider run against a GPT-5-family model id (this covers OpenAI Codex CLI runs too, since Codex auth/model routing lives under the `openai` provider). Set `true` to force the tool on outside that scope, or `false` to keep it off even for strict-agentic GPT-5 runs.
+- The `coding` profile does **not** include `update_plan`. Profile allowlists must not bypass this gate — enable via `planTool`, strict-agentic GPT-5 auto-enable, or an explicit `tools.allow` / `alsoAllow` / runtime allowlist entry (for example `update_plan` or `group:agents`).
 - When enabled, the system prompt also adds usage guidance so the model only uses it for substantial work and keeps at most one step `in_progress`.
+- With `tools.loopDetection.enabled: true`, repeated `update_plan` calls that only tweak step wording (same status pattern) count as no-progress and trip the circuit breaker.
 
 ### `agents.defaults.subagents`
 

--- a/src/agents/openclaw-tools.registration.ts
+++ b/src/agents/openclaw-tools.registration.ts
@@ -6,6 +6,7 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPrimaryBootstrapRun } from "./bootstrap-routing.js";
+import { isStrictAgenticExecutionContractActive } from "./execution-contract.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -22,7 +23,12 @@ export function collectPresentOpenClawTools(
   return candidates.filter((tool): tool is AnyAgentTool => tool !== null && tool !== undefined);
 }
 
-/** Resolves the default-on update_plan switch with an explicit kill switch. */
+/**
+ * Resolves whether update_plan is enabled by experimental flag or GPT-5 strict-agentic auto-enable.
+ *
+ * Matches docs/gateway/config-tools.md: default off unless planTool is true or a supported
+ * strict-agentic GPT-5 OpenAI/Codex run is active. Explicit `planTool: false` is a kill switch.
+ */
 function isUpdatePlanToolEnabledForOpenClawTools(params: {
   config?: OpenClawConfig;
   agentSessionKey?: string;
@@ -30,7 +36,36 @@ function isUpdatePlanToolEnabledForOpenClawTools(params: {
   modelProvider?: string;
   modelId?: string;
 }): boolean {
-  return params.config?.tools?.experimental?.planTool !== false;
+  const configured = params.config?.tools?.experimental?.planTool;
+  if (configured === false) {
+    return false;
+  }
+  if (configured === true) {
+    return true;
+  }
+  return isStrictAgenticExecutionContractActive({
+    config: params.config,
+    sessionKey: params.agentSessionKey,
+    agentId: params.agentId,
+    provider: params.modelProvider,
+    modelId: params.modelId,
+  });
+}
+
+/** True when an operator/runtime allowlist explicitly requests update_plan (or a group that expands to it). */
+function isUpdatePlanExplicitlyAllowedForOpenClawTools(params: {
+  config?: OpenClawConfig;
+  pluginToolAllowlist?: string[];
+}): boolean {
+  const allowlist = uniqueStrings([
+    ...(params.config?.tools?.allow ?? []),
+    ...(params.config?.tools?.alsoAllow ?? []),
+    ...(params.pluginToolAllowlist ?? []),
+  ]);
+  if (!allowlist.some((entry) => typeof entry === "string" && entry.trim().length > 0)) {
+    return false;
+  }
+  return isToolAllowedByPolicyName("update_plan", { allow: allowlist });
 }
 
 /** Decides whether update_plan should be included in the assembled OpenClaw tool set. */
@@ -47,9 +82,16 @@ export function shouldIncludeUpdatePlanToolForOpenClawTools(params: {
     ...(params.config?.tools?.deny ?? []),
     ...(params.pluginToolDenylist ?? []),
   ]);
+  if (!isToolAllowedByPolicyName("update_plan", { deny })) {
+    return false;
+  }
+  // Kill switch wins over allowlists and strict-agentic auto-enable.
+  if (params.config?.tools?.experimental?.planTool === false) {
+    return false;
+  }
   return (
-    isUpdatePlanToolEnabledForOpenClawTools(params) &&
-    isToolAllowedByPolicyName("update_plan", { deny })
+    isUpdatePlanToolEnabledForOpenClawTools(params) ||
+    isUpdatePlanExplicitlyAllowedForOpenClawTools(params)
   );
 }
 

--- a/src/agents/openclaw-tools.update-plan.test.ts
+++ b/src/agents/openclaw-tools.update-plan.test.ts
@@ -67,11 +67,11 @@ describe("openclaw-tools update_plan gating", () => {
     ).toEqual([]);
   });
 
-  it("enables update_plan by default", () => {
-    expectUpdatePlanEnabled({ config: {} as OpenClawConfig }, true);
+  it("keeps update_plan off by default for non-GPT-5 providers", () => {
+    expectUpdatePlanEnabled({ config: {} as OpenClawConfig }, false);
   });
 
-  it("exposes update_plan from default tool construction for every embedded model", () => {
+  it("does not expose update_plan from default tool construction for Claude/Cursor-class models", () => {
     const defaultTools = createFastToolNames({
       config: {} as OpenClawConfig,
       modelProvider: "anthropic",
@@ -84,9 +84,27 @@ describe("openclaw-tools update_plan gating", () => {
       modelId: "claude-sonnet-4-6",
     };
 
-    expect(defaultTools).toContain("update_plan");
+    expect(defaultTools).not.toContain("update_plan");
     expect(defaultTools).not.toContain("ask_user");
-    expect(shouldIncludeUpdatePlanToolForOpenClawTools(emptyAllowlistParams)).toBe(true);
+    expect(shouldIncludeUpdatePlanToolForOpenClawTools(emptyAllowlistParams)).toBe(false);
+  });
+
+  it("auto-enables update_plan for strict-agentic GPT-5 OpenAI runs", () => {
+    expectUpdatePlanEnabled(
+      {
+        config: {} as OpenClawConfig,
+        modelProvider: "openai",
+        modelId: "gpt-5.4",
+      },
+      true,
+    );
+    expect(
+      createFastToolNames({
+        config: {} as OpenClawConfig,
+        modelProvider: "openai",
+        modelId: "gpt-5.4",
+      }),
+    ).toContain("update_plan");
   });
 
   it("keeps ask_user on primary sessions and excludes spawned worker sessions", () => {

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -30,7 +30,7 @@ describe("tool-catalog", () => {
     expect(ids({ swarmEnabled: true })).toContain("agents_wait");
   });
 
-  it("includes code_execution, web_search, x_search, web_fetch, and update_plan in the coding profile policy", () => {
+  it("includes code_execution, web_search, x_search, and web_fetch in the coding profile policy", () => {
     const policy = requireCoreToolProfilePolicy("coding");
     expect(policy.allow).toEqual([
       "read",
@@ -67,7 +67,6 @@ describe("tool-catalog", () => {
       "get_goal",
       "create_goal",
       "update_goal",
-      "update_plan",
       "ask_user",
       "skill_workshop",
       "image",
@@ -76,6 +75,7 @@ describe("tool-catalog", () => {
       "video_generate",
       "bundle-mcp",
     ]);
+    expect(policy.allow).not.toContain("update_plan");
   });
 
   it("includes bundle MCP tools in coding and messaging profile policies", () => {

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -417,7 +417,9 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "update_plan",
     description: UPDATE_PLAN_TOOL_DISPLAY_SUMMARY,
     sectionId: "agents",
-    profiles: ["coding"],
+    // Opt-in via tools.experimental.planTool / strict-agentic GPT-5 / explicit allow — not coding profile.
+    // Profile membership previously bypassed the planTool gate and caused plan-only loops on Cursor/Claude.
+    profiles: [],
     includeInOpenClawGroup: true,
   },
   {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -335,6 +335,107 @@ describe("tool-loop-detection", () => {
       expect(result.stuck).toBe(false);
     });
 
+    it("normalizes update_plan wording churn into the same loop signature", () => {
+      const state = createState();
+
+      for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+        const toolCallId = `plan-${i}`;
+        const params = {
+          explanation: `tiny wording tweak ${i}`,
+          plan: [
+            { step: `read file ${i}`, status: "in_progress" },
+            { step: `patch code ${i}`, status: "pending" },
+          ],
+        };
+        const result = {
+          details: {
+            explanation: `server echoed wording ${i}`,
+            plan: [
+              { step: `read file echoed ${i}`, status: "in_progress" },
+              { step: `patch code echoed ${i}`, status: "pending" },
+            ],
+          },
+          content: [
+            { type: "text", text: `Plan updated (2 steps). Continue with: read file ${i}` },
+          ],
+        };
+        recordToolCall(state, "update_plan", params, toolCallId, enabledLoopDetectionConfig);
+        recordToolCallOutcome(state, {
+          toolName: "update_plan",
+          toolParams: params,
+          toolCallId,
+          result,
+        });
+      }
+
+      const loopResult = detectToolCallLoop(
+        state,
+        "update_plan",
+        {
+          explanation: "another tiny wording tweak",
+          plan: [
+            { step: "read file again", status: "in_progress" },
+            { step: "patch code again", status: "pending" },
+          ],
+        },
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+      }
+    });
+
+    it("treats update_plan status changes as real progress", () => {
+      const state = createState();
+
+      for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD - 1; i += 1) {
+        const toolCallId = `plan-repeat-${i}`;
+        const params = {
+          explanation: `tiny wording tweak ${i}`,
+          plan: [
+            { step: `read file ${i}`, status: "in_progress" },
+            { step: `patch code ${i}`, status: "pending" },
+          ],
+        };
+        const result = {
+          details: {
+            explanation: `server echoed wording ${i}`,
+            plan: [
+              { step: `read file echoed ${i}`, status: "in_progress" },
+              { step: `patch code echoed ${i}`, status: "pending" },
+            ],
+          },
+        };
+        recordToolCall(state, "update_plan", params, toolCallId, enabledLoopDetectionConfig);
+        recordToolCallOutcome(state, {
+          toolName: "update_plan",
+          toolParams: params,
+          toolCallId,
+          result,
+        });
+      }
+
+      const progressedParams = {
+        explanation: "status changed meaningfully",
+        plan: [
+          { step: "read file done", status: "completed" },
+          { step: "patch code now", status: "in_progress" },
+        ],
+      };
+
+      const loopResult = detectToolCallLoop(
+        state,
+        "update_plan",
+        progressedParams,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
     it("ignores repeated history from other runs", () => {
       const state = createState();
       const params = { path: "/same.txt" };

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -94,11 +94,45 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
 }
 
 /**
+ * Collapse update_plan wording churn into a status-pattern fingerprint.
+ * Step text / explanation tweaks must not look like progress to the loop breaker.
+ */
+function normalizeUpdatePlanShape(value: unknown): unknown {
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const rawPlan = Array.isArray(value.plan) ? value.plan : [];
+  const normalizedPlan = rawPlan.map((entry) => {
+    if (!isPlainObject(entry)) {
+      return { status: null, hasStep: false };
+    }
+    const status = typeof entry.status === "string" ? entry.status : null;
+    const hasStep = typeof entry.step === "string" && entry.step.trim().length > 0;
+    return { status, hasStep };
+  });
+
+  return {
+    planLength: normalizedPlan.length,
+    statuses: normalizedPlan.map((entry) => entry.status),
+    stepPresence: normalizedPlan.map((entry) => entry.hasStep),
+    hasExplanation: typeof value.explanation === "string" && value.explanation.trim().length > 0,
+  };
+}
+
+function normalizeLoopDetectionParams(toolName: string, params: unknown): unknown {
+  if (toolName !== "update_plan") {
+    return params;
+  }
+  return normalizeUpdatePlanShape(params);
+}
+
+/**
  * Hash a tool call for pattern matching.
  * Uses tool name + deterministic JSON serialization digest of params.
  */
 function hashToolCall(toolName: string, params: unknown): string {
-  return `${toolName}:${digestStable(params)}`;
+  return `${toolName}:${digestStable(normalizeLoopDetectionParams(toolName, params))}`;
 }
 
 function digestStable(value: unknown): string {
@@ -350,8 +384,9 @@ function hashToolOutcome(
 
   return {
     resultHash: digestStable({
-      details,
-      text,
+      details: toolName === "update_plan" ? normalizeUpdatePlanShape(details) : details,
+      // Ignore ack text for update_plan so one-line content does not reset the streak.
+      text: toolName === "update_plan" ? "" : text,
     }),
   };
 }

--- a/src/agents/tools/update-plan-tool.test.ts
+++ b/src/agents/tools/update-plan-tool.test.ts
@@ -14,7 +14,12 @@ describe("update_plan tool", () => {
       ],
     });
 
-    expect(result.content).toStrictEqual([]);
+    expect(result.content).toStrictEqual([
+      {
+        type: "text",
+        text: "Plan updated (3 steps). Continue with: Add tool",
+      },
+    ]);
     expect(result.details).toEqual({
       status: "updated",
       explanation: "Started work",
@@ -50,7 +55,12 @@ describe("update_plan tool", () => {
       ],
     });
 
-    expect(result.content).toStrictEqual([]);
+    expect(result.content).toStrictEqual([
+      {
+        type: "text",
+        text: "Plan updated (2 steps).",
+      },
+    ]);
     expect(result.details).toEqual({
       status: "updated",
       plan: [

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -91,8 +91,14 @@ export function createUpdatePlanTool(): AnyAgentTool {
       const params = args as Record<string, unknown>;
       const explanation = readStringParam(params, "explanation");
       const plan = readPlanSteps(params);
+      const inProgress = plan.find((step) => step.status === "in_progress");
+      // Keep details structured for UI, but return a one-line ack so models do not see
+      // "[empty content omitted]" and re-call update_plan instead of executing work.
+      const ack = inProgress
+        ? `Plan updated (${plan.length} steps). Continue with: ${inProgress.step}`
+        : `Plan updated (${plan.length} steps).`;
       return {
-        content: [],
+        content: [{ type: "text" as const, text: ack }],
         details: {
           status: "updated" as const,
           ...(explanation ? { explanation } : {}),


### PR DESCRIPTION
## Summary
- Restore documented `update_plan` gating: default **off** unless `tools.experimental.planTool: true` or a supported strict-agentic GPT-5 OpenAI/Codex run (explicit `planTool: false` remains a kill switch). Explicit allowlists still work.
- Remove `update_plan` from the `coding` profile so profile membership cannot silently expose the tool.
- Return a one-line tool ack (`Plan updated (N steps)…`) instead of empty content that becomes `[empty content omitted]` in transcripts.
- Normalize `update_plan` status patterns in loop detection so wording-only churn trips the circuit breaker when `tools.loopDetection.enabled` is on (status changes still count as progress).

## Why
On a live OpenClaw `2026.7.1-2` gateway using `litellm/cursor/auto` with `tools.profile: "coding"`, a simple DekapPrint/Brokk recommendation request produced **11 consecutive `update_plan` calls** with identical status patterns. Every tool result was empty / `[empty content omitted]`. After abort + retry, the same model successfully used `read`/`exec` — the failure mode was harness plan-tool churn, not model capability.

This also aligns runtime behavior with `docs/gateway/config-tools.md` (which already says default `false`) and closes the gap left by stale #67434 / unmerged #68673 for non-GPT-5 providers.

## Real behavior proof
**Before (ymir, OpenClaw 2026.7.1-2, `litellm/cursor/auto`, coding profile):**
- Session `fe39f6c3-…` / `agent:main:dashboard:dd5579ab-…`
- 11× `update_plan` only (03:38–03:40Z), then external abort
- Tool results: `content: []` → transcript `[empty content omitted]`
- Later hung `find` process `oceanic-pine` while still narrating “fecho agora”

**Operator mitigation that matched this PR’s gate:**
```json5
{
  tools: {
    experimental: { planTool: false },
    deny: ["update_plan"],
    loopDetection: { enabled: true },
  },
}
```

**After mitigation (same host/model):**
- Fresh session `2124b859-…`
- `update_plan` **absent** from compiled context
- Tools used: `exec` only; no plan loop
- Session ended `success` in ~22s

## Testing
- [x] `pnpm vitest run src/agents/openclaw-tools.update-plan.test.ts src/agents/tools/update-plan-tool.test.ts src/agents/tool-loop-detection.test.ts src/agents/tool-catalog.test.ts` (135 passed)
- [ ] Live re-check after merge on a coding-profile Cursor/Claude gateway without local deny

## AI assistance
- AI-assisted change; validated against a real OpenClaw gateway transcript (not synthetic-only).

## Risk
Medium/availability for operators who relied on silent default-on `update_plan` without setting `planTool`. Opt back in with `tools.experimental.planTool: true` or strict-agentic GPT-5. Explicit allowlists unchanged.

Refs: #67434 #68673 #64241 #80918

Made with [Cursor](https://cursor.com)