### PR TITLE
fix: workflow sanity audit passes on main

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -496,6 +496,7 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: read
           permission-issues: write
           permission-members: read
           permission-metadata: read
@@ -506,6 +507,7 @@ jobs:
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-contents: read
           permission-issues: write
           permission-members: read
           permission-metadata: read


### PR DESCRIPTION
Related: https://gitlab.com/xrow-public/helm-openclaw/-/work_items/48

## What Problem This Solves

The Labeler workflow creates installation tokens that read repository-owned label configuration, but the token declarations did not explicitly request `contents: read`. That made the least-privilege contract incomplete and caused the workflow audit to reject the configuration.

## Why This Change Was Made

Both Labeler GitHub App token steps now request only the missing read permission. Their existing issue, member metadata, metadata, and pull-request permissions are unchanged, and the Auto response workflow remains unchanged.

## User Impact

Maintainers keep a working Labeler workflow with its repository-content access made explicit and bounded, while Workflow Sanity can validate the current configuration without weakening audit coverage.

## Evidence

Hosted proof for exact head `6365a924bad9bc76ecb48dbfb6b4457c4e0f36bf`:

- Workflow Sanity/actionlint passed: https://github.com/openclaw/openclaw/actions/runs/31873357660/job/94985221021
- Labeler passed: https://github.com/openclaw/openclaw/actions/runs/31873356619/job/94985217952
- Auto response passed: https://github.com/openclaw/openclaw/actions/runs/31873356613/job/94985217793
- CI gate passed: https://github.com/openclaw/openclaw/actions/runs/31873357673/job/94986313438
- All 85 attached exact-head checks completed without failure.

Local proof:

- `git diff --check` passed.

Permission rationale:

- `labeler.yml` uses each GitHub App installation token to load repository label/routing configuration before applying labels through the API.
- Explicit `contents: read` keeps that required read boundary visible while preserving the existing write permissions and avoiding broader repository-content access.
