### PR TITLE
fix: watch-pr-ci exits with false FAILURE when draft-to-ready cancels superseded runs

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -35,12 +35,18 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-members: read
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-issues: write
+          permission-members: read
+          permission-pull-requests: write
       - name: Run Barnacle auto-response
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -47,12 +47,20 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+          permission-members: read
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-contents: read
+          permission-issues: write
+          permission-members: read
+          permission-pull-requests: write
       - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
         if: ${{ github.event.action != 'edited' || github.event.changes.base }}
         with:
@@ -486,12 +494,18 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-members: read
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-issues: write
+          permission-members: read
+          permission-pull-requests: write
       - name: Backfill PR labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
@@ -785,12 +799,16 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-members: read
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-issues: write
+          permission-members: read
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:

--- a/.github/workflows/pr-ci-sweeper.yml
+++ b/.github/workflows/pr-ci-sweeper.yml
@@ -40,12 +40,18 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-actions: write
+          permission-checks: read
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-actions: write
+          permission-checks: read
+          permission-pull-requests: write
       - name: Sweep dropped PR CI runs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -50,12 +50,18 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-actions: read
+          permission-issues: write
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         continue-on-error: true
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-actions: read
+          permission-issues: write
+          permission-pull-requests: write
       - name: Mark stale unassigned issues and pull requests (primary)
         id: stale-primary
         continue-on-error: true
@@ -252,6 +258,8 @@ jobs:
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-issues: write
+          permission-pull-requests: write
       - name: Backfill stale closures
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
@@ -500,6 +508,7 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-issues: write
       - name: Lock closed issues after 48h of no activity
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:

--- a/scripts/watch-pr-ci.d.mts
+++ b/scripts/watch-pr-ci.d.mts
@@ -10,22 +10,38 @@ export interface WatchPrCiArgs {
 
 export interface RollupCheck {
   kind: "CheckRun" | "StatusContext";
+  databaseId?: number;
   name?: string;
   context?: string;
   status?: string;
   conclusion?: string | null;
   state?: string;
+  checkSuite?: {
+    workflowRun?: { databaseId?: number; workflow?: { databaseId?: number } } | null;
+  } | null;
 }
 
 export interface RollupPayload {
   state?: string;
-  contexts?: { totalCount?: number; nodes?: RollupCheck[] };
+  contexts?: {
+    totalCount?: number;
+    nodes?: RollupCheck[];
+    pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+  };
+}
+
+export interface RollupPage {
+  state?: string;
+  mergeable?: boolean | string;
+  headRefOid?: string;
+  statusCheckRollup?: RollupPayload | null;
 }
 
 export interface RollupClassification {
   verdict: "GREEN" | "FAILING" | "PENDING" | "STALE-CANCELLED";
   pendingCount: number;
   failingNames: string[];
+  supersededCount: number;
 }
 
 export interface RunListItem {
@@ -54,6 +70,9 @@ export interface PollUntilDeadlineOptions<T> {
 export function parseArgs(argv: string[]): WatchPrCiArgs;
 export function sanitizeCheckName(name: string): string;
 export function classifyRollup(rollup: RollupPayload | null | undefined): RollupClassification;
+export function collectRollupContexts(
+  fetchPage: (cursor: string | null) => RollupPage | null | undefined,
+): RollupPage | null | undefined;
 export function buildFindRunArgs(repo: string, sha: string): string[];
 export function selectRunAfter(runs: RunListItem[], after?: number): RunListItem | undefined;
 export function classifyRunAttachment(

--- a/scripts/watch-pr-ci.mjs
+++ b/scripts/watch-pr-ci.mjs
@@ -14,7 +14,7 @@ const FAILURE_CONCLUSIONS = new Set([
   "STALE",
   "TIMED_OUT",
 ]);
-const ROLLUP_QUERY = `query($owner:String!,$name:String!,$pr:Int!){repository(owner:$owner,name:$name){pullRequest(number:$pr){state mergeable headRefOid statusCheckRollup{state contexts(first:100){totalCount nodes{kind:__typename ... on CheckRun{name status conclusion} ... on StatusContext{context state}}}}}}}`;
+const ROLLUP_QUERY = `query($owner:String!,$name:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$pr){state mergeable headRefOid statusCheckRollup{state contexts(first:100,after:$cursor){totalCount pageInfo{hasNextPage endCursor} nodes{kind:__typename ... on CheckRun{name status conclusion databaseId checkSuite{workflowRun{databaseId workflow{databaseId}}}} ... on StatusContext{context state}}}}}}}`;
 // Adapted from Node's MIT-licensed util.stripVTControlCharacters implementation.
 const ANSI_ESCAPE_SEQUENCE = new RegExp(
   "[\\u001B\\u009B][[\\]()#;?]*" +
@@ -87,12 +87,77 @@ const isAutoResponse = (check) =>
     .replaceAll(/[^a-z0-9]+/gu, " ")
     .trim() === "auto response";
 
+// Run identity for supersession; undefined when any id is missing so ambiguous
+// nodes are never dropped (fails toward FAILING, never toward false GREEN).
+// These databaseIds are GraphQL Int fields, but GitHub serializes Actions-scale
+// 64-bit values in them (live-verified; no fullDatabaseId exists on these types).
+// If GitHub ever nulls them, filtering degrades to pre-supersession behavior.
+function checkRunIdentity(check) {
+  if (check.kind !== "CheckRun") {
+    return undefined;
+  }
+  const runId = check.checkSuite?.workflowRun?.databaseId;
+  const workflowId = check.checkSuite?.workflowRun?.workflow?.databaseId;
+  if (typeof runId !== "number" || typeof workflowId !== "number") {
+    return undefined;
+  }
+  return { runId, workflowId };
+}
+// Strict recency ordering for same-name checks: newest run wins; within one run
+// (rerun attempts reuse the run id) the newest check-run id wins.
+const newerJob = (a, b) => (a.runId !== b.runId ? a.runId > b.runId : a.checkId > b.checkId);
+
 export function classifyRollup(rollup) {
-  const nodes = rollup?.contexts?.nodes ?? [];
+  const rawNodes = rollup?.contexts?.nodes ?? [];
   const hiddenContextCount = Math.max(
     0,
-    (rollup?.contexts?.totalCount ?? nodes.length) - nodes.length,
+    (rollup?.contexts?.totalCount ?? rawNodes.length) - rawNodes.length,
   );
+  const newestRunByWorkflow = new Map();
+  const bestByJob = new Map();
+  for (const check of rawNodes) {
+    const identity = checkRunIdentity(check);
+    if (!identity) {
+      continue;
+    }
+    newestRunByWorkflow.set(
+      identity.workflowId,
+      Math.max(newestRunByWorkflow.get(identity.workflowId) ?? 0, identity.runId),
+    );
+    if (check.name && typeof check.databaseId === "number") {
+      const key = `${identity.workflowId}:${check.name}`;
+      const candidate = { runId: identity.runId, checkId: check.databaseId };
+      const best = bestByJob.get(key);
+      if (!best || newerJob(candidate, best)) {
+        bestByJob.set(key, candidate);
+      }
+    }
+  }
+  let supersededCount = 0;
+  // Re-triggers leave every prior run's check runs on the SHA forever and GitHub's aggregate
+  // counts them. A check is superseded when a newer same-workflow check shares its name
+  // (GitHub's latest-name-wins semantics), or when it was cancelled and its workflow has a
+  // newer run (draft->ready cancels the old run before the replacement posts check runs).
+  // Older-run checks with unique names stay visible so distinct invocations are not dropped.
+  const nodes = rawNodes.filter((check) => {
+    const identity = checkRunIdentity(check);
+    if (!identity) {
+      return true;
+    }
+    if (check.name && typeof check.databaseId === "number") {
+      const best = bestByJob.get(`${identity.workflowId}:${check.name}`);
+      if (best && newerJob(best, { runId: identity.runId, checkId: check.databaseId })) {
+        supersededCount += 1;
+        return false;
+      }
+    }
+    const newestRun = newestRunByWorkflow.get(identity.workflowId);
+    if (check.conclusion === "CANCELLED" && newestRun > identity.runId) {
+      supersededCount += 1;
+      return false;
+    }
+    return true;
+  });
   const checks = nodes.filter((check) => !isAutoResponse(check));
   const successfulNames = new Set(checks.filter(isSuccess).map(checkName));
   const pendingCount = checks.filter((check) =>
@@ -113,33 +178,49 @@ export function classifyRollup(rollup) {
     .toSorted()
     .filter((name, index, names) => name !== names[index - 1]);
   if (rollup?.state === "SUCCESS") {
-    return { verdict: "GREEN", pendingCount, failingNames: [] };
+    return { verdict: "GREEN", pendingCount, failingNames: [], supersededCount };
   }
   if (rollup?.state === "ERROR" || rollup?.state === "FAILURE") {
-    const staleCancelled =
-      hiddenContextCount === 0 &&
-      pendingCount === 0 &&
-      failingChecks.length > 0 &&
-      failingChecks.every(
-        (check) =>
-          check.kind === "CheckRun" &&
-          check.conclusion === "CANCELLED" &&
-          Boolean(check.name) &&
-          successfulNames.has(check.name),
-      );
-    if (staleCancelled) {
-      return { verdict: "STALE-CANCELLED", pendingCount, failingNames };
+    if (failingChecks.length > 0) {
+      const staleCancelled =
+        hiddenContextCount === 0 &&
+        pendingCount === 0 &&
+        failingChecks.every(
+          (check) =>
+            check.kind === "CheckRun" &&
+            check.conclusion === "CANCELLED" &&
+            Boolean(check.name) &&
+            successfulNames.has(check.name),
+        );
+      if (staleCancelled) {
+        return { verdict: "STALE-CANCELLED", pendingCount, failingNames, supersededCount };
+      }
+      return {
+        verdict: "FAILING",
+        pendingCount,
+        failingNames: [
+          ...(failingNames.length > 0 ? failingNames : ["status rollup"]),
+          ...(hiddenContextCount > 0 ? [`+${hiddenContextCount} more contexts not shown`] : []),
+        ],
+        supersededCount,
+      };
     }
-    return {
-      verdict: "FAILING",
-      pendingCount,
-      failingNames: [
-        ...(failingNames.length > 0 ? failingNames : ["status rollup"]),
-        ...(hiddenContextCount > 0 ? [`+${hiddenContextCount} more contexts not shown`] : []),
-      ],
-    };
+    if (hiddenContextCount > 0) {
+      return {
+        verdict: "FAILING",
+        pendingCount,
+        failingNames: ["status rollup", `+${hiddenContextCount} more contexts not shown`],
+        supersededCount,
+      };
+    }
+    if (pendingCount > 0) {
+      return { verdict: "PENDING", pendingCount, failingNames: [], supersededCount };
+    }
+    // GitHub's aggregate permanently counts superseded cancellations. With full visibility,
+    // an all-green newest-run set is green; main() also requires the attached run to succeed.
+    return { verdict: "GREEN", pendingCount, failingNames: [], supersededCount };
   }
-  return { verdict: "PENDING", pendingCount, failingNames: [] };
+  return { verdict: "PENDING", pendingCount, failingNames: [], supersededCount };
 }
 
 function ghJson(...args) {
@@ -189,20 +270,71 @@ export function classifyRunAttachment(runId, run, after) {
   };
 }
 
+export function collectRollupContexts(fetchPage) {
+  const firstPage = fetchPage(null);
+  const firstContexts = firstPage?.statusCheckRollup?.contexts;
+  if (!firstContexts) {
+    return firstPage;
+  }
+
+  const nodes = [...(firstContexts.nodes ?? [])];
+  let pageInfo = firstContexts.pageInfo;
+  let pageCount = 1;
+  // Polling work stays bounded at 1,000 contexts. Any truncation remains visible through
+  // totalCount and must classify conservatively rather than reading as success.
+  while (pageInfo?.hasNextPage && pageCount < 10) {
+    if (typeof pageInfo.endCursor !== "string") {
+      throw new Error("rollup page advertised a next page without a cursor");
+    }
+    const page = fetchPage(pageInfo.endCursor);
+    const contexts = page?.statusCheckRollup?.contexts;
+    pageCount += 1;
+    // Losing an advertised page (head moved, transient API gap) or reading a changed snapshot
+    // must not pass off the partial first page as complete; the watch loop catches this error
+    // and re-reads the rollup on its next bounded poll.
+    if (!contexts) {
+      throw new Error("rollup snapshot changed during pagination");
+    }
+    if (
+      page.headRefOid !== firstPage.headRefOid ||
+      page.statusCheckRollup?.state !== firstPage.statusCheckRollup?.state ||
+      contexts.totalCount !== firstContexts.totalCount
+    ) {
+      throw new Error("rollup snapshot changed during pagination");
+    }
+    nodes.push(...(contexts.nodes ?? []));
+    pageInfo = contexts.pageInfo;
+  }
+
+  return {
+    ...firstPage,
+    statusCheckRollup: {
+      ...firstPage.statusCheckRollup,
+      contexts: { ...firstContexts, nodes },
+    },
+  };
+}
+
 function readRollup(pr, repo) {
   const [owner, name] = repo.split("/");
-  return ghJson(
-    "api",
-    "graphql",
-    "-f",
-    `query=${ROLLUP_QUERY}`,
-    "-f",
-    `owner=${owner}`,
-    "-f",
-    `name=${name}`,
-    "-F",
-    `pr=${pr}`,
-  ).data?.repository?.pullRequest;
+  return collectRollupContexts((cursor) => {
+    const queryArgs = [
+      "api",
+      "graphql",
+      "-f",
+      `query=${ROLLUP_QUERY}`,
+      "-f",
+      `owner=${owner}`,
+      "-f",
+      `name=${name}`,
+      "-F",
+      `pr=${pr}`,
+    ];
+    if (cursor !== null) {
+      queryArgs.push("-f", `cursor=${cursor}`);
+    }
+    return ghJson(...queryArgs).data?.repository?.pullRequest;
+  });
 }
 
 const emit = (line, code) => {
@@ -310,7 +442,9 @@ async function main(argv = process.argv.slice(2)) {
         const result = classifyRollup(pr.statusCheckRollup);
         lastState = pr.statusCheckRollup?.state ?? "NONE";
         lastPending = result.pendingCount;
-        console.log(`STATUS state=${lastState} pending=${lastPending}`);
+        console.log(
+          `STATUS state=${lastState} pending=${lastPending} superseded=${result.supersededCount}`,
+        );
         if (result.verdict === "STALE-CANCELLED") {
           return emit(
             'STALE-CANCELLED hint="aggregate FAILURE but every failing context is a CANCELLED check run with a same-name SUCCESS — likely stale attempts; verify manually"',

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -3,6 +3,7 @@ import {
   buildFindRunArgs,
   classifyRollup,
   classifyRunAttachment,
+  collectRollupContexts,
   parseArgs,
   pollUntilDeadline,
   sanitizeCheckName,
@@ -178,7 +179,7 @@ describe("watch-pr-ci", () => {
           nodes: [{ kind: "CheckRun", name: "unit", status: "COMPLETED", conclusion: "SUCCESS" }],
         },
       }),
-    ).toEqual({ verdict: "PENDING", pendingCount: 0, failingNames: [] });
+    ).toEqual({ verdict: "PENDING", pendingCount: 0, failingNames: [], supersededCount: 0 });
   });
 
   it("counts pending contexts without deriving the verdict from them", () => {
@@ -189,7 +190,7 @@ describe("watch-pr-ci", () => {
           nodes: [{ kind: "CheckRun", name: "unit", status: "IN_PROGRESS", conclusion: null }],
         },
       }),
-    ).toEqual({ verdict: "PENDING", pendingCount: 1, failingNames: [] });
+    ).toEqual({ verdict: "PENDING", pendingCount: 1, failingNames: [], supersededCount: 0 });
   });
 
   it.each(["FAILURE", "ERROR"])(
@@ -212,7 +213,12 @@ describe("watch-pr-ci", () => {
             ],
           },
         }),
-      ).toEqual({ verdict: "STALE-CANCELLED", pendingCount: 0, failingNames: ["unit"] });
+      ).toEqual({
+        verdict: "STALE-CANCELLED",
+        pendingCount: 0,
+        failingNames: ["unit"],
+        supersededCount: 0,
+      });
     },
   );
 
@@ -232,6 +238,7 @@ describe("watch-pr-ci", () => {
       verdict: "FAILING",
       pendingCount: 0,
       failingNames: ["unit", "+2 more contexts not shown"],
+      supersededCount: 0,
     });
   });
 
@@ -248,6 +255,405 @@ describe("watch-pr-ci", () => {
           ],
         },
       }),
-    ).toEqual({ verdict: "FAILING", pendingCount: 0, failingNames: ["lint", "unit"] });
+    ).toEqual({
+      verdict: "FAILING",
+      pendingCount: 0,
+      failingNames: ["lint", "unit"],
+      supersededCount: 0,
+    });
+  });
+
+  it("ignores superseded workflow runs while replacements are in progress", () => {
+    expect(
+      classifyRollup({
+        state: "FAILURE",
+        contexts: {
+          nodes: [
+            {
+              kind: "CheckRun",
+              name: "Real behavior proof",
+              status: "COMPLETED",
+              conclusion: "CANCELLED",
+              checkSuite: {
+                workflowRun: { databaseId: 100, workflow: { databaseId: 10 } },
+              },
+            },
+            {
+              kind: "CheckRun",
+              name: "Real behavior proof",
+              status: "IN_PROGRESS",
+              conclusion: null,
+              checkSuite: {
+                workflowRun: { databaseId: 200, workflow: { databaseId: 10 } },
+              },
+            },
+            {
+              kind: "CheckRun",
+              name: "CI",
+              status: "IN_PROGRESS",
+              conclusion: null,
+              checkSuite: { workflowRun: { databaseId: 150, workflow: { databaseId: 20 } } },
+            },
+          ],
+        },
+      }),
+    ).toEqual({ verdict: "PENDING", pendingCount: 2, failingNames: [], supersededCount: 1 });
+  });
+
+  it("keeps only the newest same-run check attempt while its replacement is pending", () => {
+    expect(
+      classifyRollup({
+        state: "FAILURE",
+        contexts: {
+          nodes: [
+            {
+              kind: "CheckRun",
+              databaseId: 1_000,
+              name: "unit",
+              status: "COMPLETED",
+              conclusion: "CANCELLED",
+              checkSuite: { workflowRun: { databaseId: 500, workflow: { databaseId: 20 } } },
+            },
+            {
+              kind: "CheckRun",
+              databaseId: 2_000,
+              name: "unit",
+              status: "IN_PROGRESS",
+              conclusion: null,
+              checkSuite: { workflowRun: { databaseId: 500, workflow: { databaseId: 20 } } },
+            },
+          ],
+        },
+      }),
+    ).toEqual({ verdict: "PENDING", pendingCount: 1, failingNames: [], supersededCount: 1 });
+  });
+
+  it("accepts a successful newest check attempt when the aggregate remains failed", () => {
+    expect(
+      classifyRollup({
+        state: "FAILURE",
+        contexts: {
+          nodes: [
+            {
+              kind: "CheckRun",
+              databaseId: 1_000,
+              name: "unit",
+              status: "COMPLETED",
+              conclusion: "CANCELLED",
+              checkSuite: { workflowRun: { databaseId: 500, workflow: { databaseId: 20 } } },
+            },
+            {
+              kind: "CheckRun",
+              databaseId: 2_000,
+              name: "unit",
+              status: "COMPLETED",
+              conclusion: "SUCCESS",
+              checkSuite: { workflowRun: { databaseId: 500, workflow: { databaseId: 20 } } },
+            },
+          ],
+        },
+      }),
+    ).toEqual({ verdict: "GREEN", pendingCount: 0, failingNames: [], supersededCount: 1 });
+  });
+
+  it("accepts newest successful runs when the aggregate remains failed", () => {
+    expect(
+      classifyRollup({
+        state: "FAILURE",
+        contexts: {
+          nodes: [
+            {
+              kind: "CheckRun",
+              name: "old proof",
+              status: "COMPLETED",
+              conclusion: "CANCELLED",
+              checkSuite: {
+                workflowRun: { databaseId: 100, workflow: { databaseId: 10 } },
+              },
+            },
+            {
+              kind: "CheckRun",
+              name: "proof",
+              status: "COMPLETED",
+              conclusion: "SUCCESS",
+              checkSuite: {
+                workflowRun: { databaseId: 200, workflow: { databaseId: 10 } },
+              },
+            },
+            {
+              kind: "CheckRun",
+              name: "old CI",
+              status: "COMPLETED",
+              conclusion: "CANCELLED",
+              checkSuite: { workflowRun: { databaseId: 150, workflow: { databaseId: 20 } } },
+            },
+            {
+              kind: "CheckRun",
+              name: "CI",
+              status: "COMPLETED",
+              conclusion: "SUCCESS",
+              checkSuite: { workflowRun: { databaseId: 250, workflow: { databaseId: 20 } } },
+            },
+          ],
+        },
+      }),
+    ).toEqual({ verdict: "GREEN", pendingCount: 0, failingNames: [], supersededCount: 2 });
+  });
+
+  it("preserves a genuine failure from the newest workflow run", () => {
+    expect(
+      classifyRollup({
+        state: "FAILURE",
+        contexts: {
+          nodes: [
+            {
+              kind: "CheckRun",
+              name: "superseded cancellation",
+              status: "COMPLETED",
+              conclusion: "CANCELLED",
+              checkSuite: { workflowRun: { databaseId: 100, workflow: { databaseId: 20 } } },
+            },
+            {
+              kind: "CheckRun",
+              name: "unit",
+              status: "COMPLETED",
+              conclusion: "FAILURE",
+              checkSuite: { workflowRun: { databaseId: 200, workflow: { databaseId: 20 } } },
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      verdict: "FAILING",
+      pendingCount: 0,
+      failingNames: ["unit"],
+      supersededCount: 1,
+    });
+  });
+
+  it("preserves failures across interleaved distinct workflow identities", () => {
+    expect(
+      classifyRollup({
+        state: "FAILURE",
+        contexts: {
+          nodes: [
+            {
+              kind: "CheckRun",
+              name: "old deploy",
+              status: "COMPLETED",
+              conclusion: "CANCELLED",
+              checkSuite: { workflowRun: { databaseId: 200, workflow: { databaseId: 20 } } },
+            },
+            {
+              kind: "CheckRun",
+              name: "unit",
+              status: "COMPLETED",
+              conclusion: "FAILURE",
+              checkSuite: { workflowRun: { databaseId: 300, workflow: { databaseId: 10 } } },
+            },
+            {
+              kind: "CheckRun",
+              name: "deploy",
+              status: "COMPLETED",
+              conclusion: "SUCCESS",
+              checkSuite: { workflowRun: { databaseId: 400, workflow: { databaseId: 20 } } },
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      verdict: "FAILING",
+      pendingCount: 0,
+      failingNames: ["unit"],
+      supersededCount: 1,
+    });
+  });
+
+  it("keeps an older run's unique failing job visible", () => {
+    expect(
+      classifyRollup({
+        state: "FAILURE",
+        contexts: {
+          nodes: [
+            {
+              kind: "CheckRun",
+              databaseId: 1_000,
+              name: "nightly-special",
+              status: "COMPLETED",
+              conclusion: "FAILURE",
+              checkSuite: { workflowRun: { databaseId: 300, workflow: { databaseId: 20 } } },
+            },
+            {
+              kind: "CheckRun",
+              databaseId: 2_000,
+              name: "unit",
+              status: "COMPLETED",
+              conclusion: "SUCCESS",
+              checkSuite: { workflowRun: { databaseId: 400, workflow: { databaseId: 20 } } },
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      verdict: "FAILING",
+      pendingCount: 0,
+      failingNames: ["nightly-special"],
+      supersededCount: 0,
+    });
+  });
+
+  it("supersedes same-name checks across runs of the same workflow", () => {
+    expect(
+      classifyRollup({
+        state: "FAILURE",
+        contexts: {
+          nodes: [
+            {
+              kind: "CheckRun",
+              databaseId: 1_000,
+              name: "unit",
+              status: "COMPLETED",
+              conclusion: "FAILURE",
+              checkSuite: { workflowRun: { databaseId: 300, workflow: { databaseId: 20 } } },
+            },
+            {
+              kind: "CheckRun",
+              databaseId: 2_000,
+              name: "unit",
+              status: "COMPLETED",
+              conclusion: "SUCCESS",
+              checkSuite: { workflowRun: { databaseId: 400, workflow: { databaseId: 20 } } },
+            },
+          ],
+        },
+      }),
+    ).toEqual({ verdict: "GREEN", pendingCount: 0, failingNames: [], supersededCount: 1 });
+  });
+
+  it("fails conservatively when unseen contexts may explain aggregate failure", () => {
+    expect(
+      classifyRollup({
+        state: "FAILURE",
+        contexts: {
+          totalCount: 3,
+          nodes: [
+            {
+              kind: "CheckRun",
+              name: "old CI",
+              status: "COMPLETED",
+              conclusion: "CANCELLED",
+              checkSuite: { workflowRun: { databaseId: 100, workflow: { databaseId: 20 } } },
+            },
+            {
+              kind: "CheckRun",
+              name: "CI",
+              status: "COMPLETED",
+              conclusion: "SUCCESS",
+              checkSuite: { workflowRun: { databaseId: 200, workflow: { databaseId: 20 } } },
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      verdict: "FAILING",
+      pendingCount: 0,
+      failingNames: ["status rollup", "+1 more contexts not shown"],
+      supersededCount: 1,
+    });
+  });
+
+  it("collects rollup contexts across pages", () => {
+    const cursors: Array<string | null> = [];
+    const result = collectRollupContexts((cursor) => {
+      cursors.push(cursor);
+      if (cursor === null) {
+        return {
+          statusCheckRollup: {
+            state: "PENDING",
+            contexts: {
+              totalCount: 2,
+              nodes: [{ kind: "CheckRun", name: "first" }],
+              pageInfo: { hasNextPage: true, endCursor: "next" },
+            },
+          },
+        };
+      }
+      return {
+        statusCheckRollup: {
+          state: "PENDING",
+          contexts: {
+            totalCount: 2,
+            nodes: [{ kind: "CheckRun", name: "second" }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      };
+    });
+
+    expect(cursors).toEqual([null, "next"]);
+    expect(result?.statusCheckRollup?.contexts?.totalCount).toBe(2);
+    expect(result?.statusCheckRollup?.contexts?.nodes?.map((node) => node.name)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("rejects rollup pages from a changed snapshot", () => {
+    expect(() =>
+      collectRollupContexts((cursor) => ({
+        headRefOid: "a".repeat(40),
+        statusCheckRollup: {
+          state: "PENDING",
+          contexts: {
+            totalCount: cursor === null ? 2 : 3,
+            nodes: [{ kind: "CheckRun", name: cursor === null ? "first" : "second" }],
+            pageInfo:
+              cursor === null
+                ? { hasNextPage: true, endCursor: "next" }
+                : { hasNextPage: false, endCursor: null },
+          },
+        },
+      })),
+    ).toThrow("rollup snapshot changed during pagination");
+  });
+
+  it("rejects a pagination read that loses an advertised page", () => {
+    expect(() =>
+      collectRollupContexts((cursor) =>
+        cursor === null
+          ? {
+              headRefOid: "a".repeat(40),
+              statusCheckRollup: {
+                state: "SUCCESS",
+                contexts: {
+                  totalCount: 2,
+                  nodes: [{ kind: "CheckRun", name: "first" }],
+                  pageInfo: { hasNextPage: true, endCursor: "next" },
+                },
+              },
+            }
+          : { headRefOid: "b".repeat(40), statusCheckRollup: null },
+      ),
+    ).toThrow("rollup snapshot changed during pagination");
+  });
+
+  it("caps rollup context collection at ten pages", () => {
+    let calls = 0;
+    const result = collectRollupContexts(() => {
+      calls += 1;
+      return {
+        statusCheckRollup: {
+          state: "FAILURE",
+          contexts: {
+            totalCount: 11,
+            nodes: [{ kind: "CheckRun", name: `page-${calls}` }],
+            pageInfo: { hasNextPage: true, endCursor: `cursor-${calls}` },
+          },
+        },
+      };
+    });
+
+    expect(calls).toBe(10);
+    expect(result?.statusCheckRollup?.contexts?.nodes).toHaveLength(10);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers waiting on PR CI with `node scripts/watch-pr-ci.mjs <pr> <head-sha>` would get a false terminal `FAILING` verdict when the PR went through a draft→ready transition. The concurrency-cancelled superseded workflow runs stay on the head SHA as CANCELLED contexts forever, and GitHub's aggregate `statusCheckRollup.state` counts them permanently — so the watcher reported `FAILING checks=Real behavior proof, dispatch, +70 more contexts not shown` while the actually-attached CI run was still in progress and finished green (observed on PR #113150, head `bd1b9a0e6a14`). Worse, the stuck aggregate also meant the watcher could never reach `GREEN` on such SHAs at all — it was doomed to false-FAILING or timeout.

## Why This Change Was Made

The classifier previously trusted GitHub's aggregate rollup and a name-pairing heuristic over a single `first:100` page of contexts. Live inspection of the failing SHA showed 172 contexts (so the classifier was truncation-blind) and that supersession is precisely identifiable via `checkSuite.workflowRun` identity. The fix classifies from each workflow's authoritative checks instead:

- fetch run identity (`workflowRun.databaseId`, `workflow.databaseId`) and check-run `databaseId` per CheckRun, and paginate the contexts connection (bounded at 10 pages) so large rollups are fully visible;
- supersede per workflow + check name — GitHub's own latest-name-wins semantics — which also dedupes rerun-attempt leftovers within one run via check-run id; additionally drop CANCELLED checks from replaced runs (the draft→ready cancellation artifact, covering the window before the replacement posts its check runs). Older runs' unique non-cancelled jobs stay visible so distinct invocations are never collapsed;
- classify `GREEN` when the permanently-stuck aggregate `FAILURE` is explained solely by superseded contexts with full visibility (`main()` still double-gates on the attached run completing successfully); truncated rollups and mid-pagination snapshot changes never soften — they stay conservatively `FAILING` or throw into the existing bounded retry.

Exit codes, terminal line shapes, and the bounded-poll contract are unchanged; the `STATUS` line gains a `superseded=N` field so a `state=FAILURE` that keeps polling is self-explaining.

### Included fix for red `main` (Workflow Sanity)

`main` has been red on Workflow Sanity since #112963 bumped zizmor `v1.22.0 → v1.28.0`: its `github-app` audit flags `create-github-app-token` mints without `permission-*` inputs (14 high findings across `stale.yml`, `labeler.yml`, `auto-response.yml`, `pr-ci-sweeper.yml` — the stragglers; most workflows already migrated to scoped tokens). Per the landing policy this PR fixes the breakage rather than landing onto red: each flagged mint now requests exactly the permissions its consumers use (verified against each script's API surface and GitHub's fine-grained permission reference; e.g. pr-ci-sweeper needs `actions: write` to re-fire runs, stale's state-cache check needs `actions: read`, labeler's maintainer gate needs `members: read`). Verified locally with the exact CI invocation — zizmor 1.28.0, repo config, `--persona=regular --min-severity=medium --min-confidence=medium`: **no findings**, ignore/suppress counts (55/501) match CI. Note the Workflow Sanity anti-tamper design (zizmor version pin and config are read from the base SHA) means only head-file fixes like this can turn a PR green.

## User Impact

Maintainers and agents using the CI watcher no longer get false terminal failures after draft→ready transitions, and the watcher can now reach `GREEN` on SHAs with superseded cancelled runs (previously impossible). No user-facing product behavior changes; this is repo CI tooling.

## Evidence

- Live GraphQL verification on the originally reported SHA `bd1b9a0e6a14bc2b81ee6391ff6cfee6366015e2`: 172 contexts, aggregate still `FAILURE` today despite every workflow's newest run being green; three CANCELLED "Real behavior proof" runs (30045353293/30045364384/30045369416) superseded by SUCCESS run 30045373106 with the highest run id — exactly what the new filter resolves.
- Focused tests: `node scripts/run-vitest.mjs test/scripts/watch-pr-ci.test.ts` — 28 passed, including the PR #113150 mid-flight repro (PENDING instead of false FAILING), the stuck-aggregate-but-green case, unique-older-job preservation, genuine-failure preservation, truncation conservatism, pagination merge/cap, and changed/lost-snapshot rejection.
- `check:changed` full gate (typecheck, lint, format, script-declaration contracts) green on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30068625453
- Structured autoreview (Codex, gpt-5.6-sol): three rounds; five accepted findings fixed (display-name collision on the supersession key, mid-pagination snapshot races, rerun-attempt dedup, whole-run supersession erasing unique jobs, lost-page truncation). One finding rejected with live disproof (32-bit GraphQL `Int` overflow: production returns the 64-bit ids non-null, `fullDatabaseId` does not exist on these types; failure mode degrades to pre-fix behavior, documented inline).
