### PR TITLE
fix(ci): scope GitHub App workflow tokens

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -35,12 +35,20 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-members: read
+          permission-metadata: read
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-issues: write
+          permission-members: read
+          permission-metadata: read
+          permission-pull-requests: write
       - name: Run Barnacle auto-response
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -47,12 +47,22 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+          permission-members: read
+          permission-metadata: read
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-contents: read
+          permission-issues: write
+          permission-members: read
+          permission-metadata: read
+          permission-pull-requests: write
       - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
         if: ${{ github.event.action != 'edited' || github.event.changes.base }}
         with:
@@ -486,12 +496,20 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-members: read
+          permission-metadata: read
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-issues: write
+          permission-members: read
+          permission-metadata: read
+          permission-pull-requests: write
       - name: Backfill PR labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
@@ -785,12 +803,16 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-members: read
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-issues: write
+          permission-members: read
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:

--- a/.github/workflows/pr-ci-sweeper.yml
+++ b/.github/workflows/pr-ci-sweeper.yml
@@ -40,12 +40,20 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-actions: write
+          permission-checks: read
+          permission-issues: write
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-actions: write
+          permission-checks: read
+          permission-issues: write
+          permission-pull-requests: write
       - name: Sweep dropped PR CI runs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -50,12 +50,18 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-actions: read
+          permission-issues: write
+          permission-pull-requests: write
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token-fallback
         continue-on-error: true
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-actions: read
+          permission-issues: write
+          permission-pull-requests: write
       - name: Mark stale unassigned issues and pull requests (primary)
         id: stale-primary
         continue-on-error: true
@@ -252,6 +258,8 @@ jobs:
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-issues: write
+          permission-pull-requests: write
       - name: Backfill stale closures
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
@@ -500,6 +508,7 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-issues: write
       - name: Lock closed issues after 48h of no activity
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:


### PR DESCRIPTION
Related: #113214

## What Problem This Solves

Fixes a required Workflow Sanity regression where every PR and `main` push fails after #112963 upgraded zizmor to v1.28.0. The new `github-app` audit rejects 14 GitHub App token requests that inherit every permission granted to their installations.

This maintainer fix restores the hosted gate blocking active pull requests, including the native mobile localization work in #113214.

## Why This Change Was Made

Each affected token request now declares the complete least-privilege profile used by its downstream workflow operations. Primary and fallback app tokens receive identical scopes; the fix does not suppress the audit or roll back zizmor.

## User Impact

Maintainer automation keeps its existing behavior while GitHub App tokens stop inheriting unrelated installation permissions. Workflow Sanity can pass again on `main` and active pull requests.

## Evidence

- Before: Workflow Sanity failed on `main` runs 30066566598 and 30066941688 with 14 `github-app` errors.
- Blacksmith Testbox `tbx_01ky99twtd6664xkmsghp8rmbe`, run https://github.com/openclaw/openclaw/actions/runs/30069761273:
  - `node scripts/check-workflows.mjs` passed.
  - `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` passed 90/90 tests.
  - `pnpm check:changed` passed the tooling lane.
- Hosted Workflow Sanity passed on exact head `e7326cfc8ff17d1d9b5b9a96914c18d54c364314`: https://github.com/openclaw/openclaw/actions/runs/30069779578
- Fresh autoreview: clean, no accepted/actionable findings, confidence 0.88.
- `git diff --check` passed.

AI-assisted implementation. No transcript logs attached.
