### PR TITLE
fix(codex): prevent Computer Use timeouts in isolated homes

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -115,6 +115,16 @@ also tries to register the bundled Codex marketplace from
 as a fallback for legacy standalone installs. If setup still cannot make the
 MCP server available, the turn fails before the thread starts.
 
+Current desktop bundles ship the Computer Use plugin separately from its
+signed macOS service app. For isolated agent Codex homes, `autoInstall: true`
+and explicit `/codex computer-use install` therefore also copy the
+desktop-bundled `Codex Computer Use.app` into the canonical
+`$CODEX_HOME/computer-use/` location before app-server startup. OpenClaw uses
+the same quarantine-free `ditto` copy strategy as ChatGPT desktop and leaves an
+existing matching service app unchanged. When the desktop-bundled app changes,
+OpenClaw atomically refreshes the isolated copy so the plugin and service do not
+drift across upgrades.
+
 After changing Computer Use config, use `/new` or `/reset` in the affected
 chat before testing if an existing Codex thread has already started.
 
@@ -353,6 +363,13 @@ installed through the current app-server API.
 **Status says the MCP server is unavailable.** Re-run install once so MCP
 servers reload. If it remains unavailable, fix the Codex Computer Use app,
 Codex app-server MCP status, or macOS permissions.
+
+**A readiness `thread/start` times out and Codex logs say the Computer Use
+client was not found.** Newer thin plugin bundles expect the signed service app
+under the active `$CODEX_HOME`, while older bundles carried it inside the
+plugin. Enable `autoInstall` or run `/codex computer-use install` so OpenClaw
+can provision the desktop-bundled app into an isolated agent home. This repair
+requires ChatGPT.app or the legacy Codex.app to be installed locally.
 
 **Status or a probe times out on `computer-use.list_apps`.** The plugin and
 MCP server are present, but the local Computer Use bridge did not answer.

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -674,7 +674,9 @@ describe("startCodexAttemptThread", () => {
     });
 
     await expect(run).rejects.toThrow("stop after option capture");
-    expect(clientFactory).toHaveBeenCalledWith(expect.objectContaining({ preparedAuth }));
+    expect(clientFactory).toHaveBeenCalledWith(
+      expect.objectContaining({ preparedAuth, pluginConfig }),
+    );
     expect(clientFactory.mock.calls[0]?.[0]?.preparedAuth).toBe(preparedAuth);
     expect(clientFactory).not.toHaveBeenCalledWith(
       expect.objectContaining({ authProfileId: expect.anything() }),

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -226,6 +226,7 @@ export async function startCodexAttemptThread(params: {
             const attemptParams = params.buildAttemptParams();
             startupClient = await params.attemptClientFactory({
               startOptions: params.appServer.start,
+              pluginConfig: params.pluginConfig,
               ...(params.startupPreparedAuth
                 ? { preparedAuth: params.startupPreparedAuth }
                 : { authProfileId: params.startupAuthProfileId }),

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -30,6 +30,14 @@ const oauthMocks = vi.hoisted(() => ({
   refreshOpenAICodexToken: vi.fn(),
 }));
 
+const computerUseServiceMocks = vi.hoisted(() => ({
+  ensureCodexComputerUseServiceApp: vi.fn(async () => ({
+    status: "already_installed" as const,
+    changed: false,
+    message: "Computer Use service app is installed.",
+  })),
+}));
+
 const providerRuntimeMocks = vi.hoisted(() => ({
   formatProviderAuthProfileApiKeyWithPlugin: vi.fn(),
   refreshProviderOAuthCredentialWithPlugin: vi.fn(
@@ -117,12 +125,17 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
   };
 });
 
+vi.mock("./computer-use-service.js", () => ({
+  ensureCodexComputerUseServiceApp: computerUseServiceMocks.ensureCodexComputerUseServiceApp,
+}));
+
 afterEach(() => {
   vi.unstubAllEnvs();
   clearRuntimeAuthProfileStoreSnapshots();
   oauthMocks.refreshOpenAICodexToken.mockReset();
   providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockReset();
   providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockClear();
+  computerUseServiceMocks.ensureCodexComputerUseServiceApp.mockClear();
 });
 
 function createStartOptions(
@@ -239,6 +252,36 @@ describe("bridgeCodexAppServerStartOptions", () => {
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
+  });
+
+  it("provisions the Computer Use service app before auto-install startup", async () => {
+    await withTempDir("openclaw-codex-computer-use-service-", async (agentDir) => {
+      const startOptions = createStartOptions();
+      const codexHome = resolveCodexAppServerHomeDir(agentDir);
+
+      await bridgeCodexAppServerStartOptions({
+        startOptions,
+        agentDir,
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+      });
+
+      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith({
+        codexHome,
+        appServerCommand: startOptions.command,
+      });
+    });
+  });
+
+  it("does not provision the Computer Use service app without auto-install authorization", async () => {
+    await withTempDir("openclaw-codex-computer-use-service-", async (agentDir) => {
+      await bridgeCodexAppServerStartOptions({
+        startOptions: createStartOptions(),
+        agentDir,
+        pluginConfig: { computerUse: { enabled: true, autoInstall: false } },
+      });
+
+      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).not.toHaveBeenCalled();
+    });
   });
 
   it("uses the native user Codex home for coexistence mode", async () => {

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -24,6 +24,7 @@ import { hasUsableOAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import { resolveCodexAppServerHomeDir, withEphemeralCodexAuthStore } from "./auth-start-options.js";
 import type { CodexAppServerClient } from "./client.js";
 import { ensureCodexComputerUseSharedPluginCache } from "./computer-use-cache.js";
+import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import {
   resolveCodexAppServerUserHomeDir,
   resolveCodexComputerUseConfig,
@@ -437,10 +438,17 @@ async function withCodexHomeEnvironment(
     ? startOptions.env[HOME_ENV_VAR]
     : undefined;
   await fs.mkdir(codexHome, { recursive: true });
+  const computerUseConfig = resolveCodexComputerUseConfig({ pluginConfig });
   await ensureCodexComputerUseSharedPluginCache({
     codexHome,
-    config: resolveCodexComputerUseConfig({ pluginConfig }),
+    config: computerUseConfig,
   });
+  if (computerUseConfig.enabled && computerUseConfig.autoInstall) {
+    await ensureCodexComputerUseServiceApp({
+      codexHome,
+      appServerCommand: startOptions.command,
+    });
+  }
   if (nativeHome) {
     await fs.mkdir(nativeHome, { recursive: true });
   }

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -1,0 +1,316 @@
+// Codex tests cover isolated-home Computer Use service app provisioning.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureCodexComputerUseServiceApp,
+  resolveCodexComputerUseServiceHome,
+} from "./computer-use-service.js";
+import { resolveCodexAppServerUserHomeDir } from "./config.js";
+import { resolveMacOSDesktopCodexComputerUseServiceAppCandidates } from "./desktop-app-paths.js";
+import { useAutoCleanupTempDirTracker } from "./test-support.js";
+
+const CLIENT_RELATIVE_PATH = path.join(
+  "Contents",
+  "SharedSupport",
+  "SkyComputerUseClient.app",
+  "Contents",
+  "MacOS",
+  "SkyComputerUseClient",
+);
+
+describe("Codex Computer Use service app", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it("provisions the desktop service app into an isolated Codex home", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "ChatGPT.app", "Codex Computer Use.app");
+    const codexHome = path.join(root, "agent", "codex-home");
+    await writeServiceApp(sourcePath, "desktop-client");
+    const copyServiceApp = vi.fn(
+      async (source: string, target: string) => await fs.cp(source, target, { recursive: true }),
+    );
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp,
+    });
+
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    expect(result).toMatchObject({
+      status: "installed",
+      changed: true,
+      sourcePath,
+      targetPath,
+    });
+    expect(copyServiceApp).toHaveBeenCalledTimes(1);
+    await expect(fs.readFile(path.join(targetPath, CLIENT_RELATIVE_PATH), "utf8")).resolves.toBe(
+      "desktop-client",
+    );
+  });
+
+  it("leaves an existing executable service app unchanged", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const codexHome = path.join(root, "agent", "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceApp(targetPath, "installed-client");
+    const copyServiceApp = vi.fn();
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [path.join(root, "missing-source")],
+      copyServiceApp,
+    });
+
+    expect(result).toMatchObject({ status: "already_installed", changed: false, targetPath });
+    expect(copyServiceApp).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(targetPath, CLIENT_RELATIVE_PATH), "utf8")).resolves.toBe(
+      "installed-client",
+    );
+  });
+
+  it("leaves a service app unchanged when its bundled metadata still matches", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "ChatGPT.app", "Codex Computer Use.app");
+    const codexHome = path.join(root, "agent", "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceApp(sourcePath, "desktop-client", "version-2");
+    await writeServiceApp(targetPath, "desktop-client", "version-2");
+    const copyServiceApp = vi.fn();
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp,
+    });
+
+    expect(result).toMatchObject({
+      status: "already_installed",
+      changed: false,
+      sourcePath,
+      targetPath,
+    });
+    expect(copyServiceApp).not.toHaveBeenCalled();
+  });
+
+  it("atomically refreshes an executable service app when bundled metadata changes", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "ChatGPT.app", "Codex Computer Use.app");
+    const codexHome = path.join(root, "agent", "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceApp(sourcePath, "replacement-client", "version-2", "same-code-resources");
+    await writeServiceApp(targetPath, "stale-client", "version-2", "same-code-resources");
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp: async (source, target) => await fs.cp(source, target, { recursive: true }),
+    });
+
+    expect(result).toMatchObject({ status: "installed", changed: true, sourcePath, targetPath });
+    await expect(fs.readFile(path.join(targetPath, CLIENT_RELATIVE_PATH), "utf8")).resolves.toBe(
+      "replacement-client",
+    );
+    await expect(
+      fs.readFile(path.join(targetPath, "Contents", "Info.plist"), "utf8"),
+    ).resolves.toBe("version-2");
+  });
+
+  it("preserves a valid target when the source fingerprint is unavailable", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "ChatGPT.app", "Codex Computer Use.app");
+    const codexHome = path.join(root, "agent", "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceApp(sourcePath, "desktop-client", "version-2");
+    await fs.rm(path.join(sourcePath, "Contents", "_CodeSignature"), {
+      recursive: true,
+      force: true,
+    });
+    await writeServiceApp(targetPath, "installed-client", "version-1");
+    const copyServiceApp = vi.fn();
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp,
+    });
+
+    expect(result).toMatchObject({ status: "already_installed", changed: false, targetPath });
+    expect(copyServiceApp).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(targetPath, CLIENT_RELATIVE_PATH), "utf8")).resolves.toBe(
+      "installed-client",
+    );
+  });
+
+  it("accepts a matching install won by another process during target backup", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "ChatGPT.app", "Codex Computer Use.app");
+    const codexHome = path.join(root, "agent", "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceApp(sourcePath, "replacement-client", "version-2");
+    await writeServiceApp(targetPath, "stale-client", "version-1");
+    const movePath = vi.fn(async (source: string, target: string) => {
+      if (source === targetPath) {
+        await fs.rm(targetPath, { recursive: true, force: true });
+        await fs.cp(sourcePath, targetPath, { recursive: true });
+        const error = new Error("target was moved by another process") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      }
+      await fs.rename(source, target);
+    });
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp: async (source, target) => await fs.cp(source, target, { recursive: true }),
+      movePath,
+    });
+
+    expect(result).toMatchObject({ status: "already_installed", changed: false, targetPath });
+    expect(movePath).toHaveBeenCalledTimes(2);
+    await expect(fs.readFile(path.join(targetPath, CLIENT_RELATIVE_PATH), "utf8")).resolves.toBe(
+      "replacement-client",
+    );
+  });
+
+  it("repairs an incomplete target without exposing a partial copy", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "ChatGPT.app", "Codex Computer Use.app");
+    const codexHome = path.join(root, "agent", "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceApp(sourcePath, "replacement-client");
+    await fs.mkdir(targetPath, { recursive: true });
+    await fs.writeFile(path.join(targetPath, "incomplete-marker"), "old");
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp: async (source, target) => await fs.cp(source, target, { recursive: true }),
+    });
+
+    expect(result).toMatchObject({ status: "installed", changed: true, targetPath });
+    await expect(fs.readFile(path.join(targetPath, CLIENT_RELATIVE_PATH), "utf8")).resolves.toBe(
+      "replacement-client",
+    );
+    await expect(fs.access(path.join(targetPath, "incomplete-marker"))).rejects.toThrow();
+  });
+
+  it("preserves an incomplete target when staging fails", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "ChatGPT.app", "Codex Computer Use.app");
+    const codexHome = path.join(root, "agent", "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceApp(sourcePath, "desktop-client");
+    await fs.mkdir(targetPath, { recursive: true });
+    await fs.writeFile(path.join(targetPath, "incomplete-marker"), "preserve-me");
+
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [sourcePath],
+        copyServiceApp: async () => {
+          throw new Error("copy failed");
+        },
+      }),
+    ).rejects.toThrow("copy failed");
+    await expect(fs.readFile(path.join(targetPath, "incomplete-marker"), "utf8")).resolves.toBe(
+      "preserve-me",
+    );
+  });
+
+  it("reports a missing desktop source without creating a target", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const codexHome = path.join(root, "agent", "codex-home");
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [path.join(root, "missing-source")],
+    });
+
+    expect(result).toMatchObject({ status: "source_missing", changed: false });
+    await expect(fs.access(path.join(codexHome, "computer-use"))).rejects.toThrow();
+  });
+
+  it("resolves isolated, explicit, user, and remote homes", () => {
+    const agentDir = "/tmp/openclaw-agent";
+    expect(
+      resolveCodexComputerUseServiceHome({
+        startOptions: createStartOptions(),
+        agentDir,
+      }),
+    ).toBe(path.join(agentDir, "codex-home"));
+    expect(
+      resolveCodexComputerUseServiceHome({
+        startOptions: createStartOptions({ env: { CODEX_HOME: "/tmp/custom-codex" } }),
+        agentDir,
+      }),
+    ).toBe("/tmp/custom-codex");
+    expect(
+      resolveCodexComputerUseServiceHome({
+        startOptions: createStartOptions({ homeScope: "user" }),
+        agentDir,
+      }),
+    ).toBe(resolveCodexAppServerUserHomeDir());
+    expect(
+      resolveCodexComputerUseServiceHome({
+        startOptions: {
+          ...createStartOptions(),
+          transport: "websocket",
+          url: "ws://localhost:8765",
+        },
+        agentDir,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("prefers the service app paired with the selected desktop command", () => {
+    expect(
+      resolveMacOSDesktopCodexComputerUseServiceAppCandidates(
+        "darwin",
+        "/Applications/Codex.app/Contents/Resources/codex",
+      ),
+    ).toEqual([
+      "/Applications/Codex.app/Contents/Resources/cua_node/lib/node_modules/@oai/sky/Codex Computer Use.app",
+      "/Applications/ChatGPT.app/Contents/Resources/cua_node/lib/node_modules/@oai/sky/Codex Computer Use.app",
+    ]);
+  });
+});
+
+async function writeServiceApp(
+  appPath: string,
+  contents: string,
+  metadata = `metadata:${contents}`,
+  codeResources = `signature:${metadata}:${contents}`,
+): Promise<void> {
+  const clientPath = path.join(appPath, CLIENT_RELATIVE_PATH);
+  await fs.mkdir(path.dirname(clientPath), { recursive: true });
+  await fs.writeFile(clientPath, contents, { mode: 0o755 });
+  await fs.writeFile(path.join(appPath, "Contents", "Info.plist"), metadata);
+  const codeResourcesPath = path.join(appPath, "Contents", "_CodeSignature", "CodeResources");
+  await fs.mkdir(path.dirname(codeResourcesPath), { recursive: true });
+  await fs.writeFile(codeResourcesPath, codeResources);
+}
+
+function createStartOptions(
+  overrides: Record<string, unknown> = {},
+): Parameters<typeof resolveCodexComputerUseServiceHome>[0]["startOptions"] {
+  return {
+    transport: "stdio",
+    command: "codex",
+    args: ["app-server"],
+    commandSource: "config",
+    homeScope: "agent",
+    ...overrides,
+  } as Parameters<typeof resolveCodexComputerUseServiceHome>[0]["startOptions"];
+}

--- a/extensions/codex/src/app-server/computer-use-service.ts
+++ b/extensions/codex/src/app-server/computer-use-service.ts
@@ -1,0 +1,326 @@
+/** Provisions the macOS Computer Use service app for isolated Codex homes. */
+import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveDefaultAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import { runExec } from "openclaw/plugin-sdk/process-runtime";
+import { resolveCodexAppServerHomeDir } from "./auth-start-options.js";
+import { resolveCodexAppServerUserHomeDir, type CodexAppServerStartOptions } from "./config.js";
+import { resolveMacOSDesktopCodexComputerUseServiceAppCandidates } from "./desktop-app-paths.js";
+
+const COMPUTER_USE_SERVICE_APP_NAME = "Codex Computer Use.app";
+const COMPUTER_USE_SERVICE_INFO_PLIST_RELATIVE_PATH = path.join("Contents", "Info.plist");
+const COMPUTER_USE_SERVICE_CODE_RESOURCES_RELATIVE_PATH = path.join(
+  "Contents",
+  "_CodeSignature",
+  "CodeResources",
+);
+const COMPUTER_USE_CLIENT_RELATIVE_PATH = path.join(
+  "Contents",
+  "SharedSupport",
+  "SkyComputerUseClient.app",
+  "Contents",
+  "MacOS",
+  "SkyComputerUseClient",
+);
+const COMPUTER_USE_SERVICE_COPY_TIMEOUT_MS = 120_000;
+
+export type CodexComputerUseServiceAppStatus = {
+  status: "installed" | "already_installed" | "source_missing" | "unsupported";
+  changed: boolean;
+  targetPath?: string;
+  sourcePath?: string;
+  message: string;
+};
+
+type CopyServiceApp = (sourcePath: string, targetPath: string) => Promise<void>;
+type MovePath = (sourcePath: string, targetPath: string) => Promise<void>;
+
+type CodexComputerUseServiceAppState = {
+  installs: Map<string, Promise<CodexComputerUseServiceAppStatus>>;
+  fingerprints: Map<string, { fileIdentity: string; fingerprint: string }>;
+};
+
+const COMPUTER_USE_SERVICE_APP_STATE = Symbol.for("openclaw.codexComputerUseServiceAppState");
+
+function getComputerUseServiceAppState(): CodexComputerUseServiceAppState {
+  const globalState = globalThis as typeof globalThis & {
+    [COMPUTER_USE_SERVICE_APP_STATE]?: CodexComputerUseServiceAppState;
+  };
+  globalState[COMPUTER_USE_SERVICE_APP_STATE] ??= {
+    installs: new Map(),
+    fingerprints: new Map(),
+  };
+  globalState[COMPUTER_USE_SERVICE_APP_STATE].fingerprints ??= new Map();
+  return globalState[COMPUTER_USE_SERVICE_APP_STATE];
+}
+
+/** Returns the local Codex home used by a stdio app-server start. */
+export function resolveCodexComputerUseServiceHome(params: {
+  startOptions: CodexAppServerStartOptions;
+  agentDir?: string;
+  config?: Parameters<typeof resolveDefaultAgentDir>[0];
+}): string | undefined {
+  if (params.startOptions.transport !== "stdio") {
+    return undefined;
+  }
+  const configuredHome = params.startOptions.env?.CODEX_HOME?.trim();
+  if (configuredHome) {
+    return path.resolve(configuredHome);
+  }
+  if (params.startOptions.homeScope === "user") {
+    return path.resolve(resolveCodexAppServerUserHomeDir());
+  }
+  const agentDir = params.agentDir ?? resolveDefaultAgentDir(params.config ?? {});
+  return agentDir ? resolveCodexAppServerHomeDir(agentDir) : undefined;
+}
+
+/**
+ * Copies the desktop-bundled service app into an isolated Codex home.
+ *
+ * New Computer Use plugin bundles launch this canonical per-CODEX_HOME copy;
+ * plugin/install only installs the launcher and cannot create the service app.
+ */
+export async function ensureCodexComputerUseServiceApp(params: {
+  codexHome: string;
+  platform?: NodeJS.Platform;
+  appServerCommand?: string;
+  sourceAppCandidates?: readonly string[];
+  copyServiceApp?: CopyServiceApp;
+  movePath?: MovePath;
+}): Promise<CodexComputerUseServiceAppStatus> {
+  const platform = params.platform ?? process.platform;
+  if (platform !== "darwin") {
+    return {
+      status: "unsupported",
+      changed: false,
+      message: `Computer Use service app provisioning is macOS-only, not ${platform}.`,
+    };
+  }
+  const targetPath = path.join(
+    path.resolve(params.codexHome),
+    "computer-use",
+    COMPUTER_USE_SERVICE_APP_NAME,
+  );
+  const state = getComputerUseServiceAppState();
+  const existing = state.installs.get(targetPath);
+  if (existing) {
+    return await existing;
+  }
+  const install = ensureCodexComputerUseServiceAppOnce({
+    ...params,
+    targetPath,
+    platform,
+  });
+  state.installs.set(targetPath, install);
+  try {
+    return await install;
+  } finally {
+    if (state.installs.get(targetPath) === install) {
+      state.installs.delete(targetPath);
+    }
+  }
+}
+
+async function ensureCodexComputerUseServiceAppOnce(params: {
+  targetPath: string;
+  platform: NodeJS.Platform;
+  appServerCommand?: string;
+  sourceAppCandidates?: readonly string[];
+  copyServiceApp?: CopyServiceApp;
+  movePath?: MovePath;
+}): Promise<CodexComputerUseServiceAppStatus> {
+  const targetHasExecutableClient = await hasExecutableClient(params.targetPath);
+  const sourceAppCandidates =
+    params.sourceAppCandidates ??
+    resolveMacOSDesktopCodexComputerUseServiceAppCandidates(
+      params.platform,
+      params.appServerCommand,
+    );
+  const sourcePath = await findUsableServiceApp(sourceAppCandidates);
+  const targetFreshness = sourcePath
+    ? await compareServiceAppFingerprint(sourcePath, params.targetPath)
+    : "source_unknown";
+  if (targetHasExecutableClient && (!sourcePath || targetFreshness !== "mismatch")) {
+    return {
+      status: "already_installed",
+      changed: false,
+      targetPath: params.targetPath,
+      ...(sourcePath ? { sourcePath } : {}),
+      message: `Computer Use service app is installed at ${params.targetPath}.`,
+    };
+  }
+  if (!sourcePath) {
+    return {
+      status: "source_missing",
+      changed: false,
+      targetPath: params.targetPath,
+      message: "No desktop-bundled Codex Computer Use service app was found.",
+    };
+  }
+
+  const targetParent = path.dirname(params.targetPath);
+  await fs.mkdir(targetParent, { recursive: true });
+  const stagingRoot = await fs.mkdtemp(path.join(targetParent, ".service-app.staging-"));
+  const stagedPath = path.join(stagingRoot, COMPUTER_USE_SERVICE_APP_NAME);
+  const backupPath = path.join(targetParent, `.service-app.backup-${process.pid}-${Date.now()}`);
+  let backupCreated = false;
+  try {
+    await (params.copyServiceApp ?? copyServiceAppWithDitto)(sourcePath, stagedPath);
+    if (!(await hasExecutableClient(stagedPath))) {
+      throw new Error(`Copied Computer Use service app is incomplete at ${stagedPath}.`);
+    }
+    if ((await compareServiceAppFingerprint(sourcePath, stagedPath)) === "mismatch") {
+      throw new Error(
+        `Copied Computer Use service app does not match its source at ${stagedPath}.`,
+      );
+    }
+    const targetExists = await fs.lstat(params.targetPath).then(
+      () => true,
+      () => false,
+    );
+    if (targetExists) {
+      try {
+        await (params.movePath ?? fs.rename)(params.targetPath, backupPath);
+        backupCreated = true;
+      } catch (error) {
+        // Another OpenClaw process can win the target-to-backup race. Continue
+        // only for that exact case; the staged install or winner is still safe.
+        if (!isNodeErrorWithCode(error, "ENOENT")) {
+          throw error;
+        }
+      }
+    }
+    try {
+      await (params.movePath ?? fs.rename)(stagedPath, params.targetPath);
+    } catch (error) {
+      if (await shouldPreserveUsableTarget(sourcePath, params.targetPath)) {
+        if (backupCreated) {
+          await fs.rm(backupPath, { recursive: true, force: true });
+          backupCreated = false;
+        }
+        return {
+          status: "already_installed",
+          changed: false,
+          targetPath: params.targetPath,
+          sourcePath,
+          message: `Computer Use service app is installed at ${params.targetPath}.`,
+        };
+      }
+      if (backupCreated) {
+        try {
+          await fs.rename(backupPath, params.targetPath);
+          backupCreated = false;
+        } catch (restoreError) {
+          throw new Error(
+            `Failed to install Computer Use service app at ${params.targetPath} and restore its prior copy.`,
+            { cause: restoreError },
+          );
+        }
+      }
+      throw error;
+    }
+    if (backupCreated) {
+      await fs.rm(backupPath, { recursive: true, force: true });
+    }
+    return {
+      status: "installed",
+      changed: true,
+      targetPath: params.targetPath,
+      sourcePath,
+      message: `Installed Computer Use service app at ${params.targetPath}.`,
+    };
+  } finally {
+    await fs.rm(stagingRoot, { recursive: true, force: true });
+  }
+}
+
+async function findUsableServiceApp(candidates: readonly string[]): Promise<string | undefined> {
+  for (const candidate of candidates) {
+    if (await hasExecutableClient(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+async function hasExecutableClient(appPath: string): Promise<boolean> {
+  try {
+    await fs.access(path.join(appPath, COMPUTER_USE_CLIENT_RELATIVE_PATH), fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function compareServiceAppFingerprint(
+  sourcePath: string,
+  targetPath: string,
+): Promise<"match" | "mismatch" | "source_unknown"> {
+  const sourceFingerprint = await readServiceAppFingerprint(sourcePath);
+  if (!sourceFingerprint) {
+    return "source_unknown";
+  }
+  const targetFingerprint = await readServiceAppFingerprint(targetPath);
+  return targetFingerprint === sourceFingerprint ? "match" : "mismatch";
+}
+
+async function readServiceAppFingerprint(appPath: string): Promise<string | undefined> {
+  try {
+    const relativePaths = [
+      COMPUTER_USE_SERVICE_INFO_PLIST_RELATIVE_PATH,
+      COMPUTER_USE_SERVICE_CODE_RESOURCES_RELATIVE_PATH,
+      COMPUTER_USE_CLIENT_RELATIVE_PATH,
+    ];
+    const stats = await Promise.all(
+      relativePaths.map(async (relativePath) => await fs.stat(path.join(appPath, relativePath))),
+    );
+    const fileIdentity = stats
+      .map(
+        (stat, index) =>
+          `${relativePaths[index]}:${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`,
+      )
+      .join("\0");
+    const cacheKey = path.resolve(appPath);
+    const fingerprintCache = getComputerUseServiceAppState().fingerprints;
+    const cached = fingerprintCache.get(cacheKey);
+    if (cached?.fileIdentity === fileIdentity) {
+      return cached.fingerprint;
+    }
+
+    const hash = createHash("sha256");
+    for (const relativePath of relativePaths) {
+      hash.update(relativePath);
+      hash.update("\0");
+      hash.update(await fs.readFile(path.join(appPath, relativePath)));
+      hash.update("\0");
+    }
+    const fingerprint = hash.digest("hex");
+    fingerprintCache.set(cacheKey, { fileIdentity, fingerprint });
+    return fingerprint;
+  } catch {
+    return undefined;
+  }
+}
+
+async function shouldPreserveUsableTarget(
+  sourcePath: string,
+  targetPath: string,
+): Promise<boolean> {
+  if (!(await hasExecutableClient(targetPath))) {
+    return false;
+  }
+  return (await compareServiceAppFingerprint(sourcePath, targetPath)) !== "mismatch";
+}
+
+function isNodeErrorWithCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+async function copyServiceAppWithDitto(sourcePath: string, targetPath: string): Promise<void> {
+  await runExec("/usr/bin/ditto", ["--noqtn", sourcePath, targetPath], {
+    logOutput: false,
+    timeoutMs: COMPUTER_USE_SERVICE_COPY_TIMEOUT_MS,
+  });
+}

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -12,6 +12,13 @@ const sharedClientMocks = vi.hoisted(() => ({
   getLeasedSharedCodexAppServerClient: vi.fn(),
   releaseLeasedSharedCodexAppServerClient: vi.fn(),
 }));
+const computerUseServiceMocks = vi.hoisted(() => ({
+  ensureCodexComputerUseServiceApp: vi.fn(async () => ({
+    status: "already_installed" as const,
+    changed: false,
+    message: "Computer Use service app is installed.",
+  })),
+}));
 
 vi.mock("./request.js", () => ({
   requestCodexAppServerJson: requestCodexAppServerJsonMock,
@@ -20,6 +27,11 @@ vi.mock("./request.js", () => ({
 vi.mock("./shared-client.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./shared-client.js")>()),
   ...sharedClientMocks,
+}));
+
+vi.mock("./computer-use-service.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./computer-use-service.js")>()),
+  ensureCodexComputerUseServiceApp: computerUseServiceMocks.ensureCodexComputerUseServiceApp,
 }));
 
 import {
@@ -83,6 +95,7 @@ describe("Codex Computer Use setup", () => {
     requestCodexAppServerJsonMock.mockReset();
     sharedClientMocks.getLeasedSharedCodexAppServerClient.mockReset();
     sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockReset();
+    computerUseServiceMocks.ensureCodexComputerUseServiceApp.mockClear();
   });
 
   it("stays disabled until configured", async () => {
@@ -111,10 +124,15 @@ describe("Codex Computer Use setup", () => {
           commandSource: "managed",
           managedCommandOrder: "desktop-first",
         }),
+        pluginConfig: {},
         config,
         agentDir,
       }),
     );
+    expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith({
+      codexHome: path.join(agentDir, "codex-home"),
+      appServerCommand: "codex",
+    });
   });
 
   it("holds the Codex-home fence until an install request settles", async () => {
@@ -332,6 +350,55 @@ describe("Codex Computer Use setup", () => {
     expectRequestMethodNotCalled(request, "plugin/install");
   });
 
+  it("reports empty MCP tool exposure without running the live probe", async () => {
+    const request = createComputerUseRequest({ installed: true, mcpToolsAvailable: false });
+
+    const status = await readCodexComputerUseStatus({
+      pluginConfig: { computerUse: { enabled: true, marketplaceName: "desktop-tools" } },
+      request,
+    });
+
+    expectStatusFields(status, {
+      ready: false,
+      reason: "mcp_missing",
+      installed: true,
+      pluginEnabled: true,
+      mcpServerAvailable: false,
+      tools: [],
+      message: "Computer Use is installed, but the computer-use MCP server exposes no tools.",
+    });
+    expect(status.installation).toMatchObject({ status: "installed", ok: true });
+    expect(status.exposure).toMatchObject({ status: "missing", ok: false });
+    expect(status.liveTest).toMatchObject({ status: "skipped", attempted: false, attempts: 0 });
+    expect(status.warnings).not.toContain(
+      "Computer Use live test failed, but compatibility startup remains enabled; set computerUse.strictReadiness to true to fail closed.",
+    );
+    expect(status.message).not.toContain("Startup is allowed");
+    expectRequestMethodNotCalled(request, "thread/start");
+    expectRequestMethodNotCalled(request, "mcpServer/tool/call");
+  });
+
+  it("blocks non-strict startup when the named MCP server exposes no tools", async () => {
+    const request = createComputerUseRequest({ installed: true, mcpToolsAvailable: false });
+
+    await expectSetupErrorStatus(
+      ensureCodexComputerUse({
+        pluginConfig: { computerUse: { enabled: true, marketplaceName: "desktop-tools" } },
+        request,
+      }),
+      {
+        ready: false,
+        reason: "mcp_missing",
+        installed: true,
+        pluginEnabled: true,
+        mcpServerAvailable: false,
+        message: "Computer Use is installed, but the computer-use MCP server exposes no tools.",
+      },
+    );
+    expectRequestMethodNotCalled(request, "thread/start");
+    expectRequestMethodNotCalled(request, "mcpServer/tool/call");
+  });
+
   it("repairs stale Computer Use MCP children and retries the live test once", async () => {
     const request = createComputerUseRequest({ installed: true, liveTestFailures: 1 });
     const repairComputerUseMcpChildren = vi.fn(async () => ({
@@ -487,6 +554,34 @@ describe("Codex Computer Use setup", () => {
     expect(status.message).toContain(
       "Startup is allowed because computerUse.strictReadiness is false.",
     );
+  });
+
+  it("keeps startup compatible when thread creation fails after healthy exposure", async () => {
+    const request = createComputerUseRequest({ installed: true, threadStartFailures: 2 });
+
+    const status = await ensureCodexComputerUse({
+      pluginConfig: { computerUse: { enabled: true, marketplaceName: "desktop-tools" } },
+      request,
+    });
+
+    expectStatusFields(status, {
+      ready: false,
+      reason: "live_test_failed",
+      installed: true,
+      pluginEnabled: true,
+      mcpServerAvailable: true,
+    });
+    expect(status.liveTest).toMatchObject({
+      status: "failed",
+      attempted: true,
+      attempts: 2,
+      error: "thread/start timed out",
+    });
+    expect(status.message).toContain(
+      "Startup is allowed because computerUse.strictReadiness is false.",
+    );
+    expect(requestCalls(request).filter(([method]) => method === "thread/start")).toHaveLength(2);
+    expectRequestMethodNotCalled(request, "mcpServer/tool/call");
   });
 
   it("keeps auto-install startup compatible when installation succeeds but the live test fails", async () => {
@@ -653,6 +748,52 @@ describe("Codex Computer Use setup", () => {
         mcpServerAvailable: true,
       },
     );
+  });
+
+  it("reloads empty MCP exposure once during install before failing fast", async () => {
+    const request = createComputerUseRequest({ installed: true, mcpToolsAvailable: false });
+
+    await expectSetupErrorStatus(
+      installCodexComputerUse({
+        pluginConfig: { computerUse: { marketplaceName: "desktop-tools" } },
+        request,
+      }),
+      {
+        ready: false,
+        reason: "mcp_missing",
+        mcpServerAvailable: false,
+        message: "Computer Use is installed, but the computer-use MCP server exposes no tools.",
+      },
+    );
+    expect(
+      requestCalls(request).filter(([method]) => method === "config/mcpServer/reload"),
+    ).toHaveLength(1);
+    expectRequestMethodNotCalled(request, "thread/start");
+    expectRequestMethodNotCalled(request, "mcpServer/tool/call");
+  });
+
+  it("accepts MCP exposure that appears after the install reload", async () => {
+    const request = createComputerUseRequest({
+      installed: true,
+      mcpToolsAvailable: false,
+      mcpToolsAvailableAfterReload: true,
+    });
+
+    const status = await installCodexComputerUse({
+      pluginConfig: { computerUse: { marketplaceName: "desktop-tools" } },
+      request,
+    });
+
+    expectStatusFields(status, {
+      ready: true,
+      reason: "ready",
+      mcpServerAvailable: true,
+      tools: ["list_apps"],
+    });
+    expect(
+      requestCalls(request).filter(([method]) => method === "config/mcpServer/reload"),
+    ).toHaveLength(1);
+    expect(requestCalls(request).filter(([method]) => method === "thread/start")).toHaveLength(1);
   });
 
   it("re-enables an installed but disabled Computer Use plugin during install", async () => {
@@ -1008,12 +1149,17 @@ function createComputerUseRequest(params: {
   enabled?: boolean;
   marketplaceAvailableAfterListCalls?: number;
   liveTestFailures?: number;
+  threadStartFailures?: number;
+  mcpToolsAvailable?: boolean;
+  mcpToolsAvailableAfterReload?: boolean;
 }): CodexComputerUseRequest {
   let installed = params.installed;
   let enabled = params.enabled ?? installed;
   let pluginListCalls = 0;
   let liveTestFailures = params.liveTestFailures ?? 0;
+  let threadStartFailures = params.threadStartFailures ?? 0;
   let threadStartCalls = 0;
+  let mcpReloaded = false;
   return vi.fn(async (method: string, requestParams?: unknown) => {
     if (method === "experimentalFeature/enablement/set") {
       return { enablement: { plugins: true } };
@@ -1064,21 +1210,28 @@ function createComputerUseRequest(params: {
       return { authPolicy: "ON_INSTALL", appsNeedingAuth: [] };
     }
     if (method === "config/mcpServer/reload") {
+      mcpReloaded = true;
       return undefined;
     }
     if (method === "mcpServerStatus/list") {
+      const mcpToolsAvailable =
+        mcpReloaded && params.mcpToolsAvailableAfterReload !== undefined
+          ? params.mcpToolsAvailableAfterReload
+          : (params.mcpToolsAvailable ?? true);
       return {
         data:
           installed && enabled
             ? [
                 {
                   name: "computer-use",
-                  tools: {
-                    list_apps: {
-                      name: "list_apps",
-                      inputSchema: { type: "object" },
-                    },
-                  },
+                  tools: mcpToolsAvailable
+                    ? {
+                        list_apps: {
+                          name: "list_apps",
+                          inputSchema: { type: "object" },
+                        },
+                      }
+                    : {},
                   resources: [],
                   resourceTemplates: [],
                   authStatus: "unsupported",
@@ -1090,6 +1243,10 @@ function createComputerUseRequest(params: {
     }
     if (method === "thread/start") {
       threadStartCalls += 1;
+      if (threadStartFailures > 0) {
+        threadStartFailures -= 1;
+        throw new Error("thread/start timed out");
+      }
       return {
         thread: {
           id: `computer-use-probe-thread-${threadStartCalls}`,

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -12,6 +12,10 @@ import {
   type CodexAppServerClient,
 } from "./client.js";
 import {
+  ensureCodexComputerUseServiceApp,
+  resolveCodexComputerUseServiceHome,
+} from "./computer-use-service.js";
+import {
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
   type CodexComputerUseConfig,
@@ -292,6 +296,19 @@ async function inspectCodexComputerUse(
         pluginConfig: params.pluginConfig,
         managedCommandOrder: "desktop-first",
       });
+  if (params.installPlugin && !params.client && !params.request && runtime) {
+    const codexHome = resolveCodexComputerUseServiceHome({
+      startOptions: runtime.start,
+      agentDir: params.agentDir,
+      config: params.config,
+    });
+    if (codexHome) {
+      await ensureCodexComputerUseServiceApp({
+        codexHome,
+        appServerCommand: runtime.start.command,
+      });
+    }
+  }
   const fenceKey = resolveCodexNativeConfigFenceKey({
     client: params.client,
     startOptions: runtime?.start,
@@ -317,6 +334,7 @@ async function inspectCodexComputerUse(
       }
       client = await getLeasedSharedCodexAppServerClient({
         startOptions: runtime.start,
+        pluginConfig: params.pluginConfig,
         timeoutMs: params.timeoutMs ?? runtime.requestTimeoutMs,
         config: params.config,
         agentDir: params.agentDir,
@@ -480,9 +498,11 @@ async function readComputerUseTools(params: {
   repairComputerUseMcpChildren?: () => Promise<CodexComputerUseRepairStatus>;
 }): Promise<CodexComputerUseStatus> {
   let server = await readMcpServerStatus(params.request, params.config.mcpServerName);
-  if (!server && params.installPlugin) {
+  let tools = Object.keys(server?.tools ?? {}).toSorted();
+  if ((!server || tools.length === 0) && params.installPlugin) {
     await reloadMcpServers(params.request);
     server = await readMcpServerStatus(params.request, params.config.mcpServerName);
+    tools = Object.keys(server?.tools ?? {}).toSorted();
   }
   if (!server) {
     return statusFromPlugin({
@@ -493,11 +513,20 @@ async function readComputerUseTools(params: {
       message: `Computer Use is installed, but the ${params.config.mcpServerName} MCP server is not available.`,
     });
   }
+  if (tools.length === 0) {
+    return statusFromPlugin({
+      config: params.config,
+      plugin: params.plugin,
+      tools,
+      reason: "mcp_missing",
+      message: `Computer Use is installed, but the ${params.config.mcpServerName} MCP server exposes no tools.`,
+    });
+  }
 
   const status = statusFromPlugin({
     config: params.config,
     plugin: params.plugin,
-    tools: Object.keys(server.tools).toSorted(),
+    tools,
     reason: "ready",
     message: "Computer Use is ready.",
   });
@@ -506,13 +535,19 @@ async function readComputerUseTools(params: {
     config: params.config,
     repairComputerUseMcpChildren: params.repairComputerUseMcpChildren,
   });
-  const compatibilityStartupAllowed = !liveTest.ok && !params.config.strictReadiness;
-  return {
+  const probedStatus: CodexComputerUseStatus = {
     ...status,
     ready: liveTest.ok,
     reason: liveTest.ok ? "ready" : "live_test_failed",
     liveTest,
     ...(repair ? { repair } : {}),
+  };
+  const compatibilityStartupAllowed = isNonStrictLiveTestStartupAllowed(
+    probedStatus,
+    params.config,
+  );
+  return {
+    ...probedStatus,
     warnings: [
       ...status.warnings,
       ...(repair?.warnings ?? []),

--- a/extensions/codex/src/app-server/desktop-app-paths.ts
+++ b/extensions/codex/src/app-server/desktop-app-paths.ts
@@ -1,11 +1,13 @@
 /** Shared path candidates for Codex's macOS desktop app bundle. */
 import { existsSync } from "node:fs";
+import path from "node:path";
 
 type MacOSDesktopCodexAppPathCandidate = {
   appName: "ChatGPT.app" | "Codex.app";
   appBundlePath: string;
   appServerCommandPath: string;
   bundledMarketplacePath: string;
+  computerUseServiceAppPath: string;
 };
 
 const MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES: readonly MacOSDesktopCodexAppPathCandidate[] = [
@@ -14,12 +16,16 @@ const MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES: readonly MacOSDesktopCodexAppPath
     appBundlePath: "/Applications/ChatGPT.app",
     appServerCommandPath: "/Applications/ChatGPT.app/Contents/Resources/codex",
     bundledMarketplacePath: "/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled",
+    computerUseServiceAppPath:
+      "/Applications/ChatGPT.app/Contents/Resources/cua_node/lib/node_modules/@oai/sky/Codex Computer Use.app",
   },
   {
     appName: "Codex.app",
     appBundlePath: "/Applications/Codex.app",
     appServerCommandPath: "/Applications/Codex.app/Contents/Resources/codex",
     bundledMarketplacePath: "/Applications/Codex.app/Contents/Resources/plugins/openai-bundled",
+    computerUseServiceAppPath:
+      "/Applications/Codex.app/Contents/Resources/cua_node/lib/node_modules/@oai/sky/Codex Computer Use.app",
   },
 ] as const;
 
@@ -29,6 +35,30 @@ export function resolveMacOSDesktopCodexBundledMarketplaceCandidates(
   return platform === "darwin"
     ? MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES.map((candidate) => candidate.bundledMarketplacePath)
     : [];
+}
+
+export function resolveMacOSDesktopCodexComputerUseServiceAppCandidates(
+  platform: NodeJS.Platform = process.platform,
+  appServerCommand?: string,
+): string[] {
+  if (platform !== "darwin") {
+    return [];
+  }
+  const matchingCandidate = appServerCommand
+    ? MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES.find(
+        (candidate) =>
+          path.resolve(candidate.appServerCommandPath) === path.resolve(appServerCommand),
+      )
+    : undefined;
+  const orderedCandidates = matchingCandidate
+    ? [
+        matchingCandidate,
+        ...MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES.filter(
+          (candidate) => candidate !== matchingCandidate,
+        ),
+      ]
+    : MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES;
+  return orderedCandidates.map((candidate) => candidate.computerUseServiceAppPath);
 }
 
 export function resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath(


### PR DESCRIPTION
Related: #103250

## What Problem This Solves

Fixes an issue where users with Codex Computer Use enabled could have every agent turn wait through two readiness timeouts and then fail when the current thin Computer Use plugin was installed in an isolated agent Codex home. The thin plugin launcher expects the signed service app at `$CODEX_HOME/computer-use/Codex Computer Use.app`, but OpenClaw only installed the plugin files, leaving the service absent from isolated homes.

The same failure could be reported as a live-test timeout with “startup is allowed” even though the named MCP server exposed zero tools and startup would still be blocked.

## Why This Change Was Made

When Computer Use auto-install is authorized, OpenClaw now provisions the desktop-bundled signed service app before app-server startup. It pairs the source with the selected ChatGPT/Codex desktop command, stages and atomically replaces copies with cross-process race recovery, refreshes changed copies using a cached signed-content fingerprint, and leaves an existing valid copy alone when source identity is unavailable.

Readiness now treats a named MCP server with an empty tool map as missing exposure, reloads once during explicit install, and fails immediately instead of spending two `thread/start` probes on a server that cannot serve Computer Use tools. Genuine post-exposure live-test failures retain the existing non-strict compatibility behavior.

AI-assisted: yes. The implementation and evidence were reviewed against the OpenClaw and upstream Codex runtime contracts, followed by an independent fresh diff review with all actionable findings addressed.

## User Impact

Affected macOS users can keep Computer Use enabled in isolated agent homes after the desktop plugin packaging transition without all Codex turns being blocked by the missing service app. Setup also fails faster and reports the actual empty MCP exposure when provisioning cannot make tools available.

Existing matching service apps are not recopied. Computer Use disabled configurations and enabled configurations with `autoInstall: false` do not authorize or perform this provisioning.

## Evidence

- Incident SQLite/log evidence showed the gateway child loading the expected Codex runtime and authenticated model transport, then the thin launcher reporting that `SkyComputerUseClient` was missing under the isolated `$CODEX_HOME`; disabling Computer Use immediately restored turns.
- Packaging comparison: the prior plugin bundled the service app, while the current `1.0.1000502` plugin is a thin launcher for the canonical per-home app. The installed ChatGPT desktop app contains the matching signed service source.
- Focused Codex extension tests: 155/155 passed across service provisioning, readiness, auth bridging, attempt startup, and managed binary selection.
- `pnpm check:changed` passed locally, including production/test extension typechecks, extension lint, formatting, boundary guards, and import-cycle checks.
- `pnpm check:docs` passed: formatting, markdown lint, MDX, glossary, 6,174 internal links, and docs map.
- Full Codex extension suite: 2,731 tests passed. Four unrelated failures were investigated; the three persistent failures reproduced on an untouched checkout of the exact base commit, while the 1 ms timer-boundary failure passed in isolation.
- Real macOS proof: provisioned the actual ChatGPT-bundled service into a disposable isolated Codex home, received `installed` on the first ensure and `already_installed` in 7 ms on the second, and `/usr/bin/codesign --verify --deep --strict` passed on the copied app.
- Upstream Codex contract checked at `0dfa778dae6a94b2ff2c69176cbaf063a3bf18a1`: `mcpServerStatus/list` can expose a configured server with no tools (`codex-rs/app-server/src/request_processors/mcp_processor.rs`), while exact thread binding waits for a ready MCP client (`codex-rs/codex-mcp/src/connection_manager/tool_catalog.rs`).
