### PR TITLE
refactor: drop obsolete async resolution opt-ins

### DIFF
--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -641,11 +641,10 @@ describe("prepareSimpleCompletionModel", () => {
     );
   });
 
-  it("can preserve asynchronous provider model discovery", async () => {
+  it("uses asynchronous provider model discovery", async () => {
     // Use a standalone mock so the default beforeEach delegation from
     // resolveModelAsyncMock → resolveModelMock does not pollute call
-    // history. The point of the test is that when useAsyncModelResolution
-    // is true, only the async resolver is invoked.
+    // history. Only the async resolver should be invoked.
     const resolveModelAsync = vi.fn().mockResolvedValue({
       model: {
         provider: "anthropic",
@@ -664,7 +663,6 @@ describe("prepareSimpleCompletionModel", () => {
       cfg: undefined,
       provider: "anthropic",
       modelId: "claude-opus-4-6",
-      useAsyncModelResolution: true,
       modelResolver: resolveModelAsync,
     });
 

--- a/src/gateway/chat-tool-titles.test.ts
+++ b/src/gateway/chat-tool-titles.test.ts
@@ -205,7 +205,6 @@ describe("generateToolCallTitles", () => {
       agentId: AGENT_ID,
       modelRef: "openai/gpt-test",
       preferredProfile: undefined,
-      useAsyncModelResolution: true,
       allowMissingApiKeyModes: ["aws-sdk"],
     });
   });

--- a/src/gateway/chat-tool-titles.ts
+++ b/src/gateway/chat-tool-titles.ts
@@ -220,7 +220,6 @@ async function generateMissingTitles(params: {
       // Profile-isolated sessions must not leak their tool args through the
       // agent/default credential; the session's auth profile wins.
       preferredProfile: params.sessionAuthProfile,
-      useAsyncModelResolution: true,
       allowMissingApiKeyModes: ["aws-sdk"],
     });
   } catch (err) {

--- a/src/gateway/session-observer-ask.ts
+++ b/src/gateway/session-observer-ask.ts
@@ -176,7 +176,6 @@ export function createSessionObserverAskRuntime(params: SessionObserverAskRuntim
           agentId: snapshot.agentId,
           modelRef: utilityModelRef,
           useUtilityModel: true,
-          useAsyncModelResolution: true,
           allowMissingApiKeyModes: ["aws-sdk"],
         });
         if (controller.signal.aborted || params.isDisposed()) {

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -228,7 +228,6 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       agentId: state.agentId,
       modelRef: state.utilityModelRef,
       useUtilityModel: true,
-      useAsyncModelResolution: true,
       allowMissingApiKeyModes: ["aws-sdk"],
     });
     return await state.preparedPromise;

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -571,7 +571,6 @@ async function resolveApprovedModel(params: {
       ...(selectedProfile ? { preferredProfile: selectedProfile.id } : {}),
       ...(selectedProfile ? { bindAuthOwner: true } : {}),
       allowMissingApiKeyModes: ["aws-sdk"],
-      useAsyncModelResolution: true,
       modelResolver,
     });
     return {


### PR DESCRIPTION
## What Problem This Solves

Agent and Gateway utility-model callers still passed `useAsyncModelResolution: true` even though model resolution is lifecycle-backed and always asynchronous. Those obsolete opt-ins falsely suggested that synchronous resolution remained a supported choice and added redundant plumbing to each call site.

## Why This Change Was Made

This maintainer-commissioned LOC-reduction pass removes the redundant option from every caller inside the assigned `src/agents/**` and `src/gateway/**` surface. The focused runtime test now states and proves the current invariant directly: asynchronous provider discovery is the default. The deprecated compatibility parameter remains because three callers outside this batch's ownership still use it.

AI-assisted with Codex; the patch was manually scoped and verified against callers, plugin-SDK contracts, focused tests, changed gates, and autoreview.

## User Impact

No user-visible behavior changes. Utility completions continue to resolve models asynchronously; the code now reflects that existing behavior without redundant opt-ins.

## Evidence

- LOC: +2/-9 across 6 files (production +0/-4; tests +2/-5; net -7).
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json --shell -- "corepack pnpm test src/agents/simple-completion-runtime.test.ts src/gateway/chat-tool-titles.test.ts src/gateway/session-observer.test.ts src/gateway/session-observer-ask.test.ts src/gateway/session-observer.terminal.test.ts src/gateway/worker-environments/inference-runtime.test.ts"` — 124 tests passed across 6 files; Testbox run https://github.com/openclaw/openclaw/actions/runs/30069753931.
- `node scripts/check-changed.mjs -- src/agents/simple-completion-runtime.test.ts src/gateway/chat-tool-titles.test.ts src/gateway/chat-tool-titles.ts src/gateway/session-observer-ask.ts src/gateway/session-observer.ts src/gateway/worker-environments/inference-runtime.ts` — passed core/coreTests formatting, guards, API contract checks, typechecks, lint, and import cycles; Testbox run https://github.com/openclaw/openclaw/actions/runs/30069839334.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- `git diff --check` — passed.
