### PR TITLE
test(gateway): consolidate chat and reload fixtures

### DIFF
--- a/src/gateway/server-chat.agent-events.test-helpers.ts
+++ b/src/gateway/server-chat.agent-events.test-helpers.ts
@@ -1,5 +1,8 @@
+import { vi } from "vitest";
 import type { AgentEventPayload, AgentEventStream } from "../infra/agent-events.js";
+import { createChatRunState } from "./server-chat-state.js";
 import type { ChatRunRegistration, ChatRunState } from "./server-chat-state.js";
+import type { GatewayRequestContext } from "./server-methods/shared-types.js";
 
 type AgentEventHandler = (event: AgentEventPayload) => void;
 
@@ -18,6 +21,13 @@ type AgentEventCase = readonly [
   data: Record<string, unknown>,
   overrides?: AgentEventOverrides,
 ];
+
+type TextTranscriptEventOptions = {
+  id?: string;
+  parentId?: string | null;
+  timestamp?: number;
+  message?: Record<string, unknown>;
+};
 
 export function emitAgentEvent(
   handler: AgentEventHandler,
@@ -55,4 +65,62 @@ export function registerNamedChatRun(
   overrides: Omit<ChatRunRegistration, "clientRunId" | "sessionKey"> = {},
 ) {
   registerChatRun(state, `run-${name}`, `session-${name}`, `client-${name}`, overrides);
+}
+
+export function createDirectChatContext(
+  overrides: Partial<GatewayRequestContext> = {},
+): GatewayRequestContext {
+  const config = {};
+  return {
+    loadGatewayModelCatalog: vi.fn().mockResolvedValue([]),
+    loadGatewayModelCatalogSnapshot: vi.fn().mockResolvedValue({
+      agentId: "main",
+      agentDir: "/tmp/chat-model-catalog-agent",
+      config,
+      entries: [],
+      routeVariants: [],
+    }),
+    logGateway: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    agentRunSeq: new Map(),
+    chatAbortControllers: new Map(),
+    chatRunState: createChatRunState(),
+    addChatRun: vi.fn(),
+    removeChatRun: vi.fn(),
+    broadcast: vi.fn(),
+    broadcastToConnIds: vi.fn(),
+    getSessionEventSubscriberConnIds: () => new Set(),
+    nodeSendToSession: vi.fn(),
+    registerToolEventRecipient: vi.fn(),
+    getRuntimeConfig: () => config,
+    recoveryRuntime: {
+      dispatchAgent: vi.fn(),
+      waitForAgent: vi.fn(),
+      sendRecoveryNotice: vi.fn(),
+    },
+    dedupe: new Map(),
+    ...overrides,
+  } as unknown as GatewayRequestContext;
+}
+
+export function createTextTranscriptEvent(
+  role: "assistant" | "toolResult" | "user",
+  text: string,
+  options: TextTranscriptEventOptions = {},
+) {
+  const { id, parentId, timestamp = Date.now(), message = {} } = options;
+  return {
+    ...(id ? { id } : {}),
+    ...(parentId !== undefined ? { parentId } : {}),
+    message: {
+      role,
+      content: [{ type: "text", text }],
+      timestamp,
+      ...message,
+    },
+  };
 }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1305,21 +1305,11 @@ describe("gateway hot reload model state", () => {
     const nextConfig = { mcp: { servers: {} } } as OpenClawConfig;
 
     await applyHotReload(
-      {
+      createHotTailPlan({
         changedPaths: ["mcp.servers.context7.command"],
-        restartGateway: false,
-        restartReasons: [],
         hotReasons: ["mcp.servers.context7.command"],
-        reloadHooks: false,
-        restartGmailWatcher: false,
-        restartCron: false,
-        restartHeartbeat: false,
-        restartHealthMonitor: false,
-        reloadPlugins: false,
-        restartChannels: new Set(),
         disposeMcpRuntimes: true,
-        noopPaths: [],
-      },
+      }),
       nextConfig,
     );
 
@@ -1343,21 +1333,10 @@ describe("gateway hot reload model state", () => {
     } as OpenClawConfig;
 
     await applyHotReload(
-      {
+      createHotTailPlan({
         changedPaths: ["agents.defaults.workspace"],
-        restartGateway: false,
-        restartReasons: [],
         hotReasons: ["agents.defaults.workspace"],
-        reloadHooks: false,
-        restartGmailWatcher: false,
-        restartCron: false,
-        restartHeartbeat: false,
-        restartHealthMonitor: false,
-        reloadPlugins: false,
-        restartChannels: new Set(),
-        disposeMcpRuntimes: false,
-        noopPaths: [],
-      },
+      }),
       nextConfig,
     );
 
@@ -1752,21 +1731,11 @@ describe("gateway hot reload commit policy", () => {
 
     await expect(
       applyHotReload(
-        {
+        createHotTailPlan({
           changedPaths: ["commands.restart", "hooks.enabled"],
-          restartGateway: false,
-          restartReasons: [],
           hotReasons: ["commands.restart", "hooks.enabled"],
           reloadHooks: true,
-          restartGmailWatcher: false,
-          restartCron: false,
-          restartHeartbeat: false,
-          restartHealthMonitor: false,
-          reloadPlugins: false,
-          restartChannels: new Set(),
-          disposeMcpRuntimes: false,
-          noopPaths: [],
-        },
+        }),
         { commands: { restart: true }, hooks: { enabled: true } },
       ),
     ).rejects.toThrow("hooks.enabled requires hooks.token");
@@ -2228,24 +2197,9 @@ describe("gateway restart deferral preflight", () => {
       ).toBe("recovery-pending");
 
       expect(
-        requestGatewayRestart(
-          {
-            changedPaths: ["gateway.auth"],
-            restartGateway: true,
-            restartReasons: ["gateway.auth"],
-            hotReasons: [],
-            reloadHooks: false,
-            restartGmailWatcher: false,
-            restartCron: false,
-            restartHeartbeat: false,
-            restartHealthMonitor: false,
-            reloadPlugins: false,
-            restartChannels: new Set(),
-            disposeMcpRuntimes: false,
-            noopPaths: [],
-          },
-          { gateway: { port: 18791 } },
-        ).status,
+        requestGatewayRestart(createGatewayRestartPlan("gateway.auth"), {
+          gateway: { port: 18791 },
+        }).status,
       ).toBe("accepted");
       await vi.advanceTimersByTimeAsync(1_000);
 
@@ -2410,21 +2364,11 @@ describe("gateway restart deferral preflight", () => {
     hoisted.activeEmbeddedRunCount.value = 1;
     vi.useFakeTimers();
     const reloadPromise = applyHotReload(
-      {
+      createHotTailPlan({
         changedPaths: ["channels.discord.token"],
-        restartGateway: false,
-        restartReasons: [],
         hotReasons: ["channels.discord.token"],
-        reloadHooks: false,
-        restartGmailWatcher: false,
-        restartCron: false,
-        restartHeartbeat: false,
-        restartHealthMonitor: false,
-        reloadPlugins: false,
         restartChannels: new Set(["discord"]),
-        disposeMcpRuntimes: false,
-        noopPaths: [],
-      },
+      }),
       {
         gateway: { reload: {} },
         channels: { discord: { token: "token" } },
@@ -2487,21 +2431,11 @@ describe("gateway restart deferral preflight", () => {
     hoisted.activeEmbeddedRunCount.value = 1;
     vi.useFakeTimers();
     const reloadPromise = applyHotReload(
-      {
+      createHotTailPlan({
         changedPaths: ["channels.telegram.botToken"],
-        restartGateway: false,
-        restartReasons: [],
         hotReasons: ["channels.telegram.botToken"],
-        reloadHooks: false,
-        restartGmailWatcher: false,
-        restartCron: false,
-        restartHeartbeat: false,
-        restartHealthMonitor: false,
-        reloadPlugins: false,
         restartChannels: new Set(["telegram"]),
-        disposeMcpRuntimes: false,
-        noopPaths: [],
-      },
+      }),
       {
         channels: { telegram: { botToken: "token" } },
       },
@@ -2636,21 +2570,11 @@ describe("gateway restart deferral preflight", () => {
 
 describe("gateway channel hot reload handlers", () => {
   function createChannelReloadPlan(channels: ChannelKind[]): GatewayReloadPlan {
-    return {
+    return createHotTailPlan({
       changedPaths: channels.map((channel) => `channels.${channel}.enabled`),
-      restartGateway: false,
-      restartReasons: [],
       hotReasons: ["channels"],
-      reloadHooks: false,
-      restartGmailWatcher: false,
-      restartCron: false,
-      restartHeartbeat: false,
-      restartHealthMonitor: false,
-      reloadPlugins: false,
       restartChannels: new Set(channels),
-      disposeMcpRuntimes: false,
-      noopPaths: [],
-    };
+    });
   }
 
   async function withChannelReloadsEnabled(run: () => Promise<void>) {
@@ -3098,58 +3022,29 @@ describe("gateway channel hot reload handlers", () => {
     }
   });
 
-  it("continues restarting later channels after a hot-reload stop failure", async () => {
+  it.each([
+    {
+      name: "stop",
+      expectedEvents: ["stop:telegram", "stop:discord", "start:discord"],
+    },
+    {
+      name: "start",
+      expectedEvents: ["stop:telegram", "start:telegram", "stop:discord", "start:discord"],
+    },
+  ])("continues restarting later channels after a hot-reload $name failure", async (testCase) => {
     const events: string[] = [];
     const setState = vi.fn();
     const logChannels = { info: vi.fn(), error: vi.fn() };
     const logReload = { info: vi.fn(), warn: vi.fn() };
     const stopChannel = vi.fn(async (channel: ChannelKind) => {
       events.push(`stop:${channel}`);
-      if (channel === "telegram") {
+      if (channel === "telegram" && testCase.name === "stop") {
         throw new Error("stop failed");
       }
     });
     const startChannel = vi.fn(async (channel: ChannelKind) => {
       events.push(`start:${channel}`);
-    });
-    const { applyHotReload } = createGatewayReloadHandlers({
-      setState,
-      startChannel,
-      stopChannel,
-      logChannels,
-      logReload,
-    });
-
-    await withGatewayRestartSignal(async (signalSpy) => {
-      await withChannelReloadsEnabled(async () => {
-        await expect(
-          applyHotReload(createChannelReloadPlan(["telegram", "discord"]), {}),
-        ).resolves.toBeUndefined();
-      });
-      expect(signalSpy).toHaveBeenCalledOnce();
-    });
-
-    expect(events).toEqual(["stop:telegram", "stop:discord", "start:discord"]);
-    expect(logChannels.error).toHaveBeenCalledWith(
-      "failed to restart telegram channel during hot reload: stop failed",
-    );
-    expect(setState).toHaveBeenCalledTimes(1);
-    expect(logReload.warn).toHaveBeenCalledWith(
-      "channel restart (telegram) failed after config commit; restarting gateway",
-    );
-  });
-
-  it("continues restarting later channels after a hot-reload start failure", async () => {
-    const events: string[] = [];
-    const setState = vi.fn();
-    const logChannels = { info: vi.fn(), error: vi.fn() };
-    const logReload = { info: vi.fn(), warn: vi.fn() };
-    const stopChannel = vi.fn(async (channel: ChannelKind) => {
-      events.push(`stop:${channel}`);
-    });
-    const startChannel = vi.fn(async (channel: ChannelKind) => {
-      events.push(`start:${channel}`);
-      if (channel === "telegram") {
+      if (channel === "telegram" && testCase.name === "start") {
         throw new Error("start failed");
       }
     });
@@ -3170,9 +3065,9 @@ describe("gateway channel hot reload handlers", () => {
       expect(signalSpy).toHaveBeenCalledOnce();
     });
 
-    expect(events).toEqual(["stop:telegram", "start:telegram", "stop:discord", "start:discord"]);
+    expect(events).toEqual(testCase.expectedEvents);
     expect(logChannels.error).toHaveBeenCalledWith(
-      "failed to restart telegram channel during hot reload: start failed",
+      `failed to restart telegram channel during hot reload: ${testCase.name} failed`,
     );
     expect(setState).toHaveBeenCalledTimes(1);
     expect(logReload.warn).toHaveBeenCalledWith(
@@ -3183,21 +3078,11 @@ describe("gateway channel hot reload handlers", () => {
 
 describe("gateway Gmail hot reload handlers", () => {
   function createGmailReloadPlan(): GatewayReloadPlan {
-    return {
+    return createHotTailPlan({
       changedPaths: ["hooks.gmail.account"],
-      restartGateway: false,
-      restartReasons: [],
       hotReasons: ["hooks.gmail.account"],
-      reloadHooks: false,
       restartGmailWatcher: true,
-      restartCron: false,
-      restartHeartbeat: false,
-      restartHealthMonitor: false,
-      reloadPlugins: false,
-      restartChannels: new Set<ChannelKind>(),
-      disposeMcpRuntimes: false,
-      noopPaths: [],
-    };
+    });
   }
 
   function createGmailConfig(account: string): OpenClawConfig {
@@ -3216,24 +3101,7 @@ describe("gateway Gmail hot reload handlers", () => {
       hooks: { enabled: true, gmail: { account: "next@example.com" } },
     } as never;
 
-    await applyHotReload(
-      {
-        changedPaths: ["hooks.gmail.account"],
-        restartGateway: false,
-        restartReasons: [],
-        hotReasons: ["hooks.gmail.account"],
-        reloadHooks: false,
-        restartGmailWatcher: true,
-        restartCron: false,
-        restartHeartbeat: false,
-        restartHealthMonitor: false,
-        reloadPlugins: false,
-        restartChannels: new Set(),
-        disposeMcpRuntimes: false,
-        noopPaths: [],
-      },
-      nextConfig,
-    );
+    await applyHotReload(createGmailReloadPlan(), nextConfig);
 
     expect(hoisted.refreshContextWindowCache).not.toHaveBeenCalled();
     expect(stopPostReadySidecars).toHaveBeenCalledBefore(hoisted.stopGmailWatcher);

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1,7 +1,6 @@
 // Gateway chat integration tests cover dashboard chat requests, transcript
 // history limits, model overrides, inbound dispatch, and streaming event fanout.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
@@ -32,7 +31,10 @@ import { createDeferred } from "../test-utils/deferred.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
-import { createChatRunState } from "./server-chat-state.js";
+import {
+  createDirectChatContext,
+  createTextTranscriptEvent,
+} from "./server-chat.agent-events.test-helpers.js";
 import { getMaxChatHistoryMessagesBytes } from "./server-constants.js";
 import type { GatewayRequestContext, RespondFn } from "./server-methods/shared-types.js";
 import { pendingChatSendDedupeKey } from "./server-shared.js";
@@ -110,11 +112,9 @@ async function withGatewayChatHarness(
   run: (ctx: { ws: GatewaySocket; createSessionDir: () => Promise<string> }) => Promise<void>,
   options?: { headers?: Record<string, string> },
 ) {
-  const tempDirs: string[] = [];
   const ws = await harness.openWs(options?.headers);
   const createSessionDir = async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
-    tempDirs.push(sessionDir);
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     testState.sessionStorePath = path.join(sessionDir, "sessions.json");
     return sessionDir;
   };
@@ -128,11 +128,6 @@ async function withGatewayChatHarness(
     clearConfigCache();
     testState.sessionStorePath = undefined;
     ws.close();
-    await Promise.all(
-      tempDirs.map((dir) =>
-        fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }),
-      ),
-    );
   }
 }
 
@@ -179,7 +174,7 @@ async function writeGatewayConfig(config: Record<string, unknown>) {
 
 async function writeMainSessionTranscript(
   _sessionDir: string,
-  lines: string[],
+  events: unknown[],
   sessionId = "sess-main",
   opts?: {
     agentId?: string;
@@ -190,8 +185,8 @@ async function writeMainSessionTranscript(
   if (!storePath) {
     throw new Error("session store path was not initialized");
   }
-  for (const line of lines) {
-    if (!line.trim()) {
+  for (const event of events) {
+    if (typeof event === "string" && !event.trim()) {
       continue;
     }
     await appendTranscriptEvent(
@@ -201,50 +196,21 @@ async function writeMainSessionTranscript(
         sessionKey: opts?.sessionKey ?? "agent:main:main",
         storePath,
       },
-      JSON.parse(line) as unknown,
+      typeof event === "string" ? (JSON.parse(event) as unknown) : event,
     );
   }
 }
 
-async function removeTempDir(dir: string): Promise<void> {
-  await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
-}
-
-function createDirectChatContext(): GatewayRequestContext {
-  const config = {};
-  return {
-    loadGatewayModelCatalog: vi.fn().mockResolvedValue([]),
-    loadGatewayModelCatalogSnapshot: vi.fn().mockResolvedValue({
-      agentId: "main",
-      agentDir: "/tmp/chat-model-catalog-agent",
-      config,
-      entries: [],
-      routeVariants: [],
-    }),
-    logGateway: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    },
-    agentRunSeq: new Map(),
-    chatAbortControllers: new Map(),
-    chatRunState: createChatRunState(),
-    addChatRun: vi.fn(),
-    removeChatRun: vi.fn(),
-    broadcast: vi.fn(),
-    broadcastToConnIds: vi.fn(),
-    getSessionEventSubscriberConnIds: () => new Set(),
-    nodeSendToSession: vi.fn(),
-    registerToolEventRecipient: vi.fn(),
-    getRuntimeConfig: () => config,
-    recoveryRuntime: {
-      dispatchAgent: vi.fn(),
-      waitForAgent: vi.fn(),
-      sendRecoveryNotice: vi.fn(),
-    },
-    dedupe: new Map(),
-  } as unknown as GatewayRequestContext;
+async function withDirectChatSession(run: (sessionDir: string) => Promise<void>) {
+  const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
+  testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+  try {
+    await run(sessionDir);
+  } finally {
+    dispatchInboundMessageMock.mockReset();
+    testState.sessionStorePath = undefined;
+    clearConfigCache();
+  }
 }
 
 async function sendControlUiChat(params: {
@@ -356,7 +322,6 @@ test("chat.send replays a cached result after the session is archived", async ()
     dispatchInboundMessageMock.mockReset();
     testState.sessionStorePath = undefined;
     clearConfigCache();
-    await removeTempDir(sessionDir);
   }
 });
 
@@ -445,7 +410,7 @@ describe("gateway server chat", () => {
   test.each(["chat.history", "chat.startup"] as const)(
     "%s replays the active plan snapshot in inFlightRun",
     async (method) => {
-      const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+      const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
       try {
         testState.sessionStorePath = path.join(sessionDir, "sessions.json");
         await writeMainSessionStore(sessionDir);
@@ -495,13 +460,12 @@ describe("gateway server chat", () => {
       } finally {
         testState.sessionStorePath = undefined;
         clearConfigCache();
-        await removeTempDir(sessionDir);
       }
     },
   );
 
   test("chat.history returns catalog-backed session metadata with history", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       testState.agentConfig = {
@@ -530,7 +494,7 @@ describe("gateway server chat", () => {
           compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
         },
       ];
-      const context = {
+      const context = createDirectChatContext({
         loadGatewayModelCatalogSnapshot: vi
           .fn<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>()
           .mockResolvedValue({
@@ -540,13 +504,7 @@ describe("gateway server chat", () => {
             entries: catalog,
             routeVariants: catalog,
           }),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-      } as unknown as GatewayRequestContext;
+      });
       const { chatHandlers } = await import("./server-methods/chat.js");
 
       await expectDefined(
@@ -605,7 +563,6 @@ describe("gateway server chat", () => {
       clearConfigCache();
       testState.agentConfig = undefined;
       testState.sessionStorePath = undefined;
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -626,13 +583,7 @@ describe("gateway server chat", () => {
         },
       });
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "persisted metadata" }],
-            timestamp: updatedAt,
-          },
-        }),
+        createTextTranscriptEvent("user", "persisted metadata", { timestamp: updatedAt }),
       ]);
 
       const persisted = await rpcReq<{
@@ -721,13 +672,7 @@ describe("gateway server chat", () => {
         },
       });
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "startup hydrate" }],
-            timestamp: updatedAt,
-          },
-        }),
+        createTextTranscriptEvent("user", "startup hydrate", { timestamp: updatedAt }),
       ]);
 
       const startup = await rpcReq<{
@@ -779,7 +724,7 @@ describe("gateway server chat", () => {
         list: [{ id: "main", default: true }, { id: "work" }],
       },
     } as OpenClawConfig;
-    const context = {
+    const context = createDirectChatContext({
       getRuntimeConfig: () => config,
       loadGatewayModelCatalogSnapshot: vi.fn(async () => ({
         agentId: "main",
@@ -788,11 +733,8 @@ describe("gateway server chat", () => {
         entries: [{ id: "main-only", name: "Main only", provider: "test" }],
         routeVariants: [],
       })),
-      logGateway: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-      chatAbortControllers: new Map(),
-      chatRunState: createChatRunState(),
-    } as unknown as GatewayRequestContext;
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    });
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       await writeSessionStore({
@@ -825,7 +767,6 @@ describe("gateway server chat", () => {
       expect(context.loadGatewayModelCatalogSnapshot).toHaveBeenCalledWith({ agentId: "work" });
     } finally {
       testState.sessionStorePath = undefined;
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -840,7 +781,7 @@ describe("gateway server chat", () => {
       },
     } as OpenClawConfig;
     let currentConfig = initialConfig;
-    const context = {
+    const context = createDirectChatContext({
       getRuntimeConfig: () => currentConfig,
       loadGatewayModelCatalogSnapshot: vi.fn(async () => {
         currentConfig = replacementConfig;
@@ -852,11 +793,8 @@ describe("gateway server chat", () => {
           routeVariants: [],
         };
       }),
-      logGateway: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-      chatAbortControllers: new Map(),
-      chatRunState: createChatRunState(),
-    } as unknown as GatewayRequestContext;
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    });
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       await writeSessionStore({
@@ -889,7 +827,6 @@ describe("gateway server chat", () => {
       expect(context.loadGatewayModelCatalogSnapshot).toHaveBeenCalledOnce();
     } finally {
       testState.sessionStorePath = undefined;
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -902,7 +839,7 @@ describe("gateway server chat", () => {
     } as OpenClawConfig;
     const equivalentConfig = structuredClone(initialConfig);
     let currentConfig = initialConfig;
-    const context = {
+    const context = createDirectChatContext({
       getRuntimeConfig: () => currentConfig,
       loadGatewayModelCatalogSnapshot: vi.fn(async () => {
         currentConfig = equivalentConfig;
@@ -921,11 +858,8 @@ describe("gateway server chat", () => {
           routeVariants: [],
         };
       }),
-      logGateway: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-      chatAbortControllers: new Map(),
-      chatRunState: createChatRunState(),
-    } as unknown as GatewayRequestContext;
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    });
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       await writeSessionStore({
@@ -967,12 +901,11 @@ describe("gateway server chat", () => {
       expect(context.loadGatewayModelCatalogSnapshot).toHaveBeenCalledOnce();
     } finally {
       testState.sessionStorePath = undefined;
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.startup does not wait for slow optional model catalog metadata", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       await writeSessionStore({
@@ -990,20 +923,12 @@ describe("gateway server chat", () => {
           Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>>
         >();
       const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
-      const context = {
+      const context = createDirectChatContext({
         loadGatewayModelCatalogSnapshot: vi
           .fn<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>()
           .mockReturnValue(catalog.promise),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
         getRuntimeConfig: () => ({}),
-      } as unknown as GatewayRequestContext;
+      });
       const { chatHandlers } = await import("./server-methods/chat.js");
 
       await expectDefined(
@@ -1040,7 +965,6 @@ describe("gateway server chat", () => {
       expect(payload?.metadata).toBeUndefined();
     } finally {
       testState.sessionStorePath = undefined;
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -1062,7 +986,7 @@ describe("gateway server chat", () => {
         },
       },
       async (state) => {
-        const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+        const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
         try {
           testState.sessionStorePath = path.join(sessionDir, "sessions.json");
           const config = {
@@ -1177,7 +1101,7 @@ describe("gateway server chat", () => {
             routeVariants: [subscriptionRoute, platformRoute],
           };
           const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
-          const context = {
+          const context = createDirectChatContext({
             loadGatewayModelCatalogSnapshot: vi
               .fn<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>()
               .mockResolvedValue({
@@ -1186,16 +1110,8 @@ describe("gateway server chat", () => {
                 config,
                 ...catalogSnapshot,
               }),
-            logGateway: {
-              info: vi.fn(),
-              warn: vi.fn(),
-              error: vi.fn(),
-              debug: vi.fn(),
-            },
-            chatAbortControllers: new Map(),
-            chatRunState: createChatRunState(),
             getRuntimeConfig: () => config,
-          } as unknown as GatewayRequestContext;
+          });
           const { createGatewayAgentModelCatalogProjector } =
             await import("./server-methods/models-list-result.js");
           const persistedConfig = getRuntimeConfig();
@@ -1323,7 +1239,6 @@ describe("gateway server chat", () => {
           }
         } finally {
           testState.sessionStorePath = undefined;
-          await removeTempDir(sessionDir);
         }
       },
     );
@@ -1362,7 +1277,7 @@ describe("gateway server chat", () => {
   });
 
   test("chat.startup scopes metadata to agent session keys without explicit agentId", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       await writeSessionStore({
@@ -1410,7 +1325,7 @@ describe("gateway server chat", () => {
       } as unknown as OpenClawConfig;
       await writeGatewayConfig(config);
       const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
-      const context = {
+      const context = createDirectChatContext({
         loadGatewayModelCatalogSnapshot: vi
           .fn<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>()
           .mockImplementation(async () => {
@@ -1436,16 +1351,8 @@ describe("gateway server chat", () => {
               routeVariants: entries,
             };
           }),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
         getRuntimeConfig: () => config,
-      } as unknown as GatewayRequestContext;
+      });
       const { chatHandlers } = await import("./server-methods/chat.js");
 
       await expectDefined(
@@ -1492,7 +1399,6 @@ describe("gateway server chat", () => {
       );
     } finally {
       testState.sessionStorePath = undefined;
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -1562,7 +1468,7 @@ describe("gateway server chat", () => {
   });
 
   test("chat.send returns in_flight when duplicate attachment send wins parsing race", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const dispatchRelease = createDeferred();
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
@@ -1580,7 +1486,7 @@ describe("gateway server chat", () => {
       const firstCatalog =
         createDeferred<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>>();
       const responses: Array<{ id: string; ok: boolean; payload?: unknown; error?: unknown }> = [];
-      const context = {
+      const context = createDirectChatContext({
         loadGatewayModelCatalog: vi
           .fn<GatewayRequestContext["loadGatewayModelCatalog"]>()
           .mockImplementationOnce(() => firstCatalog.promise)
@@ -1592,25 +1498,8 @@ describe("gateway server chat", () => {
               input: ["text", "image"],
             },
           ]),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        agentRunSeq: new Map<string, number>(),
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
-        addChatRun: vi.fn(),
-        removeChatRun: vi.fn(),
-        broadcast: vi.fn(),
-        broadcastToConnIds: vi.fn(),
-        getSessionEventSubscriberConnIds: () => new Set(),
-        nodeSendToSession: vi.fn(),
-        registerToolEventRecipient: vi.fn(),
         getRuntimeConfig: () => ({}),
-        dedupe: new Map(),
-      } as unknown as GatewayRequestContext;
+      });
       dispatchInboundMessageMock.mockImplementation(async () => dispatchRelease.promise);
 
       const pngB64 =
@@ -1694,12 +1583,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.abort cancels chat.send during attachment preparation before ACK", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const firstCatalog =
       createDeferred<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>>();
     try {
@@ -1722,27 +1610,12 @@ describe("gateway server chat", () => {
         error?: unknown;
       }> = [];
       const abortResponses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
-      const context = {
+      const context = createDirectChatContext({
         loadGatewayModelCatalog: vi
           .fn<GatewayRequestContext["loadGatewayModelCatalog"]>()
           .mockImplementationOnce(() => firstCatalog.promise),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        agentRunSeq: new Map<string, number>(),
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
-        addChatRun: vi.fn(),
-        removeChatRun: vi.fn(),
-        broadcast: vi.fn(),
-        nodeSendToSession: vi.fn(),
-        registerToolEventRecipient: vi.fn(),
         getRuntimeConfig: () => ({}),
-        dedupe: new Map(),
-      } as unknown as GatewayRequestContext;
+      });
 
       const pngB64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
@@ -1886,7 +1759,6 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -2033,7 +1905,6 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -2115,7 +1986,6 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -2229,7 +2099,6 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -2309,7 +2178,6 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -2453,14 +2321,13 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test.each(configuredImageModelCases)(
     "chat.send preserves text-only image uploads as MediaPaths even with configured imageModel: $id",
     async ({ id, imageModel }) => {
-      const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+      const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
       try {
         testState.sessionStorePath = path.join(sessionDir, "sessions.json");
         testState.agentConfig = {
@@ -2484,7 +2351,7 @@ describe("gateway server chat", () => {
           },
         });
 
-        const context = {
+        const context = createDirectChatContext({
           getRuntimeConfig,
           loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(
             async () => [
@@ -2514,22 +2381,7 @@ describe("gateway server chat", () => {
               },
             ],
           ),
-          logGateway: {
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-            debug: vi.fn(),
-          },
-          agentRunSeq: new Map<string, number>(),
-          chatAbortControllers: new Map(),
-          chatRunState: createChatRunState(),
-          addChatRun: vi.fn(),
-          removeChatRun: vi.fn(),
-          broadcast: vi.fn(),
-          nodeSendToSession: vi.fn(),
-          registerToolEventRecipient: vi.fn(),
-          dedupe: new Map(),
-        } as unknown as GatewayRequestContext;
+        });
         const pngB64 =
           "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
         let captured: { ctx?: Record<string, unknown>; replyOptions?: GetReplyOptions } | undefined;
@@ -2607,13 +2459,12 @@ describe("gateway server chat", () => {
         testState.agentConfig = undefined;
         testState.sessionStorePath = undefined;
         clearConfigCache();
-        await removeTempDir(sessionDir);
       }
     },
   );
 
   test("chat.send durably admits a restart-safe Control UI turn before ACK", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const dispatchRelease = createDeferred();
     try {
@@ -2691,12 +2542,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send persists optional connection identity per turn", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       await writeSessionStore({
@@ -2800,12 +2650,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send preserves a terminal source claim before admitting the next turn", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const dispatchRelease = createDeferred();
     const priorRunId = "idem-prior-terminal-claim";
@@ -2877,7 +2726,6 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -2885,7 +2733,7 @@ describe("gateway server chat", () => {
     { caseName: "tombstones an explicit abort", retryable: false, stopReason: "rpc" },
     { caseName: "retains a restart interruption", retryable: true, stopReason: "restart" },
   ])("chat.send $caseName during SQLite admission", async ({ retryable, stopReason }) => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const runId = `idem-restart-safe-abort-${stopReason}`;
     const lockEntered = createDeferred();
@@ -3043,12 +2891,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send keeps a durable Control UI retry pending when recovery remains abandoned", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const idempotencyKey = "idem-restart-safe-duplicate";
     try {
@@ -3120,12 +2967,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send retires a durable retry after recovery re-dispatch succeeds", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const idempotencyKey = "idem-restart-safe-recovered-retry";
     try {
@@ -3179,12 +3025,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send suppresses a durable retry settled while lifecycle admission waits", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const idempotencyKey = "idem-recovery-settled-during-admission";
     const releaseMutation = createDeferred();
@@ -3246,12 +3091,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send does not re-dispatch an archived durable recovery claim", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const idempotencyKey = "idem-restart-safe-archived-retry";
     try {
@@ -3293,12 +3137,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send stops automatic retry when durable recovery ownership changes", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const idempotencyKey = "idem-restart-safe-replaced-retry";
     try {
@@ -3349,7 +3192,6 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -3357,7 +3199,7 @@ describe("gateway server chat", () => {
     { caseName: "settled recovery", status: "done" as const, abortedLastRun: false },
     { caseName: "unresumable recovery", status: "failed" as const, abortedLastRun: true },
   ])("chat.send suppresses a Control UI retry after $caseName", async (terminal) => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const idempotencyKey = `idem-${terminal.status}-recovery`;
     try {
@@ -3394,12 +3236,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send releases an unadopted durable claim after dispatch rejection", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const runId = "idem-restart-safe-dispatch-error";
     try {
@@ -3492,12 +3333,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send releases a durable claim after synchronous post-admission failure", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const runId = "idem-restart-safe-setup-error";
     try {
@@ -3541,12 +3381,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send leaves a post-admission routing rejection retryable", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     const runId = "idem-restart-safe-routing-change";
     try {
@@ -3624,7 +3463,6 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
@@ -3647,7 +3485,7 @@ describe("gateway server chat", () => {
       entry: { abortedLastRun: true },
     },
   ])("chat.send leaves $caseName outside restart-safe admission", async ({ entry, runId }) => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const storePath = path.join(sessionDir, "sessions.json");
     try {
       testState.sessionStorePath = storePath;
@@ -3689,12 +3527,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send keeps matching WebChat text sends distinct by idempotency key", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const dispatchRelease = createDeferred();
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
@@ -3708,27 +3545,10 @@ describe("gateway server chat", () => {
       });
 
       const responses: Array<{ id: string; ok: boolean; payload?: unknown; error?: unknown }> = [];
-      const context = {
+      const context = createDirectChatContext({
         getRuntimeConfig,
         loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        agentRunSeq: new Map<string, number>(),
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
-        addChatRun: vi.fn(),
-        removeChatRun: vi.fn(),
-        broadcast: vi.fn(),
-        broadcastToConnIds: vi.fn(),
-        getSessionEventSubscriberConnIds: () => new Set(),
-        nodeSendToSession: vi.fn(),
-        registerToolEventRecipient: vi.fn(),
-        dedupe: new Map(),
-      } as unknown as GatewayRequestContext;
+      });
       dispatchInboundMessageMock.mockImplementation(async () => dispatchRelease.promise);
 
       const { chatHandlers } = await import("./server-methods/chat.js");
@@ -3921,14 +3741,11 @@ describe("gateway server chat", () => {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();
-      await removeTempDir(sessionDir);
     }
   });
 
   test("chat.send can suppress command interpretation for slash-prefixed system turns", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
-    try {
-      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+    await withDirectChatSession(async () => {
       await writeSessionStore({
         entries: {
           main: {
@@ -3939,25 +3756,10 @@ describe("gateway server chat", () => {
       });
 
       const responses: Array<{ id: string; ok: boolean; payload?: unknown; error?: unknown }> = [];
-      const context = {
+      const context = createDirectChatContext({
         getRuntimeConfig,
         loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        agentRunSeq: new Map<string, number>(),
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
-        addChatRun: vi.fn(),
-        removeChatRun: vi.fn(),
-        broadcast: vi.fn(),
-        nodeSendToSession: vi.fn(),
-        registerToolEventRecipient: vi.fn(),
-        dedupe: new Map(),
-      } as unknown as GatewayRequestContext;
+      });
       dispatchInboundMessageMock.mockResolvedValue({});
 
       const { chatHandlers } = await import("./server-methods/chat.js");
@@ -4029,18 +3831,11 @@ describe("gateway server chat", () => {
       await waitForFast(() => {
         expect(context.removeChatRun).toHaveBeenCalledTimes(1);
       }, FAST_WAIT_OPTS);
-    } finally {
-      dispatchInboundMessageMock.mockReset();
-      testState.sessionStorePath = undefined;
-      clearConfigCache();
-      await removeTempDir(sessionDir);
-    }
+    });
   });
 
   test("chat.send starts the next WebChat turn after the prior internal run finishes", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
-    try {
-      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+    await withDirectChatSession(async () => {
       await writeSessionStore({
         entries: {
           main: {
@@ -4051,27 +3846,10 @@ describe("gateway server chat", () => {
       });
 
       const responses: Array<{ id: string; ok: boolean; payload?: unknown; error?: unknown }> = [];
-      const context = {
+      const context = createDirectChatContext({
         getRuntimeConfig,
         loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        agentRunSeq: new Map<string, number>(),
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
-        addChatRun: vi.fn(),
-        removeChatRun: vi.fn(),
-        broadcast: vi.fn(),
-        broadcastToConnIds: vi.fn(),
-        getSessionEventSubscriberConnIds: () => new Set(),
-        nodeSendToSession: vi.fn(),
-        registerToolEventRecipient: vi.fn(),
-        dedupe: new Map(),
-      } as unknown as GatewayRequestContext;
+      });
       dispatchInboundMessageMock.mockResolvedValue(undefined);
 
       const { chatHandlers } = await import("./server-methods/chat.js");
@@ -4162,18 +3940,11 @@ describe("gateway server chat", () => {
       expect(dispatchOptions[0]?.promptCacheKey).not.toContain("main");
       expect(dispatchOptions[0]?.promptCacheKey).not.toContain("sess-main");
       expect(context.addChatRun).toHaveBeenCalledTimes(2);
-    } finally {
-      dispatchInboundMessageMock.mockReset();
-      testState.sessionStorePath = undefined;
-      clearConfigCache();
-      await removeTempDir(sessionDir);
-    }
+    });
   });
 
   test("chat.send terminalizes the client run when a followup is queued", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
-    try {
-      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+    await withDirectChatSession(async () => {
       await writeSessionStore({
         entries: {
           main: {
@@ -4184,27 +3955,12 @@ describe("gateway server chat", () => {
       });
 
       const broadcast = vi.fn((_event: string, _payload: unknown) => undefined);
-      const context = {
+      const context = createDirectChatContext({
         loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        agentRunSeq: new Map<string, number>(),
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
         chatQueuedTurns: new Map(),
-        addChatRun: vi.fn(),
-        removeChatRun: vi.fn(),
         broadcast,
-        broadcastToConnIds: vi.fn(),
-        nodeSendToSession: vi.fn(),
-        registerToolEventRecipient: vi.fn(),
         getRuntimeConfig: () => ({}),
-        dedupe: new Map(),
-      } as unknown as GatewayRequestContext;
+      });
       let turnAdoptionLifecycle: GetReplyOptions["turnAdoptionLifecycle"];
       const dispatchRelease = createDeferred();
       dispatchInboundMessageMock.mockImplementationOnce(async (args: unknown) => {
@@ -4389,18 +4145,11 @@ describe("gateway server chat", () => {
       expect(context.chatQueuedTurns.has("idem-queued-followup-post-error")).toBe(true);
       failedDispatchLifecycle?.onSettled?.();
       expect(context.chatQueuedTurns.has("idem-queued-followup-post-error")).toBe(false);
-    } finally {
-      dispatchInboundMessageMock.mockReset();
-      testState.sessionStorePath = undefined;
-      clearConfigCache();
-      await removeTempDir(sessionDir);
-    }
+    });
   });
 
   test("chat.send emits operator-only post-ACK server timing milestones", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
-    try {
-      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+    await withDirectChatSession(async () => {
       await writeSessionStore({
         entries: {
           main: {
@@ -4412,26 +4161,11 @@ describe("gateway server chat", () => {
 
       const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
       const broadcastToConnIds = vi.fn();
-      const context = {
+      const context = createDirectChatContext({
         getRuntimeConfig,
         loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        agentRunSeq: new Map<string, number>(),
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
-        addChatRun: vi.fn(),
-        removeChatRun: vi.fn(),
-        broadcast: vi.fn(),
         broadcastToConnIds,
-        nodeSendToSession: vi.fn(),
-        registerToolEventRecipient: vi.fn(),
-        dedupe: new Map(),
-      } as unknown as GatewayRequestContext;
+      });
       dispatchInboundMessageMock.mockImplementationOnce(async (args: unknown) => {
         const replyOptions = (args as { replyOptions?: GetReplyOptions }).replyOptions;
         replyOptions?.onModelSelected?.({
@@ -4537,18 +4271,11 @@ describe("gateway server chat", () => {
           }),
         ]),
       );
-    } finally {
-      dispatchInboundMessageMock.mockReset();
-      testState.sessionStorePath = undefined;
-      clearConfigCache();
-      await removeTempDir(sessionDir);
-    }
+    });
   });
 
   test("chat.send emits first-assistant timing for direct final replies", async () => {
-    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
-    try {
-      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+    await withDirectChatSession(async () => {
       await writeSessionStore({
         entries: {
           main: {
@@ -4561,26 +4288,12 @@ describe("gateway server chat", () => {
       const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
       const broadcast = vi.fn();
       const broadcastToConnIds = vi.fn();
-      const context = {
+      const context = createDirectChatContext({
         getRuntimeConfig,
         loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(),
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        agentRunSeq: new Map<string, number>(),
-        chatAbortControllers: new Map(),
-        chatRunState: createChatRunState(),
-        addChatRun: vi.fn(),
-        removeChatRun: vi.fn(),
         broadcast,
         broadcastToConnIds,
-        nodeSendToSession: vi.fn(),
-        registerToolEventRecipient: vi.fn(),
-        dedupe: new Map(),
-      } as unknown as GatewayRequestContext;
+      });
       dispatchInboundMessageMock.mockImplementationOnce(async (args: unknown) => {
         const dispatcher = (
           args as {
@@ -4692,12 +4405,7 @@ describe("gateway server chat", () => {
           "broadcast.mock.invocationCallOrder[0] test invariant",
         ),
       );
-    } finally {
-      dispatchInboundMessageMock.mockReset();
-      testState.sessionStorePath = undefined;
-      clearConfigCache();
-      await removeTempDir(sessionDir);
-    }
+    });
   });
 
   test("chat.history backfills claude-cli sessions from Claude project files", async () => {
@@ -5017,19 +4725,9 @@ describe("gateway server chat", () => {
         await writeMainSessionTranscript(
           sessionDir,
           [
-            JSON.stringify({
-              message: {
-                role: "user",
-                content: [{ type: "text", text: "dup user question" }],
-                timestamp: dupBaseMs,
-              },
-            }),
-            JSON.stringify({
-              message: {
-                role: "assistant",
-                content: [{ type: "text", text: "dup assistant reply" }],
-                timestamp: dupBaseMs + 1000,
-              },
+            createTextTranscriptEvent("user", "dup user question", { timestamp: dupBaseMs }),
+            createTextTranscriptEvent("assistant", "dup assistant reply", {
+              timestamp: dupBaseMs + 1000,
             }),
             ...Array.from({ length: 45 }, (_, index) =>
               JSON.stringify({
@@ -5342,7 +5040,7 @@ describe("gateway server chat", () => {
   });
 
   test("chat.send diagnostics timeline carries run correlation attributes", async () => {
-    const timelineDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chat-timeline-"));
+    const timelineDir = autoCleanupTempDirs.make("openclaw-chat-timeline-");
     const timelinePath = path.join(timelineDir, "timeline.jsonl");
     const previousDiagnostics = process.env.OPENCLAW_DIAGNOSTICS;
     const previousTimelinePath = process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH;
@@ -5424,7 +5122,6 @@ describe("gateway server chat", () => {
       } else {
         process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = previousTimelinePath;
       }
-      await removeTempDir(timelineDir);
     }
   });
 
@@ -5655,13 +5352,7 @@ describe("gateway server chat", () => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
       const historyMaxBytes = getMaxChatHistoryMessagesBytes();
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "reachable older message" }],
-            timestamp: Date.now(),
-          },
-        }),
+        createTextTranscriptEvent("user", "reachable older message", { timestamp: Date.now() }),
         JSON.stringify({
           message: {
             role: "assistant",
@@ -5855,13 +5546,7 @@ describe("gateway server chat", () => {
             timestamp: Date.now() + 2,
           },
         }),
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "  keep padded  " }],
-            timestamp: Date.now() + 3,
-          },
-        }),
+        createTextTranscriptEvent("assistant", "  keep padded  ", { timestamp: Date.now() + 3 }),
       ];
       await writeMainSessionTranscript(sessionDir, lines);
       const messages = await fetchHistoryMessages(ws);
@@ -5887,13 +5572,7 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "fix it" }],
-            timestamp: 1,
-          },
-        }),
+        createTextTranscriptEvent("user", "fix it", { timestamp: 1 }),
         JSON.stringify({
           message: {
             role: "assistant",
@@ -5947,13 +5626,7 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "abcdefghij" }],
-            timestamp: Date.now(),
-          },
-        }),
+        createTextTranscriptEvent("assistant", "abcdefghij", { timestamp: Date.now() }),
       ]);
 
       const messages = await fetchHistoryMessages(ws, { maxChars: 7 });
@@ -5990,14 +5663,7 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          id: "msg-full-assistant",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "abcdefghij" }],
-            timestamp: Date.now(),
-          },
-        }),
+        createTextTranscriptEvent("assistant", "abcdefghij", { id: "msg-full-assistant" }),
       ]);
 
       const historyMessages = await fetchHistoryMessages(ws, { maxChars: 5 });
@@ -6022,14 +5688,11 @@ describe("gateway server chat", () => {
         `${testSessionFilePath(sessionDir, sessionId)}.reset.2026-02-16T22-26-34.000Z`,
         [
           JSON.stringify({ type: "session", version: 1, id: sessionId }),
-          JSON.stringify({
-            id: "msg-archive-full-assistant",
-            message: {
-              role: "assistant",
-              content: [{ type: "text", text: "archive abcdefghij" }],
-              timestamp: Date.now(),
-            },
-          }),
+          JSON.stringify(
+            createTextTranscriptEvent("assistant", "archive abcdefghij", {
+              id: "msg-archive-full-assistant",
+            }),
+          ),
         ].join("\n"),
         "utf-8",
       );
@@ -6067,13 +5730,8 @@ describe("gateway server chat", () => {
       await writeMainSessionTranscript(
         sessionDir,
         [
-          JSON.stringify({
+          createTextTranscriptEvent("assistant", "global agent content", {
             id: "msg-global-agent",
-            message: {
-              role: "assistant",
-              content: [{ type: "text", text: "global agent content" }],
-              timestamp: Date.now(),
-            },
           }),
         ],
         "sess-global",
@@ -6123,14 +5781,7 @@ describe("gateway server chat", () => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
       const oversizedText = "x".repeat(300 * 1024);
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          id: "msg-oversized-sqlite",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: oversizedText }],
-            timestamp: Date.now(),
-          },
-        }),
+        createTextTranscriptEvent("assistant", oversizedText, { id: "msg-oversized-sqlite" }),
       ]);
 
       const full = await fetchChatMessage(ws, {
@@ -6146,41 +5797,18 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          id: "msg-root",
-          parentId: null,
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "question" }],
-            timestamp: Date.now(),
-          },
-        }),
-        JSON.stringify({
+        createTextTranscriptEvent("user", "question", { id: "msg-root", parentId: null }),
+        createTextTranscriptEvent("assistant", "stale branch", {
           id: "msg-stale",
           parentId: "msg-root",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "stale branch" }],
-            timestamp: Date.now(),
-          },
         }),
-        JSON.stringify({
+        createTextTranscriptEvent("assistant", "active branch", {
           id: "msg-active",
           parentId: "msg-root",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "active branch" }],
-            timestamp: Date.now(),
-          },
         }),
-        JSON.stringify({
+        createTextTranscriptEvent("assistant", "side delivery", {
           id: "msg-side-delivery",
           parentId: "msg-active",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "side delivery" }],
-            timestamp: Date.now(),
-          },
         }),
         JSON.stringify({
           type: "leaf",
@@ -6238,21 +5866,13 @@ describe("gateway server chat", () => {
             timestamp: sessionStartedAt - 2_000,
           },
         }),
-        JSON.stringify({
+        createTextTranscriptEvent("assistant", "hidden pre-session reply", {
           id: "msg-hidden-assistant",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "hidden pre-session reply" }],
-            timestamp: sessionStartedAt - 1_000,
-          },
+          timestamp: sessionStartedAt - 1_000,
         }),
-        JSON.stringify({
+        createTextTranscriptEvent("assistant", "visible reply", {
           id: "msg-visible-assistant",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "visible reply" }],
-            timestamp: sessionStartedAt + 1_000,
-          },
+          timestamp: sessionStartedAt + 1_000,
         }),
       ]);
 
@@ -6276,13 +5896,7 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "NO_REPLY" }],
-            timestamp: Date.now(),
-          },
-        }),
+        createTextTranscriptEvent("assistant", "NO_REPLY", { timestamp: Date.now() }),
       ]);
 
       const messages = await fetchHistoryMessages(ws, { maxChars: 3 });
@@ -6294,29 +5908,11 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
       const silentTail = Array.from({ length: 24 }, (_, index) =>
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "NO_REPLY" }],
-            timestamp: Date.now() + index + 2,
-          },
-        }),
+        createTextTranscriptEvent("assistant", "NO_REPLY", { timestamp: Date.now() + index + 2 }),
       );
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "visible question" }],
-            timestamp: Date.now(),
-          },
-        }),
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "visible answer" }],
-            timestamp: Date.now() + 1,
-          },
-        }),
+        createTextTranscriptEvent("user", "visible question", { timestamp: Date.now() }),
+        createTextTranscriptEvent("assistant", "visible answer", { timestamp: Date.now() + 1 }),
         ...silentTail,
       ]);
 
@@ -6360,41 +5956,11 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
       await writeMainSessionTranscript(sessionDir, [
-        JSON.stringify({
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "oldest question" }],
-            timestamp: Date.now(),
-          },
-        }),
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "oldest answer" }],
-            timestamp: Date.now() + 1,
-          },
-        }),
-        JSON.stringify({
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "visible boundary" }],
-            timestamp: Date.now() + 2,
-          },
-        }),
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "NO_REPLY" }],
-            timestamp: Date.now() + 3,
-          },
-        }),
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "visible latest" }],
-            timestamp: Date.now() + 4,
-          },
-        }),
+        createTextTranscriptEvent("user", "oldest question", { timestamp: Date.now() }),
+        createTextTranscriptEvent("assistant", "oldest answer", { timestamp: Date.now() + 1 }),
+        createTextTranscriptEvent("user", "visible boundary", { timestamp: Date.now() + 2 }),
+        createTextTranscriptEvent("assistant", "NO_REPLY", { timestamp: Date.now() + 3 }),
+        createTextTranscriptEvent("assistant", "visible latest", { timestamp: Date.now() + 4 }),
       ]);
 
       const firstPage = await rpcReq<{
@@ -6755,13 +6321,7 @@ describe("gateway server chat", () => {
       });
       try {
         await writeMainSessionTranscript(sessionDir, [
-          JSON.stringify({
-            message: {
-              role: "user",
-              content: [{ type: "text", text: "reachable older message" }],
-              timestamp: Date.now(),
-            },
-          }),
+          createTextTranscriptEvent("user", "reachable older message", { timestamp: Date.now() }),
           JSON.stringify({
             message: {
               role: "assistant",


### PR DESCRIPTION
## What Problem This Solves

The gateway chat and reload-handler suites repeated large context objects, transcript-event literals, full reload-plan defaults, temporary-directory cleanup, and near-identical channel failure cases. That made two already-large test files harder to review and maintain.

## Why This Change Was Made

This behavior-neutral test refactor extends the existing gateway chat test-helper module with default-plus-override builders, moves chat cases onto those fixtures, reuses the suite temp-directory tracker, derives reload plans from the canonical hot-tail plan builder, and table-drives the matching channel stop/start failure cases. Every assertion and fixture behavior remains covered; no production path or public surface changes.

## User Impact

None. Test-only refactor with no runtime, config, environment, SQLite, protocol, or user-visible behavior changes.

## Evidence

- LOC: +223/-727 across 3 test/helper files, net -504.
- Production LOC: +0/-0. Test/helper LOC: +223/-727.
- Test count: 194 before / 194 after; no cases or assertions removed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/server-reload-handlers.test.ts` — passed, 2 files / 194 tests.
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed -- src/gateway/server-chat.agent-events.test-helpers.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/server-reload-handlers.test.ts` — passed on Testbox `tbx_01ky9a0kwvahcdvacvqya4340b`, Actions run 30069904380.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex --model gpt-5.6-sol --thinking high` — clean; no accepted/actionable findings.
