### PR TITLE
refactor(tasks): reduce task registry test duplication

### DIFF
--- a/src/tasks/task-registry.test-support.ts
+++ b/src/tasks/task-registry.test-support.ts
@@ -1,6 +1,40 @@
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
+import { createTaskRecord as createTaskRecordOrNull } from "./task-registry.js";
 import type { TaskEventRecord, TaskRecord } from "./task-registry.types.js";
-import "./task-registry.js";
+
+type CreateTaskRecordParams = Parameters<typeof createTaskRecordOrNull>[0];
+type TaskFixtureDefaults = "runtime" | "ownerKey" | "scopeKind" | "status" | "deliveryStatus";
+type TaskFixtureParams = Omit<CreateTaskRecordParams, TaskFixtureDefaults> &
+  Partial<Pick<CreateTaskRecordParams, Exclude<TaskFixtureDefaults, "runtime">>>;
+
+export function createTaskRecord(
+  runtime: CreateTaskRecordParams["runtime"],
+  params: TaskFixtureParams,
+): TaskRecord {
+  const task = createTaskRecordOrNull({
+    runtime,
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    status: "running",
+    deliveryStatus: "not_applicable",
+    ...params,
+  });
+  if (!task) {
+    throw new Error("expected task creation to succeed");
+  }
+  return task;
+}
+
+export function createAcpTaskRecord(
+  params: Omit<TaskFixtureParams, "task"> & { runId: string; task?: string },
+): TaskRecord {
+  return createTaskRecord("acp", {
+    childSessionKey: "agent:main:acp:child",
+    task: "Investigate issue",
+    deliveryStatus: "pending",
+    ...params,
+  });
+}
 
 type TaskRegistryDeliveryRuntime = Pick<
   typeof import("./task-registry-delivery-runtime.js"),

--- a/src/tasks/task-registry.test-support.ts
+++ b/src/tasks/task-registry.test-support.ts
@@ -7,7 +7,7 @@ type TaskFixtureDefaults = "runtime" | "ownerKey" | "scopeKind" | "status" | "de
 type TaskFixtureParams = Omit<CreateTaskRecordParams, TaskFixtureDefaults> &
   Partial<Pick<CreateTaskRecordParams, Exclude<TaskFixtureDefaults, "runtime">>>;
 
-export function createTaskRecord(
+export function createTaskFixture(
   runtime: CreateTaskRecordParams["runtime"],
   params: TaskFixtureParams,
 ): TaskRecord {
@@ -28,7 +28,7 @@ export function createTaskRecord(
 export function createAcpTaskRecord(
   params: Omit<TaskFixtureParams, "task"> & { runId: string; task?: string },
 ): TaskRecord {
-  return createTaskRecord("acp", {
+  return createTaskFixture("acp", {
     childSessionKey: "agent:main:acp:child",
     task: "Investigate issue",
     deliveryStatus: "pending",

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -71,7 +71,7 @@ import {
 } from "./task-registry.maintenance.js";
 import { configureTaskRegistryRuntime } from "./task-registry.store.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
-import { createAcpTaskRecord, createTaskRecord } from "./task-registry.test-support.js";
+import { createAcpTaskRecord, createTaskFixture } from "./task-registry.test-support.js";
 import type { TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
 import {
   configureTaskFlowRegistryRuntime,
@@ -151,9 +151,9 @@ vi.mock("../utils/message-channel.js", () => ({
 }));
 
 function configureTaskRegistryMaintenanceRuntimeForTest(params: {
-  currentTasks: Map<string, ReturnType<typeof createTaskRecord>>;
-  snapshotTasks: ReturnType<typeof createTaskRecord>[];
-  listTaskRecords?: () => ReturnType<typeof createTaskRecord>[];
+  currentTasks: Map<string, ReturnType<typeof createTaskFixture>>;
+  snapshotTasks: ReturnType<typeof createTaskFixture>[];
+  listTaskRecords?: () => ReturnType<typeof createTaskFixture>[];
   acpEntry?: AcpSessionStoreEntry;
   acpEntries?: AcpSessionStoreEntry[];
   listAcpSessionEntries?: () => Promise<AcpSessionStoreEntry[]>;
@@ -549,7 +549,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord("acp", {
+      createTaskFixture("acp", {
         childSessionKey: "agent:main:acp:child",
         runId: "run-1",
         task: "Do the thing",
@@ -629,7 +629,7 @@ describe("task-registry", () => {
       await withTaskRegistryTempDir(
         async () => {
           resetTaskRegistryForTests({ persist: false });
-          createTaskRecord("acp", {
+          createTaskFixture("acp", {
             requesterSessionKey: "agent:main:main",
             runId,
             task,
@@ -669,7 +669,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord("subagent", {
+      createTaskFixture("subagent", {
         childSessionKey: "agent:main:subagent:tools",
         runId: "run-tools",
         task: "Sweep the repo",
@@ -708,7 +708,7 @@ describe("task-registry", () => {
   it("keeps subagent abort lifecycle projections provisional", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
-      createTaskRecord("subagent", {
+      createTaskFixture("subagent", {
         childSessionKey: "agent:main:subagent:abort-race",
         runId: "run-subagent-abort-race",
         task: "Finish while aborting",
@@ -744,7 +744,7 @@ describe("task-registry", () => {
   it("clears a provisional child session when the terminal outcome has none", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
-      createTaskRecord("cron", {
+      createTaskFixture("cron", {
         ownerKey: "",
         scopeKind: "system",
         childSessionKey: "agent:main:cron:provisional",
@@ -773,7 +773,7 @@ describe("task-registry", () => {
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
-      const first = createTaskRecord("acp", {
+      const first = createTaskFixture("acp", {
         ownerKey: "agent:jarvis:main",
         childSessionKey: "agent:codex:acp:child",
         runId: "run-acp-derived-flow-dedupe",
@@ -788,7 +788,7 @@ describe("task-registry", () => {
       });
       expect(linked?.parentFlowId).toBe(flow.flowId);
 
-      const duplicateCreate = createTaskRecord("acp", {
+      const duplicateCreate = createTaskFixture("acp", {
         ownerKey: "agent:jarvis:main",
         childSessionKey: "agent:codex:acp:child",
         runId: "run-acp-derived-flow-dedupe",
@@ -807,7 +807,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      const task = createTaskRecord("cli", {
+      const task = createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-cancel-then-end",
         task: "Do the thing",
@@ -852,7 +852,7 @@ describe("task-registry", () => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
 
-      const task = createTaskRecord("cron", {
+      const task = createTaskFixture("cron", {
         ownerKey: "system:cron:test",
         scopeKind: "system",
         runId: "run-terminal-error-clear",
@@ -922,7 +922,7 @@ describe("task-registry", () => {
           expectedError: "Task cancellation requested.",
         },
       ]) {
-        createTaskRecord(entry.runtime, {
+        createTaskFixture(entry.runtime, {
           childSessionKey: entry.childSessionKey,
           runId: entry.runId,
           task: entry.runId,
@@ -954,7 +954,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-timeout-then-success",
         task: "Do the thing",
@@ -989,31 +989,31 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-hard-timeout-task",
         task: "Provider timeout should not look cancelled",
         startedAt: 100,
       });
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-rpc-cancel-task",
         task: "Caller abort should cancel task",
         startedAt: 100,
       });
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-aborted-task",
         task: "Aborted runner stop should cancel task",
         startedAt: 100,
       });
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-provider-error-timeout-task",
         task: "Provider timeout error should time out task",
         startedAt: 100,
       });
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-provider-end-timeout-task",
         task: "Provider timeout end metadata should time out task",
@@ -1104,7 +1104,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-fail-then-success",
         task: "Deliver result",
@@ -1138,7 +1138,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-success-then-fail",
         task: "Deliver result",
@@ -1173,19 +1173,19 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord("acp", {
+      createTaskFixture("acp", {
         runId: "run-summary-acp",
         task: "Investigate issue",
         status: "queued",
         deliveryStatus: "pending",
       });
-      createTaskRecord("cron", {
+      createTaskFixture("cron", {
         ownerKey: "",
         scopeKind: "system",
         runId: "run-summary-cron",
         task: "Daily digest",
       });
-      createTaskRecord("subagent", {
+      createTaskFixture("subagent", {
         runId: "run-summary-subagent",
         task: "Write patch",
         status: "timed_out",
@@ -1251,7 +1251,7 @@ describe("task-registry", () => {
         goal: "Owner main flow",
       });
 
-      expect(() => createTaskRecord(runtime, { ...params, parentFlowId: flow.flowId })).toThrow(
+      expect(() => createTaskFixture(runtime, { ...params, parentFlowId: flow.flowId })).toThrow(
         error,
       );
     });
@@ -1263,7 +1263,7 @@ describe("task-registry", () => {
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         status: undefined,
         deliveryStatus: undefined,
         runId: "owner-main-task",
@@ -1301,7 +1301,7 @@ describe("task-registry", () => {
         store: createInMemoryTaskFlowRegistryStore(),
       });
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         deliveryStatus: undefined,
         runId: "flow-restore-failed-task",
         task: "Preserve linked task state",
@@ -1344,7 +1344,7 @@ describe("task-registry", () => {
       expect(requireTaskById(task.taskId).taskId).toBe(task.taskId);
 
       expect(() =>
-        createTaskRecord("acp", {
+        createTaskFixture("acp", {
           deliveryStatus: undefined,
           requesterOrigin: NOTIFYCHAT_ORIGIN,
           runId: task.runId,
@@ -1354,7 +1354,7 @@ describe("task-registry", () => {
       expect(deliveryUpsert).not.toHaveBeenCalled();
       expect(loadSnapshot).toHaveBeenCalledTimes(1);
 
-      const standalone = createTaskRecord("cli", {
+      const standalone = createTaskFixture("cli", {
         runId: "standalone-during-flow-restore-failure",
         task: "Keep standalone task state available",
       });
@@ -1427,7 +1427,7 @@ describe("task-registry", () => {
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         deliveryStatus: undefined,
         runId: "mirrored-flow-sync-fail",
         task: "Sync mirrored flow",
@@ -1506,7 +1506,7 @@ describe("task-registry", () => {
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         deliveryStatus: undefined,
         runId: "mirrored-flow-stale-retry",
         task: "Initial blocked task",
@@ -1547,7 +1547,7 @@ describe("task-registry", () => {
       expect(getTaskFlowById(flow.flowId)?.status).toBe("running");
 
       failUpsert = false;
-      const newerTask = createTaskRecord("acp", {
+      const newerTask = createTaskFixture("acp", {
         deliveryStatus: undefined,
         parentFlowId: flow.flowId,
         runId: "mirrored-flow-newer-task",
@@ -1579,14 +1579,14 @@ describe("task-registry", () => {
       });
 
       try {
-        createTaskRecord("acp", {
+        createTaskFixture("acp", {
           status: undefined,
           deliveryStatus: undefined,
           parentFlowId: flow.flowId,
           runId: "cancel-requested-link",
           task: "Should be denied",
         });
-        throw new Error("Expected createTaskRecord to throw.");
+        throw new Error("Expected createTaskFixture to throw.");
       } catch (error) {
         expect(isParentFlowLinkError(error)).toBe(true);
         expectRecordFields(error, {
@@ -1604,7 +1604,7 @@ describe("task-registry", () => {
         controllerId: "tests/task-registry",
         goal: "Wait for canonical child state",
       });
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         ownerKey: flow.ownerKey,
         parentFlowId: flow.flowId,
         childSessionKey: "agent:worker:subagent:provisional-flow",
@@ -1646,7 +1646,7 @@ describe("task-registry", () => {
       });
 
       expect(() =>
-        createTaskRecord("acp", {
+        createTaskFixture("acp", {
           status: undefined,
           deliveryStatus: undefined,
           parentFlowId: flow.flowId,
@@ -1749,7 +1749,7 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord("acp", {
+      createTaskFixture("acp", {
         requesterOrigin: {
           channel: "notifychat",
           to: "notifychat:123",
@@ -2244,14 +2244,14 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         ownerKey: "agent:codex:acp:child",
         childSessionKey: "agent:codex:acp:child",
         runId: "run-shared",
         task: "Child ACP execution",
       });
 
-      createTaskRecord("acp", {
+      createTaskFixture("acp", {
         childSessionKey: "agent:codex:acp:child",
         runId: "run-shared",
         task: "Spawn ACP child",
@@ -2270,7 +2270,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      const victimTask = createTaskRecord("acp", {
+      const victimTask = createTaskFixture("acp", {
         ownerKey: "agent:victim:main",
         childSessionKey: "agent:victim:acp:child",
         runId: "run-shared-scope",
@@ -2278,7 +2278,7 @@ describe("task-registry", () => {
         deliveryStatus: "pending",
       });
 
-      const attackerTask = createTaskRecord("cli", {
+      const attackerTask = createTaskFixture("cli", {
         ownerKey: "agent:attacker:main",
         childSessionKey: "agent:attacker:main",
         runId: "run-shared-scope",
@@ -2354,14 +2354,14 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      const victimTask = createTaskRecord("acp", {
+      const victimTask = createTaskFixture("acp", {
         ownerKey: "agent:victim:main",
         childSessionKey: "agent:victim:acp:child",
         runId: "run-cross-requester-delivery",
         task: "Victim ACP task",
         deliveryStatus: "pending",
       });
-      const attackerTask = createTaskRecord("acp", {
+      const attackerTask = createTaskFixture("acp", {
         ownerKey: "agent:attacker:main",
         childSessionKey: "agent:attacker:acp:child",
         runId: "run-cross-requester-delivery",
@@ -2432,7 +2432,7 @@ describe("task-registry", () => {
         task: "Spawn ACP child",
       });
 
-      const directTask = createTaskRecord("acp", {
+      const directTask = createTaskFixture("acp", {
         deliveryStatus: undefined,
         requesterOrigin: NOTIFYCHAT_ORIGIN,
         childSessionKey: "agent:main:acp:child",
@@ -2519,7 +2519,7 @@ describe("task-registry", () => {
       async () => {
         resetTaskRegistryForTests();
 
-        const task = createTaskRecord("subagent", {
+        const task = createTaskFixture("subagent", {
           childSessionKey: "agent:main:subagent:child",
           runId: "run-restore",
           task: "Restore me",
@@ -2546,14 +2546,14 @@ describe("task-registry", () => {
       const nowSpy = vi.spyOn(Date, "now");
       nowSpy.mockReturnValue(1_700_000_000_000);
 
-      const older = createTaskRecord("acp", {
+      const older = createTaskFixture("acp", {
         status: undefined,
         deliveryStatus: undefined,
         childSessionKey: "agent:main:subagent:child-1",
         runId: "run-session-lookup-1",
         task: "Older task",
       });
-      const latest = createTaskRecord("subagent", {
+      const latest = createTaskFixture("subagent", {
         status: undefined,
         deliveryStatus: undefined,
         childSessionKey: "agent:main:subagent:child-2",
@@ -2577,7 +2577,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest({ persist: false });
 
-      const created = createTaskRecord("cli", {
+      const created = createTaskFixture("cli", {
         ownerKey: undefined,
         scopeKind: undefined,
         taskKind: "video_generation",
@@ -2598,7 +2598,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest({ persist: false });
 
-      const created = createTaskRecord("subagent", {
+      const created = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:child",
         runId: "run-worker-subagent",
         task: "Inspect worker state",
@@ -2614,7 +2614,7 @@ describe("task-registry", () => {
   it("retains live background exec tasks and marks missing process sessions lost", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
-      const task = createTaskRecord("cli", {
+      const task = createTaskFixture("cli", {
         taskKind: "exec",
         sourceId: "amber-reef",
         runId: "exec:amber-reef",
@@ -2659,7 +2659,7 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       configureTaskRegistryMaintenance({ runtimeAuthoritative: true });
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         childSessionKey: "agent:main:acp:missing",
         runId: "run-lost",
         task: "Missing child",
@@ -2686,7 +2686,7 @@ describe("task-registry", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-06-16T00:00:00Z"));
 
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         runId: "run-inspection-freshness",
         task: "Inspect fresh task state",
         deliveryStatus: "pending",
@@ -2713,7 +2713,7 @@ describe("task-registry", () => {
       configureTaskRegistryMaintenance({ runtimeAuthoritative: true });
       const now = Date.now();
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         childSessionKey: "agent:main:acp:missing",
         runId: "run-lost-maintenance",
         task: "Missing child",
@@ -2794,7 +2794,7 @@ describe("task-registry", () => {
       resetTaskRegistryForTests();
       const now = Date.now();
       const lastEventAt = now - ageMinutes * 60_000;
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         taskKind,
         sourceId,
         runId: sourceId,
@@ -2870,7 +2870,7 @@ describe("task-registry", () => {
         resetTaskRegistryMemoryForTest();
         const now = Date.now();
         const parentSessionKey = "agent:main:telegram:direct:owner";
-        const task = createTaskRecord("acp", {
+        const task = createTaskFixture("acp", {
           ownerKey: parentSessionKey,
           requesterSessionKey: parentSessionKey,
           childSessionKey,
@@ -2933,7 +2933,7 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       const now = Date.now();
       const tasks = Array.from({ length: 20 }, (_, index) => {
-        const task = createTaskRecord("acp", {
+        const task = createTaskFixture("acp", {
           requesterSessionKey: "agent:main:main",
           childSessionKey: `agent:claude:acp:terminal-${index}`,
           runId: `run-terminal-acp-snapshot-${index}`,
@@ -2971,7 +2971,7 @@ describe("task-registry", () => {
       const now = Date.now();
       const parentSessionKey = "agent:main:telegram:direct:owner";
       const childSessionKey = "agent:claude:acp:shared-child";
-      const terminal = createTaskRecord("acp", {
+      const terminal = createTaskFixture("acp", {
         ownerKey: parentSessionKey,
         requesterSessionKey: parentSessionKey,
         childSessionKey,
@@ -2985,7 +2985,7 @@ describe("task-registry", () => {
         endedAt: now - 60_000,
         lastEventAt: now - 60_000,
       };
-      const active = createTaskRecord("acp", {
+      const active = createTaskFixture("acp", {
         ownerKey: parentSessionKey,
         requesterSessionKey: parentSessionKey,
         childSessionKey,
@@ -3079,7 +3079,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-prune",
         task: "Old completed task",
@@ -3161,7 +3161,7 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       const now = Date.now();
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         childSessionKey: "agent:main:acp:missing",
         runId: "run-deferred-maintenance-stop",
         task: "Missing child",
@@ -3261,7 +3261,7 @@ describe("task-registry", () => {
 
   it("rechecks current task state before marking a task lost", async () => {
     const now = Date.now();
-    const snapshotTask = createTaskRecord("acp", {
+    const snapshotTask = createTaskFixture("acp", {
       childSessionKey: "agent:main:acp:missing-stale",
       runId: "run-lost-stale",
       task: "Missing child",
@@ -3295,7 +3295,7 @@ describe("task-registry", () => {
 
   it("rechecks current task state before pruning a task", async () => {
     const now = Date.now();
-    const snapshotTask = createTaskRecord("cli", {
+    const snapshotTask = createTaskFixture("cli", {
       childSessionKey: "agent:main:main",
       runId: "run-prune-stale",
       task: "Old completed task",
@@ -3333,7 +3333,7 @@ describe("task-registry", () => {
   it("prunes retained lost tasks once the shorter lost retention window expires", async () => {
     const now = Date.now();
     const endedAt = now - LOST_TASK_RETENTION_MS - 1;
-    const snapshotTask = createTaskRecord("cli", {
+    const snapshotTask = createTaskFixture("cli", {
       childSessionKey: "agent:main:main",
       runId: "run-old-lost-cleanup",
       task: "Old lost task",
@@ -3366,7 +3366,7 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         runId: "run-backdated-create",
         task: "Backdated create",
         deliveryStatus: "pending",
@@ -3389,7 +3389,7 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         runId: "run-backdated-update",
         task: "Backdated update",
         status: "queued",
@@ -3457,7 +3457,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
       const now = Date.now();
-      let durableTasks = new Map<string, ReturnType<typeof createTaskRecord>>();
+      let durableTasks = new Map<string, ReturnType<typeof createTaskFixture>>();
       configureTaskRegistryRuntime({
         store: {
           loadSnapshot: () => ({
@@ -3470,7 +3470,7 @@ describe("task-registry", () => {
         },
       });
 
-      createTaskRecord("cli", {
+      createTaskFixture("cli", {
         requesterSessionKey: "agent:main:main",
         runId: "run-stale-memory",
         task: "Stale in-memory task",
@@ -3680,7 +3680,7 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         deliveryStatus: undefined,
         requesterOrigin: GUILDCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
@@ -3730,7 +3730,7 @@ describe("task-registry", () => {
       });
       vi.useFakeTimers();
 
-      createTaskRecord("acp", {
+      createTaskFixture("acp", {
         requesterOrigin: GUILDCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
         runId: "run-quiet-terminal",
@@ -3791,7 +3791,7 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord("acp", {
+      createTaskFixture("acp", {
         requesterOrigin: GUILDCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
         runId: "run-failure-terminal",
@@ -3833,7 +3833,7 @@ describe("task-registry", () => {
       });
       vi.useFakeTimers();
 
-      createTaskRecord("acp", {
+      createTaskFixture("acp", {
         requesterOrigin: GUILDCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
         runId: "run-state-stream",
@@ -3876,7 +3876,7 @@ describe("task-registry", () => {
   it("cancels background exec tasks through process control", async () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.cancelBackgroundExecSessionMock.mockReturnValue(true);
-      const task = createTaskRecord("cli", {
+      const task = createTaskFixture("cli", {
         taskKind: "exec",
         sourceId: "amber-reef",
         runId: "exec:amber-reef",
@@ -3899,7 +3899,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.cancelSessionMock.mockResolvedValue(undefined);
 
-      const task = createTaskRecord("acp", {
+      const task = createTaskFixture("acp", {
         requesterOrigin: NOTIFYCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
         runId: "run-cancel-acp",
@@ -3936,20 +3936,20 @@ describe("task-registry", () => {
 
   it("cancels subagent-backed tasks through subagent control", async () => {
     await withTaskRegistryTempDir(async () => {
-      const silentTask = createTaskRecord("subagent", {
+      const silentTask = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:child",
         runId: "run-cancel-subagent",
         task: "Silent projection",
         notifyPolicy: "silent",
       });
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         requesterOrigin: NOTIFYCHAT_ORIGIN,
         childSessionKey: "agent:worker:subagent:child",
         runId: "run-cancel-subagent",
         task: "Investigate issue",
         deliveryStatus: "pending",
       });
-      const peerTask = createTaskRecord("subagent", {
+      const peerTask = createTaskFixture("subagent", {
         requesterOrigin: NOTIFYCHAT_ORIGIN,
         childSessionKey: "agent:worker:subagent:child",
         runId: "run-cancel-subagent",
@@ -4003,7 +4003,7 @@ describe("task-registry", () => {
 
   it("promotes a provisional subagent kill that races task cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:concurrent-kill",
         runId: "run-subagent-concurrent-kill",
         task: "Cancel during teardown",
@@ -4036,7 +4036,7 @@ describe("task-registry", () => {
 
   it("reconciles an already-provisional kill before making cancellation sticky", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:provisional-completion",
         runId: "run-subagent-provisional-completion",
         task: "Finish before explicit cancellation",
@@ -4081,12 +4081,12 @@ describe("task-registry", () => {
 
   it("preserves subagent success that completes during cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:cancel-race",
         runId: "run-subagent-cancel-race",
         task: "Finish during cancellation",
       });
-      const peerTask = createTaskRecord("subagent", {
+      const peerTask = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:cancel-race",
         runId: "run-subagent-cancel-race",
         task: "Peer projection",
@@ -4127,7 +4127,7 @@ describe("task-registry", () => {
 
   it("does not cancel a lagging task projection after subagent completion wins", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:lagging-projection",
         runId: "run-subagent-lagging-projection",
         task: "Finish before task projection",
@@ -4169,7 +4169,7 @@ describe("task-registry", () => {
 
   it("reconciles a replacement run cancellation into the original task scope", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:replacement-run",
         runId: "run-subagent-before-replacement",
         task: "Cancel after recovery",
@@ -4203,7 +4203,7 @@ describe("task-registry", () => {
 
   it("ignores a stale killed snapshot after canonical completion persists", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:stale-kill-snapshot",
         runId: "run-subagent-stale-kill-snapshot",
         task: "Complete while admin kill unwinds",
@@ -4250,7 +4250,7 @@ describe("task-registry", () => {
 
   it("promotes an already-killed run projection during task cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:killed-projection",
         runId: "run-subagent-killed-projection",
         task: "Repair and cancel killed projection",
@@ -4293,7 +4293,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       const store = createInMemoryTaskRegistryStore();
       configureTaskRegistryRuntime({ store });
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:persist-failure",
         runId: "run-subagent-persist-failure",
         task: "Finish before persistence fails",
@@ -4331,7 +4331,7 @@ describe("task-registry", () => {
 
   it("returns a subagent failure that wins during cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:failed-race",
         runId: "run-subagent-failed-race",
         task: "Fail during cancellation",
@@ -4374,7 +4374,7 @@ describe("task-registry", () => {
 
   it("defers cancellation while canonical subagent completion is still finalizing", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:finalizing-race",
         runId: "run-subagent-finalizing-race",
         task: "Capture final result",
@@ -4401,7 +4401,7 @@ describe("task-registry", () => {
 
   it("keeps subagent cancellation terminal when success arrives after cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:late-success",
         runId: "run-subagent-late-success",
         task: "Finish after cancellation",
@@ -4437,7 +4437,7 @@ describe("task-registry", () => {
 
   it("accepts subagent success that completed before cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:earlier-success",
         runId: "run-subagent-earlier-success",
         task: "Finish before cancellation",
@@ -4465,7 +4465,7 @@ describe("task-registry", () => {
 
   it("does not let a repeated kill restore the provisional marker after cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:repeated-kill",
         runId: "run-subagent-repeated-kill",
         task: "Stay cancelled",
@@ -4491,12 +4491,12 @@ describe("task-registry", () => {
 
   it("promotes an existing subagent kill marker to operator cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:already-killed",
         runId: "run-subagent-already-killed",
         task: "Promote killed task",
       });
-      const peerTask = createTaskRecord("subagent", {
+      const peerTask = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:already-killed",
         runId: "run-subagent-already-killed",
         task: "Peer projection",
@@ -4546,7 +4546,7 @@ describe("task-registry", () => {
   it("suppresses terminal delivery when teardown finalizes a killed task", async () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.sendMessageMock.mockClear();
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         requesterOrigin: { channel: "notifychat", to: "notifychat:123" },
         childSessionKey: "agent:worker:subagent:teardown",
         runId: "run-subagent-teardown",
@@ -4579,7 +4579,7 @@ describe("task-registry", () => {
   it("stops a pending terminal notifier when teardown suppresses delivery", async () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.sendMessageMock.mockClear();
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         requesterOrigin: { channel: "notifychat", to: "notifychat:123" },
         childSessionKey: "agent:worker:subagent:pending-teardown",
         runId: "run-subagent-pending-teardown",
@@ -4630,7 +4630,7 @@ describe("task-registry", () => {
     "$name",
     async ({ runId, task: taskName, childSessionKey, expectedError, expectedMessage }) => {
       await withTaskRegistryTempDir(async () => {
-        const task = createTaskRecord("cli", {
+        const task = createTaskFixture("cli", {
           requesterOrigin: NOTIFYCHAT_ORIGIN,
           childSessionKey,
           runId,
@@ -4663,7 +4663,7 @@ describe("task-registry", () => {
   it("cancels active cron tasks through the cron runtime abort handle", async () => {
     await withTaskRegistryTempDir(async () => {
       const abortController = new AbortController();
-      const task = createTaskRecord("cron", {
+      const task = createTaskFixture("cron", {
         sourceId: "nightly-gmail-sync",
         ownerKey: "",
         scopeKind: "system",
@@ -4699,7 +4699,7 @@ describe("task-registry", () => {
 
   it("refuses terminal and unknown cron task cancellation before runtime dispatch", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("cron", {
+      const task = createTaskFixture("cron", {
         sourceId: "finished-cron",
         ownerKey: "",
         scopeKind: "system",
@@ -4744,7 +4744,7 @@ describe("task-registry", () => {
     },
   ])("$name", async ({ childSessionKey, cancelled, reason, status, error }) => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord("cron", {
+      const task = createTaskFixture("cron", {
         sourceId: "daily-repost",
         ownerKey: "",
         scopeKind: "system",
@@ -4794,7 +4794,7 @@ describe("task-registry", () => {
   ])("$name", async ({ taskKind, sourceId, task: taskName, cancellable }) => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryForTests();
-      const task = createTaskRecord("subagent", {
+      const task = createTaskFixture("subagent", {
         taskKind,
         sourceId,
         runId: sourceId,

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -37,7 +37,6 @@ import {
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import {
   cancelTaskById,
-  createTaskRecord as createTaskRecordOrNull,
   deleteTaskRecordById,
   finalizeTaskRunByRunId,
   findTaskByRunId,
@@ -72,6 +71,7 @@ import {
 } from "./task-registry.maintenance.js";
 import { configureTaskRegistryRuntime } from "./task-registry.store.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
+import { createAcpTaskRecord, createTaskRecord } from "./task-registry.test-support.js";
 import type { TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
 import {
   configureTaskFlowRegistryRuntime,
@@ -93,14 +93,8 @@ function waitForFast<T>(
 
 const DEFAULT_TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
 const LOST_TASK_RETENTION_MS = 24 * 60 * 60_000;
-
-function createTaskRecord(params: Parameters<typeof createTaskRecordOrNull>[0]): TaskRecord {
-  const task = createTaskRecordOrNull(params);
-  if (!task) {
-    throw new Error("expected task creation to succeed");
-  }
-  return task;
-}
+const NOTIFYCHAT_ORIGIN = { channel: "notifychat", to: "notifychat:123" } as const;
+const GUILDCHAT_ORIGIN = { channel: "guildchat", to: "guildchat:123" } as const;
 
 function createManagedTaskFlow(
   params: Parameters<typeof createManagedTaskFlowOrNull>[0],
@@ -138,13 +132,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean): number {
-  let count = 0;
-  for (const item of items) {
-    if (predicate(item)) {
-      count += 1;
-    }
-  }
-  return count;
+  return items.filter(predicate).length;
 }
 
 vi.mock("../acp/control-plane/manager.js", () => ({
@@ -307,8 +295,8 @@ function createAcpSessionStoreEntry(params: {
   };
 }
 
-async function waitForAssertion(assertion: () => void, timeoutMs = 2_000, stepMs = 5) {
-  await waitForFast(assertion, { timeout: timeoutMs, interval: stepMs });
+function waitForAssertion(assertion: () => void, timeoutMs = 2_000, stepMs = 5) {
+  return waitForFast(assertion, { timeout: timeoutMs, interval: stepMs });
 }
 
 async function flushAsyncWork(times = 4) {
@@ -361,6 +349,15 @@ function firstMockArg(
     throw new Error(`Expected ${label} call`);
   }
   return expectRecordFields(call[0], {});
+}
+
+const cancelTask = (taskId: string) => cancelTaskById({ cfg: {} as never, taskId });
+
+function finalizeSubagentTask(
+  task: TaskRecord,
+  params: Omit<Parameters<typeof finalizeTaskRunByRunId>[0], "runId" | "runtime">,
+) {
+  return finalizeTaskRunByRunId({ runId: task.runId!, runtime: "subagent", ...params });
 }
 
 function createInMemoryTaskRegistryStore() {
@@ -476,10 +473,6 @@ async function withTaskRegistryTempDir<T>(
   });
 }
 
-function configureInMemoryTaskStoresForLinkValidationTests() {
-  configureInMemoryTaskStoresForTests();
-}
-
 const HEARTBEAT_FLUSH_REASON = "task-registry-test-flush";
 let heartbeatWakeRequests: HeartbeatWakeRequest[] = [];
 let clearHeartbeatWakeHandler: (() => void) | undefined;
@@ -556,15 +549,10 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("acp", {
         childSessionKey: "agent:main:acp:child",
         runId: "run-1",
         task: "Do the thing",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -592,133 +580,99 @@ describe("task-registry", () => {
     });
   });
 
-  it("persists an ACP producer timestamp across lifecycle projection and SQLite reload", async () => {
-    await withTaskRegistryTempDir(
-      async () => {
-        resetTaskRegistryForTests({ persist: false });
-        createTaskRecord({
-          runtime: "acp",
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
-          requesterSessionKey: "agent:main:main",
-          runId: "run-reused-lifecycle",
-          task: "Reuse a persisted task row",
-          status: "queued",
-          deliveryStatus: "not_applicable",
-          notifyPolicy: "silent",
-          startedAt: 1_000,
-          lastEventAt: 1_000,
-        });
+  it.each([
+    {
+      name: "persists an ACP producer timestamp across lifecycle projection and SQLite reload",
+      runId: "run-reused-lifecycle",
+      task: "Reuse a persisted task row",
+      initialStatus: "queued" as const,
+      lastEventAt: 1_000,
+      lifecycleStartedAt: 2_000,
+      terminalStartedAt: undefined,
+      endedAt: 2_500,
+      expectedStartedAt: 2_000,
+    },
+    {
+      name: "persists an accepted zero lifecycle start timestamp over stale state",
+      runId: "run-zero-lifecycle",
+      task: "Replace a stale task timestamp",
+      initialStatus: "queued" as const,
+      lastEventAt: undefined,
+      lifecycleStartedAt: 0,
+      terminalStartedAt: undefined,
+      endedAt: 500,
+      expectedStartedAt: 0,
+    },
+    {
+      name: "ignores a non-finite lifecycle timestamp during durable terminal projection",
+      runId: "run-non-finite-terminal",
+      task: "Keep the accepted producer timestamp",
+      initialStatus: undefined,
+      lastEventAt: undefined,
+      lifecycleStartedAt: undefined,
+      terminalStartedAt: Number.NaN,
+      endedAt: 1_500,
+      expectedStartedAt: 1_000,
+    },
+  ])(
+    "$name",
+    async ({
+      runId,
+      task,
+      initialStatus,
+      lastEventAt,
+      lifecycleStartedAt,
+      terminalStartedAt,
+      endedAt,
+      expectedStartedAt,
+    }) => {
+      await withTaskRegistryTempDir(
+        async () => {
+          resetTaskRegistryForTests({ persist: false });
+          createTaskRecord("acp", {
+            requesterSessionKey: "agent:main:main",
+            runId,
+            task,
+            notifyPolicy: "silent",
+            startedAt: 1_000,
+            ...(initialStatus === undefined ? {} : { status: initialStatus }),
+            ...(lastEventAt === undefined ? {} : { lastEventAt }),
+          });
 
-        emitAcpLifecycleStart({
-          runId: "run-reused-lifecycle",
-          startedAt: 2_000,
-        });
-        emitAgentEvent({
-          runId: "run-reused-lifecycle",
-          stream: "lifecycle",
-          data: { phase: "end", endedAt: 2_500 },
-        });
+          if (lifecycleStartedAt !== undefined) {
+            emitAcpLifecycleStart({ runId, startedAt: lifecycleStartedAt });
+          }
+          emitAgentEvent({
+            runId,
+            stream: "lifecycle",
+            data: {
+              phase: "end",
+              endedAt,
+              ...(terminalStartedAt === undefined ? {} : { startedAt: terminalStartedAt }),
+            },
+          });
 
-        resetTaskRegistryForTests({ persist: false });
-        reloadTaskRegistryFromStore();
-
-        expectRecordFields(requireTaskByRunId("run-reused-lifecycle"), {
-          status: "succeeded",
-          startedAt: 2_000,
-          endedAt: 2_500,
-        });
-      },
-      { durableStore: true },
-    );
-  });
-
-  it("persists an accepted zero lifecycle start timestamp over stale state", async () => {
-    await withTaskRegistryTempDir(
-      async () => {
-        resetTaskRegistryForTests({ persist: false });
-        createTaskRecord({
-          runtime: "acp",
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
-          requesterSessionKey: "agent:main:main",
-          runId: "run-zero-lifecycle",
-          task: "Replace a stale task timestamp",
-          status: "queued",
-          deliveryStatus: "not_applicable",
-          notifyPolicy: "silent",
-          startedAt: 1_000,
-        });
-
-        emitAcpLifecycleStart({ runId: "run-zero-lifecycle", startedAt: 0 });
-        emitAgentEvent({
-          runId: "run-zero-lifecycle",
-          stream: "lifecycle",
-          data: { phase: "end", endedAt: 500 },
-        });
-
-        resetTaskRegistryForTests({ persist: false });
-        reloadTaskRegistryFromStore();
-
-        expectRecordFields(requireTaskByRunId("run-zero-lifecycle"), {
-          status: "succeeded",
-          startedAt: 0,
-          endedAt: 500,
-        });
-      },
-      { durableStore: true },
-    );
-  });
-
-  it("ignores a non-finite lifecycle timestamp during durable terminal projection", async () => {
-    await withTaskRegistryTempDir(
-      async () => {
-        resetTaskRegistryForTests({ persist: false });
-        createTaskRecord({
-          runtime: "acp",
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
-          requesterSessionKey: "agent:main:main",
-          runId: "run-non-finite-terminal",
-          task: "Keep the accepted producer timestamp",
-          status: "running",
-          deliveryStatus: "not_applicable",
-          notifyPolicy: "silent",
-          startedAt: 1_000,
-        });
-
-        emitAgentEvent({
-          runId: "run-non-finite-terminal",
-          stream: "lifecycle",
-          data: { phase: "end", startedAt: Number.NaN, endedAt: 1_500 },
-        });
-
-        resetTaskRegistryForTests({ persist: false });
-        reloadTaskRegistryFromStore();
-
-        expectRecordFields(requireTaskByRunId("run-non-finite-terminal"), {
-          status: "succeeded",
-          startedAt: 1_000,
-          endedAt: 1_500,
-        });
-      },
-      { durableStore: true },
-    );
-  });
+          resetTaskRegistryForTests({ persist: false });
+          reloadTaskRegistryFromStore();
+          expectRecordFields(requireTaskByRunId(runId), {
+            status: "succeeded",
+            startedAt: expectedStartedAt,
+            endedAt,
+          });
+        },
+        { durableStore: true },
+      );
+    },
+  );
 
   it("tracks tool activity from tool-start events", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("subagent", {
         childSessionKey: "agent:main:subagent:tools",
         runId: "run-tools",
         task: "Sweep the repo",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -754,15 +708,10 @@ describe("task-registry", () => {
   it("keeps subagent abort lifecycle projections provisional", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
-      createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("subagent", {
         childSessionKey: "agent:main:subagent:abort-race",
         runId: "run-subagent-abort-race",
         task: "Finish while aborting",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -795,15 +744,12 @@ describe("task-registry", () => {
   it("clears a provisional child session when the terminal outcome has none", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
-      createTaskRecord({
-        runtime: "cron",
+      createTaskRecord("cron", {
         ownerKey: "",
         scopeKind: "system",
         childSessionKey: "agent:main:cron:provisional",
         runId: "cron:provisional:100",
         task: "Provisional cron run",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -825,18 +771,14 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
-      configureInMemoryTaskStoresForLinkValidationTests();
+      configureInMemoryTaskStoresForTests();
 
-      const first = createTaskRecord({
-        runtime: "acp",
+      const first = createTaskRecord("acp", {
         ownerKey: "agent:jarvis:main",
-        scopeKind: "session",
         childSessionKey: "agent:codex:acp:child",
         runId: "run-acp-derived-flow-dedupe",
         label: "original ACP task",
         task: "Run ACP child",
-        status: "running",
-        deliveryStatus: "not_applicable",
         notifyPolicy: "silent",
       });
       const flow = createTaskFlowForTask({ task: first });
@@ -846,15 +788,12 @@ describe("task-registry", () => {
       });
       expect(linked?.parentFlowId).toBe(flow.flowId);
 
-      const duplicateCreate = createTaskRecord({
-        runtime: "acp",
+      const duplicateCreate = createTaskRecord("acp", {
         ownerKey: "agent:jarvis:main",
-        scopeKind: "session",
         childSessionKey: "agent:codex:acp:child",
         runId: "run-acp-derived-flow-dedupe",
         label: "late ACP mirror",
         task: "Late mirror of the same ACP child",
-        status: "running",
         deliveryStatus: "pending",
         notifyPolicy: "silent",
       });
@@ -868,15 +807,10 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      const task = createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-cancel-then-end",
         task: "Do the thing",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -918,14 +852,11 @@ describe("task-registry", () => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
 
-      const task = createTaskRecord({
-        runtime: "cron",
+      const task = createTaskRecord("cron", {
         ownerKey: "system:cron:test",
         scopeKind: "system",
         runId: "run-terminal-error-clear",
         task: "Recover cron task",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -991,15 +922,10 @@ describe("task-registry", () => {
           expectedError: "Task cancellation requested.",
         },
       ]) {
-        createTaskRecord({
-          runtime: entry.runtime,
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
+        createTaskRecord(entry.runtime, {
           childSessionKey: entry.childSessionKey,
           runId: entry.runId,
           task: entry.runId,
-          status: "running",
-          deliveryStatus: "not_applicable",
         });
         finalizeTaskRunByRunId({
           runId: entry.runId,
@@ -1028,15 +954,10 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-timeout-then-success",
         task: "Do the thing",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -1068,59 +989,34 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-hard-timeout-task",
         task: "Provider timeout should not look cancelled",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-rpc-cancel-task",
         task: "Caller abort should cancel task",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-aborted-task",
         task: "Aborted runner stop should cancel task",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-provider-error-timeout-task",
         task: "Provider timeout error should time out task",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-provider-end-timeout-task",
         task: "Provider timeout end metadata should time out task",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -1208,15 +1104,10 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-fail-then-success",
         task: "Deliver result",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -1247,15 +1138,10 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-success-then-fail",
         task: "Deliver result",
-        status: "running",
-        deliveryStatus: "not_applicable",
         startedAt: 100,
       });
 
@@ -1287,28 +1173,19 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("acp", {
         runId: "run-summary-acp",
         task: "Investigate issue",
         status: "queued",
         deliveryStatus: "pending",
       });
-      createTaskRecord({
-        runtime: "cron",
+      createTaskRecord("cron", {
         ownerKey: "",
         scopeKind: "system",
         runId: "run-summary-cron",
         task: "Daily digest",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
-      createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("subagent", {
         runId: "run-summary-subagent",
         task: "Write patch",
         status: "timed_out",
@@ -1339,54 +1216,44 @@ describe("task-registry", () => {
     });
   });
 
-  it("rejects cross-owner parent flow links during task creation", async () => {
+  it.each([
+    {
+      name: "rejects cross-owner parent flow links during task creation",
+      runtime: "acp" as const,
+      params: {
+        status: undefined,
+        deliveryStatus: undefined,
+        ownerKey: "agent:main:other",
+        runId: "cross-owner-run",
+        task: "Attempt hijack",
+      },
+      error: "Task ownerKey must match parent flow ownerKey.",
+    },
+    {
+      name: "rejects system-scoped parent flow links during task creation",
+      runtime: "cron" as const,
+      params: {
+        status: undefined,
+        scopeKind: "system" as const,
+        runId: "system-link-run",
+        task: "System task",
+      },
+      error: "Only session-scoped tasks can link to flows.",
+    },
+  ])("$name", async ({ runtime, params, error }) => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
-      configureInMemoryTaskStoresForLinkValidationTests();
-
+      configureInMemoryTaskStoresForTests();
       const flow = createManagedTaskFlow({
         ownerKey: "agent:main:main",
         controllerId: "tests/task-registry",
         goal: "Owner main flow",
       });
 
-      expect(() =>
-        createTaskRecord({
-          runtime: "acp",
-          ownerKey: "agent:main:other",
-          scopeKind: "session",
-          parentFlowId: flow.flowId,
-          runId: "cross-owner-run",
-          task: "Attempt hijack",
-        }),
-      ).toThrow("Task ownerKey must match parent flow ownerKey.");
-    });
-  });
-
-  it("rejects system-scoped parent flow links during task creation", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
-      resetTaskFlowRegistryForTests({ persist: false });
-      configureInMemoryTaskStoresForLinkValidationTests();
-
-      const flow = createManagedTaskFlow({
-        ownerKey: "agent:main:main",
-        controllerId: "tests/task-registry",
-        goal: "Owner main flow",
-      });
-
-      expect(() =>
-        createTaskRecord({
-          runtime: "cron",
-          ownerKey: "agent:main:main",
-          scopeKind: "system",
-          parentFlowId: flow.flowId,
-          runId: "system-link-run",
-          task: "System task",
-          deliveryStatus: "not_applicable",
-        }),
-      ).toThrow("Only session-scoped tasks can link to flows.");
+      expect(() => createTaskRecord(runtime, { ...params, parentFlowId: flow.flowId })).toThrow(
+        error,
+      );
     });
   });
 
@@ -1394,12 +1261,11 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
-      configureInMemoryTaskStoresForLinkValidationTests();
+      configureInMemoryTaskStoresForTests();
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("acp", {
+        status: undefined,
+        deliveryStatus: undefined,
         runId: "owner-main-task",
         task: "Safe task",
       });
@@ -1435,13 +1301,10 @@ describe("task-registry", () => {
         store: createInMemoryTaskFlowRegistryStore(),
       });
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("acp", {
+        deliveryStatus: undefined,
         runId: "flow-restore-failed-task",
         task: "Preserve linked task state",
-        status: "running",
       });
       const flow = createTaskFlowForTask({ task });
       expect(
@@ -1481,30 +1344,19 @@ describe("task-registry", () => {
       expect(requireTaskById(task.taskId).taskId).toBe(task.taskId);
 
       expect(() =>
-        createTaskRecord({
-          runtime: "acp",
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
-          requesterOrigin: {
-            channel: "notifychat",
-            to: "notifychat:123",
-          },
+        createTaskRecord("acp", {
+          deliveryStatus: undefined,
+          requesterOrigin: NOTIFYCHAT_ORIGIN,
           runId: task.runId,
           task: task.task,
-          status: "running",
         }),
       ).toThrow("Task-flow registry restore failed: SQLITE_IOERR: task-flow restore failed");
       expect(deliveryUpsert).not.toHaveBeenCalled();
       expect(loadSnapshot).toHaveBeenCalledTimes(1);
 
-      const standalone = createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const standalone = createTaskRecord("cli", {
         runId: "standalone-during-flow-restore-failure",
         task: "Keep standalone task state available",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       expect(
         markTaskTerminalById({
@@ -1573,15 +1425,12 @@ describe("task-registry", () => {
       vi.useFakeTimers();
       resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
-      configureInMemoryTaskStoresForLinkValidationTests();
+      configureInMemoryTaskStoresForTests();
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("acp", {
+        deliveryStatus: undefined,
         runId: "mirrored-flow-sync-fail",
         task: "Sync mirrored flow",
-        status: "running",
         lastEventAt: 100,
       });
       const flow = createTaskFlowForTask({ task });
@@ -1655,15 +1504,12 @@ describe("task-registry", () => {
       vi.useFakeTimers();
       resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
-      configureInMemoryTaskStoresForLinkValidationTests();
+      configureInMemoryTaskStoresForTests();
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("acp", {
+        deliveryStatus: undefined,
         runId: "mirrored-flow-stale-retry",
         task: "Initial blocked task",
-        status: "running",
         lastEventAt: 100,
       });
       const flow = createTaskFlowForTask({ task });
@@ -1701,14 +1547,11 @@ describe("task-registry", () => {
       expect(getTaskFlowById(flow.flowId)?.status).toBe("running");
 
       failUpsert = false;
-      const newerTask = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const newerTask = createTaskRecord("acp", {
+        deliveryStatus: undefined,
         parentFlowId: flow.flowId,
         runId: "mirrored-flow-newer-task",
         task: "Retry task",
-        status: "running",
         lastEventAt: 250,
       });
       expect(newerTask.parentFlowId).toBe(flow.flowId);
@@ -1726,7 +1569,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
-      configureInMemoryTaskStoresForLinkValidationTests();
+      configureInMemoryTaskStoresForTests();
 
       const flow = createManagedTaskFlow({
         ownerKey: "agent:main:main",
@@ -1736,10 +1579,9 @@ describe("task-registry", () => {
       });
 
       try {
-        createTaskRecord({
-          runtime: "acp",
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
+        createTaskRecord("acp", {
+          status: undefined,
+          deliveryStatus: undefined,
           parentFlowId: flow.flowId,
           runId: "cancel-requested-link",
           task: "Should be denied",
@@ -1762,16 +1604,12 @@ describe("task-registry", () => {
         controllerId: "tests/task-registry",
         goal: "Wait for canonical child state",
       });
-      const task = createTaskRecord({
-        runtime: "subagent",
+      const task = createTaskRecord("subagent", {
         ownerKey: flow.ownerKey,
-        scopeKind: "session",
         parentFlowId: flow.flowId,
         childSessionKey: "agent:worker:subagent:provisional-flow",
         runId: "run-provisional-managed-flow",
         task: "Resolve cancellation race",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       expect(
         requestFlowCancel({
@@ -1781,9 +1619,7 @@ describe("task-registry", () => {
         }).applied,
       ).toBe(true);
 
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "cancelled",
         endedAt: 200,
         error: SUBAGENT_KILL_TASK_ERROR,
@@ -1800,7 +1636,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
-      configureInMemoryTaskStoresForLinkValidationTests();
+      configureInMemoryTaskStoresForTests();
 
       const flow = createManagedTaskFlow({
         ownerKey: "agent:main:main",
@@ -1810,10 +1646,9 @@ describe("task-registry", () => {
       });
 
       expect(() =>
-        createTaskRecord({
-          runtime: "acp",
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
+        createTaskRecord("acp", {
+          status: undefined,
+          deliveryStatus: undefined,
           parentFlowId: flow.flowId,
           runId: "terminal-flow-link",
           task: "Should be denied",
@@ -1831,20 +1666,14 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createAcpTaskRecord({
         requesterOrigin: {
           channel: "notifychat",
           to: "notifychat:123",
           threadId: "321",
         },
-        childSessionKey: "agent:main:acp:child",
         runId: "run-delivery",
         task: "Investigate issue",
-        status: "running",
-        deliveryStatus: "pending",
         startedAt: 100,
       });
 
@@ -1879,19 +1708,11 @@ describe("task-registry", () => {
           via: "direct",
         });
 
-        const task = createTaskRecord({
-          runtime: "acp",
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
-          requesterOrigin: {
-            channel: "notifychat",
-            to: "notifychat:123",
-          },
-          childSessionKey: "agent:main:acp:child",
+        const task = createAcpTaskRecord({
+          requesterOrigin: NOTIFYCHAT_ORIGIN,
           runId: "run-delivery-retry",
           task: "Investigate issue",
           status: "succeeded",
-          deliveryStatus: "pending",
         });
 
         await waitForAssertion(() =>
@@ -1928,10 +1749,7 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("acp", {
         requesterOrigin: {
           channel: "notifychat",
           to: "notifychat:123",
@@ -1939,7 +1757,6 @@ describe("task-registry", () => {
         },
         runId: "run-direct-delivery",
         task: "Investigate issue",
-        status: "running",
         deliveryStatus: "pending",
         startedAt: 100,
       });
@@ -1985,20 +1802,15 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord({
-        runtime: "acp",
+      createAcpTaskRecord({
         ownerKey: "agent:main:discord:guild-123:channel-parent-channel",
-        scopeKind: "session",
         requesterOrigin: {
           channel: "discord",
           to: "channel:parent-channel",
           threadId: "thread-84022",
         },
-        childSessionKey: "agent:main:acp:child",
         runId,
         task: "Investigate thread-bound ACP delivery",
-        status: "running",
-        deliveryStatus: "pending",
         terminalSummary: "ACP final answer",
         startedAt: 100,
       });
@@ -2077,16 +1889,11 @@ describe("task-registry", () => {
           via: "direct",
         });
 
-        createTaskRecord({
-          runtime: "acp",
+        createAcpTaskRecord({
           ownerKey: "agent:main:discord:guild-123:channel-parent-channel",
-          scopeKind: "session",
           requesterOrigin,
-          childSessionKey: "agent:main:acp:child",
           runId,
           task: "Investigate thread-bound ACP delivery",
-          status: "running",
-          deliveryStatus: "pending",
           terminalSummary: "ACP final answer",
           startedAt: 100,
         });
@@ -2157,19 +1964,14 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord({
-        runtime: "acp",
+      createAcpTaskRecord({
         ownerKey,
-        scopeKind: "session",
         requesterOrigin: {
           channel: "guildchat",
           to: target,
         },
-        childSessionKey: "agent:main:acp:child",
         runId,
         task: "Investigate issue",
-        status: "running",
-        deliveryStatus: "pending",
         startedAt: 100,
       });
 
@@ -2204,19 +2006,10 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockRejectedValueOnce(new Error("notifychat unavailable"));
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-delivery-fail",
         task: "Investigate issue",
-        status: "running",
-        deliveryStatus: "pending",
         startedAt: 100,
       });
 
@@ -2250,19 +2043,11 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockRejectedValueOnce(new Error("notifychat unavailable"));
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-delivery-blocked",
         task: "Port the repo changes",
         status: "succeeded",
-        deliveryStatus: "pending",
         terminalOutcome: "blocked",
         terminalSummary: "Writable session or apply_patch authorization required.",
       });
@@ -2287,15 +2072,9 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        childSessionKey: "agent:main:acp:child",
+      createAcpTaskRecord({
         runId: "run-session-queued",
         task: "Investigate issue",
-        status: "running",
-        deliveryStatus: "pending",
         startedAt: 100,
       });
 
@@ -2325,15 +2104,10 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        childSessionKey: "agent:main:acp:child",
+      createAcpTaskRecord({
         runId: "run-session-blocked",
         task: "Port the repo changes",
         status: "succeeded",
-        deliveryStatus: "pending",
         terminalOutcome: "blocked",
         terminalSummary: "Writable session or apply_patch authorization required.",
       });
@@ -2363,20 +2137,14 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createAcpTaskRecord({
         requesterOrigin: {
           channel: "notifychat",
           to: "notifychat:123",
           threadId: "321",
         },
-        childSessionKey: "agent:main:acp:child",
         runId: "run-detail-leak",
         task: "Create the file and verify it",
-        status: "running",
-        deliveryStatus: "pending",
         startedAt: 100,
       });
 
@@ -2415,19 +2183,11 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-blocked-outcome",
         task: "Port the repo changes",
         status: "succeeded",
-        deliveryStatus: "pending",
         terminalOutcome: "blocked",
         terminalSummary: "Writable session or apply_patch authorization required.",
       });
@@ -2455,19 +2215,11 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-succeeded-outcome",
         task: "Create the file and verify it",
         status: "succeeded",
-        deliveryStatus: "pending",
         terminalSummary: "Created /tmp/file.txt and verified contents.",
         terminalOutcome: "succeeded",
       });
@@ -2492,25 +2244,17 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "cli",
+      createTaskRecord("cli", {
         ownerKey: "agent:codex:acp:child",
-        scopeKind: "session",
         childSessionKey: "agent:codex:acp:child",
         runId: "run-shared",
         task: "Child ACP execution",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("acp", {
         childSessionKey: "agent:codex:acp:child",
         runId: "run-shared",
         task: "Spawn ACP child",
-        status: "running",
         deliveryStatus: "pending",
       });
 
@@ -2526,26 +2270,19 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      const victimTask = createTaskRecord({
-        runtime: "acp",
+      const victimTask = createTaskRecord("acp", {
         ownerKey: "agent:victim:main",
-        scopeKind: "session",
         childSessionKey: "agent:victim:acp:child",
         runId: "run-shared-scope",
         task: "Victim ACP task",
-        status: "running",
         deliveryStatus: "pending",
       });
 
-      const attackerTask = createTaskRecord({
-        runtime: "cli",
+      const attackerTask = createTaskRecord("cli", {
         ownerKey: "agent:attacker:main",
-        scopeKind: "session",
         childSessionKey: "agent:attacker:main",
         runId: "run-shared-scope",
         task: "Attacker CLI task",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
 
       registerAgentRunContext("run-shared-scope", {
@@ -2581,34 +2318,18 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      const directTask = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      const directTask = createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-shared-delivery",
         task: "Direct ACP child",
         status: "succeeded",
-        deliveryStatus: "pending",
       });
-      const spawnedTask = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      const spawnedTask = createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-shared-delivery",
         task: "Spawn ACP child",
         preferMetadata: true,
         status: "succeeded",
-        deliveryStatus: "pending",
       });
 
       await maybeDeliverTaskTerminalUpdate(directTask.taskId);
@@ -2633,24 +2354,18 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      const victimTask = createTaskRecord({
-        runtime: "acp",
+      const victimTask = createTaskRecord("acp", {
         ownerKey: "agent:victim:main",
-        scopeKind: "session",
         childSessionKey: "agent:victim:acp:child",
         runId: "run-cross-requester-delivery",
         task: "Victim ACP task",
-        status: "running",
         deliveryStatus: "pending",
       });
-      const attackerTask = createTaskRecord({
-        runtime: "acp",
+      const attackerTask = createTaskRecord("acp", {
         ownerKey: "agent:attacker:main",
-        scopeKind: "session",
         childSessionKey: "agent:attacker:acp:child",
         runId: "run-cross-requester-delivery",
         task: "Attacker ACP task",
-        status: "running",
         deliveryStatus: "pending",
       });
 
@@ -2684,36 +2399,18 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      const directTask = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      const directTask = createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-collapse-preferred",
         task: "Direct ACP child",
-        status: "running",
-        deliveryStatus: "pending",
       });
 
-      const spawnedTask = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      const spawnedTask = createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-collapse-preferred",
         label: "Quant patch",
         task: "Implement the feature and report back",
         preferMetadata: true,
-        status: "running",
-        deliveryStatus: "pending",
       });
 
       expect(spawnedTask.taskId).toBe(directTask.taskId);
@@ -2729,33 +2426,18 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      const spawnedTask = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      const spawnedTask = createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-collapse",
         task: "Spawn ACP child",
-        status: "running",
-        deliveryStatus: "pending",
       });
 
-      const directTask = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
+      const directTask = createTaskRecord("acp", {
+        deliveryStatus: undefined,
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         childSessionKey: "agent:main:acp:child",
         runId: "run-collapse",
         task: "Direct ACP child",
-        status: "running",
       });
 
       expect(directTask.taskId).toBe(spawnedTask.taskId);
@@ -2775,19 +2457,11 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:acp:child",
+      const task = createAcpTaskRecord({
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-racing-delivery",
         task: "Investigate issue",
         status: "succeeded",
-        deliveryStatus: "pending",
         terminalOutcome: "blocked",
         terminalSummary: "Writable session or apply_patch authorization required.",
       });
@@ -2821,16 +2495,11 @@ describe("task-registry", () => {
               resolve({ channel: "notifychat", to: "notifychat:123", via: "direct" });
           }),
       );
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createAcpTaskRecord({
         requesterOrigin: { channel: "notifychat", to: "notifychat:123" },
-        childSessionKey: "agent:main:acp:child",
         runId: "run-held-delivery",
         task: "Deliver after completion",
         status: "succeeded",
-        deliveryStatus: "pending",
         terminalOutcome: "blocked",
         terminalSummary: "Waiting for parent review.",
       });
@@ -2850,14 +2519,10 @@ describe("task-registry", () => {
       async () => {
         resetTaskRegistryForTests();
 
-        const task = createTaskRecord({
-          runtime: "subagent",
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
+        const task = createTaskRecord("subagent", {
           childSessionKey: "agent:main:subagent:child",
           runId: "run-restore",
           task: "Restore me",
-          status: "running",
           deliveryStatus: "pending",
         });
 
@@ -2881,18 +2546,16 @@ describe("task-registry", () => {
       const nowSpy = vi.spyOn(Date, "now");
       nowSpy.mockReturnValue(1_700_000_000_000);
 
-      const older = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const older = createTaskRecord("acp", {
+        status: undefined,
+        deliveryStatus: undefined,
         childSessionKey: "agent:main:subagent:child-1",
         runId: "run-session-lookup-1",
         task: "Older task",
       });
-      const latest = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const latest = createTaskRecord("subagent", {
+        status: undefined,
+        deliveryStatus: undefined,
         childSessionKey: "agent:main:subagent:child-2",
         runId: "run-session-lookup-2",
         task: "Latest task",
@@ -2914,16 +2577,15 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest({ persist: false });
 
-      const created = createTaskRecord({
-        runtime: "cli",
+      const created = createTaskRecord("cli", {
+        ownerKey: undefined,
+        scopeKind: undefined,
         taskKind: "video_generation",
         sourceId: "video_generate:openai",
         requesterSessionKey: "agent:main:discord:direct:123",
         childSessionKey: "agent:main:discord:direct:123",
         runId: "tool:video_generate:agent-index",
         task: "Generate a lobster video",
-        status: "running",
-        deliveryStatus: "not_applicable",
         notifyPolicy: "silent",
       });
 
@@ -2936,14 +2598,10 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest({ persist: false });
 
-      const created = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const created = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:child",
         runId: "run-worker-subagent",
         task: "Inspect worker state",
-        status: "running",
         deliveryStatus: "pending",
       });
 
@@ -2956,16 +2614,11 @@ describe("task-registry", () => {
   it("retains live background exec tasks and marks missing process sessions lost", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
-      const task = createTaskRecord({
-        runtime: "cli",
+      const task = createTaskRecord("cli", {
         taskKind: "exec",
         sourceId: "amber-reef",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
         runId: "exec:amber-reef",
         task: "Background CLI command",
-        status: "running",
-        deliveryStatus: "not_applicable",
         lastEventAt: Date.now() - 10 * 60_000,
       });
       const currentTasks = new Map([[task.taskId, task]]);
@@ -3006,14 +2659,10 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       configureTaskRegistryMaintenance({ runtimeAuthoritative: true });
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("acp", {
         childSessionKey: "agent:main:acp:missing",
         runId: "run-lost",
         task: "Missing child",
-        status: "running",
         deliveryStatus: "pending",
         lastEventAt: Date.now() - 10 * 60_000,
       });
@@ -3037,13 +2686,9 @@ describe("task-registry", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-06-16T00:00:00Z"));
 
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         runId: "run-inspection-freshness",
         task: "Inspect fresh task state",
-        status: "running",
         deliveryStatus: "pending",
       });
       let listCalls = 0;
@@ -3068,14 +2713,10 @@ describe("task-registry", () => {
       configureTaskRegistryMaintenance({ runtimeAuthoritative: true });
       const now = Date.now();
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("acp", {
         childSessionKey: "agent:main:acp:missing",
         runId: "run-lost-maintenance",
         task: "Missing child",
-        status: "running",
         deliveryStatus: "pending",
         lastEventAt: now - 10 * 60_000,
       });
@@ -3102,234 +2743,198 @@ describe("task-registry", () => {
     });
   });
 
-  it("keeps fresh childless codex-native subagent tasks live", async () => {
+  it.each([
+    {
+      name: "keeps fresh childless codex-native subagent tasks live",
+      taskKind: "codex-native",
+      sourceId: "codex-thread:child-thread",
+      task: "Codex native child",
+      ageMinutes: 10,
+      reconciled: 0,
+      error: undefined,
+    },
+    {
+      name: "marks stale childless codex-native subagent tasks lost",
+      taskKind: "codex-native",
+      sourceId: "codex-thread:child-thread",
+      task: "Codex native child",
+      ageMinutes: 31,
+      reconciled: 1,
+      error: "Codex native subagent stopped reporting progress",
+    },
+    {
+      name: "keeps fresh childless copilot-native subagent tasks live",
+      taskKind: "copilot-native",
+      sourceId: "copilot-agent:child-agent",
+      task: "Copilot native child",
+      ageMinutes: 10,
+      reconciled: 0,
+      error: undefined,
+    },
+    {
+      name: "marks stale childless copilot-native subagent tasks lost",
+      taskKind: "copilot-native",
+      sourceId: "copilot-agent:child-agent",
+      task: "Copilot native child",
+      ageMinutes: 31,
+      reconciled: 1,
+      error: "Native subagent stopped reporting progress",
+    },
+    {
+      name: "does not mark unrelated childless subagent tasks lost",
+      taskKind: "codex-native",
+      sourceId: "other-runtime:child-thread",
+      task: "Non-Codex childless row",
+      ageMinutes: 31,
+      reconciled: 0,
+      error: undefined,
+    },
+  ])("$name", async ({ taskKind, sourceId, task: taskName, ageMinutes, reconciled, error }) => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryForTests();
       const now = Date.now();
-
-      const task = createTaskRecord({
-        runtime: "subagent",
-        taskKind: "codex-native",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        sourceId: "codex-thread:child-thread",
-        runId: "codex-thread:child-thread",
-        task: "Codex native child",
-        status: "running",
-        deliveryStatus: "not_applicable",
+      const lastEventAt = now - ageMinutes * 60_000;
+      const task = createTaskRecord("subagent", {
+        taskKind,
+        sourceId,
+        runId: sourceId,
+        task: taskName,
         notifyPolicy: "silent",
-        lastEventAt: now - 10 * 60_000,
+        lastEventAt,
       });
 
       expect(await runTaskRegistryMaintenance()).toEqual({
-        reconciled: 0,
+        reconciled,
         recovered: 0,
         cleanupStamped: 0,
         pruned: 0,
       });
-      expectRecordFields(requireTaskById(task.taskId), {
-        status: "running",
-        lastEventAt: now - 10 * 60_000,
-      });
+      expectRecordFields(
+        requireTaskById(task.taskId),
+        error === undefined ? { status: "running", lastEventAt } : { status: "lost", error },
+      );
     });
   });
 
-  it("marks stale childless codex-native subagent tasks lost", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
-      const now = Date.now();
+  it.each([
+    {
+      name: "closes terminal parent-owned one-shot ACP sessions during maintenance",
+      mode: "oneshot" as const,
+      childSessionKey: "agent:claude:acp:stale-oneshot",
+      runId: "run-terminal-acp-oneshot",
+      task: "Old ACP task",
+      status: "succeeded" as const,
+      deliveryStatus: "delivered" as const,
+      bound: false,
+      closes: true,
+      checksSummary: true,
+    },
+    {
+      name: "closes stale terminal persistent ACP sessions only when no binding remains",
+      mode: "persistent" as const,
+      childSessionKey: "agent:claude:acp:stale-persistent",
+      runId: "run-terminal-acp-persistent",
+      task: "Old persistent ACP task",
+      status: "failed" as const,
+      deliveryStatus: "failed" as const,
+      bound: false,
+      closes: true,
+      checksSummary: false,
+    },
+    {
+      name: "keeps terminal persistent ACP sessions that still have an active binding",
+      mode: "persistent" as const,
+      childSessionKey: "agent:claude:acp:bound-persistent",
+      runId: "run-terminal-acp-bound",
+      task: "Thread-bound ACP session",
+      status: "succeeded" as const,
+      deliveryStatus: "delivered" as const,
+      bound: true,
+      closes: false,
+      checksSummary: false,
+    },
+  ])(
+    "$name",
+    async ({
+      mode,
+      childSessionKey,
+      runId,
+      task: taskName,
+      status,
+      deliveryStatus,
+      bound,
+      closes,
+      checksSummary,
+    }) => {
+      await withTaskRegistryTempDir(async () => {
+        resetTaskRegistryMemoryForTest();
+        const now = Date.now();
+        const parentSessionKey = "agent:main:telegram:direct:owner";
+        const task = createTaskRecord("acp", {
+          ownerKey: parentSessionKey,
+          requesterSessionKey: parentSessionKey,
+          childSessionKey,
+          runId,
+          task: taskName,
+          status,
+          deliveryStatus,
+          lastEventAt: now - 60_000,
+        });
+        finalizeTaskRunByRunId({
+          runId,
+          runtime: "acp",
+          status,
+          endedAt: now - 60_000,
+          lastEventAt: now - 60_000,
+        });
+        const current = getTaskById(task.taskId)!;
+        const closeAcpSession = vi.fn().mockResolvedValue(undefined);
+        const unbindSessionBindings = vi.fn().mockResolvedValue([]);
 
-      const task = createTaskRecord({
-        runtime: "subagent",
-        taskKind: "codex-native",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        sourceId: "codex-thread:child-thread",
-        runId: "codex-thread:child-thread",
-        task: "Codex native child",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
-        lastEventAt: now - 31 * 60_000,
-      });
+        configureTaskRegistryMaintenanceRuntimeForTest({
+          currentTasks: new Map([[task.taskId, current]]),
+          snapshotTasks: [current],
+          acpEntry: createAcpSessionStoreEntry({
+            sessionKey: childSessionKey,
+            parentSessionKey,
+            mode,
+          }),
+          sessionBindings: bound
+            ? [createSessionBindingRecord({ targetSessionKey: childSessionKey })]
+            : [],
+          closeAcpSession,
+          unbindSessionBindings,
+        });
 
-      expect(await runTaskRegistryMaintenance()).toEqual({
-        reconciled: 1,
-        recovered: 0,
-        cleanupStamped: 0,
-        pruned: 0,
-      });
-      expectRecordFields(requireTaskById(task.taskId), {
-        status: "lost",
-        error: "Codex native subagent stopped reporting progress",
-      });
-    });
-  });
-
-  it("keeps fresh childless copilot-native subagent tasks live", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
-      const now = Date.now();
-
-      const task = createTaskRecord({
-        runtime: "subagent",
-        taskKind: "copilot-native",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        sourceId: "copilot-agent:child-agent",
-        runId: "copilot-agent:child-agent",
-        task: "Copilot native child",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
-        lastEventAt: now - 10 * 60_000,
-      });
-
-      expect(await runTaskRegistryMaintenance()).toEqual({
-        reconciled: 0,
-        recovered: 0,
-        cleanupStamped: 0,
-        pruned: 0,
-      });
-      expectRecordFields(requireTaskById(task.taskId), {
-        status: "running",
-        lastEventAt: now - 10 * 60_000,
-      });
-    });
-  });
-
-  it("marks stale childless copilot-native subagent tasks lost", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
-      const now = Date.now();
-
-      const task = createTaskRecord({
-        runtime: "subagent",
-        taskKind: "copilot-native",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        sourceId: "copilot-agent:child-agent",
-        runId: "copilot-agent:child-agent",
-        task: "Copilot native child",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
-        lastEventAt: now - 31 * 60_000,
-      });
-
-      expect(await runTaskRegistryMaintenance()).toEqual({
-        reconciled: 1,
-        recovered: 0,
-        cleanupStamped: 0,
-        pruned: 0,
-      });
-      expectRecordFields(requireTaskById(task.taskId), {
-        status: "lost",
-        error: "Native subagent stopped reporting progress",
-      });
-    });
-  });
-
-  it("does not mark unrelated childless subagent tasks lost", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
-      const now = Date.now();
-
-      const task = createTaskRecord({
-        runtime: "subagent",
-        taskKind: "codex-native",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        sourceId: "other-runtime:child-thread",
-        runId: "other-runtime:child-thread",
-        task: "Non-Codex childless row",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
-        lastEventAt: now - 31 * 60_000,
-      });
-
-      expect(await runTaskRegistryMaintenance()).toEqual({
-        reconciled: 0,
-        recovered: 0,
-        cleanupStamped: 0,
-        pruned: 0,
-      });
-      expectRecordFields(requireTaskById(task.taskId), {
-        status: "running",
-        lastEventAt: now - 31 * 60_000,
-      });
-    });
-  });
-
-  it("closes terminal parent-owned one-shot ACP sessions during maintenance", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-      const now = Date.now();
-      const parentSessionKey = "agent:main:telegram:direct:owner";
-      const childSessionKey = "agent:claude:acp:stale-oneshot";
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: parentSessionKey,
-        requesterSessionKey: parentSessionKey,
-        scopeKind: "session",
-        childSessionKey,
-        runId: "run-terminal-acp-oneshot",
-        task: "Old ACP task",
-        status: "succeeded",
-        deliveryStatus: "delivered",
-        lastEventAt: now - 60_000,
-      });
-      finalizeTaskRunByRunId({
-        runId: "run-terminal-acp-oneshot",
-        runtime: "acp",
-        status: "succeeded",
-        endedAt: now - 60_000,
-        lastEventAt: now - 60_000,
-      });
-      const current = getTaskById(task.taskId)!;
-      const closeAcpSession = vi.fn().mockResolvedValue(undefined);
-      const unbindSessionBindings = vi.fn().mockResolvedValue([]);
-
-      configureTaskRegistryMaintenanceRuntimeForTest({
-        currentTasks: new Map([[task.taskId, current]]),
-        snapshotTasks: [current],
-        acpEntry: createAcpSessionStoreEntry({
+        const result = await runTaskRegistryMaintenance();
+        if (checksSummary) {
+          expectRecordFields(result, { reconciled: 0, recovered: 0, pruned: 0 });
+        }
+        if (!closes) {
+          expect(closeAcpSession).not.toHaveBeenCalled();
+          expect(unbindSessionBindings).not.toHaveBeenCalled();
+          return;
+        }
+        expect(closeAcpSession).toHaveBeenCalledWith({
+          cfg: {},
           sessionKey: childSessionKey,
-          parentSessionKey,
-          mode: "oneshot",
-        }),
-        closeAcpSession,
-        unbindSessionBindings,
+          reason: "terminal-task-cleanup",
+        });
+        expect(unbindSessionBindings).toHaveBeenCalledWith({
+          targetSessionKey: childSessionKey,
+          reason: "terminal-task-cleanup",
+        });
       });
-
-      expectRecordFields(await runTaskRegistryMaintenance(), {
-        reconciled: 0,
-        recovered: 0,
-        pruned: 0,
-      });
-      expect(closeAcpSession).toHaveBeenCalledWith({
-        cfg: {},
-        sessionKey: childSessionKey,
-        reason: "terminal-task-cleanup",
-      });
-      expect(unbindSessionBindings).toHaveBeenCalledWith({
-        targetSessionKey: childSessionKey,
-        reason: "terminal-task-cleanup",
-      });
-    });
-  });
+    },
+  );
 
   it("does not relist task records for each terminal ACP cleanup check", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
       const now = Date.now();
       const tasks = Array.from({ length: 20 }, (_, index) => {
-        const task = createTaskRecord({
-          runtime: "acp",
-          ownerKey: "agent:main:main",
+        const task = createTaskRecord("acp", {
           requesterSessionKey: "agent:main:main",
-          scopeKind: "session",
           childSessionKey: `agent:claude:acp:terminal-${index}`,
           runId: `run-terminal-acp-snapshot-${index}`,
           task: `Terminal ACP task ${index}`,
@@ -3366,11 +2971,9 @@ describe("task-registry", () => {
       const now = Date.now();
       const parentSessionKey = "agent:main:telegram:direct:owner";
       const childSessionKey = "agent:claude:acp:shared-child";
-      const terminal = createTaskRecord({
-        runtime: "acp",
+      const terminal = createTaskRecord("acp", {
         ownerKey: parentSessionKey,
         requesterSessionKey: parentSessionKey,
-        scopeKind: "session",
         childSessionKey,
         runId: "run-terminal-acp-shared",
         task: "Old ACP task",
@@ -3382,15 +2985,12 @@ describe("task-registry", () => {
         endedAt: now - 60_000,
         lastEventAt: now - 60_000,
       };
-      const active = createTaskRecord({
-        runtime: "acp",
+      const active = createTaskRecord("acp", {
         ownerKey: parentSessionKey,
         requesterSessionKey: parentSessionKey,
-        scopeKind: "session",
         childSessionKey,
         runId: "run-active-acp-shared",
         task: "Current ACP task",
-        status: "running",
         deliveryStatus: "pending",
       });
       const closeAcpSession = vi.fn().mockResolvedValue(undefined);
@@ -3415,115 +3015,32 @@ describe("task-registry", () => {
     });
   });
 
-  it("closes stale terminal persistent ACP sessions only when no binding remains", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-      const now = Date.now();
-      const parentSessionKey = "agent:main:telegram:direct:owner";
-      const childSessionKey = "agent:claude:acp:stale-persistent";
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: parentSessionKey,
-        requesterSessionKey: parentSessionKey,
-        scopeKind: "session",
-        childSessionKey,
-        runId: "run-terminal-acp-persistent",
-        task: "Old persistent ACP task",
-        status: "failed",
-        deliveryStatus: "failed",
-        lastEventAt: now - 60_000,
-      });
-      finalizeTaskRunByRunId({
-        runId: "run-terminal-acp-persistent",
-        runtime: "acp",
-        status: "failed",
-        endedAt: now - 60_000,
-        lastEventAt: now - 60_000,
-      });
-      const current = getTaskById(task.taskId)!;
-      const closeAcpSession = vi.fn().mockResolvedValue(undefined);
-      const unbindSessionBindings = vi.fn().mockResolvedValue([]);
-
-      configureTaskRegistryMaintenanceRuntimeForTest({
-        currentTasks: new Map([[task.taskId, current]]),
-        snapshotTasks: [current],
-        acpEntry: createAcpSessionStoreEntry({
-          sessionKey: childSessionKey,
-          parentSessionKey,
-          mode: "persistent",
-        }),
-        closeAcpSession,
-        unbindSessionBindings,
-      });
-
-      await runTaskRegistryMaintenance();
-
-      expect(closeAcpSession).toHaveBeenCalledWith({
-        cfg: {},
-        sessionKey: childSessionKey,
-        reason: "terminal-task-cleanup",
-      });
-      expect(unbindSessionBindings).toHaveBeenCalledWith({
-        targetSessionKey: childSessionKey,
-        reason: "terminal-task-cleanup",
-      });
-    });
-  });
-
-  it("keeps terminal persistent ACP sessions that still have an active binding", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-      const now = Date.now();
-      const parentSessionKey = "agent:main:telegram:direct:owner";
-      const childSessionKey = "agent:claude:acp:bound-persistent";
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: parentSessionKey,
-        requesterSessionKey: parentSessionKey,
-        scopeKind: "session",
-        childSessionKey,
-        runId: "run-terminal-acp-bound",
-        task: "Thread-bound ACP session",
-        status: "succeeded",
-        deliveryStatus: "delivered",
-        lastEventAt: now - 60_000,
-      });
-      finalizeTaskRunByRunId({
-        runId: "run-terminal-acp-bound",
-        runtime: "acp",
-        status: "succeeded",
-        endedAt: now - 60_000,
-        lastEventAt: now - 60_000,
-      });
-      const current = getTaskById(task.taskId)!;
-      const closeAcpSession = vi.fn().mockResolvedValue(undefined);
-      const unbindSessionBindings = vi.fn().mockResolvedValue([]);
-
-      configureTaskRegistryMaintenanceRuntimeForTest({
-        currentTasks: new Map([[task.taskId, current]]),
-        snapshotTasks: [current],
-        acpEntry: createAcpSessionStoreEntry({
-          sessionKey: childSessionKey,
-          parentSessionKey,
-          mode: "persistent",
-        }),
-        sessionBindings: [createSessionBindingRecord({ targetSessionKey: childSessionKey })],
-        closeAcpSession,
-        unbindSessionBindings,
-      });
-
-      await runTaskRegistryMaintenance();
-
-      expect(closeAcpSession).not.toHaveBeenCalled();
-      expect(unbindSessionBindings).not.toHaveBeenCalled();
-    });
-  });
-
-  it("closes orphaned parent-owned one-shot ACP sessions after task records are gone", async () => {
+  it.each([
+    {
+      name: "closes orphaned parent-owned one-shot ACP sessions after task records are gone",
+      mode: "oneshot" as const,
+      childSessionKey: "agent:claude:acp:orphaned-oneshot",
+      bound: false,
+      closes: true,
+    },
+    {
+      name: "keeps orphaned parent-owned persistent ACP sessions while a binding is active",
+      mode: "persistent" as const,
+      childSessionKey: "agent:claude:acp:bound-orphaned-persistent",
+      bound: true,
+      closes: false,
+    },
+    {
+      name: "closes orphaned parent-owned persistent ACP sessions without active bindings",
+      mode: "persistent" as const,
+      childSessionKey: "agent:claude:acp:unbound-orphaned-persistent",
+      bound: false,
+      closes: true,
+    },
+  ])("$name", async ({ mode, childSessionKey, bound, closes }) => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
       const parentSessionKey = "agent:main:telegram:direct:owner";
-      const childSessionKey = "agent:claude:acp:orphaned-oneshot";
       const closeAcpSession = vi.fn().mockResolvedValue(undefined);
       const unbindSessionBindings = vi.fn().mockResolvedValue([]);
 
@@ -3531,84 +3048,21 @@ describe("task-registry", () => {
         currentTasks: new Map(),
         snapshotTasks: [],
         acpEntries: [
-          createAcpSessionStoreEntry({
-            sessionKey: childSessionKey,
-            parentSessionKey,
-            mode: "oneshot",
-          }),
+          createAcpSessionStoreEntry({ sessionKey: childSessionKey, parentSessionKey, mode }),
         ],
+        sessionBindings: bound
+          ? [createSessionBindingRecord({ targetSessionKey: childSessionKey })]
+          : [],
         closeAcpSession,
         unbindSessionBindings,
       });
 
       await runTaskRegistryMaintenance();
-
-      expect(closeAcpSession).toHaveBeenCalledWith({
-        cfg: {},
-        sessionKey: childSessionKey,
-        reason: "orphaned-parent-task-cleanup",
-      });
-      expect(unbindSessionBindings).toHaveBeenCalledWith({
-        targetSessionKey: childSessionKey,
-        reason: "orphaned-parent-task-cleanup",
-      });
-    });
-  });
-
-  it("keeps orphaned parent-owned persistent ACP sessions while a binding is active", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-      const parentSessionKey = "agent:main:telegram:direct:owner";
-      const childSessionKey = "agent:claude:acp:bound-orphaned-persistent";
-      const closeAcpSession = vi.fn().mockResolvedValue(undefined);
-      const unbindSessionBindings = vi.fn().mockResolvedValue([]);
-
-      configureTaskRegistryMaintenanceRuntimeForTest({
-        currentTasks: new Map(),
-        snapshotTasks: [],
-        acpEntries: [
-          createAcpSessionStoreEntry({
-            sessionKey: childSessionKey,
-            parentSessionKey,
-            mode: "persistent",
-          }),
-        ],
-        sessionBindings: [createSessionBindingRecord({ targetSessionKey: childSessionKey })],
-        closeAcpSession,
-        unbindSessionBindings,
-      });
-
-      await runTaskRegistryMaintenance();
-
-      expect(closeAcpSession).not.toHaveBeenCalled();
-      expect(unbindSessionBindings).not.toHaveBeenCalled();
-    });
-  });
-
-  it("closes orphaned parent-owned persistent ACP sessions without active bindings", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-      const parentSessionKey = "agent:main:telegram:direct:owner";
-      const childSessionKey = "agent:claude:acp:unbound-orphaned-persistent";
-      const closeAcpSession = vi.fn().mockResolvedValue(undefined);
-      const unbindSessionBindings = vi.fn().mockResolvedValue([]);
-
-      configureTaskRegistryMaintenanceRuntimeForTest({
-        currentTasks: new Map(),
-        snapshotTasks: [],
-        acpEntries: [
-          createAcpSessionStoreEntry({
-            sessionKey: childSessionKey,
-            parentSessionKey,
-            mode: "persistent",
-          }),
-        ],
-        closeAcpSession,
-        unbindSessionBindings,
-      });
-
-      await runTaskRegistryMaintenance();
-
+      if (!closes) {
+        expect(closeAcpSession).not.toHaveBeenCalled();
+        expect(unbindSessionBindings).not.toHaveBeenCalled();
+        return;
+      }
       expect(closeAcpSession).toHaveBeenCalledWith({
         cfg: {},
         sessionKey: childSessionKey,
@@ -3625,15 +3079,11 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-prune",
         task: "Old completed task",
         status: "succeeded",
-        deliveryStatus: "not_applicable",
         startedAt: Date.now() - 9 * 24 * 60 * 60_000,
         lastEventAt: Date.now() - 8 * 24 * 60 * 60_000,
       });
@@ -3711,14 +3161,10 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       const now = Date.now();
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("acp", {
         childSessionKey: "agent:main:acp:missing",
         runId: "run-deferred-maintenance-stop",
         task: "Missing child",
-        status: "running",
         deliveryStatus: "pending",
         lastEventAt: now - 10 * 60_000,
       });
@@ -3815,14 +3261,10 @@ describe("task-registry", () => {
 
   it("rechecks current task state before marking a task lost", async () => {
     const now = Date.now();
-    const snapshotTask = createTaskRecord({
-      runtime: "acp",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
+    const snapshotTask = createTaskRecord("acp", {
       childSessionKey: "agent:main:acp:missing-stale",
       runId: "run-lost-stale",
       task: "Missing child",
-      status: "running",
       deliveryStatus: "pending",
     });
     const staleTask = {
@@ -3853,15 +3295,11 @@ describe("task-registry", () => {
 
   it("rechecks current task state before pruning a task", async () => {
     const now = Date.now();
-    const snapshotTask = createTaskRecord({
-      runtime: "cli",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
+    const snapshotTask = createTaskRecord("cli", {
       childSessionKey: "agent:main:main",
       runId: "run-prune-stale",
       task: "Old completed task",
       status: "succeeded",
-      deliveryStatus: "not_applicable",
       startedAt: now - 9 * 24 * 60 * 60_000,
     });
     const staleTask = {
@@ -3895,15 +3333,11 @@ describe("task-registry", () => {
   it("prunes retained lost tasks once the shorter lost retention window expires", async () => {
     const now = Date.now();
     const endedAt = now - LOST_TASK_RETENTION_MS - 1;
-    const snapshotTask = createTaskRecord({
-      runtime: "cli",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
+    const snapshotTask = createTaskRecord("cli", {
       childSessionKey: "agent:main:main",
       runId: "run-old-lost-cleanup",
       task: "Old lost task",
       status: "lost",
-      deliveryStatus: "not_applicable",
       startedAt: endedAt - 1,
     });
     const staleTask = {
@@ -3932,13 +3366,9 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("acp", {
         runId: "run-backdated-create",
         task: "Backdated create",
-        status: "running",
         deliveryStatus: "pending",
         startedAt: 1_699_999_999_000,
       });
@@ -3959,10 +3389,7 @@ describe("task-registry", () => {
       resetTaskRegistryMemoryForTest();
       const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("acp", {
         runId: "run-backdated-update",
         task: "Backdated update",
         status: "queued",
@@ -4043,14 +3470,10 @@ describe("task-registry", () => {
         },
       });
 
-      createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      createTaskRecord("cli", {
         requesterSessionKey: "agent:main:main",
         runId: "run-stale-memory",
         task: "Stale in-memory task",
-        status: "running",
         deliveryStatus: "pending",
         notifyPolicy: "silent",
         startedAt: now - 60_000,
@@ -4257,14 +3680,9 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "guildchat",
-          to: "guildchat:123",
-        },
+      const task = createTaskRecord("acp", {
+        deliveryStatus: undefined,
+        requesterOrigin: GUILDCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
         runId: "run-state-change",
         task: "Investigate issue",
@@ -4312,18 +3730,11 @@ describe("task-registry", () => {
       });
       vi.useFakeTimers();
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "guildchat",
-          to: "guildchat:123",
-        },
+      createTaskRecord("acp", {
+        requesterOrigin: GUILDCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
         runId: "run-quiet-terminal",
         task: "Create the file",
-        status: "running",
         deliveryStatus: "pending",
       });
 
@@ -4380,18 +3791,11 @@ describe("task-registry", () => {
         via: "direct",
       });
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "guildchat",
-          to: "guildchat:123",
-        },
+      createTaskRecord("acp", {
+        requesterOrigin: GUILDCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
         runId: "run-failure-terminal",
         task: "Write the file",
-        status: "running",
         deliveryStatus: "pending",
         progressSummary:
           "I am loading session context and checking helper availability before writing the file.",
@@ -4429,18 +3833,11 @@ describe("task-registry", () => {
       });
       vi.useFakeTimers();
 
-      createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "guildchat",
-          to: "guildchat:123",
-        },
+      createTaskRecord("acp", {
+        requesterOrigin: GUILDCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
         runId: "run-state-stream",
         task: "Create the file",
-        status: "running",
         deliveryStatus: "pending",
         notifyPolicy: "state_changes",
       });
@@ -4479,19 +3876,14 @@ describe("task-registry", () => {
   it("cancels background exec tasks through process control", async () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.cancelBackgroundExecSessionMock.mockReturnValue(true);
-      const task = createTaskRecord({
-        runtime: "cli",
+      const task = createTaskRecord("cli", {
         taskKind: "exec",
         sourceId: "amber-reef",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
         runId: "exec:amber-reef",
         task: "Background CLI command",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+      const result = await cancelTask(task.taskId);
 
       expect(hoisted.cancelBackgroundExecSessionMock).toHaveBeenCalledWith("amber-reef");
       expectRecordFields(result, { found: true, cancelled: true });
@@ -4507,25 +3899,15 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.cancelSessionMock.mockResolvedValue(undefined);
 
-      const task = createTaskRecord({
-        runtime: "acp",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
+      const task = createTaskRecord("acp", {
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         childSessionKey: "agent:codex:acp:child",
         runId: "run-cancel-acp",
         task: "Investigate issue",
-        status: "running",
         deliveryStatus: "pending",
       });
 
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
+      const result = await cancelTask(task.taskId);
 
       const cancelArgs = firstMockArg(hoisted.cancelSessionMock, "cancelSession");
       expectRecordFields(cancelArgs, {
@@ -4554,49 +3936,28 @@ describe("task-registry", () => {
 
   it("cancels subagent-backed tasks through subagent control", async () => {
     await withTaskRegistryTempDir(async () => {
-      const silentTask = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const silentTask = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:child",
         runId: "run-cancel-subagent",
         task: "Silent projection",
-        status: "running",
-        deliveryStatus: "not_applicable",
         notifyPolicy: "silent",
       });
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
+      const task = createTaskRecord("subagent", {
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         childSessionKey: "agent:worker:subagent:child",
         runId: "run-cancel-subagent",
         task: "Investigate issue",
-        status: "running",
         deliveryStatus: "pending",
       });
-      const peerTask = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
+      const peerTask = createTaskRecord("subagent", {
+        requesterOrigin: NOTIFYCHAT_ORIGIN,
         childSessionKey: "agent:worker:subagent:child",
         runId: "run-cancel-subagent",
         task: "Peer projection",
-        status: "running",
         deliveryStatus: "pending",
       });
       hoisted.killSubagentRunAdminMock.mockImplementationOnce(async () => {
-        finalizeTaskRunByRunId({
-          runId: task.runId!,
-          runtime: "subagent",
+        finalizeSubagentTask(task, {
           status: "cancelled",
           endedAt: 200,
           error: SUBAGENT_KILL_TASK_ERROR,
@@ -4604,10 +3965,7 @@ describe("task-registry", () => {
         return { found: true, killed: true };
       });
 
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
+      const result = await cancelTask(task.taskId);
 
       const killArgs = firstMockArg(hoisted.killSubagentRunAdminMock, "killSubagentRunAdmin");
       expectRecordFields(killArgs, {
@@ -4645,20 +4003,13 @@ describe("task-registry", () => {
 
   it("promotes a provisional subagent kill that races task cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:concurrent-kill",
         runId: "run-subagent-concurrent-kill",
         task: "Cancel during teardown",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       hoisted.killSubagentRunAdminMock.mockImplementationOnce(async () => {
-        finalizeTaskRunByRunId({
-          runId: task.runId!,
-          runtime: "subagent",
+        finalizeSubagentTask(task, {
           status: "cancelled",
           endedAt: 200,
           error: SUBAGENT_KILL_TASK_ERROR,
@@ -4666,10 +4017,8 @@ describe("task-registry", () => {
         return { found: true, killed: false };
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      const result = await cancelTask(task.taskId);
+      finalizeSubagentTask(task, {
         status: "succeeded",
         endedAt: 201,
         terminalSummary: "completed too late",
@@ -4687,19 +4036,12 @@ describe("task-registry", () => {
 
   it("reconciles an already-provisional kill before making cancellation sticky", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:provisional-completion",
         runId: "run-subagent-provisional-completion",
         task: "Finish before explicit cancellation",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "cancelled",
         endedAt: 200,
         error: SUBAGENT_KILL_TASK_ERROR,
@@ -4720,7 +4062,7 @@ describe("task-registry", () => {
         },
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+      const result = await cancelTask(task.taskId);
 
       expect(hoisted.killSubagentRunAdminMock).toHaveBeenCalledOnce();
       expectRecordFields(result, {
@@ -4739,37 +4081,23 @@ describe("task-registry", () => {
 
   it("preserves subagent success that completes during cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:cancel-race",
         runId: "run-subagent-cancel-race",
         task: "Finish during cancellation",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
-      const peerTask = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const peerTask = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:cancel-race",
         runId: "run-subagent-cancel-race",
         task: "Peer projection",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       hoisted.killSubagentRunAdminMock.mockImplementationOnce(async () => {
-        finalizeTaskRunByRunId({
-          runId: task.runId!,
-          runtime: "subagent",
+        finalizeSubagentTask(task, {
           status: "cancelled",
           endedAt: 200,
           error: SUBAGENT_KILL_TASK_ERROR,
         });
-        finalizeTaskRunByRunId({
-          runId: task.runId!,
-          runtime: "subagent",
+        finalizeSubagentTask(task, {
           status: "succeeded",
           endedAt: 201,
           terminalSummary: "completed",
@@ -4777,7 +4105,7 @@ describe("task-registry", () => {
         return { found: true, killed: true };
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+      const result = await cancelTask(task.taskId);
 
       expectRecordFields(result, {
         found: true,
@@ -4799,15 +4127,10 @@ describe("task-registry", () => {
 
   it("does not cancel a lagging task projection after subagent completion wins", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:lagging-projection",
         runId: "run-subagent-lagging-projection",
         task: "Finish before task projection",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       hoisted.killSubagentRunAdminMock.mockResolvedValueOnce({
         found: true,
@@ -4827,7 +4150,7 @@ describe("task-registry", () => {
         },
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+      const result = await cancelTask(task.taskId);
 
       expectRecordFields(result, {
         found: true,
@@ -4846,15 +4169,10 @@ describe("task-registry", () => {
 
   it("reconciles a replacement run cancellation into the original task scope", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:replacement-run",
         runId: "run-subagent-before-replacement",
         task: "Cancel after recovery",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       hoisted.killSubagentRunAdminMock.mockResolvedValueOnce({
         found: true,
@@ -4872,7 +4190,7 @@ describe("task-registry", () => {
         },
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+      const result = await cancelTask(task.taskId);
 
       expectRecordFields(result, { found: true, cancelled: true });
       expectRecordFields(getTaskById(task.taskId), {
@@ -4885,20 +4203,13 @@ describe("task-registry", () => {
 
   it("ignores a stale killed snapshot after canonical completion persists", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:stale-kill-snapshot",
         runId: "run-subagent-stale-kill-snapshot",
         task: "Complete while admin kill unwinds",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       hoisted.killSubagentRunAdminMock.mockImplementationOnce(async () => {
-        finalizeTaskRunByRunId({
-          runId: task.runId!,
-          runtime: "subagent",
+        finalizeSubagentTask(task, {
           status: "succeeded",
           endedAt: 201,
           terminalSummary: "completed",
@@ -4921,7 +4232,7 @@ describe("task-registry", () => {
         };
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+      const result = await cancelTask(task.taskId);
 
       expectRecordFields(result, {
         found: true,
@@ -4939,15 +4250,10 @@ describe("task-registry", () => {
 
   it("promotes an already-killed run projection during task cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:killed-projection",
         runId: "run-subagent-killed-projection",
         task: "Repair and cancel killed projection",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       hoisted.killSubagentRunAdminMock.mockResolvedValueOnce({
         found: true,
@@ -4966,10 +4272,8 @@ describe("task-registry", () => {
         },
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      const result = await cancelTask(task.taskId);
+      finalizeSubagentTask(task, {
         status: "succeeded",
         endedAt: 201,
         terminalSummary: "completed too late",
@@ -4989,15 +4293,10 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       const store = createInMemoryTaskRegistryStore();
       configureTaskRegistryRuntime({ store });
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:persist-failure",
         runId: "run-subagent-persist-failure",
         task: "Finish before persistence fails",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       configureTaskRegistryRuntime({
         store: {
@@ -5019,7 +4318,7 @@ describe("task-registry", () => {
         },
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+      const result = await cancelTask(task.taskId);
 
       expectRecordFields(result, {
         found: true,
@@ -5032,15 +4331,10 @@ describe("task-registry", () => {
 
   it("returns a subagent failure that wins during cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:failed-race",
         runId: "run-subagent-failed-race",
         task: "Fail during cancellation",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       hoisted.killSubagentRunAdminMock.mockImplementationOnce(async () => {
         return {
@@ -5062,7 +4356,7 @@ describe("task-registry", () => {
         };
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+      const result = await cancelTask(task.taskId);
 
       expectRecordFields(result, {
         found: true,
@@ -5080,15 +4374,10 @@ describe("task-registry", () => {
 
   it("defers cancellation while canonical subagent completion is still finalizing", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:finalizing-race",
         runId: "run-subagent-finalizing-race",
         task: "Capture final result",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       hoisted.killSubagentRunAdminMock.mockResolvedValueOnce({
         found: true,
@@ -5099,7 +4388,7 @@ describe("task-registry", () => {
         targetState: { state: "finalizing" },
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
+      const result = await cancelTask(task.taskId);
 
       expectRecordFields(result, {
         found: true,
@@ -5112,20 +4401,13 @@ describe("task-registry", () => {
 
   it("keeps subagent cancellation terminal when success arrives after cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:late-success",
         runId: "run-subagent-late-success",
         task: "Finish after cancellation",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       hoisted.killSubagentRunAdminMock.mockImplementationOnce(async () => {
-        finalizeTaskRunByRunId({
-          runId: task.runId!,
-          runtime: "subagent",
+        finalizeSubagentTask(task, {
           status: "cancelled",
           endedAt: 200,
           error: SUBAGENT_KILL_TASK_ERROR,
@@ -5138,9 +4420,7 @@ describe("task-registry", () => {
         taskId: task.taskId,
         reason: SUBAGENT_KILL_TASK_ERROR,
       });
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "succeeded",
         endedAt: 201,
         terminalSummary: "completed too late",
@@ -5157,27 +4437,18 @@ describe("task-registry", () => {
 
   it("accepts subagent success that completed before cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:earlier-success",
         runId: "run-subagent-earlier-success",
         task: "Finish before cancellation",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "cancelled",
         endedAt: 200,
         error: "Cancelled by operator.",
       });
 
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "succeeded",
         endedAt: 199,
         terminalSummary: "completed before cancellation",
@@ -5194,24 +4465,17 @@ describe("task-registry", () => {
 
   it("does not let a repeated kill restore the provisional marker after cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:repeated-kill",
         runId: "run-subagent-repeated-kill",
         task: "Stay cancelled",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
       for (const error of [
         SUBAGENT_KILL_TASK_ERROR,
         "Cancelled by operator.",
         SUBAGENT_KILL_TASK_ERROR,
       ]) {
-        finalizeTaskRunByRunId({
-          runId: task.runId!,
-          runtime: "subagent",
+        finalizeSubagentTask(task, {
           status: "cancelled",
           endedAt: 200,
           error,
@@ -5227,29 +4491,17 @@ describe("task-registry", () => {
 
   it("promotes an existing subagent kill marker to operator cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:already-killed",
         runId: "run-subagent-already-killed",
         task: "Promote killed task",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
-      const peerTask = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const peerTask = createTaskRecord("subagent", {
         childSessionKey: "agent:worker:subagent:already-killed",
         runId: "run-subagent-already-killed",
         task: "Peer projection",
-        status: "running",
-        deliveryStatus: "not_applicable",
       });
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "cancelled",
         endedAt: 200,
         error: SUBAGENT_KILL_TASK_ERROR,
@@ -5271,10 +4523,8 @@ describe("task-registry", () => {
         },
       });
 
-      const result = await cancelTaskById({ cfg: {} as never, taskId: task.taskId });
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      const result = await cancelTask(task.taskId);
+      finalizeSubagentTask(task, {
         status: "succeeded",
         endedAt: 201,
         terminalSummary: "completed too late",
@@ -5296,29 +4546,21 @@ describe("task-registry", () => {
   it("suppresses terminal delivery when teardown finalizes a killed task", async () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.sendMessageMock.mockClear();
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         requesterOrigin: { channel: "notifychat", to: "notifychat:123" },
         childSessionKey: "agent:worker:subagent:teardown",
         runId: "run-subagent-teardown",
         task: "Stop silently",
-        status: "running",
         deliveryStatus: "pending",
       });
 
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "cancelled",
         endedAt: 200,
         error: SUBAGENT_KILL_TASK_ERROR,
         suppressDelivery: true,
       });
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "cancelled",
         endedAt: 201,
         error: SUBAGENT_KILL_TASK_ERROR,
@@ -5337,29 +4579,21 @@ describe("task-registry", () => {
   it("stops a pending terminal notifier when teardown suppresses delivery", async () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.sendMessageMock.mockClear();
-      const task = createTaskRecord({
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
+      const task = createTaskRecord("subagent", {
         requesterOrigin: { channel: "notifychat", to: "notifychat:123" },
         childSessionKey: "agent:worker:subagent:pending-teardown",
         runId: "run-subagent-pending-teardown",
         task: "Stop pending delivery",
-        status: "running",
         deliveryStatus: "pending",
       });
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "cancelled",
         endedAt: 200,
         error: SUBAGENT_KILL_TASK_ERROR,
       });
 
       const pendingDelivery = maybeDeliverTaskTerminalUpdate(task.taskId);
-      finalizeTaskRunByRunId({
-        runId: task.runId!,
-        runtime: "subagent",
+      finalizeSubagentTask(task, {
         status: "cancelled",
         endedAt: 201,
         error: SUBAGENT_KILL_TASK_ERROR,
@@ -5375,110 +4609,74 @@ describe("task-registry", () => {
     });
   });
 
-  it("cancels CLI-tracked tasks in the registry without ACP or subagent teardown", async () => {
-    await withTaskRegistryTempDir(async () => {
-      hoisted.cancelSessionMock.mockClear();
-      hoisted.killSubagentRunAdminMock.mockClear();
+  it.each([
+    {
+      name: "cancels CLI-tracked tasks in the registry without ACP or subagent teardown",
+      runId: "run-cancel-cli",
+      task: "Investigate issue",
+      childSessionKey: "agent:main:main",
+      expectedError: "Cancelled by operator.",
+      expectedMessage: "Background task cancelled: Investigate issue (run run-canc).",
+    },
+    {
+      name: "cancels CLI-tracked tasks without childSessionKey",
+      runId: "run-cli-no-child",
+      task: "Legacy row",
+      childSessionKey: undefined,
+      expectedError: undefined,
+      expectedMessage: undefined,
+    },
+  ])(
+    "$name",
+    async ({ runId, task: taskName, childSessionKey, expectedError, expectedMessage }) => {
+      await withTaskRegistryTempDir(async () => {
+        const task = createTaskRecord("cli", {
+          requesterOrigin: NOTIFYCHAT_ORIGIN,
+          childSessionKey,
+          runId,
+          task: taskName,
+          deliveryStatus: "pending",
+        });
+        const result = await cancelTask(task.taskId);
 
-      const task = createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        childSessionKey: "agent:main:main",
-        runId: "run-cancel-cli",
-        task: "Investigate issue",
-        status: "running",
-        deliveryStatus: "pending",
+        expectRecordFields(result, { found: true, cancelled: true });
+        expectRecordFields(result.task, {
+          taskId: task.taskId,
+          status: "cancelled",
+          ...(expectedError === undefined ? {} : { error: expectedError }),
+        });
+        if (expectedMessage !== undefined) {
+          expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+          expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
+          await waitForAssertion(() =>
+            expectRecordFields(sentMessageCall(), {
+              channel: "notifychat",
+              to: "notifychat:123",
+              content: expectedMessage,
+            }),
+          );
+        }
       });
-
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
-
-      expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
-      expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
-      expectRecordFields(result, {
-        found: true,
-        cancelled: true,
-      });
-      expectRecordFields(result.task, {
-        taskId: task.taskId,
-        status: "cancelled",
-        error: "Cancelled by operator.",
-      });
-      await waitForAssertion(() =>
-        expectRecordFields(sentMessageCall(), {
-          channel: "notifychat",
-          to: "notifychat:123",
-          content: "Background task cancelled: Investigate issue (run run-canc).",
-        }),
-      );
-    });
-  });
-
-  it("cancels CLI-tracked tasks without childSessionKey", async () => {
-    await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "cli",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        requesterOrigin: {
-          channel: "notifychat",
-          to: "notifychat:123",
-        },
-        runId: "run-cli-no-child",
-        task: "Legacy row",
-        status: "running",
-        deliveryStatus: "pending",
-      });
-
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
-
-      expectRecordFields(result, {
-        found: true,
-        cancelled: true,
-      });
-      expectRecordFields(result.task, {
-        taskId: task.taskId,
-        status: "cancelled",
-      });
-    });
-  });
+    },
+  );
 
   it("cancels active cron tasks through the cron runtime abort handle", async () => {
     await withTaskRegistryTempDir(async () => {
       const abortController = new AbortController();
-      const task = createTaskRecord({
-        runtime: "cron",
+      const task = createTaskRecord("cron", {
         sourceId: "nightly-gmail-sync",
         ownerKey: "",
         scopeKind: "system",
         runId: "cron:nightly-gmail-sync:123",
         task: "Nightly Gmail sync",
-        status: "running",
-        deliveryStatus: "not_applicable",
         notifyPolicy: "silent",
       });
-      if (!task) {
-        throw new Error("expected cron task");
-      }
       hoisted.cancelActiveCronTaskRunMock.mockImplementation(({ reason }: { reason?: string }) => {
         abortController.abort(reason);
         return true;
       });
 
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
+      const result = await cancelTask(task.taskId);
 
       expect(hoisted.cancelActiveCronTaskRunMock).toHaveBeenCalledWith({
         runId: "cron:nightly-gmail-sync:123",
@@ -5501,21 +4699,17 @@ describe("task-registry", () => {
 
   it("refuses terminal and unknown cron task cancellation before runtime dispatch", async () => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "cron",
+      const task = createTaskRecord("cron", {
         sourceId: "finished-cron",
         ownerKey: "",
         scopeKind: "system",
         runId: "cron:finished-cron:123",
         task: "Finished cron",
         status: "succeeded",
-        deliveryStatus: "not_applicable",
         notifyPolicy: "silent",
       });
 
-      await expect(
-        cancelTaskById({ cfg: {} as never, taskId: task.taskId }),
-      ).resolves.toMatchObject({
+      await expect(cancelTask(task.taskId)).resolves.toMatchObject({
         found: true,
         cancelled: false,
         reason: "Task is already terminal.",
@@ -5531,172 +4725,102 @@ describe("task-registry", () => {
     });
   });
 
-  it("cancels stale cron tasks without an active runtime abort handle", async () => {
+  it.each([
+    {
+      name: "cancels stale cron tasks without an active runtime abort handle",
+      childSessionKey: undefined,
+      cancelled: true,
+      reason: undefined,
+      status: "cancelled",
+      error: "Cancelled by operator.",
+    },
+    {
+      name: "does not mark session-backed cron tasks cancelled without an active runtime abort handle",
+      childSessionKey: "agent:main:cron:daily-repost",
+      cancelled: false,
+      reason: "Cron task has no active cancellation handle.",
+      status: "running",
+      error: undefined,
+    },
+  ])("$name", async ({ childSessionKey, cancelled, reason, status, error }) => {
     await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "cron",
+      const task = createTaskRecord("cron", {
         sourceId: "daily-repost",
         ownerKey: "",
         scopeKind: "system",
+        childSessionKey,
         runId: "cron:daily-repost:123",
         task: "Daily repost",
-        status: "running",
-        deliveryStatus: "not_applicable",
         notifyPolicy: "silent",
       });
-
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
+      const result = await cancelTask(task.taskId);
 
       expectRecordFields(result, {
         found: true,
-        cancelled: true,
+        cancelled,
+        ...(reason === undefined ? {} : { reason }),
       });
       expectRecordFields(result.task, {
         taskId: task.taskId,
         runtime: "cron",
-        status: "cancelled",
-        error: "Cancelled by operator.",
+        status,
+        ...(error === undefined ? {} : { error }),
       });
     });
   });
 
-  it("does not mark session-backed cron tasks cancelled without an active runtime abort handle", async () => {
-    await withTaskRegistryTempDir(async () => {
-      const task = createTaskRecord({
-        runtime: "cron",
-        sourceId: "daily-repost",
-        ownerKey: "",
-        scopeKind: "system",
-        childSessionKey: "agent:main:cron:daily-repost",
-        runId: "cron:daily-repost:123",
-        task: "Daily repost",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
-      });
-
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
-
-      expectRecordFields(result, {
-        found: true,
-        cancelled: false,
-        reason: "Cron task has no active cancellation handle.",
-      });
-      expectRecordFields(result.task, {
-        taskId: task.taskId,
-        runtime: "cron",
-        status: "running",
-      });
-    });
-  });
-
-  it("cancels childless codex-native tasks without routing through OpenClaw subagent sessions", async () => {
+  it.each([
+    {
+      name: "cancels childless codex-native tasks without routing through OpenClaw subagent sessions",
+      taskKind: "codex-native",
+      sourceId: "codex-thread:child-thread",
+      task: "Codex native child",
+      cancellable: true,
+    },
+    {
+      name: "cancels childless copilot-native tasks without routing through OpenClaw subagent sessions",
+      taskKind: "copilot-native",
+      sourceId: "copilot-agent:child-agent",
+      task: "Copilot native child",
+      cancellable: true,
+    },
+    {
+      name: "does not cancel unrelated childless subagent tasks",
+      taskKind: "codex-native",
+      sourceId: "other-runtime:child-thread",
+      task: "Non-Codex childless row",
+      cancellable: false,
+    },
+  ])("$name", async ({ taskKind, sourceId, task: taskName, cancellable }) => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryForTests();
-      const task = createTaskRecord({
-        runtime: "subagent",
-        taskKind: "codex-native",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        sourceId: "codex-thread:child-thread",
-        runId: "codex-thread:child-thread",
-        task: "Codex native child",
-        status: "running",
-        deliveryStatus: "not_applicable",
+      const task = createTaskRecord("subagent", {
+        taskKind,
+        sourceId,
+        runId: sourceId,
+        task: taskName,
         notifyPolicy: "silent",
       });
+      const result = await cancelTask(task.taskId);
 
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
-
-      expectRecordFields(result, {
-        found: true,
-        cancelled: true,
-      });
-      expectRecordFields(result.task, {
-        taskId: task.taskId,
-        status: "cancelled",
-        endedAt: expect.any(Number),
-        lastEventAt: expect.any(Number),
-        cleanupAfter: expect.any(Number),
-        error: "Cancelled by operator.",
-      });
-      expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
-    });
-  });
-
-  it("cancels childless copilot-native tasks without routing through OpenClaw subagent sessions", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
-      const task = createTaskRecord({
-        runtime: "subagent",
-        taskKind: "copilot-native",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        sourceId: "copilot-agent:child-agent",
-        runId: "copilot-agent:child-agent",
-        task: "Copilot native child",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
-      });
-
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
-
-      expectRecordFields(result, {
-        found: true,
-        cancelled: true,
-      });
-      expectRecordFields(result.task, {
-        taskId: task.taskId,
-        status: "cancelled",
-        endedAt: expect.any(Number),
-        lastEventAt: expect.any(Number),
-        cleanupAfter: expect.any(Number),
-        error: "Cancelled by operator.",
-      });
-      expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
-    });
-  });
-
-  it("does not cancel unrelated childless subagent tasks", async () => {
-    await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
-      const task = createTaskRecord({
-        runtime: "subagent",
-        taskKind: "codex-native",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        sourceId: "other-runtime:child-thread",
-        runId: "other-runtime:child-thread",
-        task: "Non-Codex childless row",
-        status: "running",
-        deliveryStatus: "not_applicable",
-        notifyPolicy: "silent",
-      });
-
-      const result = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
-      });
-
-      expect(result).toEqual({
-        found: true,
-        cancelled: false,
-        reason: "Task has no cancellable child session.",
-        task,
-      });
+      if (!cancellable) {
+        expect(result).toEqual({
+          found: true,
+          cancelled: false,
+          reason: "Task has no cancellable child session.",
+          task,
+        });
+      } else {
+        expectRecordFields(result, { found: true, cancelled: true });
+        expectRecordFields(result.task, {
+          taskId: task.taskId,
+          status: "cancelled",
+          endedAt: expect.any(Number),
+          lastEventAt: expect.any(Number),
+          cleanupAfter: expect.any(Number),
+          error: "Cancelled by operator.",
+        });
+      }
       expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## What Problem This Solves

The task registry test suite had grown to 5,704 lines, with repeated task fixture construction and near-identical maintenance and cancellation cases making the suite harder to review and maintain.

## Why This Change Was Made

This maintainer-commissioned, AI-assisted refactor centralizes task fixture defaults in the existing colocated test-support module, preserves omission-sensitive cases with explicit overrides, and table-drives only semantically parallel scenarios. Production code and behavior are unchanged.

## User Impact

No user-visible impact. Maintainers get a smaller task registry suite with the same 122 test cases and clearer failure names.

## Evidence

- LOC: test/support +674/-1,516 (net -842); production +0/-0. `src/tasks/task-registry.test.ts` is 876 lines smaller (5,704 to 4,828).
- `node scripts/run-vitest.mjs src/tasks/task-registry.test.ts src/tasks/task-boundaries.test.ts` — 122/122 task-registry tests and 5/5 boundary tests passed; task-registry case count is unchanged from `origin/main`.
- `node scripts/check-changed.mjs -- src/tasks/task-registry.test.ts src/tasks/task-registry.test-support.ts` — passed on Blacksmith Testbox `tbx_01ky9b2kp6pp8y2rbzmnnqxyvp` (typechecks, format, lint, max-lines ratchet, import cycles, and selected guards), Actions run https://github.com/openclaw/openclaw/actions/runs/30070755209.
- Initial CI caught the fixture helper's raw-mutator-style name in `task-boundaries.test.ts`; renaming it to `createTaskFixture` restored the boundary and the focused boundary suite is green.
- ClawSweeper rank-up move: fixture defaults and omission-sensitive overrides were verified by the final autoreview and exact-head ClawSweeper review artifacts. The branch was already rebased with a stable patch-id check and the rebased head passed exact-head CI (run https://github.com/openclaw/openclaw/actions/runs/30071494215). I am not chasing subsequent moving-`main` drift because the PR remains mergeable and the landing runbook makes that drift advisory after one green run plus clean rebase sanity.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings.
- `git diff --check` — passed.
