### PR TITLE
improve(acpx): reduce ACP router prompt overhead

### DIFF
--- a/extensions/acpx/skills/acp-router/SKILL.md
+++ b/extensions/acpx/skills/acp-router/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acp-router
-description: Route plain-language requests for Claude Code, Cursor, Copilot, OpenClaw ACP, OpenCode, Gemini CLI, Qwen, Kiro, Kimi, iFlow, Factory Droid, Kilocode, or explicit ACP harness work into either OpenClaw ACP runtime sessions or direct acpx-driven sessions ("telephone game" flow). For coding-agent thread requests, read this skill first, then use only `sessions_spawn` for thread creation. Codex chat binding defaults to the native Codex app-server plugin unless ACP is explicit or background spawn needs ACP.
+description: Route named coding harnesses or explicit ACP/acpx work, including harness threads; ordinary Codex chat and control stay on native Codex.
 user-invocable: false
 ---
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where every prompt containing the eligible `acp-router` skill catalog entry carried a 505-byte description that duplicated routing mechanics already present in the skill body. The description also exceeded OpenClaw's documented guidance to keep skill descriptions on one line and under 160 characters.

## Why This Change Was Made

Keeps only the model-visible selection contract: named coding harnesses or explicit ACP/acpx work, harness-thread routing, and the ordinary-Codex native-runtime boundary. Harness enumeration, mode selection, `sessions_spawn` mechanics, and failure handling remain in the on-demand skill body.

## User Impact

The `acp-router` catalog entry is 369 characters smaller (505 to 136) without changing ACP runtime behavior. Ordinary Codex chat still routes to native Codex, while named harness, explicit ACP/acpx, and harness-thread requests still select the router.

## Evidence

- `python3 skills/skill-creator/scripts/quick_validate.py extensions/acpx/skills/acp-router`
  - `Skill is valid!`
- Description measurement: 505 bytes before, 136 bytes after, one line, under 160 bytes.
- `pnpm test:extension acpx`
  - 15 test files passed; 203 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed -- extensions/acpx/skills/acp-router/SKILL.md`
  - All selected checks passed.
- `git diff --check`
  - Passed.
- Direct native-runtime contract inspection:
  - OpenAI Codex `codex-rs/app-server/README.md:74-83` and `codex-rs/app-server/src/message_processor.rs:1031-1058,1272-1282` confirm that native conversations use app-server thread and turn lifecycle RPCs.
  - OpenClaw `extensions/codex/src/conversation-binding.ts:503-524,862-878` uses those native `thread/start` and `turn/start` RPCs for ordinary bound Codex chat.

AI-assisted: Yes. The change and evidence were reviewed against the complete skill body and scoped repository instructions.
