### PR TITLE
refactor(scripts): retire the STALE-CANCELLED watch-pr-ci verdict

### DIFF
--- a/scripts/watch-pr-ci.d.mts
+++ b/scripts/watch-pr-ci.d.mts
@@ -38,7 +38,7 @@ export interface RollupPage {
 }
 
 export interface RollupClassification {
-  verdict: "GREEN" | "FAILING" | "PENDING" | "STALE-CANCELLED";
+  verdict: "GREEN" | "FAILING" | "PENDING";
   pendingCount: number;
   failingNames: string[];
   supersededCount: number;

--- a/scripts/watch-pr-ci.mjs
+++ b/scripts/watch-pr-ci.mjs
@@ -79,8 +79,6 @@ export function parseArgs(argv) {
 const checkName = (check) => (check.kind === "StatusContext" ? check.context : check.name);
 export const sanitizeCheckName = (name) =>
   name.replaceAll(ANSI_ESCAPE_SEQUENCE, "\u0000").replaceAll(UNSAFE_CHECK_NAME_RUN, "?");
-const isSuccess = (check) =>
-  check.kind === "StatusContext" ? check.state === "SUCCESS" : check.conclusion === "SUCCESS";
 const isAutoResponse = (check) =>
   checkName(check)
     ?.toLowerCase()
@@ -159,7 +157,6 @@ export function classifyRollup(rollup) {
     return true;
   });
   const checks = nodes.filter((check) => !isAutoResponse(check));
-  const successfulNames = new Set(checks.filter(isSuccess).map(checkName));
   const pendingCount = checks.filter((check) =>
     check.kind === "StatusContext"
       ? check.state === "PENDING" || check.state === "EXPECTED"
@@ -182,19 +179,6 @@ export function classifyRollup(rollup) {
   }
   if (rollup?.state === "ERROR" || rollup?.state === "FAILURE") {
     if (failingChecks.length > 0) {
-      const staleCancelled =
-        hiddenContextCount === 0 &&
-        pendingCount === 0 &&
-        failingChecks.every(
-          (check) =>
-            check.kind === "CheckRun" &&
-            check.conclusion === "CANCELLED" &&
-            Boolean(check.name) &&
-            successfulNames.has(check.name),
-        );
-      if (staleCancelled) {
-        return { verdict: "STALE-CANCELLED", pendingCount, failingNames, supersededCount };
-      }
       return {
         verdict: "FAILING",
         pendingCount,
@@ -445,12 +429,6 @@ async function main(argv = process.argv.slice(2)) {
         console.log(
           `STATUS state=${lastState} pending=${lastPending} superseded=${result.supersededCount}`,
         );
-        if (result.verdict === "STALE-CANCELLED") {
-          return emit(
-            'STALE-CANCELLED hint="aggregate FAILURE but every failing context is a CANCELLED check run with a same-name SUCCESS — likely stale attempts; verify manually"',
-            17,
-          );
-        }
         if (result.verdict === "FAILING") {
           return emit(`FAILING checks=${result.failingNames.join(", ")}`, 15);
         }

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -194,7 +194,7 @@ describe("watch-pr-ci", () => {
   });
 
   it.each(["FAILURE", "ERROR"])(
-    "classifies stale same-name cancellations for aggregate %s",
+    "keeps identity-less same-name cancellations failing for aggregate %s",
     (state) => {
       expect(
         classifyRollup({
@@ -214,7 +214,7 @@ describe("watch-pr-ci", () => {
           },
         }),
       ).toEqual({
-        verdict: "STALE-CANCELLED",
+        verdict: "FAILING",
         pendingCount: 0,
         failingNames: ["unit"],
         supersededCount: 0,
@@ -222,7 +222,7 @@ describe("watch-pr-ci", () => {
     },
   );
 
-  it("does not soften a truncated failing rollup to stale-cancelled", () => {
+  it("keeps a truncated failing rollup failing", () => {
     expect(
       classifyRollup({
         state: "FAILURE",


### PR DESCRIPTION
Related: #113230

## What Problem This Solves

Removes the now-obsolete `STALE-CANCELLED` verdict (exit 17) from `scripts/watch-pr-ci.mjs`. The verdict existed to soften a specific ambiguity — an aggregate FAILURE where every failing context was a CANCELLED check run with a same-name SUCCESS — and told the operator to "verify manually". Since #113230, the classifier resolves that scenario deterministically with workflow-run identity (superseded runs and rerun-attempt leftovers are filtered before classification), so the heuristic's real cases now classify as GREEN or PENDING on evidence instead of punting to a manual check.

## Why This Change Was Made

Follow-up agreed in #113230. The heuristic is dead weight after run-identity supersession: any Actions check run carries `checkSuite.workflowRun` identity, so the name-pairing path could only fire for identity-less duplicates (non-Actions app check runs posting duplicate same-name results), an ambiguous state that should honestly report `FAILING` rather than a special "probably fine, check yourself" exit code. Repo policy prefers deleting modes over preserving them; exit codes of this script are not an enumerated public contract (AGENTS.md documents the terminal-state behavior, not code 17).

## User Impact

Watcher consumers no longer see exit 17. The rare identity-less duplicate-cancellation case now exits 15 (`FAILING`) — both were non-green terminal states requiring attention, so no automation semantics weaken. Net −22 lines of classifier code, one fewer verdict mode.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs test/scripts/watch-pr-ci.test.ts` — 28 passed; the former stale-cancelled fixture now asserts `FAILING` for identity-less same-name cancellations, and all supersession/pagination tests from #113230 pass unchanged.
- Fresh structured autoreview on the removal diff (result noted in the PR discussion if any findings arose).
