### PR TITLE
fix(chat): trigger render invalidation on input history recall

### DIFF
--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -433,6 +433,126 @@ describe("ChatStateController render lifecycle", () => {
     expect(cancelAnimationFrame).toHaveBeenCalledWith(2);
     expect(painted).not.toHaveBeenCalled();
   });
+
+  it("invalidates the render lifecycle when input history recall mutates the draft", () => {
+    const requestUpdate = vi.fn();
+    const host = {
+      addController: () => undefined,
+      removeController: () => undefined,
+      requestUpdate,
+      updateComplete: Promise.resolve(true),
+    } satisfies ReactiveControllerHost;
+    const controller = new ChatStateController<ChatPageHost>(host);
+    controller.hostConnected();
+    const renderLifecycle = controller.createRenderLifecycle();
+
+    const navigateHistory = vi.fn().mockReturnValue({
+      handled: true,
+      preventDefault: true,
+      restoreCaret: "up" as const,
+      decision: "handled:history-up" as const,
+      historyNavigationActiveBefore: false,
+      historyNavigationActiveAfter: true,
+      selectionStart: 0,
+      selectionEnd: 0,
+      valueLength: 10,
+    });
+
+    const state = {
+      settings: undefined,
+      assistantAgentId: null,
+      agentsList: null,
+      hello: null,
+      sessionKey: "agent:main:current",
+      chatLoading: false,
+      chatMessages: [],
+      chatQueue: [],
+      renderLifecycle,
+      handleSendChat: vi.fn().mockResolvedValue(undefined),
+      handleChatDraftChange: vi.fn(),
+      handleChatInputHistoryKey: navigateHistory,
+    } as unknown as ChatPageHost;
+
+    controller.attach(state);
+
+    const input = {
+      key: "ArrowUp" as const,
+      selectionStart: 0,
+      selectionEnd: 0,
+      valueLength: 0,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      keyCode: 0,
+    };
+    const result = state.handleChatInputHistoryKey!(input);
+
+    expect(result.handled).toBe(true);
+    expect(navigateHistory).toHaveBeenCalledWith(input);
+    expect(requestUpdate).toHaveBeenCalled();
+  });
+
+  it("does not invalidate the render lifecycle when input history key is not handled", () => {
+    const requestUpdate = vi.fn();
+    const host = {
+      addController: () => undefined,
+      removeController: () => undefined,
+      requestUpdate,
+      updateComplete: Promise.resolve(true),
+    } satisfies ReactiveControllerHost;
+    const controller = new ChatStateController<ChatPageHost>(host);
+    controller.hostConnected();
+    const renderLifecycle = controller.createRenderLifecycle();
+
+    const navigateHistory = vi.fn().mockReturnValue({
+      handled: false,
+      preventDefault: false,
+      restoreCaret: null,
+      decision: "blocked:modifier-or-composition" as const,
+      historyNavigationActiveBefore: false,
+      historyNavigationActiveAfter: false,
+      selectionStart: 0,
+      selectionEnd: 0,
+      valueLength: 10,
+    });
+
+    const state = {
+      settings: undefined,
+      assistantAgentId: null,
+      agentsList: null,
+      hello: null,
+      sessionKey: "agent:main:current",
+      chatLoading: false,
+      chatMessages: [],
+      chatQueue: [],
+      renderLifecycle,
+      handleSendChat: vi.fn().mockResolvedValue(undefined),
+      handleChatDraftChange: vi.fn(),
+      handleChatInputHistoryKey: navigateHistory,
+    } as unknown as ChatPageHost;
+
+    controller.attach(state);
+
+    const input = {
+      key: "ArrowUp" as const,
+      selectionStart: 5,
+      selectionEnd: 5,
+      valueLength: 10,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      keyCode: 0,
+    };
+    const result = state.handleChatInputHistoryKey!(input);
+
+    expect(result.handled).toBe(false);
+    expect(navigateHistory).toHaveBeenCalledWith(input);
+    expect(requestUpdate).not.toHaveBeenCalled();
+  });
 });
 
 describe("session pull request refresh", () => {

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -1835,6 +1835,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
     state.handleChatInputHistoryKey = (input) => {
       const result = navigateInputHistory(input);
       if (result.handled) {
+        renderLifecycle.invalidate();
         this.composerPersistence.schedule();
       }
       return result;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- When pressing ArrowUp/ArrowDown in the chat composer to recall input history, the composer input content changes internally but the Lit reactive render cycle is not triggered, so the UI does not visually update to show the recalled history message.

Why does this matter now?

- Issue #112634: users navigating input history with keyboard arrows see a stale composer — the text visually stays the same while the internal draft has already changed.

What is the intended outcome?

- After `handleChatInputHistoryKey` returns `handled: true`, call `renderLifecycle.invalidate()` to trigger a Lit reactive update so the composer re-renders with the recalled history text.

What is intentionally out of scope?

- No changes to history storage, history navigation logic, or composer HTML structure. Only the render invalidation call is added.

What does success look like?

- Unit tests pass: `requestUpdate` is called when history is recalled (`handled: true`), and NOT called when history is not handled (`handled: false`).

What should reviewers focus on?

- `ui/src/pages/chat/chat-state.ts` line ~1838: the single `renderLifecycle.invalidate()` call added inside the `result.handled` guard.

## Linked context

Which issue does this close?

Closes #112634

Which issues, PRs, or discussions are related?

N/A

Was this requested by a maintainer or owner?

Issue reporter with clear reproduction steps. ClawSweeper has applied `fix-shape-clear` label.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: composer input history recall does not trigger UI re-render
- Real environment tested: mock dev server with Playwright Chromium
- Exact steps or command run after this patch:

```bash
npx vitest run ui/src/pages/chat/chat-state.test.ts
node _proof-112634.mjs
```

- Evidence after fix:

ArrowUp recalls history message into the composer and the UI visually updates:

```
history recall produced expected text ✅
```

Screenshots captured at `.artifacts/proof-112634/` showing:
- 01-initial: empty composer
- 02-typed: user typed a message
- 03-arrowup1, 04-arrowup2, 05-arrowup3: ArrowUp recalls 3 history messages one by one
- 06-arrowdown: ArrowDown navigates forward through history

- Observed result after fix: ArrowUp properly recalls previous input into the composer, visible in the UI
- What was not tested: live gateway session, mobile/tablet keyboard events, IME composition mode with history navigation
- Proof limitations or environment constraints: L2 via vitest unit tests + Playwright mock dev server; no live production gateway
- Before evidence (optional): without the `renderLifecycle.invalidate()` call, the composer draft internally changes but the Lit component does not re-render, leaving stale visible text

## Tests and validation

Which commands did you run?

```bash
npx vitest run ui/src/pages/chat/chat-state.test.ts
```

All 46 tests pass.

What regression coverage was added or updated?

- `ChatStateController render lifecycle > invalidates the render lifecycle when input history recall mutates the draft`: verifies `requestUpdate` is called when history key is handled
- `ChatStateController render lifecycle > does not invalidate the render lifecycle when input history key is not handled`: verifies `requestUpdate` is NOT called when history key is not handled (e.g. modifier key held, or during composition)

What failed before this fix, if known?

- `handleChatInputHistoryKey` updates the draft internally but the Lit component does not re-render, so the composer shows stale text after ArrowUp/ArrowDown.

If no test was added, why not?

N/A — 2 regression tests added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. The composer now correctly updates its visible text when navigating input history with ArrowUp/ArrowDown.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- The `invalidate()` call adds one extra reactive render cycle per history navigation keystroke. Since ArrowUp/ArrowDown is a low-frequency user interaction (not a rapid-fire event), this is negligible.

How is that risk mitigated?

- Invalidated only inside the `result.handled` guard, so modifier keys, IME composition, and unhandled keys do not trigger extra renders. The `RenderLifecycle` debounce mechanism also prevents render storms.

## Current review state

What is the next action?

- Await CI + ClawSweeper review

What is still waiting on author, maintainer, CI, or external proof?

- CI checks pending after PR creation

Which bot or reviewer comments were addressed?

- Initial submission; no open review threads yet
