### PR TITLE
refactor(ui): consolidate chat view test fixtures

### DIFF
--- a/ui/src/pages/chat/chat-view.test-helpers.ts
+++ b/ui/src/pages/chat/chat-view.test-helpers.ts
@@ -1,0 +1,79 @@
+import type { ReactiveControllerHost } from "lit";
+import { vi } from "vitest";
+import { ChatTranscriptController } from "./components/chat-thread.ts";
+
+export function createTestTranscript(): ChatTranscriptController {
+  return new ChatTranscriptController({
+    addController: () => undefined,
+    removeController: () => undefined,
+    requestUpdate: () => undefined,
+    updateComplete: Promise.resolve(true),
+  } satisfies ReactiveControllerHost);
+}
+
+export function createPasteEvent(
+  text: string,
+  itemTypes: readonly string[] = ["text/plain"],
+  extraData: Readonly<Record<string, string>> = {},
+): Event {
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      items: Object.assign(Object.fromEntries(itemTypes.map((type, index) => [index, { type }])), {
+        length: itemTypes.length,
+      }),
+      getData: (type: string) => (type === "text/plain" ? text : (extraData[type] ?? "")),
+    },
+  });
+  return event;
+}
+
+export function appendChatBubble(
+  container: Element,
+  options: {
+    entryId?: string;
+    groupClass?: string;
+    messageId?: string;
+    senderLabel?: string;
+    text?: string;
+  } = {},
+) {
+  const group = document.createElement("div");
+  group.className = options.groupClass ?? "chat-group";
+  const bubble = document.createElement("div");
+  bubble.className = "chat-bubble";
+  if (options.entryId) {
+    bubble.dataset.entryId = options.entryId;
+  }
+  if (options.messageId) {
+    bubble.dataset.messageId = options.messageId;
+  }
+  if (options.text) {
+    bubble.dataset.messageText = options.text;
+  }
+  if (options.senderLabel) {
+    const sender = document.createElement("span");
+    sender.className = "chat-sender-name";
+    sender.textContent = options.senderLabel;
+    group.append(sender);
+  }
+  group.append(bubble);
+  container.querySelector(".chat-thread-inner")?.append(group);
+  return { bubble, group };
+}
+
+export function stubAnimationFrames() {
+  const callbacks: FrameRequestCallback[] = [];
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn((callback: FrameRequestCallback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    }),
+  );
+  return () => {
+    for (const callback of callbacks.splice(0)) {
+      callback(0);
+    }
+  };
+}

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { html, render, type ReactiveControllerHost } from "lit";
+import { html, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
@@ -31,6 +31,12 @@ import {
 import { switchChatFastMode, switchChatModel, switchChatThinkingLevel } from "./chat-session.ts";
 import * as chatThread from "./chat-thread.ts";
 import { resetChatViewState } from "./chat-view-state.ts";
+import {
+  appendChatBubble,
+  createPasteEvent,
+  createTestTranscript,
+  stubAnimationFrames,
+} from "./chat-view.test-helpers.ts";
 import { renderChat } from "./chat-view.ts";
 import { resetChatComposerState } from "./components/chat-composer.ts";
 import * as chatMessage from "./components/chat-message.ts";
@@ -39,7 +45,6 @@ import {
   type ChatModelControlsProps,
 } from "./components/chat-model-controls.ts";
 import {
-  ChatTranscriptController,
   isChatThreadSearchOpen,
   resetChatThreadPresentationState,
   toggleChatThreadSearch,
@@ -479,6 +484,30 @@ function createChatHeaderState(
   return { state, request };
 }
 
+function createReasoningHeaderState(
+  options: {
+    levels?: Array<{ id: string; label: string }>;
+    models?: ModelCatalogEntry[];
+  } = {},
+) {
+  const result = createChatHeaderState({
+    model: "gpt-5.5",
+    modelProvider: "openai",
+    models: options.models ?? [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
+    thinkingDefault: "high",
+  });
+  result.state.sessionsResult = createSessionsListResult({
+    defaultsModel: "gpt-5.5",
+    defaultsProvider: "openai",
+    defaultsThinkingDefault: "high",
+    defaultsThinkingLevels: options.levels ?? [
+      { id: "low", label: "low" },
+      { id: "high", label: "high" },
+    ],
+  });
+  return result;
+}
+
 function getChatModelSelect(container: Element): HTMLElement {
   const select = container.querySelector<HTMLElement>('[data-chat-model-select="true"]');
   expect(select).toBeInstanceOf(HTMLElement);
@@ -523,6 +552,18 @@ function createChatModelControlsProps(state: ChatHeaderTestState): ChatModelCont
   };
 }
 
+function renderModelControls(
+  state: ChatHeaderTestState,
+  overrides: Partial<ChatModelControlsProps> = {},
+) {
+  const container = document.createElement("div");
+  render(
+    renderChatModelControls({ ...createChatModelControlsProps(state), ...overrides }),
+    container,
+  );
+  return container;
+}
+
 function getChatThinkingValue(control: HTMLElement): string {
   return control.dataset.chatThinkingValue ?? "";
 }
@@ -561,6 +602,14 @@ function requireElement(container: Element, selector: string, label: string): El
   return element;
 }
 
+function getComposerTextarea(container: Element): HTMLTextAreaElement {
+  return requireElement(
+    container,
+    ".agent-chat__composer-combobox > textarea",
+    "composer textarea",
+  ) as HTMLTextAreaElement;
+}
+
 function createDragEvent(type: string, types = ["Files"]): Event {
   const event = new Event(type, { bubbles: true, cancelable: true });
   Object.defineProperty(event, "dataTransfer", { value: { types } });
@@ -574,12 +623,7 @@ function itemAt<T>(items: ArrayLike<T>, index: number, label: string): T {
 function createChatProps(
   overrides: Partial<Parameters<typeof renderChat>[0]> = {},
 ): Parameters<typeof renderChat>[0] {
-  const transcript = new ChatTranscriptController({
-    addController: () => undefined,
-    removeController: () => undefined,
-    requestUpdate: () => undefined,
-    updateComplete: Promise.resolve(true),
-  } satisfies ReactiveControllerHost);
+  const transcript = createTestTranscript();
   return {
     transcript,
     paneId: "single",
@@ -956,215 +1000,127 @@ describe("direct thread avatar mode", () => {
     { role: "user", content: "me too", senderLabel: "Mario", timestamp: 3 },
   ];
 
-  it("classifies by canonical session kind even when DM rows carry sender labels", () => {
-    const direct = renderChatView({
-      sessionKey: "kind-direct",
-      sessions: sessionsListWithKind("kind-direct", "direct"),
-      messages: labeledHistory,
-    });
-    expect(
-      requireElement(direct, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(true);
+  const globalHost = {
+    agentsList: { defaultId: "work", mainKey: "main", scope: "global" as const },
+    hello: null,
+  };
+  const message = [{ role: "user", content: "hi", timestamp: 1 }] satisfies Parameters<
+    typeof renderChat
+  >[0]["messages"];
+  const avatarCase = (
+    sessionKey: string,
+    direct: boolean,
+    overrides: Partial<Parameters<typeof renderChat>[0]> = {},
+  ) => ({ props: { sessionKey, messages: message, ...overrides }, direct });
 
-    const group = renderChatView({
-      sessionKey: "kind-group",
-      sessions: sessionsListWithKind("kind-group", "group"),
-      messages: [{ role: "user", content: "hi", timestamp: 1 }],
-    });
-    expect(
-      requireElement(group, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(false);
-  });
-
-  it("keeps avatars in global sessions, which can aggregate group senders", () => {
-    const globalThread = renderChatView({
-      sessionKey: "global",
-      messages: [{ role: "user", content: "hi", timestamp: 1 }],
-    });
-    expect(
-      requireElement(globalThread, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(false);
-  });
-
-  it("matches session metadata across equivalent alias keys", () => {
-    // Default session travels as "main" or "agent:main:main" depending on caller.
-    const aliased = renderChatView({
-      sessionKey: "main",
-      sessions: sessionsListWithKind("agent:main:main", "direct"),
-      messages: labeledHistory,
-    });
-    expect(
-      requireElement(aliased, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(true);
-  });
-
-  it("keeps avatars in direct sessions when the gateway attributes identities", () => {
-    const attributed = renderChatView({
-      sessionKey: "kind-direct",
-      sessions: sessionsListWithKind("kind-direct", "direct"),
-      messages: labeledHistory,
-      userId: "profile-1",
-    });
-    // Multi-user gateways share even 1:1-shaped sessions, so the author
-    // marker is signal, not decoration.
-    expect(
-      requireElement(attributed, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(false);
-  });
-
-  it("falls back to session-key shape when session metadata is missing", () => {
-    // Labeled DM rows must not flip the mode: sanitization labels 1:1 DMs too.
-    const direct = renderChatView({
-      sessionKey: "agent:main:telegram:direct:2",
-      messages: labeledHistory,
-    });
-    expect(
-      requireElement(direct, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(true);
-
-    const group = renderChatView({
-      sessionKey: "agent:main:telegram:group:42",
-      messages: [{ role: "user", content: "hi", timestamp: 1 }],
-    });
-    expect(
-      requireElement(group, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(false);
-  });
-
-  it("keeps avatars when a main alias selects the canonical global row", () => {
-    // scope=global: sessions.list only carries the literal "global" row while
-    // the pane navigates via agent:<id>:main; the host resolves the alias.
-    const aliasedGlobal = renderChatView({
-      sessionKey: "agent:work:main",
-      sessions: sessionsListWithKind("global", "global"),
-      sessionHost: {
-        agentsList: { defaultId: "work", mainKey: "main", scope: "global" },
-        hello: null,
-      },
-      messages: [{ role: "user", content: "hi", timestamp: 1 }],
-    });
-    expect(
-      requireElement(aliasedGlobal, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(false);
-  });
-
-  it("classifies global-scope main aliases without a listed global row", () => {
-    // The capped list can omit the canonical global row (or it may not exist
-    // before the first persisted turn); configured scope alone decides.
-    const aliased = renderChatView({
-      sessionKey: "agent:work:main",
-      sessionHost: {
-        agentsList: { defaultId: "work", mainKey: "main", scope: "global" },
-        hello: null,
-      },
-      messages: [{ role: "user", content: "hi", timestamp: 1 }],
-    });
-    expect(
-      requireElement(aliased, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(false);
-  });
-
-  it("ignores stray global rows for main aliases outside global scope", () => {
-    // per-sender scope: a listed global row must not reclassify a direct main
-    // thread whose exact row is missing from the capped list.
-    const direct = renderChatView({
-      sessionKey: "agent:work:main",
-      sessions: sessionsListWithKind("global", "global"),
-      sessionHost: {
-        agentsList: { defaultId: "work", mainKey: "main", scope: "per-sender" },
-        hello: null,
-      },
-      messages: [{ role: "user", content: "hi", timestamp: 1 }],
-    });
-    expect(
-      requireElement(direct, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(true);
-  });
-
-  it("prefers the equivalent direct row over a global row for main aliases", () => {
-    const sessions = {
-      ts: 0,
-      path: "",
-      count: 2,
-      defaults: { modelProvider: "openai", model: "gpt-5.5", contextTokens: 200_000 },
-      sessions: [
-        { key: "global", kind: "global" as const, updatedAt: 2 },
-        { key: "agent:work:main", kind: "direct" as const, updatedAt: 1 },
+  it.each([
+    {
+      name: "classifies by canonical session kind even when DM rows carry sender labels",
+      cases: [
+        avatarCase("kind-direct", true, {
+          sessions: sessionsListWithKind("kind-direct", "direct"),
+          messages: labeledHistory,
+        }),
+        avatarCase("kind-group", false, {
+          sessions: sessionsListWithKind("kind-group", "group"),
+        }),
       ],
-    };
-    const direct = renderChatView({
-      sessionKey: "agent:work:main",
-      sessions,
-      sessionHost: {
-        agentsList: { defaultId: "work", mainKey: "main", scope: "global" },
-        hello: null,
-      },
-      messages: [{ role: "user", content: "hi", timestamp: 1 }],
-    });
-    expect(
-      requireElement(direct, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(true);
-  });
-
-  it("treats explicit agent global keys as global even without a session row", () => {
-    const globalAlias = renderChatView({
-      sessionKey: "agent:work:global",
-      messages: [{ role: "user", content: "hi", timestamp: 1 }],
-    });
-    expect(
-      requireElement(globalAlias, ".chat-thread", "chat thread").classList.contains(
-        "chat-thread--direct",
-      ),
-    ).toBe(false);
+    },
+    {
+      name: "keeps avatars in global sessions, which can aggregate group senders",
+      cases: [avatarCase("global", false)],
+    },
+    {
+      name: "matches session metadata across equivalent alias keys",
+      cases: [
+        avatarCase("main", true, {
+          sessions: sessionsListWithKind("agent:main:main", "direct"),
+          messages: labeledHistory,
+        }),
+      ],
+    },
+    {
+      name: "keeps avatars in direct sessions when the gateway attributes identities",
+      cases: [
+        avatarCase("kind-direct", false, {
+          sessions: sessionsListWithKind("kind-direct", "direct"),
+          messages: labeledHistory,
+          userId: "profile-1",
+        }),
+      ],
+    },
+    {
+      name: "falls back to session-key shape when session metadata is missing",
+      cases: [
+        avatarCase("agent:main:telegram:direct:2", true, { messages: labeledHistory }),
+        avatarCase("agent:main:telegram:group:42", false),
+      ],
+    },
+    {
+      name: "keeps avatars when a main alias selects the canonical global row",
+      cases: [
+        avatarCase("agent:work:main", false, {
+          sessions: sessionsListWithKind("global", "global"),
+          sessionHost: globalHost,
+        }),
+      ],
+    },
+    {
+      name: "classifies global-scope main aliases without a listed global row",
+      cases: [avatarCase("agent:work:main", false, { sessionHost: globalHost })],
+    },
+    {
+      name: "ignores stray global rows for main aliases outside global scope",
+      cases: [
+        avatarCase("agent:work:main", true, {
+          sessions: sessionsListWithKind("global", "global"),
+          sessionHost: {
+            agentsList: { defaultId: "work", mainKey: "main", scope: "per-sender" as const },
+            hello: null,
+          },
+        }),
+      ],
+    },
+    {
+      name: "prefers the equivalent direct row over a global row for main aliases",
+      cases: [
+        avatarCase("agent:work:main", true, {
+          sessions: createSessionsResultFromRows([
+            { key: "global", kind: "global", updatedAt: 2 },
+            { key: "agent:work:main", kind: "direct", updatedAt: 1 },
+          ]),
+          sessionHost: globalHost,
+        }),
+      ],
+    },
+    {
+      name: "treats explicit agent global keys as global even without a session row",
+      cases: [avatarCase("agent:work:global", false)],
+    },
+  ])("$name", ({ cases }) => {
+    for (const { props, direct } of cases) {
+      const container = renderChatView(props);
+      expect(
+        requireElement(container, ".chat-thread", "chat thread").classList.contains(
+          "chat-thread--direct",
+        ),
+      ).toBe(direct);
+    }
   });
 });
 
 describe("chat code-block copy", () => {
-  it("keeps legacy raw data-code payloads copyable", async () => {
+  it.each([
+    { name: "keeps legacy raw data-code payloads copyable", payload: "legacy text" },
+    {
+      name: "does not decode unmarked raw data-code payloads that start with the block-art prefix",
+      payload: 'openclaw:block-art-code:"literal"',
+    },
+  ])("$name", async ({ payload }) => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", { clipboard: { writeText } });
     const container = renderChatView();
     const thread = requireElement(container, ".chat-thread", "chat thread");
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "code-block-copy";
-    button.dataset.code = "legacy text";
-    thread.appendChild(button);
-
-    button.click();
-    await Promise.resolve();
-
-    expect(writeText).toHaveBeenCalledWith("legacy text");
-  });
-
-  it("does not decode unmarked raw data-code payloads that start with the block-art prefix", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    vi.stubGlobal("navigator", { clipboard: { writeText } });
-    const container = renderChatView();
-    const thread = requireElement(container, ".chat-thread", "chat thread");
-    const payload = 'openclaw:block-art-code:"literal"';
     const button = document.createElement("button");
     button.type = "button";
     button.className = "code-block-copy";
@@ -1180,12 +1136,7 @@ describe("chat code-block copy", () => {
 
 describe("chat transcript rendering", () => {
   it("refreshes cached inline reply handlers when the callback identity changes", () => {
-    const transcript = new ChatTranscriptController({
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate: () => undefined,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost);
+    const transcript = createTestTranscript();
     const firstReply = vi.fn();
     const currentReply = vi.fn();
     const message = { role: "assistant", content: "Reply target", timestamp: 1 };
@@ -1303,12 +1254,7 @@ describe("chat transcript rendering", () => {
   });
 
   it("announces only a genuinely appended assistant row", () => {
-    const transcript = new ChatTranscriptController({
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate: () => undefined,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost);
+    const transcript = createTestTranscript();
     const container = document.createElement("div");
     const message = (key: string, role: "user" | "assistant", content: string) => ({
       testVirtualRow: true,
@@ -1346,12 +1292,7 @@ describe("chat transcript rendering", () => {
   });
 
   it("does not announce appended rows from an inactive split pane", () => {
-    const transcript = new ChatTranscriptController({
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate: () => undefined,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost);
+    const transcript = createTestTranscript();
     const container = document.createElement("div");
     const existing = {
       testVirtualRow: true,
@@ -2008,12 +1949,7 @@ describe("chat transcript rendering cache", () => {
         isStreaming: false,
       },
     ]);
-    const transcript = new ChatTranscriptController({
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate: () => undefined,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost);
+    const transcript = createTestTranscript();
     const props = createChatProps({ messages, transcript, userName: "Fuller Stack" });
     const container = document.createElement("div");
 
@@ -2109,106 +2045,92 @@ describe("chat loading skeleton", () => {
     expect(container.querySelector(".agent-chat__welcome")).toBeNull();
   });
 
-  it("shows the skeleton while the initial history load has no rendered content", () => {
-    const container = renderChatView({ loading: true });
-
-    expect(container.querySelectorAll(".chat-loading-skeleton")).toHaveLength(1);
-    expect(container.querySelector(".agent-chat__welcome")).toBeNull();
-  });
-
-  it("shows the loading skeleton for an active run with no stream", () => {
-    const container = renderChatView({ canAbort: true, loading: true });
-
-    expect(container.querySelector(".chat-loading-skeleton")).not.toBeNull();
-    expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(0);
-    expect(container.querySelector(".agent-chat__welcome")).toBeNull();
-  });
-
-  it("shows the reading indicator when an active run has an empty stream", () => {
-    const container = renderChatView({ canAbort: true, stream: "" });
-
-    expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
-  });
-
-  it("keeps the working spark below a rendered response while the run continues", () => {
-    const container = renderChatView({
-      canAbort: true,
-      messages: [
-        {
-          role: "assistant",
-          content: "Finished answer",
-          timestamp: 1,
-        },
-      ],
-      stream: null,
-    });
-
-    // canAbort with no terminal status means the run is still working (e.g.
-    // between tool steps); the spark stays as the "still working" signal.
-    expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
-    expect(container.querySelector(".chat-group")?.textContent?.trim()).toBe("Finished answer");
-  });
-
-  it("drops the working spark once the run reaches a terminal status", () => {
-    const container = renderChatView({
-      canAbort: true,
-      runStatus: {
-        phase: "done",
-        runId: "run-1",
-        sessionKey: "main",
-        occurredAt: Date.now(),
+  it.each([
+    {
+      name: "shows the skeleton while the initial history load has no rendered content",
+      props: { loading: true },
+      present: { ".chat-loading-skeleton": null },
+      absent: [".agent-chat__welcome"],
+      counts: { ".chat-loading-skeleton": 1 },
+    },
+    {
+      name: "shows the loading skeleton for an active run with no stream",
+      props: { canAbort: true, loading: true },
+      present: { ".chat-loading-skeleton": null },
+      absent: [".agent-chat__welcome"],
+      counts: { ".chat-reading-indicator": 0 },
+    },
+    {
+      name: "shows the reading indicator when an active run has an empty stream",
+      props: { canAbort: true, stream: "" },
+      present: { ".chat-reading-indicator": null },
+    },
+    {
+      name: "keeps the working spark below a rendered response while the run continues",
+      props: {
+        canAbort: true,
+        messages: [{ role: "assistant", content: "Finished answer", timestamp: 1 }],
+        stream: null,
       },
-      messages: [
-        {
-          role: "assistant",
-          content: "Finished answer",
-          timestamp: 1,
+      present: { ".chat-reading-indicator": null, ".chat-group": "Finished answer" },
+    },
+    {
+      name: "drops the working spark once the run reaches a terminal status",
+      props: {
+        canAbort: true,
+        runStatus: {
+          phase: "done" as const,
+          runId: "run-1",
+          sessionKey: "main",
+          occurredAt: Date.now(),
         },
-      ],
-      stream: null,
-    });
-
-    expect(container.querySelector(".chat-reading-indicator")).toBeNull();
-  });
-
-  it("keeps existing messages visible without the skeleton during a background reload", () => {
-    const container = renderChatView({
-      loading: true,
-      messages: [
-        {
-          role: "assistant",
-          content: "Already loaded answer",
-          timestamp: 1,
-        },
-      ],
-    });
-
-    expect(container.querySelector(".chat-loading-skeleton")).toBeNull();
-    expect(container.querySelector(".chat-group")?.textContent?.trim()).toBe(
-      "Already loaded answer",
-    );
-  });
-
-  it("keeps active stream content visible without the skeleton during a background reload", () => {
-    const container = renderChatView({
-      loading: true,
-      stream: "Partial streamed answer",
-      streamStartedAt: 1,
-    });
-
-    expect(container.querySelector(".chat-loading-skeleton")).toBeNull();
-    expect(container.querySelector(".chat-stream")?.textContent).toBe("Partial streamed answer");
-  });
-
-  it("keeps the reading indicator visible without the skeleton before stream text arrives", () => {
-    const container = renderChatView({
-      loading: true,
-      stream: "",
-      streamStartedAt: 1,
-    });
-
-    expect(container.querySelector(".chat-loading-skeleton")).toBeNull();
-    expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
+        messages: [{ role: "assistant", content: "Finished answer", timestamp: 1 }],
+        stream: null,
+      },
+      absent: [".chat-reading-indicator"],
+    },
+    {
+      name: "keeps existing messages visible without the skeleton during a background reload",
+      props: {
+        loading: true,
+        messages: [{ role: "assistant", content: "Already loaded answer", timestamp: 1 }],
+      },
+      present: { ".chat-group": "Already loaded answer" },
+      absent: [".chat-loading-skeleton"],
+    },
+    {
+      name: "keeps active stream content visible without the skeleton during a background reload",
+      props: { loading: true, stream: "Partial streamed answer", streamStartedAt: 1 },
+      present: { ".chat-stream": "Partial streamed answer" },
+      absent: [".chat-loading-skeleton"],
+    },
+    {
+      name: "keeps the reading indicator visible without the skeleton before stream text arrives",
+      props: { loading: true, stream: "", streamStartedAt: 1 },
+      absent: [".chat-loading-skeleton"],
+      counts: { ".chat-reading-indicator": 1 },
+    },
+  ] satisfies Array<{
+    name: string;
+    props: Partial<Parameters<typeof renderChat>[0]>;
+    present?: Record<string, string | null>;
+    absent?: string[];
+    counts?: Record<string, number>;
+  }>)("$name", ({ props, present = {}, absent = [], counts = {} }) => {
+    const container = renderChatView(props);
+    for (const [selector, text] of Object.entries(present)) {
+      const element = container.querySelector(selector);
+      expect(element).not.toBeNull();
+      if (text !== null) {
+        expect(element?.textContent?.trim()).toBe(text);
+      }
+    }
+    for (const selector of absent) {
+      expect(container.querySelector(selector)).toBeNull();
+    }
+    for (const [selector, count] of Object.entries(counts)) {
+      expect(container.querySelectorAll(selector)).toHaveLength(count);
+    }
   });
 
   it("shows prompt-bar progress beside context usage while the current session send is awaiting acknowledgement", () => {
@@ -2323,119 +2245,122 @@ describe("chat loading skeleton", () => {
     expect(usageLink?.getAttribute("href")).toBe("/rosita/usage");
   });
 
-  it("does not announce progress for another session send", () => {
-    const container = renderChatView({
-      sessionKey: "session-b",
-      sending: true,
-      queue: [
-        {
-          id: "send-a",
-          text: "hello from A",
-          createdAt: 1,
-          sendRunId: "run-a",
-          sendState: "sending",
-          sessionKey: "session-a",
-        },
-      ],
-    });
-
-    expect(
-      container.querySelector(".agent-chat__run-status-announcement")?.textContent?.trim(),
-    ).toBe("");
-    expect(container.querySelector(".chat-reading-indicator")).toBeNull();
-  });
-
-  it("shows the working spark while the current session send waits for model switching", () => {
-    const container = renderChatView({
-      queue: [
-        {
-          id: "send-main",
-          text: "hello",
-          createdAt: 1,
-          sendRunId: "run-main",
-          sendState: "waiting-model",
-          sessionKey: "main",
-        },
-      ],
-    });
-
-    expect(container.querySelector(".agent-chat__run-status-announcement")?.textContent).toContain(
-      "Preparing model",
-    );
-    expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
-  });
-
-  it("shows active model-switch progress over the previous run's terminal status", () => {
-    const container = renderChatView({
-      runStatus: {
-        phase: "done",
-        runId: "run-previous",
-        sessionKey: "main",
-        occurredAt: 1_000,
+  it.each([
+    {
+      name: "does not announce progress for another session send",
+      props: {
+        sessionKey: "session-b",
+        sending: true,
+        queue: [
+          {
+            id: "send-a",
+            text: "hello from A",
+            createdAt: 1,
+            sendRunId: "run-a",
+            sendState: "sending" as const,
+            sessionKey: "session-a",
+          },
+        ],
       },
-      queue: [
-        {
-          id: "send-main",
-          text: "hello",
-          createdAt: 999,
-          sendRunId: "run-main",
-          sendState: "waiting-model",
-          sessionKey: "main",
-        },
-      ],
-    });
-
-    expect(container.querySelector(".agent-chat__run-status-announcement")?.textContent).toContain(
-      "Preparing model",
-    );
-    expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
-  });
-
-  it("keeps terminal status for the submitted run while its acknowledgement is pending", () => {
-    const occurredAt = Date.now();
-    const container = renderChatView({
-      runStatus: {
-        phase: "done",
-        runId: "run-main",
-        sessionKey: "main",
-        occurredAt,
+      announcement: "",
+      exact: true,
+      spark: false,
+    },
+    {
+      name: "shows the working spark while the current session send waits for model switching",
+      props: {
+        queue: [
+          {
+            id: "send-main",
+            text: "hello",
+            createdAt: 1,
+            sendRunId: "run-main",
+            sendState: "waiting-model" as const,
+            sessionKey: "main",
+          },
+        ],
       },
-      queue: [
-        {
-          id: "send-main",
-          text: "hello",
-          createdAt: 999,
-          sendRunId: "run-main",
-          sendState: "sending",
+      announcement: "Preparing model",
+      exact: false,
+      spark: true,
+    },
+    {
+      name: "shows active model-switch progress over the previous run's terminal status",
+      props: {
+        runStatus: {
+          phase: "done" as const,
+          runId: "run-previous",
           sessionKey: "main",
+          occurredAt: 1_000,
         },
-      ],
-    });
-
-    expect(
-      container.querySelector(".agent-chat__run-status-announcement")?.textContent?.trim(),
-    ).toBe("Done");
-    expect(container.querySelector(".chat-reading-indicator")).toBeNull();
-  });
-
-  it("does not announce progress for reconnect-waiting sends", () => {
-    const container = renderChatView({
-      queue: [
-        {
-          id: "send-main",
-          text: "hello",
-          createdAt: 1,
-          sendRunId: "run-main",
-          sendState: "waiting-reconnect",
+        queue: [
+          {
+            id: "send-main",
+            text: "hello",
+            createdAt: 999,
+            sendRunId: "run-main",
+            sendState: "waiting-model" as const,
+            sessionKey: "main",
+          },
+        ],
+      },
+      announcement: "Preparing model",
+      exact: false,
+      spark: true,
+    },
+    {
+      name: "keeps terminal status for the submitted run while its acknowledgement is pending",
+      props: {
+        runStatus: {
+          phase: "done" as const,
+          runId: "run-main",
           sessionKey: "main",
+          occurredAt: Date.now(),
         },
-      ],
-    });
-
-    expect(
-      container.querySelector(".agent-chat__run-status-announcement")?.textContent?.trim(),
-    ).toBe("");
-    expect(container.querySelector(".chat-reading-indicator")).toBeNull();
+        queue: [
+          {
+            id: "send-main",
+            text: "hello",
+            createdAt: 999,
+            sendRunId: "run-main",
+            sendState: "sending" as const,
+            sessionKey: "main",
+          },
+        ],
+      },
+      announcement: "Done",
+      exact: true,
+      spark: false,
+    },
+    {
+      name: "does not announce progress for reconnect-waiting sends",
+      props: {
+        queue: [
+          {
+            id: "send-main",
+            text: "hello",
+            createdAt: 1,
+            sendRunId: "run-main",
+            sendState: "waiting-reconnect" as const,
+            sessionKey: "main",
+          },
+        ],
+      },
+      announcement: "",
+      exact: true,
+      spark: false,
+    },
+  ])("$name", ({ props, announcement, exact, spark }) => {
+    const container = renderChatView(props);
+    const announcementElement = container.querySelector(".agent-chat__run-status-announcement");
+    expect(announcementElement).not.toBeNull();
+    const actual = announcementElement?.textContent?.trim() ?? "";
+    if (exact) {
+      expect(actual).toBe(announcement);
+    } else {
+      expect(actual).toContain(announcement);
+    }
+    expect(container.querySelector(".chat-reading-indicator") !== null).toBe(spark);
   });
 
   it("lets terminal run status win over stale abortable session UI", () => {
@@ -2701,11 +2626,7 @@ describe("chat voice controls", () => {
       ".agent-chat__composer-footer",
       "composer footer",
     );
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
     const focusSpy = vi.spyOn(textarea, "focus");
 
     composerFooter.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -2720,11 +2641,7 @@ describe("chat voice controls", () => {
       `[aria-label="${t("chat.composer.addAttachment")}"]`,
       "attach button",
     );
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
     const focusSpy = vi.spyOn(textarea, "focus");
 
     attachButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -2765,11 +2682,7 @@ describe("chat composer IME composition", () => {
     });
     props = { ...props, onRequestUpdate };
     render(renderChat(props), container);
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
 
     expect(container.querySelector('button[aria-label="Start voice input"]')).not.toBeNull();
 
@@ -2795,11 +2708,7 @@ describe("chat composer IME composition", () => {
     const props = createChatProps({ draft: "", onDraftChange, onRequestUpdate });
 
     render(renderChat(props), container);
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
 
     textarea.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
     textarea.value = "dangqian";
@@ -2812,11 +2721,7 @@ describe("chat composer IME composition", () => {
 
     expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("dangqian");
 
-    const rerenderedTextarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const rerenderedTextarea = getComposerTextarea(container);
     rerenderedTextarea.value = "当前";
     rerenderedTextarea.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
 
@@ -2838,11 +2743,7 @@ describe("chat composer IME composition", () => {
     }));
     const onSend = vi.fn();
     const container = renderChatView({ onHistoryKeydown, onSend });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
 
     textarea.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
     textarea.value = "dangqian";
@@ -2879,11 +2780,7 @@ describe("chat composer IME composition", () => {
       valueLength: 0,
     }));
     const container = renderChatView({ onHistoryKeydown, onRequestUpdate });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
     const arrowEvent = new KeyboardEvent("keydown", {
       key: "ArrowUp",
       bubbles: true,
@@ -2899,11 +2796,7 @@ describe("chat composer IME composition", () => {
 
   it("does not force textarea resize during IME composition", () => {
     const container = renderChatView({});
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
 
     // Set a sentinel height to detect unwanted overwrites
     textarea.style.height = "42px";
@@ -2928,11 +2821,7 @@ describe("chat composer IME composition", () => {
 describe("chat composer sizing", () => {
   it("sizes restored drafts after the rendered value is committed", async () => {
     const container = renderChatView({ draft: "A restored long draft" });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
     Object.defineProperties(textarea, {
       scrollHeight: { configurable: true, value: 180 },
       clientHeight: { configurable: true, value: 150 },
@@ -2948,11 +2837,7 @@ describe("chat composer sizing", () => {
 
   it("shows the textarea scrollbar only when the draft overflows", () => {
     const container = renderChatView({});
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
     let scrollHeight = 42;
     let clientHeight = 42;
     Object.defineProperties(textarea, {
@@ -3015,11 +2900,7 @@ describe("chat composer sizing", () => {
     }));
 
     const container = renderChatView({});
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    ) as HTMLTextAreaElement;
+    const textarea = getComposerTextarea(container);
     Object.defineProperties(textarea, {
       scrollHeight: { configurable: true, get: () => scrollHeight },
       clientHeight: { configurable: true, get: () => clientHeight },
@@ -3066,6 +2947,56 @@ describe("chat slash menu accessibility", () => {
     const event = new KeyboardEvent("keydown", { ...init, key, bubbles: true, cancelable: true });
     textarea!.dispatchEvent(event);
     return event;
+  }
+
+  function replayInput(textarea: HTMLTextAreaElement, value: string, type = "input") {
+    if (type === "input") {
+      textarea.value = value;
+    }
+    textarea.dispatchEvent(
+      new InputEvent(type, { bubbles: true, data: value, inputType: "insertText" }),
+    );
+  }
+
+  function createDraftHarness() {
+    let draft = "";
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const onSend = vi.fn(() => {
+      draft = "";
+    });
+    render(
+      renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
+      container,
+    );
+    return { container, onDraftChange, onSend };
+  }
+
+  function createSessionDraftHarness(prefix: string) {
+    const drafts: Record<string, string> = { [`${prefix}-a`]: "", [`${prefix}-b`]: "" };
+    const onDraftChange = vi.fn((sessionKey: string, next: string) => {
+      drafts[sessionKey] = next;
+    });
+    const container = document.createElement("div");
+    const renderSession = (sessionKey: string) =>
+      render(
+        renderChat(
+          createChatProps({
+            currentAgentId: `${prefix}-agent`,
+            draft: expectDefined(drafts[sessionKey], "session draft"),
+            getDraft: () => expectDefined(drafts[sessionKey], "session draft"),
+            onDraftChange: (next) => onDraftChange(sessionKey, next),
+            onSend: () => {
+              drafts[sessionKey] = "";
+            },
+            sessionKey,
+          }),
+        ),
+        container,
+      );
+    return { container, drafts, onDraftChange, renderSession };
   }
 
   it("requests slash command hydration only after slash intent", () => {
@@ -3153,22 +3084,7 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("clears the visible local draft immediately when send clears the host draft", () => {
-    let draft = "";
-    const container = document.createElement("div");
-    const onDraftChange = vi.fn((next: string) => {
-      draft = next;
-    });
-    const onSend = vi.fn(() => {
-      draft = "";
-    });
-    const renderWithDraft = () => {
-      render(
-        renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
-        container,
-      );
-    };
-
-    renderWithDraft();
+    const { container, onDraftChange, onSend } = createDraftHarness();
     inputDraft(container, "submitted message");
     container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
 
@@ -3178,119 +3094,39 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("ignores a stale native InputEvent replay after send clears the host draft", () => {
-    let draft = "";
-    const container = document.createElement("div");
-    const onDraftChange = vi.fn((next: string) => {
-      draft = next;
-    });
-    const onSend = vi.fn(() => {
-      draft = "";
-    });
-    const renderWithDraft = () => {
-      render(
-        renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
-        container,
-      );
-    };
-
-    renderWithDraft();
+    const { container, onDraftChange } = createDraftHarness();
     inputDraft(container, "submitted message");
     container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
 
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     expect(textarea?.value).toBe("");
 
-    textarea!.value = "submitted message";
-    textarea!.dispatchEvent(
-      new InputEvent("input", {
-        bubbles: true,
-        data: "submitted message",
-        inputType: "insertText",
-      }),
-    );
+    replayInput(textarea!, "submitted message");
 
     expect(textarea?.value).toBe("");
     expect(onDraftChange).toHaveBeenCalledTimes(1);
   });
 
   it("keeps a new same-session draft when a delayed stale replay arrives", () => {
-    let draft = "";
-    const container = document.createElement("div");
-    const onDraftChange = vi.fn((next: string) => {
-      draft = next;
-    });
-    const onSend = vi.fn(() => {
-      draft = "";
-    });
-    const renderWithDraft = () => {
-      render(
-        renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
-        container,
-      );
-    };
-
-    renderWithDraft();
+    const { container } = createDraftHarness();
     inputDraft(container, "submitted message");
     container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
 
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     expect(textarea?.value).toBe("");
 
-    textarea!.dispatchEvent(
-      new InputEvent("beforeinput", {
-        bubbles: true,
-        data: "new draft",
-        inputType: "insertText",
-      }),
-    );
-    textarea!.value = "new draft";
-    textarea!.dispatchEvent(
-      new InputEvent("input", {
-        bubbles: true,
-        data: "new draft",
-        inputType: "insertText",
-      }),
-    );
+    replayInput(textarea!, "new draft", "beforeinput");
+    replayInput(textarea!, "new draft");
     expect(textarea?.value).toBe("new draft");
 
-    textarea!.value = "submitted message";
-    textarea!.dispatchEvent(
-      new InputEvent("input", {
-        bubbles: true,
-        data: "submitted message",
-        inputType: "insertText",
-      }),
-    );
+    replayInput(textarea!, "submitted message");
 
     expect(textarea?.value).toBe("new draft");
   });
 
   it("does not apply a stale submitted draft replay to another session", () => {
-    const drafts = {
-      "stale-replay-a": "",
-      "stale-replay-b": "",
-    };
-    const onDraftChange = vi.fn((sessionKey: keyof typeof drafts, next: string) => {
-      drafts[sessionKey] = next;
-    });
-    const container = document.createElement("div");
-    const renderSession = (sessionKey: keyof typeof drafts) => {
-      render(
-        renderChat(
-          createChatProps({
-            currentAgentId: "stale-replay-agent",
-            draft: drafts[sessionKey],
-            getDraft: () => drafts[sessionKey],
-            onDraftChange: (next) => onDraftChange(sessionKey, next),
-            onSend: () => {
-              drafts[sessionKey] = "";
-            },
-            sessionKey,
-          }),
-        ),
-        container,
-      );
-    };
+    const { container, drafts, onDraftChange, renderSession } =
+      createSessionDraftHarness("stale-replay");
 
     renderSession("stale-replay-a");
     inputDraft(container, "submitted message");
@@ -3301,14 +3137,7 @@ describe("chat slash menu accessibility", () => {
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     expect(textarea?.value).toBe("");
 
-    textarea!.value = "submitted message";
-    textarea!.dispatchEvent(
-      new InputEvent("input", {
-        bubbles: true,
-        data: "submitted message",
-        inputType: "insertText",
-      }),
-    );
+    replayInput(textarea!, "submitted message");
 
     expect(textarea?.value).toBe("");
     expect(drafts["stale-replay-b"]).toBe("");
@@ -3316,31 +3145,7 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("does not overwrite an intervening session draft with a delayed stale replay", () => {
-    const drafts = {
-      "delayed-replay-a": "",
-      "delayed-replay-b": "",
-    };
-    const onDraftChange = vi.fn((sessionKey: keyof typeof drafts, next: string) => {
-      drafts[sessionKey] = next;
-    });
-    const container = document.createElement("div");
-    const renderSession = (sessionKey: keyof typeof drafts) => {
-      render(
-        renderChat(
-          createChatProps({
-            currentAgentId: "delayed-replay-agent",
-            draft: drafts[sessionKey],
-            getDraft: () => drafts[sessionKey],
-            onDraftChange: (next) => onDraftChange(sessionKey, next),
-            onSend: () => {
-              drafts[sessionKey] = "";
-            },
-            sessionKey,
-          }),
-        ),
-        container,
-      );
-    };
+    const { container, drafts, renderSession } = createSessionDraftHarness("delayed-replay");
 
     renderSession("delayed-replay-a");
     inputDraft(container, "submitted message");
@@ -3351,31 +3156,11 @@ describe("chat slash menu accessibility", () => {
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     expect(textarea?.value).toBe("");
 
-    textarea!.dispatchEvent(
-      new InputEvent("beforeinput", {
-        bubbles: true,
-        data: "session b draft",
-        inputType: "insertText",
-      }),
-    );
-    textarea!.value = "session b draft";
-    textarea!.dispatchEvent(
-      new InputEvent("input", {
-        bubbles: true,
-        data: "session b draft",
-        inputType: "insertText",
-      }),
-    );
+    replayInput(textarea!, "session b draft", "beforeinput");
+    replayInput(textarea!, "session b draft");
     expect(textarea?.value).toBe("session b draft");
 
-    textarea!.value = "submitted message";
-    textarea!.dispatchEvent(
-      new InputEvent("input", {
-        bubbles: true,
-        data: "submitted message",
-        inputType: "insertText",
-      }),
-    );
+    replayInput(textarea!, "submitted message");
 
     expect(textarea?.value).toBe("session b draft");
     expect(drafts["delayed-replay-b"]).toBe("session b draft");
@@ -3667,11 +3452,7 @@ describe("chat attachment picker", () => {
   it("cancels non-file drops outside the composer textarea but keeps them native inside it", () => {
     const container = renderChatView();
     const chat = requireElement(container, "section.card.chat", "chat drop target");
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(container);
 
     const outsideDrop = createDragEvent("drop", ["text/uri-list"]);
     chat.dispatchEvent(outsideDrop);
@@ -3696,21 +3477,9 @@ describe("chat attachment picker", () => {
       getDraft: () => "intro",
       onAttachmentsChange,
     });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(container);
     const pastedText = "large paste\n" + "x".repeat(1100);
-    const event = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(event, "clipboardData", {
-      value: {
-        items: { 0: { type: "text/plain" }, length: 1 },
-        getData: (type: string) => (type === "text/plain" ? pastedText : ""),
-      },
-    });
-
-    const allowed = textarea.dispatchEvent(event);
+    const allowed = textarea.dispatchEvent(createPasteEvent(pastedText));
 
     expect(allowed).toBe(false);
     await waitForFast(() => {
@@ -3728,25 +3497,15 @@ describe("chat attachment picker", () => {
   it("turns large rich-text clipboard content into a text attachment", () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(container);
     const pastedText = `large rich-text paste ${"x".repeat(1100)}`;
-    const event = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(event, "clipboardData", {
-      value: {
-        items: {
-          0: { type: "text/plain" },
-          1: { type: "text/html" },
-          length: 2,
-        },
-        getData: (type: string) => (type === "text/plain" ? pastedText : "<p>rich text</p>"),
-      },
-    });
-
-    expect(textarea.dispatchEvent(event)).toBe(false);
+    expect(
+      textarea.dispatchEvent(
+        createPasteEvent(pastedText, ["text/plain", "text/html"], {
+          "text/html": "<p>rich text</p>",
+        }),
+      ),
+    ).toBe(false);
     expect(requireFirstAttachmentsChange(onAttachmentsChange)).toHaveLength(1);
   });
 
@@ -3763,21 +3522,9 @@ describe("chat attachment picker", () => {
       },
       onSend,
     });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(container);
     const pastedText = `large paste ${"x".repeat(1100)}`;
-    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(pasteEvent, "clipboardData", {
-      value: {
-        items: { 0: { type: "text/plain" }, length: 1 },
-        getData: (type: string) => (type === "text/plain" ? pastedText : ""),
-      },
-    });
-
-    textarea.dispatchEvent(pasteEvent);
+    textarea.dispatchEvent(createPasteEvent(pastedText));
     textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
 
     expect(onSend).toHaveBeenCalledOnce();
@@ -3793,20 +3540,9 @@ describe("chat attachment picker", () => {
       getAttachments: () => attachments,
       onAttachmentsChange,
     });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(container);
     const paste = (text: string) => {
-      const event = new Event("paste", { bubbles: true, cancelable: true });
-      Object.defineProperty(event, "clipboardData", {
-        value: {
-          items: { 0: { type: "text/plain" }, length: 1 },
-          getData: (type: string) => (type === "text/plain" ? text : ""),
-        },
-      });
-      textarea.dispatchEvent(event);
+      textarea.dispatchEvent(createPasteEvent(text));
     };
     const firstText = `first ${"a".repeat(1100)}`;
     const secondText = `second ${"b".repeat(1100)}`;
@@ -3837,20 +3573,9 @@ describe("chat attachment picker", () => {
       getAttachments: () => attachments,
       onAttachmentsChange,
     });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(container);
     const chat = requireElement(container, "section.card.chat", "chat drop target");
     const pastedText = `large paste ${"x".repeat(1100)}`;
-    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(pasteEvent, "clipboardData", {
-      value: {
-        items: { 0: { type: "text/plain" }, length: 1 },
-        getData: (type: string) => (type === "text/plain" ? pastedText : ""),
-      },
-    });
     const droppedFile = new File(["%PDF-1.4\n"], "brief.pdf", { type: "application/pdf" });
     const dropEvent = new Event("drop", { bubbles: true, cancelable: true });
     Object.defineProperty(dropEvent, "dataTransfer", {
@@ -3858,7 +3583,7 @@ describe("chat attachment picker", () => {
     });
 
     try {
-      textarea.dispatchEvent(pasteEvent);
+      textarea.dispatchEvent(createPasteEvent(pastedText));
       chat.dispatchEvent(dropEvent);
 
       expect(readers).toHaveLength(1);
@@ -3889,19 +3614,8 @@ describe("chat attachment picker", () => {
         pastedTextAttachments = next;
       },
     });
-    const textarea = requireElement(
-      pasteTarget,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
-    const event = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(event, "clipboardData", {
-      value: {
-        items: { 0: { type: "text/plain" }, length: 1 },
-        getData: (type: string) => (type === "text/plain" ? `large paste ${"x".repeat(1100)}` : ""),
-      },
-    });
-    textarea.dispatchEvent(event);
+    const textarea = getComposerTextarea(pasteTarget);
+    textarea.dispatchEvent(createPasteEvent(`large paste ${"x".repeat(1100)}`));
 
     const namedLikePaste = registerChatAttachmentPayload({
       attachment: {
@@ -3946,20 +3660,9 @@ describe("chat attachment picker", () => {
         attachments = next;
       },
     });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(container);
     const text = `First words from a long pasted note ${"x".repeat(1100)}`;
-    const event = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(event, "clipboardData", {
-      value: {
-        items: { 0: { type: "text/plain" }, length: 1 },
-        getData: (type: string) => (type === "text/plain" ? text : ""),
-      },
-    });
-    textarea.dispatchEvent(event);
+    textarea.dispatchEvent(createPasteEvent(text));
     container = renderChatView({ attachments });
 
     expect(container.querySelector(".chat-attachment-file__name")?.textContent).toContain(
@@ -3979,20 +3682,9 @@ describe("chat attachment picker", () => {
         attachments = next;
       },
     });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(container);
     const text = `${"a".repeat(19)}🦞${"x".repeat(1100)}`;
-    const event = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(event, "clipboardData", {
-      value: {
-        items: { 0: { type: "text/plain" }, length: 1 },
-        getData: (type: string) => (type === "text/plain" ? text : ""),
-      },
-    });
-    textarea.dispatchEvent(event);
+    textarea.dispatchEvent(createPasteEvent(text));
     container = renderChatView({ attachments });
 
     expect(container.querySelector(".chat-attachment-file__name")?.textContent).toBe(
@@ -4003,20 +3695,8 @@ describe("chat attachment picker", () => {
   it("keeps normal short plain-text paste in the textarea", () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
-    const event = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(event, "clipboardData", {
-      value: {
-        items: { 0: { type: "text/plain" }, length: 1 },
-        getData: (type: string) => (type === "text/plain" ? "short paste" : ""),
-      },
-    });
-
-    const allowed = textarea.dispatchEvent(event);
+    const textarea = getComposerTextarea(container);
+    const allowed = textarea.dispatchEvent(createPasteEvent("short paste"));
 
     expect(allowed).toBe(true);
     expect(onAttachmentsChange).not.toHaveBeenCalled();
@@ -4025,20 +3705,9 @@ describe("chat attachment picker", () => {
   it("moves a pasted text attachment back into the composer", async () => {
     const onAttachmentsChange = vi.fn();
     const firstRender = renderChatView({ onAttachmentsChange });
-    const textarea = requireElement(
-      firstRender,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(firstRender);
     const pastedText = "large paste\n" + "x".repeat(1100);
-    const event = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(event, "clipboardData", {
-      value: {
-        items: { 0: { type: "text/plain" }, length: 1 },
-        getData: (type: string) => (type === "text/plain" ? pastedText : ""),
-      },
-    });
-    textarea.dispatchEvent(event);
+    textarea.dispatchEvent(createPasteEvent(pastedText));
 
     await waitForFast(() => {
       expect(onAttachmentsChange).toHaveBeenCalled();
@@ -4077,22 +3746,10 @@ describe("chat attachment picker", () => {
   it("converts pasted data image text into an attachment", () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });
-    const textarea = requireElement(
-      container,
-      ".agent-chat__composer-combobox > textarea",
-      "composer textarea",
-    );
+    const textarea = getComposerTextarea(container);
     const base64 = btoa("png");
     const dataUrl = ` data:image/PNG;base64,${base64.slice(0, 2)}\n${base64.slice(2)} `;
-    const event = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(event, "clipboardData", {
-      value: {
-        items: { length: 0 },
-        getData: (type: string) => (type === "text/plain" ? dataUrl : ""),
-      },
-    });
-
-    const allowed = textarea.dispatchEvent(event);
+    const allowed = textarea.dispatchEvent(createPasteEvent(dataUrl, []));
 
     expect(allowed).toBe(false);
     const attachments = requireFirstAttachmentsChange(onAttachmentsChange);
@@ -4416,8 +4073,7 @@ describe("chat model controls", () => {
     const { state } = createChatHeaderState();
     state.chatRunId = "run-123";
     state.chatStream = "Working";
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const modelSelect = getChatModelSelect(container);
     expect(modelSelect.getAttribute("aria-disabled")).toBe("true");
@@ -4433,11 +4089,7 @@ describe("chat model controls", () => {
       ],
     });
     const onModelSelect = vi.fn(async () => true);
-    const container = document.createElement("div");
-    render(
-      renderChatModelControls({ ...createChatModelControlsProps(state), onModelSelect }),
-      container,
-    );
+    const container = renderModelControls(state, { onModelSelect });
     const modelOption = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
     ).find((button) => button.getAttribute("aria-selected") === "false");
@@ -4455,8 +4107,7 @@ describe("chat model controls", () => {
         { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
       ],
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     expect(
       container.querySelector(".chat-controls__model-provenance-value--inherit"),
@@ -4481,41 +4132,22 @@ describe("chat model controls", () => {
   });
 
   it("hides model choices for locked sessions while preserving reasoning and speed", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
+    const { state } = createReasoningHeaderState({
       models: [
         { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
         { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
-      ],
-      thinkingDefault: "high",
-    });
-    state.sessionsResult = createSessionsListResult({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
-      defaultsThinkingDefault: "high",
-      defaultsThinkingLevels: [
-        { id: "low", label: "low" },
-        { id: "high", label: "high" },
       ],
     });
     const onModelSelect = vi.fn(async () => true);
     const onThinkingSelect = vi.fn(async () => true);
     const onFastModeSelect = vi.fn(async () => true);
-    const container = document.createElement("div");
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        modelSelectionLocked: true,
-        modelSelectionRuntimeId: "codex",
-        onFastModeSelect,
-        onModelSelect,
-        onThinkingSelect,
-      }),
-      container,
-    );
+    const container = renderModelControls(state, {
+      modelSelectionLocked: true,
+      modelSelectionRuntimeId: "codex",
+      onFastModeSelect,
+      onModelSelect,
+      onThinkingSelect,
+    });
 
     const modelSelect = getChatModelSelect(container);
     expect(modelSelect.dataset.chatModelLocked).toBe("true");
@@ -4544,54 +4176,45 @@ describe("chat model controls", () => {
     expect(onFastModeSelect).toHaveBeenCalledWith("on", "main");
   });
 
-  it("labels a locked session without native model metadata", () => {
+  it.each([
+    {
+      name: "labels a locked session without native model metadata",
+      runtimeId: "codex",
+      expected: "Codex-controlled model",
+      omitSession: true,
+    },
+    {
+      name: "uses a neutral model label for non-Codex locked sessions",
+      runtimeId: "openclaw",
+      expected: "Thread model",
+      omitSession: false,
+    },
+  ])("$name", ({ runtimeId, expected, omitSession }) => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",
       modelProvider: "openai",
       models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
     });
-    state.sessionsResult = createSessionsListResult({
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
+    if (omitSession) {
+      state.sessionsResult = createSessionsListResult({
+        defaultsModel: "gpt-5.5",
+        defaultsProvider: "openai",
+      });
+    }
+    const container = renderModelControls(state, {
+      modelSelectionLocked: true,
+      modelSelectionRuntimeId: runtimeId,
     });
-    const container = document.createElement("div");
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        modelSelectionLocked: true,
-        modelSelectionRuntimeId: "codex",
-      }),
-      container,
-    );
 
     expect(container.querySelector(".chat-controls__locked-model-value")?.textContent).toBe(
-      "Codex-controlled model",
+      expected,
     );
     expect(container.querySelector(".chat-controls__inline-select-label")?.textContent).toContain(
-      "Codex-controlled model",
+      expected,
     );
-  });
-
-  it("uses a neutral model label for non-Codex locked sessions", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
-    });
-    const container = document.createElement("div");
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        modelSelectionLocked: true,
-        modelSelectionRuntimeId: "openclaw",
-      }),
-      container,
-    );
-
-    expect(container.querySelector(".chat-controls__locked-model-value")?.textContent).toBe(
-      "Thread model",
-    );
-    expect(container.textContent).not.toContain("Codex-controlled model");
+    if (runtimeId === "openclaw") {
+      expect(container.textContent).not.toContain("Codex-controlled model");
+    }
   });
 
   it("does not patch the model for a locked session", async () => {
@@ -4632,11 +4255,7 @@ describe("chat model controls", () => {
     state.chatRunId = "run-123";
     state.chatStream = "Working";
     const onModelSelect = vi.fn(async () => true);
-    const container = document.createElement("div");
-    render(
-      renderChatModelControls({ ...createChatModelControlsProps(state), onModelSelect }),
-      container,
-    );
+    const container = renderModelControls(state, { onModelSelect });
     const modelOption = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
     ).find((button) => button.getAttribute("aria-selected") === "false");
@@ -4656,8 +4275,7 @@ describe("chat model controls", () => {
         { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", provider: "google" },
       ],
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const providerButtons = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
@@ -4698,8 +4316,7 @@ describe("chat model controls", () => {
         { id: "gpt-5.5", name: "GPT-5.5", provider: "codex" },
       ],
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const providerButtons = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
@@ -4723,8 +4340,7 @@ describe("chat model controls", () => {
         { id: "glm", name: "OpenCode GLM", provider: "opencode-zen" },
       ],
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const providerButtons = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
@@ -4769,8 +4385,7 @@ describe("chat model controls", () => {
         },
       ],
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     expect(
       container.querySelector(".chat-controls__inline-select-label")?.textContent?.trim(),
@@ -4826,76 +4441,44 @@ describe("chat model controls", () => {
     expect(container.querySelector('[data-chat-model-option=""]')).toBeNull();
   });
 
-  it("clears a different model override from the actual default model row", async () => {
-    const { state } = createChatHeaderState({
+  it.each([
+    {
+      name: "clears a different model override from the actual default model row",
       model: "gpt-5.4",
-      modelProvider: "openai",
       models: [
         { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
         { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
       ],
-    });
-    state.sessionsResult = createSessionsListResult({
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
-      model: "gpt-5.4",
-      modelProvider: "openai",
-    });
-    const onModelSelect = vi.fn(async () => true);
-    const container = document.createElement("div");
-    const sessionKey = "default-clear";
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        sessionKey,
-        modelOverrides: { [sessionKey]: "openai/gpt-5.4" },
-        onModelSelect,
-      }),
-      container,
-    );
-
-    const defaultOption = container.querySelector<HTMLButtonElement>(
-      '[data-chat-model-option="openai/gpt-5.5"][data-chat-model-default="true"]',
-    );
-    expect(defaultOption).toBeInstanceOf(HTMLButtonElement);
-    expect(defaultOption?.getAttribute("aria-selected")).toBe("false");
-    defaultOption?.click();
-
-    await waitForFast(() => {
-      expect(onModelSelect).toHaveBeenCalledWith("", sessionKey);
-    });
-  });
-
-  it("clears an explicit override that matches the default model", async () => {
-    const { state } = createChatHeaderState({
+      sessionKey: "default-clear",
+      selected: "false",
+    },
+    {
+      name: "clears an explicit override that matches the default model",
       model: "gpt-5.5",
-      modelProvider: "openai",
       models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
-    });
+      sessionKey: "explicit-default",
+      selected: "true",
+    },
+  ])("$name", async ({ model, models, sessionKey, selected }) => {
+    const { state } = createChatHeaderState({ model, modelProvider: "openai", models });
     state.sessionsResult = createSessionsListResult({
       defaultsModel: "gpt-5.5",
       defaultsProvider: "openai",
-      model: "gpt-5.5",
+      model,
       modelProvider: "openai",
     });
     const onModelSelect = vi.fn(async () => true);
-    const container = document.createElement("div");
-    const sessionKey = "explicit-default";
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        sessionKey,
-        modelOverrides: { [sessionKey]: "openai/gpt-5.5" },
-        onModelSelect,
-      }),
-      container,
-    );
+    const container = renderModelControls(state, {
+      sessionKey,
+      modelOverrides: { [sessionKey]: `openai/${model}` },
+      onModelSelect,
+    });
 
     const defaultOption = container.querySelector<HTMLButtonElement>(
       '[data-chat-model-option="openai/gpt-5.5"][data-chat-model-default="true"]',
     );
     expect(defaultOption).toBeInstanceOf(HTMLButtonElement);
-    expect(defaultOption?.getAttribute("aria-selected")).toBe("true");
+    expect(defaultOption?.getAttribute("aria-selected")).toBe(selected);
     defaultOption?.click();
 
     await waitForFast(() => {
@@ -4923,8 +4506,7 @@ describe("chat model controls", () => {
       defaultsModel: "google/gemma-4-26b-a4b-it",
       defaultsProvider: "openrouter",
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const providerButtons = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
@@ -4955,14 +4537,9 @@ describe("chat model controls", () => {
         },
       ],
     });
-    const container = document.createElement("div");
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        modelOverrides: { main: "moonshotai/kimi-k2.5" },
-      }),
-      container,
-    );
+    const container = renderModelControls(state, {
+      modelOverrides: { main: "moonshotai/kimi-k2.5" },
+    });
 
     const providers = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
@@ -4975,25 +4552,15 @@ describe("chat model controls", () => {
   });
 
   it("renders reasoning as a slider and speed as a fast-mode toggle", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
-      thinkingDefault: "high",
-    });
-    state.sessionsResult = createSessionsListResult({
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
-      defaultsThinkingDefault: "high",
-      defaultsThinkingLevels: [
+    const { state } = createReasoningHeaderState({
+      levels: [
         { id: "adaptive", label: "adaptive" },
         { id: "low", label: "low" },
         { id: "medium", label: "medium" },
         { id: "high", label: "high" },
       ],
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const slider = getThinkingSlider(container);
     const speedToggle = container.querySelector<HTMLButtonElement>("[data-chat-speed-toggle]");
@@ -5016,37 +4583,20 @@ describe("chat model controls", () => {
   });
 
   it("applies model, reasoning, and speed immediately for the session that opened the picker", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
+    const { state } = createReasoningHeaderState({
       models: [
         { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
         { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
-      thinkingDefault: "high",
-    });
-    state.sessionsResult = createSessionsListResult({
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
-      defaultsThinkingDefault: "high",
-      defaultsThinkingLevels: [
-        { id: "low", label: "low" },
-        { id: "high", label: "high" },
       ],
     });
     const onModelSelect = vi.fn(async () => true);
     const onThinkingSelect = vi.fn(async () => true);
     const onFastModeSelect = vi.fn(async () => true);
-    const container = document.createElement("div");
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        onFastModeSelect,
-        onModelSelect,
-        onThinkingSelect,
-      }),
-      container,
-    );
+    const container = renderModelControls(state, {
+      onFastModeSelect,
+      onModelSelect,
+      onThinkingSelect,
+    });
 
     const modelOption = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
@@ -5079,32 +4629,13 @@ describe("chat model controls", () => {
   });
 
   it("locks reasoning and speed while a model switch is pending", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
+    const { state } = createReasoningHeaderState({
       models: [
         { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
         { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
       ],
-      thinkingDefault: "high",
     });
-    state.sessionsResult = createSessionsListResult({
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
-      defaultsThinkingDefault: "high",
-      defaultsThinkingLevels: [
-        { id: "low", label: "low" },
-        { id: "high", label: "high" },
-      ],
-    });
-    const container = document.createElement("div");
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        modelSwitching: true,
-      }),
-      container,
-    );
+    const container = renderModelControls(state, { modelSwitching: true });
 
     // The session row still describes the previous model while the switch is
     // pending, so committing reasoning/speed then would target stale levels.
@@ -5385,8 +4916,7 @@ describe("chat model controls", () => {
       modelProvider: "ollama",
       models: [{ id: "local-model", name: "Local Model", provider: "ollama" }],
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const speedToggle = container.querySelector<HTMLButtonElement>("[data-chat-speed-toggle]");
     expect(speedToggle).toBeInstanceOf(HTMLButtonElement);
@@ -5407,8 +4937,7 @@ describe("chat model controls", () => {
       ],
       omitSessionFromList: true,
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     expect(getThinkingSliderValues(container)).toEqual(["off", "adaptive", "xhigh", "max"]);
     // No override -> nothing to reset, so the icon reset is not rendered.
@@ -5416,26 +4945,13 @@ describe("chat model controls", () => {
   });
 
   it("clears a reasoning override from the icon reset", async () => {
-    const { state, request } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      thinkingDefault: "high",
-    });
-    state.sessionsResult = createSessionsListResult({
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
-      defaultsThinkingDefault: "high",
-      defaultsThinkingLevels: [
-        { id: "low", label: "low" },
-        { id: "high", label: "high" },
-      ],
-    });
-    state.sessionsResult.sessions[0] = {
-      ...state.sessionsResult.sessions[0]!,
+    const { state, request } = createReasoningHeaderState();
+    const sessionsResult = expectDefined(state.sessionsResult, "reasoning sessions");
+    sessionsResult.sessions[0] = {
+      ...sessionsResult.sessions[0]!,
       thinkingLevel: "low",
     };
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     expect(getThinkingReasoningValueLabel(container)).toBe("Low");
     const reset = getThinkingResetButton(container);
@@ -5457,8 +4973,7 @@ describe("chat model controls", () => {
       modelProvider: "ollama",
       thinkingDefault: "adaptive",
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const thinkingSelect = getThinkingSelect(container);
 
@@ -5483,8 +4998,7 @@ describe("chat model controls", () => {
       modelProvider: "openai",
       thinkingDefault: "medium",
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const slider = getThinkingSlider(container);
     expect(slider?.classList.contains("chat-controls__reasoning-range--unanchored")).toBe(false);
@@ -5503,8 +5017,7 @@ describe("chat model controls", () => {
         updatedAt: 1,
       },
     ]);
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     expect(getThinkingSlider(container)).toBeNull();
     const only = container.querySelector<HTMLButtonElement>(
@@ -5530,8 +5043,7 @@ describe("chat model controls", () => {
       defaultsThinkingDefault: "adaptive",
       defaultsThinkingLevels: [{ id: "adaptive", label: "adaptive" }],
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const only = container.querySelector<HTMLButtonElement>(
       '[data-chat-thinking-option="adaptive"]',
@@ -5571,8 +5083,7 @@ describe("chat model controls", () => {
         },
       ],
     };
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const thinkingSelect = getThinkingSelect(container);
 
@@ -5602,24 +5113,14 @@ describe("chat model controls", () => {
       defaultsProvider: "minimax",
       defaultsThinkingDefault: "off",
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     expect(getThinkingReasoningValueLabel(container)).toBe("Low");
   });
 
   it("always renders full thinking labels", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
-      thinkingDefault: "high",
-    });
-    state.sessionsResult = createSessionsListResult({
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
-      defaultsThinkingDefault: "high",
-      defaultsThinkingLevels: [
+    const { state } = createReasoningHeaderState({
+      levels: [
         { id: "off", label: "off" },
         { id: "low", label: "low" },
         { id: "medium", label: "medium" },
@@ -5627,8 +5128,7 @@ describe("chat model controls", () => {
         { id: "xhigh", label: "xhigh" },
       ],
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const thinkingSelect = getThinkingSelect(container);
     const triggerLabel = container.querySelector(".chat-controls__inline-select-label");
@@ -5646,8 +5146,7 @@ describe("chat model controls", () => {
       defaultsThinkingDefault: "adaptive",
       omitSessionFromList: true,
     });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const container = renderModelControls(state);
 
     const thinkingSelect = getThinkingSelect(container);
 
@@ -5657,6 +5156,10 @@ describe("chat model controls", () => {
 });
 
 describe("right-click Reply", () => {
+  const replyTarget = { messageId: "msg-1", text: "quoted", senderLabel: "User" };
+  const renderReply = (overrides: Partial<Parameters<typeof renderChat>[0]> = {}) =>
+    renderChatView({ replyTarget, ...overrides });
+
   it("keeps inline actions in the context menu alongside user rewind and fork", () => {
     const onRewindMessage = vi.fn().mockResolvedValue(true);
     const onForkMessage = vi.fn();
@@ -5668,17 +5171,13 @@ describe("right-click Reply", () => {
       onOpenSidebar,
       onSetReply: vi.fn(),
     });
-    const section = container.querySelector<HTMLElement>(".card.chat")!;
-    const group = document.createElement("div");
-    group.className = "chat-group user";
+    const { bubble, group } = appendChatBubble(container, {
+      entryId: "persisted-user",
+      groupClass: "chat-group user",
+      messageId: "message-1",
+      text: "hello",
+    });
     group.dataset.chatRowKey = "group:user:persisted";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.messageId = "message-1";
-    bubble.dataset.entryId = "persisted-user";
-    bubble.dataset.messageText = "hello";
-    group.appendChild(bubble);
-    section.querySelector(".chat-thread-inner")!.appendChild(group);
 
     bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
 
@@ -5742,13 +5241,10 @@ describe("right-click Reply", () => {
     } satisfies Storage);
     const onRequestUpdate = vi.fn();
     const container = renderChatView({ sessionKey: "context-hide-test", onRequestUpdate });
-    const group = document.createElement("div");
-    group.className = "chat-group assistant";
+    const { bubble, group } = appendChatBubble(container, {
+      groupClass: "chat-group assistant",
+    });
     group.dataset.chatRowKey = "group:assistant:persisted";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    group.appendChild(bubble);
-    container.querySelector(".chat-thread-inner")!.appendChild(group);
 
     bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     document.querySelector<HTMLButtonElement>('[aria-label="Hide message"]')!.click();
@@ -5772,14 +5268,7 @@ describe("right-click Reply", () => {
     section.appendChild(confirmationOwner);
     window.localStorage.removeItem("openclaw:skip-rewind-confirm");
     chatMessage.openChatRewindConfirmation(confirmationTrigger, vi.fn());
-
-    const group = document.createElement("div");
-    group.className = "chat-group";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.messageText = "open message actions";
-    group.appendChild(bubble);
-    section.querySelector(".chat-thread-inner")!.appendChild(group);
+    const { bubble } = appendChatBubble(container, { text: "open message actions" });
 
     try {
       expect(confirmationOwner.querySelector(".chat-delete-confirm")).not.toBeNull();
@@ -5800,13 +5289,10 @@ describe("right-click Reply", () => {
       onRewindMessage: vi.fn(),
       onForkMessage: vi.fn(),
     });
-    const group = document.createElement("div");
-    group.className = "chat-group user";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.entryId = "persisted-user";
-    group.appendChild(bubble);
-    container.querySelector(".chat-thread-inner")!.appendChild(group);
+    const { bubble } = appendChatBubble(container, {
+      entryId: "persisted-user",
+      groupClass: "chat-group user",
+    });
 
     bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
 
@@ -5826,22 +5312,11 @@ describe("right-click Reply", () => {
   it("opens context menu and calls onSetReply when Reply is selected", () => {
     const onSetReply = vi.fn();
     const container = renderChatView({ onSetReply });
-    const section = container.querySelector<HTMLElement>(".card.chat");
-    expect(section).not.toBeNull();
-
-    // Create a real chat bubble inside a group with the data-message-text attribute
-    const group = document.createElement("div");
-    group.className = "chat-group";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.messageId = "msg-stable-1";
-    bubble.dataset.messageText = "hello world";
-    const sender = document.createElement("span");
-    sender.className = "chat-sender-name";
-    sender.textContent = "User";
-    group.appendChild(sender);
-    group.appendChild(bubble);
-    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+    const { bubble } = appendChatBubble(container, {
+      messageId: "msg-stable-1",
+      senderLabel: "User",
+      text: "hello world",
+    });
 
     const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
     bubble.dispatchEvent(evt);
@@ -5864,14 +5339,7 @@ describe("right-click Reply", () => {
   it("backs off before an emoji that crosses the reply target limit", () => {
     const onSetReply = vi.fn();
     const container = renderChatView({ onSetReply });
-    const section = container.querySelector<HTMLElement>(".card.chat");
-    const group = document.createElement("div");
-    group.className = "chat-group";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.messageText = "x".repeat(499) + "🧠tail";
-    group.appendChild(bubble);
-    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+    const { bubble } = appendChatBubble(container, { text: "x".repeat(499) + "🧠tail" });
 
     bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     document.querySelector<HTMLButtonElement>(".chat-reply-context-menu button")!.click();
@@ -5886,17 +5354,11 @@ describe("right-click Reply", () => {
 
   it("keeps the native context menu for links inside a replyable bubble", () => {
     const container = renderChatView({ onSetReply: vi.fn() });
-    const group = document.createElement("div");
-    group.className = "chat-group";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.messageText = "hello world";
+    const { bubble } = appendChatBubble(container, { text: "hello world" });
     const link = document.createElement("a");
     link.href = "https://example.com";
     link.textContent = "Example";
     bubble.appendChild(link);
-    group.appendChild(bubble);
-    container.querySelector(".chat-thread-inner")!.appendChild(group);
 
     const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
     link.dispatchEvent(evt);
@@ -5907,16 +5369,8 @@ describe("right-click Reply", () => {
 
   it("keeps the native context menu when Reply is unavailable", () => {
     const container = renderChatView();
-    const section = container.querySelector<HTMLElement>(".card.chat");
-    expect(section).not.toBeNull();
-
-    const group = document.createElement("div");
-    group.className = "chat-group";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble streaming";
-    bubble.dataset.messageText = "still streaming";
-    group.appendChild(bubble);
-    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+    const { bubble } = appendChatBubble(container, { text: "still streaming" });
+    bubble.classList.add("streaming");
 
     const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
     bubble.dispatchEvent(evt);
@@ -5927,30 +5381,12 @@ describe("right-click Reply", () => {
 
   it("dismisses the reply context menu with Escape after delayed listeners register", () => {
     const onSetReply = vi.fn();
-    const frameCallbacks: FrameRequestCallback[] = [];
-    vi.stubGlobal(
-      "requestAnimationFrame",
-      vi.fn((callback: FrameRequestCallback) => {
-        frameCallbacks.push(callback);
-        return frameCallbacks.length;
-      }),
-    );
+    const flushFrames = stubAnimationFrames();
     const container = renderChatView({ onSetReply });
-    const section = container.querySelector<HTMLElement>(".card.chat");
-    expect(section).not.toBeNull();
-
-    const group = document.createElement("div");
-    group.className = "chat-group";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.messageText = "hello world";
-    group.appendChild(bubble);
-    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+    const { bubble } = appendChatBubble(container, { text: "hello world" });
 
     bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-    for (const callback of frameCallbacks.splice(0)) {
-      callback(0);
-    }
+    flushFrames();
 
     const menu = document.querySelector<HTMLElement>(".chat-reply-context-menu");
     expect(menu).not.toBeNull();
@@ -5968,31 +5404,16 @@ describe("right-click Reply", () => {
   });
 
   it("dismisses a context-menu Rewind confirmation with Escape before closing the menu", () => {
-    const frameCallbacks: FrameRequestCallback[] = [];
-    vi.stubGlobal(
-      "requestAnimationFrame",
-      vi.fn((callback: FrameRequestCallback) => {
-        frameCallbacks.push(callback);
-        return frameCallbacks.length;
-      }),
-    );
-    const flushFrames = () => {
-      for (const callback of frameCallbacks.splice(0)) {
-        callback(0);
-      }
-    };
+    const flushFrames = stubAnimationFrames();
     const container = renderChatView({
       paneId: "pane-a",
       onRewindMessage: vi.fn(),
     });
-    const group = document.createElement("div");
-    group.className = "chat-group user";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.entryId = "persisted-user";
-    bubble.dataset.messageText = "hello";
-    group.appendChild(bubble);
-    container.querySelector(".chat-thread-inner")!.appendChild(group);
+    const { bubble } = appendChatBubble(container, {
+      entryId: "persisted-user",
+      groupClass: "chat-group user",
+      text: "hello",
+    });
 
     bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     flushFrames();
@@ -6027,31 +5448,16 @@ describe("right-click Reply", () => {
   });
 
   it("removes a portaled Rewind confirmation only when its owning pane resets", () => {
-    const frameCallbacks: FrameRequestCallback[] = [];
-    vi.stubGlobal(
-      "requestAnimationFrame",
-      vi.fn((callback: FrameRequestCallback) => {
-        frameCallbacks.push(callback);
-        return frameCallbacks.length;
-      }),
-    );
-    const flushFrames = () => {
-      for (const callback of frameCallbacks.splice(0)) {
-        callback(0);
-      }
-    };
+    const flushFrames = stubAnimationFrames();
     const removeDocumentListener = vi.spyOn(document, "removeEventListener");
     const removeWindowListener = vi.spyOn(window, "removeEventListener");
     const onRewindMessage = vi.fn();
     const container = renderChatView({ paneId: "pane-a", onRewindMessage });
-    const group = document.createElement("div");
-    group.className = "chat-group user";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.entryId = "persisted-user";
-    bubble.dataset.messageText = "hello";
-    group.appendChild(bubble);
-    container.querySelector(".chat-thread-inner")!.appendChild(group);
+    const { bubble } = appendChatBubble(container, {
+      entryId: "persisted-user",
+      groupClass: "chat-group user",
+      text: "hello",
+    });
 
     bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     flushFrames();
@@ -6074,27 +5480,11 @@ describe("right-click Reply", () => {
   });
 
   it("dismisses the reply context menu before a later context menu opens", () => {
-    const frameCallbacks: FrameRequestCallback[] = [];
-    vi.stubGlobal(
-      "requestAnimationFrame",
-      vi.fn((callback: FrameRequestCallback) => {
-        frameCallbacks.push(callback);
-        return frameCallbacks.length;
-      }),
-    );
+    const flushFrames = stubAnimationFrames();
     const container = renderChatView({ onSetReply: vi.fn() });
-    const section = container.querySelector<HTMLElement>(".card.chat");
-    const group = document.createElement("div");
-    group.className = "chat-group";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.messageText = "hello world";
-    group.appendChild(bubble);
-    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+    const { bubble } = appendChatBubble(container, { text: "hello world" });
     bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-    for (const callback of frameCallbacks.splice(0)) {
-      callback(0);
-    }
+    flushFrames();
     expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
 
     document.body.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
@@ -6103,13 +5493,7 @@ describe("right-click Reply", () => {
   });
 
   it("renders reply preview bar with quote text and dismiss button", () => {
-    const container = renderChatView({
-      replyTarget: {
-        messageId: "msg-1",
-        text: "quoted message",
-        senderLabel: "User",
-      },
-    });
+    const container = renderReply({ replyTarget: { ...replyTarget, text: "quoted message" } });
 
     const preview = container.querySelector(".chat-reply-preview");
     expect(preview).not.toBeNull();
@@ -6136,14 +5520,7 @@ describe("right-click Reply", () => {
 
   it("calls onClearReply when dismiss button is clicked", () => {
     const onClearReply = vi.fn();
-    const container = renderChatView({
-      replyTarget: {
-        messageId: "msg-1",
-        text: "quoted",
-        senderLabel: "User",
-      },
-      onClearReply,
-    });
+    const container = renderReply({ onClearReply });
 
     container.querySelector<HTMLButtonElement>(".chat-reply-preview__dismiss")!.click();
     expect(onClearReply).toHaveBeenCalledTimes(1);
@@ -6151,14 +5528,7 @@ describe("right-click Reply", () => {
 
   it("clears reply target on Escape when no other handler intercepted", () => {
     const onClearReply = vi.fn();
-    const container = renderChatView({
-      replyTarget: {
-        messageId: "msg-1",
-        text: "quoted",
-        senderLabel: "User",
-      },
-      onClearReply,
-    });
+    const container = renderReply({ onClearReply });
 
     const section = container.querySelector<HTMLElement>(".card.chat");
     const evt = new KeyboardEvent("keydown", {
@@ -6173,14 +5543,7 @@ describe("right-click Reply", () => {
 
   it("does not clear reply target when Escape is already defaultPrevented", () => {
     const onClearReply = vi.fn();
-    const container = renderChatView({
-      replyTarget: {
-        messageId: "msg-1",
-        text: "quoted",
-        senderLabel: "User",
-      },
-      onClearReply,
-    });
+    const container = renderReply({ onClearReply });
 
     const section = container.querySelector<HTMLElement>(".card.chat");
     const evt = new KeyboardEvent("keydown", {


### PR DESCRIPTION
## What Problem This Solves

The large Control UI chat-view suite repeated transcript, composer, clipboard, model-control, and context-menu setup across many cases. That duplication made behavior-preserving test maintenance noisy and kept the file substantially above the repository's line-count budget.

## Why This Change Was Made

This consolidates repeated setup into focused chat-view test fixtures and table-drives only genuinely parallel cases. Distinct behavior stays in distinct tests, event ordering and accessibility assertions remain explicit, and the production implementation is untouched.

## User Impact

No user-visible behavior changes. Maintainers get a smaller, clearer chat-view test suite with the same 197 test cases and assertion coverage.

## Evidence

- LOC: +689/-1247 across 2 test/fixture files; net -558 lines. Production LOC: +0/-0. Test LOC: +689/-1247.
- Baseline: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts` — 197 passed.
- Final focused proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts` — 197 passed.
- Final changed gate: `node scripts/check-changed.mjs -- ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-view.test-helpers.ts` — Blacksmith Testbox exit 0; format, Control UI i18n, core-test types, UI types, and lint passed.
- Autoreview: Codex/Sol high reasoning, uncommitted mode — clean, no accepted/actionable findings after fixing all first-pass findings.
