### PR TITLE
refactor(agents): split subagent registry machinery

### DIFF
--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -75,6 +75,7 @@ import { settleRequesterTurnAfterSessionSpawns } from "./subagent-registry-reque
 import type {
   PendingFinalDeliveryPayload,
   RequesterSettleWakeState,
+  SubagentCompletionRequest,
   SubagentRunRecord,
 } from "./subagent-registry.types.js";
 import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
@@ -1740,21 +1741,7 @@ export function createSubagentRegistryLifecycleController(params: {
     return true;
   };
 
-  type CompleteSubagentRunParams = {
-    runId: string;
-    endedAt?: number;
-    outcome: SubagentRunOutcome;
-    reason: SubagentLifecycleEndedReason;
-    sendFarewell?: boolean;
-    accountId?: string;
-    triggerCleanup: boolean;
-    startedAt?: number;
-    suppressSessionEffects?: boolean;
-    completionSnapshot?: { resultText: string | null; capturedAt: number };
-    recoverInterrupted?: true;
-  };
-
-  const completeSubagentRunAttempt = async (completeParams: CompleteSubagentRunParams) => {
+  const completeSubagentRunAttempt = async (completeParams: SubagentCompletionRequest) => {
     const releaseCompletionLock = await acquireTerminalCompletionLock(completeParams.runId);
     let entry: SubagentRunRecord | undefined;
     let terminalGeneration = 0;
@@ -2381,7 +2368,7 @@ export function createSubagentRegistryLifecycleController(params: {
     startSubagentAnnounceCleanupFlow(completeParams.runId, entry);
   };
 
-  const completeSubagentRun = async (completeParams: CompleteSubagentRunParams) => {
+  const completeSubagentRun = async (completeParams: SubagentCompletionRequest) => {
     // Task finalization can make the run disappear from suspension blockers
     // before browser/MCP retirement and cleanup delivery hand off. Own this
     // entire transition as an independent root so that boundary stays atomic.

--- a/src/agents/subagent-registry-pending-lifecycle.ts
+++ b/src/agents/subagent-registry-pending-lifecycle.ts
@@ -1,0 +1,98 @@
+import {
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+} from "./subagent-lifecycle-events.js";
+import type { SubagentCompletionRequest, SubagentRunRecord } from "./subagent-registry.types.js";
+
+const LIFECYCLE_RETRY_GRACE_MS = 15_000;
+const PENDING_LIFECYCLE_TERMINAL_TTL_MS = 5 * 60_000;
+
+type PendingLifecycleKind = "error" | "timeout";
+
+type PendingLifecycleTerminal = {
+  kind: PendingLifecycleKind;
+  timer: NodeJS.Timeout;
+  endedAt: number;
+  startedAt?: number;
+  error?: string;
+};
+
+export function createPendingLifecycleScheduler(params: {
+  runs: Map<string, SubagentRunRecord>;
+  completeInBackground: (completion: SubagentCompletionRequest, source: string) => void;
+}) {
+  const pendingByRunId = new Map<string, PendingLifecycleTerminal>();
+
+  function clearKind(runId: string, kind?: PendingLifecycleKind) {
+    const pending = pendingByRunId.get(runId);
+    if (!pending || (kind && pending.kind !== kind)) {
+      return;
+    }
+    clearTimeout(pending.timer);
+    pendingByRunId.delete(runId);
+  }
+
+  function clearAll() {
+    pendingByRunId.forEach(({ timer }) => clearTimeout(timer));
+    pendingByRunId.clear();
+  }
+
+  function schedule(
+    kind: PendingLifecycleKind,
+    scheduleParams: { runId: string; endedAt: number; startedAt?: number; error?: string },
+  ) {
+    clearKind(scheduleParams.runId);
+    const timer = setTimeout(() => {
+      const pending = pendingByRunId.get(scheduleParams.runId);
+      if (!pending || pending.timer !== timer) {
+        return;
+      }
+      pendingByRunId.delete(scheduleParams.runId);
+      const entry = params.runs.get(scheduleParams.runId);
+      if (!entry) {
+        return;
+      }
+      if (
+        kind === "error"
+          ? entry.endedReason === SUBAGENT_ENDED_REASON_COMPLETE || entry.outcome?.status === "ok"
+          : entry.outcome?.status === "ok" || entry.pauseReason === "sessions_yield"
+      ) {
+        return;
+      }
+      params.completeInBackground(
+        {
+          runId: scheduleParams.runId,
+          endedAt: pending.endedAt,
+          outcome:
+            kind === "error" ? { status: "error", error: pending.error } : { status: "timeout" },
+          reason: kind === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
+          sendFarewell: true,
+          accountId: entry.requesterOrigin?.accountId,
+          triggerCleanup: true,
+          startedAt: pending.startedAt,
+        },
+        `lifecycle-${kind}-grace`,
+      );
+    }, LIFECYCLE_RETRY_GRACE_MS);
+    timer.unref?.();
+    pendingByRunId.set(scheduleParams.runId, { ...scheduleParams, kind, timer });
+  }
+
+  return {
+    clear: clearKind,
+    clearError: (runId: string) => clearKind(runId, "error"),
+    clearTimeout: (runId: string) => clearKind(runId, "timeout"),
+    clearAll,
+    scheduleError: (scheduleParams: Parameters<typeof schedule>[1]) =>
+      schedule("error", scheduleParams),
+    scheduleTimeout: (scheduleParams: Parameters<typeof schedule>[1]) =>
+      schedule("timeout", scheduleParams),
+    sweepExpired(now: number) {
+      for (const [runId, pending] of pendingByRunId) {
+        if (now - pending.endedAt > PENDING_LIFECYCLE_TERMINAL_TTL_MS) {
+          clearKind(runId, pending.kind);
+        }
+      }
+    },
+  };
+}

--- a/src/agents/subagent-registry-sweep-kill.ts
+++ b/src/agents/subagent-registry-sweep-kill.ts
@@ -1,0 +1,283 @@
+import { SUBAGENT_KILL_TASK_ERROR } from "../tasks/detached-task-runtime-contract.js";
+import { finalizeTaskRunByRunId, findDetachedTaskRun } from "../tasks/detached-task-runtime.js";
+import { isProvisionalSubagentKillTask } from "../tasks/task-cancellation-state.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import {
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+  SUBAGENT_ENDED_REASON_KILLED,
+} from "./subagent-lifecycle-events.js";
+import { PROVISIONAL_KILL_RECONCILIATION_MS } from "./subagent-registry-helpers.js";
+import type { SubagentCompletionRequest, SubagentRunRecord } from "./subagent-registry.types.js";
+import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
+import {
+  resolveSubagentRunDeadlineMs,
+  resolveSubagentRunEffectiveEndedAt,
+} from "./subagent-run-timeout.js";
+import {
+  loadSubagentSessionEntry,
+  resolveCompletionFromSessionEntry,
+  type SubagentSessionStoreCache,
+} from "./subagent-session-reconciliation.js";
+
+function findNextSubagentRunCreatedAt(
+  runs: Map<string, SubagentRunRecord>,
+  entry: SubagentRunRecord,
+): number | undefined {
+  let nextCreatedAt = entry.killReconciliation?.supersededAt;
+  for (const candidate of runs.values()) {
+    if (
+      candidate.runId === entry.runId ||
+      candidate.childSessionKey !== entry.childSessionKey ||
+      compareSubagentRunGeneration(candidate, entry) <= 0
+    ) {
+      continue;
+    }
+    nextCreatedAt = Math.min(nextCreatedAt ?? candidate.createdAt, candidate.createdAt);
+  }
+  return nextCreatedAt;
+}
+
+function isStableCancellation(task: TaskRecord | undefined) {
+  return task?.status === "cancelled" && !isProvisionalSubagentKillTask(task);
+}
+
+function isUnstableTask(task: TaskRecord | undefined) {
+  return (
+    task !== undefined &&
+    (task.status === "queued" || task.status === "running" || isProvisionalSubagentKillTask(task))
+  );
+}
+
+export function resolveSubagentTaskForRun(
+  runs: Map<string, SubagentRunRecord>,
+  entry: SubagentRunRecord,
+) {
+  const nextRunCreatedAt = findNextSubagentRunCreatedAt(runs, entry);
+  const generationStartedAt = entry.sessionStartedAt ?? entry.createdAt;
+  return findDetachedTaskRun({
+    runId: entry.taskRunId ?? entry.runId,
+    runtime: "subagent",
+    sessionKey: entry.childSessionKey,
+    createdAtOrAfter: generationStartedAt,
+    createdBefore: nextRunCreatedAt,
+    // Steer/wake replaces the registry run ID while retaining the original
+    // task row. Only those continuations may adopt a session-scoped task.
+    allowSessionFallback:
+      entry.taskRunId === undefined &&
+      typeof entry.sessionStartedAt === "number" &&
+      entry.sessionStartedAt < entry.createdAt,
+  });
+}
+
+function resolveCompletionFromTerminalTask(task: TaskRecord | undefined, entry: SubagentRunRecord) {
+  if (
+    !task ||
+    typeof task.endedAt !== "number" ||
+    (task.status !== "succeeded" && task.status !== "failed" && task.status !== "timed_out")
+  ) {
+    return undefined;
+  }
+  const outcome: SubagentCompletionRequest["outcome"] =
+    task.status === "succeeded"
+      ? { status: "ok" }
+      : task.status === "timed_out"
+        ? { status: "timeout" }
+        : { status: "error", error: task.error };
+  return {
+    startedAt: entry.startedAt ?? task.startedAt,
+    endedAt: task.endedAt,
+    outcome,
+    reason: task.status === "failed" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
+    completionSnapshot: {
+      resultText: task.progressSummary ?? task.terminalSummary ?? null,
+      capturedAt: task.endedAt,
+    },
+  };
+}
+
+export async function reconcileProvisionalSubagentKill(params: {
+  runId: string;
+  entry: SubagentRunRecord;
+  now: number;
+  runs: Map<string, SubagentRunRecord>;
+  storeCache: SubagentSessionStoreCache;
+  completeSubagentRunWithRecovery: (
+    completion: SubagentCompletionRequest,
+    source: string,
+  ) => Promise<void>;
+  retireSupersededRun: (runId: string, entry: SubagentRunRecord) => Promise<void>;
+  startSubagentAnnounceCleanupFlow: (runId: string, entry: SubagentRunRecord) => boolean;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+}): Promise<boolean> {
+  const { entry, now, runId, runs } = params;
+  const killReconciliation = entry.killReconciliation;
+  if (!killReconciliation) {
+    return false;
+  }
+  const taskResolution = resolveSubagentTaskForRun(runs, entry);
+  const task = taskResolution.task;
+  const nextRunCreatedAt = findNextSubagentRunCreatedAt(runs, entry);
+  const hasStableTaskCancellation = isStableCancellation(task);
+  const killedAt = killReconciliation.killedAt;
+  const isCurrentKill = () =>
+    runs.get(runId) === entry &&
+    entry.endedReason === SUBAGENT_ENDED_REASON_KILLED &&
+    entry.killReconciliation === killReconciliation;
+  const taskCompletion =
+    nextRunCreatedAt === undefined ? resolveCompletionFromTerminalTask(task, entry) : undefined;
+  if (taskCompletion) {
+    // Replay the durable task projection before a provisional kill can age
+    // into a contradictory cancellation after an interrupted registry write.
+    await params.completeSubagentRunWithRecovery(
+      {
+        runId,
+        ...taskCompletion,
+        sendFarewell: true,
+        accountId: entry.requesterOrigin?.accountId,
+        triggerCleanup: true,
+      },
+      "sweeper-provisional-kill-task-completion",
+    );
+    return false;
+  }
+  if (killedAt + PROVISIONAL_KILL_RECONCILIATION_MS > now) {
+    return false;
+  }
+  const sessionEntry = loadSubagentSessionEntry({
+    childSessionKey: entry.childSessionKey,
+    storeCache: params.storeCache,
+  });
+  const completion = resolveCompletionFromSessionEntry(sessionEntry, now, {
+    notBeforeMs: entry.startedAt ?? entry.createdAt,
+  });
+  const completionEndedAt = completion
+    ? resolveSubagentRunEffectiveEndedAt(entry, completion.endedAt, completion.startedAt)
+    : undefined;
+  const completionDeadline = completion
+    ? resolveSubagentRunDeadlineMs(entry, completion.startedAt)
+    : undefined;
+  const killedSnapshotExpiredDeadline =
+    completion?.reason === SUBAGENT_ENDED_REASON_KILLED &&
+    completionDeadline !== undefined &&
+    completion.endedAt > completionDeadline
+      ? completionDeadline
+      : undefined;
+  const completionCanOverrideCancellation =
+    !hasStableTaskCancellation || (completionEndedAt ?? Number.POSITIVE_INFINITY) < killedAt;
+  const completionBelongsToGeneration =
+    nextRunCreatedAt === undefined || (completion != null && completion.endedAt < nextRunCreatedAt);
+  if (
+    completion &&
+    completionEndedAt !== undefined &&
+    completionCanOverrideCancellation &&
+    completionBelongsToGeneration &&
+    (completion.reason !== SUBAGENT_ENDED_REASON_KILLED ||
+      killedSnapshotExpiredDeadline !== undefined)
+  ) {
+    const hasNewerGeneration = nextRunCreatedAt !== undefined;
+    await params.completeSubagentRunWithRecovery(
+      {
+        runId,
+        startedAt: completion.startedAt,
+        endedAt: killedSnapshotExpiredDeadline ?? completion.endedAt,
+        outcome:
+          killedSnapshotExpiredDeadline !== undefined ? { status: "timeout" } : completion.outcome,
+        reason:
+          killedSnapshotExpiredDeadline !== undefined
+            ? SUBAGENT_ENDED_REASON_COMPLETE
+            : completion.reason,
+        sendFarewell: true,
+        accountId: entry.requesterOrigin?.accountId,
+        triggerCleanup: !hasNewerGeneration,
+        suppressSessionEffects: hasNewerGeneration,
+      },
+      "sweeper-provisional-kill-completion",
+    );
+    if (
+      hasNewerGeneration &&
+      runs.get(runId) === entry &&
+      entry.endedReason !== SUBAGENT_ENDED_REASON_KILLED
+    ) {
+      await params.retireSupersededRun(runId, entry);
+      return true;
+    }
+    if (!isCurrentKill()) {
+      return false;
+    }
+    const taskAfterResolution = resolveSubagentTaskForRun(runs, entry);
+    const taskAfter = taskAfterResolution.task;
+    const stableCancellationWonDuringCompletion =
+      isStableCancellation(taskAfter) && completionEndedAt >= killedAt;
+    if (!stableCancellationWonDuringCompletion && taskAfterResolution.lookup !== "unavailable") {
+      return false;
+    }
+  }
+  if (!isCurrentKill()) {
+    return false;
+  }
+  const taskBeforeResolution = resolveSubagentTaskForRun(runs, entry);
+  const taskBefore = taskBeforeResolution.task;
+  const stableTaskCancellationAfterReconciliation = isStableCancellation(taskBefore);
+  const taskNeedsStabilization =
+    taskBeforeResolution.lookup === "unavailable" || isUnstableTask(taskBefore);
+  if (taskNeedsStabilization) {
+    const observedError =
+      entry.outcome?.status === "error" ? entry.outcome.error?.trim() : undefined;
+    try {
+      const finalizedTasks = finalizeTaskRunByRunId({
+        runId: taskBefore?.runId ?? entry.taskRunId ?? runId,
+        runtime: "subagent",
+        sessionKey: taskBefore?.childSessionKey ?? entry.childSessionKey,
+        status: "cancelled",
+        endedAt: killedAt,
+        lastEventAt: killedAt,
+        error:
+          observedError && observedError !== SUBAGENT_KILL_TASK_ERROR
+            ? observedError
+            : "Subagent run cancellation finalized.",
+        suppressDelivery: true,
+      });
+      if (finalizedTasks.length === 0) {
+        const taskAfterResolution = resolveSubagentTaskForRun(runs, entry);
+        const taskAfter = taskAfterResolution.task;
+        if (taskAfterResolution.lookup === "available" && isUnstableTask(taskAfter)) {
+          params.warn("killed task was not stabilized during sweep", {
+            runId,
+            childSessionKey: entry.childSessionKey,
+          });
+          return false;
+        }
+        if (taskAfterResolution.lookup === "unavailable") {
+          params.warn("retiring killed tombstone after opaque task finalization", {
+            runId,
+            childSessionKey: entry.childSessionKey,
+          });
+        }
+      }
+    } catch (error) {
+      params.warn("failed to finalize provisional killed task during sweep", {
+        error,
+        runId,
+        childSessionKey: entry.childSessionKey,
+      });
+      return false;
+    }
+  }
+  if (findNextSubagentRunCreatedAt(runs, entry) !== undefined) {
+    await params.retireSupersededRun(runId, entry);
+    return true;
+  }
+  entry.suppressCompletionDelivery =
+    killReconciliation.suppressTaskDelivery === true ||
+    hasStableTaskCancellation ||
+    stableTaskCancellationAfterReconciliation
+      ? true
+      : undefined;
+  entry.suppressAnnounceReason = undefined;
+  entry.killReconciliation = undefined;
+  entry.cleanupHandled = false;
+  entry.cleanupCompletedAt = undefined;
+  params.startSubagentAnnounceCleanupFlow(runId, entry);
+  return true;
+}

--- a/src/agents/subagent-registry-sweeper.ts
+++ b/src/agents/subagent-registry-sweeper.ts
@@ -1,0 +1,548 @@
+import type { callGateway } from "../gateway/call.js";
+import { getAgentRunContext } from "../infra/agent-events.js";
+import { isFastTestRuntimeEnv } from "../infra/env.js";
+import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
+import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
+import { removeInternalSessionEffectsSession } from "./internal-session-effects.js";
+import {
+  ensureCompletionState,
+  ensureDeliveryState,
+  getDeliveryLastError,
+  isDeliverySuspended,
+} from "./subagent-delivery-state.js";
+import {
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+} from "./subagent-lifecycle-events.js";
+import { reconcileOrphanedRun, safeRemoveAttachmentsDir } from "./subagent-registry-helpers.js";
+import type { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
+import { reconcileProvisionalSubagentKill } from "./subagent-registry-sweep-kill.js";
+import type {
+  ContextEngineSubagentEndedParams,
+  SubagentCompletionRequest,
+  SubagentRunRecord,
+} from "./subagent-registry.types.js";
+import {
+  loadSubagentSessionEntry,
+  resolveCompletionFromSessionEntry,
+  resolveSubagentRunOrphanReason,
+  type SubagentSessionStoreCache,
+} from "./subagent-session-reconciliation.js";
+
+const SESSION_RUN_TTL_MS = 5 * 60_000;
+const STALE_ACTIVE_SUBAGENT_GRACE_MS = isFastTestRuntimeEnv() ? 1_000 : 60_000;
+const SUSPENDED_DELIVERY_CRON_EXPIRY_MS = 2 * 60 * 60_000;
+const SUSPENDED_DELIVERY_SUBAGENT_EXPIRY_MS = 6 * 60 * 60_000;
+const SUSPENDED_DELIVERY_INTERACTIVE_EXPIRY_MS = 24 * 60 * 60_000;
+const SUSPENDED_DELIVERY_SOFT_CAP = 25;
+const SUSPENDED_DELIVERY_HARD_CAP = 50;
+const SUSPENDED_DELIVERY_PRESSURE_TARGET = 10;
+
+type LifecycleController = ReturnType<typeof createSubagentRegistryLifecycleController>;
+type LifecycleOptions = Parameters<typeof createSubagentRegistryLifecycleController>[0];
+
+export async function retireSupersededSubagentRun(params: {
+  runId: string;
+  entry: SubagentRunRecord;
+  runs: Map<string, SubagentRunRecord>;
+  clearPendingLifecycleError: (runId: string) => void;
+}): Promise<void> {
+  const transcriptTarget = params.entry.execution?.transcriptTarget;
+  params.clearPendingLifecycleError(params.runId);
+  params.runs.delete(params.runId);
+  const transcriptStillOwned = Array.from(params.runs.values()).some((candidate) => {
+    const candidateTarget = candidate.execution?.transcriptTarget;
+    return (
+      candidateTarget?.sessionId === transcriptTarget?.sessionId &&
+      candidateTarget?.sessionKey === transcriptTarget?.sessionKey &&
+      candidateTarget?.storePath === transcriptTarget?.storePath
+    );
+  });
+  if (transcriptTarget && !transcriptStillOwned) {
+    await removeInternalSessionEffectsSession(transcriptTarget);
+  }
+  if (params.entry.cleanup === "delete" || !params.entry.retainAttachmentsOnKeep) {
+    await safeRemoveAttachmentsDir(params.entry);
+  }
+}
+
+export function createSubagentRegistrySweeper(params: {
+  runs: Map<string, SubagentRunRecord>;
+  resumedRuns: Set<string>;
+  persist: () => void;
+  clearPendingLifecycleError: (runId: string) => void;
+  clearPendingLifecycleTimeout: (runId: string) => void;
+  sweepPendingLifecycle: (now: number) => void;
+  completeSubagentRunWithRecovery: (
+    completion: SubagentCompletionRequest,
+    source: string,
+  ) => Promise<void>;
+  scheduleSubagentOrphanRecovery: (params?: { delayMs?: number; maxRetries?: number }) => void;
+  resumeRequesterSettleWake: LifecycleController["resumeRequesterSettleWake"];
+  startSubagentAnnounceCleanupFlow: LifecycleController["startSubagentAnnounceCleanupFlow"];
+  completeCleanupBookkeeping: LifecycleController["completeCleanupBookkeeping"];
+  shouldEmitEndedHookForRun: LifecycleOptions["shouldEmitEndedHookForRun"];
+  emitSubagentEndedHookForRun: LifecycleOptions["emitSubagentEndedHookForRun"];
+  callGateway: typeof callGateway;
+  cleanupCollectorLaunchResources: (entry: SubagentRunRecord) => Promise<boolean>;
+  runContextEngineSubagentEnded: (params: ContextEngineSubagentEndedParams) => Promise<void>;
+  notifyContextEngineSubagentEnded: (params: ContextEngineSubagentEndedParams) => Promise<void>;
+  retireSupersededRun: (runId: string, entry: SubagentRunRecord) => Promise<void>;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+}) {
+  const { runs, resumedRuns } = params;
+  let timer: NodeJS.Timeout | null = null;
+  let sweepInProgress = false;
+
+  function start() {
+    if (timer) {
+      return;
+    }
+    timer = setInterval(() => {
+      if (!sweepInProgress) {
+        void runTick();
+      }
+    }, 60_000);
+    timer.unref?.();
+  }
+
+  function stop() {
+    if (timer) {
+      clearInterval(timer);
+    }
+    timer = null;
+  }
+
+  async function runTick() {
+    try {
+      await runWithGatewayIndependentRootWorkAdmission(sweepOnce);
+    } catch (error) {
+      params.warn(
+        `subagent run sweep failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  function runCleanupTail(runId: string, label: string, run: () => Promise<unknown>) {
+    void runWithGatewayIndependentRootWorkAdmission(run).catch((error: unknown) => {
+      params.warn(`subagent sweep ${label} failed`, { runId, error });
+    });
+  }
+
+  function deleteSession(childSessionKey: string) {
+    return params.callGateway({
+      method: "sessions.delete",
+      params: { key: childSessionKey, deleteTranscript: true, emitLifecycleHooks: false },
+      timeoutMs: 10_000,
+    });
+  }
+
+  const sweptContext = (entry: SubagentRunRecord) => ({
+    childSessionKey: entry.childSessionKey,
+    reason: "swept" as const,
+    agentDir: entry.agentDir,
+    workspaceDir: entry.workspaceDir,
+  });
+
+  function isSuspendedPendingFinalDelivery(entry: SubagentRunRecord): boolean {
+    return typeof entry.endedAt === "number" && isDeliverySuspended(entry);
+  }
+
+  function resolveSuspendedDeliveryExpiryMs(entry: SubagentRunRecord): number {
+    const requester = entry.requesterSessionKey;
+    return requester.includes(":cron:")
+      ? SUSPENDED_DELIVERY_CRON_EXPIRY_MS
+      : requester.includes(":subagent:")
+        ? SUSPENDED_DELIVERY_SUBAGENT_EXPIRY_MS
+        : SUSPENDED_DELIVERY_INTERACTIVE_EXPIRY_MS;
+  }
+
+  async function discardSuspendedPendingFinalDelivery(
+    runId: string,
+    entry: SubagentRunRecord,
+    now: number,
+    reason: "expired" | "pressure-pruned",
+  ): Promise<void> {
+    const delivery = ensureDeliveryState(entry);
+    const payload = delivery.payload;
+    delivery.status = "discarded";
+    delivery.discardedAt = now;
+    delivery.discardReason = reason;
+    delivery.discardedPayloadSummary = {
+      requesterSessionKey: payload?.requesterSessionKey ?? entry.requesterSessionKey,
+      childSessionKey: payload?.childSessionKey ?? entry.childSessionKey,
+      childRunId: payload?.childRunId ?? entry.runId,
+      endedAt: payload?.endedAt ?? entry.endedAt,
+      status: payload?.outcome?.status ?? entry.outcome?.status,
+      lastError: getDeliveryLastError(entry) ?? null,
+    };
+    delivery.payload = undefined;
+    delivery.createdAt = undefined;
+    delivery.lastAttemptAt = undefined;
+    delivery.attemptCount = undefined;
+    delivery.lastError = undefined;
+    delivery.suspendedAt = undefined;
+    delivery.suspendedReason = undefined;
+    entry.wakeOnDescendantSettle = undefined;
+    const completion = ensureCompletionState(entry);
+    completion.fallbackResultText = undefined;
+    completion.fallbackCapturedAt = undefined;
+    entry.cleanupHandled = true;
+    delivery.announcedAt = undefined;
+    resumedRuns.delete(runId);
+    params.clearPendingLifecycleError(runId);
+    params.clearPendingLifecycleTimeout(runId);
+    params.warn("subagent suspended delivery discarded", {
+      reason,
+      runId: entry.runId,
+      childSessionKey: entry.childSessionKey,
+      requesterSessionKey: entry.requesterSessionKey,
+    });
+    const shouldDeleteAttachments = entry.cleanup === "delete" || !entry.retainAttachmentsOnKeep;
+    if (shouldDeleteAttachments) {
+      await safeRemoveAttachmentsDir(entry);
+    }
+    await removeInternalSessionEffectsSession(entry.execution?.transcriptTarget);
+    const completionReason = entry.endedReason ?? SUBAGENT_ENDED_REASON_COMPLETE;
+    params.completeCleanupBookkeeping({
+      runId,
+      entry,
+      cleanup: entry.cleanup,
+      completedAt: now,
+      // The requester settle wake already ran when this delivery was suspended.
+      skipRequesterSettleWake: true,
+    });
+    if (
+      entry.expectsCompletionMessage === true &&
+      params.shouldEmitEndedHookForRun({ entry, reason: completionReason })
+    ) {
+      await params.emitSubagentEndedHookForRun({
+        entry,
+        reason: completionReason,
+        sendFarewell: true,
+      });
+    }
+  }
+
+  async function sweepOnce() {
+    if (sweepInProgress) {
+      return;
+    }
+    sweepInProgress = true;
+    try {
+      const now = Date.now();
+      const storeCache: SubagentSessionStoreCache = new Map();
+      let mutated = false;
+      const archivedCollectorGroups = new Set<string>();
+      const suspendedEntries = [...runs.entries()].filter(([, entry]) =>
+        isSuspendedPendingFinalDelivery(entry),
+      );
+      const pressureDiscardRunIds = new Set<string>();
+      if (suspendedEntries.length > SUSPENDED_DELIVERY_HARD_CAP) {
+        const pressureCount = Math.max(
+          0,
+          suspendedEntries.length - SUSPENDED_DELIVERY_PRESSURE_TARGET,
+        );
+        for (const [runId] of suspendedEntries
+          .toSorted((a, b) => (a[1].delivery?.suspendedAt ?? 0) - (b[1].delivery?.suspendedAt ?? 0))
+          .slice(0, pressureCount)) {
+          pressureDiscardRunIds.add(runId);
+        }
+        params.warn("subagent suspended delivery backlog exceeded pressure cap", {
+          suspendedCount: suspendedEntries.length,
+          softCap: SUSPENDED_DELIVERY_SOFT_CAP,
+          hardCap: SUSPENDED_DELIVERY_HARD_CAP,
+          pressureTarget: SUSPENDED_DELIVERY_PRESSURE_TARGET,
+          pressureDiscardCount: pressureDiscardRunIds.size,
+        });
+      }
+      for (const [runId, entry] of runs.entries()) {
+        if (entry.requesterSettleWake) {
+          params.resumeRequesterSettleWake(runId, entry);
+          continue;
+        }
+        if (isSuspendedPendingFinalDelivery(entry)) {
+          const suspendedAgeMs = now - (entry.delivery?.suspendedAt ?? now);
+          const expired = suspendedAgeMs >= resolveSuspendedDeliveryExpiryMs(entry);
+          if (expired || pressureDiscardRunIds.has(runId)) {
+            await discardSuspendedPendingFinalDelivery(
+              runId,
+              entry,
+              now,
+              expired ? "expired" : "pressure-pruned",
+            );
+            mutated = true;
+          }
+          continue;
+        }
+        if (typeof entry.endedAt !== "number") {
+          const hasLiveRunContext = Boolean(getAgentRunContext(runId));
+          const activeAgeMs = now - (entry.startedAt ?? entry.createdAt);
+          if (!hasLiveRunContext && activeAgeMs >= STALE_ACTIVE_SUBAGENT_GRACE_MS) {
+            const orphanReason = resolveSubagentRunOrphanReason({ entry });
+            if (orphanReason) {
+              if (
+                reconcileOrphanedRun({
+                  runId,
+                  entry,
+                  reason: orphanReason,
+                  source: "resume",
+                  runs,
+                  resumedRuns,
+                })
+              ) {
+                mutated = true;
+              }
+              continue;
+            }
+
+            const sessionEntry = loadSubagentSessionEntry({
+              childSessionKey: entry.childSessionKey,
+              storeCache,
+            });
+            const completion = resolveCompletionFromSessionEntry(sessionEntry, now, {
+              notBeforeMs: entry.startedAt ?? entry.createdAt,
+            });
+            if (completion) {
+              await params.completeSubagentRunWithRecovery(
+                {
+                  runId,
+                  startedAt: completion.startedAt,
+                  endedAt: completion.endedAt,
+                  outcome: completion.outcome,
+                  reason: completion.reason,
+                  sendFarewell: true,
+                  accountId: entry.requesterOrigin?.accountId,
+                  triggerCleanup: true,
+                },
+                "sweeper-session-completion",
+              );
+              continue;
+            }
+
+            if (sessionEntry?.abortedLastRun === true) {
+              params.scheduleSubagentOrphanRecovery({ delayMs: 1_000 });
+              continue;
+            }
+
+            await params.completeSubagentRunWithRecovery(
+              {
+                runId,
+                endedAt: now,
+                outcome: {
+                  status: "error",
+                  error: "subagent run lost active execution context",
+                },
+                reason: SUBAGENT_ENDED_REASON_ERROR,
+                sendFarewell: true,
+                accountId: entry.requesterOrigin?.accountId,
+                triggerCleanup: true,
+              },
+              "sweeper-lost-context",
+            );
+            continue;
+          }
+        }
+
+        if (entry.killReconciliation) {
+          mutated =
+            (await reconcileProvisionalSubagentKill({
+              runId,
+              entry,
+              now,
+              runs,
+              storeCache,
+              completeSubagentRunWithRecovery: params.completeSubagentRunWithRecovery,
+              retireSupersededRun: params.retireSupersededRun,
+              startSubagentAnnounceCleanupFlow: params.startSubagentAnnounceCleanupFlow,
+              warn: params.warn,
+            })) || mutated;
+          continue;
+        }
+        if (entry.collect && entry.collectorCompletion) {
+          if (entry.collectorLaunchCleanupPending) {
+            try {
+              await deleteSession(entry.childSessionKey);
+            } catch (error) {
+              params.warn("failed to retry collector launch cleanup", {
+                runId,
+                childSessionKey: entry.childSessionKey,
+                error,
+              });
+              continue;
+            }
+            if (!(await params.cleanupCollectorLaunchResources(entry))) {
+              continue;
+            }
+            emitSessionLifecycleEvent({
+              sessionKey: entry.childSessionKey,
+              reason: "delete",
+              parentSessionKey: entry.swarmRequesterSessionKey ?? entry.requesterSessionKey,
+            });
+            entry.collectorLaunchCleanupPending = false;
+            entry.cleanupCompletedAt = now;
+            mutated = true;
+          }
+          const groupId = entry.groupId?.trim();
+          const swarmRequesterSessionKey =
+            entry.swarmRequesterSessionKey ?? entry.requesterSessionKey;
+          const groupKey = groupId
+            ? JSON.stringify([swarmRequesterSessionKey, groupId])
+            : undefined;
+          if (!groupKey || archivedCollectorGroups.has(groupKey)) {
+            continue;
+          }
+          const groupEntries = [...runs.entries()].filter(
+            ([, candidate]) =>
+              candidate.collect === true &&
+              (candidate.swarmRequesterSessionKey ?? candidate.requesterSessionKey) ===
+                swarmRequesterSessionKey &&
+              candidate.groupId === groupId,
+          );
+          if (
+            groupEntries.some(
+              ([, candidate]) =>
+                !candidate.collectorCompletion ||
+                candidate.collectorLaunchCleanupPending === true ||
+                candidate.archiveAtMs === undefined ||
+                candidate.archiveAtMs > now,
+            )
+          ) {
+            continue;
+          }
+          let deleteFailed = false;
+          for (const [candidateRunId, candidate] of groupEntries) {
+            try {
+              await deleteSession(candidate.childSessionKey);
+            } catch (error) {
+              params.warn("sessions.delete failed during collector group sweep; keeping group", {
+                runId: candidateRunId,
+                childSessionKey: candidate.childSessionKey,
+                groupId,
+                error,
+              });
+              deleteFailed = true;
+              break;
+            }
+          }
+          if (deleteFailed) {
+            continue;
+          }
+          let attachmentCleanupFailed = false;
+          for (const [candidateRunId, candidate] of groupEntries) {
+            if (await safeRemoveAttachmentsDir(candidate)) {
+              continue;
+            }
+            params.warn("attachment cleanup failed during collector group sweep; keeping group", {
+              runId: candidateRunId,
+              childSessionKey: candidate.childSessionKey,
+              groupId,
+            });
+            attachmentCleanupFailed = true;
+            break;
+          }
+          if (attachmentCleanupFailed) {
+            continue;
+          }
+          let contextCleanupFailed = false;
+          for (const [candidateRunId, candidate] of groupEntries) {
+            if (
+              candidate.cleanup === "delete" ||
+              typeof candidate.contextEngineCleanupCompletedAt === "number"
+            ) {
+              continue;
+            }
+            try {
+              await params.runContextEngineSubagentEnded(sweptContext(candidate));
+              candidate.contextEngineCleanupCompletedAt = Date.now();
+              params.persist();
+            } catch (error) {
+              params.warn(
+                "context-engine cleanup failed during collector group sweep; keeping group",
+                {
+                  runId: candidateRunId,
+                  childSessionKey: candidate.childSessionKey,
+                  groupId,
+                  error,
+                },
+              );
+              contextCleanupFailed = true;
+              break;
+            }
+          }
+          if (contextCleanupFailed) {
+            continue;
+          }
+          for (const [candidateRunId] of groupEntries) {
+            params.clearPendingLifecycleError(candidateRunId);
+            runs.delete(candidateRunId);
+          }
+          archivedCollectorGroups.add(groupKey);
+          mutated = true;
+          continue;
+        }
+        if (!entry.archiveAtMs && entry.cleanup === "keep" && entry.spawnMode !== "session") {
+          continue;
+        }
+        if (!entry.archiveAtMs) {
+          if (
+            typeof entry.cleanupCompletedAt === "number" &&
+            now - entry.cleanupCompletedAt > SESSION_RUN_TTL_MS
+          ) {
+            params.clearPendingLifecycleError(runId);
+            runCleanupTail(runId, "context-engine cleanup", async () => {
+              await params.notifyContextEngineSubagentEnded(sweptContext(entry));
+            });
+            runs.delete(runId);
+            mutated = true;
+            if (!entry.retainAttachmentsOnKeep) {
+              await safeRemoveAttachmentsDir(entry);
+            }
+          }
+          continue;
+        }
+        if (entry.archiveAtMs > now) {
+          continue;
+        }
+        params.clearPendingLifecycleError(runId);
+        try {
+          await deleteSession(entry.childSessionKey);
+        } catch (error) {
+          params.warn("sessions.delete failed during subagent sweep; keeping run for retry", {
+            runId,
+            childSessionKey: entry.childSessionKey,
+            error,
+          });
+          continue;
+        }
+        runs.delete(runId);
+        mutated = true;
+        await safeRemoveAttachmentsDir(entry);
+        runCleanupTail(runId, "context-engine cleanup", async () => {
+          await params.notifyContextEngineSubagentEnded(sweptContext(entry));
+        });
+      }
+      params.sweepPendingLifecycle(now);
+
+      if (mutated) {
+        params.persist();
+      }
+      if (runs.size === 0) {
+        stop();
+      }
+    } finally {
+      sweepInProgress = false;
+    }
+  }
+
+  return {
+    start,
+    stop,
+    sweepOnce,
+    runTick,
+    reset() {
+      stop();
+      sweepInProgress = false;
+    },
+  };
+}

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1,18 +1,14 @@
-/**
- * Subagent registry coordinator.
- *
- * Owns registration, lifecycle, delivery retry, steering, orphan recovery, persistence, and cleanup for child runs.
- */
+/** Coordinates subagent registration, lifecycle, delivery, steering, recovery, and persistence. */
 import type { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ResolveContextEngineOptions } from "../context-engine/registry.js";
-import type { ContextEngine, SubagentEndReason } from "../context-engine/types.js";
+import type { ContextEngine } from "../context-engine/types.js";
 import { callGateway } from "../gateway/call.js";
 import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import { getGatewayRecoveryRuntime } from "../gateway/server-recovery-runtime-context.js";
-import { getAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
+import { onAgentEvent } from "../infra/agent-events.js";
 import { isFastTestRuntimeEnv } from "../infra/env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -29,10 +25,6 @@ import {
 } from "../shared/agent-liveness.js";
 import { createLazyImportLoader, createLazyPromiseLoader } from "../shared/lazy-promise.js";
 import { importRuntimeModule } from "../shared/runtime-import.js";
-import { SUBAGENT_KILL_TASK_ERROR } from "../tasks/detached-task-runtime-contract.js";
-import { finalizeTaskRunByRunId, findDetachedTaskRun } from "../tasks/detached-task-runtime.js";
-import { isProvisionalSubagentKillTask } from "../tasks/task-cancellation-state.js";
-import type { TaskRecord } from "../tasks/task-registry.types.js";
 import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import {
   ackLeasedAgentSteeringItemsFromSubagentRuns,
@@ -44,13 +36,9 @@ import { removeInternalSessionEffectsSession } from "./internal-session-effects.
 import type { AgentRunSessionTarget } from "./run-session-target.js";
 import { isAbortedAgentStopReason } from "./run-termination.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
-import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import {
-  ensureCompletionState,
-  ensureDeliveryState,
   getDeliveryAttemptCount,
   getDeliveryLastAttemptAt,
-  getDeliveryLastError,
   isDeliverySuspended,
 } from "./subagent-delivery-state.js";
 import { applySubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
@@ -70,7 +58,6 @@ import {
   ANNOUNCE_EXPIRY_MS,
   backfillCollectorArchiveAtMs,
   MAX_ANNOUNCE_RETRY_COUNT,
-  PROVISIONAL_KILL_RECONCILIATION_MS,
   reconcileOrphanedRestoredRuns,
   reconcileOrphanedRun,
   resolveAnnounceRetryDelayMs,
@@ -78,6 +65,7 @@ import {
 } from "./subagent-registry-helpers.js";
 import { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
+import { createPendingLifecycleScheduler } from "./subagent-registry-pending-lifecycle.js";
 import {
   countActiveDescendantRunsFromRuns,
   countActiveRunsForSessionFromRuns,
@@ -102,15 +90,20 @@ import {
   restoreSubagentRunsFromDisk,
 } from "./subagent-registry-state.js";
 import { configureSubagentRegistrySteerRuntime } from "./subagent-registry-steer-runtime.js";
-import type { SubagentRunRecord, SwarmStructuredOutputState } from "./subagent-registry.types.js";
+import { resolveSubagentTaskForRun } from "./subagent-registry-sweep-kill.js";
+import {
+  createSubagentRegistrySweeper,
+  retireSupersededSubagentRun as retireSupersededSubagentRunForSweep,
+} from "./subagent-registry-sweeper.js";
+import type {
+  ContextEngineSubagentEndedParams,
+  SubagentCompletionRequest,
+  SubagentRunRecord,
+  SwarmStructuredOutputState,
+} from "./subagent-registry.types.js";
 import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
 import {
-  resolveSubagentRunDeadlineMs,
-  resolveSubagentRunEffectiveEndedAt,
-} from "./subagent-run-timeout.js";
-import {
   loadSubagentSessionEntry,
-  resolveCompletionFromSessionEntry,
   resolveSubagentRunOrphanReason,
   resolveSubagentSessionCompletion,
   resolveSubagentSessionStartedAt,
@@ -246,9 +239,7 @@ const runtimePluginsLoader = createLazyPromiseLoader(() =>
   importRuntimeModule<RuntimePluginsModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
 );
 
-let sweeper: NodeJS.Timeout | null = null;
 const resumeRetryTimers = new Set<ReturnType<typeof setTimeout>>();
-let sweepInProgress = false;
 let listenerStarted = false;
 let listenerStop: (() => void) | null = null;
 // Use var to avoid TDZ when init runs across circular imports during bootstrap.
@@ -257,31 +248,6 @@ const ORPHAN_RECOVERY_DEBOUNCE_MS = 1_000;
 let lastOrphanRecoveryScheduleAt = 0;
 const SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
 const GATEWAY_ADMISSION_RETRY_DELAY_MS = 1_000;
-/**
- * Embedded runs can emit transient lifecycle `error` events while provider/model
- * retry is still in progress. Defer terminal error cleanup briefly so a
- * subsequent lifecycle `start` / `end` can cancel premature failure announces.
- */
-const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
-/**
- * Embedded runs can also surface an intermediate lifecycle `end` with
- * `aborted=true` just before the runtime automatically retries the same run.
- * Give that timeout a short grace window so the parent does not get a stale
- * `timed out` completion right before the eventual success.
- */
-const LIFECYCLE_TIMEOUT_RETRY_GRACE_MS = 15_000;
-/** Absolute TTL for session-mode runs after cleanup completes (no archiveAtMs). */
-const SESSION_RUN_TTL_MS = 5 * 60_000; // 5 minutes
-/** Absolute TTL for orphaned pendingLifecycleError / pendingLifecycleTimeout entries. */
-const PENDING_LIFECYCLE_TERMINAL_TTL_MS = 5 * 60_000; // 5 minutes
-/** Grace period before treating a "running" subagent without a live run context as stale. */
-const STALE_ACTIVE_SUBAGENT_GRACE_MS = isFastTestRuntimeEnv() ? 1_000 : 60_000;
-const SUSPENDED_DELIVERY_CRON_EXPIRY_MS = 2 * 60 * 60_000;
-const SUSPENDED_DELIVERY_SUBAGENT_EXPIRY_MS = 6 * 60 * 60_000;
-const SUSPENDED_DELIVERY_INTERACTIVE_EXPIRY_MS = 24 * 60 * 60_000;
-const SUSPENDED_DELIVERY_SOFT_CAP = 25;
-const SUSPENDED_DELIVERY_HARD_CAP = 50;
-const SUSPENDED_DELIVERY_PRESSURE_TARGET = 10;
 
 function loadContextEngineInitModule(): Promise<ContextEngineInitModule> {
   return contextEngineInitLoader.load();
@@ -332,75 +298,7 @@ function persistSubagentRunsOrThrow() {
 }
 
 function findSubagentTaskForRun(entry: SubagentRunRecord) {
-  const nextRunCreatedAt = findNextSubagentRunCreatedAt(entry);
-  const generationStartedAt = entry.sessionStartedAt ?? entry.createdAt;
-  return findDetachedTaskRun({
-    runId: entry.taskRunId ?? entry.runId,
-    runtime: "subagent",
-    sessionKey: entry.childSessionKey,
-    createdAtOrAfter: generationStartedAt,
-    createdBefore: nextRunCreatedAt,
-    // Steer/wake replaces the registry run ID while retaining the original
-    // task row. Only those continuations may adopt a session-scoped task.
-    allowSessionFallback:
-      entry.taskRunId === undefined &&
-      typeof entry.sessionStartedAt === "number" &&
-      entry.sessionStartedAt < entry.createdAt,
-  });
-}
-
-function findNextSubagentRunCreatedAt(entry: SubagentRunRecord): number | undefined {
-  let nextCreatedAt = entry.killReconciliation?.supersededAt;
-  for (const candidate of subagentRuns.values()) {
-    if (
-      candidate.runId === entry.runId ||
-      candidate.childSessionKey !== entry.childSessionKey ||
-      compareSubagentRunGeneration(candidate, entry) <= 0
-    ) {
-      continue;
-    }
-    nextCreatedAt = Math.min(nextCreatedAt ?? candidate.createdAt, candidate.createdAt);
-  }
-  return nextCreatedAt;
-}
-
-function resolveCompletionFromTerminalTask(
-  task: TaskRecord | undefined,
-  entry: SubagentRunRecord,
-):
-  | {
-      startedAt?: number;
-      endedAt: number;
-      outcome: SubagentRunOutcome;
-      reason: SubagentLifecycleEndedReason;
-      completionSnapshot: { resultText: string | null; capturedAt: number };
-    }
-  | undefined {
-  if (
-    !task ||
-    typeof task.endedAt !== "number" ||
-    (task.status !== "succeeded" && task.status !== "failed" && task.status !== "timed_out")
-  ) {
-    return undefined;
-  }
-  const outcome: SubagentRunOutcome =
-    task.status === "succeeded"
-      ? { status: "ok" }
-      : task.status === "timed_out"
-        ? { status: "timeout" }
-        : { status: "error", error: task.error };
-  return {
-    // A steer continuation keeps the original task row but owns a new timeout
-    // window. Replay against the current registry generation, not task history.
-    startedAt: entry.startedAt ?? task.startedAt,
-    endedAt: task.endedAt,
-    outcome,
-    reason: task.status === "failed" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
-    completionSnapshot: {
-      resultText: task.progressSummary ?? task.terminalSummary ?? null,
-      capturedAt: task.endedAt,
-    },
-  };
+  return resolveSubagentTaskForRun(subagentRuns, entry);
 }
 
 export function scheduleSubagentOrphanRecovery(params?: { delayMs?: number; maxRetries?: number }) {
@@ -435,71 +333,9 @@ export function scheduleSubagentOrphanRecovery(params?: { delayMs?: number; maxR
 
 const resumedRuns = new Set<string>();
 const endedHookInFlightRunIds = new Set<string>();
-const pendingLifecycleErrorByRunId = new Map<
-  string,
-  {
-    timer: NodeJS.Timeout;
-    endedAt: number;
-    startedAt?: number;
-    error?: string;
-  }
->();
-const pendingLifecycleTimeoutByRunId = new Map<
-  string,
-  {
-    timer: NodeJS.Timeout;
-    endedAt: number;
-    startedAt?: number;
-  }
->();
-
-function clearPendingLifecycleError(runId: string) {
-  const pending = pendingLifecycleErrorByRunId.get(runId);
-  if (!pending) {
-    return;
-  }
-  clearTimeout(pending.timer);
-  pendingLifecycleErrorByRunId.delete(runId);
-}
-
-function clearAllPendingLifecycleErrors() {
-  for (const pending of pendingLifecycleErrorByRunId.values()) {
-    clearTimeout(pending.timer);
-  }
-  pendingLifecycleErrorByRunId.clear();
-}
-
-function clearPendingLifecycleTimeout(runId: string) {
-  const pending = pendingLifecycleTimeoutByRunId.get(runId);
-  if (!pending) {
-    return;
-  }
-  clearTimeout(pending.timer);
-  pendingLifecycleTimeoutByRunId.delete(runId);
-}
-
-function clearAllPendingLifecycleTimeouts() {
-  for (const pending of pendingLifecycleTimeoutByRunId.values()) {
-    clearTimeout(pending.timer);
-  }
-  pendingLifecycleTimeoutByRunId.clear();
-}
-
-type CompleteSubagentRunParams = {
-  runId: string;
-  endedAt?: number;
-  outcome: SubagentRunOutcome;
-  reason: SubagentLifecycleEndedReason;
-  sendFarewell?: boolean;
-  accountId?: string;
-  triggerCleanup: boolean;
-  startedAt?: number;
-  suppressSessionEffects?: boolean;
-  recoverInterrupted?: true;
-};
 
 async function completeSubagentRunWithRecoveryAttempt(
-  params: CompleteSubagentRunParams,
+  params: SubagentCompletionRequest,
   source: string,
 ) {
   try {
@@ -553,7 +389,7 @@ async function completeSubagentRunWithRecoveryAttempt(
 }
 
 function scheduleSubagentCompletionRetryAfterRestart(
-  params: CompleteSubagentRunParams,
+  params: SubagentCompletionRequest,
   source: string,
   expectedEntry: SubagentRunRecord,
 ) {
@@ -576,7 +412,7 @@ function scheduleSubagentCompletionRetryAfterRestart(
   resumeRetryTimers.add(timer);
 }
 
-async function completeSubagentRunWithRecovery(params: CompleteSubagentRunParams, source: string) {
+async function completeSubagentRunWithRecovery(params: SubagentCompletionRequest, source: string) {
   // Each controller attempt owns its terminal transition, while this outer
   // lease closes the gap between failed attempts and fallback cleanup.
   try {
@@ -598,103 +434,18 @@ async function completeSubagentRunWithRecovery(params: CompleteSubagentRunParams
   }
 }
 
-function completeSubagentRunInBackground(params: CompleteSubagentRunParams, source: string) {
+function completeSubagentRunInBackground(params: SubagentCompletionRequest, source: string) {
   void completeSubagentRunWithRecovery(params, source);
 }
 
-function schedulePendingLifecycleError(params: {
-  runId: string;
-  endedAt: number;
-  startedAt?: number;
-  error?: string;
-}) {
-  clearPendingLifecycleTimeout(params.runId);
-  clearPendingLifecycleError(params.runId);
-  const timer = setTimeout(() => {
-    const pending = pendingLifecycleErrorByRunId.get(params.runId);
-    if (!pending || pending.timer !== timer) {
-      return;
-    }
-    pendingLifecycleErrorByRunId.delete(params.runId);
-    const entry = subagentRuns.get(params.runId);
-    if (!entry) {
-      return;
-    }
-    if (entry.endedReason === SUBAGENT_ENDED_REASON_COMPLETE || entry.outcome?.status === "ok") {
-      return;
-    }
-    const completionParams = {
-      runId: params.runId,
-      endedAt: pending.endedAt,
-      outcome: {
-        status: "error" as const,
-        error: pending.error,
-      },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      sendFarewell: true,
-      accountId: entry.requesterOrigin?.accountId,
-      triggerCleanup: true,
-      startedAt: pending.startedAt,
-    };
-    completeSubagentRunInBackground(completionParams, "lifecycle-error-grace");
-  }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
-  timer.unref?.();
-  pendingLifecycleErrorByRunId.set(params.runId, {
-    timer,
-    endedAt: params.endedAt,
-    startedAt: params.startedAt,
-    error: params.error,
-  });
-}
-
-function schedulePendingLifecycleTimeout(params: {
-  runId: string;
-  endedAt: number;
-  startedAt?: number;
-}) {
-  clearPendingLifecycleError(params.runId);
-  clearPendingLifecycleTimeout(params.runId);
-  const timer = setTimeout(() => {
-    const pending = pendingLifecycleTimeoutByRunId.get(params.runId);
-    if (!pending || pending.timer !== timer) {
-      return;
-    }
-    pendingLifecycleTimeoutByRunId.delete(params.runId);
-    const entry = subagentRuns.get(params.runId);
-    if (!entry) {
-      return;
-    }
-    if (entry.outcome?.status === "ok" || entry.pauseReason === "sessions_yield") {
-      return;
-    }
-    const completionParams = {
-      runId: params.runId,
-      endedAt: pending.endedAt,
-      outcome: {
-        status: "timeout" as const,
-      },
-      reason: SUBAGENT_ENDED_REASON_COMPLETE,
-      sendFarewell: true,
-      accountId: entry.requesterOrigin?.accountId,
-      triggerCleanup: true,
-      startedAt: pending.startedAt,
-    };
-    completeSubagentRunInBackground(completionParams, "lifecycle-timeout-grace");
-  }, LIFECYCLE_TIMEOUT_RETRY_GRACE_MS);
-  timer.unref?.();
-  pendingLifecycleTimeoutByRunId.set(params.runId, {
-    timer,
-    endedAt: params.endedAt,
-    startedAt: params.startedAt,
-  });
-}
-
-type ContextEngineSubagentEndedParams = {
-  childSessionKey: string;
-  reason: SubagentEndReason;
-  agentDir?: string;
-  workspaceDir?: string;
-};
+const pendingLifecycle = createPendingLifecycleScheduler({
+  runs: subagentRuns,
+  completeInBackground: completeSubagentRunInBackground,
+});
+const clearPendingLifecycleError = pendingLifecycle.clearError;
+const clearPendingLifecycleTimeout = pendingLifecycle.clearTimeout;
+const schedulePendingLifecycleError = pendingLifecycle.scheduleError;
+const schedulePendingLifecycleTimeout = pendingLifecycle.scheduleTimeout;
 
 async function runContextEngineSubagentEnded(
   params: ContextEngineSubagentEndedParams,
@@ -1121,7 +872,7 @@ function restoreSubagentRunsOnce() {
     // Resume pending work.
     ensureListener();
     // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
-    startSweeper();
+    subagentSweeper.start();
     const restoredSessionCache: SubagentSessionStoreCache = new Map();
     for (const [runId, entry] of subagentRuns) {
       if (entry.collect && entry.execution?.status === "queued") {
@@ -1296,714 +1047,36 @@ function resolveSubagentWaitTimeoutMs(cfg: OpenClawConfig, runTimeoutSeconds?: n
   });
 }
 
-function startSweeper() {
-  if (sweeper) {
-    return;
-  }
-  sweeper = setInterval(() => {
-    if (sweepInProgress) {
-      return;
-    }
-    void runSubagentSweep();
-  }, 60_000);
-  sweeper.unref?.();
-}
-
-async function runSubagentSweep() {
-  try {
-    await runWithGatewayIndependentRootWorkAdmission(async () => {
-      await sweepSubagentRuns();
-    });
-  } catch (err) {
-    log.warn(`subagent run sweep failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
-}
-
-function runSubagentSweepCleanupTail(runId: string, label: string, run: () => Promise<unknown>) {
-  void runWithGatewayIndependentRootWorkAdmission(run).catch((error: unknown) => {
-    log.warn(`subagent sweep ${label} failed`, { runId, error });
-  });
-}
-
-function stopSweeper() {
-  if (!sweeper) {
-    return;
-  }
-  clearInterval(sweeper);
-  sweeper = null;
-}
-
-function isSuspendedPendingFinalDelivery(entry: SubagentRunRecord): boolean {
-  return typeof entry.endedAt === "number" && isDeliverySuspended(entry);
-}
-
-function resolveSuspendedDeliveryExpiryMs(entry: SubagentRunRecord): number {
-  const requester = entry.requesterSessionKey;
-  if (requester.includes(":cron:")) {
-    return SUSPENDED_DELIVERY_CRON_EXPIRY_MS;
-  }
-  if (requester.includes(":subagent:")) {
-    return SUSPENDED_DELIVERY_SUBAGENT_EXPIRY_MS;
-  }
-  return SUSPENDED_DELIVERY_INTERACTIVE_EXPIRY_MS;
-}
-
-async function discardSuspendedPendingFinalDelivery(
-  runId: string,
-  entry: SubagentRunRecord,
-  now: number,
-  reason: "expired" | "pressure-pruned",
-): Promise<void> {
-  const delivery = ensureDeliveryState(entry);
-  const payload = delivery.payload;
-  delivery.status = "discarded";
-  delivery.discardedAt = now;
-  delivery.discardReason = reason;
-  delivery.discardedPayloadSummary = {
-    requesterSessionKey: payload?.requesterSessionKey ?? entry.requesterSessionKey,
-    childSessionKey: payload?.childSessionKey ?? entry.childSessionKey,
-    childRunId: payload?.childRunId ?? entry.runId,
-    endedAt: payload?.endedAt ?? entry.endedAt,
-    status: payload?.outcome?.status ?? entry.outcome?.status,
-    lastError: getDeliveryLastError(entry) ?? null,
-  };
-  delivery.payload = undefined;
-  delivery.createdAt = undefined;
-  delivery.lastAttemptAt = undefined;
-  delivery.attemptCount = undefined;
-  delivery.lastError = undefined;
-  delivery.suspendedAt = undefined;
-  delivery.suspendedReason = undefined;
-  entry.wakeOnDescendantSettle = undefined;
-  const completion = ensureCompletionState(entry);
-  completion.fallbackResultText = undefined;
-  completion.fallbackCapturedAt = undefined;
-  entry.cleanupHandled = true;
-  delivery.announcedAt = undefined;
-  resumedRuns.delete(runId);
-  clearPendingLifecycleError(runId);
-  clearPendingLifecycleTimeout(runId);
-  log.warn("subagent suspended delivery discarded", {
-    reason,
-    runId: entry.runId,
-    childSessionKey: entry.childSessionKey,
-    requesterSessionKey: entry.requesterSessionKey,
-  });
-  const shouldDeleteAttachments = entry.cleanup === "delete" || !entry.retainAttachmentsOnKeep;
-  if (shouldDeleteAttachments) {
-    await safeRemoveAttachmentsDir(entry);
-  }
-  await removeInternalSessionEffectsSession(entry.execution?.transcriptTarget);
-  const completionReason = entry.endedReason ?? SUBAGENT_ENDED_REASON_COMPLETE;
-  completeCleanupBookkeeping({
+function retireSupersededSubagentRun(runId: string, entry: SubagentRunRecord): Promise<void> {
+  return retireSupersededSubagentRunForSweep({
     runId,
     entry,
-    cleanup: entry.cleanup,
-    completedAt: now,
-    // The requester settle wake already ran when this delivery was suspended.
-    skipRequesterSettleWake: true,
+    runs: subagentRuns,
+    clearPendingLifecycleError,
   });
-  if (
-    entry.expectsCompletionMessage === true &&
-    shouldEmitEndedHookForRun({
-      entry,
-      reason: completionReason,
-    })
-  ) {
-    await emitSubagentEndedHookForRun({
-      entry,
-      reason: completionReason,
-      sendFarewell: true,
-    });
-  }
 }
 
-async function retireSupersededSubagentRun(runId: string, entry: SubagentRunRecord): Promise<void> {
-  const transcriptTarget = entry.execution?.transcriptTarget;
-  clearPendingLifecycleError(runId);
-  subagentRuns.delete(runId);
-  const transcriptStillOwned = Array.from(subagentRuns.values()).some((candidate) => {
-    const candidateTarget = candidate.execution?.transcriptTarget;
-    return (
-      candidateTarget?.sessionId === transcriptTarget?.sessionId &&
-      candidateTarget?.sessionKey === transcriptTarget?.sessionKey &&
-      candidateTarget?.storePath === transcriptTarget?.storePath
-    );
-  });
-  if (transcriptTarget && !transcriptStillOwned) {
-    await removeInternalSessionEffectsSession(transcriptTarget);
-  }
-  if (entry.cleanup === "delete" || !entry.retainAttachmentsOnKeep) {
-    await safeRemoveAttachmentsDir(entry);
-  }
-}
-
-async function sweepSubagentRuns() {
-  if (sweepInProgress) {
-    return;
-  }
-  sweepInProgress = true;
-  try {
-    const now = Date.now();
-    const storeCache: SubagentSessionStoreCache = new Map();
-    let mutated = false;
-    const archivedCollectorGroups = new Set<string>();
-    const suspendedEntries = [...subagentRuns.entries()].filter(([, entry]) =>
-      isSuspendedPendingFinalDelivery(entry),
-    );
-    const pressureDiscardRunIds = new Set<string>();
-    if (suspendedEntries.length > SUSPENDED_DELIVERY_HARD_CAP) {
-      const pressureCount = Math.max(
-        0,
-        suspendedEntries.length - SUSPENDED_DELIVERY_PRESSURE_TARGET,
-      );
-      for (const [runId] of suspendedEntries
-        .toSorted((a, b) => (a[1].delivery?.suspendedAt ?? 0) - (b[1].delivery?.suspendedAt ?? 0))
-        .slice(0, pressureCount)) {
-        pressureDiscardRunIds.add(runId);
-      }
-      log.warn("subagent suspended delivery backlog exceeded pressure cap", {
-        suspendedCount: suspendedEntries.length,
-        softCap: SUSPENDED_DELIVERY_SOFT_CAP,
-        hardCap: SUSPENDED_DELIVERY_HARD_CAP,
-        pressureTarget: SUSPENDED_DELIVERY_PRESSURE_TARGET,
-        pressureDiscardCount: pressureDiscardRunIds.size,
-      });
-    }
-    for (const [runId, entry] of subagentRuns.entries()) {
-      if (entry.requesterSettleWake) {
-        resumeRequesterSettleWake(runId, entry);
-        continue;
-      }
-      if (isSuspendedPendingFinalDelivery(entry)) {
-        const suspendedAgeMs = now - (entry.delivery?.suspendedAt ?? now);
-        const expired = suspendedAgeMs >= resolveSuspendedDeliveryExpiryMs(entry);
-        if (expired || pressureDiscardRunIds.has(runId)) {
-          await discardSuspendedPendingFinalDelivery(
-            runId,
-            entry,
-            now,
-            expired ? "expired" : "pressure-pruned",
-          );
-          mutated = true;
-        }
-        continue;
-      }
-      if (typeof entry.endedAt !== "number") {
-        const hasLiveRunContext = Boolean(getAgentRunContext(runId));
-        const activeAgeMs = now - (entry.startedAt ?? entry.createdAt);
-        if (!hasLiveRunContext && activeAgeMs >= STALE_ACTIVE_SUBAGENT_GRACE_MS) {
-          const orphanReason = resolveSubagentRunOrphanReason({
-            entry,
-          });
-          if (orphanReason) {
-            if (
-              reconcileOrphanedRun({
-                runId,
-                entry,
-                reason: orphanReason,
-                source: "resume",
-                runs: subagentRuns,
-                resumedRuns,
-              })
-            ) {
-              mutated = true;
-            }
-            continue;
-          }
-
-          const sessionEntry = loadSubagentSessionEntry({
-            childSessionKey: entry.childSessionKey,
-            storeCache,
-          });
-          const completion = resolveCompletionFromSessionEntry(sessionEntry, now, {
-            notBeforeMs: entry.startedAt ?? entry.createdAt,
-          });
-          if (completion) {
-            await completeSubagentRunWithRecovery(
-              {
-                runId,
-                startedAt: completion.startedAt,
-                endedAt: completion.endedAt,
-                outcome: completion.outcome,
-                reason: completion.reason,
-                sendFarewell: true,
-                accountId: entry.requesterOrigin?.accountId,
-                triggerCleanup: true,
-              },
-              "sweeper-session-completion",
-            );
-            continue;
-          }
-
-          if (sessionEntry?.abortedLastRun === true) {
-            scheduleSubagentOrphanRecovery({ delayMs: 1_000 });
-            continue;
-          }
-
-          await completeSubagentRunWithRecovery(
-            {
-              runId,
-              endedAt: now,
-              outcome: {
-                status: "error",
-                error: "subagent run lost active execution context",
-              },
-              reason: SUBAGENT_ENDED_REASON_ERROR,
-              sendFarewell: true,
-              accountId: entry.requesterOrigin?.accountId,
-              triggerCleanup: true,
-            },
-            "sweeper-lost-context",
-          );
-          continue;
-        }
-      }
-
-      if (entry.killReconciliation) {
-        const killReconciliation = entry.killReconciliation;
-        const taskResolutionBeforeReconciliation = findSubagentTaskForRun(entry);
-        const taskBeforeReconciliation = taskResolutionBeforeReconciliation.task;
-        const nextRunCreatedAt = findNextSubagentRunCreatedAt(entry);
-        const hasStableTaskCancellation =
-          taskBeforeReconciliation?.status === "cancelled" &&
-          !isProvisionalSubagentKillTask(taskBeforeReconciliation);
-        const killedAt = killReconciliation.killedAt;
-        const taskCompletion =
-          nextRunCreatedAt === undefined
-            ? resolveCompletionFromTerminalTask(taskBeforeReconciliation, entry)
-            : undefined;
-        if (taskCompletion) {
-          // Provider reconciliation commits the non-publishing task ledger first.
-          // If the registry write was interrupted, replay that durable projection
-          // before the provisional kill can age into a contradictory cancellation.
-          await completeSubagentRunWithRecovery(
-            {
-              runId,
-              ...taskCompletion,
-              sendFarewell: true,
-              accountId: entry.requesterOrigin?.accountId,
-              triggerCleanup: true,
-            },
-            "sweeper-provisional-kill-task-completion",
-          );
-          const current = subagentRuns.get(runId);
-          if (current !== entry || current.killReconciliation !== killReconciliation) {
-            continue;
-          }
-          // A failed registry retry must preserve the replayable task evidence.
-          continue;
-        }
-        const reconcileAtMs = killedAt + PROVISIONAL_KILL_RECONCILIATION_MS;
-        if (reconcileAtMs > now) {
-          // Even durable cancellation keeps the evidence window open: a
-          // provider result persisted before killedAt remains canonical.
-          continue;
-        }
-        const sessionEntry = loadSubagentSessionEntry({
-          childSessionKey: entry.childSessionKey,
-          storeCache,
-        });
-        const completion = resolveCompletionFromSessionEntry(sessionEntry, now, {
-          notBeforeMs: entry.startedAt ?? entry.createdAt,
-        });
-        const completionEndedAt = completion
-          ? resolveSubagentRunEffectiveEndedAt(entry, completion.endedAt, completion.startedAt)
-          : undefined;
-        const completionDeadline = completion
-          ? resolveSubagentRunDeadlineMs(entry, completion.startedAt)
-          : undefined;
-        const killedSnapshotExpiredDeadline =
-          completion?.reason === SUBAGENT_ENDED_REASON_KILLED &&
-          completionDeadline !== undefined &&
-          completion.endedAt > completionDeadline
-            ? completionDeadline
-            : undefined;
-        const completionCanOverrideCancellation =
-          !hasStableTaskCancellation || (completionEndedAt ?? Number.POSITIVE_INFINITY) < killedAt;
-        const completionBelongsToGeneration =
-          nextRunCreatedAt === undefined ||
-          (completion != null && completion.endedAt < nextRunCreatedAt);
-        if (
-          completion &&
-          completionEndedAt !== undefined &&
-          completionCanOverrideCancellation &&
-          completionBelongsToGeneration &&
-          (completion.reason !== SUBAGENT_ENDED_REASON_KILLED ||
-            killedSnapshotExpiredDeadline !== undefined)
-        ) {
-          const hasNewerGeneration = nextRunCreatedAt !== undefined;
-          await completeSubagentRunWithRecovery(
-            {
-              runId,
-              startedAt: completion.startedAt,
-              endedAt: killedSnapshotExpiredDeadline ?? completion.endedAt,
-              outcome:
-                killedSnapshotExpiredDeadline !== undefined
-                  ? { status: "timeout" }
-                  : completion.outcome,
-              reason:
-                killedSnapshotExpiredDeadline !== undefined
-                  ? SUBAGENT_ENDED_REASON_COMPLETE
-                  : completion.reason,
-              sendFarewell: true,
-              accountId: entry.requesterOrigin?.accountId,
-              triggerCleanup: !hasNewerGeneration,
-              suppressSessionEffects: hasNewerGeneration,
-            },
-            "sweeper-provisional-kill-completion",
-          );
-          if (
-            hasNewerGeneration &&
-            subagentRuns.get(runId) === entry &&
-            entry.endedReason !== SUBAGENT_ENDED_REASON_KILLED
-          ) {
-            await retireSupersededSubagentRun(runId, entry);
-            mutated = true;
-            continue;
-          }
-          if (
-            subagentRuns.get(runId) !== entry ||
-            entry.endedReason !== SUBAGENT_ENDED_REASON_KILLED ||
-            entry.killReconciliation !== killReconciliation
-          ) {
-            continue;
-          }
-          const taskResolutionAfterCompletion = findSubagentTaskForRun(entry);
-          const taskAfterCompletion = taskResolutionAfterCompletion.task;
-          const stableCancellationWonDuringCompletion =
-            taskAfterCompletion?.status === "cancelled" &&
-            !isProvisionalSubagentKillTask(taskAfterCompletion) &&
-            completionEndedAt >= killedAt;
-          if (
-            !stableCancellationWonDuringCompletion &&
-            taskResolutionAfterCompletion.lookup !== "unavailable"
-          ) {
-            // The attempted completion did not commit. Keep both durable
-            // sources unless a newer stable cancellation won during capture.
-            continue;
-          }
-        }
-        // Completion capture yields. Revalidate both owners before promoting a
-        // provisional marker into a sticky operator cancellation.
-        if (
-          subagentRuns.get(runId) !== entry ||
-          entry.endedReason !== SUBAGENT_ENDED_REASON_KILLED ||
-          entry.killReconciliation !== killReconciliation
-        ) {
-          continue;
-        }
-        const taskResolutionBefore = findSubagentTaskForRun(entry);
-        const taskBefore = taskResolutionBefore.task;
-        const stableTaskCancellationAfterReconciliation =
-          taskBefore?.status === "cancelled" && !isProvisionalSubagentKillTask(taskBefore);
-        const taskNeedsStabilization =
-          taskResolutionBefore.lookup === "unavailable" ||
-          (taskBefore !== undefined &&
-            (taskBefore.status === "queued" ||
-              taskBefore.status === "running" ||
-              isProvisionalSubagentKillTask(taskBefore)));
-        if (taskNeedsStabilization) {
-          const observedError =
-            entry.outcome?.status === "error" ? entry.outcome.error?.trim() : undefined;
-          try {
-            // The live callback may be lost across restart. Make the provisional
-            // task state stable before its last reconciliation record is deleted.
-            const finalizedTasks = finalizeTaskRunByRunId({
-              runId: taskBefore?.runId ?? entry.taskRunId ?? runId,
-              runtime: "subagent",
-              sessionKey: taskBefore?.childSessionKey ?? entry.childSessionKey,
-              status: "cancelled",
-              endedAt: killedAt,
-              lastEventAt: killedAt,
-              error:
-                observedError && observedError !== SUBAGENT_KILL_TASK_ERROR
-                  ? observedError
-                  : "Subagent run cancellation finalized.",
-              suppressDelivery: true,
-            });
-            if (finalizedTasks.length === 0) {
-              const taskAfterResolution = findSubagentTaskForRun(entry);
-              const taskAfter = taskAfterResolution.task;
-              if (
-                taskAfterResolution.lookup === "available" &&
-                taskAfter !== undefined &&
-                (taskAfter.status === "queued" ||
-                  taskAfter.status === "running" ||
-                  isProvisionalSubagentKillTask(taskAfter))
-              ) {
-                log.warn("killed task was not stabilized during sweep", {
-                  runId,
-                  childSessionKey: entry.childSessionKey,
-                });
-                continue;
-              }
-              if (taskAfterResolution.lookup === "unavailable") {
-                // Legacy custom runtimes cannot distinguish missing from
-                // opaque task state. After the bounded window and one finalizer
-                // attempt, do not leak the registry/session tombstone forever.
-                log.warn("retiring killed tombstone after opaque task finalization", {
-                  runId,
-                  childSessionKey: entry.childSessionKey,
-                });
-              }
-            }
-          } catch (error) {
-            log.warn("failed to finalize provisional killed task during sweep", {
-              error,
-              runId,
-              childSessionKey: entry.childSessionKey,
-            });
-            continue;
-          }
-        }
-        if (findNextSubagentRunCreatedAt(entry) !== undefined) {
-          // A newer generation owns this session key. Retire only the old run;
-          // session-scoped hooks or context cleanup would tear down the live owner.
-          await retireSupersededSubagentRun(runId, entry);
-          mutated = true;
-          continue;
-        }
-        // Re-enter the normal cleanup owner only after cancellation is canonical.
-        // It publishes the final failure once, then applies keep/delete semantics.
-        entry.suppressCompletionDelivery =
-          killReconciliation.suppressTaskDelivery === true ||
-          hasStableTaskCancellation ||
-          stableTaskCancellationAfterReconciliation
-            ? true
-            : undefined;
-        entry.suppressAnnounceReason = undefined;
-        entry.killReconciliation = undefined;
-        entry.cleanupHandled = false;
-        entry.cleanupCompletedAt = undefined;
-        mutated = true;
-        startSubagentAnnounceCleanupFlow(runId, entry);
-        continue;
-      }
-      if (entry.collect && entry.collectorCompletion) {
-        if (entry.collectorLaunchCleanupPending) {
-          try {
-            await subagentRegistryDeps.callGateway({
-              method: "sessions.delete",
-              params: {
-                key: entry.childSessionKey,
-                deleteTranscript: true,
-                emitLifecycleHooks: false,
-              },
-              timeoutMs: 10_000,
-            });
-          } catch (err) {
-            log.warn("failed to retry collector launch cleanup", {
-              runId,
-              childSessionKey: entry.childSessionKey,
-              err,
-            });
-            continue;
-          }
-          if (!(await cleanupCollectorLaunchResources(entry))) {
-            continue;
-          }
-          emitSessionLifecycleEvent({
-            sessionKey: entry.childSessionKey,
-            reason: "delete",
-            parentSessionKey: entry.swarmRequesterSessionKey ?? entry.requesterSessionKey,
-          });
-          entry.collectorLaunchCleanupPending = false;
-          entry.cleanupCompletedAt = now;
-          mutated = true;
-        }
-        const groupId = entry.groupId?.trim();
-        const swarmRequesterSessionKey =
-          entry.swarmRequesterSessionKey ?? entry.requesterSessionKey;
-        const groupKey = groupId ? JSON.stringify([swarmRequesterSessionKey, groupId]) : undefined;
-        if (!groupKey || archivedCollectorGroups.has(groupKey)) {
-          continue;
-        }
-        const groupEntries = [...subagentRuns.entries()].filter(
-          ([, candidate]) =>
-            candidate.collect === true &&
-            (candidate.swarmRequesterSessionKey ?? candidate.requesterSessionKey) ===
-              swarmRequesterSessionKey &&
-            candidate.groupId === groupId,
-        );
-        // Collector results and lifetime cap accounting remain durable until
-        // the entire group reaches its shared TTL, then archive as one batch.
-        if (
-          groupEntries.some(
-            ([, candidate]) =>
-              !candidate.collectorCompletion ||
-              candidate.collectorLaunchCleanupPending === true ||
-              candidate.archiveAtMs === undefined ||
-              candidate.archiveAtMs > now,
-          )
-        ) {
-          continue;
-        }
-        let deleteFailed = false;
-        // Group retention owns the final session archive for both keep- and
-        // delete-mode collectors. Retry every member so the batch is idempotent.
-        for (const [candidateRunId, candidate] of groupEntries) {
-          try {
-            await subagentRegistryDeps.callGateway({
-              method: "sessions.delete",
-              params: {
-                key: candidate.childSessionKey,
-                deleteTranscript: true,
-                emitLifecycleHooks: false,
-              },
-              timeoutMs: 10_000,
-            });
-          } catch (err) {
-            log.warn("sessions.delete failed during collector group sweep; keeping group", {
-              runId: candidateRunId,
-              childSessionKey: candidate.childSessionKey,
-              groupId,
-              err,
-            });
-            deleteFailed = true;
-            break;
-          }
-        }
-        if (deleteFailed) {
-          continue;
-        }
-        let attachmentCleanupFailed = false;
-        for (const [candidateRunId, candidate] of groupEntries) {
-          if (await safeRemoveAttachmentsDir(candidate)) {
-            continue;
-          }
-          log.warn("attachment cleanup failed during collector group sweep; keeping group", {
-            runId: candidateRunId,
-            childSessionKey: candidate.childSessionKey,
-            groupId,
-          });
-          attachmentCleanupFailed = true;
-          break;
-        }
-        if (attachmentCleanupFailed) {
-          continue;
-        }
-        let contextCleanupFailed = false;
-        for (const [candidateRunId, candidate] of groupEntries) {
-          if (
-            candidate.cleanup === "delete" ||
-            typeof candidate.contextEngineCleanupCompletedAt === "number"
-          ) {
-            continue;
-          }
-          try {
-            await runContextEngineSubagentEnded({
-              childSessionKey: candidate.childSessionKey,
-              reason: "swept",
-              agentDir: candidate.agentDir,
-              workspaceDir: candidate.workspaceDir,
-            });
-            candidate.contextEngineCleanupCompletedAt = Date.now();
-            persistSubagentRuns();
-          } catch (err) {
-            log.warn("context-engine cleanup failed during collector group sweep; keeping group", {
-              runId: candidateRunId,
-              childSessionKey: candidate.childSessionKey,
-              groupId,
-              err,
-            });
-            contextCleanupFailed = true;
-            break;
-          }
-        }
-        if (contextCleanupFailed) {
-          continue;
-        }
-        for (const [candidateRunId] of groupEntries) {
-          clearPendingLifecycleError(candidateRunId);
-          subagentRuns.delete(candidateRunId);
-        }
-        archivedCollectorGroups.add(groupKey);
-        mutated = true;
-        continue;
-      }
-      if (!entry.archiveAtMs && entry.cleanup === "keep" && entry.spawnMode !== "session") {
-        continue;
-      }
-      if (!entry.archiveAtMs) {
-        if (
-          typeof entry.cleanupCompletedAt === "number" &&
-          now - entry.cleanupCompletedAt > SESSION_RUN_TTL_MS
-        ) {
-          clearPendingLifecycleError(runId);
-          runSubagentSweepCleanupTail(runId, "context-engine cleanup", async () => {
-            await notifyContextEngineSubagentEnded({
-              childSessionKey: entry.childSessionKey,
-              reason: "swept",
-              agentDir: entry.agentDir,
-              workspaceDir: entry.workspaceDir,
-            });
-          });
-          subagentRuns.delete(runId);
-          mutated = true;
-          if (!entry.retainAttachmentsOnKeep) {
-            await safeRemoveAttachmentsDir(entry);
-          }
-        }
-        continue;
-      }
-      if (entry.archiveAtMs > now) {
-        continue;
-      }
-      clearPendingLifecycleError(runId);
-      try {
-        await subagentRegistryDeps.callGateway({
-          method: "sessions.delete",
-          params: {
-            key: entry.childSessionKey,
-            deleteTranscript: true,
-            emitLifecycleHooks: false,
-          },
-          timeoutMs: 10_000,
-        });
-      } catch (err) {
-        log.warn("sessions.delete failed during subagent sweep; keeping run for retry", {
-          runId,
-          childSessionKey: entry.childSessionKey,
-          err,
-        });
-        continue;
-      }
-      subagentRuns.delete(runId);
-      mutated = true;
-      // Archive/purge is terminal for the run record; remove any retained attachments too.
-      await safeRemoveAttachmentsDir(entry);
-      runSubagentSweepCleanupTail(runId, "context-engine cleanup", async () => {
-        await notifyContextEngineSubagentEnded({
-          childSessionKey: entry.childSessionKey,
-          reason: "swept",
-          agentDir: entry.agentDir,
-          workspaceDir: entry.workspaceDir,
-        });
-      });
-    }
-    // Sweep orphaned pendingLifecycleError entries (absolute TTL).
-    for (const [runId, pending] of pendingLifecycleErrorByRunId.entries()) {
-      if (now - pending.endedAt > PENDING_LIFECYCLE_TERMINAL_TTL_MS) {
-        clearPendingLifecycleError(runId);
-      }
-    }
-    for (const [runId, pending] of pendingLifecycleTimeoutByRunId.entries()) {
-      if (now - pending.endedAt > PENDING_LIFECYCLE_TERMINAL_TTL_MS) {
-        clearPendingLifecycleTimeout(runId);
-      }
-    }
-
-    if (mutated) {
-      persistSubagentRuns();
-    }
-    if (subagentRuns.size === 0) {
-      stopSweeper();
-    }
-  } finally {
-    sweepInProgress = false;
-  }
-}
+const subagentSweeper = createSubagentRegistrySweeper({
+  runs: subagentRuns,
+  resumedRuns,
+  persist: persistSubagentRuns,
+  clearPendingLifecycleError,
+  clearPendingLifecycleTimeout,
+  sweepPendingLifecycle: (now) => pendingLifecycle.sweepExpired(now),
+  completeSubagentRunWithRecovery,
+  scheduleSubagentOrphanRecovery,
+  resumeRequesterSettleWake,
+  startSubagentAnnounceCleanupFlow,
+  completeCleanupBookkeeping,
+  shouldEmitEndedHookForRun,
+  emitSubagentEndedHookForRun,
+  callGateway: (request) => subagentRegistryDeps.callGateway(request),
+  cleanupCollectorLaunchResources,
+  runContextEngineSubagentEnded,
+  notifyContextEngineSubagentEnded,
+  retireSupersededRun: retireSupersededSubagentRun,
+  warn: (message, meta) => log.warn(message, meta),
+});
 
 function ensureListener() {
   if (listenerStarted) {
@@ -2029,8 +1102,7 @@ function ensureListener() {
         return;
       }
       if (phase === "start") {
-        clearPendingLifecycleError(evt.runId);
-        clearPendingLifecycleTimeout(evt.runId);
+        pendingLifecycle.clear(evt.runId);
         const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
         if (startedAt) {
           entry.startedAt = startedAt;
@@ -2057,8 +1129,7 @@ function ensureListener() {
       if (evt.data?.yielded === true) {
         // Drop any grace timer from an earlier aborted/error terminal so it can't
         // later fire and settle this now-paused run with a false notice.
-        clearPendingLifecycleError(evt.runId);
-        clearPendingLifecycleTimeout(evt.runId);
+        pendingLifecycle.clear(evt.runId);
         if (
           markSubagentRunPausedAfterYield({
             entry,
@@ -2071,8 +1142,7 @@ function ensureListener() {
         return;
       }
       if (isAbortedAgentStopReason(stopReason)) {
-        clearPendingLifecycleError(evt.runId);
-        clearPendingLifecycleTimeout(evt.runId);
+        pendingLifecycle.clear(evt.runId);
         await completeSubagentRunWithRecovery(
           {
             runId: evt.runId,
@@ -2103,8 +1173,7 @@ function ensureListener() {
       const blocked = isBlockedLivenessState(livenessState);
       const abandoned = isAbandonedLivenessState(livenessState);
       if (blocked || abandoned) {
-        clearPendingLifecycleError(evt.runId);
-        clearPendingLifecycleTimeout(evt.runId);
+        pendingLifecycle.clear(evt.runId);
         const blockedParams = {
           runId: evt.runId,
           endedAt,
@@ -2134,8 +1203,7 @@ function ensureListener() {
         });
         return;
       }
-      clearPendingLifecycleError(evt.runId);
-      clearPendingLifecycleTimeout(evt.runId);
+      pendingLifecycle.clear(evt.runId);
       const completionParams = {
         runId: evt.runId,
         endedAt,
@@ -2174,8 +1242,8 @@ const subagentRunManager = createSubagentRunManager({
   },
   getRuntimeConfig: () => subagentRegistryDeps.getRuntimeConfig(),
   ensureListener,
-  startSweeper,
-  stopSweeper,
+  startSweeper: subagentSweeper.start,
+  stopSweeper: subagentSweeper.stop,
   resumeSubagentRun,
   clearPendingLifecycleError,
   clearPendingLifecycleTimeout,
@@ -2266,16 +1334,14 @@ function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   subagentRuns.clear();
   resumedRuns.clear();
   endedHookInFlightRunIds.clear();
-  clearAllPendingLifecycleErrors();
-  clearAllPendingLifecycleTimeouts();
+  pendingLifecycle.clearAll();
   contextEngineInitLoader.clear();
   contextEngineRegistryLoader.clear();
   runtimePluginsLoader.clear();
   subagentAnnounceLoader.clear();
   browserCleanupLoader.clear();
   clearSubagentRunsReadCacheForTest();
-  stopSweeper();
-  sweepInProgress = false;
+  subagentSweeper.reset();
   restoreAttempted = false;
   lastOrphanRecoveryScheduleAt = 0;
   if (listenerStop) {
@@ -2291,10 +1357,10 @@ function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
 const testing = {
   failQueuedSubagentRun,
   async sweepOnceForTests() {
-    await sweepSubagentRuns();
+    await subagentSweeper.sweepOnce();
   },
   async runSweeperTickForTests() {
-    await runSubagentSweep();
+    await subagentSweeper.runTick();
   },
   setDepsForTest(overrides?: Partial<SubagentRegistryDeps>) {
     subagentRegistryDeps = overrides
@@ -2339,8 +1405,7 @@ async function finalizeInterruptedSubagentRun(params: {
     typeof params.endedAt === "number" && Number.isFinite(params.endedAt)
       ? params.endedAt
       : Date.now();
-  clearPendingLifecycleError(runId);
-  clearPendingLifecycleTimeout(runId);
+  pendingLifecycle.clear(runId);
   const entry = subagentRuns.get(runId);
   if (!entry) {
     return 0;
@@ -2351,7 +1416,7 @@ async function finalizeInterruptedSubagentRun(params: {
   ) {
     return hasCompleteSubagentTerminalState(entry) ? 1 : 0;
   }
-  const completionParams: CompleteSubagentRunParams = {
+  const completionParams: SubagentCompletionRequest = {
     runId,
     endedAt,
     outcome: {

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -1,14 +1,32 @@
-/**
- * Subagent registry record types.
- *
- * Defines execution, completion, delivery, pending-delivery, and attachment state stored for child runs.
- */
+import type { SubagentEndReason } from "../context-engine/types.js";
+/** Persisted execution, completion, delivery, and attachment state for child runs. */
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import type { AgentRunSessionTarget } from "./run-session-target.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import type { SubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
 import type { SubagentLifecycleEndedReason } from "./subagent-lifecycle-events.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
+
+export type SubagentCompletionRequest = {
+  runId: string;
+  endedAt?: number;
+  outcome: SubagentRunOutcome;
+  reason: SubagentLifecycleEndedReason;
+  sendFarewell?: boolean;
+  accountId?: string;
+  triggerCleanup: boolean;
+  startedAt?: number;
+  suppressSessionEffects?: boolean;
+  recoverInterrupted?: true;
+  completionSnapshot?: { resultText: string | null; capturedAt: number };
+};
+
+export type ContextEngineSubagentEndedParams = {
+  childSessionKey: string;
+  reason: SubagentEndReason;
+  agentDir?: string;
+  workspaceDir?: string;
+};
 
 export type SubagentProgressOrigin = {
   channel?: string;


### PR DESCRIPTION
## What Problem This Solves

The subagent registry coordinator had grown to 2,677 lines and mixed periodic sweeping, provisional-kill reconciliation, and two parallel lifecycle-grace timer implementations with the orchestration surface.

## Why This Change Was Made

This re-bounds periodic cleanup into a dedicated sweeper owner, keeps provisional-kill reconciliation in a focused sweep helper, and replaces the near-duplicate error/timeout grace schedulers with one discriminated pending-lifecycle mechanism. Existing timing, admission, persistence, cleanup, and test-hook behavior is preserved; there are no config, protocol, storage, or user-visible changes.

## User Impact

No user-visible behavior changes. Maintainers get smaller, cohesive registry modules and one lifecycle scheduling path instead of parallel implementations.

## Evidence

- Production LOC: `+1022/-1023` across 6 files (net `-1`); test LOC: `+0/-0`.
- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts` -> 1 file passed, 129 tests passed.
- `node scripts/check-changed.mjs -- src/agents/subagent-registry.ts src/agents/subagent-registry-lifecycle.ts src/agents/subagent-registry.types.ts src/agents/subagent-registry-pending-lifecycle.ts src/agents/subagent-registry-sweeper.ts src/agents/subagent-registry-sweep-kill.ts` -> passed on Blacksmith Testbox `tbx_01ky9av7nwskj719bbb9zze40g` (core prod/test types, lint, max-lines, import cycles, boundaries, and guards): https://github.com/openclaw/openclaw/actions/runs/30070566089
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` -> clean after restoring the interval's pre-admission in-flight guard.
- Additional baseline note: `src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts` has one unchanged requester-settle assertion failure reproduced identically on the clean canonical checkout; this refactor does not modify that test or behavior path.
