### PR TITLE
fix: preserve gateway requester sender for tools

### DIFF
--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -15,6 +15,7 @@ type CreateOpenClawToolsArg = {
   inheritedToolAllowlist?: string[];
   inheritedToolDenylist?: string[];
   pluginToolDenylist?: string[];
+  requesterSenderId?: string;
   sandboxed?: boolean;
   requesterAgentIdOverride?: string;
 };
@@ -410,6 +411,19 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
 
     expect(result.tools.map((tool) => tool.name)).not.toContain("exec");
     expect(readCreateToolsArgs().pluginToolDenylist).toContain("exec");
+  });
+
+  it("forwards trusted channel sender id into OpenClaw tool construction", () => {
+    resolveGatewayScopedTools({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:main:discord:channel:dev",
+      surface: "loopback",
+      senderIsOwner: true,
+      messageProvider: "discord",
+      channelContext: { sender: { id: "discord-user-1" } },
+    });
+
+    expect(readCreateToolsArgs().requesterSenderId).toBe("discord-user-1");
   });
 
   it("uses persisted delegated policy instead of the sender wildcard", async () => {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -242,6 +242,7 @@ export function resolveGatewayScopedTools(params: {
     onYield: params.onYield,
     requireExplicitMessageTarget: params.requireExplicitMessageTarget,
     senderIsOwner: params.senderIsOwner,
+    requesterSenderId: senderId,
     conversationReadOrigin: params.conversationReadOrigin,
     allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
     allowMediaInvokeCommands: params.allowMediaInvokeCommands,


### PR DESCRIPTION
## Summary
- forward trusted gateway channel sender id into OpenClaw tool construction as requesterSenderId
- add a regression test proving resolver-held channelContext.sender.id reaches the tool layer
- keeps existing sender-scoped policy behavior intact while restoring requester-scoped plugin/message/browser context

## Evidence
- `node scripts/run-vitest.mjs src/gateway/tool-resolution.exclude.test.ts`
  - 1 file passed, 28 tests
- `node scripts/run-vitest.mjs src/gateway/tool-resolution.exclude.test.ts src/gateway/tools-invoke-http.test.ts src/gateway/server-methods/tools-effective.test.ts src/agents/agent-tools-agent-config.exec.test.ts src/agents/bash-tools.exec-host-gateway.test.ts`
  - gateway shard: 3 files passed, 92 tests
  - agents shard: 2 files passed, 92 tests

## Notes
This is scoped to OpenClaw core gateway tool metadata propagation. The local deployed container visible from this machine is a webhook/proxy forwarder, not the actual gateway runtime, so this PR fixes the upstream source path rather than hotpatching that proxy container.