### PR TITLE
refactor(markdown): unify format profile declarations

### DIFF
--- a/extensions/clickclack/src/outbound.ts
+++ b/extensions/clickclack/src/outbound.ts
@@ -13,7 +13,7 @@ import {
   type OutboundMediaLoadOptions,
 } from "openclaw/plugin-sdk/outbound-media";
 import {
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   renderMarkdownWithMarkers,
   sanitizeAssistantVisibleText,
 } from "openclaw/plugin-sdk/text-chunking";
@@ -25,29 +25,10 @@ import type { ClickClackMessage, ClickClackMessageProvenance, CoreConfig } from 
 
 const CLICKCLACK_MAX_UPLOAD_BYTES = 64 * 1024 * 1024;
 
-const CLICKCLACK_FORMAT_PROFILE = {
+const CLICKCLACK_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "markdown",
-  constructs: {
-    bold: "native",
-    italic: "native",
-    underline: "native",
-    strikethrough: "native",
-    spoiler: "native",
-    codeInline: "native",
-    codeBlock: "native",
-    codeLanguage: "native",
-    linkLabel: "native",
-    heading: "native",
-    bulletList: "native",
-    orderedList: "native",
-    taskList: "native",
-    table: "native",
-    blockquote: "native",
-    image: "native",
-    mention: "native",
-  },
   chunk: { limit: 1024 * 1024, unit: "bytes" },
-} satisfies FormatCapabilityProfile;
+});
 
 function renderClickClackMarkdown(markdown: string): string {
   return renderMarkdownWithMarkers(

--- a/extensions/discord/src/markdown.ts
+++ b/extensions/discord/src/markdown.ts
@@ -3,33 +3,15 @@ import { fromMarkdown } from "mdast-util-from-markdown";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import {
   convertMarkdownTables,
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   renderMarkdownWithMarkers,
 } from "openclaw/plugin-sdk/text-chunking";
 
-const DISCORD_FORMAT_PROFILE = {
+const DISCORD_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "markdown",
-  constructs: {
-    bold: "native",
-    italic: "native",
-    underline: "native",
-    strikethrough: "native",
-    spoiler: "native",
-    codeInline: "native",
-    codeBlock: "native",
-    codeLanguage: "native",
-    linkLabel: "native",
-    heading: "native",
-    bulletList: "native",
-    orderedList: "native",
-    taskList: "native",
-    table: "fallback",
-    blockquote: "native",
-    image: "native",
-    mention: "native",
-  },
+  constructs: { table: "fallback" },
   chunk: { limit: 2_000, unit: "utf16" },
-} satisfies FormatCapabilityProfile;
+});
 
 const DISCORD_BOLD_PROBE_TEXT = "openclaw-discord-bold";
 const DISCORD_BOLD_PROBE = renderMarkdownWithMarkers(

--- a/extensions/googlechat/src/format.ts
+++ b/extensions/googlechat/src/format.ts
@@ -1,36 +1,28 @@
 import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  FormatCapabilityProfile,
   markdownToIR,
   renderMarkdownIRChunksWithinLimit,
   renderMarkdownWithMarkers,
   sanitizeAssistantVisibleText,
-  type FormatCapabilityProfile,
   type MarkdownIR,
 } from "openclaw/plugin-sdk/text-chunking";
 
-export const GOOGLE_CHAT_FORMAT_PROFILE = {
+export const GOOGLE_CHAT_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "markdown",
   constructs: {
-    bold: "native",
-    italic: "native",
     underline: "fallback",
-    strikethrough: "native",
     spoiler: "fallback",
-    codeInline: "native",
-    codeBlock: "native",
     codeLanguage: "fallback",
-    linkLabel: "native",
     heading: "fallback",
-    bulletList: "native",
     orderedList: "fallback",
     taskList: "fallback",
     table: "fallback",
-    blockquote: "native",
     image: "fallback",
     mention: "strip",
   },
   chunk: { limit: 32_000, unit: "bytes" },
-} satisfies FormatCapabilityProfile;
+});
 
 const GOOGLE_CHAT_LITERAL_FALLBACKS = new Map([
   ["*", "＊"],

--- a/extensions/imessage/src/markdown-format.ts
+++ b/extensions/imessage/src/markdown-format.ts
@@ -1,5 +1,5 @@
 import {
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   markdownToIR,
   renderMarkdownWithAttributedRanges,
 } from "openclaw/plugin-sdk/text-chunking";
@@ -12,13 +12,9 @@ type IMessageFormatRange = {
   styles: IMessageFormatStyle[];
 };
 
-const IMESSAGE_FORMAT_PROFILE = {
+const IMESSAGE_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "ranges",
   constructs: {
-    bold: "native",
-    italic: "native",
-    underline: "native",
-    strikethrough: "native",
     spoiler: "strip",
     codeInline: "fallback",
     codeBlock: "fallback",
@@ -34,12 +30,12 @@ const IMESSAGE_FORMAT_PROFILE = {
     mention: "strip",
   },
   chunk: { limit: 4_000, unit: "utf16" },
-} satisfies FormatCapabilityProfile;
+});
 
-const IMESSAGE_CODE_PROFILE = {
+const IMESSAGE_CODE_PROFILE = FormatCapabilityProfile.define({
   ...IMESSAGE_FORMAT_PROFILE,
   constructs: { ...IMESSAGE_FORMAT_PROFILE.constructs, codeInline: "native" },
-} satisfies FormatCapabilityProfile;
+});
 
 const IMESSAGE_STYLE_MAP = {
   bold: "bold",

--- a/extensions/matrix/src/matrix/format-profile.ts
+++ b/extensions/matrix/src/matrix/format-profile.ts
@@ -2,7 +2,7 @@
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import {
   convertMarkdownTables,
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   renderMarkdownWithMarkers,
 } from "openclaw/plugin-sdk/text-chunking";
 
@@ -33,29 +33,14 @@ export function createMatrixPrivateMarkers(
   return { open: markers[0] ?? "", close: markers[1] ?? "", padding: markers[2] ?? "" };
 }
 
-export const MATRIX_FORMAT_PROFILE = {
+export const MATRIX_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "html",
   constructs: {
-    bold: "native",
-    italic: "native",
-    underline: "native",
-    strikethrough: "native",
-    spoiler: "native",
-    codeInline: "native",
-    codeBlock: "native",
-    codeLanguage: "native",
-    linkLabel: "native",
-    heading: "native",
-    bulletList: "native",
-    orderedList: "native",
     taskList: "fallback",
-    table: "native",
-    blockquote: "native",
     image: "fallback",
-    mention: "native",
   },
   chunk: { limit: 4_000, unit: "chars" },
-} satisfies FormatCapabilityProfile;
+});
 
 export function isMarkdownEscaped(markdown: string, index: number): boolean {
   let slashCount = 0;

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -12,10 +12,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  convertMarkdownTables,
-  type FormatCapabilityProfile,
-} from "openclaw/plugin-sdk/text-chunking";
+import { convertMarkdownTables, FormatCapabilityProfile } from "openclaw/plugin-sdk/text-chunking";
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
@@ -72,29 +69,10 @@ type MattermostSendResult = {
 
 const MATTERMOST_BOT_USER_CACHE_MAX_ENTRIES = 64;
 const MATTERMOST_TARGET_CACHE_MAX_ENTRIES = 1024;
-const MATTERMOST_FORMAT_PROFILE = {
+const MATTERMOST_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "markdown",
-  constructs: {
-    bold: "native",
-    italic: "native",
-    underline: "native",
-    strikethrough: "native",
-    spoiler: "native",
-    codeInline: "native",
-    codeBlock: "native",
-    codeLanguage: "native",
-    linkLabel: "native",
-    heading: "native",
-    bulletList: "native",
-    orderedList: "native",
-    taskList: "native",
-    table: "native",
-    blockquote: "native",
-    image: "native",
-    mention: "native",
-  },
   chunk: { limit: 16_383, unit: "chars" },
-} satisfies FormatCapabilityProfile;
+});
 
 function renderMattermostMarkdown(
   markdown: string,

--- a/extensions/msteams/src/format.ts
+++ b/extensions/msteams/src/format.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
   convertMarkdownTables,
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   type MarkdownIR,
   markdownToIR,
   renderMarkdownWithMarkers,
@@ -12,30 +12,21 @@ const ESCAPED_MARKDOWN_RE = /\\[\\`*_{}[\]()#+\-.!|>~]/gu;
 const MARKDOWN_ENTITY_RE = /&(?:#\d+|#x[\da-f]+|[a-z][a-z\d]+);/giu;
 const TOKEN_END = "\u{E002}";
 
-const MSTEAMS_FORMAT_CAPABILITIES = {
+// Teams supports strikethrough on desktop and iOS, but not Android.
+const MSTEAMS_FORMAT_CAPABILITIES = FormatCapabilityProfile.define({
   mechanism: "markdown",
   constructs: {
-    bold: "native",
-    italic: "native",
     underline: "strip",
-    // Teams supports strikethrough on desktop and iOS, but not Android.
-    strikethrough: "native",
     spoiler: "fallback",
-    codeInline: "native",
-    codeBlock: "native",
     codeLanguage: "fallback",
-    linkLabel: "native",
     heading: "fallback",
     bulletList: "fallback",
     orderedList: "fallback",
     taskList: "fallback",
     table: "fallback",
-    blockquote: "native",
-    image: "native",
-    mention: "native",
   },
   chunk: { limit: 80_000, unit: "utf16", hardCap: 100_000 },
-} satisfies FormatCapabilityProfile;
+});
 
 const MSTEAMS_MARKERS = {
   bold: { open: "**", close: "**" },

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -5,7 +5,7 @@ import {
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import {
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   renderMarkdownWithMarkers,
 } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -31,29 +31,10 @@ const NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES = 8 * 1024;
 const NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_CHARS = 200;
 const NEXTCLOUD_TALK_SEND_TIMEOUT_MS = 30_000;
 
-const NEXTCLOUD_TALK_FORMAT_PROFILE = {
+const NEXTCLOUD_TALK_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "markdown",
-  constructs: {
-    bold: "native",
-    italic: "native",
-    underline: "native",
-    strikethrough: "native",
-    spoiler: "native",
-    codeInline: "native",
-    codeBlock: "native",
-    codeLanguage: "native",
-    linkLabel: "native",
-    heading: "native",
-    bulletList: "native",
-    orderedList: "native",
-    taskList: "native",
-    table: "native",
-    blockquote: "native",
-    image: "native",
-    mention: "native",
-  },
   chunk: { limit: 4000, unit: "chars", hardCap: 32_000 },
-} satisfies FormatCapabilityProfile;
+});
 
 function renderNextcloudTalkMarkdown(markdown: string): string {
   return renderMarkdownWithMarkers(

--- a/extensions/qqbot/src/engine/messaging/markdown-format.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-format.ts
@@ -1,7 +1,7 @@
 // QQ Bot Markdown formatting declares dialect capabilities and applies shared fallbacks.
 
 import {
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   type MarkdownIR,
   markdownToIR,
   renderMarkdownIRChunksWithinLimit,
@@ -29,29 +29,18 @@ function utf8ByteLength(text: string): number {
   return Buffer.byteLength(text, "utf8");
 }
 
-const QQBOT_FORMAT_CAPABILITIES = {
+const QQBOT_FORMAT_CAPABILITIES = FormatCapabilityProfile.define({
   mechanism: "markdown",
   constructs: {
-    bold: "native",
-    italic: "native",
     underline: "strip",
-    strikethrough: "native",
     spoiler: "strip",
     codeInline: "fallback",
     codeBlock: "fallback",
     codeLanguage: "fallback",
-    linkLabel: "native",
-    heading: "native",
-    bulletList: "native",
-    orderedList: "native",
-    taskList: "native",
     table: "fallback",
-    blockquote: "native",
-    image: "native",
-    mention: "native",
   },
   chunk: { limit: QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT, unit: "bytes" },
-} satisfies FormatCapabilityProfile;
+});
 
 const QQBOT_MARKERS = {
   bold: { open: "**", close: "**" },

--- a/extensions/signal/src/format.ts
+++ b/extensions/signal/src/format.ts
@@ -1,7 +1,7 @@
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   markdownToIR,
   type MarkdownIR,
   renderMarkdownWithAttributedRanges,
@@ -34,16 +34,10 @@ const SIGNAL_STYLE_MAP = {
   spoiler: "SPOILER",
 } as const;
 
-const SIGNAL_FORMAT_PROFILE = {
+const SIGNAL_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "ranges",
   constructs: {
-    bold: "native",
-    italic: "native",
     underline: "strip",
-    strikethrough: "native",
-    spoiler: "native",
-    codeInline: "native",
-    codeBlock: "native",
     codeLanguage: "fallback",
     linkLabel: "fallback",
     heading: "fallback",
@@ -57,7 +51,7 @@ const SIGNAL_FORMAT_PROFILE = {
   },
   // Signal clients switch beyond 2 KiB bytes; byte-aware chunking remains an open question.
   chunk: { limit: 4_000, unit: "chars" },
-} satisfies FormatCapabilityProfile;
+});
 
 function stripEquivalentSignalLinks(ir: MarkdownIR): MarkdownIR {
   const normalize = (value: string) =>

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -2,7 +2,7 @@
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import {
   chunkTextForOutbound,
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   markdownToIR,
   type MarkdownLinkSpan,
   renderMarkdownIRChunksWithinLimit,
@@ -107,29 +107,21 @@ type SlackMarkdownOptions = {
   tableMode?: MarkdownTableMode;
 };
 
-const SLACK_FORMAT_PROFILE = {
+const SLACK_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "markdown",
   constructs: {
-    bold: "native",
-    italic: "native",
     underline: "strip",
-    strikethrough: "native",
     spoiler: "fallback",
-    codeInline: "native",
-    codeBlock: "native",
     codeLanguage: "fallback",
-    linkLabel: "native",
     heading: "fallback",
     bulletList: "fallback",
     orderedList: "fallback",
     taskList: "fallback",
     table: "fallback",
-    blockquote: "native",
     image: "fallback",
-    mention: "native",
   },
   chunk: { limit: 4000, unit: "chars", hardCap: 40_000 },
-} satisfies FormatCapabilityProfile;
+});
 
 type SlackCodeMarker = "`" | "```";
 const SLACK_ASSISTANT_TRANSCRIPT_PREFIX = "`Assistant:` ";

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -1,7 +1,7 @@
 // Markdown → Bot API 10.2 InputRichBlock[] for Telegram rich messages.
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import {
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   isAutoLinkedFileRef,
   markdownToIRWithMeta,
   renderMarkdownWithMarkers,
@@ -33,29 +33,10 @@ import {
 
 const TELEGRAM_RICH_TEXT_TABLE_COLUMN_LIMIT = 20;
 
-const TELEGRAM_RICH_FORMAT_PROFILE = {
+const TELEGRAM_RICH_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "blocks",
-  constructs: {
-    bold: "native",
-    italic: "native",
-    underline: "native",
-    strikethrough: "native",
-    spoiler: "native",
-    codeInline: "native",
-    codeBlock: "native",
-    codeLanguage: "native",
-    linkLabel: "native",
-    heading: "native",
-    bulletList: "native",
-    orderedList: "native",
-    taskList: "native",
-    table: "native",
-    blockquote: "native",
-    image: "native",
-    mention: "native",
-  },
   chunk: { limit: 32_768, unit: "chars" },
-} satisfies FormatCapabilityProfile;
+});
 
 const INLINE_STYLE_RANK: Record<string, number> = {
   spoiler: 0,

--- a/extensions/whatsapp/src/targets-runtime.ts
+++ b/extensions/whatsapp/src/targets-runtime.ts
@@ -6,7 +6,7 @@ import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   type MarkdownIR,
   markdownToIRWithMeta,
   renderMarkdownIRChunksWithinLimit,
@@ -15,29 +15,20 @@ import {
 } from "openclaw/plugin-sdk/text-chunking";
 import { CONFIG_DIR, resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 
-const WHATSAPP_FORMAT_CAPABILITIES = {
+const WHATSAPP_FORMAT_CAPABILITIES = FormatCapabilityProfile.define({
   mechanism: "markdown",
   constructs: {
-    bold: "native",
-    italic: "native",
     underline: "strip",
-    strikethrough: "native",
     spoiler: "fallback",
-    codeInline: "native",
-    codeBlock: "native",
     codeLanguage: "fallback",
     linkLabel: "fallback",
     heading: "fallback",
-    bulletList: "native",
-    orderedList: "native",
     taskList: "fallback",
     table: "fallback",
-    blockquote: "native",
     image: "fallback",
-    mention: "native",
   },
   chunk: { limit: 4_096, unit: "chars" },
-} satisfies FormatCapabilityProfile;
+});
 
 const WHATSAPP_STYLE_MARKERS = {
   bold: { open: "*", close: "*" },

--- a/extensions/zalouser/src/text-styles.ts
+++ b/extensions/zalouser/src/text-styles.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import {
-  type FormatCapabilityProfile,
+  FormatCapabilityProfile,
   markdownToIR,
   renderMarkdownWithAttributedRanges,
 } from "openclaw/plugin-sdk/text-chunking";
@@ -49,29 +49,21 @@ type TokenRegistry = {
 
 type OrderedStyle = Style & { rawStart: number; rawEnd: number };
 
-const ZALOUSER_FORMAT_PROFILE = {
+const ZALOUSER_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "ranges",
   constructs: {
-    bold: "native",
-    italic: "native",
-    underline: "native",
-    strikethrough: "native",
     spoiler: "strip",
     codeInline: "fallback",
     codeBlock: "fallback",
     codeLanguage: "strip",
     linkLabel: "fallback",
-    heading: "native",
-    bulletList: "native",
-    orderedList: "native",
     taskList: "fallback",
     table: "fallback",
-    blockquote: "native",
     image: "strip",
     mention: "strip",
   },
   chunk: { limit: 2_000, unit: "utf16" },
-} satisfies FormatCapabilityProfile;
+});
 
 const ZALOUSER_STYLE_MAP = {
   bold: TextStyle.Bold,

--- a/packages/markdown-core/src/format-capabilities.ts
+++ b/packages/markdown-core/src/format-capabilities.ts
@@ -29,3 +29,61 @@ export type FormatCapabilityProfile = {
     hardCap?: number;
   };
 };
+
+const NATIVE_FORMAT_CONSTRUCTS = {
+  bold: "native",
+  italic: "native",
+  underline: "native",
+  strikethrough: "native",
+  spoiler: "native",
+  codeInline: "native",
+  codeBlock: "native",
+  codeLanguage: "native",
+  linkLabel: "native",
+  heading: "native",
+  bulletList: "native",
+  orderedList: "native",
+  taskList: "native",
+  table: "native",
+  blockquote: "native",
+  image: "native",
+  mention: "native",
+} as const satisfies FormatCapabilityProfile["constructs"];
+
+type DefinedConstructs<Overrides extends Partial<FormatCapabilityProfile["constructs"]>> = {
+  [Construct in FormatConstruct]: Construct extends keyof Overrides
+    ? Overrides[Construct]
+    : "native";
+};
+
+type DefinedChunk<Chunk extends FormatCapabilityProfile["chunk"]> = Omit<
+  FormatCapabilityProfile["chunk"],
+  "unit"
+> & { unit: Chunk["unit"] };
+
+/** Defines a channel profile with native support as the default for each construct. */
+function defineFormatProfile<
+  const Mechanism extends FormatCapabilityProfile["mechanism"],
+  const Overrides extends Partial<FormatCapabilityProfile["constructs"]> = Record<never, never>,
+  const Chunk extends FormatCapabilityProfile["chunk"] = FormatCapabilityProfile["chunk"],
+>(profile: {
+  mechanism: Mechanism;
+  constructs?: Overrides & Record<Exclude<keyof Overrides, FormatConstruct>, never>;
+  chunk: Chunk;
+}): {
+  mechanism: Mechanism;
+  constructs: DefinedConstructs<Overrides>;
+  chunk: DefinedChunk<Chunk>;
+} {
+  return {
+    ...profile,
+    constructs: { ...NATIVE_FORMAT_CONSTRUCTS, ...profile.constructs },
+  } as {
+    mechanism: Mechanism;
+    constructs: DefinedConstructs<Overrides>;
+    chunk: DefinedChunk<Chunk>;
+  };
+}
+
+/** Runtime helpers for defining static channel formatting capabilities. */
+export const FormatCapabilityProfile = { define: defineFormatProfile };

--- a/src/plugin-sdk/format-capabilities.test.ts
+++ b/src/plugin-sdk/format-capabilities.test.ts
@@ -1,18 +1,13 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import type { FormatCapabilityProfile } from "./text-chunking.js";
+import { FormatCapabilityProfile } from "./text-chunking.js";
 
 describe("FormatCapabilityProfile", () => {
-  it("preserves literal inference with satisfies", () => {
-    const profile = {
+  it("defaults constructs to native while preserving override literals", () => {
+    const profile = FormatCapabilityProfile.define({
       mechanism: "ranges",
       constructs: {
-        bold: "native",
-        italic: "native",
         underline: "strip",
-        strikethrough: "native",
         spoiler: "fallback",
-        codeInline: "native",
-        codeBlock: "native",
         codeLanguage: "strip",
         linkLabel: "fallback",
         heading: "fallback",
@@ -22,14 +17,26 @@ describe("FormatCapabilityProfile", () => {
         table: "strip",
         blockquote: "fallback",
         image: "strip",
-        mention: "native",
       },
       chunk: { limit: 2_048, unit: "bytes", hardCap: 65_536 },
-    } satisfies FormatCapabilityProfile;
+    });
 
     expectTypeOf(profile.mechanism).toEqualTypeOf<"ranges">();
+    expectTypeOf(profile.constructs.bold).toEqualTypeOf<"native">();
     expectTypeOf(profile.constructs.underline).toEqualTypeOf<"strip">();
     expectTypeOf(profile.chunk.unit).toEqualTypeOf<"bytes">();
+    expect(profile.constructs.bold).toBe("native");
     expect(profile.chunk.hardCap).toBe(65_536);
+  });
+
+  it("rejects unknown construct overrides", () => {
+    const defineMisspelledProfile = () =>
+      FormatCapabilityProfile.define({
+        mechanism: "markdown",
+        // @ts-expect-error Format profiles reject misspelled construct names.
+        constructs: { blockqoute: "fallback" },
+        chunk: { limit: 1_000, unit: "chars" },
+      });
+    expectTypeOf(defineMisspelledProfile).toBeFunction();
   });
 });

--- a/src/plugin-sdk/format-capabilities.test.ts
+++ b/src/plugin-sdk/format-capabilities.test.ts
@@ -30,13 +30,17 @@ describe("FormatCapabilityProfile", () => {
   });
 
   it("rejects unknown construct overrides", () => {
-    const defineMisspelledProfile = () =>
-      FormatCapabilityProfile.define({
-        mechanism: "markdown",
-        // @ts-expect-error Format profiles reject misspelled construct names.
-        constructs: { blockqoute: "fallback" },
-        chunk: { limit: 1_000, unit: "chars" },
-      });
-    expectTypeOf(defineMisspelledProfile).toBeFunction();
+    type MisspelledProfile = {
+      mechanism: "markdown";
+      constructs: { table: "fallback"; blockqoute: "fallback" };
+      chunk: { limit: number; unit: "chars" };
+    };
+    type AcceptsMisspelledProfile = typeof FormatCapabilityProfile.define extends (
+      profile: MisspelledProfile,
+    ) => unknown
+      ? true
+      : false;
+
+    expectTypeOf<AcceptsMisspelledProfile>().toEqualTypeOf<false>();
   });
 });

--- a/src/plugin-sdk/text-chunking.ts
+++ b/src/plugin-sdk/text-chunking.ts
@@ -10,7 +10,7 @@ export {
 /** Quote-aware HTML tag tokens for exact post-render projections. */
 export { tokenizeHtmlTags } from "../../packages/markdown-core/src/html-tags.js";
 /** Static outbound formatting capabilities declared by a channel plugin. */
-export type { FormatCapabilityProfile } from "../../packages/markdown-core/src/format-capabilities.js";
+export { FormatCapabilityProfile } from "../../packages/markdown-core/src/format-capabilities.js";
 
 /**
  * Splits outbound channel text into chunks no longer than the requested limit.


### PR DESCRIPTION
## What Problem This Solves

Channel format-capability profiles repeated the same 17-key all-native or mostly-native object shape across 14 plugins. That made capability declarations noisy and made future construct additions unnecessarily repetitive.

## Why This Change Was Made

Add `FormatCapabilityProfile.define(...)` as the SDK builder. It starts from an exhaustive native-support map, applies exact-key overrides, preserves literal mechanism/unit/override inference, and widens numeric chunk limits exactly like the replaced `satisfies` declarations.

All 14 production channel profiles now use the builder. The helper is a value companion to the existing `FormatCapabilityProfile` type, so it does not increase the Plugin SDK export or callable-export budgets.

Discord's source-position-preserving `__bold__` rewrite remains plugin-local. The current profile/research sweep found no second consumer: Discord alone has a markdown-dialect collision where CommonMark `__bold__` would render as native underline. Other underline-capable channels parse into IR/ranges/blocks, while the other markdown passthrough channels retain CommonMark-compatible bold semantics.

## User Impact

None. This is a behavior-neutral declaration refactor. Channel output bytes, chunk limits, mechanisms, and fallback policies are unchanged.

## Evidence

- LOC: production +105/-222 (net -117); tests +21/-10 (net +11); overall +126/-232 (net -106).
- `node scripts/run-vitest.mjs src/plugin-sdk/format-capabilities.test.ts` — 2 tests passed locally.
- Blacksmith Testbox run `30070648479`: `corepack pnpm check:changed` passed all changed gates (four typecheck lanes, core/extension lint, SDK API/export/surface ratchets, boundary/import-cycle/guard checks), then the focused channel matrix passed 13 Vitest shards / 567 tests.
- Focused matrix: `src/plugin-sdk/format-capabilities.test.ts`, ClickClack outbound, Discord basic sends, Google Chat format, iMessage markdown format, Matrix format, Mattermost send, Teams format, Nextcloud Talk send, QQ markdown table chunking, Signal format/chunking, Slack format, Telegram rich blocks, WhatsApp text runtime, and ZaloUser text styles.
- Blacksmith Testbox run `30071897935`: after exact-key enforcement, all four typecheck lanes, targeted lint, and the 2-test SDK profile suite passed.
- `node scripts/run-vitest.mjs src/plugin-sdk/format-capabilities.test.ts test/scripts/type-suppression-inventory.test.ts` — both focused suites passed after replacing the suppression-based negative test with a conditional type assertion.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex --stream-engine-output` — clean after accepting and fixing the exact-key finding; no accepted/actionable findings remain.
- `git diff --check` — passed.

Intended output changes: none. All existing channel golden/fixture expectations remained unchanged.
