### PR TITLE
fix(gateway): reject incomplete usage date ranges

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -150,6 +150,8 @@ describe("gateway usage helpers", () => {
     [{ endDate: "2026-2-5" }, "invalid endDate"],
     [{ startDate: 0 }, "invalid startDate"],
     [{ endDate: [] }, "invalid endDate"],
+    [{ startDate: "2026-02-01" }, "startDate and endDate must be provided together"],
+    [{ endDate: "2026-02-01" }, "startDate and endDate must be provided together"],
     [{ startDate: "2026-02-01", endDate: "2026-13-01" }, "invalid endDate"],
     [{ startDate: "2026-02-03", endDate: "2026-02-02" }, "startDate must not be after endDate"],
   ])("resolveDateRange rejects invalid explicit ranges", (params, error) => {
@@ -244,6 +246,33 @@ describe("gateway usage helpers", () => {
       expect(vi.mocked(loadCostUsageSummaryFromCache)).not.toHaveBeenCalled();
     },
   );
+
+  it.each([
+    ["usage.cost", { startDate: "2026-02-01" }],
+    ["usage.cost", { endDate: "2026-02-01" }],
+    ["sessions.usage", { startDate: "2026-02-01" }],
+    ["sessions.usage", { endDate: "2026-02-01" }],
+  ] as const)("%s rejects an incomplete explicit date range", async (method, params) => {
+    const respond = vi.fn();
+    await expectDefined(
+      usageHandlers[method],
+      "usageHandlers[method] test invariant",
+    )({
+      respond,
+      params,
+      context: { getRuntimeConfig: vi.fn(() => ({})) },
+    } as unknown as Parameters<(typeof usageHandlers)[typeof method]>[0]);
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = expectDefined(
+      respond.mock.calls[0],
+      "respond.mock.calls[0] test invariant",
+    );
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(JSON.stringify(error)).toContain("startDate and endDate must be provided together");
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).not.toHaveBeenCalled();
+  });
 
   it("parseUtcOffsetToMinutes supports whole-hour and half-hour offsets", () => {
     expect(testApi.parseUtcOffsetToMinutes("UTC-4")).toBe(-240);

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -5,6 +5,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
 
@@ -263,15 +264,13 @@ describe("gateway usage helpers", () => {
       context: { getRuntimeConfig: vi.fn(() => ({})) },
     } as unknown as Parameters<(typeof usageHandlers)[typeof method]>[0]);
 
-    expect(respond).toHaveBeenCalledTimes(1);
-    const [ok, payload, error] = expectDefined(
-      respond.mock.calls[0],
-      "respond.mock.calls[0] test invariant",
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, "startDate and endDate must be provided together"),
     );
-    expect(ok).toBe(false);
-    expect(payload).toBeUndefined();
-    expect(JSON.stringify(error)).toContain("startDate and endDate must be provided together");
     expect(vi.mocked(loadCostUsageSummaryFromCache)).not.toHaveBeenCalled();
+    expect(vi.mocked(discoverAllSessions)).not.toHaveBeenCalled();
   });
 
   it("parseUtcOffsetToMinutes supports whole-hour and half-hour offsets", () => {

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -467,6 +467,14 @@ const resolveDateRange = (
     };
   }
 
+  const startDateParts = parseDateParts(params.startDate);
+  const endDateParts = parseDateParts(params.endDate);
+  // Explicit date windows are atomic. A single boundary must not silently
+  // fall through to the unrelated default 30-day range.
+  if (Boolean(startDateParts) !== Boolean(endDateParts)) {
+    return { ok: false, error: "startDate and endDate must be provided together" };
+  }
+
   const now = new Date();
   const interpretationResolution = resolvedInterpretation
     ? { ok: true as const, value: resolvedInterpretation }
@@ -480,9 +488,6 @@ const resolveDateRange = (
   if (todayEndMs === undefined) {
     return { ok: false, error: "calendar day does not exist in requested time zone" };
   }
-
-  const startDateParts = parseDateParts(params.startDate);
-  const endDateParts = parseDateParts(params.endDate);
 
   if (startDateParts && endDateParts) {
     const startMs = datePartsToStartMs(startDateParts, interpretation);

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -467,14 +467,6 @@ const resolveDateRange = (
     };
   }
 
-  const startDateParts = parseDateParts(params.startDate);
-  const endDateParts = parseDateParts(params.endDate);
-  // Explicit date windows are atomic. A single boundary must not silently
-  // fall through to the unrelated default 30-day range.
-  if (Boolean(startDateParts) !== Boolean(endDateParts)) {
-    return { ok: false, error: "startDate and endDate must be provided together" };
-  }
-
   const now = new Date();
   const interpretationResolution = resolvedInterpretation
     ? { ok: true as const, value: resolvedInterpretation }
@@ -487,6 +479,14 @@ const resolveDateRange = (
   const todayEndMs = datePartsToEndMs(todayDateParts, interpretation);
   if (todayEndMs === undefined) {
     return { ok: false, error: "calendar day does not exist in requested time zone" };
+  }
+
+  const startDateParts = parseDateParts(params.startDate);
+  const endDateParts = parseDateParts(params.endDate);
+  // Explicit date windows are atomic. A single boundary must not silently
+  // fall through to the unrelated default 30-day range.
+  if ((startDateParts === undefined) !== (endDateParts === undefined)) {
+    return { ok: false, error: "startDate and endDate must be provided together" };
   }
 
   if (startDateParts && endDateParts) {


### PR DESCRIPTION
### What Problem This Solves

Fixes an issue where Gateway clients requesting `usage.cost` or `sessions.usage` with only `startDate` or only `endDate` received a successful report for an unrelated fallback range.

Explicit date filtering was applied only when both dates parsed successfully. When exactly one valid boundary was present, date-range resolution continued to `range`, `days`, or the default trailing 30-day window. The response therefore looked valid even though it did not represent the requested date range.

### Why This Change Was Made

Explicit date windows are now treated as one atomic input. `startDate` and `endDate` must either both be present or both be omitted:

| startDate | endDate | result |
|-----------|---------|--------|
| omitted   | omitted | use `range`, `days`, or the default range |
| present   | present | query the explicit inclusive date range |
| present   | omitted | `INVALID_REQUEST` |
| omitted   | present | `INVALID_REQUEST` |

The validation lives in the shared `resolveDateRange` path used by both `usage.cost` and `sessions.usage`. This keeps their behavior consistent and also covers raw Gateway RPC, Admin HTTP RPC, dashboard widget bindings, and third-party Gateway clients without duplicating checks in each handler.

The change intentionally does not introduce open-ended date ranges. Neither the protocol documentation nor existing callers define what a single boundary should mean, and the previous implementation did not provide open-ended semantics; it silently selected an unrelated fallback window.

### User Impact

Clients that accidentally send only one explicit date now receive a clear `INVALID_REQUEST`:

```
startDate and endDate must be provided together
```

Valid explicit ranges, preset ranges, `days`, and requests that omit both dates keep their existing behavior. The fix prevents misleading cost and session usage reports from being treated as results for the requested date.

### Evidence

- **Baseline:** on merge base `3b1212b39716`, adding only the regression assertions made `node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts` fail 6 cases while 42 existing cases passed. Both RPCs returned successful fallback reports; `sessions.usage` visibly returned the default 2026-06-26 through 2026-07-25 window.
- **Fixed head:** `63b5bc55f86b0aee24b5502302df010f799cde7c`.
- **Focused regression:** the same command passed all 48 cases on Blacksmith Testbox `tbx_01kycc6x0ff8rwmg7h5azxvyth` ([run 30154082223](https://github.com/openclaw/openclaw/actions/runs/30154082223)).
- **Live Gateway RPC:** a clean remote build launched an isolated loopback Gateway and exercised the documented `openclaw gateway call` path. Start-only and end-only requests for both `usage.cost` and `sessions.usage` exited 1 with typed `INVALID_REQUEST` and `startDate and endDate must be provided together`. Requests with neither boundary and with a complete one-day range succeeded for both methods.
- **Sibling audit:** Gateway has no other paired `startDate`/`endDate` resolver. `audit.list` and `audit.activity.list` use intentionally open-ended `after`/`before` bounds and forward either side independently.

### Tests and Validation

- `node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts` — 48/48 passed.
- `node scripts/check-changed.mjs -- src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.test.ts` — passed formatting, prod/test typecheck, lint, import-cycle, contract, dependency, and boundary guards.
- `pnpm build` — passed on the retained Testbox before the live RPC probe.
- Autoreview (`gpt-5.6-sol`) — clean, no accepted/actionable findings.
- Independent adversarial refuter (`gpt-5.6-sol`, high reasoning) — `NO-ACTIONABLE-OBJECTION`.

### Risk Checklist

- **User-visible behavior:** Yes. Incomplete explicit date ranges now return `INVALID_REQUEST` instead of a successful report for an unrelated range.
- **Config/env/migration behavior:** No.
- **Security/auth/secrets/network/tool execution:** No.
- **Plugins/providers/channels/SDK:** No. The change is contained in shared Gateway usage date-range resolution.
- **Highest-risk area:** Compatibility for clients that currently send only one boundary. There is no documented single-boundary contract, and the previous response did not honor such a boundary.
- **Mitigation:** The validation is centralized in the existing shared range resolver and covered at both helper and handler levels for both affected methods.
