### PR TITLE
refactor(policy): centralize shared helpers

### DIFF
--- a/extensions/policy/src/doctor/data-auth-shapes.ts
+++ b/extensions/policy/src/doctor/data-auth-shapes.ts
@@ -1,9 +1,9 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PolicyDataHandlingEvidence, PolicyEvidence } from "../policy-state.js";
+import { getPolicyPath } from "../policy-value.js";
 import { POLICY_CHECK_IDS } from "./check-ids.js";
 import { SUPPORTED_AUTH_PROFILE_MODES } from "./policy-constants.js";
-import { getPolicyPath } from "./policy-scope.js";
 import { policyShapeFinding, unsupportedPolicyKey } from "./shape-helpers.js";
 import { ocPathSegment } from "./utils.js";
 

--- a/extensions/policy/src/doctor/policy-runtime.ts
+++ b/extensions/policy/src/doctor/policy-runtime.ts
@@ -5,7 +5,6 @@ import type { HealthCheckContext, HealthFinding } from "openclaw/plugin-sdk/heal
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PolicyAuthProfileEvidence } from "../policy-state.js";
-import { POLICY_TOOL_GROUPS } from "../tool-policy-conformance.js";
 import { CHECK_IDS } from "./check-ids.js";
 import {
   SUPPORTED_AUTH_PROFILE_METADATA,
@@ -338,43 +337,6 @@ export function authProfileHasMetadata(
   return SUPPORTED_AUTH_PROFILE_MODES.includes(
     profile.mode as (typeof SUPPORTED_AUTH_PROFILE_MODES)[number],
   );
-}
-
-function policyToolGlobMatches(tool: string, pattern: string): boolean {
-  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`).test(tool);
-}
-
-export function toolListCoversTool(list: readonly string[], tool: string): boolean {
-  for (const entry of list) {
-    const normalized = normalizePolicyToolName(entry);
-    if (normalized === "*" || normalized === tool) {
-      return true;
-    }
-    if (POLICY_TOOL_GROUPS[normalized]?.includes(tool)) {
-      return true;
-    }
-    if (normalized.includes("*") && policyToolGlobMatches(tool, normalized)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-export function expandPolicyToolRequirement(value: string): readonly string[] {
-  const normalized = normalizePolicyToolName(value);
-  return POLICY_TOOL_GROUPS[normalized] ?? [normalized];
-}
-
-function normalizePolicyToolName(value: string): string {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "bash") {
-    return "exec";
-  }
-  if (normalized === "apply-patch") {
-    return "apply_patch";
-  }
-  return normalized;
 }
 
 export function normalizePolicyChannelId(value: string): string {

--- a/extensions/policy/src/doctor/policy-scope.ts
+++ b/extensions/policy/src/doctor/policy-scope.ts
@@ -2,6 +2,7 @@ import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PolicyAgentWorkspaceEvidence, PolicyToolPostureEvidence } from "../policy-state.js";
+import { getPolicyPath, scopedPolicyValue } from "../policy-value.js";
 import {
   SANDBOX_CONTAINER_POLICY_RULES,
   type PolicyRuleMetadata,
@@ -443,24 +444,4 @@ function scopedPolicyFields(
       metadata: rule,
       value,
     }));
-}
-
-function scopedPolicyValue(overlay: Record<string, unknown>, path: readonly string[]): unknown {
-  const [root, ...remainingPath] = path;
-  if (!root) {
-    return undefined;
-  }
-  const scopedRoot = root === "agents" ? overlay.agents : overlay[root];
-  return getPolicyPath(scopedRoot, remainingPath);
-}
-
-export function getPolicyPath(value: unknown, path: readonly string[]): unknown {
-  let current = value;
-  for (const part of path) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[part];
-  }
-  return current;
 }

--- a/extensions/policy/src/doctor/strictness.ts
+++ b/extensions/policy/src/doctor/strictness.ts
@@ -6,7 +6,7 @@ import {
   normalizeLowercaseStringOrEmpty,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { ROUTING_MATCH_KINDS } from "../policy-routing.js";
-import { POLICY_TOOL_GROUPS } from "../tool-policy-conformance.js";
+import { expandPolicyToolRequirement, toolListCoversTool } from "../tool-policy-conformance.js";
 import type { PolicyRuleMetadata } from "./metadata.js";
 
 type ExecApprovalAllowlistRequirement = {
@@ -373,41 +373,4 @@ function isChannelDenyRule(value: unknown): value is {
     isRecord(value.when) &&
     typeof value.when.provider === "string"
   );
-}
-
-function toolListCoversTool(list: readonly string[], tool: string): boolean {
-  for (const entry of list) {
-    const normalized = normalizePolicyToolName(entry);
-    if (normalized === "*" || normalized === tool) {
-      return true;
-    }
-    if (POLICY_TOOL_GROUPS[normalized]?.includes(tool)) {
-      return true;
-    }
-    if (normalized.includes("*") && policyToolGlobMatches(tool, normalized)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function expandPolicyToolRequirement(value: string): readonly string[] {
-  const normalized = normalizePolicyToolName(value);
-  return POLICY_TOOL_GROUPS[normalized] ?? [normalized];
-}
-
-function normalizePolicyToolName(value: string): string {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "bash") {
-    return "exec";
-  }
-  if (normalized === "apply-patch") {
-    return "apply_patch";
-  }
-  return normalized;
-}
-
-function policyToolGlobMatches(tool: string, pattern: string): boolean {
-  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`).test(tool);
 }

--- a/extensions/policy/src/doctor/tool-findings.ts
+++ b/extensions/policy/src/doctor/tool-findings.ts
@@ -1,10 +1,10 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PolicyEvidence, PolicyToolPostureEvidence } from "../policy-state.js";
+import { expandPolicyToolRequirement, toolListCoversTool } from "../tool-policy-conformance.js";
 import { toolPosturePolicyShapeFinding } from "./agent-tool-shapes.js";
 import { CHECK_IDS, POLICY_CHECK_IDS } from "./check-ids.js";
 import { KNOWN_RISK_LEVELS, KNOWN_SENSITIVITY_LEVELS } from "./policy-constants.js";
-import { expandPolicyToolRequirement, toolListCoversTool } from "./policy-runtime.js";
 import { agentScopedPolicyTargets, scopedToolAgentMatches } from "./policy-scope.js";
 import { hasValidScopedPolicy } from "./scoped-policy-shape.js";
 import { ocPathSegment, readPolicyBoolean, readStringList } from "./utils.js";

--- a/extensions/policy/src/policy-conformance.ts
+++ b/extensions/policy/src/policy-conformance.ts
@@ -12,6 +12,7 @@ import {
   type PolicyRuleMetadata,
   type PolicyScopeSelectorKind,
 } from "./doctor/register.js";
+import { getPolicyPath, scopedPolicyValue } from "./policy-value.js";
 
 const POLICY_CONFORMANCE_CHECK_IDS = {
   missing: "policy/policy-conformance-missing",
@@ -577,26 +578,6 @@ function normalizeSelectorValues(
     .map((entry) =>
       selector === "agentIds" ? normalizeAgentId(entry) : entry.trim().toLowerCase(),
     );
-}
-
-function scopedPolicyValue(overlay: Record<string, unknown>, path: readonly string[]): unknown {
-  const [root, ...remainingPath] = path;
-  if (!root) {
-    return undefined;
-  }
-  const scopedRoot = root === "agents" ? overlay.agents : overlay[root];
-  return getPolicyPath(scopedRoot, remainingPath);
-}
-
-function getPolicyPath(value: unknown, path: readonly string[]): unknown {
-  let current = value;
-  for (const part of path) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[part];
-  }
-  return current;
 }
 
 async function readPolicyDocument(path: string): Promise<PolicyDocumentReadResult> {

--- a/extensions/policy/src/policy-state-tool-posture.ts
+++ b/extensions/policy/src/policy-state-tool-posture.ts
@@ -5,8 +5,6 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { ocPathSegment } from "./policy-state-helpers.js";
 import type { PolicyToolPostureEvidence } from "./policy-state-types.js";
-// Policy plugin tool posture evidence.
-import { POLICY_TOOL_GROUPS } from "./tool-policy-conformance.js";
 
 export function scanPolicyToolPosture(
   cfg: Record<string, unknown>,
@@ -305,36 +303,4 @@ function readStringOrNumberArray(value: unknown): readonly string[] {
     }
   }
   return entries;
-}
-
-function normalizePolicyToolName(value: string): string {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "bash") {
-    return "exec";
-  }
-  if (normalized === "apply-patch") {
-    return "apply_patch";
-  }
-  return normalized;
-}
-
-function policyToolGlobMatches(tool: string, pattern: string): boolean {
-  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`).test(tool);
-}
-
-export function toolListCoversTool(list: readonly string[], tool: string): boolean {
-  for (const entry of list) {
-    const normalized = normalizePolicyToolName(entry);
-    if (normalized === "*" || normalized === tool) {
-      return true;
-    }
-    if (POLICY_TOOL_GROUPS[normalized]?.includes(tool)) {
-      return true;
-    }
-    if (normalized.includes("*") && policyToolGlobMatches(tool, normalized)) {
-      return true;
-    }
-  }
-  return false;
 }

--- a/extensions/policy/src/policy-state-workspace.ts
+++ b/extensions/policy/src/policy-state-workspace.ts
@@ -3,12 +3,9 @@ import {
   isRecord,
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  AGENT_WORKSPACE_POLICY_TOOLS,
-  readStringArray,
-  toolListCoversTool,
-} from "./policy-state-tool-posture.js";
+import { AGENT_WORKSPACE_POLICY_TOOLS, readStringArray } from "./policy-state-tool-posture.js";
 import type { PolicyAgentWorkspaceEvidence } from "./policy-state-types.js";
+import { toolListCoversTool } from "./tool-policy-conformance.js";
 
 export function scanPolicyAgentWorkspace(
   cfg: Record<string, unknown>,

--- a/extensions/policy/src/policy-value.test.ts
+++ b/extensions/policy/src/policy-value.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getPolicyPath, scopedPolicyValue } from "./policy-value.js";
+
+describe("policy values", () => {
+  it("reads nested policy paths", () => {
+    expect(getPolicyPath({ tools: { deny: ["exec"] } }, ["tools", "deny"])).toEqual(["exec"]);
+    expect(getPolicyPath({ tools: null }, ["tools", "deny"])).toBeUndefined();
+  });
+
+  it("reads scoped values from the canonical agents root", () => {
+    const overlay = {
+      agents: {
+        tools: {
+          deny: ["exec"],
+        },
+      },
+    };
+
+    expect(scopedPolicyValue(overlay, ["agents", "tools", "deny"])).toEqual(["exec"]);
+    expect(scopedPolicyValue(overlay, [])).toBeUndefined();
+  });
+});

--- a/extensions/policy/src/policy-value.ts
+++ b/extensions/policy/src/policy-value.ts
@@ -1,0 +1,24 @@
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export function scopedPolicyValue(
+  overlay: Record<string, unknown>,
+  path: readonly string[],
+): unknown {
+  const [root, ...remainingPath] = path;
+  if (!root) {
+    return undefined;
+  }
+  const scopedRoot = root === "agents" ? overlay.agents : overlay[root];
+  return getPolicyPath(scopedRoot, remainingPath);
+}
+
+export function getPolicyPath(value: unknown, path: readonly string[]): unknown {
+  let current = value;
+  for (const part of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return current;
+}

--- a/extensions/policy/src/tool-policy-conformance.test.ts
+++ b/extensions/policy/src/tool-policy-conformance.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it } from "vitest";
-import {
-  expandPolicyToolRequirement,
-  POLICY_TOOL_GROUPS,
-  toolListCoversTool,
-} from "./tool-policy-conformance.js";
+import { expandPolicyToolRequirement, toolListCoversTool } from "./tool-policy-conformance.js";
 
 describe("policy tool group conformance", () => {
   it("keeps computer control in both node and OpenClaw policy groups", () => {
-    expect(POLICY_TOOL_GROUPS["group:nodes"]).toContain("computer");
-    expect(POLICY_TOOL_GROUPS["group:openclaw"]).toContain("computer");
-    expect(POLICY_TOOL_GROUPS["group:nodes"]).toContain("mobile_ui");
-    expect(POLICY_TOOL_GROUPS["group:openclaw"]).toContain("mobile_ui");
+    expect(expandPolicyToolRequirement("group:nodes")).toEqual(
+      expect.arrayContaining(["computer", "mobile_ui"]),
+    );
+    expect(expandPolicyToolRequirement("group:openclaw")).toEqual(
+      expect.arrayContaining(["computer", "mobile_ui"]),
+    );
   });
 
   it("normalizes aliases and expands groups", () => {

--- a/extensions/policy/src/tool-policy-conformance.test.ts
+++ b/extensions/policy/src/tool-policy-conformance.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { POLICY_TOOL_GROUPS } from "./tool-policy-conformance.js";
+import {
+  expandPolicyToolRequirement,
+  POLICY_TOOL_GROUPS,
+  toolListCoversTool,
+} from "./tool-policy-conformance.js";
 
 describe("policy tool group conformance", () => {
   it("keeps computer control in both node and OpenClaw policy groups", () => {
@@ -7,5 +11,20 @@ describe("policy tool group conformance", () => {
     expect(POLICY_TOOL_GROUPS["group:openclaw"]).toContain("computer");
     expect(POLICY_TOOL_GROUPS["group:nodes"]).toContain("mobile_ui");
     expect(POLICY_TOOL_GROUPS["group:openclaw"]).toContain("mobile_ui");
+  });
+
+  it("normalizes aliases and expands groups", () => {
+    expect(toolListCoversTool(["bash"], "exec")).toBe(true);
+    expect(toolListCoversTool(["apply-patch"], "apply_patch")).toBe(true);
+    expect(expandPolicyToolRequirement("group:web")).toEqual([
+      "web_search",
+      "web_fetch",
+      "x_search",
+    ]);
+  });
+
+  it("matches wildcard tool requirements", () => {
+    expect(toolListCoversTool(["web_*"], "web_search")).toBe(true);
+    expect(toolListCoversTool(["web_*"], "memory_search")).toBe(false);
   });
 });

--- a/extensions/policy/src/tool-policy-conformance.ts
+++ b/extensions/policy/src/tool-policy-conformance.ts
@@ -50,3 +50,40 @@ export const POLICY_TOOL_GROUPS: Record<string, readonly string[]> = {
   "group:agents": ["agents_list", "update_plan"],
   "group:media": ["image", "image_generate", "music_generate", "video_generate", "tts"],
 } as const;
+
+export function toolListCoversTool(list: readonly string[], tool: string): boolean {
+  for (const entry of list) {
+    const normalized = normalizePolicyToolName(entry);
+    if (normalized === "*" || normalized === tool) {
+      return true;
+    }
+    if (POLICY_TOOL_GROUPS[normalized]?.includes(tool)) {
+      return true;
+    }
+    if (normalized.includes("*") && policyToolGlobMatches(tool, normalized)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function expandPolicyToolRequirement(value: string): readonly string[] {
+  const normalized = normalizePolicyToolName(value);
+  return POLICY_TOOL_GROUPS[normalized] ?? [normalized];
+}
+
+function normalizePolicyToolName(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "bash") {
+    return "exec";
+  }
+  if (normalized === "apply-patch") {
+    return "apply_patch";
+  }
+  return normalized;
+}
+
+function policyToolGlobMatches(tool: string, pattern: string): boolean {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`).test(tool);
+}

--- a/extensions/policy/src/tool-policy-conformance.ts
+++ b/extensions/policy/src/tool-policy-conformance.ts
@@ -1,5 +1,5 @@
 // Policy plugin module implements tool policy conformance behavior.
-export const POLICY_TOOL_GROUPS: Record<string, readonly string[]> = {
+const POLICY_TOOL_GROUPS: Record<string, readonly string[]> = {
   "group:openclaw": [
     "code_execution",
     "web_search",


### PR DESCRIPTION
## What Problem This Solves

Resolves a maintenance risk where policy conformance, doctor checks, and policy-state inspection independently implemented the same tool matching and nested policy lookup rules. Those copies could drift and make policy validation disagree across commands.

## Why This Change Was Made

This maintainer-requested cleanup moves tool aliases, groups, and glob matching into the existing tool-policy owner, and moves nested/scoped value lookup into one neutral policy-value module. All callers import those owners directly; the duplicate implementations are deleted without compatibility shims.

## User Impact

No intended user-visible behavior change. Policy checks now share one implementation for these rules, reducing divergence risk and removing 89 production lines.

## Evidence

- `node scripts/run-vitest.mjs extensions/policy/src/policy-value.test.ts extensions/policy/src/tool-policy-conformance.test.ts extensions/policy/src/doctor/strictness.test.ts extensions/policy/src/cli.test.ts` - 43 tests passed on the exact rebased commit
- `git diff --check origin/main...HEAD`
- autoreview: clean, no accepted/actionable findings, correctness 0.98
- `pnpm check:changed` - passed on Blacksmith Testbox `tbx_01ky9etffd7waf073k6nhga6fd` in https://github.com/openclaw/openclaw/actions/runs/30074040461

AI-assisted. I reviewed the complete diff and understand the ownership changes. No session transcript logs are attached.
