### PR TITLE
fix(sqlite): repair all canonical unique indexes

### DIFF
--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -70,6 +70,17 @@ const OPENCLAW_AGENT_CANONICAL_UNIQUE_INDEXES = [
       WHERE message_idempotency_key IS NOT NULL
     `,
   },
+  {
+    name: "idx_agent_transcript_active_event_seq",
+    definition: "ON session_transcript_active_events(session_id, event_seq)",
+  },
+  {
+    name: "idx_agent_transcript_active_messages",
+    definition: `
+      ON session_transcript_active_events(session_id, message_position)
+      WHERE message_position IS NOT NULL
+    `,
+  },
 ] as const satisfies readonly CanonicalSqliteUniqueIndex[];
 
 type OpenClawAgentMetadataDatabase = Pick<OpenClawAgentKyselyDatabase, "schema_meta">;

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -57,6 +57,8 @@ import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import {
   collectSqliteSchemaShape,
   createSqliteSchemaShapeFromSql,
+  normalizeSqliteSchemaShapeSql,
+  replaceNamedUniqueIndexesWithOrdinaryIndexes,
 } from "./sqlite-schema-shape.test-support.js";
 
 type AgentDbTestDatabase = Pick<
@@ -2292,6 +2294,33 @@ describe("openclaw agent database", () => {
         )
         .run("session-1", "event-2", 2, "message-1", 2),
     ).toThrow(/UNIQUE constraint failed/iu);
+  });
+
+  it("repairs every canonical agent-state named unique index", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const created = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const databasePath = created.path;
+    const canonicalShape = normalizeSqliteSchemaShapeSql(collectSqliteSchemaShape(created.db));
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const drifted = new DatabaseSync(databasePath);
+    try {
+      expect(replaceNamedUniqueIndexesWithOrdinaryIndexes(drifted)).toHaveLength(5);
+      expect(drifted.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+      expect(drifted.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    } finally {
+      drifted.close();
+    }
+
+    const reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    expect(normalizeSqliteSchemaShapeSql(collectSqliteSchemaShape(reopened.db))).toEqual(
+      canonicalShape,
+    );
   });
 
   it("rejects same-name transcript index drift when duplicate rows block repair", () => {

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -35,6 +35,8 @@ import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import {
   collectSqliteSchemaShape,
   createSqliteSchemaShapeFromSql,
+  normalizeSqliteSchemaShapeSql,
+  replaceNamedUniqueIndexesWithOrdinaryIndexes,
 } from "./sqlite-schema-shape.test-support.js";
 
 type StateDbTestDatabase = Pick<
@@ -1622,21 +1624,18 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ).not.toThrow();
   });
 
-  it("repairs a same-name shared-state uniqueness index", () => {
+  it("repairs every canonical shared-state named unique index", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const created = openOpenClawStateDatabase({ env });
     const databasePath = created.path;
+    const canonicalShape = normalizeSqliteSchemaShapeSql(collectSqliteSchemaShape(created.db));
     closeOpenClawStateDatabaseForTest();
 
     const { DatabaseSync } = requireNodeSqlite();
     const drifted = new DatabaseSync(databasePath);
     try {
-      drifted.exec(`
-        DROP INDEX idx_operator_approvals_resolution_ref;
-        CREATE UNIQUE INDEX idx_operator_approvals_resolution_ref
-          ON operator_approvals(approval_id);
-      `);
+      expect(replaceNamedUniqueIndexesWithOrdinaryIndexes(drifted)).toHaveLength(3);
       expect(drifted.prepare("PRAGMA integrity_check").get()).toEqual({
         integrity_check: "ok",
       });
@@ -1645,15 +1644,9 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     }
 
     const reopened = openOpenClawStateDatabase({ env });
-    expect(
-      reopened.db
-        .prepare(
-          "SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = 'idx_operator_approvals_resolution_ref'",
-        )
-        .get(),
-    ).toEqual({
-      sql: "CREATE UNIQUE INDEX idx_operator_approvals_resolution_ref ON operator_approvals(resolution_ref)",
-    });
+    expect(normalizeSqliteSchemaShapeSql(collectSqliteSchemaShape(reopened.db))).toEqual(
+      canonicalShape,
+    );
   });
 
   it("migrates the released audit ledger to message-compatible attribution exactly once", () => {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -103,6 +103,13 @@ const OPENCLAW_STATE_CANONICAL_UNIQUE_INDEXES = [
       WHERE lease_id IS NOT NULL
     `,
   },
+  {
+    name: "idx_worker_inference_turns_pending_run",
+    definition: `
+      ON worker_inference_turns(session_id, run_epoch, run_id)
+      WHERE state = 'pending'
+    `,
+  },
 ] as const satisfies readonly CanonicalSqliteUniqueIndex[];
 
 const cachedDatabases = new Map<string, OpenClawStateDatabase>();

--- a/src/state/sqlite-schema-shape.test-support.ts
+++ b/src/state/sqlite-schema-shape.test-support.ts
@@ -58,6 +58,10 @@ type SqliteMasterRow = {
   name: string;
 };
 
+type NamedIndexRow = SqliteMasterRow & {
+  tbl_name: string;
+};
+
 type IndexSqlRow = {
   sql?: unknown;
 };
@@ -105,6 +109,67 @@ export function collectSqliteSchemaShape(db: DatabaseSync): SqliteSchemaShape {
       },
     ]),
   );
+}
+
+/** Normalize only DDL whitespace while preserving the full structured shape. */
+export function normalizeSqliteSchemaShapeSql(shape: SqliteSchemaShape): SqliteSchemaShape {
+  return Object.fromEntries(
+    Object.entries(shape).map(([tableName, table]) => [
+      tableName,
+      {
+        ...table,
+        indexes: table.indexes.map((index) => ({
+          ...index,
+          sql: index.sql?.replace(/\s+/gu, " ").trim() ?? null,
+        })),
+      },
+    ]),
+  );
+}
+
+/**
+ * Replace every explicit named UNIQUE index with a same-name ordinary index.
+ *
+ * Startup repair tests use this to prove the repair registry covers the whole
+ * canonical schema rather than only a hand-picked index.
+ */
+export function replaceNamedUniqueIndexesWithOrdinaryIndexes(db: DatabaseSync): string[] {
+  const indexes = db
+    .prepare(
+      `
+        SELECT name, tbl_name
+        FROM sqlite_schema
+        WHERE type = 'index'
+          AND sql IS NOT NULL
+        ORDER BY name ASC
+      `,
+    )
+    .all() as NamedIndexRow[];
+  const uniqueIndexes = indexes.filter((index) =>
+    (
+      db
+        .prepare(`PRAGMA index_list(${quoteSqliteIdentifier(index.tbl_name)})`)
+        .all() as IndexListRow[]
+    ).some((candidate) => candidate.name === index.name && candidate.unique === 1),
+  );
+
+  for (const index of uniqueIndexes) {
+    const firstColumn = (
+      db
+        .prepare(`PRAGMA table_info(${quoteSqliteIdentifier(index.tbl_name)})`)
+        .all() as TableInfoRow[]
+    )[0];
+    if (!firstColumn) {
+      throw new Error(`SQLite table ${index.tbl_name} has no columns`);
+    }
+    db.exec(`
+      DROP INDEX main.${quoteSqliteIdentifier(index.name)};
+      CREATE INDEX main.${quoteSqliteIdentifier(index.name)}
+        ON ${quoteSqliteIdentifier(index.tbl_name)}(${quoteSqliteIdentifier(firstColumn.name)});
+    `);
+  }
+
+  return uniqueIndexes.map((index) => index.name);
 }
 
 function collectStrictFlag(db: DatabaseSync, tableName: string): number {


### PR DESCRIPTION
## What Problem This Solves

SQLite startup repair handled same-name drift for canonical `UNIQUE` indexes, but three indexes were missing from the repair registries:

- `idx_worker_inference_turns_pending_run`
- `idx_agent_transcript_active_event_seq`
- `idx_agent_transcript_active_messages`

A same-name ordinary index survives `CREATE UNIQUE INDEX IF NOT EXISTS`, and `PRAGMA integrity_check` still reports `ok`. That allowed current databases to reopen without restoring required uniqueness.

Closes #113255.

## Why This Change Was Made

Register all three omitted indexes with the existing canonical repair owner. Replace the narrow regression with schema-driven tests that corrupt every explicit named `UNIQUE` index in both databases, reopen them, and require the complete canonical schema shape to be restored.

The existing duplicate-row regression remains fail-closed: repair must not silently rewrite a database when existing data cannot satisfy the canonical constraint.

## User Impact

Shared inference state and active transcript state retain their canonical uniqueness guarantees after recoverable schema drift. Startup repairs the full known bug class instead of only selected indexes.

## Evidence

- Exact-head focused SQLite proof: 161 tests passed on Blacksmith Testbox `tbx_01ky9fdnw214skbbpqrwqmfexf`.
- Exact-head `pnpm check:changed`: passed all core and core-test lanes on the same Testbox.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30074632597
- Independent direct AWS Crabbox proof: 161 tests passed in `run_82b08e6f719a`.
- Autoreview: clean, no accepted/actionable findings, confidence `0.93`.
- `git diff --check`: passed.
