### PR TITLE
fix(update): preserve upgrades with shipped Discord DM config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Package upgrade migrations:** run the updated doctor before post-core plugin convergence so shipped channel config aliases are migrated before strict config writes.
 - **Agent database and cron upgrades:** open v13 agent databases on supported SQLite/Node combinations and treat benign same-generation session updates as claimable so isolated cron and subagent runs do not fail under large session stores. (#113151, #113088, #113085) Thanks @jalehman and @metahacker.
 - **Control UI continuity:** preserve question access across upgrades and render managed image replies exactly once when the UI is hosted under a base path. (#113153, #113163, #113161) Thanks @fuller-stack-dev.
 - **Trusted shell snapshots:** resolve snapshot `HOME` from the trusted login environment instead of injected process state so agent shell setup uses the intended user profile. (#113103) Thanks @zenglingbiao.

--- a/extensions/discord/src/doctor.test.ts
+++ b/extensions/discord/src/doctor.test.ts
@@ -21,6 +21,37 @@ function getDiscordCompatibilityNormalizer(): NonNullable<
 }
 
 describe("discord doctor", () => {
+  it("promotes shipped nested DM access at root and account scope", () => {
+    const normalize = getDiscordCompatibilityNormalizer();
+    const result = normalize({
+      cfg: {
+        channels: {
+          discord: {
+            dm: { enabled: false, policy: "allowlist", allowFrom: ["123"] },
+            accounts: {
+              work: {
+                dm: { groupEnabled: true, policy: "open", allowFrom: ["*"] },
+              },
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.config.channels?.discord).toEqual({
+      dm: { enabled: false },
+      dmPolicy: "allowlist",
+      allowFrom: ["123"],
+      accounts: {
+        work: {
+          dm: { groupEnabled: true },
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+  });
+
   it("strips retired gateway, queue, and retry tuning at root and account scope", () => {
     const normalize = getDiscordCompatibilityNormalizer();
     const result = normalize({

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1984,6 +1984,14 @@ describe("update-cli", () => {
         ),
     ).toBe(true);
     expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
+      nonInteractive: true,
+      repair: true,
+      yes: false,
+    });
+    expect(vi.mocked(doctorCommand).mock.invocationCallOrder[0] ?? 0).toBeLessThan(
+      syncPluginsForUpdateChannel.mock.invocationCallOrder[0] ?? 0,
+    );
     expect(syncPluginsForUpdateChannel).toHaveBeenCalledTimes(1);
     expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
     expect(spawn).not.toHaveBeenCalled();

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -1,3 +1,4 @@
+import { doctorCommand } from "../../commands/doctor.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV } from "../../infra/update-post-core-context.js";
@@ -9,11 +10,15 @@ import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
 import { readPackageVersion, type UpdateCommandOptions } from "./shared.js";
 import {
+  createUpdateConfigSnapshot,
   persistRequestedUpdateChannel,
   readPostCorePreUpdateSourceConfig,
   restoreDroppedPreUpdateChannels,
 } from "./update-command-config.js";
-import { completePostCorePluginUpdate } from "./update-command-fresh-doctor.js";
+import {
+  completePostCorePluginUpdate,
+  withUpdateFinalizationEnv,
+} from "./update-command-fresh-doctor.js";
 import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
 import {
   POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV,
@@ -70,6 +75,21 @@ async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams):
     sourceConfigPath: process.env[POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV],
     currentSnapshot: configSnapshot,
     updateStartedAtMs,
+  });
+  await withUpdateFinalizationEnv(async () => {
+    await createUpdateConfigSnapshot();
+    await doctorCommand(defaultRuntime, {
+      nonInteractive: true,
+      repair: true,
+      yes: params.opts.yes === true,
+    });
+  });
+  // The fresh process owns the updated migration contracts. Repair before
+  // plugin convergence writes config, or newly retired plugin keys can block
+  // the update before doctor gets a chance to migrate them.
+  configSnapshot = await readConfigFileSnapshot({
+    skipPluginValidation: true,
+    suppressFutureVersionWarning: true,
   });
   configSnapshot = await persistRequestedUpdateChannel({
     configSnapshot,


### PR DESCRIPTION
Related: #112812

## What Problem This Solves

Fixes an issue where users upgrading from `openclaw@2026.7.1-2` to the 2026.7.2 beta would have `openclaw update` fail when their shipped Discord DM access configuration still used nested `dm.policy` or `dm.allowFrom`.

## Why This Change Was Made

The updated process now runs its updated doctor migrations before post-core plugin convergence can perform strict config writes. The existing Discord-owned migration remains the single compatibility owner; runtime schema validation stays strict.

## User Impact

Existing stable installations with Discord DM access settings can upgrade through the replacement beta without manually editing their config first.

## Evidence

- Failing beta4 package acceptance: https://github.com/openclaw/openclaw/actions/runs/30072849621
- `node scripts/run-vitest.mjs extensions/discord/src/doctor.test.ts`: 17 passed
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts`: 200 passed
- `git diff --check`: clean
- Autoreview: clean, no accepted/actionable findings
- Changed-file fanout did not start: the Testbox bootstrap attempted a non-interactive `pnpm install` against the linked worktree and aborted before checks. PR CI remains authoritative for the broad gate.
