### PR TITLE
refactor(gateway): centralize approval request delivery

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -3,7 +3,6 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
 import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
@@ -15,11 +14,11 @@ import type {
 } from "../plugins/types.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "./node-command-policy.js";
 import type { NodeSession } from "./node-registry.js";
+import { runApprovalRequestDeliveries } from "./server-methods/approval-request-delivery.js";
 import {
   bindApprovalRequesterMetadata,
   buildRequestedApprovalEvent,
   handlePendingApprovalRequest,
-  isApprovalRecordVisibleToClient,
 } from "./server-methods/approval-shared.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./server-methods/types.js";
 
@@ -123,6 +122,10 @@ function createApprovalRuntime(params: {
       // this runtime-internal caller.
       const decisionPromise = manager.register(record, timeoutMs);
       const requestEvent = buildRequestedApprovalEvent(record);
+      const forwardRequest = params.context.forwardPluginApprovalRequest;
+      const iosPushRequest = params.context.pluginApprovalIosPushDelivery?.handleRequested?.bind(
+        params.context.pluginApprovalIosPushDelivery,
+      );
       await handlePendingApprovalRequest({
         manager,
         record,
@@ -134,55 +137,23 @@ function createApprovalRuntime(params: {
         requestEvent,
         twoPhase: false,
         approvalKind: "plugin",
-        deliverRequest: () => {
-          const deliveryTasks: Array<Promise<boolean>> = [];
-          const forward = params.context.forwardPluginApprovalRequest;
-          if (forward) {
-            deliveryTasks.push(
-              forward(requestEvent).catch((err: unknown) => {
-                params.context.logGateway?.error?.(
-                  `plugin approvals: forward node policy request failed: ${String(err)}`,
-                );
-                return false;
-              }),
-            );
-          }
-          const iosPushDelivery = params.context.pluginApprovalIosPushDelivery;
-          if (iosPushDelivery?.handleRequested) {
-            deliveryTasks.push(
-              iosPushDelivery
-                .handleRequested(requestEvent, {
-                  isTargetVisible: (target) =>
-                    isApprovalRecordVisibleToClient({
-                      record,
-                      client: {
-                        connect: {
-                          client: { id: GATEWAY_CLIENT_IDS.IOS_APP },
-                          device: { id: target.deviceId },
-                          scopes: [...target.scopes],
-                        },
-                      } as GatewayClient,
-                    }),
-                })
-                .catch((err: unknown) => {
-                  params.context.logGateway?.error?.(
-                    `plugin approvals: iOS push node policy request failed: ${String(err)}`,
-                  );
-                  return false;
-                }),
-            );
-          }
-          if (deliveryTasks.length === 0) {
-            return false;
-          }
-          return (async () => {
-            let delivered = false;
-            for (const task of deliveryTasks) {
-              delivered = (await task) || delivered;
-            }
-            return delivered;
-          })();
-        },
+        deliverRequest: () =>
+          runApprovalRequestDeliveries({
+            context: params.context,
+            record,
+            forward: forwardRequest
+              ? [
+                  () => forwardRequest(requestEvent),
+                  "plugin approvals: forward node policy request failed",
+                ]
+              : undefined,
+            iosPush: iosPushRequest
+              ? [
+                  (isTargetVisible) => iosPushRequest(requestEvent, { isTargetVisible }),
+                  "plugin approvals: iOS push node policy request failed",
+                ]
+              : undefined,
+          }),
         afterDecision: async (decision) => {
           if (decision === null) {
             await params.context.pluginApprovalIosPushDelivery?.handleExpired?.(requestEvent);

--- a/src/gateway/server-methods/approval-request-delivery.test.ts
+++ b/src/gateway/server-methods/approval-request-delivery.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { ExecApprovalManager } from "../exec-approval-manager.js";
+import { runApprovalRequestDeliveries } from "./approval-request-delivery.js";
+
+describe("runApprovalRequestDeliveries", () => {
+  it("returns false synchronously when no external routes exist", () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, "approval-no-delivery");
+
+    expect(runApprovalRequestDeliveries({ context: {}, record })).toBe(false);
+  });
+
+  it.each([
+    {
+      failedRoute: "forward",
+      expectedError: "forward failed: Error: offline",
+    },
+    {
+      failedRoute: "push",
+      expectedError: "push failed: Error: offline",
+    },
+  ] as const)(
+    "starts every route before awaiting and isolates $failedRoute failures",
+    async ({ failedRoute, expectedError }) => {
+      const manager = new ExecApprovalManager();
+      const record = manager.create({ command: "echo ok" }, 60_000, "approval-deliveries");
+      const started: string[] = [];
+      const error = vi.fn();
+      let finishDelivery: ((delivered: boolean) => void) | undefined;
+      const successfulResult = new Promise<boolean>((resolve) => {
+        finishDelivery = resolve;
+      });
+
+      const delivery = runApprovalRequestDeliveries({
+        context: { logGateway: { error } },
+        record,
+        forward: [
+          async () => {
+            started.push("forward");
+            if (failedRoute === "forward") {
+              throw new Error("offline");
+            }
+            return await successfulResult;
+          },
+          "forward failed",
+        ],
+        iosPush: [
+          async () => {
+            started.push("push");
+            if (failedRoute === "push") {
+              throw new Error("offline");
+            }
+            return await successfulResult;
+          },
+          "push failed",
+        ],
+      });
+
+      expect(started).toEqual(["forward", "push"]);
+      finishDelivery?.(true);
+      await expect(delivery).resolves.toBe(true);
+      expect(error).toHaveBeenCalledWith(expectedError);
+    },
+  );
+});

--- a/src/gateway/server-methods/approval-request-delivery.ts
+++ b/src/gateway/server-methods/approval-request-delivery.ts
@@ -1,0 +1,54 @@
+// Approval request delivery fans out external routes while preserving the
+// approval record's visibility boundary for iOS targets.
+import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
+import type { ExecApprovalRecord } from "../exec-approval-manager.js";
+import { isApprovalRecordVisibleToClient } from "./approval-shared.js";
+import type { GatewayClient } from "./types.js";
+
+type ApprovalRequestDeliveryTarget = {
+  deviceId: string;
+  scopes: readonly string[];
+};
+
+type ApprovalRequestDelivery = readonly [
+  run: (isTargetVisible: (target: ApprovalRequestDeliveryTarget) => boolean) => Promise<boolean>,
+  errorLabel: string,
+];
+
+type ApprovalDeliveryLogContext = { logGateway?: { error?: (message: string) => void } };
+
+/** Runs external approval deliveries concurrently and reports whether any route accepted. */
+export function runApprovalRequestDeliveries<TPayload>(params: {
+  context: ApprovalDeliveryLogContext;
+  record: ExecApprovalRecord<TPayload>;
+  forward?: ApprovalRequestDelivery;
+  iosPush?: ApprovalRequestDelivery;
+}): boolean | Promise<boolean> {
+  const isTargetVisible = (target: ApprovalRequestDeliveryTarget) =>
+    isApprovalRecordVisibleToClient({
+      record: params.record,
+      client: {
+        connect: {
+          client: { id: GATEWAY_CLIENT_IDS.IOS_APP },
+          device: { id: target.deviceId },
+          scopes: [...target.scopes],
+        },
+      } as GatewayClient,
+    });
+  const deliveryTasks = [params.forward, params.iosPush].flatMap((delivery) => {
+    if (!delivery) {
+      return [];
+    }
+    const [run, errorLabel] = delivery;
+    return [
+      run(isTargetVisible).catch((err: unknown) => {
+        params.context.logGateway?.error?.(`${errorLabel}: ${String(err)}`);
+        return false;
+      }),
+    ];
+  });
+  if (deliveryTasks.length === 0) {
+    return false;
+  }
+  return Promise.all(deliveryTasks).then((results) => results.some(Boolean));
+}

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -1,7 +1,6 @@
 // Exec approval gateway methods create, list, inspect, and resolve command
 // approval requests, including iOS push delivery and requester visibility.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -33,6 +32,7 @@ import {
 import { resolveSystemRunApprovalRequestContext } from "../../infra/system-run-approval-context.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { InvalidApprovalIdError, type ExecApprovalManager } from "../exec-approval-manager.js";
+import { runApprovalRequestDeliveries } from "./approval-request-delivery.js";
 import {
   handleApprovalWaitDecision,
   handlePendingApprovalRequest,
@@ -40,14 +40,13 @@ import {
   bindApprovalReviewerDeviceIds,
   buildRequestedApprovalEvent,
   handleApprovalResolve,
-  isApprovalRecordVisibleToClient,
   listVisiblePendingApprovalRequests,
   registerPendingApprovalRecord,
   resolveApprovalDecisionParams,
   respondPendingApprovalLookupError,
   resolvePendingApprovalRecord,
 } from "./approval-shared.js";
-import type { GatewayClient, GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestHandlers } from "./types.js";
 
 const APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS = {
   reason: "APPROVAL_ALLOW_ALWAYS_UNAVAILABLE",
@@ -396,6 +395,8 @@ export function createExecApprovalHandlers(
         return;
       }
       const requestEvent: ExecApprovalRequest = buildRequestedApprovalEvent(record);
+      const forwardRequest = opts?.forwarder?.handleRequested.bind(opts.forwarder);
+      const iosPushRequest = opts?.iosPushDelivery?.handleRequested?.bind(opts.iosPushDelivery);
       await handlePendingApprovalRequest({
         manager,
         record,
@@ -409,53 +410,20 @@ export function createExecApprovalHandlers(
         approvalKind: "exec",
         requireDeliveryRoute: p.requireDeliveryRoute,
         suppressDelivery: p.suppressDelivery,
-        deliverRequest: () => {
-          const deliveryTasks: Array<Promise<boolean>> = [];
-          if (opts?.forwarder) {
-            deliveryTasks.push(
-              opts.forwarder.handleRequested(requestEvent).catch((err: unknown) => {
-                context.logGateway?.error?.(
-                  `exec approvals: forward request failed: ${String(err)}`,
-                );
-                return false;
-              }),
-            );
-          }
-          if (opts?.iosPushDelivery?.handleRequested) {
-            deliveryTasks.push(
-              opts.iosPushDelivery
-                .handleRequested(requestEvent, {
-                  isTargetVisible: (target) =>
-                    isApprovalRecordVisibleToClient({
-                      record,
-                      client: {
-                        connect: {
-                          client: { id: GATEWAY_CLIENT_IDS.IOS_APP },
-                          device: { id: target.deviceId },
-                          scopes: [...target.scopes],
-                        },
-                      } as GatewayClient,
-                    }),
-                })
-                .catch((err: unknown) => {
-                  context.logGateway?.error?.(
-                    `exec approvals: iOS push request failed: ${String(err)}`,
-                  );
-                  return false;
-                }),
-            );
-          }
-          if (deliveryTasks.length === 0) {
-            return false;
-          }
-          return (async () => {
-            let delivered = false;
-            for (const task of deliveryTasks) {
-              delivered = (await task) || delivered;
-            }
-            return delivered;
-          })();
-        },
+        deliverRequest: () =>
+          runApprovalRequestDeliveries({
+            context,
+            record,
+            forward: forwardRequest
+              ? [() => forwardRequest(requestEvent), "exec approvals: forward request failed"]
+              : undefined,
+            iosPush: iosPushRequest
+              ? [
+                  (isTargetVisible) => iosPushRequest(requestEvent, { isTargetVisible }),
+                  "exec approvals: iOS push request failed",
+                ]
+              : undefined,
+          }),
         afterDecision: async (decision) => {
           if (decision === null) {
             await opts?.iosPushDelivery?.handleExpired?.(requestEvent);

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -1,7 +1,6 @@
 // Gateway RPC handlers for plugin approval requests and decisions.
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -18,6 +17,7 @@ import type {
 } from "../../infra/plugin-approvals.js";
 import { resolvePluginApprovalTimeoutMs } from "../../infra/plugin-approvals.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import { runApprovalRequestDeliveries } from "./approval-request-delivery.js";
 import {
   bindApprovalRequesterMetadata,
   bindApprovalReviewerDeviceIds,
@@ -25,12 +25,11 @@ import {
   handleApprovalResolve,
   handleApprovalWaitDecision,
   handlePendingApprovalRequest,
-  isApprovalRecordVisibleToClient,
   listVisiblePendingApprovalRequests,
   registerPendingApprovalRecord,
   resolveApprovalDecisionParams,
 } from "./approval-shared.js";
-import type { GatewayClient, GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestHandlers } from "./types.js";
 
 type PluginApprovalIosPushDelivery = {
   handleRequested?: (
@@ -137,6 +136,8 @@ export function createPluginApprovalHandlers(
       }
 
       const requestEvent = buildRequestedApprovalEvent(record);
+      const forwardRequest = opts?.forwarder?.handlePluginApprovalRequested?.bind(opts.forwarder);
+      const iosPushRequest = opts?.iosPushDelivery?.handleRequested?.bind(opts.iosPushDelivery);
 
       await handlePendingApprovalRequest({
         manager,
@@ -149,53 +150,20 @@ export function createPluginApprovalHandlers(
         requestEvent,
         twoPhase,
         approvalKind: "plugin",
-        deliverRequest: () => {
-          const deliveryTasks: Array<Promise<boolean>> = [];
-          if (opts?.forwarder?.handlePluginApprovalRequested) {
-            deliveryTasks.push(
-              opts.forwarder.handlePluginApprovalRequested(requestEvent).catch((err: unknown) => {
-                context.logGateway?.error?.(
-                  `plugin approvals: forward request failed: ${String(err)}`,
-                );
-                return false;
-              }),
-            );
-          }
-          if (opts?.iosPushDelivery?.handleRequested) {
-            deliveryTasks.push(
-              opts.iosPushDelivery
-                .handleRequested(requestEvent, {
-                  isTargetVisible: (target) =>
-                    isApprovalRecordVisibleToClient({
-                      record,
-                      client: {
-                        connect: {
-                          client: { id: GATEWAY_CLIENT_IDS.IOS_APP },
-                          device: { id: target.deviceId },
-                          scopes: [...target.scopes],
-                        },
-                      } as GatewayClient,
-                    }),
-                })
-                .catch((err: unknown) => {
-                  context.logGateway?.error?.(
-                    `plugin approvals: iOS push request failed: ${String(err)}`,
-                  );
-                  return false;
-                }),
-            );
-          }
-          if (deliveryTasks.length === 0) {
-            return false;
-          }
-          return (async () => {
-            let delivered = false;
-            for (const task of deliveryTasks) {
-              delivered = (await task) || delivered;
-            }
-            return delivered;
-          })();
-        },
+        deliverRequest: () =>
+          runApprovalRequestDeliveries({
+            context,
+            record,
+            forward: forwardRequest
+              ? [() => forwardRequest(requestEvent), "plugin approvals: forward request failed"]
+              : undefined,
+            iosPush: iosPushRequest
+              ? [
+                  (isTargetVisible) => iosPushRequest(requestEvent, { isTargetVisible }),
+                  "plugin approvals: iOS push request failed",
+                ]
+              : undefined,
+          }),
         afterDecision: async (decision) => {
           if (decision === null) {
             await opts?.iosPushDelivery?.handleExpired?.(requestEvent);


### PR DESCRIPTION
## What Problem This Solves

Exec approvals, plugin approvals, and node plugin-policy approvals each carried a near-identical external request-delivery loop. The copies could drift on iOS visibility filtering, route concurrency, error isolation, and delivered-result aggregation.

## Why This Change Was Made

Move the shared request fan-out into one private gateway owner while keeping each caller responsible for its request type, route functions, and exact log labels.

The helper preserves the existing contract:

- no configured routes return `false` synchronously
- forward and iOS routes start before either result is awaited
- one route failure is logged and does not suppress another successful route
- iOS targets use the existing approval visibility predicate
- bound route methods keep their original receiver

This removes 39 production lines across the three callers. The added focused tests cover no-route behavior, concurrent startup, failure isolation, log labels, and successful aggregation.

## User Impact

No intended user-visible behavior, configuration, protocol, or storage change. This is an internal duplication cleanup that gives approval request delivery one implementation owner.

## Evidence

- `OPENCLAW_TESTBOX=1 node scripts/crabbox-wrapper.mjs run --id tbx_01ky9h5t17knc82khjn74yfav0 ...`
  - 5 focused files passed
  - 277 tests passed
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 corepack pnpm check:changed -- <5 changed files>`
  - passed on the same Testbox
- Testbox: `tbx_01ky9h5t17knc82khjn74yfav0`
- Hosted run: https://github.com/openclaw/openclaw/actions/runs/30076327050
- `git diff --check`
  - passed
- Fresh branch autoreview
  - clean, no accepted/actionable findings
  - patch correctness 0.98

AI assistance was used for code review and refactoring support. No agent transcript logs are attached.
