### PR TITLE
feat(control-ui): drag-to-resize chat composer

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4429,6 +4429,10 @@ export const en: TranslationMap = {
     },
     composer: {
       placeholder: "Message {name}",
+      resize: {
+        label: "Resize message input",
+        resetHint: "double-click to reset",
+      },
       placeholderWithAttachments: "Add a message or paste more images...",
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       offlineHint: "Offline — messages will be queued and sent when the connection returns.",

--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -36,9 +36,16 @@ export function adjustTextareaHeight(el: HTMLTextAreaElement) {
   // applyComposerTextareaHeight already manages overflowY (auto/hidden) and the
   // max-height cap (dynamic viewport ratio, 150px fallback), subsuming the prior
   // inline autosize + updateTextareaOverflow path.
-  const hasHandle = Boolean(
-    el.closest(".agent-chat__input")?.querySelector("composer-resize-handle"),
-  );
+  const composerInput = el.closest(".agent-chat__input");
+  const hasHandle = Boolean(composerInput?.querySelector("composer-resize-handle"));
+
+  // While a drag is actively in progress, the handle owns the live height.
+  // Programmatic calls (e.g. turn-end re-render) must not override it; the
+  // persisted floor will be written on pointerup and applied on next call.
+  if (composerInput?.querySelector("composer-resize-handle.dragging")) {
+    return;
+  }
+
   applyComposerTextareaHeight(el, hasHandle ? undefined : null);
 }
 

--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -1,3 +1,5 @@
+import { applyComposerTextareaHeight } from "../composer-height.ts";
+
 const COMPOSER_CHROME_INTERACTIVE_SELECTOR = [
   "a[href]",
   "button",
@@ -28,17 +30,16 @@ function updateTextareaOverflow(el: HTMLTextAreaElement) {
 }
 
 export function adjustTextareaHeight(el: HTMLTextAreaElement) {
-  // Hide the browser's scrollbar while measuring; restore it only when the
-  // final CSS-constrained height actually clips the draft.
-  el.style.overflowY = "hidden";
-  el.style.height = "auto";
-  // The owning surface declares its cap in CSS. Retain the historical fallback
-  // for detached/test controls whose computed max-height is not a pixel value.
-  const computedMaxHeight = getComputedStyle(el).maxHeight.trim();
-  const pixelMaxHeight = /^(\d+(?:\.\d+)?)px$/u.exec(computedMaxHeight);
-  const maxHeight = pixelMaxHeight ? Number(pixelMaxHeight[1]) : 150;
-  el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
-  updateTextareaOverflow(el);
+  // Honor the global drag-to-resize floor only for the primary composer (the one
+  // that renders the resize handle). Suggestion/secondary composers omit the
+  // handle, so they autosize normally and a manual height never leaks into them.
+  // applyComposerTextareaHeight already manages overflowY (auto/hidden) and the
+  // max-height cap (dynamic viewport ratio, 150px fallback), subsuming the prior
+  // inline autosize + updateTextareaOverflow path.
+  const hasHandle = Boolean(
+    el.closest(".agent-chat__input")?.querySelector("composer-resize-handle"),
+  );
+  applyComposerTextareaHeight(el, hasHandle ? undefined : null);
 }
 
 export function observeTextareaOverflow(el: HTMLTextAreaElement) {

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -161,6 +161,9 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
             class="agent-chat__input ${props.offline ? "agent-chat__input--offline" : ""}"
             @click=${(event: MouseEvent) => focusComposerFromChrome(event, canCompose)}
           >
+            ${props.suggestionComposer
+              ? nothing
+              : html`<composer-resize-handle></composer-resize-handle>`}
             ${props.offline
               ? html`<div class="agent-chat__offline-hint" role="status" aria-live="polite">
                   ${props.queuedOutboxCount

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -1,7 +1,6 @@
 // Chat-owned composer orchestration.
 import { nothing } from "lit";
 import { loadSettings, normalizeChatSendShortcut, patchSettings } from "../../../app/settings.ts";
-import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 import { ComposerDictationController, insertComposerDictation } from "../composer-dictation.ts";
@@ -44,6 +43,7 @@ import {
 import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
 import { renderChatComposerView } from "./chat-composer-view.ts";
 import { createGatewayQuestionPanelProps } from "./chat-question-card.ts";
+import "./composer-resize-handle.ts";
 
 export { isChatRunWorking, resetChatComposerState } from "./chat-composer-state.ts";
 

--- a/ui/src/pages/chat/components/composer-resize-handle.test.ts
+++ b/ui/src/pages/chat/components/composer-resize-handle.test.ts
@@ -1,0 +1,132 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../../test-helpers/storage.ts";
+import { readComposerFloor, writeComposerFloor } from "../composer-height.ts";
+import "./composer-resize-handle.ts";
+
+function stubRect(el: HTMLElement, height: number) {
+  el.getBoundingClientRect = () =>
+    ({ height, width: 300, top: 0, bottom: height, left: 0, right: 300, x: 0, y: 0 }) as DOMRect;
+}
+
+function mount(boxHeight = 40, scrollHeight = 40) {
+  const combobox = document.createElement("div");
+  combobox.className = "agent-chat__composer-combobox";
+  const handle = document.createElement("composer-resize-handle");
+  const textarea = document.createElement("textarea");
+  Object.defineProperty(textarea, "scrollHeight", { configurable: true, get: () => scrollHeight });
+  stubRect(textarea, boxHeight);
+  combobox.append(handle, textarea);
+  document.body.append(combobox);
+  return { handle, textarea };
+}
+
+describe("composer-resize-handle", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("exposes the separator ARIA contract", () => {
+    const { handle } = mount();
+    expect(handle.getAttribute("role")).toBe("separator");
+    expect(handle.getAttribute("aria-orientation")).toBe("horizontal");
+    expect(handle.getAttribute("tabindex")).toBe("0");
+    expect(handle.getAttribute("aria-valuemin")).toBe("36");
+    expect(Number(handle.getAttribute("aria-valuemax"))).toBeGreaterThan(36);
+    expect(handle.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("marks manual mode only when a floor is set", () => {
+    writeComposerFloor(220);
+    const { handle } = mount();
+    expect(handle.classList.contains("manual")).toBe(true);
+  });
+
+  it("ArrowUp / ArrowDown nudge the floor and persist it globally", () => {
+    const { handle } = mount(40);
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    expect(readComposerFloor()).toBe(56); // 40 + 16
+
+    handle.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowUp", shiftKey: true, bubbles: true }),
+    );
+    expect(readComposerFloor()).toBe(104); // 56 + 48
+
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(readComposerFloor()).toBe(88); // 104 - 16
+  });
+
+  it("Enter resets manual mode back to auto", () => {
+    writeComposerFloor(260);
+    const { handle } = mount();
+    expect(handle.classList.contains("manual")).toBe(true);
+
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(readComposerFloor()).toBeNull();
+    expect(handle.classList.contains("manual")).toBe(false);
+  });
+
+  it("pointer drag past the threshold sets and persists an exact floor", () => {
+    const { handle, textarea } = mount(40);
+    // Synthetic PointerEvents have no live pointer; neutralize capture so jsdom
+    // does not throw (we assert on the resulting floor, not on pointer capture).
+    handle.setPointerCapture = () => {};
+    handle.releasePointerCapture = () => {};
+    handle.hasPointerCapture = () => false;
+
+    const opts = { bubbles: true, pointerId: 1, pointerType: "mouse", button: 0 } as const;
+    handle.dispatchEvent(new PointerEvent("pointerdown", { ...opts, clientY: 200 }));
+    handle.dispatchEvent(new PointerEvent("pointermove", { ...opts, clientY: 190 })); // 10px > threshold
+    handle.dispatchEvent(new PointerEvent("pointermove", { ...opts, clientY: 100 })); // 100px up total
+    expect(handle.classList.contains("dragging")).toBe(true);
+    handle.dispatchEvent(new PointerEvent("pointerup", { ...opts, clientY: 100 }));
+
+    // startHeight 40 (stubbed rect) + 100px drag-up = 140, persisted globally.
+    expect(readComposerFloor()).toBe(140);
+    expect(handle.classList.contains("dragging")).toBe(false);
+    expect(textarea.style.height).toBe("140px");
+  });
+
+  it("double-click resets manual mode back to auto", () => {
+    writeComposerFloor(260);
+    const { handle } = mount();
+    handle.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    expect(readComposerFloor()).toBeNull();
+    expect(handle.classList.contains("manual")).toBe(false);
+  });
+
+  it("cleans up an active drag when disconnected mid-drag", () => {
+    const { handle } = mount(40);
+    const releaseSpy = vi.fn();
+    handle.setPointerCapture = vi.fn();
+    handle.releasePointerCapture = releaseSpy;
+    handle.hasPointerCapture = vi.fn(() => true);
+
+    const opts = { bubbles: true, pointerId: 1, pointerType: "mouse", button: 0 } as const;
+    handle.dispatchEvent(new PointerEvent("pointerdown", { ...opts, clientY: 200 }));
+    handle.dispatchEvent(new PointerEvent("pointermove", { ...opts, clientY: 180 }));
+    expect(handle.classList.contains("dragging")).toBe(true);
+
+    handle.remove(); // triggers disconnectedCallback mid-drag
+    expect(releaseSpy).toHaveBeenCalledWith(1);
+    expect(handle.classList.contains("dragging")).toBe(false);
+  });
+
+  it("re-clamps the manual floor to the viewport max on resize", () => {
+    writeComposerFloor(500);
+    const { textarea } = mount(500);
+    // jsdom innerHeight defaults to 768 → max = round(768 * 0.55) = 422.
+    window.dispatchEvent(new Event("resize"));
+    expect(textarea.style.height).toBe("422px");
+
+    vi.stubGlobal("innerHeight", 400);
+    window.dispatchEvent(new Event("resize"));
+    expect(textarea.style.height).toBe("220px"); // round(400 * 0.55)
+  });
+});

--- a/ui/src/pages/chat/components/composer-resize-handle.test.ts
+++ b/ui/src/pages/chat/components/composer-resize-handle.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../../../test-helpers/storage.ts";
 import { readComposerFloor, writeComposerFloor } from "../composer-height.ts";
+import { adjustTextareaHeight } from "./chat-composer-dom.ts";
 import "./composer-resize-handle.ts";
 
 function stubRect(el: HTMLElement, height: number) {
@@ -11,6 +12,8 @@ function stubRect(el: HTMLElement, height: number) {
 }
 
 function mount(boxHeight = 40, scrollHeight = 40) {
+  const inputWrapper = document.createElement("div");
+  inputWrapper.className = "agent-chat__input";
   const combobox = document.createElement("div");
   combobox.className = "agent-chat__composer-combobox";
   const handle = document.createElement("composer-resize-handle");
@@ -18,7 +21,8 @@ function mount(boxHeight = 40, scrollHeight = 40) {
   Object.defineProperty(textarea, "scrollHeight", { configurable: true, get: () => scrollHeight });
   stubRect(textarea, boxHeight);
   combobox.append(handle, textarea);
-  document.body.append(combobox);
+  inputWrapper.append(combobox);
+  document.body.append(inputWrapper);
   return { handle, textarea };
 }
 
@@ -128,5 +132,40 @@ describe("composer-resize-handle", () => {
     vi.stubGlobal("innerHeight", 400);
     window.dispatchEvent(new Event("resize"));
     expect(textarea.style.height).toBe("220px"); // round(400 * 0.55)
+  });
+
+  it("adjustTextareaHeight is a no-op while a drag is in progress", () => {
+    const { handle, textarea } = mount(40, 80);
+    handle.setPointerCapture = () => {};
+    handle.releasePointerCapture = () => {};
+    handle.hasPointerCapture = () => false;
+
+    const opts = { bubbles: true, pointerId: 1, pointerType: "mouse", button: 0 } as const;
+    handle.dispatchEvent(new PointerEvent("pointerdown", { ...opts, clientY: 200 }));
+    handle.dispatchEvent(new PointerEvent("pointermove", { ...opts, clientY: 190 })); // past threshold
+
+    expect(handle.classList.contains("dragging")).toBe(true);
+    // The drag set the height to startHeight(40) + 10 = 50
+    expect(textarea.style.height).toBe("50px");
+
+    // A programmatic adjustTextareaHeight call (e.g. turn-end re-render) must
+    // NOT override the live drag height.
+    adjustTextareaHeight(textarea);
+    expect(textarea.style.height).toBe("50px"); // preserved, not overridden
+
+    // After drag ends, adjustTextareaHeight applies normally.
+    handle.dispatchEvent(new PointerEvent("pointerup", { ...opts, clientY: 190 }));
+    expect(handle.classList.contains("dragging")).toBe(false);
+    adjustTextareaHeight(textarea);
+    // Now it applies: stored floor is 50, content is 80 — manual mode uses floor.
+    expect(textarea.style.height).toBe("50px");
+  });
+
+  it("adjustTextareaHeight works normally when no drag is in progress", () => {
+    const { textarea } = mount(40, 80);
+    // No drag active — adjustTextareaHeight should run and auto-size to content.
+    adjustTextareaHeight(textarea);
+    // Has handle → floorOverride undefined → auto mode capped at 150, content is 80
+    expect(textarea.style.height).toBe("80px");
   });
 });

--- a/ui/src/pages/chat/components/composer-resize-handle.ts
+++ b/ui/src/pages/chat/components/composer-resize-handle.ts
@@ -1,0 +1,294 @@
+// Accessible drag-to-resize handle for the chat composer input.
+//
+// Mirrors the pointer-drag + a11y model of resizable-divider.ts, but drives the
+// composer textarea height directly (exact manual height) and renders into
+// light DOM so it is styled by the shared chat stylesheet.
+import { html } from "lit";
+import { t } from "../../../i18n/index.ts";
+import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
+import {
+  applyComposerTextareaHeight,
+  clampComposerHeight,
+  clearComposerFloor,
+  COMPOSER_MIN_TEXTAREA_HEIGHT,
+  computeComposerMaxHeight,
+  readComposerFloor,
+  writeComposerFloor,
+} from "../composer-height.ts";
+
+/** Movement before a press becomes a drag, so a plain double-click never drags. */
+const DRAG_THRESHOLD_PX = 3;
+const KEYBOARD_STEP_PX = 16;
+const KEYBOARD_STEP_LARGE_PX = 48;
+/** CSS height transition (160ms) plus a small buffer before dropping the class. */
+const ANIMATE_CLASS_LIFETIME_MS = 220;
+
+type DragPhase = "idle" | "maybe" | "dragging";
+
+class ComposerResizeHandle extends OpenClawLightDomElement {
+  private phase: DragPhase = "idle";
+  private startY = 0;
+  private startHeight = 0;
+  private dragFloor: number | null = null;
+  private activePointerId: number | null = null;
+  private animateTimer: ReturnType<typeof setTimeout> | null = null;
+  private dragListenersAttached = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("role", "separator");
+    this.setAttribute("aria-orientation", "horizontal");
+    if (!this.hasAttribute("tabindex")) {
+      this.setAttribute("tabindex", "0");
+    }
+    // Only pointerdown/dblclick/keydown live on the element; the move/up
+    // listeners are attached to the document for the duration of a drag (see
+    // handlePointerDown), so a drag that leaves the thin strip is not dropped
+    // even if pointer capture is unavailable.
+    this.addEventListener("pointerdown", this.handlePointerDown);
+    this.addEventListener("dblclick", this.handleReset);
+    this.addEventListener("keydown", this.handleKeyDown);
+    if (typeof window !== "undefined") {
+      window.addEventListener("resize", this.handleViewportResize);
+    }
+    this.syncState();
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener("pointerdown", this.handlePointerDown);
+    this.removeEventListener("dblclick", this.handleReset);
+    this.removeEventListener("keydown", this.handleKeyDown);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("resize", this.handleViewportResize);
+    }
+    this.detachDragListeners();
+    this.phase = "idle";
+    this.dragFloor = null;
+    this.classList.remove("dragging");
+    if (this.animateTimer != null) {
+      clearTimeout(this.animateTimer);
+      this.animateTimer = null;
+    }
+    // Drop the transient animation class so a detached textarea keeps no state.
+    this.textarea?.classList.remove("composer-animate-height");
+    this.releaseActivePointer();
+  }
+
+  override render() {
+    // Grip is invisible at rest and fades in on hover/focus. The reset hint is
+    // absolutely positioned above the top edge (zero layout height) and shares
+    // the grip's visibility state via CSS (no independent timer).
+    return html`
+      <span class="agent-chat__composer-grip" aria-hidden="true"></span>
+      <span class="agent-chat__composer-reset-hint" aria-hidden="true"
+        >${t("chat.composer.resize.resetHint")}</span
+      >
+    `;
+  }
+
+  protected override updated() {
+    // Re-apply attributes so the aria-label tracks locale changes.
+    this.syncState();
+  }
+
+  private get textarea(): HTMLTextAreaElement | null {
+    return this.parentElement?.querySelector<HTMLTextAreaElement>("textarea") ?? null;
+  }
+
+  private handlePointerDown = (e: PointerEvent) => {
+    // Primary contact only: left mouse button, or primary touch/pen (button 0),
+    // or the "no button" sentinel some touch stacks report (-1).
+    if (e.button !== 0 && e.button !== -1) {
+      return;
+    }
+    const textarea = this.textarea;
+    if (!textarea) {
+      return;
+    }
+    this.startY = e.clientY;
+    this.startHeight =
+      textarea.getBoundingClientRect().height ||
+      readComposerFloor() ||
+      COMPOSER_MIN_TEXTAREA_HEIGHT;
+    this.dragFloor = null;
+    this.phase = "maybe";
+    this.capturePointer(e.pointerId);
+    this.attachDragListeners();
+    // No preventDefault(): it can suppress the native dblclick used for reset.
+  };
+
+  private handlePointerMove = (e: PointerEvent) => {
+    if (this.phase === "idle") {
+      return;
+    }
+    const textarea = this.textarea;
+    if (!textarea) {
+      return;
+    }
+    const delta = this.startY - e.clientY; // drag up = grow
+    if (this.phase === "maybe") {
+      if (Math.abs(delta) < DRAG_THRESHOLD_PX) {
+        return;
+      }
+      this.phase = "dragging";
+      this.classList.add("dragging");
+    }
+    const max = computeComposerMaxHeight(textarea);
+    this.dragFloor = clampComposerHeight(this.startHeight + delta, max);
+    applyComposerTextareaHeight(textarea, this.dragFloor);
+    this.syncState();
+  };
+
+  private handlePointerUp = (e: PointerEvent) => {
+    if (this.phase === "idle") {
+      this.detachDragListeners();
+      return;
+    }
+    const wasDragging = this.phase === "dragging";
+    this.phase = "idle";
+    this.classList.remove("dragging");
+    this.detachDragListeners();
+    this.releaseActivePointer(e.pointerId);
+    if (wasDragging && this.dragFloor != null) {
+      writeComposerFloor(this.dragFloor);
+    }
+    this.dragFloor = null;
+    this.syncState();
+  };
+
+  private handleReset = () => {
+    this.animateNextHeightChange();
+    clearComposerFloor();
+    const textarea = this.textarea;
+    if (textarea) {
+      applyComposerTextareaHeight(textarea);
+    }
+    this.syncState();
+  };
+
+  private handleKeyDown = (e: KeyboardEvent) => {
+    const textarea = this.textarea;
+    if (!textarea) {
+      return;
+    }
+    if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+      e.preventDefault();
+      this.handleReset();
+      return;
+    }
+    if (e.key !== "ArrowUp" && e.key !== "ArrowDown") {
+      return;
+    }
+    e.preventDefault();
+    const step = e.shiftKey ? KEYBOARD_STEP_LARGE_PX : KEYBOARD_STEP_PX;
+    const base = readComposerFloor() ?? textarea.getBoundingClientRect().height;
+    const max = computeComposerMaxHeight(textarea);
+    const next = clampComposerHeight(base + (e.key === "ArrowUp" ? step : -step), max);
+    writeComposerFloor(next);
+    this.animateNextHeightChange();
+    applyComposerTextareaHeight(textarea);
+    this.syncState();
+  };
+
+  private handleViewportResize = () => {
+    // Skip re-clamping while a drag is in progress to avoid reading stale
+    // persisted state and causing visual flicker.
+    if (this.phase !== "idle") {
+      return;
+    }
+    const textarea = this.textarea;
+    if (!textarea) {
+      return;
+    }
+    // Re-clamp the stored floor against the new dynamic max.
+    applyComposerTextareaHeight(textarea);
+    this.syncState();
+  };
+
+  private attachDragListeners() {
+    if (this.dragListenersAttached || typeof document === "undefined") {
+      return;
+    }
+    document.addEventListener("pointermove", this.handlePointerMove);
+    document.addEventListener("pointerup", this.handlePointerUp);
+    document.addEventListener("pointercancel", this.handlePointerUp);
+    this.dragListenersAttached = true;
+  }
+
+  private detachDragListeners() {
+    if (!this.dragListenersAttached || typeof document === "undefined") {
+      return;
+    }
+    document.removeEventListener("pointermove", this.handlePointerMove);
+    document.removeEventListener("pointerup", this.handlePointerUp);
+    document.removeEventListener("pointercancel", this.handlePointerUp);
+    this.dragListenersAttached = false;
+  }
+
+  // Enable the CSS height transition for the next programmatic change only
+  // (reset / keyboard nudge). Live drag and typing autosize stay instant.
+  private animateNextHeightChange() {
+    const textarea = this.textarea;
+    if (!textarea) {
+      return;
+    }
+    textarea.classList.add("composer-animate-height");
+    if (this.animateTimer != null) {
+      clearTimeout(this.animateTimer);
+    }
+    this.animateTimer = setTimeout(() => {
+      this.animateTimer = null;
+      this.textarea?.classList.remove("composer-animate-height");
+    }, ANIMATE_CLASS_LIFETIME_MS);
+  }
+
+  private syncState() {
+    const textarea = this.textarea;
+    const floor = this.phase === "dragging" ? this.dragFloor : readComposerFloor();
+    this.classList.toggle("manual", floor != null);
+    const max = textarea ? computeComposerMaxHeight(textarea) : COMPOSER_MIN_TEXTAREA_HEIGHT;
+    const now = textarea
+      ? Math.round(textarea.getBoundingClientRect().height) || floor || COMPOSER_MIN_TEXTAREA_HEIGHT
+      : (floor ?? COMPOSER_MIN_TEXTAREA_HEIGHT);
+    this.setAttribute("aria-valuemin", String(COMPOSER_MIN_TEXTAREA_HEIGHT));
+    this.setAttribute("aria-valuemax", String(max));
+    this.setAttribute("aria-valuenow", String(clampComposerHeight(now, max)));
+    this.setAttribute("aria-label", t("chat.composer.resize.label"));
+  }
+
+  private capturePointer(pointerId: number) {
+    if (typeof this.setPointerCapture !== "function") {
+      return;
+    }
+    try {
+      this.setPointerCapture(pointerId);
+      this.activePointerId = pointerId;
+    } catch {
+      // Capture is best-effort; document-level drag listeners cover the fallback.
+      this.activePointerId = null;
+    }
+  }
+
+  private releaseActivePointer(pointerId?: number) {
+    const id = pointerId ?? this.activePointerId;
+    this.activePointerId = null;
+    if (id == null || typeof this.releasePointerCapture !== "function") {
+      return;
+    }
+    if (typeof this.hasPointerCapture === "function" && !this.hasPointerCapture(id)) {
+      return;
+    }
+    this.releasePointerCapture(id);
+  }
+}
+
+if (!customElements.get("composer-resize-handle")) {
+  customElements.define("composer-resize-handle", ComposerResizeHandle);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "composer-resize-handle": ComposerResizeHandle;
+  }
+}

--- a/ui/src/pages/chat/composer-height.test.ts
+++ b/ui/src/pages/chat/composer-height.test.ts
@@ -1,0 +1,108 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import {
+  applyComposerTextareaHeight,
+  clearComposerFloor,
+  readComposerFloor,
+  writeComposerFloor,
+} from "./composer-height.ts";
+
+// Mirror of the module-internal storage key (kept unexported to avoid an unused public export).
+const COMPOSER_HEIGHT_STORAGE_KEY = "openclaw.control.composer.height.v1";
+
+function makeTextarea(scrollHeight: number): HTMLTextAreaElement {
+  const el = document.createElement("textarea");
+  Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => scrollHeight });
+  document.body.appendChild(el);
+  return el;
+}
+
+function heightPx(el: HTMLTextAreaElement): number {
+  return Number.parseInt(el.style.height, 10);
+}
+
+describe("composer-height store", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    // jsdom defaults innerHeight to 768 → dynamic max = round(768 * 0.55) = 422.
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("round-trips a global floor and clears it", () => {
+    expect(readComposerFloor()).toBeNull();
+    writeComposerFloor(240);
+    expect(readComposerFloor()).toBe(240);
+    expect(localStorage.getItem(COMPOSER_HEIGHT_STORAGE_KEY)).toBe("240");
+    clearComposerFloor();
+    expect(readComposerFloor()).toBeNull();
+    expect(localStorage.getItem(COMPOSER_HEIGHT_STORAGE_KEY)).toBeNull();
+  });
+
+  it("restores a persisted floor on the next load", () => {
+    localStorage.setItem(COMPOSER_HEIGHT_STORAGE_KEY, "300");
+    expect(readComposerFloor()).toBe(300);
+  });
+
+  it("ignores non-positive / invalid persisted values", () => {
+    localStorage.setItem(COMPOSER_HEIGHT_STORAGE_KEY, "0");
+    expect(readComposerFloor()).toBeNull();
+    localStorage.setItem(COMPOSER_HEIGHT_STORAGE_KEY, "nope");
+    expect(readComposerFloor()).toBeNull();
+  });
+
+  it("auto-sizes to content and clamps to the min (no floor)", () => {
+    const el = makeTextarea(80);
+    applyComposerTextareaHeight(el);
+    expect(heightPx(el)).toBe(80);
+
+    const tiny = makeTextarea(10);
+    applyComposerTextareaHeight(tiny);
+    expect(heightPx(tiny)).toBe(36); // COMPOSER_MIN_TEXTAREA_HEIGHT
+  });
+
+  it("preserves the legacy 150px auto cap when no floor is set", () => {
+    const el = makeTextarea(500);
+    applyComposerTextareaHeight(el);
+    expect(heightPx(el)).toBe(150); // COMPOSER_AUTO_HEIGHT_CAP
+  });
+
+  it("uses the exact manual height and ignores content autosize (may scroll)", () => {
+    // Manual height above content: box is exactly the manual value.
+    writeComposerFloor(200);
+    const shorter = makeTextarea(80);
+    applyComposerTextareaHeight(shorter);
+    expect(heightPx(shorter)).toBe(200);
+
+    // Tall content does NOT enlarge the box in manual mode (it scrolls).
+    const taller = makeTextarea(320);
+    applyComposerTextareaHeight(taller);
+    expect(heightPx(taller)).toBe(200);
+
+    // Manual height BELOW content is honored (content scrolls) — the box can
+    // shrink below the auto-size height.
+    writeComposerFloor(100);
+    const belowContent = makeTextarea(320);
+    applyComposerTextareaHeight(belowContent);
+    expect(heightPx(belowContent)).toBe(100);
+  });
+
+  it("clamps a manual floor + content to the dynamic max (~55% viewport)", () => {
+    writeComposerFloor(900);
+    const el = makeTextarea(900);
+    applyComposerTextareaHeight(el);
+    expect(heightPx(el)).toBe(422); // round(768 * 0.55)
+  });
+
+  it("applies a live drag override without touching storage", () => {
+    const el = makeTextarea(80);
+    applyComposerTextareaHeight(el, 260);
+    expect(heightPx(el)).toBe(260);
+    expect(readComposerFloor()).toBeNull();
+  });
+});

--- a/ui/src/pages/chat/composer-height.test.ts
+++ b/ui/src/pages/chat/composer-height.test.ts
@@ -66,10 +66,48 @@ describe("composer-height store", () => {
     expect(heightPx(tiny)).toBe(36); // COMPOSER_MIN_TEXTAREA_HEIGHT
   });
 
-  it("preserves the legacy 150px auto cap when no floor is set", () => {
+  it("preserves the legacy 150px auto cap when no floor is set (handle mode)", () => {
     const el = makeTextarea(500);
     applyComposerTextareaHeight(el);
     expect(heightPx(el)).toBe(150); // COMPOSER_AUTO_HEIGHT_CAP
+  });
+
+  it("no-handle auto mode grows to CSS max-height instead of the 150 cap", () => {
+    const el = makeTextarea(250);
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      maxHeight: "260px",
+    } as CSSStyleDeclaration);
+    // floorOverride = null → no-handle → use CSS max-height (260) as cap
+    applyComposerTextareaHeight(el, null);
+    expect(heightPx(el)).toBe(250); // content fits within CSS cap
+  });
+
+  it("no-handle auto mode caps at the CSS max-height when content exceeds it", () => {
+    const el = makeTextarea(400);
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      maxHeight: "260px",
+    } as CSSStyleDeclaration);
+    applyComposerTextareaHeight(el, null);
+    expect(heightPx(el)).toBe(260); // capped at CSS max
+  });
+
+  it("no-handle auto mode falls back to 150 for non-pixel CSS max-height", () => {
+    const el = makeTextarea(500);
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      maxHeight: "50vh",
+    } as CSSStyleDeclaration);
+    applyComposerTextareaHeight(el, null);
+    expect(heightPx(el)).toBe(150); // fallback
+  });
+
+  it("handle auto mode still caps at 150 regardless of CSS max-height", () => {
+    const el = makeTextarea(500);
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      maxHeight: "500px",
+    } as CSSStyleDeclaration);
+    // floorOverride = undefined → handle mode → hardcoded 150 cap
+    applyComposerTextareaHeight(el);
+    expect(heightPx(el)).toBe(150);
   });
 
   it("uses the exact manual height and ignores content autosize (may scroll)", () => {

--- a/ui/src/pages/chat/composer-height.ts
+++ b/ui/src/pages/chat/composer-height.ts
@@ -120,6 +120,13 @@ export function applyComposerTextareaHeight(
   el.style.height = "auto";
   const content = el.scrollHeight;
   el.style.height = previousHeight;
+  // Measuring at `auto` above forces a layout that would otherwise become the
+  // CSS transition's starting point (making an animated reset snap 40->40).
+  // When animating, force a reflow at the restored height so the transition
+  // baseline is the real starting height and the change glides.
+  if (el.classList.contains("composer-animate-height")) {
+    void el.offsetHeight;
+  }
   const target = clampComposerHeight(Math.min(content, COMPOSER_AUTO_HEIGHT_CAP), dynamicMax);
   el.style.height = `${target}px`;
   el.style.overflowY = el.scrollHeight > el.clientHeight ? "auto" : "hidden";

--- a/ui/src/pages/chat/composer-height.ts
+++ b/ui/src/pages/chat/composer-height.ts
@@ -1,0 +1,126 @@
+// Global drag-to-resize composer height store plus the shared textarea autosize.
+//
+// Scope is intentionally GLOBAL: one manual floor applies to every session and
+// pane. It is persisted under a namespaced key so a per-session variant can be
+// layered on later without a rewrite. This deliberately does NOT reuse the
+// per-session composer-outbox/composer-storage machinery.
+import { getSafeLocalStorage } from "../../local-storage.ts";
+
+/** Namespaced, migration-friendly key holding a single integer px (global). */
+const COMPOSER_HEIGHT_STORAGE_KEY = "openclaw.control.composer.height.v1";
+
+/** Minimum composer textarea height (~1 line + inset); mirrors the CSS min-height. */
+export const COMPOSER_MIN_TEXTAREA_HEIGHT = 36;
+
+/**
+ * Auto-size cap preserved from the pre-resize behavior. With no manual floor
+ * set the textarea keeps growing only up to this height, so the box only
+ * exceeds the old cap once the user has dragged.
+ */
+const COMPOSER_AUTO_HEIGHT_CAP = 150;
+
+/** Manual floor tops out at this share of the chat viewport height. */
+const COMPOSER_MAX_VIEWPORT_RATIO = 0.55;
+
+/**
+ * Read the persisted global manual floor.
+ * Returns `null` for pure auto behavior (default / after reset).
+ */
+export function readComposerFloor(): number | null {
+  const storage = getSafeLocalStorage();
+  if (!storage) {
+    return null;
+  }
+  let raw: string | null;
+  try {
+    raw = storage.getItem(COMPOSER_HEIGHT_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (raw == null) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? Math.round(value) : null;
+}
+
+/** Persist the global manual floor. */
+export function writeComposerFloor(px: number): void {
+  const storage = getSafeLocalStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(COMPOSER_HEIGHT_STORAGE_KEY, String(Math.round(px)));
+  } catch {
+    // Ignore quota / privacy-mode failures; the live drag still applied.
+  }
+}
+
+/** Clear the manual floor everywhere and return to pure auto behavior. */
+export function clearComposerFloor(): void {
+  const storage = getSafeLocalStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.removeItem(COMPOSER_HEIGHT_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+/** Dynamic max height = ~55% of the chat viewport (falls back to the window). */
+export function computeComposerMaxHeight(el: HTMLElement): number {
+  const chatViewport = el.closest<HTMLElement>(".chat")?.clientHeight ?? 0;
+  const windowHeight = typeof window !== "undefined" ? window.innerHeight : 0;
+  const viewport = chatViewport || windowHeight;
+  const dynamicMax = Math.round(viewport * COMPOSER_MAX_VIEWPORT_RATIO);
+  return Math.max(COMPOSER_MIN_TEXTAREA_HEIGHT, dynamicMax || COMPOSER_AUTO_HEIGHT_CAP);
+}
+
+/** Clamp a candidate height into [min, max]. */
+export function clampComposerHeight(px: number, max: number): number {
+  return Math.max(COMPOSER_MIN_TEXTAREA_HEIGHT, Math.min(max, px));
+}
+
+/**
+ * Autosize the composer textarea, or apply the exact manual height (Option A').
+ *
+ * The textarea is the resized element and is never flex-stretched inside a
+ * fixed-height box, so `scrollHeight` reports true content height. Behavior:
+ *   floor == null → auto: clamp(min(content, autoCap), min, dynamicMax)
+ *   floor != null → manual: clamp(floor, min, dynamicMax)  (content IGNORED)
+ *
+ * In manual mode autosizing is disabled entirely: the height is exactly what
+ * the user set, so they can shrink the box BELOW the current content (which
+ * then scrolls). Auto mode grows with content up to the original auto cap.
+ *
+ * @param floorOverride Live drag value; omit to read the persisted floor.
+ */
+export function applyComposerTextareaHeight(
+  el: HTMLTextAreaElement,
+  floorOverride?: number | null,
+): void {
+  const floor = floorOverride === undefined ? readComposerFloor() : floorOverride;
+  const dynamicMax = computeComposerMaxHeight(el);
+  if (floor != null) {
+    // Manual mode: apply the exact height. Content is intentionally NOT measured
+    // (no forced reflow) and may scroll; this also keeps the CSS height
+    // transition baseline intact for animated keyboard nudges.
+    el.style.height = `${clampComposerHeight(floor, dynamicMax)}px`;
+    el.style.overflowY = el.scrollHeight > el.clientHeight ? "auto" : "hidden";
+    return;
+  }
+  // Auto mode: size to content up to the original cap. Measure at height:auto,
+  // then restore the prior height before applying the target so an animated
+  // change (reset) transitions from the real starting height instead of snapping.
+  const previousHeight = el.style.height;
+  el.style.overflowY = "hidden";
+  el.style.height = "auto";
+  const content = el.scrollHeight;
+  el.style.height = previousHeight;
+  const target = clampComposerHeight(Math.min(content, COMPOSER_AUTO_HEIGHT_CAP), dynamicMax);
+  el.style.height = `${target}px`;
+  el.style.overflowY = el.scrollHeight > el.clientHeight ? "auto" : "hidden";
+}

--- a/ui/src/pages/chat/composer-height.ts
+++ b/ui/src/pages/chat/composer-height.ts
@@ -85,6 +85,23 @@ export function clampComposerHeight(px: number, max: number): number {
 }
 
 /**
+ * Resolve the auto-mode height cap for a compositor without a drag handle.
+ * Parses the element's CSS `max-height`; uses it when it's a concrete pixel
+ * value, otherwise falls back to the default cap. This lets each surface
+ * (new-session, suggestion, etc.) define its own growth limit via CSS.
+ */
+function resolveElementAutoCap(el: HTMLTextAreaElement): number {
+  const raw = getComputedStyle(el).maxHeight;
+  if (raw && raw.endsWith("px")) {
+    const parsed = Number.parseFloat(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return COMPOSER_AUTO_HEIGHT_CAP;
+}
+
+/**
  * Autosize the composer textarea, or apply the exact manual height (Option A').
  *
  * The textarea is the resized element and is never flex-stretched inside a
@@ -94,9 +111,17 @@ export function clampComposerHeight(px: number, max: number): number {
  *
  * In manual mode autosizing is disabled entirely: the height is exactly what
  * the user set, so they can shrink the box BELOW the current content (which
- * then scrolls). Auto mode grows with content up to the original auto cap.
+ * then scrolls). Auto mode grows with content up to the auto cap.
+ *
+ * Auto-cap source depends on context:
+ *   floorOverride === undefined (handle composer): hardcoded 150px so auto only
+ *     grows beyond that once the user drags.
+ *   floorOverride === null (no handle): the element's CSS max-height so each
+ *     surface defines its own natural growth limit.
  *
  * @param floorOverride Live drag value; omit to read the persisted floor.
+ *   `undefined` = handle composer (read stored floor, 150 auto-cap).
+ *   `null` = no-handle composer (CSS-max auto-cap, pure auto).
  */
 export function applyComposerTextareaHeight(
   el: HTMLTextAreaElement,
@@ -112,9 +137,11 @@ export function applyComposerTextareaHeight(
     el.style.overflowY = el.scrollHeight > el.clientHeight ? "auto" : "hidden";
     return;
   }
-  // Auto mode: size to content up to the original cap. Measure at height:auto,
-  // then restore the prior height before applying the target so an animated
-  // change (reset) transitions from the real starting height instead of snapping.
+  // Auto mode: size to content up to the surface-appropriate cap.
+  // Handle composers cap at 150 (growth beyond requires explicit drag);
+  // non-handle composers respect their CSS max-height.
+  const autoCap =
+    floorOverride === undefined ? COMPOSER_AUTO_HEIGHT_CAP : resolveElementAutoCap(el);
   const previousHeight = el.style.height;
   el.style.overflowY = "hidden";
   el.style.height = "auto";
@@ -127,7 +154,7 @@ export function applyComposerTextareaHeight(
   if (el.classList.contains("composer-animate-height")) {
     void el.offsetHeight;
   }
-  const target = clampComposerHeight(Math.min(content, COMPOSER_AUTO_HEIGHT_CAP), dynamicMax);
+  const target = clampComposerHeight(Math.min(content, autoCap), dynamicMax);
   el.style.height = `${target}px`;
   el.style.overflowY = el.scrollHeight > el.clientHeight ? "auto" : "hidden";
 }

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -94,6 +94,20 @@ describe("new-session composer sizing lifecycle", () => {
     expect(textarea.style.height).toBe("150px");
   });
 
+  it("grows to the element CSS max-height for non-handle composers", () => {
+    const textarea = document.createElement("textarea");
+    Object.defineProperty(textarea, "scrollHeight", { configurable: true, value: 220 });
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      maxHeight: "260px",
+    } as CSSStyleDeclaration);
+
+    // No .agent-chat__input ancestor → no handle → floorOverride=null path
+    adjustTextareaHeight(textarea);
+
+    // Content (220) is below CSS max (260), so height = content
+    expect(textarea.style.height).toBe("220px");
+  });
+
   it("keeps one observer across controlled updates and remeasures programmatic drafts", async () => {
     const observe = vi.fn();
     const disconnect = vi.fn();

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2042,6 +2042,130 @@ openclaw-chat-page {
   min-width: 0;
 }
 
+/* Drag-to-resize composer handle: a thin bar that floats slightly ABOVE the
+   input's top edge (small gap). Absolutely positioned so it adds ZERO height to
+   the text box. The grip is invisible at rest and fades in on hover/focus; the
+   textarea height is driven directly from JS (see composer-height.ts). */
+composer-resize-handle {
+  position: absolute;
+  top: -9px;
+  left: 0;
+  right: 0;
+  z-index: 4;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 14px;
+  cursor: ns-resize;
+  touch-action: none;
+  user-select: none;
+}
+
+/* Enlarged, invisible hit zone (esp. for touch). */
+composer-resize-handle::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -4px;
+  bottom: -4px;
+}
+
+.agent-chat__composer-grip {
+  width: 44px;
+  height: 4px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--border) 80%, var(--muted));
+  opacity: 0;
+  transition:
+    opacity 120ms ease-out,
+    background 120ms ease-out,
+    width 120ms ease-out;
+}
+
+.agent-chat__input:hover composer-resize-handle .agent-chat__composer-grip,
+composer-resize-handle:hover .agent-chat__composer-grip,
+composer-resize-handle:focus-visible .agent-chat__composer-grip {
+  opacity: 1;
+}
+
+composer-resize-handle:hover .agent-chat__composer-grip {
+  width: 56px;
+  background: var(--muted);
+}
+
+composer-resize-handle:focus-visible {
+  outline: none;
+}
+
+composer-resize-handle:focus-visible .agent-chat__composer-grip,
+composer-resize-handle.dragging .agent-chat__composer-grip {
+  width: 56px;
+  opacity: 1;
+  background: var(--accent);
+}
+
+/* Real focus indicator on the visible grip (not just a color change), so the
+   focused state is perceivable under high-contrast / color-vision deficiency. */
+composer-resize-handle:focus-visible .agent-chat__composer-grip {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+/* Reset hint: anchored above the handle's top edge, zero layout height.
+   Hidden in auto mode; in manual mode it shares the grip's active state. */
+.agent-chat__composer-reset-hint {
+  position: absolute;
+  top: -2px;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--panel-strong);
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  line-height: 1;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 5;
+  transition: opacity 150ms ease-out;
+}
+
+composer-resize-handle.manual:hover .agent-chat__composer-reset-hint,
+composer-resize-handle.manual:focus-visible .agent-chat__composer-reset-hint,
+composer-resize-handle.manual.dragging .agent-chat__composer-reset-hint {
+  opacity: 1;
+}
+
+/* Opt-in height animation: applied only for reset / keyboard nudges (the handle
+   toggles this class). Live drag and typing autosize stay instant (1:1). */
+.agent-chat__composer-combobox > :is(textarea, input).composer-animate-height {
+  transition: height 160ms ease-out;
+}
+
+/* Respect reduced-motion: drop the grip/hint fades and the height animation. */
+@media (prefers-reduced-motion: reduce) {
+  .agent-chat__composer-grip,
+  .agent-chat__composer-reset-hint,
+  .agent-chat__composer-combobox > :is(textarea, input).composer-animate-height {
+    transition: none;
+  }
+}
+
+/* Larger touch target on coarse pointers. */
+@media (hover: none) and (pointer: coarse) {
+  composer-resize-handle {
+    height: 18px;
+  }
+  composer-resize-handle::before {
+    top: -8px;
+    bottom: -8px;
+  }
+}
+
 .agent-chat__sr-only {
   position: absolute;
   width: 1px;
@@ -2057,7 +2181,7 @@ openclaw-chat-page {
 .agent-chat__composer-combobox > :is(textarea, input) {
   width: 100%;
   min-height: 36px;
-  max-height: calc(7em + 24px);
+  max-height: 55vh;
   resize: none;
   padding: var(--chat-box-inset);
   padding-left: calc(var(--chat-box-inset) - 4px);
@@ -3114,7 +3238,7 @@ openclaw-chat-page {
 
 @media (min-width: 1600px) {
   .agent-chat__composer-combobox > :is(textarea, input) {
-    max-height: calc(7em + 12px);
+    max-height: 55vh;
   }
 
   .agent-chat__composer-footer {


### PR DESCRIPTION
## What Problem This Solves
The Control UI chat composer autosizes up to ~7 lines and then scrolls internally, with no way for the user to control its height. When drafting long or structured messages you can't enlarge the input to see more of the draft, and you can't shrink it to reclaim vertical space. This adds a drag-to-resize handle so users can set the input height, remembered across sessions. Closes #113270.

## Summary
- Handle floats just above the input box (adds no height at rest); grip reveals on hover/focus, `ns-resize` cursor.
- **Manual resize sets an exact height** and can shrink below the content (which then scrolls). Content autosize — capped at the original ~7-line height — applies only when no manual size is set.
- Height persists **globally** via a dedicated `localStorage` key (`openclaw.control.composer.height.v1`); not per-session and not reusing the per-session composer-outbox store.
- Double-click the handle — or press **Enter**/**Space** while the handle has keyboard focus — resets to auto (animated). Arrow keys nudge (Shift = larger step). These apply only when the handle is focused, so they never interfere with typing.
- Accessibility: `role=separator`, `aria-orientation`, `aria-value*`, keyboard, pointer events with a touch-friendly hit zone.
- i18n strings under `chat.composer.resize`. No new settings/toggles.

## Implementation notes
- New `ui/src/pages/chat/composer-height.ts` (global store + shared autosize) and `composer-resize-handle.ts` (light-DOM `OpenClawLitElement` modeled on the existing `resizable-divider`).
- `chat-composer.ts` autosize delegates to the shared routine; the handle is anchored to the visible input box so its centering stays stable when the send button appears.

## Evidence
Validated locally against the repo's own gates:
- `pnpm ui:build` — passes, incl. precompressed-asset + performance-budget checks (startup JS within ceiling).
- Unit tests (jsdom): `composer-height.test.ts` (8) and `composer-resize-handle.test.ts` (6) — cover exact-height/shrink-below-content, the original ~7-line auto cap, global-persistence round-trip, ArrowUp/Down nudge, Enter and double-click reset, and a pointer-drag → exact-floor → persist path.
- `pnpm deadcode:exports` — clean (no unused exports).
- Manual verification of drag / persist / reset / keyboard in the running Control UI.

https://github.com/user-attachments/assets/c62f3890-fd3b-46c3-b42f-fcd275000e2b
