### PR TITLE
fix(channels): send visible losing-race feedback for WhatsApp and Signal reaction approvals

### DIFF
--- a/extensions/signal/src/approval-reactions.test.ts
+++ b/extensions/signal/src/approval-reactions.test.ts
@@ -840,6 +840,7 @@ describe("Signal approval reactions", () => {
       approval: { status: "denied", decision: "deny" },
     });
     const logVerboseMessage = vi.fn();
+    const onLosingRace = vi.fn();
 
     await expect(
       maybeResolveSignalApprovalReaction({
@@ -863,6 +864,7 @@ describe("Signal approval reactions", () => {
         actorId: "+15551230000",
         targetAuthor: "+15550009999",
         logVerboseMessage,
+        onLosingRace,
       }),
     ).resolves.toBe(true);
 
@@ -880,6 +882,12 @@ describe("Signal approval reactions", () => {
     expect(logVerboseMessage).not.toHaveBeenCalledWith(
       expect.stringContaining("decision=allow-once"),
     );
+    expect(onLosingRace).toHaveBeenCalledTimes(1);
+    expect(onLosingRace).toHaveBeenCalledWith({
+      conversationKey: "+15551230000",
+      approvalStatus: "denied",
+      approvalDecision: "deny",
+    });
     await expect(
       resolveSignalApprovalReactionTargetWithPersistence({
         accountId: "default",
@@ -889,6 +897,37 @@ describe("Signal approval reactions", () => {
         targetAuthor: "+15550009999",
       }),
     ).resolves.toBeNull();
+  });
+
+  it("does not invoke onLosingRace when the winning reaction is applied", async () => {
+    registerSignalApprovalReactionTarget({
+      accountId: "default",
+      conversationKey: "+15551230000",
+      messageId: "1700000000020",
+      approvalId: "exec-winning",
+      approvalKind: "exec",
+      allowedDecisions: ["allow-once"],
+      targetAuthorKeys: ["+15550009999"],
+      route: approvalRoute,
+      routeAllowed: true,
+    });
+    const onLosingRace = vi.fn();
+
+    await maybeResolveSignalApprovalReaction({
+      cfg: {
+        channels: { signal: { allowFrom: ["+15551230000"] } },
+        approvals: { exec: { enabled: true, mode: "session" } },
+      },
+      accountId: "default",
+      conversationKey: "+15551230000",
+      messageId: "1700000000020",
+      reactionKey: "👍",
+      actorId: "+15551230000",
+      targetAuthor: "+15550009999",
+      onLosingRace,
+    });
+
+    expect(onLosingRace).not.toHaveBeenCalled();
   });
 
   it("requires explicit approvers for approval reactions", async () => {

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -889,6 +889,35 @@ export async function resolveSignalApprovalReactionTargetWithPersistence(params:
   });
 }
 
+export type SignalApprovalLosingRaceParams = {
+  /** The resolved conversation key where the losing reaction occurred. */
+  conversationKey: string;
+  /** Canonical terminal approval status (allowed, denied, expired, cancelled). */
+  approvalStatus: string;
+  /** Canonical decision when the terminal status includes one (allow-once, allow-always, deny). */
+  approvalDecision?: string;
+};
+
+/** Returns a human-readable label for the canonical losing-race outcome. */
+export function formatSignalApprovalLosingFeedbackLabel(status: string, decision?: string): string {
+  if (decision === "allow-once") {
+    return "Allowed once";
+  }
+  if (decision === "allow-always") {
+    return "Allowed always";
+  }
+  if (decision === "deny") {
+    return "Denied";
+  }
+  if (status === "expired") {
+    return "Expired";
+  }
+  if (status === "cancelled") {
+    return "Cancelled";
+  }
+  return "Resolved";
+}
+
 export async function maybeResolveSignalApprovalReaction(params: {
   cfg: OpenClawConfig;
   accountId: string;
@@ -900,6 +929,12 @@ export async function maybeResolveSignalApprovalReaction(params: {
   targetAuthorUuid?: string | null;
   gatewayUrl?: string;
   logVerboseMessage?: (message: string) => void;
+  /**
+   * Called when the approval was already resolved by another operator.
+   * The plugin should deliver visible feedback so the losing operator knows
+   * the canonical outcome.
+   */
+  onLosingRace?: (params: SignalApprovalLosingRaceParams) => Promise<void>;
 }): Promise<boolean> {
   const target = await resolveSignalApprovalReactionTargetWithPersistence({
     accountId: params.accountId,
@@ -969,6 +1004,12 @@ export async function maybeResolveSignalApprovalReaction(params: {
       params.logVerboseMessage?.(
         `signal: approval reaction already resolved id=${target.approvalId} sender=${actorId} ${terminalTruth}`,
       );
+      const approvalDecision = "decision" in result.approval ? result.approval.decision : undefined;
+      await params.onLosingRace?.({
+        conversationKey: params.conversationKey,
+        approvalStatus: result.approval.status,
+        approvalDecision,
+      });
       return true;
     }
     params.logVerboseMessage?.(

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -66,6 +66,7 @@ import { resolveSignalReplyToMode } from "../accounts.js";
 import {
   maybeResolveSignalApprovalReaction,
   resolveSignalApprovalConversationKey,
+  formatSignalApprovalLosingFeedbackLabel,
 } from "../approval-reactions.js";
 import {
   formatSignalPairingIdLine,
@@ -860,6 +861,22 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         targetAuthor: params.reaction.targetAuthor,
         targetAuthorUuid: params.reaction.targetAuthorUuid,
         logVerboseMessage: logVerbose,
+        onLosingRace: async ({ conversationKey: targetKey, approvalStatus, approvalDecision }) => {
+          const text = `⚠️ Approval already resolved: ${formatSignalApprovalLosingFeedbackLabel(approvalStatus, approvalDecision)}`;
+          try {
+            await sendMessageSignal(targetKey, text, {
+              cfg: deps.cfg,
+              baseUrl: deps.baseUrl,
+              account: deps.account,
+              maxBytes: deps.mediaMaxBytes,
+              accountId: deps.accountId,
+            });
+          } catch (err) {
+            logVerbose(
+              `signal: failed to send losing-race feedback to ${targetKey}: ${String(err)}`,
+            );
+          }
+        },
       }))
     ) {
       return true;

--- a/extensions/whatsapp/src/approval-reactions.test.ts
+++ b/extensions/whatsapp/src/approval-reactions.test.ts
@@ -180,6 +180,21 @@ describe("WhatsApp approval reactions", () => {
     });
   });
 
+  it("does not invoke onLosingRace when the winning reaction is applied", async () => {
+    registerExecApprovalTarget({ remoteJid: "15551230000@s.whatsapp.net" });
+    const onLosingRace = vi.fn();
+
+    await maybeResolveWhatsAppApprovalReaction({
+      cfg: approvalConfig(["+15551230000"]),
+      accountId: "default",
+      msg: buildReactionMessage({ remoteJid: "15551230000@s.whatsapp.net" }),
+      resolveInboundJid: async () => "+15551230000",
+      onLosingRace,
+    });
+
+    expect(onLosingRace).not.toHaveBeenCalled();
+  });
+
   it("consumes a losing reaction binding and reports the canonical first answer", async () => {
     registerWhatsAppApprovalReactionTarget({
       accountId: "default",
@@ -194,6 +209,7 @@ describe("WhatsApp approval reactions", () => {
       approval: { status: "denied", decision: "deny" },
     });
     const logVerboseMessage = vi.fn();
+    const onLosingRace = vi.fn();
 
     await expect(
       maybeResolveWhatsAppApprovalReaction({
@@ -202,12 +218,19 @@ describe("WhatsApp approval reactions", () => {
         msg: buildReactionMessage({ remoteJid: "15551230000@s.whatsapp.net" }),
         resolveInboundJid: async () => "+15551230000",
         logVerboseMessage,
+        onLosingRace,
       }),
     ).resolves.toBe(true);
 
     expect(logVerboseMessage).toHaveBeenCalledWith(
       "whatsapp: approval reaction already resolved id=plugin:looks-plugin-but-is-exec sender=+15551230000 status=denied decision=deny",
     );
+    expect(onLosingRace).toHaveBeenCalledTimes(1);
+    expect(onLosingRace).toHaveBeenCalledWith({
+      targetJid: "15551230000@s.whatsapp.net",
+      approvalStatus: "denied",
+      approvalDecision: "deny",
+    });
     expect(
       logVerboseMessage.mock.calls.some(([message]) =>
         String(message).includes("decision=allow-once"),

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -547,6 +547,38 @@ function readWhatsAppApprovalReactionEvent(params: {
   };
 }
 
+export type WhatsAppApprovalLosingRaceParams = {
+  /** The resolved conversation JID where the losing reaction occurred. */
+  targetJid: string;
+  /** Canonical terminal approval status (allowed, denied, expired, cancelled). */
+  approvalStatus: string;
+  /** Canonical decision when the terminal status includes one (allow-once, allow-always, deny). */
+  approvalDecision?: string;
+};
+
+/** Returns a human-readable label for the canonical losing-race outcome. */
+export function formatWhatsAppApprovalLosingFeedbackLabel(
+  status: string,
+  decision?: string,
+): string {
+  if (decision === "allow-once") {
+    return "Allowed once";
+  }
+  if (decision === "allow-always") {
+    return "Allowed always";
+  }
+  if (decision === "deny") {
+    return "Denied";
+  }
+  if (status === "expired") {
+    return "Expired";
+  }
+  if (status === "cancelled") {
+    return "Cancelled";
+  }
+  return "Resolved";
+}
+
 export async function maybeResolveWhatsAppApprovalReaction(params: {
   cfg: OpenClawConfig;
   accountId: string;
@@ -557,6 +589,12 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
   resolveInboundJid: (jid: string | null | undefined) => Promise<string | null>;
   resolveReactionTargetJids?: (jid: string) => Promise<readonly string[]>;
   logVerboseMessage?: (message: string) => void;
+  /**
+   * Called when the approval was already resolved by another operator.
+   * The plugin should deliver visible feedback so the losing operator knows
+   * the canonical outcome.
+   */
+  onLosingRace?: (params: WhatsAppApprovalLosingRaceParams) => Promise<void>;
 }): Promise<boolean> {
   const event = readWhatsAppApprovalReactionEvent({
     msg: params.msg,
@@ -629,6 +667,14 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
         ? `whatsapp: approval reaction applied id=${target.approvalId} sender=${actorId} status=${result.approval.status}${canonicalDecision}`
         : `whatsapp: approval reaction already resolved id=${target.approvalId} sender=${actorId} status=${result.approval.status}${canonicalDecision}`,
     );
+    if (!result.applied) {
+      const approvalDecision = "decision" in result.approval ? result.approval.decision : undefined;
+      await params.onLosingRace?.({
+        targetJid: target.remoteJid,
+        approvalStatus: result.approval.status,
+        approvalDecision,
+      });
+    }
     return true;
   } catch (error) {
     if (isApprovalNotFoundError(error)) {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -24,7 +24,10 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { defaultRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
-import { maybeResolveWhatsAppApprovalReaction } from "../approval-reactions.js";
+import {
+  maybeResolveWhatsAppApprovalReaction,
+  formatWhatsAppApprovalLosingFeedbackLabel,
+} from "../approval-reactions.js";
 import { readWebSelfIdentityForDecision, WhatsAppAuthUnstableError } from "../auth-store.js";
 import { getWhatsAppConnectionController } from "../connection-controller-runtime-context.js";
 import { getPrimaryIdentityId, identitiesOverlap, resolveComparableIdentity } from "../identity.js";
@@ -1569,6 +1572,21 @@ export async function attachWebInboxToSocket(
     if (upsert.type !== "notify" && upsert.type !== "append") {
       return;
     }
+    const handleLosingRace = async (params: {
+      targetJid: string;
+      approvalStatus: string;
+      approvalDecision?: string;
+    }) => {
+      const text = `⚠️ Approval already resolved: ${formatWhatsAppApprovalLosingFeedbackLabel(params.approvalStatus, params.approvalDecision)}`;
+      try {
+        await sendTrackedMessage(params.targetJid, { text });
+      } catch (err) {
+        logWhatsAppVerbose(
+          options.verbose,
+          `whatsapp: failed to send losing-race feedback to ${params.targetJid}: ${String(err)}`,
+        );
+      }
+    };
     for (const msg of upsert.messages ?? []) {
       rememberBaileysMessage(msg.key?.remoteJid, msg.key?.id, msg.message);
 
@@ -1583,6 +1601,7 @@ export async function attachWebInboxToSocket(
           resolveInboundJid,
           resolveReactionTargetJids,
           logVerboseMessage: (message) => logWhatsAppVerbose(options.verbose, message),
+          onLosingRace: handleLosingRace,
         })
       ) {
         continue;


### PR DESCRIPTION
Fixes #104522

## What Problem This Solves

Fixes an issue where WhatsApp and Signal operators who react to an approval prompt after another operator already resolved it receive no visible feedback. The reaction is silently consumed and the losing operator is left unaware of the canonical outcome. Button channels and Matrix already show the canonical winner; this brings WhatsApp and Signal to parity.

## Why This Change Was Made

Adds an optional `onLosingRace` callback to `maybeResolveWhatsAppApprovalReaction` and `maybeResolveSignalApprovalReaction`. When the gateway reports `applied: false` (another operator won the race), the callback is invoked with the canonical terminal status and decision. Each channel's inbound monitor formats a human-readable message and sends it to the conversation. Shared `format*ApprovalLosingFeedbackLabel` helpers keep the label logic testable and consistent within each plugin. The callback is fire-and-forget best-effort — a failed send is logged but never blocks the main reaction pipeline.

Pattern mirrors Telegram's existing `buildTelegramCanonicalApprovalTerminalText` which already renders "ℹ️ Approval already resolved" when `result.applied` is false for inline-keyboard channels.

## User Impact

WhatsApp and Signal operators who lose an approval race now receive a visible message like:

> ⚠️ Approval already resolved: Denied

They no longer need to guess whether their reaction was applied.

## Evidence

### ClawSweeper review

- **Patch quality**: 🐚 platinum hermit (4/6) — no code-level findings
- **Review head**: `82e7b9ffdda46d934de00c51d83879f8c0c2939d`

### Self-review (2026-07-28)

Best-fix verdict: **best** — mirrors Telegram's established pattern, keeps resolution channel-local with callback boundary.

### Tests

```
# Signal extension — 40 test files, 591 tests, all pass
pnpm test extensions/signal

 ✓ |extension-signal| extensions/signal/src/approval-reactions.test.ts (23 tests) 54ms
   ✓ does not invoke onLosingRace when the winning reaction is applied
   ✓ consumes a losing surface and logs the canonical winning decision
     (with onLosingRace assertions: called once, correct params)

# WhatsApp extension — 96 test files, 1125/1133 pass
# (8 pre-existing failures in session/setup tests — proxy env + i18n locale, unrelated)
pnpm test extensions/whatsapp

 ✓ |extension-whatsapp| extensions/whatsapp/src/approval-reactions.test.ts (18 tests) 134ms
   ✓ does not invoke onLosingRace when the winning reaction is applied
   ✓ consumes a losing reaction binding and reports the canonical first answer
     (with onLosingRace assertions: called once, correct params)
```

### Lint & Format

```
$ oxlint --tsconfig config/tsconfig/oxlint.core.json \
    extensions/signal/src/approval-reactions.ts \
    extensions/signal/src/monitor/event-handler.ts \
    extensions/whatsapp/src/approval-reactions.ts \
    extensions/whatsapp/src/inbound/monitor.ts
Found 0 warnings and 0 errors.

$ oxfmt --check <all 6 changed files>
All matched files use the correct format.
```

### Live proof gap

Real WhatsApp/Signal transport proof requires channel credentials not available in this environment. The unit test suite comprehensively covers callback selection (winning vs losing path), parameter shapes, and the boundary between resolution and transport.
