### PR TITLE
refactor(feishu): reuse hybrid account enablement

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -125,6 +125,31 @@ describe("feishuPlugin metadata", () => {
   });
 });
 
+describe("feishuPlugin config", () => {
+  it.each([
+    {
+      accountId: "default",
+      expected: { enabled: false },
+    },
+    {
+      accountId: "ops",
+      expected: { accounts: { ops: { enabled: false } } },
+    },
+  ])(
+    "writes $accountId account enablement in the shared hybrid shape",
+    ({ accountId, expected }) => {
+      const setAccountEnabled = feishuPlugin.config.setAccountEnabled;
+      if (!setAccountEnabled) {
+        throw new Error("Feishu setAccountEnabled unavailable");
+      }
+
+      expect(setAccountEnabled({ cfg: {}, accountId, enabled: false }).channels?.feishu).toEqual(
+        expected,
+      );
+    },
+  );
+});
+
 describe("feishuPlugin.status.probeAccount", () => {
   it("uses current account credentials for multi-account config", async () => {
     const cfg = {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -344,30 +344,6 @@ function describeFeishuMessageTool({
   };
 }
 
-function setFeishuNamedAccountEnabled(
-  cfg: ClawdbotConfig,
-  accountId: string,
-  enabled: boolean,
-): ClawdbotConfig {
-  const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
-  return {
-    ...cfg,
-    channels: {
-      ...cfg.channels,
-      feishu: {
-        ...feishuCfg,
-        accounts: {
-          ...feishuCfg?.accounts,
-          [accountId]: {
-            ...feishuCfg?.accounts?.[accountId],
-            enabled,
-          },
-        },
-      },
-    },
-  };
-}
-
 const feishuConfigAdapter = createHybridChannelConfigAdapter<
   ResolvedFeishuAccount,
   ResolvedFeishuAccount
@@ -989,22 +965,6 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
       configSchema: FeishuChannelConfigSchema,
       config: {
         ...feishuConfigAdapter,
-        setAccountEnabled: ({ cfg, accountId, enabled }) => {
-          const isDefault = accountId === DEFAULT_ACCOUNT_ID;
-          if (isDefault) {
-            return {
-              ...cfg,
-              channels: {
-                ...cfg.channels,
-                feishu: {
-                  ...cfg.channels?.feishu,
-                  enabled,
-                },
-              },
-            };
-          }
-          return setFeishuNamedAccountEnabled(cfg, accountId, enabled);
-        },
         deleteAccount: ({ cfg, accountId }) => {
           const isDefault = accountId === DEFAULT_ACCOUNT_ID;
 


### PR DESCRIPTION
## What Problem This Solves

The Feishu channel duplicated the shared hybrid-channel account enablement behavior, creating a second implementation for default and named account config placement.

## Why This Change Was Made

Remove the Feishu-specific helper and override so `createHybridChannelConfigAdapter` remains the canonical owner. Keep Feishu's custom account deletion behavior unchanged because its default-account semantics differ from the shared adapter.

## User Impact

No user-visible behavior changes. Feishu default-account enablement remains at the channel root and named-account enablement remains under `accounts`, with 40 production lines removed.

## Evidence

- Testbox `tbx_01ky9jm875qf0et5qbc7x66dg5`: Feishu channel and shared adapter suites passed, 130 tests total.
- Same Testbox: path-scoped `pnpm check:changed` passed, including extension typechecks, lint, plugin boundaries, runtime cycle checks, and guards.
- Fresh autoreview: clean, no accepted/actionable findings; correctness 0.94.
- `git diff --check` passed.

No agent transcript logs are attached.
