### PR TITLE
fix(update): preserve upgrades with shipped Discord DM config

### DIFF
--- a/extensions/discord/src/doctor.test.ts
+++ b/extensions/discord/src/doctor.test.ts
@@ -21,6 +21,37 @@ function getDiscordCompatibilityNormalizer(): NonNullable<
 }
 
 describe("discord doctor", () => {
+  it("promotes shipped nested DM access at root and account scope", () => {
+    const normalize = getDiscordCompatibilityNormalizer();
+    const result = normalize({
+      cfg: {
+        channels: {
+          discord: {
+            dm: { enabled: false, policy: "allowlist", allowFrom: ["123"] },
+            accounts: {
+              work: {
+                dm: { groupEnabled: true, policy: "open", allowFrom: ["*"] },
+              },
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.config.channels?.discord).toEqual({
+      dm: { enabled: false },
+      dmPolicy: "allowlist",
+      allowFrom: ["123"],
+      accounts: {
+        work: {
+          dm: { groupEnabled: true },
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+  });
+
   it("strips retired gateway, queue, and retry tuning at root and account scope", () => {
     const normalize = getDiscordCompatibilityNormalizer();
     const result = normalize({

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1984,6 +1984,14 @@ describe("update-cli", () => {
         ),
     ).toBe(true);
     expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
+      nonInteractive: true,
+      repair: true,
+      yes: false,
+    });
+    expect(vi.mocked(doctorCommand).mock.invocationCallOrder[0] ?? 0).toBeLessThan(
+      syncPluginsForUpdateChannel.mock.invocationCallOrder[0] ?? 0,
+    );
     expect(syncPluginsForUpdateChannel).toHaveBeenCalledTimes(1);
     expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
     expect(spawn).not.toHaveBeenCalled();

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -1,3 +1,4 @@
+import { doctorCommand } from "../../commands/doctor.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV } from "../../infra/update-post-core-context.js";
@@ -9,11 +10,15 @@ import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
 import { readPackageVersion, type UpdateCommandOptions } from "./shared.js";
 import {
+  createUpdateConfigSnapshot,
   persistRequestedUpdateChannel,
   readPostCorePreUpdateSourceConfig,
   restoreDroppedPreUpdateChannels,
 } from "./update-command-config.js";
-import { completePostCorePluginUpdate } from "./update-command-fresh-doctor.js";
+import {
+  completePostCorePluginUpdate,
+  withUpdateFinalizationEnv,
+} from "./update-command-fresh-doctor.js";
 import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
 import {
   POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV,
@@ -70,6 +75,21 @@ async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams):
     sourceConfigPath: process.env[POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV],
     currentSnapshot: configSnapshot,
     updateStartedAtMs,
+  });
+  await withUpdateFinalizationEnv(async () => {
+    await createUpdateConfigSnapshot();
+    await doctorCommand(defaultRuntime, {
+      nonInteractive: true,
+      repair: true,
+      yes: params.opts.yes === true,
+    });
+  });
+  // The fresh process owns the updated migration contracts. Repair before
+  // plugin convergence writes config, or newly retired plugin keys can block
+  // the update before doctor gets a chance to migrate them.
+  configSnapshot = await readConfigFileSnapshot({
+    skipPluginValidation: true,
+    suppressFutureVersionWarning: true,
   });
   configSnapshot = await persistRequestedUpdateChannel({
     configSnapshot,


### PR DESCRIPTION
Related: #112812

## What Problem This Solves

Fixes an issue where users upgrading from the current stable release could have the update fail when their shipped Discord configuration still used nested `dm.policy` or `dm.allowFrom` fields. The beta4 Package Acceptance upgrade-survivor lanes reproduced this failure before plugin convergence completed.

## Why This Change Was Made

The fresh post-core update process now runs the updated doctor migration before plugin convergence writes strict config, then reloads the repaired snapshot before persisting the requested update channel. The Discord test proves the existing owner-plugin migration promotes shipped nested DM access at root and account scope without retaining runtime compatibility aliases.

## User Impact

Upgrades from stable installations with shipped Discord DM configuration can complete normally, while runtime continues to consume only the canonical current config shape.

## Evidence

- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts` - 200 passed.
- `node scripts/run-vitest.mjs extensions/discord/src/doctor.test.ts` - 17 passed.
- `oxfmt --check` on all changed files - passed.
- `git diff --check` - passed.
- Fresh Codex autoreview - clean, no accepted/actionable findings.
- Exact-head ClawSweeper review - patch correct, no findings; requested upgrade proof only.
- Stable-to-candidate Package Acceptance - `published-upgrade-survivor` and `root-managed-vps-upgrade` passed: https://github.com/openclaw/openclaw/actions/runs/30079550101
- Original beta4 failure: https://github.com/openclaw/openclaw/actions/runs/30072849621

## Rank-up Moves

- Removed the normal PR changelog edit; release notes stay in the release process.
- Added successful stable-install upgrade-survivor evidence using legacy nested Discord DM fields.