### PR TITLE
fix(cron): decouple scheduler wakeups from active runs

### DIFF
--- a/src/cron/service.rearm-timer-when-running.test.ts
+++ b/src/cron/service.rearm-timer-when-running.test.ts
@@ -1,6 +1,4 @@
 // Cron rearm tests cover timer rearming while scheduled jobs are already running.
-import fs from "node:fs/promises";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createNoopLogger,
@@ -9,6 +7,7 @@ import {
 } from "./service.test-harness.js";
 import { createCronServiceState } from "./service/state.js";
 import { onTimer } from "./service/timer.test-support.js";
+import { saveCronStore } from "./store.js";
 import type { CronJob } from "./types.js";
 
 const noopLogger = createNoopLogger();
@@ -105,31 +104,23 @@ describe("CronService - timer re-arm when running (#12025)", () => {
     await store.cleanup();
   });
 
-  it("arms a watchdog timer while a timer tick is still executing", async () => {
+  it("arms the next scheduler wake while a reserved job is still executing", async () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const store = await makeStorePath();
     const now = Date.parse("2026-02-06T10:05:00.000Z");
+    const runStarted = createDeferred<void>();
     const deferredRun = createDeferred<{ status: "ok"; summary: string }>();
 
-    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
-    await fs.writeFile(
-      store.storePath,
-      JSON.stringify(
-        {
-          version: 1,
-          jobs: [
-            createDueRecurringJob({
-              id: "long-running-job",
-              nowMs: now,
-              nextRunAtMs: now,
-            }),
-          ],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [
+        createDueRecurringJob({
+          id: "long-running-job",
+          nowMs: now,
+          nextRunAtMs: now,
+        }),
+      ],
+    });
 
     const state = createCronServiceState({
       storePath: store.storePath,
@@ -138,7 +129,10 @@ describe("CronService - timer re-arm when running (#12025)", () => {
       nowMs: () => now,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeat: vi.fn(),
-      runIsolatedAgentJob: vi.fn(async () => await deferredRun.promise),
+      runIsolatedAgentJob: vi.fn(async () => {
+        runStarted.resolve();
+        return await deferredRun.promise;
+      }),
     });
 
     let settled = false;
@@ -147,10 +141,15 @@ describe("CronService - timer re-arm when running (#12025)", () => {
       settled = true;
     });
 
-    await Promise.resolve();
+    await Promise.race([
+      runStarted.promise,
+      timerPromise.then(() => {
+        throw new Error("Expected reserved cron job to start");
+      }),
+    ]);
     expect(settled).toBe(false);
-    expect(state.running).toBe(true);
-    expect(state.timer).toBe(latestTimeoutHandle(timeoutSpy));
+    expect(state.running).toBe(false);
+    expect(state.timer).not.toBeNull();
 
     const delays = timeoutSpy.mock.calls
       .map(([, delay]) => delay)

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1035,8 +1035,14 @@ export function recomputeNextRunsForMaintenance(
 /** Returns the next enabled wake timestamp from the in-memory cron store. */
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
+  // Active reservations retain their original due timestamp until finalization.
+  // Excluding them lets the timer target later jobs instead of polling a past slot.
   const enabled = jobs.filter(
-    (j) => isJobEnabled(j) && hasScheduledNextRunAtMs(j.state.nextRunAtMs),
+    (j) =>
+      isJobEnabled(j) &&
+      typeof j.state.queuedAtMs !== "number" &&
+      typeof j.state.runningAtMs !== "number" &&
+      hasScheduledNextRunAtMs(j.state.nextRunAtMs),
   );
   if (enabled.length === 0) {
     return undefined;

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -181,8 +181,9 @@ async function onAdmittedTimer(state: CronServiceState) {
     return;
   }
   state.running = true;
+  let ownsSchedulingPass = true;
   // Keep a watchdog timer armed while a tick is executing. If execution hangs
-  // (for example in a provider call), the scheduler still wakes to re-check.
+  // while reserving due work, the scheduler still wakes to re-check.
   armRunningRecheckTimer(state);
   try {
     const dueJobs = await locked(state, async () => {
@@ -279,6 +280,12 @@ async function onAdmittedTimer(state: CronServiceState) {
 
       return reservedDue;
     });
+    // The scheduler pass owns only discovery and reservation. Payload execution
+    // continues under per-job durable markers and the shared admission cap, so a
+    // slow sibling must not prevent later-due jobs from being discovered.
+    state.running = false;
+    ownsSchedulingPass = false;
+    armTimer(state);
 
     const runDueJob = async (params: {
       id: string;
@@ -538,7 +545,8 @@ async function onAdmittedTimer(state: CronServiceState) {
                 throw error;
               }
               if (!result.isolatedAgentSetupTimeout) {
-                return result;
+                await finalizeCompletedResults([result]);
+                return pMapSkip;
               }
               let finalizedResults: TimedCronRunOutcome[];
               try {
@@ -616,9 +624,7 @@ async function onAdmittedTimer(state: CronServiceState) {
     }
   } finally {
     // Piggyback session reaper on timer tick (self-throttled to every 5 min).
-    // Placed in `finally` so the reaper runs even when a long-running job keeps
-    // `state.running` true across multiple timer ticks — the early return at the
-    // top of onTimer would otherwise skip the reaper indefinitely.
+    // Keep it in `finally` so execution or finalization failures cannot skip it.
     const storePaths = new Set<string>();
     if (state.deps.resolveSessionStorePath) {
       const defaultAgentId = state.deps.defaultAgentId ?? DEFAULT_AGENT_ID;
@@ -651,7 +657,9 @@ async function onAdmittedTimer(state: CronServiceState) {
       }
     }
 
-    state.running = false;
-    armTimer(state);
+    if (ownsSchedulingPass) {
+      state.running = false;
+      armTimer(state);
+    }
   }
 }

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -176,6 +176,87 @@ describe("cron service timer regressions", () => {
     timeoutSpy.mockRestore();
   });
 
+  it("finalizes settled siblings and wakes later jobs while one due run remains active", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const store = timerRegressionFixtures.makeStorePath();
+    const firstDueAt = Date.parse("2026-07-24T01:00:00.000Z");
+    const laterDueAt = firstDueAt + 5 * 60_000;
+    const fastJob = createDueIsolatedJob({
+      id: "fast-sibling",
+      nowMs: firstDueAt,
+      nextRunAtMs: firstDueAt,
+    });
+    const slowJob = createDueIsolatedJob({
+      id: "slow-sibling",
+      nowMs: firstDueAt,
+      nextRunAtMs: firstDueAt,
+    });
+    const laterJob = createDueIsolatedJob({
+      id: "later-due",
+      nowMs: firstDueAt,
+      nextRunAtMs: laterDueAt,
+    });
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [fastJob, slowJob, laterJob],
+    });
+
+    let now = firstDueAt;
+    const slowStarted = createDeferred<void>();
+    const releaseSlow = createDeferred<{ status: "ok"; summary: string }>();
+    const laterStarted = createDeferred<void>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async ({ job }: { job: { id: string } }) => {
+        if (job.id === slowJob.id) {
+          slowStarted.resolve();
+          return await releaseSlow.promise;
+        }
+        if (job.id === laterJob.id) {
+          laterStarted.resolve();
+        }
+        return { status: "ok" as const, summary: job.id };
+      }),
+    });
+
+    const firstTick = onTimer(state);
+    await slowStarted.promise;
+    await vi.waitFor(async () => {
+      const persistedFast = (await loadCronStore(store.storePath)).jobs.find(
+        (job) => job.id === fastJob.id,
+      );
+      expect(persistedFast?.state.lastRunStatus).toBe("ok");
+      expect(persistedFast?.state.runningAtMs).toBeUndefined();
+    });
+    expect(
+      timeoutSpy.mock.calls
+        .map(([, delay]) => delay)
+        .filter((delay): delay is number => typeof delay === "number"),
+    ).toContain(60_000);
+
+    now = laterDueAt;
+    const laterTick = onTimer(state);
+    await laterStarted.promise;
+    await laterTick;
+
+    const persistedWhileSlow = await loadCronStore(store.storePath);
+    expect(persistedWhileSlow.jobs.find((job) => job.id === laterJob.id)?.state.lastRunStatus).toBe(
+      "ok",
+    );
+    expect(persistedWhileSlow.jobs.find((job) => job.id === slowJob.id)?.state.runningAtMs).toBe(
+      firstDueAt,
+    );
+
+    releaseSlow.resolve({ status: "ok", summary: "slow-sibling" });
+    await firstTick;
+    timeoutSpy.mockRestore();
+  });
+
   it("#24355: one-shot job retries then succeeds", async () => {
     const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
 
@@ -2278,8 +2359,9 @@ describe("cron service timer regressions", () => {
 
       const timerPromise = onTimer(state);
       await secondStarted.promise;
-      expect(isCronJobActive(first.id)).toBe(true);
+      expect(isCronJobActive(first.id)).toBe(false);
       expect(isCronJobActive(second.id)).toBe(true);
+      expect(state.store?.jobs.find((job) => job.id === first.id)?.state.lastStatus).toBe("ok");
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
       await timerPromise;


### PR DESCRIPTION
## What Problem This Solves

When several isolated cron jobs become due in one timer tick, one slow or timed-out run holds the whole batch open. Faster siblings remain marked running until the slowest worker settles, and later-due jobs cannot be discovered because the scheduler keeps `state.running` true for the payload lifetime.

## Why This Change Was Made

The timer pass now owns only due-job discovery and durable reservation. It re-arms the scheduler before payload execution, while the existing per-job markers and shared admission limit continue to prevent duplicate or excessive runs.

Each ordinary outcome is finalized as soon as that job settles instead of being accumulated until the worker pool drains. Active reservations are excluded from `nextWakeAtMs`, so their retained past-due timestamps do not cause polling loops or obscure the next eligible job.

## User Impact

Completed isolated cron runs reach terminal state independently, and later scheduled work continues to wake while an unrelated sibling remains active. Job cadence, concurrency limits, and timeout policy are unchanged.

## Evidence

- Added a regression with two co-scheduled siblings (one completed, one held active) plus a later-due job. It verifies the completed sibling is persisted before the held run resolves and the later job executes while that sibling remains active.
- Updated the scheduler re-arm regression to prove the timer is armed after reservation rather than held by payload execution.
- `pnpm exec vitest run src/cron/service/timer.regression.test.ts src/cron/service.rearm-timer-when-running.test.ts src/cron/service.armtimer-tight-loop.test.ts src/cron/service.jobs.test.ts --reporter=dot --testTimeout=10000` (167 passed)
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed` (passed)
