### PR TITLE
fix: steered webchat follow-up kills active run; camera snap picks portrait

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -15523,7 +15523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 193,
+      "line": 197,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Camera",
       "surface": "apple",
@@ -15531,7 +15531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 193,
+      "line": 197,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -30147,7 +30147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 169,
+      "line": 173,
       "path": "apps/macos/Sources/OpenClaw/CameraCaptureService.swift",
       "source": "Camera",
       "surface": "apple",
@@ -30155,7 +30155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 169,
+      "line": 173,
       "path": "apps/macos/Sources/OpenClaw/CameraCaptureService.swift",
       "source": "Microphone",
       "surface": "apple",

--- a/apps/ios/Sources/Camera/CameraController.swift
+++ b/apps/ios/Sources/Camera/CameraController.swift
@@ -79,7 +79,7 @@ actor CameraController {
             session.startRunning()
             defer { sessionStopper.stop() }
             // `.photo` can renegotiate external cameras into portrait; reselect landscape after start.
-            try CameraCapturePipelineSupport.applyPreferredCaptureFormat(
+            CameraCapturePipelineSupport.applyPreferredCaptureFormat(
                 device: prepared.device,
                 preferredMaxWidth: maxWidth)
             try Task.checkCancellation()

--- a/apps/ios/Sources/Camera/CameraController.swift
+++ b/apps/ios/Sources/Camera/CameraController.swift
@@ -78,6 +78,10 @@ actor CameraController {
             try Task.checkCancellation()
             session.startRunning()
             defer { sessionStopper.stop() }
+            // `.photo` can renegotiate external cameras into portrait; reselect landscape after start.
+            try CameraCapturePipelineSupport.applyPreferredCaptureFormat(
+                device: prepared.device,
+                preferredMaxWidth: maxWidth)
             try Task.checkCancellation()
             try await CameraCapturePipelineSupport.warmUpCaptureSession()
             try await Self.sleepDelayMs(delayMs)

--- a/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
+++ b/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
@@ -80,6 +80,10 @@ actor CameraCaptureService {
 
         session.startRunning()
         defer { session.stopRunning() }
+        // `.photo` can renegotiate external cameras into portrait; reselect landscape after start.
+        try CameraCapturePipelineSupport.applyPreferredCaptureFormat(
+            device: device,
+            preferredMaxWidth: maxWidth)
         try await CameraCapturePipelineSupport.warmUpCaptureSession()
         await self.waitForExposureAndWhiteBalance(device: device)
         await self.sleepDelayMs(delayMs)

--- a/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
+++ b/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
@@ -81,7 +81,7 @@ actor CameraCaptureService {
         session.startRunning()
         defer { session.stopRunning() }
         // `.photo` can renegotiate external cameras into portrait; reselect landscape after start.
-        try CameraCapturePipelineSupport.applyPreferredCaptureFormat(
+        CameraCapturePipelineSupport.applyPreferredCaptureFormat(
             device: device,
             preferredMaxWidth: maxWidth)
         try await CameraCapturePipelineSupport.warmUpCaptureSession()

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
@@ -219,14 +219,13 @@ public enum CameraCapturePipelineSupport {
         }
         let preferredWidth = preferredMaxWidth.flatMap { $0 > 0 ? $0 : nil }
         var bestIndex = 0
-        for index in candidates.indices.dropFirst() {
-            if Self.isPreferredCaptureFormat(
+        for index in candidates.indices.dropFirst()
+            where Self.isPreferredCaptureFormat(
                 candidates[index],
                 over: candidates[bestIndex],
                 preferredMaxWidth: preferredWidth)
-            {
-                bestIndex = index
-            }
+        {
+            bestIndex = index
         }
         return bestIndex
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
@@ -190,9 +190,11 @@ public enum CameraCapturePipelineSupport {
 
     /// Prefer landscape formats after `.photo` / `.high` renegotiation so external
     /// cameras (for example AnkerWork C310) do not stay locked to a portrait mode.
+    /// Best-effort: if the device cannot be reconfigured, keep capturing with the
+    /// active format instead of failing the whole snap.
     public static func applyPreferredCaptureFormat(
         device: AVCaptureDevice,
-        preferredMaxWidth: Int?) throws
+        preferredMaxWidth: Int?)
     {
         let sizes = device.formats.map { format in
             let dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription)
@@ -208,9 +210,13 @@ public enum CameraCapturePipelineSupport {
         if device.activeFormat === preferred {
             return
         }
-        try device.lockForConfiguration()
-        defer { device.unlockForConfiguration() }
-        device.activeFormat = preferred
+        do {
+            try device.lockForConfiguration()
+            defer { device.unlockForConfiguration() }
+            device.activeFormat = preferred
+        } catch {
+            // Keep the session's current format when reconfiguration is unavailable.
+        }
     }
 
     /// Choose the best capture size for gateway snaps: landscape first, then closest

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreMedia
 import Foundation
 
 #if !os(watchOS)
@@ -19,6 +20,20 @@ public struct CameraMovieSessionOptions: Sendable {
         self.includeAudio = includeAudio
         self.durationMs = durationMs
     }
+}
+
+/// Device-independent capture dimensions used to pick a landscape format.
+public struct CameraCaptureFormatSize: Equatable, Sendable {
+    public let width: Int
+    public let height: Int
+
+    public init(width: Int, height: Int) {
+        self.width = width
+        self.height = height
+    }
+
+    public var isLandscape: Bool { self.width >= self.height }
+    public var pixelCount: Int { max(0, self.width) * max(0, self.height) }
 }
 
 public enum CameraCapturePipelineSupport {
@@ -166,6 +181,84 @@ public enum CameraCapturePipelineSupport {
         case .back: "back"
         default: "unspecified"
         }
+    }
+
+    /// Prefer landscape formats after `.photo` / `.high` renegotiation so external
+    /// cameras (for example AnkerWork C310) do not stay locked to a portrait mode.
+    public static func applyPreferredCaptureFormat(
+        device: AVCaptureDevice,
+        preferredMaxWidth: Int?) throws
+    {
+        let sizes = device.formats.map { format in
+            let dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription)
+            return CameraCaptureFormatSize(width: Int(dimensions.width), height: Int(dimensions.height))
+        }
+        guard let index = Self.selectPreferredCaptureFormatIndex(
+            candidates: sizes,
+            preferredMaxWidth: preferredMaxWidth)
+        else {
+            return
+        }
+        let preferred = device.formats[index]
+        if device.activeFormat === preferred {
+            return
+        }
+        try device.lockForConfiguration()
+        defer { device.unlockForConfiguration() }
+        device.activeFormat = preferred
+    }
+
+    /// Choose the best capture size for gateway snaps: landscape first, then closest
+    /// to `preferredMaxWidth`, then highest pixel count.
+    public static func selectPreferredCaptureFormatIndex(
+        candidates: [CameraCaptureFormatSize],
+        preferredMaxWidth: Int?) -> Int?
+    {
+        guard !candidates.isEmpty else {
+            return nil
+        }
+        let preferredWidth = preferredMaxWidth.flatMap { $0 > 0 ? $0 : nil }
+        var bestIndex = 0
+        for index in candidates.indices.dropFirst() {
+            if Self.isPreferredCaptureFormat(
+                candidates[index],
+                over: candidates[bestIndex],
+                preferredMaxWidth: preferredWidth)
+            {
+                bestIndex = index
+            }
+        }
+        return bestIndex
+    }
+
+    static func isPreferredCaptureFormat(
+        _ candidate: CameraCaptureFormatSize,
+        over current: CameraCaptureFormatSize,
+        preferredMaxWidth: Int?) -> Bool
+    {
+        if candidate.isLandscape != current.isLandscape {
+            return candidate.isLandscape
+        }
+        if let preferredMaxWidth {
+            let candidateDistance = Self.widthDistance(candidate.width, preferredMaxWidth: preferredMaxWidth)
+            let currentDistance = Self.widthDistance(current.width, preferredMaxWidth: preferredMaxWidth)
+            if candidateDistance != currentDistance {
+                return candidateDistance < currentDistance
+            }
+        }
+        if candidate.pixelCount != current.pixelCount {
+            return candidate.pixelCount > current.pixelCount
+        }
+        return candidate.width > current.width
+    }
+
+    private static func widthDistance(_ width: Int, preferredMaxWidth: Int) -> Int {
+        // Prefer at-or-above the requested width so post-capture downscale keeps detail;
+        // undersized formats are a last resort.
+        if width >= preferredMaxWidth {
+            return width - preferredMaxWidth
+        }
+        return preferredMaxWidth - width + 1_000_000
     }
 }
 #endif

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
@@ -32,8 +32,13 @@ public struct CameraCaptureFormatSize: Equatable, Sendable {
         self.height = height
     }
 
-    public var isLandscape: Bool { self.width >= self.height }
-    public var pixelCount: Int { max(0, self.width) * max(0, self.height) }
+    public var isLandscape: Bool {
+        self.width >= self.height
+    }
+
+    public var pixelCount: Int {
+        max(0, self.width) * max(0, self.height)
+    }
 }
 
 public enum CameraCapturePipelineSupport {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/CameraCapturePipelineSupportTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/CameraCapturePipelineSupportTests.swift
@@ -94,4 +94,28 @@ struct CameraCapturePipelineSupportTests {
         #expect(counts.stops == 1)
         #expect(counts.operations == 1)
     }
+
+    @Test func `format selection prefers landscape over portrait after photo renegotiation`() {
+        let candidates = [
+            CameraCaptureFormatSize(width: 1080, height: 1920),
+            CameraCaptureFormatSize(width: 1920, height: 1080),
+            CameraCaptureFormatSize(width: 1280, height: 720),
+        ]
+        let index = CameraCapturePipelineSupport.selectPreferredCaptureFormatIndex(
+            candidates: candidates,
+            preferredMaxWidth: 1920)
+        #expect(index == 1)
+    }
+
+    @Test func `format selection prefers the landscape size closest to max width`() {
+        let candidates = [
+            CameraCaptureFormatSize(width: 3840, height: 2160),
+            CameraCaptureFormatSize(width: 1920, height: 1080),
+            CameraCaptureFormatSize(width: 1280, height: 720),
+        ]
+        let index = CameraCapturePipelineSupport.selectPreferredCaptureFormatIndex(
+            candidates: candidates,
+            preferredMaxWidth: 1920)
+        #expect(index == 1)
+    }
 }

--- a/src/gateway/server-methods/chat-send-active-run-ownership.test.ts
+++ b/src/gateway/server-methods/chat-send-active-run-ownership.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldFinalizeChatSendAsNonAgent,
+  shouldTerminalizeDeferredChatSend,
+} from "./chat-send-active-run-ownership.js";
+
+describe("shouldFinalizeChatSendAsNonAgent", () => {
+  it("keeps gateway fallback for plain non-agent replies", () => {
+    expect(
+      shouldFinalizeChatSendAsNonAgent({
+        agentRunStarted: false,
+        queuedFollowupEnqueued: false,
+        activeRunTurnAdopted: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips fallback after a steered turn is adopted by the active run", () => {
+    expect(
+      shouldFinalizeChatSendAsNonAgent({
+        agentRunStarted: false,
+        queuedFollowupEnqueued: false,
+        activeRunTurnAdopted: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips fallback when a followup was queued behind the active run", () => {
+    expect(
+      shouldFinalizeChatSendAsNonAgent({
+        agentRunStarted: false,
+        queuedFollowupEnqueued: true,
+        activeRunTurnAdopted: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips fallback once an agent run owns the turn", () => {
+    expect(
+      shouldFinalizeChatSendAsNonAgent({
+        agentRunStarted: true,
+        queuedFollowupEnqueued: false,
+        activeRunTurnAdopted: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldTerminalizeDeferredChatSend", () => {
+  it("terminalizes steered and queued admissions", () => {
+    expect(
+      shouldTerminalizeDeferredChatSend({
+        queuedFollowupEnqueued: false,
+        activeRunTurnAdopted: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldTerminalizeDeferredChatSend({
+        queuedFollowupEnqueued: true,
+        activeRunTurnAdopted: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("leaves ordinary agent dispatches to their own finalizers", () => {
+    expect(
+      shouldTerminalizeDeferredChatSend({
+        queuedFollowupEnqueued: false,
+        activeRunTurnAdopted: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/gateway/server-methods/chat-send-active-run-ownership.test.ts
+++ b/src/gateway/server-methods/chat-send-active-run-ownership.test.ts
@@ -1,83 +1,29 @@
 import { describe, expect, it } from "vitest";
-import {
-  createChatSendActiveRunOwnership,
-  shouldFinalizeChatSendAsNonAgent,
-  shouldTerminalizeDeferredChatSend,
-} from "./chat-send-active-run-ownership.js";
+import { createChatSendActiveRunOwnership } from "./chat-send-active-run-ownership.js";
 
-describe("shouldFinalizeChatSendAsNonAgent", () => {
+describe("createChatSendActiveRunOwnership", () => {
   it("keeps gateway fallback for plain non-agent replies", () => {
-    expect(
-      shouldFinalizeChatSendAsNonAgent({
-        agentRunStarted: false,
-        queuedFollowupEnqueued: false,
-        activeRunTurnAdopted: false,
-      }),
-    ).toBe(true);
+    const ownership = createChatSendActiveRunOwnership();
+    expect(ownership.shouldFinalizeAsNonAgent(false)).toBe(true);
+    expect(ownership.shouldTerminalize()).toBe(false);
   });
 
   it("skips fallback after a steered turn is adopted by the active run", () => {
-    expect(
-      shouldFinalizeChatSendAsNonAgent({
-        agentRunStarted: false,
-        queuedFollowupEnqueued: false,
-        activeRunTurnAdopted: true,
-      }),
-    ).toBe(false);
-  });
-
-  it("skips fallback when a followup was queued behind the active run", () => {
-    expect(
-      shouldFinalizeChatSendAsNonAgent({
-        agentRunStarted: false,
-        queuedFollowupEnqueued: true,
-        activeRunTurnAdopted: false,
-      }),
-    ).toBe(false);
-  });
-
-  it("skips fallback once an agent run owns the turn", () => {
-    expect(
-      shouldFinalizeChatSendAsNonAgent({
-        agentRunStarted: true,
-        queuedFollowupEnqueued: false,
-        activeRunTurnAdopted: false,
-      }),
-    ).toBe(false);
-  });
-});
-
-describe("shouldTerminalizeDeferredChatSend", () => {
-  it("terminalizes steered and queued admissions", () => {
-    expect(
-      shouldTerminalizeDeferredChatSend({
-        queuedFollowupEnqueued: false,
-        activeRunTurnAdopted: true,
-      }),
-    ).toBe(true);
-    expect(
-      shouldTerminalizeDeferredChatSend({
-        queuedFollowupEnqueued: true,
-        activeRunTurnAdopted: false,
-      }),
-    ).toBe(true);
-  });
-
-  it("leaves ordinary agent dispatches to their own finalizers", () => {
-    expect(
-      shouldTerminalizeDeferredChatSend({
-        queuedFollowupEnqueued: false,
-        activeRunTurnAdopted: false,
-      }),
-    ).toBe(false);
-  });
-});
-
-describe("createChatSendActiveRunOwnership", () => {
-  it("tracks steered adoption for post-dispatch decisions", () => {
     const ownership = createChatSendActiveRunOwnership();
     ownership.markActiveRunTurnAdopted();
     expect(ownership.shouldFinalizeAsNonAgent(false)).toBe(false);
     expect(ownership.shouldTerminalize()).toBe(true);
+  });
+
+  it("skips fallback when a followup was queued behind the active run", () => {
+    const ownership = createChatSendActiveRunOwnership();
+    ownership.markQueuedFollowupEnqueued();
+    expect(ownership.shouldFinalizeAsNonAgent(false)).toBe(false);
+    expect(ownership.shouldTerminalize()).toBe(true);
+  });
+
+  it("skips fallback once an agent run owns the turn", () => {
+    const ownership = createChatSendActiveRunOwnership();
+    expect(ownership.shouldFinalizeAsNonAgent(true)).toBe(false);
   });
 });

--- a/src/gateway/server-methods/chat-send-active-run-ownership.test.ts
+++ b/src/gateway/server-methods/chat-send-active-run-ownership.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createChatSendActiveRunOwnership,
   shouldFinalizeChatSendAsNonAgent,
   shouldTerminalizeDeferredChatSend,
 } from "./chat-send-active-run-ownership.js";
@@ -69,5 +70,14 @@ describe("shouldTerminalizeDeferredChatSend", () => {
         activeRunTurnAdopted: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("createChatSendActiveRunOwnership", () => {
+  it("tracks steered adoption for post-dispatch decisions", () => {
+    const ownership = createChatSendActiveRunOwnership();
+    ownership.markActiveRunTurnAdopted();
+    expect(ownership.shouldFinalizeAsNonAgent(false)).toBe(false);
+    expect(ownership.shouldTerminalize()).toBe(true);
   });
 });

--- a/src/gateway/server-methods/chat-send-active-run-ownership.ts
+++ b/src/gateway/server-methods/chat-send-active-run-ownership.ts
@@ -1,0 +1,23 @@
+/**
+ * Decide whether chat.send still owns user-turn fallback persistence.
+ *
+ * Steered and queued followups are already owned by the active runtime or a
+ * later aggregate turn. Writing through the gateway fallback while an embedded
+ * prompt lock is released appends a foreign user turn and kills the active run
+ * with EmbeddedAttemptSessionTakeoverError (#113194).
+ */
+export function shouldFinalizeChatSendAsNonAgent(params: {
+  agentRunStarted: boolean;
+  queuedFollowupEnqueued: boolean;
+  activeRunTurnAdopted: boolean;
+}): boolean {
+  return !params.agentRunStarted && !params.queuedFollowupEnqueued && !params.activeRunTurnAdopted;
+}
+
+/** Successful steer/queue admission ends this client run; a later turn owns work. */
+export function shouldTerminalizeDeferredChatSend(params: {
+  queuedFollowupEnqueued: boolean;
+  activeRunTurnAdopted: boolean;
+}): boolean {
+  return params.queuedFollowupEnqueued || params.activeRunTurnAdopted;
+}

--- a/src/gateway/server-methods/chat-send-active-run-ownership.ts
+++ b/src/gateway/server-methods/chat-send-active-run-ownership.ts
@@ -21,3 +21,30 @@ export function shouldTerminalizeDeferredChatSend(params: {
 }): boolean {
   return params.queuedFollowupEnqueued || params.activeRunTurnAdopted;
 }
+
+/** Track steer vs followup ownership for chat.send post-dispatch. */
+export function createChatSendActiveRunOwnership() {
+  let queuedFollowupEnqueued = false;
+  let activeRunTurnAdopted = false;
+  return {
+    markQueuedFollowupEnqueued: () => {
+      queuedFollowupEnqueued = true;
+    },
+    markActiveRunTurnAdopted: () => {
+      activeRunTurnAdopted = true;
+    },
+    isQueuedFollowupEnqueued: () => queuedFollowupEnqueued,
+    isActiveRunTurnAdopted: () => activeRunTurnAdopted,
+    shouldFinalizeAsNonAgent: (agentRunStarted: boolean) =>
+      shouldFinalizeChatSendAsNonAgent({
+        agentRunStarted,
+        queuedFollowupEnqueued,
+        activeRunTurnAdopted,
+      }),
+    shouldTerminalize: () =>
+      shouldTerminalizeDeferredChatSend({
+        queuedFollowupEnqueued,
+        activeRunTurnAdopted,
+      }),
+  };
+}

--- a/src/gateway/server-methods/chat-send-active-run-ownership.ts
+++ b/src/gateway/server-methods/chat-send-active-run-ownership.ts
@@ -6,7 +6,7 @@
  * prompt lock is released appends a foreign user turn and kills the active run
  * with EmbeddedAttemptSessionTakeoverError (#113194).
  */
-export function shouldFinalizeChatSendAsNonAgent(params: {
+function shouldFinalizeChatSendAsNonAgent(params: {
   agentRunStarted: boolean;
   queuedFollowupEnqueued: boolean;
   activeRunTurnAdopted: boolean;
@@ -15,7 +15,7 @@ export function shouldFinalizeChatSendAsNonAgent(params: {
 }
 
 /** Successful steer/queue admission ends this client run; a later turn owns work. */
-export function shouldTerminalizeDeferredChatSend(params: {
+function shouldTerminalizeDeferredChatSend(params: {
   queuedFollowupEnqueued: boolean;
   activeRunTurnAdopted: boolean;
 }): boolean {

--- a/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
@@ -64,4 +64,66 @@ describe("createChatSendDispatchErrorLifecycle", () => {
     expect(cleanupAdmittedRun).toHaveBeenCalledOnce();
     expect(removeChatRun).toHaveBeenCalledWith("run-1", "run-1", "agent:main:main");
   });
+
+  it("terminalizes an admitted steered turn as successful despite later dispatch failure", async () => {
+    const broadcast = vi.fn();
+    const cleanupAdmittedRun = vi.fn();
+    const removeChatRun = vi.fn();
+    const warn = vi.fn();
+    const dedupe = new Map();
+    const lifecycle = createChatSendDispatchErrorLifecycle({
+      admission: {
+        activeRunAbort: {
+          cleanup: vi.fn(),
+          controller: new AbortController(),
+          entry: undefined,
+          registered: true,
+        } as never,
+        cleanupAdmittedRun,
+        lifecycleGeneration: "test-generation",
+        restartSafeAdmission: undefined,
+      },
+      context: {
+        agentRunSeq: new Map(),
+        broadcast,
+        chatRunState: createChatRunState(),
+        dedupe,
+        getRuntimeConfig: () => ({}),
+        logGateway: { warn },
+        nodeSendToSession: vi.fn(),
+        removeChatRun,
+      } as never,
+      isActiveRunTurnAdopted: () => true,
+      isQueuedFollowupEnqueued: () => false,
+      persistUserTurnTranscript: vi.fn(),
+      session: {
+        agentId: "main",
+        backingSessionId: undefined,
+        cfg: {},
+        clientRunId: "run-2",
+        now: 1,
+        rawSessionKey: "agent:main:main",
+        sessionKey: "agent:main:main",
+      },
+      terminalizeRestartSafeAdmission: vi.fn(),
+      userTurnRecorder: { hasPersisted: () => false, isBlocked: () => false },
+    });
+
+    await lifecycle.handleError(new Error("late failure after steer"));
+    lifecycle.finalize();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("dispatch failed after active-run steer adoption"),
+    );
+    expect(dedupe.get("chat:run-2")).toMatchObject({
+      ok: true,
+      payload: { runId: "run-2", status: "ok" },
+    });
+    expect(broadcast).toHaveBeenCalledWith(
+      "chat",
+      expect.objectContaining({ runId: "run-2", state: "final" }),
+      { sessionKeys: ["agent:main:main"] },
+    );
+    expect(cleanupAdmittedRun).toHaveBeenCalledOnce();
+  });
 });

--- a/src/gateway/server-methods/chat-send-dispatch-errors.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.ts
@@ -27,6 +27,7 @@ export function createChatSendDispatchErrorLifecycle(params: {
     "activeRunAbort" | "cleanupAdmittedRun" | "lifecycleGeneration" | "restartSafeAdmission"
   >;
   context: GatewayRequestContext;
+  isActiveRunTurnAdopted?: () => boolean;
   isQueuedFollowupEnqueued: () => boolean;
   persistUserTurnTranscript: () => Promise<unknown>;
   session: Pick<
@@ -42,6 +43,7 @@ export function createChatSendDispatchErrorLifecycle(params: {
   const {
     admission,
     context,
+    isActiveRunTurnAdopted,
     isQueuedFollowupEnqueued,
     persistUserTurnTranscript,
     session,
@@ -56,9 +58,11 @@ export function createChatSendDispatchErrorLifecycle(params: {
 
   const handleError = async (err: unknown) => {
     const errorMessage = String(err);
+    const activeRunTurnAdopted = isActiveRunTurnAdopted?.() === true;
     const queuedFollowupEnqueued = isQueuedFollowupEnqueued();
+    const ownedByActiveRun = activeRunTurnAdopted || queuedFollowupEnqueued;
     let restartSafeDispatchFailureTerminalized = false;
-    if (restartSafeAdmission && !queuedFollowupEnqueued) {
+    if (restartSafeAdmission && !ownedByActiveRun) {
       restartSafeDispatchFailureTerminalized = await terminalizeRestartSafeAdmission({
         retryable: true,
         status: "failed",
@@ -78,9 +82,11 @@ export function createChatSendDispatchErrorLifecycle(params: {
         });
       }
     }
-    if (queuedFollowupEnqueued) {
+    if (ownedByActiveRun) {
       context.logGateway.warn(
-        `webchat dispatch failed after followup queue admission: ${formatForLog(err)}`,
+        activeRunTurnAdopted
+          ? `webchat dispatch failed after active-run steer adoption: ${formatForLog(err)}`
+          : `webchat dispatch failed after followup queue admission: ${formatForLog(err)}`,
       );
       if (!context.chatRunState.hasAbortMarker(clientRunId)) {
         setGatewayDedupeEntry({

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -32,10 +32,7 @@ import { ensureChatQueuedTurns } from "./chat-abort-runtime.js";
 import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
 import { hasGatewayAdminScope } from "./chat-origin-routing.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
-import {
-  shouldFinalizeChatSendAsNonAgent,
-  shouldTerminalizeDeferredChatSend,
-} from "./chat-send-active-run-ownership.js";
+import { createChatSendActiveRunOwnership } from "./chat-send-active-run-ownership.js";
 import { admitChatSend } from "./chat-send-admission.js";
 import { prepareChatSendAttachments } from "./chat-send-attachments.js";
 import {
@@ -43,7 +40,7 @@ import {
   scheduleChatDashboardSessionTitle,
 } from "./chat-send-background.js";
 import { createChatSendDispatchErrorLifecycle } from "./chat-send-dispatch-errors.js";
-import { finalizeChatSendNonAgentReplies } from "./chat-send-nonagent-finalization.js";
+import { finalizeChatSendPostDispatch } from "./chat-send-post-dispatch.js";
 import {
   respondChatSessionRoutingChanged,
   runChatSendPreAdmission,
@@ -55,7 +52,6 @@ import {
 import { createChatSendReplyDispatch } from "./chat-send-reply-dispatch.js";
 import { normalizeChatSendRequest } from "./chat-send-request.js";
 import { prepareChatSendSession } from "./chat-send-session.js";
-import { finalizeChatSendSourceReplies } from "./chat-send-source-finalization.js";
 import { applyChatSendManagedMedia, prepareChatSendUserTurn } from "./chat-send-user-turn.js";
 import {
   chatSendAckServerTimingAttributes,
@@ -345,14 +341,11 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
         session: preparedSession.value,
         userTurnRecorder,
       });
-    let queuedFollowupEnqueued = false;
-    // Steer adoption owns transcript writes through the active embedded run.
-    // Gateway fallback must not append again while that run's prompt lock is released.
-    let activeRunTurnAdopted = false;
+    const activeRunOwnership = createChatSendActiveRunOwnership();
     const dispatchErrorLifecycle = createChatSendDispatchErrorLifecycle({
       admission: admitted.value,
       context,
-      isQueuedFollowupEnqueued: () => queuedFollowupEnqueued,
+      isQueuedFollowupEnqueued: activeRunOwnership.isQueuedFollowupEnqueued,
       persistUserTurnTranscript: persistGatewayUserTurnTranscript,
       session: preparedSession.value,
       terminalizeRestartSafeAdmission,
@@ -451,20 +444,25 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
                   admission: "cancel-only",
                   ownerKey: queuedFollowupOwnerKey,
                   onAdopted: async () => {
-                    activeRunTurnAdopted = true;
+                    activeRunOwnership.markActiveRunTurnAdopted();
                   },
                   onDeferred: () => {
-                    queuedFollowupEnqueued = registerQueuedChatTurn({
-                      chatQueuedTurns: ensureChatQueuedTurns(context),
-                      runId: clientRunId,
-                      controller: activeRunAbort.controller,
-                      sessionId: backingSessionId ?? clientRunId,
-                      sessionKey,
-                      agentId: selectedAgent.agentId,
-                      ownerConnId: normalizeOptionalText(client?.connId),
-                      ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
-                    });
-                    return queuedFollowupEnqueued;
+                    if (
+                      !registerQueuedChatTurn({
+                        chatQueuedTurns: ensureChatQueuedTurns(context),
+                        runId: clientRunId,
+                        controller: activeRunAbort.controller,
+                        sessionId: backingSessionId ?? clientRunId,
+                        sessionKey,
+                        agentId: selectedAgent.agentId,
+                        ownerConnId: normalizeOptionalText(client?.connId),
+                        ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
+                      })
+                    ) {
+                      return false;
+                    }
+                    activeRunOwnership.markQueuedFollowupEnqueued();
+                    return true;
                   },
                   onCancellationRetired: () => {
                     retireQueuedChatTurnCancellation(
@@ -568,102 +566,22 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
         await measureDiagnosticsTimelineSpan(
           "gateway.chat_send.post_dispatch",
           async () => {
-            const returnedAgentErrorPayloads = agentRunStarted
-              ? deliveredReplies
-                  .map((entryInner) => entryInner.payload)
-                  .filter((payload) => payload.isError)
-              : [];
-            const returnedAgentErrorMessage =
-              returnedAgentErrorPayloads
-                .map((payload) => payload.text?.trim())
-                .filter((text): text is string => Boolean(text))
-                .join(" | ") || undefined;
-            if (
-              agentRunStarted &&
-              returnedAgentErrorPayloads.length > 0 &&
-              !userTurnRecorder.hasPersisted() &&
-              !userTurnRecorder.isBlocked()
-            ) {
-              await persistGatewayUserTurnTranscriptBestEffort();
-            }
-            if (
-              agentRunStarted &&
-              returnedAgentErrorPayloads.length === 0 &&
-              !userTurnRecorder.hasPersisted() &&
-              !userTurnRecorder.isBlocked() &&
-              userTurnRecorder.hasRuntimePersistencePending()
-            ) {
-              await persistGatewayUserTurnTranscriptBestEffort();
-            }
-            let broadcastedSourceReplyFinal = false;
-            // WebChat persistence has two owners. Agent runs persist model-visible turns
-            // through OpenClaw runtime's SessionManager; this dispatcher only owns live delivery payloads.
-            // Do not blindly mirror agent-run final payloads into JSONL or chat.history can
-            // duplicate normal embedded-agent assistant turns. The non-agent branch below has no
-            // runtime-owned assistant turn, so it appends a gateway-injected assistant entry before
-            // broadcasting the final UI event. Steered/queued turns already have a runtime owner.
-            if (
-              shouldFinalizeChatSendAsNonAgent({
-                agentRunStarted,
-                queuedFollowupEnqueued,
-                activeRunTurnAdopted,
-              })
-            ) {
-              await finalizeChatSendNonAgentReplies({
-                accountId,
-                context,
-                deliveredReplies,
-                emitFirstAssistantServerTiming,
-                foldCommandBlocks: isInternalTextSlashCommandTurn,
-                persistUserTurnTranscript: persistGatewayUserTurnTranscriptBestEffort,
-                session: preparedSession.value,
-                suppressReplies: hasAppendedWebchatAgentMedia(),
-              });
-            } else {
-              broadcastedSourceReplyFinal = await finalizeChatSendSourceReplies({
-                accountId,
-                context,
-                deliveredReplies,
-                emitFirstAssistantServerTiming,
-                hasReturnedAgentErrorPayloads: returnedAgentErrorPayloads.length > 0,
-                session: preparedSession.value,
-              });
-            }
-            const shouldBroadcastAgentError =
-              returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;
-            if (shouldBroadcastAgentError) {
-              broadcastChatError({
-                context,
-                runId: clientRunId,
-                sessionKey,
-                agentId,
-                errorMessage: returnedAgentErrorMessage,
-              });
-            }
-            if (!context.chatRunState.hasAbortMarker(clientRunId)) {
-              const returnedAgentError = shouldBroadcastAgentError
-                ? errorShape(
-                    ErrorCodes.UNAVAILABLE,
-                    returnedAgentErrorMessage ?? "agent returned an error payload",
-                  )
-                : undefined;
-              setGatewayDedupeEntry({
-                dedupe: context.dedupe,
-                key: `chat:${clientRunId}`,
-                entry: {
-                  ts: Date.now(),
-                  ok: !shouldBroadcastAgentError,
-                  payload: shouldBroadcastAgentError
-                    ? {
-                        runId: clientRunId,
-                        status: "error" as const,
-                        summary: returnedAgentErrorMessage ?? "agent returned an error payload",
-                      }
-                    : { runId: clientRunId, status: "ok" as const },
-                  ...(returnedAgentError ? { error: returnedAgentError } : {}),
-                },
-              });
-            }
+            await finalizeChatSendPostDispatch({
+              accountId,
+              activeRunOwnership,
+              agentId,
+              agentRunStarted,
+              clientRunId,
+              context,
+              deliveredReplies,
+              emitFirstAssistantServerTiming,
+              foldCommandBlocks: isInternalTextSlashCommandTurn,
+              hasAppendedWebchatAgentMedia,
+              persistUserTurnTranscriptBestEffort: persistGatewayUserTurnTranscriptBestEffort,
+              session: preparedSession.value,
+              sessionKey,
+              userTurnRecorder,
+            });
           },
           {
             phase: "agent-turn",
@@ -679,14 +597,10 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
           dispatchStartedAtMs,
         );
         if (
-          shouldTerminalizeDeferredChatSend({
-            queuedFollowupEnqueued,
-            activeRunTurnAdopted,
-          }) &&
+          activeRunOwnership.shouldTerminalize() &&
           !context.chatRunState.hasAbortMarker(clientRunId)
         ) {
-          // Successful steer/queue admission ends this client run. The active
-          // runtime or a later aggregate/followup owns the remaining work.
+          // Successful steer/queue admission ends this client run.
           broadcastChatFinal({
             context,
             runId: clientRunId,

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -32,6 +32,10 @@ import { ensureChatQueuedTurns } from "./chat-abort-runtime.js";
 import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
 import { hasGatewayAdminScope } from "./chat-origin-routing.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
+import {
+  shouldFinalizeChatSendAsNonAgent,
+  shouldTerminalizeDeferredChatSend,
+} from "./chat-send-active-run-ownership.js";
 import { admitChatSend } from "./chat-send-admission.js";
 import { prepareChatSendAttachments } from "./chat-send-attachments.js";
 import {
@@ -342,6 +346,9 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
         userTurnRecorder,
       });
     let queuedFollowupEnqueued = false;
+    // Steer adoption owns transcript writes through the active embedded run.
+    // Gateway fallback must not append again while that run's prompt lock is released.
+    let activeRunTurnAdopted = false;
     const dispatchErrorLifecycle = createChatSendDispatchErrorLifecycle({
       admission: admitted.value,
       context,
@@ -443,7 +450,9 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
                   // Gateway cancel identity only — share collect key via ownerKey.
                   admission: "cancel-only",
                   ownerKey: queuedFollowupOwnerKey,
-                  onAdopted: async () => {},
+                  onAdopted: async () => {
+                    activeRunTurnAdopted = true;
+                  },
                   onDeferred: () => {
                     queuedFollowupEnqueued = registerQueuedChatTurn({
                       chatQueuedTurns: ensureChatQueuedTurns(context),
@@ -592,8 +601,14 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
             // Do not blindly mirror agent-run final payloads into JSONL or chat.history can
             // duplicate normal embedded-agent assistant turns. The non-agent branch below has no
             // runtime-owned assistant turn, so it appends a gateway-injected assistant entry before
-            // broadcasting the final UI event.
-            if (!agentRunStarted && !queuedFollowupEnqueued) {
+            // broadcasting the final UI event. Steered/queued turns already have a runtime owner.
+            if (
+              shouldFinalizeChatSendAsNonAgent({
+                agentRunStarted,
+                queuedFollowupEnqueued,
+                activeRunTurnAdopted,
+              })
+            ) {
               await finalizeChatSendNonAgentReplies({
                 accountId,
                 context,
@@ -663,9 +678,15 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
           },
           dispatchStartedAtMs,
         );
-        if (queuedFollowupEnqueued && !context.chatRunState.hasAbortMarker(clientRunId)) {
-          // Successful queue admission ends this client run. The later
-          // aggregate/followup owns its own run id.
+        if (
+          shouldTerminalizeDeferredChatSend({
+            queuedFollowupEnqueued,
+            activeRunTurnAdopted,
+          }) &&
+          !context.chatRunState.hasAbortMarker(clientRunId)
+        ) {
+          // Successful steer/queue admission ends this client run. The active
+          // runtime or a later aggregate/followup owns the remaining work.
           broadcastChatFinal({
             context,
             runId: clientRunId,

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -345,6 +345,7 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
     const dispatchErrorLifecycle = createChatSendDispatchErrorLifecycle({
       admission: admitted.value,
       context,
+      isActiveRunTurnAdopted: activeRunOwnership.isActiveRunTurnAdopted,
       isQueuedFollowupEnqueued: activeRunOwnership.isQueuedFollowupEnqueued,
       persistUserTurnTranscript: persistGatewayUserTurnTranscript,
       session: preparedSession.value,

--- a/src/gateway/server-methods/chat-send-post-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-post-dispatch.ts
@@ -1,0 +1,135 @@
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import { setGatewayDedupeEntry } from "./agent-job.js";
+import { broadcastChatError } from "./chat-broadcast.js";
+import type { createChatSendActiveRunOwnership } from "./chat-send-active-run-ownership.js";
+import { finalizeChatSendNonAgentReplies } from "./chat-send-nonagent-finalization.js";
+import type { createChatSendReplyDispatch } from "./chat-send-reply-dispatch.js";
+import type { PreparedChatSendSession } from "./chat-send-session.js";
+import { finalizeChatSendSourceReplies } from "./chat-send-source-finalization.js";
+import type { GatewayRequestContext } from "./types.js";
+
+type DeliveredReply = ReturnType<typeof createChatSendReplyDispatch>["deliveredReplies"][number];
+type ActiveRunOwnership = ReturnType<typeof createChatSendActiveRunOwnership>;
+
+/** Finalize chat.send after inbound dispatch without re-owning steered turns. */
+export async function finalizeChatSendPostDispatch(params: {
+  accountId: string | undefined;
+  activeRunOwnership: ActiveRunOwnership;
+  agentId: string | undefined;
+  agentRunStarted: boolean;
+  clientRunId: string;
+  context: GatewayRequestContext;
+  deliveredReplies: readonly DeliveredReply[];
+  emitFirstAssistantServerTiming: () => void;
+  foldCommandBlocks: boolean;
+  hasAppendedWebchatAgentMedia: () => boolean;
+  persistUserTurnTranscriptBestEffort: () => Promise<void>;
+  session: PreparedChatSendSession;
+  sessionKey: string;
+  userTurnRecorder: Pick<
+    UserTurnTranscriptRecorder,
+    "hasPersisted" | "hasRuntimePersistencePending" | "isBlocked"
+  >;
+}): Promise<void> {
+  const {
+    accountId,
+    activeRunOwnership,
+    agentId,
+    agentRunStarted,
+    clientRunId,
+    context,
+    deliveredReplies,
+    emitFirstAssistantServerTiming,
+    foldCommandBlocks,
+    hasAppendedWebchatAgentMedia,
+    persistUserTurnTranscriptBestEffort,
+    session,
+    sessionKey,
+    userTurnRecorder,
+  } = params;
+  const returnedAgentErrorPayloads = agentRunStarted
+    ? deliveredReplies.map((entry) => entry.payload).filter((payload) => payload.isError)
+    : [];
+  const returnedAgentErrorMessage =
+    returnedAgentErrorPayloads
+      .map((payload) => payload.text?.trim())
+      .filter((text): text is string => Boolean(text))
+      .join(" | ") || undefined;
+  if (
+    agentRunStarted &&
+    returnedAgentErrorPayloads.length > 0 &&
+    !userTurnRecorder.hasPersisted() &&
+    !userTurnRecorder.isBlocked()
+  ) {
+    await persistUserTurnTranscriptBestEffort();
+  }
+  if (
+    agentRunStarted &&
+    returnedAgentErrorPayloads.length === 0 &&
+    !userTurnRecorder.hasPersisted() &&
+    !userTurnRecorder.isBlocked() &&
+    userTurnRecorder.hasRuntimePersistencePending()
+  ) {
+    await persistUserTurnTranscriptBestEffort();
+  }
+  let broadcastedSourceReplyFinal = false;
+  // Agent runs persist through SessionManager; non-agent turns use gateway fallback.
+  // Steered/queued turns already have a runtime owner — do not append again.
+  if (activeRunOwnership.shouldFinalizeAsNonAgent(agentRunStarted)) {
+    await finalizeChatSendNonAgentReplies({
+      accountId,
+      context,
+      deliveredReplies,
+      emitFirstAssistantServerTiming,
+      foldCommandBlocks,
+      persistUserTurnTranscript: persistUserTurnTranscriptBestEffort,
+      session,
+      suppressReplies: hasAppendedWebchatAgentMedia(),
+    });
+  } else {
+    broadcastedSourceReplyFinal = await finalizeChatSendSourceReplies({
+      accountId,
+      context,
+      deliveredReplies,
+      emitFirstAssistantServerTiming,
+      hasReturnedAgentErrorPayloads: returnedAgentErrorPayloads.length > 0,
+      session,
+    });
+  }
+  const shouldBroadcastAgentError =
+    returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;
+  if (shouldBroadcastAgentError) {
+    broadcastChatError({
+      context,
+      runId: clientRunId,
+      sessionKey,
+      agentId,
+      errorMessage: returnedAgentErrorMessage,
+    });
+  }
+  if (!context.chatRunState.hasAbortMarker(clientRunId)) {
+    const returnedAgentError = shouldBroadcastAgentError
+      ? errorShape(
+          ErrorCodes.UNAVAILABLE,
+          returnedAgentErrorMessage ?? "agent returned an error payload",
+        )
+      : undefined;
+    setGatewayDedupeEntry({
+      dedupe: context.dedupe,
+      key: `chat:${clientRunId}`,
+      entry: {
+        ts: Date.now(),
+        ok: !shouldBroadcastAgentError,
+        payload: shouldBroadcastAgentError
+          ? {
+              runId: clientRunId,
+              status: "error" as const,
+              summary: returnedAgentErrorMessage ?? "agent returned an error payload",
+            }
+          : { runId: clientRunId, status: "ok" as const },
+        ...(returnedAgentError ? { error: returnedAgentError } : {}),
+      },
+    });
+  }
+}


### PR DESCRIPTION
Closes #113194
Closes #113068

## What Problem This Solves

Fixes an issue where a second webchat message steered into an in-flight run could kill that run with `EmbeddedAttemptSessionTakeoverError`.

Also fixes macOS `camera.snap` capturing cropped portrait frames from external webcams that advertise both landscape and portrait formats.

## Why This Change Was Made

Steered turns are already owned by the active runtime. Skip the gateway non-agent user-turn fallback (and terminalize the client run) once `onAdopted` fires, matching queued-followup behavior.

After `AVCaptureSession.startRunning()`, reselect a landscape device format closest to the requested max width so `.photo` renegotiation cannot leave the camera in portrait.

## User Impact

Steered webchat follow-ups no longer abort the active reply. Camera snaps from multi-format external webcams stay landscape by default.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/chat-send-active-run-ownership.test.ts`
- Autoreview clean on `28b71544` (`patch is correct`)

Made with [Cursor](https://cursor.com)