### PR TITLE
refactor(agents): split subagent registry internals

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -522,7 +522,6 @@ src/agents/subagent-registry-lifecycle.ts
 src/agents/subagent-registry-run-manager.ts
 src/agents/subagent-registry.steer-restart.test.ts
 src/agents/subagent-registry.test.ts
-src/agents/subagent-registry.ts
 src/agents/subagent-spawn.test.ts
 src/agents/subagent-spawn.ts
 src/agents/system-prompt.test.ts

--- a/src/agents/subagent-registry-completion-runtime.ts
+++ b/src/agents/subagent-registry-completion-runtime.ts
@@ -1,0 +1,227 @@
+import {
+  isGatewayRestartDraining,
+  runWithGatewayIndependentRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
+import { SUBAGENT_ENDED_REASON_ERROR } from "./subagent-lifecycle-events.js";
+import { createPendingLifecycleScheduler } from "./subagent-registry-pending-lifecycle.js";
+import type { SubagentCompletionRequest, SubagentRunRecord } from "./subagent-registry.types.js";
+
+const GATEWAY_ADMISSION_RETRY_DELAY_MS = 1_000;
+
+export function createSubagentRegistryCompletionRuntime(config: {
+  runs: Map<string, SubagentRunRecord>;
+  resumed: Set<string>;
+  retryTimers: Set<ReturnType<typeof setTimeout>>;
+  completeSubagentRun: (params: SubagentCompletionRequest) => Promise<void>;
+  scheduleOrphanRecovery: (params?: { delayMs?: number; maxRetries?: number }) => void;
+  resumeRun: (runId: string) => void;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+}) {
+  const {
+    runs,
+    resumed,
+    retryTimers,
+    completeSubagentRun,
+    scheduleOrphanRecovery,
+    resumeRun,
+    warn,
+  } = config;
+
+  async function completeSubagentRunWithRecoveryAttempt(
+    params: SubagentCompletionRequest,
+    source: string,
+  ) {
+    try {
+      await completeSubagentRun(params);
+      return;
+    } catch (error) {
+      const current = runs.get(params.runId);
+      warn("failed to complete subagent run; retrying completion", {
+        source,
+        runId: params.runId,
+        childSessionKey: current?.childSessionKey,
+        error,
+      });
+    }
+
+    const current = runs.get(params.runId);
+    if (!current) {
+      return;
+    }
+
+    try {
+      await completeSubagentRun(params);
+      return;
+    } catch (retryError) {
+      warn("failed to complete subagent run after retry; retrying ended cleanup", {
+        source,
+        runId: params.runId,
+        childSessionKey: current.childSessionKey,
+        error: retryError,
+      });
+    }
+
+    const latest = runs.get(params.runId);
+    if (latest && typeof latest.endedAt !== "number") {
+      // The durable write rolled the in-memory entry back. Preserve the original
+      // completion through the normal persisted-session recovery path.
+      scheduleOrphanRecovery({ delayMs: 1_000 });
+      return;
+    }
+    if (
+      !latest ||
+      typeof latest.endedAt !== "number" ||
+      typeof latest.cleanupCompletedAt === "number" ||
+      latest.pauseReason === "sessions_yield"
+    ) {
+      return;
+    }
+    latest.cleanupHandled = false;
+    resumed.delete(params.runId);
+    resumeRun(params.runId);
+  }
+
+  function scheduleSubagentCompletionRetryAfterRestart(
+    params: SubagentCompletionRequest,
+    source: string,
+    expectedEntry: SubagentRunRecord,
+  ) {
+    const expectedGeneration = expectedEntry.generation;
+    const timer = setTimeout(() => {
+      retryTimers.delete(timer);
+      const current = runs.get(params.runId);
+      if (current !== expectedEntry || current.generation !== expectedGeneration) {
+        return;
+      }
+      void completeSubagentRunWithRecovery(params, source).catch((error: unknown) => {
+        warn("failed to retry subagent completion after gateway restart", {
+          source,
+          runId: params.runId,
+          error,
+        });
+      });
+    }, GATEWAY_ADMISSION_RETRY_DELAY_MS);
+    timer.unref?.();
+    retryTimers.add(timer);
+  }
+
+  async function completeSubagentRunWithRecovery(
+    params: SubagentCompletionRequest,
+    source: string,
+  ) {
+    // Each controller attempt owns its terminal transition, while this outer
+    // lease closes the gap between failed attempts and fallback cleanup.
+    try {
+      await runWithGatewayIndependentRootWorkAdmission(async () => {
+        await completeSubagentRunWithRecoveryAttempt(params, source);
+      });
+    } catch (error) {
+      if (!isGatewayRestartDraining()) {
+        throw error;
+      }
+      warn("subagent completion deferred during gateway restart", {
+        source,
+        runId: params.runId,
+      });
+      const current = runs.get(params.runId);
+      if (current) {
+        scheduleSubagentCompletionRetryAfterRestart(params, source, current);
+      }
+    }
+  }
+
+  function completeSubagentRunInBackground(params: SubagentCompletionRequest, source: string) {
+    void completeSubagentRunWithRecovery(params, source);
+  }
+
+  const pendingLifecycle = createPendingLifecycleScheduler({
+    runs,
+    completeInBackground: completeSubagentRunInBackground,
+  });
+
+  function hasCompleteSubagentTerminalState(entry: SubagentRunRecord | undefined): boolean {
+    return (
+      entry !== undefined &&
+      typeof entry.endedAt === "number" &&
+      Number.isFinite(entry.endedAt) &&
+      entry.outcome !== undefined &&
+      entry.endedReason !== undefined &&
+      entry.execution?.status === "terminal"
+    );
+  }
+
+  async function finalizeInterruptedSubagentRun(params: {
+    runId: string;
+    error: string;
+    endedAt?: number;
+  }): Promise<number> {
+    const runId = params.runId.trim();
+    if (!runId) {
+      return 0;
+    }
+
+    const endedAt =
+      typeof params.endedAt === "number" && Number.isFinite(params.endedAt)
+        ? params.endedAt
+        : Date.now();
+    pendingLifecycle.clear(runId);
+    const entry = runs.get(runId);
+    if (!entry) {
+      return 0;
+    }
+    if (
+      typeof entry.cleanupCompletedAt === "number" &&
+      entry.terminalOwner !== "interrupted-recovery"
+    ) {
+      return hasCompleteSubagentTerminalState(entry) ? 1 : 0;
+    }
+    const completionParams: SubagentCompletionRequest = {
+      runId,
+      endedAt,
+      outcome: {
+        status: "error",
+        error: params.error,
+      },
+      reason: SUBAGENT_ENDED_REASON_ERROR,
+      sendFarewell: true,
+      accountId: entry.requesterOrigin?.accountId,
+      triggerCleanup: true,
+      recoverInterrupted: true,
+    };
+    try {
+      await completeSubagentRun(completionParams);
+      // A successfully finalized stale generation can be retired once a newer
+      // generation owns the session; the captured exact row still has its result.
+      const finalized = runs.get(runId) ?? entry;
+      // Recovery preserves partial terminal evidence instead of overwriting it.
+      // Keep scheduler retries alive until the exact row is fully terminal.
+      return hasCompleteSubagentTerminalState(finalized) ? 1 : 0;
+    } catch (error) {
+      if (isGatewayRestartDraining() && runs.get(runId) === entry) {
+        warn("subagent completion deferred during gateway restart", {
+          source: "explicit-failed-mark",
+          runId,
+        });
+        scheduleSubagentCompletionRetryAfterRestart(
+          completionParams,
+          "explicit-failed-mark",
+          entry,
+        );
+        return 1;
+      }
+      warn("failed to durably finalize interrupted subagent run", {
+        runId,
+        childSessionKey: entry.childSessionKey,
+        error,
+      });
+      return 0;
+    }
+  }
+
+  return {
+    pendingLifecycle,
+    completeSubagentRunWithRecovery,
+    finalizeInterruptedSubagentRun,
+    scheduleSubagentCompletionRetryAfterRestart,
+  };
+}

--- a/src/agents/subagent-registry-context-cleanup.ts
+++ b/src/agents/subagent-registry-context-cleanup.ts
@@ -1,0 +1,209 @@
+import { isFastTestRuntimeEnv } from "../infra/env.js";
+import { removeInternalSessionEffectsSession } from "./internal-session-effects.js";
+import {
+  SUBAGENT_ENDED_OUTCOME_KILLED,
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_KILLED,
+  type SubagentLifecycleEndedReason,
+} from "./subagent-lifecycle-events.js";
+import {
+  emitSubagentEndedHookOnce,
+  resolveLifecycleOutcomeFromRunOutcome,
+} from "./subagent-registry-completion.js";
+import {
+  ensureSubagentRegistryPluginRuntimeLoaded,
+  resolveSubagentRegistryContextEngine,
+  type SubagentRegistryDeps,
+} from "./subagent-registry-deps.js";
+import { safeRemoveAttachmentsDir } from "./subagent-registry-helpers.js";
+import type {
+  ContextEngineSubagentEndedParams,
+  SubagentRunRecord,
+} from "./subagent-registry.types.js";
+
+export function createSubagentRegistryContextCleanup(config: {
+  deps: () => SubagentRegistryDeps;
+  persist: () => void;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+}) {
+  const { deps, persist, warn } = config;
+  const endedHookInFlightRunIds = new Set<string>();
+
+  async function runContextEngineSubagentEnded(
+    params: ContextEngineSubagentEndedParams,
+  ): Promise<void> {
+    const cfg = deps().getRuntimeConfig();
+    await ensureSubagentRegistryPluginRuntimeLoaded({
+      config: cfg,
+      workspaceDir: params.workspaceDir,
+      allowGatewaySubagentBinding: true,
+    });
+    const engine = await resolveSubagentRegistryContextEngine(cfg, {
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+    });
+    await engine.onSubagentEnded?.(params);
+  }
+
+  async function notifyContextEngineSubagentEnded(
+    params: ContextEngineSubagentEndedParams,
+  ): Promise<void> {
+    try {
+      await runContextEngineSubagentEnded(params);
+    } catch (err) {
+      warn("context-engine onSubagentEnded failed (best-effort)", { err });
+    }
+  }
+
+  async function finishCollectorContextEngineCleanup(
+    params: ContextEngineSubagentEndedParams,
+  ): Promise<boolean> {
+    try {
+      await runContextEngineSubagentEnded(params);
+      return true;
+    } catch (err) {
+      warn("context-engine collector cleanup failed", { err });
+      return false;
+    }
+  }
+
+  async function cleanupCollectorLaunchResources(entry: SubagentRunRecord): Promise<boolean> {
+    let internalEffectsRemoved = true;
+    try {
+      await removeInternalSessionEffectsSession(entry.execution?.transcriptTarget);
+    } catch (err) {
+      internalEffectsRemoved = false;
+      warn("failed to remove collector internal session effects", {
+        runId: entry.runId,
+        childSessionKey: entry.childSessionKey,
+        err,
+      });
+    }
+    const contextAlreadyEnded = typeof entry.contextEngineCleanupCompletedAt === "number";
+    const [attachmentsRemoved, contextEnded] = await Promise.all([
+      safeRemoveAttachmentsDir(entry),
+      contextAlreadyEnded
+        ? true
+        : finishCollectorContextEngineCleanup({
+            childSessionKey: entry.childSessionKey,
+            reason: "deleted",
+            agentDir: entry.agentDir,
+            workspaceDir: entry.workspaceDir,
+          }),
+    ]);
+    if (!contextAlreadyEnded && contextEnded) {
+      entry.contextEngineCleanupCompletedAt = Date.now();
+      persist();
+    }
+    return internalEffectsRemoved && attachmentsRemoved && contextEnded;
+  }
+
+  async function terminateAcceptedRestoredCollectorRun(params: {
+    entry: SubagentRunRecord;
+    gatewayRunId: string;
+    timeoutMs: number;
+  }): Promise<void> {
+    // A restored FIFO slot cannot be released until the accepted Gateway run is
+    // definitely stopped; otherwise the group can exceed maxConcurrent.
+    for (;;) {
+      try {
+        await deps().callGateway({
+          method: "chat.abort",
+          params: { sessionKey: params.entry.childSessionKey, runId: params.gatewayRunId },
+          timeoutMs: params.timeoutMs,
+        });
+        return;
+      } catch {
+        try {
+          await deps().callGateway({
+            method: "sessions.delete",
+            params: {
+              key: params.entry.childSessionKey,
+              deleteTranscript: true,
+              emitLifecycleHooks: false,
+            },
+            timeoutMs: params.timeoutMs,
+          });
+          return;
+        } catch {
+          await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
+            timer.unref?.();
+          });
+        }
+      }
+    }
+  }
+
+  function suppressAnnounceForSteerRestart(entry?: SubagentRunRecord) {
+    return entry?.suppressAnnounceReason === "steer-restart";
+  }
+
+  function shouldKeepThreadBindingAfterRun(params: {
+    entry: SubagentRunRecord;
+    reason: SubagentLifecycleEndedReason;
+  }) {
+    if (params.reason === SUBAGENT_ENDED_REASON_KILLED) {
+      return false;
+    }
+    return params.entry.spawnMode === "session";
+  }
+
+  function shouldEmitEndedHookForRun(params: {
+    entry: SubagentRunRecord;
+    reason: SubagentLifecycleEndedReason;
+  }) {
+    return !shouldKeepThreadBindingAfterRun(params);
+  }
+
+  async function emitSubagentEndedHookForRun(params: {
+    entry: SubagentRunRecord;
+    reason?: SubagentLifecycleEndedReason;
+    sendFarewell?: boolean;
+    accountId?: string;
+    isCurrent?: () => boolean;
+  }) {
+    if (params.entry.endedHookEmittedAt) {
+      return;
+    }
+    const cfg = deps().getRuntimeConfig();
+    await ensureSubagentRegistryPluginRuntimeLoaded({
+      config: cfg,
+      workspaceDir: params.entry.workspaceDir,
+      allowGatewaySubagentBinding: true,
+    });
+    if (params.entry.endedHookEmittedAt || params.isCurrent?.() === false) {
+      return;
+    }
+    // Plugin loading yields after the terminal lock is released. Resolve the
+    // event from the canonical row only after that boundary so an older callback
+    // cannot claim the exactly-once hook with a superseded timeout or error.
+    const reason = params.entry.endedReason ?? params.reason ?? SUBAGENT_ENDED_REASON_COMPLETE;
+    const outcome =
+      reason === SUBAGENT_ENDED_REASON_KILLED
+        ? SUBAGENT_ENDED_OUTCOME_KILLED
+        : resolveLifecycleOutcomeFromRunOutcome(params.entry.outcome);
+    const error = params.entry.outcome?.status === "error" ? params.entry.outcome.error : undefined;
+    await emitSubagentEndedHookOnce({
+      entry: params.entry,
+      reason,
+      sendFarewell: params.sendFarewell,
+      accountId: params.accountId ?? params.entry.requesterOrigin?.accountId,
+      outcome,
+      error,
+      inFlightRunIds: endedHookInFlightRunIds,
+      persist,
+    });
+  }
+
+  return {
+    runContextEngineSubagentEnded,
+    notifyContextEngineSubagentEnded,
+    cleanupCollectorLaunchResources,
+    terminateAcceptedRestoredCollectorRun,
+    suppressAnnounceForSteerRestart,
+    shouldEmitEndedHookForRun,
+    emitSubagentEndedHookForRun,
+    reset: () => endedHookInFlightRunIds.clear(),
+  };
+}

--- a/src/agents/subagent-registry-deps.ts
+++ b/src/agents/subagent-registry-deps.ts
@@ -1,0 +1,190 @@
+import type { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
+import { getRuntimeConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ResolveContextEngineOptions } from "../context-engine/registry.js";
+import type { ContextEngine } from "../context-engine/types.js";
+import { callGateway } from "../gateway/call.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
+import { getGatewayRecoveryRuntime } from "../gateway/server-recovery-runtime-context.js";
+import { onAgentEvent, type AgentEventPayload } from "../infra/agent-events.js";
+import { createLazyImportLoader, createLazyPromiseLoader } from "../shared/lazy-promise.js";
+import { importRuntimeModule } from "../shared/runtime-import.js";
+import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
+import {
+  getSubagentRunsSnapshotForChildSession,
+  getSubagentRunsSnapshotForController,
+  getSubagentRunsSnapshotForRead,
+  persistSubagentRunsToDisk,
+  persistSubagentRunsToDiskOrThrow,
+  restoreSubagentRunsFromDisk,
+} from "./subagent-registry-state.js";
+import { resolveAgentTimeoutMs } from "./timeout.js";
+
+type SubagentAnnounceModule = Pick<
+  typeof import("./subagent-announce.js"),
+  "captureSubagentCompletionReply" | "runSubagentAnnounceFlow"
+>;
+type RequesterSettleWakeModule = Pick<
+  typeof import("./subagent-announce.requester-settle-wake.js"),
+  "maybeWakeRequesterAfterAllChildrenSettled"
+>;
+type BrowserCleanupModule = Pick<
+  typeof import("../browser-lifecycle-cleanup.js"),
+  "cleanupBrowserSessionsForLifecycleEnd"
+>;
+
+export type SubagentRegistryDeps = {
+  callGateway: typeof callGateway;
+  getGatewayRecoveryRuntime: () => GatewayRecoveryRuntime | undefined;
+  captureSubagentCompletionReply: SubagentAnnounceModule["captureSubagentCompletionReply"];
+  cleanupBrowserSessionsForLifecycleEnd: typeof cleanupBrowserSessionsForLifecycleEnd;
+  getSubagentRunsSnapshotForChildSession: typeof getSubagentRunsSnapshotForChildSession;
+  getSubagentRunsSnapshotForController: typeof getSubagentRunsSnapshotForController;
+  getSubagentRunsSnapshotForRead: typeof getSubagentRunsSnapshotForRead;
+  getRuntimeConfig: typeof getRuntimeConfig;
+  onAgentEvent: (listener: (event: AgentEventPayload) => void) => () => void;
+  persistSubagentRunsToDisk: typeof persistSubagentRunsToDisk;
+  persistSubagentRunsToDiskOrThrow: typeof persistSubagentRunsToDiskOrThrow;
+  resolveAgentTimeoutMs: typeof resolveAgentTimeoutMs;
+  restoreSubagentRunsFromDisk: typeof restoreSubagentRunsFromDisk;
+  runSubagentAnnounceFlow: SubagentAnnounceModule["runSubagentAnnounceFlow"];
+  maybeWakeRequesterAfterAllChildrenSettled: RequesterSettleWakeModule["maybeWakeRequesterAfterAllChildrenSettled"];
+  ensureContextEnginesInitialized?: () => void;
+  ensureRuntimePluginsLoaded?: (
+    params: Parameters<typeof ensureRuntimePluginsLoadedFn>[0],
+  ) => void | Promise<void>;
+  resolveContextEngine?: (
+    cfg?: OpenClawConfig,
+    options?: ResolveContextEngineOptions,
+  ) => Promise<ContextEngine>;
+};
+
+const subagentAnnounceLoader = createLazyImportLoader<SubagentAnnounceModule>(
+  () => import("./subagent-announce.js"),
+);
+const browserCleanupLoader = createLazyImportLoader<BrowserCleanupModule>(
+  () => import("../browser-lifecycle-cleanup.js"),
+);
+
+async function loadSubagentAnnounceModule(): Promise<SubagentAnnounceModule> {
+  return await subagentAnnounceLoader.load();
+}
+
+async function loadCleanupBrowserSessionsForLifecycleEnd(): Promise<
+  BrowserCleanupModule["cleanupBrowserSessionsForLifecycleEnd"]
+> {
+  return (await browserCleanupLoader.load()).cleanupBrowserSessionsForLifecycleEnd;
+}
+
+const defaultSubagentRegistryDeps: SubagentRegistryDeps = {
+  callGateway,
+  getGatewayRecoveryRuntime,
+  captureSubagentCompletionReply: async (sessionKey, options) =>
+    (await loadSubagentAnnounceModule()).captureSubagentCompletionReply(sessionKey, options),
+  cleanupBrowserSessionsForLifecycleEnd: async (params) =>
+    (await loadCleanupBrowserSessionsForLifecycleEnd())(params),
+  getSubagentRunsSnapshotForChildSession,
+  getSubagentRunsSnapshotForController,
+  getSubagentRunsSnapshotForRead,
+  getRuntimeConfig,
+  onAgentEvent,
+  persistSubagentRunsToDisk,
+  persistSubagentRunsToDiskOrThrow,
+  resolveAgentTimeoutMs,
+  restoreSubagentRunsFromDisk,
+  runSubagentAnnounceFlow: async (params) =>
+    (await loadSubagentAnnounceModule()).runSubagentAnnounceFlow(params),
+  maybeWakeRequesterAfterAllChildrenSettled: async (params) =>
+    (
+      await import("./subagent-announce.requester-settle-wake.js")
+    ).maybeWakeRequesterAfterAllChildrenSettled(params),
+};
+
+export let subagentRegistryDeps: SubagentRegistryDeps = defaultSubagentRegistryDeps;
+type ContextEngineInitModule = Pick<
+  {
+    ensureContextEnginesInitialized: () => void;
+  },
+  "ensureContextEnginesInitialized"
+>;
+type ContextEngineRegistryModule = Pick<
+  {
+    resolveContextEngine: (
+      cfg?: OpenClawConfig,
+      options?: ResolveContextEngineOptions,
+    ) => Promise<ContextEngine>;
+  },
+  "resolveContextEngine"
+>;
+type RuntimePluginsModule = Pick<
+  {
+    ensureRuntimePluginsLoaded: typeof ensureRuntimePluginsLoadedFn;
+  },
+  "ensureRuntimePluginsLoaded"
+>;
+
+const SUBAGENT_REGISTRY_RUNTIME_SPEC = ["./subagent-registry.runtime", ".js"] as const;
+
+const contextEngineInitLoader = createLazyPromiseLoader(() =>
+  importRuntimeModule<ContextEngineInitModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
+);
+const contextEngineRegistryLoader = createLazyPromiseLoader(() =>
+  importRuntimeModule<ContextEngineRegistryModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
+);
+const runtimePluginsLoader = createLazyPromiseLoader(() =>
+  importRuntimeModule<RuntimePluginsModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
+);
+
+function loadContextEngineInitModule(): Promise<ContextEngineInitModule> {
+  return contextEngineInitLoader.load();
+}
+
+function loadContextEngineRegistryModule(): Promise<ContextEngineRegistryModule> {
+  return contextEngineRegistryLoader.load();
+}
+
+function loadRuntimePluginsModule(): Promise<RuntimePluginsModule> {
+  return runtimePluginsLoader.load();
+}
+
+export async function ensureSubagentRegistryPluginRuntimeLoaded(params: {
+  config: OpenClawConfig;
+  workspaceDir?: string;
+  allowGatewaySubagentBinding?: boolean;
+}) {
+  const ensureRuntimePluginsLoaded = subagentRegistryDeps.ensureRuntimePluginsLoaded;
+  if (ensureRuntimePluginsLoaded) {
+    await ensureRuntimePluginsLoaded(params);
+    return;
+  }
+  (await loadRuntimePluginsModule()).ensureRuntimePluginsLoaded(params);
+}
+
+export async function resolveSubagentRegistryContextEngine(
+  cfg: OpenClawConfig,
+  options?: ResolveContextEngineOptions,
+) {
+  const initModule = await loadContextEngineInitModule();
+  const registryModule = await loadContextEngineRegistryModule();
+  const ensureContextEnginesInitialized =
+    subagentRegistryDeps.ensureContextEnginesInitialized ??
+    initModule.ensureContextEnginesInitialized;
+  const resolveContextEngine =
+    subagentRegistryDeps.resolveContextEngine ?? registryModule.resolveContextEngine;
+  ensureContextEnginesInitialized();
+  return await resolveContextEngine(cfg, options);
+}
+
+export function setSubagentRegistryDepsForTest(overrides?: Partial<SubagentRegistryDeps>) {
+  subagentRegistryDeps = overrides
+    ? { ...defaultSubagentRegistryDeps, ...overrides }
+    : defaultSubagentRegistryDeps;
+}
+
+export function resetSubagentRegistryRuntimeLoadersForTests() {
+  contextEngineInitLoader.clear();
+  contextEngineRegistryLoader.clear();
+  runtimePluginsLoader.clear();
+  subagentAnnounceLoader.clear();
+  browserCleanupLoader.clear();
+}

--- a/src/agents/subagent-registry-listener.ts
+++ b/src/agents/subagent-registry-listener.ts
@@ -1,0 +1,198 @@
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
+import {
+  formatAbandonedLivenessError,
+  formatBlockedLivenessError,
+  isAbandonedLivenessState,
+  isBlockedLivenessState,
+} from "../shared/agent-liveness.js";
+import { isAbortedAgentStopReason } from "./run-termination.js";
+import {
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+  SUBAGENT_ENDED_REASON_KILLED,
+} from "./subagent-lifecycle-events.js";
+import { createPendingLifecycleScheduler } from "./subagent-registry-pending-lifecycle.js";
+import { markSubagentRunPausedAfterYield } from "./subagent-registry-run-manager.js";
+import type { SubagentCompletionRequest, SubagentRunRecord } from "./subagent-registry.types.js";
+
+export function createSubagentRegistryListener(config: {
+  runs: Map<string, SubagentRunRecord>;
+  pendingLifecycle: ReturnType<typeof createPendingLifecycleScheduler>;
+  onAgentEvent: (listener: (event: AgentEventPayload) => void) => () => void;
+  persist: () => void;
+  refreshFrozenResultFromSession: (sessionKey: string) => Promise<unknown>;
+  completeSubagentRunWithRecovery: (
+    params: SubagentCompletionRequest,
+    source: string,
+  ) => Promise<void>;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+}) {
+  const {
+    runs,
+    pendingLifecycle,
+    onAgentEvent,
+    persist,
+    refreshFrozenResultFromSession,
+    completeSubagentRunWithRecovery,
+    warn,
+  } = config;
+  let listenerStarted = false;
+  let listenerStop: (() => void) | null = null;
+
+  function ensureListener() {
+    if (listenerStarted) {
+      return;
+    }
+    listenerStarted = true;
+    listenerStop = onAgentEvent((evt) => {
+      void (async () => {
+        if (!evt || evt.stream !== "lifecycle") {
+          return;
+        }
+        const phase = evt.data?.phase;
+        const entry = runs.get(evt.runId);
+        if (!entry) {
+          if (phase === "end" && typeof evt.sessionKey === "string") {
+            const sessionKey = evt.sessionKey;
+            // A replacement generation can finish after its predecessor row is
+            // terminal. Keep capture + persistence inside the suspension fence.
+            await runWithGatewayIndependentRootWorkAdmission(async () => {
+              await refreshFrozenResultFromSession(sessionKey);
+            });
+          }
+          return;
+        }
+        if (phase === "start") {
+          pendingLifecycle.clear(evt.runId);
+          const startedAt =
+            typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
+          if (startedAt) {
+            entry.startedAt = startedAt;
+            if (typeof entry.sessionStartedAt !== "number") {
+              entry.sessionStartedAt = startedAt;
+            }
+            entry.execution = { ...entry.execution, status: "running", startedAt };
+            persist();
+          }
+          return;
+        }
+        if (phase !== "end" && phase !== "error") {
+          return;
+        }
+        const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
+        const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
+        const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
+        const livenessState =
+          typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
+        const stopReason =
+          typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
+        // sessions_yield ends the turn by aborting the run signal, so a yielded
+        // terminal can also look aborted. An explicit yield is authoritative — pause,
+        // don't kill — else the tracking task settles `cancelled` with a false notice (#92448).
+        if (evt.data?.yielded === true) {
+          // Drop any grace timer from an earlier aborted/error terminal so it can't
+          // later fire and settle this now-paused run with a false notice.
+          pendingLifecycle.clear(evt.runId);
+          if (
+            markSubagentRunPausedAfterYield({
+              entry,
+              endedAt,
+              startedAt: startedAt ?? entry.startedAt,
+            })
+          ) {
+            persist();
+          }
+          return;
+        }
+        if (isAbortedAgentStopReason(stopReason)) {
+          pendingLifecycle.clear(evt.runId);
+          await completeSubagentRunWithRecovery(
+            {
+              runId: evt.runId,
+              endedAt,
+              outcome: {
+                status: "error",
+                error: "subagent run terminated",
+              },
+              reason: SUBAGENT_ENDED_REASON_KILLED,
+              sendFarewell: true,
+              accountId: entry.requesterOrigin?.accountId,
+              triggerCleanup: true,
+              startedAt,
+            },
+            "lifecycle-killed-event",
+          );
+          return;
+        }
+        if (phase === "error") {
+          pendingLifecycle.scheduleError({
+            runId: evt.runId,
+            endedAt,
+            startedAt,
+            error,
+          });
+          return;
+        }
+        const blocked = isBlockedLivenessState(livenessState);
+        const abandoned = isAbandonedLivenessState(livenessState);
+        if (blocked || abandoned) {
+          pendingLifecycle.clear(evt.runId);
+          const blockedParams = {
+            runId: evt.runId,
+            endedAt,
+            outcome: {
+              status: "error" as const,
+              error: blocked
+                ? formatBlockedLivenessError(error)
+                : formatAbandonedLivenessError(error),
+            },
+            reason: SUBAGENT_ENDED_REASON_ERROR,
+            sendFarewell: true,
+            accountId: entry.requesterOrigin?.accountId,
+            triggerCleanup: true,
+            startedAt,
+          };
+          await completeSubagentRunWithRecovery(
+            blockedParams,
+            blocked ? "lifecycle-blocked-event" : "lifecycle-abandoned-event",
+          );
+          return;
+        }
+        if (evt.data?.aborted) {
+          pendingLifecycle.scheduleTimeout({
+            runId: evt.runId,
+            endedAt,
+            startedAt,
+          });
+          return;
+        }
+        pendingLifecycle.clear(evt.runId);
+        const completionParams = {
+          runId: evt.runId,
+          endedAt,
+          outcome: { status: "ok" as const },
+          reason: SUBAGENT_ENDED_REASON_COMPLETE,
+          sendFarewell: true,
+          accountId: entry.requesterOrigin?.accountId,
+          triggerCleanup: true,
+          startedAt,
+        };
+        await completeSubagentRunWithRecovery(completionParams, "lifecycle-ok-event");
+      })().catch((err: unknown) => {
+        warn("lifecycle event handler failed", { err, runId: evt.runId });
+      });
+    });
+  }
+
+  return {
+    ensure: ensureListener,
+    reset: () => {
+      if (listenerStop) {
+        listenerStop();
+        listenerStop = null;
+      }
+      listenerStarted = false;
+    },
+  };
+}

--- a/src/agents/subagent-registry-public-api.ts
+++ b/src/agents/subagent-registry-public-api.ts
@@ -1,0 +1,315 @@
+import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
+import {
+  ackLeasedAgentSteeringItemsFromSubagentRuns,
+  leasePendingAgentSteeringItemsFromSubagentRuns,
+  releaseLeasedAgentSteeringItemsFromSubagentRuns,
+} from "./agent-steering-queue.js";
+import type { SubagentRegistryDeps } from "./subagent-registry-deps.js";
+import type { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
+import {
+  countActiveDescendantRunsFromRuns,
+  countActiveRunsForSessionFromRuns,
+  countPendingDescendantRunsFromRuns,
+  getSubagentRunByChildSessionKeyFromRuns,
+  listDescendantRunsForRequesterFromRuns,
+  listRunsForControllerFromRuns,
+} from "./subagent-registry-queries.js";
+import { markRequesterTurnYieldedInRuns } from "./subagent-registry-requester-yield.js";
+import type { SubagentRunRecord, SwarmStructuredOutputState } from "./subagent-registry.types.js";
+import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
+
+export function createSubagentRegistryPublicApi(config: {
+  runs: Map<string, SubagentRunRecord>;
+  deps: () => SubagentRegistryDeps;
+  persist: () => void;
+  persistOrThrow: () => void;
+  restoreOnce: () => void;
+  startAnnounceCleanup: (runId: string, entry: SubagentRunRecord) => boolean;
+  settleRequesterTurn: ReturnType<
+    typeof createSubagentRegistryLifecycleController
+  >["settleRequesterTurnAfterSessionSpawns"];
+}) {
+  const {
+    runs,
+    deps,
+    persist,
+    persistOrThrow,
+    restoreOnce,
+    startAnnounceCleanup,
+    settleRequesterTurn,
+  } = config;
+
+  function leasePendingAgentSteeringItems(params: {
+    requesterSessionKey: string;
+    leaseId: string;
+    now?: number;
+  }) {
+    restoreOnce();
+    const leased = leasePendingAgentSteeringItemsFromSubagentRuns({
+      runs,
+      requesterSessionKey: params.requesterSessionKey,
+      leaseId: params.leaseId,
+      now: params.now,
+    });
+    if (leased) {
+      persist();
+    }
+    return leased;
+  }
+
+  function ackPendingAgentSteeringItems(params: {
+    runIds: readonly string[];
+    leaseId: string;
+    now?: number;
+  }): number {
+    const updated = ackLeasedAgentSteeringItemsFromSubagentRuns({
+      runs,
+      runIds: params.runIds,
+      leaseId: params.leaseId,
+      now: params.now,
+    });
+    if (updated > 0) {
+      persist();
+      for (const runId of params.runIds) {
+        const entry = runs.get(runId);
+        if (!entry || typeof entry.cleanupCompletedAt === "number") {
+          continue;
+        }
+        entry.cleanupHandled = false;
+        startAnnounceCleanup(runId, entry);
+      }
+    }
+    return updated;
+  }
+
+  function releasePendingAgentSteeringItems(params: {
+    runIds: readonly string[];
+    leaseId: string;
+    error?: string;
+  }): number {
+    const updated = releaseLeasedAgentSteeringItemsFromSubagentRuns({
+      runs,
+      runIds: params.runIds,
+      leaseId: params.leaseId,
+      error: params.error,
+    });
+    if (updated > 0) {
+      persist();
+    }
+    return updated;
+  }
+
+  function listSubagentRunsForController(controllerSessionKey: string): SubagentRunRecord[] {
+    return listRunsForControllerFromRuns(
+      deps().getSubagentRunsSnapshotForController(runs, controllerSessionKey),
+      controllerSessionKey,
+    );
+  }
+
+  function getSubagentRunByRunId(runId: string): SubagentRunRecord | undefined {
+    const key = runId.trim();
+    const snapshot = deps().getSubagentRunsSnapshotForRead(runs);
+    return snapshot.get(key) ?? [...snapshot.values()].find((entry) => entry.swarmRunId === key);
+  }
+
+  function getSubagentRunsByRunIds(runIds: readonly string[]): {
+    entries: Map<string, SubagentRunRecord>;
+  } {
+    const snapshot = deps().getSubagentRunsSnapshotForRead(runs);
+    const byId = new Map<string, SubagentRunRecord>();
+    for (const entry of snapshot.values()) {
+      byId.set(entry.runId, entry);
+      if (entry.swarmRunId) {
+        byId.set(entry.swarmRunId, entry);
+      }
+    }
+    return {
+      entries: new Map(
+        runIds.flatMap((runId) => {
+          const entry = byId.get(runId.trim());
+          return entry ? [[runId, entry] as const] : [];
+        }),
+      ),
+    };
+  }
+
+  function completeCollectorLaunchCleanup(runId: string): void {
+    const key = runId.trim();
+    const entry =
+      runs.get(key) ?? [...runs.values()].find((candidate) => candidate.swarmRunId === key);
+    if (!entry?.collectorLaunchCleanupPending) {
+      return;
+    }
+    entry.collectorLaunchCleanupPending = false;
+    entry.cleanupCompletedAt = Date.now();
+    entry.contextEngineCleanupCompletedAt ??= entry.cleanupCompletedAt;
+    persist();
+  }
+
+  function recordSwarmStructuredOutput(
+    identity: { runId?: string; childSessionKey?: string },
+    state: SwarmStructuredOutputState,
+  ): void {
+    const runId = identity.runId?.trim();
+    const childSessionKey = identity.childSessionKey?.trim();
+    const entry =
+      (runId
+        ? (runs.get(runId) ??
+          [...runs.values()].find((candidate) => candidate.swarmRunId === runId))
+        : undefined) ??
+      (childSessionKey
+        ? [...runs.values()]
+            .filter((candidate) => candidate.childSessionKey === childSessionKey)
+            .toSorted((left, right) => (right.generation ?? 0) - (left.generation ?? 0))[0]
+        : undefined);
+    if (!entry?.collect || entry.collectorCompletion) {
+      throw new Error("collector run is unavailable");
+    }
+    const previous = entry.structuredOutput;
+    entry.structuredOutput = structuredClone(state);
+    try {
+      persistOrThrow();
+    } catch (error) {
+      entry.structuredOutput = previous;
+      throw error;
+    }
+  }
+
+  function listSwarmRunsForGroup(
+    groupId: string,
+    requesterSessionKey?: string,
+  ): SubagentRunRecord[] {
+    const key = groupId.trim();
+    const requesterKey = requesterSessionKey?.trim();
+    return [...deps().getSubagentRunsSnapshotForRead(runs).values()].filter(
+      (entry) =>
+        entry.collect === true &&
+        entry.groupId === key &&
+        (!requesterKey ||
+          (entry.swarmRequesterSessionKey ?? entry.requesterSessionKey) === requesterKey),
+    );
+  }
+
+  /** Resolve a collector reserved by a replay-safe host bridge request. */
+  function getSwarmRunByLaunchReplayKey(
+    replayKey: string,
+    requesterSessionKey?: string,
+  ): SubagentRunRecord | undefined {
+    const key = replayKey.trim();
+    const requesterKey = requesterSessionKey?.trim();
+    if (!key) {
+      return undefined;
+    }
+    return [...deps().getSubagentRunsSnapshotForRead(runs).values()].find(
+      (entry) =>
+        entry.collect === true &&
+        entry.swarmLaunchReplayKey === key &&
+        (!requesterKey ||
+          (entry.swarmRequesterSessionKey ?? entry.requesterSessionKey) === requesterKey),
+    );
+  }
+
+  function countActiveRunsForSession(
+    requesterSessionKey: string,
+    options?: { collect?: boolean },
+  ): number {
+    return countActiveRunsForSessionFromRuns(
+      deps().getSubagentRunsSnapshotForRead(runs),
+      requesterSessionKey,
+      options,
+    );
+  }
+
+  function countActiveDescendantRuns(rootSessionKey: string): number {
+    return countActiveDescendantRunsFromRuns(
+      deps().getSubagentRunsSnapshotForRead(runs),
+      rootSessionKey,
+    );
+  }
+
+  function countPendingDescendantRuns(rootSessionKey: string): number {
+    return countPendingDescendantRunsFromRuns(
+      deps().getSubagentRunsSnapshotForRead(runs),
+      rootSessionKey,
+    );
+  }
+
+  function listDescendantRunsForRequester(rootSessionKey: string): SubagentRunRecord[] {
+    return listDescendantRunsForRequesterFromRuns(
+      deps().getSubagentRunsSnapshotForRead(runs),
+      rootSessionKey,
+    );
+  }
+
+  function getSubagentRunByChildSessionKey(childSessionKey: string): SubagentRunRecord | null {
+    return getSubagentRunByChildSessionKeyFromRuns(
+      deps().getSubagentRunsSnapshotForRead(runs),
+      childSessionKey,
+    );
+  }
+
+  function getLatestSubagentRunByChildSessionKey(
+    childSessionKey: string,
+  ): SubagentRunRecord | null {
+    const key = childSessionKey.trim();
+    if (!key) {
+      return null;
+    }
+
+    let latest: SubagentRunRecord | null = null;
+    for (const entry of deps().getSubagentRunsSnapshotForChildSession(runs, key).values()) {
+      if (entry.childSessionKey !== key) {
+        continue;
+      }
+      if (!latest || compareSubagentRunGeneration(entry, latest) > 0) {
+        latest = entry;
+      }
+    }
+
+    return latest;
+  }
+
+  /** Re-admits a delivered child batch after its requester explicitly yields. */
+  function settleRequesterAfterSessionSpawns(params: {
+    requesterSessionKey: string;
+    requesterTurnRunId: string;
+    requesterYielded: boolean;
+    acceptedSessionSpawns: readonly AcceptedSessionSpawn[];
+  }): boolean {
+    return settleRequesterTurn(params);
+  }
+
+  /** Records sessions_yield before the active requester run is aborted. */
+  function markRequesterTurnYielded(params: {
+    requesterSessionKey: string;
+    requesterTurnRunId: string;
+  }): number {
+    restoreOnce();
+    return markRequesterTurnYieldedInRuns({
+      ...params,
+      runs,
+      persistOrThrow,
+    });
+  }
+
+  return {
+    leasePendingAgentSteeringItems,
+    ackPendingAgentSteeringItems,
+    releasePendingAgentSteeringItems,
+    listSubagentRunsForController,
+    getSubagentRunByRunId,
+    getSubagentRunsByRunIds,
+    completeCollectorLaunchCleanup,
+    recordSwarmStructuredOutput,
+    listSwarmRunsForGroup,
+    getSwarmRunByLaunchReplayKey,
+    countActiveRunsForSession,
+    countActiveDescendantRuns,
+    countPendingDescendantRuns,
+    listDescendantRunsForRequester,
+    getSubagentRunByChildSessionKey,
+    getLatestSubagentRunByChildSessionKey,
+    settleRequesterAfterSessionSpawns,
+    markRequesterTurnYielded,
+  };
+}

--- a/src/agents/subagent-registry-restore.ts
+++ b/src/agents/subagent-registry-restore.ts
@@ -1,0 +1,308 @@
+import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
+import { isFastTestRuntimeEnv } from "../infra/env.js";
+import {
+  runWithGatewayIndependentRootWorkAdmission,
+  GatewayDrainingError,
+} from "../process/gateway-work-admission.js";
+import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
+import { applySubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
+import type { SubagentRegistryDeps } from "./subagent-registry-deps.js";
+import {
+  backfillCollectorArchiveAtMs,
+  reconcileOrphanedRestoredRuns,
+} from "./subagent-registry-helpers.js";
+import type { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import {
+  loadSubagentSessionEntry,
+  type SubagentSessionStoreCache,
+} from "./subagent-session-reconciliation.js";
+import { resolveSwarmConfig } from "./swarm-config.js";
+import { enqueueSwarmRun } from "./swarm-scheduler.js";
+
+export function createSubagentRegistryRestorer(config: {
+  runs: Map<string, SubagentRunRecord>;
+  resumedRuns: Set<string>;
+  deps: () => SubagentRegistryDeps;
+  persist: () => void;
+  settleRequesterTurn: ReturnType<
+    typeof createSubagentRegistryLifecycleController
+  >["settleRequesterTurnAfterSessionSpawns"];
+  ensureListener: () => void;
+  startSweeper: () => void;
+  resumeRun: (runId: string) => void;
+  listSwarmRunsForGroup: (groupId: string, requesterSessionKey?: string) => SubagentRunRecord[];
+  startQueuedSubagentRun: (runId: string, gatewayRunId?: string) => boolean;
+  terminateAcceptedRestoredCollectorRun: (params: {
+    entry: SubagentRunRecord;
+    gatewayRunId: string;
+    timeoutMs: number;
+  }) => Promise<void>;
+  cleanupCollectorLaunchResources: (entry: SubagentRunRecord) => Promise<boolean>;
+  settleFailedQueuedSubagentLaunch: (runId: string, error: string) => void;
+  completeCollectorLaunchCleanup: (runId: string) => void;
+  scheduleOrphanRecovery: (params?: { delayMs?: number; maxRetries?: number }) => void;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+}) {
+  const {
+    runs,
+    resumedRuns,
+    deps,
+    persist,
+    settleRequesterTurn,
+    ensureListener,
+    startSweeper,
+    resumeRun,
+    listSwarmRunsForGroup,
+    startQueuedSubagentRun,
+    terminateAcceptedRestoredCollectorRun,
+    cleanupCollectorLaunchResources,
+    settleFailedQueuedSubagentLaunch,
+    completeCollectorLaunchCleanup,
+    scheduleOrphanRecovery,
+    warn,
+  } = config;
+  let restoreAttempted = false;
+  const readGatewayRunId = (response: unknown): string | undefined => {
+    if (!response || typeof response !== "object") {
+      return undefined;
+    }
+    const runId = (response as { runId?: unknown }).runId;
+    return typeof runId === "string" && runId.trim() ? runId.trim() : undefined;
+  };
+
+  function restoreSubagentRunsOnce() {
+    if (restoreAttempted) {
+      return;
+    }
+    restoreAttempted = true;
+    try {
+      const restoredCount = deps().restoreSubagentRunsFromDisk({
+        runs,
+        mergeOnly: true,
+      });
+      if (restoredCount === 0) {
+        return;
+      }
+      const cfg = deps().getRuntimeConfig();
+      let restoredStateChanged = reconcileOrphanedRestoredRuns({
+        runs,
+        resumedRuns,
+      });
+      for (const entry of runs.values()) {
+        if (backfillCollectorArchiveAtMs(entry, cfg)) {
+          restoredStateChanged = true;
+        }
+      }
+      if (restoredStateChanged) {
+        persist();
+      }
+      const requesterTurns = new Map<string, Map<string, SubagentRunRecord[]>>();
+      for (const entry of runs.values()) {
+        const requesterTurnRunId = entry.requesterTurnRunId?.trim();
+        if (!requesterTurnRunId) {
+          continue;
+        }
+        let turns = requesterTurns.get(entry.requesterSessionKey);
+        if (!turns) {
+          turns = new Map();
+          requesterTurns.set(entry.requesterSessionKey, turns);
+        }
+        const entries = turns.get(requesterTurnRunId) ?? [];
+        entries.push(entry);
+        turns.set(requesterTurnRunId, entries);
+      }
+      for (const [requesterSessionKey, turns] of requesterTurns) {
+        for (const [requesterTurnRunId, entries] of turns) {
+          settleRequesterTurn({
+            requesterSessionKey,
+            requesterTurnRunId,
+            requesterYielded: entries.every((entry) => entry.requesterTurnYielded === true),
+            acceptedSessionSpawns: entries.map((entry) => ({
+              runId: entry.runId,
+              childSessionKey: entry.childSessionKey,
+            })),
+          });
+        }
+      }
+      if (runs.size === 0) {
+        return;
+      }
+      // Resume pending work.
+      ensureListener();
+      // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
+      startSweeper();
+      const restoredSessionCache: SubagentSessionStoreCache = new Map();
+      for (const [runId, entry] of runs) {
+        if (entry.collect && entry.execution?.status === "queued") {
+          const launch = entry.queuedLaunch;
+          if (!launch) {
+            void failAndCleanupRestoredQueuedRun(
+              runId,
+              entry,
+              "queued collector launch state was unavailable after restart",
+              false,
+            );
+            continue;
+          }
+          const groupRuns = listSwarmRunsForGroup(
+            entry.groupId ?? "",
+            entry.swarmRequesterSessionKey ?? entry.requesterSessionKey,
+          );
+          const currentSwarmConfig = resolveSwarmConfig(
+            deps().getRuntimeConfig(),
+            entry.requesterAgentId,
+          );
+          let launchTerminationConfirmed = false;
+          enqueueSwarmRun({
+            groupId: launch.schedulerGroupKey,
+            runId,
+            maxConcurrent: currentSwarmConfig.maxConcurrent,
+            activeRunIds: groupRuns
+              .filter((candidate) => candidate.execution?.status === "running")
+              .map((candidate) => candidate.schedulerSlotId ?? candidate.runId),
+            start: async () => {
+              await runWithGatewayIndependentRootWorkAdmission(async () => {
+                const response = await deps().callGateway({
+                  method: "agent",
+                  params: applySubagentLaunchAuthorization(launch.request, launch.authorization),
+                  // Restart replay must restore the trusted launch capability; otherwise
+                  // the queued child silently falls back to its session/default route.
+                  ...(launch.authorization ? { scopes: [ADMIN_SCOPE] } : {}),
+                  timeoutMs: launch.timeoutMs,
+                });
+                const gatewayRunId = readGatewayRunId(response) ?? runId;
+                try {
+                  if (!startQueuedSubagentRun(runId, gatewayRunId)) {
+                    throw new Error(
+                      "collector registry row could not transition from queued to running",
+                    );
+                  }
+                } catch (error) {
+                  await terminateAcceptedRestoredCollectorRun({
+                    entry,
+                    gatewayRunId,
+                    timeoutMs: launch.timeoutMs,
+                  });
+                  launchTerminationConfirmed = true;
+                  throw error;
+                }
+              });
+            },
+            onStartFailure: (error) => {
+              if (error instanceof GatewayDrainingError) {
+                return false;
+              }
+              return failAndCleanupRestoredQueuedRun(
+                runId,
+                entry,
+                error instanceof Error ? error.message : String(error),
+                launchTerminationConfirmed,
+              );
+            },
+          });
+          continue;
+        }
+        // An aborted persisted session belongs to orphan recovery. Waiting on its
+        // pre-restart run can terminalize it before the replacement turn starts.
+        if (
+          loadSubagentSessionEntry({
+            childSessionKey: entry.childSessionKey,
+            storeCache: restoredSessionCache,
+          })?.abortedLastRun === true
+        ) {
+          continue;
+        }
+        resumeRun(runId);
+      }
+
+      // Cold-start restore can precede instance-runtime registration. The post-attach
+      // startup pass retries this seam once the lifecycle-bound principal exists.
+      scheduleOrphanRecovery();
+    } catch (err) {
+      warn(
+        `failed to restore subagent runs from disk: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  async function failAndCleanupRestoredQueuedRun(
+    runId: string,
+    entry: SubagentRunRecord,
+    error: string,
+    launchTerminationConfirmed: boolean,
+  ): Promise<boolean> {
+    const cleanupComplete = await runWithGatewayIndependentRootWorkAdmission(async () => {
+      for (;;) {
+        try {
+          await deps().callGateway({
+            method: "sessions.delete",
+            params: {
+              key: entry.childSessionKey,
+              deleteTranscript: true,
+              emitLifecycleHooks: false,
+            },
+            timeoutMs: 10_000,
+          });
+          break;
+        } catch (cleanupError) {
+          warn("failed to delete restored collector session after launch failure", {
+            runId,
+            childSessionKey: entry.childSessionKey,
+            error: cleanupError,
+          });
+          if (launchTerminationConfirmed) {
+            return false;
+          }
+        }
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
+          timer.unref?.();
+        });
+      }
+      if (!(await cleanupCollectorLaunchResources(entry))) {
+        return false;
+      }
+      return true;
+    }).catch((cleanupError: unknown) => {
+      warn("failed to clean restored collector after launch failure", {
+        runId,
+        childSessionKey: entry.childSessionKey,
+        error: cleanupError,
+      });
+      return false;
+    });
+    for (;;) {
+      try {
+        settleFailedQueuedSubagentLaunch(runId, error);
+        break;
+      } catch (persistError) {
+        warn("failed to persist restored collector launch failure", {
+          runId,
+          childSessionKey: entry.childSessionKey,
+          error: persistError,
+        });
+      }
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
+        timer.unref?.();
+      });
+    }
+    if (cleanupComplete) {
+      emitSessionLifecycleEvent({
+        sessionKey: entry.childSessionKey,
+        reason: "delete",
+        parentSessionKey: entry.swarmRequesterSessionKey ?? entry.requesterSessionKey,
+      });
+      completeCollectorLaunchCleanup(runId);
+    }
+    return true;
+  }
+
+  return {
+    restoreOnce: restoreSubagentRunsOnce,
+    reset: () => {
+      restoreAttempted = false;
+    },
+  };
+}

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -577,13 +577,6 @@ const publicApi = createSubagentRegistryPublicApi({
   startAnnounceCleanup: startSubagentAnnounceCleanupFlow,
   settleRequesterTurn: settleRequesterTurnAfterSessionSpawns,
 });
-const bootstrapState = getSubagentRegistryBootstrapState();
-bootstrapState.restorer = subagentRestorer;
-bootstrapState.ready = true;
-if (bootstrapState.pending) {
-  bootstrapState.pending = false;
-  subagentRestorer.restoreOnce();
-}
 
 export const leasePendingAgentSteeringItems = publicApi.leasePendingAgentSteeringItems;
 export const ackPendingAgentSteeringItems = publicApi.ackPendingAgentSteeringItems;
@@ -612,6 +605,14 @@ export function initSubagentRegistry() {
 }
 export const settleRequesterAfterSessionSpawns = publicApi.settleRequesterAfterSessionSpawns;
 export const markRequesterTurnYielded = publicApi.markRequesterTurnYielded;
+
+const bootstrapState = getSubagentRegistryBootstrapState();
+bootstrapState.restorer = subagentRestorer;
+bootstrapState.ready = true;
+if (bootstrapState.pending) {
+  bootstrapState.pending = false;
+  subagentRestorer.restoreOnce();
+}
 
 const SUBAGENT_REGISTRY_TEST_HANDLE = Symbol.for("openclaw.subagentRegistryTestApi");
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1,293 +1,80 @@
 /** Coordinates subagent registration, lifecycle, delivery, steering, recovery, and persistence. */
-import type { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
-import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { ResolveContextEngineOptions } from "../context-engine/registry.js";
-import type { ContextEngine } from "../context-engine/types.js";
 import { callGateway } from "../gateway/call.js";
-import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
-import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import { getGatewayRecoveryRuntime } from "../gateway/server-recovery-runtime-context.js";
-import { onAgentEvent } from "../infra/agent-events.js";
-import { isFastTestRuntimeEnv } from "../infra/env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
-  GatewayDrainingError,
   isGatewayRestartDraining,
   runWithGatewayIndependentRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
-import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
-import {
-  formatAbandonedLivenessError,
-  formatBlockedLivenessError,
-  isAbandonedLivenessState,
-  isBlockedLivenessState,
-} from "../shared/agent-liveness.js";
-import { createLazyImportLoader, createLazyPromiseLoader } from "../shared/lazy-promise.js";
-import { importRuntimeModule } from "../shared/runtime-import.js";
-import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
-import {
-  ackLeasedAgentSteeringItemsFromSubagentRuns,
-  leasePendingAgentSteeringItemsFromSubagentRuns,
-  prependAgentSteeringPrompt,
-  releaseLeasedAgentSteeringItemsFromSubagentRuns,
-} from "./agent-steering-queue.js";
-import { removeInternalSessionEffectsSession } from "./internal-session-effects.js";
+import { prependAgentSteeringPrompt } from "./agent-steering-queue.js";
 import type { AgentRunSessionTarget } from "./run-session-target.js";
-import { isAbortedAgentStopReason } from "./run-termination.js";
-import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
 import {
   getDeliveryAttemptCount,
   getDeliveryLastAttemptAt,
   isDeliverySuspended,
 } from "./subagent-delivery-state.js";
-import { applySubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
+import { createSubagentRegistryCompletionRuntime } from "./subagent-registry-completion-runtime.js";
+import { emitSubagentProgressEndedHook } from "./subagent-registry-completion.js";
+import { createSubagentRegistryContextCleanup } from "./subagent-registry-context-cleanup.js";
 import {
-  SUBAGENT_ENDED_OUTCOME_KILLED,
-  SUBAGENT_ENDED_REASON_COMPLETE,
-  SUBAGENT_ENDED_REASON_ERROR,
-  SUBAGENT_ENDED_REASON_KILLED,
-  type SubagentLifecycleEndedReason,
-} from "./subagent-lifecycle-events.js";
-import {
-  emitSubagentEndedHookOnce,
-  emitSubagentProgressEndedHook,
-  resolveLifecycleOutcomeFromRunOutcome,
-} from "./subagent-registry-completion.js";
+  resetSubagentRegistryRuntimeLoadersForTests,
+  setSubagentRegistryDepsForTest,
+  subagentRegistryDeps,
+  type SubagentRegistryDeps,
+} from "./subagent-registry-deps.js";
 import {
   ANNOUNCE_EXPIRY_MS,
-  backfillCollectorArchiveAtMs,
   MAX_ANNOUNCE_RETRY_COUNT,
-  reconcileOrphanedRestoredRuns,
   reconcileOrphanedRun,
   resolveAnnounceRetryDelayMs,
-  safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
+import { createSubagentRegistryListener } from "./subagent-registry-listener.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
-import { createPendingLifecycleScheduler } from "./subagent-registry-pending-lifecycle.js";
-import {
-  countActiveDescendantRunsFromRuns,
-  countActiveRunsForSessionFromRuns,
-  countPendingDescendantRunsFromRuns,
-  getSubagentRunByChildSessionKeyFromRuns,
-  listRunsForControllerFromRuns,
-  listDescendantRunsForRequesterFromRuns,
-} from "./subagent-registry-queries.js";
-import { markRequesterTurnYieldedInRuns } from "./subagent-registry-requester-yield.js";
+import { createSubagentRegistryPublicApi } from "./subagent-registry-public-api.js";
+import { createSubagentRegistryRestorer } from "./subagent-registry-restore.js";
 import {
   createSubagentRunManager,
-  markSubagentRunPausedAfterYield,
   type RegisterSubagentRunParams,
 } from "./subagent-registry-run-manager.js";
-import {
-  clearSubagentRunsReadCacheForTest,
-  getSubagentRunsSnapshotForChildSession,
-  getSubagentRunsSnapshotForController,
-  getSubagentRunsSnapshotForRead,
-  persistSubagentRunsToDisk,
-  persistSubagentRunsToDiskOrThrow,
-  restoreSubagentRunsFromDisk,
-} from "./subagent-registry-state.js";
+import { clearSubagentRunsReadCacheForTest } from "./subagent-registry-state.js";
 import { configureSubagentRegistrySteerRuntime } from "./subagent-registry-steer-runtime.js";
 import { resolveSubagentTaskForRun } from "./subagent-registry-sweep-kill.js";
 import {
   createSubagentRegistrySweeper,
   retireSupersededSubagentRun as retireSupersededSubagentRunForSweep,
 } from "./subagent-registry-sweeper.js";
-import type {
-  ContextEngineSubagentEndedParams,
-  SubagentCompletionRequest,
-  SubagentRunRecord,
-  SwarmStructuredOutputState,
-} from "./subagent-registry.types.js";
-import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import {
-  loadSubagentSessionEntry,
   resolveSubagentRunOrphanReason,
   resolveSubagentSessionCompletion,
   resolveSubagentSessionStartedAt,
-  type SubagentSessionStoreCache,
 } from "./subagent-session-reconciliation.js";
-import { resolveSwarmConfig } from "./swarm-config.js";
-import { enqueueSwarmRun } from "./swarm-scheduler.js";
-import { resolveAgentTimeoutMs } from "./timeout.js";
 
 export type { SubagentRunRecord } from "./subagent-registry.types.js";
 const log = createSubsystemLogger("agents/subagent-registry");
 
-function readGatewayRunId(response: unknown): string | undefined {
-  if (!response || typeof response !== "object") {
-    return undefined;
-  }
-  const runId = (response as { runId?: unknown }).runId;
-  return typeof runId === "string" && runId.trim() ? runId.trim() : undefined;
-}
-
-type SubagentAnnounceModule = Pick<
-  typeof import("./subagent-announce.js"),
-  "captureSubagentCompletionReply" | "runSubagentAnnounceFlow"
->;
-type RequesterSettleWakeModule = Pick<
-  typeof import("./subagent-announce.requester-settle-wake.js"),
-  "maybeWakeRequesterAfterAllChildrenSettled"
->;
-type BrowserCleanupModule = Pick<
-  typeof import("../browser-lifecycle-cleanup.js"),
-  "cleanupBrowserSessionsForLifecycleEnd"
->;
-
-type SubagentRegistryDeps = {
-  callGateway: typeof callGateway;
-  getGatewayRecoveryRuntime: () => GatewayRecoveryRuntime | undefined;
-  captureSubagentCompletionReply: SubagentAnnounceModule["captureSubagentCompletionReply"];
-  cleanupBrowserSessionsForLifecycleEnd: typeof cleanupBrowserSessionsForLifecycleEnd;
-  getSubagentRunsSnapshotForChildSession: typeof getSubagentRunsSnapshotForChildSession;
-  getSubagentRunsSnapshotForController: typeof getSubagentRunsSnapshotForController;
-  getSubagentRunsSnapshotForRead: typeof getSubagentRunsSnapshotForRead;
-  getRuntimeConfig: typeof getRuntimeConfig;
-  onAgentEvent: typeof onAgentEvent;
-  persistSubagentRunsToDisk: typeof persistSubagentRunsToDisk;
-  persistSubagentRunsToDiskOrThrow: typeof persistSubagentRunsToDiskOrThrow;
-  resolveAgentTimeoutMs: typeof resolveAgentTimeoutMs;
-  restoreSubagentRunsFromDisk: typeof restoreSubagentRunsFromDisk;
-  runSubagentAnnounceFlow: SubagentAnnounceModule["runSubagentAnnounceFlow"];
-  maybeWakeRequesterAfterAllChildrenSettled: RequesterSettleWakeModule["maybeWakeRequesterAfterAllChildrenSettled"];
-  ensureContextEnginesInitialized?: () => void;
-  ensureRuntimePluginsLoaded?: (
-    params: Parameters<typeof ensureRuntimePluginsLoadedFn>[0],
-  ) => void | Promise<void>;
-  resolveContextEngine?: (
-    cfg?: OpenClawConfig,
-    options?: ResolveContextEngineOptions,
-  ) => Promise<ContextEngine>;
+type SubagentRegistryRestorer = ReturnType<typeof createSubagentRegistryRestorer>;
+type SubagentRegistryBootstrapState = {
+  pending?: boolean;
+  ready?: boolean;
+  restorer?: SubagentRegistryRestorer;
 };
 
-const subagentAnnounceLoader = createLazyImportLoader<SubagentAnnounceModule>(
-  () => import("./subagent-announce.js"),
-);
-const browserCleanupLoader = createLazyImportLoader<BrowserCleanupModule>(
-  () => import("../browser-lifecycle-cleanup.js"),
-);
-
-async function loadSubagentAnnounceModule(): Promise<SubagentAnnounceModule> {
-  return await subagentAnnounceLoader.load();
+function getSubagentRegistryBootstrapState(): SubagentRegistryBootstrapState {
+  const owner = getSubagentRegistryBootstrapState as typeof getSubagentRegistryBootstrapState & {
+    state?: SubagentRegistryBootstrapState;
+  };
+  owner.state ??= {};
+  return owner.state;
 }
-
-async function loadCleanupBrowserSessionsForLifecycleEnd(): Promise<
-  BrowserCleanupModule["cleanupBrowserSessionsForLifecycleEnd"]
-> {
-  return (await browserCleanupLoader.load()).cleanupBrowserSessionsForLifecycleEnd;
-}
-
-const defaultSubagentRegistryDeps: SubagentRegistryDeps = {
-  callGateway,
-  getGatewayRecoveryRuntime,
-  captureSubagentCompletionReply: async (sessionKey, options) =>
-    (await loadSubagentAnnounceModule()).captureSubagentCompletionReply(sessionKey, options),
-  cleanupBrowserSessionsForLifecycleEnd: async (params) =>
-    (await loadCleanupBrowserSessionsForLifecycleEnd())(params),
-  getSubagentRunsSnapshotForChildSession,
-  getSubagentRunsSnapshotForController,
-  getSubagentRunsSnapshotForRead,
-  getRuntimeConfig,
-  onAgentEvent,
-  persistSubagentRunsToDisk,
-  persistSubagentRunsToDiskOrThrow,
-  resolveAgentTimeoutMs,
-  restoreSubagentRunsFromDisk,
-  runSubagentAnnounceFlow: async (params) =>
-    (await loadSubagentAnnounceModule()).runSubagentAnnounceFlow(params),
-  maybeWakeRequesterAfterAllChildrenSettled: async (params) =>
-    (
-      await import("./subagent-announce.requester-settle-wake.js")
-    ).maybeWakeRequesterAfterAllChildrenSettled(params),
-};
-
-let subagentRegistryDeps: SubagentRegistryDeps = defaultSubagentRegistryDeps;
-type ContextEngineInitModule = Pick<
-  {
-    ensureContextEnginesInitialized: () => void;
-  },
-  "ensureContextEnginesInitialized"
->;
-type ContextEngineRegistryModule = Pick<
-  {
-    resolveContextEngine: (
-      cfg?: OpenClawConfig,
-      options?: ResolveContextEngineOptions,
-    ) => Promise<ContextEngine>;
-  },
-  "resolveContextEngine"
->;
-type RuntimePluginsModule = Pick<
-  {
-    ensureRuntimePluginsLoaded: typeof ensureRuntimePluginsLoadedFn;
-  },
-  "ensureRuntimePluginsLoaded"
->;
-
-const SUBAGENT_REGISTRY_RUNTIME_SPEC = ["./subagent-registry.runtime", ".js"] as const;
-
-const contextEngineInitLoader = createLazyPromiseLoader(() =>
-  importRuntimeModule<ContextEngineInitModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
-);
-const contextEngineRegistryLoader = createLazyPromiseLoader(() =>
-  importRuntimeModule<ContextEngineRegistryModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
-);
-const runtimePluginsLoader = createLazyPromiseLoader(() =>
-  importRuntimeModule<RuntimePluginsModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
-);
 
 const resumeRetryTimers = new Set<ReturnType<typeof setTimeout>>();
-let listenerStarted = false;
-let listenerStop: (() => void) | null = null;
-// Use var to avoid TDZ when init runs across circular imports during bootstrap.
-let restoreAttempted = false;
 const ORPHAN_RECOVERY_DEBOUNCE_MS = 1_000;
 let lastOrphanRecoveryScheduleAt = 0;
 const SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
 const GATEWAY_ADMISSION_RETRY_DELAY_MS = 1_000;
-
-function loadContextEngineInitModule(): Promise<ContextEngineInitModule> {
-  return contextEngineInitLoader.load();
-}
-
-function loadContextEngineRegistryModule(): Promise<ContextEngineRegistryModule> {
-  return contextEngineRegistryLoader.load();
-}
-
-function loadRuntimePluginsModule(): Promise<RuntimePluginsModule> {
-  return runtimePluginsLoader.load();
-}
-
-async function ensureSubagentRegistryPluginRuntimeLoaded(params: {
-  config: OpenClawConfig;
-  workspaceDir?: string;
-  allowGatewaySubagentBinding?: boolean;
-}) {
-  const ensureRuntimePluginsLoaded = subagentRegistryDeps.ensureRuntimePluginsLoaded;
-  if (ensureRuntimePluginsLoaded) {
-    await ensureRuntimePluginsLoaded(params);
-    return;
-  }
-  (await loadRuntimePluginsModule()).ensureRuntimePluginsLoaded(params);
-}
-
-async function resolveSubagentRegistryContextEngine(
-  cfg: OpenClawConfig,
-  options?: ResolveContextEngineOptions,
-) {
-  const initModule = await loadContextEngineInitModule();
-  const registryModule = await loadContextEngineRegistryModule();
-  const ensureContextEnginesInitialized =
-    subagentRegistryDeps.ensureContextEnginesInitialized ??
-    initModule.ensureContextEnginesInitialized;
-  const resolveContextEngine =
-    subagentRegistryDeps.resolveContextEngine ?? registryModule.resolveContextEngine;
-  ensureContextEnginesInitialized();
-  return await resolveContextEngine(cfg, options);
-}
 
 function persistSubagentRuns() {
   subagentRegistryDeps.persistSubagentRunsToDisk(subagentRuns);
@@ -334,285 +121,24 @@ export function scheduleSubagentOrphanRecovery(params?: { delayMs?: number; maxR
 const resumedRuns = new Set<string>();
 const endedHookInFlightRunIds = new Set<string>();
 
-async function completeSubagentRunWithRecoveryAttempt(
-  params: SubagentCompletionRequest,
-  source: string,
-) {
-  try {
-    await completeSubagentRun(params);
-    return;
-  } catch (error) {
-    const current = subagentRuns.get(params.runId);
-    log.warn("failed to complete subagent run; retrying completion", {
-      source,
-      runId: params.runId,
-      childSessionKey: current?.childSessionKey,
-      error,
-    });
-  }
-
-  const current = subagentRuns.get(params.runId);
-  if (!current) {
-    return;
-  }
-
-  try {
-    await completeSubagentRun(params);
-    return;
-  } catch (retryError) {
-    log.warn("failed to complete subagent run after retry; retrying ended cleanup", {
-      source,
-      runId: params.runId,
-      childSessionKey: current.childSessionKey,
-      error: retryError,
-    });
-  }
-
-  const latest = subagentRuns.get(params.runId);
-  if (latest && typeof latest.endedAt !== "number") {
-    // The durable write rolled the in-memory entry back. Preserve the original
-    // completion through the normal persisted-session recovery path.
-    scheduleSubagentOrphanRecovery({ delayMs: 1_000 });
-    return;
-  }
-  if (
-    !latest ||
-    typeof latest.endedAt !== "number" ||
-    typeof latest.cleanupCompletedAt === "number" ||
-    latest.pauseReason === "sessions_yield"
-  ) {
-    return;
-  }
-  latest.cleanupHandled = false;
-  resumedRuns.delete(params.runId);
-  resumeSubagentRun(params.runId);
-}
-
-function scheduleSubagentCompletionRetryAfterRestart(
-  params: SubagentCompletionRequest,
-  source: string,
-  expectedEntry: SubagentRunRecord,
-) {
-  const expectedGeneration = expectedEntry.generation;
-  const timer = setTimeout(() => {
-    resumeRetryTimers.delete(timer);
-    const current = subagentRuns.get(params.runId);
-    if (current !== expectedEntry || current.generation !== expectedGeneration) {
-      return;
-    }
-    void completeSubagentRunWithRecovery(params, source).catch((error: unknown) => {
-      log.warn("failed to retry subagent completion after gateway restart", {
-        source,
-        runId: params.runId,
-        error,
-      });
-    });
-  }, GATEWAY_ADMISSION_RETRY_DELAY_MS);
-  timer.unref?.();
-  resumeRetryTimers.add(timer);
-}
-
-async function completeSubagentRunWithRecovery(params: SubagentCompletionRequest, source: string) {
-  // Each controller attempt owns its terminal transition, while this outer
-  // lease closes the gap between failed attempts and fallback cleanup.
-  try {
-    await runWithGatewayIndependentRootWorkAdmission(async () => {
-      await completeSubagentRunWithRecoveryAttempt(params, source);
-    });
-  } catch (error) {
-    if (!isGatewayRestartDraining()) {
-      throw error;
-    }
-    log.warn("subagent completion deferred during gateway restart", {
-      source,
-      runId: params.runId,
-    });
-    const current = subagentRuns.get(params.runId);
-    if (current) {
-      scheduleSubagentCompletionRetryAfterRestart(params, source, current);
-    }
-  }
-}
-
-function completeSubagentRunInBackground(params: SubagentCompletionRequest, source: string) {
-  void completeSubagentRunWithRecovery(params, source);
-}
-
-const pendingLifecycle = createPendingLifecycleScheduler({
+const completionRuntime = createSubagentRegistryCompletionRuntime({
   runs: subagentRuns,
-  completeInBackground: completeSubagentRunInBackground,
+  resumed: resumedRuns,
+  retryTimers: resumeRetryTimers,
+  completeSubagentRun: (params) => completeSubagentRun(params),
+  scheduleOrphanRecovery: scheduleSubagentOrphanRecovery,
+  resumeRun: (runId) => resumeSubagentRun(runId),
+  warn: (message, meta) => log.warn(message, meta),
 });
+const pendingLifecycle = completionRuntime.pendingLifecycle;
 const clearPendingLifecycleError = pendingLifecycle.clearError;
 const clearPendingLifecycleTimeout = pendingLifecycle.clearTimeout;
-const schedulePendingLifecycleError = pendingLifecycle.scheduleError;
-const schedulePendingLifecycleTimeout = pendingLifecycle.scheduleTimeout;
 
-async function runContextEngineSubagentEnded(
-  params: ContextEngineSubagentEndedParams,
-): Promise<void> {
-  const cfg = subagentRegistryDeps.getRuntimeConfig();
-  await ensureSubagentRegistryPluginRuntimeLoaded({
-    config: cfg,
-    workspaceDir: params.workspaceDir,
-    allowGatewaySubagentBinding: true,
-  });
-  const engine = await resolveSubagentRegistryContextEngine(cfg, {
-    agentDir: params.agentDir,
-    workspaceDir: params.workspaceDir,
-  });
-  await engine.onSubagentEnded?.(params);
-}
-
-async function notifyContextEngineSubagentEnded(
-  params: ContextEngineSubagentEndedParams,
-): Promise<void> {
-  try {
-    await runContextEngineSubagentEnded(params);
-  } catch (err) {
-    log.warn("context-engine onSubagentEnded failed (best-effort)", { err });
-  }
-}
-
-async function finishCollectorContextEngineCleanup(
-  params: ContextEngineSubagentEndedParams,
-): Promise<boolean> {
-  try {
-    await runContextEngineSubagentEnded(params);
-    return true;
-  } catch (err) {
-    log.warn("context-engine collector cleanup failed", { err });
-    return false;
-  }
-}
-
-async function cleanupCollectorLaunchResources(entry: SubagentRunRecord): Promise<boolean> {
-  let internalEffectsRemoved = true;
-  try {
-    await removeInternalSessionEffectsSession(entry.execution?.transcriptTarget);
-  } catch (err) {
-    internalEffectsRemoved = false;
-    log.warn("failed to remove collector internal session effects", {
-      runId: entry.runId,
-      childSessionKey: entry.childSessionKey,
-      err,
-    });
-  }
-  const contextAlreadyEnded = typeof entry.contextEngineCleanupCompletedAt === "number";
-  const [attachmentsRemoved, contextEnded] = await Promise.all([
-    safeRemoveAttachmentsDir(entry),
-    contextAlreadyEnded
-      ? true
-      : finishCollectorContextEngineCleanup({
-          childSessionKey: entry.childSessionKey,
-          reason: "deleted",
-          agentDir: entry.agentDir,
-          workspaceDir: entry.workspaceDir,
-        }),
-  ]);
-  if (!contextAlreadyEnded && contextEnded) {
-    entry.contextEngineCleanupCompletedAt = Date.now();
-    persistSubagentRuns();
-  }
-  return internalEffectsRemoved && attachmentsRemoved && contextEnded;
-}
-
-async function terminateAcceptedRestoredCollectorRun(params: {
-  entry: SubagentRunRecord;
-  gatewayRunId: string;
-  timeoutMs: number;
-}): Promise<void> {
-  // A restored FIFO slot cannot be released until the accepted Gateway run is
-  // definitely stopped; otherwise the group can exceed maxConcurrent.
-  for (;;) {
-    try {
-      await subagentRegistryDeps.callGateway({
-        method: "chat.abort",
-        params: { sessionKey: params.entry.childSessionKey, runId: params.gatewayRunId },
-        timeoutMs: params.timeoutMs,
-      });
-      return;
-    } catch {
-      try {
-        await subagentRegistryDeps.callGateway({
-          method: "sessions.delete",
-          params: {
-            key: params.entry.childSessionKey,
-            deleteTranscript: true,
-            emitLifecycleHooks: false,
-          },
-          timeoutMs: params.timeoutMs,
-        });
-        return;
-      } catch {
-        await new Promise<void>((resolve) => {
-          const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
-          timer.unref?.();
-        });
-      }
-    }
-  }
-}
-
-function suppressAnnounceForSteerRestart(entry?: SubagentRunRecord) {
-  return entry?.suppressAnnounceReason === "steer-restart";
-}
-
-function shouldKeepThreadBindingAfterRun(params: {
-  entry: SubagentRunRecord;
-  reason: SubagentLifecycleEndedReason;
-}) {
-  if (params.reason === SUBAGENT_ENDED_REASON_KILLED) {
-    return false;
-  }
-  return params.entry.spawnMode === "session";
-}
-
-function shouldEmitEndedHookForRun(params: {
-  entry: SubagentRunRecord;
-  reason: SubagentLifecycleEndedReason;
-}) {
-  return !shouldKeepThreadBindingAfterRun(params);
-}
-
-async function emitSubagentEndedHookForRun(params: {
-  entry: SubagentRunRecord;
-  reason?: SubagentLifecycleEndedReason;
-  sendFarewell?: boolean;
-  accountId?: string;
-  isCurrent?: () => boolean;
-}) {
-  if (params.entry.endedHookEmittedAt) {
-    return;
-  }
-  const cfg = subagentRegistryDeps.getRuntimeConfig();
-  await ensureSubagentRegistryPluginRuntimeLoaded({
-    config: cfg,
-    workspaceDir: params.entry.workspaceDir,
-    allowGatewaySubagentBinding: true,
-  });
-  if (params.entry.endedHookEmittedAt || params.isCurrent?.() === false) {
-    return;
-  }
-  // Plugin loading yields after the terminal lock is released. Resolve the
-  // event from the canonical row only after that boundary so an older callback
-  // cannot claim the exactly-once hook with a superseded timeout or error.
-  const reason = params.entry.endedReason ?? params.reason ?? SUBAGENT_ENDED_REASON_COMPLETE;
-  const outcome =
-    reason === SUBAGENT_ENDED_REASON_KILLED
-      ? SUBAGENT_ENDED_OUTCOME_KILLED
-      : resolveLifecycleOutcomeFromRunOutcome(params.entry.outcome);
-  const error = params.entry.outcome?.status === "error" ? params.entry.outcome.error : undefined;
-  await emitSubagentEndedHookOnce({
-    entry: params.entry,
-    reason,
-    sendFarewell: params.sendFarewell,
-    accountId: params.accountId ?? params.entry.requesterOrigin?.accountId,
-    outcome,
-    error,
-    inFlightRunIds: endedHookInFlightRunIds,
-    persist: persistSubagentRuns,
-  });
-}
+const contextCleanup = createSubagentRegistryContextCleanup({
+  deps: () => subagentRegistryDeps,
+  persist: persistSubagentRuns,
+  warn: (message, meta) => log.warn(message, meta),
+});
 
 const subagentLifecycleController = createSubagentRegistryLifecycleController({
   runs: subagentRuns,
@@ -622,13 +148,14 @@ const subagentLifecycleController = createSubagentRegistryLifecycleController({
   persist: persistSubagentRuns,
   persistOrThrow: persistSubagentRunsOrThrow,
   clearPendingLifecycleError,
-  countPendingDescendantRuns,
-  suppressAnnounceForSteerRestart,
+  countPendingDescendantRuns: (rootSessionKey) =>
+    publicApi.countPendingDescendantRuns(rootSessionKey),
+  suppressAnnounceForSteerRestart: contextCleanup.suppressAnnounceForSteerRestart,
   resolveSubagentTask: findSubagentTaskForRun,
-  shouldEmitEndedHookForRun,
-  emitSubagentEndedHookForRun,
+  shouldEmitEndedHookForRun: contextCleanup.shouldEmitEndedHookForRun,
+  emitSubagentEndedHookForRun: contextCleanup.emitSubagentEndedHookForRun,
   emitSubagentProgressEndedForRun: emitSubagentProgressEndedHook,
-  notifyContextEngineSubagentEnded,
+  notifyContextEngineSubagentEnded: contextCleanup.notifyContextEngineSubagentEnded,
   retireSupersededRun: retireSupersededSubagentRun,
   resumeSubagentRun,
   callGateway: (request) => subagentRegistryDeps.callGateway(request),
@@ -794,7 +321,7 @@ function resumeSubagentRun(runId: string) {
       }
       return;
     }
-    if (suppressAnnounceForSteerRestart(entry)) {
+    if (contextCleanup.suppressAnnounceForSteerRestart(entry)) {
       resumedRuns.add(runId);
       return;
     }
@@ -812,233 +339,27 @@ function resumeSubagentRun(runId: string) {
   resumedRuns.add(runId);
 }
 
-function restoreSubagentRunsOnce() {
-  if (restoreAttempted) {
-    return;
-  }
-  restoreAttempted = true;
-  try {
-    const restoredCount = subagentRegistryDeps.restoreSubagentRunsFromDisk({
-      runs: subagentRuns,
-      mergeOnly: true,
-    });
-    if (restoredCount === 0) {
-      return;
-    }
-    const cfg = subagentRegistryDeps.getRuntimeConfig();
-    let restoredStateChanged = reconcileOrphanedRestoredRuns({
-      runs: subagentRuns,
-      resumedRuns,
-    });
-    for (const entry of subagentRuns.values()) {
-      if (backfillCollectorArchiveAtMs(entry, cfg)) {
-        restoredStateChanged = true;
-      }
-    }
-    if (restoredStateChanged) {
-      persistSubagentRuns();
-    }
-    const requesterTurns = new Map<string, Map<string, SubagentRunRecord[]>>();
-    for (const entry of subagentRuns.values()) {
-      const requesterTurnRunId = entry.requesterTurnRunId?.trim();
-      if (!requesterTurnRunId) {
-        continue;
-      }
-      let turns = requesterTurns.get(entry.requesterSessionKey);
-      if (!turns) {
-        turns = new Map();
-        requesterTurns.set(entry.requesterSessionKey, turns);
-      }
-      const entries = turns.get(requesterTurnRunId) ?? [];
-      entries.push(entry);
-      turns.set(requesterTurnRunId, entries);
-    }
-    for (const [requesterSessionKey, turns] of requesterTurns) {
-      for (const [requesterTurnRunId, entries] of turns) {
-        settleRequesterTurnAfterSessionSpawns({
-          requesterSessionKey,
-          requesterTurnRunId,
-          requesterYielded: entries.every((entry) => entry.requesterTurnYielded === true),
-          acceptedSessionSpawns: entries.map((entry) => ({
-            runId: entry.runId,
-            childSessionKey: entry.childSessionKey,
-          })),
-        });
-      }
-    }
-    if (subagentRuns.size === 0) {
-      return;
-    }
-    // Resume pending work.
-    ensureListener();
-    // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
-    subagentSweeper.start();
-    const restoredSessionCache: SubagentSessionStoreCache = new Map();
-    for (const [runId, entry] of subagentRuns) {
-      if (entry.collect && entry.execution?.status === "queued") {
-        const launch = entry.queuedLaunch;
-        if (!launch) {
-          void failAndCleanupRestoredQueuedRun(
-            runId,
-            entry,
-            "queued collector launch state was unavailable after restart",
-            false,
-          );
-          continue;
-        }
-        const groupRuns = listSwarmRunsForGroup(
-          entry.groupId ?? "",
-          entry.swarmRequesterSessionKey ?? entry.requesterSessionKey,
-        );
-        const currentSwarmConfig = resolveSwarmConfig(
-          subagentRegistryDeps.getRuntimeConfig(),
-          entry.requesterAgentId,
-        );
-        let launchTerminationConfirmed = false;
-        enqueueSwarmRun({
-          groupId: launch.schedulerGroupKey,
-          runId,
-          maxConcurrent: currentSwarmConfig.maxConcurrent,
-          activeRunIds: groupRuns
-            .filter((candidate) => candidate.execution?.status === "running")
-            .map((candidate) => candidate.schedulerSlotId ?? candidate.runId),
-          start: async () => {
-            await runWithGatewayIndependentRootWorkAdmission(async () => {
-              const response = await subagentRegistryDeps.callGateway({
-                method: "agent",
-                params: applySubagentLaunchAuthorization(launch.request, launch.authorization),
-                // Restart replay must restore the trusted launch capability; otherwise
-                // the queued child silently falls back to its session/default route.
-                ...(launch.authorization ? { scopes: [ADMIN_SCOPE] } : {}),
-                timeoutMs: launch.timeoutMs,
-              });
-              const gatewayRunId = readGatewayRunId(response) ?? runId;
-              try {
-                if (!startQueuedSubagentRun(runId, gatewayRunId)) {
-                  throw new Error(
-                    "collector registry row could not transition from queued to running",
-                  );
-                }
-              } catch (error) {
-                await terminateAcceptedRestoredCollectorRun({
-                  entry,
-                  gatewayRunId,
-                  timeoutMs: launch.timeoutMs,
-                });
-                launchTerminationConfirmed = true;
-                throw error;
-              }
-            });
-          },
-          onStartFailure: (error) => {
-            if (error instanceof GatewayDrainingError) {
-              return false;
-            }
-            return failAndCleanupRestoredQueuedRun(
-              runId,
-              entry,
-              error instanceof Error ? error.message : String(error),
-              launchTerminationConfirmed,
-            );
-          },
-        });
-        continue;
-      }
-      // An aborted persisted session belongs to orphan recovery. Waiting on its
-      // pre-restart run can terminalize it before the replacement turn starts.
-      if (
-        loadSubagentSessionEntry({
-          childSessionKey: entry.childSessionKey,
-          storeCache: restoredSessionCache,
-        })?.abortedLastRun === true
-      ) {
-        continue;
-      }
-      resumeSubagentRun(runId);
-    }
-
-    // Cold-start restore can precede instance-runtime registration. The post-attach
-    // startup pass retries this seam once the lifecycle-bound principal exists.
-    scheduleSubagentOrphanRecovery();
-  } catch (err) {
-    log.warn(
-      `failed to restore subagent runs from disk: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-}
-
-async function failAndCleanupRestoredQueuedRun(
-  runId: string,
-  entry: SubagentRunRecord,
-  error: string,
-  launchTerminationConfirmed: boolean,
-): Promise<boolean> {
-  const cleanupComplete = await runWithGatewayIndependentRootWorkAdmission(async () => {
-    for (;;) {
-      try {
-        await subagentRegistryDeps.callGateway({
-          method: "sessions.delete",
-          params: {
-            key: entry.childSessionKey,
-            deleteTranscript: true,
-            emitLifecycleHooks: false,
-          },
-          timeoutMs: 10_000,
-        });
-        break;
-      } catch (cleanupError) {
-        log.warn("failed to delete restored collector session after launch failure", {
-          runId,
-          childSessionKey: entry.childSessionKey,
-          error: cleanupError,
-        });
-        if (launchTerminationConfirmed) {
-          return false;
-        }
-      }
-      await new Promise<void>((resolve) => {
-        const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
-        timer.unref?.();
-      });
-    }
-    if (!(await cleanupCollectorLaunchResources(entry))) {
-      return false;
-    }
-    return true;
-  }).catch((cleanupError: unknown) => {
-    log.warn("failed to clean restored collector after launch failure", {
-      runId,
-      childSessionKey: entry.childSessionKey,
-      error: cleanupError,
-    });
-    return false;
-  });
-  for (;;) {
-    try {
-      subagentRunManager.settleFailedQueuedSubagentLaunch(runId, error);
-      break;
-    } catch (persistError) {
-      log.warn("failed to persist restored collector launch failure", {
-        runId,
-        childSessionKey: entry.childSessionKey,
-        error: persistError,
-      });
-    }
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
-      timer.unref?.();
-    });
-  }
-  if (cleanupComplete) {
-    emitSessionLifecycleEvent({
-      sessionKey: entry.childSessionKey,
-      reason: "delete",
-      parentSessionKey: entry.swarmRequesterSessionKey ?? entry.requesterSessionKey,
-    });
-    completeCollectorLaunchCleanup(runId);
-  }
-  return true;
-}
+const subagentRestorer = createSubagentRegistryRestorer({
+  runs: subagentRuns,
+  resumedRuns,
+  deps: () => subagentRegistryDeps,
+  persist: persistSubagentRuns,
+  settleRequesterTurn: settleRequesterTurnAfterSessionSpawns,
+  ensureListener: () => subagentListener.ensure(),
+  startSweeper: () => subagentSweeper.start(),
+  resumeRun: (runId) => resumeSubagentRun(runId),
+  listSwarmRunsForGroup: (groupId, requesterSessionKey) =>
+    listSwarmRunsForGroup(groupId, requesterSessionKey),
+  startQueuedSubagentRun: (runId, gatewayRunId) =>
+    subagentRunManager.startQueuedSubagentRun(runId, gatewayRunId),
+  terminateAcceptedRestoredCollectorRun: contextCleanup.terminateAcceptedRestoredCollectorRun,
+  cleanupCollectorLaunchResources: contextCleanup.cleanupCollectorLaunchResources,
+  settleFailedQueuedSubagentLaunch: (runId, error) =>
+    subagentRunManager.settleFailedQueuedSubagentLaunch(runId, error),
+  completeCollectorLaunchCleanup: (runId) => publicApi.completeCollectorLaunchCleanup(runId),
+  scheduleOrphanRecovery: scheduleSubagentOrphanRecovery,
+  warn: (message, meta) => log.warn(message, meta),
+});
 
 function resolveSubagentWaitTimeoutMs(cfg: OpenClawConfig, runTimeoutSeconds?: number) {
   return subagentRegistryDeps.resolveAgentTimeoutMs({
@@ -1063,163 +384,30 @@ const subagentSweeper = createSubagentRegistrySweeper({
   clearPendingLifecycleError,
   clearPendingLifecycleTimeout,
   sweepPendingLifecycle: (now) => pendingLifecycle.sweepExpired(now),
-  completeSubagentRunWithRecovery,
+  completeSubagentRunWithRecovery: completionRuntime.completeSubagentRunWithRecovery,
   scheduleSubagentOrphanRecovery,
   resumeRequesterSettleWake,
   startSubagentAnnounceCleanupFlow,
   completeCleanupBookkeeping,
-  shouldEmitEndedHookForRun,
-  emitSubagentEndedHookForRun,
+  shouldEmitEndedHookForRun: contextCleanup.shouldEmitEndedHookForRun,
+  emitSubagentEndedHookForRun: contextCleanup.emitSubagentEndedHookForRun,
   callGateway: (request) => subagentRegistryDeps.callGateway(request),
-  cleanupCollectorLaunchResources,
-  runContextEngineSubagentEnded,
-  notifyContextEngineSubagentEnded,
+  cleanupCollectorLaunchResources: contextCleanup.cleanupCollectorLaunchResources,
+  runContextEngineSubagentEnded: contextCleanup.runContextEngineSubagentEnded,
+  notifyContextEngineSubagentEnded: contextCleanup.notifyContextEngineSubagentEnded,
   retireSupersededRun: retireSupersededSubagentRun,
   warn: (message, meta) => log.warn(message, meta),
 });
 
-function ensureListener() {
-  if (listenerStarted) {
-    return;
-  }
-  listenerStarted = true;
-  listenerStop = subagentRegistryDeps.onAgentEvent((evt) => {
-    void (async () => {
-      if (!evt || evt.stream !== "lifecycle") {
-        return;
-      }
-      const phase = evt.data?.phase;
-      const entry = subagentRuns.get(evt.runId);
-      if (!entry) {
-        if (phase === "end" && typeof evt.sessionKey === "string") {
-          const sessionKey = evt.sessionKey;
-          // A replacement generation can finish after its predecessor row is
-          // terminal. Keep capture + persistence inside the suspension fence.
-          await runWithGatewayIndependentRootWorkAdmission(async () => {
-            await refreshFrozenResultFromSession(sessionKey);
-          });
-        }
-        return;
-      }
-      if (phase === "start") {
-        pendingLifecycle.clear(evt.runId);
-        const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
-        if (startedAt) {
-          entry.startedAt = startedAt;
-          if (typeof entry.sessionStartedAt !== "number") {
-            entry.sessionStartedAt = startedAt;
-          }
-          entry.execution = { ...entry.execution, status: "running", startedAt };
-          persistSubagentRuns();
-        }
-        return;
-      }
-      if (phase !== "end" && phase !== "error") {
-        return;
-      }
-      const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
-      const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
-      const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
-      const livenessState =
-        typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
-      const stopReason = typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
-      // sessions_yield ends the turn by aborting the run signal, so a yielded
-      // terminal can also look aborted. An explicit yield is authoritative — pause,
-      // don't kill — else the tracking task settles `cancelled` with a false notice (#92448).
-      if (evt.data?.yielded === true) {
-        // Drop any grace timer from an earlier aborted/error terminal so it can't
-        // later fire and settle this now-paused run with a false notice.
-        pendingLifecycle.clear(evt.runId);
-        if (
-          markSubagentRunPausedAfterYield({
-            entry,
-            endedAt,
-            startedAt: startedAt ?? entry.startedAt,
-          })
-        ) {
-          persistSubagentRuns();
-        }
-        return;
-      }
-      if (isAbortedAgentStopReason(stopReason)) {
-        pendingLifecycle.clear(evt.runId);
-        await completeSubagentRunWithRecovery(
-          {
-            runId: evt.runId,
-            endedAt,
-            outcome: {
-              status: "error",
-              error: "subagent run terminated",
-            },
-            reason: SUBAGENT_ENDED_REASON_KILLED,
-            sendFarewell: true,
-            accountId: entry.requesterOrigin?.accountId,
-            triggerCleanup: true,
-            startedAt,
-          },
-          "lifecycle-killed-event",
-        );
-        return;
-      }
-      if (phase === "error") {
-        schedulePendingLifecycleError({
-          runId: evt.runId,
-          endedAt,
-          startedAt,
-          error,
-        });
-        return;
-      }
-      const blocked = isBlockedLivenessState(livenessState);
-      const abandoned = isAbandonedLivenessState(livenessState);
-      if (blocked || abandoned) {
-        pendingLifecycle.clear(evt.runId);
-        const blockedParams = {
-          runId: evt.runId,
-          endedAt,
-          outcome: {
-            status: "error" as const,
-            error: blocked
-              ? formatBlockedLivenessError(error)
-              : formatAbandonedLivenessError(error),
-          },
-          reason: SUBAGENT_ENDED_REASON_ERROR,
-          sendFarewell: true,
-          accountId: entry.requesterOrigin?.accountId,
-          triggerCleanup: true,
-          startedAt,
-        };
-        await completeSubagentRunWithRecovery(
-          blockedParams,
-          blocked ? "lifecycle-blocked-event" : "lifecycle-abandoned-event",
-        );
-        return;
-      }
-      if (evt.data?.aborted) {
-        schedulePendingLifecycleTimeout({
-          runId: evt.runId,
-          endedAt,
-          startedAt,
-        });
-        return;
-      }
-      pendingLifecycle.clear(evt.runId);
-      const completionParams = {
-        runId: evt.runId,
-        endedAt,
-        outcome: { status: "ok" as const },
-        reason: SUBAGENT_ENDED_REASON_COMPLETE,
-        sendFarewell: true,
-        accountId: entry.requesterOrigin?.accountId,
-        triggerCleanup: true,
-        startedAt,
-      };
-      await completeSubagentRunWithRecovery(completionParams, "lifecycle-ok-event");
-    })().catch((err: unknown) => {
-      log.warn("lifecycle event handler failed", { err, runId: evt.runId });
-    });
-  });
-}
+const subagentListener = createSubagentRegistryListener({
+  runs: subagentRuns,
+  pendingLifecycle,
+  onAgentEvent: (listener) => subagentRegistryDeps.onAgentEvent(listener),
+  persist: persistSubagentRuns,
+  refreshFrozenResultFromSession,
+  completeSubagentRunWithRecovery: completionRuntime.completeSubagentRunWithRecovery,
+  warn: (message, meta) => log.warn(message, meta),
+});
 
 const subagentRunManager = createSubagentRunManager({
   runs: subagentRuns,
@@ -1241,7 +429,7 @@ const subagentRunManager = createSubagentRunManager({
     return await subagentRegistryDeps.callGateway<T>(request);
   },
   getRuntimeConfig: () => subagentRegistryDeps.getRuntimeConfig(),
-  ensureListener,
+  ensureListener: subagentListener.ensure,
   startSweeper: subagentSweeper.start,
   stopSweeper: subagentSweeper.stop,
   resumeSubagentRun,
@@ -1251,17 +439,18 @@ const subagentRunManager = createSubagentRunManager({
   scheduleOrphanRecovery: (args) => scheduleSubagentOrphanRecovery(args),
   resolveSubagentSessionCompletion,
   resolveSubagentSessionStartedAt,
-  notifyContextEngineSubagentEnded,
+  notifyContextEngineSubagentEnded: contextCleanup.notifyContextEngineSubagentEnded,
   completeCleanupBookkeeping,
   completeSubagentRun: async (params) => {
-    await completeSubagentRunWithRecovery(params, "subagent-wait");
+    await completionRuntime.completeSubagentRunWithRecovery(params, "subagent-wait");
   },
   resolveSubagentTask: findSubagentTaskForRun,
 });
 
 configureSubagentRegistrySteerRuntime({
   replaceSubagentRunAfterSteer: (params) => subagentRunManager.replaceSubagentRunAfterSteer(params),
-  finalizeInterruptedSubagentRun: async (params) => await finalizeInterruptedSubagentRun(params),
+  finalizeInterruptedSubagentRun: async (params) =>
+    await completionRuntime.finalizeInterruptedSubagentRun(params),
   reserveSwarmCollectorLaunch: (runId, idempotencyKey) => {
     const entry =
       subagentRuns.get(runId) ??
@@ -1335,20 +524,13 @@ function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   resumedRuns.clear();
   endedHookInFlightRunIds.clear();
   pendingLifecycle.clearAll();
-  contextEngineInitLoader.clear();
-  contextEngineRegistryLoader.clear();
-  runtimePluginsLoader.clear();
-  subagentAnnounceLoader.clear();
-  browserCleanupLoader.clear();
+  resetSubagentRegistryRuntimeLoadersForTests();
+  contextCleanup.reset();
   clearSubagentRunsReadCacheForTest();
   subagentSweeper.reset();
-  restoreAttempted = false;
+  subagentRestorer.reset();
   lastOrphanRecoveryScheduleAt = 0;
-  if (listenerStop) {
-    listenerStop();
-    listenerStop = null;
-  }
-  listenerStarted = false;
+  subagentListener.reset();
   if (opts?.persist !== false) {
     persistSubagentRuns();
   }
@@ -1363,12 +545,7 @@ const testing = {
     await subagentSweeper.runTick();
   },
   setDepsForTest(overrides?: Partial<SubagentRegistryDeps>) {
-    subagentRegistryDeps = overrides
-      ? {
-          ...defaultSubagentRegistryDeps,
-          ...overrides,
-        }
-      : defaultSubagentRegistryDeps;
+    setSubagentRegistryDepsForTest(overrides);
   },
 } as const;
 
@@ -1380,81 +557,6 @@ function releaseSubagentRun(runId: string) {
   subagentRunManager.releaseSubagentRun(runId);
 }
 
-function hasCompleteSubagentTerminalState(entry: SubagentRunRecord | undefined): boolean {
-  return (
-    entry !== undefined &&
-    typeof entry.endedAt === "number" &&
-    Number.isFinite(entry.endedAt) &&
-    entry.outcome !== undefined &&
-    entry.endedReason !== undefined &&
-    entry.execution?.status === "terminal"
-  );
-}
-
-async function finalizeInterruptedSubagentRun(params: {
-  runId: string;
-  error: string;
-  endedAt?: number;
-}): Promise<number> {
-  const runId = params.runId.trim();
-  if (!runId) {
-    return 0;
-  }
-
-  const endedAt =
-    typeof params.endedAt === "number" && Number.isFinite(params.endedAt)
-      ? params.endedAt
-      : Date.now();
-  pendingLifecycle.clear(runId);
-  const entry = subagentRuns.get(runId);
-  if (!entry) {
-    return 0;
-  }
-  if (
-    typeof entry.cleanupCompletedAt === "number" &&
-    entry.terminalOwner !== "interrupted-recovery"
-  ) {
-    return hasCompleteSubagentTerminalState(entry) ? 1 : 0;
-  }
-  const completionParams: SubagentCompletionRequest = {
-    runId,
-    endedAt,
-    outcome: {
-      status: "error",
-      error: params.error,
-    },
-    reason: SUBAGENT_ENDED_REASON_ERROR,
-    sendFarewell: true,
-    accountId: entry.requesterOrigin?.accountId,
-    triggerCleanup: true,
-    recoverInterrupted: true,
-  };
-  try {
-    await completeSubagentRun(completionParams);
-    // A successfully finalized stale generation can be retired once a newer
-    // generation owns the session; the captured exact row still has its result.
-    const finalized = subagentRuns.get(runId) ?? entry;
-    // Recovery preserves partial terminal evidence instead of overwriting it.
-    // Keep scheduler retries alive until the exact row is fully terminal.
-    return hasCompleteSubagentTerminalState(finalized) ? 1 : 0;
-  } catch (error) {
-    if (isGatewayRestartDraining() && subagentRuns.get(runId) === entry) {
-      log.warn("subagent completion deferred during gateway restart", {
-        source: "explicit-failed-mark",
-        runId,
-      });
-      scheduleSubagentCompletionRetryAfterRestart(completionParams, "explicit-failed-mark", entry);
-      return 1;
-    }
-    log.warn("failed to durably finalize interrupted subagent run", {
-      runId,
-      childSessionKey: entry.childSessionKey,
-      error,
-    });
-    return 0;
-  }
-}
-
 export function markSubagentRunTerminated(params: {
   runId?: string;
   childSessionKey?: string;
@@ -1464,273 +566,58 @@ export function markSubagentRunTerminated(params: {
   return subagentRunManager.markSubagentRunTerminated(params);
 }
 
-export function leasePendingAgentSteeringItems(params: {
-  requesterSessionKey: string;
-  leaseId: string;
-  now?: number;
-}) {
-  restoreSubagentRunsOnce();
-  const leased = leasePendingAgentSteeringItemsFromSubagentRuns({
-    runs: subagentRuns,
-    requesterSessionKey: params.requesterSessionKey,
-    leaseId: params.leaseId,
-    now: params.now,
-  });
-  if (leased) {
-    persistSubagentRuns();
-  }
-  return leased;
-}
-
-export function ackPendingAgentSteeringItems(params: {
-  runIds: readonly string[];
-  leaseId: string;
-  now?: number;
-}): number {
-  const updated = ackLeasedAgentSteeringItemsFromSubagentRuns({
-    runs: subagentRuns,
-    runIds: params.runIds,
-    leaseId: params.leaseId,
-    now: params.now,
-  });
-  if (updated > 0) {
-    persistSubagentRuns();
-    for (const runId of params.runIds) {
-      const entry = subagentRuns.get(runId);
-      if (!entry || typeof entry.cleanupCompletedAt === "number") {
-        continue;
-      }
-      entry.cleanupHandled = false;
-      startSubagentAnnounceCleanupFlow(runId, entry);
-    }
-  }
-  return updated;
-}
-
-export function releasePendingAgentSteeringItems(params: {
-  runIds: readonly string[];
-  leaseId: string;
-  error?: string;
-}): number {
-  const updated = releaseLeasedAgentSteeringItemsFromSubagentRuns({
-    runs: subagentRuns,
-    runIds: params.runIds,
-    leaseId: params.leaseId,
-    error: params.error,
-  });
-  if (updated > 0) {
-    persistSubagentRuns();
-  }
-  return updated;
-}
-
 export { prependAgentSteeringPrompt };
 
-export function listSubagentRunsForController(controllerSessionKey: string): SubagentRunRecord[] {
-  return listRunsForControllerFromRuns(
-    subagentRegistryDeps.getSubagentRunsSnapshotForController(subagentRuns, controllerSessionKey),
-    controllerSessionKey,
-  );
+const publicApi = createSubagentRegistryPublicApi({
+  runs: subagentRuns,
+  deps: () => subagentRegistryDeps,
+  persist: persistSubagentRuns,
+  persistOrThrow: persistSubagentRunsOrThrow,
+  restoreOnce: () => subagentRestorer.restoreOnce(),
+  startAnnounceCleanup: startSubagentAnnounceCleanupFlow,
+  settleRequesterTurn: settleRequesterTurnAfterSessionSpawns,
+});
+const bootstrapState = getSubagentRegistryBootstrapState();
+bootstrapState.restorer = subagentRestorer;
+bootstrapState.ready = true;
+if (bootstrapState.pending) {
+  bootstrapState.pending = false;
+  subagentRestorer.restoreOnce();
 }
 
-export function getSubagentRunByRunId(runId: string): SubagentRunRecord | undefined {
-  const key = runId.trim();
-  const snapshot = subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns);
-  return snapshot.get(key) ?? [...snapshot.values()].find((entry) => entry.swarmRunId === key);
-}
-
-export function getSubagentRunsByRunIds(runIds: readonly string[]): {
-  entries: Map<string, SubagentRunRecord>;
-} {
-  const snapshot = subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns);
-  const byId = new Map<string, SubagentRunRecord>();
-  for (const entry of snapshot.values()) {
-    byId.set(entry.runId, entry);
-    if (entry.swarmRunId) {
-      byId.set(entry.swarmRunId, entry);
-    }
-  }
-  return {
-    entries: new Map(
-      runIds.flatMap((runId) => {
-        const entry = byId.get(runId.trim());
-        return entry ? [[runId, entry] as const] : [];
-      }),
-    ),
-  };
-}
-
-export function completeCollectorLaunchCleanup(runId: string): void {
-  const key = runId.trim();
-  const entry =
-    subagentRuns.get(key) ??
-    [...subagentRuns.values()].find((candidate) => candidate.swarmRunId === key);
-  if (!entry?.collectorLaunchCleanupPending) {
+export const leasePendingAgentSteeringItems = publicApi.leasePendingAgentSteeringItems;
+export const ackPendingAgentSteeringItems = publicApi.ackPendingAgentSteeringItems;
+export const releasePendingAgentSteeringItems = publicApi.releasePendingAgentSteeringItems;
+export const listSubagentRunsForController = publicApi.listSubagentRunsForController;
+export const getSubagentRunByRunId = publicApi.getSubagentRunByRunId;
+export const getSubagentRunsByRunIds = publicApi.getSubagentRunsByRunIds;
+export const completeCollectorLaunchCleanup = publicApi.completeCollectorLaunchCleanup;
+export const recordSwarmStructuredOutput = publicApi.recordSwarmStructuredOutput;
+export const listSwarmRunsForGroup = publicApi.listSwarmRunsForGroup;
+export const getSwarmRunByLaunchReplayKey = publicApi.getSwarmRunByLaunchReplayKey;
+export const countActiveRunsForSession = publicApi.countActiveRunsForSession;
+export const countActiveDescendantRuns = publicApi.countActiveDescendantRuns;
+export const countPendingDescendantRuns = publicApi.countPendingDescendantRuns;
+export const listDescendantRunsForRequester = publicApi.listDescendantRunsForRequester;
+export const getSubagentRunByChildSessionKey = publicApi.getSubagentRunByChildSessionKey;
+export const getLatestSubagentRunByChildSessionKey =
+  publicApi.getLatestSubagentRunByChildSessionKey;
+export function initSubagentRegistry() {
+  const state = getSubagentRegistryBootstrapState();
+  if (!state.ready || !state.restorer) {
+    state.pending = true;
     return;
   }
-  entry.collectorLaunchCleanupPending = false;
-  entry.cleanupCompletedAt = Date.now();
-  entry.contextEngineCleanupCompletedAt ??= entry.cleanupCompletedAt;
-  persistSubagentRuns();
+  state.restorer.restoreOnce();
 }
-
-export function recordSwarmStructuredOutput(
-  identity: { runId?: string; childSessionKey?: string },
-  state: SwarmStructuredOutputState,
-): void {
-  const runId = identity.runId?.trim();
-  const childSessionKey = identity.childSessionKey?.trim();
-  const entry =
-    (runId
-      ? (subagentRuns.get(runId) ??
-        [...subagentRuns.values()].find((candidate) => candidate.swarmRunId === runId))
-      : undefined) ??
-    (childSessionKey
-      ? [...subagentRuns.values()]
-          .filter((candidate) => candidate.childSessionKey === childSessionKey)
-          .toSorted((left, right) => (right.generation ?? 0) - (left.generation ?? 0))[0]
-      : undefined);
-  if (!entry?.collect || entry.collectorCompletion) {
-    throw new Error("collector run is unavailable");
-  }
-  const previous = entry.structuredOutput;
-  entry.structuredOutput = structuredClone(state);
-  try {
-    persistSubagentRunsOrThrow();
-  } catch (error) {
-    entry.structuredOutput = previous;
-    throw error;
-  }
-}
-
-export function listSwarmRunsForGroup(
-  groupId: string,
-  requesterSessionKey?: string,
-): SubagentRunRecord[] {
-  const key = groupId.trim();
-  const requesterKey = requesterSessionKey?.trim();
-  return [...subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns).values()].filter(
-    (entry) =>
-      entry.collect === true &&
-      entry.groupId === key &&
-      (!requesterKey ||
-        (entry.swarmRequesterSessionKey ?? entry.requesterSessionKey) === requesterKey),
-  );
-}
-
-/** Resolve a collector reserved by a replay-safe host bridge request. */
-export function getSwarmRunByLaunchReplayKey(
-  replayKey: string,
-  requesterSessionKey?: string,
-): SubagentRunRecord | undefined {
-  const key = replayKey.trim();
-  const requesterKey = requesterSessionKey?.trim();
-  if (!key) {
-    return undefined;
-  }
-  return [...subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns).values()].find(
-    (entry) =>
-      entry.collect === true &&
-      entry.swarmLaunchReplayKey === key &&
-      (!requesterKey ||
-        (entry.swarmRequesterSessionKey ?? entry.requesterSessionKey) === requesterKey),
-  );
-}
-
-export function countActiveRunsForSession(
-  requesterSessionKey: string,
-  options?: { collect?: boolean },
-): number {
-  return countActiveRunsForSessionFromRuns(
-    subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns),
-    requesterSessionKey,
-    options,
-  );
-}
-
-export function countActiveDescendantRuns(rootSessionKey: string): number {
-  return countActiveDescendantRunsFromRuns(
-    subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns),
-    rootSessionKey,
-  );
-}
-
-export function countPendingDescendantRuns(rootSessionKey: string): number {
-  return countPendingDescendantRunsFromRuns(
-    subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns),
-    rootSessionKey,
-  );
-}
-
-export function listDescendantRunsForRequester(rootSessionKey: string): SubagentRunRecord[] {
-  return listDescendantRunsForRequesterFromRuns(
-    subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns),
-    rootSessionKey,
-  );
-}
-
-export function getSubagentRunByChildSessionKey(childSessionKey: string): SubagentRunRecord | null {
-  return getSubagentRunByChildSessionKeyFromRuns(
-    subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns),
-    childSessionKey,
-  );
-}
-
-export function getLatestSubagentRunByChildSessionKey(
-  childSessionKey: string,
-): SubagentRunRecord | null {
-  const key = childSessionKey.trim();
-  if (!key) {
-    return null;
-  }
-
-  let latest: SubagentRunRecord | null = null;
-  for (const entry of subagentRegistryDeps
-    .getSubagentRunsSnapshotForChildSession(subagentRuns, key)
-    .values()) {
-    if (entry.childSessionKey !== key) {
-      continue;
-    }
-    if (!latest || compareSubagentRunGeneration(entry, latest) > 0) {
-      latest = entry;
-    }
-  }
-
-  return latest;
-}
-
-export function initSubagentRegistry() {
-  restoreSubagentRunsOnce();
-}
-
-/** Re-admits a delivered child batch after its requester explicitly yields. */
-export function settleRequesterAfterSessionSpawns(params: {
-  requesterSessionKey: string;
-  requesterTurnRunId: string;
-  requesterYielded: boolean;
-  acceptedSessionSpawns: readonly AcceptedSessionSpawn[];
-}): boolean {
-  return settleRequesterTurnAfterSessionSpawns(params);
-}
-
-/** Records sessions_yield before the active requester run is aborted. */
-export function markRequesterTurnYielded(params: {
-  requesterSessionKey: string;
-  requesterTurnRunId: string;
-}): number {
-  restoreSubagentRunsOnce();
-  return markRequesterTurnYieldedInRuns({
-    ...params,
-    runs: subagentRuns,
-    persistOrThrow: persistSubagentRunsOrThrow,
-  });
-}
+export const settleRequesterAfterSessionSpawns = publicApi.settleRequesterAfterSessionSpawns;
+export const markRequesterTurnYielded = publicApi.markRequesterTurnYielded;
 
 const SUBAGENT_REGISTRY_TEST_HANDLE = Symbol.for("openclaw.subagentRegistryTestApi");
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[SUBAGENT_REGISTRY_TEST_HANDLE] = {
     addSubagentRunForTests,
-    finalizeInterruptedSubagentRun,
+    finalizeInterruptedSubagentRun: completionRuntime.finalizeInterruptedSubagentRun,
     releaseSubagentRun,
     resetSubagentRegistryForTests,
     testing,
@@ -1739,4 +626,3 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
 
 // Register the subagent maintenance preserve-key provider as a module side effect.
 import "./subagent-registry-maintenance.js";
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The subagent registry implementation had grown to 1,742 lines behind a grandfathered max-lines suppression, combining bootstrap wiring, completion recovery, context cleanup, lifecycle listening, persistence restoration, and public query/mutation APIs in one module.

## Why This Change Was Made

This maintainer-requested, behavior-neutral refactor keeps `subagent-registry.ts` as the stable public surface while separating dependency loading, completion recovery, context cleanup, lifecycle listening, persistence restoration, and public APIs into focused owner modules. It removes the suppression and baseline entry; every resulting production module is 628 lines or fewer.

The production diff grows by 332 lines because each extracted owner receives an explicit typed dependency contract, and bootstrap restoration now has a small deferred-init guard that preserves circular-import startup ordering until every public alias is initialized. Public exports, deterministic registry iteration, SQLite persistence, lifecycle transitions, delivery semantics, and cleanup ordering are unchanged.

## User Impact

No user-visible behavior changes. Maintainers can now review and modify registry bootstrap, restoration, lifecycle, cleanup, completion, and API behavior at their owning boundaries.

## Evidence

- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-registry-completion.test.ts src/agents/subagent-registry-cleanup.test.ts src/agents/subagent-registry.persistence.test.ts src/agents/subagent-registry.persistence.resume.test.ts src/agents/subagent-registry.store.sqlite.test.ts src/agents/subagent-registry.steer-restart.test.ts src/agents/tools/agents-wait-tool.test.ts src/gateway/server-startup-plugins.test.ts src/agents/code-mode-swarm.test.ts` — 352 tests passed across registry, lifecycle, persistence, SQLite, steering, and caller surfaces.
- Post-rebase registry/startup slice — 172 tests passed; branch patch-id remained `d57e30bf4caea2f853125006fb5390163aa65c27` across the final main rebase.
- Hosted `node scripts/check-changed.mjs -- <touched files>` on Blacksmith Testbox `tbx_01ky9q6kewm4ex01y9d34kqh7k` / Actions run 30082628615 — all guards, production/test typechecks, lint shards, database checks, and runtime import-cycle checks passed.
- Hosted `pnpm deadcode:exports` on Blacksmith Testbox `tbx_01ky9rabq851y650mqhk74p2sr` / Actions run 30083807984 — production, full-tree, and script unused-export scans passed with zero entries.
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.

ClawSweeper's optional rank-up move requested a live gateway restart trace. That extra proof is intentionally skipped for this behavior-neutral structural extraction: the maintainer-defined batch proof requires the focused persistence, restart, lifecycle, SQLite, steering, and caller suites plus hosted type/lint, import-cycle, and dead-export gates. The patch adds no new runtime branch, persistence path, schema, fallback, or user-visible behavior.

AI-assisted: yes. This maintainer-directed split was implemented and reviewed with Codex. No transcript is attached.
