### PR TITLE
refactor(memory-lancedb): remove dead legacy path scan

### DIFF
--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -1,5 +1,4 @@
 // Memory Lancedb helper module supports config behavior.
-import fs from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
@@ -28,34 +27,7 @@ export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
 const DEFAULT_MODEL = "text-embedding-3-small";
 export const DEFAULT_CAPTURE_MAX_CHARS = 500;
 export const DEFAULT_RECALL_MAX_CHARS = 1000;
-const LEGACY_STATE_DIRS: string[] = [];
-
-function resolveDefaultDbPath(): string {
-  const home = homedir();
-  const preferred = join(home, ".openclaw", "memory", "lancedb");
-  try {
-    if (fs.existsSync(preferred)) {
-      return preferred;
-    }
-  } catch {
-    // best-effort
-  }
-
-  for (const legacy of LEGACY_STATE_DIRS) {
-    const candidate = join(home, legacy, "memory", "lancedb");
-    try {
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
-    } catch {
-      // best-effort
-    }
-  }
-
-  return preferred;
-}
-
-const DEFAULT_DB_PATH = resolveDefaultDbPath();
+const DEFAULT_DB_PATH = join(homedir(), ".openclaw", "memory", "lancedb");
 
 const EMBEDDING_DIMENSIONS: Record<string, number> = {
   "text-embedding-3-small": 1536,


### PR DESCRIPTION
## What Problem This Solves

The memory-lancedb default database path resolver still performed filesystem checks and contained a legacy-directory scan even though the legacy directory list is permanently empty. Every branch ultimately returned the same preferred path.

## Why This Change Was Made

Replace the no-op resolver with the direct default path expression and remove the now-unused filesystem import. This is a behavior-neutral 29-line simplification in the existing config owner.

AI-assisted: yes. The branch was reviewed with the mandated Codex autoreview helper.

## User Impact

No user-visible behavior or config shape changes. The default remains `~/.openclaw/memory/lancedb`; plugin startup no longer performs redundant synchronous existence checks.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-lancedb/config.test.ts` — 10 passed.
- `node scripts/run-vitest.mjs extensions/memory-lancedb/index.test.ts` — 137 passed.
- `node scripts/check-changed.mjs -- extensions/memory-lancedb/config.ts` — passed on Blacksmith Testbox, including extension production/test typechecks, formatting, lint, import-cycle checks, and architecture guards.
- Global autoreview helper, Codex branch mode against `origin/main` — clean, 0 accepted/actionable findings.
