### PR TITLE
fix(cron): stop running job when cron.remove is called

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -19,8 +19,6 @@ import {
   isCronJobActive,
   markCronJobActive,
   type CronActiveJobMarker,
-  advanceCronActiveJobGeneration,
-  waitForActiveCronJobs,
 } from "../active-jobs.js";
 import { resolveCronListSnapshotRevision } from "../list-snapshot-revision.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
@@ -30,6 +28,10 @@ import {
   readCronJobScratchState,
   writeCronJobScratch,
 } from "../scratch-store.js";
+import {
+  cancelActiveCronTaskRun,
+  waitForActiveCronTaskRuns,
+} from "../service/active-run-cancellation.js";
 import { createCronStreamSourceIdentity, cronStreamScheduleKey } from "../stream-schedule.js";
 import { normalizeCronTaskRunJobId } from "../task-run-history.js";
 import type {
@@ -986,13 +988,14 @@ export async function remove(
       );
     }
 
-    // If the job is currently running, advance the generation to abort it
-    // and wait for it to finish before removing.
+    // If the job is currently running, cancel it by its runId
+    // and wait for it to finish draining before removing.
     if (removedJob && isCronJobActive(id)) {
       state.deps.log.info({ jobId: id }, "cron: aborting active job before removal");
-      advanceCronActiveJobGeneration();
-      // Wait for the job to finish/abort (bounded wait)
-      await waitForActiveCronJobs(30_000);
+      const runId = `cron-active:${id}`;
+      cancelActiveCronTaskRun({ runId, reason: "Job removed via cron remove" });
+      // Wait for the specific job run to finish draining (bounded wait)
+      await waitForActiveCronTaskRuns(30_000);
     }
 
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -19,6 +19,8 @@ import {
   isCronJobActive,
   markCronJobActive,
   type CronActiveJobMarker,
+  advanceCronActiveJobGeneration,
+  waitForActiveCronJobs,
 } from "../active-jobs.js";
 import { resolveCronListSnapshotRevision } from "../list-snapshot-revision.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
@@ -983,6 +985,16 @@ export async function remove(
         "heartbeat monitor jobs are system-owned; edit agents.*.heartbeat config instead",
       );
     }
+
+    // If the job is currently running, advance the generation to abort it
+    // and wait for it to finish before removing.
+    if (removedJob && isCronJobActive(id)) {
+      state.deps.log.info({ jobId: id }, "cron: aborting active job before removal");
+      advanceCronActiveJobGeneration();
+      // Wait for the job to finish/abort (bounded wait)
+      await waitForActiveCronJobs(state, id, 30_000);
+    }
+
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
     const removed = (state.store.jobs.length ?? 0) !== before;
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -992,7 +992,7 @@ export async function remove(
       state.deps.log.info({ jobId: id }, "cron: aborting active job before removal");
       advanceCronActiveJobGeneration();
       // Wait for the job to finish/abort (bounded wait)
-      await waitForActiveCronJobs(state, id, 30_000);
+      await waitForActiveCronJobs(30_000);
     }
 
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);


### PR DESCRIPTION
## What Problem This Solves

Fixes issue [#28715](https://github.com/openclaw/openclaw/issues/28715): `openclaw cron remove` reports success but the job frequently remains active in background and configuration files are not cleaned up.

## Why This Change Was Made

The `cron.remove` function was removing the job from the store without checking if the job was currently running. If the job was active, it would continue running in the background because:

1. The active job marker wasn't cleared
2. The job's AbortController wasn't triggered
3. The job would complete naturally but the user had no visibility into this

## User Impact

- `cron remove` now properly stops the running job before removing it
- Job is fully drained/cleaned up before removal
- No more phantom background jobs after removal
- Configuration cleanup happens after the job stops

## Solution Details

In `src/cron/service/ops.ts` `remove` function:

1. Check if job is currently running via `isCronJobActive(jobId)`
2. If running, abort the job via its AbortController (stored in active cron task runs)
3. Wait for the job to finish draining using `waitForActiveCronJobs`
4. Then proceed with removal from store and scratch cleanup

Fixes #28715