### PR TITLE
fix(test): satisfy no-map-spread in exec approvals

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -1293,7 +1293,9 @@ $0 \\"$1\\"" touch {marker}`,
 
     const scriptResult = evaluateExecAllowlist({
       analysis,
-      allowlist: entries.map((entry) => ({ ...entry, source: "allow-always" as const })),
+      allowlist: entries.map((entry) =>
+        Object.assign({}, entry, { source: "allow-always" as const }),
+      ),
       safeBins: resolveSafeBins(undefined),
       cwd: dir,
       env,


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the core lint gate at `src/infra/exec-approvals-allow-always.test.ts:1296` with `oxc(no-map-spread)`, blocking merge gates for unrelated PRs.

Provenance: commit `1fc81c20548e3323c2f5ab05cd41338b5647c726`, merged through PR #112946, introduced the failing expression. The failure is captured in CI run https://github.com/openclaw/openclaw/actions/runs/30085311660, job `check-lint`.

## Why This Change Was Made

Replace the object spread inside `entries.map` with `Object.assign({}, entry, { source: "allow-always" as const })`. This preserves the fresh shallow copy, property order, entry values, and final source override while satisfying the lint rule. No assertions or test inputs change.

AI-assisted: yes. The mandated global Codex autoreview helper completed cleanly; no substitute helper was needed.

## User Impact

No product or test behavior changes. The repair restores the shared lint/merge gate so unrelated PRs, including #113299, can proceed.

## Evidence

- `node scripts/run-vitest.mjs src/infra/exec-approvals-allow-always.test.ts` — 129 passed.
- Targeted `oxlint src/infra/exec-approvals-allow-always.test.ts` — passed.
- `node scripts/check-changed.mjs -- src/infra/exec-approvals-allow-always.test.ts` — passed on Blacksmith Testbox, Actions run https://github.com/openclaw/openclaw/actions/runs/30085883255; test typecheck, formatting, and focused lint are green.
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
