### PR TITLE
fix(update): backport JSON resume isolation to 2026.7.2

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1005,8 +1005,9 @@ describe("update-cli", () => {
     ...overrides,
   });
 
-  const runPostCoreUpdate = (env: NodeJS.ProcessEnv = {}) =>
-    withEnvAsync(
+  const runPostCoreUpdate = (env: NodeJS.ProcessEnv = {}) => {
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
+    return withEnvAsync(
       {
         OPENCLAW_UPDATE_POST_CORE: "1",
         OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
@@ -1016,12 +1017,14 @@ describe("update-cli", () => {
         await updateCommand({ yes: true, restart: false });
       },
     );
+  };
 
   const runPostCoreCommand = (
     options: Parameters<typeof updateCommand>[0],
     env: NodeJS.ProcessEnv = {},
-  ) =>
-    withEnvAsync(
+  ) => {
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
+    return withEnvAsync(
       {
         OPENCLAW_UPDATE_POST_CORE: "1",
         OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
@@ -1031,6 +1034,7 @@ describe("update-cli", () => {
         await updateCommand(options);
       },
     );
+  };
 
   const setupInstalledPackageAtNodeModules = async (nodeModules: string, version = "2026.4.21") => {
     const pkgRoot = path.join(nodeModules, "openclaw");
@@ -1472,6 +1476,34 @@ describe("update-cli", () => {
       suppressFutureVersionWarning: true,
     });
     expectNoSideEffects(updateNpmInstalledPlugins, runDaemonInstall, runDaemonRestart);
+  });
+
+  it("routes JSON post-core child output to stderr", async () => {
+    const { entrypoints } = setupUpdatedRootRefresh();
+    const stdoutPipe = vi.fn();
+    const stderrPipe = vi.fn();
+    spawn.mockImplementationOnce(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        once: EventEmitter["once"];
+        stdout: { pipe: typeof stdoutPipe };
+        stderr: { pipe: typeof stderrPipe };
+      };
+      child.stdout = { pipe: stdoutPipe };
+      child.stderr = { pipe: stderrPipe };
+      queueMicrotask(() => {
+        child.emit("exit", 0, null);
+      });
+      return child;
+    });
+
+    await updateCommand({ json: true, restart: false });
+
+    const call = spawnCall();
+    expect(call?.[1]).toEqual([entrypoints[0], "update", "--json", "--no-restart"]);
+    expect(call?.[2]?.stdio).toBe("pipe");
+    expect(stdoutPipe).toHaveBeenCalledWith(process.stderr);
+    expect(stdoutPipe).not.toHaveBeenCalledWith(process.stdout);
+    expect(stderrPipe).toHaveBeenCalledWith(process.stderr);
   });
 
   it("finishes package updates when the post-core process writes a result but keeps handles open", async () => {
@@ -1984,17 +2016,35 @@ describe("update-cli", () => {
         ),
     ).toBe(true);
     expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
-    expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
-      nonInteractive: true,
-      repair: true,
-      yes: false,
-    });
-    expect(vi.mocked(doctorCommand).mock.invocationCallOrder[0] ?? 0).toBeLessThan(
+    expectFreshPostUpdateDoctor({ yes: false });
+    const freshDoctorCall = vi
+      .mocked(runExec)
+      .mock.calls.find(
+        ([, args]) => args[0] === FRESH_POST_UPDATE_ENTRYPOINT && args[1] === "doctor",
+      );
+    expect(freshDoctorCall).toBeDefined();
+    expect(vi.mocked(runExec).mock.invocationCallOrder[0] ?? 0).toBeLessThan(
       syncPluginsForUpdateChannel.mock.invocationCallOrder[0] ?? 0,
     );
     expect(syncPluginsForUpdateChannel).toHaveBeenCalledTimes(1);
     expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
     expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("keeps fresh doctor output off stdout during json post-core resume", async () => {
+    vi.mocked(runExec).mockResolvedValueOnce({
+      stdout: "doctor ui output",
+      stderr: "doctor diagnostic output",
+    });
+
+    await runPostCoreCommand({ json: true, restart: false });
+
+    expectFreshPostUpdateDoctor({ yes: false });
+    expect(getLogOutput()).not.toContain("doctor ui output");
+    expect(getErrorOutput()).not.toContain("doctor diagnostic output");
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "ok" }),
+    );
   });
 
   it("post-core resume children exit after writing a plugin update result", async () => {

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -82,7 +82,7 @@ function createPostPluginDoctorExecutionFailure(
   };
 }
 
-async function runPostPluginDoctorInFreshProcess(params: {
+export async function runUpdateFinalizationDoctorInFreshProcess(params: {
   root: string;
   yes: boolean;
   json: boolean;
@@ -177,7 +177,7 @@ async function applyFreshPostPluginDoctor(params: {
   }
   let pluginUpdate = params.pluginUpdate;
   try {
-    await runPostPluginDoctorInFreshProcess({ ...params, entryPath });
+    await runUpdateFinalizationDoctorInFreshProcess({ ...params, entryPath });
   } catch (err) {
     pluginUpdate = createPostPluginDoctorExecutionFailure(params.pluginUpdate, String(err));
   }

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -430,8 +430,9 @@ function stopPostCoreUpdateChild(child: ChildProcess): void {
  */
 export function resolvePostCoreUpdateChildStdio(
   platform: NodeJS.Platform = process.platform,
+  jsonMode = false,
 ): "inherit" | "pipe" {
-  return platform === "win32" ? "pipe" : "inherit";
+  return platform === "win32" || jsonMode ? "pipe" : "inherit";
 }
 
 function preparePostCorePluginInstallRecordsForFreshProcess(params: {
@@ -515,7 +516,8 @@ export async function continuePostCoreUpdateInFreshProcess(params: {
     }
     await writePostCorePluginInstallRecordsFile(installRecordsPath, pluginInstallRecords);
     await writePostCoreSourceConfigFile(sourceConfigPath, params.preUpdateConfig);
-    const childStdio = resolvePostCoreUpdateChildStdio();
+    const jsonMode = params.opts.json === true;
+    const childStdio = resolvePostCoreUpdateChildStdio(process.platform, jsonMode);
     const child = spawn(params.nodeRunner ?? resolveNodeRunner(), argv, {
       stdio: childStdio,
       env: {
@@ -537,9 +539,9 @@ export async function continuePostCoreUpdateInFreshProcess(params: {
           : {}),
       },
     });
-    // When piped, relay child output to the parent process so terminal output is preserved.
+    // JSON callers own stdout, so child diagnostics must remain off that protocol stream.
     if (childStdio === "pipe") {
-      child.stdout?.pipe(process.stdout);
+      child.stdout?.pipe(jsonMode ? process.stderr : process.stdout);
       child.stderr?.pipe(process.stderr);
     }
 

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -1,4 +1,3 @@
-import { doctorCommand } from "../../commands/doctor.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV } from "../../infra/update-post-core-context.js";
@@ -17,7 +16,7 @@ import {
 } from "./update-command-config.js";
 import {
   completePostCorePluginUpdate,
-  withUpdateFinalizationEnv,
+  runUpdateFinalizationDoctorInFreshProcess,
 } from "./update-command-fresh-doctor.js";
 import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
 import {
@@ -76,13 +75,12 @@ async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams):
     currentSnapshot: configSnapshot,
     updateStartedAtMs,
   });
-  await withUpdateFinalizationEnv(async () => {
-    await createUpdateConfigSnapshot();
-    await doctorCommand(defaultRuntime, {
-      nonInteractive: true,
-      repair: true,
-      yes: params.opts.yes === true,
-    });
+  await createUpdateConfigSnapshot();
+  await runUpdateFinalizationDoctorInFreshProcess({
+    root: params.root,
+    yes: params.opts.yes === true,
+    json: params.opts.json === true,
+    timeoutMs: params.timeoutMs,
   });
   // The fresh process owns the updated migration contracts. Repair before
   // plugin convergence writes config, or newly retired plugin keys can block

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -886,6 +886,11 @@ describe("resolvePostCoreUpdateChildStdio", () => {
     expect(resolvePostCoreUpdateChildStdio("linux")).toBe("inherit");
     expect(resolvePostCoreUpdateChildStdio("darwin")).toBe("inherit");
   });
+
+  it('returns "pipe" for JSON output on every platform', () => {
+    expect(resolvePostCoreUpdateChildStdio("linux", true)).toBe("pipe");
+    expect(resolvePostCoreUpdateChildStdio("darwin", true)).toBe("pipe");
+  });
 });
 
 describe("updatePluginsAfterCoreUpdate (invalid config end-to-end)", () => {


### PR DESCRIPTION
Backport of https://github.com/openclaw/openclaw/pull/113298

## What Problem This Solves

Fixes an issue where users running `openclaw update --json` through an older installed updater could receive post-core doctor output on stdout, making the final update payload invalid JSON during the 2026.7.2 beta upgrade.

## Why This Change Was Made

Backports the landed main fix exactly with `-x`: the updated resume process runs final doctor repair in a captured fresh process, while JSON-mode post-core diagnostics are routed away from the outer stdout protocol.

## User Impact

Automations can parse `openclaw update --json` reliably while migrations and plugin convergence run after a core package swap.

## Evidence

- Main fix merged: https://github.com/openclaw/openclaw/pull/113298
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/cli/update-cli/update-command.test.ts` - 247 passed.
- `oxfmt --check` on all changed files - passed.
- `git diff --check` - passed.
- Release-branch Codex autoreview - clean, no accepted/actionable findings.
- Installed-updater Testbox run 30085953701 proved valid structured JSON; the release branch already contains fixture cleanup `0aab67cef05` needed for the exact channel-switch rerun.