### PR TITLE
fix: WhatsApp debounce blocks active-run steering

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -571,10 +571,17 @@ export async function attachWebInboxToSocket(
     };
   };
 
+  const reportInboundFlushError = (err: unknown) => {
+    inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
+    inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
+  };
   const debouncer = createInboundDebouncer<QueuedInboundMessage>({
     debounceMs: inboundDebounceMs,
     buildKey: (msg) => msg.debounceKey ?? buildInboundDebounceKey(msg),
     shouldDebounce: shouldDebounceInboundMessage,
+    // Return as soon as delivery into the session lane begins so a later same-key
+    // flush can steer the active run. Keep activeInboundFlushes until the turn
+    // settles so close() still drains in-flight work (#113180).
     onFlush: async (entries) => {
       let finishFlush!: () => void;
       const flushTask = new Promise<void>((resolve) => {
@@ -583,91 +590,91 @@ export async function attachWebInboxToSocket(
       activeInboundFlushes.add(flushTask);
       publishPendingWorkState();
       notifyDebounceWork();
-      try {
-        const orderedEntries = orderDebouncedInboundEntries(entries);
-        const last = orderedEntries.at(-1);
-        if (!last) {
-          return;
-        }
-        const { lifecycle, settle, abandon } = buildFlushIngressLifecycle(orderedEntries);
+      const runFlush = async () => {
         try {
-          if (orderedEntries.length === 1) {
-            await options.onMessage(attachWhatsAppIngressLifecycle(last, lifecycle));
+          const orderedEntries = orderDebouncedInboundEntries(entries);
+          const last = orderedEntries.at(-1);
+          if (!last) {
+            return;
+          }
+          const { lifecycle, settle, abandon } = buildFlushIngressLifecycle(orderedEntries);
+          try {
+            if (orderedEntries.length === 1) {
+              await options.onMessage(attachWhatsAppIngressLifecycle(last, lifecycle));
+              await settle();
+              await Promise.all(
+                orderedEntries.map((entry) => maybeMarkInboundAsRead(entry.readReceipt)),
+              );
+              return;
+            }
+            const mentioned = new Set<string>();
+            for (const entry of orderedEntries) {
+              for (const jid of entry.group?.mentions?.jids ?? []) {
+                mentioned.add(jid);
+              }
+            }
+            const combinedBody = orderedEntries
+              .map((entry) => entry.payload.body)
+              .filter(Boolean)
+              .join("\n");
+            const combinedCommandBody = orderedEntries
+              .map((entry) => entry.payload.commandBody ?? entry.payload.body)
+              .filter(Boolean)
+              .join("\n");
+            const combinedMentions =
+              mentioned.size > 0
+                ? {
+                    ...last.group?.mentions,
+                    jids: Array.from(mentioned),
+                  }
+                : last.group?.mentions;
+            const combinedGroup =
+              last.group || combinedMentions
+                ? {
+                    ...last.group,
+                    mentions: combinedMentions,
+                  }
+                : undefined;
+            const combinedMessage: QueuedInboundMessage = attachWhatsAppIngressLifecycle(
+              withDeprecatedWebInboundMessageFlatAliases({
+                ...last,
+                ...(lifecycle ? { turnAdoptionLifecycle: lifecycle } : {}),
+                payload: {
+                  ...last.payload,
+                  body: combinedBody,
+                  commandBody: combinedCommandBody,
+                },
+                group: combinedGroup,
+                event: {
+                  ...last.event,
+                  isBatched: true,
+                },
+              }),
+              lifecycle,
+            );
+            await options.onMessage(combinedMessage);
             await settle();
             await Promise.all(
               orderedEntries.map((entry) => maybeMarkInboundAsRead(entry.readReceipt)),
             );
-            return;
+          } catch (error) {
+            await abandon();
+            throw error;
           }
-          const mentioned = new Set<string>();
-          for (const entry of orderedEntries) {
-            for (const jid of entry.group?.mentions?.jids ?? []) {
-              mentioned.add(jid);
+        } finally {
+          for (const entry of entries) {
+            if (entry.debounceKey) {
+              pendingDebounceKeys.delete(entry.debounceKey);
             }
           }
-          const combinedBody = orderedEntries
-            .map((entry) => entry.payload.body)
-            .filter(Boolean)
-            .join("\n");
-          const combinedCommandBody = orderedEntries
-            .map((entry) => entry.payload.commandBody ?? entry.payload.body)
-            .filter(Boolean)
-            .join("\n");
-          const combinedMentions =
-            mentioned.size > 0
-              ? {
-                  ...last.group?.mentions,
-                  jids: Array.from(mentioned),
-                }
-              : last.group?.mentions;
-          const combinedGroup =
-            last.group || combinedMentions
-              ? {
-                  ...last.group,
-                  mentions: combinedMentions,
-                }
-              : undefined;
-          const combinedMessage: QueuedInboundMessage = attachWhatsAppIngressLifecycle(
-            withDeprecatedWebInboundMessageFlatAliases({
-              ...last,
-              ...(lifecycle ? { turnAdoptionLifecycle: lifecycle } : {}),
-              payload: {
-                ...last.payload,
-                body: combinedBody,
-                commandBody: combinedCommandBody,
-              },
-              group: combinedGroup,
-              event: {
-                ...last.event,
-                isBatched: true,
-              },
-            }),
-            lifecycle,
-          );
-          await options.onMessage(combinedMessage);
-          await settle();
-          await Promise.all(
-            orderedEntries.map((entry) => maybeMarkInboundAsRead(entry.readReceipt)),
-          );
-        } catch (error) {
-          await abandon();
-          throw error;
+          activeInboundFlushes.delete(flushTask);
+          finishFlush();
+          publishPendingWorkState();
         }
-      } finally {
-        for (const entry of entries) {
-          if (entry.debounceKey) {
-            pendingDebounceKeys.delete(entry.debounceKey);
-          }
-        }
-        activeInboundFlushes.delete(flushTask);
-        finishFlush();
-        publishPendingWorkState();
-      }
+      };
+      void runFlush().catch(reportInboundFlushError);
     },
-    onError: (err) => {
-      inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
-      inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
-    },
+    onError: reportInboundFlushError,
   });
   const groupMetadataCache = options.groupMetadataCache ?? new Map();
   const groupMetaCache = new Map<string, LocalGroupMetadataCacheEntry>();

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -980,68 +980,116 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
-  it("drains serialized same-lane messages after close", async () => {
-    vi.useFakeTimers();
-    try {
-      let releaseFirst: (() => void) | undefined;
-      const firstTurn = new Promise<void>((resolve) => {
-        releaseFirst = resolve;
-      });
-      const onMessage = vi.fn(async () => {
-        if (onMessage.mock.calls.length === 1) {
-          await firstTurn;
-        }
-      });
-      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
-        debounceMs: 50,
-      });
-      sock.ev.emit(
-        "messages.upsert",
-        buildNotifyMessageUpsert({
-          id: nextMessageId("debounce-close-1"),
-          remoteJid: "999@s.whatsapp.net",
-          text: "first",
-          timestamp: 1_700_000_000,
-          pushName: "Tester",
-        }),
-      );
-      await vi.advanceTimersByTimeAsync(50);
-      await waitForMessageCalls(onMessage, 1);
-      expect(inboundMessage(onMessage).payload.body).toBe("first");
-
-      const second = buildNotifyMessageUpsert({
-        id: nextMessageId("debounce-close-2"),
+  it("lets a later same-key flush start while an earlier turn is still active", async () => {
+    // Debounce must release the conversation key once delivery begins so a
+    // follow-up can steer the active run (#113180). Adopt immediately to mirror
+    // session-lane acceptance while the turn itself remains in flight.
+    let releaseFirst: (() => void) | undefined;
+    const firstTurn = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      await lifecycle.onAdopted();
+      if (onMessage.mock.calls.length === 1) {
+        await firstTurn;
+      }
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 20,
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("debounce-steer-1"),
         remoteJid: "999@s.whatsapp.net",
-        text: "second",
+        text: "first",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+    expect(inboundMessage(onMessage).payload.body).toBe("first");
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("debounce-steer-2"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "steer",
         timestamp: 1_700_000_001,
         pushName: "Tester",
-      });
-      const third = buildNotifyMessageUpsert({
-        id: nextMessageId("debounce-close-3"),
+      }),
+    );
+    await waitForMessageCalls(onMessage, 2);
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("steer");
+
+    releaseFirst?.();
+    await listener.close();
+  });
+
+  it("drains same-lane messages after close while an earlier turn is still active", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstTurn = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      await lifecycle.onAdopted();
+      if (onMessage.mock.calls.length === 1) {
+        await firstTurn;
+      }
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 20,
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("debounce-close-1"),
         remoteJid: "999@s.whatsapp.net",
-        text: "third",
-        timestamp: 1_700_000_002,
+        text: "first",
+        timestamp: 1_700_000_000,
         pushName: "Tester",
-      });
-      sock.ev.emit("messages.upsert", {
-        type: "notify",
-        messages: [...second.messages, ...third.messages],
-      });
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+    expect(inboundMessage(onMessage).payload.body).toBe("first");
 
-      const closePromise = listener.close();
-      expect(onMessage).toHaveBeenCalledTimes(1);
+    const second = buildNotifyMessageUpsert({
+      id: nextMessageId("debounce-close-2"),
+      remoteJid: "999@s.whatsapp.net",
+      text: "second",
+      timestamp: 1_700_000_001,
+      pushName: "Tester",
+    });
+    const third = buildNotifyMessageUpsert({
+      id: nextMessageId("debounce-close-3"),
+      remoteJid: "999@s.whatsapp.net",
+      text: "third",
+      timestamp: 1_700_000_002,
+      pushName: "Tester",
+    });
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [...second.messages, ...third.messages],
+    });
 
-      releaseFirst?.();
-      await closePromise;
+    const closePromise = listener.close();
+    await waitForMessageCalls(onMessage, 3);
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("second");
+    expect(inboundMessage(onMessage, 1).admission?.conversation.kind).toBe("direct");
+    expect(inboundMessage(onMessage, 2).payload.body).toBe("third");
+    expect(inboundMessage(onMessage, 2).admission?.conversation.kind).toBe("direct");
 
-      expect(onMessage).toHaveBeenCalledTimes(3);
-      expect(inboundMessage(onMessage, 1).payload.body).toBe("second");
-      expect(inboundMessage(onMessage, 1).admission?.conversation.kind).toBe("direct");
-      expect(inboundMessage(onMessage, 2).payload.body).toBe("third");
-      expect(inboundMessage(onMessage, 2).admission?.conversation.kind).toBe("direct");
-    } finally {
-      vi.useRealTimers();
-    }
+    releaseFirst?.();
+    await closePromise;
   });
 
   it("completes shutdown under a long durable debounce without waiting for the window", async () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -754,6 +754,66 @@ describe("createInboundDebouncer", () => {
     await Promise.all([first, second]);
   });
 
+  it("allows a later debounced flush when onFlush returns before the turn settles", async () => {
+    // Callers that kick off delivery without awaiting the full agent turn can
+    // release the keyed chain so a follow-up flush can steer (#113180).
+    const started: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 50,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        void (async () => {
+          const id = items[0]?.id ?? "";
+          started.push(id);
+          if (id === "1") {
+            await firstGate;
+          }
+        })();
+      },
+    });
+
+    try {
+      await debouncer.enqueue({ key: "a", id: "1" });
+      const firstTimerIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 50);
+      expect(firstTimerIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[firstTimerIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      (setTimeoutSpy.mock.calls[firstTimerIndex]?.[0] as (() => void) | undefined)?.();
+
+      await vi.waitFor(() => {
+        expect(started).toEqual(["1"]);
+      });
+
+      await debouncer.enqueue({ key: "a", id: "2" });
+      const secondTimerIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call, index) => index > firstTimerIndex && call[1] === 50,
+      );
+      expect(secondTimerIndex).toBeGreaterThan(firstTimerIndex);
+      clearTimeout(
+        setTimeoutSpy.mock.results[secondTimerIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      (setTimeoutSpy.mock.calls[secondTimerIndex]?.[0] as (() => void) | undefined)?.();
+
+      await vi.waitFor(() => {
+        expect(started).toEqual(["1", "2"]);
+      });
+
+      if (!releaseFirst) {
+        throw new Error("Expected first inbound debounce release callback to be initialized");
+      }
+      releaseFirst();
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("serializes keyed turns when immediate serialization is enabled", async () => {
     const started: string[] = [];
     let releaseFirst: (() => void) | undefined;


### PR DESCRIPTION
Closes #113180

## What Problem This Solves

Fixes an issue where WhatsApp users with inbound debounce enabled could not steer an active agent turn — a follow-up message waited until the previous turn finished.

## Why This Change Was Made

Debounce flush held the conversation key for the full agent turn. It now releases once delivery into the session lane begins, while still tracking in-flight work for shutdown drain.

## User Impact

With debounce on, a later WhatsApp message in the same chat can steer the active run instead of queuing behind it.

## Evidence

- `node scripts/run-vitest.mjs run extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts -t "later same-key flush|same-lane messages after close"`
- `node scripts/run-vitest.mjs run src/auto-reply/inbound.test.ts -t "returns before the turn settles"`
- autoreview clean on `c89c8567`


Made with [Cursor](https://cursor.com)