### PR TITLE
fix(doctor): prevent legacy channel config from blocking upgrades

### DIFF
--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   applyPluginAutoEnable: vi.fn(),
   materializePluginAutoEnableCandidates: vi.fn(),
   collectActiveToolSchemaProjectionWarnings: vi.fn(),
+  collectChannelDoctorCompatibilityMutations: vi.fn(),
   ensureAuthProfileStore: vi.fn(),
   evaluateStoredCredentialEligibility: vi.fn(),
   getInstalledPluginRecord: vi.fn(),
@@ -76,6 +77,7 @@ vi.mock("../../plugins/installed-plugin-index.js", async (importOriginal) => ({
 }));
 
 vi.mock("./shared/channel-doctor.js", () => ({
+  collectChannelDoctorCompatibilityMutations: mocks.collectChannelDoctorCompatibilityMutations,
   collectChannelDoctorRepairMutations: ({ cfg }: { cfg: OpenClawConfig }) => {
     const allowFrom = cfg.channels?.discord?.allowFrom as unknown[] | undefined;
     if (allowFrom?.[0] === 123) {
@@ -287,6 +289,7 @@ describe("doctor repair sequencing", () => {
       warnings: [],
     });
     mocks.collectActiveToolSchemaProjectionWarnings.mockReturnValue([]);
+    mocks.collectChannelDoctorCompatibilityMutations.mockReturnValue([]);
     mocks.resolveAuthProfileOrder.mockReturnValue([]);
     mocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(null);
     mocks.maybeRepairStalePluginConfig.mockImplementation((cfg: OpenClawConfig) => ({
@@ -656,6 +659,91 @@ describe("doctor repair sequencing", () => {
     expect(result.changeNotes).toStrictEqual([
       'Installed missing configured plugin "brave" from @openclaw/brave-plugin.',
       "brave web search provider selected, enabled automatically.",
+    ]);
+  });
+
+  it("applies doctor contracts exposed by newly installed plugins", async () => {
+    mocks.repairMissingConfiguredPluginInstalls.mockResolvedValueOnce({
+      changes: ['Installed missing configured plugin "discord" from @openclaw/discord.'],
+      warnings: [],
+      repairedPluginIds: ["discord"],
+    });
+    mocks.materializePluginAutoEnableCandidates.mockImplementationOnce(
+      (params: { config: OpenClawConfig }) => ({
+        config: {
+          ...params.config,
+          plugins: {
+            ...params.config.plugins,
+            entries: {
+              ...params.config.plugins?.entries,
+              discord: { enabled: true },
+            },
+          },
+        },
+        changes: ["discord installed for existing configuration, enabled automatically."],
+      }),
+    );
+    mocks.collectChannelDoctorCompatibilityMutations.mockImplementationOnce(
+      (cfg: OpenClawConfig) => [
+        {
+          config: {
+            ...cfg,
+            channels: {
+              ...cfg.channels,
+              discord: {
+                ...cfg.channels?.discord,
+                dmPolicy: "allowlist",
+                allowFrom: [123],
+                dm: { enabled: true },
+              },
+            },
+          },
+          changes: [
+            "Moved channels.discord.dm.policy → channels.discord.dmPolicy.",
+            "Moved channels.discord.dm.allowFrom → channels.discord.allowFrom.",
+          ],
+        },
+      ],
+    );
+
+    const result = await runDoctorRepairSequence({
+      state: {
+        cfg: {
+          channels: {
+            discord: {
+              dm: { enabled: true, policy: "allowlist", allowFrom: [123] },
+            },
+          },
+        } as OpenClawConfig,
+        candidate: {
+          channels: {
+            discord: {
+              dm: { enabled: true, policy: "allowlist", allowFrom: [123] },
+            },
+          },
+        } as OpenClawConfig,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(mocks.collectChannelDoctorCompatibilityMutations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: { entries: { discord: { enabled: true } } },
+      }),
+      { env: process.env },
+    );
+    expect(result.state.candidate.channels?.discord).toEqual({
+      dmPolicy: "allowlist",
+      allowFrom: ["123"],
+      dm: { enabled: true },
+    });
+    expect(result.changeNotes).toStrictEqual([
+      'Installed missing configured plugin "discord" from @openclaw/discord.',
+      "discord installed for existing configuration, enabled automatically.",
+      "Moved channels.discord.dm.policy → channels.discord.dmPolicy.\nMoved channels.discord.dm.allowFrom → channels.discord.allowFrom.",
+      "channels.discord.allowFrom: converted 1 numeric ID to strings",
     ]);
   });
 

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -21,6 +21,7 @@ import { maybeRepairGroupAllowFromFallback } from "./shared/allowfrom-fallback-m
 import { maybeRepairAllowlistPolicyAllowFrom } from "./shared/allowlist-policy-repair.js";
 import { maybeRepairBundledPluginLoadPaths } from "./shared/bundled-plugin-load-paths.js";
 import {
+  collectChannelDoctorCompatibilityMutations,
   createChannelDoctorEmptyAllowlistPolicyHooks,
   collectChannelDoctorRepairMutations,
 } from "./shared/channel-doctor.js";
@@ -144,6 +145,19 @@ export async function runDoctorRepairSequence(params: {
           })),
         }),
       );
+      // Missing external plugins cannot expose their doctor contracts until
+      // installation completes. Normalize legacy shapes before channel repair
+      // so later validation and gateway restart consume canonical config.
+      for (const mutation of collectChannelDoctorCompatibilityMutations(state.candidate, { env })) {
+        applyMutation(mutation);
+      }
+      for (const mutation of await collectChannelDoctorRepairMutations({
+        cfg: state.candidate,
+        doctorFixCommand: params.doctorFixCommand,
+        env,
+      })) {
+        applyMutation(mutation);
+      }
     }
   }
   if (missingConfiguredPluginInstallRepair.warnings.length > 0) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading with a configured external channel plugin could end up with an invalid legacy channel config when the plugin had to be installed during doctor repair. The gateway restart then failed even though doctor reported the plugin installation as successful.

## Why This Change Was Made

After a missing plugin is installed and enabled, doctor now runs the compatibility normalizers that became available from that plugin before later validation and restart processing. The pass uses the existing generic channel doctor contract and remains scoped to upgrades that actually repaired plugin installs.

## User Impact

Upgrades can migrate plugin-owned legacy channel settings in the same repair pass and restart the gateway with valid config. This specifically fixes the beta5 release gate where legacy Discord `dm.policy` and `dm.allowFrom` survived external plugin installation.

## Evidence

- Reproduced in exact-SHA release validation: https://github.com/openclaw/openclaw/actions/runs/30090205409 (Docker lane `update-restart-auth`)
- `node scripts/run-vitest.mjs src/commands/doctor/repair-sequencing.test.ts` (18 passed)
- `node scripts/check-changed.mjs -- src/commands/doctor/repair-sequencing.ts src/commands/doctor/repair-sequencing.test.ts` (passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30090887228)
- Autoreview clean, patch correct 0.91

AI-assisted: yes.