### PR TITLE
fix(ui): preserve session identity across gateway snapshots

### DIFF
--- a/test/vitest/vitest.ui.config.ts
+++ b/test/vitest/vitest.ui.config.ts
@@ -12,6 +12,7 @@ import { jsdomOptimizedDeps } from "./vitest.shared.config.ts";
 // keep this list in sync with vitest.ui-isolated.config.ts's include.
 export const UI_ISOLATED_TEST_FILES = [
   "ui/src/pages/chat/chat-pane-history.test.ts",
+  "ui/src/pages/chat/chat-pane-identity.test.ts",
   "ui/src/pages/chat/chat-pane-lifecycle.test.ts",
   "ui/src/pages/chat/chat-pane-pull-requests.test.ts",
   "ui/src/pages/chat/chat-pane.message-cut.test.ts",

--- a/ui/src/pages/chat/chat-pane-identity.test.ts
+++ b/ui/src/pages/chat/chat-pane-identity.test.ts
@@ -1,0 +1,40 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { createTestChatPane } from "./chat-pane.test-support.ts";
+import type { ChatPageHost } from "./chat-state.ts";
+
+describe("chat pane assistant identity snapshots", () => {
+  it("keeps a session-specific assistant identity across ordinary gateway snapshots", () => {
+    const client = {} as GatewayBrowserClient;
+    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const state = (pane as unknown as { state: ChatPageHost }).state;
+    state.client = client;
+    state.connected = true;
+    state.assistantName = "Session Agent";
+
+    pane.applyGatewaySnapshot({
+      ...pane.context.gateway.snapshot,
+      client,
+    });
+
+    expect(state.assistantName).toBe("Session Agent");
+  });
+
+  it("resets a session-specific identity when the logical connection changes", () => {
+    const client = {} as GatewayBrowserClient;
+    const nextClient = {} as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    state.assistantName = "Session Agent";
+
+    pane.applyGatewaySnapshot({
+      ...pane.context.gateway.snapshot,
+      client: nextClient,
+      phase: "reconnecting" as const,
+    });
+
+    expect(state.assistantName).toBe(pane.context.config.current.assistantIdentity.name);
+  });
+});

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -170,7 +170,7 @@ describe("chat pane pull request refresh", () => {
 
   it("keeps a session-specific assistant identity across ordinary gateway snapshots", () => {
     const client = {} as GatewayBrowserClient;
-    const { pane } = createTestChatPane({ client });
+    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
     const state = (pane as unknown as { state: ChatPageHost }).state;
     state.client = client;
     state.connected = true;
@@ -179,7 +179,6 @@ describe("chat pane pull request refresh", () => {
     pane.applyGatewaySnapshot({
       ...pane.context.gateway.snapshot,
       client,
-      connected: true,
     });
 
     expect(state.assistantName).toBe("Session Agent");
@@ -188,13 +187,13 @@ describe("chat pane pull request refresh", () => {
   it("resets a session-specific identity when the logical connection changes", () => {
     const client = {} as GatewayBrowserClient;
     const nextClient = {} as GatewayBrowserClient;
-    const { pane, state } = createTestChatPane({ client });
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
     state.assistantName = "Session Agent";
 
     pane.applyGatewaySnapshot({
       ...pane.context.gateway.snapshot,
       client: nextClient,
-      connected: false,
+      phase: "reconnecting" as const,
     });
 
     expect(state.assistantName).toBe(pane.context.config.current.assistantIdentity.name);

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -168,37 +168,6 @@ describe("chat pane pull request refresh", () => {
     expect(pane.sessionPullRequests).toEqual([]);
   });
 
-  it("keeps a session-specific assistant identity across ordinary gateway snapshots", () => {
-    const client = {} as GatewayBrowserClient;
-    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    const state = (pane as unknown as { state: ChatPageHost }).state;
-    state.client = client;
-    state.connected = true;
-    state.assistantName = "Session Agent";
-
-    pane.applyGatewaySnapshot({
-      ...pane.context.gateway.snapshot,
-      client,
-    });
-
-    expect(state.assistantName).toBe("Session Agent");
-  });
-
-  it("resets a session-specific identity when the logical connection changes", () => {
-    const client = {} as GatewayBrowserClient;
-    const nextClient = {} as GatewayBrowserClient;
-    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    state.assistantName = "Session Agent";
-
-    pane.applyGatewaySnapshot({
-      ...pane.context.gateway.snapshot,
-      client: nextClient,
-      phase: "reconnecting" as const,
-    });
-
-    expect(state.assistantName).toBe(pane.context.config.current.assistantIdentity.name);
-  });
-
   it("preserves shared PR state for an empty rate-limited snapshot", async () => {
     const request = vi.fn().mockResolvedValue({ pullRequests: [], rateLimited: true });
     const setPullRequestSummary = vi.fn();

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -185,6 +185,21 @@ describe("chat pane pull request refresh", () => {
     expect(state.assistantName).toBe("Session Agent");
   });
 
+  it("resets a session-specific identity when the logical connection changes", () => {
+    const client = {} as GatewayBrowserClient;
+    const nextClient = {} as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client });
+    state.assistantName = "Session Agent";
+
+    pane.applyGatewaySnapshot({
+      ...pane.context.gateway.snapshot,
+      client: nextClient,
+      connected: false,
+    });
+
+    expect(state.assistantName).toBe(pane.context.config.current.assistantIdentity.name);
+  });
+
   it("preserves shared PR state for an empty rate-limited snapshot", async () => {
     const request = vi.fn().mockResolvedValue({ pullRequests: [], rateLimited: true });
     const setPullRequestSummary = vi.fn();

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -168,6 +168,23 @@ describe("chat pane pull request refresh", () => {
     expect(pane.sessionPullRequests).toEqual([]);
   });
 
+  it("keeps a session-specific assistant identity across ordinary gateway snapshots", () => {
+    const client = {} as GatewayBrowserClient;
+    const { pane } = createTestChatPane({ client });
+    const state = (pane as unknown as { state: ChatPageHost }).state;
+    state.client = client;
+    state.connected = true;
+    state.assistantName = "Session Agent";
+
+    pane.applyGatewaySnapshot({
+      ...pane.context.gateway.snapshot,
+      client,
+      connected: true,
+    });
+
+    expect(state.assistantName).toBe("Session Agent");
+  });
+
   it("preserves shared PR state for an empty rate-limited snapshot", async () => {
     const request = vi.fn().mockResolvedValue({ pullRequests: [], rateLimited: true });
     const setPullRequestSummary = vi.fn();

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -3315,7 +3315,13 @@ class ChatPane extends OpenClawLightDomElement {
         return;
       }
     }
-    state.assistantName = this.context.config.current.assistantIdentity.name;
+    // Keep the session-specific identity loaded by agent.identity.get across
+    // ordinary gateway snapshots. Reset to the configured fallback only when
+    // the logical connection changes; the startup path refreshes the identity
+    // for the active session afterward.
+    if (sourceChanged) {
+      state.assistantName = this.context.config.current.assistantIdentity.name;
+    }
     if (snapshot.phase !== "connected") {
       if (wasConnected) {
         const currentSessionId =

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -2,6 +2,7 @@ import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as assistantIdentity from "../../app/assistant-identity.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import {
   buildFallbackSlashCommands,
@@ -1382,6 +1383,46 @@ describe("resolveChatAvatarUrl", () => {
     } as unknown as ChatPageHost;
 
     expect(resolveChatAvatarUrl(state)).toBe("blob:authenticated-avatar");
+  });
+});
+
+describe("loadPageAssistantIdentity", () => {
+  it("loads the identity for the current session after a same-client route switch", async () => {
+    const request = vi.fn().mockResolvedValue({ name: "Second Session", agentId: "main" });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const context = {
+      agents: { state: { agentsList: null }, adoptList: vi.fn() },
+      agentSelection: { state: { selectedId: "main" } },
+      basePath: "",
+      config: {
+        current: {
+          allowExternalEmbedUrls: false,
+          assistantIdentity: { name: "Assistant" },
+          chatMessageMaxWidth: null,
+          embedSandboxMode: "scripts",
+          localMediaPreviewRoots: [],
+        },
+      },
+      gateway: { snapshot: { client, connected: true, hello: null } },
+      initialUserMessage: createInitialUserMessageHandoff(),
+      sessions: {},
+    } as unknown as ApplicationContext;
+    const state = createPageState(
+      context,
+      { invalidate: vi.fn(), afterCommit: () => () => {} },
+      { querySelector: () => null },
+    );
+    state.client = client;
+    state.connected = true;
+    state.assistantName = "First Session";
+    state.sessionKey = "agent:main:second";
+
+    await state.loadAssistantIdentity();
+
+    expect(request).toHaveBeenCalledWith("agent.identity.get", {
+      sessionKey: "agent:main:second",
+    });
+    expect(state.assistantName).toBe("Second Session");
   });
 });
 

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -1,8 +1,8 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import * as assistantIdentity from "../../app/assistant-identity.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import {
   buildFallbackSlashCommands,


### PR DESCRIPTION
Related: #98742

## What Problem This Solves

Fixes an issue where users creating a new Control UI session from a split view could see the assistant identity revert to the generic "Assistant" label after ordinary Gateway snapshots, even after a session-specific identity had loaded.

## Why This Change Was Made

The Control UI now preserves the identity loaded for the active session across ordinary Gateway snapshots. It resets to the configured fallback only when the logical connection changes, while the existing startup path reloads the active session identity.

This is a separate Control UI state-preservation path from the gateway session-title fallback addressed by #98841.

The maintainer takeover rebased the contributor commits onto current main, corrected the logical-connection regression fixture to use an actual reconnecting snapshot, and moved the new pane coverage into a dedicated isolated test module so the change does not extend or suppress the grandfathered oversized chat-pane test file.

## User Impact

Creating or switching to a session from split view no longer loses the session-specific assistant identity during normal Gateway updates.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-isolated.config.ts --configLoader runner` — 8 files and 88 tests passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-state.test.ts` — 45 tests passed.
- `node scripts/check-changed.mjs -- test/vitest/vitest.ui.config.ts ui/src/pages/chat/chat-pane-identity.test.ts ui/src/pages/chat/chat-pane.ts ui/src/pages/chat/chat-state.test.ts` — passed on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30116354182, including max-lines, formatting, i18n, three typecheck lanes, repository lint, and script guards.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean on the final rebased head.
- `git diff --check` — clean.
- Regression coverage proves ordinary-snapshot preservation, logical-connection fallback reset, and loading the current session identity after a same-client route switch.

## ClawSweeper proof note

The requested transition coverage is now complete and the contributor reported a manual split-view reproduction. A screenshot or static recording is not attached because it cannot independently prove that an ordinary internal Gateway snapshot occurred; the focused state-transition tests deterministically exercise that exact event plus both reset/reload boundaries. The final head was refreshed against current main and passed the full hosted changed gate.
