### PR TITLE
fix(update): repair plugin config during upgrade finalization

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -80,7 +80,6 @@ let originalProcessTitleDescriptor: PropertyDescriptor | undefined;
 let observedProcessTitle: string;
 let originalNodeNoWarnings: string | undefined;
 let originalHideBanner: string | undefined;
-let originalPostCoreUpdate: string | undefined;
 let originalForceStderr: boolean;
 
 beforeAll(async () => {
@@ -95,7 +94,6 @@ beforeEach(() => {
   observedProcessTitle = originalProcessTitle;
   originalNodeNoWarnings = process.env.NODE_NO_WARNINGS;
   originalHideBanner = process.env.OPENCLAW_HIDE_BANNER;
-  originalPostCoreUpdate = process.env.OPENCLAW_UPDATE_POST_CORE;
   originalForceStderr = loggingState.forceConsoleToStderr;
   // Worker-thread Vitest runs do not reliably mutate the real process title,
   // so capture writes at the property boundary instead.
@@ -110,7 +108,6 @@ beforeEach(() => {
   loggingState.forceConsoleToStderr = false;
   delete process.env.NODE_NO_WARNINGS;
   delete process.env.OPENCLAW_HIDE_BANNER;
-  delete process.env.OPENCLAW_UPDATE_POST_CORE;
 });
 
 afterEach(() => {
@@ -135,11 +132,6 @@ afterEach(() => {
     delete process.env.OPENCLAW_HIDE_BANNER;
   } else {
     process.env.OPENCLAW_HIDE_BANNER = originalHideBanner;
-  }
-  if (originalPostCoreUpdate === undefined) {
-    delete process.env.OPENCLAW_UPDATE_POST_CORE;
-  } else {
-    process.env.OPENCLAW_UPDATE_POST_CORE = originalPostCoreUpdate;
   }
 });
 
@@ -375,8 +367,7 @@ describe("registerPreActionHooks", () => {
     );
   });
 
-  it("allows invalid config only for the internal post-core update resume", async () => {
-    process.env.OPENCLAW_UPDATE_POST_CORE = "1";
+  it("allows invalid config for update migration commands", async () => {
     await runPreAction({
       parseArgv: ["update"],
       processArgv: ["node", "openclaw", "update", "--json"],
@@ -389,15 +380,16 @@ describe("registerPreActionHooks", () => {
     });
 
     vi.clearAllMocks();
-    delete process.env.OPENCLAW_UPDATE_POST_CORE;
     await runPreAction({
-      parseArgv: ["update"],
-      processArgv: ["node", "openclaw", "update", "--json"],
+      parseArgv: ["update", "status"],
+      processArgv: ["node", "openclaw", "update", "status", "--json"],
     });
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
-      commandPath: ["update"],
+      commandPath: ["update", "status"],
+      allowInvalid: true,
+      suppressDoctorStdout: true,
     });
   });
 
@@ -654,6 +646,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["update", "status"],
+      allowInvalid: true,
       suppressDoctorStdout: true,
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -80,6 +80,7 @@ let originalProcessTitleDescriptor: PropertyDescriptor | undefined;
 let observedProcessTitle: string;
 let originalNodeNoWarnings: string | undefined;
 let originalHideBanner: string | undefined;
+let originalPostCoreUpdate: string | undefined;
 let originalForceStderr: boolean;
 
 beforeAll(async () => {
@@ -94,6 +95,7 @@ beforeEach(() => {
   observedProcessTitle = originalProcessTitle;
   originalNodeNoWarnings = process.env.NODE_NO_WARNINGS;
   originalHideBanner = process.env.OPENCLAW_HIDE_BANNER;
+  originalPostCoreUpdate = process.env.OPENCLAW_UPDATE_POST_CORE;
   originalForceStderr = loggingState.forceConsoleToStderr;
   // Worker-thread Vitest runs do not reliably mutate the real process title,
   // so capture writes at the property boundary instead.
@@ -108,6 +110,7 @@ beforeEach(() => {
   loggingState.forceConsoleToStderr = false;
   delete process.env.NODE_NO_WARNINGS;
   delete process.env.OPENCLAW_HIDE_BANNER;
+  delete process.env.OPENCLAW_UPDATE_POST_CORE;
 });
 
 afterEach(() => {
@@ -132,6 +135,11 @@ afterEach(() => {
     delete process.env.OPENCLAW_HIDE_BANNER;
   } else {
     process.env.OPENCLAW_HIDE_BANNER = originalHideBanner;
+  }
+  if (originalPostCoreUpdate === undefined) {
+    delete process.env.OPENCLAW_UPDATE_POST_CORE;
+  } else {
+    process.env.OPENCLAW_UPDATE_POST_CORE = originalPostCoreUpdate;
   }
 });
 
@@ -365,6 +373,32 @@ describe("registerPreActionHooks", () => {
         commandPath: ["gateway", "run"],
       }),
     );
+  });
+
+  it("allows invalid config only for the internal post-core update resume", async () => {
+    process.env.OPENCLAW_UPDATE_POST_CORE = "1";
+    await runPreAction({
+      parseArgv: ["update"],
+      processArgv: ["node", "openclaw", "update", "--json"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["update"],
+      allowInvalid: true,
+    });
+
+    vi.clearAllMocks();
+    delete process.env.OPENCLAW_UPDATE_POST_CORE;
+    await runPreAction({
+      parseArgv: ["update"],
+      processArgv: ["node", "openclaw", "update", "--json"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["update"],
+    });
   });
 
   it("loads plugins for text local agent runs", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -2,6 +2,7 @@
 import type { Command } from "commander";
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { setVerbose } from "../../globals.js";
+import { POST_CORE_UPDATE_ENV } from "../../infra/update-post-core-context.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveCliArgvInvocation } from "../argv-invocation.js";
@@ -35,6 +36,7 @@ function setProcessTitleForCommand(actionCommand: Command) {
 
 function shouldAllowInvalidConfigForAction(actionCommand: Command, commandPath: string[]): boolean {
   return (
+    (commandPath[0] === "update" && process.env[POST_CORE_UPDATE_ENV] === "1") ||
     resolvePluginInstallInvalidConfigPolicy(
       resolvePluginInstallPreactionRequest({
         actionCommand,

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -2,7 +2,6 @@
 import type { Command } from "commander";
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { setVerbose } from "../../globals.js";
-import { POST_CORE_UPDATE_ENV } from "../../infra/update-post-core-context.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveCliArgvInvocation } from "../argv-invocation.js";
@@ -36,7 +35,7 @@ function setProcessTitleForCommand(actionCommand: Command) {
 
 function shouldAllowInvalidConfigForAction(actionCommand: Command, commandPath: string[]): boolean {
   return (
-    (commandPath[0] === "update" && process.env[POST_CORE_UPDATE_ENV] === "1") ||
+    commandPath[0] === "update" ||
     resolvePluginInstallInvalidConfigPolicy(
       resolvePluginInstallPreactionRequest({
         actionCommand,

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6690,6 +6690,7 @@ describe("update-cli", () => {
         OPENCLAW_UPDATE_IN_PROGRESS: undefined,
         OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: undefined,
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: undefined,
+        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: undefined,
       },
       async () => {
         let doctorEnv: NodeJS.ProcessEnv | undefined;
@@ -6709,9 +6710,11 @@ describe("update-cli", () => {
         expect(doctorEnv?.OPENCLAW_UPDATE_IN_PROGRESS).toBe("1");
         expect(doctorEnv?.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBe("1");
         expect(doctorEnv?.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBe("1");
+        expect(doctorEnv?.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBe("1");
         expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBeUndefined();
+        expect(process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBeUndefined();
         expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
           nonInteractive: true,
           repair: true,
@@ -6834,6 +6837,7 @@ describe("update-cli", () => {
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
     });
     expect(syncPluginCall()?.channel).toBe("beta");

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -2,6 +2,7 @@
 import {
   UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV,
   UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
+  UPDATE_POST_CORE_CONVERGENCE_ENV,
 } from "../../commands/doctor/shared/update-phase.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
@@ -25,9 +26,11 @@ export function withUpdateFinalizationEnv<T>(run: () => Promise<T>): Promise<T> 
     process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
   const previousParentSupportsDoctorConfigWrite =
     process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
+  const previousPostCoreConvergence = process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
   process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
   process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] = "1";
   process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] = "1";
+  process.env[UPDATE_POST_CORE_CONVERGENCE_ENV] = "1";
   return run().finally(() => {
     if (previousUpdateInProgress === undefined) {
       delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
@@ -45,6 +48,11 @@ export function withUpdateFinalizationEnv<T>(run: () => Promise<T>): Promise<T> 
     } else {
       process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] =
         previousParentSupportsDoctorConfigWrite;
+    }
+    if (previousPostCoreConvergence === undefined) {
+      delete process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
+    } else {
+      process.env[UPDATE_POST_CORE_CONVERGENCE_ENV] = previousPostCoreConvergence;
     }
   });
 }
@@ -112,6 +120,7 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
       OPENCLAW_UPDATE_IN_PROGRESS: "1",
       [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
       [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
+      [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
     },
   });
   if (!params.json) {

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -35,6 +35,7 @@ import {
   type ControlPlaneUpdateSentinelMetaFile,
 } from "../../infra/update-control-plane-sentinel.js";
 import {
+  POST_CORE_UPDATE_ENV,
   POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV,
   type PreUpdateConfigRestoreInput,
 } from "../../infra/update-post-core-context.js";
@@ -82,7 +83,7 @@ import {
 } from "./update-command-service.js";
 
 const DEFAULT_UPDATE_STEP_TIMEOUT_MS = 30 * 60_000;
-export const POST_CORE_UPDATE_ENV = "OPENCLAW_UPDATE_POST_CORE";
+export { POST_CORE_UPDATE_ENV };
 export const POST_CORE_UPDATE_CHANNEL_ENV = "OPENCLAW_UPDATE_POST_CORE_CHANNEL";
 export const POST_CORE_UPDATE_REQUESTED_CHANNEL_ENV = "OPENCLAW_UPDATE_POST_CORE_REQUESTED_CHANNEL";
 export const POST_CORE_UPDATE_RESULT_PATH_ENV = "OPENCLAW_UPDATE_POST_CORE_RESULT_PATH";

--- a/src/infra/update-post-core-context.ts
+++ b/src/infra/update-post-core-context.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
+export const POST_CORE_UPDATE_ENV = "OPENCLAW_UPDATE_POST_CORE";
 export const POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV =
   "OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH";
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading with legacy plugin-owned configuration could be rejected before the package swap or could reach finalization without Doctor receiving the phase marker needed to repair configured plugin state.

## Why This Change Was Made

The `update` command family now loads invalid snapshots so the update/Doctor migration path can repair tagged legacy configuration while preserving normal bootstrap, state migration, and write safeguards. The fresh post-core resume remains scoped to the update path, and finalization Doctor receives the post-core-convergence marker with parent environment restoration.

## User Impact

Upgrades can pass startup validation, complete the package swap, and repair eligible configured-plugin state instead of stopping on legacy plugin configuration. Other commands still reject invalid configuration, and unrelated user configuration remains outside this repair path.

## Evidence

- Focused tests on the final rebased branch: `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/cli/program/preaction.test.ts` (230 passed).
- Adjacent Doctor tests: `src/commands/doctor/repair-sequencing.test.ts` and `src/commands/doctor/shared/missing-configured-plugin-install.test.ts` (102 passed).
- Exact run that exposed the initial `openclaw update` guard: https://github.com/openclaw/openclaw/actions/runs/30097612383
- Corrected exact-runtime-diff four-lane package acceptance: https://github.com/openclaw/openclaw/actions/runs/30098791156
- Final rebased branch autoreview: clean, no accepted/actionable findings.
