### PR TITLE
fix(workboard): ignore expired claims for owner capacity

### DIFF
--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 import { cleanupWorkboardRunWorktree } from "./dispatcher-workspace.js";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
 import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
-import { CLAIM_RECLAIM_MS } from "./store-constants.js";
 import { WorkboardStore } from "./store.js";
+
+const CLAIM_RECLAIM_GRACE_MS = 5 * 60 * 1000;
 
 function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
   const entries = new Map<string, T>();
@@ -944,7 +945,7 @@ describe("dispatchAndStartWorkboardCards", () => {
       store,
       subagent: { run },
       options: {
-        now: expiresAt! + CLAIM_RECLAIM_MS + 1,
+        now: expiresAt! + CLAIM_RECLAIM_GRACE_MS + 1,
         maxStarts: 1,
         boardId: "ops",
       },
@@ -953,6 +954,103 @@ describe("dispatchAndStartWorkboardCards", () => {
     expect(result.started).toEqual([expect.objectContaining({ cardId: ready.id })]);
     expect(run).toHaveBeenCalledOnce();
     expect((await store.get(expired.id))?.metadata?.claim).toBeDefined();
+  });
+
+  it("ignores a reclaimable running card on another board for owner capacity", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const stale = await store.create({
+      title: "Abandoned product run",
+      status: "running",
+      agentId: "codex-main",
+      boardId: "product",
+      execution: {
+        id: "stale-execution",
+        kind: "agent-session",
+        mode: "autonomous",
+        status: "running",
+        startedAt: 1,
+        updatedAt: 1,
+      },
+    });
+    const claimed = await store.claim(stale.id, {
+      ownerId: "codex-main",
+      token: "stale-token",
+      ttlSeconds: 1,
+    });
+    const ready = await store.create({
+      title: "Ready ops recovery",
+      status: "ready",
+      agentId: "codex-main",
+      boardId: "ops",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-recovery" });
+    const expiresAt = claimed.card.metadata?.claim?.expiresAt;
+    expect(expiresAt).toBeDefined();
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: {
+        now: expiresAt! + CLAIM_RECLAIM_GRACE_MS + 1,
+        maxStarts: 1,
+        boardId: "ops",
+      },
+    });
+
+    expect(result.started).toEqual([expect.objectContaining({ cardId: ready.id })]);
+    expect(run).toHaveBeenCalledOnce();
+    await expect(store.get(stale.id)).resolves.toMatchObject({
+      status: "running",
+      execution: { status: "running" },
+      metadata: { claim: { ownerId: "codex-main" } },
+    });
+  });
+
+  it("keeps a live running card in the owner capacity slot", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const active = await store.create({
+      title: "Active product run",
+      status: "running",
+      agentId: "codex-main",
+      boardId: "product",
+      execution: {
+        id: "active-execution",
+        kind: "agent-session",
+        mode: "autonomous",
+        status: "running",
+        startedAt: 1,
+        updatedAt: 1,
+      },
+    });
+    const claimed = await store.claim(active.id, {
+      ownerId: "codex-main",
+      token: "active-token",
+      ttlSeconds: 60,
+    });
+    await store.create({
+      title: "Ready ops work",
+      status: "ready",
+      agentId: "codex-main",
+      boardId: "ops",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-ops" });
+    const expiresAt = claimed.card.metadata?.claim?.expiresAt;
+    expect(expiresAt).toBeDefined();
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: {
+        now: expiresAt! + CLAIM_RECLAIM_GRACE_MS,
+        maxStarts: 1,
+        boardId: "ops",
+      },
+    });
+
+    expect(result.started).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
   });
 
   it("keeps claimed review cards in the owner running slot", async () => {

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -917,46 +917,7 @@ describe("dispatchAndStartWorkboardCards", () => {
     });
   });
 
-  it("ignores an expired claim on another board when reserving owner capacity", async () => {
-    const store = new WorkboardStore(createMemoryStore());
-    const expired = await store.create({
-      title: "Expired product review",
-      status: "review",
-      agentId: "codex-main",
-      boardId: "product",
-    });
-    const claimed = await store.claim(expired.id, {
-      ownerId: "codex-main",
-      token: "expired-token",
-      ttlSeconds: 1,
-    });
-    const ready = await store.create({
-      title: "Ready ops work",
-      status: "ready",
-      agentId: "codex-main",
-      boardId: "ops",
-      workspaceAccess: { unrestricted: true },
-    });
-    const run = vi.fn().mockResolvedValue({ runId: "run-ops" });
-    const expiresAt = claimed.card.metadata?.claim?.expiresAt;
-    expect(expiresAt).toBeDefined();
-
-    const result = await dispatchAndStartWorkboardCards({
-      store,
-      subagent: { run },
-      options: {
-        now: expiresAt! + CLAIM_RECLAIM_GRACE_MS + 1,
-        maxStarts: 1,
-        boardId: "ops",
-      },
-    });
-
-    expect(result.started).toEqual([expect.objectContaining({ cardId: ready.id })]);
-    expect(run).toHaveBeenCalledOnce();
-    expect((await store.get(expired.id))?.metadata?.claim).toBeDefined();
-  });
-
-  it("ignores a reclaimable running card on another board for owner capacity", async () => {
+  it("keeps a running card in capacity until its claim is reclaimable", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const stale = await store.create({
       title: "Abandoned product run",
@@ -988,58 +949,7 @@ describe("dispatchAndStartWorkboardCards", () => {
     const expiresAt = claimed.card.metadata?.claim?.expiresAt;
     expect(expiresAt).toBeDefined();
 
-    const result = await dispatchAndStartWorkboardCards({
-      store,
-      subagent: { run },
-      options: {
-        now: expiresAt! + CLAIM_RECLAIM_GRACE_MS + 1,
-        maxStarts: 1,
-        boardId: "ops",
-      },
-    });
-
-    expect(result.started).toEqual([expect.objectContaining({ cardId: ready.id })]);
-    expect(run).toHaveBeenCalledOnce();
-    await expect(store.get(stale.id)).resolves.toMatchObject({
-      status: "running",
-      execution: { status: "running" },
-      metadata: { claim: { ownerId: "codex-main" } },
-    });
-  });
-
-  it("keeps a live running card in the owner capacity slot", async () => {
-    const store = new WorkboardStore(createMemoryStore());
-    const active = await store.create({
-      title: "Active product run",
-      status: "running",
-      agentId: "codex-main",
-      boardId: "product",
-      execution: {
-        id: "active-execution",
-        kind: "agent-session",
-        mode: "autonomous",
-        status: "running",
-        startedAt: 1,
-        updatedAt: 1,
-      },
-    });
-    const claimed = await store.claim(active.id, {
-      ownerId: "codex-main",
-      token: "active-token",
-      ttlSeconds: 60,
-    });
-    await store.create({
-      title: "Ready ops work",
-      status: "ready",
-      agentId: "codex-main",
-      boardId: "ops",
-      workspaceAccess: { unrestricted: true },
-    });
-    const run = vi.fn().mockResolvedValue({ runId: "run-ops" });
-    const expiresAt = claimed.card.metadata?.claim?.expiresAt;
-    expect(expiresAt).toBeDefined();
-
-    const result = await dispatchAndStartWorkboardCards({
+    const withinGrace = await dispatchAndStartWorkboardCards({
       store,
       subagent: { run },
       options: {
@@ -1049,8 +959,31 @@ describe("dispatchAndStartWorkboardCards", () => {
       },
     });
 
-    expect(result.started).toEqual([]);
+    expect(withinGrace.started).toEqual([]);
     expect(run).not.toHaveBeenCalled();
+    await expect(store.get(stale.id)).resolves.toMatchObject({
+      status: "running",
+      execution: { status: "running" },
+      metadata: { claim: { ownerId: "codex-main" } },
+    });
+
+    const reclaimable = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: {
+        now: expiresAt! + CLAIM_RECLAIM_GRACE_MS + 1,
+        maxStarts: 1,
+        boardId: "ops",
+      },
+    });
+
+    expect(reclaimable.started).toEqual([expect.objectContaining({ cardId: ready.id })]);
+    expect(run).toHaveBeenCalledOnce();
+    await expect(store.get(stale.id)).resolves.toMatchObject({
+      status: "running",
+      execution: { status: "running" },
+      metadata: { claim: { ownerId: "codex-main" } },
+    });
   });
 
   it("keeps claimed review cards in the owner running slot", async () => {

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { cleanupWorkboardRunWorktree } from "./dispatcher-workspace.js";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
 import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import { CLAIM_RECLAIM_MS } from "./store-constants.js";
 import { WorkboardStore } from "./store.js";
 
 function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
@@ -913,6 +914,45 @@ describe("dispatchAndStartWorkboardCards", () => {
       status: "ready",
       metadata: { automation: { boardId: "product" } },
     });
+  });
+
+  it("ignores an expired claim on another board when reserving owner capacity", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const expired = await store.create({
+      title: "Expired product review",
+      status: "review",
+      agentId: "codex-main",
+      boardId: "product",
+    });
+    const claimed = await store.claim(expired.id, {
+      ownerId: "codex-main",
+      token: "expired-token",
+      ttlSeconds: 1,
+    });
+    const ready = await store.create({
+      title: "Ready ops work",
+      status: "ready",
+      agentId: "codex-main",
+      boardId: "ops",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-ops" });
+    const expiresAt = claimed.card.metadata?.claim?.expiresAt;
+    expect(expiresAt).toBeDefined();
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: {
+        now: expiresAt! + CLAIM_RECLAIM_MS + 1,
+        maxStarts: 1,
+        boardId: "ops",
+      },
+    });
+
+    expect(result.started).toEqual([expect.objectContaining({ cardId: ready.id })]);
+    expect(run).toHaveBeenCalledOnce();
+    expect((await store.get(expired.id))?.metadata?.claim).toBeDefined();
   });
 
   it("keeps claimed review cards in the owner running slot", async () => {

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -237,10 +237,12 @@ function selectStartableCards(
   const runningByOwner = new Map<string, number>();
   for (const card of cards) {
     const claim = card.metadata?.claim;
+    const claimIsReclaimable = isWorkboardClaimReclaimable(claim, now);
+    // Cleanup is board-scoped, but owner capacity is global. Ignore the same
+    // reclaimable running state here before its board gets a cleanup pass.
     const consumesOwnerSlot =
-      card.status === "running" ||
-      Boolean(claim && !isWorkboardClaimReclaimable(claim, now)) ||
-      card.execution?.status === "running";
+      !claimIsReclaimable &&
+      (card.status === "running" || Boolean(claim) || card.execution?.status === "running");
     if (!consumesOwnerSlot || cardIsArchived(card)) {
       continue;
     }

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -14,6 +14,7 @@ import {
   resolveDispatchWorkspaceAccess,
   type ResolveAgentWorkspaceRuntime,
 } from "./dispatcher-workspace.js";
+import { isWorkboardClaimReclaimable } from "./store-constants.js";
 import { WorkboardStore, type WorkboardDispatchResult } from "./store.js";
 import {
   assertCanonicalWorkboardRootAccess,
@@ -227,6 +228,7 @@ function sortReadyCards(a: WorkboardCard, b: WorkboardCard): number {
 function selectStartableCards(
   cards: WorkboardCard[],
   limit: number,
+  now: number,
   candidates: WorkboardCard[] = cards,
 ): WorkboardCard[] {
   if (limit <= 0) {
@@ -234,9 +236,10 @@ function selectStartableCards(
   }
   const runningByOwner = new Map<string, number>();
   for (const card of cards) {
+    const claim = card.metadata?.claim;
     const consumesOwnerSlot =
       card.status === "running" ||
-      Boolean(card.metadata?.claim) ||
+      Boolean(claim && !isWorkboardClaimReclaimable(claim, now)) ||
       card.execution?.status === "running";
     if (!consumesOwnerSlot || cardIsArchived(card)) {
       continue;
@@ -279,7 +282,7 @@ export async function dispatchAndStartWorkboardCards(params: {
   const cards = await params.store.list();
   const candidates = await params.store.list({ boardId });
 
-  for (const card of selectStartableCards(cards, maxStarts, candidates)) {
+  for (const card of selectStartableCards(cards, maxStarts, now, candidates)) {
     const ownerId = params.options?.ownerId?.trim() || card.agentId || DEFAULT_DISPATCH_OWNER;
     const sessionKey = buildSessionKey(card);
     let claimValue = "";

--- a/extensions/workboard/src/store-constants.ts
+++ b/extensions/workboard/src/store-constants.ts
@@ -1,3 +1,4 @@
+import type { WorkboardClaim } from "@openclaw/workboard-contract";
 import {
   MAX_DATE_TIMESTAMP_MS,
   resolveExpiresAtMsFromDurationMs,
@@ -23,6 +24,15 @@ export const READY_STRANDED_MS = 60 * 60 * 1000;
 export const RUNNING_HEARTBEAT_STALE_MS = 20 * 60 * 1000;
 export const BLOCKED_TOO_LONG_MS = 24 * 60 * 60 * 1000;
 export const CLAIM_RECLAIM_MS = 5 * 60 * 1000;
+
+// Dispatch gives late heartbeats a fixed grace window before reclaiming.
+// Capacity checks must reuse this rule or stale cross-board claims can starve an owner.
+export function isWorkboardClaimReclaimable(
+  claim: WorkboardClaim | undefined,
+  now: number,
+): boolean {
+  return Boolean(claim?.expiresAt && now - claim.expiresAt > CLAIM_RECLAIM_MS);
+}
 
 export function secondsToDurationMs(seconds: number): number {
   const ms = Math.trunc(seconds) * 1000;

--- a/extensions/workboard/src/store-constants.ts
+++ b/extensions/workboard/src/store-constants.ts
@@ -23,7 +23,7 @@ export const DEFAULT_CLAIM_TTL_MS = 30 * 60 * 1000;
 export const READY_STRANDED_MS = 60 * 60 * 1000;
 export const RUNNING_HEARTBEAT_STALE_MS = 20 * 60 * 1000;
 export const BLOCKED_TOO_LONG_MS = 24 * 60 * 60 * 1000;
-export const CLAIM_RECLAIM_MS = 5 * 60 * 1000;
+const CLAIM_RECLAIM_MS = 5 * 60 * 1000;
 
 // Dispatch gives late heartbeats a fixed grace window before reclaiming.
 // Capacity checks must reuse this rule or stale cross-board claims can starve an owner.

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -20,7 +20,7 @@ import {
   retryBudgetExhausted,
 } from "./store-card-helpers.js";
 import {
-  CLAIM_RECLAIM_MS,
+  isWorkboardClaimReclaimable,
   MAX_ATTACHMENT_ENTRIES,
   MAX_CARDS,
   MAX_CARD_NOTIFICATIONS,
@@ -78,7 +78,7 @@ export class WorkboardStore extends WorkboardNotificationStore {
         const timedOut =
           Boolean(maxRuntimeSeconds && runtimeStartedAt) &&
           now - runtimeStartedAt! > secondsToDurationMs(maxRuntimeSeconds!);
-        const claimExpired = Boolean(claim?.expiresAt && now - claim.expiresAt > CLAIM_RECLAIM_MS);
+        const claimExpired = isWorkboardClaimReclaimable(claim, now);
         const retriesExhausted = retryBudgetExhausted(latest);
         if (latest.status === "running" && (timedOut || claimExpired)) {
           const reason = timedOut


### PR DESCRIPTION
[AI-assisted]

Closes #113252

## What Problem This Solves

Fixes a Workboard starvation case where a reclaimable running card on one board could continue consuming its owner's global concurrency slot and prevent ready cards on another board from starting.

## Why This Change Was Made

- Reuse one claim-reclaimability predicate for store cleanup and dispatcher capacity accounting.
- Treat the whole stale active state consistently: after the existing five-minute grace, a claimed card's stale `running` card status, running execution, and claim no longer reserve global owner capacity.
- Preserve the slot through the grace boundary, including for a genuinely live running card.
- Keep cleanup board-scoped; cross-board capacity selection does not mutate the stale card.

## User Impact

Workboard fleets can resume same-owner work on another board after an abandoned running claim becomes reclaimable, without weakening the existing late-heartbeat grace period or requiring a cleanup pass on the stale card's board first.

## Evidence

- **Final product head:** [`9f8c1a7853f0`](https://github.com/openclaw/openclaw/commit/9f8c1a7853f01c98983c4dbecaa35e0276f5f723).
- **Canonical PR CI:** [run 30149971736](https://github.com/openclaw/openclaw/actions/runs/30149971736) is green, including `check-lint`, `check-dependencies`, `check-test-types`, build artifacts, and required `openclaw/ci-gate`.
- **Exact-head real-runtime proof:** [secretless fork run 30150439792](https://github.com/shaoohh/openclaw/actions/runs/30150439792) passed on Ubuntu 24.04 in 6m44s. The [redacted runtime artifact](https://github.com/shaoohh/openclaw/actions/runs/30150439792/artifacts/8617503924) is retained by the workflow.
- The proof-only commit [`446e6a391104`](https://github.com/shaoohh/openclaw/commit/446e6a39110450087b10707510023690a99858f7) has parent exactly equal to the final product head. Its workflow verifies that only `.github/proof/workboard-113325-real-dispatch.ts` and `.github/workflows/proof-workboard-113325.yml` differ, so proof assets are not part of this PR's product diff.
- **Focused regressions:** `extensions/workboard/src/dispatcher.test.ts` passed 27/27 tests and `extensions/workboard/src/store.test.ts` passed 100/100 tests in the proof run.
- **Real behavior trace:** a real `WorkboardStore` and SQLite database held a cross-board card with both `status=running` and `execution=running`. Thirty seconds before the reclaim boundary it still reserved capacity (`started=0`, `worker_calls=0`); after the full grace it released capacity and the ready same-owner card on the other board started exactly once, while the stale card/claim/execution remained untouched for its board-scoped cleanup path.
- **Persistence trace:** the primary store was closed, SQLite was reopened through a new store, and the started target still had `status=running`, `execution=running`, and `run_id=proof-run-113325`.
- The unit regression checks the exact boundary and +1 ms behavior; the wall-clock proof uses a 30-second pre-boundary margin to avoid hosted-runner scheduling flakes.
- Fresh external Codex autoreview of the final product follow-up tree returned no accepted/actionable findings and judged the patch correct with 0.91 confidence.
- The two proof-only files underwent repeated external autoreview. After addressing findings about boundary strength, close/reopen semantics, and runner timing margin, the final review returned no findings and judged the proof patch correct with 0.91 confidence.
- Contributor code was not executed locally. Tests and real behavior proof ran in secretless fork GitHub Actions.

## Changelog

No root changelog edit in this contributor PR; release-note context remains here for maintainer release assembly.
