### PR TITLE
fix(logging): redact Shopify access tokens [AI]

### DIFF
--- a/src/logging/redact-patterns.ts
+++ b/src/logging/redact-patterns.ts
@@ -80,6 +80,9 @@ export const AWS_SECRET_ACCESS_KEY_VALUE_PATTERN = String.raw`(?=[A-Za-z0-9/+=]{
 const AWS_SECRET_ACCESS_KEY_VALUE_REDACT_PATTERN = String.raw`/${AWS_SECRET_ACCESS_KEY_VALUE_BOUNDARY}(${AWS_SECRET_ACCESS_KEY_VALUE_PATTERN})(?!_)/g`;
 const TELEGRAM_BOT_TOKEN_REDACT_PATTERN = String.raw`\bbot(\d{6,}:[A-Za-z0-9_-]{20,})\b`;
 const TELEGRAM_TOKEN_REDACT_PATTERN = String.raw`\b(\d{6,}:[A-Za-z0-9_-]{20,})\b`;
+// Shopify access tokens are a fixed 38-char whole token (prefix + 32 hex) with no left boundary,
+// so they must run against the full string; a chunk slice can split the token and leak it.
+const SHOPIFY_ACCESS_TOKEN_REDACT_PATTERN = String.raw`(shp(?:at|ca|pa|ss)_[A-Fa-f0-9]{32})`;
 const CREDENTIAL_STYLE_HEADER_KEYS = "x-goog-api-key|api-key|apikey|x-api-token|x-access-token";
 const GATEWAY_SECURITY_HEADER_KEYS =
   "X-OpenClaw-Token|x-pomerium-jwt-assertion|X-Api-Key|X-Auth-Token";
@@ -120,6 +123,7 @@ export const CHUNK_UNSAFE_PATTERN_SOURCES = new Set([
   AUTHORIZATION_BOT_REDACT_PATTERN,
   STANDALONE_BEARER_REDACT_PATTERN,
   AWS_SECRET_ACCESS_KEY_VALUE_REDACT_PATTERN,
+  SHOPIFY_ACCESS_TOKEN_REDACT_PATTERN,
   ...HTTP_AUTH_HEADER_REDACT_PATTERNS,
 ]);
 
@@ -193,6 +197,7 @@ export const DEFAULT_REDACT_PATTERNS: readonly string[] = [
   String.raw`(SG\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})`,
   String.raw`(npm_[A-Za-z0-9]{10,})`,
   String.raw`(pypi-[A-Za-z0-9_-]{10,})`,
+  SHOPIFY_ACCESS_TOKEN_REDACT_PATTERN,
   String.raw`(dop_v1_[A-Za-z0-9]{10,})`,
   String.raw`(doo_v1_[A-Za-z0-9]{10,})`,
   String.raw`(dor_v1_[A-Za-z0-9]{10,})`,

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -1404,6 +1404,15 @@ describe("redactSensitiveText", () => {
     expect(output).toBe("r8_ABC…stuv");
   });
 
+  it("masks Shopify access tokens (shp*_ prefixes)", () => {
+    for (const prefix of ["shpat", "shpca", "shppa", "shpss"]) {
+      const token = `${prefix}_${"a".repeat(32)}`;
+      const output = redactSensitiveText(token, { mode: "tools" });
+      expect(output, token).toBe(`${prefix}_…aaaa`);
+      expect(output).not.toContain(token);
+    }
+  });
+
   it("masks expanded vendor-prefix token corpus", () => {
     const fireworksTokens = [
       { token: `fw-${"C".repeat(40)}`, redacted: "fw-CCC…CCCC" },
@@ -1437,6 +1446,10 @@ describe("redactSensitiveText", () => {
       "SG.abcdefghijklmnopqrstuvwxyz.0123456789abcdefghijklmnopqrstuvwxyz",
       "npm_abcdefghijklmnopqrstuvwxyz",
       "pypi-abcdefghijklmnopqrstuvwxyz",
+      `shpat_${"a".repeat(32)}`,
+      `shpca_${"b".repeat(32)}`,
+      `shppa_${"c".repeat(32)}`,
+      `shpss_${"d".repeat(32)}`,
       "dop_v1_abcdefghijklmnopqrstuvwxyz",
       "doo_v1_abcdefghijklmnopqrstuvwxyz",
       "dor_v1_abcdefghijklmnopqrstuvwxyz",
@@ -1548,7 +1561,7 @@ describe("redactSensitiveText", () => {
 
   it("does not redact ordinary identifiers containing short token-prefix substrings", () => {
     const input = [
-      "npm_telegram_package_spec ask_openclaw_query_patterns team_management risk_assessment glpat-docs gloas-docs gldt-docs glcbt-docs glptt-docs glft-docs glimt-docs glagent-docs glwt-docs glsoat-docs glffct-docs glrt-docs glrtr-docs GR1348941-docs _gitlab_session=short dapi-example sbp_short nfp_site CCIPAT_docs ATATT-example fw-tooshort fw_tooshort fpk_tooshort",
+      "npm_telegram_package_spec ask_openclaw_query_patterns team_management risk_assessment glpat-docs gloas-docs gldt-docs glcbt-docs glptt-docs glft-docs glimt-docs glagent-docs glwt-docs glsoat-docs glffct-docs glrt-docs glrtr-docs GR1348941-docs _gitlab_session=short dapi-example sbp_short nfp_site CCIPAT_docs ATATT-example fw-tooshort fw_tooshort fpk_tooshort shpat_tooshort shpca_notavalidshopifyaccesstoken",
       `fixturefw-${"C".repeat(40)}`,
       `fixture_fw_${"A".repeat(40)}`,
       `fixture_fpk_${"B".repeat(40)}`,
@@ -1562,6 +1575,24 @@ describe("redactSensitiveText", () => {
     const prefix = `${"x".repeat(chunkSize - 2)} `;
     const suffix = "y".repeat(chunkSize);
     const tokens = [`fw-${"C".repeat(40)}`, `fw_${"A".repeat(40)}`, `fpk_${"B".repeat(40)}`];
+
+    for (const token of tokens) {
+      expect(redactSensitiveText(`${prefix}${token}${suffix}`, { mode: "tools" })).not.toContain(
+        token,
+      );
+    }
+  });
+
+  it("masks Shopify access tokens that cross bounded-replacement chunk boundaries", () => {
+    const chunkSize = 16_384;
+    const prefix = `${"x".repeat(chunkSize - 2)} `;
+    const suffix = "y".repeat(chunkSize);
+    const tokens = [
+      `shpat_${"a".repeat(32)}`,
+      `shpca_${"b".repeat(32)}`,
+      `shppa_${"c".repeat(32)}`,
+      `shpss_${"d".repeat(32)}`,
+    ];
 
     for (const token of tokens) {
       expect(redactSensitiveText(`${prefix}${token}${suffix}`, { mode: "tools" })).not.toContain(

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -109,7 +109,7 @@ const DEFAULT_REDACT_PREFILTER_SOURCES: string[] = [
   // URL userinfo and connection-string password slots (`scheme://user:pass@host`).
   String.raw`:\/\/[^\/\s:@]*:[^\/\s@]+@`,
   // Vendor token prefixes and webhook hosts, ordered like DEFAULT_REDACT_PATTERNS.
-  String.raw`sk-|gh[opsur]_|github_pat_|glpat-|gloas-|gldt-|glcbt-|glptt-|glft-|glimt-|glagent-|glwt-|glsoat-|glffct-|glrt-|glrtr-|GR1348941|_gitlab_session=|xox[baprs]-|xapp-|hooks\.slack\.com|discord|gsk_|AIza|ya29\.|1\/\/0|eyJ|pplx-|fal_|fc-|bb_live_|gAAAA|[sr]k_(?:live|test)_|\bSG\.|npm_|pypi-|do[opr]_v1_|dp\.(?:ct|pt|sa|st|scim|audit)\.|dckr_|bkua_|CCIPAT_|sbp_|dapi[0-9a-f]|dd[pw]_|glsa_|nfp_|CFPAT-|ATCTT3|ATATT|ATBB|BBDC-|HRKU-|pat-(?:eu|na)1-|apify_api_|FlyV1|fio-u-|tvly-|exa_|syt_|retaindb_|mem0_|brv_|xai-|fw-|fw_|fpk_`,
+  String.raw`sk-|gh[opsur]_|github_pat_|glpat-|gloas-|gldt-|glcbt-|glptt-|glft-|glimt-|glagent-|glwt-|glsoat-|glffct-|glrt-|glrtr-|GR1348941|_gitlab_session=|xox[baprs]-|xapp-|hooks\.slack\.com|discord|gsk_|AIza|ya29\.|1\/\/0|eyJ|pplx-|fal_|fc-|bb_live_|gAAAA|[sr]k_(?:live|test)_|\bSG\.|npm_|pypi-|shp(?:at|ca|pa|ss)_|do[opr]_v1_|dp\.(?:ct|pt|sa|st|scim|audit)\.|dckr_|bkua_|CCIPAT_|sbp_|dapi[0-9a-f]|dd[pw]_|glsa_|nfp_|CFPAT-|ATCTT3|ATATT|ATBB|BBDC-|HRKU-|pat-(?:eu|na)1-|apify_api_|FlyV1|fio-u-|tvly-|exa_|syt_|retaindb_|mem0_|brv_|xai-|fw-|fw_|fpk_`,
   String.raw`(?:^|[^A-Za-z0-9_])(?:am_|sk_)`,
   String.raw`A[KS]IA[A-Z0-9]|AKID|LTAI|hf_|api_org_|r8_`,
   AWS_SECRET_ACCESS_KEY_VALUE_PATTERN,


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's log/diagnostic redaction (`src/logging/redact.ts`) scrubs a large corpus of vendor secret formats (~80: Stripe, SendGrid, GitHub, GitLab, npm, DigitalOcean, Datadog, Atlassian, and many more). **Shopify Admin API access tokens were missing.** A leaked Shopify token (`shpat_…`, `shpca_…`, `shppa_…`, `shpss_…`) could therefore appear unredacted in logs and support bundles, the exact class of leak this module exists to prevent.

## Why This Change Was Made

Shopify access tokens have a well-known, unambiguous shape used by standard secret scanners (GitHub secret scanning, gitleaks): a `shpat_` / `shpca_` / `shppa_` / `shpss_` prefix followed by 32 hexadecimal characters. They sit naturally alongside the payment/SaaS tokens already covered (Stripe `sk_live_`, SendGrid `SG.`, etc.), so this closes a gap in an already-comprehensive list.

The change:
- Adds `(shp(?:at|ca|pa|ss)_[A-Fa-f0-9]{32})` to `DEFAULT_REDACT_PATTERNS`.
- Adds the matching `shp(?:at|ca|pa|ss)_` trigger to `DEFAULT_REDACT_PREFILTER_SOURCES` — required, or the fast-path prefilter would skip the pattern and silently leak the secret (per the note in that block).

The strict `[A-Fa-f0-9]{32}` body avoids false positives on ordinary identifiers that merely start with `shp`.

## User Impact

Shopify credentials that end up in captured log lines, tool output, or diagnostic/support bundles are now masked (`shpat_…aaaa`) like every other supported vendor token. No behavior change for non-secret text.

## Evidence

Two-file change: `src/logging/redact.ts` + `src/logging/redact.test.ts`.

- `pnpm exec vitest run src/logging/redact.test.ts` → **149/149 pass**, including:
  - new `masks Shopify access tokens (shp*_ prefixes)` (asserts each prefix masks to `<prefix>_…aaaa`),
  - the `masks expanded vendor-prefix token corpus` reachability test (extended with the four Shopify tokens, proving each stays reachable through `DEFAULT_REDACT_PREFILTER_RE`),
  - the `does not redact ordinary identifiers…` false-positive guard (extended with short/non-hex `shp*_` samples that must stay untouched).
- `oxfmt --check` clean, `oxlint` clean on both files.

## AI/Vibe-Coded

- [x] AI-assisted (marked in title)
- [x] Evidence section included above
- [x] Author understands what the code does


---

**Update (chunk-safety, addressing Codex P2):** the Shopify pattern is a fixed 38-char whole token with no left-boundary assertion, so `replacePatternBounded` could slice it across a 16,384-char chunk boundary and leave it unredacted. Extracted it to a named `SHOPIFY_ACCESS_TOKEN_REDACT_PATTERN` and registered it in `CHUNK_UNSAFE_PATTERN_SOURCES` so it runs against the full string (matching the AWS/Telegram whole-token handling). Added a chunk-boundary regression test; verified it fails without the registration and passes with it. Full file now **150/150** (`vitest run src/logging/redact.test.ts`), oxfmt + oxlint clean.
