### PR TITLE
fix(release): keep msteams packaging and Docker reruns reliable

### DIFF
--- a/.github/workflows/pr-ci-sweeper.yml
+++ b/.github/workflows/pr-ci-sweeper.yml
@@ -39,13 +39,13 @@ jobs:
       # lack actions:write/checks:read (every sweep failed 2026-07-24 until the
       # subset was reverted). No inputs = the app's full granted set, which the
       # sweep's re-fire lane is known to work with.
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # zizmor: ignore[github-app] v3
         id: app-token
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # zizmor: ignore[github-app] v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
         with:

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -76,6 +76,7 @@
       "runtimeFormat": "cjs"
     },
     "release": {
+      "bundleRuntimeDependencies": false,
       "publishToClawHub": true,
       "publishToNpm": true
     }

--- a/scripts/docker-e2e-rerun.mjs
+++ b/scripts/docker-e2e-rerun.mjs
@@ -417,10 +417,14 @@ function downloadDockerArtifacts(runId, repo, outputDir) {
   if (names.length === 0) {
     throw new Error(`No docker-e2e-* artifacts found for run ${runId}`);
   }
-  for (const name of names) {
+  for (const [index, name] of names.entries()) {
+    const artifactDir = path.join(
+      outputDir,
+      `${String(index).padStart(3, "0")}-${safePathSegment(name)}`,
+    );
     run(
       "gh",
-      ["run", "download", String(runId), "--repo", repo, "--name", name, "--dir", outputDir],
+      ["run", "download", String(runId), "--repo", repo, "--name", name, "--dir", artifactDir],
       {
         stdio: "inherit",
       },

--- a/test/plugin-npm-package-manifest.test.ts
+++ b/test/plugin-npm-package-manifest.test.ts
@@ -140,6 +140,14 @@ function writeOptionalPlatformDependencyPackage(packageDir: string): string {
 }
 
 describe("plugin npm package manifest staging", () => {
+  it("keeps msteams runtime dependencies registry-installed", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(process.cwd(), "extensions", "msteams", "package.json"), "utf8"),
+    ) as { openclaw?: { release?: { bundleRuntimeDependencies?: boolean } } };
+
+    expect(packageJson.openclaw?.release?.bundleRuntimeDependencies).toBe(false);
+  });
+
   it("wraps Windows npm.cmd staging through cmd.exe without shell mode", () => {
     const nodeDir = "C:\\Program Files\\nodejs";
     const npmCmdPath = win32.resolve(nodeDir, "npm.cmd");

--- a/test/scripts/docker-e2e-helper-cli.test.ts
+++ b/test/scripts/docker-e2e-helper-cli.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -687,8 +688,22 @@ describe("Docker E2E helper CLIs", () => {
       expect(firstDir).not.toBe(secondDir);
       expect(path.basename(firstDir)).toMatch(/^openclaw-docker-e2e-rerun-12345-/u);
       expect(path.basename(secondDir)).toMatch(/^openclaw-docker-e2e-rerun-12345-/u);
-      expect(existsSync(path.join(firstDir, "artifact", "failures.json"))).toBe(true);
-      expect(existsSync(path.join(secondDir, "artifact", "failures.json"))).toBe(true);
+      const firstArtifactDir = readdirSync(firstDir, { withFileTypes: true }).find((entry) =>
+        entry.isDirectory(),
+      );
+      const secondArtifactDir = readdirSync(secondDir, { withFileTypes: true }).find((entry) =>
+        entry.isDirectory(),
+      );
+      expect(firstArtifactDir).toBeDefined();
+      expect(secondArtifactDir).toBeDefined();
+      expect(
+        existsSync(path.join(firstDir, firstArtifactDir?.name ?? "", "artifact", "failures.json")),
+      ).toBe(true);
+      expect(
+        existsSync(
+          path.join(secondDir, secondArtifactDir?.name ?? "", "artifact", "failures.json"),
+        ),
+      ).toBe(true);
       expect(first.stdout).toContain(`-f ref='${"d".repeat(40)}'`);
       expect(first.stdout).not.toContain("-f ref='abc123'");
       expect(second.stdout).toContain(`-f ref='${"d".repeat(40)}'`);
@@ -696,6 +711,81 @@ describe("Docker E2E helper CLIs", () => {
       for (const dir of generatedDirs) {
         rmSync(dir, { force: true, recursive: true });
       }
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("isolates files with the same name across downloaded artifacts", () => {
+    const root = mkdtempSync(`${tmpdir()}/openclaw-docker-e2e-rerun-collisions-`);
+    try {
+      const binDir = path.join(root, "bin");
+      const outputDir = path.join(root, "artifacts");
+      const ghPath = path.join(binDir, "gh");
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(
+        ghPath,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const path = require('node:path');",
+          "const args = process.argv.slice(2);",
+          "if (args[0] === 'run' && args[1] === 'view') {",
+          "  console.log(JSON.stringify({ headBranch: 'main', headSha: 'f'.repeat(40), url: 'https://example.invalid/run', workflowName: 'Live E2E' }));",
+          "  process.exit(0);",
+          "}",
+          "if (args[0] === 'api') {",
+          "  console.log(JSON.stringify([",
+          "    { expired: false, name: 'docker-e2e-a' },",
+          "    { expired: false, name: 'docker-e2e-b' },",
+          "  ]));",
+          "  process.exit(0);",
+          "}",
+          "if (args[0] === 'run' && args[1] === 'download') {",
+          "  const name = args[args.indexOf('--name') + 1];",
+          "  const dir = args[args.indexOf('--dir') + 1];",
+          "  fs.mkdirSync(dir, { recursive: true });",
+          "  const plan = path.join(dir, 'targeted-plan.json');",
+          "  if (fs.existsSync(plan)) {",
+          "    console.error('targeted-plan.json already exists');",
+          "    process.exit(2);",
+          "  }",
+          "  fs.writeFileSync(plan, '{}');",
+          "  fs.writeFileSync(path.join(dir, 'failures.json'), JSON.stringify({",
+          "    lanes: [{ name: name.endsWith('-a') ? 'gateway-network' : 'install-e2e', status: 1 }],",
+          "    ref: 'd'.repeat(40),",
+          "    status: 'failed',",
+          "  }));",
+          "  process.exit(0);",
+          "}",
+          "console.error(`unexpected gh args: ${args.join(' ')}`);",
+          "process.exit(1);",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      chmodSync(ghPath, 0o755);
+
+      const result = runHelper(
+        "scripts/docker-e2e-rerun.mjs",
+        "12345",
+        "--repo",
+        "openclaw/openclaw",
+        "--dir",
+        outputDir,
+        { PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("gateway-network");
+      expect(result.stdout).toContain("install-e2e");
+      const artifactDirs = readdirSync(outputDir, { withFileTypes: true }).filter((entry) =>
+        entry.isDirectory(),
+      );
+      expect(artifactDirs).toHaveLength(2);
+      for (const entry of artifactDirs) {
+        expect(existsSync(path.join(outputDir, entry.name, "targeted-plan.json"))).toBe(true);
+      }
+    } finally {
       rmSync(root, { force: true, recursive: true });
     }
   });


### PR DESCRIPTION
Related: #113280

## What Problem This Solves

Fixes two release-recovery failures found while preparing `2026.7.2-beta.5`: Microsoft Teams package preparation could exceed the archive entry safety budget by bundling its large runtime dependency tree, and Docker E2E rerun discovery could fail while extracting multiple Actions artifacts that contain the same filenames.

It also repairs the `main` Workflow Sanity baseline introduced when #113280's PR CI sweeper token fix restored the apps' required full installation grants. Zizmor correctly flags that broad grant by default, but the narrower token request cannot be minted because these app installations do not grant the requested Actions/check permissions.

## Why This Change Was Made

Microsoft Teams now keeps its declared runtime dependencies registry-installed, matching the plugin package ownership contract without changing runtime behavior. Docker rerun downloads now isolate each immutable Actions artifact in its own indexed directory while retaining recursive failure discovery and exact target-SHA validation.

The PR CI sweeper keeps the known-working full-grant token behavior and uses an exact inline Zizmor suppression on those two token-minting steps. The surrounding workflow comment records why explicit permission inputs are not viable, so the exception remains reviewable rather than silently weakening the release gate.

The updater/doctor blocker itself is already fixed on `main` by #113280, #113298, and #113317; this PR forward-ports the remaining release-only packaging repair and the recovery-tooling fix uncovered while diagnosing that blocker.

## User Impact

Microsoft Teams installs from a small parser-safe package and still receives its declared Teams/Azure dependencies from npm. Maintainers can reliably derive targeted Docker reruns from multi-artifact release runs instead of manually downloading each artifact after a filename collision. The canonical main workflow gate is green again without changing the PR CI sweeper's proven authentication behavior.

## Evidence

- `node scripts/run-vitest.mjs test/plugin-npm-package-manifest.test.ts` — 10/10 passed.
- `node scripts/run-vitest.mjs test/scripts/docker-e2e-helper-cli.test.ts` — 28/28 passed.
- Real msteams release pack dry-run: 26 entries, 617,520 bytes unpacked, zero `node_modules/` archive entries.
- Blacksmith Testbox packaged msteams install/load proof: packed `@openclaw/msteams@2026.7.2`, installed it through `npm-pack:`, loaded `msteams` with runtime status `loaded`, and resolved `@microsoft/teams.apps` plus `@azure/identity` from the managed plugin npm project (run 30099382065).
- Real Docker rerun discovery against failed Package Acceptance run 30072849621: all 12 `docker-e2e-*` artifacts downloaded successfully; exact target `5e63b365d4d3e62ef600b783fad7c5043b6f4738`; four failed update lanes recovered.
- `plugin-npm-release-check.ts --plugins @openclaw/msteams` passed.
- Zizmor v1.28.0 against `.github/workflows/pr-ci-sweeper.yml`: both intentional `github-app` findings ignored; zero active high-severity findings.
- Full `pnpm check:workflows`: actionlint passed; Zizmor reached the repository-wide live action-tag drift baseline with the sweeper findings suppressed.
- Codex autoreview: clean, no accepted/actionable findings, including a fresh review of the workflow exception.
- Source-blind behavior contract: 3/3 clauses passed; repeated-name artifact and tracked-tree mutation probes passed.
