### PR TITLE
feat(feeds): consume signed catalog changes

### DIFF
--- a/src/plugins/official-external-plugin-catalog-changes.test.ts
+++ b/src/plugins/official-external-plugin-catalog-changes.test.ts
@@ -1,0 +1,197 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE,
+  applyVerifiedOfficialExternalPluginCatalogChangeBodies,
+  parseOfficialExternalPluginCatalogChangePayload,
+  parseOfficialExternalPluginCatalogIncrementalSnapshot,
+  serializeOfficialExternalPluginCatalogIncrementalSnapshot,
+  verifyOfficialExternalPluginCatalogChangeEnvelopeBody,
+} from "./official-external-plugin-catalog-changes.js";
+import type { OfficialExternalPluginCatalogFeed } from "./official-external-plugin-catalog.js";
+
+const keys = crypto.generateKeyPairSync("ed25519", {
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+function signChangePayload(payload: unknown): string {
+  const payloadBytes = Buffer.from(JSON.stringify(payload), "utf8");
+  const typeBytes = Buffer.from(OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE, "utf8");
+  const signingInput = Buffer.concat([
+    Buffer.from(
+      `DSSEv1 ${typeBytes.length} ${OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE} ${payloadBytes.length} `,
+      "utf8",
+    ),
+    payloadBytes,
+  ]);
+  return JSON.stringify({
+    payloadType: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE,
+    payload: payloadBytes.toString("base64url"),
+    signatures: [
+      {
+        keyid: "catalog-root",
+        sig: crypto.sign(null, signingInput, keys.privateKey).toString("base64url"),
+      },
+    ],
+  });
+}
+
+function catalogEntry(id: string) {
+  return {
+    type: "plugin" as const,
+    id,
+    title: id,
+    version: "1.0.0",
+    state: "available",
+    publisher: { id: "openclaw", trust: "official" },
+    install: {
+      candidates: [
+        {
+          sourceRef: "public-clawhub",
+          package: id,
+          version: "1.0.0",
+          integrity: `sha256:${"a".repeat(64)}`,
+        },
+      ],
+    },
+  };
+}
+
+function page(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    feedId: "clawhub-official",
+    fromSequence: 1,
+    toSequence: 3,
+    generatedAt: "2026-07-24T12:00:00.000Z",
+    expiresAt: "2026-07-24T12:05:00.000Z",
+    requestCursor: null,
+    pageIndex: 0,
+    startIndex: 0,
+    changeCount: 3,
+    changes: [
+      { sequence: 2, operation: "upsert", entry: catalogEntry("beta") },
+      {
+        sequence: 2,
+        operation: "metadata",
+        metadata: { description: "Current catalog" },
+      },
+    ],
+    nextCursor: "page-2",
+    ...overrides,
+  };
+}
+
+const baseFeed: OfficialExternalPluginCatalogFeed = {
+  schemaVersion: 1,
+  id: "clawhub-official",
+  sequence: 1,
+  generatedAt: "2026-07-24T11:00:00.000Z",
+  expiresAt: "2026-07-24T11:05:00.000Z",
+  description: "Old catalog",
+  entries: [catalogEntry("alpha")],
+};
+
+describe("official external plugin catalog changes", () => {
+  it("verifies a complete paginated range and applies it atomically", () => {
+    const bodies = [
+      signChangePayload(page()),
+      signChangePayload(
+        page({
+          requestCursor: "page-2",
+          pageIndex: 1,
+          startIndex: 2,
+          changes: [{ sequence: 3, operation: "remove", entryId: "alpha", entryType: "plugin" }],
+          nextCursor: null,
+        }),
+      ),
+    ];
+
+    const result = applyVerifiedOfficialExternalPluginCatalogChangeBodies({
+      feed: baseFeed,
+      changeBodies: bodies,
+      trustedKeys: [{ keyId: "catalog-root", publicKey: keys.publicKey }],
+      expectedFeedId: "clawhub-official",
+    });
+
+    expect(result.feed).toMatchObject({
+      sequence: 3,
+      generatedAt: "2026-07-24T12:00:00.000Z",
+      expiresAt: "2026-07-24T12:05:00.000Z",
+      description: "Current catalog",
+      entries: [{ id: "beta" }],
+    });
+  });
+
+  it("rejects partial ranges, sequence gaps, and tampered envelopes", () => {
+    const firstBody = signChangePayload(page());
+    expect(() =>
+      applyVerifiedOfficialExternalPluginCatalogChangeBodies({
+        feed: baseFeed,
+        changeBodies: [firstBody],
+        trustedKeys: [{ keyId: "catalog-root", publicKey: keys.publicKey }],
+      }),
+    ).toThrow("incomplete range");
+
+    const gap = signChangePayload(
+      page({
+        toSequence: 4,
+        changeCount: 1,
+        changes: [{ sequence: 4, operation: "upsert", entry: catalogEntry("gap") }],
+        nextCursor: null,
+      }),
+    );
+    expect(() =>
+      applyVerifiedOfficialExternalPluginCatalogChangeBodies({
+        feed: baseFeed,
+        changeBodies: [gap],
+        trustedKeys: [{ keyId: "catalog-root", publicKey: keys.publicKey }],
+      }),
+    ).toThrow("invalid sequence range");
+
+    const envelope = JSON.parse(firstBody) as { payload: string };
+    envelope.payload = `${envelope.payload.slice(0, -1)}A`;
+    expect(() =>
+      verifyOfficialExternalPluginCatalogChangeEnvelopeBody(JSON.stringify(envelope), {
+        trustedKeys: [{ keyId: "catalog-root", publicKey: keys.publicKey }],
+      }),
+    ).toThrow();
+  });
+
+  it("strictly parses signed reset responses without treating them as deltas", () => {
+    const reset = {
+      schemaVersion: 1,
+      feedId: "clawhub-official",
+      fromSequence: 1,
+      currentSequence: 9,
+      generatedAt: "2026-07-24T12:00:00.000Z",
+      expiresAt: "2026-07-24T12:05:00.000Z",
+      resetRequired: true,
+      snapshotUrl: "https://clawhub.ai/api/v1/feeds/plugins",
+    };
+    expect(parseOfficialExternalPluginCatalogChangePayload(reset)).toMatchObject({
+      resetRequired: true,
+      currentSequence: 9,
+    });
+    expect(() =>
+      parseOfficialExternalPluginCatalogChangePayload({ ...reset, unexpected: true }),
+    ).toThrow("reset response is malformed");
+  });
+
+  it("round-trips the signed base and exact change envelope bytes", () => {
+    const body = signChangePayload(
+      page({ toSequence: 2, changeCount: 1, changes: [page().changes[0]], nextCursor: null }),
+    );
+    const serialized = serializeOfficialExternalPluginCatalogIncrementalSnapshot({
+      baseBody: "signed-base",
+      changeBodies: [body],
+    });
+
+    expect(parseOfficialExternalPluginCatalogIncrementalSnapshot(JSON.parse(serialized))).toEqual({
+      kind: "official-external-plugin-catalog-changes-v1",
+      baseBody: "signed-base",
+      changeBodies: [body],
+    });
+  });
+});

--- a/src/plugins/official-external-plugin-catalog-changes.test.ts
+++ b/src/plugins/official-external-plugin-catalog-changes.test.ts
@@ -1,15 +1,15 @@
 import crypto from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
-  OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE,
   applyVerifiedOfficialExternalPluginCatalogChangeBodies,
   applyVerifiedOfficialExternalPluginCatalogChanges,
-  parseOfficialExternalPluginCatalogChangePayload,
   parseOfficialExternalPluginCatalogIncrementalSnapshot,
   serializeOfficialExternalPluginCatalogIncrementalSnapshot,
   verifyOfficialExternalPluginCatalogChangeEnvelopeBody,
 } from "./official-external-plugin-catalog-changes.js";
 import type { OfficialExternalPluginCatalogFeed } from "./official-external-plugin-catalog.js";
+
+const CHANGES_PAYLOAD_TYPE = "openclaw.official-external-plugin-catalog-changes.v1";
 
 const keys = crypto.generateKeyPairSync("ed25519", {
   publicKeyEncoding: { type: "spki", format: "pem" },
@@ -18,16 +18,16 @@ const keys = crypto.generateKeyPairSync("ed25519", {
 
 function signChangePayload(payload: unknown): string {
   const payloadBytes = Buffer.from(JSON.stringify(payload), "utf8");
-  const typeBytes = Buffer.from(OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE, "utf8");
+  const typeBytes = Buffer.from(CHANGES_PAYLOAD_TYPE, "utf8");
   const signingInput = Buffer.concat([
     Buffer.from(
-      `DSSEv1 ${typeBytes.length} ${OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE} ${payloadBytes.length} `,
+      `DSSEv1 ${typeBytes.length} ${CHANGES_PAYLOAD_TYPE} ${payloadBytes.length} `,
       "utf8",
     ),
     payloadBytes,
   ]);
   return JSON.stringify({
-    payloadType: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE,
+    payloadType: CHANGES_PAYLOAD_TYPE,
     payload: payloadBytes.toString("base64url"),
     signatures: [
       {
@@ -171,12 +171,19 @@ describe("official external plugin catalog changes", () => {
       resetRequired: true,
       snapshotUrl: "https://clawhub.ai/api/v1/feeds/plugins",
     };
-    expect(parseOfficialExternalPluginCatalogChangePayload(reset)).toMatchObject({
+    const verified = verifyOfficialExternalPluginCatalogChangeEnvelopeBody(
+      signChangePayload(reset),
+      { trustedKeys: [{ keyId: "catalog-root", publicKey: keys.publicKey }] },
+    );
+    expect(verified.payload).toMatchObject({
       resetRequired: true,
       currentSequence: 9,
     });
     expect(() =>
-      parseOfficialExternalPluginCatalogChangePayload({ ...reset, unexpected: true }),
+      verifyOfficialExternalPluginCatalogChangeEnvelopeBody(
+        signChangePayload({ ...reset, unexpected: true }),
+        { trustedKeys: [{ keyId: "catalog-root", publicKey: keys.publicKey }] },
+      ),
     ).toThrow("reset response is malformed");
   });
 
@@ -218,16 +225,19 @@ describe("official external plugin catalog changes", () => {
         ],
       },
     };
-    const parsed = parseOfficialExternalPluginCatalogChangePayload(
-      page({
-        toSequence: 2,
-        changeCount: 1,
-        changes: [{ sequence: 2, operation: "upsert", entry }],
-        nextCursor: null,
-      }),
+    const verified = verifyOfficialExternalPluginCatalogChangeEnvelopeBody(
+      signChangePayload(
+        page({
+          toSequence: 2,
+          changeCount: 1,
+          changes: [{ sequence: 2, operation: "upsert", entry }],
+          nextCursor: null,
+        }),
+      ),
+      { trustedKeys: [{ keyId: "catalog-root", publicKey: keys.publicKey }] },
     );
 
-    expect(parsed).toMatchObject({ changes: [{ entry }] });
+    expect(verified.payload).toMatchObject({ changes: [{ entry }] });
   });
 
   it("applies pages that the live path has already verified", () => {

--- a/src/plugins/official-external-plugin-catalog-changes.test.ts
+++ b/src/plugins/official-external-plugin-catalog-changes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE,
   applyVerifiedOfficialExternalPluginCatalogChangeBodies,
+  applyVerifiedOfficialExternalPluginCatalogChanges,
   parseOfficialExternalPluginCatalogChangePayload,
   parseOfficialExternalPluginCatalogIncrementalSnapshot,
   serializeOfficialExternalPluginCatalogIncrementalSnapshot,
@@ -193,5 +194,71 @@ describe("official external plugin catalog changes", () => {
       baseBody: "signed-base",
       changeBodies: [body],
     });
+  });
+
+  it("accepts producer-shaped upserts with presentation and GitHub source metadata", () => {
+    const entry = {
+      ...catalogEntry("producer-plugin"),
+      description: "Producer description",
+      icon: "https://clawhub.ai/icons/producer-plugin.png",
+      install: {
+        candidates: [
+          {
+            sourceRef: "public-clawhub",
+            package: "producer-plugin",
+            version: "1.0.0",
+            integrity: `sha256:${"a".repeat(64)}`,
+            github: {
+              repo: "openclaw/plugins",
+              path: "plugins/producer-plugin",
+              commit: "f".repeat(40),
+              contentHash: `sha256:${"b".repeat(64)}`,
+            },
+          },
+        ],
+      },
+    };
+    const parsed = parseOfficialExternalPluginCatalogChangePayload(
+      page({
+        toSequence: 2,
+        changeCount: 1,
+        changes: [{ sequence: 2, operation: "upsert", entry }],
+        nextCursor: null,
+      }),
+    );
+
+    expect(parsed).toMatchObject({ changes: [{ entry }] });
+  });
+
+  it("applies pages that the live path has already verified", () => {
+    const body = signChangePayload(
+      page({ toSequence: 2, changeCount: 1, changes: [page().changes[0]], nextCursor: null }),
+    );
+    const verified = verifyOfficialExternalPluginCatalogChangeEnvelopeBody(body, {
+      trustedKeys: [{ keyId: "catalog-root", publicKey: keys.publicKey }],
+    });
+
+    expect(
+      applyVerifiedOfficialExternalPluginCatalogChanges({
+        feed: baseFeed,
+        changes: [verified],
+        expectedFeedId: "clawhub-official",
+      }).feed,
+    ).toMatchObject({ sequence: 2, entries: [{ id: "alpha" }, { id: "beta" }] });
+  });
+
+  it("bounds persisted change history so the caller can compact through the full root", () => {
+    expect(() =>
+      serializeOfficialExternalPluginCatalogIncrementalSnapshot({
+        baseBody: "signed-base",
+        changeBodies: Array.from({ length: 2048 }, () => "signed-change"),
+      }),
+    ).not.toThrow();
+    expect(() =>
+      serializeOfficialExternalPluginCatalogIncrementalSnapshot({
+        baseBody: "signed-base",
+        changeBodies: Array.from({ length: 2049 }, () => "signed-change"),
+      }),
+    ).toThrow("invalid change page count");
   });
 });

--- a/src/plugins/official-external-plugin-catalog-changes.ts
+++ b/src/plugins/official-external-plugin-catalog-changes.ts
@@ -9,7 +9,7 @@ import {
   type OfficialExternalPluginCatalogFeed,
 } from "./official-external-plugin-catalog.js";
 
-export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE =
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE =
   "openclaw.official-external-plugin-catalog-changes.v1";
 
 const INCREMENTAL_SNAPSHOT_KIND = "official-external-plugin-catalog-changes-v1";
@@ -26,7 +26,7 @@ type CatalogChange =
   | { sequence: number; operation: "remove"; entryId: string; entryType: "plugin" | "skill" }
   | { sequence: number; operation: "metadata"; metadata: { description: string | null } };
 
-export type OfficialExternalPluginCatalogChangePage = {
+type OfficialExternalPluginCatalogChangePage = {
   schemaVersion: 1;
   feedId: string;
   fromSequence: number;
@@ -41,7 +41,7 @@ export type OfficialExternalPluginCatalogChangePage = {
   nextCursor: string | null;
 };
 
-export type OfficialExternalPluginCatalogResetRequired = {
+type OfficialExternalPluginCatalogResetRequired = {
   schemaVersion: 1;
   feedId: string;
   fromSequence: number;
@@ -52,20 +52,20 @@ export type OfficialExternalPluginCatalogResetRequired = {
   snapshotUrl: string;
 };
 
-export type OfficialExternalPluginCatalogIncrementalSnapshot = {
+type OfficialExternalPluginCatalogIncrementalSnapshot = {
   kind: typeof INCREMENTAL_SNAPSHOT_KIND;
   baseBody: string;
   changeBodies: readonly string[];
   materializedFeedSha256?: string;
 };
 
-export type OfficialExternalPluginCatalogResetFloorSnapshot = {
+type OfficialExternalPluginCatalogResetFloorSnapshot = {
   kind: typeof RESET_FLOOR_SNAPSHOT_KIND;
   snapshotBody: string;
   minimumSequence: number;
 };
 
-export type VerifiedOfficialExternalPluginCatalogChangePayload = {
+type VerifiedOfficialExternalPluginCatalogChangePayload = {
   payload: OfficialExternalPluginCatalogChangePage | OfficialExternalPluginCatalogResetRequired;
   signedBy: string;
   signatureCount: number;
@@ -267,7 +267,7 @@ function parseProjectionHeader(value: Record<string, unknown>) {
   return { feedId, generatedAt, expiresAt };
 }
 
-export function parseOfficialExternalPluginCatalogChangePayload(
+function parseOfficialExternalPluginCatalogChangePayload(
   value: unknown,
 ): OfficialExternalPluginCatalogChangePage | OfficialExternalPluginCatalogResetRequired {
   if (!isRecord(value)) {

--- a/src/plugins/official-external-plugin-catalog-changes.ts
+++ b/src/plugins/official-external-plugin-catalog-changes.ts
@@ -13,6 +13,7 @@ export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE =
   "openclaw.official-external-plugin-catalog-changes.v1";
 
 const INCREMENTAL_SNAPSHOT_KIND = "official-external-plugin-catalog-changes-v1";
+const RESET_FLOOR_SNAPSHOT_KIND = "official-external-plugin-catalog-reset-floor-v1";
 const MAX_CHANGE_RECORDS_PER_PAGE = 500;
 const MAX_CHANGE_PAGES_PER_SNAPSHOT = 2048;
 const MAX_CURSOR_BYTES = 4096;
@@ -55,6 +56,13 @@ export type OfficialExternalPluginCatalogIncrementalSnapshot = {
   kind: typeof INCREMENTAL_SNAPSHOT_KIND;
   baseBody: string;
   changeBodies: readonly string[];
+  materializedFeedSha256?: string;
+};
+
+export type OfficialExternalPluginCatalogResetFloorSnapshot = {
+  kind: typeof RESET_FLOOR_SNAPSHOT_KIND;
+  snapshotBody: string;
+  minimumSequence: number;
 };
 
 export type VerifiedOfficialExternalPluginCatalogChangePayload = {
@@ -531,11 +539,9 @@ function applyChangePages(
   return materialized;
 }
 
-export function applyVerifiedOfficialExternalPluginCatalogChangeBodies(params: {
+export function applyVerifiedOfficialExternalPluginCatalogChanges(params: {
   feed: OfficialExternalPluginCatalogFeed;
-  changeBodies: readonly string[];
-  trustedKeys: readonly TrustedSigningKey[];
-  threshold?: number;
+  changes: readonly VerifiedOfficialExternalPluginCatalogChangePayload[];
   expectedFeedId?: string;
 }): {
   feed: OfficialExternalPluginCatalogFeed;
@@ -543,17 +549,13 @@ export function applyVerifiedOfficialExternalPluginCatalogChangeBodies(params: {
   signatureCount: number;
   threshold: number;
 } {
-  if (
-    params.changeBodies.length === 0 ||
-    params.changeBodies.length > MAX_CHANGE_PAGES_PER_SNAPSHOT
-  ) {
+  if (params.changes.length === 0 || params.changes.length > MAX_CHANGE_PAGES_PER_SNAPSHOT) {
     throw new Error("hosted catalog incremental snapshot has an invalid change page count");
   }
   let feed = params.feed;
   let range: OfficialExternalPluginCatalogChangePage[] = [];
   let lastVerification: VerifiedOfficialExternalPluginCatalogChangePayload | undefined;
-  for (const body of params.changeBodies) {
-    const verified = verifyOfficialExternalPluginCatalogChangeEnvelopeBody(body, params);
+  for (const verified of params.changes) {
     if ("resetRequired" in verified.payload) {
       throw new Error("hosted catalog incremental snapshot cannot contain a reset response");
     }
@@ -585,6 +587,27 @@ export function applyVerifiedOfficialExternalPluginCatalogChangeBodies(params: {
   };
 }
 
+export function applyVerifiedOfficialExternalPluginCatalogChangeBodies(params: {
+  feed: OfficialExternalPluginCatalogFeed;
+  changeBodies: readonly string[];
+  trustedKeys: readonly TrustedSigningKey[];
+  threshold?: number;
+  expectedFeedId?: string;
+}): {
+  feed: OfficialExternalPluginCatalogFeed;
+  signedBy: string;
+  signatureCount: number;
+  threshold: number;
+} {
+  return applyVerifiedOfficialExternalPluginCatalogChanges({
+    feed: params.feed,
+    changes: params.changeBodies.map((body) =>
+      verifyOfficialExternalPluginCatalogChangeEnvelopeBody(body, params),
+    ),
+    expectedFeedId: params.expectedFeedId,
+  });
+}
+
 export function parseOfficialExternalPluginCatalogIncrementalSnapshot(
   value: unknown,
 ): OfficialExternalPluginCatalogIncrementalSnapshot | null {
@@ -592,12 +615,16 @@ export function parseOfficialExternalPluginCatalogIncrementalSnapshot(
     return null;
   }
   if (
-    !hasExactKeys(value, ["kind", "baseBody", "changeBodies"]) ||
+    (!hasExactKeys(value, ["kind", "baseBody", "changeBodies"]) &&
+      !hasExactKeys(value, ["kind", "baseBody", "changeBodies", "materializedFeedSha256"])) ||
     typeof value.baseBody !== "string" ||
     !Array.isArray(value.changeBodies) ||
     !value.changeBodies.every((body): body is string => typeof body === "string") ||
     value.changeBodies.length === 0 ||
-    value.changeBodies.length > MAX_CHANGE_PAGES_PER_SNAPSHOT
+    value.changeBodies.length > MAX_CHANGE_PAGES_PER_SNAPSHOT ||
+    (value.materializedFeedSha256 !== undefined &&
+      (typeof value.materializedFeedSha256 !== "string" ||
+        !/^sha256:[a-f0-9]{64}$/u.test(value.materializedFeedSha256)))
   ) {
     throw new Error("hosted catalog incremental snapshot is malformed");
   }
@@ -605,12 +632,16 @@ export function parseOfficialExternalPluginCatalogIncrementalSnapshot(
     kind: INCREMENTAL_SNAPSHOT_KIND,
     baseBody: value.baseBody,
     changeBodies: value.changeBodies,
+    ...(typeof value.materializedFeedSha256 === "string"
+      ? { materializedFeedSha256: value.materializedFeedSha256 }
+      : {}),
   };
 }
 
 export function serializeOfficialExternalPluginCatalogIncrementalSnapshot(params: {
   baseBody: string;
   changeBodies: readonly string[];
+  materializedFeedSha256?: string;
 }): string {
   if (
     params.changeBodies.length === 0 ||
@@ -618,9 +649,48 @@ export function serializeOfficialExternalPluginCatalogIncrementalSnapshot(params
   ) {
     throw new Error("hosted catalog incremental snapshot has an invalid change page count");
   }
+  if (
+    params.materializedFeedSha256 !== undefined &&
+    !/^sha256:[a-f0-9]{64}$/u.test(params.materializedFeedSha256)
+  ) {
+    throw new Error("hosted catalog incremental snapshot materialized feed digest is invalid");
+  }
   return JSON.stringify({
     kind: INCREMENTAL_SNAPSHOT_KIND,
     baseBody: params.baseBody,
     changeBodies: params.changeBodies,
+    ...(params.materializedFeedSha256
+      ? { materializedFeedSha256: params.materializedFeedSha256 }
+      : {}),
   });
+}
+
+export function parseOfficialExternalPluginCatalogResetFloorSnapshot(
+  value: unknown,
+): OfficialExternalPluginCatalogResetFloorSnapshot | null {
+  if (!isRecord(value) || value.kind !== RESET_FLOOR_SNAPSHOT_KIND) {
+    return null;
+  }
+  if (
+    !hasExactKeys(value, ["kind", "snapshotBody", "minimumSequence"]) ||
+    typeof value.snapshotBody !== "string" ||
+    !isOfficialExternalPluginCatalogSequence(value.minimumSequence)
+  ) {
+    throw new Error("hosted catalog reset floor snapshot is malformed");
+  }
+  return {
+    kind: RESET_FLOOR_SNAPSHOT_KIND,
+    snapshotBody: value.snapshotBody,
+    minimumSequence: value.minimumSequence,
+  };
+}
+
+export function serializeOfficialExternalPluginCatalogResetFloorSnapshot(params: {
+  snapshotBody: string;
+  minimumSequence: number;
+}): string {
+  if (!isOfficialExternalPluginCatalogSequence(params.minimumSequence)) {
+    throw new Error("hosted catalog reset floor snapshot sequence is invalid");
+  }
+  return JSON.stringify({ kind: RESET_FLOOR_SNAPSHOT_KIND, ...params });
 }

--- a/src/plugins/official-external-plugin-catalog-changes.ts
+++ b/src/plugins/official-external-plugin-catalog-changes.ts
@@ -1,0 +1,626 @@
+import { Buffer } from "node:buffer";
+import { isRecord } from "../utils.js";
+import { verifyOfficialExternalPluginCatalogEnvelopePayload } from "./official-external-plugin-catalog-envelope.js";
+import {
+  isOfficialExternalPluginCatalogFeed,
+  isOfficialExternalPluginCatalogSequence,
+  parseOfficialExternalPluginCatalogTimestamp,
+  type OfficialExternalPluginCatalogEntry,
+  type OfficialExternalPluginCatalogFeed,
+} from "./official-external-plugin-catalog.js";
+
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE =
+  "openclaw.official-external-plugin-catalog-changes.v1";
+
+const INCREMENTAL_SNAPSHOT_KIND = "official-external-plugin-catalog-changes-v1";
+const MAX_CHANGE_RECORDS_PER_PAGE = 500;
+const MAX_CHANGE_PAGES_PER_SNAPSHOT = 2048;
+const MAX_CURSOR_BYTES = 4096;
+const MAX_DESCRIPTION_BYTES = 1024;
+
+type TrustedSigningKey = { keyId: string; publicKey: string };
+
+type CatalogChange =
+  | { sequence: number; operation: "upsert"; entry: OfficialExternalPluginCatalogEntry }
+  | { sequence: number; operation: "remove"; entryId: string; entryType: "plugin" | "skill" }
+  | { sequence: number; operation: "metadata"; metadata: { description: string | null } };
+
+export type OfficialExternalPluginCatalogChangePage = {
+  schemaVersion: 1;
+  feedId: string;
+  fromSequence: number;
+  toSequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  requestCursor: string | null;
+  pageIndex: number;
+  startIndex: number;
+  changeCount: number;
+  changes: readonly CatalogChange[];
+  nextCursor: string | null;
+};
+
+export type OfficialExternalPluginCatalogResetRequired = {
+  schemaVersion: 1;
+  feedId: string;
+  fromSequence: number;
+  currentSequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  resetRequired: true;
+  snapshotUrl: string;
+};
+
+export type OfficialExternalPluginCatalogIncrementalSnapshot = {
+  kind: typeof INCREMENTAL_SNAPSHOT_KIND;
+  baseBody: string;
+  changeBodies: readonly string[];
+};
+
+export type VerifiedOfficialExternalPluginCatalogChangePayload = {
+  payload: OfficialExternalPluginCatalogChangePage | OfficialExternalPluginCatalogResetRequired;
+  signedBy: string;
+  signatureCount: number;
+  threshold: number;
+};
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const expected = new Set(keys);
+  return (
+    Object.keys(value).length === expected.size &&
+    Object.keys(value).every((key) => expected.has(key))
+  );
+}
+
+function requireString(value: unknown, label: string, maxBytes = 256): string {
+  if (
+    typeof value !== "string" ||
+    Buffer.byteLength(value, "utf8") < 1 ||
+    Buffer.byteLength(value, "utf8") > maxBytes
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function requireAnyString(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function requireSequence(value: unknown, label: string): number {
+  if (!isOfficialExternalPluginCatalogSequence(value)) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function requireTimestamp(value: unknown, label: string): string {
+  const timestamp = requireString(value, label, 64);
+  if (
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u.test(timestamp) ||
+    parseOfficialExternalPluginCatalogTimestamp(timestamp) === undefined
+  ) {
+    throw new Error(`${label} must be an RFC 3339 timestamp`);
+  }
+  return timestamp;
+}
+
+function requireCursor(value: unknown, label: string): string | null {
+  if (value === null) {
+    return null;
+  }
+  return requireString(value, label, MAX_CURSOR_BYTES);
+}
+
+function parseCatalogEntry(value: unknown): OfficialExternalPluginCatalogEntry {
+  if (!isRecord(value)) {
+    throw new Error("hosted catalog change upsert entry is malformed");
+  }
+  const optional = new Set(["description", "icon", "featured", "featuredAt"]);
+  const required = ["type", "id", "title", "version", "state", "publisher", "install"];
+  if (
+    !Object.keys(value).every((key) => required.includes(key) || optional.has(key)) ||
+    !required.every((key) => key in value)
+  ) {
+    throw new Error("hosted catalog change upsert entry is malformed");
+  }
+  if (value.type !== "plugin" && value.type !== "skill") {
+    throw new Error("hosted catalog change upsert entry type is invalid");
+  }
+  requireString(value.id, "hosted catalog change upsert entry id");
+  requireAnyString(value.title, "hosted catalog change upsert entry title");
+  requireAnyString(value.version, "hosted catalog change upsert entry version");
+  if (
+    typeof value.state !== "string" ||
+    !["available", "recommended", "disabled", "blocked", "deprecated"].includes(value.state)
+  ) {
+    throw new Error("hosted catalog change upsert entry state is invalid");
+  }
+  if (value.description !== undefined) {
+    requireAnyString(value.description, "hosted catalog change upsert entry description");
+  }
+  if (value.icon !== undefined) {
+    requireAnyString(value.icon, "hosted catalog change upsert entry icon");
+  }
+  if (value.featured !== undefined && typeof value.featured !== "boolean") {
+    throw new Error("hosted catalog change upsert entry featured is invalid");
+  }
+  if (
+    value.featuredAt !== undefined &&
+    (!Number.isSafeInteger(value.featuredAt) ||
+      Number(value.featuredAt) < 0 ||
+      value.featured !== true)
+  ) {
+    throw new Error("hosted catalog change upsert entry featuredAt is invalid");
+  }
+  if (
+    !isRecord(value.publisher) ||
+    !hasExactKeys(value.publisher, ["id", "trust"]) ||
+    (value.publisher.trust !== "official" && value.publisher.trust !== "community")
+  ) {
+    throw new Error("hosted catalog change upsert publisher is malformed");
+  }
+  requireAnyString(value.publisher.id, "hosted catalog change upsert publisher id");
+  if (
+    !isRecord(value.install) ||
+    !hasExactKeys(value.install, ["candidates"]) ||
+    !Array.isArray(value.install.candidates)
+  ) {
+    throw new Error("hosted catalog change upsert install is malformed");
+  }
+  for (const candidate of value.install.candidates) {
+    if (!isRecord(candidate)) {
+      throw new Error("hosted catalog change upsert install candidate is malformed");
+    }
+    const keys =
+      candidate.github === undefined
+        ? ["sourceRef", "package", "version", "integrity"]
+        : ["sourceRef", "package", "version", "integrity", "github"];
+    if (!hasExactKeys(candidate, keys)) {
+      throw new Error("hosted catalog change upsert install candidate is malformed");
+    }
+    for (const field of ["sourceRef", "package", "version", "integrity"] as const) {
+      requireAnyString(candidate[field], `hosted catalog change upsert install candidate ${field}`);
+    }
+    if (candidate.github !== undefined) {
+      if (
+        !isRecord(candidate.github) ||
+        !hasExactKeys(candidate.github, ["repo", "path", "commit", "contentHash"])
+      ) {
+        throw new Error("hosted catalog change upsert GitHub source is malformed");
+      }
+      for (const field of ["repo", "path", "commit", "contentHash"] as const) {
+        requireAnyString(
+          candidate.github[field],
+          `hosted catalog change upsert GitHub source ${field}`,
+        );
+      }
+    }
+  }
+  return value;
+}
+
+function parseChange(value: unknown): CatalogChange {
+  if (!isRecord(value)) {
+    throw new Error("hosted catalog change record is malformed");
+  }
+  const sequence = requireSequence(value.sequence, "hosted catalog change sequence");
+  if (value.operation === "upsert" && hasExactKeys(value, ["sequence", "operation", "entry"])) {
+    return { sequence, operation: "upsert", entry: parseCatalogEntry(value.entry) };
+  }
+  if (
+    value.operation === "remove" &&
+    hasExactKeys(value, ["sequence", "operation", "entryId", "entryType"]) &&
+    (value.entryType === "plugin" || value.entryType === "skill")
+  ) {
+    return {
+      sequence,
+      operation: "remove",
+      entryId: requireString(value.entryId, "hosted catalog change removed entry id"),
+      entryType: value.entryType,
+    };
+  }
+  if (
+    value.operation === "metadata" &&
+    hasExactKeys(value, ["sequence", "operation", "metadata"]) &&
+    isRecord(value.metadata) &&
+    hasExactKeys(value.metadata, ["description"]) &&
+    (value.metadata.description === null || typeof value.metadata.description === "string")
+  ) {
+    if (typeof value.metadata.description === "string") {
+      requireString(
+        value.metadata.description,
+        "hosted catalog change description",
+        MAX_DESCRIPTION_BYTES,
+      );
+    }
+    return {
+      sequence,
+      operation: "metadata",
+      metadata: { description: value.metadata.description },
+    };
+  }
+  throw new Error("hosted catalog change record is malformed");
+}
+
+function parseProjectionHeader(value: Record<string, unknown>) {
+  if (value.schemaVersion !== 1) {
+    throw new Error("hosted catalog change schema version is unsupported");
+  }
+  const feedId = requireString(value.feedId, "hosted catalog change feed id");
+  const generatedAt = requireTimestamp(value.generatedAt, "hosted catalog change generatedAt");
+  const expiresAt = requireTimestamp(value.expiresAt, "hosted catalog change expiresAt");
+  if (Date.parse(expiresAt) <= Date.parse(generatedAt)) {
+    throw new Error("hosted catalog change validity window is invalid");
+  }
+  return { feedId, generatedAt, expiresAt };
+}
+
+export function parseOfficialExternalPluginCatalogChangePayload(
+  value: unknown,
+): OfficialExternalPluginCatalogChangePage | OfficialExternalPluginCatalogResetRequired {
+  if (!isRecord(value)) {
+    throw new Error("hosted catalog change payload is malformed");
+  }
+  const header = parseProjectionHeader(value);
+  if (value.resetRequired === true) {
+    if (
+      !hasExactKeys(value, [
+        "schemaVersion",
+        "feedId",
+        "fromSequence",
+        "currentSequence",
+        "generatedAt",
+        "expiresAt",
+        "resetRequired",
+        "snapshotUrl",
+      ])
+    ) {
+      throw new Error("hosted catalog reset response is malformed");
+    }
+    const fromSequence = requireSequence(value.fromSequence, "hosted catalog reset fromSequence");
+    const currentSequence = requireSequence(
+      value.currentSequence,
+      "hosted catalog reset currentSequence",
+    );
+    if (currentSequence <= fromSequence) {
+      throw new Error("hosted catalog reset currentSequence must advance fromSequence");
+    }
+    let snapshotUrl: URL;
+    try {
+      snapshotUrl = new URL(
+        requireString(value.snapshotUrl, "hosted catalog reset snapshot URL", 4096),
+      );
+    } catch {
+      throw new Error("hosted catalog reset snapshot URL is invalid");
+    }
+    if (snapshotUrl.protocol !== "https:" || snapshotUrl.username || snapshotUrl.password) {
+      throw new Error("hosted catalog reset snapshot URL must be credential-free HTTPS");
+    }
+    return {
+      schemaVersion: 1,
+      ...header,
+      fromSequence,
+      currentSequence,
+      resetRequired: true,
+      snapshotUrl: snapshotUrl.href,
+    };
+  }
+  if (
+    !hasExactKeys(value, [
+      "schemaVersion",
+      "feedId",
+      "fromSequence",
+      "toSequence",
+      "generatedAt",
+      "expiresAt",
+      "requestCursor",
+      "pageIndex",
+      "startIndex",
+      "changeCount",
+      "changes",
+      "nextCursor",
+    ]) ||
+    !Array.isArray(value.changes)
+  ) {
+    throw new Error("hosted catalog change page is malformed");
+  }
+  const fromSequence = requireSequence(value.fromSequence, "hosted catalog change fromSequence");
+  const toSequence = requireSequence(value.toSequence, "hosted catalog change toSequence");
+  const pageIndex = requireSequence(value.pageIndex, "hosted catalog change pageIndex");
+  const startIndex = requireSequence(value.startIndex, "hosted catalog change startIndex");
+  const changeCount = requireSequence(value.changeCount, "hosted catalog change changeCount");
+  if (toSequence < fromSequence) {
+    throw new Error("hosted catalog change toSequence precedes fromSequence");
+  }
+  if (value.changes.length > MAX_CHANGE_RECORDS_PER_PAGE) {
+    throw new Error("hosted catalog change page exceeds its record limit");
+  }
+  const changes = value.changes.map(parseChange);
+  let prior = fromSequence;
+  for (const change of changes) {
+    if (
+      change.sequence <= fromSequence ||
+      change.sequence > toSequence ||
+      change.sequence < prior ||
+      (change.sequence > prior + 1 && (pageIndex === 0 || prior > fromSequence))
+    ) {
+      throw new Error("hosted catalog change page contains an invalid sequence range");
+    }
+    prior = change.sequence;
+  }
+  const requestCursor = requireCursor(value.requestCursor, "hosted catalog change request cursor");
+  const nextCursor = requireCursor(value.nextCursor, "hosted catalog change next cursor");
+  if (requestCursor === null && (pageIndex !== 0 || startIndex !== 0)) {
+    throw new Error("hosted catalog change first page must start at zero");
+  }
+  if (requestCursor !== null && pageIndex === 0) {
+    throw new Error("hosted catalog change continuation page index is invalid");
+  }
+  if (
+    startIndex + changes.length > changeCount ||
+    (nextCursor === null && startIndex + changes.length !== changeCount) ||
+    (nextCursor !== null &&
+      (changes.length === 0 ||
+        startIndex + changes.length >= changeCount ||
+        nextCursor === requestCursor))
+  ) {
+    throw new Error("hosted catalog change page bounds are invalid");
+  }
+  if (nextCursor === null && (changes.at(-1)?.sequence ?? fromSequence) !== toSequence) {
+    throw new Error("hosted catalog terminal change page does not reach toSequence");
+  }
+  return {
+    schemaVersion: 1,
+    ...header,
+    fromSequence,
+    toSequence,
+    requestCursor,
+    pageIndex,
+    startIndex,
+    changeCount,
+    changes,
+    nextCursor,
+  };
+}
+
+export function verifyOfficialExternalPluginCatalogChangeEnvelopeBody(
+  body: string,
+  params: { trustedKeys: readonly TrustedSigningKey[]; threshold?: number },
+): VerifiedOfficialExternalPluginCatalogChangePayload {
+  let document: unknown;
+  try {
+    document = JSON.parse(body) as unknown;
+  } catch {
+    throw new Error("hosted catalog change envelope is not valid JSON");
+  }
+  const threshold = Math.max(1, Math.trunc(params.threshold ?? 1));
+  const verified = verifyOfficialExternalPluginCatalogEnvelopePayload(document, {
+    trustedKeys: params.trustedKeys,
+    acceptedPayloadTypes: new Set([OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHANGES_PAYLOAD_TYPE]),
+    threshold,
+  });
+  if (!verified.ok) {
+    throw new Error(verified.message);
+  }
+  return {
+    payload: parseOfficialExternalPluginCatalogChangePayload(verified.payload),
+    signedBy: verified.signedBy,
+    signatureCount: verified.signatureCount ?? 1,
+    threshold,
+  };
+}
+
+function entryKey(entry: OfficialExternalPluginCatalogEntry): string {
+  if (
+    (entry.type !== "plugin" && entry.type !== "skill") ||
+    typeof entry.id !== "string" ||
+    entry.id.length === 0
+  ) {
+    throw new Error("hosted catalog incremental base entry has no stable identity");
+  }
+  return `${entry.type}\0${entry.id}`;
+}
+
+function compareEntries(
+  left: OfficialExternalPluginCatalogEntry,
+  right: OfficialExternalPluginCatalogEntry,
+): number {
+  return Buffer.compare(Buffer.from(entryKey(left), "utf8"), Buffer.from(entryKey(right), "utf8"));
+}
+
+function applyChangePages(
+  feed: OfficialExternalPluginCatalogFeed,
+  pages: readonly OfficialExternalPluginCatalogChangePage[],
+): OfficialExternalPluginCatalogFeed {
+  if (pages.length === 0) {
+    return feed;
+  }
+  const first = pages[0]!;
+  if (first.feedId !== feed.id || first.fromSequence !== feed.sequence) {
+    throw new Error("hosted catalog change range does not continue the accepted feed");
+  }
+  let expectedCursor: string | null = null;
+  let expectedStartIndex = 0;
+  let priorSequence = first.fromSequence;
+  const consumedCursors = new Set<string>();
+  for (const [index, page] of pages.entries()) {
+    if (
+      page.feedId !== first.feedId ||
+      page.fromSequence !== first.fromSequence ||
+      page.toSequence !== first.toSequence ||
+      page.generatedAt !== first.generatedAt ||
+      page.expiresAt !== first.expiresAt ||
+      page.changeCount !== first.changeCount
+    ) {
+      throw new Error("hosted catalog change page chain changed its pinned range");
+    }
+    if (
+      page.pageIndex !== index ||
+      page.startIndex !== expectedStartIndex ||
+      page.requestCursor !== expectedCursor
+    ) {
+      throw new Error("hosted catalog change page chain contains a cursor, page, or offset gap");
+    }
+    if (page.requestCursor !== null) {
+      if (consumedCursors.has(page.requestCursor)) {
+        throw new Error("hosted catalog change page chain reuses a continuation cursor");
+      }
+      consumedCursors.add(page.requestCursor);
+    }
+    for (const change of page.changes) {
+      if (change.sequence !== priorSequence && change.sequence !== priorSequence + 1) {
+        throw new Error("hosted catalog change page chain contains a missing revision");
+      }
+      priorSequence = change.sequence;
+    }
+    expectedStartIndex += page.changes.length;
+    expectedCursor = page.nextCursor;
+  }
+  if (
+    expectedCursor !== null ||
+    expectedStartIndex !== first.changeCount ||
+    priorSequence !== first.toSequence
+  ) {
+    throw new Error("hosted catalog change page chain is incomplete");
+  }
+  if (
+    first.toSequence === feed.sequence &&
+    Date.parse(first.generatedAt) < Date.parse(feed.generatedAt)
+  ) {
+    throw new Error("hosted catalog change range rolls back the accepted generation time");
+  }
+  const entries = new Map<string, OfficialExternalPluginCatalogEntry>();
+  for (const entry of feed.entries) {
+    const key = entryKey(entry);
+    if (entries.has(key)) {
+      throw new Error("hosted catalog incremental base contains duplicate entry identities");
+    }
+    entries.set(key, entry);
+  }
+  let description = feed.description;
+  for (const page of pages) {
+    for (const change of page.changes) {
+      if (change.operation === "upsert") {
+        entries.set(entryKey(change.entry), change.entry);
+      } else if (change.operation === "remove") {
+        entries.delete(`${change.entryType}\0${change.entryId}`);
+      } else {
+        description = change.metadata.description ?? undefined;
+      }
+    }
+  }
+  const materialized: OfficialExternalPluginCatalogFeed = {
+    ...feed,
+    sequence: first.toSequence,
+    generatedAt: first.generatedAt,
+    expiresAt: first.expiresAt,
+    entries: [...entries.values()].toSorted(compareEntries),
+  };
+  if (description === undefined) {
+    delete materialized.description;
+  } else {
+    materialized.description = description;
+  }
+  if (!isOfficialExternalPluginCatalogFeed(materialized)) {
+    throw new Error("hosted catalog incremental result is invalid");
+  }
+  return materialized;
+}
+
+export function applyVerifiedOfficialExternalPluginCatalogChangeBodies(params: {
+  feed: OfficialExternalPluginCatalogFeed;
+  changeBodies: readonly string[];
+  trustedKeys: readonly TrustedSigningKey[];
+  threshold?: number;
+  expectedFeedId?: string;
+}): {
+  feed: OfficialExternalPluginCatalogFeed;
+  signedBy: string;
+  signatureCount: number;
+  threshold: number;
+} {
+  if (
+    params.changeBodies.length === 0 ||
+    params.changeBodies.length > MAX_CHANGE_PAGES_PER_SNAPSHOT
+  ) {
+    throw new Error("hosted catalog incremental snapshot has an invalid change page count");
+  }
+  let feed = params.feed;
+  let range: OfficialExternalPluginCatalogChangePage[] = [];
+  let lastVerification: VerifiedOfficialExternalPluginCatalogChangePayload | undefined;
+  for (const body of params.changeBodies) {
+    const verified = verifyOfficialExternalPluginCatalogChangeEnvelopeBody(body, params);
+    if ("resetRequired" in verified.payload) {
+      throw new Error("hosted catalog incremental snapshot cannot contain a reset response");
+    }
+    if (params.expectedFeedId && verified.payload.feedId !== params.expectedFeedId) {
+      throw new Error("hosted catalog change feed identity did not match the configured feed");
+    }
+    if (verified.payload.pageIndex === 0) {
+      if (range.length > 0) {
+        throw new Error("hosted catalog incremental snapshot contains an incomplete range");
+      }
+    } else if (range.length === 0) {
+      throw new Error("hosted catalog incremental snapshot starts with a continuation page");
+    }
+    range.push(verified.payload);
+    if (verified.payload.nextCursor === null) {
+      feed = applyChangePages(feed, range);
+      range = [];
+    }
+    lastVerification = verified;
+  }
+  if (range.length > 0 || !lastVerification) {
+    throw new Error("hosted catalog incremental snapshot contains an incomplete range");
+  }
+  return {
+    feed,
+    signedBy: lastVerification.signedBy,
+    signatureCount: lastVerification.signatureCount,
+    threshold: lastVerification.threshold,
+  };
+}
+
+export function parseOfficialExternalPluginCatalogIncrementalSnapshot(
+  value: unknown,
+): OfficialExternalPluginCatalogIncrementalSnapshot | null {
+  if (!isRecord(value) || value.kind !== INCREMENTAL_SNAPSHOT_KIND) {
+    return null;
+  }
+  if (
+    !hasExactKeys(value, ["kind", "baseBody", "changeBodies"]) ||
+    typeof value.baseBody !== "string" ||
+    !Array.isArray(value.changeBodies) ||
+    !value.changeBodies.every((body): body is string => typeof body === "string") ||
+    value.changeBodies.length === 0 ||
+    value.changeBodies.length > MAX_CHANGE_PAGES_PER_SNAPSHOT
+  ) {
+    throw new Error("hosted catalog incremental snapshot is malformed");
+  }
+  return {
+    kind: INCREMENTAL_SNAPSHOT_KIND,
+    baseBody: value.baseBody,
+    changeBodies: value.changeBodies,
+  };
+}
+
+export function serializeOfficialExternalPluginCatalogIncrementalSnapshot(params: {
+  baseBody: string;
+  changeBodies: readonly string[];
+}): string {
+  if (
+    params.changeBodies.length === 0 ||
+    params.changeBodies.length > MAX_CHANGE_PAGES_PER_SNAPSHOT
+  ) {
+    throw new Error("hosted catalog incremental snapshot has an invalid change page count");
+  }
+  return JSON.stringify({
+    kind: INCREMENTAL_SNAPSHOT_KIND,
+    baseBody: params.baseBody,
+    changeBodies: params.changeBodies,
+  });
+}

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -8,8 +8,10 @@ import {
   type OfficialExternalPluginCatalogFeed,
 } from "./official-external-plugin-catalog.js";
 
-const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE =
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE =
   "openclaw.official-external-plugin-catalog-feed.v1";
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE =
+  "openclaw.official-external-plugin-catalog-shard-root.v1";
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_SIGNATURES = 16;
 
 type OfficialExternalPluginCatalogEnvelopeSignature = {
@@ -26,6 +28,31 @@ type OfficialExternalPluginCatalogTrustedSigningKey = {
   publicKey: string;
 };
 
+type OfficialExternalPluginCatalogEnvelopeVerificationError = {
+  ok: false;
+  error:
+    | "invalid-envelope"
+    | "unsupported-payload"
+    | "invalid-payload"
+    | "missing-trust-key"
+    | "invalid-signature";
+  message: string;
+  authenticatedPayload?: unknown;
+};
+
+export type OfficialExternalPluginCatalogEnvelopePayloadVerificationResult =
+  | {
+      ok: true;
+      payloadType: string;
+      payload: unknown;
+      payloadBytes: Buffer;
+      signedBy: string;
+      signedByKeyIds?: readonly string[];
+      signatureCount?: number;
+      threshold?: number;
+    }
+  | OfficialExternalPluginCatalogEnvelopeVerificationError;
+
 type OfficialExternalPluginCatalogEnvelopeVerificationResult =
   | {
       ok: true;
@@ -35,17 +62,7 @@ type OfficialExternalPluginCatalogEnvelopeVerificationResult =
       signatureCount?: number;
       threshold?: number;
     }
-  | {
-      ok: false;
-      error:
-        | "invalid-envelope"
-        | "unsupported-payload"
-        | "invalid-payload"
-        | "missing-trust-key"
-        | "invalid-signature";
-      message: string;
-      authenticatedPayload?: unknown;
-    };
+  | OfficialExternalPluginCatalogEnvelopeVerificationError;
 function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
   payloadType: string;
   payloadBytes: Buffer;
@@ -53,14 +70,15 @@ function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
   return dssePreAuthenticationEncoding(params.payloadType, params.payloadBytes);
 }
 
-export function verifyOfficialExternalPluginCatalogSignedEnvelope(
+export function verifyOfficialExternalPluginCatalogEnvelopePayload(
   raw: unknown,
   params: {
     trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
+    acceptedPayloadTypes: ReadonlySet<string>;
     threshold?: number;
     allowLegacyBetaEnvelope?: boolean;
   },
-): OfficialExternalPluginCatalogEnvelopeVerificationResult {
+): OfficialExternalPluginCatalogEnvelopePayloadVerificationResult {
   const envelope = parseOfficialExternalPluginCatalogSignedEnvelope(raw, {
     allowLegacyBetaEnvelope: params.allowLegacyBetaEnvelope === true,
   });
@@ -71,7 +89,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
       message: "hosted catalog signed envelope is malformed",
     };
   }
-  if (envelope.payloadType !== OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE) {
+  if (!params.acceptedPayloadTypes.has(envelope.payloadType)) {
     return {
       ok: false,
       error: "unsupported-payload",
@@ -119,17 +137,18 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   }
   if (trustedSignaturePublicKeys.size >= threshold) {
     const decoded = decodeOfficialExternalPluginCatalogEnvelopePayload(payloadBytes);
-    if (!decoded?.feed) {
+    if (!decoded) {
       return {
         ok: false,
         error: "invalid-payload",
         message: "hosted catalog signed envelope payload is invalid",
-        ...(decoded ? { authenticatedPayload: decoded.raw } : {}),
       };
     }
     return {
       ok: true,
-      feed: decoded.feed,
+      payloadType: envelope.payloadType,
+      payload: decoded.raw,
+      payloadBytes,
       signedBy: trustedSignatureKeyIds[0] ?? "",
       ...(threshold > 1
         ? {
@@ -157,6 +176,41 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
         error: "missing-trust-key",
         message: "hosted catalog signed envelope was not signed by a trusted key",
       };
+}
+
+export function verifyOfficialExternalPluginCatalogSignedEnvelope(
+  raw: unknown,
+  params: {
+    trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
+    threshold?: number;
+    allowLegacyBetaEnvelope?: boolean;
+  },
+): OfficialExternalPluginCatalogEnvelopeVerificationResult {
+  const verification = verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
+    ...params,
+    acceptedPayloadTypes: new Set([OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE]),
+  });
+  if (!verification.ok) {
+    return verification;
+  }
+  if (!isOfficialExternalPluginCatalogFeed(verification.payload)) {
+    return {
+      ok: false,
+      error: "invalid-payload",
+      message: "hosted catalog signed envelope payload is invalid",
+      authenticatedPayload: verification.payload,
+    };
+  }
+  return {
+    ok: true,
+    feed: verification.payload,
+    signedBy: verification.signedBy,
+    ...(verification.signedByKeyIds ? { signedByKeyIds: verification.signedByKeyIds } : {}),
+    ...(verification.signatureCount !== undefined
+      ? { signatureCount: verification.signatureCount }
+      : {}),
+    ...(verification.threshold !== undefined ? { threshold: verification.threshold } : {}),
+  };
 }
 
 function parseOfficialExternalPluginCatalogSignedEnvelope(
@@ -258,13 +312,10 @@ function decodeOfficialExternalPluginCatalogEnvelopePayloadBytes(payload: string
 
 function decodeOfficialExternalPluginCatalogEnvelopePayload(
   payloadBytes: Buffer,
-): { raw: unknown; feed: OfficialExternalPluginCatalogFeed | null } | null {
+): { raw: unknown } | null {
   try {
     const raw = JSON.parse(payloadBytes.toString("utf8")) as unknown;
-    return {
-      raw,
-      feed: isOfficialExternalPluginCatalogFeed(raw) ? raw : null,
-    };
+    return { raw };
   } catch {
     return null;
   }

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -40,7 +40,7 @@ type OfficialExternalPluginCatalogEnvelopeVerificationError = {
   authenticatedPayload?: unknown;
 };
 
-export type OfficialExternalPluginCatalogEnvelopePayloadVerificationResult =
+type OfficialExternalPluginCatalogEnvelopePayloadVerificationResult =
   | {
       ok: true;
       payloadType: string;
@@ -63,6 +63,7 @@ type OfficialExternalPluginCatalogEnvelopeVerificationResult =
       threshold?: number;
     }
   | OfficialExternalPluginCatalogEnvelopeVerificationError;
+
 function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
   payloadType: string;
   payloadBytes: Buffer;

--- a/src/plugins/official-external-plugin-catalog-shards.test.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.test.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  parseOfficialExternalPluginCatalogShardRoot,
+  parseOfficialExternalPluginCatalogShardedSnapshot,
+  serializeOfficialExternalPluginCatalogShardedSnapshot,
+  validateOfficialExternalPluginCatalogShardSet,
+} from "./official-external-plugin-catalog-shards.js";
+
+function shardBody(index: number, ids: readonly string[]): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    feedId: "clawhub-official",
+    sequence: 7,
+    index,
+    entries: ids.map((id) => ({ type: "plugin", id })),
+  });
+}
+
+function rootFor(shardBodies: readonly string[]) {
+  return {
+    schemaVersion: 1,
+    feedId: "clawhub-official",
+    sequence: 7,
+    generatedAt: "2026-07-17T12:00:00Z",
+    expiresAt: "2026-07-24T12:00:00Z",
+    metadata: { description: "ClawHub plugins" },
+    entryCount: shardBodies.length,
+    shards: shardBodies.map((body, index) => ({
+      index,
+      url: `https://clawhub.ai/v1/feeds/plugins/shards/${index}.json`,
+      sha256: createHash("sha256").update(body).digest("hex"),
+      byteLength: Buffer.byteLength(body, "utf8"),
+      entryCount: 1,
+    })),
+  };
+}
+
+describe("official external plugin catalog shards", () => {
+  it("assembles a complete deterministically ordered shard set", () => {
+    const bodies = [shardBody(0, ["@acme/alpha"]), shardBody(1, ["@acme/beta"])];
+    const root = parseOfficialExternalPluginCatalogShardRoot(rootFor(bodies));
+
+    expect(validateOfficialExternalPluginCatalogShardSet(root, bodies)).toMatchObject({
+      schemaVersion: 1,
+      id: "clawhub-official",
+      sequence: 7,
+      entries: [{ id: "@acme/alpha" }, { id: "@acme/beta" }],
+    });
+  });
+
+  it("rejects cross-shard ordering and duplicate identities", () => {
+    const unordered = [shardBody(0, ["@acme/beta"]), shardBody(1, ["@acme/alpha"])];
+    expect(() =>
+      validateOfficialExternalPluginCatalogShardSet(
+        parseOfficialExternalPluginCatalogShardRoot(rootFor(unordered)),
+        unordered,
+      ),
+    ).toThrow("shard set ordering is invalid");
+
+    const duplicated = [shardBody(0, ["@acme/alpha"]), shardBody(1, ["@acme/alpha"])];
+    expect(() =>
+      validateOfficialExternalPluginCatalogShardSet(
+        parseOfficialExternalPluginCatalogShardRoot(rootFor(duplicated)),
+        duplicated,
+      ),
+    ).toThrow("identity is duplicated");
+  });
+
+  it("rejects malformed roots before any shard fetch", () => {
+    const bodies = [shardBody(0, ["@acme/alpha"])];
+    expect(() =>
+      parseOfficialExternalPluginCatalogShardRoot({
+        ...rootFor(bodies),
+        unexpected: true,
+      }),
+    ).toThrow("shard root is malformed");
+    expect(() =>
+      parseOfficialExternalPluginCatalogShardRoot({
+        ...rootFor(bodies),
+        shards: [{ ...rootFor(bodies).shards[0], sha256: "ABC" }],
+      }),
+    ).toThrow("lowercase SHA-256 hex");
+  });
+
+  it("round-trips the exact authenticated root and shard bytes for fallback", () => {
+    const bodies = [shardBody(0, ["@acme/alpha"])];
+    const rootBody = '{"signed":"root"}';
+    const serialized = serializeOfficialExternalPluginCatalogShardedSnapshot({
+      rootBody,
+      shardBodies: bodies,
+    });
+
+    expect(parseOfficialExternalPluginCatalogShardedSnapshot(JSON.parse(serialized))).toEqual({
+      kind: "official-external-plugin-catalog-shards-v1",
+      rootBody,
+      shardBodies: bodies,
+    });
+  });
+});

--- a/src/plugins/official-external-plugin-catalog-shards.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.ts
@@ -1,0 +1,366 @@
+import { createHash } from "node:crypto";
+import { isRecord } from "../utils.js";
+import type {
+  OfficialExternalPluginCatalogEntry,
+  OfficialExternalPluginCatalogFeed,
+} from "./official-external-plugin-catalog.js";
+
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES = 1024 * 1024;
+export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES = 10_000;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_BYTES = 1024 * 1024;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_SHARDS = 1024;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_ENTRIES = 1_000_000;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_SET_MAX_BYTES = 256 * 1024 * 1024;
+const SHARDED_SNAPSHOT_KIND = "official-external-plugin-catalog-shards-v1";
+
+export type OfficialExternalPluginCatalogShardDescriptor = {
+  index: number;
+  url: string;
+  sha256: string;
+  byteLength: number;
+  entryCount: number;
+};
+
+export type OfficialExternalPluginCatalogShardRoot = {
+  schemaVersion: 1;
+  feedId: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  metadata: { description: string | null };
+  entryCount: number;
+  shards: readonly OfficialExternalPluginCatalogShardDescriptor[];
+};
+
+type OfficialExternalPluginCatalogShard = {
+  schemaVersion: 1;
+  feedId: string;
+  sequence: number;
+  index: number;
+  entries: readonly OfficialExternalPluginCatalogEntry[];
+};
+
+export type OfficialExternalPluginCatalogShardedSnapshot = {
+  kind: typeof SHARDED_SNAPSHOT_KIND;
+  rootBody: string;
+  shardBodies: readonly string[];
+};
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).toSorted();
+  const expected = [...keys].toSorted();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function requireNonNegativeInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function parseRfc3339Instant(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length > 64) {
+    throw new Error(`${label} is invalid`);
+  }
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|([+-])(\d{2}):(\d{2}))$/u.exec(
+      value,
+    );
+  if (!match) {
+    throw new Error(`${label} is invalid`);
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = Number(match[8] ?? "0");
+  const offsetMinute = Number(match[9] ?? "0");
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth[month - 1]! ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59 ||
+    !Number.isFinite(Date.parse(value))
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function parseShardDescriptor(
+  value: unknown,
+  expectedIndex: number,
+): OfficialExternalPluginCatalogShardDescriptor {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["index", "url", "sha256", "byteLength", "entryCount"])
+  ) {
+    throw new Error("hosted catalog shard descriptor is malformed");
+  }
+  const index = requireNonNegativeInteger(value.index, "hosted catalog shard index");
+  if (index !== expectedIndex) {
+    throw new Error("hosted catalog shard indexes must be contiguous");
+  }
+  if (typeof value.sha256 !== "string" || !/^[a-f0-9]{64}$/u.test(value.sha256)) {
+    throw new Error("hosted catalog shard digest must be lowercase SHA-256 hex");
+  }
+  const byteLength = requireNonNegativeInteger(value.byteLength, "hosted catalog shard byteLength");
+  if (byteLength < 1 || byteLength > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES) {
+    throw new Error("hosted catalog shard byteLength is invalid");
+  }
+  const entryCount = requireNonNegativeInteger(value.entryCount, "hosted catalog shard entryCount");
+  if (entryCount < 1 || entryCount > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES) {
+    throw new Error("hosted catalog shard entryCount is invalid");
+  }
+  if (typeof value.url !== "string" || Buffer.byteLength(value.url, "utf8") > 2048) {
+    throw new Error("hosted catalog shard URL must be absolute HTTPS");
+  }
+  let url: URL;
+  try {
+    url = new URL(value.url);
+  } catch {
+    throw new Error("hosted catalog shard URL must be absolute HTTPS");
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.hash) {
+    throw new Error("hosted catalog shard URL must be absolute HTTPS without credentials");
+  }
+  return {
+    index,
+    url: url.href,
+    sha256: value.sha256,
+    byteLength,
+    entryCount,
+  };
+}
+
+export function parseOfficialExternalPluginCatalogShardRoot(
+  value: unknown,
+): OfficialExternalPluginCatalogShardRoot {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "schemaVersion",
+      "feedId",
+      "sequence",
+      "generatedAt",
+      "expiresAt",
+      "metadata",
+      "entryCount",
+      "shards",
+    ]) ||
+    value.schemaVersion !== 1 ||
+    typeof value.feedId !== "string" ||
+    value.feedId.trim().length === 0 ||
+    value.feedId.length > 256 ||
+    !isRecord(value.metadata) ||
+    !hasExactKeys(value.metadata, ["description"]) ||
+    (value.metadata.description !== null && typeof value.metadata.description !== "string") ||
+    !Array.isArray(value.shards)
+  ) {
+    throw new Error("hosted catalog shard root is malformed");
+  }
+  if (
+    Buffer.byteLength(JSON.stringify(value), "utf8") >
+    OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_BYTES
+  ) {
+    throw new Error("hosted catalog shard root exceeds its byte limit");
+  }
+  if (
+    typeof value.metadata.description === "string" &&
+    Buffer.byteLength(value.metadata.description, "utf8") > 1024
+  ) {
+    throw new Error("hosted catalog shard root description exceeds its limit");
+  }
+  const sequence = requireNonNegativeInteger(value.sequence, "hosted catalog shard root sequence");
+  const generatedAt = parseRfc3339Instant(
+    value.generatedAt,
+    "hosted catalog shard root generatedAt",
+  );
+  const expiresAt = parseRfc3339Instant(value.expiresAt, "hosted catalog shard root expiresAt");
+  if (Date.parse(expiresAt) <= Date.parse(generatedAt)) {
+    throw new Error("hosted catalog shard root validity window is invalid");
+  }
+  const entryCount = requireNonNegativeInteger(
+    value.entryCount,
+    "hosted catalog shard root entryCount",
+  );
+  if (entryCount > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_ENTRIES) {
+    throw new Error("hosted catalog shard root entryCount exceeds its limit");
+  }
+  if (value.shards.length > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_SHARDS) {
+    throw new Error("hosted catalog shard root exceeds its shard limit");
+  }
+  if ((entryCount === 0) !== (value.shards.length === 0)) {
+    throw new Error("hosted catalog empty shard roots must have no shard descriptors");
+  }
+  const shards = value.shards.map(parseShardDescriptor);
+  const urls = new Set<string>();
+  const digests = new Set<string>();
+  let describedEntries = 0;
+  let describedBytes = 0;
+  for (const shard of shards) {
+    if (urls.has(shard.url) || digests.has(shard.sha256)) {
+      throw new Error("hosted catalog shard descriptors must be unique");
+    }
+    urls.add(shard.url);
+    digests.add(shard.sha256);
+    describedEntries += shard.entryCount;
+    describedBytes += shard.byteLength;
+  }
+  if (describedEntries !== entryCount) {
+    throw new Error("hosted catalog shard root entryCount does not match its descriptors");
+  }
+  if (describedBytes > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_SET_MAX_BYTES) {
+    throw new Error("hosted catalog shard set exceeds its aggregate byte limit");
+  }
+  return {
+    schemaVersion: 1,
+    feedId: value.feedId,
+    sequence,
+    generatedAt,
+    expiresAt,
+    metadata: { description: value.metadata.description },
+    entryCount,
+    shards,
+  };
+}
+
+function parseShard(value: unknown): OfficialExternalPluginCatalogShard {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["schemaVersion", "feedId", "sequence", "index", "entries"]) ||
+    value.schemaVersion !== 1 ||
+    typeof value.feedId !== "string" ||
+    value.feedId.trim().length === 0 ||
+    !Array.isArray(value.entries)
+  ) {
+    throw new Error("hosted catalog shard is malformed");
+  }
+  const sequence = requireNonNegativeInteger(value.sequence, "hosted catalog shard sequence");
+  const index = requireNonNegativeInteger(value.index, "hosted catalog shard index");
+  if (
+    value.entries.length < 1 ||
+    value.entries.length > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES
+  ) {
+    throw new Error("hosted catalog shard entry count is invalid");
+  }
+  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  let previousId: string | undefined;
+  for (const entry of value.entries) {
+    if (
+      !isRecord(entry) ||
+      entry.type !== "plugin" ||
+      typeof entry.id !== "string" ||
+      entry.id.trim().length === 0
+    ) {
+      throw new Error("hosted catalog shard entry is invalid");
+    }
+    if (previousId !== undefined && previousId.localeCompare(entry.id) >= 0) {
+      throw new Error("hosted catalog shard entries must use deterministic id ordering");
+    }
+    previousId = entry.id;
+    entries.push(entry);
+  }
+  return { schemaVersion: 1, feedId: value.feedId, sequence, index, entries };
+}
+
+export function validateOfficialExternalPluginCatalogShardSet(
+  root: OfficialExternalPluginCatalogShardRoot,
+  shardBodies: readonly string[],
+): OfficialExternalPluginCatalogFeed {
+  if (shardBodies.length !== root.shards.length) {
+    throw new Error("hosted catalog shard set is incomplete");
+  }
+  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  const identities = new Set<string>();
+  let previousId: string | undefined;
+  for (const [index, body] of shardBodies.entries()) {
+    const descriptor = root.shards[index];
+    if (!descriptor) {
+      throw new Error("hosted catalog shard set is incomplete");
+    }
+    const bytes = Buffer.from(body, "utf8");
+    if (
+      bytes.length !== descriptor.byteLength ||
+      createHash("sha256").update(bytes).digest("hex") !== descriptor.sha256
+    ) {
+      throw new Error("hosted catalog shard bytes do not match their signed descriptor");
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(body) as unknown;
+    } catch {
+      throw new Error("hosted catalog shard payload is not valid JSON");
+    }
+    const shard = parseShard(raw);
+    if (
+      shard.feedId !== root.feedId ||
+      shard.sequence !== root.sequence ||
+      shard.index !== index ||
+      shard.entries.length !== descriptor.entryCount
+    ) {
+      throw new Error("hosted catalog shard does not match its signed root");
+    }
+    for (const entry of shard.entries) {
+      const identity = `${entry.type}\0${entry.id}`;
+      if (identities.has(identity)) {
+        throw new Error("hosted catalog shard set identity is duplicated");
+      }
+      identities.add(identity);
+      if (previousId !== undefined && previousId.localeCompare(entry.id as string) >= 0) {
+        throw new Error("hosted catalog shard set ordering is invalid");
+      }
+      previousId = entry.id as string;
+      entries.push(entry);
+    }
+  }
+  if (entries.length !== root.entryCount) {
+    throw new Error("hosted catalog shard set entry count is incomplete");
+  }
+  return {
+    schemaVersion: 1,
+    id: root.feedId,
+    sequence: root.sequence,
+    generatedAt: root.generatedAt,
+    ...(root.metadata.description === null ? {} : { description: root.metadata.description }),
+    entries,
+  };
+}
+
+export function parseOfficialExternalPluginCatalogShardedSnapshot(
+  value: unknown,
+): OfficialExternalPluginCatalogShardedSnapshot | null {
+  if (!isRecord(value) || value.kind !== SHARDED_SNAPSHOT_KIND) {
+    return null;
+  }
+  if (
+    !hasExactKeys(value, ["kind", "rootBody", "shardBodies"]) ||
+    typeof value.rootBody !== "string" ||
+    !Array.isArray(value.shardBodies) ||
+    !value.shardBodies.every((body): body is string => typeof body === "string")
+  ) {
+    throw new Error("hosted catalog sharded snapshot is malformed");
+  }
+  return { kind: SHARDED_SNAPSHOT_KIND, rootBody: value.rootBody, shardBodies: value.shardBodies };
+}
+
+export function serializeOfficialExternalPluginCatalogShardedSnapshot(params: {
+  rootBody: string;
+  shardBodies: readonly string[];
+}): string {
+  return JSON.stringify({
+    kind: SHARDED_SNAPSHOT_KIND,
+    rootBody: params.rootBody,
+    shardBodies: params.shardBodies,
+  });
+}

--- a/src/plugins/official-external-plugin-catalog-shards.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.ts
@@ -55,6 +55,7 @@ type OfficialExternalPluginCatalogShardedSnapshot = {
   kind: typeof SHARDED_SNAPSHOT_KIND;
   rootBody: string;
   shardBodies: readonly string[];
+  materializedFeedSha256?: string;
 };
 
 function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
@@ -356,23 +357,44 @@ export function parseOfficialExternalPluginCatalogShardedSnapshot(
     return null;
   }
   if (
-    !hasExactKeys(value, ["kind", "rootBody", "shardBodies"]) ||
+    (!hasExactKeys(value, ["kind", "rootBody", "shardBodies"]) &&
+      !hasExactKeys(value, ["kind", "rootBody", "shardBodies", "materializedFeedSha256"])) ||
     typeof value.rootBody !== "string" ||
     !Array.isArray(value.shardBodies) ||
-    !value.shardBodies.every((body): body is string => typeof body === "string")
+    !value.shardBodies.every((body): body is string => typeof body === "string") ||
+    (value.materializedFeedSha256 !== undefined &&
+      (typeof value.materializedFeedSha256 !== "string" ||
+        !/^sha256:[a-f0-9]{64}$/u.test(value.materializedFeedSha256)))
   ) {
     throw new Error("hosted catalog sharded snapshot is malformed");
   }
-  return { kind: SHARDED_SNAPSHOT_KIND, rootBody: value.rootBody, shardBodies: value.shardBodies };
+  return {
+    kind: SHARDED_SNAPSHOT_KIND,
+    rootBody: value.rootBody,
+    shardBodies: value.shardBodies,
+    ...(typeof value.materializedFeedSha256 === "string"
+      ? { materializedFeedSha256: value.materializedFeedSha256 }
+      : {}),
+  };
 }
 
 export function serializeOfficialExternalPluginCatalogShardedSnapshot(params: {
   rootBody: string;
   shardBodies: readonly string[];
+  materializedFeedSha256?: string;
 }): string {
+  if (
+    params.materializedFeedSha256 !== undefined &&
+    !/^sha256:[a-f0-9]{64}$/u.test(params.materializedFeedSha256)
+  ) {
+    throw new Error("hosted catalog sharded snapshot materialized feed digest is invalid");
+  }
   return JSON.stringify({
     kind: SHARDED_SNAPSHOT_KIND,
     rootBody: params.rootBody,
     shardBodies: params.shardBodies,
+    ...(params.materializedFeedSha256
+      ? { materializedFeedSha256: params.materializedFeedSha256 }
+      : {}),
   });
 }

--- a/src/plugins/official-external-plugin-catalog-shards.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.ts
@@ -332,6 +332,7 @@ export function validateOfficialExternalPluginCatalogShardSet(
     id: root.feedId,
     sequence: root.sequence,
     generatedAt: root.generatedAt,
+    expiresAt: root.expiresAt,
     ...(root.metadata.description === null ? {} : { description: root.metadata.description }),
     entries,
   };

--- a/src/plugins/official-external-plugin-catalog-shards.ts
+++ b/src/plugins/official-external-plugin-catalog-shards.ts
@@ -1,19 +1,15 @@
 import { createHash } from "node:crypto";
 import { isRecord } from "../utils.js";
-import type {
-  OfficialExternalPluginCatalogEntry,
-  OfficialExternalPluginCatalogFeed,
-} from "./official-external-plugin-catalog.js";
 
-export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES = 1024 * 1024;
-export const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES = 10_000;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_BYTES = 1024 * 1024;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_MAX_ENTRIES = 10_000;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_BYTES = 1024 * 1024;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_SHARDS = 1024;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_MAX_ENTRIES = 1_000_000;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_SET_MAX_BYTES = 256 * 1024 * 1024;
 const SHARDED_SNAPSHOT_KIND = "official-external-plugin-catalog-shards-v1";
 
-export type OfficialExternalPluginCatalogShardDescriptor = {
+type OfficialExternalPluginCatalogShardDescriptor = {
   index: number;
   url: string;
   sha256: string;
@@ -32,15 +28,30 @@ export type OfficialExternalPluginCatalogShardRoot = {
   shards: readonly OfficialExternalPluginCatalogShardDescriptor[];
 };
 
+type OfficialExternalPluginCatalogShardEntry = Record<string, unknown> & {
+  type: "plugin";
+  id: string;
+};
+
 type OfficialExternalPluginCatalogShard = {
   schemaVersion: 1;
   feedId: string;
   sequence: number;
   index: number;
-  entries: readonly OfficialExternalPluginCatalogEntry[];
+  entries: readonly OfficialExternalPluginCatalogShardEntry[];
 };
 
-export type OfficialExternalPluginCatalogShardedSnapshot = {
+type OfficialExternalPluginCatalogShardedFeed = {
+  schemaVersion: 1;
+  id: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  description?: string;
+  entries: readonly OfficialExternalPluginCatalogShardEntry[];
+};
+
+type OfficialExternalPluginCatalogShardedSnapshot = {
   kind: typeof SHARDED_SNAPSHOT_KIND;
   rootBody: string;
   shardBodies: readonly string[];
@@ -254,7 +265,7 @@ function parseShard(value: unknown): OfficialExternalPluginCatalogShard {
   ) {
     throw new Error("hosted catalog shard entry count is invalid");
   }
-  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  const entries: OfficialExternalPluginCatalogShardEntry[] = [];
   let previousId: string | undefined;
   for (const entry of value.entries) {
     if (
@@ -269,7 +280,7 @@ function parseShard(value: unknown): OfficialExternalPluginCatalogShard {
       throw new Error("hosted catalog shard entries must use deterministic id ordering");
     }
     previousId = entry.id;
-    entries.push(entry);
+    entries.push(entry as OfficialExternalPluginCatalogShardEntry);
   }
   return { schemaVersion: 1, feedId: value.feedId, sequence, index, entries };
 }
@@ -277,11 +288,11 @@ function parseShard(value: unknown): OfficialExternalPluginCatalogShard {
 export function validateOfficialExternalPluginCatalogShardSet(
   root: OfficialExternalPluginCatalogShardRoot,
   shardBodies: readonly string[],
-): OfficialExternalPluginCatalogFeed {
+): OfficialExternalPluginCatalogShardedFeed {
   if (shardBodies.length !== root.shards.length) {
     throw new Error("hosted catalog shard set is incomplete");
   }
-  const entries: OfficialExternalPluginCatalogEntry[] = [];
+  const entries: OfficialExternalPluginCatalogShardEntry[] = [];
   const identities = new Set<string>();
   let previousId: string | undefined;
   for (const [index, body] of shardBodies.entries()) {
@@ -317,10 +328,10 @@ export function validateOfficialExternalPluginCatalogShardSet(
         throw new Error("hosted catalog shard set identity is duplicated");
       }
       identities.add(identity);
-      if (previousId !== undefined && previousId.localeCompare(entry.id as string) >= 0) {
+      if (previousId !== undefined && previousId.localeCompare(entry.id) >= 0) {
         throw new Error("hosted catalog shard set ordering is invalid");
       }
-      previousId = entry.id as string;
+      previousId = entry.id;
       entries.push(entry);
     }
   }

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -15,11 +15,13 @@ import {
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
   HostedCatalogSignedFeedMonotonicityError,
+  hashOfficialExternalPluginCatalogMaterializedFeed,
   type HostedOfficialExternalPluginCatalogMetadata,
   type HostedOfficialExternalPluginCatalogSnapshot,
   type HostedOfficialExternalPluginCatalogSnapshotMonotonicState,
   type HostedOfficialExternalPluginCatalogSnapshotStore,
   type HostedOfficialExternalPluginCatalogTrustState,
+  type OfficialExternalPluginCatalogFeed,
   isOfficialExternalPluginCatalogSequence,
   parseOfficialExternalPluginCatalogTimestamp,
 } from "./official-external-plugin-catalog.js";
@@ -54,6 +56,7 @@ type StoredHostedCatalogMonotonicState = {
   sequence: number;
   generatedAt?: string;
   payloadSha256: string;
+  payloadDigestMode: "materialized" | "legacy-wire";
 };
 
 function resolveStoreEnv(
@@ -119,10 +122,22 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
       kind?: unknown;
       changeBodies?: unknown;
       rootBody?: unknown;
+      minimumSequence?: unknown;
+      materializedFeedSha256?: unknown;
       payload?: unknown;
       sequence?: unknown;
       generatedAt?: unknown;
     };
+    if (
+      document.kind === "official-external-plugin-catalog-reset-floor-v1" &&
+      isOfficialExternalPluginCatalogSequence(document.minimumSequence)
+    ) {
+      return {
+        sequence: document.minimumSequence,
+        payloadSha256: createHash("sha256").update(body).digest("hex"),
+        payloadDigestMode: "legacy-wire",
+      };
+    }
     if (
       document.kind === "official-external-plugin-catalog-changes-v1" &&
       Array.isArray(document.changeBodies) &&
@@ -149,7 +164,13 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
         parseOfficialExternalPluginCatalogTimestamp(change.generatedAt) !== undefined
           ? { generatedAt: change.generatedAt }
           : {}),
-        payloadSha256: createHash("sha256").update(body).digest("hex"),
+        payloadSha256:
+          typeof document.materializedFeedSha256 === "string" &&
+          /^sha256:[a-f0-9]{64}$/u.test(document.materializedFeedSha256)
+            ? document.materializedFeedSha256
+            : createHash("sha256").update(body).digest("hex"),
+        payloadDigestMode:
+          typeof document.materializedFeedSha256 === "string" ? "materialized" : "legacy-wire",
       };
     }
     const wireDocument =
@@ -173,19 +194,37 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
     if (!isOfficialExternalPluginCatalogSequence(feed.sequence)) {
       return undefined;
     }
+    const materializedFeedSha256 =
+      typeof document.materializedFeedSha256 === "string" &&
+      /^sha256:[a-f0-9]{64}$/u.test(document.materializedFeedSha256)
+        ? document.materializedFeedSha256
+        : undefined;
+    const legacyShardedSnapshot =
+      document.kind === "official-external-plugin-catalog-shards-v1" &&
+      materializedFeedSha256 === undefined;
+    const payloadSha256 =
+      materializedFeedSha256 ??
+      (legacyShardedSnapshot
+        ? createHash("sha256").update(body).digest("hex")
+        : hashOfficialExternalPluginCatalogMaterializedFeed(
+            feed as OfficialExternalPluginCatalogFeed,
+          ));
+    const payloadDigestMode = legacyShardedSnapshot ? "legacy-wire" : "materialized";
     if (
       typeof feed.generatedAt !== "string" ||
       parseOfficialExternalPluginCatalogTimestamp(feed.generatedAt) === undefined
     ) {
       return {
         sequence: feed.sequence,
-        payloadSha256: createHash("sha256").update(payload).digest("hex"),
+        payloadSha256,
+        payloadDigestMode,
       };
     }
     return {
       sequence: feed.sequence,
       generatedAt: feed.generatedAt,
-      payloadSha256: createHash("sha256").update(payload).digest("hex"),
+      payloadSha256,
+      payloadDigestMode,
     };
   } catch {
     return undefined;
@@ -229,9 +268,13 @@ function assertSignedSnapshotWriteIsMonotonic(params: {
     return;
   }
   const candidate = readMonotonicStateFromBody(params.candidateBody);
+  const currentPayloadSha256 =
+    current.payloadDigestMode === "legacy-wire" && params.candidate.currentMaterializedFeedSha256
+      ? params.candidate.currentMaterializedFeedSha256
+      : current.payloadSha256;
   if (
     candidate?.sequence === params.candidate.sequence &&
-    candidate.payloadSha256 !== current.payloadSha256
+    candidate.payloadSha256 !== currentPayloadSha256
   ) {
     throw new HostedCatalogSignedFeedMonotonicityError(
       "hosted catalog signed feed payload changed without a sequence increment",

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -132,9 +132,7 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
           })
         : document;
     const payload =
-      typeof wireDocument.payload === "string"
-        ? decodeBase64Payload(wireDocument.payload)
-        : body;
+      typeof wireDocument.payload === "string" ? decodeBase64Payload(wireDocument.payload) : body;
     const feed =
       typeof wireDocument.payload === "string"
         ? (JSON.parse(payload) as {

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -117,11 +117,41 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
   try {
     const document = JSON.parse(body) as {
       kind?: unknown;
+      changeBodies?: unknown;
       rootBody?: unknown;
       payload?: unknown;
       sequence?: unknown;
       generatedAt?: unknown;
     };
+    if (
+      document.kind === "official-external-plugin-catalog-changes-v1" &&
+      Array.isArray(document.changeBodies) &&
+      document.changeBodies.length > 0
+    ) {
+      const lastBody = document.changeBodies.at(-1);
+      if (typeof lastBody !== "string") {
+        return undefined;
+      }
+      const envelope = JSON.parse(lastBody) as { payload?: unknown };
+      if (typeof envelope.payload !== "string") {
+        return undefined;
+      }
+      const change = JSON.parse(decodeBase64Payload(envelope.payload)) as {
+        toSequence?: unknown;
+        generatedAt?: unknown;
+      };
+      if (!isOfficialExternalPluginCatalogSequence(change.toSequence)) {
+        return undefined;
+      }
+      return {
+        sequence: change.toSequence,
+        ...(typeof change.generatedAt === "string" &&
+        parseOfficialExternalPluginCatalogTimestamp(change.generatedAt) !== undefined
+          ? { generatedAt: change.generatedAt }
+          : {}),
+        payloadSha256: createHash("sha256").update(body).digest("hex"),
+      };
+    }
     const wireDocument =
       document.kind === "official-external-plugin-catalog-shards-v1" &&
       typeof document.rootBody === "string"

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -116,19 +116,32 @@ function decodeBase64Payload(payload: string): string {
 function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicState | undefined {
   try {
     const document = JSON.parse(body) as {
+      kind?: unknown;
+      rootBody?: unknown;
       payload?: unknown;
       sequence?: unknown;
       generatedAt?: unknown;
     };
-    const payload =
-      typeof document.payload === "string" ? decodeBase64Payload(document.payload) : body;
-    const feed =
-      typeof document.payload === "string"
-        ? (JSON.parse(payload) as {
+    const wireDocument =
+      document.kind === "official-external-plugin-catalog-shards-v1" &&
+      typeof document.rootBody === "string"
+        ? (JSON.parse(document.rootBody) as {
+            payload?: unknown;
             sequence?: unknown;
             generatedAt?: unknown;
           })
         : document;
+    const payload =
+      typeof wireDocument.payload === "string"
+        ? decodeBase64Payload(wireDocument.payload)
+        : body;
+    const feed =
+      typeof wireDocument.payload === "string"
+        ? (JSON.parse(payload) as {
+            sequence?: unknown;
+            generatedAt?: unknown;
+          })
+        : wireDocument;
     if (!isOfficialExternalPluginCatalogSequence(feed.sequence)) {
       return undefined;
     }

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { serializeOfficialExternalPluginCatalogIncrementalSnapshot } from "./official-external-plugin-catalog-changes.js";
+import { serializeOfficialExternalPluginCatalogShardedSnapshot } from "./official-external-plugin-catalog-shards.js";
 import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
 import {
   type HostedOfficialExternalPluginCatalogSnapshot,
@@ -14,6 +15,7 @@ import {
   type OfficialExternalPluginCatalogFeed,
   getOfficialExternalPluginCatalogEntry,
   getOfficialExternalPluginCatalogManifest,
+  hashOfficialExternalPluginCatalogMaterializedFeed,
   isOfficialExternalPluginCatalogFeed,
   listOfficialExternalPluginCatalogEntries,
   loadConfiguredHostedOfficialExternalPluginCatalogEntries,
@@ -116,6 +118,35 @@ function hostedCatalogFeed(params: {
         },
       },
     ],
+  };
+}
+
+function changeCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
+  return {
+    type: "plugin",
+    id,
+    title: id,
+    description: `${id} description`,
+    icon: "https://packages.acme.example/icons/plugin.png",
+    version: "1.0.0",
+    state: "available",
+    publisher: { id: "openclaw", trust: "official" },
+    install: {
+      candidates: [
+        {
+          sourceRef: "acme-npm",
+          package: id,
+          version: "1.0.0",
+          integrity: `sha256:${"a".repeat(64)}`,
+          github: {
+            repo: "openclaw/plugins",
+            path: `plugins/${id}`,
+            commit: "f".repeat(40),
+            contentHash: `sha256:${"b".repeat(64)}`,
+          },
+        },
+      ],
+    },
   };
 }
 
@@ -301,7 +332,11 @@ function signedCatalogConfig(publicKeyPem: string, keyId = "acme-root"): HostedC
 function signedHostedCatalogSnapshot(params: {
   body: string;
   savedAt?: string;
-  monotonic?: { sequence: number; generatedAt: string };
+  monotonic?: {
+    sequence: number;
+    generatedAt: string;
+    currentMaterializedFeedSha256?: string;
+  };
 }): HostedOfficialExternalPluginCatalogSnapshot {
   const savedAt = params.savedAt ?? "2026-06-22T00:00:10.000Z";
   return {
@@ -355,6 +390,24 @@ describe("official external plugin catalog", () => {
       sequence: 1,
     });
     expect(officialExternalPluginCatalog.entries.length).toBeGreaterThan(0);
+  });
+
+  it("hashes materialized feed entries independently of transport ordering", () => {
+    const feed = {
+      schemaVersion: 1,
+      id: "clawhub-official",
+      sequence: 1,
+      generatedAt: "2026-07-24T12:00:00.000Z",
+      expiresAt: "2026-07-24T12:05:00.000Z",
+      entries: [changeCatalogEntry("beta"), changeCatalogEntry("alpha")],
+    } satisfies OfficialExternalPluginCatalogFeed;
+
+    expect(hashOfficialExternalPluginCatalogMaterializedFeed(feed)).toBe(
+      hashOfficialExternalPluginCatalogMaterializedFeed({
+        ...feed,
+        entries: feed.entries.toReversed(),
+      }),
+    );
   });
 
   it("keeps Codex installable as a harness without declaring a model provider", () => {
@@ -1254,7 +1307,7 @@ describe("official external plugin catalog", () => {
     }
   });
 
-  it("enforces SQLite monotonicity across persisted signed change wrappers", async () => {
+  it("enforces monotonicity while compacting an incremental wrapper to an equivalent full feed", async () => {
     const initial = signedHostedCatalogFeed({
       feed: hostedCatalogFeed({ sequence: 1, pluginName: "@openclaw/initial" }),
     });
@@ -1282,9 +1335,23 @@ describe("official external plugin catalog", () => {
         nextCursor: null,
       },
     });
+    const materializedFeed = {
+      ...hostedCatalogFeed({ sequence: 1, pluginName: "@openclaw/initial" }),
+      sequence: 2,
+      generatedAt: "2026-07-24T12:00:00.000Z",
+      expiresAt: "2026-07-24T12:05:00.000Z",
+      description: "Current",
+    } satisfies OfficialExternalPluginCatalogFeed;
+    const legacyWrapperBody = serializeOfficialExternalPluginCatalogIncrementalSnapshot({
+      baseBody: initial.body,
+      changeBodies: [change.body],
+    });
+    const materializedFeedSha256 =
+      hashOfficialExternalPluginCatalogMaterializedFeed(materializedFeed);
     const wrapperBody = serializeOfficialExternalPluginCatalogIncrementalSnapshot({
       baseBody: initial.body,
       changeBodies: [change.body],
+      materializedFeedSha256,
     });
     const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-changes-store-"));
     const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
@@ -1300,13 +1367,69 @@ describe("official external plugin catalog", () => {
       );
       await snapshotStore.write(
         signedHostedCatalogSnapshot({
-          body: wrapperBody,
+          body: legacyWrapperBody,
           monotonic: { sequence: 2, generatedAt: "2026-07-24T12:00:00.000Z" },
+        }),
+      );
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: wrapperBody,
+          monotonic: {
+            sequence: 2,
+            generatedAt: "2026-07-24T12:00:00.000Z",
+            currentMaterializedFeedSha256: materializedFeedSha256,
+          },
         }),
       );
       await expect(
         snapshotStore.read("https://packages.acme.example/openclaw/feed"),
       ).resolves.toMatchObject({ body: wrapperBody, monotonic: { sequence: 2 } });
+
+      const compacted = signedHostedCatalogFeed({
+        feed: materializedFeed,
+        privateKeyPem: initial.privateKeyPem,
+      });
+      await expect(
+        snapshotStore.write(
+          signedHostedCatalogSnapshot({
+            body: compacted.body,
+            monotonic: { sequence: 2, generatedAt: materializedFeed.generatedAt },
+          }),
+        ),
+      ).resolves.toBeUndefined();
+      const resigned = signedHostedCatalogFeed({
+        feed: {
+          ...materializedFeed,
+          generatedAt: "2026-07-24T12:01:00.000Z",
+          expiresAt: "2026-07-24T12:06:00.000Z",
+        },
+        privateKeyPem: initial.privateKeyPem,
+      });
+      await expect(
+        snapshotStore.write(
+          signedHostedCatalogSnapshot({
+            body: resigned.body,
+            monotonic: { sequence: 2, generatedAt: "2026-07-24T12:01:00.000Z" },
+          }),
+        ),
+      ).resolves.toBeUndefined();
+      const conflicting = signedHostedCatalogFeed({
+        feed: {
+          ...materializedFeed,
+          description: "Conflicting",
+          generatedAt: "2026-07-24T12:02:00.000Z",
+          expiresAt: "2026-07-24T12:07:00.000Z",
+        },
+        privateKeyPem: initial.privateKeyPem,
+      });
+      await expect(
+        snapshotStore.write(
+          signedHostedCatalogSnapshot({
+            body: conflicting.body,
+            monotonic: { sequence: 2, generatedAt: "2026-07-24T12:02:00.000Z" },
+          }),
+        ),
+      ).rejects.toThrow("payload changed without a sequence increment");
 
       await expect(
         snapshotStore.write(
@@ -1316,6 +1439,71 @@ describe("official external plugin catalog", () => {
           }),
         ),
       ).rejects.toThrow("sequence is older");
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("compacts a legacy sharded wrapper using its already-verified materialized digest", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const entries = fixture.shardBodies.flatMap(
+      (body) => (JSON.parse(body) as { entries: OfficialExternalPluginCatalogEntry[] }).entries,
+    );
+    const feed: OfficialExternalPluginCatalogFeed = {
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      sequence: 12,
+      generatedAt: "2026-06-22T00:00:12.000Z",
+      expiresAt: "2026-06-29T00:00:12.000Z",
+      description: "Acme plugins",
+      entries,
+    };
+    const legacyBody = serializeOfficialExternalPluginCatalogShardedSnapshot({
+      rootBody: fixture.signedRoot.body,
+      shardBodies: fixture.shardBodies,
+    });
+    const compacted = signedHostedCatalogFeed({
+      feed,
+      privateKeyPem: fixture.signedRoot.privateKeyPem,
+    });
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-shards-store-"));
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+
+    try {
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: legacyBody,
+          monotonic: { sequence: 12, generatedAt: feed.generatedAt },
+        }),
+      );
+      const rollback = signedHostedCatalogFeed({
+        feed: hostedCatalogFeed({ sequence: 11, pluginName: "@openclaw/rollback" }),
+        privateKeyPem: fixture.signedRoot.privateKeyPem,
+      });
+      await expect(
+        snapshotStore.write(
+          signedHostedCatalogSnapshot({
+            body: rollback.body,
+            monotonic: { sequence: 11, generatedAt: "2026-06-22T00:00:11.000Z" },
+          }),
+        ),
+      ).rejects.toThrow("sequence is older");
+      await expect(
+        snapshotStore.write(
+          signedHostedCatalogSnapshot({
+            body: compacted.body,
+            monotonic: {
+              sequence: 12,
+              generatedAt: feed.generatedAt,
+              currentMaterializedFeedSha256:
+                hashOfficialExternalPluginCatalogMaterializedFeed(feed),
+            },
+          }),
+        ),
+      ).resolves.toBeUndefined();
     } finally {
       closeOpenClawStateDatabaseForTest();
       rmSync(stateDir, { recursive: true, force: true });
@@ -1478,6 +1666,85 @@ describe("official external plugin catalog", () => {
       });
       expectHostedSnapshot(retainedCurrent);
       expect(retainedCurrent.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-v9"]);
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("retains a same-sequence legacy wrapper when its signing key has rotated", async () => {
+    const previous = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 8, pluginName: "@openclaw/legacy" }),
+      keyId: "old-root",
+    });
+    const change = signedHostedCatalogDocument({
+      payloadType: HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE,
+      privateKeyPem: previous.privateKeyPem,
+      document: {
+        schemaVersion: 1,
+        feedId: "openclaw-official-external-plugins",
+        fromSequence: 8,
+        toSequence: 9,
+        generatedAt: "2026-07-24T12:00:00.000Z",
+        expiresAt: "2026-07-24T12:05:00.000Z",
+        requestCursor: null,
+        pageIndex: 0,
+        startIndex: 0,
+        changeCount: 1,
+        changes: [{ sequence: 9, operation: "metadata", metadata: { description: "Current" } }],
+        nextCursor: null,
+      },
+    });
+    const legacyBody = serializeOfficialExternalPluginCatalogIncrementalSnapshot({
+      baseBody: previous.body,
+      changeBodies: [change.body],
+    });
+    const candidate = signedHostedCatalogFeed({
+      feed: {
+        ...hostedCatalogFeed({ sequence: 8, pluginName: "@openclaw/legacy" }),
+        sequence: 9,
+        generatedAt: "2026-07-24T12:00:00.000Z",
+        expiresAt: "2026-07-24T12:05:00.000Z",
+        description: "Current",
+      },
+      keyId: "new-root",
+    });
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-legacy-key-rotation-"));
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+
+    try {
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: legacyBody,
+          monotonic: { sequence: 9, generatedAt: "2026-07-24T12:00:00.000Z" },
+        }),
+      );
+      const load = () =>
+        loadHostedCatalog({
+          feedProfile: "acme",
+          catalogConfig: signedCatalogConfig(candidate.publicKeyPem, "new-root"),
+          fetchImpl: vi.fn(async () => dsseResponse(candidate.body)),
+          now: () => new Date("2026-07-24T12:01:00.000Z"),
+          snapshotStore,
+        });
+
+      const result = await load();
+      expectHosted(result);
+      await expect(
+        snapshotStore.read("https://packages.acme.example/openclaw/feed"),
+      ).resolves.toMatchObject({ body: legacyBody });
+      await expect(
+        loadHostedCatalog({
+          feedProfile: "acme",
+          catalogConfig: signedCatalogConfig(candidate.publicKeyPem, "new-root"),
+          fetchImpl: vi.fn(async () => dsseResponse(candidate.body)),
+          now: () => new Date("2026-07-24T12:01:00.000Z"),
+          snapshotStore,
+          requireSnapshotWrite: true,
+        }),
+      ).rejects.toThrow("cannot compact a same-sequence legacy catalog snapshot");
     } finally {
       closeOpenClawStateDatabaseForTest();
       rmSync(stateDir, { recursive: true, force: true });
@@ -1773,6 +2040,322 @@ describe("official external plugin catalog", () => {
     });
     expectHostedSnapshot(offline);
     expect(offline.feed).toMatchObject({ sequence: 2, entries: [{ id: "beta" }] });
+  });
+
+  it("persists same-sequence signed freshness for later offline use", async () => {
+    const initial = signedHostedCatalogFeed({
+      feed: {
+        schemaVersion: 1,
+        id: "openclaw-official-external-plugins",
+        sequence: 1,
+        generatedAt: "2026-07-24T12:00:00.000Z",
+        expiresAt: "2026-07-24T12:01:00.000Z",
+        entries: [changeCatalogEntry("alpha")],
+      },
+    });
+    const freshness = signedHostedCatalogDocument({
+      payloadType: HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE,
+      privateKeyPem: initial.privateKeyPem,
+      document: {
+        schemaVersion: 1,
+        feedId: "openclaw-official-external-plugins",
+        fromSequence: 1,
+        toSequence: 1,
+        generatedAt: "2026-07-24T12:00:30.000Z",
+        expiresAt: "2026-07-24T13:00:00.000Z",
+        requestCursor: null,
+        pageIndex: 0,
+        startIndex: 0,
+        changeCount: 0,
+        changes: [],
+        nextCursor: null,
+      },
+    });
+    const catalogConfig = signedCatalogConfig(initial.publicKeyPem);
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
+    await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      now: () => new Date("2026-07-24T12:00:10.000Z"),
+      fetchImpl: vi.fn(async () => dsseResponse(initial.body)),
+    });
+    const writeSpy = vi.spyOn(snapshotStore, "write");
+
+    const refreshed = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      now: () => new Date("2026-07-24T12:00:40.000Z"),
+      fetchImpl: vi.fn(async () => dsseResponse(freshness.body)),
+    });
+
+    expectHosted(refreshed);
+    expect(refreshed.feed).toMatchObject({ sequence: 1, expiresAt: "2026-07-24T13:00:00.000Z" });
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const offline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      offline: true,
+      now: () => new Date("2026-07-24T12:30:00.000Z"),
+    });
+    expectHostedSnapshot(offline);
+    expect(offline.feed.expiresAt).toBe("2026-07-24T13:00:00.000Z");
+    expect(offline.entries[0]?.install).toBeDefined();
+  });
+
+  it("validates schema-v2 snapshot digests before stripping install authority", async () => {
+    const initial = signedHostedCatalogFeed({
+      feed: {
+        schemaVersion: 2,
+        id: "openclaw-official-external-plugins",
+        sequence: 1,
+        generatedAt: "2026-07-24T12:00:00.000Z",
+        expiresAt: "2026-07-24T12:01:00.000Z",
+        entries: [{ ...changeCatalogEntry("disabled"), state: "disabled" }],
+      },
+    });
+    const freshness = signedHostedCatalogDocument({
+      payloadType: HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE,
+      privateKeyPem: initial.privateKeyPem,
+      document: {
+        schemaVersion: 1,
+        feedId: "openclaw-official-external-plugins",
+        fromSequence: 1,
+        toSequence: 1,
+        generatedAt: "2026-07-24T12:00:30.000Z",
+        expiresAt: "2026-07-24T13:00:00.000Z",
+        requestCursor: null,
+        pageIndex: 0,
+        startIndex: 0,
+        changeCount: 0,
+        changes: [],
+        nextCursor: null,
+      },
+    });
+    const catalogConfig = signedCatalogConfig(initial.publicKeyPem);
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
+    await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      now: () => new Date("2026-07-24T12:00:10.000Z"),
+      fetchImpl: vi.fn(async () => dsseResponse(initial.body)),
+    });
+
+    const refreshed = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      now: () => new Date("2026-07-24T12:00:40.000Z"),
+      fetchImpl: vi.fn(async () => dsseResponse(freshness.body)),
+    });
+    expectHosted(refreshed);
+    expect(refreshed.feed.entries[0]?.install).toBeUndefined();
+
+    const offline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      offline: true,
+      now: () => new Date("2026-07-24T12:30:00.000Z"),
+    });
+    expectHostedSnapshot(offline);
+    expect(offline.feed.entries[0]?.install).toBeUndefined();
+  });
+
+  it("rechecks incremental expiry after the terminal page before persisting", async () => {
+    const initial = signedHostedCatalogFeed({
+      feed: {
+        ...hostedCatalogFeed({ sequence: 1, pluginName: "@openclaw/initial" }),
+        generatedAt: "2026-07-24T11:00:00.000Z",
+        expiresAt: "2026-07-24T12:10:00.000Z",
+      },
+    });
+    const page = (pageIndex: number, requestCursor: string | null, nextCursor: string | null) =>
+      signedHostedCatalogDocument({
+        payloadType: HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE,
+        privateKeyPem: initial.privateKeyPem,
+        document: {
+          schemaVersion: 1,
+          feedId: "openclaw-official-external-plugins",
+          fromSequence: 1,
+          toSequence: 2,
+          generatedAt: "2026-07-24T12:00:00.000Z",
+          expiresAt: "2026-07-24T12:05:00.000Z",
+          requestCursor,
+          pageIndex,
+          startIndex: pageIndex,
+          changeCount: 2,
+          changes: [
+            {
+              sequence: 2,
+              operation: "metadata",
+              metadata: { description: pageIndex === 0 ? "First" : "Terminal" },
+            },
+          ],
+          nextCursor,
+        },
+      });
+    const first = page(0, null, "terminal");
+    const terminal = page(1, "terminal", null);
+    const catalogConfig = signedCatalogConfig(initial.publicKeyPem);
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
+    await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      now: () => new Date("2026-07-24T11:01:00.000Z"),
+      fetchImpl: vi.fn(async () => dsseResponse(initial.body)),
+    });
+    const writeSpy = vi.spyOn(snapshotStore, "write");
+    const now = vi
+      .fn<() => Date>()
+      .mockReturnValueOnce(new Date("2026-07-24T12:04:59.000Z"))
+      .mockReturnValue(new Date("2026-07-24T12:05:01.000Z"));
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const requestUrl = new URL(String(input));
+      if (requestUrl.pathname.endsWith("/changes")) {
+        return dsseResponse(requestUrl.searchParams.has("cursor") ? terminal.body : first.body);
+      }
+      return new Response(null, { status: 503 });
+    });
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      now,
+      fetchImpl,
+    });
+
+    expectHostedSnapshot(result);
+    expect(result.feed.sequence).toBe(1);
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(now.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("uses a signed reset sequence as the floor for the configured root", async () => {
+    const initial = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 10, pluginName: "@openclaw/initial" }),
+    });
+    const reset = signedHostedCatalogDocument({
+      payloadType: HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE,
+      privateKeyPem: initial.privateKeyPem,
+      document: {
+        schemaVersion: 1,
+        feedId: "openclaw-official-external-plugins",
+        fromSequence: 10,
+        currentSequence: 20,
+        generatedAt: "2026-07-24T12:00:00.000Z",
+        expiresAt: "2026-07-24T12:05:00.000Z",
+        resetRequired: true,
+        snapshotUrl: "https://untrusted.example/ignored",
+      },
+    });
+    const expiredReset = signedHostedCatalogDocument({
+      payloadType: HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE,
+      privateKeyPem: initial.privateKeyPem,
+      document: {
+        schemaVersion: 1,
+        feedId: "openclaw-official-external-plugins",
+        fromSequence: 10,
+        currentSequence: 99,
+        generatedAt: "2026-07-24T11:00:00.000Z",
+        expiresAt: "2026-07-24T11:05:00.000Z",
+        resetRequired: true,
+        snapshotUrl: "https://untrusted.example/ignored",
+      },
+    });
+    const staleRoot = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 15, pluginName: "@openclaw/stale-root" }),
+      privateKeyPem: initial.privateKeyPem,
+    });
+    const currentRoot = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 20, pluginName: "@openclaw/current-root" }),
+      privateKeyPem: initial.privateKeyPem,
+    });
+    const catalogConfig = signedCatalogConfig(initial.publicKeyPem);
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
+    await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      fetchImpl: vi.fn(async () => dsseResponse(initial.body)),
+    });
+    const refreshFrom = async (rootBody: string) =>
+      await loadHostedCatalog({
+        feedProfile: "acme",
+        catalogConfig,
+        snapshotStore,
+        now: () => new Date("2026-07-24T12:01:00.000Z"),
+        fetchImpl: vi.fn(async (input: RequestInfo | URL) => {
+          const requestUrl = new URL(String(input));
+          return requestUrl.pathname.endsWith("/changes")
+            ? dsseResponse(reset.body, { status: 409 })
+            : dsseResponse(rootBody);
+        }),
+      });
+
+    const rejected = await refreshFrom(staleRoot.body);
+    expectBundledFallback(rejected);
+    expect(rejected.entries).toEqual([]);
+    expect(rejected.error).toContain("reset floor 20");
+
+    const offlineAfterReset = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      offline: true,
+      now: () => new Date("2026-07-24T12:02:00.000Z"),
+    });
+    expectBundledFallback(offlineAfterReset);
+    expect(offlineAfterReset.entries).toEqual([]);
+    expect(offlineAfterReset.error).toContain("reset floor 20");
+
+    const outage = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      now: () => new Date("2026-07-24T12:01:00.000Z"),
+      fetchImpl: vi.fn(async (input: RequestInfo | URL) => {
+        const requestUrl = new URL(String(input));
+        return requestUrl.pathname.endsWith("/changes")
+          ? dsseResponse(reset.body, { status: 409 })
+          : new Response(null, { status: 503 });
+      }),
+    });
+    expectBundledFallback(outage);
+    expect(outage.entries).toEqual([]);
+    expect(outage.error).toContain("reset floor 20");
+
+    const replaySnapshotStore = createInMemoryHostedCatalogSnapshotStore([
+      signedHostedCatalogSnapshot({ body: initial.body }),
+    ]);
+    const replaySafe = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore: replaySnapshotStore,
+      now: () => new Date("2026-07-24T12:01:00.000Z"),
+      fetchImpl: vi.fn(async (input: RequestInfo | URL) => {
+        const requestUrl = new URL(String(input));
+        return requestUrl.pathname.endsWith("/changes")
+          ? dsseResponse(expiredReset.body, { status: 409 })
+          : dsseResponse(
+              signedHostedCatalogFeed({
+                feed: hostedCatalogFeed({ sequence: 11, pluginName: "@openclaw/replay-safe" }),
+                privateKeyPem: initial.privateKeyPem,
+              }).body,
+            );
+      }),
+    });
+    expectHosted(replaySafe);
+    expect(replaySafe.feed.sequence).toBe(11);
+
+    const accepted = await refreshFrom(currentRoot.body);
+    expectHosted(accepted);
+    expect(accepted.feed.sequence).toBe(20);
   });
 
   it("rejects expired signed feeds and keeps expired snapshots visible but not installable", async () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -33,6 +33,8 @@ function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
 }
 
 const HOSTED_CATALOG_PAYLOAD_TYPE = "openclaw.official-external-plugin-catalog-feed.v1";
+const HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE =
+  "openclaw.official-external-plugin-catalog-shard-root.v1";
 
 type HostedCatalogConfig = NonNullable<
   NonNullable<
@@ -176,6 +178,127 @@ function toLegacyBetaSignedEnvelope(body: string): string {
       signature: signature.sig,
     })),
   });
+}
+
+function signedHostedCatalogDocument(params: {
+  document: unknown;
+  payloadType: string;
+  privateKeyPem?: string;
+}): { body: string; privateKeyPem: string; publicKeyPem: string } {
+  const keys = params.privateKeyPem
+    ? {
+        privateKeyPem: params.privateKeyPem,
+        publicKeyPem: crypto
+          .createPublicKey(params.privateKeyPem)
+          .export({ type: "spki", format: "pem" }),
+      }
+    : (() => {
+        const generated = crypto.generateKeyPairSync("ed25519", {
+          publicKeyEncoding: { type: "spki", format: "pem" },
+          privateKeyEncoding: { type: "pkcs8", format: "pem" },
+        });
+        return { privateKeyPem: generated.privateKey, publicKeyPem: generated.publicKey };
+      })();
+  const payloadBytes = Buffer.from(JSON.stringify(params.document), "utf8");
+  const payloadTypeBytes = Buffer.from(params.payloadType, "utf8");
+  const signingInput = Buffer.concat([
+    Buffer.from(
+      `DSSEv1 ${payloadTypeBytes.length} ${params.payloadType} ${payloadBytes.length} `,
+      "utf8",
+    ),
+    payloadBytes,
+  ]);
+  return {
+    body: JSON.stringify({
+      payloadType: params.payloadType,
+      payload: payloadBytes.toString("base64url"),
+      signatures: [
+        {
+          keyid: "acme-root",
+          sig: crypto
+            .sign(null, signingInput, crypto.createPrivateKey(keys.privateKeyPem))
+            .toString("base64url"),
+        },
+      ],
+    }),
+    ...keys,
+  };
+}
+
+function shardedHostedCatalogFixture() {
+  const shardBodies = [
+    JSON.stringify({
+      schemaVersion: 1,
+      feedId: "openclaw-official-external-plugins",
+      sequence: 12,
+      index: 0,
+      entries: [
+        {
+          type: "plugin",
+          id: "@acme/alpha",
+          title: "Alpha",
+          version: "1.0.0",
+          state: "available",
+          publisher: { id: "acme", trust: "official" },
+          install: {
+            candidates: [
+              {
+                sourceRef: "acme-npm",
+                package: "@acme/alpha",
+                version: "1.0.0",
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    JSON.stringify({
+      schemaVersion: 1,
+      feedId: "openclaw-official-external-plugins",
+      sequence: 12,
+      index: 1,
+      entries: [
+        {
+          type: "plugin",
+          id: "@acme/beta",
+          title: "Beta",
+          version: "2.0.0",
+          state: "available",
+          publisher: { id: "acme", trust: "official" },
+          install: {
+            candidates: [
+              {
+                sourceRef: "acme-npm",
+                package: "@acme/beta",
+                version: "2.0.0",
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  ];
+  const shards = shardBodies.map((body, index) => ({
+    index,
+    url: `https://packages.acme.example/openclaw/shards/${index}.json`,
+    sha256: crypto.createHash("sha256").update(body).digest("hex"),
+    byteLength: Buffer.byteLength(body, "utf8"),
+    entryCount: 1,
+  }));
+  const signedRoot = signedHostedCatalogDocument({
+    payloadType: HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+    document: {
+      schemaVersion: 1,
+      feedId: "openclaw-official-external-plugins",
+      sequence: 12,
+      generatedAt: "2026-06-22T00:00:12.000Z",
+      expiresAt: "2026-06-29T00:00:12.000Z",
+      metadata: { description: "Acme plugins" },
+      entryCount: 2,
+      shards,
+    },
+  });
+  return { shardBodies, shards, signedRoot };
 }
 
 function signedCatalogConfig(publicKeyPem: string, keyId = "acme-root"): HostedCatalogConfig {
@@ -773,6 +896,144 @@ describe("official external plugin catalog", () => {
     } finally {
       closeOpenClawStateDatabaseForTest();
       rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads signed catalog shards and re-verifies their durable offline snapshot", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://packages.acme.example/openclaw/feed") {
+        return new Response(fixture.signedRoot.body, {
+          status: 200,
+          headers: { etag: '"root-12"' },
+        });
+      }
+      const shard = fixture.shards.find((candidate) => candidate.url === url);
+      if (!shard) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(fixture.shardBodies[shard.index], { status: 200 });
+    });
+
+    const live = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore,
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(live.source).toBe("hosted");
+    expect(live.entries.map((entry) => entry.id)).toEqual(["@acme/alpha", "@acme/beta"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    const snapshot = await snapshotStore.read("https://packages.acme.example/openclaw/feed");
+    expect(JSON.parse(snapshot?.body ?? "null")).toMatchObject({
+      kind: "official-external-plugin-catalog-shards-v1",
+      rootBody: fixture.signedRoot.body,
+      shardBodies: fixture.shardBodies,
+    });
+
+    const offline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      offline: true,
+      snapshotStore,
+      now: () => new Date("2026-06-23T00:00:00.000Z"),
+    });
+    expect(offline.source).toBe("hosted-snapshot");
+    expect(offline.entries.map((entry) => entry.id)).toEqual(["@acme/alpha", "@acme/beta"]);
+
+    const expiredOffline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      offline: true,
+      snapshotStore,
+      now: () => new Date("2026-06-30T00:00:00.000Z"),
+    });
+    expect(expiredOffline.source).toBe("bundled-fallback");
+    expect(expiredOffline.entries).toEqual([]);
+  });
+
+  it("fails closed when catalog shard bytes do not match the signed root", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://packages.acme.example/openclaw/feed") {
+        return new Response(fixture.signedRoot.body, { status: 200 });
+      }
+      const shard = fixture.shards.find((candidate) => candidate.url === url);
+      return new Response(
+        shard?.index === 0
+          ? fixture.shardBodies[0]?.replace('"Alpha"', '"Alphx"')
+          : fixture.shardBodies[1],
+        { status: 200 },
+      );
+    });
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("shard bytes do not match their signed descriptor");
+    }
+  });
+
+  it("rejects signed catalog shard URLs outside the root origin before fetching them", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const root = JSON.parse(
+      Buffer.from(JSON.parse(fixture.signedRoot.body).payload as string, "base64url").toString(
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    const shards = root.shards as Array<Record<string, unknown>>;
+    shards[0] = { ...shards[0], url: "https://cdn.example.net/catalog/0.json" };
+    const signedRoot = signedHostedCatalogDocument({
+      document: root,
+      payloadType: HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+      privateKeyPem: fixture.signedRoot.privateKeyPem,
+    });
+    const fetchImpl = vi.fn(async () => new Response(signedRoot.body, { status: 200 }));
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("shard URL must use the signed root origin");
+    }
+  });
+
+  it("rejects expired signed shard roots before fetching any shard", async () => {
+    const fixture = shardedHostedCatalogFixture();
+    const fetchImpl = vi.fn(async () => new Response(fixture.signedRoot.body, { status: 200 }));
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-30T00:00:00.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("shard root has expired");
     }
   });
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { serializeOfficialExternalPluginCatalogIncrementalSnapshot } from "./official-external-plugin-catalog-changes.js";
 import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
 import {
   type HostedOfficialExternalPluginCatalogSnapshot,
@@ -35,6 +36,7 @@ function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
 const HOSTED_CATALOG_PAYLOAD_TYPE = "openclaw.official-external-plugin-catalog-feed.v1";
 const HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE =
   "openclaw.official-external-plugin-catalog-shard-root.v1";
+const HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE = "openclaw.official-external-plugin-catalog-changes.v1";
 
 type HostedCatalogConfig = NonNullable<
   NonNullable<
@@ -1252,6 +1254,74 @@ describe("official external plugin catalog", () => {
     }
   });
 
+  it("enforces SQLite monotonicity across persisted signed change wrappers", async () => {
+    const initial = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 1, pluginName: "@openclaw/initial" }),
+    });
+    const change = signedHostedCatalogDocument({
+      payloadType: HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE,
+      privateKeyPem: initial.privateKeyPem,
+      document: {
+        schemaVersion: 1,
+        feedId: "openclaw-official-external-plugins",
+        fromSequence: 1,
+        toSequence: 2,
+        generatedAt: "2026-07-24T12:00:00.000Z",
+        expiresAt: "2026-07-24T12:05:00.000Z",
+        requestCursor: null,
+        pageIndex: 0,
+        startIndex: 0,
+        changeCount: 1,
+        changes: [
+          {
+            sequence: 2,
+            operation: "metadata",
+            metadata: { description: "Current" },
+          },
+        ],
+        nextCursor: null,
+      },
+    });
+    const wrapperBody = serializeOfficialExternalPluginCatalogIncrementalSnapshot({
+      baseBody: initial.body,
+      changeBodies: [change.body],
+    });
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-changes-store-"));
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+
+    try {
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: initial.body,
+          monotonic: { sequence: 1, generatedAt: "2026-06-22T00:00:01.000Z" },
+        }),
+      );
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: wrapperBody,
+          monotonic: { sequence: 2, generatedAt: "2026-07-24T12:00:00.000Z" },
+        }),
+      );
+      await expect(
+        snapshotStore.read("https://packages.acme.example/openclaw/feed"),
+      ).resolves.toMatchObject({ body: wrapperBody, monotonic: { sequence: 2 } });
+
+      await expect(
+        snapshotStore.write(
+          signedHostedCatalogSnapshot({
+            body: initial.body,
+            monotonic: { sequence: 1, generatedAt: "2026-06-22T00:00:01.000Z" },
+          }),
+        ),
+      ).rejects.toThrow("sequence is older");
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects malformed feed timestamps before rollback handling", async () => {
     const malformed = signedHostedCatalogFeed({
       feed: {
@@ -1580,6 +1650,129 @@ describe("official external plugin catalog", () => {
     expectBundledFallback(result);
     expect(result.entries).toEqual([]);
     expect(result.error).toContain("must use application/vnd.dsse+json");
+  });
+
+  it("refreshes a stored signed feed through changes and replays it offline", async () => {
+    const entry = (id: string) => ({
+      type: "plugin" as const,
+      id,
+      title: id,
+      version: "1.0.0",
+      state: "available",
+      publisher: { id: "openclaw", trust: "official" },
+      install: {
+        candidates: [
+          {
+            sourceRef: "acme-npm",
+            package: id,
+            version: "1.0.0",
+            integrity: `sha256:${"a".repeat(64)}`,
+          },
+        ],
+      },
+    });
+    const initial = signedHostedCatalogFeed({
+      feed: {
+        schemaVersion: 1,
+        id: "openclaw-official-external-plugins",
+        sequence: 1,
+        generatedAt: "2026-07-24T11:00:00.000Z",
+        expiresAt: "2026-07-24T11:05:00.000Z",
+        description: "Initial",
+        entries: [entry("alpha")],
+      },
+    });
+    const changePageOne = signedHostedCatalogDocument({
+      payloadType: HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE,
+      privateKeyPem: initial.privateKeyPem,
+      document: {
+        schemaVersion: 1,
+        feedId: "openclaw-official-external-plugins",
+        fromSequence: 1,
+        toSequence: 2,
+        generatedAt: "2026-07-24T12:00:00.000Z",
+        expiresAt: "2026-07-24T12:05:00.000Z",
+        requestCursor: null,
+        pageIndex: 0,
+        startIndex: 0,
+        changeCount: 3,
+        changes: [
+          { sequence: 2, operation: "remove", entryId: "alpha", entryType: "plugin" },
+          { sequence: 2, operation: "upsert", entry: entry("beta") },
+        ],
+        nextCursor: "page-2",
+      },
+    });
+    const changePageTwo = signedHostedCatalogDocument({
+      payloadType: HOSTED_CATALOG_CHANGES_PAYLOAD_TYPE,
+      privateKeyPem: initial.privateKeyPem,
+      document: {
+        schemaVersion: 1,
+        feedId: "openclaw-official-external-plugins",
+        fromSequence: 1,
+        toSequence: 2,
+        generatedAt: "2026-07-24T12:00:00.000Z",
+        expiresAt: "2026-07-24T12:05:00.000Z",
+        requestCursor: "page-2",
+        pageIndex: 1,
+        startIndex: 2,
+        changeCount: 3,
+        changes: [
+          {
+            sequence: 2,
+            operation: "metadata",
+            metadata: { description: "Updated" },
+          },
+        ],
+        nextCursor: null,
+      },
+    });
+    const catalogConfig = signedCatalogConfig(initial.publicKeyPem);
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
+    const seeded = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      now: () => new Date("2026-07-24T11:01:00.000Z"),
+      fetchImpl: vi.fn(async () => dsseResponse(initial.body)),
+    });
+    expectHosted(seeded);
+
+    const changeFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const requestUrl = new URL(String(input));
+      expect(requestUrl.pathname).toBe("/openclaw/feed/changes");
+      if (requestUrl.searchParams.has("cursor")) {
+        expect([...requestUrl.searchParams.entries()]).toEqual([["cursor", "page-2"]]);
+        return dsseResponse(changePageTwo.body);
+      }
+      expect(requestUrl.searchParams.get("fromSequence")).toBe("1");
+      expect(requestUrl.searchParams.get("limit")).toBe("500");
+      return dsseResponse(changePageOne.body);
+    });
+    const refreshed = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      now: () => new Date("2026-07-24T12:01:00.000Z"),
+      fetchImpl: changeFetch,
+    });
+    expectHosted(refreshed);
+    expect(changeFetch).toHaveBeenCalledTimes(2);
+    expect(refreshed.feed).toMatchObject({
+      sequence: 2,
+      description: "Updated",
+      entries: [{ id: "beta" }],
+    });
+
+    const offline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      snapshotStore,
+      offline: true,
+      now: () => new Date("2026-07-24T12:02:00.000Z"),
+    });
+    expectHostedSnapshot(offline);
+    expect(offline.feed).toMatchObject({ sequence: 2, entries: [{ id: "beta" }] });
   });
 
   it("rejects expired signed feeds and keeps expired snapshots visible but not installable", async () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -882,7 +882,7 @@ describe("official external plugin catalog", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : input.toString();
       if (url === "https://packages.acme.example/openclaw/feed") {
-        return new Response(fixture.signedRoot.body, {
+        return dsseResponse(fixture.signedRoot.body, {
           status: 200,
           headers: { etag: '"root-12"' },
         });
@@ -929,8 +929,12 @@ describe("official external plugin catalog", () => {
       snapshotStore,
       now: () => new Date("2026-06-30T00:00:00.000Z"),
     });
-    expect(expiredOffline.source).toBe("bundled-fallback");
-    expect(expiredOffline.entries).toEqual([]);
+    expect(expiredOffline.source).toBe("hosted-snapshot");
+    expect(expiredOffline.entries).toMatchObject([
+      { id: "@acme/alpha", state: "unavailable" },
+      { id: "@acme/beta", state: "unavailable" },
+    ]);
+    expect(expiredOffline.entries.every((entry) => entry.install === undefined)).toBe(true);
   });
 
   it("fails closed when catalog shard bytes do not match the signed root", async () => {
@@ -938,7 +942,7 @@ describe("official external plugin catalog", () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : input.toString();
       if (url === "https://packages.acme.example/openclaw/feed") {
-        return new Response(fixture.signedRoot.body, { status: 200 });
+        return dsseResponse(fixture.signedRoot.body, { status: 200 });
       }
       const shard = fixture.shards.find((candidate) => candidate.url === url);
       return new Response(
@@ -971,7 +975,7 @@ describe("official external plugin catalog", () => {
       const url = input instanceof Request ? input.url : input.toString();
       fetchedUrls.push(url);
       if (url === "https://packages.acme.example/openclaw/feed") {
-        return new Response(fixture.signedRoot.body, { status: 200 });
+        return dsseResponse(fixture.signedRoot.body, { status: 200 });
       }
       if (url.endsWith("/0.json")) {
         return new Response(null, { status: 503 });
@@ -1017,7 +1021,7 @@ describe("official external plugin catalog", () => {
       payloadType: HOSTED_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
       privateKeyPem: fixture.signedRoot.privateKeyPem,
     });
-    const fetchImpl = vi.fn(async () => new Response(signedRoot.body, { status: 200 }));
+    const fetchImpl = vi.fn(async () => dsseResponse(signedRoot.body, { status: 200 }));
 
     const result = await loadHostedCatalog({
       feedProfile: "acme",
@@ -1036,7 +1040,7 @@ describe("official external plugin catalog", () => {
 
   it("rejects expired signed shard roots before fetching any shard", async () => {
     const fixture = shardedHostedCatalogFixture();
-    const fetchImpl = vi.fn(async () => new Response(fixture.signedRoot.body, { status: 200 }));
+    const fetchImpl = vi.fn(async () => dsseResponse(fixture.signedRoot.body, { status: 200 }));
 
     const result = await loadHostedCatalog({
       feedProfile: "acme",
@@ -1049,7 +1053,7 @@ describe("official external plugin catalog", () => {
     expect(result.source).toBe("bundled-fallback");
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     if (result.source === "bundled-fallback") {
-      expect(result.error).toContain("shard root has expired");
+      expect(result.error).toContain("shard root expired at");
     }
   });
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -225,59 +225,36 @@ function signedHostedCatalogDocument(params: {
   };
 }
 
-function shardedHostedCatalogFixture() {
-  const shardBodies = [
-    JSON.stringify({
+function shardedHostedCatalogFixture(shardCount = 2) {
+  const shardBodies = Array.from({ length: shardCount }, (_, index) => {
+    const name = index === 0 ? "alpha" : index === 1 ? "beta" : `plugin-${index}`;
+    const title = index === 0 ? "Alpha" : index === 1 ? "Beta" : `Plugin ${index}`;
+    return JSON.stringify({
       schemaVersion: 1,
       feedId: "openclaw-official-external-plugins",
       sequence: 12,
-      index: 0,
+      index,
       entries: [
         {
           type: "plugin",
-          id: "@acme/alpha",
-          title: "Alpha",
-          version: "1.0.0",
+          id: `@acme/${name}`,
+          title,
+          version: `${index + 1}.0.0`,
           state: "available",
           publisher: { id: "acme", trust: "official" },
           install: {
             candidates: [
               {
                 sourceRef: "acme-npm",
-                package: "@acme/alpha",
-                version: "1.0.0",
+                package: `@acme/${name}`,
+                version: `${index + 1}.0.0`,
               },
             ],
           },
         },
       ],
-    }),
-    JSON.stringify({
-      schemaVersion: 1,
-      feedId: "openclaw-official-external-plugins",
-      sequence: 12,
-      index: 1,
-      entries: [
-        {
-          type: "plugin",
-          id: "@acme/beta",
-          title: "Beta",
-          version: "2.0.0",
-          state: "available",
-          publisher: { id: "acme", trust: "official" },
-          install: {
-            candidates: [
-              {
-                sourceRef: "acme-npm",
-                package: "@acme/beta",
-                version: "2.0.0",
-              },
-            ],
-          },
-        },
-      ],
-    }),
-  ];
+    });
+  });
   const shards = shardBodies.map((body, index) => ({
     index,
     url: `https://packages.acme.example/openclaw/shards/${index}.json`,
@@ -294,7 +271,7 @@ function shardedHostedCatalogFixture() {
       generatedAt: "2026-06-22T00:00:12.000Z",
       expiresAt: "2026-06-29T00:00:12.000Z",
       metadata: { description: "Acme plugins" },
-      entryCount: 2,
+      entryCount: shardCount,
       shards,
     },
   });
@@ -985,6 +962,45 @@ describe("official external plugin catalog", () => {
     if (result.source === "bundled-fallback") {
       expect(result.error).toContain("shard bytes do not match their signed descriptor");
     }
+  });
+
+  it("stops queued shard downloads after the first failure", async () => {
+    const fixture = shardedHostedCatalogFixture(8);
+    const fetchedUrls: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      fetchedUrls.push(url);
+      if (url === "https://packages.acme.example/openclaw/feed") {
+        return new Response(fixture.signedRoot.body, { status: 200 });
+      }
+      if (url.endsWith("/0.json")) {
+        return new Response(null, { status: 503 });
+      }
+      if (init?.signal?.aborted) {
+        throw init.signal.reason instanceof Error ? init.signal.reason : new Error("aborted");
+      }
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () =>
+            reject(
+              init.signal?.reason instanceof Error ? init.signal.reason : new Error("aborted"),
+            ),
+          { once: true },
+        );
+      });
+    });
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(fixture.signedRoot.publicKeyPem),
+      fetchImpl,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+      now: () => new Date("2026-06-22T00:00:13.000Z"),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(fetchedUrls.some((url) => /\/[4-7]\.json$/u.test(url))).toBe(false);
   });
 
   it("rejects signed catalog shard URLs outside the root origin before fetching them", async () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -2006,7 +2006,7 @@ describe("official external plugin catalog", () => {
     expectHosted(seeded);
 
     const changeFetch = vi.fn(async (input: RequestInfo | URL) => {
-      const requestUrl = new URL(String(input));
+      const requestUrl = input instanceof Request ? new URL(input.url) : new URL(input.toString());
       expect(requestUrl.pathname).toBe("/openclaw/feed/changes");
       if (requestUrl.searchParams.has("cursor")) {
         expect([...requestUrl.searchParams.entries()]).toEqual([["cursor", "page-2"]]);
@@ -2215,7 +2215,7 @@ describe("official external plugin catalog", () => {
       .mockReturnValueOnce(new Date("2026-07-24T12:04:59.000Z"))
       .mockReturnValue(new Date("2026-07-24T12:05:01.000Z"));
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
-      const requestUrl = new URL(String(input));
+      const requestUrl = input instanceof Request ? new URL(input.url) : new URL(input.toString());
       if (requestUrl.pathname.endsWith("/changes")) {
         return dsseResponse(requestUrl.searchParams.has("cursor") ? terminal.body : first.body);
       }
@@ -2291,7 +2291,8 @@ describe("official external plugin catalog", () => {
         snapshotStore,
         now: () => new Date("2026-07-24T12:01:00.000Z"),
         fetchImpl: vi.fn(async (input: RequestInfo | URL) => {
-          const requestUrl = new URL(String(input));
+          const requestUrl =
+            input instanceof Request ? new URL(input.url) : new URL(input.toString());
           return requestUrl.pathname.endsWith("/changes")
             ? dsseResponse(reset.body, { status: 409 })
             : dsseResponse(rootBody);
@@ -2320,7 +2321,8 @@ describe("official external plugin catalog", () => {
       snapshotStore,
       now: () => new Date("2026-07-24T12:01:00.000Z"),
       fetchImpl: vi.fn(async (input: RequestInfo | URL) => {
-        const requestUrl = new URL(String(input));
+        const requestUrl =
+          input instanceof Request ? new URL(input.url) : new URL(input.toString());
         return requestUrl.pathname.endsWith("/changes")
           ? dsseResponse(reset.body, { status: 409 })
           : new Response(null, { status: 503 });
@@ -2339,7 +2341,8 @@ describe("official external plugin catalog", () => {
       snapshotStore: replaySnapshotStore,
       now: () => new Date("2026-07-24T12:01:00.000Z"),
       fetchImpl: vi.fn(async (input: RequestInfo | URL) => {
-        const requestUrl = new URL(String(input));
+        const requestUrl =
+          input instanceof Request ? new URL(input.url) : new URL(input.toString());
         return requestUrl.pathname.endsWith("/changes")
           ? dsseResponse(expiredReset.body, { status: 409 })
           : dsseResponse(

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -794,6 +794,17 @@ async function parseHostedCatalogFeedBody(params: {
       feed = verification.payload;
     } else {
       const root = parseOfficialExternalPluginCatalogShardRoot(verification.payload);
+      const rootGeneratedAtMs = parseOfficialExternalPluginCatalogTimestamp(root.generatedAt);
+      const rootExpiresAtMs = parseOfficialExternalPluginCatalogTimestamp(root.expiresAt);
+      if (rootGeneratedAtMs === undefined || rootExpiresAtMs === undefined) {
+        throw new Error("hosted catalog shard root requires valid timestamps");
+      }
+      if (rootExpiresAtMs <= rootGeneratedAtMs) {
+        throw new Error("hosted catalog shard root expiresAt must be later than generatedAt");
+      }
+      if (rootExpiresAtMs <= params.now.getTime() && params.allowExpired !== true) {
+        throw new Error(`hosted catalog shard root expired at ${root.expiresAt}`);
+      }
       const shardBodies = snapshot?.shardBodies ?? (await params.loadShardBodies?.(root));
       if (!shardBodies) {
         throw new Error("hosted catalog shard set is unavailable");

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -744,6 +744,7 @@ async function parseHostedCatalogFeedBody(params: {
       OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
       OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
       verifyOfficialExternalPluginCatalogEnvelopePayload,
+      verifyOfficialExternalPluginCatalogSignedEnvelope,
     } = await import("./official-external-plugin-catalog-envelope.js");
     const {
       parseOfficialExternalPluginCatalogShardedSnapshot,
@@ -755,15 +756,30 @@ async function parseHostedCatalogFeedBody(params: {
     const wireBody = snapshot?.rootBody ?? params.body;
     const raw = snapshot ? (JSON.parse(snapshot.rootBody) as unknown) : document;
     const threshold = params.verification.threshold ?? 1;
-    const verification = verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
-      trustedKeys: params.verification.keys,
-      acceptedPayloadTypes: new Set([
-        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
-        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
-      ]),
-      threshold,
-      ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
-    });
+    const verification =
+      isRecord(raw) && raw.payloadType === OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE
+        ? (() => {
+            const feedVerification = verifyOfficialExternalPluginCatalogSignedEnvelope(raw, {
+              trustedKeys: params.verification.keys,
+              threshold,
+              ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
+            });
+            return feedVerification.ok
+              ? {
+                  ...feedVerification,
+                  payloadType: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+                  payload: feedVerification.feed,
+                }
+              : feedVerification;
+          })()
+        : verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
+            trustedKeys: params.verification.keys,
+            acceptedPayloadTypes: new Set([
+              OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+            ]),
+            threshold,
+            ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
+          });
     if (!verification.ok) {
       const invalidTimestampSequence =
         verification.error === "invalid-payload" && "authenticatedPayload" in verification
@@ -809,7 +825,11 @@ async function parseHostedCatalogFeedBody(params: {
       if (!shardBodies) {
         throw new Error("hosted catalog shard set is unavailable");
       }
-      feed = validateOfficialExternalPluginCatalogShardSet(root, shardBodies);
+      const shardedFeed = validateOfficialExternalPluginCatalogShardSet(root, shardBodies);
+      if (!isOfficialExternalPluginCatalogFeed(shardedFeed)) {
+        throw new Error("hosted catalog shard set contains an invalid feed");
+      }
+      feed = shardedFeed;
       snapshotBody =
         snapshot === null
           ? serializeOfficialExternalPluginCatalogShardedSnapshot({

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -219,6 +219,7 @@ export type HostedOfficialExternalPluginCatalogSnapshotMonotonicState = {
   mode: "signed-feed";
   sequence: number;
   generatedAt?: string;
+  currentMaterializedFeedSha256?: string;
 };
 
 export type HostedOfficialExternalPluginCatalogLoadResult =
@@ -376,6 +377,51 @@ function normalizeHostedCatalogHeader(value: string | null): string | undefined 
 
 function sha256Hex(value: string): string {
   return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function stableJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableJsonValue);
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, stableJsonValue(child)]),
+    );
+  }
+  return value;
+}
+
+/** Hashes authenticated catalog content while excluding refresh-window metadata. */
+export function hashOfficialExternalPluginCatalogMaterializedFeed(
+  feed: OfficialExternalPluginCatalogFeed,
+): string {
+  const { generatedAt: _generatedAt, expiresAt: _expiresAt, entries, ...rest } = feed;
+  const content = {
+    ...rest,
+    entries: entries
+      .map((entry) => stableJsonValue(entry))
+      .toSorted((left, right) => {
+        const leftJson = JSON.stringify(left);
+        const rightJson = JSON.stringify(right);
+        return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+      }),
+  };
+  return sha256Hex(JSON.stringify(stableJsonValue(content)));
+}
+
+function isLegacyCatalogSnapshotWithoutMaterializedDigest(body: string): boolean {
+  try {
+    const document = JSON.parse(body) as Record<string, unknown>;
+    return (
+      (document.kind === "official-external-plugin-catalog-changes-v1" ||
+        document.kind === "official-external-plugin-catalog-shards-v1") &&
+      typeof document.materializedFeedSha256 !== "string"
+    );
+  } catch {
+    return false;
+  }
 }
 
 function resolveHostedCatalogFeedUrl(raw: string): URL {
@@ -737,13 +783,31 @@ async function parseHostedCatalogFeedBody(params: {
   expired?: boolean;
   snapshotBody?: string;
   wireBody?: string;
+  authenticatedMaterializedFeedSha256?: string;
 }> {
   const document = JSON.parse(params.body) as unknown;
   if (params.verification?.mode === "signed") {
     const {
       applyVerifiedOfficialExternalPluginCatalogChangeBodies,
       parseOfficialExternalPluginCatalogIncrementalSnapshot,
+      parseOfficialExternalPluginCatalogResetFloorSnapshot,
     } = await import("./official-external-plugin-catalog-changes.js");
+    const resetFloorSnapshot = parseOfficialExternalPluginCatalogResetFloorSnapshot(document);
+    if (resetFloorSnapshot) {
+      const base = await parseHostedCatalogFeedBody({
+        ...params,
+        body: resetFloorSnapshot.snapshotBody,
+      });
+      if (base.feed.sequence < resetFloorSnapshot.minimumSequence) {
+        throw new HostedCatalogSignedFeedMonotonicityError(
+          `hosted catalog signed feed sequence is older than reset floor ${resetFloorSnapshot.minimumSequence}`,
+        );
+      }
+      return {
+        ...base,
+        wireBody: base.wireBody ?? resetFloorSnapshot.snapshotBody,
+      };
+    }
     const incrementalSnapshot = parseOfficialExternalPluginCatalogIncrementalSnapshot(document);
     if (incrementalSnapshot) {
       const base = await parseHostedCatalogFeedBody({
@@ -762,6 +826,17 @@ async function parseHostedCatalogFeedBody(params: {
         threshold: params.verification.threshold,
         expectedFeedId: params.expectedFeedId,
       });
+      const authenticatedMaterializedFeedSha256 = hashOfficialExternalPluginCatalogMaterializedFeed(
+        applied.feed,
+      );
+      if (
+        incrementalSnapshot.materializedFeedSha256 !== undefined &&
+        incrementalSnapshot.materializedFeedSha256 !== authenticatedMaterializedFeedSha256
+      ) {
+        throw new Error(
+          "hosted catalog incremental snapshot materialized feed digest did not match",
+        );
+      }
       const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(applied.feed.generatedAt);
       const expiresAt = normalizeOptionalString(applied.feed.expiresAt);
       const expiresAtMs = expiresAt
@@ -788,6 +863,7 @@ async function parseHostedCatalogFeedBody(params: {
           verifiedAt: params.verifiedAt,
         },
         ...(expired ? { expired: true } : {}),
+        authenticatedMaterializedFeedSha256,
       };
     }
     const {
@@ -885,8 +961,15 @@ async function parseHostedCatalogFeedBody(params: {
           ? serializeOfficialExternalPluginCatalogShardedSnapshot({
               rootBody: params.body,
               shardBodies,
+              materializedFeedSha256: hashOfficialExternalPluginCatalogMaterializedFeed(feed),
             })
           : params.body;
+    }
+    if (
+      snapshot?.materializedFeedSha256 !== undefined &&
+      snapshot.materializedFeedSha256 !== hashOfficialExternalPluginCatalogMaterializedFeed(feed)
+    ) {
+      throw new Error("hosted catalog sharded snapshot materialized feed digest did not match");
     }
     if (params.expectedFeedId && feed.id !== params.expectedFeedId) {
       throw new Error(
@@ -933,6 +1016,7 @@ async function parseHostedCatalogFeedBody(params: {
       ...(expired ? { expired: true } : {}),
       ...(snapshotBody ? { snapshotBody } : {}),
       ...(snapshot ? { wireBody } : {}),
+      authenticatedMaterializedFeedSha256: hashOfficialExternalPluginCatalogMaterializedFeed(feed),
     };
   }
   if (!isOfficialExternalPluginCatalogFeed(document)) {
@@ -1003,6 +1087,7 @@ async function loadHostedCatalogSnapshotResult(params: {
   expectedFeedId?: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
   now: Date;
+  minimumSignedSequence?: number;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   assertSnapshotMatchesRequestValidators({
     snapshot: params.snapshot,
@@ -1026,6 +1111,14 @@ async function loadHostedCatalogSnapshotResult(params: {
   const wireChecksum = sha256Hex(parsed.wireBody ?? params.snapshot.body);
   if (params.expectedSha256 && params.expectedSha256 !== wireChecksum) {
     throw new Error("hosted catalog snapshot checksum did not match expected checksum");
+  }
+  if (
+    params.minimumSignedSequence !== undefined &&
+    parsed.feed.sequence < params.minimumSignedSequence
+  ) {
+    throw new HostedCatalogSignedFeedMonotonicityError(
+      `hosted catalog signed feed sequence is older than reset floor ${params.minimumSignedSequence}`,
+    );
   }
   const entries = dedupeOfficialExternalPluginCatalogEntries(
     filterOfficialExternalPluginCatalogEntriesBySourceRefs(
@@ -1113,6 +1206,7 @@ async function snapshotOrBundledFallbackResult(params: {
   expectedFeedId?: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
   now: Date;
+  minimumSignedSequence?: number;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   if (params.snapshotStore) {
     try {
@@ -1129,6 +1223,7 @@ async function snapshotOrBundledFallbackResult(params: {
           expectedFeedId: params.expectedFeedId,
           verification: params.verification,
           now: params.now,
+          minimumSignedSequence: params.minimumSignedSequence,
         });
       }
     } catch (snapshotErr) {
@@ -1269,9 +1364,9 @@ async function tryLoadHostedCatalogIncrementalRefresh(params: {
   fetchImpl?: FetchLike;
   timeoutMs: number;
   chunkTimeoutMs: number;
-  now: Date;
+  now: () => Date;
   requireSnapshotWrite?: boolean;
-}): Promise<HostedOfficialExternalPluginCatalogLoadResult | null> {
+}): Promise<HostedOfficialExternalPluginCatalogLoadResult | { resetSequenceFloor: number } | null> {
   if (!params.snapshotStore) {
     return null;
   }
@@ -1285,7 +1380,7 @@ async function tryLoadHostedCatalogIncrementalRefresh(params: {
     verification: params.verification,
     verifiedAt: snapshot.trust.verifiedAt,
     allowLegacyBetaEnvelope: true,
-    now: params.now,
+    now: params.now(),
     allowExpired: true,
     allowMissingExpiry: true,
   }).catch(() => null);
@@ -1293,7 +1388,9 @@ async function tryLoadHostedCatalogIncrementalRefresh(params: {
     return null;
   }
   const {
+    applyVerifiedOfficialExternalPluginCatalogChanges,
     parseOfficialExternalPluginCatalogIncrementalSnapshot,
+    serializeOfficialExternalPluginCatalogResetFloorSnapshot,
     serializeOfficialExternalPluginCatalogIncrementalSnapshot,
     verifyOfficialExternalPluginCatalogChangeEnvelopeBody,
   } = await import("./official-external-plugin-catalog-changes.js");
@@ -1305,13 +1402,13 @@ async function tryLoadHostedCatalogIncrementalRefresh(params: {
   changesUrl.search = "";
   changesUrl.hash = "";
   const newBodies: string[] = [];
+  const newVerifications: Array<
+    ReturnType<typeof verifyOfficialExternalPluginCatalogChangeEnvelopeBody>
+  > = [];
   let cursor: string | null = null;
   let downloadedBytes = 0;
   const consumedCursors = new Set<string>();
   let lastStatus = 200;
-  let lastVerification:
-    | ReturnType<typeof verifyOfficialExternalPluginCatalogChangeEnvelopeBody>
-    | undefined;
   const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
   for (let pageCount = 0; pageCount < 2048; pageCount += 1) {
     const requestUrl = new URL(changesUrl.href);
@@ -1369,7 +1466,6 @@ async function tryLoadHostedCatalogIncrementalRefresh(params: {
         trustedKeys: params.verification.keys,
         threshold: params.verification.threshold,
       });
-      lastVerification = verified;
       if (
         verified.payload.feedId !== current.feed.id ||
         verified.payload.fromSequence !== current.feed.sequence
@@ -1379,12 +1475,53 @@ async function tryLoadHostedCatalogIncrementalRefresh(params: {
       if ("resetRequired" in verified.payload) {
         // The signed reset URL is never followed here: the configured root
         // remains the authority. Cross-origin reset locations are ignored too.
-        return null;
+        const resetExpiresAtMs = parseOfficialExternalPluginCatalogTimestamp(
+          verified.payload.expiresAt,
+        );
+        const resetNow = params.now();
+        if (resetExpiresAtMs === undefined || resetExpiresAtMs <= resetNow.getTime()) {
+          return null;
+        }
+        const floorBody = serializeOfficialExternalPluginCatalogResetFloorSnapshot({
+          snapshotBody: snapshot.body,
+          minimumSequence: verified.payload.currentSequence,
+        });
+        await params.snapshotStore
+          .write({
+            body: floorBody,
+            metadata: {
+              ...snapshot.metadata,
+              status: response.status,
+              checksum: sha256Hex(floorBody),
+            },
+            savedAt: resetNow.toISOString(),
+            trust: {
+              mode: "signed",
+              signedBy: verified.signedBy,
+              signatureCount: verified.signatureCount,
+              threshold: verified.threshold,
+              verifiedAt: resetNow.toISOString(),
+            },
+            monotonic: {
+              mode: "signed-feed",
+              sequence: verified.payload.currentSequence,
+            },
+          })
+          .catch((error: unknown) => {
+            if (error instanceof HostedCatalogSignedFeedMonotonicityError) {
+              throw error;
+            }
+            if (params.requireSnapshotWrite) {
+              throw new HostedCatalogSnapshotWriteError(error);
+            }
+          });
+        return { resetSequenceFloor: verified.payload.currentSequence };
       }
       if (response.status !== 200) {
         return null;
       }
       newBodies.push(body);
+      newVerifications.push(verified);
       cursor = verified.payload.nextCursor;
       if (cursor === null) {
         break;
@@ -1396,31 +1533,51 @@ async function tryLoadHostedCatalogIncrementalRefresh(params: {
       await release?.().catch(() => undefined);
     }
   }
-  if (cursor !== null || newBodies.length === 0 || !lastVerification) {
+  if (cursor !== null || newBodies.length === 0) {
     return null;
   }
   const existingBodies = storedWrapper?.changeBodies ?? [];
   if (existingBodies.length + newBodies.length > 2048) {
     return null;
   }
+  const applied = applyVerifiedOfficialExternalPluginCatalogChanges({
+    feed: current.feed,
+    changes: newVerifications,
+    expectedFeedId: params.expectedFeedId,
+  });
+  const terminalNow = params.now();
+  const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(applied.feed.generatedAt);
+  const expiresAt = normalizeOptionalString(applied.feed.expiresAt);
+  const expiresAtMs = expiresAt
+    ? parseOfficialExternalPluginCatalogTimestamp(expiresAt)
+    : undefined;
+  if (generatedAtMs === undefined || expiresAtMs === undefined || expiresAtMs <= generatedAtMs) {
+    throw new Error("hosted catalog incremental result has an invalid validity window");
+  }
+  if (expiresAtMs <= terminalNow.getTime()) {
+    throw new Error(`hosted catalog signed feed expired at ${expiresAt}`);
+  }
+  const materializedFeedSha256 = hashOfficialExternalPluginCatalogMaterializedFeed(applied.feed);
+  const feed = enforceHostedCatalogFeedInstallAuthority(applied.feed);
   const baseBody = storedWrapper?.baseBody ?? snapshot.body;
   const snapshotBody = serializeOfficialExternalPluginCatalogIncrementalSnapshot({
     baseBody,
     changeBodies: [...existingBodies, ...newBodies],
+    materializedFeedSha256,
   });
   if (Buffer.byteLength(snapshotBody, "utf8") > 256 * 1024 * 1024) {
     return null;
   }
-  const verifiedAt = params.now.toISOString();
-  const parsed = await parseHostedCatalogFeedBody({
-    body: snapshotBody,
-    expectedFeedId: params.expectedFeedId,
-    verification: params.verification,
+  const verifiedAt = terminalNow.toISOString();
+  const trust: HostedOfficialExternalPluginCatalogTrustState = {
+    mode: "signed",
+    signedBy: applied.signedBy,
+    signatureCount: applied.signatureCount,
+    threshold: applied.threshold,
     verifiedAt,
-    now: params.now,
-  });
+  };
   const entries = filterOfficialExternalPluginCatalogEntriesBySourceRefs(
-    parseOfficialExternalPluginCatalogEntries(parsed.feed),
+    parseOfficialExternalPluginCatalogEntries(feed),
     {
       catalogConfig: params.catalogConfig,
       requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
@@ -1431,36 +1588,35 @@ async function tryLoadHostedCatalogIncrementalRefresh(params: {
     status: lastStatus,
     checksum: sha256Hex(snapshotBody),
   };
-  // A signed empty range is useful as a live freshness proof, but persisting it
-  // would change the stored bytes without advancing the accepted sequence.
-  if (parsed.feed.sequence !== current.feed.sequence) {
-    await params.snapshotStore
-      .write({
-        body: snapshotBody,
-        metadata,
-        savedAt: verifiedAt,
-        trust: parsed.trust,
-        monotonic: {
-          mode: "signed-feed",
-          sequence: parsed.feed.sequence,
-          generatedAt: parsed.feed.generatedAt,
-        },
-      })
-      .catch((error: unknown) => {
-        if (error instanceof HostedCatalogSignedFeedMonotonicityError) {
-          throw error;
-        }
-        if (params.requireSnapshotWrite) {
-          throw new HostedCatalogSnapshotWriteError(error);
-        }
-      });
-  }
+  await params.snapshotStore
+    .write({
+      body: snapshotBody,
+      metadata,
+      savedAt: verifiedAt,
+      trust,
+      monotonic: {
+        mode: "signed-feed",
+        sequence: feed.sequence,
+        generatedAt: feed.generatedAt,
+        currentMaterializedFeedSha256:
+          current.authenticatedMaterializedFeedSha256 ??
+          hashOfficialExternalPluginCatalogMaterializedFeed(current.feed),
+      },
+    })
+    .catch((error: unknown) => {
+      if (error instanceof HostedCatalogSignedFeedMonotonicityError) {
+        throw error;
+      }
+      if (params.requireSnapshotWrite) {
+        throw new HostedCatalogSnapshotWriteError(error);
+      }
+    });
   return {
     source: "hosted",
     entries: dedupeOfficialExternalPluginCatalogEntries(entries),
-    feed: parsed.feed,
+    feed,
     metadata,
-    trust: parsed.trust,
+    trust,
   };
 }
 
@@ -1512,6 +1668,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     feedProfile: params?.feedProfile,
     catalogConfig: params?.catalogConfig,
   });
+  let incrementalResetSequenceFloor: number | undefined;
   if (params?.offline === true) {
     return await snapshotOrBundledFallbackResult({
       error: "hosted catalog feed offline mode",
@@ -1523,6 +1680,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       expectedFeedId: source.expectedFeedId,
       verification: source.verification,
       now: currentTime(),
+      minimumSignedSequence: incrementalResetSequenceFloor,
     });
   }
   if (
@@ -1545,11 +1703,15 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         chunkTimeoutMs:
           params?.chunkTimeoutMs ??
           DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
-        now: currentTime(),
+        now: currentTime,
         requireSnapshotWrite: params?.requireSnapshotWrite,
       });
       if (incremental) {
-        return incremental;
+        if ("resetSequenceFloor" in incremental) {
+          incrementalResetSequenceFloor = incremental.resetSequenceFloor;
+        } else {
+          return incremental;
+        }
       }
     } catch (error) {
       if (error instanceof HostedCatalogSnapshotWriteError) {
@@ -1565,6 +1727,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
           expectedFeedId: source.expectedFeedId,
           verification: source.verification,
           now: currentTime(),
+          minimumSignedSequence: incrementalResetSequenceFloor,
         });
       }
       // A missing, unavailable, or malformed changes route is compatible with
@@ -1628,6 +1791,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         expectedFeedId: source.expectedFeedId,
         verification: source.verification,
         now: currentTime(),
+        minimumSignedSequence: incrementalResetSequenceFloor,
       });
     }
     if (!response.ok) {
@@ -1644,6 +1808,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         expectedFeedId: source.expectedFeedId,
         verification: source.verification,
         now: currentTime(),
+        minimumSignedSequence: incrementalResetSequenceFloor,
       });
     }
     if (
@@ -1663,6 +1828,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         expectedFeedId: source.expectedFeedId,
         verification: source.verification,
         now: currentTime(),
+        minimumSignedSequence: incrementalResetSequenceFloor,
       });
     }
     const body = await readHostedCatalogResponseText({
@@ -1691,6 +1857,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         expectedFeedId: source.expectedFeedId,
         verification: source.verification,
         now: currentTime(),
+        minimumSignedSequence: incrementalResetSequenceFloor,
       });
     }
     const now = currentTime();
@@ -1727,36 +1894,54 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         expectedFeedId: source.expectedFeedId,
         verification: source.verification,
         now,
+        minimumSignedSequence: incrementalResetSequenceFloor,
       });
     });
     if ("source" in parsed) {
       return parsed;
     }
+    if (
+      incrementalResetSequenceFloor !== undefined &&
+      parsed.trust?.mode === "signed" &&
+      parsed.feed.sequence < incrementalResetSequenceFloor
+    ) {
+      throw new HostedCatalogSignedFeedMonotonicityError(
+        `hosted catalog signed feed sequence is older than reset floor ${incrementalResetSequenceFloor}`,
+      );
+    }
+    let currentMaterializedFeedSha256: string | undefined;
+    let skipSameSequenceLegacySnapshotWrite = false;
     if (snapshotStore && parsed.trust?.mode === "signed") {
       const currentSnapshot = await snapshotStore.read(url.href);
       if (currentSnapshot?.trust?.mode === "signed") {
+        const parsedCurrent = await parseHostedCatalogFeedBody({
+          body: currentSnapshot.body,
+          expectedFeedId: source.expectedFeedId,
+          verification: source.verification,
+          verifiedAt: currentSnapshot.trust.verifiedAt,
+          allowLegacyBetaEnvelope: true,
+          now,
+          allowExpired: true,
+          allowMissingExpiry: true,
+        }).catch((err: unknown) => {
+          // Invalid timestamps remain repairable, and accepted monotonic metadata stays
+          // authoritative when configured signing keys rotate away from the stored signer.
+          if (err instanceof HostedCatalogFeedTimestampError) {
+            return { feed: { sequence: err.sequence } };
+          }
+          if (currentSnapshot.monotonic?.mode === "signed-feed") {
+            return undefined;
+          }
+          throw err;
+        });
         const current =
           currentSnapshot.monotonic?.mode === "signed-feed"
             ? currentSnapshot.monotonic
-            : (
-                await parseHostedCatalogFeedBody({
-                  body: currentSnapshot.body,
-                  expectedFeedId: source.expectedFeedId,
-                  verification: source.verification,
-                  verifiedAt: currentSnapshot.trust.verifiedAt,
-                  allowLegacyBetaEnvelope: true,
-                  now,
-                  allowExpired: true,
-                  allowMissingExpiry: true,
-                }).catch((err: unknown) => {
-                  // Only an authenticated invalid-timestamp payload is repairable. Signature
-                  // and trust failures must remain fail-closed so rollback checks cannot be bypassed.
-                  if (err instanceof HostedCatalogFeedTimestampError) {
-                    return { feed: { sequence: err.sequence } };
-                  }
-                  throw err;
-                })
-              ).feed;
+            : parsedCurrent!.feed;
+        currentMaterializedFeedSha256 =
+          parsedCurrent && "authenticatedMaterializedFeedSha256" in parsedCurrent
+            ? parsedCurrent.authenticatedMaterializedFeedSha256
+            : undefined;
         if (
           isHostedCatalogSignedFeedRollback({
             candidate: parsed.feed,
@@ -1767,6 +1952,10 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
             "hosted catalog signed feed sequence is older than current snapshot",
           );
         }
+        skipSameSequenceLegacySnapshotWrite =
+          parsed.feed.sequence === current.sequence &&
+          currentMaterializedFeedSha256 === undefined &&
+          isLegacyCatalogSnapshotWithoutMaterializedDigest(currentSnapshot.body);
       }
     }
     const entries = filterOfficialExternalPluginCatalogEntriesBySourceRefs(
@@ -1781,7 +1970,14 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       ...metadata,
       checksum: sha256Hex(snapshotBody),
     };
-    await snapshotStore
+    if (skipSameSequenceLegacySnapshotWrite && params?.requireSnapshotWrite) {
+      throw new HostedCatalogSnapshotWriteError(
+        new Error(
+          "cannot compact a same-sequence legacy catalog snapshot after its signing key rotated",
+        ),
+      );
+    }
+    await (skipSameSequenceLegacySnapshotWrite ? undefined : snapshotStore)
       ?.write({
         body: snapshotBody,
         metadata: snapshotMetadata,
@@ -1793,6 +1989,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
                 mode: "signed-feed",
                 sequence: parsed.feed.sequence,
                 generatedAt: parsed.feed.generatedAt,
+                ...(currentMaterializedFeedSha256 ? { currentMaterializedFeedSha256 } : {}),
               },
             }
           : {}),
@@ -1828,6 +2025,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       expectedFeedId: source.expectedFeedId,
       verification: source.verification,
       now: currentTime(),
+      minimumSignedSequence: incrementalResetSequenceFloor,
     });
   } finally {
     if (response?.bodyUsed !== true) {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import pLimit from "p-limit";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -14,6 +15,7 @@ import type {
   PluginPackageInstall,
 } from "./manifest.js";
 import { BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS } from "./official-external-plugin-bundled-catalogs.js";
+import type { OfficialExternalPluginCatalogShardRoot } from "./official-external-plugin-catalog-shards.js";
 
 type ManifestKey = typeof MANIFEST_KEY;
 
@@ -284,8 +286,10 @@ const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG: OfficialExternalP
   };
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SIGNED_MAX_BYTES = 2 * 1024 * 1024;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
 const DSSE_ENVELOPE_MEDIA_TYPE = "application/vnd.dsse+json";
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY = 4;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["clawhub.ai"];
 const ISO_CALENDAR_DATE_PREFIX_RE = /^(\d{4})-(\d{2})-(\d{2})/u;
 
@@ -727,18 +731,37 @@ async function parseHostedCatalogFeedBody(params: {
   now: Date;
   allowExpired?: boolean;
   allowMissingExpiry?: boolean;
+  loadShardBodies?: (root: OfficialExternalPluginCatalogShardRoot) => Promise<readonly string[]>;
 }): Promise<{
   feed: OfficialExternalPluginCatalogFeed;
   trust?: HostedOfficialExternalPluginCatalogTrustState;
   expired?: boolean;
+  snapshotBody?: string;
+  wireBody?: string;
 }> {
-  const raw = JSON.parse(params.body) as unknown;
+  const document = JSON.parse(params.body) as unknown;
   if (params.verification?.mode === "signed") {
-    const { verifyOfficialExternalPluginCatalogSignedEnvelope } =
-      await import("./official-external-plugin-catalog-envelope.js");
+    const {
+      OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+      OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+      verifyOfficialExternalPluginCatalogEnvelopePayload,
+    } = await import("./official-external-plugin-catalog-envelope.js");
+    const {
+      parseOfficialExternalPluginCatalogShardedSnapshot,
+      parseOfficialExternalPluginCatalogShardRoot,
+      serializeOfficialExternalPluginCatalogShardedSnapshot,
+      validateOfficialExternalPluginCatalogShardSet,
+    } = await import("./official-external-plugin-catalog-shards.js");
+    const snapshot = parseOfficialExternalPluginCatalogShardedSnapshot(document);
+    const wireBody = snapshot?.rootBody ?? params.body;
+    const raw = snapshot ? (JSON.parse(snapshot.rootBody) as unknown) : document;
     const threshold = params.verification.threshold ?? 1;
-    const verification = verifyOfficialExternalPluginCatalogSignedEnvelope(raw, {
+    const verification = verifyOfficialExternalPluginCatalogEnvelopePayload(raw, {
       trustedKeys: params.verification.keys,
+      acceptedPayloadTypes: new Set([
+        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+        OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
+      ]),
       threshold,
       ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
     });
@@ -754,15 +777,44 @@ async function parseHostedCatalogFeedBody(params: {
       }
       throw new Error(verification.message);
     }
-    if (params.expectedFeedId && verification.feed.id !== params.expectedFeedId) {
+    let feed: OfficialExternalPluginCatalogFeed;
+    let snapshotBody: string | undefined;
+    if (verification.payloadType === OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE) {
+      if (!isOfficialExternalPluginCatalogFeed(verification.payload)) {
+        const invalidTimestampSequence = readOfficialExternalPluginCatalogInvalidTimestampSequence(
+          verification.payload,
+        );
+        if (invalidTimestampSequence !== undefined) {
+          throw new HostedCatalogFeedTimestampError(
+            "hosted catalog signed envelope payload is invalid",
+            invalidTimestampSequence,
+          );
+        }
+        throw new Error("hosted catalog signed envelope payload is invalid");
+      }
+      feed = verification.payload;
+    } else {
+      const root = parseOfficialExternalPluginCatalogShardRoot(verification.payload);
+      const shardBodies = snapshot?.shardBodies ?? (await params.loadShardBodies?.(root));
+      if (!shardBodies) {
+        throw new Error("hosted catalog shard set is unavailable");
+      }
+      feed = validateOfficialExternalPluginCatalogShardSet(root, shardBodies);
+      snapshotBody =
+        snapshot === null
+          ? serializeOfficialExternalPluginCatalogShardedSnapshot({
+              rootBody: params.body,
+              shardBodies,
+            })
+          : params.body;
+    }
+    if (params.expectedFeedId && feed.id !== params.expectedFeedId) {
       throw new Error(
-        `hosted catalog feed id "${verification.feed.id}" did not match expected "${params.expectedFeedId}"`,
+        `hosted catalog feed id "${feed.id}" did not match expected "${params.expectedFeedId}"`,
       );
     }
-    const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(
-      verification.feed.generatedAt,
-    );
-    const expiresAt = normalizeOptionalString(verification.feed.expiresAt);
+    const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(feed.generatedAt);
+    const expiresAt = normalizeOptionalString(feed.expiresAt);
     if (generatedAtMs === undefined) {
       throw new Error("hosted catalog signed feed requires a valid generatedAt value");
     }
@@ -790,7 +842,7 @@ async function parseHostedCatalogFeedBody(params: {
       );
     }
     return {
-      feed: enforceHostedCatalogFeedInstallAuthority(verification.feed),
+      feed: enforceHostedCatalogFeedInstallAuthority(feed),
       trust: {
         mode: "signed",
         signedBy: verification.signedBy,
@@ -799,17 +851,19 @@ async function parseHostedCatalogFeedBody(params: {
         verifiedAt: params.verifiedAt,
       },
       ...(expired ? { expired: true } : {}),
+      ...(snapshotBody ? { snapshotBody } : {}),
+      ...(snapshot ? { wireBody } : {}),
     };
   }
-  if (!isOfficialExternalPluginCatalogFeed(raw)) {
+  if (!isOfficialExternalPluginCatalogFeed(document)) {
     throw new Error("hosted catalog feed did not match a supported schema version");
   }
-  if (params.expectedFeedId && raw.id !== params.expectedFeedId) {
+  if (params.expectedFeedId && document.id !== params.expectedFeedId) {
     throw new Error(
-      `hosted catalog feed id "${raw.id}" did not match expected "${params.expectedFeedId}"`,
+      `hosted catalog feed id "${document.id}" did not match expected "${params.expectedFeedId}"`,
     );
   }
-  return { feed: enforceHostedCatalogFeedInstallAuthority(raw) };
+  return { feed: enforceHostedCatalogFeedInstallAuthority(document) };
 }
 
 function enforceHostedCatalogFeedInstallAuthority(
@@ -879,9 +933,6 @@ async function loadHostedCatalogSnapshotResult(params: {
   if (checksum !== params.snapshot.metadata.checksum) {
     throw new Error("hosted catalog snapshot checksum mismatch");
   }
-  if (params.expectedSha256 && params.expectedSha256 !== checksum) {
-    throw new Error("hosted catalog snapshot checksum did not match expected checksum");
-  }
   const parsed = await parseHostedCatalogFeedBody({
     body: params.snapshot.body,
     expectedFeedId: params.expectedFeedId,
@@ -892,6 +943,10 @@ async function loadHostedCatalogSnapshotResult(params: {
     allowExpired: true,
     allowMissingExpiry: true,
   });
+  const wireChecksum = sha256Hex(parsed.wireBody ?? params.snapshot.body);
+  if (params.expectedSha256 && params.expectedSha256 !== wireChecksum) {
+    throw new Error("hosted catalog snapshot checksum did not match expected checksum");
+  }
   const entries = dedupeOfficialExternalPluginCatalogEntries(
     filterOfficialExternalPluginCatalogEntriesBySourceRefs(
       parseOfficialExternalPluginCatalogEntries(parsed.feed),
@@ -908,7 +963,7 @@ async function loadHostedCatalogSnapshotResult(params: {
     source: "hosted-snapshot",
     entries: visibleEntries,
     feed: parsed.expired ? { ...parsed.feed, entries: visibleEntries } : parsed.feed,
-    metadata: params.snapshot.metadata,
+    metadata: { ...params.snapshot.metadata, checksum: wireChecksum },
     snapshot: params.snapshot,
     ...(parsed.trust ? { trust: parsed.trust } : {}),
     error: parsed.expired
@@ -1031,6 +1086,62 @@ async function resolveHostedCatalogSnapshotStore(params: {
   });
 }
 
+async function loadHostedCatalogShardBodies(params: {
+  root: OfficialExternalPluginCatalogShardRoot;
+  rootUrl: string;
+  hostnameAllowlist: readonly string[];
+  fetchImpl?: FetchLike;
+  timeoutMs: number;
+  chunkTimeoutMs: number;
+}): Promise<readonly string[]> {
+  const rootOrigin = new URL(params.rootUrl).origin;
+  for (const descriptor of params.root.shards) {
+    if (new URL(descriptor.url).origin !== rootOrigin) {
+      throw new Error("hosted catalog shard URL must use the signed root origin");
+    }
+  }
+  const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
+  const limit = pLimit(DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY);
+  return await Promise.all(
+    params.root.shards.map((descriptor) =>
+      limit(async () => {
+        let response: Response | undefined;
+        let release: (() => Promise<void>) | undefined;
+        try {
+          const guarded = await fetchWithSsrFGuard({
+            url: descriptor.url,
+            fetchImpl: params.fetchImpl,
+            init: { method: "GET" },
+            requireHttps: true,
+            maxRedirects: 2,
+            timeoutMs: params.timeoutMs,
+            policy: { hostnameAllowlist: [...params.hostnameAllowlist] },
+            auditContext: "official-external-plugin-catalog-shard",
+          });
+          response = guarded.response;
+          release = guarded.release;
+          if (new URL(guarded.finalUrl).origin !== rootOrigin) {
+            throw new Error("hosted catalog shard redirect changed the signed root origin");
+          }
+          if (!response.ok) {
+            throw new Error(`hosted catalog shard returned HTTP ${response.status}`);
+          }
+          return await readHostedCatalogResponseText({
+            response,
+            maxBytes: descriptor.byteLength,
+            chunkTimeoutMs: params.chunkTimeoutMs,
+          });
+        } finally {
+          if (response?.bodyUsed !== true) {
+            await response?.body?.cancel().catch(() => undefined);
+          }
+          await release?.().catch(() => undefined);
+        }
+      }),
+    ),
+  );
+}
+
 async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   feedUrl?: string;
   feedProfile?: string;
@@ -1133,6 +1244,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     });
     response = guarded.response;
     release = guarded.release;
+    const rootFinalUrl = guarded.finalUrl;
     const base = metadataBase(response);
     if (response.status === 304) {
       return await snapshotOrBundledFallbackResult({
@@ -1187,7 +1299,11 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     }
     const body = await readHostedCatalogResponseText({
       response,
-      maxBytes: params?.maxBytes ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES,
+      maxBytes:
+        params?.maxBytes ??
+        (source.verification?.mode === "signed"
+          ? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SIGNED_MAX_BYTES
+          : DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES),
       chunkTimeoutMs:
         params?.chunkTimeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
     });
@@ -1217,6 +1333,18 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       verification: source.verification,
       verifiedAt,
       now,
+      loadShardBodies: async (root) =>
+        await loadHostedCatalogShardBodies({
+          root,
+          rootUrl: rootFinalUrl,
+          hostnameAllowlist: source.hostnameAllowlist,
+          fetchImpl: params?.fetchImpl,
+          timeoutMs:
+            params?.timeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS,
+          chunkTimeoutMs:
+            params?.chunkTimeoutMs ??
+            DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
+        }),
     }).catch(async (err: unknown) => {
       return await snapshotOrBundledFallbackResult({
         error: err,
@@ -1280,10 +1408,15 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         requireManifestInstallSourceRef,
       },
     );
+    const snapshotBody = parsed.snapshotBody ?? body;
+    const snapshotMetadata = {
+      ...metadata,
+      checksum: sha256Hex(snapshotBody),
+    };
     await snapshotStore
       ?.write({
-        body,
-        metadata,
+        body: snapshotBody,
+        metadata: snapshotMetadata,
         savedAt: verifiedAt,
         ...(parsed.trust ? { trust: parsed.trust } : {}),
         ...(parsed.trust?.mode === "signed"

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -2,7 +2,6 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import pLimit from "p-limit";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -1101,10 +1100,23 @@ async function loadHostedCatalogShardBodies(params: {
     }
   }
   const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
-  const limit = pLimit(DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY);
-  return await Promise.all(
-    params.root.shards.map((descriptor) =>
-      limit(async () => {
+  const controller = new AbortController();
+  const bodies = Array.from({ length: params.root.shards.length }, () => "");
+  let nextIndex = 0;
+  let firstError: unknown;
+  let failed = false;
+  const worker = async () => {
+    while (!controller.signal.aborted) {
+      const index = nextIndex;
+      if (index >= params.root.shards.length) {
+        return;
+      }
+      nextIndex += 1;
+      const descriptor = params.root.shards[index];
+      if (!descriptor) {
+        return;
+      }
+      try {
         let response: Response | undefined;
         let release: (() => Promise<void>) | undefined;
         try {
@@ -1115,6 +1127,7 @@ async function loadHostedCatalogShardBodies(params: {
             requireHttps: true,
             maxRedirects: 2,
             timeoutMs: params.timeoutMs,
+            signal: controller.signal,
             policy: { hostnameAllowlist: [...params.hostnameAllowlist] },
             auditContext: "official-external-plugin-catalog-shard",
           });
@@ -1126,7 +1139,7 @@ async function loadHostedCatalogShardBodies(params: {
           if (!response.ok) {
             throw new Error(`hosted catalog shard returned HTTP ${response.status}`);
           }
-          return await readHostedCatalogResponseText({
+          bodies[index] = await readHostedCatalogResponseText({
             response,
             maxBytes: descriptor.byteLength,
             chunkTimeoutMs: params.chunkTimeoutMs,
@@ -1137,9 +1150,31 @@ async function loadHostedCatalogShardBodies(params: {
           }
           await release?.().catch(() => undefined);
         }
-      }),
+      } catch (error) {
+        if (!failed) {
+          failed = true;
+          firstError = error;
+          controller.abort(error);
+        }
+        return;
+      }
+    }
+  };
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.min(
+          DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_CONCURRENCY,
+          params.root.shards.length,
+        ),
+      },
+      worker,
     ),
   );
+  if (failed) {
+    throw firstError;
+  }
+  return bodies;
 }
 
 async function loadHostedOfficialExternalPluginCatalogEntries(params?: {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -741,6 +741,56 @@ async function parseHostedCatalogFeedBody(params: {
   const document = JSON.parse(params.body) as unknown;
   if (params.verification?.mode === "signed") {
     const {
+      applyVerifiedOfficialExternalPluginCatalogChangeBodies,
+      parseOfficialExternalPluginCatalogIncrementalSnapshot,
+    } = await import("./official-external-plugin-catalog-changes.js");
+    const incrementalSnapshot = parseOfficialExternalPluginCatalogIncrementalSnapshot(document);
+    if (incrementalSnapshot) {
+      const base = await parseHostedCatalogFeedBody({
+        ...params,
+        body: incrementalSnapshot.baseBody,
+        allowExpired: true,
+        allowMissingExpiry: true,
+      });
+      if (!base.trust) {
+        throw new Error("hosted catalog incremental base is not signed");
+      }
+      const applied = applyVerifiedOfficialExternalPluginCatalogChangeBodies({
+        feed: base.feed,
+        changeBodies: incrementalSnapshot.changeBodies,
+        trustedKeys: params.verification.keys,
+        threshold: params.verification.threshold,
+        expectedFeedId: params.expectedFeedId,
+      });
+      const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(applied.feed.generatedAt);
+      const expiresAt = normalizeOptionalString(applied.feed.expiresAt);
+      const expiresAtMs = expiresAt
+        ? parseOfficialExternalPluginCatalogTimestamp(expiresAt)
+        : undefined;
+      if (
+        generatedAtMs === undefined ||
+        expiresAtMs === undefined ||
+        expiresAtMs <= generatedAtMs
+      ) {
+        throw new Error("hosted catalog incremental result has an invalid validity window");
+      }
+      const expired = expiresAtMs <= params.now.getTime();
+      if (expired && params.allowExpired !== true) {
+        throw new Error(`hosted catalog signed feed expired at ${expiresAt}`);
+      }
+      return {
+        feed: enforceHostedCatalogFeedInstallAuthority(applied.feed),
+        trust: {
+          mode: "signed",
+          signedBy: applied.signedBy,
+          signatureCount: applied.signatureCount,
+          threshold: applied.threshold,
+          verifiedAt: params.verifiedAt,
+        },
+        ...(expired ? { expired: true } : {}),
+      };
+    }
+    const {
       OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
       OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SHARD_ROOT_PAYLOAD_TYPE,
       verifyOfficialExternalPluginCatalogEnvelopePayload,
@@ -1208,6 +1258,212 @@ async function loadHostedCatalogShardBodies(params: {
   return bodies;
 }
 
+async function tryLoadHostedCatalogIncrementalRefresh(params: {
+  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore;
+  url: URL;
+  hostnameAllowlist: readonly string[];
+  expectedFeedId?: string;
+  verification: Extract<OfficialExternalPluginCatalogFeedVerification, { mode: "signed" }>;
+  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
+  requireManifestInstallSourceRef: boolean;
+  fetchImpl?: FetchLike;
+  timeoutMs: number;
+  chunkTimeoutMs: number;
+  now: Date;
+  requireSnapshotWrite?: boolean;
+}): Promise<HostedOfficialExternalPluginCatalogLoadResult | null> {
+  if (!params.snapshotStore) {
+    return null;
+  }
+  const snapshot = await params.snapshotStore.read(params.url.href).catch(() => null);
+  if (!snapshot || snapshot.trust?.mode !== "signed") {
+    return null;
+  }
+  const current = await parseHostedCatalogFeedBody({
+    body: snapshot.body,
+    expectedFeedId: params.expectedFeedId,
+    verification: params.verification,
+    verifiedAt: snapshot.trust.verifiedAt,
+    allowLegacyBetaEnvelope: true,
+    now: params.now,
+    allowExpired: true,
+    allowMissingExpiry: true,
+  }).catch(() => null);
+  if (!current?.trust) {
+    return null;
+  }
+  const {
+    parseOfficialExternalPluginCatalogIncrementalSnapshot,
+    serializeOfficialExternalPluginCatalogIncrementalSnapshot,
+    verifyOfficialExternalPluginCatalogChangeEnvelopeBody,
+  } = await import("./official-external-plugin-catalog-changes.js");
+  const storedWrapper = parseOfficialExternalPluginCatalogIncrementalSnapshot(
+    JSON.parse(snapshot.body) as unknown,
+  );
+  const changesUrl = new URL(params.url.href);
+  changesUrl.pathname = `${changesUrl.pathname.replace(/\/$/u, "")}/changes`;
+  changesUrl.search = "";
+  changesUrl.hash = "";
+  const newBodies: string[] = [];
+  let cursor: string | null = null;
+  let downloadedBytes = 0;
+  const consumedCursors = new Set<string>();
+  let lastStatus = 200;
+  let lastVerification:
+    | ReturnType<typeof verifyOfficialExternalPluginCatalogChangeEnvelopeBody>
+    | undefined;
+  const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
+  for (let pageCount = 0; pageCount < 2048; pageCount += 1) {
+    const requestUrl = new URL(changesUrl.href);
+    if (cursor === null) {
+      requestUrl.searchParams.set("fromSequence", String(current.feed.sequence));
+      requestUrl.searchParams.set("limit", "500");
+    } else {
+      if (consumedCursors.has(cursor)) {
+        return null;
+      }
+      consumedCursors.add(cursor);
+      requestUrl.searchParams.set("cursor", cursor);
+    }
+    let response: Response | undefined;
+    let release: (() => Promise<void>) | undefined;
+    try {
+      const guarded = await fetchWithSsrFGuard({
+        url: requestUrl.href,
+        fetchImpl: params.fetchImpl,
+        init: {
+          method: "GET",
+          headers: { accept: DSSE_ENVELOPE_MEDIA_TYPE },
+        },
+        requireHttps: true,
+        maxRedirects: 2,
+        timeoutMs: params.timeoutMs,
+        policy: { hostnameAllowlist: [...params.hostnameAllowlist] },
+        auditContext: "official-external-plugin-catalog-changes",
+      });
+      response = guarded.response;
+      release = guarded.release;
+      if (new URL(guarded.finalUrl).origin !== params.url.origin) {
+        return null;
+      }
+      lastStatus = response.status;
+      if (response.status !== 200 && response.status !== 409) {
+        return null;
+      }
+      if (
+        response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase() !==
+        DSSE_ENVELOPE_MEDIA_TYPE
+      ) {
+        return null;
+      }
+      const body = await readHostedCatalogResponseText({
+        response,
+        maxBytes: DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_SIGNED_MAX_BYTES,
+        chunkTimeoutMs: params.chunkTimeoutMs,
+      });
+      downloadedBytes += Buffer.byteLength(body, "utf8");
+      if (downloadedBytes > 256 * 1024 * 1024) {
+        return null;
+      }
+      const verified = verifyOfficialExternalPluginCatalogChangeEnvelopeBody(body, {
+        trustedKeys: params.verification.keys,
+        threshold: params.verification.threshold,
+      });
+      lastVerification = verified;
+      if (
+        verified.payload.feedId !== current.feed.id ||
+        verified.payload.fromSequence !== current.feed.sequence
+      ) {
+        return null;
+      }
+      if ("resetRequired" in verified.payload) {
+        // The signed reset URL is never followed here: the configured root
+        // remains the authority. Cross-origin reset locations are ignored too.
+        return null;
+      }
+      if (response.status !== 200) {
+        return null;
+      }
+      newBodies.push(body);
+      cursor = verified.payload.nextCursor;
+      if (cursor === null) {
+        break;
+      }
+    } finally {
+      if (response?.bodyUsed !== true) {
+        await response?.body?.cancel().catch(() => undefined);
+      }
+      await release?.().catch(() => undefined);
+    }
+  }
+  if (cursor !== null || newBodies.length === 0 || !lastVerification) {
+    return null;
+  }
+  const existingBodies = storedWrapper?.changeBodies ?? [];
+  if (existingBodies.length + newBodies.length > 2048) {
+    return null;
+  }
+  const baseBody = storedWrapper?.baseBody ?? snapshot.body;
+  const snapshotBody = serializeOfficialExternalPluginCatalogIncrementalSnapshot({
+    baseBody,
+    changeBodies: [...existingBodies, ...newBodies],
+  });
+  if (Buffer.byteLength(snapshotBody, "utf8") > 256 * 1024 * 1024) {
+    return null;
+  }
+  const verifiedAt = params.now.toISOString();
+  const parsed = await parseHostedCatalogFeedBody({
+    body: snapshotBody,
+    expectedFeedId: params.expectedFeedId,
+    verification: params.verification,
+    verifiedAt,
+    now: params.now,
+  });
+  const entries = filterOfficialExternalPluginCatalogEntriesBySourceRefs(
+    parseOfficialExternalPluginCatalogEntries(parsed.feed),
+    {
+      catalogConfig: params.catalogConfig,
+      requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
+    },
+  );
+  const metadata: HostedOfficialExternalPluginCatalogMetadata = {
+    url: params.url.href,
+    status: lastStatus,
+    checksum: sha256Hex(snapshotBody),
+  };
+  // A signed empty range is useful as a live freshness proof, but persisting it
+  // would change the stored bytes without advancing the accepted sequence.
+  if (parsed.feed.sequence !== current.feed.sequence) {
+    await params.snapshotStore
+      .write({
+        body: snapshotBody,
+        metadata,
+        savedAt: verifiedAt,
+        trust: parsed.trust,
+        monotonic: {
+          mode: "signed-feed",
+          sequence: parsed.feed.sequence,
+          generatedAt: parsed.feed.generatedAt,
+        },
+      })
+      .catch((error: unknown) => {
+        if (error instanceof HostedCatalogSignedFeedMonotonicityError) {
+          throw error;
+        }
+        if (params.requireSnapshotWrite) {
+          throw new HostedCatalogSnapshotWriteError(error);
+        }
+      });
+  }
+  return {
+    source: "hosted",
+    entries: dedupeOfficialExternalPluginCatalogEntries(entries),
+    feed: parsed.feed,
+    metadata,
+    trust: parsed.trust,
+  };
+}
+
 async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   feedUrl?: string;
   feedProfile?: string;
@@ -1268,6 +1524,52 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       verification: source.verification,
       now: currentTime(),
     });
+  }
+  if (
+    source.verification?.mode === "signed" &&
+    !expectedSha256 &&
+    !normalizeOptionalString(params?.ifNoneMatch) &&
+    !normalizeOptionalString(params?.ifModifiedSince)
+  ) {
+    try {
+      const incremental = await tryLoadHostedCatalogIncrementalRefresh({
+        snapshotStore,
+        url,
+        hostnameAllowlist: source.hostnameAllowlist,
+        expectedFeedId: source.expectedFeedId,
+        verification: source.verification,
+        catalogConfig: params?.catalogConfig,
+        requireManifestInstallSourceRef,
+        fetchImpl: params?.fetchImpl,
+        timeoutMs: params?.timeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS,
+        chunkTimeoutMs:
+          params?.chunkTimeoutMs ??
+          DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
+        now: currentTime(),
+        requireSnapshotWrite: params?.requireSnapshotWrite,
+      });
+      if (incremental) {
+        return incremental;
+      }
+    } catch (error) {
+      if (error instanceof HostedCatalogSnapshotWriteError) {
+        throw error.originalError;
+      }
+      if (error instanceof HostedCatalogSignedFeedMonotonicityError) {
+        return await snapshotOrBundledFallbackResult({
+          error,
+          snapshotStore,
+          url: url.href,
+          catalogConfig: params?.catalogConfig,
+          requireManifestInstallSourceRef,
+          expectedFeedId: source.expectedFeedId,
+          verification: source.verification,
+          now: currentTime(),
+        });
+      }
+      // A missing, unavailable, or malformed changes route is compatible with
+      // older publishers. Continue with the existing full snapshot refresh.
+    }
   }
   const headers = new Headers();
   const ifNoneMatch = normalizeOptionalString(params?.ifNoneMatch);


### PR DESCRIPTION
<!-- feed-stack:start -->
## Feed stack

Review and merge in this order:

1. #110250 — signed sharded catalog consumer
2. **#113333 — signed incremental change consumer**

The branch is stacked on #110250. Because both heads are in a fork, GitHub keeps the PR base on `main`; the incremental review delta is the commits after #110250 (`f7cd3d2d67b`, `5227e3ce62d`, and the test-only lint follow-up `9de57084ab1`). Producer counterparts are openclaw/clawhub#3163 for shards and openclaw/clawhub#3160 for changes. Production signing keys are not required to review or merge this consumer stack.
<!-- feed-stack:end -->

## Summary

- refresh an accepted signed catalog through paginated, signed `/changes` ranges and fall back to the configured full root when incremental refresh is unavailable
- verify each live change envelope once, apply only new pages to the already verified materialized feed, and retain bounded history for cold/offline replay
- persist same-sequence freshness proofs and durable signed reset floors
- use a representation-independent materialized catalog digest so full, sharded, and incremental snapshots can compact without weakening same-sequence equivocation checks
- keep expiry, rollback, reset-floor, signing-key rotation, schema-v2 install authority, and legacy snapshot transitions fail-closed
- accept producer-shaped upserts including `description`, `icon`, integrity, and nested GitHub source metadata

## Validation

- `npx -y node@24.15.0 scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog-changes.test.ts src/plugins/official-external-plugin-catalog-shards.test.ts src/plugins/official-external-plugin-catalog-envelope.test.ts src/plugins/official-external-plugin-catalog.test.ts` — 97 tests passed
- targeted `oxfmt` and `oxlint`
- `git diff --check`
- `codex review --uncommitted` — clean; no actionable correctness issues

## Review fixes included

- terminal-page expiry is evaluated at acceptance time
- same-sequence freshness is durable across restart/offline use
- signed reset floors apply to roots and fallback snapshots, reject expired reset replays, and persist across restarts
- legacy incremental/sharded snapshots retain monotonic protection through format and key transitions
- entry ordering and schema-v2 authority normalization cannot destabilize semantic digests
- change history is bounded and full-root compaction remains available

## Real behavior proof

Cross-repo exact-head proof completed on 2026-07-25:

- openclaw/clawhub#3160/#3163 at `408f26e09c95825ff97c991fdaec53d62056ea65` used the production shard builder, signed root handler, signed `/changes` handler, cursor signer, schema serializers, and DSSE signer to produce a sequence-40 base, two signed change pages advancing through sequence 42, a signed 409 reset, and the sequence-42 signed sharded root.
- the pre-rebase review head `4e379bbdae0323f7a993a9216bd85f71e6603ea9` loaded that base, applied both producer pages, persisted the resulting sequence-42 state in SQLite, closed/reopened the state database, and re-verified it offline. A second run accepted the producer's signed 409 reset, fell back to the signed sequence-42 sharded root, persisted it, and re-verified it offline.
- producer marker: `CLAWHUB_SIGNED_CHANGES_PRODUCED` (`fromSequence=40`, `toSequence=42`, `pages=2`, `changes=3`, `resetStatus=409`, `latestRootSequence=42`)
- consumer marker: `OPENCLAW_SIGNED_CHANGES_REFRESHED_RESET_AND_REPLAYED` (`liveSource=hosted`, `restartSource=hosted-snapshot`, `resetFallbackSource=hosted`, `resetOfflineSource=hosted-snapshot`, `sqlitePersisted=true`, `restartReverified=true`)
- current review head `1d09b84ad0bd06dd3ed9575e2d53357700b364e7` is restacked on the exact #110250 head and narrows test-only change-parser internals; 83 incremental-slice tests, type-aware lint, deadcode:full, both zero-cycle checks, and diff checks pass on this head.

The transport was injected locally so the two public PR heads could be exercised together before deployment; producer representation/signatures and consumer verification, pagination, mutation, reset fallback, persistence, restart, and offline replay used the real implementations. The ephemeral private key and generated bundle were deleted after the run. Full markers are recorded in the maintainer proof comment below.

Maintainer decision: accept this incremental consumer as a staged, inactive contract after #110250. The production signing key, deployed endpoint, and live production proof remain activation gates; they are not review or merge dependencies.


