### PR TITLE
test: restore shared runtime state

### DIFF
--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1,6 +1,6 @@
 // Context engine tests cover context extraction and prompt context assembly.
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -26,7 +26,10 @@ import {
   resolveContextEngine,
   resolveContextEngineOwnerPluginId,
 } from "./registry.js";
-import { resetContextEngineRuntimeQuarantineForTests } from "./registry.test-support.js";
+import {
+  captureContextEngineRegistryStateForTests,
+  resetContextEngineRuntimeQuarantineForTests,
+} from "./registry.test-support.js";
 import type {
   ContextEngine,
   ContextEngineInfo,
@@ -92,6 +95,16 @@ function configWithSlot(engineId: string): OpenClawConfig {
 function makeMockMessage(role: "user" | "assistant" = "user", text = "hello"): AgentMessage {
   return { role, content: text, timestamp: Date.now() } as AgentMessage;
 }
+
+let restoreContextEngineRegistry = () => {};
+
+beforeAll(() => {
+  restoreContextEngineRegistry = captureContextEngineRegistryStateForTests();
+});
+
+afterAll(() => {
+  restoreContextEngineRegistry();
+});
 
 let uniqueEngineIdCounter = 0;
 function uniqueEngineId(prefix: string): string {

--- a/src/context-engine/registry.test-support.ts
+++ b/src/context-engine/registry.test-support.ts
@@ -1,18 +1,53 @@
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-import { clearPersistedContextEngineQuarantineForProcess } from "./quarantine-health.js";
+import {
+  clearPersistedContextEngineQuarantineForProcess,
+  recordPersistedContextEngineQuarantine,
+} from "./quarantine-health.js";
+
+type ContextEngineRuntimeQuarantineForTests = {
+  engineId: string;
+  owner?: string;
+  operation: string;
+  reason: string;
+  failedAt: Date;
+};
 
 type ContextEngineRegistryStateForTests = {
   engines: Map<string, unknown>;
-  quarantinedEngines: Map<string, unknown>;
+  quarantinedEngines: Map<string, ContextEngineRuntimeQuarantineForTests>;
 };
 
 const CONTEXT_ENGINE_REGISTRY_STATE = Symbol.for("openclaw.contextEngineRegistryState");
 
-export function resetContextEngineRuntimeQuarantineForTests(): void {
-  const state = resolveGlobalSingleton<ContextEngineRegistryStateForTests>(
+function getContextEngineRegistryStateForTests(): ContextEngineRegistryStateForTests {
+  return resolveGlobalSingleton<ContextEngineRegistryStateForTests>(
     CONTEXT_ENGINE_REGISTRY_STATE,
     () => ({ engines: new Map(), quarantinedEngines: new Map() }),
   );
+}
+
+export function captureContextEngineRegistryStateForTests(): () => void {
+  const state = getContextEngineRegistryStateForTests();
+  const engines = new Map(state.engines);
+  const quarantinedEngines = new Map(state.quarantinedEngines);
+
+  return () => {
+    state.engines.clear();
+    for (const [engineId, registration] of engines) {
+      state.engines.set(engineId, registration);
+    }
+
+    state.quarantinedEngines.clear();
+    clearPersistedContextEngineQuarantineForProcess(undefined, process.pid);
+    for (const [engineId, quarantine] of quarantinedEngines) {
+      state.quarantinedEngines.set(engineId, quarantine);
+      recordPersistedContextEngineQuarantine(quarantine);
+    }
+  };
+}
+
+export function resetContextEngineRuntimeQuarantineForTests(): void {
+  const state = getContextEngineRegistryStateForTests();
   state.quarantinedEngines.clear();
   clearPersistedContextEngineQuarantineForProcess(undefined, process.pid);
 }

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -1,7 +1,7 @@
 // Gmail watcher tests cover watcher events and Gmail hook message flow.
 import { EventEmitter } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   hasBinary: vi.fn(() => true),
@@ -102,6 +102,11 @@ describe("startGmailWatcher", () => {
         killed: false,
       });
     });
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await stopGmailWatcher();
   });
 
   it("does not let a stale cancelled startup clear newer watcher config", async () => {

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -169,6 +169,7 @@ describe("web search runtime", () => {
   let runWebSearch: typeof import("./runtime.js").runWebSearch;
   let activateSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").activateSecretsRuntimeSnapshot;
   let clearSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").clearSecretsRuntimeSnapshot;
+  let clearRuntimeConfigSnapshot: typeof import("../config/config.js").clearRuntimeConfigSnapshot;
   let setRuntimeConfigSnapshot: typeof import("../config/config.js").setRuntimeConfigSnapshot;
   const tempDirs: string[] = [];
 
@@ -176,10 +177,12 @@ describe("web search runtime", () => {
     ({ hasUsableWebSearchProvider, runWebSearch } = await import("./runtime.js"));
     ({ activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } =
       await import("../secrets/runtime.js"));
-    ({ setRuntimeConfigSnapshot } = await import("../config/config.js"));
+    ({ clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =
+      await import("../config/config.js"));
   });
 
   beforeEach(() => {
+    clearRuntimeConfigSnapshot();
     resolveManifestContractOwnerPluginIdMock.mockReset();
     resolvePluginWebSearchProvidersMock.mockReset();
     resolveRuntimeWebSearchProvidersMock.mockReset();
@@ -189,6 +192,7 @@ describe("web search runtime", () => {
   });
 
   afterEach(() => {
+    clearRuntimeConfigSnapshot();
     clearSecretsRuntimeSnapshot();
     clearRuntimeAuthProfileStoreSnapshots();
     for (const tempDir of tempDirs.splice(0)) {


### PR DESCRIPTION
## What Problem This Solves

Three test suites leave process-global runtime state behind under shared workers: context-engine registrations/quarantines survive the file, Gmail watcher state can survive the final case, and web-search tests can retain a pinned runtime config snapshot.

## Why This Change Was Made

Add a reversible context-engine registry test snapshot that restores registrations, runtime quarantines, and the current-process persisted quarantine mirror after the suite. Always stop the Gmail watcher and restore real timers after each case. Clear the web-search runtime config snapshot before and after each test alongside its existing secret/auth cleanup.

## User Impact

Developers get deterministic shared-worker tests without production behavior changes.

## Evidence

- Blacksmith Testbox, Linux Node 24:
  - context-engine: 47 tests passed
  - web-search runtime: 33 tests passed
  - Gmail watcher: 17 tests passed
  - total: **97 tests passed**
  - formatting check passed
- `git diff --check`: passed
- Formal Codex autoreview: clean, no accepted/actionable findings

AI-assisted: yes.
