### PR TITLE
test(macos): block real process fallthrough

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -267,6 +267,12 @@ extension GatewayLaunchAgentManager {
                 payload: Data(payload.utf8),
                 message: nil)
         }
+        if ProcessInfo.processInfo.isRunningTests {
+            return CommandResult(
+                success: false,
+                payload: nil,
+                message: "Gateway daemon commands require explicit interception during tests")
+        }
         #endif
         let command = CommandResolver.openclawCommand(
             subcommand: "gateway",

--- a/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
+++ b/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
@@ -34,15 +34,29 @@ extension ProcessInfo {
             isAppBundle: isAppBundle)
     }
 
-    var isRunningTests: Bool {
-        // SwiftPM tests load one or more `.xctest` bundles. With Swift Testing, `Bundle.main` is not
-        // guaranteed to be the `.xctest` bundle, so check all loaded bundles.
-        if Bundle.allBundles.contains(where: { $0.bundleURL.pathExtension == "xctest" }) { return true }
-        if Bundle.main.bundleURL.pathExtension == "xctest" { return true }
+    static func resolveIsRunningTests(
+        environment: [String: String],
+        processName: String,
+        arguments: [String],
+        bundleURLs: [URL]) -> Bool
+    {
+        if bundleURLs.contains(where: { $0.pathExtension == "xctest" }) { return true }
+        if processName == "swiftpm-testing-helper" || processName == "swiftpm-xctest-helper" {
+            return true
+        }
+        if arguments.first.map({ URL(fileURLWithPath: $0).lastPathComponent }) == "swiftpm-testing-helper" {
+            return true
+        }
+        return environment["XCTestConfigurationFilePath"] != nil
+            || environment["XCTestBundlePath"] != nil
+            || environment["XCTestSessionIdentifier"] != nil
+    }
 
-        // Backwards-compatible fallbacks for runners that still set XCTest env vars.
-        return self.environment["XCTestConfigurationFilePath"] != nil
-            || self.environment["XCTestBundlePath"] != nil
-            || self.environment["XCTestSessionIdentifier"] != nil
+    var isRunningTests: Bool {
+        Self.resolveIsRunningTests(
+            environment: self.environment,
+            processName: self.processName,
+            arguments: self.arguments,
+            bundleURLs: Bundle.allBundles.map(\.bundleURL) + [Bundle.main.bundleURL])
     }
 }

--- a/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
+++ b/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 extension ProcessInfo {
+    /// SwiftPM loads test bundles into these helpers, so bundle inspection alone
+    /// cannot identify every test process. Keep current and legacy runner names.
+    private static let swiftPMTestHelperNames: Set<String> = [
+        "swiftpm-testing-helper",
+        "swiftpm-xctest-helper",
+    ]
+
     var isPreview: Bool {
         guard let raw = getenv("XCODE_RUNNING_FOR_PREVIEWS") else { return false }
         return String(cString: raw) == "1"
@@ -41,10 +48,10 @@ extension ProcessInfo {
         bundleURLs: [URL]) -> Bool
     {
         if bundleURLs.contains(where: { $0.pathExtension == "xctest" }) { return true }
-        if processName == "swiftpm-testing-helper" || processName == "swiftpm-xctest-helper" {
-            return true
-        }
-        if arguments.first.map({ URL(fileURLWithPath: $0).lastPathComponent }) == "swiftpm-testing-helper" {
+        if self.swiftPMTestHelperNames.contains(processName) { return true }
+        if let executable = arguments.first.map({ URL(fileURLWithPath: $0).lastPathComponent }),
+           self.swiftPMTestHelperNames.contains(executable)
+        {
             return true
         }
         return environment["XCTestConfigurationFilePath"] != nil

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import OpenClaw
 
+@Suite(.serialized)
 struct GatewayLaunchAgentManagerTests {
     @Test func `reads Gateway service ownership command directly from launchd`() throws {
         let url = FileManager.default.temporaryDirectory
@@ -73,6 +74,22 @@ struct GatewayLaunchAgentManagerTests {
         #expect(kickstartError == nil)
         #expect(FileManager().fileExists(atPath: marker.path))
         #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
+    }
+
+    @Test func `unintercepted daemon commands fail closed during tests`() async {
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-no-disable-marker-\(UUID().uuidString)")
+        defer {
+            GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+        }
+
+        GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
+        GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+
+        let error = await GatewayLaunchAgentManager.kickstart()
+
+        #expect(error == "Gateway daemon commands require explicit interception during tests")
     }
 
     @Test func `launch agent plist snapshot parses args and env`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -337,55 +337,12 @@ struct LowCoverageHelperTests {
         #expect(siblingPlan.reap.isEmpty)
     }
 
-    @Test func `port guardian classifies a real orphaned tunnel process for reaping`() async throws {
-        // Real ssh that hangs safely: ProxyCommand replaces the TCP transport, so no
-        // network traffic happens and the -L port is never bound (forwards only bind
-        // after auth). Spawned through sh so the parent exits and ssh reparents to
-        // launchd — the exact orphan shape the reaper must detect.
-        let port = 45871
-        // Detach the child's stdio: the pipe must reach EOF when sh exits, not when ssh dies.
-        let script = "/usr/bin/ssh -o BatchMode=yes -o ProxyCommand='sleep 60' " +
-            "-N -L \(port):127.0.0.1:\(port) orphan-reap-test-host >/dev/null 2>&1 & echo $!"
-        let spawn = Process()
-        spawn.executableURL = URL(fileURLWithPath: "/bin/sh")
-        spawn.arguments = ["-c", script]
-        let out = Pipe()
-        spawn.standardOutput = out
-        try spawn.run()
-        spawn.waitUntilExit()
-        let pidText = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let pid = try #require(Int32(pidText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        defer { kill(pid, SIGKILL) }
+    @Test func `port guardian reads current process metadata without spawning children`() throws {
+        let info = try #require(PortGuardian._testTunnelProcessInfo(pid: getpid()))
 
-        // Reparenting to launchd is immediate once sh exits, but give ps/sysctl a beat.
-        var info: PortGuardian.TunnelProcessInfo?
-        for _ in 0..<40 {
-            info = PortGuardian._testTunnelProcessInfo(pid: pid)
-            if info?.parentPid == 1, info?.fullCommand?.isEmpty == false { break }
-            try await Task.sleep(nanoseconds: 50_000_000)
-        }
-        let orphan = try #require(info)
-        #expect(orphan.parentPid == 1)
-        // Kernel start time must be sane so the pid-reuse gate can rely on it.
-        #expect(abs(orphan.startedAt - Date().timeIntervalSince1970) < 60)
-        let recordedAt = Date().timeIntervalSince1970
-        let record = PortGuardian.Record(
-            port: port, pid: pid, command: "/usr/bin/ssh", mode: "remote", timestamp: recordedAt)
-        #expect(PortGuardian.classifyTunnelRecord(record, process: orphan) == .reap)
-
-        // Same process under a different recorded port must never be reap-eligible.
-        let mismatched = PortGuardian.Record(
-            port: port + 1, pid: pid, command: "/usr/bin/ssh", mode: "remote", timestamp: recordedAt)
-        #expect(PortGuardian.classifyTunnelRecord(mismatched, process: orphan) == .drop)
-
-        // A record predating this process (reused pid) must drop, not reap.
-        let predates = PortGuardian.Record(
-            port: port,
-            pid: pid,
-            command: "/usr/bin/ssh",
-            mode: "remote",
-            timestamp: orphan.startedAt - 3600)
-        #expect(PortGuardian.classifyTunnelRecord(predates, process: orphan) == .drop)
+        #expect(info.parentPid > 0)
+        #expect(abs(info.startedAt - Date().timeIntervalSince1970) < 60)
+        #expect(info.fullCommand?.isEmpty == false)
     }
 
     @Test @MainActor func `canvas scheme handler resolves files and errors`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -339,9 +339,11 @@ struct LowCoverageHelperTests {
 
     @Test func `port guardian reads current process metadata without spawning children`() throws {
         let info = try #require(PortGuardian._testTunnelProcessInfo(pid: getpid()))
+        let now = Date().timeIntervalSince1970
 
         #expect(info.parentPid > 0)
-        #expect(abs(info.startedAt - Date().timeIntervalSince1970) < 60)
+        #expect(info.startedAt > now - ProcessInfo.processInfo.systemUptime - 1)
+        #expect(info.startedAt <= now + 1)
         #expect(info.fullCommand?.isEmpty == false)
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/NixModeStableSuiteTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NixModeStableSuiteTests.swift
@@ -25,6 +25,34 @@ struct NixModeStableSuiteTests {
         #expect(resolved)
     }
 
+    @Test func `detects SwiftPM and XCTest runners`() {
+        #expect(ProcessInfo.resolveIsRunningTests(
+            environment: [:],
+            processName: "swiftpm-testing-helper",
+            arguments: [],
+            bundleURLs: []))
+        #expect(ProcessInfo.resolveIsRunningTests(
+            environment: [:],
+            processName: "swiftpm-xctest-helper",
+            arguments: [],
+            bundleURLs: []))
+        #expect(ProcessInfo.resolveIsRunningTests(
+            environment: ["XCTestSessionIdentifier": "session"],
+            processName: "OpenClawTests",
+            arguments: [],
+            bundleURLs: []))
+        #expect(ProcessInfo.resolveIsRunningTests(
+            environment: [:],
+            processName: "OpenClawTests",
+            arguments: [],
+            bundleURLs: [URL(fileURLWithPath: "/tmp/OpenClawTests.xctest")]))
+        #expect(!ProcessInfo.resolveIsRunningTests(
+            environment: [:],
+            processName: "OpenClaw",
+            arguments: [],
+            bundleURLs: []))
+    }
+
     @Test func `ignores stable suite outside app bundles`() throws {
         let suite = try #require(UserDefaults(suiteName: launchdLabel))
         let key = "openclaw.nixMode"

--- a/apps/macos/Tests/OpenClawIPCTests/NixModeStableSuiteTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NixModeStableSuiteTests.swift
@@ -36,6 +36,13 @@ struct NixModeStableSuiteTests {
             processName: "swiftpm-xctest-helper",
             arguments: [],
             bundleURLs: []))
+        for helper in ["swiftpm-testing-helper", "swiftpm-xctest-helper"] {
+            #expect(ProcessInfo.resolveIsRunningTests(
+                environment: [:],
+                processName: "OpenClawTests",
+                arguments: ["/Library/Developer/Toolchains/usr/libexec/swift/pm/\(helper)"],
+                bundleURLs: []))
+        }
         #expect(ProcessInfo.resolveIsRunningTests(
             environment: ["XCTestSessionIdentifier": "session"],
             processName: "OpenClawTests",


### PR DESCRIPTION
## What Problem This Solves

macOS unit tests can race shared launch-agent test hooks and fall through to the real `openclaw gateway` CLI. Another unit test launches a real orphaned SSH child on a fixed port solely to inspect process metadata.

## Why This Change Was Made

In DEBUG test processes, un-intercepted daemon commands now fail closed before command resolution or `ShellExecutor` execution. `ProcessInfo.isRunningTests` now recognizes SwiftPM's `swiftpm-testing-helper` and legacy `swiftpm-xctest-helper` runners, with injectable resolver coverage. The launch-agent suite is serialized.

The real SSH child test is replaced by a current-process metadata probe. Orphan/reap classification remains covered by the adjacent synthetic process-info matrix, so the unit suite no longer launches SSH or depends on a fixed port.

## User Impact

macOS tests can no longer invoke the operator's real gateway CLI or create stray SSH children. Production release behavior is unchanged; the fail-closed branch is DEBUG-only and test-runner-gated.

## Evidence

- Full Xcode beta build completed successfully.
- Focused Swift Testing run:
  - 3 suites passed
  - 31 tests passed
  - no SSH child launched
  - un-intercepted daemon command returned the fail-closed test error
- `git diff --check`: passed
- Formal Codex autoreview: clean, no accepted/actionable findings

Raw `swift test` required staging SwiftPM's built Sparkle framework into the disposable XCTest bundle before execution; exact-head macOS CI owns the normal packaged test environment.

AI-assisted: yes.
