### PR TITLE
test(plugin-sdk): restore memory-host timers

### DIFF
--- a/src/plugin-sdk/memory-host-events.test.ts
+++ b/src/plugin-sdk/memory-host-events.test.ts
@@ -35,6 +35,7 @@ function createDedupe(root: string, overrides?: { ttlMs?: number }) {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   setMaxMemoryHostEventsForTests(undefined);
   resetPluginStateStoreForTests();


### PR DESCRIPTION
## What Problem This Solves

`memory-host-events.test.ts` enables fake timers for its wall-clock retention case but does not restore real timers in teardown. The file runs in the dedicated shared fake-timer lane, so explicit cleanup prevents clock state from leaking into later files.

## Why This Change Was Made

Call `vi.useRealTimers()` in the existing `afterEach` before restoring mocks and resetting memory/plugin stores.

## User Impact

Developers get deterministic fake-timer worker reuse. Production behavior is unchanged.

## Evidence

- Blacksmith Testbox, Linux Node 24:
  - 1 test file passed
  - 17 tests passed
  - formatting check passed
- Formal Codex autoreview: clean
- `git diff --check`: passed

AI-assisted: yes.
