### PR TITLE
test(infra): clean exec approval temp roots

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -496,35 +496,31 @@ describe("resolveAllowAlwaysPatterns", () => {
       const scriptPath = path.join(dir, "script.ps1");
       fs.writeFileSync(scriptPath, "");
       fs.chmodSync(scriptPath, 0o755);
-      try {
-        const env = makePathEnv(dir);
-        const analysis = analyzeArgvCommand({
-          argv: [...argvPrefix, "pwsh", fileFlag, scriptPath, ...scriptArgs],
-          cwd: dir,
-          env,
-        });
-        expect(analysis.ok).toBe(true);
+      const env = makePathEnv(dir);
+      const analysis = analyzeArgvCommand({
+        argv: [...argvPrefix, "pwsh", fileFlag, scriptPath, ...scriptArgs],
+        cwd: dir,
+        env,
+      });
+      expect(analysis.ok).toBe(true);
 
-        const entries = resolveAllowAlwaysPatternEntries({
-          segments: analysis.segments,
-          cwd: dir,
-          env,
-          platform: "win32",
-        });
-        expect(entries).toEqual([{ pattern: scriptPath, argPattern: expectedArgPattern }]);
+      const entries = resolveAllowAlwaysPatternEntries({
+        segments: analysis.segments,
+        cwd: dir,
+        env,
+        platform: "win32",
+      });
+      expect(entries).toEqual([{ pattern: scriptPath, argPattern: expectedArgPattern }]);
 
-        const result = evaluateExecAllowlist({
-          analysis,
-          allowlist: [...entries],
-          safeBins: new Set(),
-          cwd: dir,
-          env,
-          platform: "win32",
-        });
-        expect(result.allowlistSatisfied).toBe(true);
-      } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
+      const result = evaluateExecAllowlist({
+        analysis,
+        allowlist: [...entries],
+        safeBins: new Set(),
+        cwd: dir,
+        env,
+        platform: "win32",
+      });
+      expect(result.allowlistSatisfied).toBe(true);
     },
   );
 

--- a/src/infra/exec-approvals-analysis.test.ts
+++ b/src/infra/exec-approvals-analysis.test.ts
@@ -261,27 +261,23 @@ describe("Windows inline allowlist analysis", () => {
       fs.writeFileSync(file, "");
       fs.chmodSync(file, 0o755);
     }
-    try {
-      const env = makePathEnv(dir);
-      const analysis = analyzeArgvCommand({
-        argv: ["cmd.exe", "/c", "node.exe", "app.js"],
-        cwd: dir,
-        env,
-      });
+    const env = makePathEnv(dir);
+    const analysis = analyzeArgvCommand({
+      argv: ["cmd.exe", "/c", "node.exe", "app.js"],
+      cwd: dir,
+      env,
+    });
 
-      expect(analysis.ok).toBe(true);
-      const result = evaluateExecAllowlist({
-        analysis,
-        allowlist: [{ pattern: nodePath }],
-        safeBins: new Set(),
-        cwd: dir,
-        env,
-        platform: "win32",
-      });
-      expect(result.allowlistSatisfied).toBe(true);
-      expect(result.allowlistMatches.map((entry) => entry.pattern)).toEqual([nodePath]);
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
+    expect(analysis.ok).toBe(true);
+    const result = evaluateExecAllowlist({
+      analysis,
+      allowlist: [{ pattern: nodePath }],
+      safeBins: new Set(),
+      cwd: dir,
+      env,
+      platform: "win32",
+    });
+    expect(result.allowlistSatisfied).toBe(true);
+    expect(result.allowlistMatches.map((entry) => entry.pattern)).toEqual([nodePath]);
   });
 });

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -1,4 +1,5 @@
 // Covers exec approval config normalization and safe-bin policy.
+import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { makeTempDir } from "./exec-approvals-test-helpers.js";
@@ -14,6 +15,19 @@ import {
   type ExecAllowlistEntry,
   type ExecApprovalsFile,
 } from "./exec-approvals.js";
+
+describe.sequential("exec approval temp fixture cleanup", () => {
+  let cleanupProbeRoot = "";
+
+  it("creates a disposable fixture root", () => {
+    cleanupProbeRoot = makeTempDir();
+    expect(existsSync(cleanupProbeRoot)).toBe(true);
+  });
+
+  it("removes the fixture root before the next test", () => {
+    expect(existsSync(cleanupProbeRoot), cleanupProbeRoot).toBe(false);
+  });
+});
 
 describe("exec approvals wildcard agent", () => {
   it("merges wildcard allowlist entries with agent entries", () => {

--- a/src/infra/exec-approvals-test-helpers.ts
+++ b/src/infra/exec-approvals-test-helpers.ts
@@ -2,7 +2,15 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { afterEach } from "vitest";
+import { cleanupTempDirs } from "../../test/helpers/temp-dir.js";
 import type { CommandResolution, ExecutableResolution } from "./exec-command-resolution.js";
+
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  cleanupTempDirs(tempDirs);
+});
 
 // Shared exec-approval fixtures keep parser, allowlist, and wrapper tests on
 // the same mock resolution shape.
@@ -15,7 +23,11 @@ export function makePathEnv(binDir: string): NodeJS.ProcessEnv {
 
 /** Create a real temp directory for exec-approval tests that need filesystem paths. */
 export function makeTempDir(): string {
-  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-approvals-")));
+  const tempDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-approvals-")),
+  );
+  tempDirs.add(tempDir);
+  return tempDir;
 }
 
 /** Create an executable file in a test bin directory. */


### PR DESCRIPTION
## What Problem This Solves

The shared exec-approval fixture helper creates canonical real temporary directories for twelve consumer suites but did not own their lifecycle. Repeated tests therefore left `openclaw-exec-approvals-*` roots behind, while two consumers attempted narrower one-off deletion loops.

## Why This Change Was Made

The shared producer now tracks only the canonical real paths it creates in a module-local `Set`, registers one Vitest `afterEach`, and delegates deletion exclusively to `cleanupTempDirs`. That repository helper owns recursive force removal, bounded retry/backoff, and collection clearing. The two consumer-local `rmSync` loops were removed so this fixture class has one cleanup spelling.

This directly addresses ClawSweeper's retry-policy finding and keeps lifecycle ownership at the producer rather than relying on every importer.

ClawSweeper's rank-up moves are addressed: deletion now uses `cleanupTempDirs`, every current importer passed, the clean-box no-roots assertion passed, and normal maintainer handling continues through the repository-native landing flow.

## User Impact

Developers and CI workers no longer accumulate exec-approval fixture directories across tests. Production behavior is unchanged.

Windows cleanup is the main risk. The canonical helper uses Node recursive `fs.rmSync` with `force: true`, `maxRetries: 5`, and `retryDelay: 20`; Node 24 documents linear-backoff retries for `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, and `EPERM`. A native Azure Windows proof was attempted, but the broker rejected the Windows image selector before creating a lease with HTTP 403 `admin_required`. No Windows runtime pass is claimed.

## Evidence

- Regression before producer cleanup (`node scripts/run-vitest.mjs src/infra/exec-approvals-config.test.ts -- -t 'exec approval temp fixture cleanup'`):
  - `Tests 1 failed | 1 passed | 24 skipped`
  - the next test observed the prior fixture root still present
  - `[vitest] FAILED (exit 1)`
- Regression after cleanup (same command):
  - `Tests 2 passed | 24 skipped`
  - `[test] passed 1 Vitest shard in 4.05s`
- All twelve current importer suites on the rebased head:
  - unit-fast: 3 files, 42 tests passed
  - infra: 9 files, 431 tests passed
  - total: 12 files, 473 tests passed
  - `[test] passed 2 Vitest shards in 9.91s`
- Clean-box importer + external no-roots proof:
  - Blacksmith Testbox `tbx_01kzk7h9b9b2m4h097f26vqak1`
  - https://github.com/openclaw/openclaw/actions/runs/31313088092
  - 473 tests passed, followed by `no openclaw-exec-approvals-* roots remain`
  - `runStatus: succeeded`, `exitCode: 0`
- Changed-file gate (`node scripts/check-changed.mjs`):
  - Blacksmith Testbox `tbx_01kzk71914g2z2be8mp6w5ab9a`
  - https://github.com/openclaw/openclaw/actions/runs/31312714984
  - core/core-test types, formatting, API/boundary/deadcode/schema/import-cycle guards, and lint passed
  - lint: `0 warnings and 0 errors`
  - `runStatus: succeeded`, `exitCode: 0`
- `git diff --check`: passed.
- Fresh Codex autoreview on rebased head `656979297c5456ac57117599a4fd8a08b1102820`: clean after one round; no accepted/actionable findings, confidence 0.99.
- Exact-head CI (`node scripts/watch-pr-ci.mjs 113342 656979297c5456ac57117599a4fd8a08b1102820`): `GREEN`, `pending=0`.

AI-assisted: yes.
