### PR TITLE
fix(ui): paginate sidebar session sections independently

### DIFF
--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -15,7 +15,6 @@ import {
   type SessionListHost,
 } from "./app-sidebar-session-row-render.ts";
 import {
-  limitSidebarSessionRows,
   rowDemandsVisibility,
   RowVisibilityReason,
   SIDEBAR_SESSION_PAGE_SIZE,
@@ -26,6 +25,9 @@ import { icons } from "./icons.ts";
 
 type RenderableSessionSection = SidebarSessionSection<SidebarRecentSession> & {
   totalRowCount: number;
+  visibleRowCount: number;
+  visibleLimit: number;
+  collapsedVisibleRowCount: number;
 };
 
 type SessionCatalogRenderSnapshot = {
@@ -235,7 +237,7 @@ function renderSessionSection(params: {
                   ${section.rows.map((session) => renderSessionTree({ host, session }))}
                 </div>`
               : nothing}
-            ${trailing}
+            ${renderSessionPagination({ host, section })} ${trailing}
           `}
     </div>
   `;
@@ -258,13 +260,13 @@ function renderDraftSessionRow() {
 
 function renderSessionPagination(params: {
   host: SessionListHost;
-  rows: SidebarRecentSession[];
-  visible: number;
+  section: RenderableSessionSection;
 }) {
-  const { host, rows, visible } = params;
-  const canShowMore = visible < rows.length;
-  const collapsedVisible = limitSidebarSessionRows(rows, SIDEBAR_SESSION_PAGE_SIZE).length;
-  const canShowLess = visible > SIDEBAR_SESSION_SEE_LESS_THRESHOLD && visible > collapsedVisible;
+  const { host, section } = params;
+  const canShowMore = section.visibleRowCount < section.totalRowCount;
+  const canShowLess =
+    section.visibleRowCount > SIDEBAR_SESSION_SEE_LESS_THRESHOLD &&
+    section.visibleRowCount > section.collapsedVisibleRowCount;
   if (!canShowMore && !canShowLess) {
     return nothing;
   }
@@ -276,7 +278,10 @@ function renderSessionPagination(params: {
             class="sidebar-session-pagination__button"
             aria-label=${t("chat.selectors.loadMoreSessions")}
             @click=${() => {
-              host.setVisibleSessionLimit(visible + SIDEBAR_SESSION_PAGE_SIZE);
+              host.setVisibleSessionLimit(
+                section.id,
+                section.visibleLimit + SIDEBAR_SESSION_PAGE_SIZE,
+              );
             }}
           >
             ${t("chat.selectors.loadMoreSessions")}
@@ -289,7 +294,7 @@ function renderSessionPagination(params: {
             aria-label=${t("usage.details.collapse")}
             @click=${() => {
               host.clearSessionSelection();
-              host.setVisibleSessionLimit(SIDEBAR_SESSION_PAGE_SIZE);
+              host.setVisibleSessionLimit(section.id, SIDEBAR_SESSION_PAGE_SIZE);
             }}
           >
             ${t("usage.details.collapse")}
@@ -336,8 +341,6 @@ function renderSessionCatalogs(params: {
 function renderSessionListBody(params: {
   host: SessionListHost;
   sections: RenderableSessionSection[];
-  expandedRows: SidebarRecentSession[];
-  visibleRowCount: number;
   showDraft: boolean;
   codingTrailing?: TemplateResult | typeof nothing;
   codingTrailingPresent?: boolean;
@@ -372,11 +375,6 @@ function renderSessionListBody(params: {
       }
       return renderSessionSection({ host, section, showDraft });
     })}
-    ${renderSessionPagination({
-      host,
-      rows: params.expandedRows,
-      visible: params.visibleRowCount,
-    })}
   `;
 }
 
@@ -384,8 +382,6 @@ export function renderSessionList(params: {
   host: SessionListHost;
   empty: boolean;
   sections: RenderableSessionSection[];
-  expandedRows: SidebarRecentSession[];
-  visibleRowCount: number;
   showDraft: boolean;
   catalogs: SessionCatalogRenderSnapshot;
 }) {
@@ -424,8 +420,6 @@ export function renderSessionList(params: {
         ${renderSessionListBody({
           host,
           sections: params.sections,
-          expandedRows: params.expandedRows,
-          visibleRowCount: params.visibleRowCount,
           showDraft: params.showDraft,
           codingTrailing:
             host.sessionsStatusFilter === "archived"

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -36,6 +36,7 @@ import { formatSidebarTimestamp } from "./app-sidebar-session-catalogs.ts";
 import {
   limitSidebarSessionRows,
   SIDEBAR_SESSION_NO_ATTENTION,
+  SIDEBAR_SESSION_PAGE_SIZE,
   type SidebarRecentSession,
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
@@ -173,7 +174,12 @@ export function buildSidebarSessionNavigationState(input: {
 }
 
 export type SidebarVisibleSections = {
-  sections: (SidebarSessionSection<SidebarRecentSession> & { totalRowCount: number })[];
+  sections: (SidebarSessionSection<SidebarRecentSession> & {
+    totalRowCount: number;
+    visibleRowCount: number;
+    visibleLimit: number;
+    collapsedVisibleRowCount: number;
+  })[];
   expandedRows: SidebarRecentSession[];
   visibleRows: SidebarRecentSession[];
 };
@@ -184,7 +190,7 @@ export function partitionSidebarVisibleSections(input: {
   knownGroups: string[] | undefined;
   collapsedSections: ReadonlySet<string>;
   hideEmptyCreatorFilteredGroup: (category: string | undefined, rowCount: number) => boolean;
-  visibleSessionLimit: number;
+  visibleSessionLimits: ReadonlyMap<string, number>;
 }): SidebarVisibleSections {
   const isCollapsed = (sectionId: string) =>
     sidebarSectionHasHeader(sectionId, input.grouping) && input.collapsedSections.has(sectionId);
@@ -196,18 +202,33 @@ export function partitionSidebarVisibleSections(input: {
       section.id !== "pinned" &&
       !input.hideEmptyCreatorFilteredGroup(section.category, section.rows.length),
   );
-  const expandedRows = sections.flatMap((section) => (isCollapsed(section.id) ? [] : section.rows));
-  const visibleRows = limitSidebarSessionRows(expandedRows, input.visibleSessionLimit);
-  const keep = new Set(visibleRows.map((row) => row.key));
+  const expandedRows: SidebarRecentSession[] = [];
+  const visibleRows: SidebarRecentSession[] = [];
   // totalRowCount is the pre-pagination size: headers and empty-zone
   // checks must not mistake a page-filtered section for an empty one.
   const limitedSections: SidebarVisibleSections["sections"] = [];
   for (const section of sections) {
     const totalRowCount = section.rows.length;
+    const visibleLimit = input.visibleSessionLimits.get(section.id) ?? SIDEBAR_SESSION_PAGE_SIZE;
+    const collapsedVisibleRowCount = limitSidebarSessionRows(
+      section.rows,
+      SIDEBAR_SESSION_PAGE_SIZE,
+    ).length;
+    let visibleRowCount = 0;
     if (!isCollapsed(section.id)) {
-      section.rows = section.rows.filter((row) => keep.has(row.key));
+      expandedRows.push(...section.rows);
+      section.rows = limitSidebarSessionRows(section.rows, visibleLimit);
+      visibleRows.push(...section.rows);
+      visibleRowCount = section.rows.length;
     }
-    limitedSections.push(Object.assign(section, { totalRowCount }));
+    limitedSections.push(
+      Object.assign(section, {
+        totalRowCount,
+        visibleRowCount,
+        visibleLimit,
+        collapsedVisibleRowCount,
+      }),
+    );
   }
   return { sections: limitedSections, expandedRows, visibleRows };
 }

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -45,7 +45,6 @@ import {
   loadStoredSidebarSessionStatusFilter,
   loadStoredSidebarSessionsGrouping,
   loadStoredSidebarSessionsShowCron,
-  SIDEBAR_SESSION_PAGE_SIZE,
   type SidebarRecentSession,
   type SidebarSessionSortMode,
   type SidebarSessionStatusFilter,
@@ -276,12 +275,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     });
   };
 
-  /**
-   * Zone partition with the visible-page limit applied only to expanded
-   * sections: collapsed zones keep full rows (true header counts) but do not
-   * consume the page budget, so a collapsed Coding zone cannot crowd threads
-   * out of the first page.
-   */
+  /** Collapsed zones keep full rows for true header counts and status dots. */
   protected zonedVisibleSections(rows: SidebarRecentSession[]): SidebarVisibleSections {
     return partitionSidebarVisibleSections({
       rows,
@@ -290,7 +284,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       collapsedSections: this.collapsedSessionSections,
       hideEmptyCreatorFilteredGroup: (category, rowCount) =>
         this.hideEmptyCreatorFilteredGroup(category, rowCount),
-      visibleSessionLimit: this.sessionData.visibleSessionLimit,
+      visibleSessionLimits: this.sessionData.visibleSessionLimits,
     });
   }
 
@@ -421,7 +415,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     }
     this.clearSessionSelection();
     this.expandedChildSessionKeys = new Set();
-    this.sessionData.setVisibleSessionLimit(SIDEBAR_SESSION_PAGE_SIZE);
+    this.sessionData.visibleSessionLimits.clear();
     context.agentSelection.set(nextAgentId);
     void this.sessionData.refreshSidebarSessions(nextAgentId);
   };

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -102,7 +102,7 @@ export interface SessionListHost {
   finishSessionGroupDrag(): void;
   toggleSection(sectionId: string): void;
   openNewSession(): void;
-  setVisibleSessionLimit(limit: number): void;
+  setVisibleSessionLimit(sectionId: string, limit: number): void;
   clearSessionSelection(): void;
   handleSessionListDragOver(event: DragEvent): void;
   handleSessionListDragLeave(event: DragEvent): void;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -276,8 +276,8 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     this.onOpenNewSession?.(this.expandedAgentId());
   }
 
-  setVisibleSessionLimit(limit: number): void {
-    this.sessionData.setVisibleSessionLimit(limit);
+  setVisibleSessionLimit(sectionId: string, limit: number): void {
+    this.sessionData.setVisibleSessionLimit(sectionId, limit);
   }
 
   dismissSessionMutationError(): void {
@@ -317,13 +317,11 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
         sidebarRowsByKey.set(row.key, navigationState.toSidebarSession(row));
       }
     }
-    const { sections, expandedRows, visibleRows } = this.zonedVisibleSections(visibleSessions);
+    const { sections } = this.zonedVisibleSections(visibleSessions);
     return renderSessionList({
       host: this,
       empty: visibleSessions.length === 0,
       sections,
-      expandedRows,
-      visibleRowCount: visibleRows.length,
       showDraft:
         Boolean(this.draftSessionAgentId) &&
         normalizeAgentId(this.draftSessionAgentId) === expandedAgentId,

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -26,7 +26,6 @@ import { SessionCatalogLiveState } from "./app-sidebar-session-catalog-live.ts";
 import { bindAdoptedCatalogSession } from "./app-sidebar-session-catalogs.ts";
 import {
   SIDEBAR_AGENT_SESSION_LIST_LIMIT,
-  SIDEBAR_SESSION_PAGE_SIZE,
   resolveSidebarSessionsScrollState,
   type SidebarSessionMutationScope,
   type SidebarSessionStatusFilter,
@@ -47,7 +46,7 @@ import {
 export class SessionDataController implements ReactiveController, SessionCatalogDataOwner {
   sessionCatalogs: SessionCatalog[] = [];
   loadingMoreSessionCatalogIds: ReadonlySet<string> = new Set();
-  visibleSessionLimit = SIDEBAR_SESSION_PAGE_SIZE;
+  visibleSessionLimits = new Map<string, number>();
   sessionsResult: SessionsListResult | null = null;
   sessionsAgentId: string | null = null;
   sessionsLoading = false;
@@ -482,7 +481,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       this.activeSessionLineageRetryTimer = null;
     }
     this.sessionCreatedOrder.clear();
-    this.visibleSessionLimit = SIDEBAR_SESSION_PAGE_SIZE;
+    this.visibleSessionLimits.clear();
     this.notify();
   }
 
@@ -669,8 +668,8 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.activeSessionLineageLoaded = true;
   }
 
-  setVisibleSessionLimit(limit: number): void {
-    this.visibleSessionLimit = limit;
+  setVisibleSessionLimit(sectionId: string, limit: number): void {
+    this.visibleSessionLimits.set(sectionId, limit);
     this.notify();
   }
 
@@ -680,7 +679,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   }
 
   resetForStatusFilter(statusFilter: SidebarSessionStatusFilter): void {
-    this.visibleSessionLimit = SIDEBAR_SESSION_PAGE_SIZE;
+    this.visibleSessionLimits.clear();
     this.childSessionRowsByParent = {};
     this.loadedChildSessionKeys = new Set();
     this.failedChildSessionKeys = new Set();

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -470,7 +470,7 @@ suite("Claude native session catalog", () => {
     });
     await page.goto(`${server.baseUrl}chat`);
     await expandCodingSection(page);
-    await page.getByRole("button", { name: "Load more threads" }).click();
+    await page.locator('[data-session-catalog-load-more="claude"]').click();
     await page.getByText("Older remote review", { exact: true }).waitFor();
     expect((await gateway.getRequests("sessions.catalog.list")).at(-1)?.params).toEqual({
       agentId: "main",

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -1227,8 +1227,6 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
             .getAttribute("aria-expanded"),
         )
         .toBe("false");
-      await expect.poll(() => page.locator(".sidebar-recent-session").count()).toBe(10);
-      await page.getByRole("button", { name: "Load more threads" }).click();
       await expect.poll(() => page.locator(".sidebar-recent-session").count()).toBe(11);
 
       const patchCountBeforeFlatDrag = (await gateway.getRequests("sessions.patch")).length;
@@ -1541,7 +1539,9 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     try {
       await page.goto(`${server.baseUrl}chat`);
       await page.locator('[data-session-section="work"] .sidebar-session-group-toggle').click();
-      const loadMore = page.getByRole("button", { name: "Load more threads" });
+      const loadMore = page
+        .locator('[data-session-section="ungrouped"]')
+        .getByRole("button", { name: "Show more" });
       for (let pageIndex = 0; pageIndex < 3 && (await loadMore.isVisible()); pageIndex += 1) {
         await loadMore.click();
       }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4293,7 +4293,7 @@ export const en: TranslationMap = {
       session: "Chat thread",
       sessionSearch: "Search threads",
       clearSessionSearch: "Clear thread search",
-      loadMoreSessions: "Load more threads",
+      loadMoreSessions: "Show more",
       model: "Chat model",
       modelSection: "Model",
       modelLocked: "Locked",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1699,6 +1699,7 @@ html.openclaw-native-macos
 
 .sidebar-session-pagination {
   display: flex;
+  justify-content: center;
   gap: 14px;
   padding: 0 10px 10px;
 }

--- a/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
@@ -70,7 +70,41 @@ describe("AppSidebar session section visibility", () => {
     expect(
       section?.querySelectorAll(".sidebar-recent-session:not(.sidebar-recent-session--draft)"),
     ).toHaveLength(10);
-    expect(draftSidebar.querySelector('[aria-label="Load more threads"]')).not.toBeNull();
+    expect(draftSidebar.querySelector('[aria-label="Show more"]')).not.toBeNull();
+  });
+
+  it("paginates each expanded section independently", async () => {
+    const threadKeys = Array.from({ length: 12 }, (_, index) => `agent:main:thread-${index}`);
+    const categoryKeys = Array.from({ length: 12 }, (_, index) => `agent:main:alpha-${index}`);
+    const sessions = createSessionsHarness("main", [...threadKeys, ...categoryKeys]);
+    const result = sessions.sessions.state.result;
+    if (!result) {
+      throw new Error("expected session list fixture");
+    }
+    for (const row of result.sessions) {
+      if (categoryKeys.includes(row.key)) {
+        row.category = "Alpha";
+      }
+    }
+    sessions.publish({ groups: ["Alpha"] });
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, sessions.sessions);
+    const category = sidebar.querySelector('[data-session-section="category:Alpha"]');
+    const threads = sidebar.querySelector('[data-session-section="ungrouped"]');
+
+    expect(category?.querySelectorAll(".sidebar-recent-session")).toHaveLength(10);
+    expect(threads?.querySelectorAll(".sidebar-recent-session")).toHaveLength(10);
+    expect(category?.querySelector('[aria-label="Show more"]')).not.toBeNull();
+    expect(threads?.querySelector('[aria-label="Show more"]')).not.toBeNull();
+    expect(sidebar.querySelectorAll(".sidebar-session-pagination")).toHaveLength(2);
+
+    threads?.querySelector<HTMLButtonElement>('[aria-label="Show more"]')?.click();
+    await sidebar.updateComplete;
+
+    expect(category?.querySelectorAll(".sidebar-recent-session")).toHaveLength(10);
+    expect(threads?.querySelectorAll(".sidebar-recent-session")).toHaveLength(12);
+    expect(category?.querySelector('[aria-label="Show more"]')).not.toBeNull();
+    expect(threads?.querySelector('[aria-label="Show more"]')).toBeNull();
   });
 
   it("hides empty Threads at rest but keeps empty categories and the drag drop target", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -124,35 +124,35 @@ describe("AppSidebar session pagination", () => {
       sidebar.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
 
     expect(rows()).toHaveLength(10);
-    expect(button("Load more threads")).not.toBeNull();
+    expect(button("Show more")).not.toBeNull();
     expect(button("Collapse")).toBeNull();
 
-    button("Load more threads")?.click();
+    button("Show more")?.click();
     await sidebar.updateComplete;
     expect(rows()).toHaveLength(20);
     expect(button("Collapse")).toBeNull();
 
-    button("Load more threads")?.click();
+    button("Show more")?.click();
     await sidebar.updateComplete;
     expect(rows()).toHaveLength(30);
     expect(button("Collapse")).toBeNull();
 
-    button("Load more threads")?.click();
+    button("Show more")?.click();
     await sidebar.updateComplete;
     expect(rows()).toHaveLength(40);
-    expect(button("Load more threads")).not.toBeNull();
+    expect(button("Show more")).not.toBeNull();
     expect(button("Collapse")).not.toBeNull();
 
-    button("Load more threads")?.click();
+    button("Show more")?.click();
     await sidebar.updateComplete;
     expect(rows()).toHaveLength(41);
-    expect(button("Load more threads")).toBeNull();
+    expect(button("Show more")).toBeNull();
     expect(button("Collapse")).not.toBeNull();
 
     button("Collapse")?.click();
     await sidebar.updateComplete;
     expect(rows()).toHaveLength(10);
-    expect(button("Load more threads")).not.toBeNull();
+    expect(button("Show more")).not.toBeNull();
     expect(button("Collapse")).toBeNull();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The sidebar session list applied one global visible-row limit (10) across all sections. With several sections, one zone could consume the whole budget — e.g. a category with 9 rows left Threads showing 1 of 15 sessions — and the single "Load more threads" control rendered at the very bottom of the sidebar, below Groups and Coding, visually disconnected from the truncated section. Users did not find it.

## Why This Change Was Made

Pagination is now per-section: each session section (Threads, each custom category, Groups, Coding) owns an independent visible limit (initial 10). The pager renders directly beneath its own section's rows, centered, as a small muted "Show more" (+10) with a per-section "Collapse" past 30 rows. The global limit path is deleted; active and pinned rows still bypass the limit.

## User Impact

Every truncated sidebar section shows its own centered "Show more" right under its rows. Expanding one section no longer hides rows in another.

Before: https://artifacts.openclaw.ai/pr-sidebar-section-pagination-1b7ae72/pagination-before.png
After: https://artifacts.openclaw.ai/pr-sidebar-section-pagination-1b7ae72/pagination-after.png

![before](https://artifacts.openclaw.ai/pr-sidebar-section-pagination-1b7ae72/pagination-before.png)
![after](https://artifacts.openclaw.ai/pr-sidebar-section-pagination-1b7ae72/pagination-after.png)

(Screenshots captured from the sanitized mock-gateway e2e harness; artifact manifest at https://artifacts.openclaw.ai/pr-sidebar-section-pagination-1b7ae72/artifact-manifest.json)

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 166 passed, including new per-section independence coverage (expanding Threads leaves a category section untouched, each truncated section renders its own pager).
- `node scripts/check-changed.mjs` — all formatting/i18n/typecheck/lint/guard lanes green on Blacksmith Testbox.
- `pnpm ui:i18n:baseline` — clean (label change "Load more threads" -> "Show more" in en.ts only; generated locales untouched per ui i18n policy).
- Codex autoreview (`--mode uncommitted`, gpt-5.6-sol) — clean, no accepted findings.
