### PR TITLE
test(wizard): restore stdin TTY state

### DIFF
--- a/src/wizard/setup.post-install-migration.test.ts
+++ b/src/wizard/setup.post-install-migration.test.ts
@@ -1,5 +1,5 @@
 // Post-install migration tests cover migration prompts and command guidance.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createNonExitingRuntime } from "../runtime.js";
@@ -41,6 +41,8 @@ const migrateDefaultCommand = vi.hoisted(() =>
 vi.mock("../commands/migrate.js", () => ({ migrateDefaultCommand }));
 
 import { offerPostInstallMigrations } from "./setup.post-install-migration.js";
+
+const originalStdinIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 
 type ProviderMock = {
   id: string;
@@ -108,6 +110,20 @@ describe("offerPostInstallMigrations", () => {
     resolveStateDir.mockReset().mockReturnValue("/tmp/state");
     migrateDefaultCommand.mockReset().mockResolvedValue(undefined);
     setTTY(true);
+  });
+
+  afterEach(() => {
+    if (originalStdinIsTTYDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", originalStdinIsTTYDescriptor);
+    } else {
+      delete (process.stdin as Partial<typeof process.stdin>).isTTY;
+    }
+  });
+
+  afterAll(() => {
+    expect(Object.getOwnPropertyDescriptor(process.stdin, "isTTY")).toEqual(
+      originalStdinIsTTYDescriptor,
+    );
   });
 
   it("returns early when no plugins were installed in this onboarding step", async () => {


### PR DESCRIPTION
## What Problem This Solves

The post-install migration wizard tests redefine the process-global `process.stdin.isTTY` descriptor but did not restore it. Because the wizard Vitest shard runs with isolation disabled, later suites in the same worker could inherit a test-created TTY state.

## Why This Change Was Made

The suite now captures the exact incoming descriptor once and restores it after every test. If `isTTY` was inherited rather than an own property, teardown deletes only the property created by the test. A suite-level invariant asserts that teardown returns stdin to the descriptor state the suite received.

This is the owner-boundary fix: the suite that mutates process-global state also restores it. A consumer-side override would only hide the leak. The implementation matches the established descriptor restore-or-delete pattern in `src/commands/doctor-update.test.ts`.

ClawSweeper's latest rank-up move said no separate repair lane was needed because this focused maintainer PR already owns the repair; no code action was required beyond completing and proving this PR.

## User Impact

Developers get deterministic wizard shard behavior, including on non-isolated workers. Production behavior is unchanged.

The cleanup is cross-platform: it uses JavaScript property-descriptor operations only, with no Unix paths, signals, or filesystem deletion semantics. The focused before/after proof ran on macOS, and the changed-file gate ran on Linux. Exact-head CI supplies the repository's hosted platform coverage; no Windows-specific branch is involved.

## Evidence

- Regression, before the teardown fix (`node scripts/run-vitest.mjs src/wizard/setup.post-install-migration.test.ts`):
  - `Test Files  1 failed (1)`
  - `Tests  11 passed (11)`
  - Suite invariant received `{ value: true, configurable: true }` for `stdin.isTTY` instead of the original `undefined`.
  - `[vitest] FAILED (exit 1)`
- Regression, after the teardown fix (same command):
  - `Test Files  1 passed (1)`
  - `Tests  11 passed (11)`
  - `[test] passed 1 Vitest shard in 22.82s` on the rebased head
- Changed-file gate (`node scripts/check-changed.mjs`):
  - Blacksmith Testbox `tbx_01kzk12d662d2j0q7snn8ep91w`
  - https://github.com/openclaw/openclaw/actions/runs/31308416791
  - core test types, formatting, lint (`0 warnings and 0 errors`), and repository guards passed
  - `runStatus: succeeded`, `exitCode: 0`
- `git diff --check`: passed.
- Codex autoreview on rebased head `95a13d34a6e3545f2443d37a69cf960bd2c52faa`: clean after one round; no accepted/actionable findings.
- Exact-head CI (`node scripts/watch-pr-ci.mjs 113345 95a13d34a6e3545f2443d37a69cf960bd2c52faa`): `GREEN` on https://github.com/openclaw/openclaw/actions/runs/31308796636. The workflow was rerun once after GitHub left its first successful `openclaw/ci-gate` check-run nonterminal; the rerun completed with `pending=0` and `SUCCESS`.

AI-assisted: yes.
