### PR TITLE
test(updater): clean cloned Git fixtures

### DIFF
--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -17,7 +17,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import {
   acquireMaintenanceLock,
   assertNoSystemLaunchDaemonOwnership,
@@ -48,10 +48,12 @@ import {
   RUNTIME_POSTBUILD_STAMP_FILE,
 } from "../../scripts/lib/local-build-metadata.mjs";
 import { listCoreRuntimePostBuildOutputs } from "../../scripts/runtime-postbuild.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const script = path.join(repoRoot, ".agents/skills/openclaw-live-updater/scripts/update-main.mjs");
 const fixtureOrigins = new Map<string, string>();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 let fixtureTemplate: ReturnType<typeof initializeFixture> | undefined;
 const posixTest = process.platform === "win32" ? test.skip : test;
 
@@ -165,7 +167,7 @@ function makeFixture(options?: { includeSeed?: boolean }) {
   if (!fixtureTemplate) {
     throw new Error("fixture template is not initialized");
   }
-  const root = realpathSync(mkdtempSync(path.join(tmpdir(), "openclaw-live-updater-")));
+  const root = realpathSync(tempDirs.make("openclaw-live-updater-"));
   const origin = path.join(root, "origin.git");
   const seed = path.join(root, "seed");
   const mirror = path.join(root, "mirror");
@@ -245,9 +247,15 @@ function managedTimeoutError() {
 }
 
 describe("openclaw live updater", () => {
+  let cleanupProbeRoot = "";
+
   beforeAll(() => {
     const root = realpathSync(mkdtempSync(path.join(tmpdir(), "openclaw-live-updater-template-")));
     fixtureTemplate = initializeFixture(root);
+  });
+
+  afterEach(() => {
+    fixtureOrigins.clear();
   });
 
   afterAll(() => {
@@ -255,6 +263,17 @@ describe("openclaw live updater", () => {
       rmSync(fixtureTemplate.root, { recursive: true, force: true });
       fixtureTemplate = undefined;
     }
+  });
+
+  describe.sequential("fixture cleanup boundary", () => {
+    test("creates a disposable clone fixture", () => {
+      cleanupProbeRoot = makeFixture().root;
+      expect(existsSync(cleanupProbeRoot)).toBe(true);
+    });
+
+    test("removes the disposable clone before the next test", () => {
+      expect(existsSync(cleanupProbeRoot), cleanupProbeRoot).toBe(false);
+    });
   });
 
   test("audits only error and warning logs emitted after Gateway restart", () => {
@@ -559,7 +578,7 @@ describe("openclaw live updater", () => {
   });
 
   test("ignores restart-window logs emitted by a foreign OpenClaw checkout", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "openclaw-log-attribution-"));
+    const root = tempDirs.make("openclaw-log-attribution-");
     const sourceRoot = path.join(root, "managed/openclaw/dist");
     const foreignRoot = path.join(root, "worktree/openclaw");
     mkdirSync(path.join(foreignRoot, ".git"), { recursive: true });
@@ -609,7 +628,7 @@ describe("openclaw live updater", () => {
   });
 
   test("keeps managed restart logs when the deployment root is symlinked", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "openclaw-log-symlink-attribution-"));
+    const root = tempDirs.make("openclaw-log-symlink-attribution-");
     const releaseRoot = path.join(root, "releases/abc");
     const releaseDist = path.join(releaseRoot, "dist");
     const linkedRoot = path.join(root, "current");
@@ -639,7 +658,7 @@ describe("openclaw live updater", () => {
   });
 
   test("scopes embedded RPC records without dropping unattributed errors", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "openclaw-rpc-log-attribution-"));
+    const root = tempDirs.make("openclaw-rpc-log-attribution-");
     const sourceRoot = path.join(root, "managed/openclaw/dist");
     const foreignRoot = path.join(root, "worktree/openclaw");
     mkdirSync(path.join(foreignRoot, ".git"), { recursive: true });
@@ -1076,7 +1095,7 @@ console.log(JSON.stringify({ ok: true, channels: {} }));
   });
 
   test("pins managed Gateway calls with a backward-compatible local overlay", () => {
-    const root = realpathSync(mkdtempSync(path.join(tmpdir(), "openclaw-gateway-call-")));
+    const root = realpathSync(tempDirs.make("openclaw-gateway-call-"));
     const checkout = path.join(root, "checkout");
     const entrypoint = path.join(checkout, "dist/index.js");
     const capture = path.join(root, "capture.mjs");


### PR DESCRIPTION
## What Problem This Solves

The live-updater test suite creates cloned Git fixtures and several other temporary attribution/call roots per test, but current main removes only the suite-wide fixture template. Repeated runs therefore leave disposable repositories and directories under the system temp root.

## Why This Change Was Made

Every current per-test root producer now uses the repository's canonical `useAutoCleanupTempDirTracker(afterEach)` owner. That shared helper removes roots recursively with force and bounded retries, then clears its registry. The suite also clears the mirror-origin lookup after each test. The expensive initialized Git template deliberately remains suite-wide and continues to be owned by `beforeAll`/`afterAll`.

This is the lifecycle-owner repair: allocation registers cleanup at the producer. Per-test deletion loops would duplicate policy and would miss newly added root producers.

ClawSweeper's stale-head rank-up move is addressed: the branch was rebuilt from current main, the focused cleanup boundary and full expanded suite were rerun, and exact-head CI is green. Normal maintainer handling continues through the repository-native prepare and merge wrappers.

## User Impact

Developers and CI workers no longer accumulate live-updater Git fixtures or sibling temporary roots across tests. Production behavior is unchanged.

Windows cleanup is the main risk. The implementation delegates to `test/helpers/temp-dir.ts`, which calls Node's recursive `fs.rmSync` with `force: true`, `maxRetries: 5`, and `retryDelay: 20`. Node 24 documents linear-backoff retries for `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, and `EPERM`. A direct Azure Windows proof was attempted but no lease was created: the broker rejected the Windows image selector with HTTP 403 `admin_required`. No Windows runtime pass is claimed.

## Evidence

- Regression before cleanup (`node scripts/run-vitest.mjs test/scripts/openclaw-live-updater.test.ts -- -t 'fixture cleanup boundary'`):
  - `Tests 1 failed | 1 passed | 81 skipped`
  - the next test observed the previous clone root still present
  - `[vitest] FAILED (exit 1)`
- Regression after cleanup (same command):
  - `Tests 2 passed | 81 skipped`
  - `[test] passed 1 Vitest shard in 4.06s`
- Full rebased suite (`node scripts/run-vitest.mjs test/scripts/openclaw-live-updater.test.ts`):
  - `Test Files 1 passed`
  - `Tests 83 passed`
  - `[test] passed 1 Vitest shard in 29.03s`
  - post-run scan found no updater, attribution, RPC-log, or Gateway-call temp roots
- Changed-file gate (`node scripts/check-changed.mjs`):
  - Blacksmith Testbox `tbx_01kzk52fy5fqjxg0bbfgsjzw9y`
  - https://github.com/openclaw/openclaw/actions/runs/31311296633
  - root-test types, formatting, script declarations, repository guards, and script lint passed
  - lint: `0 warnings and 0 errors` across 901 files
  - `runStatus: succeeded`, `exitCode: 0`
- `git diff --check`: passed.
- Codex autoreview on rebased head `2639920d6ede49b3dc500c99c007e17cd42e7804`: clean after one round; no accepted/actionable findings, confidence 0.99.
- Exact-head CI (`node scripts/watch-pr-ci.mjs 113348 2639920d6ede49b3dc500c99c007e17cd42e7804`): `GREEN`, with 66 successful checks, 25 skipped, and 0 pending or failed.

AI-assisted: yes.
