### PR TITLE
fix(sdk): preserve zero values in normalized event IDs

### DIFF
--- a/packages/sdk/src/normalize.test.ts
+++ b/packages/sdk/src/normalize.test.ts
@@ -7,6 +7,25 @@ function agentItemEvent(data: Record<string, unknown>) {
   return { event: "agent", payload: { runId: "r1", stream: "item", data } };
 }
 
+describe("normalizeGatewayEvent IDs", () => {
+  it("preserves zero sequence and timestamp values", () => {
+    const event = normalizeGatewayEvent({
+      event: "agent",
+      seq: 0,
+      payload: {
+        runId: "r1",
+        sessionKey: "main",
+        ts: 0,
+        stream: "lifecycle",
+        data: { phase: "start" },
+      },
+    });
+
+    expect(event.id).toBe("0:agent:r1:main:0");
+    expect(event.ts).toBe(0);
+  });
+});
+
 describe("normalizeGatewayEvent terminal tool item status", () => {
   it("classifies a failed terminal tool item as tool.call.failed", () => {
     expect(normalizeGatewayEvent(agentItemEvent({ phase: "end", status: "failed" })).type).toBe(

--- a/packages/sdk/src/normalize.test.ts
+++ b/packages/sdk/src/normalize.test.ts
@@ -8,21 +8,24 @@ function agentItemEvent(data: Record<string, unknown>) {
 }
 
 describe("normalizeGatewayEvent IDs", () => {
-  it("preserves zero sequence and timestamp values", () => {
+  it.each([
+    { field: "sequence", seq: 0, ts: 123, expectedId: "0:agent:r1:main:123" },
+    { field: "timestamp", seq: 1, ts: 0, expectedId: "1:agent:r1:main:0" },
+  ])("preserves zero $field values", ({ seq, ts, expectedId }) => {
     const event = normalizeGatewayEvent({
       event: "agent",
-      seq: 0,
+      seq,
       payload: {
         runId: "r1",
         sessionKey: "main",
-        ts: 0,
+        ts,
         stream: "lifecycle",
         data: { phase: "start" },
       },
     });
 
-    expect(event.id).toBe("0:agent:r1:main:0");
-    expect(event.ts).toBe(0);
+    expect(event.id).toBe(expectedId);
+    expect(event.ts).toBe(ts);
   });
 });
 

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -177,7 +177,9 @@ export function normalizeGatewayEvent(event: GatewayEvent): OpenClawEvent {
   const taskId = readString(payload.taskId);
   const agentId = readString(payload.agentId);
   const ts = readNumber(payload.ts) ?? Date.now();
-  const idParts = [event.seq ?? "local", event.event, runId, sessionKey, ts].filter(Boolean);
+  const idParts = [event.seq ?? "local", event.event, runId, sessionKey, ts].filter(
+    (part) => part !== undefined,
+  );
 
   return {
     version: 1,


### PR DESCRIPTION
Closes #101768

AI-assisted: Yes — implementation and validation were performed with OpenAI Codex.

## What Problem This Solves

Fixes an issue where SDK consumers using normalized gateway events could receive event IDs that omit protocol-valid zero sequence and timestamp components. This weakens the stable identity used for replay/live event deduplication.

## Why This Change Was Made

Event ID construction now omits only absent (`undefined`) metadata instead of filtering every falsy value. A focused regression test covers `seq: 0` together with `payload.ts: 0`; no gateway protocol or schema behavior changes.

## User Impact

SDK consumers now receive normalized event IDs that preserve valid zero values, keeping replay and live-stream event identity stable for the first sequence value.

## Evidence

- Red/green regression proof:
  - before the fix, the new test received `agent:r1:main` instead of `0:agent:r1:main:0`
  - after the fix, `node scripts/run-vitest.mjs packages/sdk/src/normalize.test.ts` passed (5/5)
- Core production TypeScript project (`tsconfig.core.json`) passed with the repository-pinned `tsgo` compiler.
- Focused `oxfmt --check` and type-aware `oxlint` passed for both changed files.
- `node scripts/check-sdk-package-extension-import-boundary.mjs --json` passed with `[]`.
- `git diff --check` passed.

Local `check:changed` was attempted, but its wrapper delegated to Blacksmith Testbox and no usable local Crabbox binary was available. The relevant focused test, formatting, lint, production typecheck, and package-boundary lanes were therefore run directly as listed above; GitHub CI remains the authoritative full gate.
