### PR TITLE
fix(release): validate isolated plugin dependencies independently

### DIFF
--- a/scripts/lib/plugin-package-dependencies.mjs
+++ b/scripts/lib/plugin-package-dependencies.mjs
@@ -50,6 +50,11 @@ export function collectBundledPluginPackageDependencySpecs(bundledPluginsDir) {
 
   for (const packageJsonPath of packageJsonPaths) {
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    // External official plugins own isolated npm projects, so their dependency
+    // specs do not need to match packages bundled into the root distribution.
+    if (packageJson.openclaw?.build?.bundledDist === false) {
+      continue;
+    }
     const pluginId = path.basename(path.dirname(packageJsonPath));
     for (const [name, spec] of collectRuntimeDependencySpecs(packageJson)) {
       const existing = specs.get(name);

--- a/test/scripts/plugin-package-dependencies.test.ts
+++ b/test/scripts/plugin-package-dependencies.test.ts
@@ -74,6 +74,16 @@ describe("scripts/lib/plugin-package-dependencies.mjs", () => {
         shared: "^1.1.0",
       },
     });
+    writePackageJson(root, "external", {
+      dependencies: {
+        shared: "^9.0.0",
+      },
+      openclaw: {
+        build: {
+          bundledDist: false,
+        },
+      },
+    });
 
     expect([...collectBundledPluginPackageDependencySpecs(root)]).toEqual([
       [


### PR DESCRIPTION
Related: #113332

## What Problem This Solves

Fixes an issue where release validation rejected independently installed official plugins when their dependency versions legitimately differ from plugins bundled into the root distribution. This blocked `2026.7.2-beta.5` because Slack must use `undici@7` for the `@slack/socket-mode@3` peer contract while bundled channels use `undici@8`.

## Why This Change Was Made

The dependency-conflict collector now applies only to packages actually bundled into the root distribution. Official external plugins marked `openclaw.build.bundledDist: false` remain covered by their own package metadata, shrinkwrap, install, and runtime checks, without being forced into an unrelated shared dependency version.

## User Impact

Release validation can preserve valid plugin-owned dependency contracts instead of forcing incompatible upgrades or blocking publication. Checks remain unchanged for every plugin whose runtime is bundled into OpenClaw.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugin-package-dependencies.test.ts test/release-check.test.ts` — 62/62 passed.
- Regression fixture proves a conflicting `bundledDist: false` package is excluded while the conflicting bundled package remains reported.
- `@slack/socket-mode@3.0.0` registry contract declares peer dependency `undici@^7.0.0`; Slack pins `7.28.0`, while root-bundled channels use `8.6.0`.
- Release preflight run 30102478018 reached the dependency-conflict gate after the exact beta.5 build and all generated checks passed.
- Codex autoreview: clean, no accepted/actionable findings.
