### PR TITLE
fix(ui): chat bubbles overlap after switching to the dashboard face

### DIFF
--- a/ui/src/pages/chat/components/chat-thread.measure.test.ts
+++ b/ui/src/pages/chat/components/chat-thread.measure.test.ts
@@ -1,0 +1,129 @@
+/* @vitest-environment jsdom */
+
+// Regression: re-stamping the transcript into a new container (the
+// chat<->dashboard face switch) must keep every rendered row observed for
+// size changes. A synchronous measureElement(null) prune during the commit
+// unobserved just-registered sibling rows, freezing their heights at the old
+// pane width and overlapping the bubbles in the dashboard chat dock.
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetChatThreadState } from "../chat-thread.ts";
+import { createTestTranscript } from "../chat-view.test-helpers.ts";
+import { renderChatThread, resetChatThreadPresentationState } from "./chat-thread.ts";
+
+const observedElements = new Set<Element>();
+
+class RecordingResizeObserver implements ResizeObserver {
+  private readonly targets = new Set<Element>();
+  constructor(_callback: ResizeObserverCallback) {}
+  observe(target: Element): void {
+    this.targets.add(target);
+    observedElements.add(target);
+  }
+  unobserve(target: Element): void {
+    this.targets.delete(target);
+    observedElements.delete(target);
+  }
+  disconnect(): void {
+    for (const target of this.targets) {
+      observedElements.delete(target);
+    }
+    this.targets.clear();
+  }
+}
+
+function threadProps(paneId: string) {
+  return {
+    paneId,
+    sessionKey: "agent:main:main",
+    loading: false,
+    messages: [
+      { role: "user", content: "message one", timestamp: 1_000 },
+      { role: "assistant", content: "reply one", timestamp: 2_000 },
+      { role: "user", content: "message two", timestamp: 3_000 },
+      { role: "assistant", content: "reply two", timestamp: 4_000 },
+    ],
+    toolMessages: [],
+    streamSegments: [],
+    stream: null,
+    streamStartedAt: null,
+    queue: [],
+    showThinking: false,
+    showToolCalls: false,
+    sessions: null,
+    assistantName: "Molty",
+    assistantAvatar: null,
+    onDraftChange: () => {},
+    onSend: () => {},
+  };
+}
+
+function transcriptRows(container: HTMLElement): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>(".chat-virtual-row")];
+}
+
+async function flushDeferredRowPrune(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("chat transcript row measurement", () => {
+  beforeEach(() => {
+    observedElements.clear();
+    vi.stubGlobal("ResizeObserver", RecordingResizeObserver);
+    // jsdom reports 0x0 rects and offsetHeight 0; keep the virtualizer
+    // viewport and measured row sizes non-zero so re-renders keep producing
+    // virtual rows.
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(100);
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 800,
+      bottom: 600,
+      width: 800,
+      height: 600,
+      toJSON: () => ({}),
+    } as DOMRect);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    resetChatThreadPresentationState();
+    resetChatThreadState();
+    document.body.replaceChildren();
+  });
+
+  it("keeps every re-stamped row observed after moving containers", async () => {
+    const transcript = createTestTranscript();
+    const props = threadProps("pane-measure");
+    const chatFace = document.body.appendChild(document.createElement("div"));
+    render(renderChatThread(props, transcript), chatFace);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+
+    const chatRows = transcriptRows(chatFace);
+    expect(chatRows.length).toBeGreaterThanOrEqual(4);
+    for (const row of chatRows) {
+      expect(observedElements.has(row)).toBe(true);
+    }
+
+    // Re-stamp the same session transcript into a new container while the old
+    // tree is still tracked, mirroring the dashboard face-switch commit.
+    const dashboardDock = document.body.appendChild(document.createElement("div"));
+    render(renderChatThread(props, transcript), dashboardDock);
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+
+    const dockRows = transcriptRows(dashboardDock);
+    expect(dockRows.length).toBe(chatRows.length);
+    for (const row of dockRows) {
+      expect(observedElements.has(row)).toBe(true);
+    }
+    for (const row of chatRows) {
+      expect(observedElements.has(row)).toBe(false);
+    }
+  });
+});

--- a/ui/src/pages/chat/components/chat-thread.measure.test.ts
+++ b/ui/src/pages/chat/components/chat-thread.measure.test.ts
@@ -15,7 +15,6 @@ const observedElements = new Set<Element>();
 
 class RecordingResizeObserver implements ResizeObserver {
   private readonly targets = new Set<Element>();
-  constructor(_callback: ResizeObserverCallback) {}
   observe(target: Element): void {
     this.targets.add(target);
     observedElements.add(target);
@@ -63,7 +62,9 @@ function transcriptRows(container: HTMLElement): HTMLElement[] {
 }
 
 async function flushDeferredRowPrune(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
 }
 
 describe("chat transcript row measurement", () => {

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -229,13 +229,30 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
     this.threadInnerElement = element instanceof HTMLDivElement ? element : null;
   };
   private readonly measureRowRefs = new Map<string, (element?: Element) => void>();
+  private pruneDetachedRowsQueued = false;
   private measureRowRefFor(key: string): (element?: Element) => void {
     let callback = this.measureRowRefs.get(key);
     if (!callback) {
-      callback = (element?: Element) =>
-        this.virtualizerController
-          .getVirtualizer()
-          .measureElement(element instanceof HTMLElement ? element : null);
+      callback = (element?: Element) => {
+        if (element instanceof HTMLElement) {
+          this.virtualizerController.getVirtualizer().measureElement(element);
+          return;
+        }
+        // Re-stamps (e.g. the chat<->dashboard face switch) re-invoke each
+        // stable row ref as an (undefined, element) pair while the new subtree
+        // is still detached. measureElement(null) prunes every disconnected
+        // row, so calling it synchronously unobserves just-registered sibling
+        // rows and freezes their heights at the old pane width (overlapping
+        // bubbles). Defer until the commit lands so only removed rows prune.
+        if (this.pruneDetachedRowsQueued) {
+          return;
+        }
+        this.pruneDetachedRowsQueued = true;
+        queueMicrotask(() => {
+          this.pruneDetachedRowsQueued = false;
+          this.virtualizerController.getVirtualizer().measureElement(null);
+        });
+      };
       this.measureRowRefs.set(key, callback);
     }
     return callback;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where switching a session from the Chat face to the Dashboard face (or back) left the chat transcript garbled: message bubbles overlapped each other in the dashboard's docked chat panel, and the full-width chat showed large empty gaps between messages. The broken layout persisted until the user scrolled far enough for every row to re-render.

## Why This Change Was Made

The chat transcript is virtualized (`@tanstack/lit-virtual`) with absolutely positioned rows whose heights are measured per row and observed via `ResizeObserver`. Each row's Lit `ref` forwards to `virtualizer.measureElement(...)`.

When the face switch re-stamps the transcript into the new container, Lit re-invokes every stable row ref as an `(undefined, element)` pair *while the newly stamped subtree is still detached* (refs fire mid-commit, before the fragment is connected). The `undefined` call runs `measureElement(null)`, which prunes every disconnected element from the virtualizer's element cache — and mid-commit that includes the sibling rows registered a moment earlier. The net effect: after the commit only the last transcript row was still ResizeObserver-observed, so no row was ever re-measured at the new pane width. Rows stayed positioned by heights measured at the old width — overlap in the narrow dashboard dock, gaps in the wide chat face. (Initial load is unaffected because there are no prior elements, so the `undefined` calls never fire.)

The fix defers the `measureElement(null)` prune to a microtask (coalesced), so it runs after the commit lands, when only genuinely removed rows are still disconnected. Newly stamped rows keep their observation and heal to the new width within a frame.

## User Impact

Chat ⇄ Dashboard face switches now keep the transcript readable: no overlapping bubbles in the docked chat, no phantom gaps in the full-width chat. Row size tracking (streaming updates, images loading) also works for all visible rows again instead of only the most recently registered one.

**Before** (dashboard dock after switching from chat; 13 overlapping rows):

![before](https://gist.githubusercontent.com/steipete/42bfbddb270c7efdf3978724c8a4a3f1/raw/before-fix.png)

**After** (same flow; 0 overlaps):

![after](https://gist.githubusercontent.com/steipete/42bfbddb270c7efdf3978724c8a4a3f1/raw/after-fix.png)

## Evidence

- Reproduced in the Control UI mock harness (`pnpm dev:ui:mock` + `?mockBoard=1`): switching Chat → Dashboard produced 13 overlapping virtual rows; the virtualizer's `elementsCache` had collapsed to a single entry (`background-tasks`) out of 14 rendered rows, so only one row was observed for resizes.
- New regression test `ui/src/pages/chat/components/chat-thread.measure.test.ts` re-stamps the same session transcript into a new container and asserts every rendered row stays ResizeObserver-observed (and old rows are released). It fails without the fix (dock rows lose observation) and passes with it.
- `node scripts/run-vitest.mjs` over `chat-thread.test.ts`, `chat-thread.question.test.ts`, `chat-view.test.ts`, `scroll.test.ts`, and the new test: 373 passed.
- Playwright capture against the mock harness reports `{"rowCount":15,"overlaps":13}` before and `{"rowCount":17,"overlaps":0}` after (screenshots above).
- Changed-file checks on Blacksmith Testbox: conflict markers, max-lines ratchet, format, i18n catalog, core/UI typecheck, and lint lanes green on the rebased head.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no findings — "The deferred, coalesced prune preserves newly registered rows until the Lit commit has attached them."
