### PR TITLE
feat(approvals): configurable exec approval outcome echo

### DIFF
--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -202,6 +202,7 @@ Config:
       mode: "session", // "session" | "targets" | "both"
       agentFilter: ["main"],
       sessionFilter: ["discord"], // substring or regex
+      outcome: "message", // "message" | "none"
       targets: [
         { channel: "slack", to: "U12345678" },
         { channel: "telegram", to: "123456789" },
@@ -210,6 +211,13 @@ Config:
   },
 }
 ```
+
+When a forwarded approval is resolved, OpenClaw posts a follow-up outcome message
+(`Exec approval: Allowed` / `Exec approval: Denied`, or the plugin equivalent) to the forward
+targets. Set `outcome: "none"` to suppress that resolved-outcome follow-up entirely; the default
+`"message"` keeps the current behavior. `outcome` applies only to target forwarding: native
+approval clients deliver their own resolved outcomes through channel adapters and are not affected
+by this setting.
 
 Reply in chat:
 
@@ -235,6 +243,7 @@ For plugin-authoring behavior, request fields, and decision semantics, see
       enabled: true,
       mode: "targets",
       agentFilter: ["main"],
+      outcome: "message", // "message" | "none"
       targets: [
         { channel: "slack", to: "U12345678" },
         { channel: "telegram", to: "123456789" },
@@ -245,7 +254,7 @@ For plugin-authoring behavior, request fields, and decision semantics, see
 ```
 
 The config shape is identical to `approvals.exec`: `enabled`, `mode`, `agentFilter`,
-`sessionFilter`, and `targets` work the same way.
+`sessionFilter`, `outcome`, and `targets` work the same way.
 
 Channels that support shared interactive replies render the same approval buttons for both exec and
 plugin approvals. Channels without shared interactive UI fall back to plain text with `/approve`

--- a/src/config/types.approvals.ts
+++ b/src/config/types.approvals.ts
@@ -3,6 +3,8 @@ export type NativeExecApprovalEnableMode = boolean | "auto";
 
 export type ExecApprovalForwardingMode = "session" | "targets" | "both";
 
+export type ExecApprovalForwardingOutcome = "message" | "none";
+
 export type ExecApprovalForwardTarget = {
   /** Channel id (e.g. "discord", "slack", or plugin channel id). */
   channel: string;
@@ -25,6 +27,8 @@ export type ExecApprovalForwardingConfig = {
   sessionFilter?: string[];
   /** Explicit delivery targets (used when mode includes targets). */
   targets?: ExecApprovalForwardTarget[];
+  /** How to publish the approval outcome. Default: "message". */
+  outcome?: ExecApprovalForwardingOutcome;
 };
 
 export type ApprovalsConfig = {

--- a/src/config/zod-schema.approvals.ts
+++ b/src/config/zod-schema.approvals.ts
@@ -20,6 +20,7 @@ const ExecApprovalForwardingSchema = z
     agentFilter: z.array(z.string()).optional(),
     sessionFilter: z.array(z.string()).optional(),
     targets: z.array(ExecApprovalForwardTargetSchema).optional(),
+    outcome: z.union([z.literal("message"), z.literal("none")]).optional(),
   })
   .strict()
   .optional();

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -896,4 +896,40 @@ describe("exec approval forwarder", () => {
       expect(deliver).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("outcome", () => {
+    it("delivers resolved message by default when outcome is undefined", async () => {
+      vi.useFakeTimers();
+      const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+      await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+      await forwarder.handleResolved({
+        id: baseRequest.id,
+        decision: "allow-once",
+        ts: 2000,
+      });
+      expect(deliver).toHaveBeenCalledTimes(2);
+    });
+
+    it("suppresses resolved message when outcome is none", async () => {
+      vi.useFakeTimers();
+      const cfg = {
+        approvals: {
+          exec: {
+            enabled: true,
+            mode: "targets",
+            targets: [{ channel: "slack", to: "U1" }],
+            outcome: "none",
+          },
+        },
+      } as OpenClawConfig;
+      const { deliver, forwarder } = createForwarder({ cfg });
+      await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+      await forwarder.handleResolved({
+        id: baseRequest.id,
+        decision: "allow-once",
+        ts: 2000,
+      });
+      expect(deliver).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -689,10 +689,49 @@ function createApprovalHandlers<
   };
 
   const handleResolved = async (resolved: TResolved) => {
-    const settled = pending.settle(params.strategy.getResolvedId(resolved), (entry) =>
-      deliverResolved(resolved, entry.value),
-    );
-    if (settled.status === "queued") {
+    const resolvedId = params.strategy.getResolvedId(resolved);
+    const entry = pending.get(resolvedId);
+    if (entry?.timeoutId) {
+      clearTimeout(entry.timeoutId);
+    }
+    if (entry) {
+      pending.delete(resolvedId);
+    }
+
+    const cfg = params.getConfig();
+    const forwardingConfig = params.strategy.config(cfg);
+    const outcome = forwardingConfig?.outcome ?? "message";
+    if (outcome === "none") {
+      return;
+    }
+
+    let targets = entry?.targets;
+    if (!targets) {
+      const routeRequest = params.strategy.getRouteRequestFromResolved(resolved);
+      if (routeRequest) {
+        const config = params.strategy.config(cfg);
+        targets = [
+          ...(shouldForwardRoute({ config, routeRequest })
+            ? await resolveForwardTargets({
+                cfg,
+                config,
+                approvalKind: params.strategy.kind,
+                routeRequest,
+                resolveSessionTarget: params.resolveSessionTarget,
+              })
+            : []),
+        ].filter(
+          (target) =>
+            !shouldSkipForwardingFallback({
+              approvalKind: params.strategy.kind,
+              target,
+              cfg,
+              routeRequest,
+            }),
+        );
+      }
+    }
+    if (!targets?.length) {
       return;
     }
     if (settled.status === "taken") {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -701,6 +701,9 @@ function createApprovalHandlers<
     const cfg = params.getConfig();
     const forwardingConfig = params.strategy.config(cfg);
     const outcome = forwardingConfig?.outcome ?? "message";
+    // Contract: `outcome` gates only the resolved-outcome echo for target
+    // forwarding; native approval clients deliver their own resolved
+    // outcomes through channel adapters and are intentionally unaffected.
     if (outcome === "none") {
       return;
     }

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -689,52 +689,20 @@ function createApprovalHandlers<
   };
 
   const handleResolved = async (resolved: TResolved) => {
-    const resolvedId = params.strategy.getResolvedId(resolved);
-    const entry = pending.get(resolvedId);
-    if (entry?.timeoutId) {
-      clearTimeout(entry.timeoutId);
-    }
-    if (entry) {
-      pending.delete(resolvedId);
-    }
-
+    // Gate the outcome echo via config
     const cfg = params.getConfig();
     const forwardingConfig = params.strategy.config(cfg);
     const outcome = forwardingConfig?.outcome ?? "message";
-    // Contract: `outcome` gates only the resolved-outcome echo for target
-    // forwarding; native approval clients deliver their own resolved
-    // outcomes through channel adapters and are intentionally unaffected.
     if (outcome === "none") {
+      // Still settle to avoid leaks, but suppress delivery
+      pending.settle(params.strategy.getResolvedId(resolved), () => {});
       return;
     }
 
-    let targets = entry?.targets;
-    if (!targets) {
-      const routeRequest = params.strategy.getRouteRequestFromResolved(resolved);
-      if (routeRequest) {
-        const config = params.strategy.config(cfg);
-        targets = [
-          ...(shouldForwardRoute({ config, routeRequest })
-            ? await resolveForwardTargets({
-                cfg,
-                config,
-                approvalKind: params.strategy.kind,
-                routeRequest,
-                resolveSessionTarget: params.resolveSessionTarget,
-              })
-            : []),
-        ].filter(
-          (target) =>
-            !shouldSkipForwardingFallback({
-              approvalKind: params.strategy.kind,
-              target,
-              cfg,
-              routeRequest,
-            }),
-        );
-      }
-    }
-    if (!targets?.length) {
+    const settled = pending.settle(params.strategy.getResolvedId(resolved), (entry) =>
+      deliverResolved(resolved, entry.value),
+    );
+    if (settled.status === "queued") {
       return;
     }
     if (settled.status === "taken") {

--- a/src/infra/plugin-approval-forwarder.test.ts
+++ b/src/infra/plugin-approval-forwarder.test.ts
@@ -479,4 +479,26 @@ describe("plugin approval forwarding", () => {
       expect(deliver).not.toHaveBeenCalled();
     });
   });
+
+  describe("outcome", () => {
+    it("suppresses resolved message when outcome is none", async () => {
+      const cfg = {
+        ...PLUGIN_TARGETS_CFG,
+        approvals: {
+          ...PLUGIN_TARGETS_CFG.approvals,
+          plugin: {
+            ...PLUGIN_TARGETS_CFG.approvals?.plugin,
+            outcome: "none",
+          },
+        },
+      } as OpenClawConfig;
+      const deliver = vi.fn().mockResolvedValue([]);
+      const { forwarder } = createForwarder({ cfg, deliver });
+
+      await registerPendingApproval(forwarder, deliver);
+
+      await forwarder.handlePluginApprovalResolved!(makePluginResolved());
+      expect(deliver).toHaveBeenCalledTimes(0);
+    });
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Closes #113262

When an exec or plugin approval request is forwarded to a chat target and the operator resolves it, OpenClaw always posts a follow-up outcome echo (`Exec approval: <decision>` / plugin equivalent) to the forwarded target. In busy channels (for example Matrix) this resolved-outcome echo can dominate the bot's traffic, and there was no way to suppress it.

## Why This Change Was Made

The approval forwarder always delivered the resolved-outcome payload from `handleResolved` (`src/infra/exec-approval-forwarder.ts`). The fix inserts a single configuration decision between resolution and outbound delivery: the forwarding config now carries an optional `outcome` knob that decides whether the resolved follow-up is sent.

- The setting lives on the existing forwarding config (`approvals.exec` / `approvals.plugin`), next to `mode` and `targets`, and is shared between both approval kinds because they use the same delivery pipeline (`createApprovalStrategy`).
- Scope is explicitly **target-forwarding only**: native approval clients (Discord, Slack, Telegram, Matrix, QQ bot, Google Chat) deliver their own resolved outcomes through channel adapters and are intentionally unaffected. This is stated in the code contract comment and in the docs.
- The planned `"update"` mode (edit the original approval request message instead of sending a new echo) is deferred: it needs per-delivery message-id tracking and generic channel edit support.

## User Impact

- `approvals.exec.outcome` and `approvals.plugin.outcome` accept `"message"` (default) or `"none"`.
- Default behavior is unchanged: operators who do not touch the setting keep receiving the resolved-outcome echo.
- With `outcome: "none"`, the resolved-outcome follow-up is suppressed for forwarded approvals; the pending request message and the expiry notification are unaffected.
- Native approval clients (reaction shortcuts, DM cards, same-chat `/approve`) keep their own resolved-outcome behavior; the knob does not change them.

## Solution Details

- `src/config/types.approvals.ts`: new `ExecApprovalForwardingOutcome = "message" | "none"` type and optional `outcome` field on `ExecApprovalForwardingConfig` (shared by exec and plugin forwarding).
- `src/config/zod-schema.approvals.ts`: optional `outcome` union on the forwarding schema (strict schema, so invalid values are rejected at config parse time).
- `src/infra/exec-approval-forwarder.ts`: `handleResolved` returns early when the effective outcome is `"none"`, before resolved-outcome delivery; the pending-delivery path is untouched. A contract comment documents the target-forwarding-only scope.
- `docs/tools/exec-approvals-advanced.md`: documents `outcome` under "Approval forwarding to chat channels" and "Plugin approval forwarding", including default, values, and the native-client scope note.

## Evidence

Real-config harness against production code (no mocks of the forwarder or schema):

- Ran the production `createExecApprovalForwarder` with a recording delivery backend and the production `OpenClawSchema` config parser, driving `handleRequested` -> `handleResolved` (decision `allow-once`) for three configs: `outcome: "message"`, `outcome` unset (default), and `outcome: "none"`.
- Command: `node scripts/run-vitest.mjs src/infra/exec-approval-outcome-proof.test.ts` (temporary harness, removed after capture).
- Verdict JSON + redacted transcript:

```json
{
  "pr": "openclaw/openclaw#113357",
  "results": [
    { "scenario": "message", "pendingDelivered": true, "resolvedDeliveries": 1, "resolvedText": "✅ Exec approval allowed once. ID: req-1", "suppressed": false },
    { "scenario": "default", "pendingDelivered": true, "resolvedDeliveries": 1, "resolvedText": "✅ Exec approval allowed once. ID: req-1", "suppressed": false },
    { "scenario": "none",    "pendingDelivered": true, "resolvedDeliveries": 0, "resolvedText": null, "suppressed": true },
    { "scenario": "invalid-value", "schemaRejected": true }
  ]
}
```

```
=== scenario: outcome=message (parsed=message) ===
accepted=true
delivery[0] (pending): 🔒 Exec approval required...
resolved deliveries: 1
  -> ✅ Exec approval allowed once. ID: req-1

=== scenario: outcome=default (parsed=undefined) ===
accepted=true
delivery[0] (pending): 🔒 Exec approval required...
resolved deliveries: 1
  -> ✅ Exec approval allowed once. ID: req-1

=== scenario: outcome=none (parsed=none) ===
accepted=true
delivery[0] (pending): 🔒 Exec approval required...
resolved deliveries: 0

=== invalid outcome value rejected by schema: true ===
```

- Unit tests (kept in the PR): `src/infra/exec-approval-forwarder.test.ts` ("outcome" describe: default delivers, `none` suppresses) and `src/infra/plugin-approval-forwarder.test.ts` (`none` suppresses). Both suites pass locally (42 tests).
- IDs in the transcript are synthetic (`req-1`); no credentials or real targets are included.
