### PR TITLE
fix(snapshot): make SQLite publication crash recoverable

### DIFF
--- a/src/infra/sqlite-path-durability.test.ts
+++ b/src/infra/sqlite-path-durability.test.ts
@@ -105,6 +105,39 @@ describe("SQLite path durability", () => {
     expect(replaced).toBe(true);
   });
 
+  it.runIf(process.platform !== "win32")(
+    "rejects an existing ancestor replaced before the create callback",
+    async () => {
+      const directoryPath = await fs.realpath(
+        tempDirs.make("openclaw-sqlite-durable-existing-race-"),
+      );
+      const displacedPath = `${directoryPath}.displaced`;
+      const originalOpen = fs.open.bind(fs);
+      let replaced = false;
+      let createCalled = false;
+      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        if (!replaced && flags === "r" && path.resolve(String(filePath)) === directoryPath) {
+          replaced = true;
+          await fs.rename(directoryPath, displacedPath);
+          await fs.mkdir(directoryPath);
+        }
+        return await originalOpen(filePath, flags, mode);
+      });
+
+      await expect(
+        ensureDurableSqliteDirectory({
+          directoryPath,
+          label: "test directory",
+          create: async () => {
+            createCalled = true;
+          },
+        }),
+      ).rejects.toThrow(/handle changed during directory sync/u);
+      expect(replaced).toBe(true);
+      expect(createCalled).toBe(false);
+    },
+  );
+
   it("rejects a parent swapped out only for the directory sync", async () => {
     const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-parent-race-"));
     const directoryPath = path.join(rootPath, "one", "two");

--- a/src/infra/sqlite-path-durability.test.ts
+++ b/src/infra/sqlite-path-durability.test.ts
@@ -1,0 +1,181 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  ensureDurableSqliteDirectory,
+  syncSqliteDirectoryForDurability,
+} from "./sqlite-path-durability.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SQLite path durability", () => {
+  it.runIf(process.platform !== "win32")(
+    "syncs every newly created parent edge through the nearest existing ancestor",
+    async () => {
+      const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-parent-"));
+      const directoryPath = path.join(rootPath, "one", "two", "three");
+      const syncedPaths: string[] = [];
+      const originalOpen = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        const handle = await originalOpen(filePath, flags, mode);
+        if (flags === "r") {
+          const resolvedPath = path.resolve(String(filePath));
+          const originalSync = handle.sync.bind(handle);
+          vi.spyOn(handle, "sync").mockImplementation(async () => {
+            syncedPaths.push(resolvedPath);
+            await originalSync();
+          });
+        }
+        return handle;
+      });
+
+      const receipt = await ensureDurableSqliteDirectory({
+        directoryPath,
+        label: "test directory",
+        create: async (targetPath) => {
+          await fs.mkdir(targetPath, { recursive: true });
+        },
+      });
+
+      expect(receipt).toMatchObject({ path: directoryPath, parentSync: "synced" });
+      expect(syncedPaths).toEqual([
+        path.join(rootPath, "one", "two"),
+        path.join(rootPath, "one"),
+        rootPath,
+      ]);
+    },
+  );
+
+  it("fails when a newly created parent edge cannot be synced", async () => {
+    const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-failure-"));
+    const directoryPath = path.join(rootPath, "one", "two");
+    const originalOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      if (flags === "r" && path.resolve(String(filePath)) === rootPath) {
+        throw Object.assign(new Error("parent sync failed"), { code: "EIO" });
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
+
+    await expect(
+      ensureDurableSqliteDirectory({
+        directoryPath,
+        label: "test directory",
+        create: async (targetPath) => {
+          await fs.mkdir(targetPath, { recursive: true });
+        },
+      }),
+    ).rejects.toThrow(/could not sync created directory edge/u);
+    expect((await fs.stat(directoryPath)).isDirectory()).toBe(true);
+  });
+
+  it("detects a created directory replaced while its parent edge is synced", async () => {
+    const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-race-"));
+    const directoryPath = path.join(rootPath, "one", "two");
+    const displacedPath = path.join(rootPath, "displaced-two");
+    const originalOpen = fs.open.bind(fs);
+    let replaced = false;
+    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      if (
+        !replaced &&
+        flags === "r" &&
+        path.resolve(String(filePath)) === path.join(rootPath, "one")
+      ) {
+        replaced = true;
+        await fs.rename(directoryPath, displacedPath);
+        await fs.mkdir(directoryPath);
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
+
+    await expect(
+      ensureDurableSqliteDirectory({
+        directoryPath,
+        label: "test directory",
+        create: async (targetPath) => {
+          await fs.mkdir(targetPath, { recursive: true });
+        },
+      }),
+    ).rejects.toThrow(/changed during durable directory operation/u);
+    expect(replaced).toBe(true);
+  });
+
+  it("rejects a parent swapped out only for the directory sync", async () => {
+    const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-parent-race-"));
+    const directoryPath = path.join(rootPath, "one", "two");
+    const parentPath = path.dirname(directoryPath);
+    const displacedParentPath = path.join(rootPath, "owned-parent");
+    const replacementParentPath = path.join(rootPath, "replacement-parent");
+    const originalOpen = fs.open.bind(fs);
+    let swapped = false;
+    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      if (!swapped && flags === "r" && path.resolve(String(filePath)) === parentPath) {
+        swapped = true;
+        await fs.rename(parentPath, displacedParentPath);
+        await fs.mkdir(parentPath);
+        const handle = await originalOpen(filePath, flags, mode);
+        await fs.rename(parentPath, replacementParentPath);
+        await fs.rename(displacedParentPath, parentPath);
+        return handle;
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
+
+    await expect(
+      ensureDurableSqliteDirectory({
+        directoryPath,
+        label: "test directory",
+        create: async (targetPath) => {
+          await fs.mkdir(targetPath, { recursive: true });
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringMatching(/could not sync created directory edge/u),
+      cause: expect.objectContaining({
+        message: expect.stringMatching(/handle changed during directory sync/u),
+      }),
+    });
+    expect(swapped).toBe(true);
+    expect((await fs.stat(directoryPath)).isDirectory()).toBe(true);
+    expect((await fs.stat(replacementParentPath)).isDirectory()).toBe(true);
+  });
+
+  it.each(["EINVAL", "ENOSYS", "ENOTSUP"] as const)(
+    "propagates %s directory sync failures outside Windows",
+    async (code) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      const directoryPath = tempDirs.make("openclaw-sqlite-posix-sync-");
+      const originalOpen = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        const handle = await originalOpen(filePath, flags, mode);
+        vi.spyOn(handle, "sync").mockRejectedValue(Object.assign(new Error(code), { code }));
+        return handle;
+      });
+
+      await expect(syncSqliteDirectoryForDurability(directoryPath)).rejects.toMatchObject({
+        code,
+      });
+    },
+  );
+
+  it.each(["EACCES", "EINVAL", "EISDIR", "ENOSYS", "ENOTSUP", "EPERM"] as const)(
+    "reports %s directory sync failures as unsupported on Windows",
+    async (code) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const directoryPath = tempDirs.make("openclaw-sqlite-windows-sync-");
+      const originalOpen = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        const handle = await originalOpen(filePath, flags, mode);
+        vi.spyOn(handle, "sync").mockRejectedValue(Object.assign(new Error(code), { code }));
+        return handle;
+      });
+
+      await expect(syncSqliteDirectoryForDurability(directoryPath)).resolves.toBe("unsupported");
+    },
+  );
+});

--- a/src/infra/sqlite-path-durability.test.ts
+++ b/src/infra/sqlite-path-durability.test.ts
@@ -124,28 +124,27 @@ describe("SQLite path durability", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "repairs the pinned existing target and rejects a path replacement",
+    "rejects an expected existing target replaced before it can be pinned",
     async () => {
       const directoryPath = await fs.realpath(
         tempDirs.make("openclaw-sqlite-durable-existing-race-"),
       );
       const displacedPath = `${directoryPath}.displaced`;
+      const expectedIdentity = await fs.lstat(directoryPath);
       const originalOpen = fs.open.bind(fs);
       let replaced = false;
       let createCalled = false;
       vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        const handle = await originalOpen(filePath, flags, mode);
-        if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === directoryPath) {
-          const originalChmod = handle.chmod.bind(handle);
-          vi.spyOn(handle, "chmod").mockImplementation(async (targetMode) => {
-            replaced = true;
-            await fs.rename(directoryPath, displacedPath);
-            await fs.mkdir(directoryPath);
-            await fs.chmod(directoryPath, 0o755);
-            await originalChmod(targetMode);
-          });
+        if (
+          !replaced &&
+          isDirectoryOpen(flags) &&
+          path.resolve(String(filePath)) === directoryPath
+        ) {
+          replaced = true;
+          await fs.rename(directoryPath, displacedPath);
+          await fs.mkdir(directoryPath);
         }
-        return handle;
+        return await originalOpen(filePath, flags, mode);
       });
 
       try {
@@ -153,16 +152,14 @@ describe("SQLite path durability", () => {
           ensureDurableSqliteDirectory({
             directoryPath,
             label: "test directory",
-            repairExistingMode: 0o700,
+            expectedExistingIdentity: expectedIdentity,
             create: async () => {
               createCalled = true;
             },
           }),
-        ).rejects.toThrow(/changed during durable directory operation/u);
+        ).rejects.toThrow(/changed during directory sync/u);
         expect(replaced).toBe(true);
         expect(createCalled).toBe(false);
-        expect((await fs.stat(displacedPath)).mode & 0o777).toBe(0o700);
-        expect((await fs.stat(directoryPath)).mode & 0o777).not.toBe(0o700);
       } finally {
         await fs.rm(directoryPath, { recursive: true, force: true });
         await fs.rename(displacedPath, directoryPath).catch(() => undefined);

--- a/src/infra/sqlite-path-durability.test.ts
+++ b/src/infra/sqlite-path-durability.test.ts
@@ -1,7 +1,9 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { runExec } from "../process/exec.js";
 import {
   ensureDurableSqliteDirectory,
   syncSqliteDirectoryForDurability,
@@ -13,6 +15,12 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function isDirectoryOpen(flags: string | number): boolean {
+  return (
+    flags === "r" || (typeof flags === "number" && (flags & fsSync.constants.O_DIRECTORY) !== 0)
+  );
+}
+
 describe("SQLite path durability", () => {
   it.runIf(process.platform !== "win32")(
     "syncs every newly created parent edge through the nearest existing ancestor",
@@ -23,7 +31,7 @@ describe("SQLite path durability", () => {
       const originalOpen = fs.open.bind(fs);
       vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
         const handle = await originalOpen(filePath, flags, mode);
-        if (flags === "r") {
+        if (isDirectoryOpen(flags)) {
           const resolvedPath = path.resolve(String(filePath));
           const originalSync = handle.sync.bind(handle);
           vi.spyOn(handle, "sync").mockImplementation(async () => {
@@ -57,7 +65,7 @@ describe("SQLite path durability", () => {
     const originalOpen = fs.open.bind(fs);
     vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
       const handle = await originalOpen(filePath, flags, mode);
-      if (flags === "r" && path.resolve(String(filePath)) === rootPath) {
+      if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === rootPath) {
         vi.spyOn(handle, "sync").mockImplementation(async () => {
           throw Object.assign(new Error("parent sync failed"), { code: "EIO" });
         });
@@ -87,7 +95,10 @@ describe("SQLite path durability", () => {
       let replaced = false;
       vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
         const handle = await originalOpen(filePath, flags, mode);
-        if (flags === "r" && path.resolve(String(filePath)) === path.join(rootPath, "one")) {
+        if (
+          isDirectoryOpen(flags) &&
+          path.resolve(String(filePath)) === path.join(rootPath, "one")
+        ) {
           const originalSync = handle.sync.bind(handle);
           vi.spyOn(handle, "sync").mockImplementation(async () => {
             replaced = true;
@@ -123,7 +134,11 @@ describe("SQLite path durability", () => {
       let replaced = false;
       let createCalled = false;
       vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        if (!replaced && flags === "r" && path.resolve(String(filePath)) === directoryPath) {
+        if (
+          !replaced &&
+          isDirectoryOpen(flags) &&
+          path.resolve(String(filePath)) === directoryPath
+        ) {
           replaced = true;
           await fs.rename(directoryPath, displacedPath);
           await fs.mkdir(directoryPath);
@@ -146,6 +161,51 @@ describe("SQLite path durability", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "rejects a FIFO swapped into a directory path without blocking",
+    async () => {
+      const directoryPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-fifo-race-"));
+      const displacedPath = `${directoryPath}.displaced`;
+      const originalOpen = fs.open.bind(fs);
+      let replaced = false;
+      let createCalled = false;
+      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        if (
+          !replaced &&
+          isDirectoryOpen(flags) &&
+          path.resolve(String(filePath)) === directoryPath
+        ) {
+          expect(typeof flags).toBe("number");
+          const numericFlags = flags as number;
+          expect(numericFlags & fsSync.constants.O_DIRECTORY).toBe(fsSync.constants.O_DIRECTORY);
+          expect(numericFlags & fsSync.constants.O_NOFOLLOW).toBe(fsSync.constants.O_NOFOLLOW);
+          expect(numericFlags & fsSync.constants.O_NONBLOCK).toBe(fsSync.constants.O_NONBLOCK);
+          replaced = true;
+          await fs.rename(directoryPath, displacedPath);
+          await runExec("mkfifo", [directoryPath], { logOutput: false });
+        }
+        return await originalOpen(filePath, flags, mode);
+      });
+
+      try {
+        await expect(
+          ensureDurableSqliteDirectory({
+            directoryPath,
+            label: "test directory",
+            create: async () => {
+              createCalled = true;
+            },
+          }),
+        ).rejects.toBeDefined();
+        expect(replaced).toBe(true);
+        expect(createCalled).toBe(false);
+      } finally {
+        await fs.unlink(directoryPath).catch(() => undefined);
+        await fs.rename(displacedPath, directoryPath).catch(() => undefined);
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "syncs the pinned parent when its path is transiently replaced",
     async () => {
       const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-parent-race-"));
@@ -157,7 +217,7 @@ describe("SQLite path durability", () => {
       let swapped = false;
       vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
         const handle = await originalOpen(filePath, flags, mode);
-        if (flags === "r" && path.resolve(String(filePath)) === parentPath) {
+        if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === parentPath) {
           const originalSync = handle.sync.bind(handle);
           vi.spyOn(handle, "sync").mockImplementation(async () => {
             swapped = true;

--- a/src/infra/sqlite-path-durability.test.ts
+++ b/src/infra/sqlite-path-durability.test.ts
@@ -55,9 +55,13 @@ describe("SQLite path durability", () => {
     const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-failure-"));
     const directoryPath = path.join(rootPath, "one", "two");
     const originalOpen = fs.open.bind(fs);
+    let rootOpenCount = 0;
     vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
       if (flags === "r" && path.resolve(String(filePath)) === rootPath) {
-        throw Object.assign(new Error("parent sync failed"), { code: "EIO" });
+        rootOpenCount += 1;
+        if (rootOpenCount > 1) {
+          throw Object.assign(new Error("parent sync failed"), { code: "EIO" });
+        }
       }
       return await originalOpen(filePath, flags, mode);
     });

--- a/src/infra/sqlite-path-durability.test.ts
+++ b/src/infra/sqlite-path-durability.test.ts
@@ -124,7 +124,7 @@ describe("SQLite path durability", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "rejects an existing ancestor replaced before the create callback",
+    "repairs the pinned existing target and rejects a path replacement",
     async () => {
       const directoryPath = await fs.realpath(
         tempDirs.make("openclaw-sqlite-durable-existing-race-"),
@@ -134,29 +134,39 @@ describe("SQLite path durability", () => {
       let replaced = false;
       let createCalled = false;
       vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        if (
-          !replaced &&
-          isDirectoryOpen(flags) &&
-          path.resolve(String(filePath)) === directoryPath
-        ) {
-          replaced = true;
-          await fs.rename(directoryPath, displacedPath);
-          await fs.mkdir(directoryPath);
+        const handle = await originalOpen(filePath, flags, mode);
+        if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === directoryPath) {
+          const originalChmod = handle.chmod.bind(handle);
+          vi.spyOn(handle, "chmod").mockImplementation(async (targetMode) => {
+            replaced = true;
+            await fs.rename(directoryPath, displacedPath);
+            await fs.mkdir(directoryPath);
+            await fs.chmod(directoryPath, 0o755);
+            await originalChmod(targetMode);
+          });
         }
-        return await originalOpen(filePath, flags, mode);
+        return handle;
       });
 
-      await expect(
-        ensureDurableSqliteDirectory({
-          directoryPath,
-          label: "test directory",
-          create: async () => {
-            createCalled = true;
-          },
-        }),
-      ).rejects.toThrow(/handle changed during directory sync/u);
-      expect(replaced).toBe(true);
-      expect(createCalled).toBe(false);
+      try {
+        await expect(
+          ensureDurableSqliteDirectory({
+            directoryPath,
+            label: "test directory",
+            repairExistingMode: 0o700,
+            create: async () => {
+              createCalled = true;
+            },
+          }),
+        ).rejects.toThrow(/changed during durable directory operation/u);
+        expect(replaced).toBe(true);
+        expect(createCalled).toBe(false);
+        expect((await fs.stat(displacedPath)).mode & 0o777).toBe(0o700);
+        expect((await fs.stat(directoryPath)).mode & 0o777).not.toBe(0o700);
+      } finally {
+        await fs.rm(directoryPath, { recursive: true, force: true });
+        await fs.rename(displacedPath, directoryPath).catch(() => undefined);
+      }
     },
   );
 

--- a/src/infra/sqlite-path-durability.test.ts
+++ b/src/infra/sqlite-path-durability.test.ts
@@ -55,15 +55,14 @@ describe("SQLite path durability", () => {
     const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-failure-"));
     const directoryPath = path.join(rootPath, "one", "two");
     const originalOpen = fs.open.bind(fs);
-    let rootOpenCount = 0;
     vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const handle = await originalOpen(filePath, flags, mode);
       if (flags === "r" && path.resolve(String(filePath)) === rootPath) {
-        rootOpenCount += 1;
-        if (rootOpenCount > 1) {
+        vi.spyOn(handle, "sync").mockImplementation(async () => {
           throw Object.assign(new Error("parent sync failed"), { code: "EIO" });
-        }
+        });
       }
-      return await originalOpen(filePath, flags, mode);
+      return handle;
     });
 
     await expect(
@@ -78,36 +77,40 @@ describe("SQLite path durability", () => {
     expect((await fs.stat(directoryPath)).isDirectory()).toBe(true);
   });
 
-  it("detects a created directory replaced while its parent edge is synced", async () => {
-    const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-race-"));
-    const directoryPath = path.join(rootPath, "one", "two");
-    const displacedPath = path.join(rootPath, "displaced-two");
-    const originalOpen = fs.open.bind(fs);
-    let replaced = false;
-    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      if (
-        !replaced &&
-        flags === "r" &&
-        path.resolve(String(filePath)) === path.join(rootPath, "one")
-      ) {
-        replaced = true;
-        await fs.rename(directoryPath, displacedPath);
-        await fs.mkdir(directoryPath);
-      }
-      return await originalOpen(filePath, flags, mode);
-    });
+  it.runIf(process.platform !== "win32")(
+    "detects a created directory replaced while its parent edge is synced",
+    async () => {
+      const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-race-"));
+      const directoryPath = path.join(rootPath, "one", "two");
+      const displacedPath = path.join(rootPath, "displaced-two");
+      const originalOpen = fs.open.bind(fs);
+      let replaced = false;
+      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        const handle = await originalOpen(filePath, flags, mode);
+        if (flags === "r" && path.resolve(String(filePath)) === path.join(rootPath, "one")) {
+          const originalSync = handle.sync.bind(handle);
+          vi.spyOn(handle, "sync").mockImplementation(async () => {
+            replaced = true;
+            await fs.rename(directoryPath, displacedPath);
+            await fs.mkdir(directoryPath);
+            await originalSync();
+          });
+        }
+        return handle;
+      });
 
-    await expect(
-      ensureDurableSqliteDirectory({
-        directoryPath,
-        label: "test directory",
-        create: async (targetPath) => {
-          await fs.mkdir(targetPath, { recursive: true });
-        },
-      }),
-    ).rejects.toThrow(/changed during durable directory operation/u);
-    expect(replaced).toBe(true);
-  });
+      await expect(
+        ensureDurableSqliteDirectory({
+          directoryPath,
+          label: "test directory",
+          create: async (targetPath) => {
+            await fs.mkdir(targetPath, { recursive: true });
+          },
+        }),
+      ).rejects.toThrow(/changed during durable directory operation/u);
+      expect(replaced).toBe(true);
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "rejects an existing ancestor replaced before the create callback",
@@ -142,45 +145,46 @@ describe("SQLite path durability", () => {
     },
   );
 
-  it("rejects a parent swapped out only for the directory sync", async () => {
-    const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-parent-race-"));
-    const directoryPath = path.join(rootPath, "one", "two");
-    const parentPath = path.dirname(directoryPath);
-    const displacedParentPath = path.join(rootPath, "owned-parent");
-    const replacementParentPath = path.join(rootPath, "replacement-parent");
-    const originalOpen = fs.open.bind(fs);
-    let swapped = false;
-    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      if (!swapped && flags === "r" && path.resolve(String(filePath)) === parentPath) {
-        swapped = true;
-        await fs.rename(parentPath, displacedParentPath);
-        await fs.mkdir(parentPath);
+  it.runIf(process.platform !== "win32")(
+    "syncs the pinned parent when its path is transiently replaced",
+    async () => {
+      const rootPath = await fs.realpath(tempDirs.make("openclaw-sqlite-durable-parent-race-"));
+      const directoryPath = path.join(rootPath, "one", "two");
+      const parentPath = path.dirname(directoryPath);
+      const displacedParentPath = path.join(rootPath, "owned-parent");
+      const replacementParentPath = path.join(rootPath, "replacement-parent");
+      const originalOpen = fs.open.bind(fs);
+      let swapped = false;
+      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
         const handle = await originalOpen(filePath, flags, mode);
-        await fs.rename(parentPath, replacementParentPath);
-        await fs.rename(displacedParentPath, parentPath);
+        if (flags === "r" && path.resolve(String(filePath)) === parentPath) {
+          const originalSync = handle.sync.bind(handle);
+          vi.spyOn(handle, "sync").mockImplementation(async () => {
+            swapped = true;
+            await fs.rename(parentPath, displacedParentPath);
+            await fs.mkdir(parentPath);
+            await originalSync();
+            await fs.rename(parentPath, replacementParentPath);
+            await fs.rename(displacedParentPath, parentPath);
+          });
+        }
         return handle;
-      }
-      return await originalOpen(filePath, flags, mode);
-    });
+      });
 
-    await expect(
-      ensureDurableSqliteDirectory({
-        directoryPath,
-        label: "test directory",
-        create: async (targetPath) => {
-          await fs.mkdir(targetPath, { recursive: true });
-        },
-      }),
-    ).rejects.toMatchObject({
-      message: expect.stringMatching(/could not sync created directory edge/u),
-      cause: expect.objectContaining({
-        message: expect.stringMatching(/handle changed during directory sync/u),
-      }),
-    });
-    expect(swapped).toBe(true);
-    expect((await fs.stat(directoryPath)).isDirectory()).toBe(true);
-    expect((await fs.stat(replacementParentPath)).isDirectory()).toBe(true);
-  });
+      await expect(
+        ensureDurableSqliteDirectory({
+          directoryPath,
+          label: "test directory",
+          create: async (targetPath) => {
+            await fs.mkdir(targetPath, { recursive: true });
+          },
+        }),
+      ).resolves.toMatchObject({ path: directoryPath, parentSync: "synced" });
+      expect(swapped).toBe(true);
+      expect((await fs.stat(directoryPath)).isDirectory()).toBe(true);
+      expect((await fs.stat(replacementParentPath)).isDirectory()).toBe(true);
+    },
+  );
 
   it.each(["EINVAL", "ENOSYS", "ENOTSUP"] as const)(
     "propagates %s directory sync failures outside Windows",

--- a/src/infra/sqlite-path-durability.test.ts
+++ b/src/infra/sqlite-path-durability.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function isDirectoryOpen(flags: string | number): boolean {
+function isDirectoryOpen(flags: string | number | undefined): boolean {
   return (
     flags === "r" || (typeof flags === "number" && (flags & fsSync.constants.O_DIRECTORY) !== 0)
   );

--- a/src/infra/sqlite-path-durability.ts
+++ b/src/infra/sqlite-path-durability.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from "node:fs";
 import type { Stats } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
@@ -18,6 +19,21 @@ type OpenSqliteDirectoryReceipt = {
   handle: FileHandle;
   receipt: SqlitePathIdentityReceipt;
 };
+
+function sqliteDirectoryOpenFlags(): string | number {
+  if (process.platform === "win32") {
+    return "r";
+  }
+  // The identity checks close ordinary rename races after open. These flags
+  // also prevent a substituted symlink or FIFO from redirecting or blocking it.
+  return (
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK
+  );
+}
+
+async function openDirectoryHandle(directoryPath: string): Promise<FileHandle> {
+  return await fs.open(directoryPath, sqliteDirectoryOpenFlags());
+}
 
 function isWindowsDirectorySyncUnsupported(error: unknown): boolean {
   if (process.platform !== "win32") {
@@ -66,11 +82,11 @@ async function assertOpenDirectoryCurrent(
   await assertDirectoryReceiptCurrent(receipt, label);
 }
 
-async function openCurrentDirectory(
+export async function openSqliteDirectoryForDurability(
   receipt: SqlitePathIdentityReceipt,
   label: string,
 ): Promise<FileHandle> {
-  const handle = await fs.open(receipt.path, "r");
+  const handle = await openDirectoryHandle(receipt.path);
   try {
     await assertOpenDirectoryCurrent(handle, receipt, label);
     return handle;
@@ -84,7 +100,7 @@ async function openDirectoryPath(
   directoryPath: string,
   label: string,
 ): Promise<OpenSqliteDirectoryReceipt> {
-  const handle = await fs.open(directoryPath, "r");
+  const handle = await openDirectoryHandle(directoryPath);
   try {
     const identity = await handle.stat();
     const receipt = { path: directoryPath, identity };
@@ -128,7 +144,7 @@ export async function syncSqliteDirectoryForDurability(
 
   let handle: FileHandle;
   try {
-    handle = await fs.open(receipt.path, "r");
+    handle = await openDirectoryHandle(receipt.path);
   } catch (error) {
     if (!isWindowsDirectorySyncUnsupported(error)) {
       throw error;
@@ -176,7 +192,7 @@ export async function ensureDurableSqliteDirectory(params: {
   const ancestor = await findExistingAncestorReceipt(directoryPath, params.label);
   // Keep the preexisting anchor open while the creator runs. Otherwise a
   // remove/recreate race can recycle its inode and hide an unsynced new edge.
-  const ancestorHandle = await openCurrentDirectory(ancestor, params.label);
+  const ancestorHandle = await openSqliteDirectoryForDurability(ancestor, params.label);
   const openedReceipts: OpenSqliteDirectoryReceipt[] = [
     { handle: ancestorHandle, receipt: ancestor },
   ];

--- a/src/infra/sqlite-path-durability.ts
+++ b/src/infra/sqlite-path-durability.ts
@@ -14,6 +14,11 @@ export type DurableSqliteDirectoryReceipt = SqlitePathIdentityReceipt & {
   parentSync: SqliteDirectorySyncOutcome | "not-needed";
 };
 
+type OpenSqliteDirectoryReceipt = {
+  handle: FileHandle;
+  receipt: SqlitePathIdentityReceipt;
+};
+
 function isWindowsDirectorySyncUnsupported(error: unknown): boolean {
   if (process.platform !== "win32") {
     return false;
@@ -75,6 +80,40 @@ async function openCurrentDirectory(
   }
 }
 
+async function openDirectoryPath(
+  directoryPath: string,
+  label: string,
+): Promise<OpenSqliteDirectoryReceipt> {
+  const handle = await fs.open(directoryPath, "r");
+  try {
+    const identity = await handle.stat();
+    const receipt = { path: directoryPath, identity };
+    await assertOpenDirectoryCurrent(handle, receipt, label);
+    return { handle, receipt };
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function syncOpenDirectoryForDurability(
+  handle: FileHandle,
+  receipt: SqlitePathIdentityReceipt,
+): Promise<SqliteDirectorySyncOutcome> {
+  await assertOpenDirectoryCurrent(handle, receipt, "SQLite durability directory");
+  try {
+    await handle.sync();
+  } catch (error) {
+    if (!isWindowsDirectorySyncUnsupported(error)) {
+      throw error;
+    }
+    await assertOpenDirectoryCurrent(handle, receipt, "SQLite durability directory");
+    return "unsupported";
+  }
+  await assertOpenDirectoryCurrent(handle, receipt, "SQLite durability directory");
+  return "synced";
+}
+
 export async function syncSqliteDirectoryForDurability(
   directory: string | SqlitePathIdentityReceipt,
 ): Promise<SqliteDirectorySyncOutcome> {
@@ -99,18 +138,7 @@ export async function syncSqliteDirectoryForDurability(
   }
 
   try {
-    await assertOpenDirectoryCurrent(handle, receipt, "SQLite durability directory");
-    try {
-      await handle.sync();
-    } catch (error) {
-      if (!isWindowsDirectorySyncUnsupported(error)) {
-        throw error;
-      }
-      await assertOpenDirectoryCurrent(handle, receipt, "SQLite durability directory");
-      return "unsupported";
-    }
-    await assertOpenDirectoryCurrent(handle, receipt, "SQLite durability directory");
-    return "synced";
+    return await syncOpenDirectoryForDurability(handle, receipt);
   } finally {
     await handle.close();
   }
@@ -149,34 +177,34 @@ export async function ensureDurableSqliteDirectory(params: {
   // Keep the preexisting anchor open while the creator runs. Otherwise a
   // remove/recreate race can recycle its inode and hide an unsynced new edge.
   const ancestorHandle = await openCurrentDirectory(ancestor, params.label);
+  const openedReceipts: OpenSqliteDirectoryReceipt[] = [
+    { handle: ancestorHandle, receipt: ancestor },
+  ];
   try {
     await assertOpenDirectoryCurrent(ancestorHandle, ancestor, params.label);
     await params.create(directoryPath);
     await assertOpenDirectoryCurrent(ancestorHandle, ancestor, params.label);
 
-    const receipts = [ancestor];
     let currentPath = ancestor.path;
     for (const segment of path
       .relative(ancestor.path, directoryPath)
       .split(path.sep)
       .filter(Boolean)) {
       currentPath = path.join(currentPath, segment);
-      const identity = await fs.lstat(currentPath);
-      assertDirectory(identity, currentPath, params.label);
-      receipts.push({ path: currentPath, identity });
+      openedReceipts.push(await openDirectoryPath(currentPath, params.label));
     }
 
     let parentSync: DurableSqliteDirectoryReceipt["parentSync"] = "not-needed";
-    for (let index = receipts.length - 1; index > 0; index -= 1) {
-      const parent = receipts[index - 1];
-      const child = receipts[index];
+    for (let index = openedReceipts.length - 1; index > 0; index -= 1) {
+      const parent = openedReceipts[index - 1];
+      const child = openedReceipts[index];
       if (!parent || !child) {
         throw new Error(`${params.label} directory receipt chain is incomplete.`);
       }
-      await assertDirectoryReceiptCurrent(parent, params.label);
-      await assertDirectoryReceiptCurrent(child, params.label);
+      await assertOpenDirectoryCurrent(parent.handle, parent.receipt, params.label);
+      await assertOpenDirectoryCurrent(child.handle, child.receipt, params.label);
       try {
-        const outcome = await syncSqliteDirectoryForDurability(parent);
+        const outcome = await syncOpenDirectoryForDurability(parent.handle, parent.receipt);
         if (outcome === "unsupported") {
           parentSync = "unsupported";
         } else if (parentSync === "not-needed") {
@@ -184,15 +212,15 @@ export async function ensureDurableSqliteDirectory(params: {
         }
       } catch (error) {
         throw new Error(
-          `${params.label} could not sync created directory edge ${child.path} through ${parent.path}`,
+          `${params.label} could not sync created directory edge ${child.receipt.path} through ${parent.receipt.path}`,
           { cause: error },
         );
       }
-      await assertDirectoryReceiptCurrent(parent, params.label);
-      await assertDirectoryReceiptCurrent(child, params.label);
+      await assertOpenDirectoryCurrent(parent.handle, parent.receipt, params.label);
+      await assertOpenDirectoryCurrent(child.handle, child.receipt, params.label);
     }
 
-    const finalReceipt = receipts.at(-1);
+    const finalReceipt = openedReceipts.at(-1)?.receipt;
     if (!finalReceipt) {
       throw new Error(`${params.label} directory receipt is missing.`);
     }
@@ -200,6 +228,6 @@ export async function ensureDurableSqliteDirectory(params: {
     await assertDirectoryReceiptCurrent(finalReceipt, params.label);
     return { ...finalReceipt, parentSync };
   } finally {
-    await ancestorHandle.close();
+    await Promise.all(openedReceipts.toReversed().map(({ handle }) => handle.close()));
   }
 }

--- a/src/infra/sqlite-path-durability.ts
+++ b/src/infra/sqlite-path-durability.ts
@@ -4,7 +4,7 @@ import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 
-export type SqliteDirectorySyncOutcome = "synced" | "unsupported";
+type SqliteDirectorySyncOutcome = "synced" | "unsupported";
 
 export type SqlitePathIdentityReceipt = {
   path: string;

--- a/src/infra/sqlite-path-durability.ts
+++ b/src/infra/sqlite-path-durability.ts
@@ -61,6 +61,20 @@ async function assertOpenDirectoryCurrent(
   await assertDirectoryReceiptCurrent(receipt, label);
 }
 
+async function openCurrentDirectory(
+  receipt: SqlitePathIdentityReceipt,
+  label: string,
+): Promise<FileHandle> {
+  const handle = await fs.open(receipt.path, "r");
+  try {
+    await assertOpenDirectoryCurrent(handle, receipt, label);
+    return handle;
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    throw error;
+  }
+}
+
 export async function syncSqliteDirectoryForDurability(
   directory: string | SqlitePathIdentityReceipt,
 ): Promise<SqliteDirectorySyncOutcome> {
@@ -132,50 +146,60 @@ export async function ensureDurableSqliteDirectory(params: {
 }): Promise<DurableSqliteDirectoryReceipt> {
   const directoryPath = path.resolve(params.directoryPath);
   const ancestor = await findExistingAncestorReceipt(directoryPath, params.label);
-  await params.create(directoryPath);
+  // Keep the preexisting anchor open while the creator runs. Otherwise a
+  // remove/recreate race can recycle its inode and hide an unsynced new edge.
+  const ancestorHandle = await openCurrentDirectory(ancestor, params.label);
+  try {
+    await assertOpenDirectoryCurrent(ancestorHandle, ancestor, params.label);
+    await params.create(directoryPath);
+    await assertOpenDirectoryCurrent(ancestorHandle, ancestor, params.label);
 
-  const receipts = [ancestor];
-  let currentPath = ancestor.path;
-  for (const segment of path
-    .relative(ancestor.path, directoryPath)
-    .split(path.sep)
-    .filter(Boolean)) {
-    currentPath = path.join(currentPath, segment);
-    const identity = await fs.lstat(currentPath);
-    assertDirectory(identity, currentPath, params.label);
-    receipts.push({ path: currentPath, identity });
-  }
-
-  let parentSync: DurableSqliteDirectoryReceipt["parentSync"] = "not-needed";
-  for (let index = receipts.length - 1; index > 0; index -= 1) {
-    const parent = receipts[index - 1];
-    const child = receipts[index];
-    if (!parent || !child) {
-      throw new Error(`${params.label} directory receipt chain is incomplete.`);
+    const receipts = [ancestor];
+    let currentPath = ancestor.path;
+    for (const segment of path
+      .relative(ancestor.path, directoryPath)
+      .split(path.sep)
+      .filter(Boolean)) {
+      currentPath = path.join(currentPath, segment);
+      const identity = await fs.lstat(currentPath);
+      assertDirectory(identity, currentPath, params.label);
+      receipts.push({ path: currentPath, identity });
     }
-    await assertDirectoryReceiptCurrent(parent, params.label);
-    await assertDirectoryReceiptCurrent(child, params.label);
-    try {
-      const outcome = await syncSqliteDirectoryForDurability(parent);
-      if (outcome === "unsupported") {
-        parentSync = "unsupported";
-      } else if (parentSync === "not-needed") {
-        parentSync = "synced";
+
+    let parentSync: DurableSqliteDirectoryReceipt["parentSync"] = "not-needed";
+    for (let index = receipts.length - 1; index > 0; index -= 1) {
+      const parent = receipts[index - 1];
+      const child = receipts[index];
+      if (!parent || !child) {
+        throw new Error(`${params.label} directory receipt chain is incomplete.`);
       }
-    } catch (error) {
-      throw new Error(
-        `${params.label} could not sync created directory edge ${child.path} through ${parent.path}`,
-        { cause: error },
-      );
+      await assertDirectoryReceiptCurrent(parent, params.label);
+      await assertDirectoryReceiptCurrent(child, params.label);
+      try {
+        const outcome = await syncSqliteDirectoryForDurability(parent);
+        if (outcome === "unsupported") {
+          parentSync = "unsupported";
+        } else if (parentSync === "not-needed") {
+          parentSync = "synced";
+        }
+      } catch (error) {
+        throw new Error(
+          `${params.label} could not sync created directory edge ${child.path} through ${parent.path}`,
+          { cause: error },
+        );
+      }
+      await assertDirectoryReceiptCurrent(parent, params.label);
+      await assertDirectoryReceiptCurrent(child, params.label);
     }
-    await assertDirectoryReceiptCurrent(parent, params.label);
-    await assertDirectoryReceiptCurrent(child, params.label);
-  }
 
-  const finalReceipt = receipts.at(-1);
-  if (!finalReceipt) {
-    throw new Error(`${params.label} directory receipt is missing.`);
+    const finalReceipt = receipts.at(-1);
+    if (!finalReceipt) {
+      throw new Error(`${params.label} directory receipt is missing.`);
+    }
+    await assertOpenDirectoryCurrent(ancestorHandle, ancestor, params.label);
+    await assertDirectoryReceiptCurrent(finalReceipt, params.label);
+    return { ...finalReceipt, parentSync };
+  } finally {
+    await ancestorHandle.close();
   }
-  await assertDirectoryReceiptCurrent(finalReceipt, params.label);
-  return { ...finalReceipt, parentSync };
 }

--- a/src/infra/sqlite-path-durability.ts
+++ b/src/infra/sqlite-path-durability.ts
@@ -1,0 +1,181 @@
+import { type Stats } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { sameFileIdentity } from "./fs-safe-advanced.js";
+
+export type SqliteDirectorySyncOutcome = "synced" | "unsupported";
+
+export type SqlitePathIdentityReceipt = {
+  path: string;
+  identity: Stats;
+};
+
+export type DurableSqliteDirectoryReceipt = SqlitePathIdentityReceipt & {
+  parentSync: SqliteDirectorySyncOutcome | "not-needed";
+};
+
+function isWindowsDirectorySyncUnsupported(error: unknown): boolean {
+  if (process.platform !== "win32") {
+    return false;
+  }
+  // Node can open Windows directories for metadata, but directory handles are
+  // not guaranteed to support FlushFileBuffers. Keep real I/O failures strict.
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    code === "EACCES" ||
+    code === "EINVAL" ||
+    code === "EISDIR" ||
+    code === "ENOSYS" ||
+    code === "ENOTSUP" ||
+    code === "EPERM"
+  );
+}
+
+function assertDirectory(identity: Stats, pathname: string, label: string): void {
+  if (identity.isSymbolicLink() || !identity.isDirectory()) {
+    throw new Error(`${label} must be a real directory: ${pathname}`);
+  }
+}
+
+async function assertDirectoryReceiptCurrent(
+  receipt: SqlitePathIdentityReceipt,
+  label: string,
+): Promise<void> {
+  const currentIdentity = await fs.lstat(receipt.path);
+  assertDirectory(currentIdentity, receipt.path, label);
+  if (!sameFileIdentity(receipt.identity, currentIdentity)) {
+    throw new Error(`${label} changed during durable directory operation: ${receipt.path}`);
+  }
+}
+
+async function assertOpenDirectoryCurrent(
+  handle: FileHandle,
+  receipt: SqlitePathIdentityReceipt,
+  label: string,
+): Promise<void> {
+  const openedIdentity = await handle.stat();
+  assertDirectory(openedIdentity, receipt.path, label);
+  if (!sameFileIdentity(receipt.identity, openedIdentity)) {
+    throw new Error(`${label} handle changed during directory sync: ${receipt.path}`);
+  }
+  await assertDirectoryReceiptCurrent(receipt, label);
+}
+
+export async function syncSqliteDirectoryForDurability(
+  directory: string | SqlitePathIdentityReceipt,
+): Promise<SqliteDirectorySyncOutcome> {
+  let receipt: SqlitePathIdentityReceipt;
+  if (typeof directory === "string") {
+    const directoryPath = path.resolve(directory);
+    receipt = { path: directoryPath, identity: await fs.lstat(directoryPath) };
+  } else {
+    receipt = { path: path.resolve(directory.path), identity: directory.identity };
+  }
+  await assertDirectoryReceiptCurrent(receipt, "SQLite durability directory");
+
+  let handle: FileHandle;
+  try {
+    handle = await fs.open(receipt.path, "r");
+  } catch (error) {
+    if (!isWindowsDirectorySyncUnsupported(error)) {
+      throw error;
+    }
+    await assertDirectoryReceiptCurrent(receipt, "SQLite durability directory");
+    return "unsupported";
+  }
+
+  try {
+    await assertOpenDirectoryCurrent(handle, receipt, "SQLite durability directory");
+    try {
+      await handle.sync();
+    } catch (error) {
+      if (!isWindowsDirectorySyncUnsupported(error)) {
+        throw error;
+      }
+      await assertOpenDirectoryCurrent(handle, receipt, "SQLite durability directory");
+      return "unsupported";
+    }
+    await assertOpenDirectoryCurrent(handle, receipt, "SQLite durability directory");
+    return "synced";
+  } finally {
+    await handle.close();
+  }
+}
+
+async function findExistingAncestorReceipt(
+  targetPath: string,
+  label: string,
+): Promise<SqlitePathIdentityReceipt> {
+  let currentPath = path.resolve(targetPath);
+  while (true) {
+    try {
+      const identity = await fs.lstat(currentPath);
+      assertDirectory(identity, currentPath, label);
+      return { path: currentPath, identity };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) {
+      throw new Error(`${label} has no existing directory ancestor: ${targetPath}`);
+    }
+    currentPath = parentPath;
+  }
+}
+
+export async function ensureDurableSqliteDirectory(params: {
+  directoryPath: string;
+  label: string;
+  create: (directoryPath: string) => Promise<void>;
+}): Promise<DurableSqliteDirectoryReceipt> {
+  const directoryPath = path.resolve(params.directoryPath);
+  const ancestor = await findExistingAncestorReceipt(directoryPath, params.label);
+  await params.create(directoryPath);
+
+  const receipts = [ancestor];
+  let currentPath = ancestor.path;
+  for (const segment of path
+    .relative(ancestor.path, directoryPath)
+    .split(path.sep)
+    .filter(Boolean)) {
+    currentPath = path.join(currentPath, segment);
+    const identity = await fs.lstat(currentPath);
+    assertDirectory(identity, currentPath, params.label);
+    receipts.push({ path: currentPath, identity });
+  }
+
+  let parentSync: DurableSqliteDirectoryReceipt["parentSync"] = "not-needed";
+  for (let index = receipts.length - 1; index > 0; index -= 1) {
+    const parent = receipts[index - 1];
+    const child = receipts[index];
+    if (!parent || !child) {
+      throw new Error(`${params.label} directory receipt chain is incomplete.`);
+    }
+    await assertDirectoryReceiptCurrent(parent, params.label);
+    await assertDirectoryReceiptCurrent(child, params.label);
+    try {
+      const outcome = await syncSqliteDirectoryForDurability(parent);
+      if (outcome === "unsupported") {
+        parentSync = "unsupported";
+      } else if (parentSync === "not-needed") {
+        parentSync = "synced";
+      }
+    } catch (error) {
+      throw new Error(
+        `${params.label} could not sync created directory edge ${child.path} through ${parent.path}`,
+        { cause: error },
+      );
+    }
+    await assertDirectoryReceiptCurrent(parent, params.label);
+    await assertDirectoryReceiptCurrent(child, params.label);
+  }
+
+  const finalReceipt = receipts.at(-1);
+  if (!finalReceipt) {
+    throw new Error(`${params.label} directory receipt is missing.`);
+  }
+  await assertDirectoryReceiptCurrent(finalReceipt, params.label);
+  return { ...finalReceipt, parentSync };
+}

--- a/src/infra/sqlite-path-durability.ts
+++ b/src/infra/sqlite-path-durability.ts
@@ -1,4 +1,4 @@
-import { type Stats } from "node:fs";
+import type { Stats } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { sameFileIdentity } from "./fs-safe-advanced.js";

--- a/src/infra/sqlite-path-durability.ts
+++ b/src/infra/sqlite-path-durability.ts
@@ -20,6 +20,9 @@ type OpenSqliteDirectoryReceipt = {
   receipt: SqlitePathIdentityReceipt;
 };
 
+const LINUX_O_PATH = 0x20_0000;
+const DARWIN_O_SEARCH = 0x4010_0000;
+
 function sqliteDirectoryOpenFlags(): string | number {
   if (process.platform === "win32") {
     return "r";
@@ -33,6 +36,16 @@ function sqliteDirectoryOpenFlags(): string | number {
 
 async function openDirectoryHandle(directoryPath: string): Promise<FileHandle> {
   return await fs.open(directoryPath, sqliteDirectoryOpenFlags());
+}
+
+function sqliteDirectoryModeRepairFlags(): number | undefined {
+  if (process.platform === "linux") {
+    return LINUX_O_PATH | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK;
+  }
+  if (process.platform === "darwin") {
+    return DARWIN_O_SEARCH | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK;
+  }
+  return undefined;
 }
 
 function isWindowsDirectorySyncUnsupported(error: unknown): boolean {
@@ -85,10 +98,42 @@ async function assertOpenDirectoryCurrent(
 export async function openSqliteDirectoryForDurability(
   receipt: SqlitePathIdentityReceipt,
   label: string,
+  options: { mode?: number } = {},
 ): Promise<FileHandle> {
-  const handle = await openDirectoryHandle(receipt.path);
+  let handle: FileHandle;
+  try {
+    handle = await openDirectoryHandle(receipt.path);
+  } catch (error) {
+    const repairFlags = sqliteDirectoryModeRepairFlags();
+    if (
+      (error as NodeJS.ErrnoException).code !== "EACCES" ||
+      options.mode === undefined ||
+      repairFlags === undefined
+    ) {
+      throw error;
+    }
+    const repairHandle = await fs.open(receipt.path, repairFlags);
+    try {
+      await assertOpenDirectoryCurrent(repairHandle, receipt, label);
+      if (process.platform === "linux") {
+        // O_PATH pins an unreadable Linux directory but cannot be fchmod'd.
+        // /proc resolves this descriptor to the pinned inode, not the pathname.
+        await fs.chmod(`/proc/self/fd/${repairHandle.fd}`, options.mode);
+      } else {
+        await repairHandle.chmod(options.mode);
+      }
+      await assertOpenDirectoryCurrent(repairHandle, receipt, label);
+    } finally {
+      await repairHandle.close();
+    }
+    handle = await openDirectoryHandle(receipt.path);
+  }
   try {
     await assertOpenDirectoryCurrent(handle, receipt, label);
+    if (options.mode !== undefined && process.platform !== "win32") {
+      await handle.chmod(options.mode);
+      await assertOpenDirectoryCurrent(handle, receipt, label);
+    }
     return handle;
   } catch (error) {
     await handle.close().catch(() => undefined);
@@ -186,19 +231,25 @@ async function findExistingAncestorReceipt(
 export async function ensureDurableSqliteDirectory(params: {
   directoryPath: string;
   label: string;
+  repairExistingMode?: number;
   create: (directoryPath: string) => Promise<void>;
 }): Promise<DurableSqliteDirectoryReceipt> {
   const directoryPath = path.resolve(params.directoryPath);
   const ancestor = await findExistingAncestorReceipt(directoryPath, params.label);
+  const targetExists = ancestor.path === directoryPath;
   // Keep the preexisting anchor open while the creator runs. Otherwise a
   // remove/recreate race can recycle its inode and hide an unsynced new edge.
-  const ancestorHandle = await openSqliteDirectoryForDurability(ancestor, params.label);
+  const ancestorHandle = await openSqliteDirectoryForDurability(ancestor, params.label, {
+    mode: targetExists ? params.repairExistingMode : undefined,
+  });
   const openedReceipts: OpenSqliteDirectoryReceipt[] = [
     { handle: ancestorHandle, receipt: ancestor },
   ];
   try {
     await assertOpenDirectoryCurrent(ancestorHandle, ancestor, params.label);
-    await params.create(directoryPath);
+    if (!targetExists) {
+      await params.create(directoryPath);
+    }
     await assertOpenDirectoryCurrent(ancestorHandle, ancestor, params.label);
 
     let currentPath = ancestor.path;

--- a/src/infra/sqlite-path-durability.ts
+++ b/src/infra/sqlite-path-durability.ts
@@ -20,9 +20,6 @@ type OpenSqliteDirectoryReceipt = {
   receipt: SqlitePathIdentityReceipt;
 };
 
-const LINUX_O_PATH = 0x20_0000;
-const DARWIN_O_SEARCH = 0x4010_0000;
-
 function sqliteDirectoryOpenFlags(): string | number {
   if (process.platform === "win32") {
     return "r";
@@ -36,16 +33,6 @@ function sqliteDirectoryOpenFlags(): string | number {
 
 async function openDirectoryHandle(directoryPath: string): Promise<FileHandle> {
   return await fs.open(directoryPath, sqliteDirectoryOpenFlags());
-}
-
-function sqliteDirectoryModeRepairFlags(): number | undefined {
-  if (process.platform === "linux") {
-    return LINUX_O_PATH | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK;
-  }
-  if (process.platform === "darwin") {
-    return DARWIN_O_SEARCH | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK;
-  }
-  return undefined;
 }
 
 function isWindowsDirectorySyncUnsupported(error: unknown): boolean {
@@ -98,42 +85,10 @@ async function assertOpenDirectoryCurrent(
 export async function openSqliteDirectoryForDurability(
   receipt: SqlitePathIdentityReceipt,
   label: string,
-  options: { mode?: number } = {},
 ): Promise<FileHandle> {
-  let handle: FileHandle;
-  try {
-    handle = await openDirectoryHandle(receipt.path);
-  } catch (error) {
-    const repairFlags = sqliteDirectoryModeRepairFlags();
-    if (
-      (error as NodeJS.ErrnoException).code !== "EACCES" ||
-      options.mode === undefined ||
-      repairFlags === undefined
-    ) {
-      throw error;
-    }
-    const repairHandle = await fs.open(receipt.path, repairFlags);
-    try {
-      await assertOpenDirectoryCurrent(repairHandle, receipt, label);
-      if (process.platform === "linux") {
-        // O_PATH pins an unreadable Linux directory but cannot be fchmod'd.
-        // /proc resolves this descriptor to the pinned inode, not the pathname.
-        await fs.chmod(`/proc/self/fd/${repairHandle.fd}`, options.mode);
-      } else {
-        await repairHandle.chmod(options.mode);
-      }
-      await assertOpenDirectoryCurrent(repairHandle, receipt, label);
-    } finally {
-      await repairHandle.close();
-    }
-    handle = await openDirectoryHandle(receipt.path);
-  }
+  const handle = await openDirectoryHandle(receipt.path);
   try {
     await assertOpenDirectoryCurrent(handle, receipt, label);
-    if (options.mode !== undefined && process.platform !== "win32") {
-      await handle.chmod(options.mode);
-      await assertOpenDirectoryCurrent(handle, receipt, label);
-    }
     return handle;
   } catch (error) {
     await handle.close().catch(() => undefined);
@@ -231,17 +186,21 @@ async function findExistingAncestorReceipt(
 export async function ensureDurableSqliteDirectory(params: {
   directoryPath: string;
   label: string;
-  repairExistingMode?: number;
+  expectedExistingIdentity?: Stats;
   create: (directoryPath: string) => Promise<void>;
 }): Promise<DurableSqliteDirectoryReceipt> {
   const directoryPath = path.resolve(params.directoryPath);
   const ancestor = await findExistingAncestorReceipt(directoryPath, params.label);
   const targetExists = ancestor.path === directoryPath;
+  if (
+    params.expectedExistingIdentity &&
+    (!targetExists || !sameFileIdentity(params.expectedExistingIdentity, ancestor.identity))
+  ) {
+    throw new Error(`${params.label} changed before durable directory pinning: ${directoryPath}`);
+  }
   // Keep the preexisting anchor open while the creator runs. Otherwise a
   // remove/recreate race can recycle its inode and hide an unsynced new edge.
-  const ancestorHandle = await openSqliteDirectoryForDurability(ancestor, params.label, {
-    mode: targetExists ? params.repairExistingMode : undefined,
-  });
+  const ancestorHandle = await openSqliteDirectoryForDurability(ancestor, params.label);
   const openedReceipts: OpenSqliteDirectoryReceipt[] = [
     { handle: ancestorHandle, receipt: ancestor },
   ];

--- a/src/infra/sqlite-snapshot.test.ts
+++ b/src/infra/sqlite-snapshot.test.ts
@@ -19,6 +19,12 @@ async function createTempDir(): Promise<string> {
   return tempDir;
 }
 
+function isDirectoryOpen(flags: string | number | undefined): boolean {
+  return (
+    flags === "r" || (typeof flags === "number" && (flags & fsSync.constants.O_DIRECTORY) !== 0)
+  );
+}
+
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((tempDir) => fs.rm(tempDir, { recursive: true })));
 });
@@ -590,8 +596,12 @@ describe("createVerifiedSqliteSnapshot", () => {
     const sqlite = requireNodeSqlite();
     createEmptySqliteDatabase(sqlite, sourcePath);
     const originalOpen = fs.open.bind(fs);
+    let targetDirectoryOpenCount = 0;
     const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      if (path.resolve(String(filePath)) === tempDir) {
+      if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === tempDir) {
+        targetDirectoryOpenCount += 1;
+      }
+      if (targetDirectoryOpenCount === 2 && path.resolve(String(filePath)) === tempDir) {
         throw Object.assign(new Error("directory sync failed"), { code: "EIO" });
       }
       return await originalOpen(filePath, flags, mode);
@@ -606,6 +616,50 @@ describe("createVerifiedSqliteSnapshot", () => {
       openSpy.mockRestore();
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a transient publication directory replacement during sync",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const targetPath = path.join(tempDir, "snapshot.sqlite");
+      const displacedPath = `${tempDir}.displaced`;
+      const replacementPath = `${tempDir}.replacement`;
+      const sqlite = requireNodeSqlite();
+      createEmptySqliteDatabase(sqlite, sourcePath);
+      const originalOpen = fs.open.bind(fs);
+      let targetDirectoryOpenCount = 0;
+      let replaced = false;
+      const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        const resolvedPath = path.resolve(String(filePath));
+        if (isDirectoryOpen(flags) && resolvedPath === tempDir) {
+          targetDirectoryOpenCount += 1;
+          if (targetDirectoryOpenCount === 2) {
+            replaced = true;
+            await fs.rename(tempDir, displacedPath);
+            await fs.mkdir(tempDir);
+            const replacementHandle = await originalOpen(filePath, flags, mode);
+            await fs.rename(tempDir, replacementPath);
+            await fs.rename(displacedPath, tempDir);
+            return replacementHandle;
+          }
+        }
+        return await originalOpen(filePath, flags, mode);
+      });
+
+      try {
+        await expect(createVerifiedSqliteSnapshot({ sourcePath, targetPath })).rejects.toThrow(
+          /handle changed during directory sync/u,
+        );
+        expect(replaced).toBe(true);
+        await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        openSpy.mockRestore();
+        await fs.rm(replacementPath, { recursive: true, force: true });
+        await fs.rename(displacedPath, tempDir).catch(() => undefined);
+      }
+    },
+  );
 
   it("validates both the source and transformed snapshot", async () => {
     const tempDir = await createTempDir();

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -16,6 +16,7 @@ import {
 } from "./node-sqlite.js";
 import { resolveSystemBin } from "./resolve-system-bin.js";
 import { assertSqliteIntegrity } from "./sqlite-integrity.js";
+import { syncSqliteDirectoryForDurability } from "./sqlite-path-durability.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
 
 const SQLITE_DIRECTORY_MODE = 0o700;
@@ -651,12 +652,12 @@ export async function publishVerifiedSqliteFile(
     target ??= await fs.open(options.targetPath, "r");
     await assertOpenFileIdentity(target, options.targetPath, initialPublishedIdentity);
     ownershipPinned = true;
-    await syncDirectoryBestEffort(targetDirectory);
+    await syncSqliteDirectoryForDurability(targetDirectory);
     await fs.unlink(stagedPath);
     const expectedIdentity = await target.stat();
     publishedIdentity = expectedIdentity;
     await fs.rmdir(stagingDir);
-    await syncDirectoryBestEffort(targetDirectory);
+    await syncSqliteDirectoryForDurability(targetDirectory);
     const linkedContent = await hashOpenPublishedFile(target, options.targetPath, expectedIdentity);
     assertExpectedContent(linkedContent, expectedContent, options.targetPath);
     await target.close();

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -16,7 +16,11 @@ import {
 } from "./node-sqlite.js";
 import { resolveSystemBin } from "./resolve-system-bin.js";
 import { assertSqliteIntegrity } from "./sqlite-integrity.js";
-import { syncSqliteDirectoryForDurability } from "./sqlite-path-durability.js";
+import {
+  openSqliteDirectoryForDurability,
+  syncSqliteDirectoryForDurability,
+  type SqlitePathIdentityReceipt,
+} from "./sqlite-path-durability.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
 
 const SQLITE_DIRECTORY_MODE = 0o700;
@@ -564,11 +568,25 @@ export async function publishVerifiedSqliteFile(
   options: PublishVerifiedSqliteFileOptions,
 ): Promise<void> {
   await assertTargetAbsent(options.targetPath);
-  const targetDirectory = path.dirname(options.targetPath);
-  const stagingDir = await createPrivateSqliteTempDirectory(
-    targetDirectory,
-    `.sqlite-publish-${randomUUID()}-`,
+  const targetDirectory = path.resolve(path.dirname(options.targetPath));
+  const targetDirectoryReceipt: SqlitePathIdentityReceipt = {
+    path: targetDirectory,
+    identity: await fs.lstat(targetDirectory),
+  };
+  const targetDirectoryPin = await openSqliteDirectoryForDurability(
+    targetDirectoryReceipt,
+    "SQLite publication directory",
   );
+  let stagingDir: string;
+  try {
+    stagingDir = await createPrivateSqliteTempDirectory(
+      targetDirectory,
+      `.sqlite-publish-${randomUUID()}-`,
+    );
+  } catch (error) {
+    await targetDirectoryPin.close().catch(() => undefined);
+    throw error;
+  }
   const stagedPath = path.join(stagingDir, "database.sqlite");
   let stagingIdentity: Stats | undefined;
   let source: FileHandle | undefined;
@@ -652,12 +670,12 @@ export async function publishVerifiedSqliteFile(
     target ??= await fs.open(options.targetPath, "r");
     await assertOpenFileIdentity(target, options.targetPath, initialPublishedIdentity);
     ownershipPinned = true;
-    await syncSqliteDirectoryForDurability(targetDirectory);
+    await syncSqliteDirectoryForDurability(targetDirectoryReceipt);
     await fs.unlink(stagedPath);
     const expectedIdentity = await target.stat();
     publishedIdentity = expectedIdentity;
     await fs.rmdir(stagingDir);
-    await syncSqliteDirectoryForDurability(targetDirectory);
+    await syncSqliteDirectoryForDurability(targetDirectoryReceipt);
     const linkedContent = await hashOpenPublishedFile(target, options.targetPath, expectedIdentity);
     assertExpectedContent(linkedContent, expectedContent, options.targetPath);
     await target.close();
@@ -734,7 +752,7 @@ export async function publishVerifiedSqliteFile(
         !ownershipPinned,
       );
       if (removed) {
-        await syncDirectoryBestEffort(targetDirectory).catch(() => undefined);
+        await syncSqliteDirectoryForDurability(targetDirectoryReceipt).catch(() => undefined);
       }
     }
     if (stagingIdentity) {
@@ -753,6 +771,7 @@ export async function publishVerifiedSqliteFile(
     if (source) {
       await source.close().catch(() => undefined);
     }
+    await targetDirectoryPin.close().catch(() => undefined);
   }
 }
 

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -326,6 +326,30 @@ describe("local SQLite snapshot repository", () => {
     }
   });
 
+  it.runIf(process.platform !== "win32")(
+    "repairs an existing private repository before pinning it",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const repositoryPath = path.join(tempDir, "snapshots");
+      createGenericDatabase(sourcePath);
+      await fs.mkdir(repositoryPath, { mode: 0o300 });
+      const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+
+      try {
+        await expect(
+          provider.create({
+            path: sourcePath,
+            identity: { role: "generic", id: "repair-existing-repository" },
+          }),
+        ).resolves.toBeDefined();
+        expect((await fs.stat(repositoryPath)).mode & 0o777).toBe(0o700);
+      } finally {
+        await fs.chmod(repositoryPath, 0o700).catch(() => undefined);
+      }
+    },
+  );
+
   it("fails creation when a nested repository parent edge cannot be synced", async () => {
     const tempDir = await createTempDir();
     const sourcePath = path.join(tempDir, "source.sqlite");

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -1231,6 +1231,80 @@ describe("local SQLite snapshot repository", () => {
     }
   });
 
+  it("rejects an artifact changed after removing the commit marker", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const originalUnlink = fsSync.unlinkSync.bind(fsSync);
+    let mutated = false;
+    const unlinkSpy = vi.spyOn(fsSync, "unlinkSync").mockImplementation((filePath) => {
+      originalUnlink(filePath);
+      if (!mutated && path.basename(String(filePath)) === ".pending") {
+        fsSync.appendFileSync(
+          path.join(path.dirname(String(filePath)), SNAPSHOT_SQLITE_FILENAME),
+          "changed-after-commit-marker",
+        );
+        mutated = true;
+      }
+    });
+
+    try {
+      await expect(
+        provider.create({
+          path: sourcePath,
+          identity: { role: "generic", id: "post-commit-artifact-race" },
+        }),
+      ).rejects.toThrow(/size mismatch/u);
+    } finally {
+      unlinkSpy.mockRestore();
+    }
+    expect(mutated).toBe(true);
+    await expect(fs.readdir(repositoryPath)).resolves.toEqual([]);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a snapshot directory restored after commit-marker removal",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const repositoryPath = path.join(tempDir, "snapshots");
+      createGenericDatabase(sourcePath);
+      const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+      const originalUnlink = fsSync.unlinkSync.bind(fsSync);
+      let raced = false;
+      const unlinkSpy = vi.spyOn(fsSync, "unlinkSync").mockImplementation((filePath) => {
+        if (raced || path.basename(String(filePath)) !== ".pending") {
+          originalUnlink(filePath);
+          return;
+        }
+        const snapshotDir = path.dirname(String(filePath));
+        const displacedDir = `${snapshotDir}.displaced`;
+        fsSync.renameSync(snapshotDir, displacedDir);
+        fsSync.mkdirSync(snapshotDir, { mode: 0o700 });
+        fsSync.writeFileSync(path.join(snapshotDir, ".pending"), "", { mode: 0o600 });
+        originalUnlink(filePath);
+        fsSync.rmdirSync(snapshotDir);
+        fsSync.renameSync(displacedDir, snapshotDir);
+        raced = true;
+      });
+
+      try {
+        await expect(
+          provider.create({
+            path: sourcePath,
+            identity: { role: "generic", id: "post-commit-directory-race" },
+          }),
+        ).rejects.toThrow(/unexpected entry/u);
+      } finally {
+        unlinkSpy.mockRestore();
+      }
+      expect(raced).toBe(true);
+      await expect(fs.readdir(repositoryPath)).resolves.toEqual([]);
+    },
+  );
+
   it("cleans a linked entry when post-link inspection fails", async () => {
     const tempDir = await createTempDir();
     const sourcePath = path.join(tempDir, "source.sqlite");

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -319,6 +320,199 @@ describe("local SQLite snapshot repository", () => {
     }
   });
 
+  it("fails creation when a nested repository parent edge cannot be synced", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "nested", "repository", "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const canonicalTempDir = await fs.realpath(tempDir);
+    const originalOpen = fs.open.bind(fs);
+    let syncFailed = false;
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      if (
+        !syncFailed &&
+        flags === "r" &&
+        path.resolve(String(filePath)) === canonicalTempDir &&
+        fsSync.existsSync(repositoryPath)
+      ) {
+        syncFailed = true;
+        throw Object.assign(new Error("repository parent sync failed"), { code: "EIO" });
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
+
+    try {
+      await expect(
+        provider.create({
+          path: sourcePath,
+          identity: { role: "generic", id: "nested-parent-sync" },
+        }),
+      ).rejects.toThrow(/could not sync created directory edge/u);
+    } finally {
+      openSpy.mockRestore();
+    }
+    expect(syncFailed).toBe(true);
+    await expect(fs.readdir(repositoryPath)).resolves.toEqual([]);
+  });
+
+  it("fails restore when a nested target parent edge cannot be synced", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    const restorePath = path.join(tempDir, "restore", "nested", "source.sqlite");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const snapshot = await provider.create({
+      path: sourcePath,
+      identity: { role: "generic", id: "nested-restore-parent-sync" },
+    });
+    const canonicalTempDir = await fs.realpath(tempDir);
+    const originalOpen = fs.open.bind(fs);
+    let syncFailed = false;
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      if (
+        !syncFailed &&
+        flags === "r" &&
+        path.resolve(String(filePath)) === canonicalTempDir &&
+        fsSync.existsSync(path.dirname(restorePath)) &&
+        !fsSync.existsSync(restorePath)
+      ) {
+        syncFailed = true;
+        throw Object.assign(new Error("restore parent sync failed"), { code: "EIO" });
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
+
+    try {
+      await expect(provider.restoreFresh(snapshot.ref, restorePath)).rejects.toThrow(
+        /could not sync created directory edge/u,
+      );
+    } finally {
+      openSpy.mockRestore();
+    }
+    expect(syncFailed).toBe(true);
+    await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("cleans a pending marker whose file sync fails", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    createGenericDatabase(sourcePath);
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const originalOpen = fs.open.bind(fs);
+    let syncFailed = false;
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const handle = await originalOpen(filePath, flags, mode);
+      if (!syncFailed && flags === "wx+" && path.basename(String(filePath)) === ".pending") {
+        vi.spyOn(handle, "sync").mockImplementation(async () => {
+          syncFailed = true;
+          throw Object.assign(new Error("pending sync failed"), { code: "EIO" });
+        });
+      }
+      return handle;
+    });
+
+    try {
+      await expect(
+        provider.create({
+          path: sourcePath,
+          identity: { role: "generic", id: "pending-sync-failure" },
+        }),
+      ).rejects.toThrow(/pending sync failed/u);
+    } finally {
+      openSpy.mockRestore();
+    }
+    expect(syncFailed).toBe(true);
+    await expect(fs.readdir(repositoryPath)).resolves.toEqual([]);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "publishes payload only after the pending directory is durable",
+    async () => {
+      const tempDir = await createTempDir();
+      const sourcePath = path.join(tempDir, "source.sqlite");
+      const repositoryPath = path.join(tempDir, "snapshots");
+      createGenericDatabase(sourcePath);
+      await fs.mkdir(repositoryPath, { mode: 0o700 });
+      const provider = createLocalSqliteSnapshotProvider({
+        repositoryPath,
+        now: () => new Date("2026-07-24T16:00:00.000Z"),
+      });
+      const events: string[] = [];
+      let snapshotDir: string | undefined;
+      const originalOpen = fs.open.bind(fs);
+      const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+        const resolvedPath = path.resolve(String(filePath));
+        const handle = await originalOpen(filePath, flags, mode);
+        if (flags === "wx+" && path.basename(resolvedPath) === ".pending") {
+          snapshotDir = path.dirname(resolvedPath);
+          const originalSync = handle.sync.bind(handle);
+          vi.spyOn(handle, "sync").mockImplementation(async () => {
+            events.push("pending-sync");
+            await originalSync();
+          });
+        } else if (flags === "r" && snapshotDir && resolvedPath === snapshotDir) {
+          const originalSync = handle.sync.bind(handle);
+          vi.spyOn(handle, "sync").mockImplementation(async () => {
+            events.push("snapshot-sync");
+            await originalSync();
+          });
+        } else if (flags === "r" && resolvedPath === repositoryPath) {
+          const originalSync = handle.sync.bind(handle);
+          vi.spyOn(handle, "sync").mockImplementation(async () => {
+            events.push("repository-sync");
+            await originalSync();
+          });
+        }
+        return handle;
+      });
+      const originalLink = fs.link.bind(fs);
+      const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
+        if (snapshotDir && path.dirname(String(target)) === snapshotDir) {
+          events.push(`publish:${path.basename(String(target))}`);
+        }
+        await originalLink(source, target);
+      });
+      const originalUnlink = fsSync.unlinkSync.bind(fsSync);
+      const unlinkSpy = vi.spyOn(fsSync, "unlinkSync").mockImplementation((filePath) => {
+        if (path.basename(String(filePath)) === ".pending") {
+          events.push("pending-unlink");
+        }
+        originalUnlink(filePath);
+      });
+
+      try {
+        await provider.create({
+          path: sourcePath,
+          identity: { role: "generic", id: "publication-order" },
+        });
+      } finally {
+        openSpy.mockRestore();
+        linkSpy.mockRestore();
+        unlinkSpy.mockRestore();
+      }
+
+      const pendingSync = events.indexOf("pending-sync");
+      const repositorySync = events.indexOf("repository-sync");
+      const artifactPublish = events.indexOf(`publish:${SNAPSHOT_SQLITE_FILENAME}`);
+      const manifestPublish = events.indexOf(`publish:${SNAPSHOT_MANIFEST_FILENAME}`);
+      const pendingUnlink = events.indexOf("pending-unlink");
+      const snapshotSyncs = events
+        .map((event, index) => (event === "snapshot-sync" ? index : -1))
+        .filter((index) => index >= 0);
+      expect(snapshotSyncs).toHaveLength(3);
+      expect(pendingSync).toBeLessThan(snapshotSyncs[0] ?? -1);
+      expect(snapshotSyncs[0]).toBeLessThan(repositorySync);
+      expect(repositorySync).toBeLessThan(artifactPublish);
+      expect(artifactPublish).toBeLessThan(manifestPublish);
+      expect(manifestPublish).toBeLessThan(snapshotSyncs[1] ?? -1);
+      expect(snapshotSyncs[1]).toBeLessThan(pendingUnlink);
+      expect(pendingUnlink).toBeLessThan(snapshotSyncs[2] ?? -1);
+    },
+  );
+
   it("sorts snapshots newest first and ignores incomplete staging directories", async () => {
     const tempDir = await createTempDir();
     const sourcePath = path.join(tempDir, "source.sqlite");
@@ -341,8 +535,29 @@ describe("local SQLite snapshot repository", () => {
     await fs.mkdir(path.join(repositoryPath, "interrupted-final"));
     await fs.writeFile(path.join(repositoryPath, "interrupted-final", ".pending"), "");
     await fs.mkdir(path.join(repositoryPath, "empty-final"));
+    await fs.mkdir(path.join(repositoryPath, "artifact-only"));
+    await fs.writeFile(
+      path.join(repositoryPath, "artifact-only", SNAPSHOT_SQLITE_FILENAME),
+      "partial",
+    );
+    await fs.mkdir(path.join(repositoryPath, "manifest-only"));
+    await fs.writeFile(
+      path.join(repositoryPath, "manifest-only", SNAPSHOT_MANIFEST_FILENAME),
+      "partial",
+    );
 
     await expect(provider.list()).resolves.toEqual([second, first]);
+  });
+
+  it("rejects unknown entries inside an incomplete snapshot directory", async () => {
+    const tempDir = await createTempDir();
+    const repositoryPath = path.join(tempDir, "snapshots");
+    await fs.mkdir(path.join(repositoryPath, "interrupted"), { recursive: true });
+    await fs.writeFile(path.join(repositoryPath, "interrupted", ".pending"), "");
+    await fs.writeFile(path.join(repositoryPath, "interrupted", "unexpected"), "");
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+
+    await expect(provider.list()).rejects.toThrow(/unexpected incomplete entry/u);
   });
 
   it("uses caller-owned verification scratch and stages restore beside the target", async () => {
@@ -906,7 +1121,7 @@ describe("local SQLite snapshot repository", () => {
     }
   });
 
-  it("does not report best-effort directory sync as a failed restore", async () => {
+  it("fails restore when the final cleanup directory sync fails", async () => {
     const tempDir = await createTempDir();
     const sourcePath = path.join(tempDir, "source.sqlite");
     const repositoryPath = path.join(tempDir, "snapshots");
@@ -933,9 +1148,9 @@ describe("local SQLite snapshot repository", () => {
     });
 
     try {
-      await expect(provider.restoreFresh(snapshot.ref, restorePath)).resolves.toMatchObject({
-        ok: true,
-      });
+      await expect(provider.restoreFresh(snapshot.ref, restorePath)).rejects.toThrow(
+        /directory sync unavailable/u,
+      );
     } finally {
       openSpy.mockRestore();
     }
@@ -1456,7 +1671,7 @@ describe("local SQLite snapshot repository", () => {
 
       try {
         await expect(provider.restoreFresh(snapshot.ref, restorePath)).rejects.toThrow(
-          /restore target changed|outside snapshot repository/u,
+          /restore target changed|outside snapshot repository|must be a real directory/u,
         );
       } finally {
         realpathSpy.mockRestore();
@@ -1622,7 +1837,7 @@ describe("local SQLite snapshot repository", () => {
     await expect(provider.verify({ path: tempDir })).rejects.toThrow(/immediate child/u);
     await fs.writeFile(path.join(snapshot.ref.path, `${SNAPSHOT_SQLITE_FILENAME}-wal`), "orphan");
     await expect(provider.verify(snapshot.ref)).rejects.toThrow(/unexpected entry/u);
-    await expect(provider.list()).rejects.toThrow(/unexpected entry/u);
+    await expect(provider.list()).rejects.toThrow(/unexpected (?:incomplete )?entry/u);
   });
 
   it("bounds manifest reads before parsing untrusted snapshot metadata", async () => {
@@ -1661,7 +1876,7 @@ describe("local SQLite snapshot repository", () => {
           path: sourcePath,
           identity: { role: "generic", id: "symlink-repository" },
         }),
-      ).rejects.toThrow(/symlink|Invalid path/iu);
+      ).rejects.toThrow(/symlink|Invalid path|real directory/iu);
 
       const provider = createLocalSqliteSnapshotProvider({
         repositoryPath: realRepositoryPath,

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -326,14 +326,20 @@ describe("local SQLite snapshot repository", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32").each([0o000, 0o200, 0o300])(
-    "repairs an existing private repository from mode %o before pinning it",
-    async (initialMode) => {
+  it.runIf(process.platform !== "win32").each([
+    { label: "000", mode: 0o000 },
+    { label: "200", mode: 0o200 },
+    { label: "300", mode: 0o300 },
+    { label: "777", mode: 0o777 },
+  ])(
+    "repairs an existing private repository from mode $label before pinning it",
+    async (testCase) => {
       const tempDir = await createTempDir();
       const sourcePath = path.join(tempDir, "source.sqlite");
       const repositoryPath = path.join(tempDir, "snapshots");
       createGenericDatabase(sourcePath);
-      await fs.mkdir(repositoryPath, { mode: initialMode });
+      await fs.mkdir(repositoryPath, { mode: testCase.mode });
+      await fs.chmod(repositoryPath, testCase.mode);
       const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
 
       try {

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -35,6 +35,12 @@ async function createTempDir(): Promise<string> {
   return tempDir;
 }
 
+function isDirectoryOpen(flags: string | number): boolean {
+  return (
+    flags === "r" || (typeof flags === "number" && (flags & fsSync.constants.O_DIRECTORY) !== 0)
+  );
+}
+
 function createGenericDatabase(
   databasePath: string,
   options: { userVersion?: number; values?: string[]; wal?: boolean } = {},
@@ -331,7 +337,7 @@ describe("local SQLite snapshot repository", () => {
     let syncFailed = false;
     const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
       const handle = await originalOpen(filePath, flags, mode);
-      if (flags === "r" && path.resolve(String(filePath)) === canonicalTempDir) {
+      if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === canonicalTempDir) {
         const originalSync = handle.sync.bind(handle);
         vi.spyOn(handle, "sync").mockImplementation(async () => {
           if (!syncFailed && fsSync.existsSync(repositoryPath)) {
@@ -374,7 +380,7 @@ describe("local SQLite snapshot repository", () => {
     let syncFailed = false;
     const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
       const handle = await originalOpen(filePath, flags, mode);
-      if (flags === "r" && path.resolve(String(filePath)) === canonicalTempDir) {
+      if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === canonicalTempDir) {
         const originalSync = handle.sync.bind(handle);
         vi.spyOn(handle, "sync").mockImplementation(async () => {
           if (
@@ -460,13 +466,13 @@ describe("local SQLite snapshot repository", () => {
             events.push("pending-sync");
             await originalSync();
           });
-        } else if (flags === "r" && snapshotDir && resolvedPath === snapshotDir) {
+        } else if (isDirectoryOpen(flags) && snapshotDir && resolvedPath === snapshotDir) {
           const originalSync = handle.sync.bind(handle);
           vi.spyOn(handle, "sync").mockImplementation(async () => {
             events.push("snapshot-sync");
             await originalSync();
           });
-        } else if (flags === "r" && resolvedPath === repositoryPath) {
+        } else if (isDirectoryOpen(flags) && resolvedPath === repositoryPath) {
           const originalSync = handle.sync.bind(handle);
           vi.spyOn(handle, "sync").mockImplementation(async () => {
             events.push("repository-sync");
@@ -1146,7 +1152,7 @@ describe("local SQLite snapshot repository", () => {
     });
     const originalOpen = fs.open.bind(fs);
     const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      if (path.resolve(String(filePath)) === restoreParentPath && flags === "r") {
+      if (path.resolve(String(filePath)) === restoreParentPath && isDirectoryOpen(flags)) {
         const entries = await fs.readdir(restoreParentPath);
         if (
           entries.includes(path.basename(restorePath)) &&

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -542,19 +542,23 @@ describe("local SQLite snapshot repository", () => {
     await fs.mkdir(path.join(repositoryPath, "interrupted-final"));
     await fs.writeFile(path.join(repositoryPath, "interrupted-final", ".pending"), "");
     await fs.mkdir(path.join(repositoryPath, "empty-final"));
-    await fs.mkdir(path.join(repositoryPath, "artifact-only"));
-    await fs.writeFile(
-      path.join(repositoryPath, "artifact-only", SNAPSHOT_SQLITE_FILENAME),
-      "partial",
-    );
-    await fs.mkdir(path.join(repositoryPath, "manifest-only"));
-    await fs.writeFile(
-      path.join(repositoryPath, "manifest-only", SNAPSHOT_MANIFEST_FILENAME),
-      "partial",
-    );
 
     await expect(provider.list()).resolves.toEqual([second, first]);
   });
+
+  it.each([SNAPSHOT_SQLITE_FILENAME, SNAPSHOT_MANIFEST_FILENAME])(
+    "rejects markerless partial snapshot directories containing only %s",
+    async (entryName) => {
+      const tempDir = await createTempDir();
+      const repositoryPath = path.join(tempDir, "snapshots");
+      const partialPath = path.join(repositoryPath, "markerless-partial");
+      await fs.mkdir(partialPath, { recursive: true });
+      await fs.writeFile(path.join(partialPath, entryName), "partial");
+      const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+
+      await expect(provider.list()).rejects.toThrow();
+    },
+  );
 
   it("rejects unknown entries inside an incomplete snapshot directory", async () => {
     const tempDir = await createTempDir();

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -330,16 +330,18 @@ describe("local SQLite snapshot repository", () => {
     const originalOpen = fs.open.bind(fs);
     let syncFailed = false;
     const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      if (
-        !syncFailed &&
-        flags === "r" &&
-        path.resolve(String(filePath)) === canonicalTempDir &&
-        fsSync.existsSync(repositoryPath)
-      ) {
-        syncFailed = true;
-        throw Object.assign(new Error("repository parent sync failed"), { code: "EIO" });
+      const handle = await originalOpen(filePath, flags, mode);
+      if (flags === "r" && path.resolve(String(filePath)) === canonicalTempDir) {
+        const originalSync = handle.sync.bind(handle);
+        vi.spyOn(handle, "sync").mockImplementation(async () => {
+          if (!syncFailed && fsSync.existsSync(repositoryPath)) {
+            syncFailed = true;
+            throw Object.assign(new Error("repository parent sync failed"), { code: "EIO" });
+          }
+          await originalSync();
+        });
       }
-      return await originalOpen(filePath, flags, mode);
+      return handle;
     });
 
     try {
@@ -371,17 +373,22 @@ describe("local SQLite snapshot repository", () => {
     const originalOpen = fs.open.bind(fs);
     let syncFailed = false;
     const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      if (
-        !syncFailed &&
-        flags === "r" &&
-        path.resolve(String(filePath)) === canonicalTempDir &&
-        fsSync.existsSync(path.dirname(restorePath)) &&
-        !fsSync.existsSync(restorePath)
-      ) {
-        syncFailed = true;
-        throw Object.assign(new Error("restore parent sync failed"), { code: "EIO" });
+      const handle = await originalOpen(filePath, flags, mode);
+      if (flags === "r" && path.resolve(String(filePath)) === canonicalTempDir) {
+        const originalSync = handle.sync.bind(handle);
+        vi.spyOn(handle, "sync").mockImplementation(async () => {
+          if (
+            !syncFailed &&
+            fsSync.existsSync(path.dirname(restorePath)) &&
+            !fsSync.existsSync(restorePath)
+          ) {
+            syncFailed = true;
+            throw Object.assign(new Error("restore parent sync failed"), { code: "EIO" });
+          }
+          await originalSync();
+        });
       }
-      return await originalOpen(filePath, flags, mode);
+      return handle;
     });
 
     try {

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -35,7 +35,7 @@ async function createTempDir(): Promise<string> {
   return tempDir;
 }
 
-function isDirectoryOpen(flags: string | number): boolean {
+function isDirectoryOpen(flags: string | number | undefined): boolean {
   return (
     flags === "r" || (typeof flags === "number" && (flags & fsSync.constants.O_DIRECTORY) !== 0)
   );

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -1762,7 +1762,7 @@ describe("local SQLite snapshot repository", () => {
 
       try {
         await expect(provider.restoreFresh(snapshot.ref, restorePath)).rejects.toThrow(
-          /restore target changed|outside snapshot repository|must be a real directory/u,
+          /restore target changed|outside snapshot repository|must be a real directory|not a directory/u,
         );
       } finally {
         realpathSpy.mockRestore();

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -326,14 +326,14 @@ describe("local SQLite snapshot repository", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
-    "repairs an existing private repository before pinning it",
-    async () => {
+  it.runIf(process.platform !== "win32").each([0o000, 0o200, 0o300])(
+    "repairs an existing private repository from mode %o before pinning it",
+    async (initialMode) => {
       const tempDir = await createTempDir();
       const sourcePath = path.join(tempDir, "source.sqlite");
       const repositoryPath = path.join(tempDir, "snapshots");
       createGenericDatabase(sourcePath);
-      await fs.mkdir(repositoryPath, { mode: 0o300 });
+      await fs.mkdir(repositoryPath, { mode: initialMode });
       const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
 
       try {

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -1219,7 +1219,12 @@ async function assertTrustedStagingRoot(
     return trustedRootPath;
   }
   const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
-  if (uid === undefined || rootIdentity.uid !== uid || (rootIdentity.mode & 0o022) !== 0) {
+  const unsafeMode = (rootIdentity.mode & 0o022) !== 0;
+  if (
+    uid === undefined ||
+    rootIdentity.uid !== uid ||
+    (unsafeMode && options.allowModeRepair !== true)
+  ) {
     throw new Error(
       `Private SQLite staging root must be owned by the current user and not writable by other users: ${resolvedRootPath}`,
     );

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -788,10 +788,32 @@ async function ensurePrivateDirectory(
   directoryPath: string,
   scopeLabel: string,
 ): Promise<DurableSqliteDirectoryReceipt> {
+  let expectedExistingIdentity: Stats | undefined;
+  if (process.platform !== "win32") {
+    try {
+      const existingIdentity = await fs.lstat(directoryPath);
+      assertDirectory(existingIdentity, directoryPath, scopeLabel);
+      // Repair only after ownership and ancestors prove another user cannot
+      // redirect chmod, then bind the durability pin to that exact directory.
+      await assertTrustedStagingRoot(existingIdentity, directoryPath, {
+        allowModeRepair: true,
+      });
+      applyPrivateModeSync(directoryPath, SNAPSHOT_DIRECTORY_MODE);
+      const repairedIdentity = await fs.lstat(directoryPath);
+      if (!sameFileIdentity(existingIdentity, repairedIdentity)) {
+        throw new Error(`${scopeLabel} changed during private mode repair: ${directoryPath}`);
+      }
+      expectedExistingIdentity = repairedIdentity;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
   return await ensureDurableSqliteDirectory({
     directoryPath,
     label: scopeLabel,
-    repairExistingMode: process.platform === "win32" ? undefined : SNAPSHOT_DIRECTORY_MODE,
+    expectedExistingIdentity,
     create: async (targetPath) => {
       if (process.platform === "win32") {
         const parentResult = await ensureAbsoluteDirectory(path.dirname(targetPath), {
@@ -1183,6 +1205,7 @@ async function withPrivateSqliteStagingDirectory<T>(options: {
 async function assertTrustedStagingRoot(
   expectedIdentity: Stats,
   rootPath: string,
+  options: { allowModeRepair?: boolean } = {},
 ): Promise<string> {
   const resolvedRootPath = path.resolve(rootPath);
   const trustedRootPath = await fs.realpath(resolvedRootPath);
@@ -1202,7 +1225,7 @@ async function assertTrustedStagingRoot(
     );
   }
   if (process.platform === "darwin") {
-    await assertTrustedMacosAcl(trustedRootPath, true);
+    await assertTrustedMacosAcl(trustedRootPath, options.allowModeRepair !== true);
   }
   await assertTrustedPosixStagingAncestors(trustedRootPath, rootIdentity, uid);
   return trustedRootPath;

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -791,6 +791,7 @@ async function ensurePrivateDirectory(
   return await ensureDurableSqliteDirectory({
     directoryPath,
     label: scopeLabel,
+    repairExistingMode: process.platform === "win32" ? undefined : SNAPSHOT_DIRECTORY_MODE,
     create: async (targetPath) => {
       if (process.platform === "win32") {
         const parentResult = await ensureAbsoluteDirectory(path.dirname(targetPath), {

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -19,6 +19,7 @@ import { resolveSystemBin } from "../infra/resolve-system-bin.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import {
   ensureDurableSqliteDirectory,
+  openSqliteDirectoryForDurability,
   syncSqliteDirectoryForDurability,
   type DurableSqliteDirectoryReceipt,
 } from "../infra/sqlite-path-durability.js";
@@ -326,7 +327,10 @@ class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
       publishedIdentity = await fs.lstat(snapshotDir);
       applyPrivateModeSync(snapshotDir, SNAPSHOT_DIRECTORY_MODE);
       await assertPrivateStagingDirectory(publishedIdentity, snapshotDir);
-      publishedDirectory = await fs.open(snapshotDir, "r");
+      publishedDirectory = await openSqliteDirectoryForDurability(
+        { path: snapshotDir, identity: publishedIdentity },
+        "SQLite snapshot directory",
+      );
       await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
       const pendingPath = path.join(snapshotDir, SNAPSHOT_PENDING_FILENAME);
       const pendingHandle = await fs.open(pendingPath, "wx+", SNAPSHOT_FILE_MODE);

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -18,6 +18,11 @@ import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { resolveSystemBin } from "../infra/resolve-system-bin.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import {
+  ensureDurableSqliteDirectory,
+  syncSqliteDirectoryForDurability,
+  type DurableSqliteDirectoryReceipt,
+} from "../infra/sqlite-path-durability.js";
+import {
   createPrivateSqliteDirectory,
   createPrivateSqliteTempDirectory,
   createVerifiedSqliteSnapshot,
@@ -241,8 +246,11 @@ class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
   }
 
   async create(database: SnapshotDatabaseRef): Promise<SnapshotResult> {
-    await ensurePrivateDirectory(this.#repositoryPath, "SQLite snapshot repository");
-    const repositoryIdentity = await fs.lstat(this.#repositoryPath);
+    const repositoryReceipt = await ensurePrivateDirectory(
+      this.#repositoryPath,
+      "SQLite snapshot repository",
+    );
+    const repositoryIdentity = repositoryReceipt.identity;
     const trustedRepositoryPath = await assertTrustedStagingRoot(
       repositoryIdentity,
       this.#repositoryPath,
@@ -321,11 +329,23 @@ class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
       publishedDirectory = await fs.open(snapshotDir, "r");
       await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
       const pendingPath = path.join(snapshotDir, SNAPSHOT_PENDING_FILENAME);
-      await fs.writeFile(pendingPath, "", {
-        flag: "wx",
-        mode: SNAPSHOT_FILE_MODE,
+      const pendingHandle = await fs.open(pendingPath, "wx+", SNAPSHOT_FILE_MODE);
+      try {
+        publishedEntries.set(SNAPSHOT_PENDING_FILENAME, await pendingHandle.stat());
+        await pendingHandle.sync();
+      } finally {
+        await pendingHandle.close();
+      }
+      await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
+      await syncSqliteDirectoryForDurability({
+        path: snapshotDir,
+        identity: publishedIdentity,
       });
-      publishedEntries.set(SNAPSHOT_PENDING_FILENAME, await fs.lstat(pendingPath));
+      await assertDirectoryIdentity(trustedRepositoryPath, repositoryIdentity);
+      await syncSqliteDirectoryForDurability({
+        path: trustedRepositoryPath,
+        identity: repositoryIdentity,
+      });
       await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
       await publishSnapshotEntryNoOverwrite(
         path.join(stagingDir, SNAPSHOT_SQLITE_FILENAME),
@@ -341,7 +361,10 @@ class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
         publishedEntries,
       );
       await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
-      await syncDirectoryBestEffort(snapshotDir);
+      await syncSqliteDirectoryForDurability({
+        path: snapshotDir,
+        identity: publishedIdentity,
+      });
       await assertPendingSnapshotContents(snapshotDir);
       const publishedManifest = await readSnapshotManifest(snapshotDir, snapshotId);
       if (!isDeepStrictEqual(publishedManifest, manifest)) {
@@ -364,28 +387,15 @@ class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
       ) {
         throw new Error(`SQLite snapshot pending marker changed: ${pendingPath}`);
       }
-      fsSync.unlinkSync(pendingPath);
-      publishedEntries.delete(SNAPSHOT_PENDING_FILENAME);
-      await syncDirectoryBestEffort(snapshotDir);
+      await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
       await publishedDirectory.close();
       publishedDirectory = undefined;
-      const committedManifest = await readSnapshotManifest(snapshotDir, snapshotId);
-      if (!isDeepStrictEqual(committedManifest, manifest)) {
-        throw new Error(`SQLite snapshot manifest changed after commit: ${snapshotDir}`);
-      }
-      const committedArtifact = await hashSnapshotArtifact(snapshotDir);
-      assertArtifactMatchesManifest(
-        path.join(snapshotDir, SNAPSHOT_SQLITE_FILENAME),
-        committedArtifact,
-        committedManifest,
-      );
-      const currentIdentity = await fs.lstat(snapshotDir);
-      if (!sameFileIdentity(publishedIdentity, currentIdentity)) {
-        throw new Error(`SQLite snapshot directory changed during publication: ${snapshotDir}`);
-      }
-      await assertExactSnapshotContents(snapshotDir);
-      await assertDirectoryIdentity(trustedRepositoryPath, repositoryIdentity);
-      await syncDirectoryBestEffort(trustedRepositoryPath);
+      fsSync.unlinkSync(pendingPath);
+      publishedEntries.delete(SNAPSHOT_PENDING_FILENAME);
+      await syncSqliteDirectoryForDurability({
+        path: snapshotDir,
+        identity: publishedIdentity,
+      });
       return { ref: { path: snapshotRefPath }, manifest };
     } catch (error) {
       await publishedDirectory?.close().catch(() => undefined);
@@ -461,7 +471,7 @@ class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
       );
     }
     const restoreParentPath = path.dirname(canonicalTargetPath);
-    await ensureRestoreParentDirectory(restoreParentPath);
+    const restoreParentReceipt = await ensureRestoreParentDirectory(restoreParentPath);
     const trustedRestoreParentPath = await fs.realpath(restoreParentPath);
     const trustedTargetPath = path.join(
       trustedRestoreParentPath,
@@ -481,6 +491,11 @@ class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
       );
     }
     const restoreParentIdentity = await fs.lstat(trustedRestoreParentPath);
+    if (!sameFileIdentity(restoreParentReceipt.identity, restoreParentIdentity)) {
+      throw new Error(
+        `SQLite restore parent changed after durable creation: ${trustedRestoreParentPath}`,
+      );
+    }
     // Existing databases need a crash-recoverable main/WAL/SHM swap protocol.
     // This path is deliberately fresh-only and refuses every preexisting sidecar.
     await assertFreshRestorePathsAbsent(trustedTargetPath);
@@ -751,42 +766,59 @@ function buildSnapshotId(now: Date): string {
   return `${timestamp}-${randomUUID()}`;
 }
 
-async function ensurePrivateDirectory(directoryPath: string, scopeLabel: string): Promise<void> {
-  if (process.platform === "win32") {
-    const parentResult = await ensureAbsoluteDirectory(path.dirname(directoryPath), {
-      mode: SNAPSHOT_DIRECTORY_MODE,
-      scopeLabel,
-    });
-    if (!parentResult.ok) {
-      throw parentResult.error;
-    }
-    try {
-      await createPrivateSqliteDirectory(directoryPath);
-      return;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
+async function ensurePrivateDirectory(
+  directoryPath: string,
+  scopeLabel: string,
+): Promise<DurableSqliteDirectoryReceipt> {
+  return await ensureDurableSqliteDirectory({
+    directoryPath,
+    label: scopeLabel,
+    create: async (targetPath) => {
+      if (process.platform === "win32") {
+        const parentResult = await ensureAbsoluteDirectory(path.dirname(targetPath), {
+          mode: SNAPSHOT_DIRECTORY_MODE,
+          scopeLabel,
+        });
+        if (!parentResult.ok) {
+          throw parentResult.error;
+        }
+        try {
+          await createPrivateSqliteDirectory(targetPath);
+          return;
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+            throw error;
+          }
+        }
       }
-    }
-  }
-  const result = await ensureAbsoluteDirectory(directoryPath, {
-    mode: SNAPSHOT_DIRECTORY_MODE,
-    scopeLabel,
+      const result = await ensureAbsoluteDirectory(targetPath, {
+        mode: SNAPSHOT_DIRECTORY_MODE,
+        scopeLabel,
+      });
+      if (!result.ok) {
+        throw result.error;
+      }
+      applyPrivateModeSync(result.path, SNAPSHOT_DIRECTORY_MODE);
+    },
   });
-  if (!result.ok) {
-    throw result.error;
-  }
-  applyPrivateModeSync(result.path, SNAPSHOT_DIRECTORY_MODE);
 }
 
-async function ensureRestoreParentDirectory(directoryPath: string): Promise<void> {
-  const result = await ensureAbsoluteDirectory(directoryPath, {
-    mode: SNAPSHOT_DIRECTORY_MODE,
-    scopeLabel: "SQLite restore target",
+async function ensureRestoreParentDirectory(
+  directoryPath: string,
+): Promise<DurableSqliteDirectoryReceipt> {
+  return await ensureDurableSqliteDirectory({
+    directoryPath,
+    label: "SQLite restore target",
+    create: async (targetPath) => {
+      const result = await ensureAbsoluteDirectory(targetPath, {
+        mode: SNAPSHOT_DIRECTORY_MODE,
+        scopeLabel: "SQLite restore target",
+      });
+      if (!result.ok) {
+        throw result.error;
+      }
+    },
   });
-  if (!result.ok) {
-    throw result.error;
-  }
 }
 
 function assertDirectory(stat: Stats, pathname: string, label: string): void {
@@ -978,14 +1010,24 @@ async function assertSnapshotContents(snapshotDir: string, expected: Set<string>
 
 async function isIncompleteSnapshotDirectory(snapshotDir: string): Promise<boolean> {
   const entries = await fs.readdir(snapshotDir, { withFileTypes: true });
+  const knownEntries = new Set([
+    SNAPSHOT_MANIFEST_FILENAME,
+    SNAPSHOT_PENDING_FILENAME,
+    SNAPSHOT_SQLITE_FILENAME,
+  ]);
+  for (const entry of entries) {
+    if (!knownEntries.has(entry.name) || entry.isSymbolicLink() || !entry.isFile()) {
+      throw new Error(
+        `SQLite snapshot contains unexpected incomplete entry: ${path.join(snapshotDir, entry.name)}`,
+      );
+    }
+  }
   const names = new Set(entries.map((entry) => entry.name));
-  if (names.has(SNAPSHOT_PENDING_FILENAME)) {
-    return true;
-  }
-  if (names.has(SNAPSHOT_MANIFEST_FILENAME)) {
-    return false;
-  }
-  return entries.length === 0;
+  return (
+    names.size !== 2 ||
+    !names.has(SNAPSHOT_MANIFEST_FILENAME) ||
+    !names.has(SNAPSHOT_SQLITE_FILENAME)
+  );
 }
 
 async function assertFreshRestorePathsAbsent(databasePath: string): Promise<void> {
@@ -1113,7 +1155,10 @@ async function withPrivateSqliteStagingDirectory<T>(options: {
       cause: cleanupOutcome.error,
     });
   }
-  await syncDirectoryBestEffort(trustedRootPath).catch(() => undefined);
+  await syncSqliteDirectoryForDurability({
+    path: trustedRootPath,
+    identity: options.expectedRootIdentity,
+  });
   if (!outcome.ok) {
     throw outcome.error;
   }

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -388,14 +388,28 @@ class LocalSqliteSnapshotProvider implements SqliteSnapshotProvider {
         throw new Error(`SQLite snapshot pending marker changed: ${pendingPath}`);
       }
       await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
-      await publishedDirectory.close();
-      publishedDirectory = undefined;
       fsSync.unlinkSync(pendingPath);
-      publishedEntries.delete(SNAPSHOT_PENDING_FILENAME);
       await syncSqliteDirectoryForDurability({
         path: snapshotDir,
         identity: publishedIdentity,
       });
+      await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
+      const committedManifest = await readSnapshotManifest(snapshotDir, snapshotId);
+      if (!isDeepStrictEqual(committedManifest, manifest)) {
+        throw new Error(`SQLite snapshot manifest changed after commit: ${snapshotDir}`);
+      }
+      const committedArtifact = await hashSnapshotArtifact(snapshotDir);
+      assertArtifactMatchesManifest(
+        path.join(snapshotDir, SNAPSHOT_SQLITE_FILENAME),
+        committedArtifact,
+        committedManifest,
+      );
+      await assertExactSnapshotContents(snapshotDir);
+      await assertOpenDirectoryIdentity(publishedDirectory, snapshotDir, publishedIdentity);
+      await assertDirectoryIdentity(trustedRepositoryPath, repositoryIdentity);
+      publishedEntries.delete(SNAPSHOT_PENDING_FILENAME);
+      await publishedDirectory.close();
+      publishedDirectory = undefined;
       return { ref: { path: snapshotRefPath }, manifest };
     } catch (error) {
       await publishedDirectory?.close().catch(() => undefined);

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -1037,11 +1037,7 @@ async function isIncompleteSnapshotDirectory(snapshotDir: string): Promise<boole
     }
   }
   const names = new Set(entries.map((entry) => entry.name));
-  return (
-    names.size !== 2 ||
-    !names.has(SNAPSHOT_MANIFEST_FILENAME) ||
-    !names.has(SNAPSHOT_SQLITE_FILENAME)
-  );
+  return names.size === 0 || names.has(SNAPSHOT_PENDING_FILENAME);
 }
 
 async function assertFreshRestorePathsAbsent(databasePath: string): Promise<void> {


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Fixes an issue where SQLite snapshot creation and fresh restore could report success after newly created parent links or final publication metadata had not been durably synchronized. A crash at those boundaries could leave missing, partial, or ambiguously committed state.

## Why This Change Was Made

The change adds an identity-pinned directory durability primitive that is strict on POSIX filesystems and explicitly classifies unsupported Windows directory flushing. POSIX directory opens reject symlinks and FIFOs without blocking. Existing private repositories are repaired only after owner, ancestor, and ACL validation, then the durability pin is bound to the exact repaired directory identity.

Snapshot repositories now durably link newly created parent chains, fsync the `.pending` marker before publishing payloads, persist the repository entry before payload publication, and use pending removal plus a directory sync as the commit point. Shared SQLite publication pins the destination directory before staging or linking and uses that receipt for every strict sync. Fresh restore verifies the exact durably created parent identity and reports final staging-cleanup sync failures.

## User Impact

Operators get stronger crash consistency for snapshot creation and fresh restore. On supported filesystems, success now means the relevant parent and publication metadata syncs completed. Empty or `.pending` directories remain recoverable interrupted state; markerless artifact-only, manifest-only, or unknown contents fail closed instead of being silently hidden.

## Evidence

- Exact head `8adfdb2c2a02ee669ebb49e95ee68706f1062158` on Blacksmith Testbox `tbx_01kyadf1xhgz410c460skrffdf` (run https://github.com/openclaw/openclaw/actions/runs/30107403342): 94 focused assertions passed and 5 platform assertions skipped across repository create/list/verify/restore, strict directory durability, and shared SQLite publication.
- Exact-head `pnpm check:changed` passed on the same Testbox.
- Native macOS: the two focused infra suites passed 38 assertions with 2 Windows-only assertions skipped, including FIFO rejection and transient publication-directory replacement.
- Native Windows x64: https://github.com/openclaw/openclaw/actions/runs/30113968403 checked out the exact head and passed all 10 `pnpm test:windows:ci` shards, including deep-path snapshot, unsafe-index, and SQLite publication coverage. WSL2 was unavailable and is not claimed by this PR.
- Fault coverage includes recursive parent-sync failure, transient parent and publication-directory replacement, FIFO substitution, private-mode repair from `000`, `200`, `300`, and `777`, POSIX unsupported-code propagation, Windows unsupported classification, pending-file sync failure, exact publication ordering, markerless partial state, post-commit mutation, and final restore cleanup sync failure.
- Fresh full-branch autoreview completed with no accepted/actionable findings for the documented Linux, macOS, and Windows host contract.
- `git diff --check` passed.
