### PR TITLE
fix(telegram): persist update offset only after durable spool write in isolated polling

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -477,6 +477,7 @@ function createPollingSession(params: {
   telegramTransport?: ReturnType<typeof makeTelegramTransport>;
   createTelegramTransport?: () => ReturnType<typeof makeTelegramTransport>;
   getLastUpdateId?: () => number | null;
+  persistUpdateId?: ConstructorParameters<typeof TelegramPollingSession>[0]["persistUpdateId"];
   stallThresholdMs?: number;
   setStatus?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
   isolatedIngress?: ConstructorParameters<typeof TelegramPollingSession>[0]["isolatedIngress"];
@@ -490,7 +491,7 @@ function createPollingSession(params: {
     abortSignal: params.abortSignal,
     runnerOptions: {},
     getLastUpdateId: params.getLastUpdateId ?? (() => null),
-    persistUpdateId: async () => undefined,
+    persistUpdateId: params.persistUpdateId ?? (async () => undefined),
     log: params.log ?? (() => undefined),
     telegramTransport: params.telegramTransport,
     stallThresholdMs: params.stallThresholdMs,
@@ -789,6 +790,7 @@ function startIsolatedIngressSession(params: {
   getLastUpdateId?: () => number | null;
   init?: AsyncVoidFn;
   log?: (message: string) => void;
+  persistUpdateId?: ConstructorParameters<typeof TelegramPollingSession>[0]["persistUpdateId"];
   stop?: () => Promise<void>;
   spooledUpdateHandlerTimeoutMs?: number;
   spooledUpdateHandlerAbortGraceMs?: number;
@@ -806,6 +808,7 @@ function startIsolatedIngressSession(params: {
     abortSignal: params.abort.signal,
     getLastUpdateId: params.getLastUpdateId,
     log: params.log,
+    persistUpdateId: params.persistUpdateId,
     stallThresholdMs: params.stallThresholdMs,
     isolatedIngress: {
       enabled: true,
@@ -1080,7 +1083,6 @@ describe("TelegramPollingSession", () => {
       expect(mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset).toEqual({
         lastUpdateId: null,
         persistenceFloorUpdateId: null,
-        onUpdateId: expect.any(Function),
       });
       expect(init).toHaveBeenCalledBefore(handleUpdate);
       expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } });
@@ -1118,6 +1120,107 @@ describe("TelegramPollingSession", () => {
         await waitForTelegramTestState(async () =>
           expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
         );
+      } finally {
+        abort.abort();
+        await runPromise;
+      }
+    });
+  });
+
+  it("persists the update offset only after the update is durably spooled", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const persistUpdateId = vi.fn(async () => undefined);
+      const log: string[] = [];
+      const handleUpdate = vi.fn(async () => undefined);
+      const worker = createListeningIngressWorker();
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: worker.createWorker,
+        persistUpdateId,
+        log: (line) => log.push(line),
+      });
+      try {
+        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
+        worker.emit({
+          type: "update",
+          requestId: "offset-1",
+          update: { update_id: 42, message: { text: "hello" } },
+          queued: 1,
+        });
+        await waitForTelegramTestState(() =>
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("offset-1", {
+            ok: true,
+            updateId: 42,
+          }),
+        );
+        await waitForTelegramTestState(() =>
+          expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } }),
+        );
+        expect(persistUpdateId).toHaveBeenCalledWith(42);
+        expect(
+          log.some((line) => line.includes("isolated polling update spooled updateId=42")),
+        ).toBe(true);
+        expect(
+          log.some((line) => line.includes("isolated polling offset persisted updateId=42")),
+        ).toBe(true);
+      } finally {
+        abort.abort();
+        await runPromise;
+      }
+    });
+  });
+
+  it("does not persist the update offset when spooling fails", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const persistUpdateId = vi.fn(async () => undefined);
+      const log: string[] = [];
+      setTelegramRuntime({
+        state: {
+          resolveStateDir: () => tempDir,
+          openChannelIngressQueue: (
+            options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
+          ) => {
+            const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
+            return {
+              ...queue,
+              enqueue: async () => {
+                throw new Error("spool write failure");
+              },
+            };
+          },
+        },
+      } as TelegramRuntime);
+      const worker = createListeningIngressWorker();
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate: vi.fn(async () => undefined),
+        createWorker: worker.createWorker,
+        persistUpdateId,
+        log: (line) => log.push(line),
+      });
+      try {
+        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
+        worker.emit({
+          type: "update",
+          requestId: "offset-fail-1",
+          update: { update_id: 99, message: { text: "hello" } },
+          queued: 1,
+        });
+        await waitForTelegramTestState(() =>
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("offset-fail-1", {
+            ok: false,
+            message: "spool write failure",
+          }),
+        );
+        expect(persistUpdateId).not.toHaveBeenCalled();
+        expect(
+          log.some((line) => line.includes("isolated polling update spool failed updateId=99")),
+        ).toBe(true);
       } finally {
         abort.abort();
         await runPromise;
@@ -1292,7 +1395,6 @@ describe("TelegramPollingSession", () => {
       expect(mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset).toEqual({
         lastUpdateId: null,
         persistenceFloorUpdateId: 42,
-        onUpdateId: expect.any(Function),
       });
       expect(handleUpdate).toHaveBeenCalledWith({
         update_id: 42,

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -234,7 +234,7 @@ function installTelegramIngressQueueRuntime(resolveStateDir: () => string): void
         options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
       ) => createChannelIngressQueue({ ...options, channelId: "telegram" }),
     },
-  } as TelegramRuntime);
+  } as unknown as TelegramRuntime);
 }
 
 function mockObjectArg(
@@ -1173,6 +1173,169 @@ describe("TelegramPollingSession", () => {
     });
   });
 
+  it("persists offsets in contiguous order even when out-of-order spools complete first", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const persistUpdateId = vi.fn(async () => undefined);
+      const log: string[] = [];
+      let release41: (() => void) | undefined;
+      const gate41 = new Promise<void>((resolve) => {
+        release41 = resolve;
+      });
+
+      setTelegramRuntime({
+        state: {
+          resolveStateDir: () => tempDir,
+          openChannelIngressQueue: (
+            options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
+          ) => {
+            const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
+            return {
+              ...queue,
+              enqueue: async (
+                eventId: string,
+                payload: unknown,
+                meta?: { metadata?: unknown; receivedAt?: number; laneKey?: string },
+              ) => {
+                const payloadRecord = payload as { updateId?: number };
+                if (payloadRecord.updateId === 41) {
+                  await gate41;
+                }
+                return queue.enqueue(eventId, payload as never, meta as never);
+              },
+            };
+          },
+        },
+      } as unknown as TelegramRuntime);
+
+      const handleUpdate = vi.fn(async () => undefined);
+      const worker = createListeningIngressWorker();
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: worker.createWorker,
+        persistUpdateId,
+        log: (line) => log.push(line),
+        getLastUpdateId: () => 40,
+      });
+      try {
+        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
+        worker.emit({
+          type: "update",
+          requestId: "out-of-order-41",
+          update: { update_id: 41, message: { text: "first" } },
+          queued: 1,
+        });
+        worker.emit({
+          type: "update",
+          requestId: "out-of-order-42",
+          update: { update_id: 42, message: { text: "second" } },
+          queued: 1,
+        });
+
+        // 42 should spool and ack, but offset should not advance past 41.
+        await waitForTelegramTestState(() =>
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("out-of-order-42", {
+            ok: true,
+            updateId: 42,
+          }),
+        );
+        expect(persistUpdateId).not.toHaveBeenCalled();
+
+        // Now let 41 spool. The durable boundary can advance through 42.
+        release41?.();
+        await waitForTelegramTestState(() => expect(persistUpdateId).toHaveBeenCalledWith(42));
+        expect(
+          log.some((line) => line.includes("isolated polling offset persisted updateId=42")),
+        ).toBe(true);
+      } finally {
+        abort.abort();
+        await runPromise;
+      }
+    });
+  });
+
+  it("does not persist a higher offset while a lower update id has not spooled", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const persistUpdateId = vi.fn(async () => undefined);
+      let shouldFail41 = true;
+
+      setTelegramRuntime({
+        state: {
+          resolveStateDir: () => tempDir,
+          openChannelIngressQueue: (
+            options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
+          ) => {
+            const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
+            return {
+              ...queue,
+              enqueue: async (
+                eventId: string,
+                payload: unknown,
+                meta?: { metadata?: unknown; receivedAt?: number; laneKey?: string },
+              ) => {
+                const payloadRecord = payload as { updateId?: number };
+                if (payloadRecord.updateId === 41 && shouldFail41) {
+                  throw new Error("forced spool failure for 41");
+                }
+                return queue.enqueue(eventId, payload as never, meta as never);
+              },
+            };
+          },
+        },
+      } as unknown as TelegramRuntime);
+
+      const handleUpdate = vi.fn(async () => undefined);
+      const worker = createListeningIngressWorker();
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: worker.createWorker,
+        persistUpdateId,
+        getLastUpdateId: () => 40,
+      });
+      try {
+        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
+
+        worker.emit({
+          type: "update",
+          requestId: "blocked-41",
+          update: { update_id: 41, message: { text: "first" } },
+          queued: 1,
+        });
+        worker.emit({
+          type: "update",
+          requestId: "blocked-42",
+          update: { update_id: 42, message: { text: "second" } },
+          queued: 1,
+        });
+
+        await waitForTelegramTestState(() =>
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("blocked-42", {
+            ok: true,
+            updateId: 42,
+          }),
+        );
+        expect(persistUpdateId).not.toHaveBeenCalled();
+
+        shouldFail41 = false;
+        worker.emit({
+          type: "update",
+          requestId: "retry-41",
+          update: { update_id: 41, message: { text: "first" } },
+          queued: 1,
+        });
+        await waitForTelegramTestState(() => expect(persistUpdateId).toHaveBeenCalledWith(42));
+      } finally {
+        abort.abort();
+        await runPromise;
+      }
+    });
+  });
+
   it("does not persist the update offset when spooling fails", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
@@ -1193,8 +1356,9 @@ describe("TelegramPollingSession", () => {
             };
           },
         },
-      } as TelegramRuntime);
+      } as unknown as TelegramRuntime);
       const worker = createListeningIngressWorker();
+
       const { runPromise } = startIsolatedIngressSession({
         abort,
         spoolDir: tempDir,
@@ -1300,7 +1464,7 @@ describe("TelegramPollingSession", () => {
             };
           },
         },
-      } as TelegramRuntime);
+      } as unknown as TelegramRuntime);
 
       await writeTelegramSpooledUpdate({
         spoolDir: tempDir,

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -234,7 +234,7 @@ function installTelegramIngressQueueRuntime(resolveStateDir: () => string): void
         options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
       ) => createChannelIngressQueue({ ...options, channelId: "telegram" }),
     },
-  } as unknown as TelegramRuntime);
+  } as TelegramRuntime);
 }
 
 function mockObjectArg(
@@ -1127,45 +1127,42 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("persists the update offset only after the update is durably spooled", async () => {
+  it("spools, persists the actual update id, then acknowledges", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
-      const persistUpdateId = vi.fn(async () => undefined);
-      const log: string[] = [];
-      const handleUpdate = vi.fn(async () => undefined);
+      const persistUpdateId = vi.fn(async (updateId: number) => {
+        expect(updateId).toBe(42);
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([42]);
+      });
       const worker = createListeningIngressWorker();
       const { runPromise } = startIsolatedIngressSession({
         abort,
         spoolDir: tempDir,
-        handleUpdate,
+        handleUpdate: vi.fn(async () => undefined),
         createWorker: worker.createWorker,
+        drainIntervalMs: 60_000,
+        getLastUpdateId: () => 40,
         persistUpdateId,
-        log: (line) => log.push(line),
       });
       try {
         await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
         worker.emit({
           type: "update",
-          requestId: "offset-1",
+          requestId: "offset-gap",
           update: { update_id: 42, message: { text: "hello" } },
           queued: 1,
         });
         await waitForTelegramTestState(() =>
-          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("offset-1", {
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("offset-gap", {
             ok: true,
             updateId: 42,
           }),
         );
-        await waitForTelegramTestState(() =>
-          expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } }),
+        expect(
+          expectDefined(persistUpdateId.mock.invocationCallOrder[0], "offset persistence order"),
+        ).toBeLessThan(
+          expectDefined(worker.ackSpooledUpdate.mock.invocationCallOrder[0], "worker ack order"),
         );
-        expect(persistUpdateId).toHaveBeenCalledWith(42);
-        expect(
-          log.some((line) => line.includes("isolated polling update spooled updateId=42")),
-        ).toBe(true);
-        expect(
-          log.some((line) => line.includes("isolated polling offset persisted updateId=42")),
-        ).toBe(true);
       } finally {
         abort.abort();
         await runPromise;
@@ -1173,82 +1170,36 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("persists offsets in contiguous order even when out-of-order spools complete first", async () => {
+  it("acknowledges a durable update when offset persistence fails", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
-      const persistUpdateId = vi.fn(async () => undefined);
-      const log: string[] = [];
-      let release41: (() => void) | undefined;
-      const gate41 = new Promise<void>((resolve) => {
-        release41 = resolve;
-      });
-
-      setTelegramRuntime({
-        state: {
-          resolveStateDir: () => tempDir,
-          openChannelIngressQueue: (
-            options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
-          ) => {
-            const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
-            return {
-              ...queue,
-              enqueue: async (
-                eventId: string,
-                payload: unknown,
-                meta?: { metadata?: unknown; receivedAt?: number; laneKey?: string },
-              ) => {
-                const payloadRecord = payload as { updateId?: number };
-                if (payloadRecord.updateId === 41) {
-                  await gate41;
-                }
-                return queue.enqueue(eventId, payload as never, meta as never);
-              },
-            };
-          },
-        },
-      } as unknown as TelegramRuntime);
-
-      const handleUpdate = vi.fn(async () => undefined);
+      const log = vi.fn();
       const worker = createListeningIngressWorker();
       const { runPromise } = startIsolatedIngressSession({
         abort,
         spoolDir: tempDir,
-        handleUpdate,
+        handleUpdate: vi.fn(async () => undefined),
         createWorker: worker.createWorker,
-        persistUpdateId,
-        log: (line) => log.push(line),
-        getLastUpdateId: () => 40,
+        log,
+        persistUpdateId: vi.fn(async () => {
+          throw new Error("offset store unavailable");
+        }),
       });
       try {
         await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
         worker.emit({
           type: "update",
-          requestId: "out-of-order-41",
-          update: { update_id: 41, message: { text: "first" } },
+          requestId: "offset-failure",
+          update: { update_id: 43, message: { text: "hello" } },
           queued: 1,
         });
-        worker.emit({
-          type: "update",
-          requestId: "out-of-order-42",
-          update: { update_id: 42, message: { text: "second" } },
-          queued: 1,
-        });
-
-        // 42 should spool and ack, but offset should not advance past 41.
         await waitForTelegramTestState(() =>
-          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("out-of-order-42", {
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("offset-failure", {
             ok: true,
-            updateId: 42,
+            updateId: 43,
           }),
         );
-        expect(persistUpdateId).not.toHaveBeenCalled();
-
-        // Now let 41 spool. The durable boundary can advance through 42.
-        release41?.();
-        await waitForTelegramTestState(() => expect(persistUpdateId).toHaveBeenCalledWith(42));
-        expect(
-          log.some((line) => line.includes("isolated polling offset persisted updateId=42")),
-        ).toBe(true);
+        expectLogIncludes(log, "isolated polling offset persist failed updateId=43");
       } finally {
         abort.abort();
         await runPromise;
@@ -1256,135 +1207,33 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("does not persist a higher offset while a lower update id has not spooled", async () => {
+  it("does not persist or acknowledge success when spooling fails", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
       const persistUpdateId = vi.fn(async () => undefined);
-      let shouldFail41 = true;
-
-      setTelegramRuntime({
-        state: {
-          resolveStateDir: () => tempDir,
-          openChannelIngressQueue: (
-            options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
-          ) => {
-            const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
-            return {
-              ...queue,
-              enqueue: async (
-                eventId: string,
-                payload: unknown,
-                meta?: { metadata?: unknown; receivedAt?: number; laneKey?: string },
-              ) => {
-                const payloadRecord = payload as { updateId?: number };
-                if (payloadRecord.updateId === 41 && shouldFail41) {
-                  throw new Error("forced spool failure for 41");
-                }
-                return queue.enqueue(eventId, payload as never, meta as never);
-              },
-            };
-          },
-        },
-      } as unknown as TelegramRuntime);
-
-      const handleUpdate = vi.fn(async () => undefined);
       const worker = createListeningIngressWorker();
-      const { runPromise } = startIsolatedIngressSession({
-        abort,
-        spoolDir: tempDir,
-        handleUpdate,
-        createWorker: worker.createWorker,
-        persistUpdateId,
-        getLastUpdateId: () => 40,
-      });
-      try {
-        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
-
-        worker.emit({
-          type: "update",
-          requestId: "blocked-41",
-          update: { update_id: 41, message: { text: "first" } },
-          queued: 1,
-        });
-        worker.emit({
-          type: "update",
-          requestId: "blocked-42",
-          update: { update_id: 42, message: { text: "second" } },
-          queued: 1,
-        });
-
-        await waitForTelegramTestState(() =>
-          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("blocked-42", {
-            ok: true,
-            updateId: 42,
-          }),
-        );
-        expect(persistUpdateId).not.toHaveBeenCalled();
-
-        shouldFail41 = false;
-        worker.emit({
-          type: "update",
-          requestId: "retry-41",
-          update: { update_id: 41, message: { text: "first" } },
-          queued: 1,
-        });
-        await waitForTelegramTestState(() => expect(persistUpdateId).toHaveBeenCalledWith(42));
-      } finally {
-        abort.abort();
-        await runPromise;
-      }
-    });
-  });
-
-  it("does not persist the update offset when spooling fails", async () => {
-    await withTempSpool(async (tempDir) => {
-      const abort = new AbortController();
-      const persistUpdateId = vi.fn(async () => undefined);
-      const log: string[] = [];
-      setTelegramRuntime({
-        state: {
-          resolveStateDir: () => tempDir,
-          openChannelIngressQueue: (
-            options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
-          ) => {
-            const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
-            return {
-              ...queue,
-              enqueue: async () => {
-                throw new Error("spool write failure");
-              },
-            };
-          },
-        },
-      } as unknown as TelegramRuntime);
-      const worker = createListeningIngressWorker();
-
       const { runPromise } = startIsolatedIngressSession({
         abort,
         spoolDir: tempDir,
         handleUpdate: vi.fn(async () => undefined),
         createWorker: worker.createWorker,
         persistUpdateId,
-        log: (line) => log.push(line),
       });
       try {
         await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
         worker.emit({
           type: "update",
-          requestId: "offset-fail-1",
-          update: { update_id: 99, message: { text: "hello" } },
+          requestId: "spool-failure",
+          update: { message: { text: "missing update id" } },
           queued: 1,
         });
         await waitForTelegramTestState(() =>
-          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("offset-fail-1", {
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("spool-failure", {
             ok: false,
-            message: "spool write failure",
+            message: "Telegram update missing numeric update_id.",
           }),
         );
         expect(persistUpdateId).not.toHaveBeenCalled();
-        expect(
-          log.some((line) => line.includes("isolated polling update spool failed updateId=99")),
-        ).toBe(true);
       } finally {
         abort.abort();
         await runPromise;
@@ -1464,7 +1313,7 @@ describe("TelegramPollingSession", () => {
             };
           },
         },
-      } as unknown as TelegramRuntime);
+      } as TelegramRuntime);
 
       await writeTelegramSpooledUpdate({
         spoolDir: tempDir,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -126,6 +126,18 @@ export class TelegramPollingSession {
   #spooledUpdateHandlerTimeoutMs: number;
   #deliveryDrainInFlight = false;
   #nextDeliveryDrainAt = 0;
+  // Ingested update ids whose durable spool finished but whose offset has not
+  // yet been persisted because lower update ids are still in flight.
+  #spooledUpdateIds = new Set<number>();
+  // Promises for update ids currently being spooled, used to coalesce duplicate
+  // worker deliveries for the same update_id.
+  #pendingSpoolPromises = new Map<number, Promise<void>>();
+  // Highest update id whose offset has been durably persisted. Starts from the
+  // persisted offset at the beginning of the isolated ingress cycle. While it is
+  // null, spooling is serialized so the first successful spool becomes the floor.
+  #lastPersistedUpdateId: number | null = null;
+  // Serializes spooling until a durable offset floor exists.
+  #spoolOffsetQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
     this.#transportState = new TelegramPollingTransportState({
@@ -276,6 +288,49 @@ export class TelegramPollingSession {
     this.#nextDeliveryDrainAt = 0;
   }
 
+  #isUpdateOffsetAlreadyPersisted(updateId: number): boolean {
+    return this.#lastPersistedUpdateId !== null && updateId <= this.#lastPersistedUpdateId;
+  }
+
+  /**
+   * Advance the persisted offset only across a contiguous run of successfully
+   * spooled updates. This prevents a later update_id from being persisted before
+   * an earlier one has finished spooling, which would make the earlier update
+   * unrecoverable after a restart.
+   */
+  #advanceOffsetBoundary(): void {
+    // The floor must already exist; bootstrap is handled by serializing spools
+    // until the first successful one is persisted.
+    if (this.#lastPersistedUpdateId === null) {
+      return;
+    }
+
+    let advanced = false;
+    let nextId = this.#lastPersistedUpdateId + 1;
+    while (this.#spooledUpdateIds.has(nextId)) {
+      this.#spooledUpdateIds.delete(nextId);
+      this.#lastPersistedUpdateId = nextId;
+      advanced = true;
+      nextId += 1;
+    }
+
+    if (advanced) {
+      const updateIdToPersist = this.#lastPersistedUpdateId;
+      void this.opts
+        .persistUpdateId(updateIdToPersist)
+        .then(() => {
+          this.opts.log(
+            `[telegram][diag] isolated polling offset persisted updateId=${updateIdToPersist}`,
+          );
+        })
+        .catch((err: unknown) => {
+          this.opts.log(
+            `[telegram] isolated polling offset persist failed updateId=${updateIdToPersist}: ${formatErrorMessage(err)}`,
+          );
+        });
+    }
+  }
+
   async #createPollingBot(): Promise<TelegramBot | undefined> {
     const cycleAbortController = new AbortController();
     this.#activeCycleAbort = cycleAbortController;
@@ -402,6 +457,11 @@ export class TelegramPollingSession {
     }
     const spoolDir =
       ingress.spoolDir ?? resolveTelegramIngressSpoolDir({ accountId: this.opts.accountId });
+    // Resume from the durable offset. Updates <= this id are considered already
+    // persisted and will be acknowledged without re-spooling.
+    this.#lastPersistedUpdateId = this.opts.getLastUpdateId();
+    this.#spooledUpdateIds.clear();
+    this.#pendingSpoolPromises.clear();
     const workerFactory = ingress.createWorker ?? createTelegramIngressWorker;
     const worker = workerFactory({
       token: this.opts.token,
@@ -516,33 +576,70 @@ export class TelegramPollingSession {
         this.opts.log(
           `[telegram][diag] isolated polling worker update received updateId=${updateIdHint} queued=${message.queued}`,
         );
-        void writeTelegramSpooledUpdate({
-          spoolDir,
-          update: message.update,
-          laneKey: telegramSpooledUpdateLaneKey(message.update, this.opts.botInfo),
-        }).then(
-          (updateId) => {
+
+        const updateIdNumber = typeof updateIdHint === "number" ? updateIdHint : null;
+        if (updateIdNumber !== null && this.#isUpdateOffsetAlreadyPersisted(updateIdNumber)) {
+          // Duplicate of an already-persisted update; the worker will only stop
+          // re-delivering once we acknowledge it.
+          ackSpooledUpdate(message.requestId, { ok: true, updateId: updateIdNumber });
+          return;
+        }
+
+        // Coalesce duplicate deliveries for the same update_id so we only spool
+        // it once. This can happen when the worker retries before the first spool
+        // has settled.
+        if (updateIdNumber !== null) {
+          const pending = this.#pendingSpoolPromises.get(updateIdNumber);
+          if (pending) {
+            void pending.then(
+              () => {
+                ackSpooledUpdate(message.requestId, { ok: true, updateId: updateIdNumber });
+              },
+              () => {
+                ackSpooledUpdate(message.requestId, {
+                  ok: false,
+                  message: "duplicate spool failed",
+                });
+              },
+            );
+            return;
+          }
+        }
+
+        const spoolAndAck = async (): Promise<void> => {
+          try {
+            const updateId = await writeTelegramSpooledUpdate({
+              spoolDir,
+              update: message.update,
+              laneKey: telegramSpooledUpdateLaneKey(message.update, this.opts.botInfo),
+            });
             this.opts.log(`[telegram][diag] isolated polling update spooled updateId=${updateId}`);
-            // Persist the offset only after the update is durably spooled. This
-            // guarantees the worker will not re-fetch this update after a restart
-            // (at the cost of a potential duplicate spool entry, which the
-            // channel ingress queue deduplicates by update_id).
-            void this.opts
-              .persistUpdateId(updateId)
-              .then(() => {
-                this.opts.log(
-                  `[telegram][diag] isolated polling offset persisted updateId=${updateId}`,
-                );
-              })
-              .catch((err: unknown) => {
+            if (this.#lastPersistedUpdateId === null) {
+              // Bootstrap: the first successfully spooled update becomes the
+              // durable floor. This only happens when there is no persisted
+              // offset yet; afterwards the worker's offset guarantees a
+              // contiguous sequence from the floor.
+              this.#lastPersistedUpdateId = updateId;
+              this.opts.log(
+                `[telegram][diag] isolated polling offset persisted updateId=${updateId}`,
+              );
+              void this.opts.persistUpdateId(updateId).catch((err: unknown) => {
                 this.opts.log(
                   `[telegram] isolated polling offset persist failed updateId=${updateId}: ${formatErrorMessage(err)}`,
                 );
               });
+            } else {
+              // Only advance the durable offset along a contiguous boundary of
+              // successfully spooled updates. This prevents a later update_id
+              // from being persisted before an earlier one has finished
+              // spooling, which would make the earlier update unrecoverable
+              // after a restart.
+              this.#spooledUpdateIds.add(updateId);
+              this.#advanceOffsetBoundary();
+            }
             ackSpooledUpdate(message.requestId, { ok: true, updateId });
             requestImmediateDrain();
-          },
-          (err: unknown) => {
+          } catch (err: unknown) {
             this.opts.log(
               `[telegram] isolated polling update spool failed updateId=${updateIdHint}: ${formatErrorMessage(err)}`,
             );
@@ -550,8 +647,27 @@ export class TelegramPollingSession {
               ok: false,
               message: formatErrorMessage(err),
             });
-          },
-        );
+          }
+        };
+
+        if (this.#lastPersistedUpdateId === null) {
+          // Serialize spooling until the first successful spool establishes the
+          // durable floor. This avoids picking a higher update_id as the floor
+          // while a lower one is still in flight.
+          this.#spoolOffsetQueue = this.#spoolOffsetQueue.then(
+            () => spoolAndAck(),
+            () => spoolAndAck(),
+          );
+          return;
+        }
+
+        const spoolPromise = spoolAndAck();
+        if (updateIdNumber !== null) {
+          this.#pendingSpoolPromises.set(updateIdNumber, spoolPromise);
+          void spoolPromise.finally(() => {
+            this.#pendingSpoolPromises.delete(updateIdNumber);
+          });
+        }
         return;
       }
       if (message.type === "spooled") {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -126,18 +126,6 @@ export class TelegramPollingSession {
   #spooledUpdateHandlerTimeoutMs: number;
   #deliveryDrainInFlight = false;
   #nextDeliveryDrainAt = 0;
-  // Ingested update ids whose durable spool finished but whose offset has not
-  // yet been persisted because lower update ids are still in flight.
-  #spooledUpdateIds = new Set<number>();
-  // Promises for update ids currently being spooled, used to coalesce duplicate
-  // worker deliveries for the same update_id.
-  #pendingSpoolPromises = new Map<number, Promise<void>>();
-  // Highest update id whose offset has been durably persisted. Starts from the
-  // persisted offset at the beginning of the isolated ingress cycle. While it is
-  // null, spooling is serialized so the first successful spool becomes the floor.
-  #lastPersistedUpdateId: number | null = null;
-  // Serializes spooling until a durable offset floor exists.
-  #spoolOffsetQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
     this.#transportState = new TelegramPollingTransportState({
@@ -288,49 +276,6 @@ export class TelegramPollingSession {
     this.#nextDeliveryDrainAt = 0;
   }
 
-  #isUpdateOffsetAlreadyPersisted(updateId: number): boolean {
-    return this.#lastPersistedUpdateId !== null && updateId <= this.#lastPersistedUpdateId;
-  }
-
-  /**
-   * Advance the persisted offset only across a contiguous run of successfully
-   * spooled updates. This prevents a later update_id from being persisted before
-   * an earlier one has finished spooling, which would make the earlier update
-   * unrecoverable after a restart.
-   */
-  #advanceOffsetBoundary(): void {
-    // The floor must already exist; bootstrap is handled by serializing spools
-    // until the first successful one is persisted.
-    if (this.#lastPersistedUpdateId === null) {
-      return;
-    }
-
-    let advanced = false;
-    let nextId = this.#lastPersistedUpdateId + 1;
-    while (this.#spooledUpdateIds.has(nextId)) {
-      this.#spooledUpdateIds.delete(nextId);
-      this.#lastPersistedUpdateId = nextId;
-      advanced = true;
-      nextId += 1;
-    }
-
-    if (advanced) {
-      const updateIdToPersist = this.#lastPersistedUpdateId;
-      void this.opts
-        .persistUpdateId(updateIdToPersist)
-        .then(() => {
-          this.opts.log(
-            `[telegram][diag] isolated polling offset persisted updateId=${updateIdToPersist}`,
-          );
-        })
-        .catch((err: unknown) => {
-          this.opts.log(
-            `[telegram] isolated polling offset persist failed updateId=${updateIdToPersist}: ${formatErrorMessage(err)}`,
-          );
-        });
-    }
-  }
-
   async #createPollingBot(): Promise<TelegramBot | undefined> {
     const cycleAbortController = new AbortController();
     this.#activeCycleAbort = cycleAbortController;
@@ -457,11 +402,6 @@ export class TelegramPollingSession {
     }
     const spoolDir =
       ingress.spoolDir ?? resolveTelegramIngressSpoolDir({ accountId: this.opts.accountId });
-    // Resume from the durable offset. Updates <= this id are considered already
-    // persisted and will be acknowledged without re-spooling.
-    this.#lastPersistedUpdateId = this.opts.getLastUpdateId();
-    this.#spooledUpdateIds.clear();
-    this.#pendingSpoolPromises.clear();
     const workerFactory = ingress.createWorker ?? createTelegramIngressWorker;
     const worker = workerFactory({
       token: this.opts.token,
@@ -576,69 +516,17 @@ export class TelegramPollingSession {
         this.opts.log(
           `[telegram][diag] isolated polling worker update received updateId=${updateIdHint} queued=${message.queued}`,
         );
-
-        const updateIdNumber = typeof updateIdHint === "number" ? updateIdHint : null;
-        if (updateIdNumber !== null && this.#isUpdateOffsetAlreadyPersisted(updateIdNumber)) {
-          // Duplicate of an already-persisted update; the worker will only stop
-          // re-delivering once we acknowledge it.
-          ackSpooledUpdate(message.requestId, { ok: true, updateId: updateIdNumber });
-          return;
-        }
-
-        // Coalesce duplicate deliveries for the same update_id so we only spool
-        // it once. This can happen when the worker retries before the first spool
-        // has settled.
-        if (updateIdNumber !== null) {
-          const pending = this.#pendingSpoolPromises.get(updateIdNumber);
-          if (pending) {
-            void pending.then(
-              () => {
-                ackSpooledUpdate(message.requestId, { ok: true, updateId: updateIdNumber });
-              },
-              () => {
-                ackSpooledUpdate(message.requestId, {
-                  ok: false,
-                  message: "duplicate spool failed",
-                });
-              },
-            );
-            return;
-          }
-        }
-
-        const spoolAndAck = async (): Promise<void> => {
+        // The worker waits for this request's ACK before emitting the next update.
+        // Keep spool, offset persistence, and ACK on that single ordered path.
+        void (async () => {
+          let updateId: number;
           try {
-            const updateId = await writeTelegramSpooledUpdate({
+            updateId = await writeTelegramSpooledUpdate({
               spoolDir,
               update: message.update,
               laneKey: telegramSpooledUpdateLaneKey(message.update, this.opts.botInfo),
             });
             this.opts.log(`[telegram][diag] isolated polling update spooled updateId=${updateId}`);
-            if (this.#lastPersistedUpdateId === null) {
-              // Bootstrap: the first successfully spooled update becomes the
-              // durable floor. This only happens when there is no persisted
-              // offset yet; afterwards the worker's offset guarantees a
-              // contiguous sequence from the floor.
-              this.#lastPersistedUpdateId = updateId;
-              this.opts.log(
-                `[telegram][diag] isolated polling offset persisted updateId=${updateId}`,
-              );
-              void this.opts.persistUpdateId(updateId).catch((err: unknown) => {
-                this.opts.log(
-                  `[telegram] isolated polling offset persist failed updateId=${updateId}: ${formatErrorMessage(err)}`,
-                );
-              });
-            } else {
-              // Only advance the durable offset along a contiguous boundary of
-              // successfully spooled updates. This prevents a later update_id
-              // from being persisted before an earlier one has finished
-              // spooling, which would make the earlier update unrecoverable
-              // after a restart.
-              this.#spooledUpdateIds.add(updateId);
-              this.#advanceOffsetBoundary();
-            }
-            ackSpooledUpdate(message.requestId, { ok: true, updateId });
-            requestImmediateDrain();
           } catch (err: unknown) {
             this.opts.log(
               `[telegram] isolated polling update spool failed updateId=${updateIdHint}: ${formatErrorMessage(err)}`,
@@ -647,27 +535,22 @@ export class TelegramPollingSession {
               ok: false,
               message: formatErrorMessage(err),
             });
+            return;
           }
-        };
 
-        if (this.#lastPersistedUpdateId === null) {
-          // Serialize spooling until the first successful spool establishes the
-          // durable floor. This avoids picking a higher update_id as the floor
-          // while a lower one is still in flight.
-          this.#spoolOffsetQueue = this.#spoolOffsetQueue.then(
-            () => spoolAndAck(),
-            () => spoolAndAck(),
-          );
-          return;
-        }
-
-        const spoolPromise = spoolAndAck();
-        if (updateIdNumber !== null) {
-          this.#pendingSpoolPromises.set(updateIdNumber, spoolPromise);
-          void spoolPromise.finally(() => {
-            this.#pendingSpoolPromises.delete(updateIdNumber);
-          });
-        }
+          try {
+            await this.opts.persistUpdateId(updateId);
+            this.opts.log(
+              `[telegram][diag] isolated polling offset persisted updateId=${updateId}`,
+            );
+          } catch (err: unknown) {
+            this.opts.log(
+              `[telegram] isolated polling offset persist failed updateId=${updateId}: ${formatErrorMessage(err)}`,
+            );
+          }
+          ackSpooledUpdate(message.requestId, { ok: true, updateId });
+          requestImmediateDrain();
+        })();
         return;
       }
       if (message.type === "spooled") {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -23,6 +23,7 @@ import { createTelegramTransportIngressMonitor } from "./telegram-ingress-drain-
 import { resolveTelegramAdoptionStallTimeoutMs } from "./telegram-ingress-drain.js";
 import {
   resolveTelegramIngressSpoolDir,
+  resolveTelegramUpdateId,
   telegramSpooledUpdateLaneKey,
   writeTelegramSpooledUpdate,
 } from "./telegram-ingress-spool.js";
@@ -292,7 +293,10 @@ export class TelegramPollingSession {
     const updateOffset = {
       lastUpdateId,
       persistenceFloorUpdateId: persistedLastUpdateId,
-      onUpdateId: this.opts.persistUpdateId,
+      // In isolated mode the offset is persisted as soon as the update is
+      // durably spooled (see #runIsolatedIngressCycle), so the bot's update
+      // tracker does not need to persist it again after dispatch.
+      ...(this.opts.isolatedIngress?.enabled ? {} : { onUpdateId: this.opts.persistUpdateId }),
     };
     try {
       return createTelegramBot({
@@ -476,6 +480,9 @@ export class TelegramPollingSession {
         }
       };
       if (message.type === "poll-start") {
+        this.opts.log(
+          `[telegram][diag] isolated polling worker poll-start offset=${message.offset ?? "null"}`,
+        );
         liveness.noteGetUpdatesStarted({ offset: message.offset }, message.startedAt);
         pollState.startedAt = message.startedAt;
         pollState.offset = message.offset;
@@ -505,16 +512,40 @@ export class TelegramPollingSession {
         return;
       }
       if (message.type === "update") {
+        const updateIdHint = resolveTelegramUpdateId(message.update) ?? "unknown";
+        this.opts.log(
+          `[telegram][diag] isolated polling worker update received updateId=${updateIdHint} queued=${message.queued}`,
+        );
         void writeTelegramSpooledUpdate({
           spoolDir,
           update: message.update,
           laneKey: telegramSpooledUpdateLaneKey(message.update, this.opts.botInfo),
         }).then(
           (updateId) => {
+            this.opts.log(`[telegram][diag] isolated polling update spooled updateId=${updateId}`);
+            // Persist the offset only after the update is durably spooled. This
+            // guarantees the worker will not re-fetch this update after a restart
+            // (at the cost of a potential duplicate spool entry, which the
+            // channel ingress queue deduplicates by update_id).
+            void this.opts
+              .persistUpdateId(updateId)
+              .then(() => {
+                this.opts.log(
+                  `[telegram][diag] isolated polling offset persisted updateId=${updateId}`,
+                );
+              })
+              .catch((err: unknown) => {
+                this.opts.log(
+                  `[telegram] isolated polling offset persist failed updateId=${updateId}: ${formatErrorMessage(err)}`,
+                );
+              });
             ackSpooledUpdate(message.requestId, { ok: true, updateId });
             requestImmediateDrain();
           },
           (err: unknown) => {
+            this.opts.log(
+              `[telegram] isolated polling update spool failed updateId=${updateIdHint}: ${formatErrorMessage(err)}`,
+            );
             ackSpooledUpdate(message.requestId, {
               ok: false,
               message: formatErrorMessage(err),


### PR DESCRIPTION
Refs #113315

## What Problem This Solves

Isolated Telegram polling previously allowed the normal bot update tracker to persist an update offset before the ingress worker's durable spool write completed. A crash in that window could make Telegram stop redelivering an update that OpenClaw had not stored.

## Changes

- Persist isolated polling offsets only after `writeTelegramSpooledUpdate` commits.
- Keep spool, offset persistence, and worker acknowledgement on the worker's existing one-update-at-a-time path.
- Omit the post-dispatch `onUpdateId` callback in isolated mode so each offset has one owner.
- Add diagnostics for polling, spool, and offset persistence stages.
- Add regressions for non-consecutive Telegram update IDs, persistence failure after durable spool, and spool failure before acknowledgement.

## Evidence

- Current head `27de15889cb` is rebased onto `d4ed57bc884`; `git range-diff` confirms the reviewed patch series is unchanged.
- Exact-head full CI and required `openclaw/ci-gate` passed: https://github.com/openclaw/openclaw/actions/runs/30247109038
- `extensions/telegram/src/polling-session.test.ts` proves spool → persist → ACK ordering and proves a spool failure produces no persisted offset or successful ACK.
- `extensions/telegram/src/telegram-ingress-worker.runtime.test.ts` proves the worker waits for each parent ACK before advancing the next `getUpdates` offset.
- Earlier live isolated-polling evidence established the spool-before-offset observable sequence. The current head removes unnecessary concurrency bookkeeping while retaining that single serialized boundary.
