### PR TITLE
fix(acpx): treat ACP sessions with dead PIDs as fresh after gateway restart

### DIFF
--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -350,30 +350,47 @@ async function terminatePids(
   return terminated;
 }
 
-/** Verify that a PID currently maps to a live, OpenClaw-owned ACPX wrapper
+export type AcpxProcessWrapperVerification =
+  | { kind: "live" }
+  | { kind: "dead" }
+  | { kind: "unavailable" };
+
+/** Verify whether a PID currently maps to a live, OpenClaw-owned ACPX wrapper
  * process matching the expected wrapper root, stored command, and lease
- * identity. Any dead, mismatched, or unverifiable PID returns false so callers
- * can treat the stored session as fresh (#109285 PID-reuse hardening). */
-export async function isLiveOpenClawOwnedAcpxWrapper(params: {
+ * identity (#109285 PID-reuse hardening).
+ *
+ * - `live`: the PID maps to a matching OpenClaw-owned wrapper.
+ * - `dead`: ownership is disproven (the PID is missing from a populated
+ *   process table, or the process does not match). Callers may treat the
+ *   stored session as fresh.
+ * - `unavailable`: process inspection could not run (unsupported platform,
+ *   empty process table, or listing error). Absence from the table is not
+ *   proof of death, so callers should preserve the stored session. */
+export async function verifyLiveOpenClawOwnedAcpxWrapper(params: {
   pid: number;
   wrapperRoot?: string;
   expectedCommand?: string;
   expectedLeaseId?: string;
   expectedGatewayInstanceId?: string;
   deps?: AcpxProcessCleanupDeps;
-}): Promise<boolean> {
+}): Promise<AcpxProcessWrapperVerification> {
   if (!params.pid || params.pid <= 0 || params.pid === process.pid) {
-    return false;
+    return { kind: "dead" };
   }
   let processes: AcpxProcessInfo[];
   try {
     processes = await (params.deps?.listProcesses ?? listPlatformProcesses)();
   } catch {
-    return false;
+    return { kind: "unavailable" };
+  }
+  if (processes.length === 0) {
+    // No process table is exposed (e.g. Windows returns an empty table). A PID
+    // missing from the table is not proof that the process died.
+    return { kind: "unavailable" };
   }
   const proc = processes.find((processInfo) => processInfo.pid === params.pid);
   if (!proc) {
-    return false;
+    return { kind: "dead" };
   }
   const liveCommand = proc.command;
   const liveCommandWasGeneratedWrapper = commandMentionsGeneratedWrapper(
@@ -383,13 +400,13 @@ export async function isLiveOpenClawOwnedAcpxWrapper(params: {
     normalizePathLike(params.expectedCommand ?? ""),
   );
   if (!liveCommandWasGeneratedWrapper && storedCommandWasGeneratedWrapper) {
-    return false;
+    return { kind: "dead" };
   }
   if (
     !liveCommandWasGeneratedWrapper &&
     !commandsReferToSameRootCommand(liveCommand, params.expectedCommand)
   ) {
-    return false;
+    return { kind: "dead" };
   }
   if (
     !isOpenClawOwnedAcpxProcessCommand({
@@ -397,7 +414,7 @@ export async function isLiveOpenClawOwnedAcpxWrapper(params: {
       wrapperRoot: params.wrapperRoot,
     })
   ) {
-    return false;
+    return { kind: "dead" };
   }
   if (
     !liveCommandMatchesLeaseIdentity({
@@ -406,9 +423,9 @@ export async function isLiveOpenClawOwnedAcpxWrapper(params: {
       expectedGatewayInstanceId: params.expectedGatewayInstanceId,
     })
   ) {
-    return false;
+    return { kind: "dead" };
   }
-  return true;
+  return { kind: "live" };
 }
 
 /** Terminate one validated OpenClaw-owned ACPX wrapper process tree. */

--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -350,6 +350,67 @@ async function terminatePids(
   return terminated;
 }
 
+/** Verify that a PID currently maps to a live, OpenClaw-owned ACPX wrapper
+ * process matching the expected wrapper root, stored command, and lease
+ * identity. Any dead, mismatched, or unverifiable PID returns false so callers
+ * can treat the stored session as fresh (#109285 PID-reuse hardening). */
+export async function isLiveOpenClawOwnedAcpxWrapper(params: {
+  pid: number;
+  wrapperRoot?: string;
+  expectedCommand?: string;
+  expectedLeaseId?: string;
+  expectedGatewayInstanceId?: string;
+  deps?: AcpxProcessCleanupDeps;
+}): Promise<boolean> {
+  if (!params.pid || params.pid <= 0 || params.pid === process.pid) {
+    return false;
+  }
+  let processes: AcpxProcessInfo[];
+  try {
+    processes = await (params.deps?.listProcesses ?? listPlatformProcesses)();
+  } catch {
+    return false;
+  }
+  const proc = processes.find((processInfo) => processInfo.pid === params.pid);
+  if (!proc) {
+    return false;
+  }
+  const liveCommand = proc.command;
+  const liveCommandWasGeneratedWrapper = commandMentionsGeneratedWrapper(
+    normalizePathLike(liveCommand),
+  );
+  const storedCommandWasGeneratedWrapper = commandMentionsGeneratedWrapper(
+    normalizePathLike(params.expectedCommand ?? ""),
+  );
+  if (!liveCommandWasGeneratedWrapper && storedCommandWasGeneratedWrapper) {
+    return false;
+  }
+  if (
+    !liveCommandWasGeneratedWrapper &&
+    !commandsReferToSameRootCommand(liveCommand, params.expectedCommand)
+  ) {
+    return false;
+  }
+  if (
+    !isOpenClawOwnedAcpxProcessCommand({
+      command: liveCommand,
+      wrapperRoot: params.wrapperRoot,
+    })
+  ) {
+    return false;
+  }
+  if (
+    !liveCommandMatchesLeaseIdentity({
+      command: liveCommand,
+      expectedLeaseId: params.expectedLeaseId,
+      expectedGatewayInstanceId: params.expectedGatewayInstanceId,
+    })
+  ) {
+    return false;
+  }
+  return true;
+}
+
 /** Terminate one validated OpenClaw-owned ACPX wrapper process tree. */
 export async function cleanupOpenClawOwnedAcpxProcessTree(params: {
   rootPid?: number;

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -179,9 +179,21 @@ function processCleanupDepsWithLiveLeases(leaseStore: ReturnType<typeof makeLeas
           .map((lease) => ({
             pid: Number(lease.rootPid),
             ppid: 0,
-            command: `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} ${lease.leaseId} ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} ${lease.gatewayInstanceId}`,
+            command: `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} ${String(lease.leaseId)} ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} ${String(lease.gatewayInstanceId)}`,
           })),
       ),
+      killProcess: vi.fn(() => {}),
+      sleep: vi.fn(async () => {}),
+    },
+  };
+}
+
+function processCleanupDepsWithListingError() {
+  return {
+    openclawProcessCleanup: {
+      listProcesses: vi.fn(async () => {
+        throw new Error("process listing unavailable");
+      }),
       killProcess: vi.fn(() => {}),
       sleep: vi.fn(async () => {}),
     },
@@ -1954,7 +1966,9 @@ describe("AcpxRuntime fresh reset wrapper", () => {
         openclawGatewayInstanceId: "gateway-test",
         openclawProcessLeaseStore: makeLeaseStore().store,
       },
-      processCleanupDepsWithTable([]),
+      processCleanupDepsWithTable([
+        { pid: deadPid - 1, ppid: 1, command: "node /usr/bin/scheduler.js" },
+      ]),
     );
 
     const loaded = await wrappedStore.load("agent:codex:acp:test");
@@ -2083,7 +2097,9 @@ describe("AcpxRuntime fresh reset wrapper", () => {
         openclawGatewayInstanceId: "gateway-test",
         openclawProcessLeaseStore: leaseStore.store,
       },
-      processCleanupDepsWithTable([]),
+      processCleanupDepsWithTable([
+        { pid: deadPid - 1, ppid: 1, command: "node /usr/bin/scheduler.js" },
+      ]),
     );
 
     const loaded = await wrappedStore.load("agent:codex:acp:test");
@@ -2212,6 +2228,113 @@ describe("AcpxRuntime fresh reset wrapper", () => {
         acpxRecordId: "agent:codex:acp:test",
         agentCommand: CODEX_ACP_COMMAND,
         openclawLeaseId: "lease-live",
+        openclawGatewayInstanceId: "gateway-test",
+      }),
+    );
+  });
+
+  it("preserves a stored session when process listing is unavailable on an empty table (#109285)", async () => {
+    const unavailablePid = 999_991;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: unavailablePid,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: makeLeaseStore().store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      processCleanupDepsWithTable([]),
+    );
+
+    const loaded = (await wrappedStore.load("agent:codex:acp:test")) as Record<string, unknown>;
+
+    expect(loaded).toEqual(
+      expect.objectContaining({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: unavailablePid,
+      }),
+    );
+  });
+
+  it("preserves a stored session when process listing fails (#109285)", async () => {
+    const unavailablePid = 999_990;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: unavailablePid,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: makeLeaseStore().store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      processCleanupDepsWithListingError(),
+    );
+
+    const loaded = (await wrappedStore.load("agent:codex:acp:test")) as Record<string, unknown>;
+
+    expect(loaded).toEqual(
+      expect.objectContaining({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: unavailablePid,
+      }),
+    );
+  });
+
+  it("preserves a stored session and its open lease when process listing is unavailable (#109285)", async () => {
+    const unavailablePid = 999_989;
+    const leaseStore = makeLeaseStore();
+    await leaseStore.store.save({
+      leaseId: "lease-unavailable",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "codex-acp-wrapper.mjs",
+      rootPid: unavailablePid,
+      commandHash: "hash",
+      startedAt: Date.now(),
+      state: "open",
+    });
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: unavailablePid,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      processCleanupDepsWithListingError(),
+    );
+
+    const loaded = (await wrappedStore.load("agent:codex:acp:test")) as Record<string, unknown>;
+
+    expect(loaded).toEqual(
+      expect.objectContaining({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: unavailablePid,
+        openclawLeaseId: "lease-unavailable",
         openclawGatewayInstanceId: "gateway-test",
       }),
     );

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -158,9 +158,26 @@ function readFirstEnsureSessionInput(ensure: {
   return input as Parameters<AcpRuntime["ensureSession"]>[0];
 }
 
+function mockProcessAliveByPid(alivePids: Set<number>) {
+  return vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+    if (signal !== 0) {
+      return true;
+    }
+    if (!alivePids.has(pid as number)) {
+      const error = new Error("ESRCH");
+      (error as { code?: string }).code = "ESRCH";
+      throw error;
+    }
+    return true;
+  });
+}
+
 describe("AcpxRuntime fresh reset wrapper", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    // Default: treat every PID as alive so tests that use synthetic PIDs do not
+    // depend on real process state. Tests that need a dead PID override this.
+    vi.spyOn(process, "kill").mockImplementation(() => true);
   });
 
   it("rejects unsupported runtime session modes with a clear AcpRuntimeError (issue #73071)", async () => {
@@ -1906,6 +1923,126 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
     expect(await wrappedStore.load("agent:codex:acp:binding:test")).toBeUndefined();
     expect(baseStore["load"]).toHaveBeenCalledOnce();
+  });
+
+  it("treats a stored session with a dead pid as fresh so the gateway does not hang (#109285)", async () => {
+    const deadPid = 999_999;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: deadPid,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: makeLeaseStore().store,
+    });
+    const killSpy = mockProcessAliveByPid(new Set());
+
+    const loaded = await wrappedStore.load("agent:codex:acp:test");
+
+    expect(loaded).toBeUndefined();
+    expect(killSpy).toHaveBeenCalledWith(deadPid, 0);
+  });
+
+  it("returns a stored session when its pid is still alive (#109285)", async () => {
+    const livePid = 999_998;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: livePid,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: makeLeaseStore().store,
+    });
+    mockProcessAliveByPid(new Set([livePid]));
+
+    const loaded = (await wrappedStore.load("agent:codex:acp:test")) as Record<string, unknown>;
+
+    expect(loaded).toEqual(
+      expect.objectContaining({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: livePid,
+      }),
+    );
+  });
+
+  it("treats a session as fresh when an open lease's root pid is dead (#109285)", async () => {
+    const deadPid = 999_997;
+    const leaseStore = makeLeaseStore();
+    await leaseStore.store.save({
+      leaseId: "lease-dead",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "codex-acp-wrapper.mjs",
+      rootPid: deadPid,
+      commandHash: "hash",
+      startedAt: Date.now(),
+      state: "open",
+    });
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+    });
+    mockProcessAliveByPid(new Set());
+
+    const loaded = await wrappedStore.load("agent:codex:acp:test");
+
+    expect(loaded).toBeUndefined();
+  });
+
+  it("enriches a stored session with lease metadata when the lease root pid is alive (#109285)", async () => {
+    const livePid = 999_996;
+    const leaseStore = makeLeaseStore();
+    await leaseStore.store.save({
+      leaseId: "lease-live",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "codex-acp-wrapper.mjs",
+      rootPid: livePid,
+      commandHash: "hash",
+      startedAt: Date.now(),
+      state: "open",
+    });
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+    });
+    mockProcessAliveByPid(new Set([livePid]));
+
+    const loaded = (await wrappedStore.load("agent:codex:acp:test")) as Record<string, unknown>;
+
+    expect(loaded).toEqual(
+      expect.objectContaining({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        openclawLeaseId: "lease-live",
+        openclawGatewayInstanceId: "gateway-test",
+      }),
+    );
   });
 
   it("releases managed OpenClaw tools MCP delegates after close", async () => {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -158,26 +158,39 @@ function readFirstEnsureSessionInput(ensure: {
   return input as Parameters<AcpRuntime["ensureSession"]>[0];
 }
 
-function mockProcessAliveByPid(alivePids: Set<number>) {
-  return vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
-    if (signal !== 0) {
-      return true;
-    }
-    if (!alivePids.has(pid as number)) {
-      const error = new Error("ESRCH");
-      (error as { code?: string }).code = "ESRCH";
-      throw error;
-    }
-    return true;
-  });
+type ProcessTableRow = { pid: number; ppid: number; command: string };
+
+function processCleanupDepsWithTable(rows: ProcessTableRow[]) {
+  return {
+    openclawProcessCleanup: {
+      listProcesses: vi.fn(async () => rows),
+      killProcess: vi.fn(() => {}),
+      sleep: vi.fn(async () => {}),
+    },
+  };
+}
+
+function processCleanupDepsWithLiveLeases(leaseStore: ReturnType<typeof makeLeaseStore>) {
+  return {
+    openclawProcessCleanup: {
+      listProcesses: vi.fn(async () =>
+        Array.from(leaseStore.leases.values())
+          .filter((lease) => Number(lease.rootPid) > 0)
+          .map((lease) => ({
+            pid: Number(lease.rootPid),
+            ppid: 0,
+            command: `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} ${lease.leaseId} ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} ${lease.gatewayInstanceId}`,
+          })),
+      ),
+      killProcess: vi.fn(() => {}),
+      sleep: vi.fn(async () => {}),
+    },
+  };
 }
 
 describe("AcpxRuntime fresh reset wrapper", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    // Default: treat every PID as alive so tests that use synthetic PIDs do not
-    // depend on real process state. Tests that need a dead PID override this.
-    vi.spyOn(process, "kill").mockImplementation(() => true);
   });
 
   it("rejects unsupported runtime session modes with a clear AcpRuntimeError (issue #73071)", async () => {
@@ -1935,19 +1948,21 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       })),
       save: vi.fn(async () => {}),
     };
-    const { wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: makeLeaseStore().store,
-    });
-    const killSpy = mockProcessAliveByPid(new Set());
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: makeLeaseStore().store,
+      },
+      processCleanupDepsWithTable([]),
+    );
 
     const loaded = await wrappedStore.load("agent:codex:acp:test");
 
     expect(loaded).toBeUndefined();
-    expect(killSpy).toHaveBeenCalledWith(deadPid, 0);
   });
 
-  it("returns a stored session when its pid is still alive (#109285)", async () => {
+  it("returns a stored session when its pid maps to a live OpenClaw wrapper (#109285)", async () => {
     const livePid = 999_998;
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
@@ -1957,11 +1972,14 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       })),
       save: vi.fn(async () => {}),
     };
-    const { wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: makeLeaseStore().store,
-    });
-    mockProcessAliveByPid(new Set([livePid]));
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: makeLeaseStore().store,
+      },
+      processCleanupDepsWithTable([{ pid: livePid, ppid: 1, command: CODEX_ACP_WRAPPER_COMMAND }]),
+    );
 
     const loaded = (await wrappedStore.load("agent:codex:acp:test")) as Record<string, unknown>;
 
@@ -1972,6 +1990,70 @@ describe("AcpxRuntime fresh reset wrapper", () => {
         pid: livePid,
       }),
     );
+  });
+
+  it("treats a session as fresh when the pid was reused by an unrelated live process (#109285)", async () => {
+    const reusedPid = 999_995;
+    // The reused PID is alive (a live `process.kill` probe would succeed) but
+    // belongs to a different, unrelated process. Only a process-table identity
+    // check can detect this.
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: reusedPid,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: makeLeaseStore().store,
+      },
+      processCleanupDepsWithTable([
+        { pid: reusedPid, ppid: 1, command: "node /usr/bin/unrelated-server.js" },
+      ]),
+    );
+
+    const loaded = await wrappedStore.load("agent:codex:acp:test");
+
+    expect(loaded).toBeUndefined();
+  });
+
+  it("treats a session as fresh when the pid was reused by an unrelated live process that resembles a wrapper (#109285)", async () => {
+    const reusedPid = 999_994;
+    // The reused PID is alive but its command, while path-shaped like a Node
+    // wrapper, is not an OpenClaw-owned wrapper under the expected root.
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+        pid: reusedPid,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: makeLeaseStore().store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      processCleanupDepsWithTable([
+        {
+          pid: reusedPid,
+          ppid: 1,
+          command: `node "/tmp/other-tool/acpx/codex-acp-wrapper.mjs"`,
+        },
+      ]),
+    );
+
+    const loaded = await wrappedStore.load("agent:codex:acp:test");
+
+    expect(loaded).toBeUndefined();
   });
 
   it("treats a session as fresh when an open lease's root pid is dead (#109285)", async () => {
@@ -1995,18 +2077,99 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       })),
       save: vi.fn(async () => {}),
     };
-    const { wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-    });
-    mockProcessAliveByPid(new Set());
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+      },
+      processCleanupDepsWithTable([]),
+    );
 
     const loaded = await wrappedStore.load("agent:codex:acp:test");
 
     expect(loaded).toBeUndefined();
   });
 
-  it("enriches a stored session with lease metadata when the lease root pid is alive (#109285)", async () => {
+  it("treats a session as fresh when an open lease's root pid was reused (#109285)", async () => {
+    const reusedPid = 999_993;
+    const leaseStore = makeLeaseStore();
+    await leaseStore.store.save({
+      leaseId: "lease-reused",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "codex-acp-wrapper.mjs",
+      rootPid: reusedPid,
+      commandHash: "hash",
+      startedAt: Date.now(),
+      state: "open",
+    });
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+      },
+      processCleanupDepsWithTable([
+        { pid: reusedPid, ppid: 1, command: "node /usr/bin/unrelated-server.js" },
+      ]),
+    );
+
+    const loaded = await wrappedStore.load("agent:codex:acp:test");
+
+    expect(loaded).toBeUndefined();
+  });
+
+  it("treats a session as fresh when the lease root pid does not match the lease identity (#109285)", async () => {
+    const reusedPid = 999_992;
+    const leaseStore = makeLeaseStore();
+    await leaseStore.store.save({
+      leaseId: "lease-identity",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "codex-acp-wrapper.mjs",
+      rootPid: reusedPid,
+      commandHash: "hash",
+      startedAt: Date.now(),
+      state: "open",
+    });
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+      },
+      processCleanupDepsWithTable([
+        {
+          pid: reusedPid,
+          ppid: 1,
+          command: `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-other ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-other`,
+        },
+      ]),
+    );
+
+    const loaded = await wrappedStore.load("agent:codex:acp:test");
+
+    expect(loaded).toBeUndefined();
+  });
+
+  it("enriches a stored session with lease metadata when the lease root pid is a matching live wrapper (#109285)", async () => {
     const livePid = 999_996;
     const leaseStore = makeLeaseStore();
     await leaseStore.store.save({
@@ -2027,11 +2190,20 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       })),
       save: vi.fn(async () => {}),
     };
-    const { wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-    });
-    mockProcessAliveByPid(new Set([livePid]));
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+      },
+      processCleanupDepsWithTable([
+        {
+          pid: livePid,
+          ppid: 1,
+          command: `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-live ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`,
+        },
+      ]),
+    );
 
     const loaded = (await wrappedStore.load("agent:codex:acp:test")) as Record<string, unknown>;
 
@@ -2148,16 +2320,20 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       }),
     };
     const leaseStore = makeLeaseStore();
-    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-      agentRegistry: {
-        resolve: (agentName: string) =>
-          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
-        list: () => ["codex"],
+    const { runtime, delegate, wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
       },
-    });
+      processCleanupDepsWithLiveLeases(leaseStore),
+    );
     vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
       const command = (
         runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
@@ -2267,16 +2443,20 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       startedAt: 1,
       state: "open",
     });
-    const { runtime, delegate } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-      agentRegistry: {
-        resolve: (agentName: string) =>
-          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
-        list: () => ["codex"],
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
       },
-    });
+      processCleanupDepsWithTable([{ pid: 777, ppid: 0, command: leasedCommand }]),
+    );
     const resolvedCommands: string[] = [];
     vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
       resolvedCommands.push(
@@ -2318,16 +2498,20 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       }),
     };
     const leaseStore = makeLeaseStore();
-    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-      agentRegistry: {
-        resolve: (agentName: string) =>
-          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
-        list: () => ["codex"],
+    const { runtime, delegate, wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
       },
-    });
+      processCleanupDepsWithTable([{ pid: 777, ppid: 0, command: leasedCommand }]),
+    );
     vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
       const command = (
         runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
@@ -2372,16 +2556,20 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       }),
     };
     const leaseStore = makeLeaseStore();
-    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-      agentRegistry: {
-        resolve: (agentName: string) =>
-          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
-        list: () => ["codex"],
+    const { runtime, delegate, wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
       },
-    });
+      processCleanupDepsWithLiveLeases(leaseStore),
+    );
     const resolvedCommands: string[] = [];
     vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
       const command = (
@@ -2498,16 +2686,20 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       }),
     };
     const leaseStore = makeLeaseStore();
-    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-      agentRegistry: {
-        resolve: (agentName: string) =>
-          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
-        list: () => ["codex"],
+    const { runtime, delegate, wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
       },
-    });
+      processCleanupDepsWithLiveLeases(leaseStore),
+    );
     let releaseFirst!: () => void;
     const firstBlocked = new Promise<void>((resolve) => {
       releaseFirst = resolve;
@@ -2582,16 +2774,20 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       }),
     };
     const leaseStore = makeLeaseStore();
-    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-      agentRegistry: {
-        resolve: (agentName: string) =>
-          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
-        list: () => ["codex"],
+    const { runtime, delegate, wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
       },
-    });
+      processCleanupDepsWithTable([{ pid: 777, ppid: 0, command: CODEX_ACP_WRAPPER_COMMAND }]),
+    );
     const resolvedCommands: string[] = [];
     vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
       resolvedCommands.push(
@@ -2752,11 +2948,15 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       save: vi.fn(async () => {}),
     };
     const leaseStore = makeLeaseStore();
-    const { runtime, delegate } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-    });
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      processCleanupDepsWithTable([{ pid: 777, ppid: 0, command: leasedCommand }]),
+    );
     vi.spyOn(delegate, "runTurn").mockImplementation(async function* () {
       expect(leaseStore.leases.get("lease-live-reconnect")).toMatchObject({
         rootPid: 777,
@@ -3065,11 +3265,18 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       startedAt: 1,
       state: "open",
     });
-    const { runtime, delegate } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-    });
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      processCleanupDepsWithTable([
+        { pid: 777, ppid: 0, command: oldCommand },
+        { pid: 888, ppid: 0, command: newCommand },
+      ]),
+    );
     let markTurnStarted!: () => void;
     const turnStarted = new Promise<void>((resolve) => {
       markTurnStarted = resolve;
@@ -3537,11 +3744,21 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       })),
       save: vi.fn(async () => {}),
     };
-    const { wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-    });
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      processCleanupDepsWithTable([
+        {
+          pid: 777,
+          ppid: 0,
+          command: `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-loaded ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`,
+        },
+      ]),
+    );
 
     const loadedRecord = await wrappedStore.load("agent:codex:acp:binding:test");
     expect(loadedRecord?.openclawGatewayInstanceId).toBe("gateway-test");
@@ -3580,11 +3797,21 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       })),
       save: vi.fn(async () => {}),
     };
-    const { wrappedStore } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-    });
+    const { wrappedStore } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      processCleanupDepsWithTable([
+        {
+          pid: 777,
+          ppid: 0,
+          command: `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-current ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`,
+        },
+      ]),
+    );
 
     const loadedRecord = await wrappedStore.load("agent:codex:acp:binding:test");
     expect(loadedRecord?.openclawGatewayInstanceId).toBe("gateway-test");

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -44,6 +44,7 @@ import {
 import {
   cleanupOpenClawOwnedAcpxPendingLease,
   cleanupOpenClawOwnedAcpxProcessTree,
+  isLiveOpenClawOwnedAcpxWrapper,
   isOpenClawLeaseAwareAcpxProcessCommand,
   type AcpxProcessCleanupDeps,
 } from "./process-reaper.js";
@@ -211,16 +212,6 @@ function readRecordAgentPid(record: unknown): number | undefined {
   return numericPid && Number.isInteger(numericPid) && numericPid > 0 ? numericPid : undefined;
 }
 
-/** Best-effort check that a PID is still alive and signalable. */
-function isProcessAliveByPid(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function readOpenClawLeaseIdFromRecord(record: unknown): string | undefined {
   if (typeof record !== "object" || record === null) {
     return undefined;
@@ -276,6 +267,7 @@ function createResetAwareSessionStore(
     leaseStore?: AcpxProcessLeaseStore;
     launchScope?: AsyncLocalStorage<AcpxLaunchLeaseContext | undefined>;
     wrapperRoot?: string;
+    processDeps?: AcpxProcessCleanupDeps;
   },
 ): ResetAwareSessionStore {
   const freshSessionKeys = new Set<string>();
@@ -291,10 +283,19 @@ function createResetAwareSessionStore(
         return record;
       }
       const recordPid = readRecordAgentPid(record);
-      if (recordPid && !isProcessAliveByPid(recordPid)) {
-        // The wrapper process that owned this session is gone. Treat the stored
-        // session as fresh so we do not try to resume a dead process, which
-        // can hang the gateway after a restart (#109285).
+      if (
+        recordPid &&
+        !(await isLiveOpenClawOwnedAcpxWrapper({
+          pid: recordPid,
+          wrapperRoot: params.wrapperRoot,
+          expectedCommand: readRecordAgentCommand(record),
+          deps: params.processDeps,
+        }))
+      ) {
+        // The wrapper process that owned this session is gone (or the PID has
+        // been reused by a different process). Treat the stored session as
+        // fresh so we do not try to resume a dead process, which can hang the
+        // gateway after a restart (#109285).
         return undefined;
       }
       const sessionName = readSessionRecordName(record) || normalized;
@@ -306,9 +307,21 @@ function createResetAwareSessionStore(
       if (!lease) {
         return record;
       }
-      // Defensive: the lease might still be open but its process has died
-      // without being reaped (e.g. gateway crash). Treat as fresh.
-      if (!isProcessAliveByPid(lease.rootPid)) {
+      // Defensive: the lease might still be open but its process has died or
+      // the PID has been reused by a non-OpenClaw process (e.g. gateway
+      // crash). Treat as fresh. Pending leases (rootPid 0) have not been
+      // claimed by a process yet, so there is no identity to verify.
+      if (
+        lease.rootPid > 0 &&
+        !(await isLiveOpenClawOwnedAcpxWrapper({
+          pid: lease.rootPid,
+          wrapperRoot: lease.wrapperRoot ?? params.wrapperRoot,
+          expectedCommand: readRecordAgentCommand(record),
+          expectedLeaseId: lease.leaseId,
+          expectedGatewayInstanceId: lease.gatewayInstanceId,
+          deps: params.processDeps,
+        }))
+      ) {
         return undefined;
       }
       return withOpenClawLeaseSessionMetadata(record, {
@@ -857,6 +870,7 @@ export class AcpxRuntime implements AcpRuntime {
       leaseStore: this.processLeaseStore,
       launchScope: this.launchLeaseScope,
       wrapperRoot: this.wrapperRoot,
+      processDeps: this.processCleanupDeps,
     });
     this.agentRegistry = options.agentRegistry;
     this.scopedAgentRegistry = createModelScopedAgentRegistry({

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -211,6 +211,16 @@ function readRecordAgentPid(record: unknown): number | undefined {
   return numericPid && Number.isInteger(numericPid) && numericPid > 0 ? numericPid : undefined;
 }
 
+/** Best-effort check that a PID is still alive and signalable. */
+function isProcessAliveByPid(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function readOpenClawLeaseIdFromRecord(record: unknown): string | undefined {
   if (typeof record !== "object" || record === null) {
     return undefined;
@@ -280,14 +290,26 @@ function createResetAwareSessionStore(
       if (!record || !params?.leaseStore || !params.gatewayInstanceId) {
         return record;
       }
+      const recordPid = readRecordAgentPid(record);
+      if (recordPid && !isProcessAliveByPid(recordPid)) {
+        // The wrapper process that owned this session is gone. Treat the stored
+        // session as fresh so we do not try to resume a dead process, which
+        // can hang the gateway after a restart (#109285).
+        return undefined;
+      }
       const sessionName = readSessionRecordName(record) || normalized;
       const lease = selectCurrentSessionLease({
         leases: await params.leaseStore.listOpen(params.gatewayInstanceId),
         sessionKeys: [sessionName, normalized],
-        rootPid: readRecordAgentPid(record),
+        rootPid: recordPid,
       });
       if (!lease) {
         return record;
+      }
+      // Defensive: the lease might still be open but its process has died
+      // without being reaped (e.g. gateway crash). Treat as fresh.
+      if (!isProcessAliveByPid(lease.rootPid)) {
+        return undefined;
       }
       return withOpenClawLeaseSessionMetadata(record, {
         openclawLeaseId: lease.leaseId,

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -44,7 +44,7 @@ import {
 import {
   cleanupOpenClawOwnedAcpxPendingLease,
   cleanupOpenClawOwnedAcpxProcessTree,
-  isLiveOpenClawOwnedAcpxWrapper,
+  verifyLiveOpenClawOwnedAcpxWrapper,
   isOpenClawLeaseAwareAcpxProcessCommand,
   type AcpxProcessCleanupDeps,
 } from "./process-reaper.js";
@@ -285,12 +285,14 @@ function createResetAwareSessionStore(
       const recordPid = readRecordAgentPid(record);
       if (
         recordPid &&
-        !(await isLiveOpenClawOwnedAcpxWrapper({
-          pid: recordPid,
-          wrapperRoot: params.wrapperRoot,
-          expectedCommand: readRecordAgentCommand(record),
-          deps: params.processDeps,
-        }))
+        (
+          await verifyLiveOpenClawOwnedAcpxWrapper({
+            pid: recordPid,
+            wrapperRoot: params.wrapperRoot,
+            expectedCommand: readRecordAgentCommand(record),
+            deps: params.processDeps,
+          })
+        ).kind === "dead"
       ) {
         // The wrapper process that owned this session is gone (or the PID has
         // been reused by a different process). Treat the stored session as
@@ -310,17 +312,20 @@ function createResetAwareSessionStore(
       // Defensive: the lease might still be open but its process has died or
       // the PID has been reused by a non-OpenClaw process (e.g. gateway
       // crash). Treat as fresh. Pending leases (rootPid 0) have not been
-      // claimed by a process yet, so there is no identity to verify.
+      // claimed by a process yet, and unavailable process inspection is not
+      // proof of death, so neither resets the stored session.
       if (
         lease.rootPid > 0 &&
-        !(await isLiveOpenClawOwnedAcpxWrapper({
-          pid: lease.rootPid,
-          wrapperRoot: lease.wrapperRoot ?? params.wrapperRoot,
-          expectedCommand: readRecordAgentCommand(record),
-          expectedLeaseId: lease.leaseId,
-          expectedGatewayInstanceId: lease.gatewayInstanceId,
-          deps: params.processDeps,
-        }))
+        (
+          await verifyLiveOpenClawOwnedAcpxWrapper({
+            pid: lease.rootPid,
+            wrapperRoot: lease.wrapperRoot ?? params.wrapperRoot,
+            expectedCommand: readRecordAgentCommand(record),
+            expectedLeaseId: lease.leaseId,
+            expectedGatewayInstanceId: lease.gatewayInstanceId,
+            deps: params.processDeps,
+          })
+        ).kind === "dead"
       ) {
         return undefined;
       }


### PR DESCRIPTION
Closes #109285

## What Problem This Solves

After a gateway restart, the ACPX runtime may try to resume persistent sessions whose wrapper process no longer exists. This causes the gateway to hang while attempting to communicate with a dead process, or to fail with ACP_TURN_FAILED. A simple liveness probe (`process.kill(pid, 0)`) is not enough: a recycled PID can point to an unrelated live process, and the stored session would then be resumed against the wrong process.

## Changes

- Add `verifyLiveOpenClawOwnedAcpxWrapper` to `process-reaper.ts`: inspects the process table and reports one of `live`, `dead`, or `unavailable`.
  - `live`: the PID maps to an OpenClaw-owned ACPX wrapper matching the expected wrapper root, stored command, and (when present) lease identity.
  - `dead`: ownership is disproven (PID missing from a populated process table, or owned by a different process).
  - `unavailable`: process inspection could not run (empty table, e.g. Windows; or a listing error). Absence from the table is not proof of death.
- In `createResetAwareSessionStore.load()`, replace `isProcessAliveByPid` with the verification for both the record PID and the matching lease's root PID. Only a proven `dead` result treats the stored session as fresh; `live` and `unavailable` both preserve it, so existing persistent sessions on platforms without process enumeration (Windows) are never reset.
- Pending leases (`rootPid: 0`) skip verification.
- Wire `processCleanupDeps` from the runtime so the identity check uses the same injectable process-listing dependency as the reaper.
- Tests: 8 original regression tests plus 3 new ones covering unavailable listing (empty table and listing error), covering record PIDs and open leases.

## Evidence

### Unit tests

- `runtime.test.ts` 114/114, `process-reaper.test.ts` 14/14.
- `pnpm lint` 0 warnings, 0 errors.
- The ACPX extension typecheck reports only pre-existing module/type resolution errors from the unbuilt `openclaw/plugin-sdk` dependency, unrelated to these files.

### Real behavior proof (end-to-end harness)

Patched gateway build (v2026.7.2, commit 9aa5a5b) running in an isolated state dir on loopback. Agent `codex` with runtime `acp` / backend `acpx` / mode `persistent`; codex model traffic routed through a local loopback proxy translating the Responses wire format to an external chat-completions provider (`minimaxai/minimax-m3`).

1. **Spawn a persistent ACP session** (`/acp spawn codex`):

   ```
   ✅ Spawned ACP session agent:codex:acp:624a1f62-… (persistent, backend acpx).
   ```

2. **First turn on the session** (`Reply exactly OK`):

   ```
   session keys: ["agent:codex:main", "agent:codex:acp:624a1f62-…"]
   > Reply exactly OK
   < "Warning: Model metadata for `minimaxai/minimax-m3` not found. …\n\nOK"
   ```

   Provider proxy log confirms the request: `model=minimaxai/minimax-m3`, response delta content `OK`.

3. **Kill the wrapper + restart the gateway** (the scenario from #109285):
   `kill -9 <wrapper-pid>` (the `codex-acp-wrapper.mjs` process that owns the session lease and the codex child), then restart the gateway. The wrapper comes back under a new PID:

   ```
   before kill: codex-acp-wrapper.mjs pid 510131
   after  kill: codex-acp-wrapper.mjs pid 510665 (fresh, with new codex app-server child)
   ```

4. **Same session key, same message, after restart** — `agent:codex:acp:624a1f62-…`:

   ```
   > Reply exactly OK
   < "Warning: Model metadata for `minimaxai/minimax-m3` not found. …\n\nOK"
   ```

   No hang, no `ACP_SESSION_INIT_FAILED`, no `ACP_TURN_FAILED`. The resumed conversation reaches the model provider again and completes.

5. **Repeatability**: the kill + gateway-restart cycle was repeated; the session replied again on the same key.

Notes:

- The warning line about unknown model metadata is emitted by codex itself (fallback metadata for an unrecognized model id) and is unrelated to the ACP session lifecycle.
- In one of the kill cycles the previous codex child survived as an orphan while the new wrapper attached; the turn then ended via the gateway's `reply_dispatch` 120 s timeout with a surfaced error message instead of hanging, and the session continued to work on the next turn.
- Provider credentials, gateway tokens, and host paths are redacted from this transcript.
