### PR TITLE
fix(sessions): keep new session delivery state canonical

### DIFF
--- a/extensions/canvas/src/host-url.test.ts
+++ b/extensions/canvas/src/host-url.test.ts
@@ -31,7 +31,7 @@ describe("resolveCanvasHostUrl", () => {
         hostOverride: "127.0.0.1",
         requestHost: "example.com:8443",
       },
-      expected: "http://example.com:3000",
+      expected: "http://example.com:8443",
     },
     {
       name: "maps proxied default gateway ports to request-host ports",

--- a/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
@@ -275,7 +275,8 @@ describe("Codex app-server main thread cleanup", () => {
       },
     });
 
-    await expect(run).resolves.toMatchObject({ aborted: false, timedOut: false });
+    const result = await run;
+    expect(readAttemptTerminal(result)).toMatchObject({ aborted: false, timedOut: false });
     expect(requests.map((entry) => entry.method)).toEqual(["thread/start", "turn/start"]);
     expect(requests[0]?.params).toEqual(expect.objectContaining({ ephemeral: true }));
   });

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -308,7 +308,7 @@ describe("Codex trajectory recorder", () => {
       turnId: "turn-1",
       timedOut: false,
       result: {
-        aborted: false,
+        terminal: { kind: "ok" },
         attemptUsage: usage,
         assistantTexts: ["done"],
         messagesSnapshot: Array.from({ length: 20 }, (_value, index) => ({

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -68,6 +68,7 @@ import {
 } from "../sessions/session-lifecycle-admission.js";
 import { recordSessionCreated } from "../sessions/session-state-events.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 import { ADMIN_SCOPE } from "./operator-scopes.js";
 import { buildForkedGatewaySessionEntry } from "./session-create-fork-entry.js";
 import { shouldPreserveSessionAuthProfileOverride } from "./session-model-patch-origin.js";
@@ -910,6 +911,11 @@ export async function createGatewaySession(params: {
           : undefined;
         const initializedEntry: SessionEntry = {
           ...patched.entry,
+          // New rows must expose the same canonical delivery shape to callbacks
+          // that the SQLite writer persists, or guarded finalization sees its own write as drift.
+          ...(existingEntry === undefined && patched.entry.delivery === undefined
+            ? { delivery: normalizeSessionDeliveryState() }
+            : {}),
           // Stamp provenance only for genuinely new rows: adopting an existing key
           // must not restamp write-once node facts (this direct store write bypasses
           // the merge-level write-once guard), and legacy rows stay "unknown".

--- a/src/plugins/hook-runner-global.compose.test.ts
+++ b/src/plugins/hook-runner-global.compose.test.ts
@@ -41,6 +41,28 @@ function addToolOwner(registry: PluginRegistry, pluginId: string, toolName: stri
   });
 }
 
+function addChannelOwner(registry: PluginRegistry, pluginId: string) {
+  registry.channels.push({
+    pluginId,
+    source: "test",
+    plugin: {
+      id: pluginId,
+      meta: {
+        id: pluginId,
+        label: pluginId,
+        selectionLabel: pluginId,
+        docsPath: `/channels/${pluginId}`,
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => undefined,
+      },
+    },
+  });
+}
+
 afterEach(() => {
   resetGlobalHookRunner();
   resetPluginRuntimeStateForTest();
@@ -182,7 +204,7 @@ describe("global hook runner composition (#91918, #107933)", () => {
     // Give the active registry a channel so the channel-presentation selector
     // would prefer it and evict the zero-channel pinned registry — the raw
     // live-registry collector must keep the pinned one regardless.
-    (channelActive.channels as unknown[]).push({});
+    addChannelOwner(channelActive, "chan");
 
     setActivePluginRegistry(channelActive);
     pinActivePluginChannelRegistry(hookOnlyPinned);

--- a/src/plugins/host-hook-cleanup.session-store.test.ts
+++ b/src/plugins/host-hook-cleanup.session-store.test.ts
@@ -121,6 +121,7 @@ describe("plugin host cleanup session stores", () => {
     const unrelatedEntry: SessionEntry = {
       sessionId: "unrelated-session",
       updatedAt: unrelatedUpdatedAt,
+      delivery: { kind: "none" },
       pluginExtensions: {
         cleanup: { state: { keep: true } },
       },

--- a/src/plugins/runtime/runtime-agent.test.ts
+++ b/src/plugins/runtime/runtime-agent.test.ts
@@ -84,6 +84,7 @@ describe("plugin runtime session creation", () => {
         sessionId: created.entry.sessionId,
         entry: {
           agentHarnessId: "codex",
+          delivery: { kind: "none" },
           modelSelectionLocked: true,
           label: "Native Codex thread",
           pluginExtensions: {
@@ -609,6 +610,7 @@ describe("plugin runtime session creation", () => {
         const existing = {
           sessionId: "foreign-workspace-initializer",
           updatedAt: Date.now(),
+          delivery: { kind: "none" as const },
           initializationPending: true as const,
           agentHarnessId: "codex",
           modelSelectionLocked: true,
@@ -656,6 +658,7 @@ describe("plugin runtime session creation", () => {
         const existing = {
           sessionId: "foreign-initializer",
           updatedAt: Date.now(),
+          delivery: { kind: "none" as const },
           initializationPending: true as const,
           agentHarnessId: "codex",
           modelSelectionLocked: true,
@@ -704,6 +707,7 @@ describe("plugin runtime session creation", () => {
       const existing = {
         sessionId: "foreign-initializer",
         updatedAt: Date.now(),
+        delivery: { kind: "none" as const },
         initializationPending: true as const,
         modelSelectionLocked: true,
         pluginOwnerId: "other-plugin",


### PR DESCRIPTION
Related: #113225

## What Problem This Solves

Fixes an issue where plugin-owned session initialization could reject its own freshly created row as concurrently changed after SQLite added the canonical empty delivery state. The same current-main drift left three release-only plugin shards asserting retired result, host-port, and registry fixture shapes.

## Why This Change Was Made

New session rows now receive their canonical `delivery: { kind: "none" }` state before the creation callback and SQLite write, so guarded finalization and rollback compare the same object. Existing rows and explicit delivery states are unchanged. The accompanying test repairs keep the release-only Plugin Prerelease suite aligned with current runtime, SDK, and Codex attempt contracts.

## User Impact

Plugin and harness sessions can initialize and roll back reliably without false session-drift conflicts. Release validation also exercises the current Codex terminal result shape, hosted plugin port behavior, and valid channel-registry fixtures.

## Evidence

- Reproduced on Full Release Validation Plugin Prerelease run `30110282095`: agentic plugins, extension shard 1, and extension shard 7.
- `node scripts/run-vitest.mjs src/plugins/runtime/runtime-agent.test.ts src/plugins/host-hook-cleanup.session-store.test.ts src/plugins/hook-runner-global.compose.test.ts extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts extensions/codex/src/app-server/trajectory.test.ts extensions/canvas/src/host-url.test.ts` — 57 passed.
- `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts` — 67 passed.
- `pnpm build` — passed; full production build and Control UI performance checks green.
- Targeted `oxfmt --check` and `git diff --check` — passed.
- Fresh Codex autoreview — clean, no accepted/actionable findings; patch correct 0.93.
- Blacksmith Testbox `30111205069` did not reach the command because its delegated sync timed out; trusted-source validation fell back locally as repository policy permits.
- Upstream Codex contract checked at `openai/codex@a177013eb0`: `TurnCompletedNotification` carries the final `Turn` (`codex-rs/app-server-protocol/src/protocol/v2/turn.rs:407`), ephemeral thread start is an explicit option (`codex-rs/app-server-protocol/src/protocol/v2/thread.rs:108`), and `thread/unsubscribe` remains the cleanup RPC (`codex-rs/app-server-protocol/src/protocol/v2/thread.rs:679`).

AI-assisted: yes.
