### PR TITLE
fix(sessions): return canonical created entries

### DIFF
--- a/extensions/canvas/src/host-url.test.ts
+++ b/extensions/canvas/src/host-url.test.ts
@@ -31,7 +31,7 @@ describe("resolveCanvasHostUrl", () => {
         hostOverride: "127.0.0.1",
         requestHost: "example.com:8443",
       },
-      expected: "http://example.com:3000",
+      expected: "http://example.com:8443",
     },
     {
       name: "maps proxied default gateway ports to request-host ports",

--- a/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
@@ -275,7 +275,7 @@ describe("Codex app-server main thread cleanup", () => {
       },
     });
 
-    await expect(run).resolves.toMatchObject({ aborted: false, timedOut: false });
+    await expect(run).resolves.toMatchObject({ terminal: { kind: "ok" } });
     expect(requests.map((entry) => entry.method)).toEqual(["thread/start", "turn/start"]);
     expect(requests[0]?.params).toEqual(expect.objectContaining({ ephemeral: true }));
   });

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -308,7 +308,7 @@ describe("Codex trajectory recorder", () => {
       turnId: "turn-1",
       timedOut: false,
       result: {
-        aborted: false,
+        terminal: { kind: "ok" },
         attemptUsage: usage,
         assistantTexts: ["done"],
         messagesSnapshot: Array.from({ length: 20 }, (_value, index) => ({

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -13,6 +13,7 @@ import {
 } from "./session-accessor.entry.js";
 import type { SessionLifecycleStoreTarget } from "./session-accessor.lifecycle-types.js";
 import { applySessionEntryLifecycleMutation } from "./session-accessor.lifecycle.js";
+import { normalizeSqliteSessionEntryTimestamp } from "./session-accessor.sqlite-session-row.js";
 import {
   appendSqliteTranscriptEvent,
   forkSqliteSessionEntryFromParentTarget,
@@ -186,13 +187,14 @@ export async function createSessionEntryWithTranscript<TError = string>(
     };
   }
 
-  const entry =
+  const entryWithSessionFile =
     created.entry.sessionFile === sessionFile
       ? created.entry
       : {
           ...created.entry,
           sessionFile,
         };
+  const entry = normalizeSqliteSessionEntryTimestamp(entryWithSessionFile);
   await applySessionEntryLifecycleMutation({
     agentId,
     storePath,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -993,6 +993,7 @@ describe("session accessor seam", () => {
     }
     expect(created.sessionFile).toContain("sqlite:main:session-1:");
     expect(created.entry.sessionFile).toBe(created.sessionFile);
+    expect(created.entry.delivery).toEqual({ kind: "none" });
     await expect(
       loadTranscriptEvents({
         agentId: "main",

--- a/src/plugins/hook-runner-global.compose.test.ts
+++ b/src/plugins/hook-runner-global.compose.test.ts
@@ -182,7 +182,12 @@ describe("global hook runner composition (#91918, #107933)", () => {
     // Give the active registry a channel so the channel-presentation selector
     // would prefer it and evict the zero-channel pinned registry — the raw
     // live-registry collector must keep the pinned one regardless.
-    (channelActive.channels as unknown[]).push({});
+    channelActive.channels.push({
+      pluginId: "chan",
+      pluginName: "chan",
+      plugin: { id: "chan", meta: { label: "chan" } } as never,
+      source: "test",
+    });
 
     setActivePluginRegistry(channelActive);
     pinActivePluginChannelRegistry(hookOnlyPinned);

--- a/src/plugins/host-hook-cleanup.session-store.test.ts
+++ b/src/plugins/host-hook-cleanup.session-store.test.ts
@@ -121,6 +121,7 @@ describe("plugin host cleanup session stores", () => {
     const unrelatedEntry: SessionEntry = {
       sessionId: "unrelated-session",
       updatedAt: unrelatedUpdatedAt,
+      delivery: { kind: "none" },
       pluginExtensions: {
         cleanup: { state: { keep: true } },
       },

--- a/src/plugins/runtime/runtime-agent.test.ts
+++ b/src/plugins/runtime/runtime-agent.test.ts
@@ -609,6 +609,7 @@ describe("plugin runtime session creation", () => {
         const existing = {
           sessionId: "foreign-workspace-initializer",
           updatedAt: Date.now(),
+          delivery: { kind: "none" as const },
           initializationPending: true as const,
           agentHarnessId: "codex",
           modelSelectionLocked: true,
@@ -656,6 +657,7 @@ describe("plugin runtime session creation", () => {
         const existing = {
           sessionId: "foreign-initializer",
           updatedAt: Date.now(),
+          delivery: { kind: "none" as const },
           initializationPending: true as const,
           agentHarnessId: "codex",
           modelSelectionLocked: true,
@@ -704,6 +706,7 @@ describe("plugin runtime session creation", () => {
       const existing = {
         sessionId: "foreign-initializer",
         updatedAt: Date.now(),
+        delivery: { kind: "none" as const },
         initializationPending: true as const,
         modelSelectionLocked: true,
         pluginOwnerId: "other-plugin",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin-owned session initialization could fail finalization or rollback after SQLite canonicalized a newly created entry, blocking the `2026.7.2-beta.5` release validation.

## Why This Change Was Made

Normalize the returned session entry through the same SQLite canonicalizer used for persistence before lifecycle mutation. The release validation fixtures are also aligned with the current delivery, terminal-result, channel-registration, and hosted-URL contracts.

## User Impact

Plugin-owned and Codex session creation can finalize and roll back safely. The beta release validation no longer fails because returned and persisted session snapshots disagree.

## Evidence

- 135 focused tests passed across session accessors, plugin runtime/hooks, Codex app-server cleanup/trajectory, and Canvas host URLs.
- Fresh autoreview: no accepted or actionable findings.
- Changed-surface Blacksmith Testbox passed: https://github.com/openclaw/openclaw/actions/runs/30110934291
- Reproduced release blocker: https://github.com/openclaw/openclaw/actions/runs/30110282095
- Invalidated candidate validation: https://github.com/openclaw/openclaw/actions/runs/30109586382