### PR TITLE
Update android-release.yml

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -124,6 +124,10 @@ jobs:
           echo "build_timestamp=${build_timestamp}" >> "${GITHUB_OUTPUT}"
           unexpected_assets="$(printf '%s' "${release_json}" | jq -r '[.assets[]? | select(.name | startswith("OpenClaw-Android")) | .name] | join(", ")')"
           if [[ -n "${unexpected_assets}" ]]; then
+            if [[ "${DIRECT_RELEASE_RECOVERY}" != "true" ]]; then
+              echo "Target release already contains Android assets: ${unexpected_assets}. Refusing to proceed on a normal (non-recovery) run." >&2
+              exit 1
+            fi
             echo "Target release already contains Android assets: ${unexpected_assets}. Immutable recovery accepts them only after rebuilding identical bytes." >&2
           fi
 


### PR DESCRIPTION
1.  Added an exit 1 path for the default case (direct_release_recovery: false) — this makes the check consistent with every other validation in the same step, which all fail hard rather than just logging.
2.  Kept the original warning-only behavior, but now it's scoped specifically to direct_release_recovery: true — matching the comment's own stated intent ("Immutable recovery accepts them only after rebuilding identical bytes"), which implies recovery is the only case where pre-existing assets should be tolerated at all.
3. DIRECT_RELEASE_RECOVERY is already exported as an env var earlier in the same step (env: DIRECT_RELEASE_RECOVERY: ${{ inputs.direct_release_recovery && 'true' || 'false' }}), so no extra plumbing is needed.

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
