### PR TITLE
[AI-assisted] docs(providers): drop stray /index suffix from Card hrefs

### DIFF
--- a/docs/providers/comfy.md
+++ b/docs/providers/comfy.md
@@ -359,7 +359,7 @@ The `image` and `video` sections also support a reference-image input node:
   <Card title="Music Generation" href="/tools/music-generation" icon="music">
     Music and audio generation tool setup.
   </Card>
-  <Card title="Provider Directory" href="/providers/index" icon="layers">
+  <Card title="Provider Directory" href="/providers" icon="layers">
     Overview of all providers and model refs.
   </Card>
   <Card title="Configuration reference" href="/gateway/config-agents#agent-defaults" icon="gear">

--- a/docs/providers/vydra.md
+++ b/docs/providers/vydra.md
@@ -162,7 +162,7 @@ Use `https://www.vydra.ai/api/v1` as the base URL. Vydra's apex host (`https://v
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Provider directory" href="/providers/index" icon="list">
+  <Card title="Provider directory" href="/providers" icon="list">
     Browse all available providers.
   </Card>
   <Card title="Image generation" href="/tools/image-generation" icon="image">

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -668,7 +668,7 @@ verifies the completed video download.
   <Card title="Video generation" href="/tools/video-generation" icon="video">
     Shared video tool parameters and provider selection.
   </Card>
-  <Card title="All providers" href="/providers/index" icon="grid-2">
+  <Card title="All providers" href="/providers" icon="grid-2">
     The broader provider overview.
   </Card>
   <Card title="Troubleshooting" href="/help/troubleshooting" icon="wrench">


### PR DESCRIPTION
## What Problem This Solves

Fixes a link-consistency issue where three provider docs — `xai`, `vydra`, and `comfy` — pointed their "All providers" / "Provider directory" Card at `href="/providers/index"` instead of the canonical `href="/providers"`. `docs/AGENTS.md` mandates root-relative internal links with no suffix, and sibling provider docs (`inworld`, `azure-speech`) already use `href="/providers"`, so these three were the only outliers.

## Why This Change Was Made

Normalizes the three `<Card href>` values from `/providers/index` to `/providers`. Mintlify resolves both to the same `docs/providers/index.md` page, so this is a no-behavior-change consistency fix that brings the three Cards in line with the repo's own Mintlify link rule and the pattern already used across `docs/providers/`.

This complements #112282, which dropped stray `/index` suffixes from markdown `](...)` links but did not cover these JSX `<Card href>` attributes.

## User Impact

No user-visible behavior change (both link forms resolve to the same provider directory page). Readers clicking "All providers" / "Provider directory" on the xAI, Vydra, and Comfy provider pages land on the same provider directory as before; the links now match the canonical form used across the rest of the provider docs.

## Evidence

- `docs/AGENTS.md` Mintlify rule: _"Internal doc links in `docs/**/*.md` must stay root-relative with no `.md` or `.mdx` suffix"_.
- Before: exactly 3 occurrences of `href="/providers/index"` in docs — `xai.md:671`, `vydra.md:165`, `comfy.md:362`.
- After: `rg 'href="/providers/index"' docs/` returns no matches; the 3 Cards now use `href="/providers"`.
- Canonical form already in use: `docs/providers/inworld.md` and `docs/providers/azure-speech.md` both use `href="/providers"`.
- Target page exists: `/providers` resolves to the existing `docs/providers/index.md`.
- Diff is three one-line href changes only (no other content touched).

Notes:
- Same `/index`-suffix cleanup theme as #112282, scoped to the three provider docs whose JSX `<Card href>` attributes that PR's markdown-link pass did not cover. Happy to close this in favor of folding these three files into #112282 if a maintainer prefers a single PR; I kept it separate because #112282 is already behind `main` and under review.
- Branch is takeover-ready (fork PR, "allow edits by maintainers" enabled); no CHANGELOG entry (maintainer-added on land).
