### PR TITLE
fix(release): align extension prerelease contracts

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -2948,8 +2948,9 @@ describe("google-meet plugin", () => {
           return { ok: true };
         }
         if (request.path === "/act") {
-          if (String(request.body?.fn).includes("state = window.__openclawMeetCaptions")) {
-            const finalizing = String(request.body?.fn).includes("if (true &&");
+          const script = String(request.body?.fn);
+          if (script.includes("const expectedSessionId =")) {
+            const finalizing = script.includes("if (true &&");
             if (
               !finalizing &&
               transcriptReadIndex >= (options?.skipNonFinalTranscriptGateReads ?? 0)
@@ -3105,13 +3106,9 @@ describe("google-meet plugin", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
     try {
+      const transcript = { epoch: "page-1", lines: [{ text: "before reload" }] };
       mockLocalMeetBrowserRequestWithTabState({
-        transcriptSequence: [
-          { epoch: "page-1", lines: [] },
-          { epoch: "page-1", lines: [{ text: "before reload" }] },
-          { epoch: "page-2", lines: [{ text: "after reload" }] },
-          { epoch: "page-2", lines: [{ text: "after reload" }] },
-        ],
+        transcript,
       });
       const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
       const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
@@ -3121,6 +3118,8 @@ describe("google-meet plugin", () => {
       const first = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
         sessionId: joined.session.id,
       })) as { nextIndex: number; lines: Array<{ text: string }> };
+      transcript.epoch = "page-2";
+      transcript.lines = [{ text: "after reload" }];
       const second = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
         sessionId: joined.session.id,
         sinceIndex: first.nextIndex,
@@ -3190,9 +3189,7 @@ describe("google-meet plugin", () => {
       const finalCaptures = callGatewayFromCli.mock.calls.filter((call) => {
         const request = call[2] as { body?: { fn?: string } };
         const script = String(request.body?.fn);
-        return (
-          script.includes("state = window.__openclawMeetCaptions") && script.includes("if (true &&")
-        );
+        return script.includes("const expectedSessionId =") && script.includes("if (true &&");
       });
       expect(finalCaptures).toHaveLength(1);
       const result = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
@@ -4404,7 +4401,7 @@ describe("google-meet plugin", () => {
       const { methods } = setup({
         chrome: {
           audioBridgeCommand: ["bridge", "start"],
-          waitForInCallMs: 10,
+          waitForInCallMs: 100,
         },
       });
       const handler = methods.get("googlemeet.join") as

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -1030,9 +1030,19 @@ describe("iMessage monitor last-route updates", () => {
     expect(runtimeErrorMock).not.toHaveBeenCalled();
     await vi.waitFor(() => {
       expect(getSessionEntry({ storePath, sessionKey })).toMatchObject({
-        lastChannel: "imessage",
-        lastTo: "imessage:+15550001111",
-        lastAccountId: "default",
+        delivery: {
+          kind: "external",
+          context: {
+            channel: "imessage",
+            to: "imessage:+15550001111",
+            accountId: "default",
+          },
+          route: {
+            channel: "imessage",
+            accountId: "default",
+            target: { to: "imessage:+15550001111" },
+          },
+        },
       });
     });
     expect(getSessionEntry({ storePath, sessionKey: "agent:main:main" })).toBeUndefined();

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -155,6 +155,7 @@ async function seedDreamingSessionTranscript(params: {
   messages: Array<{
     role: "assistant" | "user";
     content: unknown;
+    provenance?: { kind: "internal_system"; sourceTool: "heartbeat" };
     timestamp: number | string;
   }>;
   sessionId: string;
@@ -193,6 +194,7 @@ async function seedDreamingSessionTranscript(params: {
       message: {
         role: message.role,
         content: message.content,
+        ...(message.provenance ? { provenance: message.provenance } : {}),
         timestamp: message.timestamp,
       },
     });
@@ -1727,6 +1729,7 @@ describe("memory-core dreaming phases", () => {
           timestamp: "2026-04-16T18:04:00.000Z",
           content:
             "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.",
+          provenance: { kind: "internal_system", sourceTool: "heartbeat" },
         },
         {
           role: "assistant",

--- a/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
@@ -179,7 +179,12 @@ describe("qa suite runtime agent session helpers", () => {
         gateway: { tempRoot },
       } as never),
     ).resolves.toEqual({
-      "session-1": { sessionId: "session-1", status: "running", updatedAt: 10 },
+      "session-1": {
+        sessionId: "session-1",
+        status: "running",
+        updatedAt: 10,
+        delivery: { kind: "none" },
+      },
     });
   });
 

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -239,7 +239,7 @@ describe("auth.test boot call", () => {
     expect(createSlackStartupAuthClientMock).toHaveBeenCalledWith(
       "bot-token",
       expect.objectContaining({
-        agent: expect.anything(),
+        fetch: expect.any(Function),
         slackApiUrl: "https://slack.test/api/",
       }),
     );
@@ -279,7 +279,7 @@ describe("auth.test boot call", () => {
       expect(events).toContain("auth-settled");
       expect(events.indexOf("auth-settled")).toBeLessThan(events.indexOf("app-start"));
       expect(runtimeLog).toHaveBeenCalledWith(
-        expect.stringContaining("timeout of 10000ms exceeded"),
+        expect.stringMatching(/slack auth\.test failed at boot .*timeout/i),
       );
     } finally {
       monitor.controller.abort();

--- a/qa/scenarios/scheduling/cron-explicit-authority-execution.yaml
+++ b/qa/scenarios/scheduling/cron-explicit-authority-execution.yaml
@@ -8,8 +8,8 @@ scenario:
     primary:
       - automation.isolated-cron-execution
     secondary:
-      - scheduling.cron
-      - agents.tool-fs-write
+      - automation.cron-rpcs
+      - agent-runtime.tool-fs-write
   gatewayConfigPatch:
     commands:
       ownerAllowFrom:


### PR DESCRIPTION
Related: #113373

## What Problem This Solves

Fixes an issue where the release-only Plugin Prerelease sweep for `2026.7.2-beta.5` remained red after the session canonicalization repair exposed stale extension contracts in shards 4, 6, and 8.

## Why This Change Was Made

The affected fixtures now use canonical delivery state, canonical QA taxonomy IDs, authenticated heartbeat provenance, and the current abortable Slack startup client contract. The Google Meet transcript harness now distinguishes transcript capture from ordinary status inspection by the session-ID marker and controls epoch changes explicitly, removing the timing-dependent snapshot consumption that could also deadlock leave finalization.

## User Impact

There is no production behavior change. Maintainers can validate the beta candidate against the current runtime contracts without fixture drift or Google Meet worker-timing races masking real release failures.

## Evidence

- Reproduced release blocker: Plugin Prerelease run https://github.com/openclaw/openclaw/actions/runs/30112796298 failed extension shards 4, 6, and 8.
- Focused proof: 295 tests passed across QA coverage/session, iMessage last-route, Slack startup auth, Google Meet, and memory dreaming fixtures.
- Exact failed-batch proof on Blacksmith Testbox `tbx_01kyakg214arh8tr9qyfq7eg1k`: shard 4 passed, shard 6 passed, and shard 8 passed after the heartbeat-provenance port. Run: https://github.com/openclaw/openclaw/actions/runs/30114004071
- `pnpm check:changed` passed remotely, including full project `tsgo`, core/extensions/scripts lint, plugin boundaries, database-first guard, format, and import-cycle checks.
- Codex autoreview: clean, no accepted or actionable findings (0.94 confidence).

AI-assisted: yes. The patch was inspected against the runtime owners and release-branch provenance, then verified in the exact failing batch shapes.
