### PR TITLE
fix(sqlite): verify canonical index b-trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **SQLite canonical index integrity:** verify the physical B-tree for every canonical unique index during database startup and rebuild forged or stale indexes transactionally, preventing canonical-looking schema text from hiding missed reads or unenforced uniqueness.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.
 - **Control UI terminal error messages:** preserve message-only assistant output beginning with `Error:` or a warning marker instead of treating text prefixes as synthetic failures. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **SQLite canonical index integrity:** verify the physical B-tree for every canonical unique index during database startup and rebuild forged or stale indexes transactionally, preventing canonical-looking schema text from hiding missed reads or unenforced uniqueness.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.
 - **Control UI terminal error messages:** preserve message-only assistant output beginning with `Error:` or a warning marker instead of treating text prefixes as synthetic failures. Thanks @shakkernerd.

--- a/src/infra/sqlite-index-schema.test.ts
+++ b/src/infra/sqlite-index-schema.test.ts
@@ -7,6 +7,7 @@ import {
 
 const CANONICAL_INDEX: CanonicalSqliteUniqueIndex = {
   name: "idx_records_identity",
+  tableName: "records",
   definition: `
     ON records(
       tenant_id COLLATE NOCASE,
@@ -119,6 +120,73 @@ describe("repairCanonicalSqliteUniqueIndexes", () => {
           .all(),
       ).toEqual([]);
       expect(db.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("repairs a physically drifted index hidden behind canonical schema text", () => {
+    const db = createDatabase();
+    try {
+      db.exec(`
+        DROP INDEX idx_records_identity;
+        CREATE UNIQUE INDEX idx_records_identity ON records(id);
+        INSERT INTO records VALUES
+          (1, 'Tenant', NULL, 1),
+          (2, 'Other', NULL, 1);
+      `);
+      db.enableDefensive?.(false);
+      db.exec("PRAGMA writable_schema = ON;");
+      db.prepare("UPDATE sqlite_schema SET sql = ? WHERE name = 'idx_records_identity'").run(
+        `CREATE UNIQUE INDEX idx_records_identity
+           ON records(
+             tenant_id COLLATE NOCASE,
+             IFNULL(external_id, '')
+           )
+          WHERE active = 1`,
+      );
+      db.exec("PRAGMA writable_schema = OFF;");
+      const schemaVersion = db.prepare("PRAGMA schema_version").get() as {
+        schema_version?: unknown;
+      };
+      db.exec(`PRAGMA schema_version = ${Number(schemaVersion.schema_version) + 1};`);
+
+      expect(db.prepare("PRAGMA integrity_check('records')").all()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            integrity_check: expect.stringMatching(/missing from index idx_records_identity/),
+          }),
+        ]),
+      );
+      expect(
+        db
+          .prepare(
+            `SELECT id
+               FROM records INDEXED BY idx_records_identity
+              WHERE tenant_id = 'Tenant'
+                AND IFNULL(external_id, '') = ''
+                AND active = 1`,
+          )
+          .all(),
+      ).toEqual([]);
+
+      repairCanonicalSqliteUniqueIndexes(db, "test database", [CANONICAL_INDEX]);
+
+      expect(db.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+      expect(
+        db
+          .prepare(
+            `SELECT id
+               FROM records INDEXED BY idx_records_identity
+              WHERE tenant_id = 'Tenant'
+                AND IFNULL(external_id, '') = ''
+                AND active = 1`,
+          )
+          .all(),
+      ).toEqual([{ id: 1 }]);
+      expect(() => db.exec("INSERT INTO records VALUES (3, 'tenant', NULL, 1);")).toThrow(
+        /UNIQUE constraint failed/iu,
+      );
     } finally {
       db.close();
     }

--- a/src/infra/sqlite-index-schema.ts
+++ b/src/infra/sqlite-index-schema.ts
@@ -1,7 +1,9 @@
 import type { DatabaseSync } from "node:sqlite";
+import { assertSqliteIntegrity, assertSqliteTableIntegrity } from "./sqlite-integrity.js";
 
 export type CanonicalSqliteUniqueIndex = {
   name: string;
+  tableName: string;
   definition: string;
 };
 
@@ -20,18 +22,36 @@ export function repairCanonicalSqliteUniqueIndexes(
   databaseLabel: string,
   indexes: readonly CanonicalSqliteUniqueIndex[],
 ): void {
-  const drifted = indexes.filter((index) => {
+  const indexesByTable = new Map<string, CanonicalSqliteUniqueIndex[]>();
+  const repairIndexes = new Set<CanonicalSqliteUniqueIndex>();
+  for (const index of indexes) {
     assertSqliteIdentifier(index.name);
+    assertSqliteIdentifier(index.tableName);
+    const tableIndexes = indexesByTable.get(index.tableName) ?? [];
+    tableIndexes.push(index);
+    indexesByTable.set(index.tableName, tableIndexes);
     const row = db
       .prepare("SELECT sql FROM main.sqlite_schema WHERE type = 'index' AND name = ?")
       .get(index.name) as SqliteSchemaRow | undefined;
-    return (
+    if (
       typeof row?.sql !== "string" ||
       normalizeCreateIndexSql(row.sql) !==
         normalizeCreateIndexSql(createIndexSql(index, index.name, false))
-    );
-  });
-  if (drifted.length === 0) {
+    ) {
+      repairIndexes.add(index);
+    }
+  }
+
+  for (const [tableName, tableIndexes] of indexesByTable) {
+    try {
+      assertSqliteTableIntegrity(db, databaseLabel, tableName);
+    } catch {
+      for (const index of tableIndexes) {
+        repairIndexes.add(index);
+      }
+    }
+  }
+  if (repairIndexes.size === 0) {
     return;
   }
 
@@ -39,16 +59,20 @@ export function repairCanonicalSqliteUniqueIndexes(
   let activeIndex: CanonicalSqliteUniqueIndex | undefined;
   db.exec(`SAVEPOINT ${savepoint};`);
   try {
-    for (const index of drifted) {
+    for (const index of repairIndexes) {
       activeIndex = index;
       const probeName = findUnusedProbeIndexName(db, index.name);
       // Build the canonical constraint first. If existing rows conflict, the
       // wrong same-name index remains in place and the whole repair rolls back.
       db.exec(createIndexSql(index, probeName, true));
-      db.exec(`DROP INDEX main.${index.name};`);
+      db.exec(`DROP INDEX IF EXISTS main.${index.name};`);
       db.exec(createIndexSql(index, index.name, true));
       db.exec(`DROP INDEX main.${probeName};`);
     }
+    for (const tableName of indexesByTable.keys()) {
+      assertSqliteTableIntegrity(db, databaseLabel, tableName);
+    }
+    assertSqliteIntegrity(db, databaseLabel);
     db.exec(`RELEASE SAVEPOINT ${savepoint};`);
   } catch (error) {
     try {

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -45,6 +45,7 @@ import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
 const OPENCLAW_AGENT_CANONICAL_UNIQUE_INDEXES = [
   {
     name: "idx_agent_conversations_identity",
+    tableName: "conversations",
     definition: `
       ON conversations(
         channel,
@@ -58,6 +59,7 @@ const OPENCLAW_AGENT_CANONICAL_UNIQUE_INDEXES = [
   },
   {
     name: "idx_agent_session_conversations_primary",
+    tableName: "session_conversations",
     definition: `
       ON session_conversations(session_id)
       WHERE role = 'primary'
@@ -65,6 +67,7 @@ const OPENCLAW_AGENT_CANONICAL_UNIQUE_INDEXES = [
   },
   {
     name: "idx_agent_transcript_message_idempotency",
+    tableName: "transcript_event_identities",
     definition: `
       ON transcript_event_identities(session_id, message_idempotency_key)
       WHERE message_idempotency_key IS NOT NULL
@@ -72,10 +75,12 @@ const OPENCLAW_AGENT_CANONICAL_UNIQUE_INDEXES = [
   },
   {
     name: "idx_agent_transcript_active_event_seq",
+    tableName: "session_transcript_active_events",
     definition: "ON session_transcript_active_events(session_id, event_seq)",
   },
   {
     name: "idx_agent_transcript_active_messages",
+    tableName: "session_transcript_active_events",
     definition: `
       ON session_transcript_active_events(session_id, message_position)
       WHERE message_position IS NOT NULL

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -366,7 +366,7 @@ function createUnsafeSchemaMetaIndexDrift(databasePath: string): void {
 
 function createTranscriptIdempotencyIndexDrift(
   databasePath: string,
-  options: { duplicateRows?: boolean } = {},
+  options: { duplicateRows?: boolean; hideWithCanonicalSql?: boolean } = {},
 ): void {
   const { DatabaseSync } = requireNodeSqlite();
   const database = new DatabaseSync(databasePath);
@@ -401,8 +401,28 @@ function createTranscriptIdempotencyIndexDrift(
         );
       `);
     }
+    if (options.hideWithCanonicalSql) {
+      database.enableDefensive?.(false);
+      database.exec("PRAGMA writable_schema = ON;");
+      database
+        .prepare(
+          `UPDATE sqlite_schema
+              SET sql = ?
+            WHERE type = 'index'
+              AND name = 'idx_agent_transcript_message_idempotency'`,
+        )
+        .run(
+          `CREATE UNIQUE INDEX idx_agent_transcript_message_idempotency
+             ON transcript_event_identities(session_id, message_idempotency_key)
+            WHERE message_idempotency_key IS NOT NULL`,
+        );
+      const schemaVersion = readSqliteNumberPragma(database, "schema_version");
+      database.exec(`PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schemaVersion + 1};`);
+    }
     expect(database.prepare("PRAGMA integrity_check").get()).toEqual({
-      integrity_check: "ok",
+      integrity_check: options.hideWithCanonicalSql
+        ? expect.stringMatching(/idx_agent_transcript_message_idempotency/)
+        : "ok",
     });
     expect(database.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   } finally {
@@ -2285,6 +2305,40 @@ describe("openclaw agent database", () => {
     );
     expect(index.sql).toContain("WHERE message_idempotency_key IS NOT NULL");
 
+    expect(() =>
+      reopened.db
+        .prepare(
+          `INSERT INTO transcript_event_identities (
+             session_id, event_id, seq, message_idempotency_key, created_at
+           ) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run("session-1", "event-2", 2, "message-1", 2),
+    ).toThrow(/UNIQUE constraint failed/iu);
+  });
+
+  it("repairs physical transcript index drift hidden behind canonical schema text", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const created = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const databasePath = created.path;
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    createTranscriptIdempotencyIndexDrift(databasePath, { hideWithCanonicalSql: true });
+
+    const reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    expect(reopened.db.prepare("PRAGMA integrity_check").get()).toEqual({
+      integrity_check: "ok",
+    });
+    expect(
+      reopened.db
+        .prepare(
+          `SELECT event_id
+             FROM transcript_event_identities
+            WHERE session_id = ?
+              AND message_idempotency_key = ?`,
+        )
+        .get("session-1", "message-1"),
+    ).toEqual({ event_id: "event-1" });
     expect(() =>
       reopened.db
         .prepare(

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -97,10 +97,12 @@ export { withOpenClawStateStartupMigrationCheckpointDatabase } from "./openclaw-
 const OPENCLAW_STATE_CANONICAL_UNIQUE_INDEXES = [
   {
     name: "idx_operator_approvals_resolution_ref",
+    tableName: "operator_approvals",
     definition: "ON operator_approvals(resolution_ref)",
   },
   {
     name: "idx_worker_environments_provider_lease",
+    tableName: "worker_environments",
     definition: `
       ON worker_environments(provider_id, lease_id)
       WHERE lease_id IS NOT NULL
@@ -108,6 +110,7 @@ const OPENCLAW_STATE_CANONICAL_UNIQUE_INDEXES = [
   },
   {
     name: "idx_worker_inference_turns_pending_run",
+    tableName: "worker_inference_turns",
     definition: `
       ON worker_inference_turns(session_id, run_epoch, run_id)
       WHERE state = 'pending'


### PR DESCRIPTION
## What Problem This Solves

Canonical unique-index repair trusted `sqlite_schema.sql` alone. A physically wrong SQLite B-tree could therefore be hidden behind canonical-looking schema text, causing indexed reads to miss existing rows and uniqueness constraints to stop enforcing duplicates.

Fixes the canonical-index tranche of #113306.

## Why This Change Was Made

Bind every canonical unique index to its owning table, run targeted table integrity checks during startup, and transactionally rebuild all canonical indexes for a table when its physical index state is stale. The repair still creates a probe constraint first, rolls back on conflicting data, and now requires targeted plus full integrity before commit.

## User Impact

OpenClaw cold-open now repairs forged or stale canonical unique-index B-trees before exposing writable state. Transcript idempotency lookups, active transcript projections, approvals, worker leases, and pending inference ownership cannot silently operate on canonical-looking but physically incorrect indexes.

## Evidence

- Reproduced on current `main`: forged canonical SQL over a physically wrong index returned no row through `INDEXED BY` and accepted a duplicate key.
- Local focused proof: `node scripts/run-vitest.mjs src/infra/sqlite-index-schema.test.ts src/state/openclaw-agent-db.test.ts` -> 70 passed, 1 skipped.
- Blacksmith Testbox `tbx_01kyammcm5m9wf3wf6c9xnbrcz`: `pnpm test:serial src/infra/sqlite-index-schema.test.ts src/state/openclaw-agent-db.test.ts src/state/openclaw-state-db.test.ts` -> 163 passed.
- Same Testbox: `pnpm check:changed` -> passed.
- Autoreview: clean, no accepted/actionable findings.
