### PR TITLE
fix(google-meet): accept elapsed browser action timeout budget

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -4869,18 +4869,22 @@ describe("google-meet plugin", () => {
     if (!englishTabActCall) {
       throw new Error("Expected browser.proxy /act on the English replacement tab");
     }
-    expect(
-      requireRecord(requireRecord(englishTabActCall[0], "act node invoke").params, "act params"),
-    ).toEqual({
+    const actParams = requireRecord(
+      requireRecord(englishTabActCall[0], "act node invoke").params,
+      "act params",
+    );
+    expect(actParams).toEqual({
       method: "POST",
       path: "/act",
-      timeoutMs: 10000,
+      timeoutMs: expect.any(Number),
       body: {
         kind: "evaluate",
         targetId: "english-meet-tab",
         fn: expect.any(String),
       },
     });
+    expect(actParams.timeoutMs).toBeGreaterThan(0);
+    expect(actParams.timeoutMs).toBeLessThanOrEqual(10_000);
   });
 
   it("does not navigate a reused join tab that is already using English UI", async () => {


### PR DESCRIPTION
Related: #113383

## What Problem This Solves

Fixes an issue where the Google Meet release-validation suite could fail when a serialized browser action began one millisecond after its timeout deadline was created.

## Why This Change Was Made

The browser-action lock intentionally forwards the remaining deadline budget, so the test now verifies that the action timeout is positive and capped at 10 seconds instead of requiring an impossible-to-guarantee exact `10_000` milliseconds.

## User Impact

No production behavior changes. Google Meet validation no longer reports a false failure from normal event-loop timing.

## Evidence

- Reproduced on the exact `release/2026.7.2` tip as `timeoutMs: 9_999` versus an expected `10_000`.
- Focused regression test: 1 passed.
- Full Google Meet suite on current main: 161 passed in 24.30 seconds.
- Formatting and `git diff --check`: clean.
- Autoreview: clean, no accepted/actionable findings; patch correct at 0.93 confidence.
