### PR TITLE
fix(sqlite): prevent snapshot WAL growth under writes

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -51,7 +51,7 @@ The repository contains one directory per committed snapshot. Each snapshot dire
 - `manifest.json`
 - `database.sqlite`
 
-Snapshot creation verifies the live database before reading it, uses SQLite `VACUUM INTO` to capture committed WAL state into a compact database, verifies the generated database again, and publishes the completed directory without overwriting existing paths. Global snapshots remove transient delivery queue rows and compact again so deleted queue payloads are not retained in free pages.
+Snapshot creation verifies the live database before reading it, uses SQLite's online backup API to capture committed WAL state without holding one long read transaction, closes the live database, compacts the private copy with `VACUUM`, verifies the generated database again, and publishes the completed directory without overwriting existing paths. Global snapshots remove transient delivery queue rows before compaction so deleted queue payloads are not retained in free pages.
 
 Do not copy live `.sqlite`, `-wal`, `-shm`, or `-journal` files as a portability artifact. Copy only completed snapshot directories.
 
@@ -103,7 +103,7 @@ During archive creation, OpenClaw excludes known live-mutation paths before `tar
 
 These rules do not filter workspace files outside the state directory. They also omit completed transcript and log files that match the table, so retain those records separately when needed. The JSON result's `skippedVolatileCount` reports how many files were intentionally omitted.
 
-SQLite databases under the state directory are compacted with `VACUUM INTO` so deleted-page remnants do not enter the archive, and live WAL/SHM files are not copied. A plugin-owned database that requires unavailable owner-defined SQLite capabilities fails closed rather than falling back to a raw page copy. SQLite files included through workspace backups are copied as workspace files and are not covered by the compaction guarantee.
+SQLite databases under the state directory are captured with SQLite's online backup API and compacted offline with `VACUUM` so deleted-page remnants do not enter the archive, and live WAL/SHM files are not copied. A plugin-owned database that requires unavailable owner-defined SQLite capabilities fails closed rather than falling back to a direct file copy. SQLite files included through workspace backups are copied as workspace files and are not covered by the compaction guarantee.
 
 Installed plugin source and manifest files under the state directory's `extensions/` tree are included, but their nested `node_modules/` dependency trees are skipped as rebuildable install artifacts. After restoring an archive, use `openclaw plugins update <id>` or reinstall with `openclaw plugins install <spec> --force` if a restored plugin reports missing dependencies.
 

--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -1410,7 +1410,7 @@ sessionId})`; create, branch, continue, list, and fork flows live in their
   Runtime tests no longer create invalid or empty `runs.json` fixtures to prove
   registry behavior; they seed/read SQLite rows directly.
 - Backup stages the state directory before archiving, copies non-database files,
-  snapshots databases with `VACUUM INTO`, omits live WAL/SHM sidecars, records
+  snapshots databases with online backup plus offline `VACUUM`, omits live WAL/SHM sidecars, records
   snapshot metadata in the archive manifest, and records
   completed backup runs in SQLite with the archive manifest. `openclaw backup
 create` validates the written archive by default; `--no-verify` is the
@@ -1891,7 +1891,7 @@ The migration imports old JSONL files once, records counts/hashes in
 Backups remain one archive file:
 
 - Checkpoint every global and agent database.
-- Snapshot each DB with SQLite backup semantics or `VACUUM INTO`.
+- Snapshot each DB with SQLite online backup followed by offline `VACUUM`.
 - Archive compact DB snapshots, config, external credentials, and requested
   workspace exports.
 - Omit raw live `*.sqlite-wal` and `*.sqlite-shm` files.
@@ -1932,9 +1932,10 @@ doctor input or support/export output:
 Backups should be one archive file, but database capture should be
 SQLite-native:
 
-1. Stop long-running write activity or enter a short backup barrier.
-2. For every global and agent database, run a checkpoint.
-3. Snapshot databases with `VACUUM INTO` into a temporary backup directory.
+1. Keep write transactions bounded so online backup can make forward progress.
+2. Verify every live global and agent database before capture.
+3. Capture each database with SQLite online backup into a temporary backup
+   directory, then close the live connection and `VACUUM` the private copy.
    Plugin schemas that require owner-defined SQLite capabilities fail closed
    until the owner provides a safe snapshot contract.
 4. Archive the database snapshots, config file, credentials directory, selected
@@ -2057,8 +2058,8 @@ payload.
      lifetime and cancellation behavior are boring.
 
 8. Backup integration.
-   - Teach backup to snapshot global, agent, and plugin databases with
-     `VACUUM INTO`. Done for discovered `*.sqlite` files under the state asset;
+   - Teach backup to snapshot global, agent, and plugin databases with online
+     backup followed by offline `VACUUM`. Done for discovered `*.sqlite` files under the state asset;
      plugin schemas requiring unavailable owner capabilities fail closed.
    - Add backup verification for canonical SQLite integrity and schema identity,
      plus generic file-shape validation for dedicated plugin snapshots. Done for

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -725,7 +725,7 @@ async function createStateSqliteBackupPlan(params: {
       });
     } catch (err) {
       throw new Error(
-        `SQLite database cannot be compacted safely for backup: ${archiveSourcePath}. ${formatErrorMessage(err)}. The source must pass full integrity checks and VACUUM INTO with its required SQLite capabilities; raw page backup was refused because it can retain deleted data.`,
+        `SQLite database cannot be compacted safely for backup: ${archiveSourcePath}. ${formatErrorMessage(err)}. The source must pass full integrity checks, online SQLite backup, and offline compaction with its required SQLite capabilities; a direct file copy was refused because it can retain deleted data.`,
         { cause: err },
       );
     }

--- a/src/infra/sqlite-snapshot.test.ts
+++ b/src/infra/sqlite-snapshot.test.ts
@@ -154,11 +154,44 @@ describe("createVerifiedSqliteSnapshot", () => {
         expect(snapshot.prepare("SELECT value FROM records").all()).toEqual([
           { value: "survivor" },
         ]);
+        expect(snapshot.prepare("PRAGMA journal_mode;").get()).toEqual({
+          journal_mode: "delete",
+        });
+      } finally {
+        snapshot.close();
+      }
+      await expect(fs.access(`${targetPath}-wal`)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(`${targetPath}-shm`)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      source.close();
+    }
+  });
+
+  it("uses online backup before compacting the private copy", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    const source = new sqlite.DatabaseSync(sourcePath);
+    source.exec("CREATE TABLE records (value TEXT NOT NULL); INSERT INTO records VALUES ('ok');");
+    source.close();
+    const backupSpy = vi.spyOn(sqlite, "backup");
+    const prepareSpy = vi.spyOn(sqlite.DatabaseSync.prototype, "prepare");
+
+    try {
+      await createVerifiedSqliteSnapshot({ sourcePath, targetPath });
+
+      expect(backupSpy).toHaveBeenCalledTimes(1);
+      expect(prepareSpy.mock.calls.some(([sql]) => /\bVACUUM\s+INTO\b/iu.test(sql))).toBe(false);
+      const snapshot = new sqlite.DatabaseSync(targetPath, { readOnly: true });
+      try {
+        expect(snapshot.prepare("SELECT value FROM records").get()).toEqual({ value: "ok" });
       } finally {
         snapshot.close();
       }
     } finally {
-      source.close();
+      prepareSpy.mockRestore();
+      backupSpy.mockRestore();
     }
   });
 

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -830,7 +830,9 @@ export async function createVerifiedSqliteSnapshot(
       await loadSqliteVecExtension({ db: source });
       assertSqliteIntegrity(source, options.sourcePath);
       options.validate?.(source, options.sourcePath);
-      source.prepare("VACUUM INTO ?").run(resolveSqliteFilesystemPath(stagedPath));
+      // Copy in incremental steps so concurrent writers are blocked only while
+      // each batch is read. Compaction happens after releasing the live source.
+      await sqlite.backup(source, resolveSqliteFilesystemPath(stagedPath));
     } finally {
       source.close();
     }
@@ -842,12 +844,15 @@ export async function createVerifiedSqliteSnapshot(
     try {
       snapshot.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF;");
       await loadSqliteVecExtension({ db: snapshot });
+      // Online backup preserves WAL mode. Switch the private copy to rollback
+      // journaling so verification and restore need only the published file.
+      snapshot.exec("PRAGMA journal_mode = DELETE;");
       if (options.transform) {
         await options.transform(snapshot);
-        // A transform may delete sensitive rows. Compact again so the
-        // published artifact cannot retain their bytes in free pages.
-        snapshot.exec("VACUUM;");
       }
+      // Compact the private copy so the published artifact is single-file and
+      // cannot retain deleted or transformed data in free pages.
+      snapshot.exec("VACUUM;");
       assertSqliteIntegrity(snapshot, options.targetPath);
       options.validate?.(snapshot, options.targetPath);
       const userVersion = readSqliteUserVersion(snapshot);


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Fixes an issue where creating SQLite snapshots while OpenClaw was actively writing could hold a long-lived read snapshot, preventing WAL reuse and allowing disk usage to grow for the duration of compaction.

## Why This Change Was Made

Snapshot creation now verifies the live database, captures it with SQLite's incremental online backup API, closes the live connection, then normalizes and compacts the private copy before publication. The staged copy is explicitly switched to rollback journaling so the portable artifact remains one sidecar-free file.

## User Impact

Operators can snapshot and archive busy OpenClaw databases with shorter live read-lock windows while retaining committed WAL state, deleted-page scrubbing, full integrity checks, atomic publication, and portable single-file restore artifacts.

## Evidence

- Blacksmith Testbox `tbx_01kyaphwmjxdhezkyrp9cy49jb`: `src/infra/sqlite-snapshot.test.ts` and `src/infra/backup-create.test.ts`, 93 passed and 2 Windows-only tests skipped on Linux.
- Path-scoped `pnpm check:changed`: core and core-test typecheck, lint, database-first guards, import-cycle checks, and docs formatting passed.
- Regression proof covers committed WAL capture, `journal_mode=delete`, absent `-wal`/`-shm` sidecars, deleted-byte removal, unsafe-index rejection, and archive sanitization.
- Fresh structured autoreview: clean, no accepted or actionable findings, confidence 0.88.
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/30117502977
