### PR TITLE
fix(auth): refresh Anthropic OAuth tokens inside the pre-expiry margin window

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -1145,6 +1145,88 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("keeps a scoped OAuth profile usable when an in-margin refresh fails", async () => {
+    // Rotation now runs inside the pre-expiry margin, so the token endpoint is
+    // contacted while the scoped credential still authenticates. A transient
+    // failure there must not cost the login: the credential is served until raw
+    // expiry and the next attempt retries the rotation.
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    oauthMocks.refreshOpenAICodexToken.mockRejectedValueOnce(new Error("503 service_unavailable"));
+    try {
+      const inMarginExpiry = Date.now() + 2 * 60_000;
+      const authProfileStore: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          "openai:work": {
+            type: "oauth",
+            provider: "openai",
+            access: "scoped-in-margin-access",
+            refresh: "scoped-refresh",
+            expires: inMarginExpiry,
+            accountId: "scoped-account",
+          },
+        },
+      };
+
+      await applyCodexAppServerAuthProfile({
+        client: { request } as never,
+        agentDir,
+        authProfileId: "openai:work",
+        authProfileStore,
+      });
+
+      // The rotation was attempted, so the margin fix is still in force.
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("scoped-refresh");
+      // ...and the login still went through on the unexpired credential.
+      expect(request).toHaveBeenCalledWith("account/login/start", {
+        type: "chatgptAuthTokens",
+        accessToken: "scoped-in-margin-access",
+        chatgptAccountId: "scoped-account",
+        chatgptPlanType: null,
+      });
+      expect(authProfileStore.profiles["openai:work"]).toMatchObject({
+        access: "scoped-in-margin-access",
+        expires: inMarginExpiry,
+      });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails a scoped OAuth profile whose refresh fails past raw expiry", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    oauthMocks.refreshOpenAICodexToken.mockRejectedValueOnce(new Error("503 service_unavailable"));
+    try {
+      const authProfileStore: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          "openai:work": {
+            type: "oauth",
+            provider: "openai",
+            access: "scoped-expired-access",
+            refresh: "scoped-refresh",
+            expires: Date.now() - 60_000,
+            accountId: "scoped-account",
+          },
+        },
+      };
+
+      await expect(
+        applyCodexAppServerAuthProfile({
+          client: { request } as never,
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+        }),
+      ).rejects.toThrow(/service_unavailable/);
+      expect(request).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("routes a supplied persisted OAuth clone through canonical refresh", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -1030,7 +1030,19 @@ async function resolveScopedOAuthCredential(params: {
     if (!params.forceRefresh && hasUsableOAuthCredential(credential)) {
       return credential;
     }
-    const refreshed = await refreshOAuthCredentialForRuntime({ credential });
+    let refreshed: Awaited<ReturnType<typeof refreshOAuthCredentialForRuntime>>;
+    try {
+      refreshed = await refreshOAuthCredentialForRuntime({ credential });
+    } catch (error) {
+      // Rotation now happens inside the pre-expiry margin, so a transient token
+      // endpoint failure can reach a request whose token still authenticates.
+      // The margin decides when to rotate; raw expiry decides whether we may
+      // still serve. Forced refreshes want the rotation itself, so they throw.
+      if (!params.forceRefresh && hasUsableOAuthCredential(credential, { refreshMarginMs: 0 })) {
+        return credential;
+      }
+      throw error;
+    }
     if (!refreshed?.access?.trim()) {
       throw new Error(`Codex app-server auth profile "${params.profileId}" could not refresh.`);
     }

--- a/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
+++ b/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
@@ -6,6 +6,10 @@
 import { afterAll, vi } from "vitest";
 
 const fileLockPassthroughMock = vi.hoisted(() => ({
+  // Mirror the real module constant so refresh-failure paths that classify the
+  // cause (e.g. createRedactedOAuthRefreshCause / lock-timeout checks) resolve it
+  // instead of hitting a "no export defined" mock error.
+  FILE_LOCK_TIMEOUT_ERROR_CODE: "file_lock_timeout",
   drainFileLockStateForTest: async () => undefined,
   resetFileLockStateForTest: () => undefined,
   withFileLock: async <T>(_filePath: string, _options: unknown, run: () => Promise<T>) => run(),

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -20,6 +20,7 @@ import {
 import {
   areOAuthCredentialsEquivalent,
   hasMatchingOAuthIdentity,
+  hasUnexpiredOAuthCredential,
   hasUsableOAuthCredential,
   isSafeToAdoptBootstrapOAuthIdentity,
   isSafeToAdoptMainStoreOAuthIdentity,
@@ -243,7 +244,7 @@ async function loadFreshStoredOAuthCredential(params: {
   if (
     reloaded?.type !== "oauth" ||
     reloaded.provider !== params.provider ||
-    !hasUsableOAuthCredential(reloaded)
+    !hasUnexpiredOAuthCredential(reloaded)
   ) {
     return null;
   }
@@ -743,9 +744,12 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     } catch (error) {
       const refreshedStore = loadStoredOAuthRefreshStore(params.agentDir);
       const refreshed = refreshedStore.profiles[params.profileId];
+      // Refreshes now run inside the pre-expiry margin, so this fallback must
+      // measure raw expiry: a token that is merely due for rotation still
+      // authenticates, and rejecting it turns one endpoint error into an outage.
       if (
         refreshed?.type === "oauth" &&
-        hasUsableOAuthCredential(refreshed) &&
+        hasUnexpiredOAuthCredential(refreshed) &&
         canReuseOAuthCredentialAfterRefreshFailure({
           forceRefresh: params.forceRefresh,
           attempted: effectiveCredential,
@@ -808,7 +812,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           if (
             mainCred?.type === "oauth" &&
             mainCred.provider === params.credential.provider &&
-            hasUsableOAuthCredential(mainCred) &&
+            hasUnexpiredOAuthCredential(mainCred) &&
             canReuseOAuthCredentialAfterRefreshFailure({
               forceRefresh: params.forceRefresh,
               attempted: effectiveCredential,

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -478,7 +478,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           adopted = params.refreshed;
           return true;
         }
-        adopted = hasUsableOAuthCredential(existing) ? existing : null;
+        // Same rule as the refresh-failure gates: a concurrent re-login that is
+        // merely due for rotation is still servable, so raw expiry decides here.
+        adopted = hasUnexpiredOAuthCredential(existing) ? existing : null;
         return false;
       },
     });

--- a/src/agents/auth-profiles/oauth-refresh-queue.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-queue.test.ts
@@ -33,8 +33,7 @@ const {
 } = getOAuthProviderRuntimeMocks();
 
 vi.mock("../../llm/oauth.js", () => ({
-  getOAuthApiKey: vi.fn(async () => null),
-  getOAuthProviders: () => [{ id: "openai" }],
+  getOAuthProviders: () => [{ id: "openai", refreshToken: vi.fn() }],
 }));
 
 describe("OAuth refresh in-process queue", () => {

--- a/src/agents/auth-profiles/oauth-shared.ts
+++ b/src/agents/auth-profiles/oauth-shared.ts
@@ -81,6 +81,20 @@ export function hasUsableOAuthCredential(
   return hasUsableStoredOAuthCredential(credential, { now });
 }
 
+/**
+ * Returns true when an OAuth access token has not reached raw expiry.
+ * Refresh-failure fallbacks read this instead of hasUsableOAuthCredential: the
+ * pre-expiry margin decides when to rotate, not whether an already-issued token
+ * still authenticates. Applying the margin here would let one transient
+ * token-endpoint error revoke access that is still valid for minutes.
+ */
+export function hasUnexpiredOAuthCredential(
+  credential: OAuthCredential | undefined,
+  now = Date.now(),
+): boolean {
+  return hasUsableStoredOAuthCredential(credential, { now, refreshMarginMs: 0 });
+}
+
 /** Returns true when an OAuth credential has account or email identity. */
 export function hasOAuthIdentity(
   credential: Pick<OAuthCredential, "accountId" | "email">,

--- a/src/agents/auth-profiles/oauth.adopt-identity.test.ts
+++ b/src/agents/auth-profiles/oauth.adopt-identity.test.ts
@@ -54,8 +54,10 @@ function expectPersistedOpenAICodexProfile(
 // production branch refuses a mismatched accountId.
 
 vi.mock("../../llm/oauth.js", () => ({
-  getOAuthApiKey: vi.fn(async () => null),
-  getOAuthProviders: () => [{ id: "openai" }, { id: "anthropic" }],
+  getOAuthProviders: () => [
+    { id: "openai", refreshToken: vi.fn() },
+    { id: "anthropic", refreshToken: vi.fn() },
+  ],
 }));
 
 describe("OAuth credential adoption is identity-gated", () => {

--- a/src/agents/auth-profiles/oauth.concurrent-agents.test.ts
+++ b/src/agents/auth-profiles/oauth.concurrent-agents.test.ts
@@ -48,8 +48,7 @@ async function loadOAuthModuleForTest() {
 }
 
 vi.mock("../../llm/oauth.js", () => ({
-  getOAuthApiKey: vi.fn(async () => null),
-  getOAuthProviders: () => [{ id: "openai" }],
+  getOAuthProviders: () => [{ id: "openai", refreshToken: vi.fn() }],
 }));
 
 async function runConcurrentRefreshCase(): Promise<ConcurrentRefreshResult> {

--- a/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
+++ b/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
@@ -18,18 +18,20 @@ import {
   saveAuthProfileStore,
 } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
-const { getOAuthApiKeyMock } = vi.hoisted(() => {
+const { refreshTokenMock } = vi.hoisted(() => {
   vi.resetModules();
   return {
-    getOAuthApiKeyMock: vi.fn(async () => {
+    refreshTokenMock: vi.fn(async () => {
       throw new Error("invalid_grant");
     }),
   };
 });
 
 vi.mock("../../llm/oauth.js", () => ({
-  getOAuthApiKey: getOAuthApiKeyMock,
-  getOAuthProviders: () => [{ id: "anthropic" }, { id: "openai" }],
+  getOAuthProviders: () => [
+    { id: "anthropic", refreshToken: refreshTokenMock },
+    { id: "openai", refreshToken: refreshTokenMock },
+  ],
 }));
 
 vi.mock("../cli-credentials.js", () => ({
@@ -70,8 +72,8 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
 
   beforeEach(async () => {
     resetFileLockStateForTest();
-    getOAuthApiKeyMock.mockReset();
-    getOAuthApiKeyMock.mockImplementation(async () => {
+    refreshTokenMock.mockReset();
+    refreshTokenMock.mockImplementation(async () => {
       throw new Error("invalid_grant");
     });
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-fallback-test-"));
@@ -390,7 +392,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
       }),
     );
 
-    getOAuthApiKeyMock
+    refreshTokenMock
       .mockImplementationOnce(async () => {
         throw new Error("refresh_token_reused");
       })

--- a/src/agents/auth-profiles/oauth.margin-refresh.test.ts
+++ b/src/agents/auth-profiles/oauth.margin-refresh.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tests the built-in OAuth refresh margin-window fix (#103846).
+ *
+ * Once the manager's pre-expiry margin gate (`hasUsableOAuthCredential`, 5min)
+ * decides a refresh is due, the built-in provider branch must rotate the token
+ * directly instead of the previous no-op that handed back the same near-expiry
+ * credential. A transient rotation failure inside the margin window must fail
+ * open to the still-valid credential; a rotation failure after hard expiry must
+ * still propagate.
+ */
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetFileLockStateForTest } from "../../infra/file-lock.js";
+import { captureEnv } from "../../test-utils/env.js";
+import { getOAuthProviderRuntimeMocks } from "./oauth-common-mocks.test-support.js";
+import "./oauth-external-auth-passthrough.test-support.js";
+import "./oauth-file-lock-passthrough.test-support.js";
+import {
+  OAUTH_AGENT_ENV_KEYS,
+  createOAuthMainAgentDir,
+  createOAuthTestTempRoot,
+  oauthCred,
+  readAuthProfileStoreForTest,
+  removeOAuthTestTempRoot,
+  resetOAuthProviderRuntimeMocks,
+  resolveApiKeyForProfileInTest,
+  storeWith,
+} from "./oauth-test-utils.js";
+import { resolveApiKeyForProfile } from "./oauth.js";
+import { resetOAuthRefreshQueuesForTest } from "./oauth.test-support.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStore,
+  saveAuthProfileStore,
+} from "./store.js";
+import type { OAuthCredential, OAuthCredentials } from "./types.js";
+
+const { refreshTokenMock } = vi.hoisted(() => ({
+  refreshTokenMock: vi.fn(async (_credential: OAuthCredential): Promise<OAuthCredentials> => {
+    throw new Error("refreshToken not stubbed for this test");
+  }),
+}));
+
+const {
+  refreshProviderOAuthCredentialWithPluginMock,
+  formatProviderAuthProfileApiKeyWithPluginMock,
+} = getOAuthProviderRuntimeMocks();
+
+vi.mock("../../llm/oauth.js", () => ({
+  // The fixed branch is generic across built-in providers; cover a second one
+  // (github-copilot, which applies the same parse-time refresh skew) to prove
+  // the behavior is not Anthropic-specific.
+  getOAuthProviders: () => [
+    { id: "anthropic", refreshToken: refreshTokenMock },
+    { id: "github-copilot", refreshToken: refreshTokenMock },
+  ],
+}));
+
+const PROFILE_ID = "anthropic:default";
+const PROVIDER = "anthropic";
+
+/** Expiry inside the 5min refresh margin: unusable to the manager, not raw-expired. */
+function marginWindowExpiry(): number {
+  return Date.now() + 2 * 60_000;
+}
+
+function seedMarginWindowStore(agentDir: string): void {
+  saveAuthProfileStore(
+    storeWith(
+      PROFILE_ID,
+      oauthCred({
+        provider: PROVIDER,
+        access: "stale-access-token",
+        refresh: "stale-refresh-token",
+        expires: marginWindowExpiry(),
+        accountId: "acct-margin",
+      }),
+    ),
+    agentDir,
+  );
+}
+
+describe("built-in OAuth refresh inside the pre-expiry margin window (#103846)", () => {
+  const envSnapshot = captureEnv(OAUTH_AGENT_ENV_KEYS);
+  let tempRoot = "";
+  let agentDir = "";
+  let caseIndex = 0;
+
+  beforeAll(async () => {
+    tempRoot = await createOAuthTestTempRoot("openclaw-oauth-margin-");
+  });
+
+  beforeEach(async () => {
+    resetFileLockStateForTest();
+    resetOAuthProviderRuntimeMocks({
+      refreshProviderOAuthCredentialWithPluginMock,
+      formatProviderAuthProfileApiKeyWithPluginMock,
+    });
+    refreshTokenMock.mockReset();
+    clearRuntimeAuthProfileStoreSnapshots();
+    const caseRoot = path.join(tempRoot, `case-${++caseIndex}`);
+    agentDir = await createOAuthMainAgentDir(caseRoot);
+    resetOAuthRefreshQueuesForTest();
+  });
+
+  afterEach(async () => {
+    envSnapshot.restore();
+    resetFileLockStateForTest();
+    clearRuntimeAuthProfileStoreSnapshots();
+    resetOAuthRefreshQueuesForTest();
+  });
+
+  afterAll(async () => {
+    await removeOAuthTestTempRoot(tempRoot);
+  });
+
+  it("rotates the token when the manager enters the refresh margin (no silent no-op)", async () => {
+    seedMarginWindowStore(agentDir);
+    const rotatedExpiry = Date.now() + 60 * 60_000;
+    refreshTokenMock.mockResolvedValueOnce({
+      access: "rotated-access-token",
+      refresh: "rotated-refresh-token",
+      expires: rotatedExpiry,
+    });
+
+    const result = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(agentDir),
+      profileId: PROFILE_ID,
+      agentDir,
+    });
+
+    // The refresh actually contacted the provider instead of no-oping.
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+    expect(result?.apiKey).toBe("rotated-access-token");
+
+    // The rotated credential was persisted, not the stale near-expiry one.
+    const persisted = readAuthProfileStoreForTest(agentDir).profiles[PROFILE_ID];
+    if (persisted?.type !== "oauth") {
+      throw new Error(`expected persisted OAuth credential for ${PROFILE_ID}`);
+    }
+    expect(persisted.access).toBe("rotated-access-token");
+    expect(persisted.refresh).toBe("rotated-refresh-token");
+    expect(persisted.expires).toBe(rotatedExpiry);
+  });
+
+  it("refreshes an identity-less in-window credential instead of hard-failing it", async () => {
+    // Before the fix, an identity-less credential inside the margin window returned
+    // stale, tripped the persist-miss path (no identity to recover), and hard-failed
+    // even though the token was still valid (#103846 §Actual). A real refresh rotates
+    // it and persists cleanly.
+    saveAuthProfileStore(
+      storeWith(
+        PROFILE_ID,
+        oauthCred({
+          provider: PROVIDER,
+          access: "stale-access-token",
+          refresh: "stale-refresh-token",
+          expires: marginWindowExpiry(),
+          // no accountId: identity-less
+        }),
+      ),
+      agentDir,
+    );
+    refreshTokenMock.mockResolvedValueOnce({
+      access: "rotated-access-token",
+      refresh: "rotated-refresh-token",
+      expires: Date.now() + 60 * 60_000,
+    });
+
+    const result = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(agentDir),
+      profileId: PROFILE_ID,
+      agentDir,
+    });
+
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+    expect(result?.apiKey).toBe("rotated-access-token");
+  });
+
+  it("surfaces a margin-window refresh failure instead of hiding it behind the stale token", async () => {
+    // A failed refresh must propagate so forced (doctor/CLI) and margin refreshes
+    // alike report the failure rather than silently returning the stale token.
+    seedMarginWindowStore(agentDir);
+    refreshTokenMock.mockRejectedValueOnce(new Error("invalid_grant"));
+
+    await expect(
+      resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+        store: ensureAuthProfileStore(agentDir),
+        profileId: PROFILE_ID,
+        agentDir,
+      }),
+    ).rejects.toThrow(/OAuth token refresh failed for anthropic/);
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates the refresh failure once the credential is hard-expired", async () => {
+    saveAuthProfileStore(
+      storeWith(
+        PROFILE_ID,
+        oauthCred({
+          provider: PROVIDER,
+          access: "expired-access-token",
+          refresh: "expired-refresh-token",
+          expires: Date.now() - 60_000,
+        }),
+      ),
+      agentDir,
+    );
+    refreshTokenMock.mockRejectedValueOnce(new Error("invalid_grant"));
+
+    await expect(
+      resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+        store: ensureAuthProfileStore(agentDir),
+        profileId: PROFILE_ID,
+        agentDir,
+      }),
+    ).rejects.toThrow(/OAuth token refresh failed for anthropic/);
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rotates an in-window github-copilot credential through the same generic branch", async () => {
+    const profileId = "github-copilot:default";
+    saveAuthProfileStore(
+      storeWith(
+        profileId,
+        oauthCred({
+          provider: "github-copilot",
+          access: "stale-access-token",
+          refresh: "stale-refresh-token",
+          expires: marginWindowExpiry(),
+          accountId: "acct-copilot",
+        }),
+      ),
+      agentDir,
+    );
+    refreshTokenMock.mockResolvedValueOnce({
+      access: "rotated-copilot-access",
+      refresh: "rotated-copilot-refresh",
+      expires: Date.now() + 60 * 60_000,
+    });
+
+    const result = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(agentDir),
+      profileId,
+      agentDir,
+    });
+
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+    expect(result?.apiKey).toBe("rotated-copilot-access");
+  });
+
+  it("does not refresh a credential that is still comfortably before the margin", async () => {
+    saveAuthProfileStore(
+      storeWith(
+        PROFILE_ID,
+        oauthCred({
+          provider: PROVIDER,
+          access: "fresh-access-token",
+          refresh: "fresh-refresh-token",
+          expires: Date.now() + 24 * 60 * 60_000,
+        }),
+      ),
+      agentDir,
+    );
+
+    const result = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(agentDir),
+      profileId: PROFILE_ID,
+      agentDir,
+    });
+
+    expect(refreshTokenMock).not.toHaveBeenCalled();
+    expect(result?.apiKey).toBe("fresh-access-token");
+  });
+});

--- a/src/agents/auth-profiles/oauth.margin-refresh.test.ts
+++ b/src/agents/auth-profiles/oauth.margin-refresh.test.ts
@@ -4,9 +4,13 @@
  * Once the manager's pre-expiry margin gate (`hasUsableOAuthCredential`, 5min)
  * decides a refresh is due, the built-in provider branch must rotate the token
  * directly instead of the previous no-op that handed back the same near-expiry
- * credential. A transient rotation failure inside the margin window must fail
- * open to the still-valid credential; a rotation failure after hard expiry must
- * still propagate.
+ * credential.
+ *
+ * Rotating inside the margin also means a transient token-endpoint failure can
+ * now reach a request whose access token is still valid. The manager's existing
+ * refresh-failure fallback covers that, measured against raw expiry rather than
+ * the margin, so a non-forced request keeps working; forced refreshes and
+ * hard-expired credentials still propagate the failure.
  */
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -178,9 +182,35 @@ describe("built-in OAuth refresh inside the pre-expiry margin window (#103846)",
     expect(result?.apiKey).toBe("rotated-access-token");
   });
 
-  it("surfaces a margin-window refresh failure instead of hiding it behind the stale token", async () => {
-    // A failed refresh must propagate so forced (doctor/CLI) and margin refreshes
-    // alike report the failure rather than silently returning the stale token.
+  it("keeps serving the unexpired token when a non-forced margin refresh fails", async () => {
+    // Rotating inside the margin means the token endpoint is now contacted while
+    // the stored access token still authenticates. A transient failure there must
+    // not revoke it: the manager's refresh-failure fallback measures raw expiry,
+    // so the request is served and the next call retries the rotation.
+    seedMarginWindowStore(agentDir);
+    refreshTokenMock.mockRejectedValueOnce(new Error("token endpoint unavailable"));
+
+    const result = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(agentDir),
+      profileId: PROFILE_ID,
+      agentDir,
+    });
+
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+    expect(result?.apiKey).toBe("stale-access-token");
+
+    // The failed rotation left the stored credential untouched, so nothing was
+    // persisted as if the refresh had succeeded.
+    const persisted = readAuthProfileStoreForTest(agentDir).profiles[PROFILE_ID];
+    if (persisted?.type !== "oauth") {
+      throw new Error(`expected persisted OAuth credential for ${PROFILE_ID}`);
+    }
+    expect(persisted.access).toBe("stale-access-token");
+  });
+
+  it("still propagates a forced margin-window refresh failure", async () => {
+    // Forced refreshes (doctor --fix, CLI re-auth) ask for rotation as the result,
+    // not for a served request, so the fallback must not absorb their failures.
     seedMarginWindowStore(agentDir);
     refreshTokenMock.mockRejectedValueOnce(new Error("invalid_grant"));
 
@@ -189,6 +219,7 @@ describe("built-in OAuth refresh inside the pre-expiry margin window (#103846)",
         store: ensureAuthProfileStore(agentDir),
         profileId: PROFILE_ID,
         agentDir,
+        forceRefresh: true,
       }),
     ).rejects.toThrow(/OAuth token refresh failed for anthropic/);
     expect(refreshTokenMock).toHaveBeenCalledTimes(1);

--- a/src/agents/auth-profiles/oauth.margin-refresh.test.ts
+++ b/src/agents/auth-profiles/oauth.margin-refresh.test.ts
@@ -47,9 +47,10 @@ const {
 } = getOAuthProviderRuntimeMocks();
 
 vi.mock("../../llm/oauth.js", () => ({
-  // The fixed branch is generic across built-in providers; cover a second one
-  // (github-copilot, which applies the same parse-time refresh skew) to prove
-  // the behavior is not Anthropic-specific.
+  // The fixed branch is generic across whatever getOAuthProviders() returns, so a
+  // second descriptor proves the behavior is not Anthropic-specific. `github-copilot`
+  // is a stand-in id only — #118063 moved that provider out of the built-in registry
+  // into its own plugin, and this stub registry is what the branch iterates.
   getOAuthProviders: () => [
     { id: "anthropic", refreshToken: refreshTokenMock },
     { id: "github-copilot", refreshToken: refreshTokenMock },

--- a/src/agents/auth-profiles/oauth.mirror-refresh.test.ts
+++ b/src/agents/auth-profiles/oauth.mirror-refresh.test.ts
@@ -56,16 +56,10 @@ function requireOAuthCredential(store: AuthProfileStore, profileId: string): OAu
 }
 
 vi.mock("../../llm/oauth.js", () => ({
-  getOAuthProviders: () => [{ id: "anthropic" }, { id: "openai" }],
-  getOAuthApiKey: vi.fn(async (provider: string, credentials: Record<string, OAuthCredential>) => {
-    const credential = credentials[provider];
-    return credential
-      ? {
-          apiKey: credential.access,
-          newCredentials: credential,
-        }
-      : null;
-  }),
+  getOAuthProviders: () => [
+    { id: "anthropic", refreshToken: vi.fn() },
+    { id: "openai", refreshToken: vi.fn() },
+  ],
 }));
 
 describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => {
@@ -505,7 +499,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
     saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), mainAgentDir);
 
     // Plugin returns a truthy refreshed credential — this takes the plugin
-    // branch instead of falling through to getOAuthApiKey.
+    // branch instead of falling through to the built-in provider refresh.
     refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async () =>
         ({

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -23,17 +23,15 @@ import {
   ensureAuthProfileStore,
   saveAuthProfileStore,
 } from "./store.js";
-import type { AuthProfileStore, OAuthCredential } from "./types.js";
+import type { AuthProfileStore, OAuthCredential, OAuthCredentials } from "./types.js";
 let resolveApiKeyForProfile: typeof import("./oauth.js").resolveApiKeyForProfile;
 let resolveApiKeyForProvider: typeof import("../model-auth.js").resolveApiKeyForProvider;
 let hasAvailableAuthForProvider: typeof import("../model-auth.js").hasAvailableAuthForProvider;
 let markAuthProfileSuccess: typeof import("./profiles.js").markAuthProfileSuccess;
-type GetOAuthApiKey = typeof import("../../llm/oauth.js").getOAuthApiKey;
-
-const { getOAuthApiKeyMock } = vi.hoisted(() => {
+const { refreshTokenMock } = vi.hoisted(() => {
   vi.resetModules();
   return {
-    getOAuthApiKeyMock: vi.fn<GetOAuthApiKey>(async () => {
+    refreshTokenMock: vi.fn(async (_credential: OAuthCredential): Promise<OAuthCredentials> => {
       throw new Error("Failed to extract accountId from token");
     }),
   };
@@ -65,10 +63,9 @@ vi.mock("../cli-credentials.js", () => ({
 }));
 
 vi.mock("../../llm/oauth.js", () => ({
-  getOAuthApiKey: getOAuthApiKeyMock,
   getOAuthProviders: () => [
-    { id: "openai", envApiKey: "OPENAI_API_KEY", oauthTokenEnv: "OPENAI_OAUTH_TOKEN" }, // pragma: allowlist secret
-    { id: "anthropic", envApiKey: "ANTHROPIC_API_KEY", oauthTokenEnv: "ANTHROPIC_OAUTH_TOKEN" }, // pragma: allowlist secret
+    { id: "openai", refreshToken: refreshTokenMock },
+    { id: "anthropic", refreshToken: refreshTokenMock },
   ],
 }));
 
@@ -168,8 +165,8 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
 
   beforeEach(async () => {
     resetFileLockStateForTest();
-    getOAuthApiKeyMock.mockReset();
-    getOAuthApiKeyMock.mockImplementation(async () => {
+    refreshTokenMock.mockReset();
+    refreshTokenMock.mockImplementation(async () => {
       throw new Error("Failed to extract accountId from token");
     });
     readCodexCliCredentialsCachedMock.mockReset();
@@ -249,7 +246,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       /OAuth token refresh failed for openai/,
     );
     expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
-    expect(getOAuthApiKeyMock).not.toHaveBeenCalled();
+    expect(refreshTokenMock).not.toHaveBeenCalled();
   });
 
   it("surfaces refresh contention once without local lock details", async () => {
@@ -994,7 +991,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       }),
       agentDir,
     );
-    getOAuthApiKeyMock.mockImplementationOnce(async () => {
+    refreshTokenMock.mockImplementationOnce(async () => {
       saveAuthProfileStore(
         {
           version: 1,
@@ -1027,7 +1024,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       email: undefined,
     });
 
-    expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
   });
 
   it("clears stale lastGood before selecting an alternate Codex OAuth profile", async () => {
@@ -1057,7 +1054,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       },
       agentDir,
     );
-    getOAuthApiKeyMock.mockImplementationOnce(async () => {
+    refreshTokenMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
       );
@@ -1075,7 +1072,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       email: "user@example.test",
     });
 
-    expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
     expect((await readPersistedStore(agentDir)).lastGood).toBeUndefined();
   });
 
@@ -1106,7 +1103,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       },
       agentDir,
     );
-    getOAuthApiKeyMock.mockImplementationOnce(async () => {
+    refreshTokenMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
       );
@@ -1143,9 +1140,9 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       }),
       agentDir,
     );
-    getOAuthApiKeyMock
-      .mockImplementationOnce(async (_provider, creds) => {
-        expect(creds["openai"]?.refresh).toBe("refresh-token");
+    refreshTokenMock
+      .mockImplementationOnce(async (credential) => {
+        expect(credential.refresh).toBe("refresh-token");
         saveAuthProfileStore(
           {
             version: 1,
@@ -1165,15 +1162,12 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
           '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
         );
       })
-      .mockImplementationOnce(async (_provider, creds) => {
-        expect(creds["openai"]?.refresh).toBe("rotated-refresh-token");
+      .mockImplementationOnce(async (credential) => {
+        expect(credential.refresh).toBe("rotated-refresh-token");
         return {
-          apiKey: "retried-access-token",
-          newCredentials: {
-            access: "retried-access-token",
-            refresh: "retried-refresh-token",
-            expires: Date.now() + 10 * 60_000,
-          },
+          access: "retried-access-token",
+          refresh: "retried-refresh-token",
+          expires: Date.now() + 10 * 60_000,
         };
       });
 
@@ -1189,7 +1183,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       email: undefined,
     });
 
-    expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(2);
+    expect(refreshTokenMock).toHaveBeenCalledTimes(2);
     const persisted = await readPersistedStore(agentDir);
     expectPersistedOpenAICodexProfile(
       expectDefined(persisted.profiles[profileId], "persisted.profiles[profileId] test invariant"),

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -9,12 +9,7 @@ import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import {
-  getOAuthApiKey,
-  getOAuthProviders,
-  type OAuthCredentials,
-  type OAuthProviderId,
-} from "../../llm/oauth.js";
+import { getOAuthProviders, type OAuthCredentials, type OAuthProviderId } from "../../llm/oauth.js";
 import { OAuthProviderConfiguredUnavailableError } from "../../plugins/provider-runtime.errors.js";
 import {
   formatProviderAuthProfileApiKeyWithPlugin,
@@ -210,14 +205,25 @@ async function refreshOAuthCredential(
     return await refreshChutesTokens({ credential });
   }
 
-  const oauthProvider = resolveOAuthProvider(credential.provider);
-  if (!oauthProvider || typeof getOAuthApiKey !== "function") {
+  const providerId = resolveOAuthProvider(credential.provider);
+  const provider = providerId
+    ? getOAuthProviders().find((candidate) => candidate.id === providerId)
+    : undefined;
+  if (!provider) {
     return null;
   }
-  const result = await getOAuthApiKey(oauthProvider, {
-    [credential.provider]: credential,
-  });
-  return result?.newCredentials ?? null;
+  try {
+    // The manager only delegates here after its own pre-expiry margin gate
+    // already decided a refresh is due, so rotate the token directly. The prior
+    // built-in path applied a second, unmargined raw-expiry check that no-oped
+    // inside the margin window and silently handed back the same near-expiry
+    // credential the manager could not tell apart from a real refresh (#103846).
+    return await provider.refreshToken(credential);
+  } catch (error) {
+    // Surface refresh failures (including forced doctor/CLI refreshes) instead of
+    // hiding them behind a stale credential; wrap to match the previous error.
+    throw new Error(`Failed to refresh OAuth token for ${credential.provider}`, { cause: error });
+  }
 }
 
 /** Refresh one OAuth credential and merge provider-returned token fields. */

--- a/src/agents/runtime-plan/resolve-auth.test.ts
+++ b/src/agents/runtime-plan/resolve-auth.test.ts
@@ -19,12 +19,24 @@ vi.mock("../model-auth-env-vars.js", async (importOriginal) => ({
   }),
 }));
 
-vi.mock("../../llm/oauth.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../llm/oauth.js")>()),
-  getOAuthApiKey: vi.fn(async () => {
-    throw new Error("invalid_grant");
-  }),
-}));
+function withFailingRefresh<T extends object>(provider: T): T {
+  return {
+    ...provider,
+    refreshToken: async () => {
+      throw new Error("invalid_grant");
+    },
+  };
+}
+
+vi.mock("../../llm/oauth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../llm/oauth.js")>();
+  return {
+    ...actual,
+    // Keep the real provider set/ids but make the built-in refresh fail so the
+    // OAuth refresh-failure fallthrough is exercised without a live token call.
+    getOAuthProviders: () => actual.getOAuthProviders().map(withFailingRefresh),
+  };
+});
 
 const platformModel = {
   id: "gpt-5.5",

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -664,7 +664,7 @@ export class AuthStorage {
   }
 
   /**
-   * Get all credentials (for passing to getOAuthApiKey).
+   * Get all credentials (for passing to the OAuth provider registry).
    */
   getAll(): AuthStorageData {
     return { ...this.data };

--- a/src/llm/utils/oauth/index.ts
+++ b/src/llm/utils/oauth/index.ts
@@ -87,37 +87,8 @@ export class OAuthProviderRegistry {
 }
 
 /**
- * Get a built-in OAuth provider by ID.
- */
-function getOAuthProvider(id: OAuthProviderId): OAuthProviderInterface | undefined {
-  return BUILT_IN_OAUTH_PROVIDERS.find((provider) => provider.id === id);
-}
-
-/**
  * Get all built-in OAuth providers.
  */
 export function getOAuthProviders(): OAuthProviderInterface[] {
   return [...BUILT_IN_OAUTH_PROVIDERS];
-}
-
-// ============================================================================
-// High-level built-in provider API
-// ============================================================================
-
-/**
- * Get API key for a provider from OAuth credentials.
- * Automatically refreshes expired tokens.
- *
- * @returns API key string and updated credentials, or null if no credentials
- * @throws Error if refresh fails
- */
-export async function getOAuthApiKey(
-  providerId: OAuthProviderId,
-  credentials: Record<string, OAuthCredentials>,
-): Promise<{ newCredentials: OAuthCredentials; apiKey: string } | null> {
-  const provider = getOAuthProvider(providerId);
-  if (!provider) {
-    throw new Error(`Unknown OAuth provider: ${providerId}`);
-  }
-  return resolveOAuthApiKey(provider, credentials);
 }

--- a/test/setup.shared.ts
+++ b/test/setup.shared.ts
@@ -7,7 +7,6 @@ type GlobalWithOpenAiCodexTokenRefreshTestHook = typeof globalThis & {
 };
 
 vi.mock("../src/llm/oauth.js", () => ({
-  getOAuthApiKey: () => undefined,
   getOAuthProviders: () => [],
   loginOpenAICodex: vi.fn(),
   refreshOpenAICodexToken: vi.fn((...args: unknown[]) =>


### PR DESCRIPTION
Closes #103846

## What Problem This Solves

A built-in OAuth credential is silently left un-refreshed during the auth
manager's own pre-expiry refresh window. Once a stored token is inside the
5-minute refresh margin but not yet past its raw expiry, the manager decides a
refresh is due and takes the global refresh lock, but the refresh call hands
back the same unchanged credential without ever contacting the token endpoint.
The manager cannot tell that apart from a real rotation, so it reports success.

For a credential that carries an account identity this is wasted lock churn on
every request inside the window. For one without an identity it is a hard
`OAuthRefreshFailureError` while the token is still valid, because the stale
credential trips the persist-miss path and there is no identity to recover from.

Making the rotation actually happen inside the margin has a second-order
consequence that this PR also has to answer: the token endpoint is now contacted
while the stored access token still authenticates, so a transient failure there
reaches code paths that previously could not see one. Four recovery paths in
the manager and one in the Codex app-server plugin decided whether a stored
credential was still usable with the *margin-aware* predicate, which classifies
an in-margin token as `expiring` rather than `valid`. Left alone, one 503 from
the token endpoint would surface an auth failure to a caller whose token still had
minutes of life left. The
margin decides when to rotate; raw expiry decides whether we may still serve.

## Real behavior proof

Behavior addressed: (1) a built-in OAuth credential inside the 5-minute
pre-expiry margin is judged "needs refresh" by the auth manager, yet no token
request is made and the same stale credential is handed back (#103846); (2) once
the rotation does happen in-margin, a transient token-endpoint failure must not
cost a non-forced caller its still-unexpired access token.

Real environment tested: Node v24.18.0 on Linux, driving the real
`resolveApiKeyForProfile` -> OAuth manager -> `anthropicOAuthProvider.refreshToken`
-> `refreshAnthropicToken` -> `postJson` chain outside Vitest, against a real
on-disk isolated `OPENCLAW_STATE_DIR` auth-profile store seeded through the
production writer `saveAuthProfileStore`. Two boundaries are faked and neither is
the code under test. The global `fetch` binding is replaced, so the request to the
hardcoded token endpoint is observed there and never leaves the process. The
plugin-runtime module is replaced by an inert stub whose hooks return what the
real runtime returns for a built-in credential with no provider plugin registered:
`resolveProviderOAuthCredentialWithPlugin` answers `{ status: "unowned" }` and the
refresh, api-key-format and doctor-hint hooks answer `undefined`, so execution
falls through to the built-in branch under test. That the real runtime answers the
same way for an unowned ref is a contract assumption of this capture, cited in the
stub against `src/plugins/provider-runtime.ts` and `src/plugins/providers.ts`
rather than measured here. Everything between them is
production code: `refreshAnthropicToken` builds the request, and on the success
cases it parses the synthetic 200 response and merges the rotated fields through
the normal path.

Exact steps or command run after this patch: run the driver and harness inlined
at the end of this body; neither is part of the diff. The driver also loads a
third file that registers the plugin-runtime stub described above. It runs one
harness three times in one worktree over the same fixtures, restoring only the
touched production files between stages. Because it restores those files from
`HEAD` on exit, it refuses to start when any of them is dirty; other uncommitted
work is left alone. By default it resolves `upstream/main` live and derives the
pre-repair commit from history, so to reproduce this capture rather than today's
`main`, check out the captured head and pin both refs the inlined driver reads:

```bash
BASE_REF=bfcce12e6b381aac1452ae4e686ffee8394b6adf \
  PRE_REPAIR_REF=ac4497439d7d9343ef3309d6dee0c6c8f6e75f06 \
  bash repro.sh
```

| stage | this PR's production files restored to |
|---|---|
| `before` | `upstream/main` `bfcce12e6b381aac1452ae4e686ffee8394b6adf` |
| `without-failure-repair` | `ac4497439d7d9343ef3309d6dee0c6c8f6e75f06` — margin rotation present, recovery paths not yet widened |
| `after` | this PR head `9a141fc887f848b2bbab4ce75051bd55e13d581d` |

The three stages differ only in this PR's production files; every other file stays
at the PR head in all three. So this is a controlled comparison of the
patch against itself and against `main`'s version of the same files, not three
full checkouts — which is what makes the differences attributable to the patch.

Five fixtures: expiry 2 min away (inside the margin), 24 h away, already expired
by 1 s, plus the in-margin and already-expired cases again with the token endpoint
answering `503 service_unavailable`. Reported fields are the ones the issue prescribes —
`managerSaysNeedsRefresh` (the harness evaluating `hasUsableOAuthCredential` on the
stored credential — the same predicate the manager gates on, not a reading of the
manager's internal decision), `networkRefreshCallWasMade` (observed at the replaced
`fetch` boundary), and `returnedAccessSameAsStale`, which compares the api key the
caller received. Two more fields read the on-disk store rather than the
return value, and are named for that, so a failed rotation can be seen leaving both
halves of the stored credential untouched. A last field records which response the
fake token endpoint gave. Only synthetic `*-synthetic` tokens are used, `resolvedApiKey`
is length-redacted, and the checkout path is stripped from emitted stack frames,
so no real credential and no private path appears.

Observed result after fix: reading the three stages of the same case,

| case | `before` | `without-failure-repair` | `after` |
|---|---|---|---|
| `margin-window` | no call, stale token served | call, rotated | call, rotated |
| `margin-window-endpoint-down` | no call, stale served (failure invisible) | call, **auth error** | call, **stale token served** |
| `hard-expired-endpoint-down` | call, auth error | call, auth error | call, auth error |

Row 1 is the reported defect closing. Row 2 is the second-order regression
appearing in the middle stage and closing in the last one, with the rotation
still attempted in both — the margin fix is not walked back to avoid it. Row 3 is
unchanged across all three stages on every reported field except the stage label:
nothing about the strict path widened.

Evidence after fix: captured at `9a141fc887f848b2bbab4ce75051bd55e13d581d`, the current head of this PR.

```
# repro for openclaw/openclaw#103846 — 2026-08-04T22:15:14Z
# head = 9a141fc887f848b2bbab4ce75051bd55e13d581d (branch base 8fc44585931decce2e821efac34a599b5845c08a)
# before stage restores the touched production files to upstream/main bfcce12e6b381aac1452ae4e686ffee8394b6adf
# node = v24.18.0

===== BEFORE (production files restored to upstream/main bfcce12e6b381aac1452ae4e686ffee8394b6adf, defect present on current main) =====
{
  "label": "before",
  "target": "<worktree>",
  "results": [
    {
      "case": "margin-window",
      "label": "before",
      "marginMs": 300000,
      "tokenEndpoint": "ok",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": false,
      "returnedAccessSameAsStale": true,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": "stale-access-t…(28 chars)",
      "error": null
    },
    {
      "case": "far-expiry",
      "label": "before",
      "marginMs": 300000,
      "tokenEndpoint": "ok",
      "managerSaysNeedsRefresh": false,
      "networkRefreshCallWasMade": false,
      "returnedAccessSameAsStale": true,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": "stale-access-t…(28 chars)",
      "error": null
    },
    {
      "case": "hard-expired",
      "label": "before",
      "marginMs": 300000,
      "tokenEndpoint": "ok",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": false,
      "persistedExpiresSameAsStale": false,
      "persistedRefreshSameAsStale": false,
      "resolvedApiKey": "rotated-access…(30 chars)",
      "error": null
    },
    {
      "case": "margin-window-endpoint-down",
      "label": "before",
      "marginMs": 300000,
      "tokenEndpoint": "transient-failure",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": false,
      "returnedAccessSameAsStale": true,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": "stale-access-t…(28 chars)",
      "error": null
    },
    {
      "case": "hard-expired-endpoint-down",
      "label": "before",
      "marginMs": 300000,
      "tokenEndpoint": "transient-failure",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": null,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": null,
      "error": "OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic | Anthropic token refresh request failed. url=https://platform.claude.com/v1/oauth/token; details=Error: HTTP request failed. status=503; url=https://platform.claude.com/v1/oauth/token; body={\"error\":\"service_unavailable\"}| HTTP request failed. status=503; url=https://platform.claude.com/v1/oauth/token; body={\"error\":\"service_unavailable\"}. Please try again or re-authenticate."
    }
  ]
}

===== WITHOUT-FAILURE-REPAIR (production files restored to ac4497439d7d9343ef3309d6dee0c6c8f6e75f06: margin rotation added, refresh-failure fallback not yet widened) =====
{
  "label": "without-failure-repair",
  "target": "<worktree>",
  "results": [
    {
      "case": "margin-window",
      "label": "without-failure-repair",
      "marginMs": 300000,
      "tokenEndpoint": "ok",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": false,
      "persistedExpiresSameAsStale": false,
      "persistedRefreshSameAsStale": false,
      "resolvedApiKey": "rotated-access…(30 chars)",
      "error": null
    },
    {
      "case": "far-expiry",
      "label": "without-failure-repair",
      "marginMs": 300000,
      "tokenEndpoint": "ok",
      "managerSaysNeedsRefresh": false,
      "networkRefreshCallWasMade": false,
      "returnedAccessSameAsStale": true,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": "stale-access-t…(28 chars)",
      "error": null
    },
    {
      "case": "hard-expired",
      "label": "without-failure-repair",
      "marginMs": 300000,
      "tokenEndpoint": "ok",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": false,
      "persistedExpiresSameAsStale": false,
      "persistedRefreshSameAsStale": false,
      "resolvedApiKey": "rotated-access…(30 chars)",
      "error": null
    },
    {
      "case": "margin-window-endpoint-down",
      "label": "without-failure-repair",
      "marginMs": 300000,
      "tokenEndpoint": "transient-failure",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": null,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": null,
      "error": "OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic | Anthropic token refresh request failed. url=https://platform.claude.com/v1/oauth/token; details=Error: HTTP request failed. status=503; url=https://platform.claude.com/v1/oauth/token; body={\"error\":\"service_unavailable\"}| HTTP request failed. status=503; url=https://platform.claude.com/v1/oauth/token; body={\"error\":\"service_unavailable\"}. Please try again or re-authenticate."
    },
    {
      "case": "hard-expired-endpoint-down",
      "label": "without-failure-repair",
      "marginMs": 300000,
      "tokenEndpoint": "transient-failure",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": null,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": null,
      "error": "OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic | Anthropic token refresh request failed. url=https://platform.claude.com/v1/oauth/token; details=Error: HTTP request failed. status=503; url=https://platform.claude.com/v1/oauth/token; body={\"error\":\"service_unavailable\"}| HTTP request failed. status=503; url=https://platform.claude.com/v1/oauth/token; body={\"error\":\"service_unavailable\"}. Please try again or re-authenticate."
    }
  ]
}

===== AFTER (this PR, head 9a141fc887f848b2bbab4ce75051bd55e13d581d) =====
{
  "label": "after",
  "target": "<worktree>",
  "results": [
    {
      "case": "margin-window",
      "label": "after",
      "marginMs": 300000,
      "tokenEndpoint": "ok",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": false,
      "persistedExpiresSameAsStale": false,
      "persistedRefreshSameAsStale": false,
      "resolvedApiKey": "rotated-access…(30 chars)",
      "error": null
    },
    {
      "case": "far-expiry",
      "label": "after",
      "marginMs": 300000,
      "tokenEndpoint": "ok",
      "managerSaysNeedsRefresh": false,
      "networkRefreshCallWasMade": false,
      "returnedAccessSameAsStale": true,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": "stale-access-t…(28 chars)",
      "error": null
    },
    {
      "case": "hard-expired",
      "label": "after",
      "marginMs": 300000,
      "tokenEndpoint": "ok",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": false,
      "persistedExpiresSameAsStale": false,
      "persistedRefreshSameAsStale": false,
      "resolvedApiKey": "rotated-access…(30 chars)",
      "error": null
    },
    {
      "case": "margin-window-endpoint-down",
      "label": "after",
      "marginMs": 300000,
      "tokenEndpoint": "transient-failure",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": true,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": "stale-access-t…(28 chars)",
      "error": null
    },
    {
      "case": "hard-expired-endpoint-down",
      "label": "after",
      "marginMs": 300000,
      "tokenEndpoint": "transient-failure",
      "managerSaysNeedsRefresh": true,
      "networkRefreshCallWasMade": true,
      "returnedAccessSameAsStale": null,
      "persistedExpiresSameAsStale": true,
      "persistedRefreshSameAsStale": true,
      "resolvedApiKey": null,
      "error": "OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic | Anthropic token refresh request failed. url=https://platform.claude.com/v1/oauth/token; details=Error: HTTP request failed. status=503; url=https://platform.claude.com/v1/oauth/token; body={\"error\":\"service_unavailable\"}| HTTP request failed. status=503; url=https://platform.claude.com/v1/oauth/token; body={\"error\":\"service_unavailable\"}. Please try again or re-authenticate."
    }
  ]
}
```

What was not tested: the token endpoint is faked, so no response from Anthropic's
real service is exercised. The synthetic 200 is parsed by the production refresh
code, but a live rotation could differ in ways this cannot show. Two paths sit outside
the capture entirely and are covered by unit tests instead: the Codex app-server scoped path, which
needs a live app-server client, and the compare-and-set race behind the
persist-miss change, which needs two concurrent writers against one on-disk store.

## Why This Change Was Made

The manager delegates a refresh through `refreshOAuthCredential`, whose built-in
branch routed back through `getOAuthApiKey`. That helper applies its own,
**unmargined** raw-expiry check (`Date.now() >= creds.expires`); inside the margin
that check is false, so `provider.refreshToken` was never called and the stale
credential came back. Two expiry gates disagreed.

The built-in branch now calls the resolved provider's existing `refreshToken`
directly — the manager has already decided a refresh is due, so it should
actually refresh. The plugin-hook and Chutes branches already refresh
unconditionally; this removes the built-in branch's asymmetric second gate. The
branch is provider-generic: it serves every entry of `BUILT_IN_OAUTH_PROVIDERS`,
so this is one generic fix rather than an Anthropic special case.

### Where the failure-path repair belongs

`refreshOAuthCredential` keeps throwing. It never receives `forceRefresh`, so a
fallback there would also mask forced doctor/CLI refresh failures — that is the
wrong owner. The manager does know `forceRefresh`, and it already has a helper for
exactly this decision (`canReuseOAuthCredentialAfterRefreshFailure`). What was
missing was only the expiry predicate those gates read.

`hasUnexpiredOAuthCredential` (raw expiry, no margin) is added in
`src/agents/auth-profiles/oauth-shared.ts`, alongside that file's existing
`hasUsableOAuthCredential` wrapper, and delegates to the same `credential-state`
classifier with the margin set to zero. `credential-state.ts` itself is unchanged.
The four connected recovery sites now read it:

- `resolveOAuthAccess` catch — reuse the reloaded own-store credential. This is the
  one the new regression tests and the live capture drive.
- `resolveOAuthAccess` catch — inherit a main-store credential. Exercised by the
  existing `oauth.fallback-to-main-agent` suite, which drives it with expired
  credentials; the in-margin variant is not separately pinned.
- `loadFreshStoredOAuthCredential` — the reused-refresh-token recovery reload.
  Exercised by the existing reuse-recovery coverage, likewise on expired input.
- `resolveOAuthCredentialAfterPersistMiss` — adopt after a lost compare-and-set.
  Not directly pinned; see the limitation above.

The existing margin-aware gates that answer "should we rotate?" are deliberately
untouched; changing them would restore the original no-op.

The fallback does not classify the failure, and that is deliberate: it is bounded
by raw expiry, so even a permanent `invalid_grant` only delays the visible failure
by the remainder of the margin — at most five minutes — after which the credential
is expired, the fallback no longer applies, and the error surfaces. Classifying
transient against permanent at this layer would mean interpreting provider error
shapes in the manager, which is a larger contract than this PR should take, and
getting it wrong in the permanent direction would revoke a still-valid token.

### Codex app-server scoped path

`resolveScopedOAuthCredential` runs its own refresh queue outside the manager. It
gates on the margin and then called `refreshOAuthCredentialForRuntime` with no
fallback, so the same transient failure turned a non-forced scoped request into a
hard login failure. It now serves the credential until raw expiry using the
predicate it already imports from `openclaw/plugin-sdk/provider-auth`, passing
`refreshMarginMs: 0`. Raw-expired credentials still throw, which is pinned. Forced
scoped refreshes also still throw, by the same `!params.forceRefresh` condition the
manager gate uses, but the regression tests added here cover the non-forced
in-margin and the raw-expired cases rather than a forced in-margin one. This adds no plugin-SDK surface: `provider-auth` already re-exports the
`credential-state` form that takes `refreshMarginMs`.

`grep -rn refreshOAuthCredentialForRuntime src/ extensions/ packages/ --include=*.ts`
returns this bridge as the only plugin consumer; the remaining hits are the
definition in `src/agents/auth-profiles/oauth.ts` and the two barrel re-exports in
`src/agents/auth-profiles.ts` and `src/plugin-sdk/agent-runtime.ts`. The same shape
of search is what establishes that the removed `getOAuthApiKey` had one non-test
caller; the diff shows the removal, so the claim is checkable against it.

### Boundaries

- **`getOAuthApiKey`'s raw-expiry semantics are unchanged.** This branch was its
  only non-test caller, so the exported wrapper and its private `getOAuthProvider`
  helper became dead code and are removed. `resolveOAuthApiKey` — the raw-expiry
  gate itself — is untouched and still backs the `OAuthProviderRegistry` path. The
  removal is internal: the symbol appears in no published entry point, and
  `docs/.generated/plugin-sdk-api-baseline.sha256` is untouched. Leaving the
  unreachable export in place fails the repo's `knip` dead-export scan.
- **The `auth-storage` / `OAuthProviderRegistry.getApiKey` path is unaffected.** It
  applies its own 0-margin gate before refreshing, so it only reaches a refresh
  once the credential is genuinely expired.
- **No new config, env, or SDK surface.**
- **Production LOC: +60 / -47, net +13** (tests counted separately: +449 / -59).
  The growth is one predicate, the plugin fallback, and a completed mock export in
  a shared test-support helper; the first two are required by the availability
  invariant named above.

### Why this is one PR

The diff spans `src/` and `extensions/codex/`, which normally reads as two topics.
The second half is not hardening — it is the regression the first half causes,
and the capture above measures it. The `without-failure-repair` stage restores the
production files to the commit that has the margin rotation and nothing else: that
is what shipping the core fix alone looks like, and on `margin-window-endpoint-down`
it returns an auth error where current `main` serves the request. Splitting would
land that row. The plugin path breaks for the same reason and cannot be fixed
before the core change, because until then the endpoint is never contacted
in-margin and there is nothing to guard. The plugin side is 13 production lines
and reuses the core predicate rather than restating the rule.

`src/agents/auth-profiles/oauth.margin-refresh.test.ts` is a new file rather than
an addition to an existing suite because the directory already organises these by
topic — `oauth.adopt-identity`, `oauth.mirror-refresh`, `oauth.fallback-to-main-agent`,
`oauth.concurrent-agents` — and this is the margin-window topic. It is happy to be
folded into a neighbour if you would rather have it there.

### Non-scope

This change is limited to when a built-in OAuth rotation is attempted and whether
an already-issued credential may still be served after that attempt fails. It does
not change the 5-minute margin value, the raw-expiry semantics of
`resolveOAuthApiKey`, refresh-token rotation or reuse detection, the persistence
and locking protocol, or any provider's token request and response handling.

The capture seeds every fixture with an account id. The identity-less hard-fail
described above is covered by
`src/agents/auth-profiles/oauth.margin-refresh.test.ts :: refreshes an identity-less
in-window credential instead of hard-failing it`, which exercises a successful
rotation. The refresh-failure fallback is not separately exercised on an
identity-less credential; it reads the same predicate and the same gate, but the
measured cases all carry an account id.

Known limitation: `github-copilot` and `openai-chatgpt` share the built-in branch
but are not exercised end to end here — Anthropic is the one driven through the
live harness, and the others rest on the adapter contract being identical, which
is visible in the diff-adjacent source rather than in a capture.

## User Impact

A Claude Pro/Max credential now actually rotates during the pre-expiry window
instead of churning the refresh lock, and an identity-less credential no longer
hard-fails inside that window while it is still valid. The branch is shared by the
other built-in providers, so the same change applies to them, but Anthropic is the
one measured here — see the limitation under Non-scope.

Because rotation now happens while the old token is still good, a transient token
endpoint outage is absorbed rather than surfaced: a non-forced request keeps
working on the unexpired token. Nothing is written when the rotation fails, so the
credential is still inside the margin and the next manager invocation attempts the
rotation again. The capture calls each fixture once, so it shows the unchanged
stored credential rather than the retry itself; the retry follows from the stored
state, not from a measurement.

The fallback is gated on the request not being forced, so any caller that asks for
a forced refresh — `doctor --fix` and CLI re-auth are the operator-facing ones —
keeps receiving the failure and drives re-authentication. What is pinned is the
gate itself (`still propagates a forced margin-window refresh failure`), not each
caller. A credential past raw expiry is unaffected either way: it rotates when the endpoint
answers and surfaces the error when it does not, exactly as before — both in the
capture and in tests.

## Evidence

Focused suites on this head, run with `node scripts/run-vitest.mjs <path>`:

- `src/agents/auth-profiles` — 122 files, 1644 tests, green.
- `extensions/codex/src/app-server/auth-bridge.test.ts` — 89 tests, green.

New regression coverage. Each was verified by reverting the corresponding change
and confirming that exactly the intended case fails:

- `src/agents/auth-profiles/oauth.margin-refresh.test.ts :: keeps serving the
  unexpired token when a non-forced margin refresh fails` — reverting the predicate
  at the manager's reuse gates makes this throw `OAuthManagerRefreshError`.
- `src/agents/auth-profiles/oauth.margin-refresh.test.ts :: still propagates a
  forced margin-window refresh failure` — pins the other half of the contract.
- `extensions/codex/src/app-server/auth-bridge.test.ts :: keeps a scoped OAuth
  profile usable when an in-margin refresh fails` and `:: fails a scoped OAuth
  profile whose refresh fails past raw expiry` — disabling the plugin guard fails
  exactly the first (1 failed, 88 passed).

The rotation assertions from the original fix (`rotates the token when the manager
enters the refresh margin`, the identity-less case, the far-expiry no-refresh case)
are unchanged and still pass, so the failure-path work did not weaken the
margin-window fix.

## Proof harness

The driver and harness that produced the capture above. Neither is part of this
PR's diff.

```bash
#!/usr/bin/env bash
# Real-behavior boundary-capture proof for openclaw/openclaw#103846.
#
#   bash docs/work-items/oauth-refresh-margin-noop/proof/repro.sh
#
# Runnable from anywhere: it resolves its own directory and uses WT (default: the
# enclosing worktree root) as the checkout it drives.
#
# Drives the REAL production manager path (resolveApiKeyForProfile -> OAuth
# manager -> built-in Anthropic provider refreshToken -> refreshAnthropicToken
# -> postJson -> fetch) against a real on-disk isolated auth-profile store.
# Two boundaries are faked: the outbound Anthropic token HTTPS call, and the
# plugin-runtime module, stubbed per hook to answer what the real runtime answers
# for a built-in credential with no provider plugin registered (see
# stub-provider-runtime.mjs).
#
# BEFORE is captured by restoring every production file this PR touches (the
# list below) to current upstream/main inside the same worktree. The rest of the
# tree stays where it is, so BEFORE is this PR's production files replaced by
# main's version of the same files, not a full checkout of main. That is the
# point: only the patch differs between stages, so the differences are
# attributable to it. It also means the comparison is against current main
# rather than the older SHA the branch happens to sit on.
#
# Requires Node >= 22.22.3 and the worktree's node_modules (pnpm install).
# Nothing is staged/committed/pushed; only synthetic tokens + ephemeral state.
# It rewrites the listed production files between stages and restores them from
# HEAD on exit, so it refuses to start when any of THOSE files is dirty. Other
# uncommitted work is untouched. It does overwrite raw-output.txt in place.
set -euo pipefail

WT="${WT:-$(git rev-parse --show-toplevel)}"
PROOF_DIR="$(cd "$(dirname "$0")" && pwd)"
OUT="$PROOF_DIR/raw-output.txt"
BASE_REF="${BASE_REF:-upstream/main}"

# The production files this PR changes. BEFORE restores exactly these.
PROD_FILES=(
  src/agents/auth-profiles/oauth.ts
  src/llm/utils/oauth/index.ts
  src/agents/sessions/auth-storage.ts
  src/agents/auth-profiles/oauth-manager.ts
  src/agents/auth-profiles/oauth-shared.ts
  extensions/codex/src/app-server/auth-bridge.ts
)

# The last commit that has the margin rotation but not the refresh-failure
# repair. Restoring the production files to it reproduces the regression the
# review reported, so the three stages read as one continuous story.
# Derived from history rather than pinned, so a rebase cannot silently point
# this at a commit that already carries the repair (which would make the
# middle stage look identical to AFTER).
PRE_REPAIR_REF="${PRE_REPAIR_REF:-}"

cd "$WT"

# Stages rewrite the listed files and restore them from HEAD, so an uncommitted
# edit to any of them would be lost. Refuse rather than silently discard.
if ! git diff --quiet -- "${PROD_FILES[@]}" || ! git diff --cached --quiet -- "${PROD_FILES[@]}"; then
  echo "refusing to run: uncommitted changes in the production files this script rewrites" >&2
  git status --short -- "${PROD_FILES[@]}" >&2
  exit 1
fi

BASE_SHA="$(git rev-parse "$BASE_REF")"
HEAD_SHA="$(git rev-parse HEAD)"
if [ -z "$PRE_REPAIR_REF" ]; then
  REPAIR_COMMIT="$(git log --reverse --format=%H -S hasUnexpiredOAuthCredential \
    -- src/agents/auth-profiles/oauth-shared.ts | head -1)"
  if [ -z "$REPAIR_COMMIT" ]; then
    echo "cannot locate the commit that introduced hasUnexpiredOAuthCredential" >&2
    exit 1
  fi
  PRE_REPAIR_REF="${REPAIR_COMMIT}^"
fi
PRE_REPAIR_SHA="$(git rev-parse "$PRE_REPAIR_REF")"
BRANCH_BASE_SHA="$(git merge-base HEAD "$BASE_REF")"

run_one() {
  local label="$1"
  PROOF_TARGET="$WT" PROOF_LABEL="$label" \
    node --import tsx --import "$PROOF_DIR/register-stubs.mjs" "$PROOF_DIR/harness.mjs" \
    2>&1 | grep -v '^\[harness:'
}

restore_ours() { git checkout HEAD -- "${PROD_FILES[@]}"; }
trap restore_ours EXIT

{
  echo "# repro for openclaw/openclaw#103846 — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
  echo "# head = $HEAD_SHA (branch base $BRANCH_BASE_SHA)"
  echo "# before stage restores the touched production files to $BASE_REF $BASE_SHA"
  echo "# node = $(node -v)"
  echo
  echo "===== BEFORE (production files restored to $BASE_REF $BASE_SHA, defect present on current main) ====="
  git checkout "$BASE_REF" -- "${PROD_FILES[@]}"
  run_one before
  restore_ours
  echo
  echo "===== WITHOUT-FAILURE-REPAIR (production files restored to $PRE_REPAIR_SHA: margin rotation added, refresh-failure fallback not yet widened) ====="
  git checkout "$PRE_REPAIR_REF" -- "${PROD_FILES[@]}"
  run_one without-failure-repair
  restore_ours
  echo
  echo "===== AFTER (this PR, head $HEAD_SHA) ====="
  run_one after
} 2>&1 | tee "$OUT"
```

```js
/**
 * Boundary-capture real-behavior proof for openclaw/openclaw#103846.
 *
 * Drives the REAL production manager path (`resolveApiKeyForProfile` ->
 * OAuth manager -> built-in Anthropic provider `refreshToken`) against a real
 * on-disk isolated auth-profile store, seeded through the production writer.
 * Two boundaries are faked: the outbound HTTPS call to Anthropic's hardcoded
 * token endpoint (`platform.claude.com/v1/oauth/token`), replaced here, and the
 * provider-runtime wrapper, stubbed by register-stubs.mjs to return undefined —
 * which is what it really returns for a built-in credential with no provider
 * plugin registered. The network implementation (`refreshAnthropicToken`) is
 * unchanged by the fix and is exercised end to end up to the fetch boundary,
 * including parsing the synthetic success response, so this observes
 * orchestration rather than a stubbed seam.
 *
 * Emits the evidence-JSON shape the issue itself prescribes, per case:
 *   { marginMs, managerSaysNeedsRefresh, networkRefreshCallWasMade,
 *     returnedAccessSameAsStale, persistedExpiresSameAsStale,
 *     persistedRefreshSameAsStale }
 *
 * Run indirectly via repro.sh (sets PROOF_TARGET / PROOF_LABEL). Nothing is
 * written outside an ephemeral OPENCLAW_STATE_DIR; only synthetic tokens are used.
 */
import { mkdir, mkdtemp, rm } from "node:fs/promises";
import { tmpdir } from "node:os";
import { join } from "node:path";
import { pathToFileURL } from "node:url";

const TARGET = process.env.PROOF_TARGET;
const LABEL = process.env.PROOF_LABEL ?? "unknown";
if (!TARGET) {
  throw new Error("PROOF_TARGET (worktree root) is required");
}

const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
const PROFILE_ID = "anthropic:default";

// --- fake ONLY the Anthropic token endpoint; anything else is a real leak ---
let networkRefreshCallWasMade = false;
// "ok" rotates; "transient-failure" answers 503 the way an unavailable token
// endpoint does, so the manager's refresh-failure path runs for real.
let tokenEndpointMode = "ok";
globalThis.fetch = async (input) => {
  const url = typeof input === "string" ? input : (input?.url ?? String(input));
  if (url === TOKEN_URL) {
    networkRefreshCallWasMade = true;
    if (tokenEndpointMode === "transient-failure") {
      return new Response(JSON.stringify({ error: "service_unavailable" }), {
        status: 503,
        headers: { "content-type": "application/json" },
      });
    }
    return new Response(
      JSON.stringify({
        access_token: "rotated-access-token-synthetic",
        refresh_token: "rotated-refresh-token-synthetic",
        expires_in: 3600,
      }),
      { status: 200, headers: { "content-type": "application/json" } },
    );
  }
  throw new Error(`unexpected outbound network call in proof harness: ${url}`);
};

// Establish the isolated state dir BEFORE importing production modules that may
// resolve store paths from the environment at load time.
process.env.OPENCLAW_STATE_ROOT = await mkdtemp(join(tmpdir(), "openclaw-oauth-proof-"));
process.env.OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_ROOT;

const importFromTarget = (rel) => import(pathToFileURL(join(TARGET, rel)).href);

const stage = (m) => process.stderr.write(`[harness:${LABEL}] ${m}\n`);

stage("importing oauth.ts");
const { resolveApiKeyForProfile } = await importFromTarget("src/agents/auth-profiles/oauth.ts");
stage("imported oauth.ts");
const { saveAuthProfileStore, ensureAuthProfileStore } = await importFromTarget(
  "src/agents/auth-profiles/store.ts",
);
const { hasUsableOAuthCredential, DEFAULT_OAUTH_REFRESH_MARGIN_MS } = await importFromTarget(
  "src/agents/auth-profiles/credential-state.ts",
);
const { clearRuntimeAuthProfileStoreSnapshots } = await importFromTarget(
  "src/agents/auth-profiles/runtime-snapshots.ts",
);

const STALE_ACCESS = "stale-access-token-synthetic";

function seededCredential(expires) {
  return {
    type: "oauth",
    provider: "anthropic",
    access: STALE_ACCESS,
    refresh: "stale-refresh-token-synthetic",
    expires,
    accountId: "acct-proof",
  };
}

async function runCase(name, expiresOffsetMs, endpointMode = "ok") {
  tokenEndpointMode = endpointMode;
  clearRuntimeAuthProfileStoreSnapshots?.();
  // Fresh isolated state dir per case: the manager mirrors refreshed credentials
  // into the main store, so a shared root would let one case's rotation bleed
  // into the next via main-store adoption.
  const stateDir = await mkdtemp(join(tmpdir(), `openclaw-oauth-proof-${name}-`));
  process.env.OPENCLAW_STATE_DIR = stateDir;
  const agentDir = join(stateDir, "agents", "main", "agent");
  await mkdir(agentDir, { recursive: true });
  process.env.OPENCLAW_AGENT_DIR = agentDir;

  const expires = Date.now() + expiresOffsetMs;
  const seeded = seededCredential(expires);

  // Production writer seeds the real on-disk store.
  stage(`case ${name}: saveAuthProfileStore`);
  saveAuthProfileStore({ version: 1, profiles: { [PROFILE_ID]: seeded } }, agentDir);
  stage(`case ${name}: ensureAuthProfileStore`);
  const store = ensureAuthProfileStore(agentDir);

  const managerSaysNeedsRefresh = !hasUsableOAuthCredential(store.profiles[PROFILE_ID]);
  networkRefreshCallWasMade = false;

  let error = null;
  let result = null;
  try {
    stage(`case ${name}: resolveApiKeyForProfile`);
    result = await resolveApiKeyForProfile({ cfg: {}, store, profileId: PROFILE_ID, agentDir });
    stage(`case ${name}: resolved`);
  } catch (e) {
    error = redactPaths(e instanceof Error ? e.message : String(e));
  }

  // Authoritative read-back from the on-disk store (not the in-memory object).
  clearRuntimeAuthProfileStoreSnapshots?.();
  const persisted = ensureAuthProfileStore(agentDir).profiles[PROFILE_ID];
  const out = {
    case: name,
    label: LABEL,
    marginMs: DEFAULT_OAUTH_REFRESH_MARGIN_MS,
    tokenEndpoint: endpointMode,
    managerSaysNeedsRefresh,
    networkRefreshCallWasMade,
    returnedAccessSameAsStale: result ? result.apiKey === STALE_ACCESS : null,
    persistedExpiresSameAsStale: persisted?.type === "oauth" ? persisted.expires === expires : null,
    persistedRefreshSameAsStale:
      persisted?.type === "oauth" ? persisted.refresh === seeded.refresh : null,
    resolvedApiKey: result ? redact(result.apiKey) : null,
    error,
  };
  await rm(stateDir, { recursive: true, force: true });
  return out;
}

/**
 * Keep the message chain, drop the stack. The frames only restate the call path
 * already described in the PR body, and they carry the local checkout path.
 */
function redactPaths(message) {
  return message
    .split(`${TARGET}/`)
    .join("")
    .split(TARGET)
    .join("<worktree>")
    .replaceAll(/;? ?stack=Error: [^|]*/g, "")
    .replaceAll(/\n\s+at [^\n]*/g, "")
    .trim();
}

function redact(token) {
  if (typeof token !== "string") return token;
  // Synthetic tokens only; still show shape, not full value.
  return `${token.slice(0, 14)}…(${token.length} chars)`;
}

const cases = [
  ["margin-window", 2 * 60 * 1000, "ok"], // inside 5min margin, not raw-expired
  ["far-expiry", 24 * 60 * 60 * 1000, "ok"], // comfortably valid: must NOT refresh
  ["hard-expired", -1000, "ok"], // already expired: must attempt refresh
  // Rotating in-margin means the endpoint is now contacted while the stored
  // token still authenticates. A 503 there must not cost the caller access.
  ["margin-window-endpoint-down", 2 * 60 * 1000, "transient-failure"],
  // Same failure past raw expiry: nothing is left to serve, so it must surface.
  ["hard-expired-endpoint-down", -1000, "transient-failure"],
];

const results = [];
for (const [name, offset, endpointMode] of cases) {
  results.push(await runCase(name, offset, endpointMode));
}

// The checkout path is local detail; the head SHA in repro.sh identifies the code.
console.log(JSON.stringify({ label: LABEL, target: "<worktree>", results }, null, 2));

await rm(process.env.OPENCLAW_STATE_ROOT, { recursive: true, force: true });
```

```js
// Registers the provider-runtime boundary stub loader (see stub-provider-runtime.mjs).
import { register } from "node:module";

register("./stub-provider-runtime.mjs", import.meta.url);
```

```js
/**
 * ESM load hook: replaces the heavy plugin provider-runtime wrapper with an
 * inert stub so the proof harness does not have to boot the full plugin runtime
 * (gateway/registry). This is a BOUNDARY fake, not part of the fix under test:
 * for a built-in Anthropic credential with no provider plugin registered, the
 * real runtime returns `undefined` from both hooks too — the built-in branch of
 * `refreshOAuthCredential` (the code being proven) runs entirely unmocked.
 */
const TARGET_SUFFIX = "/src/plugins/provider-runtime.runtime.ts";

const STUB_SOURCE = `
// no provider plugin registered -> built-in provider path handles refresh
export async function refreshProviderOAuthCredentialWithPlugin() { return undefined; }
// Added 2026-08-03: upstream c28b524f38b (#118063) moved the plugin-first branch of
// refreshOAuthCredential onto this hook. For a built-in provider like anthropic,
// resolveProviderRuntimePlugin() finds no plugin and resolveProviderRefOwnership()
// classifies the ref as "unowned" (src/plugins/provider-runtime.ts:851-863 +
// src/plugins/providers.ts:675-698), so production returns exactly this shape and
// execution falls through to the built-in branch under test.
export async function resolveProviderOAuthCredentialWithPlugin() { return { status: "unowned" }; }
// no plugin api-key formatter -> caller falls back to credentials.access
export async function formatProviderAuthProfileApiKeyWithPlugin() { return undefined; }
export async function buildProviderAuthDoctorHintWithPlugin() { return undefined; }
export async function prepareProviderRuntimeAuth() { return undefined; }
export async function augmentModelCatalogWithProviderPlugins(models) { return models; }
`;

export async function load(url, context, nextLoad) {
  if (url.endsWith(TARGET_SUFFIX)) {
    return { format: "module", shortCircuit: true, source: STUB_SOURCE };
  }
  return nextLoad(url, context);
}
```
