### PR TITLE
fix(ci): log every pr-ci-sweeper classification and scan by creation time

### DIFF
--- a/scripts/github/pr-ci-sweeper.mjs
+++ b/scripts/github/pr-ci-sweeper.mjs
@@ -5,6 +5,12 @@
 // attached to the PR head and reruns their PR-event workflows without disturbing
 // auto-merge. The workflow authenticates with a GitHub App token because
 // GITHUB_TOKEN-authored events do not trigger new workflow runs.
+//
+// Observability contract: the re-fire lane logs a decision for every scanned
+// PR, including ci-attached skips with the attached run ids. A PR absent from
+// the log was outside the scan (created before the lookback), never silently
+// classified — silent skips previously made a correctly-skipped PR look like a
+// missed dropped-CI PR (2026-07-24, #113355).
 
 const CI_WORKFLOW_FILE = "ci.yml";
 const LOOKBACK_MS = 24 * 60 * 60 * 1000;
@@ -95,6 +101,24 @@ export function classifyRunForRevive({ run, prCreatedAt, prHeadBranch, repoFullN
     return { action: "skip", reason: "fork-head-repository" };
   }
   return { action: "revive", reason: "cancelled-pr-event-run" };
+}
+
+async function listRecentOpenPrs({ github, owner, repo, now }) {
+  // Sort by creation time, which is immutable: updated-sort pagination shifts
+  // items between page fetches whenever bot activity bumps a PR mid-scan, and a
+  // boundary PR can silently drop out of the listing. Both lanes only act on
+  // PRs created within the lookback, so stop fetching once a page crosses that
+  // horizon instead of listing every open PR (~2900 at last count, hourly).
+  return await github.paginate(
+    github.rest.pulls.list,
+    { owner, repo, state: "open", sort: "created", direction: "desc", per_page: 100 },
+    (response, done) => {
+      if (response.data.some((item) => now - Date.parse(item.created_at) > LOOKBACK_MS)) {
+        done();
+      }
+      return response.data;
+    },
+  );
 }
 
 async function listPullRequestCiRuns({ github, owner, repo, headSha }) {
@@ -219,25 +243,13 @@ export async function runPrCiSweeper({
   const results = [];
   let refires = 0;
   let revives = 0;
-  const openPrs = await github.paginate(github.rest.pulls.list, {
-    owner,
-    repo,
-    state: "open",
-    sort: "updated",
-    direction: "desc",
-    per_page: 100,
-  });
+  const openPrs = await listRecentOpenPrs({ github, owner, repo, now });
   const seenRunIds = new Set();
   reviveLane: for (const listed of openPrs) {
-    if (now - Date.parse(listed.updated_at) > LOOKBACK_MS) {
+    if (now - Date.parse(listed.created_at) > LOOKBACK_MS) {
       break;
     }
-    if (
-      listed.draft ||
-      !listed.auto_merge ||
-      now - Date.parse(listed.created_at) > LOOKBACK_MS ||
-      now - Date.parse(listed.updated_at) < MIN_QUIET_MS
-    ) {
+    if (listed.draft || !listed.auto_merge || now - Date.parse(listed.updated_at) < MIN_QUIET_MS) {
       continue;
     }
     const checks = await listLatestChecksForHead({
@@ -377,24 +389,52 @@ export async function runPrCiSweeper({
     }
   }
   for (const listed of openPrs) {
-    if (now - Date.parse(listed.updated_at) > LOOKBACK_MS) {
-      break;
-    }
-    if (refires >= MAX_REFIRES_PER_SWEEP) {
-      core.info(`pr-ci-sweeper: per-sweep re-fire cap (${MAX_REFIRES_PER_SWEEP}) reached`);
+    if (now - Date.parse(listed.created_at) > LOOKBACK_MS) {
       break;
     }
     if (listed.draft) {
+      results.push({
+        number: listed.number,
+        sha: listed.head.sha.slice(0, 12),
+        action: "skip",
+        reason: "draft",
+      });
+      core.info(`pr-ci-sweeper: skip #${listed.number} (draft)`);
       continue;
     }
     const ciRuns = await listPullRequestCiRuns({ github, owner, repo, headSha: listed.head.sha });
-    if (ciRuns.some((run) => run.conclusion !== "startup_failure")) {
+    // Classify on cheap list data first so most PRs (usually ci-attached) skip
+    // without the authoritative pulls.get + close-history reads, but still log
+    // the decision with the attached run ids as evidence: the silent skip here
+    // previously made "sweeper judged CI attached" indistinguishable from
+    // "sweeper never saw the PR".
+    const preliminary = classifyPrForSweep({ pr: listed, ciRuns, botCloseCount: 0, now });
+    if (preliminary.action !== "refire") {
+      const attachedRuns = ciRuns
+        .filter((run) => run.conclusion !== "startup_failure")
+        .map((run) => `${run.id ?? "?"}:${run.status ?? "?"}/${run.conclusion ?? "pending"}`);
+      const detail = preliminary.reason === "ci-attached" ? `: ${attachedRuns.join(", ")}` : "";
+      results.push({ number: listed.number, sha: listed.head.sha.slice(0, 12), ...preliminary });
+      core.info(`pr-ci-sweeper: skip #${listed.number} (${preliminary.reason}${detail})`);
+      continue;
+    }
+    // Past the cap, keep classifying (so every scanned PR still gets a logged
+    // decision) but convert would-be re-fires into skips instead of mutating.
+    if (refires >= MAX_REFIRES_PER_SWEEP) {
+      results.push({
+        number: listed.number,
+        sha: listed.head.sha.slice(0, 12),
+        action: "skip",
+        reason: "refire-cap-reached",
+      });
+      core.info(`pr-ci-sweeper: skip #${listed.number} (refire-cap-reached)`);
       continue;
     }
     // Candidate: fetch authoritative state (mergeable, current head) and the
     // close history so a racing push or human action wins over the sweep.
     const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: listed.number });
     if (pr.state !== "open" || pr.head.sha !== listed.head.sha) {
+      core.info(`pr-ci-sweeper: #${listed.number} changed during sweep; leaving it alone`);
       continue;
     }
     const events = await github.paginate(github.rest.issues.listEvents, {
@@ -475,7 +515,7 @@ export async function runPrCiSweeper({
     await reopenWithRetry({ github, core, owner, repo, pullNumber: pr.number });
   }
   core.info(
-    `pr-ci-sweeper: checked ${openPrs.length} open PRs, ${results.length} candidates, ${refires} re-fire${refires === 1 ? "" : "s"}, ${revives} revive${revives === 1 ? "" : "s"}${dryRun ? " (dry-run)" : ""}`,
+    `pr-ci-sweeper: scanned ${openPrs.length} open PRs, ${results.length} classified, ${refires} re-fire${refires === 1 ? "" : "s"}, ${revives} revive${revives === 1 ? "" : "s"}${dryRun ? " (dry-run)" : ""}`,
   );
   return results;
 }

--- a/test/scripts/pr-ci-sweeper.test.ts
+++ b/test/scripts/pr-ci-sweeper.test.ts
@@ -288,29 +288,53 @@ type FakeCheckRun = {
 
 function fakeGithub(options: {
   prs: Array<Record<string, unknown>>;
-  runsBySha: Record<string, Array<{ conclusion: string | null; event?: string }>>;
+  runsBySha: Record<
+    string,
+    Array<{ conclusion: string | null; event?: string; id?: number; status?: string }>
+  >;
   checksByRef?: Record<string, FakeCheckRun[]>;
   workflowRunsById?: Record<number, FakeWorkflowRun>;
   pullsGetByNumber?: Record<number, Record<string, unknown>>;
   events?: Array<Record<string, unknown>>;
+  pageSize?: number;
 }) {
   const calls: FakeCall[] = [];
   const record = (method: string, args: Record<string, unknown>) => {
     calls.push({ method, args });
   };
   const github = {
-    paginate: (endpoint: { endpointName: string }, args: Record<string, unknown>) => {
+    paginate: (
+      endpoint: { endpointName: string },
+      args: Record<string, unknown>,
+      mapFn?: (response: { data: unknown[] }, done: () => void) => unknown[],
+    ) => {
       record(endpoint.endpointName, args);
+      // Emulate octokit's paged mapFn contract: the page where done() fires is
+      // still included in the result, and later pages are never fetched.
+      const paged = (items: unknown[]) => {
+        if (!mapFn) {
+          return Promise.resolve(items);
+        }
+        const pageSize = options.pageSize ?? Math.max(items.length, 1);
+        const collected: unknown[] = [];
+        let stopped = false;
+        for (let start = 0; start < items.length && !stopped; start += pageSize) {
+          record(`${endpoint.endpointName}.page`, { start });
+          collected.push(
+            ...mapFn({ data: items.slice(start, start + pageSize) }, () => {
+              stopped = true;
+            }),
+          );
+        }
+        return Promise.resolve(collected);
+      };
       if (endpoint.endpointName === "pulls.list") {
-        return Promise.resolve(options.prs);
+        return paged(options.prs);
       }
       if (endpoint.endpointName === "actions.listWorkflowRuns") {
         return Promise.resolve(
           (options.runsBySha[args.head_sha as string] ?? [])
-            .map((run) => ({
-              event: run.event ?? "pull_request",
-              conclusion: run.conclusion,
-            }))
+            .map((run) => ({ ...run, event: run.event ?? "pull_request" }))
             .filter((run) => !args.event || run.event === args.event),
         );
       }
@@ -438,8 +462,120 @@ describe("runPrCiSweeper", () => {
     });
     expect(results).toEqual([
       { number: 7, sha: "a".repeat(12), action: "refire", reason: "ci-startup-failure" },
+      { number: 8, sha: "b".repeat(12), action: "skip", reason: "ci-attached" },
     ]);
     expect(calls.filter((call) => call.method === "pulls.update")).toEqual([]);
+  });
+
+  it("logs a ci-attached skip with the attached run ids", async () => {
+    const attached = {
+      ...pr(),
+      number: 21,
+      state: "open",
+      head: { sha: "5".repeat(40) },
+    };
+    const { github } = fakeGithub({
+      prs: [attached],
+      runsBySha: {
+        [attached.head.sha]: [{ id: 30105208438, status: "completed", conclusion: "failure" }],
+      },
+    });
+    const { core: loggedCore, logs } = recordingCore();
+    const results = await runPrCiSweeper({
+      github: github as never,
+      context: context as never,
+      core: loggedCore as never,
+      now: NOW,
+    });
+    expect(results).toEqual([
+      { number: 21, sha: "5".repeat(12), action: "skip", reason: "ci-attached" },
+    ]);
+    expect(logs).toContain("pr-ci-sweeper: skip #21 (ci-attached: 30105208438:completed/failure)");
+  });
+
+  it("logs draft skips so every scanned PR has a decision", async () => {
+    const draft = {
+      ...pr({ draft: true }),
+      number: 22,
+      state: "open",
+      head: { sha: "6".repeat(40) },
+    };
+    const { github, calls } = fakeGithub({ prs: [draft], runsBySha: {} });
+    const { core: loggedCore, logs } = recordingCore();
+    const results = await runPrCiSweeper({
+      github: github as never,
+      context: context as never,
+      core: loggedCore as never,
+      now: NOW,
+    });
+    expect(results).toEqual([{ number: 22, sha: "6".repeat(12), action: "skip", reason: "draft" }]);
+    expect(logs).toContain("pr-ci-sweeper: skip #22 (draft)");
+    // Drafts skip before the per-head run lookup so they cost no Actions reads.
+    expect(calls.filter((call) => call.method === "actions.listWorkflowRuns")).toEqual([]);
+  });
+
+  it("keeps logging decisions after the per-sweep re-fire cap", async () => {
+    const dropped = Array.from({ length: 11 }, (_, index) => ({
+      ...pr(),
+      number: 100 + index,
+      state: "open",
+      head: { sha: index.toString(16).padStart(2, "0").repeat(20) },
+    }));
+    const { github, calls } = fakeGithub({ prs: dropped, runsBySha: {} });
+    const { core: loggedCore, logs } = recordingCore();
+    const results = await runPrCiSweeper({
+      github: github as never,
+      context: context as never,
+      core: loggedCore as never,
+      dryRun: true,
+      now: NOW,
+    });
+    expect(results.filter((entry) => entry.action === "refire")).toHaveLength(10);
+    expect(results.at(-1)).toEqual({
+      number: 110,
+      sha: "0a".repeat(6),
+      action: "skip",
+      reason: "refire-cap-reached",
+    });
+    expect(logs).toContain("pr-ci-sweeper: skip #110 (refire-cap-reached)");
+    // The capped PR is classified from list data only, never fetched.
+    expect(
+      calls.filter((call) => call.method === "pulls.get" && call.args.pull_number === 110),
+    ).toEqual([]);
+  });
+
+  it("stops listing pages once creation dates cross the lookback", async () => {
+    const recent = { ...pr(), number: 30, state: "open", head: { sha: "7".repeat(40) } };
+    const oldA = {
+      ...pr({ created_at: new Date(NOW - 25 * HOURS).toISOString() }),
+      number: 31,
+      state: "open",
+      head: { sha: "8".repeat(40) },
+    };
+    const oldB = {
+      ...pr({ created_at: new Date(NOW - 30 * HOURS).toISOString() }),
+      number: 32,
+      state: "open",
+      head: { sha: "9".repeat(40) },
+    };
+    const { github, calls } = fakeGithub({
+      prs: [recent, oldA, oldB],
+      runsBySha: {},
+      pageSize: 1,
+    });
+    const results = await runPrCiSweeper({
+      github: github as never,
+      context: context as never,
+      core: core as never,
+      dryRun: true,
+      now: NOW,
+    });
+    // Page 2 crossed the 24h creation horizon, so page 3 is never fetched and
+    // the outside-lookback PR on page 2 stops the scan without a decision.
+    expect(calls.filter((call) => call.method === "pulls.list.page")).toHaveLength(2);
+    expect(results).toEqual([
+      { number: 30, sha: "7".repeat(12), action: "refire", reason: "ci-run-missing" },
+    ]);
   });
 
   it("closes and reopens a dropped-CI PR in live mode", async () => {


### PR DESCRIPTION
## What Problem This Solves

The hourly PR CI Sweeper could not be trusted as a diagnostic surface: its re-fire lane silently skipped any PR whose head had an attached ci.yml `pull_request` run (the common case), so a PR absent from the sweep log was indistinguishable from a PR the sweeper never saw. On 2026-07-24 this silence caused a real misdiagnosis: PR #113355 (head `95b10a5b`) and PR #113042 (head `fc548660`) were reported as "dropped CI the sweeper failed to repair," and were manually closed/reopened. Ground truth from the Actions API shows both heads had real CI runs attached ~15s after PR creation that failed with deterministic test failures (the same jobs failed again after close/reopen; both PRs went green only after new commits). The sweeper had classified both correctly as ci-attached — but logged nothing, so nobody could tell.

Separately, the scan listed every open PR (~2,900, ~30 API pages hourly) sorted by mutable `updated` time. Updated-sort pagination shifts items between page fetches whenever bot activity bumps a PR mid-scan, which can silently drop a boundary PR from the listing entirely — a latent detection gap on top of wasted quota.

## Why This Change Was Made

- **Log every classification decision.** The re-fire lane now records a decision (log line + results entry) for every scanned PR: drafts, `ci-attached` skips with the attached run ids/status/conclusion as evidence, the previously silent "changed during sweep" revalidation skip, and `refire-cap-reached` once the per-sweep re-fire budget is spent (the loop keeps classifying instead of breaking, so PRs after the cap are not silent either). The file header documents the contract: a PR absent from the log was outside the scan window, never silently classified.
- **Stable, bounded pagination.** The open-PR scan now sorts by immutable `created` time and stops fetching pages once a page crosses the 24h lookback. This removes the page-shift omission hazard and cuts the hourly listing from ~30 pages to ~1, since both lanes only act on PRs created within the lookback anyway.

## User Impact

Maintainers debugging "why didn't the sweeper repair PR #X" get a definitive answer from any sweep run's log, including the exact run ids the sweeper judged as attached CI. No behavior change for genuinely dropped-CI PRs: re-fire and revive semantics, budgets, and safety revalidations are unchanged. Hourly Actions API usage drops substantially.

## Evidence

- Live-incident forensics (2026-07-24): sweep run 30106237202 logged 17 candidates out of 2,901 open PRs with no mention of #113355; head `95b10a5b` had ci.yml runs 30105196240 (skipped) and 30105208438 (69 jobs, failure at 15:36Z) — the silent ci-attached pre-filter is confirmed as the cause of the missing log line. Post-reopen run 30108571708 failed the identical jobs, proving the close/reopen repair was never needed.
- `node scripts/run-vitest.mjs test/scripts/pr-ci-sweeper.test.ts` — 35/35 passing, including new tests for ci-attached evidence logging, draft logging, cap continuation (11 dropped PRs → 10 re-fires + 1 logged `refire-cap-reached` skip), and early pagination stop.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/github/pr-ci-sweeper.mjs`, `oxfmt --check`, `node scripts/check-script-declarations.mjs` (241 contracts), and `tsgo` test-root lane — all clean. `check:changed` Testbox delegation was unavailable (backend warmup deadline exceeded), so the planned lanes ran locally per trusted-source fallback policy.
- Codex autoreview (gpt-5.6-sol, xhigh): first pass accepted one P2 (cap break recreated silence) which is fixed in this diff; rerun clean with no accepted/actionable findings.


### After-fix real-behavior proof (live dry run, 2026-07-24 ~20:4xZ)

Ran this branch's `runPrCiSweeper` live against `openclaw/openclaw` with `dryRun: true` (mutation paths log-and-continue; reads only), driven through `@octokit/rest` — the same client family `actions/github-script` provides, so the `paginate` mapFn/`done()` early-stop contract is exercised for real. Driver: instantiate Octokit with a maintainer token, call `runPrCiSweeper({ github, context: { repo: { owner: "openclaw", repo: "openclaw" } }, core: console-backed, dryRun: true })`.

Result: **one page fetched (100 PRs) instead of the previous ~30 pages / ~2,900 PRs**, and **every PR created within the 24h lookback received a logged decision** (73 classifications, zero silent skips, 0 re-fires — correct, since no dropped-CI PR currently exists). Full unredacted transcript (all identifiers are public PR numbers and Actions run ids):

<details>
<summary>Full dry-run transcript (75 lines)</summary>

```
pr-ci-sweeper: skip #113400 (recently-updated)
pr-ci-sweeper: skip #113399 (recently-updated)
pr-ci-sweeper: skip #113398 (merge-conflict)
pr-ci-sweeper: skip #113397 (recently-updated)
pr-ci-sweeper: skip #113395 (recently-updated)
pr-ci-sweeper: skip #113394 (ci-attached: 30122597112:completed/failure)
pr-ci-sweeper: skip #113392 (recently-updated)
pr-ci-sweeper: skip #113391 (ci-attached: 30122191191:completed/failure, 30122159127:completed/skipped)
pr-ci-sweeper: skip #113379 (ci-attached: 30115822373:completed/success)
pr-ci-sweeper: skip #113377 (ci-attached: 30114269903:completed/success)
pr-ci-sweeper: skip #113376 (ci-attached: 30114025643:completed/success)
pr-ci-sweeper: skip #113372 (ci-attached: 30123317872:in_progress/pending)
pr-ci-sweeper: skip #113371 (ci-attached: 30110408173:completed/success)
pr-ci-sweeper: skip #113368 (ci-attached: 30115754196:completed/success)
pr-ci-sweeper: skip #113366 (ci-attached: 30108595882:completed/failure)
pr-ci-sweeper: skip #113361 (ci-attached: 30106966168:completed/failure)
pr-ci-sweeper: skip #113359 (ci-attached: 30118695252:completed/success)
pr-ci-sweeper: skip #113357 (ci-attached: 30106675940:completed/success)
pr-ci-sweeper: skip #113354 (ci-attached: 30115217179:completed/success)
pr-ci-sweeper: skip #113352 (ci-attached: 30108204713:completed/success)
pr-ci-sweeper: skip #113349 (ci-attached: 30102120953:completed/success, 30102100144:completed/skipped)
pr-ci-sweeper: skip #113348 (ci-attached: 30101912323:completed/success, 30101898161:completed/skipped)
pr-ci-sweeper: skip #113347 (ci-attached: 30101451151:completed/success)
pr-ci-sweeper: skip #113345 (ci-attached: 30101390358:completed/success, 30101370739:completed/skipped)
pr-ci-sweeper: skip #113344 (ci-attached: 30101184713:completed/success)
pr-ci-sweeper: skip #113342 (ci-attached: 30100399503:completed/success, 30100385771:completed/skipped)
pr-ci-sweeper: skip #113341 (ci-attached: 30104185502:completed/success)
pr-ci-sweeper: skip #113340 (ci-attached: 30108212754:completed/success)
pr-ci-sweeper: skip #113337 (ci-attached: 30100908610:completed/success)
pr-ci-sweeper: skip #113333 (draft)
pr-ci-sweeper: skip #113330 (ci-attached: 30097286318:completed/action_required)
pr-ci-sweeper: skip #113325 (draft)
pr-ci-sweeper: skip #113312 (ci-attached: 30089115635:completed/success)
pr-ci-sweeper: skip #113311 (ci-attached: 30099679026:completed/success)
pr-ci-sweeper: skip #113307 (ci-attached: 30087850959:completed/success)
pr-ci-sweeper: skip #113300 (ci-attached: 30088095206:completed/failure)
pr-ci-sweeper: skip #113292 (ci-attached: 30083464481:completed/success)
pr-ci-sweeper: skip #113288 (ci-attached: 30103619093:completed/failure)
pr-ci-sweeper: skip #113286 (ci-attached: 30090753760:completed/cancelled)
pr-ci-sweeper: skip #113285 (ci-attached: 30079563394:completed/success)
pr-ci-sweeper: skip #113273 (ci-attached: 30077235976:completed/success)
pr-ci-sweeper: skip #113271 (ci-attached: 30083496424:completed/success)
pr-ci-sweeper: skip #113266 (ci-attached: 30075960224:completed/success, 30075952402:completed/skipped)
pr-ci-sweeper: skip #113259 (ci-attached: 30074064421:completed/success)
pr-ci-sweeper: skip #113257 (ci-attached: 30099801849:completed/success, 30095928343:completed/skipped, 30074104489:completed/success)
pr-ci-sweeper: skip #113249 (ci-attached: 30070906416:completed/failure)
pr-ci-sweeper: skip #113241 (ci-attached: 30070423731:completed/success, 30070412124:completed/skipped)
pr-ci-sweeper: skip #113233 (ci-attached: 30078353532:completed/failure)
pr-ci-sweeper: skip #113232 (recently-updated)
pr-ci-sweeper: skip #113226 (recently-updated)
pr-ci-sweeper: skip #113217 (ci-attached: 30066518918:completed/failure)
pr-ci-sweeper: skip #113215 (recently-updated)
pr-ci-sweeper: skip #113207 (ci-attached: 30064145574:completed/success)
pr-ci-sweeper: skip #113206 (ci-attached: 30063027162:completed/action_required)
pr-ci-sweeper: skip #113205 (ci-attached: 30063004749:completed/action_required)
pr-ci-sweeper: skip #113204 (ci-attached: 30062445369:completed/failure, 30062440272:completed/skipped)
pr-ci-sweeper: skip #113200 (ci-attached: 30060569994:completed/success)
pr-ci-sweeper: skip #113197 (ci-attached: 30103302218:completed/success, 30071258252:completed/skipped)
pr-ci-sweeper: skip #113192 (ci-attached: 30058961063:completed/success)
pr-ci-sweeper: skip #113190 (ci-attached: 30066979323:completed/success)
pr-ci-sweeper: skip #113189 (ci-attached: 30060247907:completed/cancelled)
pr-ci-sweeper: skip #113188 (ci-attached: 30058230653:completed/failure)
pr-ci-sweeper: skip #113185 (ci-attached: 30057855492:completed/success)
pr-ci-sweeper: skip #113184 (auto-merge-enabled)
pr-ci-sweeper: skip #113183 (ci-attached: 30057054315:completed/failure)
pr-ci-sweeper: skip #113176 (ci-attached: 30057621366:completed/success)
pr-ci-sweeper: skip #113172 (ci-attached: 30062213632:completed/failure)
pr-ci-sweeper: skip #113171 (ci-attached: 30053080447:completed/failure)
pr-ci-sweeper: skip #113168 (draft)
pr-ci-sweeper: skip #113164 (draft)
pr-ci-sweeper: skip #113162 (draft)
pr-ci-sweeper: skip #113160 (ci-attached: 30050548846:completed/success)
pr-ci-sweeper: skip #113146 (ci-attached: 30113985770:completed/success)
pr-ci-sweeper: scanned 100 open PRs, 73 classified, 0 re-fires, 0 revives (dry-run)
results entries: 73
```

</details>

Note on the remaining checklist item ("normal human review"): this change was investigated, directed, and landed by the repository owner; the landing instruction is the maintainer decision.
