### PR TITLE
fix(agents): allow explicit tool-less runs

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -170,6 +170,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
         callableToolNames: toolSearchRunPlan.emptyAllowlistCallableNames,
         toolsEnabled,
         disableTools: attempt.disableTools,
+        toolsAllowExplicitlyEmpty: preparedToolBase.effectiveToolsAllow?.length === 0,
       });
   logAgentRuntimeToolDiagnostics({
     runtimePlan: attempt.runtimePlan,

--- a/src/agents/tool-allowlist-guard.test.ts
+++ b/src/agents/tool-allowlist-guard.test.ts
@@ -46,6 +46,32 @@ describe("tool allowlist guard", () => {
     ).toBeNull();
   });
 
+  it("allows inherited config allowlists when runtime toolsAllow is explicitly empty", () => {
+    expect(
+      buildEmptyExplicitToolAllowlistError({
+        sources: [{ label: "tools.allow", entries: ["*", "read", "cron"] }],
+        callableToolNames: [],
+        toolsEnabled: true,
+        toolsAllowExplicitlyEmpty: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("still enforces command-time allowlists for explicitly tool-less runs", () => {
+    const error = buildEmptyExplicitToolAllowlistError({
+      sources: [
+        { label: "tools.allow", entries: ["read"] },
+        { label: "runtime toolsAllow", entries: ["query_db"], enforceWhenToolsDisabled: true },
+      ],
+      callableToolNames: [],
+      toolsEnabled: true,
+      toolsAllowExplicitlyEmpty: true,
+    });
+
+    expect(error?.message).toContain("runtime toolsAllow: query_db");
+    expect(error?.message).not.toContain("tools.allow: read");
+  });
+
   it("fails closed when the selected model cannot use requested tools", () => {
     const error = buildEmptyExplicitToolAllowlistError({
       sources: [{ label: "agents.db.tools.allow", entries: ["query_db"] }],

--- a/src/agents/tool-allowlist-guard.ts
+++ b/src/agents/tool-allowlist-guard.ts
@@ -37,11 +37,13 @@ export function buildEmptyExplicitToolAllowlistError(params: {
   callableToolNames: string[];
   toolsEnabled: boolean;
   disableTools?: boolean;
+  toolsAllowExplicitlyEmpty?: boolean;
 }): Error | null {
-  const sources =
-    params.disableTools === true
-      ? params.sources.filter((source) => source.enforceWhenToolsDisabled === true)
-      : params.sources;
+  const toolsIntentionallyDisabled =
+    params.disableTools === true || params.toolsAllowExplicitlyEmpty === true;
+  const sources = toolsIntentionallyDisabled
+    ? params.sources.filter((source) => source.enforceWhenToolsDisabled === true)
+    : params.sources;
   const callableToolNames = normalizeToolList(params.callableToolNames);
   if (sources.length === 0 || callableToolNames.length > 0) {
     return null;


### PR DESCRIPTION
Closes #113402

> **Scout patch provenance:** Lobster OpenClaw patch
> `0011-cron-toolless-run-guard`.

## What Problem This Solves

Automations with an explicitly empty runtime `toolsAllow: []` could fail before
the model ran whenever inherited configuration declared a non-empty
`tools.allow`.

The runner already treats `toolsAllow: []` as an intentional no-tools request
and constructs zero tools. The empty-allowlist guard nevertheless evaluated
inherited allowlist sources against that intentionally empty callable set and
raised `No callable tools remain`.

## Why This Change Was Made

The guard now treats an effective runtime allowlist of `[]` like deliberate tool
disabling for inherited sources. Sources marked `enforceWhenToolsDisabled`
remain enforced, preserving fail-closed behavior for command-time restrictions.

The call site uses the effective allowlist after host-required tools have been
merged, so forced message or structured-output tools are not misclassified as a
tool-less run.

## User Impact

Explicitly tool-less Automations can reach the model with zero tools even when
the installation has a global or agent allowlist. Broken non-empty allowlists
and command-time restrictions continue to fail closed.

## Evidence

```text
node scripts/run-vitest.mjs src/agents/tool-allowlist-guard.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  9 passed (9)

node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts \
  --reporter=verbose
Test Files  1 passed (1)
Tests  25 passed (25)

git diff --check
node_modules/.bin/oxfmt --check \
  src/agents/tool-allowlist-guard.ts \
  src/agents/tool-allowlist-guard.test.ts \
  src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
All matched files use the correct format.
```

## Real behavior proof

Behavior addressed: an embedded Automation run with `toolsAllow: []` and an
inherited non-empty `tools.allow` no longer fails the empty-allowlist guard.

Environment tested: Blacksmith Testbox through Crabbox, lease
`tbx_01kyb3f4sd4c1850yhjcnn1yfw`, using a packaged OpenClaw Docker image, a real
Gateway and Automation execution, and the repository mock OpenAI Responses
provider. Actions hydration run:
https://github.com/openclaw/openclaw/actions/runs/30130667826

Scenario:

1. Seed inherited `tools.allow: ["read"]`.
2. Create an isolated `agentTurn` Automation with `toolsAllow: []`.
3. Force-run it through the public cron CLI and wait for completion.
4. Inspect the actual provider request.

Observed result:

```json
{"ok":true,"inheritedToolsAllow":["read"],"automationToolsAllow":[],"providerRequestTools":[]}
```

The Automation completed with `OPENCLAW_CRON_TOOLLESS_OK`, the model provider
received the request, and the request exposed zero callable tools. Crabbox
reported `provider=blacksmith-testbox`, `syncDelegated=true`, and `exitCode=0`.
