### PR TITLE
fix(sqlite): keep read-only state journal-aware

### DIFF
--- a/src/claws/doctor.ts
+++ b/src/claws/doctor.ts
@@ -324,7 +324,7 @@ export async function collectClawStateHealthFindings(
   }
   let database: OpenClawStateDatabase | undefined;
   try {
-    database = openExistingOpenClawStateDatabaseReadOnly(options);
+    database = await openExistingOpenClawStateDatabaseReadOnly(options);
     if (!database) {
       return [];
     }

--- a/src/claws/update-plan.ts
+++ b/src/claws/update-plan.ts
@@ -81,7 +81,8 @@ export async function buildClawUpdatePlan(params: {
 }): Promise<ClawUpdatePlan> {
   const ownsDatabase = !params.stateOptions?.database;
   const database =
-    params.stateOptions?.database ?? openExistingOpenClawStateDatabaseReadOnly(params.stateOptions);
+    params.stateOptions?.database ??
+    (await openExistingOpenClawStateDatabaseReadOnly(params.stateOptions));
   if (!database) {
     return makeEmptyClawUpdatePlan({
       agentId: params.agentId,

--- a/src/cli/claws-update-cli.runtime.ts
+++ b/src/cli/claws-update-cli.runtime.ts
@@ -83,7 +83,7 @@ export async function runClawsUpdateCommand(
 
   let source = opts.from;
   if (!source) {
-    const database = openExistingOpenClawStateDatabaseReadOnly();
+    const database = await openExistingOpenClawStateDatabaseReadOnly();
     let status: Awaited<ReturnType<typeof readClawStatus>> | { records: never[] } = {
       records: [],
     };

--- a/src/infra/node-sqlite.test.ts
+++ b/src/infra/node-sqlite.test.ts
@@ -1,13 +1,8 @@
 // Covers the SQLite WAL-reset corruption safety floor.
 import path from "node:path";
 import { DatabaseSync, type StatementSync } from "node:sqlite";
-import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  openNodeSqliteDatabase,
-  resolveNodeSqliteLocation,
-  resolveNodeSqliteReadOnlyLocation,
-} from "./node-sqlite.js";
+import { openNodeSqliteDatabase, resolveNodeSqliteLocation } from "./node-sqlite.js";
 
 const originalPrepare = Reflect.get(DatabaseSync.prototype, "prepare") as DatabaseSync["prepare"];
 
@@ -100,23 +95,7 @@ describe("node SQLite locations", () => {
     expect(namespacedSpy).toHaveBeenCalledWith("resolved-openclaw.sqlite");
   });
 
-  it("uses immutable URIs for local databases without WAL sidecars", () => {
-    const pathname =
-      process.platform === "win32"
-        ? String.raw`C:\Users\OpenClaw\.openclaw\state\openclaw.sqlite`
-        : "/var/lib/openclaw/state/openclaw.sqlite";
-
-    expect(resolveNodeSqliteReadOnlyLocation(pathname, false)).toBe(
-      `${pathToFileURL(pathname).href}?mode=ro&immutable=1`,
-    );
-    expect(resolveNodeSqliteReadOnlyLocation(pathname, true)).toBe(
-      resolveNodeSqliteLocation(pathname),
-    );
-    const immutableLocation = resolveNodeSqliteReadOnlyLocation(pathname, false);
-    expect(resolveNodeSqliteLocation(immutableLocation)).toBe(immutableLocation);
-  });
-
-  it("keeps UNC and namespaced Windows paths out of SQLite URI authority parsing", () => {
+  it("keeps UNC and namespaced Windows paths on the Windows VFS path boundary", () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const resolvedPaths = new Map([
       [
@@ -142,12 +121,10 @@ describe("node SQLite locations", () => {
       .mockImplementation((pathname) => pathname);
 
     for (const [pathname, resolvedPath] of resolvedPaths) {
-      const readOnlyLocation = resolveNodeSqliteReadOnlyLocation(pathname, false);
-      expect(readOnlyLocation).toBe(resolvedPath);
-      expect(resolveNodeSqliteLocation(readOnlyLocation)).toBe(resolvedPath);
+      expect(resolveNodeSqliteLocation(pathname)).toBe(resolvedPath);
     }
-    expect(resolveSpy).toHaveBeenCalledTimes(resolvedPaths.size * 2);
-    expect(namespacedSpy).toHaveBeenCalledTimes(resolvedPaths.size * 2);
+    expect(resolveSpy).toHaveBeenCalledTimes(resolvedPaths.size);
+    expect(namespacedSpy).toHaveBeenCalledTimes(resolvedPaths.size);
   });
 });
 

--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -1,7 +1,6 @@
 // Loads node:sqlite with OpenClaw warning handling.
 import { createRequire } from "node:module";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { formatErrorMessage } from "./errors.js";
 import { isSqliteWalResetSafeVersion } from "./sqlite-runtime-version.js";
 import { installProcessWarningFilter } from "./warning-filter.js";
@@ -27,25 +26,6 @@ export function resolveNodeSqliteLocation(location: string): string {
     return location;
   }
   return resolveSqliteFilesystemPath(location);
-}
-
-export function resolveNodeSqliteReadOnlyLocation(
-  pathname: string,
-  hasWalSidecars: boolean,
-): string {
-  if (process.platform === "win32") {
-    const resolvedPath = path.resolve(pathname);
-    // SQLite URI authorities reject UNC hosts, while ordinary Windows paths
-    // preserve UNC and already-namespaced locations through the Windows VFS.
-    if (hasWalSidecars || resolvedPath.startsWith("\\\\")) {
-      return path.toNamespacedPath(resolvedPath);
-    }
-    return `${pathToFileURL(resolvedPath).href}?mode=ro&immutable=1`;
-  }
-  if (hasWalSidecars) {
-    return pathname;
-  }
-  return `${pathToFileURL(pathname).href}?mode=ro&immutable=1`;
 }
 
 function assertSqliteWalResetSafeVersion(version: string, nodeVersion: string): void {

--- a/src/infra/sqlite-private-directory.ts
+++ b/src/infra/sqlite-private-directory.ts
@@ -1,0 +1,152 @@
+// Creates private SQLite staging directories without pulling higher-level runtime modules.
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveSystemBin } from "./resolve-system-bin.js";
+
+const SQLITE_DIRECTORY_MODE = 0o700;
+const WINDOWS_DIRECTORY_EXISTS_MARKER = "OPENCLAW_SQLITE_DIRECTORY_EXISTS";
+
+// Managed directory creation accepts existing paths. CreateDirectoryW applies the
+// protected DACL atomically while preserving fail-if-exists semantics.
+const WINDOWS_PRIVATE_DIRECTORY_NATIVE_SOURCE = `
+using System;
+using System.Runtime.InteropServices;
+
+public static class OpenClawPrivateDirectory
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SecurityAttributes
+    {
+        public int Length;
+        public IntPtr SecurityDescriptor;
+        public int InheritHandle;
+    }
+
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool ConvertStringSecurityDescriptorToSecurityDescriptorW(
+        string securityDescriptor,
+        uint revision,
+        out IntPtr convertedSecurityDescriptor,
+        out uint convertedSecurityDescriptorSize);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CreateDirectoryW(
+        string path,
+        ref SecurityAttributes securityAttributes);
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr LocalFree(IntPtr memory);
+
+    public static int Create(string path, string securityDescriptor)
+    {
+        IntPtr descriptor;
+        uint descriptorSize;
+        if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                securityDescriptor,
+                1,
+                out descriptor,
+                out descriptorSize))
+        {
+            return Marshal.GetLastWin32Error();
+        }
+
+        try
+        {
+            var attributes = new SecurityAttributes
+            {
+                Length = Marshal.SizeOf(typeof(SecurityAttributes)),
+                SecurityDescriptor = descriptor,
+                InheritHandle = 0,
+            };
+            return CreateDirectoryW(path, ref attributes) ? 0 : Marshal.GetLastWin32Error();
+        }
+        finally
+        {
+            LocalFree(descriptor);
+        }
+    }
+}
+`;
+
+function runPrivateDirectoryPowerShell(powershell: string, encodedCommand: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      powershell,
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encodedCommand],
+      {
+        maxBuffer: 64 * 1024,
+        timeout: 10_000,
+        windowsHide: true,
+      },
+      (error) => {
+        if (error) {
+          reject(new Error(error.message, { cause: error }));
+          return;
+        }
+        resolve();
+      },
+    );
+  });
+}
+
+export async function createPrivateSqliteDirectory(directoryPath: string): Promise<void> {
+  if (process.platform !== "win32") {
+    await fs.mkdir(directoryPath, { mode: SQLITE_DIRECTORY_MODE });
+    return;
+  }
+  // This raw Win32 call bypasses Node's automatic long-path normalization.
+  const nativeDirectoryPath = path.toNamespacedPath(path.resolve(directoryPath));
+  const encodedPath = Buffer.from(nativeDirectoryPath, "utf8").toString("base64");
+  const encodedNativeSource = Buffer.from(WINDOWS_PRIVATE_DIRECTORY_NATIVE_SOURCE, "utf8").toString(
+    "base64",
+  );
+  const command = [
+    "$ErrorActionPreference = 'Stop'",
+    `$path = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encodedPath}'))`,
+    `$nativeSource = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encodedNativeSource}'))`,
+    "Add-Type -TypeDefinition $nativeSource -Language CSharp",
+    "$current = [System.Security.Principal.WindowsIdentity]::GetCurrent().User",
+    "$security = New-Object System.Security.AccessControl.DirectorySecurity",
+    "$security.SetAccessRuleProtection($true, $false)",
+    "$security.SetOwner($current)",
+    "$inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit",
+    "$propagation = [System.Security.AccessControl.PropagationFlags]::None",
+    "foreach ($sidValue in @($current.Value, 'S-1-5-18', 'S-1-5-32-544')) { $sid = New-Object System.Security.Principal.SecurityIdentifier($sidValue); $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, $inheritance, $propagation, [System.Security.AccessControl.AccessControlType]::Allow); [void]$security.AddAccessRule($rule) }",
+    "$sections = [System.Security.AccessControl.AccessControlSections]::Owner -bor [System.Security.AccessControl.AccessControlSections]::Access",
+    "$sddl = $security.GetSecurityDescriptorSddlForm($sections)",
+    "$errorCode = [OpenClawPrivateDirectory]::Create($path, $sddl)",
+    `if ($errorCode -eq 80 -or $errorCode -eq 183) { throw '${WINDOWS_DIRECTORY_EXISTS_MARKER}' }`,
+    "if ($errorCode -ne 0) { $exception = New-Object System.ComponentModel.Win32Exception($errorCode); throw $exception }",
+  ].join("; ");
+  const powershell = resolveSystemBin("powershell");
+  if (!powershell) {
+    throw new Error("Unable to resolve PowerShell for private Windows SQLite staging.");
+  }
+  const encodedCommand = Buffer.from(command, "utf16le").toString("base64");
+  try {
+    await runPrivateDirectoryPowerShell(powershell, encodedCommand);
+  } catch (error) {
+    if (String(error).includes(WINDOWS_DIRECTORY_EXISTS_MARKER)) {
+      const existsError = new Error(`Private SQLite directory already exists: ${directoryPath}`);
+      (existsError as NodeJS.ErrnoException).code = "EEXIST";
+      throw existsError;
+    }
+    throw new Error(`Unable to create private Windows SQLite directory: ${directoryPath}`, {
+      cause: error,
+    });
+  }
+}
+
+export async function createPrivateSqliteTempDirectory(
+  rootPath: string,
+  prefix: string,
+): Promise<string> {
+  if (process.platform !== "win32") {
+    return await fs.mkdtemp(path.join(rootPath, prefix));
+  }
+  const directoryPath = path.join(rootPath, `${prefix}${randomUUID()}`);
+  await createPrivateSqliteDirectory(directoryPath);
+  return directoryPath;
+}

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -1,0 +1,375 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { prepareSqliteReadOnlyLocation } from "./sqlite-readonly-location.js";
+
+const workers: Worker[] = [];
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(workers.splice(0).map(async (worker) => await worker.terminate()));
+    cleanup();
+  });
+});
+
+function createTempDatabasePath(): string {
+  const tempDir = tempDirs.make("openclaw-sqlite-readonly-");
+  return path.join(tempDir, "state.sqlite");
+}
+
+function readFamily(pathname: string): Map<string, Buffer> {
+  const family = new Map<string, Buffer>();
+  for (const suffix of ["", "-journal", "-shm", "-wal"]) {
+    const memberPath = `${pathname}${suffix}`;
+    if (fs.existsSync(memberPath)) {
+      family.set(suffix, fs.readFileSync(memberPath));
+    }
+  }
+  return family;
+}
+
+function readLogicalFamily(pathname: string): Map<string, Buffer> {
+  const family = readFamily(pathname);
+  family.delete("-shm");
+  return family;
+}
+
+function waitForWorkerMessage(worker: Worker, expected: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      worker.off("message", onMessage);
+      reject(error);
+    };
+    const onMessage = (message: unknown) => {
+      if (message !== expected) {
+        return;
+      }
+      worker.off("error", onError);
+      resolve();
+    };
+    worker.once("error", onError);
+    worker.on("message", onMessage);
+  });
+}
+
+describe("prepareSqliteReadOnlyLocation", () => {
+  it("retries a same-size WAL reset instead of accepting an impossible pair", async () => {
+    const sqlite = requireNodeSqlite();
+    const livePath = createTempDatabasePath();
+    const writer = new sqlite.DatabaseSync(livePath);
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      CREATE TABLE before_reset (value TEXT PRIMARY KEY);
+      CREATE TABLE after_reset (value TEXT PRIMARY KEY);
+      PRAGMA wal_checkpoint(TRUNCATE);
+      INSERT INTO before_reset VALUES ('A');
+    `);
+    const databasePath = createTempDatabasePath();
+    fs.copyFileSync(livePath, databasePath);
+    fs.copyFileSync(`${livePath}-wal`, `${databasePath}-wal`);
+    writer.close();
+    expect(fs.existsSync(`${databasePath}-shm`)).toBe(false);
+    const walSizeBeforeReset = fs.statSync(`${databasePath}-wal`).size;
+    const fsyncSync = fs.fsyncSync.bind(fs);
+    let injected = false;
+    let raceWriter: DatabaseSync | undefined;
+    let sourceAfterReset: Map<string, Buffer> | undefined;
+    vi.spyOn(fs, "fsyncSync").mockImplementation((descriptor) => {
+      fsyncSync(descriptor);
+      if (!injected) {
+        injected = true;
+        raceWriter = new sqlite.DatabaseSync(databasePath);
+        raceWriter.exec(`
+          PRAGMA wal_checkpoint(TRUNCATE);
+          INSERT INTO after_reset VALUES ('B');
+        `);
+        sourceAfterReset = readLogicalFamily(databasePath);
+      }
+    });
+
+    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    expect(injected).toBe(true);
+    expect(fs.statSync(`${databasePath}-wal`).size).toBe(walSizeBeforeReset);
+    const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+    expect(snapshot.prepare("SELECT value FROM before_reset").all()).toEqual([{ value: "A" }]);
+    expect(snapshot.prepare("SELECT value FROM after_reset").all()).toEqual([{ value: "B" }]);
+    expect(snapshot.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+    snapshot.close();
+    expect(readLogicalFamily(databasePath)).toEqual(sourceAfterReset);
+    expect(prepared.cleanup()).toBe(true);
+    raceWriter?.close();
+  });
+
+  it("backs up an active WAL database while another connection keeps writing", async () => {
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const seed = new sqlite.DatabaseSync(databasePath);
+    seed.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      CREATE TABLE writes (sequence INTEGER PRIMARY KEY);
+      CREATE TABLE payload (data BLOB NOT NULL);
+      INSERT INTO payload VALUES (zeroblob(16777216));
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+    const worker = new Worker(
+      `
+        const { parentPort, workerData } = require("node:worker_threads");
+        const { DatabaseSync } = require("node:sqlite");
+        const database = new DatabaseSync(workerData);
+        database.exec("PRAGMA busy_timeout = 30000; PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;");
+        const insert = database.prepare("INSERT INTO writes DEFAULT VALUES");
+        let running = true;
+        parentPort.on("message", (message) => {
+          if (message === "stop") {
+            running = false;
+          }
+        });
+        parentPort.postMessage("ready");
+        function writeBatch() {
+          if (!running) {
+            database.close();
+            parentPort.postMessage("stopped");
+            return;
+          }
+          database.exec("BEGIN IMMEDIATE;");
+          for (let index = 0; index < 32; index += 1) {
+            insert.run();
+          }
+          database.exec("COMMIT;");
+          setImmediate(writeBatch);
+        }
+        writeBatch();
+      `,
+      { eval: true, workerData: databasePath },
+    );
+    workers.push(worker);
+    try {
+      await waitForWorkerMessage(worker, "ready");
+
+      const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+      const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+      expect(snapshot.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+      expect(snapshot.prepare("SELECT COUNT(*) AS count FROM payload").get()).toEqual({ count: 1 });
+      snapshot.close();
+      expect(prepared.cleanup()).toBe(true);
+    } finally {
+      worker.postMessage("stop", []);
+      await worker.terminate();
+      const workerIndex = workers.indexOf(worker);
+      if (workerIndex >= 0) {
+        workers.splice(workerIndex, 1);
+      }
+      seed.close();
+    }
+  });
+
+  it("backs up live MEMORY-journal transactions atomically", async () => {
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const seed = new sqlite.DatabaseSync(databasePath);
+    seed.exec(`
+      CREATE TABLE pair (name TEXT PRIMARY KEY, value INTEGER NOT NULL);
+      INSERT INTO pair VALUES ('left', 0), ('right', 0);
+      CREATE TABLE payload (data BLOB NOT NULL);
+      INSERT INTO payload VALUES (zeroblob(8388608));
+    `);
+    const worker = new Worker(
+      `
+        const { parentPort, workerData } = require("node:worker_threads");
+        const { DatabaseSync } = require("node:sqlite");
+        const database = new DatabaseSync(workerData);
+        database.exec("PRAGMA busy_timeout = 30000; PRAGMA journal_mode = MEMORY;");
+        const update = database.prepare("UPDATE pair SET value = ? WHERE name = ?");
+        let running = true;
+        let sequence = 0;
+        parentPort.on("message", (message) => {
+          if (message === "stop") {
+            running = false;
+          }
+        });
+        parentPort.postMessage("ready");
+        function writePair() {
+          if (!running) {
+            database.close();
+            return;
+          }
+          sequence += 1;
+          database.exec("BEGIN IMMEDIATE;");
+          update.run(sequence, "left");
+          update.run(sequence, "right");
+          database.exec("COMMIT;");
+          setImmediate(writePair);
+        }
+        writePair();
+      `,
+      { eval: true, workerData: databasePath },
+    );
+    workers.push(worker);
+    try {
+      await waitForWorkerMessage(worker, "ready");
+
+      const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+      const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+      const values = snapshot
+        .prepare("SELECT value FROM pair ORDER BY name")
+        .all()
+        .map((row) => (row as { value: number }).value);
+      expect(values[0]).toBe(values[1]);
+      expect(snapshot.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+      snapshot.close();
+      expect(prepared.cleanup()).toBe(true);
+    } finally {
+      worker.postMessage("stop", []);
+      await worker.terminate();
+      const workerIndex = workers.indexOf(worker);
+      if (workerIndex >= 0) {
+        workers.splice(workerIndex, 1);
+      }
+      seed.close();
+    }
+  });
+
+  it("keeps a rollback-to-WAL transition off the source path", async () => {
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const seed = new sqlite.DatabaseSync(databasePath);
+    seed.exec("CREATE TABLE probe (value TEXT); INSERT INTO probe VALUES ('ok');");
+    seed.close();
+    const fsyncSync = fs.fsyncSync.bind(fs);
+    let injected = false;
+    let sourceAfterTransition: Map<string, Buffer> | undefined;
+    vi.spyOn(fs, "fsyncSync").mockImplementation((descriptor) => {
+      fsyncSync(descriptor);
+      if (!injected) {
+        injected = true;
+        const writer = new sqlite.DatabaseSync(databasePath);
+        writer.exec("PRAGMA journal_mode = WAL; PRAGMA wal_checkpoint(TRUNCATE);");
+        writer.close();
+        sourceAfterTransition = readFamily(databasePath);
+      }
+    });
+
+    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    expect(injected).toBe(true);
+    expect(path.resolve(prepared.location)).not.toBe(path.resolve(databasePath));
+    const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+    expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "ok" }]);
+    snapshot.close();
+    expect(readFamily(databasePath)).toEqual(sourceAfterTransition);
+    expect(prepared.cleanup()).toBe(true);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "finds WAL state beside a canonical symlink target",
+    async () => {
+      const sqlite = requireNodeSqlite();
+      const databasePath = createTempDatabasePath();
+      const writer = new sqlite.DatabaseSync(databasePath);
+      writer.exec(`
+        PRAGMA journal_mode = WAL;
+        PRAGMA wal_autocheckpoint = 0;
+        CREATE TABLE probe (value TEXT);
+        PRAGMA wal_checkpoint(TRUNCATE);
+        INSERT INTO probe VALUES ('from-wal');
+      `);
+      const symlinkPath = path.join(path.dirname(databasePath), "state-link.sqlite");
+      fs.symlinkSync(path.basename(databasePath), symlinkPath);
+
+      const prepared = await prepareSqliteReadOnlyLocation(symlinkPath);
+      const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+      expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "from-wal" }]);
+      snapshot.close();
+      expect(fs.existsSync(`${symlinkPath}-wal`)).toBe(false);
+      expect(fs.existsSync(`${symlinkPath}-shm`)).toBe(false);
+      expect(prepared.cleanup()).toBe(true);
+      writer.close();
+    },
+  );
+
+  it("retries when a pathname disappears after its file is opened", async () => {
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const seed = new sqlite.DatabaseSync(databasePath);
+    seed.exec("CREATE TABLE probe (value TEXT); INSERT INTO probe VALUES ('ok');");
+    seed.close();
+    const statSync = fs.statSync.bind(fs);
+    let injected = false;
+    vi.spyOn(fs, "statSync").mockImplementation(((pathname, options) => {
+      if (!injected && path.resolve(String(pathname)) === path.resolve(databasePath)) {
+        injected = true;
+        const error = new Error("missing");
+        (error as NodeJS.ErrnoException).code = "ENOENT";
+        throw error;
+      }
+      return statSync(pathname, options as never);
+    }) as typeof fs.statSync);
+
+    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    expect(injected).toBe(true);
+    const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+    expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "ok" }]);
+    snapshot.close();
+    expect(prepared.cleanup()).toBe(true);
+  });
+
+  it("retries cleanup after a transient removal failure", async () => {
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const seed = new sqlite.DatabaseSync(databasePath);
+    seed.exec("CREATE TABLE probe (value TEXT);");
+    seed.close();
+    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    const privateDirectory = path.dirname(prepared.location);
+    const rmSync = fs.rmSync.bind(fs);
+    let failRemoval = true;
+    vi.spyOn(fs, "rmSync").mockImplementation(((pathname, options) => {
+      if (failRemoval && path.resolve(String(pathname)) === path.resolve(privateDirectory)) {
+        failRemoval = false;
+        const error = new Error("busy");
+        (error as NodeJS.ErrnoException).code = "EBUSY";
+        throw error;
+      }
+      return rmSync(pathname, options);
+    }) as typeof fs.rmSync);
+
+    expect(prepared.cleanup()).toBe(false);
+    expect(fs.existsSync(privateDirectory)).toBe(true);
+    expect(prepared.cleanup()).toBe(true);
+    expect(fs.existsSync(privateDirectory)).toBe(false);
+  });
+
+  it("copies an orphan SHM privately without creating a source WAL", async () => {
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const seed = new sqlite.DatabaseSync(databasePath);
+    seed.exec(`
+      PRAGMA journal_mode = WAL;
+      CREATE TABLE probe (value TEXT);
+      INSERT INTO probe VALUES ('committed');
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+    seed.close();
+    fs.rmSync(`${databasePath}-wal`, { force: true });
+    const orphanShm = Buffer.alloc(32 * 1024, 0x5a);
+    fs.writeFileSync(`${databasePath}-shm`, orphanShm, { mode: 0o600 });
+    const beforeMain = fs.readFileSync(databasePath);
+    const beforeEntries = fs.readdirSync(path.dirname(databasePath)).toSorted();
+
+    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+    expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "committed" }]);
+    snapshot.close();
+    expect(prepared.cleanup()).toBe(true);
+
+    expect(fs.existsSync(`${databasePath}-wal`)).toBe(false);
+    expect(fs.readFileSync(`${databasePath}-shm`)).toEqual(orphanShm);
+    expect(fs.readFileSync(databasePath)).toEqual(beforeMain);
+    expect(fs.readdirSync(path.dirname(databasePath)).toSorted()).toEqual(beforeEntries);
+  });
+});

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -169,6 +169,40 @@ describe("prepareSqliteReadOnlyLocation", () => {
     }
   });
 
+  it("retries when backup fallback inspection sees a replaced source", async () => {
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const writer = new sqlite.DatabaseSync(databasePath);
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      CREATE TABLE probe (value TEXT);
+      INSERT INTO probe VALUES ('ok');
+    `);
+    let failNextSourceStat = false;
+    vi.spyOn(sqlite, "backup").mockImplementationOnce(async () => {
+      failNextSourceStat = true;
+      throw new Error("simulated backup race");
+    });
+    const statSync = fs.statSync.bind(fs);
+    vi.spyOn(fs, "statSync").mockImplementation(((pathname, options) => {
+      if (failNextSourceStat && path.resolve(String(pathname)) === path.resolve(databasePath)) {
+        failNextSourceStat = false;
+        const error = new Error("missing");
+        (error as NodeJS.ErrnoException).code = "ENOENT";
+        throw error;
+      }
+      return statSync(pathname, options as never);
+    }) as typeof fs.statSync);
+
+    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+    expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "ok" }]);
+    snapshot.close();
+    expect(prepared.cleanup()).toBe(true);
+    writer.close();
+  });
+
   it("backs up live MEMORY-journal transactions atomically", async () => {
     const sqlite = requireNodeSqlite();
     const databasePath = createTempDatabasePath();

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -7,7 +7,7 @@ import {
   requireNodeSqlite,
   resolveSqliteFilesystemPath,
 } from "./node-sqlite.js";
-import { createPrivateSqliteTempDirectory } from "./sqlite-snapshot.js";
+import { createPrivateSqliteTempDirectory } from "./sqlite-private-directory.js";
 import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
 
 const MAX_SNAPSHOT_ATTEMPTS = 10;

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -1,0 +1,429 @@
+// Prepares consistent private SQLite read-only snapshots.
+import fs, { type BigIntStats } from "node:fs";
+import path from "node:path";
+import { sameFileIdentity } from "./fs-safe-advanced.js";
+import {
+  openNodeSqliteDatabase,
+  requireNodeSqlite,
+  resolveSqliteFilesystemPath,
+} from "./node-sqlite.js";
+import { createPrivateSqliteTempDirectory } from "./sqlite-snapshot.js";
+import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
+
+const MAX_SNAPSHOT_ATTEMPTS = 10;
+const COPY_BUFFER_BYTES = 1024 * 1024;
+const SQLITE_HEADER_BYTES = 20;
+const pendingTempDirectoryCleanup = new Set<string>();
+let cleanupExitHandlerInstalled = false;
+
+type PinnedFile = {
+  descriptor: number;
+  identity: BigIntStats;
+  pathname: string;
+};
+
+type SourceSidecars = {
+  journal: boolean;
+  shm: boolean;
+  wal: boolean;
+};
+
+type PreparedSqliteReadOnlyLocation = {
+  cleanup: () => boolean;
+  location: string;
+};
+
+class SqliteSourceChangedError extends Error {}
+
+function statIfPresent(pathname: string): BigIntStats | undefined {
+  try {
+    return fs.statSync(pathname, { bigint: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function readSourceSidecars(pathname: string): SourceSidecars {
+  return {
+    journal: Boolean(statIfPresent(`${pathname}-journal`)),
+    shm: Boolean(statIfPresent(`${pathname}-shm`)),
+    wal: Boolean(statIfPresent(`${pathname}-wal`)),
+  };
+}
+
+function sameSidecars(left: SourceSidecars, right: SourceSidecars): boolean {
+  return left.journal === right.journal && left.shm === right.shm && left.wal === right.wal;
+}
+
+function openPinnedFile(pathname: string): PinnedFile {
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(pathname, "r");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new SqliteSourceChangedError(`SQLite source disappeared: ${pathname}`);
+    }
+    throw error;
+  }
+  try {
+    const identity = fs.fstatSync(descriptor, { bigint: true });
+    const current = statIfPresent(pathname);
+    if (!identity.isFile() || !current?.isFile() || !sameFileIdentity(identity, current)) {
+      throw new SqliteSourceChangedError(`SQLite source changed while opening: ${pathname}`);
+    }
+    return { descriptor, identity, pathname };
+  } catch (error) {
+    fs.closeSync(descriptor);
+    throw error;
+  }
+}
+
+function readSourceJournalMode(pathname: string): "rollback" | "unknown" | "wal" {
+  const source = openPinnedFile(pathname);
+  try {
+    const header = Buffer.alloc(SQLITE_HEADER_BYTES);
+    const bytesRead = fs.readSync(source.descriptor, header, 0, header.length, 0);
+    const confirmedHeader = Buffer.alloc(SQLITE_HEADER_BYTES);
+    const confirmedBytesRead = fs.readSync(
+      source.descriptor,
+      confirmedHeader,
+      0,
+      confirmedHeader.length,
+      0,
+    );
+    assertPinnedIdentityUnchanged(source);
+    if (
+      bytesRead !== header.length ||
+      confirmedBytesRead !== confirmedHeader.length ||
+      !header.equals(confirmedHeader) ||
+      header.subarray(0, 16).toString("utf8") !== "SQLite format 3\u0000"
+    ) {
+      return "unknown";
+    }
+    return header[18] === 2 || header[19] === 2 ? "wal" : "rollback";
+  } finally {
+    fs.closeSync(source.descriptor);
+  }
+}
+
+function assertPinnedIdentityUnchanged(file: PinnedFile): void {
+  const opened = fs.fstatSync(file.descriptor, { bigint: true });
+  const current = statIfPresent(file.pathname);
+  if (
+    !opened.isFile() ||
+    !current?.isFile() ||
+    !sameFileIdentity(file.identity, opened) ||
+    !sameFileIdentity(file.identity, current)
+  ) {
+    throw new SqliteSourceChangedError(`SQLite source changed while copying: ${file.pathname}`);
+  }
+}
+
+function copyPinnedFile(source: PinnedFile, targetPath: string): void {
+  let target: number | undefined;
+  try {
+    target = fs.openSync(targetPath, "wx", 0o600);
+    const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+    let offset = 0;
+    while (true) {
+      const bytesRead = fs.readSync(source.descriptor, buffer, 0, buffer.length, offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      let bytesWritten = 0;
+      while (bytesWritten < bytesRead) {
+        const count = fs.writeSync(
+          target,
+          buffer,
+          bytesWritten,
+          bytesRead - bytesWritten,
+          offset + bytesWritten,
+        );
+        if (count === 0) {
+          throw new Error(`SQLite read-only snapshot copy made no progress: ${targetPath}`);
+        }
+        bytesWritten += count;
+      }
+      offset += bytesRead;
+    }
+    fs.fsyncSync(target);
+    assertPinnedIdentityUnchanged(source);
+  } finally {
+    if (target !== undefined) {
+      fs.closeSync(target);
+    }
+  }
+}
+
+function copySourceFile(sourcePath: string, targetPath: string): void {
+  const source = openPinnedFile(sourcePath);
+  try {
+    copyPinnedFile(source, targetPath);
+  } finally {
+    fs.closeSync(source.descriptor);
+  }
+}
+
+function filesEqual(leftPath: string, rightPath: string): boolean {
+  const leftStat = fs.statSync(leftPath, { bigint: true });
+  const rightStat = fs.statSync(rightPath, { bigint: true });
+  if (!leftStat.isFile() || !rightStat.isFile() || leftStat.size !== rightStat.size) {
+    return false;
+  }
+  const left = fs.openSync(leftPath, "r");
+  const right = fs.openSync(rightPath, "r");
+  try {
+    const leftBuffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+    const rightBuffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+    let offset = 0;
+    while (BigInt(offset) < leftStat.size) {
+      const length = Math.min(COPY_BUFFER_BYTES, Number(leftStat.size - BigInt(offset)));
+      const leftBytes = fs.readSync(left, leftBuffer, 0, length, offset);
+      const rightBytes = fs.readSync(right, rightBuffer, 0, length, offset);
+      if (
+        leftBytes !== rightBytes ||
+        leftBytes !== length ||
+        !leftBuffer.subarray(0, leftBytes).equals(rightBuffer.subarray(0, rightBytes))
+      ) {
+        return false;
+      }
+      offset += leftBytes;
+    }
+    return true;
+  } finally {
+    fs.closeSync(right);
+    fs.closeSync(left);
+  }
+}
+
+function assertExpectedSidecars(pathname: string, expected: SourceSidecars): void {
+  if (!sameSidecars(readSourceSidecars(pathname), expected)) {
+    throw new SqliteSourceChangedError(`SQLite journal state changed while copying: ${pathname}`);
+  }
+}
+
+function replaceFile(sourcePath: string, targetPath: string): void {
+  fs.rmSync(targetPath, { force: true });
+  fs.renameSync(sourcePath, targetPath);
+}
+
+function removeTempDirectory(tempDir: string): boolean {
+  try {
+    fs.rmSync(tempDir, { force: true, maxRetries: 3, recursive: true, retryDelay: 20 });
+    pendingTempDirectoryCleanup.delete(tempDir);
+    return true;
+  } catch {
+    pendingTempDirectoryCleanup.add(tempDir);
+    if (!cleanupExitHandlerInstalled) {
+      cleanupExitHandlerInstalled = true;
+      process.once("exit", () => {
+        for (const pendingDir of pendingTempDirectoryCleanup) {
+          try {
+            fs.rmSync(pendingDir, { force: true, recursive: true });
+          } catch {
+            // The directory is private and remains registered until process teardown completes.
+          }
+        }
+      });
+    }
+    return false;
+  }
+}
+
+async function createStableReadOnlyCopy(pathname: string): Promise<PreparedSqliteReadOnlyLocation> {
+  const tempDir = await createPrivateSqliteTempDirectory(
+    resolvePreferredOpenClawTmpDir(),
+    `openclaw-sqlite-readonly-${process.pid}-`,
+  );
+  const snapshotPath = path.join(tempDir, "database.sqlite");
+  const firstPath = path.join(tempDir, "first");
+  const secondPath = path.join(tempDir, "second");
+  try {
+    if (process.platform !== "win32") {
+      fs.chmodSync(tempDir, 0o700);
+    }
+    if (readSourceJournalMode(pathname) !== "wal") {
+      throw new SqliteSourceChangedError(`SQLite journal mode changed before copying: ${pathname}`);
+    }
+    const sidecars = readSourceSidecars(pathname);
+    if (sidecars.journal && sidecars.wal) {
+      throw new SqliteSourceChangedError(`SQLite journal modes overlapped: ${pathname}`);
+    }
+
+    if (sidecars.wal) {
+      copySourceFile(`${pathname}-wal`, firstPath);
+      copySourceFile(pathname, snapshotPath);
+      copySourceFile(`${pathname}-wal`, secondPath);
+      assertExpectedSidecars(pathname, sidecars);
+      if (!filesEqual(firstPath, secondPath)) {
+        throw new SqliteSourceChangedError(`SQLite WAL changed while copying: ${pathname}`);
+      }
+      replaceFile(secondPath, `${snapshotPath}-wal`);
+    } else if (sidecars.journal) {
+      copySourceFile(`${pathname}-journal`, firstPath);
+      copySourceFile(pathname, snapshotPath);
+      copySourceFile(`${pathname}-journal`, secondPath);
+      assertExpectedSidecars(pathname, sidecars);
+      if (!filesEqual(firstPath, secondPath)) {
+        throw new SqliteSourceChangedError(
+          `SQLite rollback journal changed while copying: ${pathname}`,
+        );
+      }
+      replaceFile(secondPath, `${snapshotPath}-journal`);
+    } else {
+      copySourceFile(pathname, firstPath);
+      assertExpectedSidecars(pathname, sidecars);
+      copySourceFile(pathname, secondPath);
+      assertExpectedSidecars(pathname, sidecars);
+      if (!filesEqual(firstPath, secondPath)) {
+        throw new SqliteSourceChangedError(
+          `SQLite main database changed while copying: ${pathname}`,
+        );
+      }
+      replaceFile(secondPath, snapshotPath);
+    }
+
+    if (readSourceJournalMode(pathname) !== "wal") {
+      throw new SqliteSourceChangedError(`SQLite journal mode changed while copying: ${pathname}`);
+    }
+    fs.rmSync(firstPath, { force: true });
+    let active = true;
+    return {
+      location: snapshotPath,
+      cleanup: () => {
+        if (!active) {
+          return true;
+        }
+        const removed = removeTempDirectory(tempDir);
+        if (removed) {
+          active = false;
+        }
+        return removed;
+      },
+    };
+  } catch (error) {
+    removeTempDirectory(tempDir);
+    throw error;
+  }
+}
+
+async function createOnlineReadOnlyBackup(
+  pathname: string,
+): Promise<PreparedSqliteReadOnlyLocation> {
+  const tempDir = await createPrivateSqliteTempDirectory(
+    resolvePreferredOpenClawTmpDir(),
+    `openclaw-sqlite-readonly-${process.pid}-`,
+  );
+  const snapshotPath = path.join(tempDir, "database.sqlite");
+  const sqlite = requireNodeSqlite();
+  try {
+    if (process.platform !== "win32") {
+      fs.chmodSync(tempDir, 0o700);
+    }
+    const source = openNodeSqliteDatabase(pathname, {
+      readOnly: true,
+    });
+    try {
+      source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF; BEGIN;");
+      source.prepare("PRAGMA schema_version;").get();
+      await sqlite.backup(source, resolveSqliteFilesystemPath(snapshotPath));
+      source.exec("ROLLBACK;");
+    } finally {
+      if (source.isOpen) {
+        source.close();
+      }
+    }
+    const snapshot = openNodeSqliteDatabase(snapshotPath);
+    try {
+      snapshot.exec("PRAGMA journal_mode = DELETE;");
+    } finally {
+      snapshot.close();
+    }
+    const descriptor = fs.openSync(snapshotPath, "r+");
+    try {
+      fs.fsyncSync(descriptor);
+    } finally {
+      fs.closeSync(descriptor);
+    }
+    let active = true;
+    return {
+      location: snapshotPath,
+      cleanup: () => {
+        if (!active) {
+          return true;
+        }
+        const removed = removeTempDirectory(tempDir);
+        if (removed) {
+          active = false;
+        }
+        return removed;
+      },
+    };
+  } catch (error) {
+    removeTempDirectory(tempDir);
+    throw error;
+  }
+}
+
+/**
+ * Rollback modes and active WAL state use SQLite's locking and backup protocol.
+ * WAL state without a complete WAL/SHM pair is copied privately so inspecting
+ * crash residue never creates coordination files beside the source.
+ */
+export async function prepareSqliteReadOnlyLocation(
+  pathname: string,
+): Promise<PreparedSqliteReadOnlyLocation> {
+  const canonicalPath = fs.realpathSync.native(pathname);
+  let lastChange: Error | undefined;
+  for (let attempt = 0; attempt < MAX_SNAPSHOT_ATTEMPTS; attempt += 1) {
+    let journalMode: ReturnType<typeof readSourceJournalMode>;
+    try {
+      journalMode = readSourceJournalMode(canonicalPath);
+    } catch (error) {
+      if (!(error instanceof SqliteSourceChangedError)) {
+        throw error;
+      }
+      lastChange = error;
+      continue;
+    }
+    const sidecars = readSourceSidecars(canonicalPath);
+    if (journalMode !== "wal" || (sidecars.wal && sidecars.shm)) {
+      try {
+        return await createOnlineReadOnlyBackup(canonicalPath);
+      } catch (error) {
+        // A last WAL writer can remove sidecars before SQLite opens. Retry the
+        // now-sidecar-free WAL through the private-copy path.
+        let currentMode: ReturnType<typeof readSourceJournalMode>;
+        try {
+          currentMode = readSourceJournalMode(canonicalPath);
+        } catch (inspectionError) {
+          if (!(inspectionError instanceof SqliteSourceChangedError)) {
+            throw inspectionError;
+          }
+          lastChange = inspectionError;
+          continue;
+        }
+        const currentSidecars = readSourceSidecars(canonicalPath);
+        if (currentMode !== "wal" || (currentSidecars.wal && currentSidecars.shm)) {
+          throw error;
+        }
+        lastChange = error instanceof Error ? error : new Error(String(error));
+        continue;
+      }
+    }
+    try {
+      return await createStableReadOnlyCopy(canonicalPath);
+    } catch (error) {
+      if (!(error instanceof SqliteSourceChangedError)) {
+        throw error;
+      }
+      lastChange = error;
+    }
+  }
+  throw new Error(`SQLite source did not stabilize for read-only inspection: ${canonicalPath}`, {
+    cause: lastChange,
+  });
+}

--- a/src/infra/sqlite-snapshot.test.ts
+++ b/src/infra/sqlite-snapshot.test.ts
@@ -4,7 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { requireNodeSqlite } from "./node-sqlite.js";
-import { createPrivateSqliteDirectory, createVerifiedSqliteSnapshot } from "./sqlite-snapshot.js";
+import { createPrivateSqliteDirectory } from "./sqlite-private-directory.js";
+import { createVerifiedSqliteSnapshot } from "./sqlite-snapshot.js";
 
 const tempDirs: string[] = [];
 

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -6,7 +6,6 @@ import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/engine-storage.js";
-import { runExec } from "../process/exec.js";
 import { formatErrorMessage } from "./errors.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 import {
@@ -14,79 +13,14 @@ import {
   requireNodeSqlite,
   resolveSqliteFilesystemPath,
 } from "./node-sqlite.js";
-import { resolveSystemBin } from "./resolve-system-bin.js";
 import { assertSqliteIntegrity } from "./sqlite-integrity.js";
 import {
   openSqliteDirectoryForDurability,
   syncSqliteDirectoryForDurability,
   type SqlitePathIdentityReceipt,
 } from "./sqlite-path-durability.js";
+import { createPrivateSqliteTempDirectory } from "./sqlite-private-directory.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
-
-const SQLITE_DIRECTORY_MODE = 0o700;
-const WINDOWS_DIRECTORY_EXISTS_MARKER = "OPENCLAW_SQLITE_DIRECTORY_EXISTS";
-
-// Managed directory creation accepts existing paths. CreateDirectoryW applies the
-// protected DACL atomically while preserving fail-if-exists semantics.
-const WINDOWS_PRIVATE_DIRECTORY_NATIVE_SOURCE = `
-using System;
-using System.Runtime.InteropServices;
-
-public static class OpenClawPrivateDirectory
-{
-    [StructLayout(LayoutKind.Sequential)]
-    private struct SecurityAttributes
-    {
-        public int Length;
-        public IntPtr SecurityDescriptor;
-        public int InheritHandle;
-    }
-
-    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern bool ConvertStringSecurityDescriptorToSecurityDescriptorW(
-        string securityDescriptor,
-        uint revision,
-        out IntPtr convertedSecurityDescriptor,
-        out uint convertedSecurityDescriptorSize);
-
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern bool CreateDirectoryW(
-        string path,
-        ref SecurityAttributes securityAttributes);
-
-    [DllImport("kernel32.dll")]
-    private static extern IntPtr LocalFree(IntPtr memory);
-
-    public static int Create(string path, string securityDescriptor)
-    {
-        IntPtr descriptor;
-        uint descriptorSize;
-        if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                securityDescriptor,
-                1,
-                out descriptor,
-                out descriptorSize))
-        {
-            return Marshal.GetLastWin32Error();
-        }
-
-        try
-        {
-            var attributes = new SecurityAttributes
-            {
-                Length = Marshal.SizeOf(typeof(SecurityAttributes)),
-                SecurityDescriptor = descriptor,
-                InheritHandle = 0,
-            };
-            return CreateDirectoryW(path, ref attributes) ? 0 : Marshal.GetLastWin32Error();
-        }
-        finally
-        {
-            LocalFree(descriptor);
-        }
-    }
-}
-`;
 
 export type SqliteSnapshotValidator = (database: DatabaseSync, databaseLabel: string) => void;
 
@@ -127,73 +61,6 @@ type VerifiedSqliteSnapshot = {
   path: string;
   userVersion: number;
 };
-
-export async function createPrivateSqliteDirectory(directoryPath: string): Promise<void> {
-  if (process.platform !== "win32") {
-    await fs.mkdir(directoryPath, { mode: SQLITE_DIRECTORY_MODE });
-    return;
-  }
-  // This raw Win32 call bypasses Node's automatic long-path normalization.
-  const nativeDirectoryPath = path.toNamespacedPath(path.resolve(directoryPath));
-  const encodedPath = Buffer.from(nativeDirectoryPath, "utf8").toString("base64");
-  const encodedNativeSource = Buffer.from(WINDOWS_PRIVATE_DIRECTORY_NATIVE_SOURCE, "utf8").toString(
-    "base64",
-  );
-  const command = [
-    "$ErrorActionPreference = 'Stop'",
-    `$path = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encodedPath}'))`,
-    `$nativeSource = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encodedNativeSource}'))`,
-    "Add-Type -TypeDefinition $nativeSource -Language CSharp",
-    "$current = [System.Security.Principal.WindowsIdentity]::GetCurrent().User",
-    "$security = New-Object System.Security.AccessControl.DirectorySecurity",
-    "$security.SetAccessRuleProtection($true, $false)",
-    "$security.SetOwner($current)",
-    "$inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit",
-    "$propagation = [System.Security.AccessControl.PropagationFlags]::None",
-    "foreach ($sidValue in @($current.Value, 'S-1-5-18', 'S-1-5-32-544')) { $sid = New-Object System.Security.Principal.SecurityIdentifier($sidValue); $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, $inheritance, $propagation, [System.Security.AccessControl.AccessControlType]::Allow); [void]$security.AddAccessRule($rule) }",
-    "$sections = [System.Security.AccessControl.AccessControlSections]::Owner -bor [System.Security.AccessControl.AccessControlSections]::Access",
-    "$sddl = $security.GetSecurityDescriptorSddlForm($sections)",
-    "$errorCode = [OpenClawPrivateDirectory]::Create($path, $sddl)",
-    `if ($errorCode -eq 80 -or $errorCode -eq 183) { throw '${WINDOWS_DIRECTORY_EXISTS_MARKER}' }`,
-    "if ($errorCode -ne 0) { $exception = New-Object System.ComponentModel.Win32Exception($errorCode); throw $exception }",
-  ].join("; ");
-  const powershell = resolveSystemBin("powershell");
-  if (!powershell) {
-    throw new Error("Unable to resolve PowerShell for private Windows SQLite staging.");
-  }
-  const encodedCommand = Buffer.from(command, "utf16le").toString("base64");
-  try {
-    await runExec(
-      powershell,
-      ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encodedCommand],
-      {
-        timeoutMs: 10_000,
-        maxBuffer: 64 * 1024,
-      },
-    );
-  } catch (error) {
-    if (String(error).includes(WINDOWS_DIRECTORY_EXISTS_MARKER)) {
-      const existsError = new Error(`Private SQLite directory already exists: ${directoryPath}`);
-      (existsError as NodeJS.ErrnoException).code = "EEXIST";
-      throw existsError;
-    }
-    throw new Error(`Unable to create private Windows SQLite directory: ${directoryPath}`, {
-      cause: error,
-    });
-  }
-}
-
-export async function createPrivateSqliteTempDirectory(
-  rootPath: string,
-  prefix: string,
-): Promise<string> {
-  if (process.platform !== "win32") {
-    return await fs.mkdtemp(path.join(rootPath, prefix));
-  }
-  const directoryPath = path.join(rootPath, `${prefix}${randomUUID()}`);
-  await createPrivateSqliteDirectory(directoryPath);
-  return directoryPath;
-}
 
 async function assertRegularSourceFile(
   sourcePath: string,

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
-import { createPrivateSqliteDirectory } from "../infra/sqlite-snapshot.js";
+import { createPrivateSqliteDirectory } from "../infra/sqlite-private-directory.js";
 import { runExec } from "../process/exec.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.generated.js";

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -26,6 +26,8 @@ import {
 import {
   createPrivateSqliteDirectory,
   createPrivateSqliteTempDirectory,
+} from "../infra/sqlite-private-directory.js";
+import {
   createVerifiedSqliteSnapshot,
   publishVerifiedSqliteFile,
   syncDirectoryBestEffort,

--- a/src/snapshot/local-repository.windows.test.ts
+++ b/src/snapshot/local-repository.windows.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
-import { createPrivateSqliteDirectory } from "../infra/sqlite-snapshot.js";
+import { createPrivateSqliteDirectory } from "../infra/sqlite-private-directory.js";
 import { createLocalSqliteSnapshotProvider } from "./local-repository.js";
 import { SNAPSHOT_SQLITE_FILENAME } from "./snapshot-provider.js";
 

--- a/src/state/openclaw-database-paths.windows.test.ts
+++ b/src/state/openclaw-database-paths.windows.test.ts
@@ -118,14 +118,14 @@ describe("OpenClaw database paths on Windows", () => {
           },
         }),
       ).toEqual({ incompatible: [], indeterminate: [] });
-      const immutableState = openExistingOpenClawStateDatabaseReadOnly({ env });
-      expect(immutableState?.path).toBe(statePath);
+      const readOnlyState = openExistingOpenClawStateDatabaseReadOnly({ env });
+      expect(readOnlyState?.path).toBe(statePath);
       expect(
-        immutableState?.db
+        readOnlyState?.db
           .prepare("SELECT role, schema_version FROM schema_meta WHERE meta_key = 'primary'")
           .get(),
       ).toEqual({ role: "global", schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
-      immutableState?.walMaintenance.close();
+      readOnlyState?.walMaintenance.close();
 
       await expect(runDoctorStateSqliteCompact({ env })).resolves.toMatchObject({
         integrityCheck: "ok",

--- a/src/state/openclaw-database-paths.windows.test.ts
+++ b/src/state/openclaw-database-paths.windows.test.ts
@@ -118,14 +118,34 @@ describe("OpenClaw database paths on Windows", () => {
           },
         }),
       ).toEqual({ incompatible: [], indeterminate: [] });
-      const readOnlyState = openExistingOpenClawStateDatabaseReadOnly({ env });
+      fs.rmSync(`${statePath}-wal`, { force: true });
+      fs.rmSync(`${statePath}-shm`, { force: true });
+      const stateBytesBeforeReadOnly = fs.readFileSync(statePath);
+      const stateEntriesBeforeReadOnly = fs
+        .readdirSync(path.dirname(statePath), { withFileTypes: true })
+        .map((entry) => entry.name)
+        .toSorted();
+      const readOnlyState = await openExistingOpenClawStateDatabaseReadOnly({ env });
       expect(readOnlyState?.path).toBe(statePath);
       expect(
         readOnlyState?.db
           .prepare("SELECT role, schema_version FROM schema_meta WHERE meta_key = 'primary'")
           .get(),
       ).toEqual({ role: "global", schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
-      readOnlyState?.walMaintenance.close();
+      const openedStatePath = readOnlyState?.db.prepare("PRAGMA database_list").get() as
+        | { file?: unknown }
+        | undefined;
+      expect(path.resolve(String(openedStatePath?.file))).not.toBe(path.resolve(statePath));
+      const privateDirectory = path.dirname(String(openedStatePath?.file));
+      expect(readOnlyState?.walMaintenance.close()).toBe(true);
+      expect(fs.existsSync(privateDirectory)).toBe(false);
+      expect(fs.readFileSync(statePath)).toEqual(stateBytesBeforeReadOnly);
+      expect(
+        fs
+          .readdirSync(path.dirname(statePath), { withFileTypes: true })
+          .map((entry) => entry.name)
+          .toSorted(),
+      ).toEqual(stateEntriesBeforeReadOnly);
 
       await expect(runDoctorStateSqliteCompact({ env })).resolves.toMatchObject({
         integrityCheck: "ok",

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { buildApprovalResolutionRef } from "../infra/approval-resolution-ref.js";
@@ -485,14 +486,8 @@ function createTaskRunStatusIndexPhysicalDrift(databasePath: string): void {
   const { DatabaseSync } = requireNodeSqlite();
   const database = new DatabaseSync(databasePath);
   try {
+    insertTaskRunProbe(database, "task-index-repair");
     database.exec(`
-      INSERT INTO task_runs (
-        task_id, runtime, owner_key, scope_kind, task, status,
-        delivery_status, notify_policy, created_at
-      ) VALUES (
-        'task-index-repair', 'subagent', 'owner', 'session', 'repair index',
-        'running', 'pending', 'summary', 1
-      );
       DROP INDEX idx_task_runs_status;
       CREATE INDEX idx_task_runs_status ON task_runs(task_id);
     `);
@@ -515,6 +510,18 @@ function createTaskRunStatusIndexPhysicalDrift(databasePath: string): void {
   } finally {
     database.close();
   }
+}
+
+function insertTaskRunProbe(database: DatabaseSync, taskId: string): void {
+  database
+    .prepare(
+      `INSERT INTO task_runs (
+         task_id, runtime, owner_key, scope_kind, task, status,
+         delivery_status, notify_policy, created_at
+       ) VALUES (?, 'subagent', 'owner', 'session', 'sqlite read probe',
+                 'running', 'pending', 'summary', 1)`,
+    )
+    .run(taskId);
 }
 
 function createUnsafeSchemaMetaIndexDrift(databasePath: string): void {
@@ -540,8 +547,11 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
   committedRowsAfterRecovery: number;
   immutableDirtyRowsBeforeKill: number;
   integrity: string;
+  journalBytesBeforeReadOnly: number;
   journalExistsAfterReadOnly: boolean;
   journalExistsAfterRecovery: boolean;
+  journalShaAfterReadOnly: string;
+  journalShaBeforeReadOnly: string;
   readOnly: {
     error: string | null;
     opened: boolean;
@@ -550,6 +560,7 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
 } {
   const probeSource = `
     import { spawn } from "node:child_process";
+    import { createHash } from "node:crypto";
     import fs from "node:fs";
     import path from "node:path";
     import { DatabaseSync } from "node:sqlite";
@@ -656,9 +667,13 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
         throw new Error(\`writer was not killed: \${JSON.stringify(outcome)} \${writerStderr}\`);
       }
 
+      const hashJournal = () =>
+        createHash("sha256").update(fs.readFileSync(journalPath)).digest("hex");
+      const journalBytesBeforeReadOnly = fs.statSync(journalPath).size;
+      const journalShaBeforeReadOnly = hashJournal();
       let readOnly;
       try {
-        const database = openExistingOpenClawStateDatabaseReadOnly({ path: databasePath });
+        const database = await openExistingOpenClawStateDatabaseReadOnly({ path: databasePath });
         const readOnlyRow = database?.db
           .prepare("SELECT COUNT(*) AS count FROM hot_journal_probe WHERE value = 'uncommitted'")
           .get();
@@ -676,6 +691,7 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
         };
       }
       const journalExistsAfterReadOnly = fs.existsSync(journalPath);
+      const journalShaAfterReadOnly = hashJournal();
       const reopened = openOpenClawStateDatabase({ path: databasePath });
       const row = reopened.db
         .prepare("SELECT COUNT(*) AS count FROM hot_journal_probe WHERE value = 'committed'")
@@ -686,8 +702,11 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
         committedRowsAfterRecovery: Number(row?.count ?? 0),
         immutableDirtyRowsBeforeKill,
         integrity: integrity?.integrity_check,
+        journalBytesBeforeReadOnly,
         journalExistsAfterReadOnly,
         journalExistsAfterRecovery: fs.existsSync(journalPath),
+        journalShaAfterReadOnly,
+        journalShaBeforeReadOnly,
         readOnly,
       }));
     } finally {
@@ -711,8 +730,11 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
     committedRowsAfterRecovery: number;
     immutableDirtyRowsBeforeKill: number;
     integrity: string;
+    journalBytesBeforeReadOnly: number;
     journalExistsAfterReadOnly: boolean;
     journalExistsAfterRecovery: boolean;
+    journalShaAfterReadOnly: string;
+    journalShaBeforeReadOnly: string;
     readOnly: {
       error: string | null;
       opened: boolean;
@@ -2292,7 +2314,141 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     );
   });
 
-  it("rejects noncanonical indexes from read-only state without rewriting them", () => {
+  it("opens sidecar-free WAL state without creating files beside the source", async () => {
+    const stateDir = createTempStateDir();
+    const databasePath = createCanonicalAuditStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const walHeader = new DatabaseSync(databasePath);
+    walHeader.exec("PRAGMA journal_mode = WAL; PRAGMA wal_checkpoint(TRUNCATE);");
+    walHeader.close();
+    fs.rmSync(`${databasePath}-wal`, { force: true });
+    fs.rmSync(`${databasePath}-shm`, { force: true });
+    const beforeBytes = fs.readFileSync(databasePath);
+    const beforeEntries = fs.readdirSync(stateDir).toSorted();
+
+    const database = await openExistingOpenClawStateDatabaseReadOnly({ path: databasePath });
+    expect(database).toBeDefined();
+    const openedPath = database?.db.prepare("PRAGMA database_list").get() as
+      | { file?: unknown }
+      | undefined;
+    expect(openedPath?.file).toEqual(expect.any(String));
+    expect(path.resolve(String(openedPath?.file))).not.toBe(path.resolve(databasePath));
+    expect(database?.db.prepare("PRAGMA integrity_check").get()).toEqual({
+      integrity_check: "ok",
+    });
+    const privateDirectory = path.dirname(String(openedPath?.file));
+    expect(database?.walMaintenance.close()).toBe(true);
+
+    expect(fs.existsSync(privateDirectory)).toBe(false);
+    expect(fs.readFileSync(databasePath)).toEqual(beforeBytes);
+    expect(fs.readdirSync(stateDir).toSorted()).toEqual(beforeEntries);
+  });
+
+  it("reports success when retrying transient read-only snapshot cleanup", async () => {
+    const stateDir = createTempStateDir();
+    const databasePath = createCanonicalAuditStateDatabase(stateDir);
+    const database = await openExistingOpenClawStateDatabaseReadOnly({ path: databasePath });
+    const openedPath = database?.db.prepare("PRAGMA database_list").get() as
+      | { file?: unknown }
+      | undefined;
+    const privateDirectory = path.dirname(String(openedPath?.file));
+    const rmSync = fs.rmSync.bind(fs);
+    let failRemoval = true;
+    vi.spyOn(fs, "rmSync").mockImplementation(((pathname, options) => {
+      if (pathname === privateDirectory && failRemoval) {
+        failRemoval = false;
+        const error = new Error("busy");
+        (error as NodeJS.ErrnoException).code = "EBUSY";
+        throw error;
+      }
+      return rmSync(pathname, options);
+    }) as typeof fs.rmSync);
+
+    expect(database?.walMaintenance.close()).toBe(false);
+    expect(fs.existsSync(privateDirectory)).toBe(true);
+    expect(database?.walMaintenance.close()).toBe(true);
+    expect(fs.existsSync(privateDirectory)).toBe(false);
+    expect(database?.walMaintenance.close()).toBe(false);
+  });
+
+  it("reads committed live WAL rows without changing source database content", async () => {
+    const stateDir = createTempStateDir();
+    const writer = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+    writer.db.exec("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA wal_autocheckpoint = 0;");
+    insertTaskRunProbe(writer.db, "task-live-wal");
+    expect(fs.existsSync(`${writer.path}-wal`)).toBe(true);
+    expect(fs.existsSync(`${writer.path}-shm`)).toBe(true);
+    const beforeMain = fs.readFileSync(writer.path);
+    const beforeWal = fs.readFileSync(`${writer.path}-wal`);
+    const beforeShmSize = fs.statSync(`${writer.path}-shm`).size;
+    const beforeEntries = fs.readdirSync(stateDir).toSorted();
+
+    const database = await openExistingOpenClawStateDatabaseReadOnly({ path: writer.path });
+    expect(
+      database?.db.prepare("SELECT task_id FROM task_runs WHERE task_id = ?").get("task-live-wal"),
+    ).toEqual({ task_id: "task-live-wal" });
+    const openedPath = database?.db.prepare("PRAGMA database_list").get() as
+      | { file?: unknown }
+      | undefined;
+    expect(path.resolve(String(openedPath?.file))).not.toBe(path.resolve(writer.path));
+    const privateDirectory = path.dirname(String(openedPath?.file));
+    expect(database?.walMaintenance.close()).toBe(true);
+
+    expect(fs.existsSync(privateDirectory)).toBe(false);
+    expect(fs.readFileSync(writer.path)).toEqual(beforeMain);
+    expect(fs.readFileSync(`${writer.path}-wal`)).toEqual(beforeWal);
+    expect(fs.statSync(`${writer.path}-shm`).size).toBe(beforeShmSize);
+    expect(fs.readdirSync(stateDir).toSorted()).toEqual(beforeEntries);
+  });
+
+  it("reads committed WAL rows without recreating a missing source SHM", async () => {
+    const { DatabaseSync } = requireNodeSqlite();
+    const sourceDir = createTempStateDir();
+    const writer = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: sourceDir } });
+    writer.db.exec("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA wal_autocheckpoint = 0;");
+    insertTaskRunProbe(writer.db, "task-wal-without-shm");
+    const fixtureDir = createTempStateDir();
+    const fixturePath = path.join(fixtureDir, "wal-without-shm.sqlite");
+    fs.copyFileSync(writer.path, fixturePath);
+    fs.copyFileSync(`${writer.path}-wal`, `${fixturePath}-wal`);
+    const mainOnlyPath = path.join(createTempStateDir(), "main-only.sqlite");
+    fs.copyFileSync(writer.path, mainOnlyPath);
+    closeOpenClawStateDatabaseForTest();
+    expect(fs.existsSync(`${fixturePath}-shm`)).toBe(false);
+    const immutable = new DatabaseSync(`${pathToFileURL(mainOnlyPath).href}?mode=ro&immutable=1`, {
+      readOnly: true,
+    });
+    expect(
+      immutable
+        .prepare("SELECT task_id FROM task_runs WHERE task_id = ?")
+        .get("task-wal-without-shm"),
+    ).toBeUndefined();
+    immutable.close();
+    const beforeMain = fs.readFileSync(fixturePath);
+    const beforeWal = fs.readFileSync(`${fixturePath}-wal`);
+    const beforeEntries = fs.readdirSync(fixtureDir).toSorted();
+
+    const database = await openExistingOpenClawStateDatabaseReadOnly({ path: fixturePath });
+    expect(
+      database?.db
+        .prepare("SELECT task_id FROM task_runs WHERE task_id = ?")
+        .get("task-wal-without-shm"),
+    ).toEqual({ task_id: "task-wal-without-shm" });
+    const openedPath = database?.db.prepare("PRAGMA database_list").get() as
+      | { file?: unknown }
+      | undefined;
+    const privateDirectory = path.dirname(String(openedPath?.file));
+    expect(path.resolve(String(openedPath?.file))).not.toBe(path.resolve(fixturePath));
+    expect(database?.walMaintenance.close()).toBe(true);
+
+    expect(fs.existsSync(privateDirectory)).toBe(false);
+    expect(fs.existsSync(`${fixturePath}-shm`)).toBe(false);
+    expect(fs.readFileSync(fixturePath)).toEqual(beforeMain);
+    expect(fs.readFileSync(`${fixturePath}-wal`)).toEqual(beforeWal);
+    expect(fs.readdirSync(fixtureDir).toSorted()).toEqual(beforeEntries);
+  });
+
+  it("rejects noncanonical indexes from read-only state without rewriting them", async () => {
     const stateDir = createTempStateDir();
     const databasePath = createCanonicalAuditStateDatabase(stateDir);
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
@@ -2307,7 +2463,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       drifted.close();
     }
 
-    expect(() => openExistingOpenClawStateDatabaseReadOnly(options)).toThrow(
+    await expect(openExistingOpenClawStateDatabaseReadOnly(options)).rejects.toThrow(
       /missing or drifted index idx_task_runs_status/iu,
     );
 
@@ -2325,16 +2481,16 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     }
   });
 
-  it("rejects physical canonical-index corruption from read-only state", () => {
+  it("rejects physical canonical-index corruption from read-only state", async () => {
     const stateDir = createTempStateDir();
     const databasePath = createCanonicalAuditStateDatabase(stateDir);
     createTaskRunStatusIndexPhysicalDrift(databasePath);
 
-    expect(() =>
+    await expect(
       openExistingOpenClawStateDatabaseReadOnly({
         env: { OPENCLAW_STATE_DIR: stateDir },
       }),
-    ).toThrow(/integrity_check failed.*idx_task_runs_status/iu);
+    ).rejects.toThrow(/integrity_check failed.*idx_task_runs_status/iu);
   });
 
   it("rejects unrelated current-schema index corruption before exposure", () => {
@@ -2453,10 +2609,13 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         committedRowsAfterRecovery: 256,
         immutableDirtyRowsBeforeKill: expect.any(Number),
         integrity: "ok",
+        journalBytesBeforeReadOnly: expect.any(Number),
         journalExistsAfterReadOnly: true,
         journalExistsAfterRecovery: false,
       });
       expect(result.immutableDirtyRowsBeforeKill).toBeGreaterThan(0);
+      expect(result.journalBytesBeforeReadOnly).toBeGreaterThan(0);
+      expect(result.journalShaAfterReadOnly).toBe(result.journalShaBeforeReadOnly);
     },
   );
 

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -25,6 +25,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   detectOpenClawStateDatabaseSchemaMigrations,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+  openExistingOpenClawStateDatabaseReadOnly,
   openOpenClawStateDatabase,
   OPENCLAW_STATE_SCHEMA_VERSION,
   repairOpenClawStateDatabaseSchema,
@@ -536,21 +537,31 @@ function createUnsafeSchemaMetaIndexDrift(databasePath: string): void {
 }
 
 function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir: string }): {
+  committedRowsAfterRecovery: number;
+  immutableDirtyRowsBeforeKill: number;
   integrity: string;
+  journalExistsAfterReadOnly: boolean;
   journalExistsAfterRecovery: boolean;
-  value: string;
+  readOnly: {
+    error: string | null;
+    opened: boolean;
+    uncommittedRows: number | null;
+  };
 } {
   const probeSource = `
     import { spawn } from "node:child_process";
     import fs from "node:fs";
     import path from "node:path";
     import { DatabaseSync } from "node:sqlite";
+    import { pathToFileURL } from "node:url";
 
     const moduleUrl = ${JSON.stringify(params.moduleUrl)};
     const databasePath = path.join(${JSON.stringify(params.rootDir)}, "hot-journal.sqlite");
     const readyPath = path.join(${JSON.stringify(params.rootDir)}, "writer-ready");
+    const rowCount = 256;
     const {
       closeOpenClawStateDatabaseForTest,
+      openExistingOpenClawStateDatabaseReadOnly,
       openOpenClawStateDatabase,
     } = await import(moduleUrl);
 
@@ -558,9 +569,16 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
     initial.db.exec(\`
       CREATE TABLE hot_journal_probe (
         id INTEGER PRIMARY KEY,
-        value TEXT NOT NULL
+        value TEXT NOT NULL,
+        payload BLOB NOT NULL
       );
-      INSERT INTO hot_journal_probe (id, value) VALUES (1, 'committed');
+      WITH RECURSIVE rows(id) AS (
+        SELECT 1
+        UNION ALL
+        SELECT id + 1 FROM rows WHERE id < \${rowCount}
+      )
+      INSERT INTO hot_journal_probe (id, value, payload)
+      SELECT id, 'committed', zeroblob(8192) FROM rows;
     \`);
     closeOpenClawStateDatabaseForTest();
 
@@ -573,10 +591,14 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
       import { DatabaseSync } from "node:sqlite";
 
       const database = new DatabaseSync(process.env.OPENCLAW_HOT_JOURNAL_DATABASE_PATH);
-      database.exec("PRAGMA journal_mode = DELETE; PRAGMA synchronous = FULL; BEGIN IMMEDIATE;");
-      database
-        .prepare("UPDATE hot_journal_probe SET value = ? WHERE id = 1")
-        .run("uncommitted");
+      database.exec(
+        "PRAGMA journal_mode = DELETE; " +
+        "PRAGMA synchronous = FULL; " +
+        "PRAGMA cache_size = 2; " +
+        "PRAGMA cache_spill = ON; " +
+        "BEGIN IMMEDIATE; " +
+        "UPDATE hot_journal_probe SET value = 'uncommitted';",
+      );
       fs.writeFileSync(process.env.OPENCLAW_HOT_JOURNAL_READY_PATH, "ready");
       setInterval(() => {}, 1_000);
     \`;
@@ -616,22 +638,57 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
       if (!fs.existsSync(journalPath) || fs.statSync(journalPath).size === 0) {
         throw new Error("writer did not leave a rollback journal");
       }
+      const immutable = new DatabaseSync(
+        \`\${pathToFileURL(databasePath).href}?mode=ro&immutable=1\`,
+        { readOnly: true },
+      );
+      const immutableDirty = immutable
+        .prepare("SELECT COUNT(*) AS count FROM hot_journal_probe WHERE value = 'uncommitted'")
+        .get();
+      immutable.close();
+      const immutableDirtyRowsBeforeKill = Number(immutableDirty?.count ?? 0);
+      if (immutableDirtyRowsBeforeKill === 0) {
+        throw new Error("writer did not spill uncommitted pages into the main database");
+      }
       writer.kill("SIGKILL");
       const outcome = await writerClosed;
       if (outcome.signal !== "SIGKILL") {
         throw new Error(\`writer was not killed: \${JSON.stringify(outcome)} \${writerStderr}\`);
       }
 
+      let readOnly;
+      try {
+        const database = openExistingOpenClawStateDatabaseReadOnly({ path: databasePath });
+        const readOnlyRow = database?.db
+          .prepare("SELECT COUNT(*) AS count FROM hot_journal_probe WHERE value = 'uncommitted'")
+          .get();
+        database?.walMaintenance.close();
+        readOnly = {
+          error: null,
+          opened: true,
+          uncommittedRows: Number(readOnlyRow?.count ?? 0),
+        };
+      } catch (error) {
+        readOnly = {
+          error: error instanceof Error ? error.message : String(error),
+          opened: false,
+          uncommittedRows: null,
+        };
+      }
+      const journalExistsAfterReadOnly = fs.existsSync(journalPath);
       const reopened = openOpenClawStateDatabase({ path: databasePath });
       const row = reopened.db
-        .prepare("SELECT value FROM hot_journal_probe WHERE id = 1")
+        .prepare("SELECT COUNT(*) AS count FROM hot_journal_probe WHERE value = 'committed'")
         .get();
       const integrity = reopened.db.prepare("PRAGMA integrity_check").get();
       closeOpenClawStateDatabaseForTest();
       console.log(JSON.stringify({
+        committedRowsAfterRecovery: Number(row?.count ?? 0),
+        immutableDirtyRowsBeforeKill,
         integrity: integrity?.integrity_check,
+        journalExistsAfterReadOnly,
         journalExistsAfterRecovery: fs.existsSync(journalPath),
-        value: row?.value,
+        readOnly,
       }));
     } finally {
       if (writer.exitCode === null && writer.signalCode === null) {
@@ -651,9 +708,16 @@ function runHotRollbackJournalRecoveryProbe(params: { moduleUrl: string; rootDir
     throw new Error("hot rollback journal recovery probe produced no result");
   }
   return JSON.parse(resultLine) as {
+    committedRowsAfterRecovery: number;
+    immutableDirtyRowsBeforeKill: number;
     integrity: string;
+    journalExistsAfterReadOnly: boolean;
     journalExistsAfterRecovery: boolean;
-    value: string;
+    readOnly: {
+      error: string | null;
+      opened: boolean;
+      uncommittedRows: number | null;
+    };
   };
 }
 
@@ -2228,6 +2292,51 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     );
   });
 
+  it("rejects noncanonical indexes from read-only state without rewriting them", () => {
+    const stateDir = createTempStateDir();
+    const databasePath = createCanonicalAuditStateDatabase(stateDir);
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const { DatabaseSync } = requireNodeSqlite();
+    const drifted = new DatabaseSync(databasePath);
+    try {
+      drifted.exec(`
+        DROP INDEX idx_task_runs_status;
+        CREATE INDEX idx_task_runs_status ON task_runs(task_id);
+      `);
+    } finally {
+      drifted.close();
+    }
+
+    expect(() => openExistingOpenClawStateDatabaseReadOnly(options)).toThrow(
+      /missing or drifted index idx_task_runs_status/iu,
+    );
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        preserved
+          .prepare("SELECT sql FROM sqlite_schema WHERE name = 'idx_task_runs_status'")
+          .get(),
+      ).toEqual({
+        sql: "CREATE INDEX idx_task_runs_status ON task_runs(task_id)",
+      });
+    } finally {
+      preserved.close();
+    }
+  });
+
+  it("rejects physical canonical-index corruption from read-only state", () => {
+    const stateDir = createTempStateDir();
+    const databasePath = createCanonicalAuditStateDatabase(stateDir);
+    createTaskRunStatusIndexPhysicalDrift(databasePath);
+
+    expect(() =>
+      openExistingOpenClawStateDatabaseReadOnly({
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      }),
+    ).toThrow(/integrity_check failed.*idx_task_runs_status/iu);
+  });
+
   it("rejects unrelated current-schema index corruption before exposure", () => {
     const stateDir = createTempStateDir();
     const databasePath = createCanonicalAuditStateDatabase(stateDir);
@@ -2328,18 +2437,26 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   });
 
   it.skipIf(process.platform === "win32")(
-    "recovers a hot rollback journal before checking integrity",
+    "refuses a hot rollback journal read-only before writable recovery",
     () => {
-      expect(
-        runHotRollbackJournalRecoveryProbe({
-          moduleUrl: new URL("./openclaw-state-db.ts", import.meta.url).href,
-          rootDir: createTempStateDir(),
-        }),
-      ).toEqual({
-        integrity: "ok",
-        journalExistsAfterRecovery: false,
-        value: "committed",
+      const result = runHotRollbackJournalRecoveryProbe({
+        moduleUrl: new URL("./openclaw-state-db.ts", import.meta.url).href,
+        rootDir: createTempStateDir(),
       });
+
+      expect(result.readOnly).toEqual({
+        error: expect.stringMatching(/readonly|read-only|rollback/iu),
+        opened: false,
+        uncommittedRows: null,
+      });
+      expect(result).toMatchObject({
+        committedRowsAfterRecovery: 256,
+        immutableDirtyRowsBeforeKill: expect.any(Number),
+        integrity: "ok",
+        journalExistsAfterReadOnly: true,
+        journalExistsAfterRecovery: false,
+      });
+      expect(result.immutableDirtyRowsBeforeKill).toBeGreaterThan(0);
     },
   );
 

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -7,7 +7,7 @@ import {
   executeSqliteQuerySync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { openNodeSqliteDatabase, resolveNodeSqliteReadOnlyLocation } from "../infra/node-sqlite.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { repairCanonicalSqliteIndexes } from "../infra/sqlite-index-schema.js";
 import {
   assertSqliteIntegrity,
@@ -42,6 +42,7 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db-contract.js";
 import {
+  assertOpenClawStateDatabaseForMaintenance,
   assertSupportedSchemaVersion,
   createOpenClawDatabaseVerificationError,
   resolveDatabasePath,
@@ -294,16 +295,38 @@ function ensureSchema(db: DatabaseSync, pathname: string): void {
 export function openExistingOpenClawStateDatabaseReadOnly(
   options: OpenClawStateDatabaseOptions = {},
 ): OpenClawStateDatabase | undefined {
+  const env = options.env ?? process.env;
   const pathname = resolveDatabasePath(options);
   if (!existsSync(pathname)) {
     return undefined;
   }
-  const hasWalSidecars = existsSync(`${pathname}-wal`) || existsSync(`${pathname}-shm`);
-  const db = openNodeSqliteDatabase(resolveNodeSqliteReadOnlyLocation(pathname, hasWalSidecars), {
+  const terminalFailure = terminalOpenLatch.get(pathname);
+  if (terminalFailure) {
+    throw terminalFailure;
+  }
+  try {
+    const quarantine = readOpenClawDatabaseQuarantine(pathname, { env });
+    if (quarantine) {
+      throw createOpenClawDatabaseVerificationError("state", pathname, quarantine.reason);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === "SqliteIntegrityError") {
+      throw error;
+    }
+    // A broken quarantine store must not brick read-only diagnostics.
+  }
+  // This is live shared state, so immutable=1 would disable the locking and
+  // journal detection required to avoid exposing uncommitted crash residue.
+  const db = openNodeSqliteDatabase(pathname, {
     readOnly: true,
   });
   try {
+    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     assertSupportedSchemaVersion(db, pathname);
+    assertSqliteIntegrity(db, pathname);
+    if (readSqliteUserVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
+      assertOpenClawStateDatabaseForMaintenance(db, { pathname });
+    }
   } catch (error) {
     db.close();
     throw error;

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -13,6 +13,7 @@ import {
   assertSqliteIntegrity,
   isTerminalSqliteIntegrityError,
 } from "../infra/sqlite-integrity.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
 import { migrateSqliteSchemaToStrictInTransaction } from "../infra/sqlite-strict.js";
 import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
 import {
@@ -292,9 +293,9 @@ function ensureSchema(db: DatabaseSync, pathname: string): void {
 }
 
 /** Open existing shared state without creating, migrating, chmodding, or configuring it. */
-export function openExistingOpenClawStateDatabaseReadOnly(
+export async function openExistingOpenClawStateDatabaseReadOnly(
   options: OpenClawStateDatabaseOptions = {},
-): OpenClawStateDatabase | undefined {
+): Promise<OpenClawStateDatabase | undefined> {
   const env = options.env ?? process.env;
   const pathname = resolveDatabasePath(options);
   if (!existsSync(pathname)) {
@@ -315,11 +316,16 @@ export function openExistingOpenClawStateDatabaseReadOnly(
     }
     // A broken quarantine store must not brick read-only diagnostics.
   }
-  // This is live shared state, so immutable=1 would disable the locking and
-  // journal detection required to avoid exposing uncommitted crash residue.
-  const db = openNodeSqliteDatabase(pathname, {
-    readOnly: true,
-  });
+  const prepared = await prepareSqliteReadOnlyLocation(pathname);
+  let db: DatabaseSync;
+  try {
+    db = openNodeSqliteDatabase(prepared.location, {
+      readOnly: true,
+    });
+  } catch (error) {
+    prepared.cleanup();
+    throw error;
+  }
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     assertSupportedSchemaVersion(db, pathname);
@@ -328,20 +334,35 @@ export function openExistingOpenClawStateDatabaseReadOnly(
       assertOpenClawStateDatabaseForMaintenance(db, { pathname });
     }
   } catch (error) {
-    db.close();
+    try {
+      db.close();
+    } catch {
+      // Preserve the verification failure that explains why the database was refused.
+    }
+    prepared.cleanup();
     throw error;
   }
+  let cleanupComplete = false;
   return {
     db,
     path: pathname,
     walMaintenance: {
       checkpoint: () => false,
+      // Cleanup can fail transiently after the database closes. Keep the
+      // close contract retryable until one call finishes both responsibilities.
       close: () => {
-        if (!db.isOpen) {
+        const wasOpen = db.isOpen;
+        if (!wasOpen && cleanupComplete) {
           return false;
         }
-        db.close();
-        return true;
+        try {
+          if (wasOpen) {
+            db.close();
+          }
+        } finally {
+          cleanupComplete = prepared.cleanup();
+        }
+        return cleanupComplete;
       },
     },
   };


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Fixes read-only state diagnostics that could bypass SQLite journal handling with `immutable=1`, require writes beside a sidecar-free WAL database, or inspect a mixed database/sidecar generation while a writer reset WAL or replaced the source file.

## Why This Change Was Made

Read-only state access now resolves SQLite's canonical filename and prepares a private, single-file snapshot before validation. Rollback journals and complete active WAL families use SQLite locking plus online backup under a pinned read transaction. Incomplete WAL families are copied with stable source and sidecar fingerprints so crash residue can be inspected without creating source coordination files.

The private snapshot is normalized to rollback journaling, checked for integrity and canonical current-schema indexes, and cleaned on close with retry support for transient cleanup failures.

Private staging-directory setup is isolated in a dependency-light module so state diagnostics do not pull snapshot transforms, process logging, or plugin/runtime initialization into their import graph.

## User Impact

Doctor and update-planning diagnostics get a consistent point-in-time view that includes committed WAL state, preserves source bytes and directory entries, rejects unsafe indexes, and does not race source replacement or journal-mode transitions. Writable startup remains the sole owner of recovery and maintenance.

## Evidence

- Exact head: `7d82a818d12d271d2469172ae178f507cb360fbe`.
- Focused Blacksmith Testbox proof: 229 passed; 6 expected platform-specific skips on Linux (`tbx_01kyb9q5fe6kaswcmwc56masd7`).
- Exact-head `pnpm deadcode:exports`: production, full-tree, and script scans passed with zero findings.
- Exact-head `pnpm check:changed`: formatting, API/schema/database guards, core/core-test typecheck, import cycles, database-first guards, and the full core lint sweep passed in 17m08s.
- Exact-head GitHub CI passed 58 jobs, including build artifacts, bundled metadata, SQLite flip proof, QA profiles, and native Windows `checks-windows-node-test`.
- Fresh structured autoreview on the complete patch and final lint-only delta reported no accepted or actionable findings.
- Behavioral coverage includes hot rollback recovery, 16 MiB active-WAL I/O, atomic MEMORY-journal pairs, rollback-to-WAL transitions, same-size WAL reset, canonical symlink lookup, missing WAL/SHM pairs, source replacement, cleanup retry, unsafe indexes, and source-byte/directory-entry preservation.
- Exact-head CI run: https://github.com/openclaw/openclaw/actions/runs/30135620488
