### PR TITLE
docs(anthropic): document the rolling opus alias and pin alias-split coverage

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -283,6 +283,13 @@ for the node command and security boundary.
 
 ## Thinking defaults (Claude Opus 5, Sonnet 5, Mythos 5, Fable 5, 4.8, and 4.6)
 
+Bare family aliases are rolling: `opus` tracks the current supported Claude
+Opus generation and today resolves to `anthropic/claude-opus-5`, the same way
+`sonnet` tracks the current Sonnet. Upgrading OpenClaw can therefore move a
+config that says `opus` onto a newer model generation. Pin a version to opt
+out — versioned aliases such as `opus-4.8` keep resolving to their own model,
+and configs that already name `claude-opus-4-8` are never rewritten.
+
 `anthropic/claude-opus-5` uses adaptive thinking at `high` effort by default.
 Use `/think off` to disable thinking, or `/think xhigh|max` for the model's
 higher native effort levels. OpenClaw omits manual thinking budgets, custom

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -61,6 +61,19 @@ describe("anthropic Claude model refs", () => {
     );
   });
 
+  it("resolves the bare opus family alias to the current default Opus", () => {
+    // Bare family aliases and retired-ref upgrades both land on the current
+    // default Opus; only an explicitly pinned ref keeps its own target.
+    expect(resolveKnownAnthropicModelRef("opus")).toBe("anthropic/claude-opus-5");
+    expect(resolveKnownAnthropicModelRef("claude-cli/opus")).toBe("anthropic/claude-opus-5");
+    expect(resolveKnownAnthropicModelRef("anthropic/claude-opus-4-5")).toBe(
+      "anthropic/claude-opus-5",
+    );
+    expect(resolveKnownAnthropicModelRef("anthropic/claude-opus-4-8")).toBe(
+      "anthropic/claude-opus-4-8",
+    );
+  });
+
   it("canonicalizes fable family aliases in bare and provider-qualified forms", () => {
     // "fable-5" must map to the full model id, not the family name: the
     // canonicalizer only accepts alias values that already start with

--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -49,6 +49,13 @@ describe("provider model id policy normalization", () => {
     ).toBe("claude-haiku-4-5");
     expect(normalizeStaticProviderModelIdWithPolicies("anthropic", "opus")).toBe("claude-opus-5");
     expect(normalizeStaticProviderModelIdWithPolicies("anthropic", "opus-5")).toBe("claude-opus-5");
+    // Bare family aliases track the current default for that family; pinned
+    // version aliases keep resolving to their own model.
+    expect(normalizeStaticProviderModelIdWithPolicies("anthropic", "opus")).toBe("claude-opus-5");
+    expect(normalizeStaticProviderModelIdWithPolicies("anthropic", "opus-5")).toBe("claude-opus-5");
+    expect(normalizeStaticProviderModelIdWithPolicies("anthropic", "opus-4.8")).toBe(
+      "claude-opus-4-8",
+    );
     expect(normalizeStaticProviderModelIdWithPolicies("anthropic", "sonnet")).toBe(
       "claude-sonnet-5",
     );


### PR DESCRIPTION
## What Problem This Solves

`main` already resolves the bare `opus` alias to Claude Opus 5 (#113392), but it documents nothing about that behavior and has no coverage separating the three ways an Opus ref can resolve. Two gaps follow:

- **Undocumented rolling behavior.** Upgrading OpenClaw silently moves a config that says `opus` onto a newer model generation. Nothing in `docs/providers/anthropic.md` tells an operator that this happens, or that pinning is the way to opt out. ClawSweeper flagged exactly this on the original version of this PR and recommended documenting it.
- **No regression coverage for the alias split.** Bare aliases, pinned aliases, and retired-ref upgrades have three different intended behaviors, and nothing pins them apart. A future change could collapse them without a test noticing.

## Why This Change Was Made

This PR originally also carried the alias code change, but #113392 landed the same thing first, so the code is dropped and only the genuinely missing parts remain — docs and tests, no production code.

- `docs/providers/anthropic.md` states that bare family aliases are rolling, that upgrading can move an `opus` config to a newer generation, and that pinning a versioned alias is the opt-out.
- `packages/model-catalog-core/src/provider-model-id-normalization.test.ts` pins bare `opus` → `claude-opus-5`, `opus-5` → `claude-opus-5`, and pinned `opus-4.8` → `claude-opus-4-8`, alongside the existing Sonnet assertions.
- `extensions/anthropic/cli-migration.test.ts` pins `opus` and `claude-cli/opus` → `anthropic/claude-opus-5`, a retired `claude-opus-4-5` ref → `anthropic/claude-opus-5`, and an explicitly pinned `claude-opus-4-8` ref left untouched.

The retired-ref assertion documents current behavior rather than my initial assumption: I expected retired Opus refs to upgrade to `claude-opus-4-8` (mirroring retired Sonnet refs, which upgrade to `claude-sonnet-4-6` rather than Sonnet 5), but `main` upgrades them to `claude-opus-5`. The test asserts what the code actually does. Whether that asymmetry with the Sonnet family is intended is worth a maintainer's eye, but it is not changed here.

## User Impact

Documentation only — operators learn that `opus` follows the current Opus generation and that pinning a version opts out. No runtime behavior changes; the tests lock in behavior `main` already has.

## Evidence

- `node scripts/run-vitest.mjs packages/model-catalog-core extensions/anthropic/cli-migration.test.ts` — green.
- The retired-ref assertion was corrected after a failing run proved `main` resolves `claude-opus-4-5` to `claude-opus-5`, not `claude-opus-4-8`; verified in source at `extensions/anthropic/claude-model-refs.ts:145`.
- `git diff --stat`: docs and tests only, +27 lines, no production code.
- `docs/docs_map.md` regenerated via `pnpm docs:map:gen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
