### PR TITLE
fix(codex): validate canonical steering abort outcome

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT } from "openclaw/plugin-sdk/provider-model-shared";
 import { describe, expect, it, vi } from "vitest";
+import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
 import type { CodexServerNotification } from "./protocol.js";
 import {
   createParams,
@@ -128,7 +129,7 @@ describe("runCodexAppServerAttempt steering", () => {
     handle?.abort();
     expect(handle?.isAborted?.()).toBe(true);
     expect(activeRunRegistrationMocks.clearActiveEmbeddedRun).not.toHaveBeenCalled();
-    await expect(run).resolves.toMatchObject({ aborted: true });
+    expect(readAttemptTerminal(await run).aborted).toBe(true);
     expect(activeRunRegistrationMocks.clearActiveEmbeddedRun).toHaveBeenCalledWith(
       params.sessionId,
       handle,


### PR DESCRIPTION
Related: #113408

## What Problem This Solves

Fixes a Plugin Prerelease failure where the Codex steering test still expected the retired top-level `aborted` projection after attempt results moved to the canonical terminal outcome.

## Why This Change Was Made

The test now reads the existing canonical terminal projection through `readAttemptTerminal`, matching every adjacent Codex attempt test. Runtime behavior is unchanged: the active handle becomes aborted immediately, cleanup remains asynchronous, and `turn/interrupt` is still emitted.

## User Impact

No production behavior changes. Release validation now checks Codex abort ordering through the current result contract instead of a removed compatibility field.

## Evidence

- Reproduced in Plugin Prerelease run 30126600843, shard 1, where the result contained `terminal.kind = "aborted"` but no top-level `aborted` field.
- Focused Codex steering suite: 10 passed.
- Direct Codex source check: app-server `turn/interrupt` queues its response until `TurnAborted`, and the abort event resolves pending interrupts before emitting the interrupted lifecycle.
- oxfmt and `git diff --check`: clean.
- Autoreview: clean, no accepted/actionable findings; patch correct at 0.93 confidence.
