### PR TITLE
fix(anthropic): detect Claude CLI routes pinned to non-default models

### DIFF
--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -27,6 +27,16 @@ export const CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS = [
   `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-6`,
 ] as const;
 
+/**
+ * Claude CLI model ids probed when detecting an existing CLI route, canonical
+ * default first. Route detection must not depend on which model is currently
+ * the default: existing configs route older Claude models, so probing only the
+ * default would stop advertising session creation after a default bump.
+ */
+export const CLAUDE_CLI_ROUTE_PROBE_MODEL_IDS = CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.map((ref) =>
+  ref.slice(CLAUDE_CLI_BACKEND_ID.length + 1),
+);
+
 /** User-facing Claude CLI model aliases normalized before execution. */
 export const CLAUDE_CLI_MODEL_ALIASES: Record<string, string> = {
   opus: "opus",

--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -11,7 +11,7 @@ export const CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER = ["openclaw", "claude-cli-ap
 /** Default Claude CLI model ref for agent defaults and live tests. */
 export const CLAUDE_CLI_DEFAULT_MODEL_REF = `${CLAUDE_CLI_BACKEND_ID}/claude-opus-5`;
 /** Provider-relative model id for Anthropic runtime-policy resolution. */
-export const CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_ID = CLAUDE_CLI_DEFAULT_MODEL_REF.slice(
+const CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_ID = CLAUDE_CLI_DEFAULT_MODEL_REF.slice(
   CLAUDE_CLI_BACKEND_ID.length + 1,
 );
 /** Canonical model ref routed to the Claude CLI backend by Anthropic setup. */

--- a/extensions/anthropic/session-catalog-runtime.ts
+++ b/extensions/anthropic/session-catalog-runtime.ts
@@ -8,11 +8,7 @@ import { resolveEffectiveAgentRuntime } from "openclaw/plugin-sdk/command-auth-n
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  CLAUDE_CLI_BACKEND_ID,
-  CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_ID,
-  CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_REF,
-} from "./cli-constants.js";
+import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_ROUTE_PROBE_MODEL_IDS } from "./cli-constants.js";
 import { adoptedSourceKey, CLAUDE_LOCAL_SESSION_HOST_ID } from "./session-catalog-adoption.js";
 
 export function currentClaudeSessionCatalogConfig(api: OpenClawPluginApi): OpenClawConfig {
@@ -70,26 +66,43 @@ export function listBoundClaudeSessions(api: OpenClawPluginApi): Map<string, str
   return bound;
 }
 
+/**
+ * Resolve the Claude model an agent actually routes to the Claude CLI backend.
+ * Callers must not assume the current default is routed: existing configs pin
+ * older Claude models, and stamping the default onto their sessions would
+ * select a model the operator never routed or allowed.
+ */
+export function resolveClaudeCliRoutedModelId(
+  config: OpenClawConfig,
+  agentId: string,
+): string | undefined {
+  return CLAUDE_CLI_ROUTE_PROBE_MODEL_IDS.find(
+    (modelId) =>
+      resolveEffectiveAgentRuntime({
+        cfg: config,
+        provider: "anthropic",
+        modelId,
+        agentId,
+      }) === CLAUDE_CLI_BACKEND_ID,
+  );
+}
+
 export function resolveClaudeCatalogCreateSession(
   api: OpenClawPluginApi,
   requestedAgentId?: string,
 ): { model: string; agentRuntime: string } | undefined {
   const config = currentClaudeSessionCatalogConfig(api);
   const agentId = requestedAgentId ?? resolveDefaultAgentId(config);
-  const agentRuntime = resolveEffectiveAgentRuntime({
-    cfg: config,
-    provider: "anthropic",
-    modelId: CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_ID,
-    agentId,
-  });
-  if (agentRuntime !== CLAUDE_CLI_BACKEND_ID) {
+  const routedModelId = resolveClaudeCliRoutedModelId(config, agentId);
+  if (!routedModelId) {
     return undefined;
   }
+  const routedModelRef = `anthropic/${routedModelId}`;
   const defaultModel = resolveDefaultModelForAgent({ cfg: config, agentId });
   const allowed = resolveAllowedModelRef({
     cfg: config,
     catalog: [],
-    raw: CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_REF,
+    raw: routedModelRef,
     defaultProvider: defaultModel.provider,
     defaultModel: defaultModel.model,
     agentId,
@@ -97,7 +110,7 @@ export function resolveClaudeCatalogCreateSession(
   return "error" in allowed
     ? undefined
     : {
-        model: CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_REF,
+        model: routedModelRef,
         agentRuntime: CLAUDE_CLI_BACKEND_ID,
       };
 }

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -611,6 +611,33 @@ describe("Claude session catalog", () => {
     expect(provider?.resolveCreateSession?.({})).toBeUndefined();
   });
 
+  it("detects a Claude CLI route pinned to a non-default Claude model", () => {
+    // Regression: route detection previously probed only the packaged default
+    // model id, so bumping that default silently stopped advertising session
+    // creation for configs routing an older Claude model.
+    for (const routedModel of ["anthropic/claude-opus-4-8", "anthropic/claude-sonnet-4-6"]) {
+      const config = {
+        agents: { defaults: { models: { [routedModel]: { agentRuntime: { id: "claude-cli" } } } } },
+      } as unknown as OpenClawConfig;
+      let provider: SessionCatalogProvider | undefined;
+      const api = {
+        id: "anthropic",
+        config,
+        runtime: { config: { current: () => config } },
+        registerSessionCatalog: (candidate: SessionCatalogProvider) => {
+          provider = candidate;
+        },
+      } as unknown as OpenClawPluginApi;
+
+      registerClaudeSessionCatalog(api);
+
+      expect(provider?.resolveCreateSession?.({})).toEqual({
+        model: routedModel,
+        agentRuntime: "claude-cli",
+      });
+    }
+  });
+
   it("resolves creation against the requested agent's runtime policy", () => {
     const config = {
       agents: {

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -26,6 +26,7 @@ import {
   currentClaudeSessionCatalogConfig,
   listBoundClaudeSessions,
   resolveClaudeCatalogCreateSession,
+  resolveClaudeCliRoutedModelId,
 } from "./session-catalog-runtime.js";
 import {
   CLAUDE_CLI_NODE_RUN_COMMAND,
@@ -1455,7 +1456,12 @@ async function continueClaudeSession(
     }
     const history = await readBoundedClaudeHistory({ runtime: api.runtime, hostId, threadId });
     const config = currentClaudeSessionCatalogConfig(api);
-    const model = CLAUDE_CLI_DEFAULT_MODEL_REF.slice(`${CLAUDE_CLI_BACKEND_ID}/`.length);
+    const adoptingAgentId = resolveDefaultAgentId(config);
+    // Adopt onto the model this agent actually routes to the CLI backend; the
+    // packaged default may not be routed or allowed in an existing config.
+    const model =
+      resolveClaudeCliRoutedModelId(config, adoptingAgentId) ??
+      CLAUDE_CLI_DEFAULT_MODEL_REF.slice(`${CLAUDE_CLI_BACKEND_ID}/`.length);
     const marker = {
       sourceThreadId: threadId,
       ...(hostId !== CLAUDE_LOCAL_SESSION_HOST_ID ? { sourceHostId: hostId } : {}),


### PR DESCRIPTION
## What Problem This Solves

`main` carries a user-facing regression for existing Claude CLI users that CI did not catch.

#113392 moved `CLAUDE_CLI_DEFAULT_MODEL_REF` to `claude-opus-5`, but Claude CLI route detection probes **one hardcoded model id**. `resolveClaudeCatalogCreateSession` asked "is `CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_ID` routed to `claude-cli` for this agent?", so once that constant moved, every config whose model-scoped route names an older Claude model stopped matching:

```json5
models: { "anthropic/claude-opus-4-8": { agentRuntime: { id: "claude-cli" } } }
```

That is exactly the shape setup seeds and `docs/providers/anthropic.md` prescribes, so on upgrade those users silently stop being offered Claude session creation — no error, the capability just disappears.

Four `extensions/anthropic/session-catalog.test.ts` cases fail on a clean checkout of current `main` (`5bea2681286`), even though the post-merge checks for that commit report success — so this is a live regression plus a test-selection gap, not a red build:

```
adopts a local CLI row with a locked one-shot fork binding
does not advertise creation without a configured Claude CLI route
resolves creation against the requested agent's runtime policy
uses the requested agent's model allowlist for creation
```

The adoption path had the same bug independently: it stamped `initialEntry.model` from the packaged default rather than the routed model, so adopting an existing Claude session would pin it to a model the operator never routed or allowed.

## Why This Change Was Made

Replaces the single hardcoded probe with an ordered probe over the Claude CLI model ids OpenClaw already seeds (`CLAUDE_CLI_ROUTE_PROBE_MODEL_IDS`, derived from `CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS`, canonical default first), and returns the model that is actually routed:

- `resolveClaudeCliRoutedModelId(config, agentId)` is the single owner of "which Claude model does this agent route to the CLI backend", used by both creation advertisement and session adoption.
- Creation keeps its existing allowlist semantics unchanged: the routed model is still checked with `resolveAllowedModelRef`, and a routed-but-disallowed model still yields `undefined` (pinned by the existing allowlist test).
- Adoption falls back to the packaged default only when nothing is routed, preserving prior behavior for configs with no CLI route.

Because the canonical default is probed first, configs that already route the current default keep the exact previous fast path; only configs that would previously have gone dark now resolve.

This is the fix proposed in #113410, brought forward because the regression is now live on `main` rather than hypothetical. The alternative — updating the four tests to expect `claude-opus-5` — was rejected: it turns a user-facing regression into green CI while leaving upgraded users without session creation.

## User Impact

Restores Claude session creation for existing Claude CLI users whose config routes any seeded Claude model (Opus 4.8/4.7/4.6, Sonnet 5/4.6, Fable 5), not just whichever model is currently the packaged default. Adopted sessions are stamped with the routed model instead of the packaged default. New installs routing the current default are unaffected. Unblocks `main`.

## Evidence

- **Reproduction on a clean checkout of `5bea2681286`** (run twice, deterministic): `node scripts/run-vitest.mjs extensions/anthropic/session-catalog.test.ts` → 4 failed / 36 passed, each `expected undefined to deeply equal { agentRuntime: "claude-cli", model: "anthropic/claude-opus-4-8" }`.
- **The failure is structural, not environmental:** on `main`, `CLAUDE_CLI_DEFAULT_MODEL_REF` is `claude-cli/claude-opus-5` (`cli-constants.ts:12`), the probe reads `CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_ID` (`session-catalog-runtime.ts:82`), and the test configs route `anthropic/claude-opus-4-8` — so the lookup cannot match.
- **CI gap worth a maintainer look:** the post-merge checks on `5bea2681286` report 24/24 test shards successful with zero failures, so this file evidently was not exercised for that commit. I could not determine why from the check metadata; flagging it rather than guessing, since a selection gap that hides a provider regression is worth more than this one fix.
- **After the fix:** `node scripts/run-vitest.mjs extensions/anthropic/session-catalog.test.ts` → 40 passed; full `node scripts/run-vitest.mjs extensions/anthropic` → 228 passed.
- **New regression coverage** (`detects a Claude CLI route pinned to a non-default Claude model`) asserts detection for a route pinned to `claude-opus-4-8` and to `claude-sonnet-4-6`, so a future default bump cannot silently reintroduce this.
- Precedence and allowlist behavior are pinned by the existing tests this change had to keep green: per-agent runtime overrides still yield `undefined`, and a routed-but-disallowed model still yields `undefined`.
- `$autoreview` (Codex `gpt-5.6-sol`, high): clean — no accepted/actionable findings; "patch is correct (0.99)".

Closes #113410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
