### PR TITLE
fix(release): backport sessions_spawn QA coverage tracking

### DIFF
--- a/extensions/qa-lab/src/tool-coverage-report.test.ts
+++ b/extensions/qa-lab/src/tool-coverage-report.test.ts
@@ -645,6 +645,13 @@ describe("qa tool coverage report", () => {
           "#80320 Codex app-server intentionally owns apply_patch natively; this fixture still needs valid patch-shaped fault injection before it can prove product behavior.",
       }),
     );
+    expect(report.rows.find((row) => row.tool === "sessions_spawn")).toEqual(
+      expect.objectContaining({
+        required: true,
+        tracking: expect.stringContaining("#80319"),
+        action: expect.stringContaining("report-only"),
+      }),
+    );
     expect(report.rows.find((row) => row.tool === "message-tool")).toEqual(
       expect.objectContaining({
         bucket: "optional-profile-or-plugin",

--- a/qa/scenarios/runtime/tools/sessions-spawn.yaml
+++ b/qa/scenarios/runtime/tools/sessions-spawn.yaml
@@ -7,12 +7,12 @@ scenario:
   coverage:
     primary:
       - agent-runtime.subagent-turns-sessions-spawn
-  objective: Verify sessions_spawn preserves arguments and result shape across OpenClaw and Codex.
+  objective: Verify sessions_spawn exposure and provider planning across OpenClaw and Codex.
   successCriteria:
     - Effective tools expose sessions_spawn.
     - The mock provider plans exactly one happy-path sessions_spawn call.
     - The mock provider plans one denied-input failure-path sessions_spawn call.
-    - Runtime parity coverage hard-fails call/result drift in the core runtime-pair lane.
+    - Runtime parity reports provider-plan evidence separately while transcript execution coverage remains tracked.
   docsRefs:
     - qa/scenarios/index.yaml
   codeRefs:
@@ -30,12 +30,14 @@ scenario:
         expectedLayer: openclaw-dynamic
         capabilityLayer: openclaw-dynamic-direct
         required: true
+        tracking: "#80319"
         codexDefaultImpact: P4
         qaImpact: P1
-        action: hard gate in the core runtime-pair lane
-        reason: sessions_spawn is an OpenClaw integration tool and must stay visible and callable under OpenClaw and Codex direct runtime parity.
+        action: report-only until the core runtime-pair lane captures transcript-backed sessions_spawn execution
+        reason: The fixture proves exposure and provider planning, but its parity cell does not retain transcript-backed parent execution after subagent spawning.
       knownHarnessGap:
-        reason: Live failure-path injection for sessions_spawn can be refused safely in prose before the model calls the tool; happy-path visibility and execution still run in this fixture.
+        issue: "#80319"
+        reason: The parity cell currently retains provider-plan evidence but not transcript-backed parent execution after subagent spawning.
       promptSnippet: "target=sessions_spawn"
       failurePromptSnippet: "failure target=sessions_spawn"
 


### PR DESCRIPTION
## Summary

Backports #113420 onto `release/2026.7.2` so beta.5 release validation distinguishes provider-plan intent from transcript-backed `sessions_spawn` execution.

The required coverage row remains present, but the known harness gap is report-only and tracked by #80319 until parent transcript execution is captured.

## Validation

- `node scripts/run-vitest.mjs extensions/qa-lab/src/tool-coverage-report.test.ts extensions/qa-lab/src/scenario-catalog.test.ts` (49 passed)
- `./node_modules/.bin/oxfmt --check qa/scenarios/runtime/tools/sessions-spawn.yaml extensions/qa-lab/src/tool-coverage-report.test.ts`
- `git diff --check origin/release/2026.7.2...HEAD`
- autoreview clean (0.93)

## Source

- Main PR: #113420
- Main squash: `4e83914748da7b8c35b38fc0766274fe2f90ba95`