### PR TITLE
fix(codex): prevent session-changed errors after /new

### DIFF
--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -283,6 +283,24 @@ describe("Codex agent harness supports()", () => {
 });
 
 describe("Codex agent harness reset()", () => {
+  it("is idempotent before the retained session has a binding", async () => {
+    const harness = createCodexAppServerAgentHarness({
+      bindingStore: createCodexTestBindingStore(),
+    });
+    if (!harness.reset) {
+      throw new Error("expected Codex harness reset hook");
+    }
+
+    await expect(
+      harness.reset({
+        agentId: "worker",
+        sessionId: "session-1",
+        sessionKey: "agent:worker:main",
+        reason: "reset",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("clears an in-place session generation without stranding its replacement", async () => {
     const bindingStore = createCodexTestBindingStore();
     const identity = sessionBindingIdentity({

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -291,14 +291,14 @@ describe("Codex agent harness reset()", () => {
       throw new Error("expected Codex harness reset hook");
     }
 
-    await expect(
-      harness.reset({
-        agentId: "worker",
-        sessionId: "session-1",
-        sessionKey: "agent:worker:main",
-        reason: "reset",
-      }),
-    ).resolves.toBeUndefined();
+    const resetParams = {
+      agentId: "worker",
+      sessionId: "session-1",
+      sessionKey: "agent:worker:main",
+      reason: "reset" as const,
+    };
+    await expect(harness.reset(resetParams)).resolves.toBeUndefined();
+    await expect(harness.reset(resetParams)).resolves.toBeUndefined();
   });
 
   it("clears an in-place session generation without stranding its replacement", async () => {

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -284,9 +284,8 @@ describe("Codex agent harness supports()", () => {
 
 describe("Codex agent harness reset()", () => {
   it("is idempotent before the retained session has a binding", async () => {
-    const harness = createCodexAppServerAgentHarness({
-      bindingStore: createCodexTestBindingStore(),
-    });
+    const bindingStore = createCodexTestBindingStore();
+    const harness = createCodexAppServerAgentHarness({ bindingStore });
     if (!harness.reset) {
       throw new Error("expected Codex harness reset hook");
     }
@@ -299,6 +298,15 @@ describe("Codex agent harness reset()", () => {
     };
     await expect(harness.reset(resetParams)).resolves.toBeUndefined();
     await expect(harness.reset(resetParams)).resolves.toBeUndefined();
+
+    const identity = sessionBindingIdentity(resetParams);
+    await expect(
+      bindingStore.mutate(identity, {
+        kind: "set",
+        binding: { threadId: "thread-1", cwd: "/repo" },
+      }),
+    ).resolves.toBe(true);
+    await expect(bindingStore.read(identity)).resolves.toMatchObject({ threadId: "thread-1" });
   });
 
   it("clears an in-place session generation without stranding its replacement", async () => {

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -436,6 +436,23 @@ async function assertCodexHarnessSessionSelection(params: {
   expect(row?.thinkingLevel).toBe(CODEX_HARNESS_THINKING);
 }
 
+async function readCodexHarnessSessionId(params: {
+  client: GatewayClient;
+  sessionKey: string;
+}): Promise<string> {
+  // The live reset proof must distinguish logical generation rollover from
+  // physical session-id rotation, so read the persisted row through Gateway.
+  const result: {
+    sessions?: Array<{ key?: string; sessionId?: string }>;
+  } = await params.client.request("sessions.list", {
+    includeGlobal: true,
+    limit: 200,
+  });
+  const sessionId = result.sessions?.find((entry) => entry.key === params.sessionKey)?.sessionId;
+  expect(sessionId, `expected sessionId for ${params.sessionKey}`).toBeTypeOf("string");
+  return sessionId as string;
+}
+
 async function readCodexHarnessSessionUsageFreshness(params: {
   client: GatewayClient;
   sessionKey: string;
@@ -1961,6 +1978,40 @@ describeLive("gateway live (Codex harness)", () => {
               });
               expect(secondText).toContain(secondToken);
               logCodexLiveStep("second-turn", { secondText });
+
+              // `/new` deliberately retains the physical OpenClaw session id. Prove the
+              // retired Codex thread does not poison the next app-server turn (#116022).
+              const preResetSessionId = await readCodexHarnessSessionId({
+                client: activeClient,
+                sessionKey,
+              });
+              const preResetThreadId = observedCodexThreadIds.get(sessionKey);
+              expect(preResetThreadId).toBeTypeOf("string");
+              const resetText = await requestCodexCommandText({
+                client: activeClient,
+                events: gatewayEvents,
+                sessionKey,
+                command: "/new",
+                expectedText: "New session started.",
+              });
+              logCodexLiveStep("new-command", { resetText });
+              expect(await readCodexHarnessSessionId({ client: activeClient, sessionKey })).toBe(
+                preResetSessionId,
+              );
+
+              const resetNonce = randomBytes(3).toString("hex").toUpperCase();
+              const resetToken = `CODEX-HARNESS-AFTER-NEW-${resetNonce}`;
+              const resetReply = await requestAgentText({
+                client: activeClient,
+                sessionKey,
+                expectedReply: resetToken,
+                message: `Reply with exactly ${resetToken} and nothing else.`,
+              });
+              expect(resetReply).toContain(resetToken);
+              expect(observedCodexThreadIds.get(sessionKey)).not.toBe(preResetThreadId);
+              expect(observedCodexThreadActions.get(sessionKey)).toBe("started");
+              logCodexLiveStep("post-new-turn", { resetReply });
+
               await assertCodexHarnessSessionSelection({
                 client: activeClient,
                 modelKey,


### PR DESCRIPTION
Closes #116022
Related: #112246, #112247

## What Problem This Solves

Fixes an issue where users starting a new Codex-backed conversation with `/new` could have the next message fail before inference when the logical reset retained the same physical OpenClaw session ID and a delayed lifecycle event persisted a durable retired stable-key binding.

Production observations on shipped builds captured the exact sequence: ordinary turns succeeded, `/new` recorded a reset while retaining the physical session, the stable binding became a non-expiring retired tombstone for that still-current session, and deleting only that tombstone restored the same session. Raw session, thread, and binding identifiers remain redacted in the linked issue evidence.

## Why This Change Was Made

Current `main` already contains the production owner repair in `5a79d19ba179d`: Codex distinguishes reset from permanent retirement, resets the binding before delayed end handling, suppresses same-physical-ID delayed retirement, reclaims only through the authoritative session store, and fences native subscription cleanup to the exact client/thread generation. `c7b7fe4c328b5` restored the related continuity fixtures.

This PR is rebased onto that repair and intentionally adds only the missing regression proof. The earlier generic `resetHarnessIds` lifecycle payload and unused `reset-generation` mutation were removed rather than expanding the shared plugin contract for Codex-owned state.

The upstream Codex contract was checked directly at `openai/codex@3aae5d885b`:

- `codex-rs/app-server/README.md:70-83,163-166` — a thread is the durable conversation; `thread/resume` reopens it and later `turn/start` calls append turns.
- `codex-rs/app-server-protocol/src/protocol/common.rs:492-503,863-878` — start is fresh, while resume and turn operations serialize against the existing thread.
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:311-325` — resume prefers the persisted thread ID and rejoins a running thread.
- `codex-rs/core/src/session/session.rs:657-683` — fresh/cleared sessions create an ID; resumed sessions preserve the persisted conversation ID.
- `codex-rs/app-server/src/request_processors/turn_processor.rs:474-607` — `turn/start` loads the existing thread and submits the new user input.
- `codex-rs/app-server/tests/suite/v2/thread_resume.rs:4367-4423,4686-4753` and `turn_start.rs:1450-1553` — restart/resume keeps the thread identity and multiple turns use distinct turn IDs on that same thread.

## User Impact

The production behavior is unchanged from current `main`; this PR makes the repaired `/new` contract durable in tests:

- Reset is idempotent before a binding exists and leaves the stable session immediately writable.
- The real gateway scenario checks the `/new` acknowledgement, retained physical OpenClaw session ID, a fresh native Codex thread, and a successful next reply.

Production LOC: `+0/-0`  
Test LOC: `+77/-0`

## Evidence

Exact head: `897a38f02f699ac9b364202046b6a312a9a2681c`

- Sanitized AWS proof on the prior exact PR head: Crabbox run `run_f53e3dd17ab7`, 135 focused tests passed across Codex binding, harness, plugin lifecycle, registry, and gateway reset hooks.
- Final focused owner proof: 114 tests passed across `extensions/codex/harness.test.ts`, `extensions/codex/index.test.ts`, `extensions/codex/src/app-server/session-binding.test.ts`, and `extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts`.
- Final changed-test proof: `extensions/codex/harness.test.ts` passed 30/30 after repeated reset plus post-reset bind/read assertions.
- `git diff --check`: clean.
- Structured autoreview: clean, no accepted/actionable findings; secret scan clean.
- Independent exact-head read-only review: clean at `897a38f02f699ac9b364202046b6a312a9a2681c`.
- Successful exact-head live proof: GitHub-backed AWS hydration run https://github.com/openclaw/openclaw/actions/runs/31252631574 plus Crabbox run `run_210bb52151bb`. The supported `OPENCLAW_LIVE_CODEX_HARNESS_AUTH=api-key` seam forwarded one redacted API-key variable; `src/gateway/gateway-codex-harness.live.test.ts` passed its real gateway scenario in 267.9s. The committed assertions verify `/new` returned `New session started.`, the physical OpenClaw session ID stayed unchanged, the next reply returned its unique marker, and the observed native Codex thread ID changed with action `started`.
- Exact-head CI: run https://github.com/openclaw/openclaw/actions/runs/31250981001 completed green on attempt 3. The only prior failure was an unrelated compact infra shard timeout; rerunning the failed job on the unchanged head passed.
- Previous exact-head ClawSweeper review: https://github.com/openclaw/openclaw/pull/113429#issuecomment-5075551379 found no code or security findings and confirmed the test-only shape. A same-head re-review is requested now that successful credentialed live proof is available.

ClawSweeper move status:

- Applied: removed the unused reset-generation mutation and generic lifecycle payload.
- Applied: kept Codex reset/retirement facts in the Codex binding owner; no shared public plugin lifecycle field was added.
- Applied: successful credentialed exact-head `/new` then next-reply proof is recorded in Crabbox run `run_210bb52151bb`, with the four boundary assertions inspectable in the committed live test.

Contributor credit is preserved in the rewritten commit history.