### PR TITLE
fix: production audit rejects vulnerable brace expansion

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   file-type: 22.0.1
   form-data: 2.5.6
   ip-address: 10.2.0
+  brace-expansion: 5.0.8
   minimatch: 10.2.5
   path-to-regexp: 8.4.2
   qs: 6.15.3
@@ -5483,9 +5484,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -11984,7 +11985,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13894,7 +13895,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ minimumReleaseAgeExclude:
   - "axios"
   - "basic-ftp"
   - "baileys@7.0.0-rc13"
+  - "brace-expansion@5.0.8"
   - "hono"
   - "libopus-wasm@0.2.0"
   - "libsignal@6.0.0"
@@ -134,6 +135,7 @@ overrides:
   file-type: 22.0.1
   form-data: 2.5.6
   ip-address: 10.2.0
+  brace-expansion: 5.0.8
   minimatch: 10.2.5
   path-to-regexp: 8.4.2
   qs: 6.15.3


### PR DESCRIPTION
Related: https://gitlab.com/xrow-public/helm-openclaw/-/work_items/49

## What Problem This Solves

Fixes an issue where pull request validation would fail in the `security-fast` production dependency audit because the lockfile resolved `brace-expansion` to a release covered by GHSA-mh99-v99m-4gvg.

AI-assisted: yes.

## Why This Change Was Made

The workspace now pins `brace-expansion` to `5.0.8`, which is the patched release currently accepted by the audit feed. Because the patched release is still inside the repository's minimum release age window, the workspace policy includes a narrow `minimumReleaseAgeExclude` entry for this exact security patch.

## User Impact

Maintainers and contributors can get production security audit validation back to green without changing runtime behavior.

## Evidence

- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` passed: no high or higher production advisories found.
- `pnpm install --lockfile-only --frozen-lockfile` passed and reported the lockfile passes supply-chain policies.
- `git diff --check` passed.

Note: local `pnpm` commands warned that this environment uses Node `v24.14.1`, below the repository floor of Node `24.15+`; the focused audit and lockfile checks still completed successfully.
