### PR TITLE
fix(nextcloud-talk): preserve current-room aliases across plugin upgrades

### DIFF
--- a/src/channels/plugins/message-action-dispatch.ts
+++ b/src/channels/plugins/message-action-dispatch.ts
@@ -43,6 +43,14 @@ type ChannelMessageActionDispatchContext = Omit<ChannelMessageActionContext, "ac
   action: unknown;
 };
 
+type PreparedMessageActionReadContext = {
+  actionContext: ChannelMessageActionContext;
+  plugin: ChannelPlugin;
+  origin: ServerOwnedConversationReadOrigin;
+  actionPolicy: ChannelMessageActionReadPolicy;
+  enforcement: MessageActionReadEnforcement;
+};
+
 type ChannelMessageActionReadPolicy =
   | { readonly kind: "none" }
   | {
@@ -535,6 +543,54 @@ function canonicalizeExternalExactCurrentTarget(ctx: ChannelMessageActionContext
   }
 }
 
+function prepareMessageActionReadContext(
+  ctx: ChannelMessageActionDispatchContext,
+): PreparedMessageActionReadContext | undefined {
+  const actionPolicy = resolveChannelMessageActionReadPolicy(ctx.action);
+  if (!actionPolicy) {
+    return undefined;
+  }
+  const registration = resolveChannelPluginRegistration(ctx.channel);
+  if (!registration) {
+    return undefined;
+  }
+  const action = ctx.action as ChannelMessageActionName;
+  const origin = resolveServerOwnedConversationReadOrigin(ctx.conversationReadOrigin);
+  const actionContext: ChannelMessageActionContext = {
+    ...ctx,
+    action,
+    conversationReadOrigin: origin,
+  };
+  return {
+    actionContext,
+    plugin: registration.plugin,
+    origin,
+    actionPolicy,
+    enforcement: resolveMessageActionReadEnforcement({
+      action,
+      channel: actionContext.channel,
+      pluginOrigin: registration.origin,
+    }),
+  };
+}
+
+function isExternalDelegatedMessageActionRead(
+  prepared: PreparedMessageActionReadContext | undefined,
+): prepared is PreparedMessageActionReadContext & {
+  actionPolicy: Extract<ChannelMessageActionReadPolicy, { kind: "conversation-read" }>;
+  enforcement: Extract<MessageActionReadEnforcement, { kind: "host-exact-current" }> & {
+    pluginTrust: "external";
+  };
+} {
+  return Boolean(
+    prepared &&
+    prepared.origin !== "direct-operator" &&
+    prepared.actionPolicy.kind === "conversation-read" &&
+    prepared.enforcement.kind === "host-exact-current" &&
+    prepared.enforcement.pluginTrust === "external",
+  );
+}
+
 /** The sole host chokepoint before any read-capable plugin callback runs. */
 function enforceMessageActionConversationReadGate(params: {
   ctx: ChannelMessageActionContext;
@@ -573,6 +629,40 @@ function enforceMessageActionConversationReadGate(params: {
   }
 }
 
+/** Authorizes and canonicalizes external exact-current targets before target resolution. */
+export function prepareExternalMessageActionTargetForResolution(
+  ctx: ChannelMessageActionDispatchContext,
+): Record<string, unknown> {
+  const prepared = prepareMessageActionReadContext(ctx);
+  if (!isExternalDelegatedMessageActionRead(prepared)) {
+    return ctx.params;
+  }
+  // External target resolution can execute plugin directory/provider lookups.
+  // Establish exact-current authority before that boundary, then recheck at dispatch.
+  const authorizedActionContext = attachExternalCurrentTargetSibling({
+    ctx: prepared.actionContext,
+    plugin: prepared.plugin,
+    origin: prepared.origin,
+    actionPolicy: prepared.actionPolicy,
+    enforcement: prepared.enforcement,
+  });
+  enforceMessageActionConversationReadGate({
+    ctx: authorizedActionContext,
+    plugin: prepared.plugin,
+    origin: prepared.origin,
+    actionPolicy: prepared.actionPolicy,
+    enforcement: prepared.enforcement,
+  });
+  return authorizedActionContext.params;
+}
+
+/** Defers delegated external target interpretation to the attested Gateway boundary. */
+export function shouldDeferExternalMessageActionTargetResolution(
+  ctx: ChannelMessageActionDispatchContext,
+): boolean {
+  return isExternalDelegatedMessageActionRead(prepareMessageActionReadContext(ctx));
+}
+
 function requiresTrustedRequesterSender(
   ctx: ChannelMessageActionContext,
   plugin: ChannelPlugin,
@@ -591,33 +681,15 @@ function requiresTrustedRequesterSender(
 export async function dispatchChannelMessageAction(
   ctx: ChannelMessageActionDispatchContext,
 ): Promise<AgentToolResult<unknown> | null> {
-  const actionPolicy = resolveChannelMessageActionReadPolicy(ctx.action);
-  if (!actionPolicy) {
+  const prepared = prepareMessageActionReadContext(ctx);
+  if (!prepared) {
     return null;
   }
-  // The policy lookup is the runtime proof that this is a core-owned action.
-  const action = ctx.action as ChannelMessageActionName;
-  const registration = resolveChannelPluginRegistration(ctx.channel);
-  if (!registration) {
-    return null;
-  }
-  const { plugin } = registration;
+  const { actionContext, plugin, origin, actionPolicy, enforcement } = prepared;
   const actions = plugin.actions;
   if (!actions?.handleAction) {
     return null;
   }
-  const origin = resolveServerOwnedConversationReadOrigin(ctx.conversationReadOrigin);
-  const actionContext: ChannelMessageActionContext = {
-    ...ctx,
-    action,
-    // Plugins receive only the closed server-normalized classification.
-    conversationReadOrigin: origin,
-  };
-  const enforcement = resolveMessageActionReadEnforcement({
-    action: actionContext.action,
-    channel: actionContext.channel,
-    pluginOrigin: registration.origin,
-  });
   const authorizedActionContext = attachExternalCurrentTargetSibling({
     ctx: actionContext,
     plugin,

--- a/src/channels/plugins/message-action-dispatch.ts
+++ b/src/channels/plugins/message-action-dispatch.ts
@@ -339,6 +339,65 @@ function hasTargetInput(value: unknown): boolean {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+function attachExternalCurrentTargetSibling(params: {
+  ctx: ChannelMessageActionContext;
+  plugin: ChannelPlugin;
+  origin: ServerOwnedConversationReadOrigin;
+  actionPolicy: ChannelMessageActionReadPolicy;
+  enforcement: MessageActionReadEnforcement;
+}): ChannelMessageActionContext {
+  if (
+    params.origin === "direct-operator" ||
+    params.actionPolicy.kind !== "conversation-read" ||
+    params.enforcement.kind !== "host-exact-current" ||
+    params.enforcement.pluginTrust !== "external"
+  ) {
+    return params.ctx;
+  }
+  const target =
+    typeof params.ctx.params.target === "string" ? params.ctx.params.target.trim() : "";
+  if (!target) {
+    return params.ctx;
+  }
+  const mirroredTo = params.ctx.params.to;
+  if (typeof mirroredTo !== "string" || mirroredTo.trim() !== target) {
+    return params.ctx;
+  }
+  const providerPrefixes = params.plugin.messaging?.targetPrefixes;
+  const requestedTarget = normalizeHostConversationTarget({
+    value: target,
+    channel: params.ctx.channel,
+    providerPrefixes,
+  });
+  if (!requestedTarget) {
+    return params.ctx;
+  }
+  const trustedCurrentTarget = [
+    params.ctx.toolContext?.currentMessagingTarget,
+    params.ctx.toolContext?.currentChannelId,
+  ].find((value) => {
+    const normalized = normalizeHostConversationTarget({
+      value,
+      channel: params.ctx.channel,
+      providerPrefixes,
+    });
+    return (
+      normalized?.id === requestedTarget.id &&
+      (!requestedTarget.kind || !normalized.kind || normalized.kind === requestedTarget.kind)
+    );
+  });
+  if (typeof trustedCurrentTarget !== "string" || !trustedCurrentTarget.trim()) {
+    return params.ctx;
+  }
+  return {
+    ...params.ctx,
+    params: {
+      ...params.ctx.params,
+      to: trustedCurrentTarget.trim(),
+    },
+  };
+}
+
 function isExactCurrentConversation(params: {
   ctx: ChannelMessageActionContext;
   plugin: ChannelPlugin;
@@ -554,31 +613,42 @@ export async function dispatchChannelMessageAction(
     // Plugins receive only the closed server-normalized classification.
     conversationReadOrigin: origin,
   };
-  enforceMessageActionConversationReadGate({
+  const enforcement = resolveMessageActionReadEnforcement({
+    action: actionContext.action,
+    channel: actionContext.channel,
+    pluginOrigin: registration.origin,
+  });
+  const authorizedActionContext = attachExternalCurrentTargetSibling({
     ctx: actionContext,
     plugin,
     origin,
     actionPolicy,
-    enforcement: resolveMessageActionReadEnforcement({
-      action: actionContext.action,
-      channel: actionContext.channel,
-      pluginOrigin: registration.origin,
-    }),
+    enforcement,
+  });
+  enforceMessageActionConversationReadGate({
+    ctx: authorizedActionContext,
+    plugin,
+    origin,
+    actionPolicy,
+    enforcement,
   });
   // Some plugin actions depend on the sender identity to enforce channel-local
   // trust. Reject tool-driven calls before invoking the action without it.
   if (
-    requiresTrustedRequesterSender(actionContext, plugin) &&
-    !actionContext.requesterSenderId?.trim()
+    requiresTrustedRequesterSender(authorizedActionContext, plugin) &&
+    !authorizedActionContext.requesterSenderId?.trim()
   ) {
     throw new Error(
-      `Trusted sender identity is required for ${actionContext.channel}:${actionContext.action} in tool-driven contexts.`,
+      `Trusted sender identity is required for ${authorizedActionContext.channel}:${authorizedActionContext.action} in tool-driven contexts.`,
     );
   }
   // `handleAction` may be broad; `supportsAction` lets plugins cheaply decline
   // action names before the dispatcher enters channel-specific behavior.
-  if (actions.supportsAction && !actions.supportsAction({ action: actionContext.action })) {
+  if (
+    actions.supportsAction &&
+    !actions.supportsAction({ action: authorizedActionContext.action })
+  ) {
     return null;
   }
-  return await actions.handleAction(actionContext);
+  return await actions.handleAction(authorizedActionContext);
 }

--- a/src/channels/plugins/message-actions.security.test.ts
+++ b/src/channels/plugins/message-actions.security.test.ts
@@ -346,6 +346,30 @@ describe("dispatchChannelMessageAction conversation-read provenance", () => {
     expect(handleAction).not.toHaveBeenCalled();
   });
 
+  it("does not rewrite an untyped channelId mirror from a typed user target", async () => {
+    setReadPlugin();
+
+    await expect(
+      dispatchChannelMessageAction({
+        channel: "discord",
+        action: "read",
+        cfg: {} as OpenClawConfig,
+        params: {
+          target: "123",
+          channelId: "123",
+        },
+        accountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelProvider: "discord",
+          currentMessagingTarget: "user:123",
+        },
+      }),
+    ).rejects.toThrow("requires the exact current conversation and account");
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+
   it("keeps external conversation ids case-sensitive after prefix normalization", async () => {
     setReadPlugin();
 
@@ -670,6 +694,128 @@ describe("dispatchChannelMessageAction conversation-read provenance", () => {
       expect(handleAction).toHaveBeenCalledOnce();
     },
   );
+
+  it("replaces an external normalization mirror with the trusted current target", async () => {
+    setReadPlugin({
+      channel: "nextcloud-talk",
+      origin: "workspace",
+      targetPrefixes: ["nextcloud-talk", "nc-talk", "nc"],
+    });
+
+    await dispatchChannelMessageAction({
+      channel: "nextcloud-talk",
+      action: "read",
+      cfg: {} as OpenClawConfig,
+      params: {
+        target: "room:current",
+        to: "room:current",
+      },
+      accountId: "default",
+      requesterAccountId: "default",
+      conversationReadOrigin: "delegated",
+      toolContext: {
+        currentChannelProvider: "nextcloud-talk",
+        currentChannelId: "nextcloud-talk:current",
+        currentChatType: "group",
+      },
+    });
+
+    expect(handleAction.mock.calls[0]?.[0].params).toMatchObject({
+      target: "nextcloud-talk:current",
+      to: "nextcloud-talk:current",
+    });
+    expect(handleAction).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a conflicting trusted target kind even when an untyped sibling exists", async () => {
+    setReadPlugin({
+      channel: "nextcloud-talk",
+      origin: "workspace",
+      targetPrefixes: ["nextcloud-talk", "nc-talk", "nc"],
+    });
+
+    await expect(
+      dispatchChannelMessageAction({
+        channel: "nextcloud-talk",
+        action: "read",
+        cfg: {} as OpenClawConfig,
+        params: {
+          target: "room:current",
+          to: "room:current",
+        },
+        accountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelProvider: "nextcloud-talk",
+          currentChannelId: "nextcloud-talk:current",
+          currentMessagingTarget: "channel:current",
+          currentChatType: "group",
+        },
+      }),
+    ).rejects.toThrow("requires the exact current conversation and account");
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+
+  it("rejects an external normalization mirror for a different conversation", async () => {
+    setReadPlugin({
+      channel: "nextcloud-talk",
+      origin: "workspace",
+      targetPrefixes: ["nextcloud-talk", "nc-talk", "nc"],
+    });
+
+    await expect(
+      dispatchChannelMessageAction({
+        channel: "nextcloud-talk",
+        action: "read",
+        cfg: {} as OpenClawConfig,
+        params: {
+          target: "room:other",
+          to: "room:other",
+        },
+        accountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelProvider: "nextcloud-talk",
+          currentChannelId: "nextcloud-talk:current",
+          currentChatType: "group",
+        },
+      }),
+    ).rejects.toThrow("requires the exact current conversation and account");
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+
+  it("does not rewrite direct external targets from current context", async () => {
+    setReadPlugin({
+      channel: "nextcloud-talk",
+      origin: "workspace",
+      targetPrefixes: ["nextcloud-talk", "nc-talk", "nc"],
+    });
+
+    await dispatchChannelMessageAction({
+      channel: "nextcloud-talk",
+      action: "read",
+      cfg: {} as OpenClawConfig,
+      params: {
+        target: "room:other",
+        to: "room:other",
+      },
+      accountId: "default",
+      conversationReadOrigin: "direct-operator",
+      toolContext: {
+        currentChannelProvider: "nextcloud-talk",
+        currentChannelId: "nextcloud-talk:current",
+        currentChatType: "group",
+      },
+    });
+
+    expect(handleAction.mock.calls[0]?.[0].params).toMatchObject({
+      target: "room:other",
+      to: "room:other",
+    });
+    expect(handleAction).toHaveBeenCalledOnce();
+  });
 
   it("does not let an external provider prefix erase a conflicting target kind", async () => {
     setReadPlugin({

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -531,14 +531,14 @@ describe("runMessageAction context isolation", () => {
       message: /Cross-context messaging denied/,
     },
     {
-      name: "rejects channel ids that resolve to user targets",
+      name: "blocks delegated channel reads without current context before target resolution",
       action: "channel-info" as const,
       cfg: workspaceConfig,
       actionParams: {
         channel: "workspace",
         channelId: "U12345678",
       },
-      message: 'Channel id "U12345678" resolved to a user target.',
+      message: "requires the exact current conversation and account",
     },
     {
       name: "blocks actions outside the per-agent allowlist",
@@ -577,6 +577,62 @@ describe("runMessageAction context isolation", () => {
         agentId,
       }),
     ).rejects.toThrow(message);
+  });
+
+  it("retains direct-operator target-kind validation", async () => {
+    await expect(
+      runMessageAction({
+        cfg: workspaceConfig,
+        action: "channel-info",
+        params: {
+          channel: "workspace",
+          channelId: "U12345678",
+        },
+        conversationReadOrigin: "direct-operator",
+        dryRun: true,
+      }),
+    ).rejects.toThrow('Channel id "U12345678" resolved to a user target.');
+  });
+
+  it("retains direct-operator cross-provider reads", async () => {
+    await expect(
+      runMessageAction({
+        cfg: workspaceConfig,
+        action: "read",
+        params: {
+          channel: "workspace",
+          target: "C12345678",
+        },
+        defaultAccountId: "default",
+        conversationReadOrigin: "direct-operator",
+        toolContext: {
+          currentChannelId: "forum-current",
+          currentChannelProvider: "forum",
+        },
+        dryRun: false,
+      }),
+    ).resolves.toMatchObject({ kind: "action", channel: "workspace", action: "read" });
+    expect(handleWorkspaceAction).toHaveBeenCalledOnce();
+  });
+
+  it("retains cross-provider policy for direct operators", async () => {
+    await expect(
+      runMessageAction({
+        cfg: workspaceConfig,
+        action: "pin",
+        params: {
+          channel: "forum",
+          target: "@opsbot",
+          messageId: "forum-message-1",
+        },
+        conversationReadOrigin: "direct-operator",
+        toolContext: {
+          currentChannelId: "C12345678",
+          currentChannelProvider: "workspace",
+        },
+        dryRun: true,
+      }),
+    ).rejects.toThrow(/Cross-context messaging denied/);
   });
 
   it.each([

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -739,6 +739,43 @@ describe("runMessageAction plugin dispatch", () => {
       );
     });
 
+    it("preserves a trusted canonical sibling for a typed external current target", async () => {
+      await runMessageAction({
+        cfg: {
+          channels: {
+            actionhub: {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "pin",
+        params: {
+          channel: "actionhub",
+          target: "channel:current",
+          messageId: "om_123",
+        },
+        defaultAccountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelId: "actionhub:current",
+          currentChannelProvider: "actionhub",
+          currentChatType: "channel",
+        },
+        dryRun: false,
+      });
+
+      const call = readFirstPluginCall(handleAction);
+      expectRecordFields(
+        readRecordField(call, "params", "normalized plugin params"),
+        {
+          target: "actionhub:current",
+          to: "actionhub:current",
+        },
+        "normalized plugin params",
+      );
+    });
+
     it("preserves no-context owner Discord admin actions through the shared runner", async () => {
       const handleDiscordAction = vi.fn(async (ctx: ChannelMessageActionContext) => {
         const currentProvider = ctx.toolContext?.currentChannelProvider?.trim().toLowerCase();

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -1107,6 +1107,134 @@ describe("runMessageAction plugin dispatch", () => {
       );
     });
 
+    it("rejects unauthorized gateway-mode dry runs without resolving a target", async () => {
+      const looksLikeId = vi.fn(() => true);
+      const gatewayPlugin = createGatewayActionPlugin({
+        pluginId: "gatewaychat",
+        label: "Gateway Chat",
+        blurb: "Gateway Chat dry-run authorization test plugin.",
+        actions: ["react"],
+        capabilities: { chatTypes: ["direct"], reactions: true },
+        messaging: {
+          targetResolver: {
+            looksLikeId,
+          },
+        },
+        handleAction: vi.fn(async () => jsonResult({ ok: true, local: true })),
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "gatewaychat",
+            source: "test",
+            origin: "config",
+            plugin: gatewayPlugin,
+          },
+        ]),
+      );
+
+      await expect(
+        runMessageAction({
+          cfg: {
+            channels: {
+              gatewaychat: {
+                enabled: true,
+              },
+            },
+          } as OpenClawConfig,
+          action: "react",
+          params: {
+            channel: "gatewaychat",
+            target: "room:current",
+            messageId: "message-1",
+            emoji: "eyes",
+          },
+          defaultAccountId: "other",
+          requesterAccountId: "default",
+          conversationReadOrigin: "delegated",
+          toolContext: {
+            currentChannelId: "gatewaychat:current",
+            currentChannelProvider: "gatewaychat",
+            currentChatType: "group",
+          },
+          gateway: {
+            clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+            mode: GATEWAY_CLIENT_MODES.BACKEND,
+          },
+          dryRun: true,
+        }),
+      ).rejects.toThrow("requires the exact current conversation and account");
+      expect(looksLikeId).not.toHaveBeenCalled();
+      expect(mocks.callGatewayLeastPrivilege).not.toHaveBeenCalled();
+    });
+
+    it("resolves authorized gateway-mode dry-run targets locally", async () => {
+      const looksLikeId = vi.fn(() => true);
+      const handleDryRunAction = vi.fn(async () => jsonResult({ ok: true, local: true }));
+      const gatewayPlugin = createGatewayActionPlugin({
+        pluginId: "gatewaychat",
+        label: "Gateway Chat",
+        blurb: "Gateway Chat dry-run target test plugin.",
+        actions: ["react"],
+        capabilities: { chatTypes: ["direct"], reactions: true },
+        messaging: {
+          targetResolver: {
+            looksLikeId,
+          },
+        },
+        handleAction: handleDryRunAction,
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "gatewaychat",
+            source: "test",
+            origin: "config",
+            plugin: gatewayPlugin,
+          },
+        ]),
+      );
+
+      const result = await runMessageAction({
+        cfg: {
+          channels: {
+            gatewaychat: {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "react",
+        params: {
+          channel: "gatewaychat",
+          target: "room:current",
+          messageId: "message-1",
+          emoji: "eyes",
+        },
+        defaultAccountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelId: "gatewaychat:current",
+          currentChannelProvider: "gatewaychat",
+          currentChatType: "group",
+        },
+        gateway: {
+          clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+          mode: GATEWAY_CLIENT_MODES.BACKEND,
+        },
+        dryRun: true,
+      });
+
+      expect(result).toMatchObject({
+        kind: "action",
+        handledBy: "dry-run",
+        dryRun: true,
+      });
+      expect(looksLikeId).toHaveBeenCalledOnce();
+      expect(handleDryRunAction).not.toHaveBeenCalled();
+      expect(mocks.callGatewayLeastPrivilege).not.toHaveBeenCalled();
+    });
+
     it("keeps blank backend requester provenance least-privileged", async () => {
       const handleActionEntry = vi.fn(async () => jsonResult({ ok: true, local: true }));
       const gatewayPlugin = createGatewayActionPlugin({

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -776,6 +776,120 @@ describe("runMessageAction plugin dispatch", () => {
       );
     });
 
+    it("canonicalizes an external exact-current alias before legacy target resolution", async () => {
+      const looksLikeId = vi.fn((raw: string) => !/^room:/i.test(raw));
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "actionhub",
+            source: "test",
+            origin: "config",
+            plugin: {
+              ...actionHubPlugin,
+              messaging: {
+                targetPrefixes: ["actionhub"],
+                normalizeTarget: (raw: string) =>
+                  raw.replace(/^room:/i, "actionhub:").replace(/^actionhub:/i, "actionhub:"),
+                targetResolver: {
+                  looksLikeId,
+                },
+              },
+            },
+          },
+        ]),
+      );
+
+      await runMessageAction({
+        cfg: {
+          channels: {
+            actionhub: {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "pin",
+        params: {
+          channel: "actionhub",
+          target: "room:current",
+          messageId: "om_123",
+        },
+        defaultAccountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelId: "actionhub:current",
+          currentChannelProvider: "actionhub",
+          currentChatType: "group",
+        },
+        dryRun: false,
+      });
+
+      expect(looksLikeId).toHaveBeenCalledWith("actionhub:current", "actionhub:current");
+      const call = readFirstPluginCall(handleAction);
+      expectRecordFields(
+        readRecordField(call, "params", "normalized plugin params"),
+        {
+          target: "actionhub:current",
+          to: "actionhub:current",
+        },
+        "normalized plugin params",
+      );
+    });
+
+    it.each([false, true])(
+      "rejects an external exact-current alias with the wrong account before target resolution (dryRun=%s)",
+      async (dryRun) => {
+        const looksLikeId = vi.fn(() => true);
+        setActivePluginRegistry(
+          createTestRegistry([
+            {
+              pluginId: "actionhub",
+              source: "test",
+              origin: "config",
+              plugin: {
+                ...actionHubPlugin,
+                messaging: {
+                  ...actionHubPlugin.messaging,
+                  targetResolver: {
+                    looksLikeId,
+                  },
+                },
+              },
+            },
+          ]),
+        );
+
+        await expect(
+          runMessageAction({
+            cfg: {
+              channels: {
+                actionhub: {
+                  enabled: true,
+                },
+              },
+            } as OpenClawConfig,
+            action: "pin",
+            params: {
+              channel: "actionhub",
+              target: "room:current",
+              messageId: "om_123",
+            },
+            defaultAccountId: "other",
+            requesterAccountId: "default",
+            conversationReadOrigin: "delegated",
+            toolContext: {
+              currentChannelId: "actionhub:current",
+              currentChannelProvider: "actionhub",
+              currentChatType: "group",
+            },
+            dryRun,
+          }),
+        ).rejects.toThrow("requires the exact current conversation and account");
+        expect(looksLikeId).not.toHaveBeenCalled();
+        expect(handleAction).not.toHaveBeenCalled();
+      },
+    );
+
     it("preserves no-context owner Discord admin actions through the shared runner", async () => {
       const handleDiscordAction = vi.fn(async (ctx: ChannelMessageActionContext) => {
         const currentProvider = ctx.toolContext?.currentChannelProvider?.trim().toLowerCase();
@@ -892,12 +1006,18 @@ describe("runMessageAction plugin dispatch", () => {
           local: true,
         }),
       );
+      const looksLikeId = vi.fn(() => true);
       const gatewayPlugin = createGatewayActionPlugin({
         pluginId: "gatewaychat",
         label: "Gateway Chat",
         blurb: "Gateway Chat reaction test plugin.",
         actions: ["react"],
         capabilities: { chatTypes: ["direct"], reactions: true },
+        messaging: {
+          targetResolver: {
+            looksLikeId,
+          },
+        },
         handleAction: handleActionEntry,
       });
       setTestPlugin(gatewayPlugin, "gatewaychat");
@@ -965,6 +1085,7 @@ describe("runMessageAction plugin dispatch", () => {
       expect(gatewayParams).not.toHaveProperty("requesterAccountId");
       expect(gatewayParams).not.toHaveProperty("requesterSenderId");
       expect(gatewayParams).not.toHaveProperty("toolContext");
+      expect(looksLikeId).not.toHaveBeenCalled();
       expect(handleActionEntry).not.toHaveBeenCalled();
       expectRecordFields(
         result,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1954,6 +1954,7 @@ export async function runMessageAction(
     channelPlugin?.actions?.resolveExecutionMode?.({ action }) === "gateway";
   const defersExternalTargetResolution =
     delegatesActionToGateway &&
+    !dryRun &&
     shouldDeferExternalMessageActionTargetResolution({
       channel,
       action,
@@ -1964,7 +1965,7 @@ export async function runMessageAction(
         input.conversationReadOrigin,
       ),
     });
-  if (!delegatesActionToGateway) {
+  if (!delegatesActionToGateway || dryRun) {
     const authorization = input.messageActionAuthorization;
     params = prepareExternalMessageActionTargetForResolution({
       channel,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -513,6 +513,26 @@ async function resolveChannel(
   return selection.channel;
 }
 
+function enforceCrossProviderEgressPolicyBeforeTargetResolution(params: {
+  channel: ChannelId;
+  action: ChannelMessageActionName;
+  args: Record<string, unknown>;
+  toolContext?: ChannelThreadingToolContext;
+  cfg: OpenClawConfig;
+  agentId?: string | null;
+}): void {
+  const currentProvider = params.toolContext?.currentChannelProvider;
+  if (!currentProvider || currentProvider === params.channel) {
+    return;
+  }
+  // Cross-context egress policy applies to direct and delegated callers alike;
+  // direct origin bypasses only the conversation-read visibility gate. A
+  // provider mismatch needs no target interpretation, so reject it before an
+  // external resolver can perform provider I/O. Same-provider aliases still
+  // wait for canonicalization before the full policy check below.
+  enforceCrossContextPolicy(params);
+}
+
 function addCandidateAndUnprefixedAlias(candidates: Set<string>, value?: string | null) {
   const normalized = normalizeOptionalString(value);
   if (!normalized) {
@@ -1949,6 +1969,14 @@ export async function runMessageAction(
     params.accountId = accountId;
   }
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
+  enforceCrossProviderEgressPolicyBeforeTargetResolution({
+    channel,
+    action,
+    args: params,
+    toolContext: input.toolContext,
+    cfg,
+    agentId: resolvedAgentId,
+  });
   const delegatesActionToGateway =
     Boolean(input.gateway) &&
     channelPlugin?.actions?.resolveExecutionMode?.({ action }) === "gateway";

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -26,7 +26,11 @@ import {
   normalizeConversationReadInvocationOrigin,
   type ConversationReadInvocationOrigin,
 } from "../../channels/plugins/conversation-read-origin.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
+import {
+  dispatchChannelMessageAction,
+  prepareExternalMessageActionTargetForResolution,
+  shouldDeferExternalMessageActionTargetResolution,
+} from "../../channels/plugins/message-action-dispatch.js";
 import type {
   ChannelId,
   ChannelMessageActionName,
@@ -1945,6 +1949,39 @@ export async function runMessageAction(
     params.accountId = accountId;
   }
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
+  const delegatesActionToGateway =
+    Boolean(input.gateway) &&
+    channelPlugin?.actions?.resolveExecutionMode?.({ action }) === "gateway";
+  const defersExternalTargetResolution =
+    delegatesActionToGateway &&
+    shouldDeferExternalMessageActionTargetResolution({
+      channel,
+      action,
+      cfg,
+      params,
+      accountId: accountId ?? undefined,
+      conversationReadOrigin: normalizeConversationReadInvocationOrigin(
+        input.conversationReadOrigin,
+      ),
+    });
+  if (!delegatesActionToGateway) {
+    const authorization = input.messageActionAuthorization;
+    params = prepareExternalMessageActionTargetForResolution({
+      channel,
+      action,
+      cfg,
+      params,
+      accountId: accountId ?? undefined,
+      requesterAccountId:
+        authorization !== undefined
+          ? authorization.requesterAccountId
+          : (input.requesterAccountId ?? undefined),
+      conversationReadOrigin: normalizeConversationReadInvocationOrigin(
+        input.conversationReadOrigin,
+      ),
+      toolContext: authorization !== undefined ? authorization.toolContext : input.toolContext,
+    });
+  }
   const normalizationPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
     mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, resolvedAgentId),
@@ -2014,13 +2051,15 @@ export async function runMessageAction(
     await hydrateActionAttachmentParams();
   }
 
-  const resolvedTarget = await resolveActionTarget({
-    cfg,
-    channel,
-    action,
-    args: params,
-    accountId,
-  });
+  const resolvedTarget = defersExternalTargetResolution
+    ? undefined
+    : await resolveActionTarget({
+        cfg,
+        channel,
+        action,
+        args: params,
+        accountId,
+      });
 
   enforceCrossContextPolicy({
     channel,


### PR DESCRIPTION
Closes #113431

## What Problem This Solves

Fixes an issue where users running a current OpenClaw core with a previous external Nextcloud Talk plugin release could not react in the active room when the model used the equivalent `room:<current-room>` target form.

## Why This Change Was Made

The shared message-action path now carries the host's canonical current destination into external-plugin target resolution while preserving the requested spelling for validation. Gateway-owned actions keep target interpretation at the Gateway boundary. Gateway-mode dry runs resolve authorized targets locally without invoking the plugin or Gateway. Pure host cross-provider egress policy runs before external target resolution, while same-provider aliases retain post-canonicalization validation. Existing direct-operator and bundled-plugin behavior is unchanged.

## User Impact

Nextcloud Talk current-room reactions continue to work across this supported previous-plugin/current-core upgrade combination, including model-selected delegated actions.

## Evidence

- Before: a real inbound Talk message and model-selected reaction with external `@openclaw/nextcloud-talk` 2026.7.1 failed with `Unknown target "room:<redacted>"`; no provider mutation occurred.
- Live compatibility proof at pre-rebase HEAD `a25b2558f078bd5237c5623840b3a05ba02b77ee`: real inbound Talk event, real model turn, model-selected delegated `message` reaction using `room:<current-room>`, successful tool audit, provider-side reaction verification, and visible reply all passed.
- The rebase onto `d5e46646f2b70dbacd6afe504b03300696029563` had no touched-file overlap, no conflicts, and replayed all four commits identically by `git range-diff`.
- Exact HEAD `4bfd7ac9454f333abd095542dbcfa4f3fb209ef9`: 641 focused tests passed across Gateway send, shared message-action dispatch/context/security, agent message-tool, Nextcloud Talk actions, plugin loading, active registries, provenance, and registry lifecycle.
- Exact-HEAD `pnpm check:changed` and production `pnpm build` passed on Blacksmith Testbox `tbx_01kyk4dyam35qmemvx68th768g` ([run](https://github.com/openclaw/openclaw/actions/runs/30319552076)).
- Fresh whole-branch autoreview: clean, with no accepted/actionable findings.
- Sanitized live evidence retains no provider identifiers, payloads, private content, or credential material.

AI-assisted: yes. I reviewed the implementation, owner and sibling paths, security-sensitive invariants, deterministic tests, and live provider evidence.