### PR TITLE
fix(release): backport brace-expansion 5.0.8

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -796,15 +796,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ overrides:
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
   basic-ftp: 6.0.1
+  brace-expansion: 5.0.8
   file-type: 22.0.1
   form-data: 2.5.6
   ip-address: 10.2.0
@@ -5483,9 +5484,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -11984,7 +11985,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13894,7 +13895,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ minimumReleaseAgeExclude:
   - "axios"
   - "basic-ftp"
   - "baileys@7.0.0-rc13"
+  - "brace-expansion@5.0.8"
   - "hono"
   - "libopus-wasm@0.2.0"
   - "libsignal@6.0.0"
@@ -131,6 +132,7 @@ overrides:
   request: "npm:@cypress/request@3.0.10"
   request-promise: "npm:@cypress/request-promise@5.0.0"
   basic-ftp: 6.0.1
+  brace-expansion: 5.0.8
   file-type: 22.0.1
   form-data: 2.5.6
   ip-address: 10.2.0


### PR DESCRIPTION
## What Problem This Solves

Resolves a release blocker where `release/2026.7.2` still resolved the high-severity vulnerable `brace-expansion@5.0.7`, causing exact-SHA full release validation to fail its production security audit.

## Why This Change Was Made

Backports the exact main squash from #113428 (`78d8c1f934df33ec7654814a91bdce60fc547488`). It pins the patched `brace-expansion@5.0.8`, synchronizes pnpm and npm resolution records, and carries the explicitly approved one-version release-age exception.

## User Impact

Beta 5 can proceed without shipping the affected dependency version. There is no product behavior change.

## Evidence

- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high`: no high-or-higher advisories
- `CI=true pnpm install --lockfile-only --frozen-lockfile`: supply-chain policy passes
- `CI=true pnpm deps:shrinkwrap:check`: all 82 shrinkwraps current
- `node scripts/run-vitest.mjs test/package-manager-config.test.ts`: 13/13 pass
- `oxfmt --check pnpm-workspace.yaml`
- `git diff --check origin/release/2026.7.2...HEAD`
- autoreview: clean, patch correct (0.95)
- npm registry SRI for 5.0.8 matches both lockfiles exactly
