### PR TITLE
fix(tool-display): stop re-wrapping presented text in search summaries

### DIFF
--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -22,6 +22,38 @@ import {
   unwrapShellWrapper,
 } from "./tool-display-exec-shell.js";
 
+// Longest pattern we will echo verbatim into a `search "..."` label. Beyond
+// this the quoted pattern stops being a concise summary and starts being a
+// wall of text in the tool display.
+const MAX_DISPLAYED_SEARCH_PATTERN = 60;
+
+// Text that means the pattern is already presentation output rather than a
+// plain search term. Echoing it produces the nested `search "...search ..." in
+// ...` labels reported in #113401.
+const PRESENTED_PATTERN_MARKERS = ["search ", "bash failed:", "run command"];
+
+/**
+ * Whether an extracted grep/rg pattern is safe to echo verbatim into a
+ * `search "<pattern>"` label.
+ *
+ * Display-only guard: execution is untouched. A pattern that already looks like
+ * summarizer output, spans lines, or is simply too long falls back to the
+ * neutral `search text` label instead of being re-wrapped.
+ */
+function isDisplayablePattern(pattern: string): boolean {
+  if (pattern.length > MAX_DISPLAYED_SEARCH_PATTERN) {
+    return false;
+  }
+  if (/[\n\r`]/.test(pattern)) {
+    return false;
+  }
+  const normalized = pattern.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return !PRESENTED_PATTERN_MARKERS.some((marker) => normalized.startsWith(marker));
+}
+
 function summarizeKnownExec(words: string[]): string {
   if (words.length === 0) {
     return "run command";
@@ -117,10 +149,10 @@ function summarizeKnownExec(words: string[]): string {
     ]);
     const pattern = optionValue(words, ["-e", "--regexp"]) ?? positional[0];
     const target = positional.length > 1 ? positional.at(-1) : undefined;
-    if (pattern) {
+    if (pattern && isDisplayablePattern(pattern)) {
       return target ? `search "${pattern}" in ${target}` : `search "${pattern}"`;
     }
-    return "search text";
+    return target ? `search text in ${target}` : "search text";
   }
 
   if (bin === "find") {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -906,3 +906,45 @@ describe("coerceDisplayValue middle truncation", () => {
     expect(detail).toContain("AKIDAB…7890");
   });
 });
+
+describe("search summary pattern guard (#113401)", () => {
+  it("keeps ordinary grep patterns verbatim", () => {
+    expect(resolveExecDetail({ command: 'grep "needle" src/app.ts' })).toContain(
+      'search "needle" in src/app.ts',
+    );
+  });
+
+  it("keeps ordinary rg patterns verbatim without a target", () => {
+    expect(resolveExecDetail({ command: 'rg "TODO"' })).toContain('search "TODO"');
+  });
+
+  it("does not re-wrap a pattern that is already summarizer output", () => {
+    const detail = resolveExecDetail({ command: 'rg "search \\"foo\\" in bar" src' }) ?? "";
+    const label = detail.split(" \u00b7 ")[0] ?? "";
+    expect(label).toBe("search text in src");
+  });
+
+  it("does not re-wrap a pattern carrying a failure prefix", () => {
+    const detail = resolveExecDetail({ command: 'grep "Bash failed: boom" src' }) ?? "";
+    const label = detail.split(" \u00b7 ")[0] ?? "";
+    expect(label).toBe("search text in src");
+  });
+
+  it("falls back for very long patterns", () => {
+    const detail = resolveExecDetail({ command: `rg "${"x".repeat(120)}" src` }) ?? "";
+    const label = detail.split(" \u00b7 ")[0] ?? "";
+    expect(label).toBe("search text in src");
+  });
+
+  it("falls back for patterns containing backticks", () => {
+    const detail = resolveExecDetail({ command: 'rg "`whoami`" src' }) ?? "";
+    const label = detail.split(" \u00b7 ")[0] ?? "";
+    expect(label).toBe("search text in src");
+  });
+
+  it("keeps the target in the neutral fallback label", () => {
+    const detail = resolveExecDetail({ command: 'grep "search foo" lib/util.ts' }) ?? "";
+    const label = detail.split(" \u00b7 ")[0] ?? "";
+    expect(label).toBe("search text in lib/util.ts");
+  });
+});


### PR DESCRIPTION
Closes #113401.

The grep/rg branch of `summarizeKnownExec()` interpolated the extracted pattern directly into `search "<pattern>" in <target>`. When the pattern already carried presentation text, the summary layer re-wrapped it and produced nested, malformed labels like `search "...search ..." in ...`.

This adds a display-only guard at that boundary. A pattern is echoed verbatim only when it is a plain search term. It falls back to the neutral `search text` / `search text in <target>` label when it already starts with presentation text (`search `, `bash failed:`, `run command`), spans lines, contains backticks, or exceeds 60 characters.

Execution is untouched, only the rendered label changes. Ordinary summaries are unaffected: `grep "needle" src/app.ts` still renders `search "needle" in src/app.ts`.

Tests: 7 cases added to `src/agents/tool-display.test.ts` covering the recursive form, the failure-prefix form, long and backtick patterns, and the ordinary direct and no-target summaries. `node scripts/run-vitest.mjs src/agents/tool-display.test.ts` passes 61/61.