### PR TITLE
fix(qa): preserve provider state during gateway restarts

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1241,9 +1241,9 @@ describe("buildQaRuntimeEnv", () => {
     expect([child.exitCode, child.signalCode]).not.toEqual([null, null]);
   });
 
-  it("allows loaded runners time to reap force-killed gateway process groups", () => {
+  it("lets the gateway finish its bounded shutdown before process-tree escalation", () => {
     expect(testing.resolveQaGatewayChildStopTimeouts()).toEqual({
-      gracefulTimeoutMs: 5_000,
+      gracefulTimeoutMs: 30_000,
       forceTimeoutMs: 10_000,
     });
     expect(

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -79,7 +79,9 @@ const QA_GATEWAY_CHILD_STARTUP_MAX_ATTEMPTS = 5;
 const QA_GATEWAY_CHILD_RPC_STARTUP_TIMEOUT_MS = 30_000;
 const QA_GATEWAY_CHILD_RPC_RETRY_HEALTH_TIMEOUT_MS = 60_000;
 const QA_GATEWAY_CHILD_RESTART_BOUNDARY_TIMEOUT_MS = 90_000;
-const QA_GATEWAY_CHILD_GRACEFUL_SHUTDOWN_TIMEOUT_MS = 5_000;
+// The Gateway owns a 25s shutdown watchdog. Let it flush provider state before
+// the QA parent escalates to a process-tree kill.
+const QA_GATEWAY_CHILD_GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30_000;
 // Loaded Docker runners can take several seconds to reap a force-killed process group.
 const QA_GATEWAY_CHILD_FORCE_SHUTDOWN_TIMEOUT_MS = 10_000;
 const QA_MOCK_OPENAI_API_KEY = ["qa", "mock", "openai", "key"].join("-");


### PR DESCRIPTION
Closes #113438

## What Problem This Solves

Fixes an issue where QA Lab restart scenarios could force-stop an isolated Gateway before its bounded shutdown completed, causing provider state to be left unclean and valid restart behavior to fail validation.

## Why This Change Was Made

QA Lab now gives the Gateway's existing 25-second shutdown watchdog a 30-second parent grace window before retaining the same bounded process-tree force-kill fallback. Provider shutdown ordering and production Gateway behavior are unchanged.

## User Impact

No production runtime behavior changes. Maintainers get reliable restart/replay validation without premature termination interrupting provider persistence.

## Evidence

- Baseline live reproduction: Matrix `matrix-initial-catchup-then-incremental` failed with a present cursor marked as an unclean shutdown.
- Observation-only control: extending only the QA parent grace window made catch-up and incremental replies pass.
- Focused deterministic test: `81 passed` in `extensions/qa-lab/src/gateway-child.test.ts` on Node 24.15.
- Changed checks: extension typechecks, test typechecks, format, lint, import cycles, and repository guards passed on Node 24.15.
- Exact HEAD `fecfe0ec8fc54e3bb5e1de36708bb046771d349c`: live Matrix catch-up restart and subsequent incremental reply passed on direct AWS Crabbox ([run](https://crabbox.openclaw.ai/portal/runs/run_421764aca1c7)).
- Fresh autoreview: clean, no actionable findings (`patch is correct`, 0.98).
