### PR TITLE
fix(telegram): 401-suspension recovery names a CLI command that does not exist

### DIFF
--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -125,12 +125,31 @@ describe("createTelegramSendChatActionHandler", () => {
 
     expect(handler.isSuspended()).toBe(true);
     expect(logger.mock.calls.at(-1)).toEqual([
-      "CRITICAL: sendChatAction suspended after 3 consecutive 401 errors. Bot token is likely invalid. Telegram may DELETE the bot if requests continue. Replace the token and restart: openclaw channels restart telegram",
+      "CRITICAL: sendChatAction suspended after 3 consecutive 401 errors. Bot token is likely invalid. Telegram may DELETE the bot if requests continue. Replace the token with `openclaw channels add --channel telegram --token <token>`, then restart the gateway with `openclaw gateway restart`.",
     ]);
 
     // Subsequent calls are silently skipped
     await handler.sendChatAction(123, "typing");
     expect(fn).toHaveBeenCalledTimes(3); // not called again
+  });
+
+  it("suspension guidance does not point at a non-existent CLI subcommand", async () => {
+    const fn = vi.fn().mockRejectedValue(make401Error());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 1,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+
+    const critical = String(logger.mock.calls.at(-1)?.[0] ?? "");
+    expect(critical).toContain("CRITICAL");
+    // `openclaw channels` has no `restart` subcommand; recovery must name real commands.
+    expect(critical).not.toContain("channels restart");
+    expect(critical).toContain("openclaw channels add --channel telegram --token <token>");
+    expect(critical).toContain("openclaw gateway restart");
   });
 
   it("resets failure counter on success", async () => {
@@ -354,7 +373,7 @@ describe("createTelegramSendChatActionHandler", () => {
 
     expect(handler.isSuspended()).toBe(true);
     expect(logger.mock.calls.at(-1)).toEqual([
-      "CRITICAL: sendChatAction suspended after 2 consecutive 401 errors. Bot token is likely invalid. Telegram may DELETE the bot if requests continue. Replace the token and restart: openclaw channels restart telegram",
+      "CRITICAL: sendChatAction suspended after 2 consecutive 401 errors. Bot token is likely invalid. Telegram may DELETE the bot if requests continue. Replace the token with `openclaw channels add --channel telegram --token <token>`, then restart the gateway with `openclaw gateway restart`.",
     ]);
   });
 

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -199,7 +199,8 @@ export function createTelegramSendChatActionHandler({
           logger(
             `CRITICAL: sendChatAction suspended after ${consecutive401Failures} consecutive 401 errors. ` +
               `Bot token is likely invalid. Telegram may DELETE the bot if requests continue. ` +
-              `Replace the token and restart: openclaw channels restart telegram`,
+              `Replace the token with \`openclaw channels add --channel telegram --token <token>\`, ` +
+              `then restart the gateway with \`openclaw gateway restart\`.`,
           );
         } else {
           logger(


### PR DESCRIPTION
Closes #112477

## What Problem This Solves

Fixes an issue where operators hitting the Telegram consecutive-401 provider suspension were sent to a dead end by the product's own recovery guidance. The CRITICAL log line told them to run `openclaw channels restart telegram`, but `openclaw channels` has no `restart` subcommand, so the command exits 1 with "Too many arguments for this command" at exactly the moment the bot is at risk.

## Why This Change Was Made

The suspension message now names commands that actually exist: replacing the token with `openclaw channels add --channel telegram --token <token>`, then restarting with `openclaw gateway restart`. Message-text only, no behavior change to the backoff or suspension logic.

## User Impact

An operator following the CRITICAL recovery instruction can now actually recover instead of hitting an exit-1 dead end while the bot is suspended.

## Evidence

`extensions/telegram/src/sendchataction-401-backoff.test.ts` — 20 passed. Added a regression test asserting the suspension text never contains `channels restart` and does name both real commands; it fails on main (3 failures with the old string) and passes with the fix.
