### PR TITLE
feat(ui): render chat notice rows as markdown

### DIFF
--- a/ui/src/pages/chat/components/chat-divider.ts
+++ b/ui/src/pages/chat/components/chat-divider.ts
@@ -1,5 +1,8 @@
 import { html, nothing } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
+import { detectTextDirection } from "../../../lib/text-direction.ts";
 
 export function renderChatDivider(
   item: Extract<ChatItem, { kind: "divider" }>,
@@ -51,7 +54,9 @@ export function renderChatDivider(
 export function renderChatNotice(item: Extract<ChatItem, { kind: "notice" }>) {
   return html`
     <div class="chat-notice" data-chat-row-key=${item.key} data-ts=${String(item.timestamp)}>
-      ${item.text}
+      <div class="chat-text" dir=${detectTextDirection(item.text)}>
+        ${unsafeHTML(toSanitizedMarkdownHtml(item.text, { codeBlockChrome: "none" }))}
+      </div>
     </div>
   `;
 }

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./chat-message.ts";
 
 const localStorageValues = new Map<string, string>();
+const renderMarkdownHtml = markdown.toSanitizedMarkdownHtml;
 const markdownRenderMock = vi.fn(
   (value: string, _options?: { codeBlockChrome?: "copy" | "none"; fileLinks?: boolean }) => value,
 );
@@ -1903,21 +1904,31 @@ describe("grouped chat rendering", () => {
     expect(attribution?.nextElementSibling?.classList.contains("chat-bubble")).toBe(true);
   });
 
-  it("renders multiline system notices as plain centered rows", () => {
+  it("renders multiline system notices as sanitized markdown", () => {
     const container = document.createElement("div");
+    markdownRenderMock.mockImplementationOnce(renderMarkdownHtml);
     render(
       renderChatNotice({
         kind: "notice",
         key: "notice:command",
-        text: "first line\n  second line",
+        text: "**first line**\nsecond line\n<img src=x onerror=alert(1)><script>alert(1)</script>",
         timestamp: 1000,
       }),
       container,
     );
 
     const notice = container.querySelector<HTMLElement>(".chat-notice");
-    expect(notice?.textContent?.trim()).toBe("first line\n  second line");
+    expect(notice?.querySelector("strong")?.textContent).toBe("first line");
+    expect(notice?.textContent).not.toContain("**");
+    expect(notice?.querySelector("br")).not.toBeNull();
+    expect(notice?.textContent).toContain("first line");
+    expect(notice?.textContent).toContain("second line");
+    expect(notice?.querySelector("script")).toBeNull();
+    expect(notice?.querySelector("img[onerror]")).toBeNull();
     expect(notice?.dataset.chatRowKey).toBe("notice:command");
+    expect(markdownRenderMock).toHaveBeenCalledWith(expect.any(String), {
+      codeBlockChrome: "none",
+    });
   });
 
   it("uses the current profile display name for the signed-in user's historical messages", () => {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -411,7 +411,21 @@
   font-size: 12px;
   line-height: 1.4;
   text-align: center;
-  white-space: pre-wrap;
+}
+
+.chat-notice .chat-text {
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.chat-notice :where(ul, ol, pre, blockquote) {
+  display: inline-block;
+  text-align: left;
+}
+
+.chat-notice :where(:not(pre) > code) {
+  color: inherit;
 }
 
 /* Avatar Styles */


### PR DESCRIPTION
## What Problem This Solves

System-notice rows in the Control UI chat transcript (introduced in #112938 for local slash-command output) render their text as literal plain text, so authored markdown shows raw: `**Available Commands**` with visible asterisks and backticks around command names.

## Why This Change Was Made

`renderChatNotice` now renders through the same sanitized markdown pipeline messages use (`toSanitizedMarkdownHtml`, DOMPurify allowlist, `breaks: true` so command-output line structure survives, code-block chrome disabled). A direct `renderMarkdownText` import would have created a `chat-divider → chat-message-markdown → chat-thread → chat-divider` cycle, so the notice renderer inlines the non-streaming pipeline call instead (madge: 0 cycles). CSS keeps notices centered and muted; block content (lists, pre, blockquote) centers as a block but reads left-aligned.

## User Impact

`/help`, `/status` errors, and other command output read as formatted text instead of markdown source. No behavior change for any other transcript row.

| before | after |
| --- | --- |
| ![before](https://artifacts.openclaw.ai/pr-notice-markdown-20260724/notice-before.png) | ![after](https://artifacts.openclaw.ai/pr-notice-markdown-20260724/notice-after.png) |

Manifest: https://artifacts.openclaw.ai/pr-notice-markdown-20260724/artifact-manifest.json

## Evidence

- Screenshots above captured with the repo's mock-gateway e2e harness (`startControlUiE2eServer` + `installMockGateway`, seeded system-role history message) — before = current `main`, after = this branch, identical fixture.
- `node scripts/run-vitest.mjs ui/src/pages/chat` — 71 files, 1782 passed / 9 skipped. Updated notice regression asserts `<strong>` rendering, no literal `**`, preserved line breaks, and that `<script>`/`onerror` payloads are sanitized away.
- `node --import tsx scripts/check-madge-import-cycles.ts` — 0 cycles.
- Codex autoreview (gpt-5.6-sol): clean, no accepted/actionable findings.
