### PR TITLE
fix(workboard): restore sqlite cleanup policy coverage

### DIFF
--- a/extensions/workboard/src/sqlite-store-policy.test.ts
+++ b/extensions/workboard/src/sqlite-store-policy.test.ts
@@ -8,10 +8,8 @@ const { close, configureSqliteConnectionPragmas } = vi.hoisted(() => ({
   configureSqliteConnectionPragmas: vi.fn(),
 }));
 
-vi.mock("node:sqlite", () => ({
-  DatabaseSync: vi.fn(function DatabaseSync() {
-    return { close };
-  }),
+vi.mock("openclaw/plugin-sdk/sqlite-runtime", () => ({
+  openNodeSqliteDatabase: vi.fn(() => ({ close })),
 }));
 vi.mock("openclaw/plugin-sdk/plugin-state-runtime", () => ({
   configureSqliteConnectionPragmas,


### PR DESCRIPTION
Related: #113418

## What Problem This Solves

Resolves a release-blocking Plugin Prerelease failure where Workboard's SQLite cleanup policy test no longer observed the database opened by the production path after #113418 moved construction behind the plugin SDK SQLite runtime.

## Why This Change Was Made

The test now mocks `openclaw/plugin-sdk/sqlite-runtime`, the same public boundary used by Workboard production code. This keeps the existing assertion that a database is closed when connection policy setup fails, without changing runtime behavior.

## User Impact

No user-visible runtime change. This restores reliable release validation for the existing Workboard cleanup behavior.

## Evidence

- Before: `node scripts/run-vitest.mjs extensions/workboard/src/sqlite-store-policy.test.ts` failed because `close` was called zero times.
- After: the same focused test passes.
- `./node_modules/.bin/oxfmt --write extensions/workboard/src/sqlite-store-policy.test.ts`
- `git diff --check`
- Codex autoreview: no accepted/actionable findings.

AI-assisted: yes. The change and its production/test ownership boundary were reviewed by the submitting maintainer.
