### PR TITLE
fix(moonshot): type anyOf branches so Kimi accepts MCP tool schemas

### DIFF
--- a/extensions/moonshot/index.test.ts
+++ b/extensions/moonshot/index.test.ts
@@ -254,3 +254,33 @@ describe("moonshot provider plugin", () => {
     expect(provider.isModernModelRef?.({ provider: "moonshot", modelId: "kimi-k3" })).toBe(true);
   });
 });
+
+describe("moonshot tool schema normalization", () => {
+  it("normalizes tool schemas through the registered provider hook", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const normalized = provider.normalizeToolSchemas?.({
+      provider: "moonshot",
+      modelId: "kimi-k2.6",
+      modelApi: "openai-completions",
+      tools: [
+        {
+          name: "apollo_tasks_bulk_create",
+          description: "create tasks",
+          parameters: {
+            type: "object",
+            anyOf: [{ required: ["contact_id"] }, { required: ["account_id"] }],
+            properties: { contact_id: { type: "string" }, account_id: { type: "string" } },
+          },
+        },
+      ],
+    } as never) as Array<{ parameters?: Record<string, unknown> }> | null | undefined;
+
+    const parameters = normalized?.[0]?.parameters;
+    expect(parameters?.type).toBeUndefined();
+    expect(parameters?.anyOf).toEqual([
+      { type: "object", required: ["contact_id"] },
+      { type: "object", required: ["account_id"] },
+    ]);
+  });
+});

--- a/extensions/moonshot/index.ts
+++ b/extensions/moonshot/index.ts
@@ -14,6 +14,7 @@ import {
   resolveThinkingProfile,
 } from "./provider-policy-api.js";
 import { createKimiWebSearchProvider } from "./src/kimi-web-search-provider.js";
+import { normalizeMoonshotToolSchemas } from "./tool-schemas.js";
 
 const PROVIDER_ID = "moonshot";
 export default defineSingleProviderPluginEntry({
@@ -74,6 +75,7 @@ export default defineSingleProviderPluginEntry({
     wrapStreamFn: (ctx) => wrapMoonshotStream(ctx),
     wrapSimpleCompletionStreamFn: (ctx) => wrapMoonshotStream(ctx, true),
     resolveThinkingProfile,
+    normalizeToolSchemas: normalizeMoonshotToolSchemas,
     isModernModelRef: ({ modelId }) => isMoonshotAlwaysThinkingModelId(modelId),
   },
   register(api) {

--- a/extensions/moonshot/tool-schemas.test.ts
+++ b/extensions/moonshot/tool-schemas.test.ts
@@ -1,6 +1,6 @@
 // Moonshot tests cover the "moonshot flavored json schema" tool normalization.
 import { describe, expect, it } from "vitest";
-import { normalizeMoonshotSchema, normalizeMoonshotToolSchemas } from "./tool-schemas.js";
+import { normalizeMoonshotToolSchemas } from "./tool-schemas.js";
 
 // The reporter's Apollo.io MCP tool shape (apollo_tasks_bulk_create) from issue #113130.
 const apolloToolSchema = {
@@ -33,9 +33,18 @@ function itemsOf(schema: unknown): Record<string, unknown> {
   return (properties?.tasks_attributes?.items ?? {}) as Record<string, unknown>;
 }
 
-describe("normalizeMoonshotSchema", () => {
+// Drives one schema through the exported provider hook that `index.ts` wires
+// into, so these cases exercise the real registration path, not the internal
+// walker behind it.
+function normalizeSchema(parameters: unknown): unknown {
+  return normalizeMoonshotToolSchemas({
+    tools: [{ name: "probe", description: "", parameters }],
+  } as never)[0]?.parameters;
+}
+
+describe("moonshot schema normalization", () => {
   it("moves the parent type into nested anyOf branches", () => {
-    const items = itemsOf(normalizeMoonshotSchema(apolloToolSchema));
+    const items = itemsOf(normalizeSchema(apolloToolSchema));
 
     expect(items.type).toBeUndefined();
     expect(items.anyOf).toEqual([
@@ -57,7 +66,7 @@ describe("normalizeMoonshotSchema", () => {
       ],
     };
 
-    expect(normalizeMoonshotSchema(schema)).toEqual({
+    expect(normalizeSchema(schema)).toEqual({
       anyOf: [
         { type: "object", required: ["a"] },
         { type: "object", required: ["b"] },
@@ -84,7 +93,7 @@ describe("normalizeMoonshotSchema", () => {
     },
   ])("leaves the node as sent for $name", ({ node }) => {
     const schema = { type: "object", properties: { entry: node } };
-    expect(normalizeMoonshotSchema(schema)).toEqual(schema);
+    expect(normalizeSchema(schema)).toEqual(schema);
   });
 
   it("keeps an own hostile __proto__ key an own key", () => {
@@ -93,7 +102,7 @@ describe("normalizeMoonshotSchema", () => {
         {"required":["a"],"__proto__":{"polluted":true}},{"required":["b"]}]}}}`,
     ) as Record<string, unknown>;
 
-    const normalized = normalizeMoonshotSchema(schema) as {
+    const normalized = normalizeSchema(schema) as {
       properties: { entry: { anyOf: Array<Record<string, unknown>> } };
     };
     const branch = normalized.properties.entry.anyOf[0] as Record<string, unknown>;
@@ -108,7 +117,7 @@ describe("normalizeMoonshotSchema", () => {
       type: "object",
       properties: { entry: { type: "object", oneOf: [{ required: ["a"] }, { required: ["b"] }] } },
     };
-    expect(normalizeMoonshotSchema(schema)).toEqual(schema);
+    expect(normalizeSchema(schema)).toEqual(schema);
   });
 });
 

--- a/extensions/moonshot/tool-schemas.test.ts
+++ b/extensions/moonshot/tool-schemas.test.ts
@@ -1,0 +1,129 @@
+// Moonshot tests cover the "moonshot flavored json schema" tool normalization.
+import { describe, expect, it } from "vitest";
+import { normalizeMoonshotSchema, normalizeMoonshotToolSchemas } from "./tool-schemas.js";
+
+// The reporter's Apollo.io MCP tool shape (apollo_tasks_bulk_create) from issue #113130.
+const apolloToolSchema = {
+  type: "object",
+  properties: {
+    tasks_attributes: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["user_id", "type"],
+        anyOf: [
+          { required: ["contact_id"] },
+          { required: ["account_id"] },
+          { required: ["opportunity_id"] },
+        ],
+        properties: {
+          user_id: { type: "string" },
+          type: { type: "string" },
+          contact_id: { type: "string" },
+          account_id: { type: "string" },
+          opportunity_id: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+function itemsOf(schema: unknown): Record<string, unknown> {
+  const properties = (schema as { properties?: Record<string, { items?: unknown }> }).properties;
+  return (properties?.tasks_attributes?.items ?? {}) as Record<string, unknown>;
+}
+
+describe("normalizeMoonshotSchema", () => {
+  it("moves the parent type into nested anyOf branches", () => {
+    const items = itemsOf(normalizeMoonshotSchema(apolloToolSchema));
+
+    expect(items.type).toBeUndefined();
+    expect(items.anyOf).toEqual([
+      { type: "object", required: ["contact_id"] },
+      { type: "object", required: ["account_id"] },
+      { type: "object", required: ["opportunity_id"] },
+    ]);
+    // Sibling constraints stay on the parent node.
+    expect(items.required).toEqual(["user_id", "type"]);
+    expect(Object.keys(items.properties as Record<string, unknown>)).toHaveLength(5);
+  });
+
+  it("keeps a union that already types every branch", () => {
+    const schema = {
+      type: "object",
+      anyOf: [
+        { type: "object", required: ["a"] },
+        { type: "object", required: ["b"] },
+      ],
+    };
+
+    expect(normalizeMoonshotSchema(schema)).toEqual({
+      anyOf: [
+        { type: "object", required: ["a"] },
+        { type: "object", required: ["b"] },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      name: "a branch that is itself a union",
+      node: { type: "object", anyOf: [{ anyOf: [{ required: ["a"] }] }, { required: ["b"] }] },
+    },
+    {
+      name: "a branch declaring a wider type",
+      node: { type: "object", anyOf: [{ required: ["a"] }, { type: "string" }] },
+    },
+    {
+      name: "a $ref branch of unknown type",
+      node: { type: "object", anyOf: [{ required: ["a"] }, { $ref: "#/$defs/other" }] },
+    },
+    {
+      name: "a boolean branch",
+      node: { type: "object", anyOf: [{ required: ["a"] }, true] },
+    },
+  ])("leaves the node as sent for $name", ({ node }) => {
+    const schema = { type: "object", properties: { entry: node } };
+    expect(normalizeMoonshotSchema(schema)).toEqual(schema);
+  });
+
+  it("keeps an own hostile __proto__ key an own key", () => {
+    const schema = JSON.parse(
+      `{"type":"object","properties":{"entry":{"type":"object","anyOf":[
+        {"required":["a"],"__proto__":{"polluted":true}},{"required":["b"]}]}}}`,
+    ) as Record<string, unknown>;
+
+    const normalized = normalizeMoonshotSchema(schema) as {
+      properties: { entry: { anyOf: Array<Record<string, unknown>> } };
+    };
+    const branch = normalized.properties.entry.anyOf[0] as Record<string, unknown>;
+
+    expect(Object.getPrototypeOf(branch)).toBe(Object.prototype);
+    expect(Object.hasOwn(branch, "__proto__")).toBe(true);
+    expect(branch.type).toBe("object");
+  });
+
+  it("leaves oneOf alone because only anyOf is evidenced by the provider error", () => {
+    const schema = {
+      type: "object",
+      properties: { entry: { type: "object", oneOf: [{ required: ["a"] }, { required: ["b"] }] } },
+    };
+    expect(normalizeMoonshotSchema(schema)).toEqual(schema);
+  });
+});
+
+describe("normalizeMoonshotToolSchemas", () => {
+  it("rewrites tool parameters and passes through parameterless tools", () => {
+    const tools = [
+      { name: "apollo_tasks_bulk_create", description: "", parameters: apolloToolSchema },
+      { name: "no_params", description: "", parameters: undefined },
+    ];
+
+    const normalized = normalizeMoonshotToolSchemas({ tools } as never);
+
+    expect(itemsOf(normalized[0]?.parameters).type).toBeUndefined();
+    expect(normalized[1]).toBe(tools[1]);
+    // The source schema is not mutated in place.
+    expect(itemsOf(apolloToolSchema).type).toBe("object");
+  });
+});

--- a/extensions/moonshot/tool-schemas.test.ts
+++ b/extensions/moonshot/tool-schemas.test.ts
@@ -74,6 +74,31 @@ describe("moonshot schema normalization", () => {
     });
   });
 
+  // JSON Schema treats `integer` as a subtype of `number`, so a branch already typed
+  // `integer` must not block the rewrite under a `number` parent the way a genuinely
+  // wider type (e.g. `string`) does.
+  it("keeps a union already typed with a number-compatible integer subtype", () => {
+    const schema = {
+      type: "number",
+      anyOf: [{ type: "integer", minimum: 0 }, { type: "number" }],
+    };
+
+    expect(normalizeSchema(schema)).toEqual({
+      anyOf: [{ type: "integer", minimum: 0 }, { type: "number" }],
+    });
+  });
+
+  it("pushes the parent type into an untyped branch alongside a compatible typed integer branch", () => {
+    const schema = {
+      type: "number",
+      anyOf: [{ minimum: 0 }, { type: "integer" }],
+    };
+
+    expect(normalizeSchema(schema)).toEqual({
+      anyOf: [{ type: "number", minimum: 0 }, { type: "integer" }],
+    });
+  });
+
   it.each([
     {
       name: "a branch that is itself a union",

--- a/extensions/moonshot/tool-schemas.test.ts
+++ b/extensions/moonshot/tool-schemas.test.ts
@@ -112,6 +112,39 @@ describe("moonshot schema normalization", () => {
     expect(branch.type).toBe("object");
   });
 
+  // Draft-07 `dependencies` maps a property name to either a schema or a list of
+  // required property names. The schema form nests a real subschema, so a walker that
+  // skips the keyword copies the rejected parent-type/untyped-anyOf shape through.
+  it("normalizes schemas nested under legacy dependencies", () => {
+    const normalized = normalizeSchema({
+      type: "object",
+      properties: { billing: { type: "string" } },
+      dependencies: {
+        billing: {
+          type: "object",
+          anyOf: [{ required: ["card"] }, { required: ["invoice"] }],
+        },
+      },
+    }) as { dependencies: Record<string, Record<string, unknown>> };
+
+    const nested = normalized.dependencies.billing ?? {};
+    expect(nested.type).toBeUndefined();
+    expect(nested.anyOf).toEqual([
+      { type: "object", required: ["card"] },
+      { type: "object", required: ["invoice"] },
+    ]);
+  });
+
+  it("leaves the property-name-list form of dependencies untouched", () => {
+    const normalized = normalizeSchema({
+      type: "object",
+      properties: { billing: { type: "string" } },
+      dependencies: { billing: ["card", "invoice"] },
+    }) as { dependencies: Record<string, unknown> };
+
+    expect(normalized.dependencies.billing).toEqual(["card", "invoice"]);
+  });
+
   it("leaves oneOf alone because only anyOf is evidenced by the provider error", () => {
     const schema = {
       type: "object",

--- a/extensions/moonshot/tool-schemas.ts
+++ b/extensions/moonshot/tool-schemas.ts
@@ -3,6 +3,7 @@ import type {
   AnyAgentTool,
   ProviderNormalizeToolSchemasContext,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { asOptionalRecord as readRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 // Draft-07 `dependencies` is the union of the modern `dependentSchemas` and
 // `dependentRequired`: each value is either a subschema or a list of property names.
@@ -36,12 +37,6 @@ const SCHEMA_VALUE_KEYS = new Set([
   "contentSchema",
 ]);
 
-function readRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
 /** Own-property assignment so an own `__proto__` key from an MCP server stays an own key. */
 function setOwnKey(target: Record<string, unknown>, key: string, value: unknown): void {
   Object.defineProperty(target, key, {
@@ -62,6 +57,15 @@ function readSchemaTypes(schema: Record<string, unknown>): string[] | null {
     return type as string[];
   }
   return null;
+}
+
+/**
+ * JSON Schema treats `integer` as a numeric subtype: every integer value already satisfies
+ * `number`, so a branch typed `integer` is no wider than a `number` parent even though the
+ * literal strings differ.
+ */
+function isBranchTypeCompatible(branchType: string, parentTypeSet: Set<string>): boolean {
+  return parentTypeSet.has(branchType) || (branchType === "integer" && parentTypeSet.has("number"));
 }
 
 /**
@@ -87,7 +91,7 @@ function canPushTypeIntoBranches(branches: unknown[], parentTypes: string[]): bo
       const branchTypes = readSchemaTypes(record);
       return branchTypes === null
         ? !("type" in record)
-        : branchTypes.every((entry) => parentTypeSet.has(entry));
+        : branchTypes.every((entry) => isBranchTypeCompatible(entry, parentTypeSet));
     })
   );
 }

--- a/extensions/moonshot/tool-schemas.ts
+++ b/extensions/moonshot/tool-schemas.ts
@@ -4,10 +4,15 @@ import type {
   ProviderNormalizeToolSchemasContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 
+// Draft-07 `dependencies` is the union of the modern `dependentSchemas` and
+// `dependentRequired`: each value is either a subschema or a list of property names.
+// Walking it is safe for both, because the list form holds strings and a string is
+// not a record, so it round-trips unchanged.
 const SCHEMA_MAP_KEYS = new Set([
   "properties",
   "patternProperties",
   "dependentSchemas",
+  "dependencies",
   "$defs",
   "definitions",
 ]);

--- a/extensions/moonshot/tool-schemas.ts
+++ b/extensions/moonshot/tool-schemas.ts
@@ -1,0 +1,170 @@
+// Moonshot tool-schema normalization for the "moonshot flavored json schema" contract.
+import type {
+  AnyAgentTool,
+  ProviderNormalizeToolSchemasContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+const SCHEMA_MAP_KEYS = new Set([
+  "properties",
+  "patternProperties",
+  "dependentSchemas",
+  "$defs",
+  "definitions",
+]);
+
+const SCHEMA_VALUE_KEYS = new Set([
+  "items",
+  "additionalItems",
+  "prefixItems",
+  "additionalProperties",
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "then",
+  "else",
+  "if",
+  "not",
+  "contains",
+  "propertyNames",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+  "contentSchema",
+]);
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** Own-property assignment so an own `__proto__` key from an MCP server stays an own key. */
+function setOwnKey(target: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/** Declared types of a schema node, or null when it declares none we can safely move. */
+function readSchemaTypes(schema: Record<string, unknown>): string[] | null {
+  const type = schema.type;
+  if (typeof type === "string") {
+    return [type];
+  }
+  if (Array.isArray(type) && type.length > 0 && type.every((entry) => typeof entry === "string")) {
+    return type as string[];
+  }
+  return null;
+}
+
+/**
+ * Only move a parent `type` when every branch keeps the same value set: untyped branches inherit
+ * it, and already-typed branches must be no wider than the parent.
+ *
+ * `$ref` and boolean branches have an unknown type, and a branch that is itself a union would need
+ * `type` as an item of the outer union while forbidding it as the parent of its own — no rewrite
+ * satisfies Moonshot there, so those nodes keep the schema the server sent.
+ */
+function canPushTypeIntoBranches(branches: unknown[], parentTypes: string[]): boolean {
+  const parentTypeSet = new Set(parentTypes);
+  return (
+    branches.length > 0 &&
+    branches.every((branch) => {
+      const record = readRecord(branch);
+      if (!record || "$ref" in record) {
+        return false;
+      }
+      if (Array.isArray(record.anyOf) || Array.isArray(record.oneOf)) {
+        return false;
+      }
+      const branchTypes = readSchemaTypes(record);
+      return branchTypes === null
+        ? !("type" in record)
+        : branchTypes.every((entry) => parentTypeSet.has(entry));
+    })
+  );
+}
+
+/**
+ * Moonshot rejects the whole request when an `anyOf` branch omits `type`, demanding the type sit on
+ * the branches instead of the parent. Parent keywords and union branches are conjunctive, so moving
+ * the parent `type` into every untyped branch accepts the identical value set while satisfying that
+ * contract. Only `anyOf` is rewritten because only `anyOf` is evidenced by the provider error.
+ */
+export function normalizeMoonshotSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map(normalizeMoonshotSchema);
+  }
+  const record = readRecord(schema);
+  if (!record) {
+    return schema;
+  }
+
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (SCHEMA_MAP_KEYS.has(key) && readRecord(value)) {
+      const mapped: Record<string, unknown> = {};
+      for (const [entryKey, entryValue] of Object.entries(value as Record<string, unknown>)) {
+        setOwnKey(mapped, entryKey, normalizeMoonshotSchema(entryValue));
+      }
+      setOwnKey(next, key, mapped);
+      continue;
+    }
+    if (SCHEMA_VALUE_KEYS.has(key)) {
+      setOwnKey(next, key, normalizeMoonshotSchema(value));
+      continue;
+    }
+    setOwnKey(next, key, value);
+  }
+
+  const parentTypes = readSchemaTypes(next);
+  const branches = next.anyOf;
+  if (!parentTypes || !Array.isArray(branches) || !canPushTypeIntoBranches(branches, parentTypes)) {
+    return next;
+  }
+
+  const parentType = next.type;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(next)) {
+    if (key !== "type") {
+      setOwnKey(result, key, value);
+    }
+  }
+  setOwnKey(
+    result,
+    "anyOf",
+    branches.map((branch) => {
+      const branchRecord = branch as Record<string, unknown>;
+      if ("type" in branchRecord) {
+        return branchRecord;
+      }
+      const typedBranch: Record<string, unknown> = {};
+      setOwnKey(typedBranch, "type", parentType);
+      for (const [key, value] of Object.entries(branchRecord)) {
+        setOwnKey(typedBranch, key, value);
+      }
+      return typedBranch;
+    }),
+  );
+  return result;
+}
+
+/**
+ * Runs on every tool the runner registers, including MCP tools materialized after the base tool
+ * set, which is where the rejected schemas in practice come from.
+ */
+export function normalizeMoonshotToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): AnyAgentTool[] {
+  return ctx.tools.map((tool) => {
+    if (!tool.parameters || typeof tool.parameters !== "object") {
+      return tool;
+    }
+    return {
+      ...tool,
+      parameters: normalizeMoonshotSchema(tool.parameters) as AnyAgentTool["parameters"],
+    };
+  });
+}

--- a/extensions/moonshot/tool-schemas.ts
+++ b/extensions/moonshot/tool-schemas.ts
@@ -93,7 +93,7 @@ function canPushTypeIntoBranches(branches: unknown[], parentTypes: string[]): bo
  * the parent `type` into every untyped branch accepts the identical value set while satisfying that
  * contract. Only `anyOf` is rewritten because only `anyOf` is evidenced by the provider error.
  */
-export function normalizeMoonshotSchema(schema: unknown): unknown {
+function normalizeMoonshotSchema(schema: unknown): unknown {
   if (Array.isArray(schema)) {
     return schema.map(normalizeMoonshotSchema);
   }

--- a/extensions/moonshot/tool-schemas.ts
+++ b/extensions/moonshot/tool-schemas.ts
@@ -53,8 +53,9 @@ function readSchemaTypes(schema: Record<string, unknown>): string[] | null {
   if (typeof type === "string") {
     return [type];
   }
-  if (Array.isArray(type) && type.length > 0 && type.every((entry) => typeof entry === "string")) {
-    return type as string[];
+  if (Array.isArray(type) && type.length > 0) {
+    const names = type.filter((entry): entry is string => typeof entry === "string");
+    return names.length === type.length ? names : null;
   }
   return null;
 }
@@ -113,9 +114,10 @@ function normalizeMoonshotSchema(schema: unknown): unknown {
 
   const next: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
-    if (SCHEMA_MAP_KEYS.has(key) && readRecord(value)) {
+    const mapEntries = SCHEMA_MAP_KEYS.has(key) ? readRecord(value) : undefined;
+    if (mapEntries) {
       const mapped: Record<string, unknown> = {};
-      for (const [entryKey, entryValue] of Object.entries(value as Record<string, unknown>)) {
+      for (const [entryKey, entryValue] of Object.entries(mapEntries)) {
         setOwnKey(mapped, entryKey, normalizeMoonshotSchema(entryValue));
       }
       setOwnKey(next, key, mapped);
@@ -145,9 +147,11 @@ function normalizeMoonshotSchema(schema: unknown): unknown {
     result,
     "anyOf",
     branches.map((branch) => {
-      const branchRecord = branch as Record<string, unknown>;
-      if ("type" in branchRecord) {
-        return branchRecord;
+      // canPushTypeIntoBranches above already rejected any non-record branch; coerce
+      // again rather than assert so this stays correct if that guard ever loosens.
+      const branchRecord = readRecord(branch);
+      if (!branchRecord || "type" in branchRecord) {
+        return branch;
       }
       const typedBranch: Record<string, unknown> = {};
       setOwnKey(typedBranch, "type", parentType);
@@ -173,6 +177,9 @@ export function normalizeMoonshotToolSchemas(
     }
     return {
       ...tool,
+      // SAFETY: normalizeMoonshotSchema only rewrites `type`/`anyOf` placement inside the
+      // schema record it is given and never changes the node's shape, so the normalized
+      // value is the same JSON Schema the tool already declared.
       parameters: normalizeMoonshotSchema(tool.parameters) as AnyAgentTool["parameters"],
     };
   });

--- a/extensions/moonshot/tool-schemas.ts
+++ b/extensions/moonshot/tool-schemas.ts
@@ -177,9 +177,7 @@ export function normalizeMoonshotToolSchemas(
     }
     return {
       ...tool,
-      // SAFETY: normalizeMoonshotSchema only rewrites `type`/`anyOf` placement inside the
-      // schema record it is given and never changes the node's shape, so the normalized
-      // value is the same JSON Schema the tool already declared.
+      // SAFETY: normalizeMoonshotSchema only moves `type` into existing `anyOf` branches and never changes a node's shape, so the result is the same JSON Schema the tool declared.
       parameters: normalizeMoonshotSchema(tool.parameters) as AnyAgentTool["parameters"],
     };
   });


### PR DESCRIPTION
Related: #113130

## What Problem This Solves

Fixes an issue where users running a Moonshot (Kimi) model would have every turn fail when a connected MCP tool declares a parent-level `anyOf`.

Moonshot enforces a stricter "moonshot flavored JSON schema": each `anyOf` branch must declare its own `type`. A tool schema that puts `type` on the parent and uses `anyOf` only to constrain `required` — valid JSON Schema, and common in MCP servers — makes Moonshot reject the **entire request** with HTTP 400:

```
400 Invalid request: tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'properties.tasks_attributes.items': when using anyOf,
         type should be defined in anyOf items instead of the parent schema>
```

Because the whole request is refused, the turn always fails over to another provider (`candidate_failed requested=moonshot/kimi-k2.6 reason=format`). Kimi never serves those turns, ~50s is wasted per attempt, and Kimi-only setups hard-error. The reporter hit it with the Apollo.io MCP server's `apollo_tasks_bulk_create`, but any tool with that shape re-triggers it, so the documented workaround (excluding tools one by one) is whack-a-mole.

## Why This Change Was Made

The fix moves the parent `type` into untyped `anyOf` branches. Parent keywords and union branches are conjunctive, so adding the parent's `type` to each branch accepts an identical set of values — a shape change, not a semantic one.

It is registered as the provider-owned `normalizeToolSchemas` hook, which is documented for exactly this ("transport-family schema cleanup before OpenClaw registers tools with the embedded runner", `src/plugins/provider-plugin.types.ts:249-256`) and already used this way by `extensions/clawrouter` for Perplexity.

**Placing it at this seam matters.** The runner calls `normalizeAgentRuntimeTools` twice — once for the base tool set (`src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts:44`) and once for bundled MCP tools (`:165`) — and both routes reach this hook. That second route is the one the reported bug travels: MCP tools are materialized separately at `src/agents/agent-bundle-mcp-materialize.ts:299` via `normalizeToolParameterSchema(tool.inputSchema)` with **no** provider options, so anything keyed off model compat alone never sees them. I first built this against the shared normalizer's `toolSchemaProfile` and it did not cover the reporter's MCP path; the hook does.

Keeping the transform in the plugin also matches the repo's owner-boundary rule — provider-specific schema policy lives in the owner plugin, core keeps the generic seam. Core is untouched by this PR.

The transform is deliberately conservative, leaving the node exactly as the server sent it when it cannot be rewritten safely:

- a branch declares a wider or different `type`, or is a `$ref`/boolean schema (its type is unknowable);
- a branch is **itself** a union — such a branch would need `type` as an item of the outer union and no `type` as the parent of its own, so no rewrite satisfies Moonshot; emitting a half-rewritten schema would still be rejected.

Only `anyOf` is rewritten. Moonshot's error names `anyOf` and I have no evidence about `oneOf`, so the patch stays with what is evidenced; a test locks that in as intentional rather than an oversight.

**Related work.** #110138 (open) fixes the same Moonshot quirk for Kimi models proxied **through OpenRouter**, in `extensions/openrouter`, via this same `normalizeToolSchemas` hook. It does not cover the native `api.moonshot.ai` provider the reporter is on, so the two do not overlap — but they differ in approach: #110138 *strips* `anyOf`/`oneOf`, while this PR moves the parent `type` into the branches, which keeps the "exactly one of X/Y/Z" constraint the schema was expressing. If maintainers prefer one strategy for both routes, I am happy to align this PR to #110138 or to share this transform with it — worth deciding together rather than landing two different behaviors for the same vendor.

Gemini solves the same invariant in the opposite direction — it *drops* the parent `type` when a union is present (`packages/ai/src/providers/clean-for-gemini.ts:374`) — so its path is untouched, as are Anthropic and OpenAI Responses, which accept the schema as-is.

## User Impact

Moonshot/Kimi users can use MCP tools with parent-level `anyOf` schemas instead of hitting a hard 400 and silently failing over on every turn. No other provider is affected: the entire change lives in `extensions/moonshot`, and the hook only runs for Moonshot-routed models, so no other provider's tool-schema bytes change.

## Evidence

AI-assisted change (authored with Claude Code); the analysis, patch, and proof below were reviewed and run locally.

**Real-behavior before/after** — the reporter's exact Apollo.io schema through the real registered hook, nothing mocked:

```
=== BEFORE (current main: tool schema as the MCP server sent it) ===
{
  "type": "object",
  "anyOf": [
    { "required": [ "contact_id" ] },
    { "required": [ "account_id" ] },
    { "required": [ "opportunity_id" ] }
  ]
}

=== AFTER (moonshot normalizeToolSchemas hook) ===
{
  "anyOf": [
    { "type": "object", "required": [ "contact_id" ] },
    { "type": "object", "required": [ "account_id" ] },
    { "type": "object", "required": [ "opportunity_id" ] }
  ]
}

PASS  BEFORE reproduces the Moonshot-rejected shape (parent type + untyped anyOf branches)
PASS  AFTER moves type off the parent node
PASS  AFTER gives every anyOf branch its own type
PASS  AFTER preserves the sibling constraints (required/properties)
PASS  AFTER preserves each branch's own required constraint

PROOF PASS
```

**Negative control.** With the hook registration reverted to `origin/main` and the tests kept, the integration test fails:

```
× normalizes tool schemas through the registered provider hook
  Tests  1 failed | 8 passed (9)
```

With the hook registered:

```
node scripts/run-vitest.mjs extensions/moonshot
  Test Files  5 passed (5)
        Tests  39 passed (39)     # 30 before + 9 new
```

The added tests pin the conservative boundaries: a branch that is itself a union, a wider-typed branch, a `$ref` branch and a boolean branch each leave the node exactly as sent; `oneOf` is left alone; an own `__proto__` key from a JSON-parsed schema stays an own key (branch copies go through `Object.defineProperty`, not `Object.assign`, which would otherwise hit the prototype setter on untrusted MCP input); and the source schema is not mutated in place.

`pnpm tsgo:core` and `pnpm tsgo:extensions:test` pass; `oxfmt --check`, `oxlint`, and `git diff --check` are clean on the changed files.

**Limitations, stated plainly:**

- I have no Moonshot API key, so I cannot prove the server *accepts* the transformed schema. The transform is derived from Moonshot's own error text, and the before/after above shows exactly the shape change it asks for. One live call from the reporter would close this gap.
- A nested node that has `properties`/`required` but **no explicit `type`** is left untouched — there is no parent type to move, and inferring one would go beyond what the error evidences. If Moonshot also rejects that shape, it needs a follow-up.
- Whether Moonshot applies the same rule to `oneOf`, or to other parent-level keywords beside `anyOf`, is untested.
- Unrelated pre-existing failures on this base: `src/agents/agent-tools.before-tool-call.e2e.test.ts` has 3 failures that reproduce on unmodified `origin/main`.
- Adjacent pre-existing gap, not fixed here: a schema whose `anyOf` sits at the tool's **root** (beside `type: "object"` and `properties`) has that `anyOf` dropped entirely by the shared top-level union flatten, for every provider — silently discarding a "requires exactly one of X/Y/Z" constraint. It does not produce the reported 400, so I left it alone; happy to file it separately.


---

### Update 2026-08-04 — legacy `dependencies` gap closed, rebased

**Review finding fixed.** The walker covered `dependentSchemas` but not draft-07 `dependencies`, so a subschema nested there kept the exact parent-type/untyped-`anyOf` shape Moonshot rejects and the request still failed. That was a real hole in this fix, not a style point.

`dependencies` maps a property name to **either** a subschema **or** a list of required property names. Walking it is safe for both: the list form holds strings, and a string is not a record, so `normalizeMoonshotSchema` round-trips it unchanged. One line in `SCHEMA_MAP_KEYS`, plus a test for each form.

RED before the fix — only the new schema-form case fails, and the list-form guard already passes, so the change cannot regress it:

```
 ❯ extensions/moonshot/tool-schemas.test.ts:131:25
     expect(nested.type).toBeUndefined();
   + Received: "object"

 Tests  1 failed | 10 passed (11)
```

GREEN after:

```
node scripts/run-vitest.mjs run extensions/moonshot/tool-schemas.test.ts extensions/moonshot/index.test.ts
 Test Files  2 passed (2)
      Tests  20 passed (20)
```

**Completeness check.** Rather than fix only the reported keyword, I audited every JSON Schema keyword whose value is a map of name→schema. All six are now walked: `properties`, `patternProperties`, `$defs`, `definitions`, `dependentSchemas`, `dependencies`. `dependencies` was the only gap.

**Rebased** onto current `main`; the branch was behind and CI had been red on a stale base.

**On the native-endpoint proof — I can't produce it.** The remaining ask is evidence that a live Moonshot/Kimi endpoint accepts the transformed request. That needs a real Moonshot API key against the live service, which I don't have. I'm not going to substitute something weaker and present it as that. What is proven here is the transformation itself: the schemas this hook emits, driven through the real exported provider hook that `index.ts` registers, against the reporter's actual Apollo.io MCP tool shape from #113130. Whether Moonshot then accepts it needs someone with a key — happy to hand over an exact repro command if that helps.
