### PR TITLE
fix(ui): keep long Markdown previews scrollable

### DIFF
--- a/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
@@ -14,6 +14,7 @@ type DetailPanel = HTMLElement & {
 describe.runIf(browserMode)("chat sidebar layout", () => {
   it("keeps long markdown scrollable inside a bounded sidebar", async () => {
     const container = document.createElement("div");
+    container.className = "sidebar-column__panel";
     container.style.cssText = "display:flex;width:480px;height:320px;";
 
     const panel = document.createElement("openclaw-chat-detail-panel") as DetailPanel;
@@ -44,6 +45,7 @@ describe.runIf(browserMode)("chat sidebar layout", () => {
 
   it("keeps long files scrollable inside CodeMirror", async () => {
     const container = document.createElement("div");
+    container.className = "sidebar-column__panel";
     container.style.cssText = "display:flex;width:480px;height:320px;";
 
     const panel = document.createElement("openclaw-chat-detail-panel") as DetailPanel;

--- a/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import "../../../styles.css";
+import "../../../styles/chat.css";
+import type { SidebarContent } from "./chat-sidebar.ts";
+import "./chat-sidebar.ts";
+
+const browserMode = "__vitest_browser__" in globalThis;
+
+type DetailPanel = HTMLElement & {
+  content: SidebarContent;
+  updateComplete: Promise<unknown>;
+};
+
+describe.runIf(browserMode)("chat markdown sidebar layout", () => {
+  it("keeps long markdown scrollable inside a bounded sidebar", async () => {
+    const container = document.createElement("div");
+    container.style.cssText = "display:flex;width:480px;height:320px;";
+
+    const panel = document.createElement("openclaw-chat-detail-panel") as DetailPanel;
+    panel.className = "chat-sidebar";
+    panel.content = {
+      kind: "markdown",
+      content: Array.from(
+        { length: 40 },
+        (_, index) => `## Section ${index + 1}\n\nLong preview content for scrolling.`,
+      ).join("\n\n"),
+    };
+    container.append(panel);
+    document.body.append(container);
+
+    try {
+      await panel.updateComplete;
+      const content = panel.querySelector<HTMLElement>(".sidebar-content");
+      expect(content).not.toBeNull();
+      expect(content!.clientHeight).toBeLessThan(content!.scrollHeight);
+
+      content!.scrollTop = content!.scrollHeight;
+      await new Promise(requestAnimationFrame);
+      expect(content!.scrollTop).toBeGreaterThan(0);
+    } finally {
+      container.remove();
+    }
+  });
+});

--- a/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
@@ -11,7 +11,7 @@ type DetailPanel = HTMLElement & {
   updateComplete: Promise<unknown>;
 };
 
-describe.runIf(browserMode)("chat markdown sidebar layout", () => {
+describe.runIf(browserMode)("chat sidebar layout", () => {
   it("keeps long markdown scrollable inside a bounded sidebar", async () => {
     const container = document.createElement("div");
     container.style.cssText = "display:flex;width:480px;height:320px;";
@@ -37,6 +37,42 @@ describe.runIf(browserMode)("chat markdown sidebar layout", () => {
       content!.scrollTop = content!.scrollHeight;
       await new Promise(requestAnimationFrame);
       expect(content!.scrollTop).toBeGreaterThan(0);
+    } finally {
+      container.remove();
+    }
+  });
+
+  it("keeps long files scrollable inside CodeMirror", async () => {
+    const container = document.createElement("div");
+    container.style.cssText = "display:flex;width:480px;height:320px;";
+
+    const panel = document.createElement("openclaw-chat-detail-panel") as DetailPanel;
+    panel.className = "chat-sidebar";
+    panel.content = {
+      kind: "file",
+      path: "src/long-example.ts",
+      name: "long-example.ts",
+      language: "typescript",
+      content: Array.from(
+        { length: 200 },
+        (_, index) => `export const value${index + 1} = ${index + 1};`,
+      ).join("\n"),
+    };
+    container.append(panel);
+    document.body.append(container);
+
+    try {
+      await panel.updateComplete;
+      await expect
+        .poll(() => panel.querySelector<HTMLElement>(".cm-scroller"), { timeout: 5_000 })
+        .not.toBeNull();
+      const scroller = panel.querySelector<HTMLElement>(".cm-scroller");
+      expect(scroller).not.toBeNull();
+      expect(scroller!.clientHeight).toBeLessThan(scroller!.scrollHeight);
+
+      scroller!.scrollTop = scroller!.scrollHeight;
+      await new Promise(requestAnimationFrame);
+      expect(scroller!.scrollTop).toBeGreaterThan(0);
     } finally {
       container.remove();
     }

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -1280,9 +1280,10 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     const currentMatchIndex = matches.length
       ? Math.min(this.fileSearchMatchIndex, matches.length - 1)
       : 0;
-    // Markdown previews need a bounded host wrapper so their inner content can
-    // shrink and scroll. Content-sized kinds keep auto height.
-    const fillHost = this.visibleContent?.kind === "markdown";
+    // Markdown previews and file editors need a bounded host wrapper so their
+    // inner content can shrink and scroll. Content-sized kinds keep auto height.
+    const fillHost =
+      this.visibleContent?.kind === "file" || this.visibleContent?.kind === "markdown";
     return html`
       <div class=${fillHost ? "sidebar-panel-host--fill" : ""} @click=${this.handlePanelClick}>
         ${renderMarkdownSidebar({

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -1280,8 +1280,11 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     const currentMatchIndex = matches.length
       ? Math.min(this.fileSearchMatchIndex, matches.length - 1)
       : 0;
+    // Markdown previews need a bounded host wrapper so their inner content can
+    // shrink and scroll. Content-sized kinds keep auto height.
+    const fillHost = this.visibleContent?.kind === "markdown";
     return html`
-      <div @click=${this.handlePanelClick}>
+      <div class=${fillHost ? "sidebar-panel-host--fill" : ""} @click=${this.handlePanelClick}>
         ${renderMarkdownSidebar({
           content: this.visibleContent,
           error: this.error,

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1352,6 +1352,15 @@ openclaw-chat-sidebar-region,
   padding: 16px;
 }
 
+/* Full-height panel kinds need a bounded wrapper so their inner content can
+   shrink and scroll instead of expanding past the rail. */
+.sidebar-panel-host--fill {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
 openclaw-session-discussion {
   display: flex;
   flex: 1 1 0;

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1347,6 +1347,7 @@ openclaw-chat-sidebar-region,
 
 .sidebar-content {
   flex: 1;
+  min-height: 0;
   overflow: auto;
   padding: 16px;
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4040,6 +4040,7 @@ td.data-table-key-col {
 
 .md-preview-dialog__body {
   flex: 1;
+  min-height: 0;
   overflow: auto;
   overscroll-behavior: contain;
   padding: clamp(18px, 3vw, 28px);


### PR DESCRIPTION
Closes #107571
Incorporates and completes #107592.

## What Problem This Solves

Fixes an issue where long rendered Markdown and long file previews in the chat detail sidebar could expand their intermediate light-DOM wrapper past the visible rail instead of keeping their inner scroll container bounded. Resetting the flex scroll child's minimum height alone did not fix the unresolved parent height.

## Why This Change Was Made

This keeps the original `min-height: 0` fix from #107592, preserves its author's commit, and reuses the full-height host wrapper already present on current `main` for Markdown previews and file editors. Browser regressions verify real overflow and positive `scrollTop` in both the Markdown scroll container and CodeMirror. Content-sized detail kinds remain unchanged.

## User Impact

Long rendered Markdown remains independently scrollable inside the chat sidebar instead of being clipped, including in Firefox. Long files now remain bounded to the detail rail and scroll inside CodeMirror rather than growing beyond it. The Agents Markdown preview modal also retains the flex minimum-height repair from #107592.

## Evidence

- Before the Markdown host-wrapper fix, the focused browser regression measured `clientHeight = 4207` and `scrollHeight = 4207`; the sidebar had no overflow and could not scroll.
- After the Markdown fix, the same Chromium regression verifies overflow and a positive `scrollTop`.
- Following review feedback, a bounded 320 px file-sidebar reproduction measured a 3,694 px host and CodeMirror `clientHeight = scrollHeight = 3516`, proving the file editor had the same unresolved-parent-height problem.
- Adding `file` to the existing full-height host contract made the file regression pass and restored a positive CodeMirror `scrollTop`.
- Focused validation:
  `node ../scripts/run-vitest.mjs run --config vitest.config.ts src/pages/chat/components/chat-sidebar-scroll.browser.test.ts src/pages/chat/components/chat-sidebar-file-view.browser.test.ts src/pages/chat/components/chat-sidebar.test.ts`
  passed 3 files and 22 tests.
- The equivalent wrapper constraint was previously exercised successfully in Firefox 151 and Chromium; this version adapts it to the host-wrapper abstraction on current `main`.
- Targeted `oxlint` and `git diff --check` passed.
- TruffleHog pre-review scan passed with no findings.

AI-assisted: yes. I reviewed the layout path, reproduced both failures before their host-wrapper repairs, and understand the resulting flex and overflow contract.
