### PR TITLE
fix(qa): capture multi-session runtime tools

### DIFF
--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -463,6 +463,58 @@ describe("runtime parity", () => {
     expect(cell.toolCalls[0]?.argsHash).toBe(stableHash({ query: "release marker" }));
   });
 
+  it("captures tool evidence across multiple root sessions", async () => {
+    const now = Date.now();
+    const tempRoot = await seedRuntimeParityTranscript({
+      sessionId: "session-status-happy",
+      sessionKey: "agent:qa:runtime-tool:session_status:happy",
+      messages: [{ role: "user", content: "tool search qa check target=session_status" }],
+      updatedAt: now - 1_000,
+      trajectoryEvents: [
+        {
+          type: "tool.call",
+          data: {
+            toolCallId: "session-status-1",
+            name: "session_status",
+            arguments: {},
+          },
+        },
+        {
+          type: "tool.result",
+          data: {
+            toolCallId: "session-status-1",
+            name: "session_status",
+            status: "completed",
+            result: { status: "completed" },
+          },
+        },
+      ],
+    });
+    await seedRuntimeParityTranscript({
+      tempRoot,
+      sessionId: "session-status-failure",
+      sessionKey: "agent:qa:runtime-tool:session_status:failure",
+      messages: [
+        {
+          role: "user",
+          content: "tool search qa failure target=session_status",
+        },
+      ],
+      updatedAt: now,
+    });
+
+    const cell = await captureRuntimeParityCell({
+      runtime: "codex",
+      gateway: { tempRoot },
+      scenarioResult: { status: "pass" },
+      wallClockMs: 10,
+    });
+
+    expect(cell.transcriptBytes).toContain("target=session_status");
+    expect(cell.transcriptBytes).toContain("failure target=session_status");
+    expect(cell.toolCalls).toEqual([expect.objectContaining({ tool: "session_status" })]);
+  });
+
   it("keeps an explicitly identified orphan result separate", async () => {
     const tempRoot = await seedRuntimeParityTranscript({
       sessionId: "orphan-trajectory-result",

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -136,6 +136,7 @@ type RuntimeParityCaptureParams = {
 };
 
 type RuntimeParitySessionEntry = {
+  createdAt?: number;
   sessionId?: string;
   sessionFile?: string;
   updatedAt?: number;
@@ -175,8 +176,11 @@ type RuntimeParityPendingToolCall = RuntimeParityObservedToolCall & {
 };
 
 type RuntimeParityCaptureSources = {
+  sessions: Array<{
+    transcriptBytes: string;
+    trajectoryToolCalls: RuntimeParityObservedToolCall[];
+  }>;
   transcriptBytes: string;
-  trajectoryToolCalls: RuntimeParityObservedToolCall[];
 };
 
 const DEFAULT_AGENT_ID = "qa";
@@ -1215,9 +1219,11 @@ function readRuntimeParitySessionEntries(params: {
       .filter(({ entry }) => !readNonEmptyString(entry.heartbeatIsolatedBaseSessionKey));
     const rootEntries = entries.filter(({ entry }) => isRuntimeParityRootSession(entry));
     const candidates = rootEntries.length > 0 ? rootEntries : entries;
-    return candidates.toSorted(
-      (left, right) => (right.entry.updatedAt ?? 0) - (left.entry.updatedAt ?? 0),
-    );
+    return candidates.toSorted((left, right) => {
+      const leftCreatedAt = left.entry.createdAt ?? left.entry.updatedAt ?? 0;
+      const rightCreatedAt = right.entry.createdAt ?? right.entry.updatedAt ?? 0;
+      return leftCreatedAt - rightCreatedAt || left.sessionKey.localeCompare(right.sessionKey);
+    });
   } catch {
     return [];
   }
@@ -1234,6 +1240,7 @@ async function loadRuntimeParityCaptureSources(params: {
     stateDir,
     agentId: params.agentId,
   });
+  const sessions: RuntimeParityCaptureSources["sessions"] = [];
   for (const { entry, sessionKey } of sessionEntries) {
     const sessionId = readNonEmptyString(entry.sessionId);
     if (!sessionId) {
@@ -1270,10 +1277,16 @@ async function loadRuntimeParityCaptureSources(params: {
       // Transcript evidence remains authoritative when diagnostics are unavailable.
     }
     if (transcriptBytes || trajectoryToolCalls.length > 0) {
-      return { transcriptBytes, trajectoryToolCalls };
+      sessions.push({ transcriptBytes, trajectoryToolCalls });
     }
   }
-  return { transcriptBytes: "", trajectoryToolCalls: [] };
+  return {
+    sessions,
+    transcriptBytes: sessions
+      .map((session) => session.transcriptBytes)
+      .filter(Boolean)
+      .join("\n"),
+  };
 }
 
 async function loadRuntimeParityMockToolCalls(
@@ -1325,17 +1338,20 @@ export async function captureRuntimeParityCell(
   params: RuntimeParityCaptureParams,
 ): Promise<RuntimeParityCell> {
   const agentId = params.agentId ?? DEFAULT_AGENT_ID;
-  const { transcriptBytes, trajectoryToolCalls } = await loadRuntimeParityCaptureSources({
+  const { sessions, transcriptBytes } = await loadRuntimeParityCaptureSources({
     gateway: params.gateway,
     agentId,
   });
   const transcriptRecords = buildTranscriptRecords(transcriptBytes);
-  const transcriptToolCalls = resolveToolCallOrder(transcriptRecords);
+  // Runtime-tool fixtures split happy and failure paths across root sessions.
+  // Resolve each session separately so repeated tool-call ids cannot cross-link.
   const runtimeToolCalls = removeRuntimeParityToolCallIdentity(
-    mergeRuntimeParityToolCalls({
-      transcriptToolCalls,
-      trajectoryToolCalls,
-    }),
+    sessions.flatMap((session) =>
+      mergeRuntimeParityToolCalls({
+        transcriptToolCalls: resolveToolCallOrder(buildTranscriptRecords(session.transcriptBytes)),
+        trajectoryToolCalls: session.trajectoryToolCalls,
+      }),
+    ),
   );
   const parentPrompts = transcriptRecords
     .filter((record) => record.role === "user")


### PR DESCRIPTION
Related: #113461

## What Problem This Solves

Fixes an issue where `2026.7.2-beta.5` release validation reported zero
`session_status` calls when the QA scenario stored its happy and denied-input
paths in separate root sessions.

## Why This Change Was Made

Backports the exact main fix from
`d4a90c7bbb69b78990582a3b8952ff99f1812fa3`. Runtime parity capture now
aggregates every non-heartbeat root session in deterministic order and resolves
tool calls within each session before combining evidence.

## User Impact

Release validation can accurately enforce runtime tool coverage for
multi-session fixtures instead of blocking beta5 on a false zero-call result.

## Evidence

- Main PR: https://github.com/openclaw/openclaw/pull/113461
- Failing beta5 gate: https://github.com/openclaw/openclaw/actions/runs/30138562485/job/89629502761
- `node scripts/run-vitest.mjs extensions/qa-lab/src/runtime-parity.test.ts` (24/24 passed)
- `./node_modules/.bin/oxlint extensions/qa-lab/src/runtime-parity.ts extensions/qa-lab/src/runtime-parity.test.ts`
- `./node_modules/.bin/oxfmt --check extensions/qa-lab/src/runtime-parity.ts extensions/qa-lab/src/runtime-parity.test.ts`
- `git diff --check origin/release/2026.7.2..HEAD`
- Autoreview clean with no accepted or actionable findings
- Exact Testbox runtime-pair proof captured two `session_status` calls for both
  OpenClaw and Codex, including the denied-input result
