### PR TITLE
fix(qa): Slack and Discord scenario coverage

### DIFF
--- a/qa/scenarios/channels/discord-thread-reply-filepath-attachment.yaml
+++ b/qa/scenarios/channels/discord-thread-reply-filepath-attachment.yaml
@@ -4,6 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - discord.thread-actions
       - discord.media-and-rich-content
   execution:
     kind: flow

--- a/qa/scenarios/channels/slack-allowlist-block.yaml
+++ b/qa/scenarios/channels/slack-allowlist-block.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - slack.access-and-identity
+      - slack.channel-allowlists
   execution:
     profiles: { "slack:default": 2 }
     kind: flow

--- a/qa/scenarios/channels/slack-approval-exec-native.yaml
+++ b/qa/scenarios/channels/slack-approval-exec-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 7 }

--- a/qa/scenarios/channels/slack-approval-plugin-native.yaml
+++ b/qa/scenarios/channels/slack-approval-plugin-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 8 }

--- a/qa/scenarios/channels/slack-canary.yaml
+++ b/qa/scenarios/channels/slack-canary.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - slack.runtime-lifecycle
+      - slack.socket
   execution:
     profiles: { "slack:default": 0 }
     kind: flow

--- a/qa/scenarios/channels/slack-channel-disabled-warning.yaml
+++ b/qa/scenarios/channels/slack-channel-disabled-warning.yaml
@@ -4,7 +4,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - slack.access-and-identity
+      - slack.channel-allowlists
   execution:
     kind: flow
     channel: slack

--- a/qa/scenarios/channels/slack-codex-approval-exec-native.yaml
+++ b/qa/scenarios/channels/slack-codex-approval-exec-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 9 }

--- a/qa/scenarios/channels/slack-codex-approval-plugin-native.yaml
+++ b/qa/scenarios/channels/slack-codex-approval-plugin-native.yaml
@@ -4,6 +4,8 @@ scenario:
   surface: channels
   coverage:
     primary:
+      - slack.native-approvals
+    secondary:
       - channels.channel-native-approval-prompts
   execution:
     profiles: { "slack:default": 10 }


### PR DESCRIPTION
Closes #112842

## What Problem This Solves

Resolves a QA reporting problem where several Slack live scenarios credit broad or shared coverage owners even though their executions prove exact Slack behaviors, while one Discord filepath scenario omits the exact thread-action owner it exercises.

## Why This Change Was Made

The catalog now maps the affected scenarios to the current taxonomy owners their existing assertions actually prove: Slack Socket Mode, Slack channel allowlists, Slack native approvals, and Discord thread actions. Shared approval-prompt coverage remains secondary because those executions also assert the shared prompt/routing behavior. No taxonomy IDs, scenario execution, profiles, provider/model constraints, runtime code, or driver selection changed.

## User Impact

Runtime users see no behavior change. Maintainers and QA coverage consumers get more truthful Slack and Discord feature coverage without primary-evidence loss, hidden no-op fulfillment, or taxonomy padding.

## Evidence

- Audited all 31 current Slack/Discord catalog declarations: 18 dedicated Slack scenarios, 6 dedicated Discord scenarios, 6 shared scenarios retained in the Slack adapter profile, and 1 Discord-attributed setup script.
- Final-base Blacksmith Testbox proof passed 7 files / 162 tests: generic catalog/channel validation, Slack and Discord live runtime helpers, adapter registration, scenario lane, and suite planning: https://github.com/openclaw/openclaw/actions/runs/30140496056.
- The broad changed gate passed all fail-safe lanes, formatting, repository guards, full-project tsgo, full lint with zero warnings/errors, and runtime cycle checks: https://github.com/openclaw/openclaw/actions/runs/29974429893.
- Fresh final-base Codex autoreview (`gpt-5.6-sol`, high reasoning) returned zero findings, `patch is correct` (0.94).
- `git diff --check` passed. Final numstat is 8 YAML files, +12/-3, with zero production or test LOC.
- The two Codex approval mappings were checked against the command/file method declarations in `../codex/codex-rs/app-server-protocol/src/protocol/common.rs:1469` and `:1476`, request/response shapes in `../codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs:1427` and `:1506`, and lifecycle documentation in `../codex/codex-rs/app-server/README.md:1463` and `:1473`, at sibling Codex SHA `2e1607ee2fa8099a233df7437adee5f16a741905`.
- AI-assisted; I inspected the complete scenario flows, channel adapters/runtimes, taxonomy owners, sibling-channel implementations, callers/callees, and focused tests, and I understand the resulting mappings.
