### PR TITLE
fix(k8s): scope --delete to OpenClaw resources instead of the whole namespace

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -163,7 +163,15 @@ This applies all manifests and restarts the pod to pick up any config or secret 
 ./scripts/k8s/deploy.sh --delete
 ```
 
-This deletes the namespace and all resources in it, including the PVC.
+This deletes the OpenClaw resources (Deployment, Service, ConfigMap, PVC, and Secret) but leaves the namespace itself in place, so a shared namespace keeps its other workloads.
+
+To remove the namespace as well:
+
+```bash
+./scripts/k8s/deploy.sh --delete --delete-namespace
+```
+
+That destroys everything in the namespace, including resources OpenClaw did not create.
 
 ## Architecture notes
 

--- a/scripts/k8s/deploy.sh
+++ b/scripts/k8s/deploy.sh
@@ -8,7 +8,9 @@
 #   ./scripts/k8s/deploy.sh                   # Deploy (requires API key in env or secret already in cluster)
 #   ./scripts/k8s/deploy.sh --create-secret   # Create or update the K8s Secret from env vars
 #   ./scripts/k8s/deploy.sh --show-token      # Print the gateway token after deploy
-#   ./scripts/k8s/deploy.sh --delete          # Tear down
+#   ./scripts/k8s/deploy.sh --delete          # Tear down OpenClaw resources (keeps the namespace)
+#   ./scripts/k8s/deploy.sh --delete --delete-namespace
+#                                             # Also delete the namespace itself
 #
 # Environment:
 #   OPENCLAW_NAMESPACE   Kubernetes namespace (default: openclaw)
@@ -34,7 +36,10 @@ Usage: ./scripts/k8s/deploy.sh [OPTION]
   (no args)        Deploy OpenClaw (creates secret from env if needed)
   --create-secret  Create or update the K8s Secret from env vars without deploying
   --show-token     Print the gateway token after deploy or secret creation
-  --delete         Delete the namespace and all resources
+  --delete         Delete the OpenClaw resources (the namespace is preserved)
+  --delete-namespace
+                   With --delete, also delete the namespace itself. This
+                   destroys every other workload in that namespace.
   -h, --help       Show this help
 
 Environment:
@@ -47,6 +52,7 @@ HELP
 fi
 
 SHOW_TOKEN=false
+DELETE_NAMESPACE=false
 MODE="deploy"
 
 while [[ $# -gt 0 ]]; do
@@ -56,6 +62,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --delete)
       MODE="delete"
+      ;;
+    --delete-namespace)
+      MODE="delete"
+      DELETE_NAMESPACE=true
       ;;
     --show-token)
       SHOW_TOKEN=true
@@ -73,8 +83,19 @@ done
 # --delete
 # ---------------------------------------------------------------------------
 if [[ "$MODE" == "delete" ]]; then
-  echo "Deleting namespace '$NS' and all resources..."
-  kubectl delete namespace "$NS" --ignore-not-found
+  # Only remove what this script created. Deleting the namespace outright also
+  # destroys unrelated workloads whenever OPENCLAW_NAMESPACE points at a shared
+  # namespace, which is data loss the user never asked for.
+  echo "Deleting OpenClaw resources in namespace '$NS'..."
+  kubectl delete -k "$MANIFESTS" -n "$NS" --ignore-not-found
+  kubectl delete secret openclaw-secrets -n "$NS" --ignore-not-found
+
+  if $DELETE_NAMESPACE; then
+    echo "Deleting namespace '$NS'..."
+    kubectl delete namespace "$NS" --ignore-not-found
+  else
+    echo "Namespace '$NS' was left in place. Remove it with --delete --delete-namespace."
+  fi
   echo "Done."
   exit 0
 fi


### PR DESCRIPTION
Closes #112307

## What Problem This Solves

Fixes an issue where users tearing down a Kubernetes deployment with `./scripts/k8s/deploy.sh --delete` would lose every unrelated workload in that namespace. The script ran `kubectl delete namespace "$NS"`, and since `OPENCLAW_NAMESPACE` lets an operator deploy into an existing shared namespace, teardown destroyed services OpenClaw never created.

## Why This Change Was Made

`--delete` now removes only the resources this script applies: the kustomize manifest set (Deployment, Service, ConfigMap, PVC) plus the `openclaw-secrets` Secret. The namespace is preserved by default. Operators who genuinely want the namespace gone can opt in with `--delete --delete-namespace`, which keeps the old behavior available but makes the blast radius an explicit choice rather than the default.

## User Impact

Tearing down OpenClaw no longer risks deleting other people's workloads. Anyone deploying into a shared or pre-existing namespace can now run `--delete` safely; the destructive path still exists but has to be asked for by name.

## Evidence

`bash -n scripts/k8s/deploy.sh` is clean. The deletion is a label-free exact match on our own manifests: every resource in `scripts/k8s/manifests/` is listed in `kustomization.yaml`, so `kubectl delete -k` targets precisely the set that `kubectl apply -k` creates during deploy. The Secret is deleted separately because it is generated at runtime rather than checked in. `--delete-namespace` reproduces the previous behavior verbatim. Docs in `docs/install/kubernetes.md` updated to match, since the old text promised namespace deletion.
