### PR TITLE
fix(qa): retain runtime tool evidence after agent completion

### DIFF
--- a/extensions/qa-lab/src/runtime-parity-session-selection.test.ts
+++ b/extensions/qa-lab/src/runtime-parity-session-selection.test.ts
@@ -1,0 +1,125 @@
+import path from "node:path";
+import { resolveStorePath, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import {
+  appendSqliteTrajectoryRuntimeEvents,
+  formatSqliteSessionFileMarker,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { afterEach, describe, expect, it } from "vitest";
+import { captureRuntimeParityCell } from "./runtime-parity.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
+
+const tempDirs = createTempDirHarness();
+
+afterEach(async () => {
+  await tempDirs.cleanup();
+});
+
+async function seedSession(params: {
+  messages: Array<Record<string, unknown>>;
+  parentSessionKey?: string;
+  sessionId: string;
+  sessionKey: string;
+  tempRoot?: string;
+  trajectoryEvents?: Array<{ data?: Record<string, unknown>; type: string }>;
+  updatedAt: number;
+}) {
+  const tempRoot = params.tempRoot ?? (await tempDirs.makeTempDir("qa-runtime-selection-"));
+  const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(tempRoot, "state") };
+  const storePath = resolveStorePath(undefined, { agentId: "qa", env });
+  await upsertSessionEntry({
+    agentId: "qa",
+    env,
+    sessionKey: params.sessionKey,
+    storePath,
+    entry: {
+      sessionId: params.sessionId,
+      sessionFile: formatSqliteSessionFileMarker({
+        agentId: "qa",
+        sessionId: params.sessionId,
+        storePath,
+      }),
+      updatedAt: params.updatedAt,
+      ...(params.parentSessionKey ? { parentSessionKey: params.parentSessionKey } : {}),
+    },
+  });
+  for (const message of params.messages) {
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "qa",
+      env,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      storePath,
+      message: message as never,
+    });
+  }
+  if (params.trajectoryEvents?.length) {
+    appendSqliteTrajectoryRuntimeEvents(
+      { agentId: "qa", env, sessionId: params.sessionId, storePath },
+      params.trajectoryEvents.map((event, index) => ({
+        traceSchema: "openclaw-trajectory",
+        schemaVersion: 1,
+        traceId: params.sessionId,
+        source: "runtime",
+        type: event.type,
+        ts: new Date(index + 1).toISOString(),
+        seq: index + 1,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        runId: "run-1",
+        data: event.data,
+      })),
+    );
+  }
+  return tempRoot;
+}
+
+describe("runtime parity session selection", () => {
+  it("keeps fixture-owned tool sessions when Codex attaches parent metadata", async () => {
+    const now = Date.now();
+    const rootSessionKey = "agent:qa:unrelated-root";
+    const tempRoot = await seedSession({
+      sessionId: "unrelated-root",
+      sessionKey: rootSessionKey,
+      messages: [{ role: "assistant", content: "Setup complete." }],
+      updatedAt: now,
+    });
+    await seedSession({
+      tempRoot,
+      sessionId: "web-fetch-fixture",
+      sessionKey: "agent:qa:runtime-tool:web_fetch:failure",
+      parentSessionKey: rootSessionKey,
+      messages: [{ role: "user", content: "failure target=web_fetch" }],
+      updatedAt: now - 1_000,
+      trajectoryEvents: [
+        {
+          type: "tool.call",
+          data: {
+            toolCallId: "web-fetch-1",
+            name: "web_fetch",
+            arguments: { __qaFailureMode: "denied-input" },
+          },
+        },
+        {
+          type: "tool.result",
+          data: {
+            toolCallId: "web-fetch-1",
+            name: "web_fetch",
+            status: "failed",
+            success: false,
+            result: { error: "url required" },
+          },
+        },
+      ],
+    });
+
+    const cell = await captureRuntimeParityCell({
+      runtime: "codex",
+      gateway: { tempRoot },
+      scenarioResult: { status: "pass" },
+      wallClockMs: 10,
+    });
+
+    expect(cell.toolCalls).toEqual([expect.objectContaining({ tool: "web_fetch" })]);
+  });
+});

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -31,6 +31,7 @@ afterEach(async () => {
 async function seedRuntimeParityTranscript(params: {
   heartbeatIsolatedBaseSessionKey?: string;
   messages: Array<Record<string, unknown>>;
+  parentSessionKey?: string;
   sessionId: string;
   sessionKey: string;
   tempRoot?: string;
@@ -59,6 +60,7 @@ async function seedRuntimeParityTranscript(params: {
       ...(params.heartbeatIsolatedBaseSessionKey
         ? { heartbeatIsolatedBaseSessionKey: params.heartbeatIsolatedBaseSessionKey }
         : {}),
+      ...(params.parentSessionKey ? { parentSessionKey: params.parentSessionKey } : {}),
     },
   });
   for (const [index, message] of params.messages.entries()) {
@@ -513,6 +515,53 @@ describe("runtime parity", () => {
     expect(cell.transcriptBytes).toContain("target=session_status");
     expect(cell.transcriptBytes).toContain("failure target=session_status");
     expect(cell.toolCalls).toEqual([expect.objectContaining({ tool: "session_status" })]);
+  });
+
+  it("keeps fixture-owned tool sessions when Codex attaches parent metadata", async () => {
+    const now = Date.now();
+    const tempRoot = await seedRuntimeParityTranscript({
+      sessionId: "unrelated-root",
+      sessionKey: "agent:qa:unrelated-root",
+      messages: [{ role: "assistant", content: "Setup complete." }],
+      updatedAt: now,
+    });
+    await seedRuntimeParityTranscript({
+      tempRoot,
+      sessionId: "web-fetch-fixture",
+      sessionKey: "agent:qa:runtime-tool:web_fetch:failure",
+      parentSessionKey: "agent:qa:unrelated-root",
+      messages: [{ role: "user", content: "failure target=web_fetch" }],
+      updatedAt: now - 1_000,
+      trajectoryEvents: [
+        {
+          type: "tool.call",
+          data: {
+            toolCallId: "web-fetch-1",
+            name: "web_fetch",
+            arguments: { __qaFailureMode: "denied-input" },
+          },
+        },
+        {
+          type: "tool.result",
+          data: {
+            toolCallId: "web-fetch-1",
+            name: "web_fetch",
+            status: "failed",
+            success: false,
+            result: { error: "url required" },
+          },
+        },
+      ],
+    });
+
+    const cell = await captureRuntimeParityCell({
+      runtime: "codex",
+      gateway: { tempRoot },
+      scenarioResult: { status: "pass" },
+      wallClockMs: 10,
+    });
+
+    expect(cell.toolCalls).toEqual([expect.objectContaining({ tool: "web_fetch" })]);
   });
 
   it("keeps an explicitly identified orphan result separate", async () => {

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -31,7 +31,6 @@ afterEach(async () => {
 async function seedRuntimeParityTranscript(params: {
   heartbeatIsolatedBaseSessionKey?: string;
   messages: Array<Record<string, unknown>>;
-  parentSessionKey?: string;
   sessionId: string;
   sessionKey: string;
   tempRoot?: string;
@@ -60,7 +59,6 @@ async function seedRuntimeParityTranscript(params: {
       ...(params.heartbeatIsolatedBaseSessionKey
         ? { heartbeatIsolatedBaseSessionKey: params.heartbeatIsolatedBaseSessionKey }
         : {}),
-      ...(params.parentSessionKey ? { parentSessionKey: params.parentSessionKey } : {}),
     },
   });
   for (const [index, message] of params.messages.entries()) {
@@ -515,53 +513,6 @@ describe("runtime parity", () => {
     expect(cell.transcriptBytes).toContain("target=session_status");
     expect(cell.transcriptBytes).toContain("failure target=session_status");
     expect(cell.toolCalls).toEqual([expect.objectContaining({ tool: "session_status" })]);
-  });
-
-  it("keeps fixture-owned tool sessions when Codex attaches parent metadata", async () => {
-    const now = Date.now();
-    const tempRoot = await seedRuntimeParityTranscript({
-      sessionId: "unrelated-root",
-      sessionKey: "agent:qa:unrelated-root",
-      messages: [{ role: "assistant", content: "Setup complete." }],
-      updatedAt: now,
-    });
-    await seedRuntimeParityTranscript({
-      tempRoot,
-      sessionId: "web-fetch-fixture",
-      sessionKey: "agent:qa:runtime-tool:web_fetch:failure",
-      parentSessionKey: "agent:qa:unrelated-root",
-      messages: [{ role: "user", content: "failure target=web_fetch" }],
-      updatedAt: now - 1_000,
-      trajectoryEvents: [
-        {
-          type: "tool.call",
-          data: {
-            toolCallId: "web-fetch-1",
-            name: "web_fetch",
-            arguments: { __qaFailureMode: "denied-input" },
-          },
-        },
-        {
-          type: "tool.result",
-          data: {
-            toolCallId: "web-fetch-1",
-            name: "web_fetch",
-            status: "failed",
-            success: false,
-            result: { error: "url required" },
-          },
-        },
-      ],
-    });
-
-    const cell = await captureRuntimeParityCell({
-      runtime: "codex",
-      gateway: { tempRoot },
-      scenarioResult: { status: "pass" },
-      wallClockMs: 10,
-    });
-
-    expect(cell.toolCalls).toEqual([expect.objectContaining({ tool: "web_fetch" })]);
   });
 
   it("keeps an explicitly identified orphan result separate", async () => {

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -1,5 +1,4 @@
 import {
-  listSessionEntries,
   loadTranscriptEventsSync,
   resolveStorePath,
 } from "openclaw/plugin-sdk/session-store-runtime";
@@ -21,6 +20,7 @@ import {
 } from "./gateway-log-sentinel.js";
 import { discardIgnoredResponseBody } from "./ignored-response-body.js";
 import * as parity from "./parity-shared.js";
+import { readRawQaSessionStore } from "./suite-runtime-agent-session.js";
 
 export type RuntimeId = "openclaw" | "codex";
 
@@ -1201,32 +1201,30 @@ function runtimeParitySessionEnv(stateDir: string): NodeJS.ProcessEnv {
   return { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 }
 
-function readRuntimeParitySessionEntries(params: {
-  stateDir: string;
+async function readRuntimeParitySessionEntries(params: {
+  gateway: QaGatewayLike;
   agentId: string;
-}): RuntimeParitySessionCandidate[] {
-  try {
-    const entries = listSessionEntries({
-      agentId: params.agentId,
-      env: runtimeParitySessionEnv(params.stateDir),
-      readOnly: true,
-    })
-      .filter(({ entry }) => readNonEmptyString(entry.sessionId))
-      .map(({ entry, sessionKey }) => ({
-        entry: entry as RuntimeParitySessionEntry,
-        sessionKey,
-      }))
-      .filter(({ entry }) => !readNonEmptyString(entry.heartbeatIsolatedBaseSessionKey));
-    const rootEntries = entries.filter(({ entry }) => isRuntimeParityRootSession(entry));
-    const candidates = rootEntries.length > 0 ? rootEntries : entries;
-    return candidates.toSorted((left, right) => {
-      const leftCreatedAt = left.entry.createdAt ?? left.entry.updatedAt ?? 0;
-      const rightCreatedAt = right.entry.createdAt ?? right.entry.updatedAt ?? 0;
-      return leftCreatedAt - rightCreatedAt || left.sessionKey.localeCompare(right.sessionKey);
-    });
-  } catch {
-    return [];
-  }
+}): Promise<RuntimeParitySessionCandidate[]> {
+  // This feeds release evidence: after bounded FTS-settle retries, a persistent
+  // store failure must fail capture instead of becoming an empty false green.
+  const store = await readRawQaSessionStore(
+    { gateway: params.gateway },
+    { agentId: params.agentId },
+  );
+  const entries = Object.entries(store)
+    .filter(([, entry]) => readNonEmptyString(entry.sessionId))
+    .map(([sessionKey, entry]) => ({
+      entry: entry as RuntimeParitySessionEntry,
+      sessionKey,
+    }))
+    .filter(({ entry }) => !readNonEmptyString(entry.heartbeatIsolatedBaseSessionKey));
+  const rootEntries = entries.filter(({ entry }) => isRuntimeParityRootSession(entry));
+  const candidates = rootEntries.length > 0 ? rootEntries : entries;
+  return candidates.toSorted((left, right) => {
+    const leftCreatedAt = left.entry.createdAt ?? left.entry.updatedAt ?? 0;
+    const rightCreatedAt = right.entry.createdAt ?? right.entry.updatedAt ?? 0;
+    return leftCreatedAt - rightCreatedAt || left.sessionKey.localeCompare(right.sessionKey);
+  });
 }
 
 async function loadRuntimeParityCaptureSources(params: {
@@ -1236,8 +1234,8 @@ async function loadRuntimeParityCaptureSources(params: {
   const stateDir = `${params.gateway.tempRoot}/state`;
   const env = runtimeParitySessionEnv(stateDir);
   const storePath = resolveStorePath(undefined, { agentId: params.agentId, env });
-  const sessionEntries = readRuntimeParitySessionEntries({
-    stateDir,
+  const sessionEntries = await readRuntimeParitySessionEntries({
+    gateway: params.gateway,
     agentId: params.agentId,
   });
   const sessions: RuntimeParityCaptureSources["sessions"] = [];

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -1201,6 +1201,10 @@ function runtimeParitySessionEnv(stateDir: string): NodeJS.ProcessEnv {
   return { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 }
 
+function isRuntimeToolFixtureSessionKey(sessionKey: string, agentId: string) {
+  return sessionKey.startsWith(`agent:${agentId}:runtime-tool:`);
+}
+
 async function readRuntimeParitySessionEntries(params: {
   gateway: QaGatewayLike;
   agentId: string;
@@ -1219,7 +1223,19 @@ async function readRuntimeParitySessionEntries(params: {
     }))
     .filter(({ entry }) => !readNonEmptyString(entry.heartbeatIsolatedBaseSessionKey));
   const rootEntries = entries.filter(({ entry }) => isRuntimeParityRootSession(entry));
-  const candidates = rootEntries.length > 0 ? rootEntries : entries;
+  const candidates = rootEntries.length > 0 ? [...rootEntries] : [...entries];
+  // Runtime-tool fixtures own these dedicated sessions even when Codex attaches
+  // parent metadata. Keep them beside roots without admitting arbitrary children.
+  const candidateKeys = new Set(candidates.map(({ sessionKey }) => sessionKey));
+  for (const entry of entries) {
+    if (
+      !candidateKeys.has(entry.sessionKey) &&
+      isRuntimeToolFixtureSessionKey(entry.sessionKey, params.agentId)
+    ) {
+      candidates.push(entry);
+      candidateKeys.add(entry.sessionKey);
+    }
+  }
   return candidates.toSorted((left, right) => {
     const leftCreatedAt = left.entry.createdAt ?? left.entry.updatedAt ?? 0;
     const rightCreatedAt = right.entry.createdAt ?? right.entry.updatedAt ?? 0;

--- a/extensions/qa-lab/src/runtime-tool-fixture.test.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.test.ts
@@ -181,6 +181,10 @@ describe("runtime tool fixture", () => {
     );
     const createdKeys: string[] = [];
     const promptKeys: string[] = [];
+    const promptEvidence: Array<{
+      requireSuccessfulTranscriptToolResult?: boolean;
+      transcriptToolName?: string;
+    }> = [];
     const readEffectiveTools = vi.fn(async (_env, sessionKey: string) => {
       expect(sessionKey).toBe("agent:qa:runtime-tool:read:happy");
       return new Set(["read"]);
@@ -203,6 +207,10 @@ describe("runtime tool fixture", () => {
         readEffectiveTools,
         runAgentPrompt: vi.fn(async (_env, params) => {
           promptKeys.push(params.sessionKey);
+          promptEvidence.push({
+            transcriptToolName: params.transcriptToolName,
+            requireSuccessfulTranscriptToolResult: params.requireSuccessfulTranscriptToolResult,
+          });
           return {};
         }),
         fetchJson: vi.fn(),
@@ -217,6 +225,10 @@ describe("runtime tool fixture", () => {
     expect(promptKeys).toEqual([
       "agent:qa:runtime-tool:read:happy",
       "agent:qa:runtime-tool:read:failure",
+    ]);
+    expect(promptEvidence).toEqual([
+      { transcriptToolName: "read", requireSuccessfulTranscriptToolResult: true },
+      { transcriptToolName: "read", requireSuccessfulTranscriptToolResult: undefined },
     ]);
   });
 

--- a/extensions/qa-lab/src/runtime-tool-fixture.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.ts
@@ -70,6 +70,8 @@ type QaRuntimeToolFixtureDeps = {
       sessionKey: string;
       message: string;
       timeoutMs?: number;
+      transcriptToolName?: string;
+      requireSuccessfulTranscriptToolResult?: boolean;
     },
   ) => Promise<unknown>;
   fetchJson: (url: string) => Promise<unknown>;
@@ -676,11 +678,15 @@ export async function runRuntimeToolFixture(
     sessionKey: happySessionKey,
     message: happyPrompt,
     timeoutMs: liveTurnTimeoutMs(env, 45_000),
+    ...(happyPathOutputRequired
+      ? { transcriptToolName: toolName, requireSuccessfulTranscriptToolResult: true }
+      : {}),
   });
   await deps.runAgentPrompt(env, {
     sessionKey: failureSessionKey,
     message: failurePrompt,
     timeoutMs: liveTurnTimeoutMs(env, 45_000),
+    transcriptToolName: toolName,
   });
 
   if (!env.mock) {

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -9,6 +9,7 @@ const spawnSyncMock = vi.hoisted(() => vi.fn());
 const resolveQaNodeExecPathMock = vi.hoisted(() => vi.fn(async () => "/usr/bin/node"));
 const waitForGatewayHealthyMock = vi.hoisted(() => vi.fn(async () => undefined));
 const waitForTransportReadyMock = vi.hoisted(() => vi.fn(async () => undefined));
+const readSessionTranscriptSummaryMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
   spawn: spawnMock,
@@ -22,6 +23,10 @@ vi.mock("./node-exec.js", () => ({
 vi.mock("./suite-runtime-gateway.js", () => ({
   waitForGatewayHealthy: waitForGatewayHealthyMock,
   waitForTransportReady: waitForTransportReadyMock,
+}));
+
+vi.mock("./suite-runtime-agent-session.js", () => ({
+  readSessionTranscriptSummary: readSessionTranscriptSummaryMock,
 }));
 
 import { QA_CHILD_STDERR_TAIL_BYTES, QA_CHILD_STDOUT_MAX_BYTES } from "./child-output.js";
@@ -86,6 +91,7 @@ describe("qa suite runtime agent process helpers", () => {
     resolveQaNodeExecPathMock.mockClear();
     waitForGatewayHealthyMock.mockClear();
     waitForTransportReadyMock.mockClear();
+    readSessionTranscriptSummaryMock.mockReset();
   });
 
   it("runs the qa cli through the resolved node executable", async () => {
@@ -766,6 +772,103 @@ describe("qa suite runtime agent process helpers", () => {
       started: { runId: "run-error-completed" },
       waited: { status: "error", error: "completed" },
     });
+  });
+
+  it("waits for persisted transcript tool evidence after agent completion", async () => {
+    vi.useFakeTimers();
+    try {
+      const gatewayCall = vi
+        .fn()
+        .mockResolvedValueOnce({ runId: "run-transcript-evidence" })
+        .mockResolvedValueOnce({ status: "completed" });
+      readSessionTranscriptSummaryMock
+        .mockResolvedValueOnce({
+          assistantToolCallCounts: {},
+          completedToolCallCounts: {},
+          successfulToolCallCounts: {},
+          finalText: "",
+        })
+        .mockResolvedValueOnce({
+          assistantToolCallCounts: { session_status: 1 },
+          completedToolCallCounts: { session_status: 1 },
+          successfulToolCallCounts: { session_status: 1 },
+          finalText: "",
+        });
+      const env = {
+        gateway: { call: gatewayCall },
+        transport: {
+          buildAgentDelivery: vi.fn(() => ({
+            channel: "qa-channel",
+            replyChannel: "reply-channel",
+            replyTo: "reply-target",
+          })),
+        },
+      } as never;
+
+      const pending = runAgentPrompt(env, {
+        sessionKey: "session-transcript-evidence",
+        message: "call session_status",
+        transcriptToolName: "session_status",
+        requireSuccessfulTranscriptToolResult: true,
+      });
+      await vi.advanceTimersByTimeAsync(50);
+
+      await expect(pending).resolves.toEqual({
+        started: { runId: "run-transcript-evidence" },
+        waited: { status: "completed" },
+      });
+      expect(readSessionTranscriptSummaryMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for a persisted failed tool result after the call is visible", async () => {
+    vi.useFakeTimers();
+    try {
+      const gatewayCall = vi
+        .fn()
+        .mockResolvedValueOnce({ runId: "run-failed-tool-evidence" })
+        .mockResolvedValueOnce({ status: "completed" });
+      readSessionTranscriptSummaryMock
+        .mockResolvedValueOnce({
+          assistantToolCallCounts: { session_status: 1 },
+          completedToolCallCounts: {},
+          successfulToolCallCounts: {},
+          finalText: "",
+        })
+        .mockResolvedValueOnce({
+          assistantToolCallCounts: { session_status: 1 },
+          completedToolCallCounts: { session_status: 1 },
+          successfulToolCallCounts: {},
+          finalText: "",
+        });
+      const env = {
+        gateway: { call: gatewayCall },
+        transport: {
+          buildAgentDelivery: vi.fn(() => ({
+            channel: "qa-channel",
+            replyChannel: "reply-channel",
+            replyTo: "reply-target",
+          })),
+        },
+      } as never;
+
+      const pending = runAgentPrompt(env, {
+        sessionKey: "session-failed-tool-evidence",
+        message: "call session_status with invalid input",
+        transcriptToolName: "session_status",
+      });
+      await vi.advanceTimersByTimeAsync(50);
+
+      await expect(pending).resolves.toEqual({
+        started: { runId: "run-failed-tool-evidence" },
+        waited: { status: "completed" },
+      });
+      expect(readSessionTranscriptSummaryMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("waits for the latest assistant history reply", async () => {

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -20,6 +20,7 @@ import { QaSuiteInfraError } from "./errors.js";
 import { extractGatewayMessageText } from "./gateway-log-sentinel.js";
 import { resolveQaNodeExecPath } from "./node-exec.js";
 import { liveTurnTimeoutMs } from "./suite-runtime-agent-common.js";
+import { readSessionTranscriptSummary } from "./suite-runtime-agent-session.js";
 import { waitForGatewayHealthy, waitForTransportReady } from "./suite-runtime-gateway.js";
 import type { QaDreamingStatus, QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
 import { resolveQaGatewayTimeoutWithGraceMs } from "./timer-timeouts.js";
@@ -56,6 +57,8 @@ const MANAGED_DREAMING_PROMPT = "__openclaw_memory_core_short_term_promotion_dre
 const QA_HISTORY_RETRY_DEFAULT_MS = 250;
 const QA_HISTORY_RETRY_MIN_MS = 100;
 const QA_HISTORY_RETRY_MAX_MS = 5_000;
+const QA_TRANSCRIPT_EVIDENCE_TIMEOUT_MS = 5_000;
+const QA_TRANSCRIPT_EVIDENCE_POLL_MS = 50;
 
 function stripAnsiCodes(text: string) {
   return text.replace(ANSI_ESCAPE_PATTERN, "");
@@ -602,6 +605,42 @@ async function forceMemoryIndex(params: {
   return result;
 }
 
+async function waitForPersistedTranscriptToolEvidence(
+  env: Pick<QaSuiteRuntimeEnv, "gateway">,
+  params: {
+    sessionKey: string;
+    toolName: string;
+    requireSuccessfulResult: boolean;
+  },
+) {
+  const startedAt = Date.now();
+  let lastError: unknown;
+  while (Date.now() - startedAt < QA_TRANSCRIPT_EVIDENCE_TIMEOUT_MS) {
+    try {
+      const summary = await readSessionTranscriptSummary(env, params.sessionKey, {
+        allowEmpty: true,
+      });
+      const completedCount = summary.completedToolCallCounts[params.toolName] ?? 0;
+      const successfulCount = summary.successfulToolCallCounts[params.toolName] ?? 0;
+      if (completedCount > 0 && (!params.requireSuccessfulResult || successfulCount > 0)) {
+        return;
+      }
+      lastError = undefined;
+    } catch (error) {
+      lastError = error;
+    }
+    const remainingMs = QA_TRANSCRIPT_EVIDENCE_TIMEOUT_MS - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      break;
+    }
+    await sleep(Math.min(QA_TRANSCRIPT_EVIDENCE_POLL_MS, remainingMs));
+  }
+  throw new Error(
+    `timed out after ${QA_TRANSCRIPT_EVIDENCE_TIMEOUT_MS}ms waiting for persisted ${params.toolName} transcript evidence`,
+    lastError === undefined ? undefined : { cause: lastError },
+  );
+}
+
 async function runAgentPrompt(
   env: Pick<QaSuiteRuntimeEnv, "gateway" | "transport">,
   params: {
@@ -612,6 +651,8 @@ async function runAgentPrompt(
     provider?: string;
     model?: string;
     timeoutMs?: number;
+    transcriptToolName?: string;
+    requireSuccessfulTranscriptToolResult?: boolean;
     attachments?: Array<{
       mimeType: string;
       fileName: string;
@@ -625,6 +666,13 @@ async function runAgentPrompt(
     throw new Error(
       `agent.wait returned ${waited.status ?? "unknown"}: ${waited.error ?? "no error"}`,
     );
+  }
+  if (params.transcriptToolName) {
+    await waitForPersistedTranscriptToolEvidence(env, {
+      sessionKey: params.sessionKey,
+      toolName: params.transcriptToolName,
+      requireSuccessfulResult: params.requireSuccessfulTranscriptToolResult === true,
+    });
   }
   return {
     started,

--- a/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
@@ -188,6 +188,19 @@ describe("qa suite runtime agent session helpers", () => {
     });
   });
 
+  it("reads a requested agent session store", async () => {
+    const readEntries = vi.fn(() => []);
+
+    await expect(
+      readRawQaSessionStore({ gateway: { tempRoot: "/tmp/qa-agent-store" } } as never, {
+        agentId: "alternate",
+        readEntries,
+        retryDelaysMs: [],
+      }),
+    ).resolves.toEqual({});
+    expect(readEntries).toHaveBeenCalledWith(expect.objectContaining({ agentId: "alternate" }));
+  });
+
   it("retries transient FTS integrity mismatches while child transcripts settle", async () => {
     const readEntries = vi
       .fn()
@@ -356,6 +369,7 @@ describe("qa suite runtime agent session helpers", () => {
       ),
     ).resolves.toEqual({
       assistantToolCallCounts: { message: 1 },
+      completedToolCallCounts: {},
       eventCursor: 2,
       successfulToolCallCounts: {},
       finalText: "",
@@ -382,6 +396,7 @@ describe("qa suite runtime agent session helpers", () => {
       ),
     ).resolves.toEqual({
       assistantToolCallCounts: { message: 1 },
+      completedToolCallCounts: {},
       eventCursor: 3,
       successfulToolCallCounts: {},
       finalText: "Sent.",
@@ -436,6 +451,7 @@ describe("qa suite runtime agent session helpers", () => {
       ),
     ).resolves.toEqual({
       assistantToolCallCounts: { message: 1 },
+      completedToolCallCounts: {},
       eventCursor: 4,
       successfulToolCallCounts: {},
       finalText: "Sent.",
@@ -542,6 +558,7 @@ describe("qa suite runtime agent session helpers", () => {
       ),
     ).resolves.toMatchObject({
       assistantToolCallCounts: { update_plan: 2, write: 1 },
+      completedToolCallCounts: { update_plan: 2 },
       successfulToolCallCounts: { update_plan: 1 },
     });
   });
@@ -607,6 +624,7 @@ describe("qa suite runtime agent session helpers", () => {
       }),
     ).resolves.toEqual({
       assistantToolCallCounts: {},
+      completedToolCallCounts: {},
       eventCursor: 0,
       successfulToolCallCounts: {},
       finalText: "",

--- a/extensions/qa-lab/src/suite-runtime-agent-session.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.ts
@@ -48,6 +48,7 @@ const SESSION_STORE_FTS_SETTLE_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000] a
 type QaSessionTranscriptSummary = {
   assistantMirrors?: Array<{ identity: string; text: string }>;
   assistantToolCallCounts: Record<string, number>;
+  completedToolCallCounts: Record<string, number>;
   eventCursor: number;
   successfulToolCallCounts: Record<string, number>;
   finalText: string;
@@ -117,8 +118,10 @@ function summarizeSessionTranscriptEvents(
   const scanner = createDirectReplyTranscriptSentinelScanner();
   const assistantMirrors: Array<{ identity: string; text: string }> = [];
   const assistantToolCallCounts: Record<string, number> = {};
+  const completedToolCallCounts: Record<string, number> = {};
   const successfulToolCallCounts: Record<string, number> = {};
   const assistantToolNamesByCallId = new Map<string, string>();
+  const completedToolCallIds = new Set<string>();
   const successfulToolCallIds = new Set<string>();
   let finalText = "";
   let lastAssistantContentTypes: string[] = [];
@@ -136,6 +139,15 @@ function summarizeSessionTranscriptEvents(
     if (message.role === "toolResult") {
       const toolCallId = readNonEmptyString(message.toolCallId);
       const toolName = readNonEmptyString(message.toolName);
+      if (
+        toolCallId &&
+        toolName &&
+        assistantToolNamesByCallId.get(toolCallId) === toolName &&
+        !completedToolCallIds.has(toolCallId)
+      ) {
+        completedToolCallIds.add(toolCallId);
+        completedToolCallCounts[toolName] = (completedToolCallCounts[toolName] ?? 0) + 1;
+      }
       if (
         toolCallId &&
         toolName &&
@@ -186,6 +198,7 @@ function summarizeSessionTranscriptEvents(
   return {
     ...(assistantMirrors.length > 0 ? { assistantMirrors } : {}),
     assistantToolCallCounts,
+    completedToolCallCounts,
     eventCursor,
     successfulToolCallCounts,
     finalText,
@@ -201,6 +214,7 @@ function summarizeSessionTranscriptEvents(
 function emptySessionTranscriptSummary(eventCursor: number): QaSessionTranscriptSummary {
   return {
     assistantToolCallCounts: {},
+    completedToolCallCounts: {},
     eventCursor,
     successfulToolCallCounts: {},
     finalText: "",
@@ -353,17 +367,19 @@ async function seedQaSessionTranscript(
 async function readRawQaSessionStore(
   env: Pick<QaSuiteRuntimeEnv, "gateway">,
   options: {
+    agentId?: string;
     readEntries?: typeof listSessionEntries;
     retryDelaysMs?: readonly number[];
   } = {},
 ) {
   const runtimeEnv = qaSessionRuntimeEnv(env.gateway.tempRoot);
+  const agentId = readNonEmptyString(options.agentId) ?? "qa";
   const readEntries = options.readEntries ?? listSessionEntries;
   const retryDelaysMs = options.retryDelaysMs ?? SESSION_STORE_FTS_SETTLE_RETRY_DELAYS_MS;
   for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
     try {
       return Object.fromEntries(
-        readEntries({ agentId: "qa", env: runtimeEnv }).map(({ sessionKey, entry }) => [
+        readEntries({ agentId, env: runtimeEnv }).map(({ sessionKey, entry }) => [
           sessionKey,
           entry as QaRawSessionStoreEntry,
         ]),

--- a/extensions/qa-lab/src/suite-runtime-agent-session.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.ts
@@ -365,7 +365,7 @@ async function seedQaSessionTranscript(
 }
 
 async function readRawQaSessionStore(
-  env: Pick<QaSuiteRuntimeEnv, "gateway">,
+  env: { gateway: Pick<QaSuiteRuntimeEnv["gateway"], "tempRoot"> },
   options: {
     agentId?: string;
     readEntries?: typeof listSessionEntries;


### PR DESCRIPTION
Related: #113399
Related: #113452
Related: #113461

## What Problem This Solves

Fixes release-validation races where runtime-tool fixtures finish successfully but Codex parity capture sees no persisted sessions. The core tool-coverage gate first missed `session_status`; after #113461 added multi-session capture, it then missed `web_fetch` because Codex attached parent metadata to the dedicated fixture sessions.

## Why This Change Was Made

This builds on #113461 and #113484. Runtime-tool prompts wait for matching persisted results; session summaries distinguish completed from successful results; parity capture uses the FTS-settling session reader; and fixture-owned child sessions remain eligible. The PR also repairs current `main`'s env-surface ratchet by renaming a non-environment constant that accidentally used the `OPENCLAW_*` namespace. Provider-plan diagnostics stay separate from runtime evidence.

## User Impact

No shipped runtime behavior changes. Release QA now reports persisted OpenClaw/Codex tool execution instead of intermittently losing fixture sessions.

## Evidence

- Reproduced in Full Release Validation child `30138562485`: all 27 runtime-pair scenarios passed, but runtime tool coverage missed `session_status`.
- Reproduced after #113461 in child `30140988851`: OpenClaw captured two `web_fetch` calls while Codex captured zero because its fixture sessions were parent-linked.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/runtime-parity.test.ts extensions/qa-lab/src/runtime-tool-fixture.test.ts extensions/qa-lab/src/suite-runtime-agent-process.test.ts extensions/qa-lab/src/suite-runtime-agent-session.test.ts` — 4 files / 107 tests passed.
- Blacksmith Testbox `tbx_01kybhwyp20kf4m4ga9anhjawq`: three consecutive exact `openai/gpt-5.5` mock runtime-pair runs captured `session_status` in both OpenClaw and Codex.
- Final head Testbox `30142769154`: exact `openai/gpt-5.5` runtime-pair proof captured both `web_fetch` calls and both `session_status` calls in OpenClaw and Codex.
- Rebased-head Testbox `30143866279`: 108 focused tests and exact `web_fetch`/`session_status` runtime-pair proof passed on current main.
- Current-main ratchet repair: `OPENCLAW_* count 521/521`; OpenAI completions compatibility suite passed 22 tests.
- `git diff --check`
- Codex autoreview: no accepted/actionable findings after the final review/fix cycle.

AI-assisted: yes. Findings were verified against the release artifacts, persisted Testbox state, and the full fixture/capture ownership path.
