### PR TITLE
fix(memory): close previous embedding provider before replacement

### DIFF
--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -165,6 +165,18 @@ describe("createEmbeddingProvider", () => {
   });
 
   it("uses a generic embedding provider when no memory-specific provider exists", async () => {
+    const genericProvider = {
+      id: "generic",
+      model: "generic-model",
+      closed: false,
+      embed: async (_input: unknown, callOptions?: { inputType?: string }) =>
+        callOptions?.inputType === "query" ? [1] : [2],
+      embedBatch: async (inputs: unknown[], callOptions?: { inputType?: string }) =>
+        inputs.map(() => (callOptions?.inputType === "document" ? [3] : [4])),
+      async close() {
+        this.closed = true;
+      },
+    };
     registerGenericEmbeddingProvider({
       id: "openai-compatible",
       create: async (options) => {
@@ -176,13 +188,7 @@ describe("createEmbeddingProvider", () => {
           ).acquireLocalService,
         ).toBe(mockEmbeddingRegistry.acquireLocalService);
         return {
-          provider: {
-            id: "generic",
-            model: "generic-model",
-            embed: async (_input, callOptions) => (callOptions?.inputType === "query" ? [1] : [2]),
-            embedBatch: async (inputs, callOptions) =>
-              inputs.map(() => (callOptions?.inputType === "document" ? [3] : [4])),
-          },
+          provider: genericProvider,
         };
       },
     });
@@ -194,6 +200,8 @@ describe("createEmbeddingProvider", () => {
     expect(mockEmbeddingRegistry.genericLookupConfigs).toEqual([options.config]);
     await expect(result.provider?.embedQuery("hello")).resolves.toEqual([1]);
     await expect(result.provider?.embedBatch(["doc"])).resolves.toEqual([[3]]);
+    await result.provider?.close?.();
+    expect(genericProvider.closed).toBe(true);
   });
 
   it("keeps concurrent provider creation bound to each caller's local-service hook", async () => {

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -75,7 +75,7 @@ function adaptGenericEmbeddingProvider(
         ...options,
         inputType: "document",
       }),
-    ...(provider.close ? { close: provider.close } : {}),
+    ...(provider.close ? { close: async () => await provider.close?.() } : {}),
   };
   const getRuntimeFacts = Reflect.get(provider, LOCAL_EMBEDDING_RUNTIME_FACTS);
   if (typeof getRuntimeFacts === "function") {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2063,6 +2063,113 @@ describe("memory index", () => {
     });
   });
 
+  it("waits for degraded provider shutdown before replacement initialization", async () => {
+    const cfg = createCfg({ fallback: "fallback-provider" });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+
+    let releaseProviderClose: () => void = () => {};
+    providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+    const fields = manager as unknown as {
+      provider: {
+        id: string;
+        model: string;
+        embedQuery: (text: string) => Promise<number[]>;
+        embedBatch: (texts: string[]) => Promise<number[][]>;
+        close: () => Promise<void>;
+      } | null;
+      markLocalEmbeddingProviderDegraded: (err: unknown) => void;
+    };
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    fields.provider.id = "local";
+    fields.markLocalEmbeddingProviderDegraded(createLocalWorkerExitError());
+    await vi.waitFor(() => expect(providerCloseCalls).toBe(1));
+
+    const callsBeforeSearch = providerCalls.length;
+    const searchPromise = manager.search("alpha");
+    try {
+      await Promise.resolve();
+      expect(providerCalls).toHaveLength(callsBeforeSearch);
+    } finally {
+      releaseProviderClose();
+      providerCloseGate = null;
+      await searchPromise;
+    }
+    expect(providerCalls.slice(callsBeforeSearch).map((call) => call.provider)).toEqual(["openai"]);
+  });
+
+  it("waits for provider shutdown before retry initialization", async () => {
+    const cfg = createCfg({ provider: "openai" });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+
+    let releaseProviderClose: () => void = () => {};
+    providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+    (
+      manager as unknown as {
+        resetProviderInitializationForRetry: () => void;
+      }
+    ).resetProviderInitializationForRetry();
+    await vi.waitFor(() => expect(providerCloseCalls).toBe(1));
+
+    const callsBeforeProbe = providerCalls.length;
+    const probePromise = manager.probeEmbeddingAvailability();
+    try {
+      await Promise.resolve();
+      expect(providerCalls).toHaveLength(callsBeforeProbe);
+    } finally {
+      releaseProviderClose();
+      providerCloseGate = null;
+      await probePromise;
+    }
+    expect(providerCalls.slice(callsBeforeProbe).map((call) => call.provider)).toEqual(["openai"]);
+  });
+
+  it("waits for active provider shutdown before fallback initialization", async () => {
+    const cfg = createCfg({
+      fallback: "fallback-provider",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+
+    let releaseProviderClose: () => void = () => {};
+    providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+    const fields = manager as unknown as {
+      provider: {
+        embedQuery: (text: string) => Promise<number[]>;
+      } | null;
+    };
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    fields.provider.embedQuery = async () => {
+      throw new Error("embedding provider failed");
+    };
+
+    const callsBeforeSearch = providerCalls.length;
+    const searchPromise = manager.search("alpha");
+    try {
+      await vi.waitFor(() => expect(providerCloseCalls).toBe(1));
+      expect(providerCalls).toHaveLength(callsBeforeSearch);
+    } finally {
+      releaseProviderClose();
+      providerCloseGate = null;
+      await searchPromise;
+    }
+    expect(providerCalls.slice(callsBeforeSearch).map((call) => call.provider)).toEqual([
+      "fallback-provider",
+    ]);
+  });
+
   it("does not activate fallback during search when index identity is already mismatched", async () => {
     const cfg = createCfg({
       fallback: "fallback-provider",

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2497,6 +2497,59 @@ describe("memory index", () => {
     await expect(concurrentSearch).resolves.toBeDefined();
   });
 
+  it("waits for admitted provider users before retirement", async () => {
+    const cfg = createCfg({ provider: "openai" });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      provider: {
+        embedQuery: (text: string) => Promise<number[]>;
+      } | null;
+      embedQueryWithRetry: (text: string) => Promise<number[]>;
+      retireCurrentProvider: () => Promise<void>;
+    };
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    let releaseFirstQuery: () => void = () => {};
+    let markFirstQueryStarted: () => void = () => {};
+    const firstQueryGate = new Promise<void>((resolve) => {
+      releaseFirstQuery = resolve;
+    });
+    const firstQueryStarted = new Promise<void>((resolve) => {
+      markFirstQueryStarted = resolve;
+    });
+    fields.provider.embedQuery = async () => {
+      markFirstQueryStarted();
+      await firstQueryGate;
+      return [1, 0, 0, 0];
+    };
+
+    const queryPromise = fields.embedQueryWithRetry("alpha");
+    await firstQueryStarted;
+    const retirementPromise = fields.retireCurrentProvider();
+    let retirementSettled = false;
+    void retirementPromise.then(
+      () => {
+        retirementSettled = true;
+      },
+      () => {
+        retirementSettled = true;
+      },
+    );
+    try {
+      await Promise.resolve();
+      expect(retirementSettled).toBe(false);
+      expect(providerCloseCalls).toBe(0);
+    } finally {
+      releaseFirstQuery();
+    }
+
+    await expect(queryPromise).resolves.toEqual([1, 0, 0, 0]);
+    await retirementPromise;
+    expect(providerCloseCalls).toBe(1);
+  });
+
   it("fails closed when fallback initialization fails for an explicit provider", async () => {
     const cfg = createCfg({
       provider: "openai",

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -43,6 +43,7 @@ let providerRuntimeActiveBatchCalls = 0;
 let providerRuntimeMaxActiveBatchCalls = 0;
 let providerCloseCalls = 0;
 let providerCloseFailuresRemaining = 0;
+let providerCreationFailure: string | null = null;
 let providerCloseGate: Promise<void> | null = null;
 let providerInitGate: Promise<void> | null = null;
 let providerCalls: Array<{ provider?: string; model?: string; outputDimensionality?: number }> = [];
@@ -132,6 +133,9 @@ vi.mock("./embeddings.js", () => {
         outputDimensionality: options.outputDimensionality,
       });
       await providerInitGate;
+      if (options.provider === providerCreationFailure) {
+        throw new Error(`provider creation failed: ${options.provider}`);
+      }
       if (forceNoProvider) {
         return {
           provider: null,
@@ -312,6 +316,7 @@ describe("memory index", () => {
     providerRuntimeMaxActiveBatchCalls = 0;
     providerCloseCalls = 0;
     providerCloseFailuresRemaining = 0;
+    providerCreationFailure = null;
     providerCloseGate = null;
     providerInitGate = null;
     providerCalls = [];
@@ -2208,6 +2213,35 @@ describe("memory index", () => {
       "fallback-provider",
     ]);
     await expect(concurrentSearch).resolves.toBeDefined();
+  });
+
+  it("fails closed when fallback initialization fails for an explicit provider", async () => {
+    const cfg = createCfg({
+      provider: "openai",
+      fallback: "fallback-provider",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      provider: {
+        embedQuery: (text: string) => Promise<number[]>;
+      } | null;
+    };
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    fields.provider.embedQuery = async () => {
+      throw new Error("embedding provider failed");
+    };
+    providerCreationFailure = "fallback-provider";
+
+    await expect(manager.search("alpha")).rejects.toThrow(
+      /Memory search unavailable: embedding provider "openai" is configured but unavailable\./,
+    );
+
+    providerCreationFailure = null;
+    await expect(manager.search("alpha")).resolves.toBeDefined();
   });
 
   it("does not activate fallback during search when index identity is already mismatched", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2244,6 +2244,39 @@ describe("memory index", () => {
     await expect(manager.search("alpha")).resolves.toBeDefined();
   });
 
+  it("retries the optional primary after fallback initialization fails", async () => {
+    const cfg = createCfg({
+      fallback: "fallback-provider",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      provider: {
+        id: string;
+        embedQuery: (text: string) => Promise<number[]>;
+      } | null;
+    };
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    fields.provider.embedQuery = async () => {
+      throw new Error("embedding provider failed");
+    };
+    providerCreationFailure = "fallback-provider";
+    const callsBeforeSearch = providerCalls.length;
+
+    await expect(manager.search("alpha")).resolves.toBeDefined();
+
+    providerCreationFailure = null;
+    await expect(manager.search("alpha")).resolves.toBeDefined();
+    expect(providerCalls.slice(callsBeforeSearch).map((call) => call.provider)).toEqual([
+      "fallback-provider",
+      "openai",
+    ]);
+    expect(fields.provider?.id).toBe("mock");
+  });
+
   it("does not activate fallback during search when index identity is already mismatched", async () => {
     const cfg = createCfg({
       fallback: "fallback-provider",

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -43,6 +43,7 @@ let providerRuntimeActiveBatchCalls = 0;
 let providerRuntimeMaxActiveBatchCalls = 0;
 let providerCloseCalls = 0;
 let providerCloseFailuresRemaining = 0;
+let providerCloseFailure: unknown = new Error("provider close failed");
 let providerCreationFailure: string | null = null;
 let providerCloseGate: Promise<void> | null = null;
 let providerInitGate: Promise<void> | null = null;
@@ -169,7 +170,7 @@ vi.mock("./embeddings.js", () => {
             await providerCloseGate;
             if (providerCloseFailuresRemaining > 0) {
               providerCloseFailuresRemaining -= 1;
-              throw new Error("provider close failed");
+              throw providerCloseFailure;
             }
           },
           embedQuery: async (text: string) => embedText(text),
@@ -316,6 +317,7 @@ describe("memory index", () => {
     providerRuntimeMaxActiveBatchCalls = 0;
     providerCloseCalls = 0;
     providerCloseFailuresRemaining = 0;
+    providerCloseFailure = new Error("provider close failed");
     providerCreationFailure = null;
     providerCloseGate = null;
     providerInitGate = null;
@@ -1669,6 +1671,51 @@ describe("memory index", () => {
     const replacement = await replacementPromise;
     managersForCleanup.add(replacement);
     expect(replacement === first).toBe(false);
+  });
+
+  it("retains a failed global close owner until provider retirement succeeds", async () => {
+    const cfg = createCfg({
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const first = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    managersForCleanup.add(first);
+    await first.probeEmbeddingAvailability();
+    providerCloseFailuresRemaining = 2;
+    providerCloseFailure = undefined;
+
+    let globalCloseRejected = false;
+    await closeAllMemorySearchManagers().then(
+      () => {},
+      () => {
+        globalCloseRejected = true;
+      },
+    );
+    expect(globalCloseRejected).toBe(true);
+    expect(providerCloseCalls).toBe(2);
+
+    let releaseProviderClose: () => void = () => {};
+    providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+    const callsBeforeReplacement = providerCalls.length;
+    const replacementPromise = getMemorySearchManager({ cfg, agentId: "main" }).then((result) =>
+      requireManager(result),
+    );
+    let concurrentGlobalClose: Promise<void> = Promise.resolve();
+    try {
+      await vi.waitFor(() => expect(providerCloseCalls).toBe(3));
+      expect(providerCalls).toHaveLength(callsBeforeReplacement);
+      concurrentGlobalClose = closeAllMemorySearchManagers();
+    } finally {
+      releaseProviderClose();
+      providerCloseGate = null;
+    }
+
+    const replacement = await replacementPromise;
+    await concurrentGlobalClose;
+    managersForCleanup.add(replacement);
+    expect(replacement === first).toBe(false);
+    expect((replacement as unknown as { closed: boolean }).closed).toBe(false);
   });
 
   it("does not reuse memory index managers across local-service hosts", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1681,6 +1681,38 @@ describe("memory index", () => {
     expect((third as unknown as { closed: boolean }).closed).toBe(false);
   });
 
+  it("canonicalizes agent ids before builtin manager acquisition", async () => {
+    const cfg = createCfg({ model: "canonical-model" });
+    const first = await RuntimeMemoryIndexManager.get({ cfg, agentId: "Main-Agent" });
+    const second = await RuntimeMemoryIndexManager.get({ cfg, agentId: "main-agent" });
+    if (!first || !second) {
+      throw new Error("Expected canonical memory index managers");
+    }
+    managersForCleanup.add(first);
+    managersForCleanup.add(second);
+    expect(second).toBe(first);
+  });
+
+  it("retires the prior builtin manager when an agent workspace changes", async () => {
+    const firstCfg = createCfg({ model: "workspace-model" });
+    const secondCfg = createCfg({ model: "workspace-model" });
+    if (!firstCfg.agents?.defaults || !secondCfg.agents?.defaults) {
+      throw new Error("Expected agent defaults");
+    }
+    firstCfg.agents.defaults.workspace = path.join(fixtureRoot, "workspace-a");
+    secondCfg.agents.defaults.workspace = path.join(fixtureRoot, "workspace-b");
+
+    const first = await RuntimeMemoryIndexManager.get({ cfg: firstCfg, agentId: "main" });
+    const second = await RuntimeMemoryIndexManager.get({ cfg: secondCfg, agentId: "main" });
+    if (!first || !second) {
+      throw new Error("Expected workspace memory index managers");
+    }
+    managersForCleanup.add(first);
+    managersForCleanup.add(second);
+    expect(second === first).toBe(false);
+    expect((first as unknown as { closed: boolean }).closed).toBe(true);
+  });
+
   it("does not block another agent while one scope retires its manager", async () => {
     const firstCfg = createCfg({
       model: "first-model",

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2948,6 +2948,50 @@ describe("memory index", () => {
     expect(providerCloseCalls).toBe(1);
   });
 
+  it("waits for an admitted vector probe before manager teardown", async () => {
+    const manager = await getPersistentManager(createCfg({ provider: "openai" }));
+    const fields = manager as unknown as {
+      ensureVectorReady: () => Promise<boolean>;
+    };
+    let releaseProbe: () => void = () => {};
+    let markProbeStarted: () => void = () => {};
+    const probeGate = new Promise<void>((resolve) => {
+      releaseProbe = resolve;
+    });
+    const probeStarted = new Promise<void>((resolve) => {
+      markProbeStarted = resolve;
+    });
+    fields.ensureVectorReady = async () => {
+      markProbeStarted();
+      await probeGate;
+      return true;
+    };
+
+    const probePromise = manager.probeVectorAvailability();
+    await probeStarted;
+    const closePromise = manager.close();
+    let closeSettled = false;
+    void closePromise.then(
+      () => {
+        closeSettled = true;
+      },
+      () => {
+        closeSettled = true;
+      },
+    );
+    try {
+      await Promise.resolve();
+      expect(closeSettled).toBe(false);
+      expect(providerCloseCalls).toBe(0);
+    } finally {
+      releaseProbe();
+    }
+
+    await expect(probePromise).resolves.toBe(true);
+    await closePromise;
+    expect(providerCloseCalls).toBe(1);
+  });
+
   it("fails closed when fallback initialization fails for an explicit provider", async () => {
     const cfg = createCfg({
       provider: "openai",

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2674,6 +2674,84 @@ describe("memory index", () => {
     });
   });
 
+  it("keeps an active FTS-only generation stable while fallback activates", async () => {
+    const manager = await getFreshManager(
+      createCfg({ provider: "openai", fallback: "fallback-provider" }),
+      "cli",
+    );
+    managersForCleanup.add(manager);
+    type IndexEntry = {
+      path: string;
+      absPath: string;
+      mtimeMs: number;
+      size: number;
+      hash: string;
+      content: string;
+    };
+    const fields = manager as unknown as {
+      provider: { id: string } | null;
+      providerKey: string;
+      computeProviderKey: () => string;
+      ensureProviderInitialized: () => Promise<void>;
+      markLocalEmbeddingProviderDegraded: (err: unknown) => void;
+      activateFallbackProvider: (reason: string) => Promise<boolean>;
+      beginSyncProviderGeneration: () => void;
+      endSyncProviderGeneration: () => void;
+      indexFile: (
+        entry: IndexEntry,
+        options: { source: "memory"; content: string },
+      ) => Promise<void>;
+      db: {
+        prepare: (sql: string) => {
+          get: (...params: unknown[]) => { model?: string } | undefined;
+        };
+      };
+    };
+    await fields.ensureProviderInitialized();
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    fields.provider.id = "local";
+    fields.providerKey = fields.computeProviderKey();
+    fields.markLocalEmbeddingProviderDegraded(createLocalWorkerExitError());
+    await vi.waitFor(() => {
+      expect(fields.provider).toBeNull();
+      expect(providerCloseCalls).toBe(1);
+    });
+
+    const createEntry = (name: string): IndexEntry => {
+      const content = `# Log\n${name} FTS-only generation.`;
+      return {
+        path: `memory/${name}.md`,
+        absPath: path.join(memoryDir, `${name}.md`),
+        mtimeMs: Date.now(),
+        size: Buffer.byteLength(content),
+        hash: hashText(content),
+        content,
+      };
+    };
+    const first = createEntry("fts-first");
+    const second = createEntry("fts-second");
+
+    fields.beginSyncProviderGeneration();
+    try {
+      await fields.indexFile(first, { source: "memory", content: first.content });
+      await expect(fields.activateFallbackProvider("local worker exited")).resolves.toBe(true);
+      await fields.indexFile(second, { source: "memory", content: second.content });
+    } finally {
+      fields.endSyncProviderGeneration();
+    }
+
+    expect(
+      fields.db.prepare("SELECT model FROM memory_index_chunks WHERE path = ?").get(first.path)
+        ?.model,
+    ).toBe("fts-only");
+    expect(
+      fields.db.prepare("SELECT model FROM memory_index_chunks WHERE path = ?").get(second.path)
+        ?.model,
+    ).toBe("fts-only");
+  });
+
   it("waits for admitted provider users before retirement", async () => {
     const cfg = createCfg({ provider: "openai" });
     const manager = await getPersistentManager(cfg);

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2550,6 +2550,51 @@ describe("memory index", () => {
     expect(providerCloseCalls).toBe(1);
   });
 
+  it("waits for an admitted search before manager teardown", async () => {
+    const manager = await getPersistentManager(createCfg({ provider: "openai" }));
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      searchVector: () => Promise<unknown[]>;
+    };
+    let releaseVectorSearch: () => void = () => {};
+    let markVectorSearchStarted: () => void = () => {};
+    const vectorSearchGate = new Promise<void>((resolve) => {
+      releaseVectorSearch = resolve;
+    });
+    const vectorSearchStarted = new Promise<void>((resolve) => {
+      markVectorSearchStarted = resolve;
+    });
+    fields.searchVector = async () => {
+      markVectorSearchStarted();
+      await vectorSearchGate;
+      return [];
+    };
+
+    const searchPromise = manager.search("alpha");
+    await vectorSearchStarted;
+    const closePromise = manager.close();
+    let closeSettled = false;
+    void closePromise.then(
+      () => {
+        closeSettled = true;
+      },
+      () => {
+        closeSettled = true;
+      },
+    );
+    try {
+      await Promise.resolve();
+      expect(closeSettled).toBe(false);
+      expect(providerCloseCalls).toBe(0);
+    } finally {
+      releaseVectorSearch();
+    }
+
+    await expect(searchPromise).resolves.toBeDefined();
+    await closePromise;
+    expect(providerCloseCalls).toBe(1);
+  });
+
   it("fails closed when fallback initialization fails for an explicit provider", async () => {
     const cfg = createCfg({
       provider: "openai",

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2369,6 +2369,7 @@ describe("memory index", () => {
       } | null;
       markLocalEmbeddingProviderDegraded: (err: unknown) => void;
       activateFallbackProvider: (reason: string) => Promise<boolean>;
+      withTimeout: <T>(promise: Promise<T>, timeoutMs: number, message: string) => Promise<T>;
     };
     if (!fields.provider) {
       throw new Error("Expected a test embedding provider");
@@ -2495,6 +2496,182 @@ describe("memory index", () => {
       "fallback-provider",
     ]);
     await expect(concurrentSearch).resolves.toBeDefined();
+  });
+
+  it("leases the indexing provider generation through chunk publication", async () => {
+    const manager = await getFreshManager(
+      createCfg({
+        provider: "openai",
+        fallback: "fallback-provider",
+        cacheEnabled: true,
+        hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+      }),
+      "cli",
+    );
+    managersForCleanup.add(manager);
+    const fields = manager as unknown as {
+      provider: {
+        id: string;
+        model: string;
+        embedBatch: (texts: string[]) => Promise<number[][]>;
+      } | null;
+      providerKey: string;
+      computeProviderKey: () => string;
+      ensureProviderInitialized: () => Promise<void>;
+      markLocalEmbeddingProviderDegraded: (err: unknown) => void;
+      activateFallbackProvider: (reason: string) => Promise<boolean>;
+      withTimeout: <T>(promise: Promise<T>, timeoutMs: number, message: string) => Promise<T>;
+      indexFile: (
+        entry: {
+          path: string;
+          absPath: string;
+          mtimeMs: number;
+          size: number;
+          hash: string;
+          content: string;
+        },
+        options: { source: "memory"; content: string },
+      ) => Promise<void>;
+      ensureVectorReady: (dimensions?: number) => Promise<boolean>;
+      db: {
+        prepare: (sql: string) => {
+          get: (
+            ...params: unknown[]
+          ) => { model?: string; provider?: string; provider_key?: string } | undefined;
+        };
+      };
+    };
+    await fields.ensureProviderInitialized();
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    const indexedProvider = fields.provider;
+    indexedProvider.id = "local";
+    fields.providerKey = fields.computeProviderKey();
+    const indexedProviderKey = fields.providerKey;
+    const firstContent = "# Log\nFirst memory line indexed during provider fallback.";
+    const secondContent = "# Log\nSecond memory line indexed during provider fallback.";
+
+    let releaseFirstEmbedding: () => void = () => {};
+    let releaseSecondEmbedding: () => void = () => {};
+    let markFirstEmbeddingStarted: () => void = () => {};
+    let markSecondEmbeddingStarted: () => void = () => {};
+    const firstEmbeddingGate = new Promise<void>((resolve) => {
+      releaseFirstEmbedding = resolve;
+    });
+    const secondEmbeddingGate = new Promise<void>((resolve) => {
+      releaseSecondEmbedding = resolve;
+    });
+    const firstEmbeddingStarted = new Promise<void>((resolve) => {
+      markFirstEmbeddingStarted = resolve;
+    });
+    const secondEmbeddingStarted = new Promise<void>((resolve) => {
+      markSecondEmbeddingStarted = resolve;
+    });
+    indexedProvider.embedBatch = async (texts) => {
+      if (texts.some((text) => text.includes("First"))) {
+        markFirstEmbeddingStarted();
+        await firstEmbeddingGate;
+      } else {
+        markSecondEmbeddingStarted();
+        await secondEmbeddingGate;
+      }
+      return texts.map(() => [1, 0, 0, 0]);
+    };
+    let releasePublication: () => void = () => {};
+    let markPublicationStarted: () => void = () => {};
+    const publicationGate = new Promise<void>((resolve) => {
+      releasePublication = resolve;
+    });
+    const publicationStarted = new Promise<void>((resolve) => {
+      markPublicationStarted = resolve;
+    });
+    const ensureVectorReady = fields.ensureVectorReady.bind(manager);
+    let publicationCalls = 0;
+    fields.ensureVectorReady = async (dimensions) => {
+      publicationCalls += 1;
+      if (publicationCalls === 1) {
+        return await ensureVectorReady(dimensions);
+      }
+      markPublicationStarted();
+      await publicationGate;
+      return await ensureVectorReady(dimensions);
+    };
+
+    const callsBeforeFallback = providerCalls.length;
+    const firstIndexPromise = fields.indexFile(
+      {
+        path: "memory/generation-race-first.md",
+        absPath: path.join(memoryDir, "generation-race-first.md"),
+        mtimeMs: Date.now(),
+        size: Buffer.byteLength(firstContent),
+        hash: hashText(firstContent),
+        content: firstContent,
+      },
+      { source: "memory", content: firstContent },
+    );
+    const secondIndexPromise = fields.indexFile(
+      {
+        path: "memory/generation-race-second.md",
+        absPath: path.join(memoryDir, "generation-race-second.md"),
+        mtimeMs: Date.now(),
+        size: Buffer.byteLength(secondContent),
+        hash: hashText(secondContent),
+        content: secondContent,
+      },
+      { source: "memory", content: secondContent },
+    );
+    let fallbackPromise: Promise<boolean> | null = null;
+    try {
+      await fields.withTimeout(
+        Promise.all([firstEmbeddingStarted, secondEmbeddingStarted]),
+        5_000,
+        "concurrent embeddings did not start",
+      );
+      fields.markLocalEmbeddingProviderDegraded(createLocalWorkerExitError());
+      await vi.waitFor(() => expect(fields.provider).toBeNull());
+      fallbackPromise = fields.activateFallbackProvider("local worker exited");
+      releaseFirstEmbedding();
+      await firstIndexPromise;
+      expect(providerCloseCalls).toBe(0);
+      expect(providerCalls).toHaveLength(callsBeforeFallback);
+
+      releaseSecondEmbedding();
+      await fields.withTimeout(publicationStarted, 5_000, "publication did not start");
+      expect(providerCloseCalls).toBe(0);
+      expect(providerCalls).toHaveLength(callsBeforeFallback);
+
+      releasePublication();
+      await secondIndexPromise;
+      await expect(fallbackPromise).resolves.toBe(true);
+    } finally {
+      releaseFirstEmbedding();
+      releaseSecondEmbedding();
+      releasePublication();
+      await Promise.allSettled([
+        firstIndexPromise,
+        secondIndexPromise,
+        ...(fallbackPromise ? [fallbackPromise] : []),
+      ]);
+    }
+
+    expect(providerCalls.slice(callsBeforeFallback).map((call) => call.provider)).toEqual([
+      "fallback-provider",
+    ]);
+    expect(
+      fields.db
+        .prepare("SELECT model FROM memory_index_chunks WHERE path = ?")
+        .get("memory/generation-race-second.md")?.model,
+    ).toBe(indexedProvider.model);
+    expect(
+      fields.db
+        .prepare("SELECT provider, model, provider_key FROM memory_embedding_cache LIMIT 1")
+        .get(),
+    ).toEqual({
+      provider: indexedProvider.id,
+      model: indexedProvider.model,
+      provider_key: indexedProviderKey,
+    });
   });
 
   it("waits for admitted provider users before retirement", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2727,6 +2727,60 @@ describe("memory index", () => {
     expect(providerCloseCalls).toBe(1);
   });
 
+  it("uses the leased provider runtime after retirement starts", async () => {
+    const manager = await getPersistentManager(createCfg({ provider: "openai" }));
+    type QueryProvider = {
+      embedQuery: (text: string, options?: { signal?: AbortSignal }) => Promise<number[]>;
+    };
+    const fields = manager as unknown as {
+      provider: QueryProvider | null;
+      providerRuntime?: { inlineQueryTimeoutMs?: number };
+      acquireProviderUse: (provider: QueryProvider) => () => void;
+      retireCurrentProvider: () => Promise<void>;
+      embedQueryWithRetry: (
+        text: string,
+        signal: AbortSignal | undefined,
+        provider: QueryProvider,
+        markDegraded: boolean,
+        providerRuntime: { inlineQueryTimeoutMs?: number },
+      ) => Promise<number[]>;
+    };
+    await manager.probeEmbeddingAvailability();
+    const provider = fields.provider;
+    if (!provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    const providerRuntime = { inlineQueryTimeoutMs: 10 };
+    fields.providerRuntime = providerRuntime;
+    provider.embedQuery = async (_text, options) =>
+      await new Promise<number[]>((resolve, reject) => {
+        const timer = setTimeout(() => resolve([1, 0, 0, 0]), 100);
+        options?.signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(options.signal?.reason);
+          },
+          { once: true },
+        );
+      });
+
+    const releaseProvider = fields.acquireProviderUse(provider);
+    const retirementPromise = fields.retireCurrentProvider();
+    try {
+      await vi.waitFor(() => expect(fields.provider).toBeNull());
+      await expect(
+        fields.embedQueryWithRetry("alpha", undefined, provider, false, providerRuntime),
+      ).rejects.toThrow("timed out");
+      expect(providerCloseCalls).toBe(0);
+    } finally {
+      releaseProvider();
+    }
+
+    await retirementPromise;
+    expect(providerCloseCalls).toBe(1);
+  });
+
   it("waits for an admitted search before manager teardown", async () => {
     const manager = await getPersistentManager(createCfg({ provider: "openai" }));
     await manager.sync({ reason: "test" });

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1508,6 +1508,7 @@ describe("memory index", () => {
     });
 
     const closePromise = manager.close();
+    const concurrentClosePromise = manager.close();
     try {
       await Promise.resolve();
       expect(providerCloseCalls).toBe(0);
@@ -1522,7 +1523,7 @@ describe("memory index", () => {
     } finally {
       resolveSync();
     }
-    await closePromise;
+    await Promise.all([closePromise, concurrentClosePromise]);
     expect(providerCloseCalls).toBe(1);
   });
 
@@ -1580,7 +1581,7 @@ describe("memory index", () => {
     expect(providerCloseCalls).toBe(1);
   });
 
-  it("evicts scoped memory index managers before close settles", async () => {
+  it("waits for scoped manager close before initializing a replacement", async () => {
     let releaseProviderClose: () => void = () => {};
     providerCloseGate = new Promise<void>((resolve) => {
       releaseProviderClose = resolve;
@@ -1592,24 +1593,82 @@ describe("memory index", () => {
     managersForCleanup.add(first);
     await first.probeEmbeddingAvailability();
     const closePromise = closeMemoryIndexManagersForAgent({ cfg, agentId: "main" });
-    let second: MemoryIndexManager | null;
+    const callsBeforeReplacement = providerCalls.length;
+    const secondPromise = getMemorySearchManager({ cfg, agentId: "main" }).then((result) =>
+      requireManager(result),
+    );
+    const concurrentSecondPromise = getMemorySearchManager({ cfg, agentId: "main" }).then(
+      (result) => requireManager(result),
+    );
+    const secondProbe = secondPromise.then(async (manager) => {
+      await manager.probeEmbeddingAvailability();
+    });
+    let secondSettled = false;
+    void secondPromise.then(
+      () => {
+        secondSettled = true;
+      },
+      () => {
+        secondSettled = true;
+      },
+    );
     try {
       await vi.waitFor(() => {
         expect(providerCloseCalls).toBe(1);
       });
-
-      second = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
-      managersForCleanup.add(second);
-      expect(second).not.toBe(first);
+      await Promise.resolve();
+      expect(secondSettled).toBe(false);
+      expect(providerCalls).toHaveLength(callsBeforeReplacement);
     } finally {
       releaseProviderClose();
       providerCloseGate = null;
     }
     await closePromise;
+    const second = await secondPromise;
+    const concurrentSecond = await concurrentSecondPromise;
+    await secondProbe;
+    managersForCleanup.add(second);
+    expect(second === first).toBe(false);
+    expect(concurrentSecond).toBe(second);
 
     const third = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
     managersForCleanup.add(third);
     expect(third).toBe(second);
+  });
+
+  it("retains a failed scoped close owner until provider retirement succeeds", async () => {
+    const cfg = createCfg({
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const first = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    managersForCleanup.add(first);
+    await first.probeEmbeddingAvailability();
+    providerCloseFailuresRemaining = 2;
+
+    await expect(closeMemoryIndexManagersForAgent({ cfg, agentId: "main" })).rejects.toThrow(
+      "provider close failed",
+    );
+    expect(providerCloseCalls).toBe(2);
+
+    let releaseProviderClose: () => void = () => {};
+    providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+    const callsBeforeReplacement = providerCalls.length;
+    const replacementPromise = getMemorySearchManager({ cfg, agentId: "main" }).then((result) =>
+      requireManager(result),
+    );
+    try {
+      await vi.waitFor(() => expect(providerCloseCalls).toBe(3));
+      expect(providerCalls).toHaveLength(callsBeforeReplacement);
+    } finally {
+      releaseProviderClose();
+      providerCloseGate = null;
+    }
+
+    const replacement = await replacementPromise;
+    managersForCleanup.add(replacement);
+    expect(replacement === first).toBe(false);
   });
 
   it("does not reuse memory index managers across local-service hosts", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -49,6 +49,7 @@ let providerCloseCalls = 0;
 let providerCloseFailuresRemaining = 0;
 let providerCloseFailure: unknown = new Error("provider close failed");
 let providerCreationFailure: string | null = null;
+let providerNullResult: string | null = null;
 let providerCloseGate: Promise<void> | null = null;
 let providerInitGate: Promise<void> | null = null;
 let providerCalls: Array<{ provider?: string; model?: string; outputDimensionality?: number }> = [];
@@ -140,6 +141,13 @@ vi.mock("./embeddings.js", () => {
       await providerInitGate;
       if (options.provider === providerCreationFailure) {
         throw new Error(`provider creation failed: ${options.provider}`);
+      }
+      if (options.provider === providerNullResult) {
+        return {
+          provider: null,
+          requestedProvider: options.provider,
+          providerUnavailableReason: `provider unavailable: ${options.provider}`,
+        };
       }
       if (forceNoProvider) {
         return {
@@ -323,6 +331,7 @@ describe("memory index", () => {
     providerCloseFailuresRemaining = 0;
     providerCloseFailure = new Error("provider close failed");
     providerCreationFailure = null;
+    providerNullResult = null;
     providerCloseGate = null;
     providerInitGate = null;
     providerCalls = [];
@@ -2547,6 +2556,58 @@ describe("memory index", () => {
       "fallback-provider",
       "openai",
     ]);
+    expect(fields.provider?.id).toBe("mock");
+  });
+
+  it("fails closed and retries a required primary after a null fallback result", async () => {
+    const cfg = createCfg({
+      provider: "openai",
+      fallback: "fallback-provider",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      provider: { embedQuery: (text: string) => Promise<number[]> } | null;
+    };
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    fields.provider.embedQuery = async () => {
+      throw new Error("embedding provider failed");
+    };
+    providerNullResult = "fallback-provider";
+
+    await expect(manager.search("alpha")).rejects.toThrow(
+      /Memory search unavailable: embedding provider "openai" is configured but unavailable\./,
+    );
+
+    providerNullResult = null;
+    await expect(manager.search("alpha")).resolves.toBeDefined();
+  });
+
+  it("retries an optional primary after a null fallback result", async () => {
+    const cfg = createCfg({
+      fallback: "fallback-provider",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      provider: { id: string; embedQuery: (text: string) => Promise<number[]> } | null;
+    };
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    fields.provider.embedQuery = async () => {
+      throw new Error("embedding provider failed");
+    };
+    providerNullResult = "fallback-provider";
+
+    await expect(manager.search("alpha")).resolves.toBeDefined();
+
+    providerNullResult = null;
+    await expect(manager.search("alpha")).resolves.toBeDefined();
     expect(fields.provider?.id).toBe("mock");
   });
 

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -23,7 +23,11 @@ import "./test-runtime-mocks.js";
 import type { MemoryIndexManager } from "./index.js";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexMeta } from "./manager-reindex-state.js";
-import { closeMemoryIndexManagersForAgent } from "./manager.js";
+import {
+  closeAllMemoryIndexManagers,
+  closeMemoryIndexManagersForAgent,
+  MemoryIndexManager as RuntimeMemoryIndexManager,
+} from "./manager.js";
 
 // This suite performs real sqlite/media indexing and can exceed the global
 // timeout when it shares a packed CI extension shard.
@@ -1675,6 +1679,98 @@ describe("memory index", () => {
     expect(third === second).toBe(false);
     expect((second as unknown as { closed: boolean }).closed).toBe(true);
     expect((third as unknown as { closed: boolean }).closed).toBe(false);
+  });
+
+  it("does not block another agent while one scope retires its manager", async () => {
+    const firstCfg = createCfg({
+      model: "first-model",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const first = requireManager(await getMemorySearchManager({ cfg: firstCfg, agentId: "main" }));
+    managersForCleanup.add(first);
+    await first.probeEmbeddingAvailability();
+    let releaseProviderClose: () => void = () => {};
+    providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+
+    const replacementPromise = getMemorySearchManager({
+      cfg: createCfg({ model: "second-model" }),
+      agentId: "main",
+    });
+    await vi.waitFor(() => expect(providerCloseCalls).toBe(1));
+    const otherAgentPromise = getMemorySearchManager({
+      cfg: createCfg({ model: "other-model" }),
+      agentId: "other",
+    });
+    let otherAgentSettled = false;
+    void otherAgentPromise.then(
+      () => {
+        otherAgentSettled = true;
+      },
+      () => {
+        otherAgentSettled = true;
+      },
+    );
+    try {
+      await vi.waitFor(() => expect(otherAgentSettled).toBe(true));
+    } finally {
+      releaseProviderClose();
+      providerCloseGate = null;
+    }
+
+    const otherAgent = requireManager(await otherAgentPromise);
+    const replacement = requireManager(await replacementPromise);
+    managersForCleanup.add(otherAgent);
+    managersForCleanup.add(replacement);
+    expect((otherAgent as unknown as { closed: boolean }).closed).toBe(false);
+  });
+
+  it("global teardown waits for an admitted builtin manager replacement", async () => {
+    const first = await RuntimeMemoryIndexManager.get({
+      cfg: createCfg({ model: "first-model" }),
+      agentId: "main",
+    });
+    if (!first) {
+      throw new Error("Expected first memory index manager");
+    }
+    managersForCleanup.add(first);
+    await first.probeEmbeddingAvailability();
+    let releaseProviderClose: () => void = () => {};
+    providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+
+    const replacementPromise = RuntimeMemoryIndexManager.get({
+      cfg: createCfg({ model: "second-model" }),
+      agentId: "main",
+    });
+    await vi.waitFor(() => expect(providerCloseCalls).toBe(1));
+    const globalClosePromise = closeAllMemoryIndexManagers();
+    let globalCloseSettled = false;
+    void globalClosePromise.then(
+      () => {
+        globalCloseSettled = true;
+      },
+      () => {
+        globalCloseSettled = true;
+      },
+    );
+    try {
+      await Promise.resolve();
+      expect(globalCloseSettled).toBe(false);
+    } finally {
+      releaseProviderClose();
+      providerCloseGate = null;
+    }
+
+    const replacement = await replacementPromise;
+    await globalClosePromise;
+    if (!replacement) {
+      throw new Error("Expected replacement memory index manager");
+    }
+    managersForCleanup.add(replacement);
+    expect((replacement as unknown as { closed: boolean }).closed).toBe(true);
   });
 
   it("retains a failed scoped close owner until provider retirement succeeds", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1651,6 +1651,46 @@ describe("memory index", () => {
     expect(third).toBe(second);
   });
 
+  it("does not reuse a cached manager after direct close starts", async () => {
+    let releaseProviderClose: () => void = () => {};
+    providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+    const cfg = createCfg({
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const first = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    managersForCleanup.add(first);
+    await first.probeEmbeddingAvailability();
+
+    const closePromise = first.close();
+    const replacementPromise = getMemorySearchManager({ cfg, agentId: "main" }).then((result) =>
+      requireManager(result),
+    );
+    let replacementSettled = false;
+    void replacementPromise.then(
+      () => {
+        replacementSettled = true;
+      },
+      () => {
+        replacementSettled = true;
+      },
+    );
+    try {
+      await vi.waitFor(() => expect(providerCloseCalls).toBe(1));
+      await Promise.resolve();
+      expect(replacementSettled).toBe(false);
+    } finally {
+      releaseProviderClose();
+      providerCloseGate = null;
+    }
+
+    await closePromise;
+    const replacement = await replacementPromise;
+    managersForCleanup.add(replacement);
+    expect(replacement === first).toBe(false);
+  });
+
   it("serializes concurrent acquisitions with different cache identities", async () => {
     const firstCfg = createCfg({
       model: "first-model",

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2277,6 +2277,73 @@ describe("memory index", () => {
     expect(fields.provider?.id).toBe("mock");
   });
 
+  it("keeps concurrent optional searches in FTS mode when shared fallback fails", async () => {
+    const cfg = createCfg({
+      fallback: "fallback-provider",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      provider: {
+        embedQuery: (text: string) => Promise<number[]>;
+      } | null;
+      ensureProviderInitialized: () => Promise<void>;
+    };
+    if (!fields.provider) {
+      throw new Error("Expected a test embedding provider");
+    }
+    fields.provider.embedQuery = async () => {
+      throw new Error("embedding provider failed");
+    };
+    const ensureProviderInitialized = fields.ensureProviderInitialized.bind(manager);
+    let providerInitializationCalls = 0;
+    fields.ensureProviderInitialized = async () => {
+      providerInitializationCalls += 1;
+      await ensureProviderInitialized();
+    };
+    providerCreationFailure = "fallback-provider";
+    let releaseProviderInit: () => void = () => {};
+    providerInitGate = new Promise<void>((resolve) => {
+      releaseProviderInit = resolve;
+    });
+
+    const callsBeforeSearch = providerCalls.length;
+    const firstSearch = manager.search("alpha");
+    await vi.waitFor(() =>
+      expect(providerCalls.some((call) => call.provider === "fallback-provider")).toBe(true),
+    );
+    const initializationCallsBeforeSecondSearch = providerInitializationCalls;
+    const secondSearch = manager.search("zebra");
+    let secondSettled = false;
+    void secondSearch.then(
+      () => {
+        secondSettled = true;
+      },
+      () => {
+        secondSettled = true;
+      },
+    );
+    try {
+      await vi.waitFor(() =>
+        expect(providerInitializationCalls).toBeGreaterThan(initializationCallsBeforeSecondSearch),
+      );
+      expect(secondSettled).toBe(false);
+      releaseProviderInit();
+      const results = await Promise.all([firstSearch, secondSearch]);
+      expect(results.every((result) => result.length > 0)).toBe(true);
+      expect(
+        providerCalls
+          .slice(callsBeforeSearch)
+          .filter((call) => call.provider === "fallback-provider"),
+      ).toHaveLength(1);
+    } finally {
+      providerInitGate = null;
+      releaseProviderInit();
+      await Promise.allSettled([firstSearch, secondSearch]);
+    }
+  });
+
   it("does not activate fallback during search when index identity is already mismatched", async () => {
     const cfg = createCfg({
       fallback: "fallback-provider",

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2063,7 +2063,7 @@ describe("memory index", () => {
     });
   });
 
-  it("waits for degraded provider shutdown before replacement initialization", async () => {
+  it("waits for degraded provider shutdown before fallback initialization", async () => {
     const cfg = createCfg({ fallback: "fallback-provider" });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
@@ -2081,6 +2081,7 @@ describe("memory index", () => {
         close: () => Promise<void>;
       } | null;
       markLocalEmbeddingProviderDegraded: (err: unknown) => void;
+      activateFallbackProvider: (reason: string) => Promise<boolean>;
     };
     if (!fields.provider) {
       throw new Error("Expected a test embedding provider");
@@ -2089,17 +2090,19 @@ describe("memory index", () => {
     fields.markLocalEmbeddingProviderDegraded(createLocalWorkerExitError());
     await vi.waitFor(() => expect(providerCloseCalls).toBe(1));
 
-    const callsBeforeSearch = providerCalls.length;
-    const searchPromise = manager.search("alpha");
+    const callsBeforeFallback = providerCalls.length;
+    const fallbackPromise = fields.activateFallbackProvider("local worker exited");
     try {
       await Promise.resolve();
-      expect(providerCalls).toHaveLength(callsBeforeSearch);
+      expect(providerCalls).toHaveLength(callsBeforeFallback);
     } finally {
       releaseProviderClose();
       providerCloseGate = null;
-      await searchPromise;
+      await fallbackPromise;
     }
-    expect(providerCalls.slice(callsBeforeSearch).map((call) => call.provider)).toEqual(["openai"]);
+    expect(providerCalls.slice(callsBeforeFallback).map((call) => call.provider)).toEqual([
+      "fallback-provider",
+    ]);
   });
 
   it("waits for provider shutdown before retry initialization", async () => {
@@ -2133,6 +2136,7 @@ describe("memory index", () => {
 
   it("waits for active provider shutdown before fallback initialization", async () => {
     const cfg = createCfg({
+      provider: "openai",
       fallback: "fallback-provider",
       hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
@@ -2157,17 +2161,31 @@ describe("memory index", () => {
 
     const callsBeforeSearch = providerCalls.length;
     const searchPromise = manager.search("alpha");
+    let concurrentSearch: ReturnType<typeof manager.search> = Promise.resolve([]);
     try {
       await vi.waitFor(() => expect(providerCloseCalls).toBe(1));
+      concurrentSearch = manager.search("zebra");
+      let concurrentSettled = false;
+      void concurrentSearch.then(
+        () => {
+          concurrentSettled = true;
+        },
+        () => {
+          concurrentSettled = true;
+        },
+      );
+      await Promise.resolve();
+      expect(concurrentSettled).toBe(false);
       expect(providerCalls).toHaveLength(callsBeforeSearch);
     } finally {
       releaseProviderClose();
       providerCloseGate = null;
-      await searchPromise;
+      await Promise.allSettled([searchPromise, concurrentSearch]);
     }
     expect(providerCalls.slice(callsBeforeSearch).map((call) => call.provider)).toEqual([
       "fallback-provider",
     ]);
+    await expect(concurrentSearch).resolves.toBeDefined();
   });
 
   it("does not activate fallback during search when index identity is already mismatched", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1638,6 +1638,45 @@ describe("memory index", () => {
     expect(third).toBe(second);
   });
 
+  it("serializes concurrent acquisitions with different cache identities", async () => {
+    const firstCfg = createCfg({
+      model: "first-model",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const first = requireManager(await getMemorySearchManager({ cfg: firstCfg, agentId: "main" }));
+    managersForCleanup.add(first);
+    await first.probeEmbeddingAvailability();
+    let releaseProviderClose: () => void = () => {};
+    providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+
+    const secondPromise = getMemorySearchManager({
+      cfg: createCfg({ model: "second-model" }),
+      agentId: "main",
+    }).then((result) => requireManager(result));
+    await vi.waitFor(() => expect(providerCloseCalls).toBe(1));
+    const thirdPromise = getMemorySearchManager({
+      cfg: createCfg({ model: "third-model" }),
+      agentId: "main",
+    }).then((result) => requireManager(result));
+    try {
+      await Promise.resolve();
+      expect(providerCalls).toHaveLength(1);
+    } finally {
+      releaseProviderClose();
+      providerCloseGate = null;
+    }
+
+    const [second, third] = await Promise.all([secondPromise, thirdPromise]);
+    managersForCleanup.add(second);
+    managersForCleanup.add(third);
+    expect(second === first).toBe(false);
+    expect(third === second).toBe(false);
+    expect((second as unknown as { closed: boolean }).closed).toBe(true);
+    expect((third as unknown as { closed: boolean }).closed).toBe(false);
+  });
+
   it("retains a failed scoped close owner until provider retirement succeeds", async () => {
     const cfg = createCfg({
       hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
@@ -1715,7 +1754,7 @@ describe("memory index", () => {
     await concurrentGlobalClose;
     managersForCleanup.add(replacement);
     expect(replacement === first).toBe(false);
-    expect((replacement as unknown as { closed: boolean }).closed).toBe(false);
+    expect((replacement as unknown as { closed: boolean }).closed).toBe(true);
   });
 
   it("does not reuse memory index managers across local-service hosts", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2105,6 +2105,28 @@ describe("memory index", () => {
     ]);
   });
 
+  it("retries failed provider retirement before fallback initialization", async () => {
+    const cfg = createCfg({ fallback: "fallback-provider" });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+    providerCloseFailuresRemaining = 1;
+    const fields = manager as unknown as {
+      activateFallbackProvider: (reason: string) => Promise<boolean>;
+    };
+    const callsBeforeFallback = providerCalls.length;
+
+    await expect(fields.activateFallbackProvider("provider failed")).rejects.toThrow(
+      "provider close failed",
+    );
+    expect(providerCalls).toHaveLength(callsBeforeFallback);
+
+    await expect(fields.activateFallbackProvider("provider failed")).resolves.toBe(true);
+    expect(providerCloseCalls).toBe(2);
+    expect(providerCalls.slice(callsBeforeFallback).map((call) => call.provider)).toEqual([
+      "fallback-provider",
+    ]);
+  });
+
   it("waits for provider shutdown before retry initialization", async () => {
     const cfg = createCfg({ provider: "openai" });
     const manager = await getPersistentManager(cfg);

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2877,7 +2877,8 @@ describe("memory index", () => {
           "abort",
           () => {
             clearTimeout(timer);
-            reject(options.signal?.reason);
+            const reason = options.signal?.reason;
+            reject(reason instanceof Error ? reason : new Error("embedding aborted"));
           },
           { once: true },
         );

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2864,6 +2864,8 @@ describe("memory index", () => {
     await manager.sync({ reason: "test" });
     const fields = manager as unknown as {
       searchVector: () => Promise<unknown[]>;
+      closing: boolean;
+      closed: boolean;
     };
     let releaseVectorSearch: () => void = () => {};
     let markVectorSearchStarted: () => void = () => {};
@@ -2894,6 +2896,8 @@ describe("memory index", () => {
     try {
       await Promise.resolve();
       expect(closeSettled).toBe(false);
+      expect(fields.closing).toBe(true);
+      expect(fields.closed).toBe(false);
       expect(providerCloseCalls).toBe(0);
     } finally {
       releaseVectorSearch();

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1754,7 +1754,7 @@ describe("memory index", () => {
     await concurrentGlobalClose;
     managersForCleanup.add(replacement);
     expect(replacement === first).toBe(false);
-    expect((replacement as unknown as { closed: boolean }).closed).toBe(true);
+    expect((replacement as unknown as { closed: boolean }).closed).toBe(false);
   });
 
   it("does not reuse memory index managers across local-service hosts", async () => {

--- a/extensions/memory-core/src/memory/manager-cache.test.ts
+++ b/extensions/memory-core/src/memory/manager-cache.test.ts
@@ -1,29 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 // Memory Core tests cover manager cache plugin behavior.
-import {
-  closeManagedCacheEntries,
-  getOrCreateManagedCacheEntry,
-  resolveSingletonManagedCache,
-} from "./manager-cache.js";
+import { getOrCreateManagedCacheEntry, resolveSingletonManagedCache } from "./manager-cache.js";
 
 type ManagedCache<T> = ReturnType<typeof resolveSingletonManagedCache<T>>;
-
-function createDeferred<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: unknown) => void;
-} {
-  let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
-  let reject: ((reason?: unknown) => void) | undefined;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  if (!resolve || !reject) {
-    throw new Error("Expected deferred callbacks to be initialized");
-  }
-  return { promise, resolve, reject };
-}
 
 type TestEntry = {
   id: string;
@@ -45,14 +24,12 @@ describe("manager cache", () => {
   const cachesForCleanup: ManagedCache<TestEntry>[] = [];
 
   afterEach(async () => {
-    await Promise.all(
-      cachesForCleanup.splice(0).map((cache) =>
-        closeManagedCacheEntries({
-          cache: cache.cache,
-          pending: cache.pending,
-        }),
-      ),
-    );
+    for (const cache of cachesForCleanup.splice(0)) {
+      await Promise.allSettled(cache.pending.values());
+      await Promise.allSettled(Array.from(cache.cache.values(), (entry) => entry.close()));
+      cache.cache.clear();
+      cache.pending.clear();
+    }
   });
 
   it("repairs an invalid singleton cache shape", async () => {
@@ -99,45 +76,6 @@ describe("manager cache", () => {
     expect(results).toHaveLength(12);
     expect(new Set(results).size).toBe(1);
     expect(createCalls).toBe(1);
-  });
-
-  it("waits for pending creation before global teardown closes cached entries", async () => {
-    const cache = createTestCache();
-    const first = createEntry("first");
-    const second = createEntry("second");
-    cachesForCleanup.push(cache);
-    const gate = createDeferred();
-
-    const pendingFirst = getOrCreateManagedCacheEntry({
-      cache: cache.cache,
-      pending: cache.pending,
-      key: "same",
-      create: async () => {
-        await gate.promise;
-        return first;
-      },
-    });
-
-    const teardown = closeManagedCacheEntries({
-      cache: cache.cache,
-      pending: cache.pending,
-    });
-    gate.resolve();
-
-    await teardown;
-    expect(first.close).toHaveBeenCalledTimes(1);
-
-    const resolvedFirst = await pendingFirst;
-    const resolvedSecond = await getOrCreateManagedCacheEntry({
-      cache: cache.cache,
-      pending: cache.pending,
-      key: "same",
-      create: async () => second,
-    });
-
-    expect(resolvedFirst).toBe(first);
-    expect(resolvedSecond).toBe(second);
-    expect(resolvedSecond).not.toBe(resolvedFirst);
   });
 
   it("bypasses identity caching for status-only callers", async () => {

--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -1,10 +1,6 @@
 // Memory Core plugin module implements manager cache behavior.
 import { resolveGlobalSingleton } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 
-type Closable = {
-  close?: () => Promise<void> | void;
-};
-
 type ManagedCache<T> = {
   cache: Map<string, T>;
   pending: Map<string, Promise<T>>;
@@ -64,29 +60,6 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
   } finally {
     if (params.pending.get(params.key) === createPromise) {
       params.pending.delete(params.key);
-    }
-  }
-}
-
-export async function closeManagedCacheEntries<T extends Closable>(params: {
-  cache: Map<string, T>;
-  pending: Map<string, Promise<T>>;
-  onCloseError?: (err: unknown) => void;
-}): Promise<void> {
-  const pending = Array.from(params.pending.values());
-  if (pending.length > 0) {
-    await Promise.allSettled(pending);
-  }
-  const entries = Array.from(params.cache.values());
-  params.cache.clear();
-  for (const entry of entries) {
-    if (typeof entry.close !== "function") {
-      continue;
-    }
-    try {
-      await entry.close();
-    } catch (err) {
-      params.onCloseError?.(err);
     }
   }
 }

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -570,8 +570,12 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  protected async embedQueryWithRetry(text: string, signal?: AbortSignal): Promise<number[]> {
-    const provider = this.provider;
+  protected async embedQueryWithRetry(
+    text: string,
+    signal?: AbortSignal,
+    providerOverride?: EmbeddingProvider,
+  ): Promise<number[]> {
+    const provider = providerOverride ?? this.provider;
     if (!provider) {
       throw new Error("Cannot embed query in FTS-only mode (no embedding provider)");
     }

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -25,6 +25,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { MAX_TIMER_TIMEOUT_MS, resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { runSqliteImmediateTransactionSync } from "openclaw/plugin-sdk/sqlite-runtime";
+import type { EmbeddingProvider } from "./embeddings.js";
 import {
   MEMORY_BATCH_FAILURE_LIMIT,
   recordMemoryBatchFailure,
@@ -215,6 +216,41 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected abstract batchFailureLastProvider?: string;
   protected abstract batchFailureLock: Promise<void>;
   protected abstract markLocalEmbeddingProviderDegraded(err: unknown): void;
+  private activeProviderUses = new Map<EmbeddingProvider, number>();
+  private providerIdleWaiters = new Map<EmbeddingProvider, Set<() => void>>();
+
+  protected async withProviderUse<T>(
+    provider: EmbeddingProvider,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    this.activeProviderUses.set(provider, (this.activeProviderUses.get(provider) ?? 0) + 1);
+    try {
+      return await run();
+    } finally {
+      const remaining = (this.activeProviderUses.get(provider) ?? 1) - 1;
+      if (remaining > 0) {
+        this.activeProviderUses.set(provider, remaining);
+      } else {
+        this.activeProviderUses.delete(provider);
+        const waiters = this.providerIdleWaiters.get(provider);
+        this.providerIdleWaiters.delete(provider);
+        for (const resolve of waiters ?? []) {
+          resolve();
+        }
+      }
+    }
+  }
+
+  protected async awaitProviderIdle(provider: EmbeddingProvider): Promise<void> {
+    if (!this.activeProviderUses.has(provider)) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      const waiters = this.providerIdleWaiters.get(provider) ?? new Set();
+      waiters.add(resolve);
+      this.providerIdleWaiters.set(provider, waiters);
+    });
+  }
 
   protected pruneEmbeddingCacheIfNeeded(): void {
     if (!this.cache.enabled) {
@@ -410,39 +446,43 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       throw new Error("Cannot embed batch in FTS-only mode (no embedding provider)");
     }
     try {
-      return await runMemoryEmbeddingBatchRetryWithSplit({
-        items: texts,
-        run: async (batchTexts) => {
-          const timeoutMs = this.resolveEmbeddingTimeout("batch");
-          log.debug("memory embeddings: batch start", {
-            provider: provider.id,
-            items: batchTexts.length,
-            timeoutMs,
-          });
-          const result = await runEmbeddingOperationWithTimeout({
-            timeoutMs,
-            message: `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
-            run: async (signal) => await provider.embedBatch(batchTexts, { signal }),
-          });
-          log.debug("memory embeddings: batch completed", {
-            provider: provider.id,
-            items: batchTexts.length,
-          });
-          return result;
-        },
-        isRetryable: isRetryableMemoryEmbeddingError,
-        isSplittable: isSplittableMemoryEmbeddingTransportError,
-        waitForRetry: async (delayMs) => {
-          await this.waitForEmbeddingRetry(delayMs, "retrying");
-        },
-        maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-        baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
-        onSplit: ({ itemCount, splitAt }) => {
-          log.warn(
-            `memory embeddings transport failed after retries; splitting batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
-          );
-        },
-      });
+      return await this.withProviderUse(
+        provider,
+        async () =>
+          await runMemoryEmbeddingBatchRetryWithSplit({
+            items: texts,
+            run: async (batchTexts) => {
+              const timeoutMs = this.resolveEmbeddingTimeout("batch");
+              log.debug("memory embeddings: batch start", {
+                provider: provider.id,
+                items: batchTexts.length,
+                timeoutMs,
+              });
+              const result = await runEmbeddingOperationWithTimeout({
+                timeoutMs,
+                message: `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
+                run: async (signal) => await provider.embedBatch(batchTexts, { signal }),
+              });
+              log.debug("memory embeddings: batch completed", {
+                provider: provider.id,
+                items: batchTexts.length,
+              });
+              return result;
+            },
+            isRetryable: isRetryableMemoryEmbeddingError,
+            isSplittable: isSplittableMemoryEmbeddingTransportError,
+            waitForRetry: async (delayMs) => {
+              await this.waitForEmbeddingRetry(delayMs, "retrying");
+            },
+            maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
+            baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+            onSplit: ({ itemCount, splitAt }) => {
+              log.warn(
+                `memory embeddings transport failed after retries; splitting batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
+              );
+            },
+          }),
+      );
     } catch (err) {
       log.debug("memory embeddings: batch failed", {
         provider: provider.id,
@@ -467,34 +507,38 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       return await this.embedBatchWithRetry(inputs.map((input) => input.text));
     }
     try {
-      return await runMemoryEmbeddingBatchRetryWithSplit({
-        items: inputs,
-        run: async (batchInputs) => {
-          const timeoutMs = this.resolveEmbeddingTimeout("batch");
-          log.debug("memory embeddings: structured batch start", {
-            provider: provider.id,
-            items: batchInputs.length,
-            timeoutMs,
-          });
-          return await runEmbeddingOperationWithTimeout({
-            timeoutMs,
-            message: `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
-            run: async (signal) => await embedBatchInputs(batchInputs, { signal }),
-          });
-        },
-        isRetryable: isRetryableMemoryEmbeddingError,
-        isSplittable: isSplittableMemoryEmbeddingTransportError,
-        waitForRetry: async (delayMs) => {
-          await this.waitForEmbeddingRetry(delayMs, "retrying structured batch");
-        },
-        maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-        baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
-        onSplit: ({ itemCount, splitAt }) => {
-          log.warn(
-            `memory embeddings transport failed after retries; splitting structured batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
-          );
-        },
-      });
+      return await this.withProviderUse(
+        provider,
+        async () =>
+          await runMemoryEmbeddingBatchRetryWithSplit({
+            items: inputs,
+            run: async (batchInputs) => {
+              const timeoutMs = this.resolveEmbeddingTimeout("batch");
+              log.debug("memory embeddings: structured batch start", {
+                provider: provider.id,
+                items: batchInputs.length,
+                timeoutMs,
+              });
+              return await runEmbeddingOperationWithTimeout({
+                timeoutMs,
+                message: `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
+                run: async (signal) => await embedBatchInputs(batchInputs, { signal }),
+              });
+            },
+            isRetryable: isRetryableMemoryEmbeddingError,
+            isSplittable: isSplittableMemoryEmbeddingTransportError,
+            waitForRetry: async (delayMs) => {
+              await this.waitForEmbeddingRetry(delayMs, "retrying structured batch");
+            },
+            maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
+            baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+            onSplit: ({ itemCount, splitAt }) => {
+              log.warn(
+                `memory embeddings transport failed after retries; splitting structured batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
+              );
+            },
+          }),
+      );
     } catch (err) {
       this.markLocalEmbeddingProviderDegraded(err);
       throw createMemoryEmbeddingOperationError({
@@ -532,26 +576,30 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       throw new Error("Cannot embed query in FTS-only mode (no embedding provider)");
     }
     try {
-      return await runMemoryEmbeddingRetryLoop({
-        run: async () => {
-          signal?.throwIfAborted();
-          const timeoutMs = this.resolveEmbeddingTimeout("query");
-          log.debug("memory embeddings: query start", { provider: provider.id, timeoutMs });
-          return await runEmbeddingOperationWithTimeout({
-            timeoutMs,
-            message: `memory embeddings query timed out after ${Math.round(timeoutMs / 1000)}s`,
+      return await this.withProviderUse(
+        provider,
+        async () =>
+          await runMemoryEmbeddingRetryLoop({
+            run: async () => {
+              signal?.throwIfAborted();
+              const timeoutMs = this.resolveEmbeddingTimeout("query");
+              log.debug("memory embeddings: query start", { provider: provider.id, timeoutMs });
+              return await runEmbeddingOperationWithTimeout({
+                timeoutMs,
+                message: `memory embeddings query timed out after ${Math.round(timeoutMs / 1000)}s`,
+                signal,
+                run: async (opSignal) => await provider.embedQuery(text, { signal: opSignal }),
+              });
+            },
             signal,
-            run: async (opSignal) => await provider.embedQuery(text, { signal: opSignal }),
-          });
-        },
-        signal,
-        isRetryable: isRetryableMemoryEmbeddingError,
-        waitForRetry: async (delayMs) => {
-          await this.waitForEmbeddingRetry(delayMs, "retrying query");
-        },
-        maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-        baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
-      });
+            isRetryable: isRetryableMemoryEmbeddingError,
+            waitForRetry: async (delayMs) => {
+              await this.waitForEmbeddingRetry(delayMs, "retrying query");
+            },
+            maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
+            baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+          }),
+      );
     } catch (err) {
       this.markLocalEmbeddingProviderDegraded(err);
       throw createMemoryEmbeddingOperationError({

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -52,6 +52,7 @@ import {
   resolveMemoryIndexProviderIdentities,
   type MemoryIndexProviderIdentity,
 } from "./manager-reindex-state.js";
+import type { MemorySyncProviderGeneration } from "./manager-sync-base.js";
 import { MemoryManagerSyncOps, type MemoryIndexWorkItem } from "./manager-sync-ops.js";
 import { logMemoryVectorDegradedWrite } from "./manager-vector-warning.js";
 import { replaceMemoryVectorRow } from "./manager-vector-write.js";
@@ -218,6 +219,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected abstract markLocalEmbeddingProviderDegraded(err: unknown): void;
   private activeProviderUses = new Map<EmbeddingProvider, number>();
   private providerIdleWaiters = new Map<EmbeddingProvider, Set<() => void>>();
+  private syncProviderGenerationRelease: (() => void) | null = null;
+  private syncProviderGenerationOwners = 0;
 
   protected acquireProviderUse(provider: EmbeddingProvider): () => void {
     this.activeProviderUses.set(provider, (this.activeProviderUses.get(provider) ?? 0) + 1);
@@ -264,6 +267,42 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
+  protected beginSyncProviderGeneration(): void {
+    if (this.syncProviderGeneration) {
+      this.syncProviderGenerationOwners += 1;
+      return;
+    }
+    const provider = this.provider;
+    if (!provider) {
+      return;
+    }
+    const runtime = this.providerRuntime;
+    const identities = resolveMemoryIndexProviderIdentities({
+      provider,
+      cacheKeyData: runtime?.cacheKeyData,
+      aliases: runtime?.indexIdentityAliases,
+    });
+    this.syncProviderGeneration = {
+      provider,
+      ...(runtime ? { runtime } : {}),
+      providerKey: expectDefined(identities.at(0), "primary memory provider identity").providerKey,
+      identities,
+    };
+    this.syncProviderGenerationRelease = this.acquireProviderUse(provider);
+    this.syncProviderGenerationOwners = 1;
+  }
+
+  protected endSyncProviderGeneration(): void {
+    if (this.syncProviderGenerationOwners > 1) {
+      this.syncProviderGenerationOwners -= 1;
+      return;
+    }
+    this.syncProviderGenerationOwners = 0;
+    this.syncProviderGeneration = null;
+    this.syncProviderGenerationRelease?.();
+    this.syncProviderGenerationRelease = null;
+  }
+
   protected pruneEmbeddingCacheIfNeeded(): void {
     if (!this.cache.enabled) {
       return;
@@ -294,23 +333,26 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
   private upsertEmbeddingCacheEntries(
     entries: Array<{ hash: string; embedding: number[] }>,
-    provider: { id: string; model: string } | null = this.provider,
+    generation: MemorySyncProviderGeneration,
   ): void {
     upsertMemoryEmbeddingCache({
       db: this.db,
       enabled: this.cache.enabled,
-      provider,
-      providerKey: this.providerKey,
+      provider: generation.provider,
+      providerKey: generation.providerKey,
       entries,
       tableName: EMBEDDING_CACHE_TABLE,
     });
   }
 
-  private async embedChunksInBatches(chunks: MemoryChunk[]): Promise<number[][]> {
+  private async embedChunksInBatches(
+    chunks: MemoryChunk[],
+    generation: MemorySyncProviderGeneration,
+  ): Promise<number[][]> {
     if (chunks.length === 0) {
       return [];
     }
-    const { embeddings, missing } = this.collectCachedEmbeddings(chunks);
+    const { embeddings, missing } = this.collectCachedEmbeddings(chunks, generation);
 
     if (missing.length === 0) {
       return embeddings;
@@ -318,10 +360,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
     const missingChunks = missing.map((m) => m.chunk);
     const batches = buildMemoryEmbeddingBatches(missingChunks, EMBEDDING_BATCH_MAX_TOKENS);
-    const provider = this.provider;
-    if (!provider) {
-      throw new Error("Cannot embed batch in FTS-only mode (no embedding provider)");
-    }
+    const provider = generation.provider;
     let cursor = 0;
     for (const batch of batches) {
       const inputs = buildTextEmbeddingInputs(batch);
@@ -336,8 +375,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         });
       }
       const batchEmbeddings = hasStructuredInputs
-        ? await this.embedBatchInputsWithRetry(inputs)
-        : await this.embedBatchWithRetry(batch.map((chunk) => chunk.text));
+        ? await this.embedBatchInputsWithRetry(inputs, generation)
+        : await this.embedBatchWithRetry(
+            batch.map((chunk) => chunk.text),
+            generation,
+          );
       const batchCacheEntries: Array<{ hash: string; embedding: number[] }> = [];
       for (let i = 0; i < batch.length; i += 1) {
         const item = missing[cursor + i];
@@ -347,7 +389,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           batchCacheEntries.push({ hash: item.chunk.hash, embedding });
         }
       }
-      this.upsertEmbeddingCacheEntries(batchCacheEntries);
+      this.upsertEmbeddingCacheEntries(batchCacheEntries, generation);
       cursor += batch.length;
     }
     return embeddings;
@@ -386,17 +428,18 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     chunks: MemoryChunk[],
     _entry: MemoryIndexEntry,
     source: string,
+    generation: MemorySyncProviderGeneration,
     debugContext: Record<string, unknown> = {},
   ): Promise<number[][]> {
-    const provider = this.provider;
-    const batchEmbed = this.providerRuntime?.batchEmbed;
-    if (!provider || !batchEmbed) {
-      return this.embedChunksInBatches(chunks);
+    const provider = generation.provider;
+    const batchEmbed = generation.runtime?.batchEmbed;
+    if (!batchEmbed) {
+      return this.embedChunksInBatches(chunks, generation);
     }
     if (chunks.length === 0) {
       return [];
     }
-    const { embeddings, missing } = this.collectCachedEmbeddings(chunks);
+    const { embeddings, missing } = this.collectCachedEmbeddings(chunks, generation);
     if (missing.length === 0) {
       return embeddings;
     }
@@ -414,10 +457,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           timeoutMs: this.batch.timeoutMs,
           debug: this.buildBatchDebug(source, chunks, debugContext),
         }),
-      fallback: async () => await this.embedChunksInBatches(missingChunks),
+      fallback: async () => await this.embedChunksInBatches(missingChunks, generation),
     });
     if (!batchResult) {
-      return this.embedChunksInBatches(chunks);
+      return this.embedChunksInBatches(chunks, generation);
     }
     const toCache: Array<{ hash: string; embedding: number[] }> = [];
     for (let index = 0; index < missing.length; index += 1) {
@@ -429,11 +472,14 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       embeddings[item.index] = embedding;
       toCache.push({ hash: item.chunk.hash, embedding });
     }
-    this.upsertEmbeddingCacheEntries(toCache, provider);
+    this.upsertEmbeddingCacheEntries(toCache, generation);
     return embeddings;
   }
 
-  private collectCachedEmbeddings(chunks: MemoryChunk[]): {
+  private collectCachedEmbeddings(
+    chunks: MemoryChunk[],
+    generation: MemorySyncProviderGeneration,
+  ): {
     embeddings: number[][];
     missing: Array<{ index: number; chunk: MemoryChunk }>;
   } {
@@ -442,18 +488,21 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       cached: loadMemoryEmbeddingCache({
         db: this.db,
         enabled: this.cache.enabled,
-        providerIdentities: this.provider ? this.resolveProviderIndexIdentities() : [],
+        providerIdentities: generation.identities,
         hashes: chunks.map((chunk) => chunk.hash),
         tableName: EMBEDDING_CACHE_TABLE,
       }),
     });
   }
 
-  protected async embedBatchWithRetry(texts: string[]): Promise<number[][]> {
+  protected async embedBatchWithRetry(
+    texts: string[],
+    generation?: MemorySyncProviderGeneration,
+  ): Promise<number[][]> {
     if (texts.length === 0) {
       return [];
     }
-    const provider = this.provider;
+    const provider = generation?.provider ?? this.provider;
     if (!provider) {
       throw new Error("Cannot embed batch in FTS-only mode (no embedding provider)");
     }
@@ -464,7 +513,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           await runMemoryEmbeddingBatchRetryWithSplit({
             items: texts,
             run: async (batchTexts) => {
-              const timeoutMs = this.resolveEmbeddingTimeout("batch");
+              const timeoutMs = this.resolveEmbeddingTimeout(
+                "batch",
+                provider,
+                generation?.runtime,
+              );
               log.debug("memory embeddings: batch start", {
                 provider: provider.id,
                 items: batchTexts.length,
@@ -509,14 +562,20 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
   }
 
-  protected async embedBatchInputsWithRetry(inputs: EmbeddingInput[]): Promise<number[][]> {
+  protected async embedBatchInputsWithRetry(
+    inputs: EmbeddingInput[],
+    generation?: MemorySyncProviderGeneration,
+  ): Promise<number[][]> {
     if (inputs.length === 0) {
       return [];
     }
-    const provider = this.provider;
+    const provider = generation?.provider ?? this.provider;
     const embedBatchInputs = provider?.embedBatchInputs;
     if (!embedBatchInputs) {
-      return await this.embedBatchWithRetry(inputs.map((input) => input.text));
+      return await this.embedBatchWithRetry(
+        inputs.map((input) => input.text),
+        generation,
+      );
     }
     try {
       return await this.withProviderUse(
@@ -525,7 +584,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           await runMemoryEmbeddingBatchRetryWithSplit({
             items: inputs,
             run: async (batchInputs) => {
-              const timeoutMs = this.resolveEmbeddingTimeout("batch");
+              const timeoutMs = this.resolveEmbeddingTimeout(
+                "batch",
+                provider,
+                generation?.runtime,
+              );
               log.debug("memory embeddings: structured batch start", {
                 provider: provider.id,
                 items: batchInputs.length,
@@ -573,11 +636,15 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  private resolveEmbeddingTimeout(kind: "query" | "batch"): number {
+  private resolveEmbeddingTimeout(
+    kind: "query" | "batch",
+    provider: EmbeddingProvider | null = this.provider,
+    providerRuntime: MemoryEmbeddingProviderRuntime | undefined = this.providerRuntime,
+  ): number {
     return resolveEmbeddingTimeoutMs({
       kind,
-      providerId: this.provider?.id,
-      providerRuntime: this.providerRuntime,
+      providerId: provider?.id,
+      providerRuntime,
       configuredBatchTimeoutSeconds: this.settings.sync.embeddingBatchTimeoutSeconds,
     });
   }
@@ -766,7 +833,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     return resolveMemoryIndexConcurrency({
       batch: this.batch,
       configuredNonBatchConcurrency: this.settings.remote?.nonBatchConcurrency,
-      providerId: this.provider?.id,
+      providerId: this.syncProviderGeneration?.provider.id ?? this.provider?.id,
     });
   }
 
@@ -886,6 +953,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   private async prepareIndexEntry(
     entry: MemoryIndexEntry,
     options: { source: MemorySource; content?: string },
+    generation: MemorySyncProviderGeneration | null,
   ): Promise<PreparedMemoryIndexEntry | null> {
     if ("kind" in entry && entry.kind === "multimodal") {
       const multimodalChunk = await buildMultimodalChunkForIndexing(entry);
@@ -910,8 +978,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         `read memory markdown for indexing ${entry.absPath}`,
       ));
     const baseChunks = filterNonEmptyMemoryChunks(chunkMarkdown(content, this.settings.chunking));
-    const chunks = this.provider
-      ? enforceEmbeddingMaxInputTokens(this.provider, baseChunks, EMBEDDING_BATCH_MAX_TOKENS)
+    const chunks = generation
+      ? enforceEmbeddingMaxInputTokens(generation.provider, baseChunks, EMBEDDING_BATCH_MAX_TOKENS)
       : baseChunks;
     if (options.source === "sessions" && "lineMap" in entry) {
       remapChunkLines(chunks, entry.lineMap);
@@ -923,16 +991,30 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (items.length === 0) {
       return;
     }
-    const provider = this.provider;
-    const batchEmbed = this.providerRuntime?.batchEmbed;
+    this.beginSyncProviderGeneration();
+    try {
+      await this.indexFilesWithGeneration(items, this.syncProviderGeneration);
+    } finally {
+      this.endSyncProviderGeneration();
+    }
+  }
+
+  private async indexFilesWithGeneration(
+    items: MemoryIndexWorkItem[],
+    generation: MemorySyncProviderGeneration | null,
+  ): Promise<void> {
+    const batchEmbed = generation?.runtime?.batchEmbed;
     if (
-      !provider ||
+      !generation ||
       !this.batch.enabled ||
       !batchEmbed ||
-      this.providerRuntime?.sourceWideBatchEmbed !== true
+      generation.runtime?.sourceWideBatchEmbed !== true
     ) {
       await runWithConcurrency(
-        items.map((item) => async () => await this.indexFile(item.entry, { source: item.source })),
+        items.map(
+          (item) => async () =>
+            await this.indexFileWithGeneration(item.entry, { source: item.source }, generation),
+        ),
         this.getIndexConcurrency(),
       );
       return;
@@ -985,7 +1067,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       for (let requestIndex = 0; requestIndex < chunkBatches.length; requestIndex += 1) {
         const chunkBatch = chunkBatches[requestIndex] ?? [];
         embeddings.push(
-          ...(await this.embedChunksWithBatch(chunkBatch, firstEntry, source, {
+          ...(await this.embedChunksWithBatch(chunkBatch, firstEntry, source, generation, {
             sourceWideFiles: current.length,
             sourceWideSources: sourceCounts,
             sourceWideBatchGroup,
@@ -1003,7 +1085,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         this.writeChunks(
           item.entry,
           item.source,
-          provider.model,
+          generation.provider.model,
           item.chunks,
           fileEmbeddings,
           vectorReady,
@@ -1015,10 +1097,14 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
     for (const item of items) {
       if ("kind" in item.entry && item.entry.kind === "multimodal") {
-        await this.indexFile(item.entry, { source: item.source });
+        await this.indexFileWithGeneration(item.entry, { source: item.source }, generation);
         continue;
       }
-      const preparedEntry = await this.prepareIndexEntry(item.entry, { source: item.source });
+      const preparedEntry = await this.prepareIndexEntry(
+        item.entry,
+        { source: item.source },
+        generation,
+      );
       if (!preparedEntry) {
         continue;
       }
@@ -1045,19 +1131,32 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected async indexFile(
     entry: MemoryIndexEntry,
     options: { source: MemorySource; content?: string },
-  ) {
+  ): Promise<void> {
+    this.beginSyncProviderGeneration();
+    try {
+      await this.indexFileWithGeneration(entry, options, this.syncProviderGeneration);
+    } finally {
+      this.endSyncProviderGeneration();
+    }
+  }
+
+  private async indexFileWithGeneration(
+    entry: MemoryIndexEntry,
+    options: { source: MemorySource; content?: string },
+    generation: MemorySyncProviderGeneration | null,
+  ): Promise<void> {
     // FTS-only mode: no embedding provider, but we can still build a FTS index
-    if (!this.provider) {
+    if (!generation) {
       // Multimodal files require an embedding provider; skip in FTS-only mode.
       if ("kind" in entry && entry.kind === "multimodal") {
         return;
       }
-      const prepared = await this.prepareIndexEntry(entry, options);
+      const prepared = await this.prepareIndexEntry(entry, options, null);
       this.writeChunks(entry, options.source, "fts-only", prepared?.chunks ?? [], [], false);
       return;
     }
 
-    const prepared = await this.prepareIndexEntry(entry, options);
+    const prepared = await this.prepareIndexEntry(entry, options, generation);
     if (!prepared) {
       return;
     }
@@ -1065,8 +1164,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     let embeddings: number[][];
     try {
       embeddings = this.batch.enabled
-        ? await this.embedChunksWithBatch(prepared.chunks, entry, options.source)
-        : await this.embedChunksInBatches(prepared.chunks);
+        ? await this.embedChunksWithBatch(prepared.chunks, entry, options.source, generation)
+        : await this.embedChunksInBatches(prepared.chunks, generation);
     } catch (err) {
       const message = formatErrorMessage(err);
       if (
@@ -1079,8 +1178,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         log.warn("memory embeddings: skipping multimodal file rejected as too large", {
           path: entry.path,
           bytes: prepared.structuredInputBytes,
-          provider: this.provider.id,
-          model: this.provider.model,
+          provider: generation.provider.id,
+          model: generation.provider.model,
           error: message,
         });
         this.clearIndexedFileData(entry.path, options.source);
@@ -1094,7 +1193,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     this.writeChunks(
       entry,
       options.source,
-      this.provider.model,
+      generation.provider.model,
       prepared.chunks,
       embeddings,
       vectorReady,

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -52,8 +52,11 @@ import {
   resolveMemoryIndexProviderIdentities,
   type MemoryIndexProviderIdentity,
 } from "./manager-reindex-state.js";
-import type { MemorySyncProviderGeneration } from "./manager-sync-base.js";
-import { MemoryManagerSyncOps, type MemoryIndexWorkItem } from "./manager-sync-ops.js";
+import {
+  MemoryManagerSyncOps,
+  type MemoryIndexWorkItem,
+  type MemorySyncProviderGeneration,
+} from "./manager-sync-ops.js";
 import { logMemoryVectorDegradedWrite } from "./manager-vector-warning.js";
 import { replaceMemoryVectorRow } from "./manager-vector-write.js";
 

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -55,6 +55,7 @@ import {
 import {
   MemoryManagerSyncOps,
   type MemoryIndexWorkItem,
+  type MemorySemanticProviderGeneration,
   type MemorySyncProviderGeneration,
 } from "./manager-sync-ops.js";
 import { logMemoryVectorDegradedWrite } from "./manager-vector-warning.js";
@@ -276,22 +277,26 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       return;
     }
     const provider = this.provider;
-    if (!provider) {
-      return;
-    }
     const runtime = this.providerRuntime;
     const identities = resolveMemoryIndexProviderIdentities({
       provider,
       cacheKeyData: runtime?.cacheKeyData,
       aliases: runtime?.indexIdentityAliases,
     });
-    this.syncProviderGeneration = {
-      provider,
-      ...(runtime ? { runtime } : {}),
-      providerKey: expectDefined(identities.at(0), "primary memory provider identity").providerKey,
-      identities,
-    };
-    this.syncProviderGenerationRelease = this.acquireProviderUse(provider);
+    const providerKey = expectDefined(
+      identities.at(0),
+      "primary memory provider identity",
+    ).providerKey;
+    this.syncProviderGeneration = provider
+      ? {
+          kind: "semantic",
+          provider,
+          ...(runtime ? { runtime } : {}),
+          providerKey,
+          identities,
+        }
+      : { kind: "fts-only", provider: null, providerKey, identities };
+    this.syncProviderGenerationRelease = provider ? this.acquireProviderUse(provider) : null;
     this.syncProviderGenerationOwners = 1;
   }
 
@@ -336,7 +341,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
   private upsertEmbeddingCacheEntries(
     entries: Array<{ hash: string; embedding: number[] }>,
-    generation: MemorySyncProviderGeneration,
+    generation: MemorySemanticProviderGeneration,
   ): void {
     upsertMemoryEmbeddingCache({
       db: this.db,
@@ -350,7 +355,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
   private async embedChunksInBatches(
     chunks: MemoryChunk[],
-    generation: MemorySyncProviderGeneration,
+    generation: MemorySemanticProviderGeneration,
   ): Promise<number[][]> {
     if (chunks.length === 0) {
       return [];
@@ -431,7 +436,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     chunks: MemoryChunk[],
     _entry: MemoryIndexEntry,
     source: string,
-    generation: MemorySyncProviderGeneration,
+    generation: MemorySemanticProviderGeneration,
     debugContext: Record<string, unknown> = {},
   ): Promise<number[][]> {
     const provider = generation.provider;
@@ -481,7 +486,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
   private collectCachedEmbeddings(
     chunks: MemoryChunk[],
-    generation: MemorySyncProviderGeneration,
+    generation: MemorySemanticProviderGeneration,
   ): {
     embeddings: number[][];
     missing: Array<{ index: number; chunk: MemoryChunk }>;
@@ -500,7 +505,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
   protected async embedBatchWithRetry(
     texts: string[],
-    generation?: MemorySyncProviderGeneration,
+    generation?: MemorySemanticProviderGeneration,
   ): Promise<number[][]> {
     if (texts.length === 0) {
       return [];
@@ -567,7 +572,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
   protected async embedBatchInputsWithRetry(
     inputs: EmbeddingInput[],
-    generation?: MemorySyncProviderGeneration,
+    generation?: MemorySemanticProviderGeneration,
   ): Promise<number[][]> {
     if (inputs.length === 0) {
       return [];
@@ -838,7 +843,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     return resolveMemoryIndexConcurrency({
       batch: this.batch,
       configuredNonBatchConcurrency: this.settings.remote?.nonBatchConcurrency,
-      providerId: this.syncProviderGeneration?.provider.id ?? this.provider?.id,
+      providerId: this.syncProviderGeneration
+        ? this.syncProviderGeneration.provider?.id
+        : this.provider?.id,
     });
   }
 
@@ -983,9 +990,14 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         `read memory markdown for indexing ${entry.absPath}`,
       ));
     const baseChunks = filterNonEmptyMemoryChunks(chunkMarkdown(content, this.settings.chunking));
-    const chunks = generation
-      ? enforceEmbeddingMaxInputTokens(generation.provider, baseChunks, EMBEDDING_BATCH_MAX_TOKENS)
-      : baseChunks;
+    const chunks =
+      generation?.kind === "semantic"
+        ? enforceEmbeddingMaxInputTokens(
+            generation.provider,
+            baseChunks,
+            EMBEDDING_BATCH_MAX_TOKENS,
+          )
+        : baseChunks;
     if (options.source === "sessions" && "lineMap" in entry) {
       remapChunkLines(chunks, entry.lineMap);
     }
@@ -1008,9 +1020,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     items: MemoryIndexWorkItem[],
     generation: MemorySyncProviderGeneration | null,
   ): Promise<void> {
-    const batchEmbed = generation?.runtime?.batchEmbed;
+    const batchEmbed = generation?.kind === "semantic" ? generation.runtime?.batchEmbed : undefined;
     if (
-      !generation ||
+      generation?.kind !== "semantic" ||
       !this.batch.enabled ||
       !batchEmbed ||
       generation.runtime?.sourceWideBatchEmbed !== true
@@ -1151,7 +1163,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     generation: MemorySyncProviderGeneration | null,
   ): Promise<void> {
     // FTS-only mode: no embedding provider, but we can still build a FTS index
-    if (!generation) {
+    if (generation?.kind !== "semantic") {
       // Multimodal files require an embedding provider; skip in FTS-only mode.
       if ("kind" in entry && entry.kind === "multimodal") {
         return;

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -657,8 +657,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     signal?: AbortSignal,
     providerOverride?: EmbeddingProvider,
     markDegraded = true,
+    providerRuntimeOverride?: MemoryEmbeddingProviderRuntime,
   ): Promise<number[]> {
     const provider = providerOverride ?? this.provider;
+    const providerRuntime = providerOverride ? providerRuntimeOverride : this.providerRuntime;
     if (!provider) {
       throw new Error("Cannot embed query in FTS-only mode (no embedding provider)");
     }
@@ -669,7 +671,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           await runMemoryEmbeddingRetryLoop({
             run: async () => {
               signal?.throwIfAborted();
-              const timeoutMs = this.resolveEmbeddingTimeout("query");
+              const timeoutMs = this.resolveEmbeddingTimeout("query", provider, providerRuntime);
               log.debug("memory embeddings: query start", { provider: provider.id, timeoutMs });
               return await runEmbeddingOperationWithTimeout({
                 timeoutMs,

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -219,25 +219,37 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   private activeProviderUses = new Map<EmbeddingProvider, number>();
   private providerIdleWaiters = new Map<EmbeddingProvider, Set<() => void>>();
 
+  protected acquireProviderUse(provider: EmbeddingProvider): () => void {
+    this.activeProviderUses.set(provider, (this.activeProviderUses.get(provider) ?? 0) + 1);
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      const remaining = (this.activeProviderUses.get(provider) ?? 1) - 1;
+      if (remaining > 0) {
+        this.activeProviderUses.set(provider, remaining);
+        return;
+      }
+      this.activeProviderUses.delete(provider);
+      const waiters = this.providerIdleWaiters.get(provider);
+      this.providerIdleWaiters.delete(provider);
+      for (const resolve of waiters ?? []) {
+        resolve();
+      }
+    };
+  }
+
   protected async withProviderUse<T>(
     provider: EmbeddingProvider,
     run: () => Promise<T>,
   ): Promise<T> {
-    this.activeProviderUses.set(provider, (this.activeProviderUses.get(provider) ?? 0) + 1);
+    const release = this.acquireProviderUse(provider);
     try {
       return await run();
     } finally {
-      const remaining = (this.activeProviderUses.get(provider) ?? 1) - 1;
-      if (remaining > 0) {
-        this.activeProviderUses.set(provider, remaining);
-      } else {
-        this.activeProviderUses.delete(provider);
-        const waiters = this.providerIdleWaiters.get(provider);
-        this.providerIdleWaiters.delete(provider);
-        for (const resolve of waiters ?? []) {
-          resolve();
-        }
-      }
+      release();
     }
   }
 
@@ -574,6 +586,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     text: string,
     signal?: AbortSignal,
     providerOverride?: EmbeddingProvider,
+    markDegraded = true,
   ): Promise<number[]> {
     const provider = providerOverride ?? this.provider;
     if (!provider) {
@@ -605,7 +618,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           }),
       );
     } catch (err) {
-      this.markLocalEmbeddingProviderDegraded(err);
+      if (markDegraded) {
+        this.markLocalEmbeddingProviderDegraded(err);
+      }
       throw createMemoryEmbeddingOperationError({
         operation: "query",
         providerId: provider.id,

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -267,7 +267,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  protected beginSyncProviderGeneration(): void {
+  protected override beginSyncProviderGeneration(): void {
     if (this.syncProviderGeneration) {
       this.syncProviderGenerationOwners += 1;
       return;
@@ -292,7 +292,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     this.syncProviderGenerationOwners = 1;
   }
 
-  protected endSyncProviderGeneration(): void {
+  protected override endSyncProviderGeneration(): void {
     if (this.syncProviderGenerationOwners > 1) {
       this.syncProviderGenerationOwners -= 1;
       return;

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -74,6 +74,13 @@ export type MemoryIndexWorkItem = {
   afterIndex?: () => void;
 };
 
+export type MemorySyncProviderGeneration = {
+  provider: EmbeddingProvider;
+  runtime?: EmbeddingProviderRuntime;
+  providerKey: string;
+  identities: MemoryIndexProviderIdentity[];
+};
+
 export type MemorySourceSyncPlan = {
   indexItems: MemoryIndexWorkItem[];
   finalize: () => Promise<void> | void;
@@ -119,6 +126,7 @@ export abstract class MemoryManagerSyncBase {
   protected abstract providerUnavailableReason?: string;
   protected abstract providerLifecycle: MemoryProviderLifecycleState;
   protected providerRuntime?: EmbeddingProviderRuntime;
+  protected syncProviderGeneration: MemorySyncProviderGeneration | null = null;
   protected abstract batch: {
     enabled: boolean;
     wait: boolean;
@@ -178,6 +186,8 @@ export abstract class MemoryManagerSyncBase {
   ): Promise<T>;
   protected abstract getIndexConcurrency(): number;
   protected abstract pruneEmbeddingCacheIfNeeded(): void;
+  protected abstract beginSyncProviderGeneration(): void;
+  protected abstract endSyncProviderGeneration(): void;
   protected abstract resetProviderInitializationForRetry(): void;
   protected abstract assertRequiredProviderAvailable(operation: "search" | "sync"): void;
   protected abstract indexFile(
@@ -265,11 +275,13 @@ export abstract class MemoryManagerSyncBase {
   }
 
   protected shouldDeferSourceWideBatch(): boolean {
+    const provider = this.syncProviderGeneration?.provider ?? this.provider;
+    const providerRuntime = this.syncProviderGeneration?.runtime ?? this.providerRuntime;
     return Boolean(
       this.batch.enabled &&
-      this.provider &&
-      this.providerRuntime?.batchEmbed &&
-      this.providerRuntime.sourceWideBatchEmbed === true,
+      provider &&
+      providerRuntime?.batchEmbed &&
+      providerRuntime.sourceWideBatchEmbed === true,
     );
   }
 

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -186,8 +186,8 @@ export abstract class MemoryManagerSyncBase {
   ): Promise<T>;
   protected abstract getIndexConcurrency(): number;
   protected abstract pruneEmbeddingCacheIfNeeded(): void;
-  protected abstract beginSyncProviderGeneration(): void;
-  protected abstract endSyncProviderGeneration(): void;
+  protected beginSyncProviderGeneration(): void {}
+  protected endSyncProviderGeneration(): void {}
   protected abstract resetProviderInitializationForRetry(): void;
   protected abstract assertRequiredProviderAvailable(operation: "search" | "sync"): void;
   protected abstract indexFile(

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -74,13 +74,6 @@ export type MemoryIndexWorkItem = {
   afterIndex?: () => void;
 };
 
-export type MemorySyncProviderGeneration = {
-  provider: EmbeddingProvider;
-  runtime?: EmbeddingProviderRuntime;
-  providerKey: string;
-  identities: MemoryIndexProviderIdentity[];
-};
-
 export type MemorySourceSyncPlan = {
   indexItems: MemoryIndexWorkItem[];
   finalize: () => Promise<void> | void;
@@ -126,7 +119,6 @@ export abstract class MemoryManagerSyncBase {
   protected abstract providerUnavailableReason?: string;
   protected abstract providerLifecycle: MemoryProviderLifecycleState;
   protected providerRuntime?: EmbeddingProviderRuntime;
-  protected syncProviderGeneration: MemorySyncProviderGeneration | null = null;
   protected abstract batch: {
     enabled: boolean;
     wait: boolean;
@@ -186,8 +178,6 @@ export abstract class MemoryManagerSyncBase {
   ): Promise<T>;
   protected abstract getIndexConcurrency(): number;
   protected abstract pruneEmbeddingCacheIfNeeded(): void;
-  protected beginSyncProviderGeneration(): void {}
-  protected endSyncProviderGeneration(): void {}
   protected abstract resetProviderInitializationForRetry(): void;
   protected abstract assertRequiredProviderAvailable(operation: "search" | "sync"): void;
   protected abstract indexFile(
@@ -275,13 +265,11 @@ export abstract class MemoryManagerSyncBase {
   }
 
   protected shouldDeferSourceWideBatch(): boolean {
-    const provider = this.syncProviderGeneration?.provider ?? this.provider;
-    const providerRuntime = this.syncProviderGeneration?.runtime ?? this.providerRuntime;
     return Boolean(
       this.batch.enabled &&
-      provider &&
-      providerRuntime?.batchEmbed &&
-      providerRuntime.sourceWideBatchEmbed === true,
+      this.provider &&
+      this.providerRuntime?.batchEmbed &&
+      this.providerRuntime.sourceWideBatchEmbed === true,
     );
   }
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -82,7 +82,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   }
 
   private assertFtsOnlySyncAllowed(): void {
-    if (this.provider) {
+    if (this.syncProviderGeneration?.provider ?? this.provider) {
       return;
     }
     this.assertRequiredProviderAvailable("sync");
@@ -131,12 +131,16 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     if (params?.reason === "cli" && !params.force && !hasTargetArchiveFiles) {
       await this.markSessionStartupCatchupDirtyFiles();
     }
+    const syncProvider = this.syncProviderGeneration?.provider ?? this.provider;
+    const syncProviderKey = this.syncProviderGeneration?.providerKey ?? this.providerKey;
+    const syncProviderIdentities =
+      this.syncProviderGeneration?.identities ?? this.resolveProviderIndexIdentities();
     const indexIdentity = resolveMemoryIndexIdentityState({
       meta,
       // Also detects provider→FTS-only transitions so orphaned old-model FTS rows are cleaned up.
-      provider: this.provider ? { id: this.provider.id, model: this.provider.model } : null,
-      providerKey: this.providerKey ?? undefined,
-      providerAliases: this.resolveProviderIndexIdentities().slice(1),
+      provider: syncProvider ? { id: syncProvider.id, model: syncProvider.model } : null,
+      providerKey: syncProviderKey ?? undefined,
+      providerAliases: syncProviderIdentities.slice(1),
       configuredSources: resolveConfiguredSourcesForMeta(this.sources),
       configuredScopeHash: resolveConfiguredScopeHash({
         workspaceDir: this.workspaceDir,
@@ -165,12 +169,12 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     const needsFtsOnlyClassification =
       indexIdentity.status === "missing" &&
       hasIndexedChunks &&
-      this.provider === null &&
+      syncProvider === null &&
       Boolean(this.settings.provider) &&
       this.settings.provider !== "none";
     const hasOnlyFtsChunks = needsFtsOnlyClassification && !this.hasSemanticChunks();
     const canRebuildMissingIdentity =
-      this.provider !== null ||
+      syncProvider !== null ||
       !this.settings.provider ||
       this.settings.provider === "none" ||
       hasOnlyFtsChunks;
@@ -211,7 +215,10 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
           await this.syncArchiveFiles(targetedParams);
         },
         shouldFallbackOnError: (err) => this.shouldFallbackOnError(err),
-        activateFallbackProvider: async (reason) => await this.activateFallbackProvider(reason),
+        activateFallbackProvider: async (reason) => {
+          this.endSyncProviderGeneration();
+          return await this.activateFallbackProvider(reason);
+        },
       });
       if (targetedSessionSync.handled) {
         this.sessionsDirty = targetedSessionSync.sessionsDirty;
@@ -269,10 +276,15 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       }
     } catch (err) {
       const reason = formatErrorMessage(err);
-      const activated =
-        this.shouldFallbackOnError(err) && (await this.activateFallbackProvider(reason));
+      const shouldFallback = this.shouldFallbackOnError(err);
+      if (shouldFallback) {
+        // A failed generation cannot wait on its own sync lease while activating fallback.
+        this.endSyncProviderGeneration();
+      }
+      const activated = shouldFallback && (await this.activateFallbackProvider(reason));
       if (activated) {
         if (needsFullReindex && !hasTargetArchiveFiles) {
+          this.beginSyncProviderGeneration();
           await this.runInPlaceReindex({
             reason: params?.reason ?? "fallback",
             force: true,
@@ -503,10 +515,11 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         this.clearMemoryRetryState();
       }
       const vectorIndexComplete = this.vector.available === true;
+      const syncProvider = this.syncProviderGeneration?.provider ?? this.provider;
       const nextMeta: MemoryIndexMeta = {
-        model: this.provider?.model ?? "fts-only",
-        provider: this.provider?.id ?? "none",
-        providerKey: this.providerKey!,
+        model: syncProvider?.model ?? "fts-only",
+        provider: syncProvider?.id ?? "none",
+        providerKey: this.syncProviderGeneration?.providerKey ?? this.providerKey!,
         sources: resolveConfiguredSourcesForMeta(this.sources),
         scopeHash: resolveConfiguredScopeHash({
           workspaceDir: this.workspaceDir,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -49,12 +49,23 @@ import { markMemoryVectorIndexClean } from "./manager-vector-rebuild-state.js";
 
 export type { MemoryIndexWorkItem } from "./manager-sync-base.js";
 
-export type MemorySyncProviderGeneration = {
-  provider: EmbeddingProvider;
-  runtime?: EmbeddingProviderRuntime;
+type MemorySyncProviderGenerationBase = {
   providerKey: string;
   identities: MemoryIndexProviderIdentity[];
 };
+
+export type MemorySyncProviderGeneration =
+  | (MemorySyncProviderGenerationBase & { kind: "fts-only"; provider: null })
+  | (MemorySyncProviderGenerationBase & {
+      kind: "semantic";
+      provider: EmbeddingProvider;
+      runtime?: EmbeddingProviderRuntime;
+    });
+
+export type MemorySemanticProviderGeneration = Extract<
+  MemorySyncProviderGeneration,
+  { kind: "semantic" }
+>;
 
 const log = createSubsystemLogger("memory");
 
@@ -66,8 +77,13 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   protected endSyncProviderGeneration(): void {}
 
   protected override shouldDeferSourceWideBatch(): boolean {
-    const provider = this.syncProviderGeneration?.provider ?? this.provider;
-    const providerRuntime = this.syncProviderGeneration?.runtime ?? this.providerRuntime;
+    const generation = this.syncProviderGeneration;
+    const provider = generation ? generation.provider : this.provider;
+    const providerRuntime = generation
+      ? generation.kind === "semantic"
+        ? generation.runtime
+        : undefined
+      : this.providerRuntime;
     return Boolean(
       this.batch.enabled &&
       provider &&
@@ -109,7 +125,10 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   }
 
   private assertFtsOnlySyncAllowed(): void {
-    if (this.syncProviderGeneration?.provider ?? this.provider) {
+    const provider = this.syncProviderGeneration
+      ? this.syncProviderGeneration.provider
+      : this.provider;
+    if (provider) {
       return;
     }
     this.assertRequiredProviderAvailable("sync");
@@ -158,8 +177,12 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     if (params?.reason === "cli" && !params.force && !hasTargetArchiveFiles) {
       await this.markSessionStartupCatchupDirtyFiles();
     }
-    const syncProvider = this.syncProviderGeneration?.provider ?? this.provider;
-    const syncProviderKey = this.syncProviderGeneration?.providerKey ?? this.providerKey;
+    const syncProvider = this.syncProviderGeneration
+      ? this.syncProviderGeneration.provider
+      : this.provider;
+    const syncProviderKey = this.syncProviderGeneration
+      ? this.syncProviderGeneration.providerKey
+      : this.providerKey;
     const syncProviderIdentities =
       this.syncProviderGeneration?.identities ?? this.resolveProviderIndexIdentities();
     const indexIdentity = resolveMemoryIndexIdentityState({
@@ -542,11 +565,15 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         this.clearMemoryRetryState();
       }
       const vectorIndexComplete = this.vector.available === true;
-      const syncProvider = this.syncProviderGeneration?.provider ?? this.provider;
+      const syncProvider = this.syncProviderGeneration
+        ? this.syncProviderGeneration.provider
+        : this.provider;
       const nextMeta: MemoryIndexMeta = {
         model: syncProvider?.model ?? "fts-only",
         provider: syncProvider?.id ?? "none",
-        providerKey: this.syncProviderGeneration?.providerKey ?? this.providerKey!,
+        providerKey: this.syncProviderGeneration
+          ? this.syncProviderGeneration.providerKey
+          : this.providerKey!,
         sources: resolveConfiguredSourcesForMeta(this.sources),
         scopeHash: resolveConfiguredScopeHash({
           workspaceDir: this.workspaceDir,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -390,6 +390,10 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       this.resetProviderInitializationForRetry();
       throw err;
     }
+    if (!fallbackResult.provider) {
+      this.resetProviderInitializationForRetry();
+      return false;
+    }
 
     const fallbackState = applyMemoryFallbackProviderState({
       current: currentState,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -47,6 +47,15 @@ export type { MemoryIndexWorkItem } from "./manager-sync-base.js";
 const log = createSubsystemLogger("memory");
 
 export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
+  private fallbackProviderInitPromise: Promise<boolean> | null = null;
+
+  protected async retireCurrentProvider(): Promise<void> {
+    const provider = this.provider;
+    this.provider = null;
+    this.providerRuntime = undefined;
+    await provider?.close?.();
+  }
+
   private createSyncProgress(
     onProgress: (update: MemorySyncProgressUpdate) => void,
   ): MemorySyncProgressState {
@@ -310,6 +319,29 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   }
 
   protected async activateFallbackProvider(reason: string): Promise<boolean> {
+    if (this.closed) {
+      return false;
+    }
+    const pending = this.fallbackProviderInitPromise;
+    if (pending) {
+      return await pending;
+    }
+    const activation = this.activateFallbackProviderOnce(reason);
+    this.fallbackProviderInitPromise = activation;
+    try {
+      return await activation;
+    } finally {
+      if (this.fallbackProviderInitPromise === activation) {
+        this.fallbackProviderInitPromise = null;
+      }
+    }
+  }
+
+  protected getPendingFallbackProviderInitialization(): Promise<boolean> | null {
+    return this.fallbackProviderInitPromise;
+  }
+
+  private async activateFallbackProviderOnce(reason: string): Promise<boolean> {
     const currentProviderId = resolveFallbackCurrentProviderId({
       provider: this.provider,
       lifecycle: this.providerLifecycle,
@@ -326,6 +358,24 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       return false;
     }
 
+    const currentState = {
+      provider: this.provider,
+      fallbackFrom: this.fallbackFrom,
+      fallbackReason: this.fallbackReason,
+      providerUnavailableReason: undefined,
+      providerRuntime: this.providerRuntime,
+      lifecycle: this.providerLifecycle,
+    };
+    this.providerLifecycle = {
+      mode: "degraded",
+      providerId: currentProviderId,
+      reason,
+    };
+    await this.retireCurrentProvider();
+    if (this.closed) {
+      return false;
+    }
+
     const fallbackResult = await createEmbeddingProvider({
       config: this.cfg,
       agentDir: resolveAgentDir(this.cfg, this.agentId),
@@ -334,14 +384,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     });
 
     const fallbackState = applyMemoryFallbackProviderState({
-      current: {
-        provider: this.provider,
-        fallbackFrom: this.fallbackFrom,
-        fallbackReason: this.fallbackReason,
-        providerUnavailableReason: undefined,
-        providerRuntime: this.providerRuntime,
-        lifecycle: this.providerLifecycle,
-      },
+      current: currentState,
       fallbackFrom: currentProviderId,
       reason,
       result: fallbackResult,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -12,7 +12,11 @@ import type {
   MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
-import { createEmbeddingProvider } from "./embeddings.js";
+import {
+  createEmbeddingProvider,
+  type EmbeddingProvider,
+  type EmbeddingProviderRuntime,
+} from "./embeddings.js";
 import {
   cleanupAgedMemoryReindexTempFiles,
   closeMemoryDatabase,
@@ -33,6 +37,7 @@ import {
   resolveConfiguredSourcesForMeta,
   resolveMemoryIndexIdentityState,
   type MemoryIndexMeta,
+  type MemoryIndexProviderIdentity,
 } from "./manager-reindex-state.js";
 import { MemoryManagerSourceSyncOps } from "./manager-source-sync-ops.js";
 import { MEMORY_INDEX_META_KEY, type MemorySyncProgressState } from "./manager-sync-base.js";
@@ -44,10 +49,32 @@ import { markMemoryVectorIndexClean } from "./manager-vector-rebuild-state.js";
 
 export type { MemoryIndexWorkItem } from "./manager-sync-base.js";
 
+export type MemorySyncProviderGeneration = {
+  provider: EmbeddingProvider;
+  runtime?: EmbeddingProviderRuntime;
+  providerKey: string;
+  identities: MemoryIndexProviderIdentity[];
+};
+
 const log = createSubsystemLogger("memory");
 
 export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   private fallbackProviderInitPromise: Promise<boolean> | null = null;
+  protected syncProviderGeneration: MemorySyncProviderGeneration | null = null;
+
+  protected beginSyncProviderGeneration(): void {}
+  protected endSyncProviderGeneration(): void {}
+
+  protected override shouldDeferSourceWideBatch(): boolean {
+    const provider = this.syncProviderGeneration?.provider ?? this.provider;
+    const providerRuntime = this.syncProviderGeneration?.runtime ?? this.providerRuntime;
+    return Boolean(
+      this.batch.enabled &&
+      provider &&
+      providerRuntime?.batchEmbed &&
+      providerRuntime.sourceWideBatchEmbed === true,
+    );
+  }
 
   protected async retireCurrentProvider(): Promise<void> {
     const provider = this.provider;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -376,12 +376,20 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       return false;
     }
 
-    const fallbackResult = await createEmbeddingProvider({
-      config: this.cfg,
-      agentDir: resolveAgentDir(this.cfg, this.agentId),
-      ...(this.acquireLocalService ? { acquireLocalService: this.acquireLocalService } : {}),
-      ...fallbackRequest,
-    });
+    let fallbackResult;
+    try {
+      fallbackResult = await createEmbeddingProvider({
+        config: this.cfg,
+        agentDir: resolveAgentDir(this.cfg, this.agentId),
+        ...(this.acquireLocalService ? { acquireLocalService: this.acquireLocalService } : {}),
+        ...fallbackRequest,
+      });
+    } catch (err) {
+      // Retirement already removed the primary before fallback construction.
+      // Make the configured provider retryable instead of stranding FTS-only mode.
+      this.resetProviderInitializationForRetry();
+      throw err;
+    }
 
     const fallbackState = applyMemoryFallbackProviderState({
       current: currentState,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1690,6 +1690,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       pendingProviderInit: pendingFallbackInit?.then(() => undefined),
       onError: reportPendingWorkError,
     });
+    await awaitCurrentSync();
     for (
       let attempt = 0;
       attempt < 2 && (this.provider !== null || this.providersPendingRetirement.size > 0);
@@ -1704,7 +1705,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     rememberCurrentProvider();
     try {
-      await awaitCurrentSync();
       rememberCurrentProvider();
       await drainTrackedProviders();
     } finally {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -102,7 +102,9 @@ const PATH_FTS_TABLE = MEMORY_INDEX_PATHS_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
 const MEMORY_INDEX_MANAGER_SCOPE_CLOSES_KEY = Symbol.for("openclaw.memoryIndexManagerScopeCloses");
-const MEMORY_INDEX_MANAGER_GLOBAL_CLOSE_KEY = Symbol.for("openclaw.memoryIndexManagerGlobalClose");
+const MEMORY_INDEX_MANAGER_GLOBAL_LIFECYCLE_KEY = Symbol.for(
+  "openclaw.memoryIndexManagerGlobalLifecycle.v2",
+);
 const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const KEYWORD_FALLBACK_SEARCH_TERM_LIMIT = 6;
 const EXACT_PATH_CANDIDATE_LIMIT = 200;
@@ -120,10 +122,53 @@ const INDEX_SCOPE_CLOSES = resolveGlobalSingleton<Map<string, Promise<void>>>(
   MEMORY_INDEX_MANAGER_SCOPE_CLOSES_KEY,
   () => new Map(),
 );
-const INDEX_GLOBAL_CLOSE = resolveGlobalSingleton<{ promise: Promise<void> | null }>(
-  MEMORY_INDEX_MANAGER_GLOBAL_CLOSE_KEY,
-  () => ({ promise: null }),
-);
+const INDEX_GLOBAL_LIFECYCLE = resolveGlobalSingleton<{
+  tail: Promise<void>;
+  closeFailed: boolean;
+}>(MEMORY_INDEX_MANAGER_GLOBAL_LIFECYCLE_KEY, () => ({
+  tail: Promise.resolve(),
+  closeFailed: false,
+}));
+
+async function runMemoryIndexManagerGlobalOperation<T>(operation: () => Promise<T>): Promise<T> {
+  const result = INDEX_GLOBAL_LIFECYCLE.tail.then(operation, operation);
+  INDEX_GLOBAL_LIFECYCLE.tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return await result;
+}
+
+async function closeAllMemoryIndexManagersUnlocked(): Promise<void> {
+  const scopedCloses = Array.from(INDEX_SCOPE_CLOSES.values());
+  if (scopedCloses.length > 0) {
+    await Promise.allSettled(scopedCloses);
+  }
+  const pending = Array.from(INDEX_CACHE_PENDING.values());
+  if (pending.length > 0) {
+    await Promise.allSettled(pending);
+  }
+  const entries = Array.from(INDEX_CACHE.entries());
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const [key, manager] of entries) {
+    try {
+      await manager.close();
+      if (INDEX_CACHE.get(key) === manager) {
+        INDEX_CACHE.delete(key);
+      }
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+      log.warn(`failed to close memory index manager: ${String(err)}`);
+    }
+  }
+  if (closeFailed) {
+    throw firstError;
+  }
+}
 
 type EmbeddingProbeCacheEntry = {
   result: MemoryEmbeddingProbeResult;
@@ -176,44 +221,15 @@ const EMBEDDING_PROBE_CACHE = new Map<string, EmbeddingProbeCacheEntry>();
 
 export async function closeAllMemoryIndexManagers(): Promise<void> {
   EMBEDDING_PROBE_CACHE.clear();
-  const previousClose = INDEX_GLOBAL_CLOSE.promise ?? Promise.resolve();
-  const closePromise = previousClose
-    .catch(() => undefined)
-    .then(async () => {
-      const scopedCloses = Array.from(INDEX_SCOPE_CLOSES.values());
-      if (scopedCloses.length > 0) {
-        await Promise.allSettled(scopedCloses);
-      }
-      const pending = Array.from(INDEX_CACHE_PENDING.values());
-      if (pending.length > 0) {
-        await Promise.allSettled(pending);
-      }
-      const entries = Array.from(INDEX_CACHE.entries());
-      let firstError: unknown;
-      let closeFailed = false;
-      for (const [key, manager] of entries) {
-        try {
-          await manager.close();
-          if (INDEX_CACHE.get(key) === manager) {
-            INDEX_CACHE.delete(key);
-          }
-        } catch (err) {
-          if (!closeFailed) {
-            firstError = err;
-          }
-          closeFailed = true;
-          log.warn(`failed to close memory index manager: ${String(err)}`);
-        }
-      }
-      if (closeFailed) {
-        throw firstError;
-      }
-    });
-  INDEX_GLOBAL_CLOSE.promise = closePromise;
-  await closePromise;
-  if (INDEX_GLOBAL_CLOSE.promise === closePromise) {
-    INDEX_GLOBAL_CLOSE.promise = null;
-  }
+  await runMemoryIndexManagerGlobalOperation(async () => {
+    try {
+      await closeAllMemoryIndexManagersUnlocked();
+      INDEX_GLOBAL_LIFECYCLE.closeFailed = false;
+    } catch (err) {
+      INDEX_GLOBAL_LIFECYCLE.closeFailed = true;
+      throw err;
+    }
+  });
 }
 
 export async function closeMemoryIndexManagersForAgent(params: {
@@ -317,56 +333,76 @@ function resolveMemoryIndexManagerScopeKey(params: {
   return JSON.stringify([params.agentId, params.workspaceDir, params.purpose]);
 }
 
+async function runMemoryIndexManagerScopeOperation<T>(
+  params: {
+    agentId: string;
+    workspaceDir: string;
+    purpose: MemoryIndexManagerPurpose;
+  },
+  operation: () => Promise<T>,
+): Promise<T> {
+  const scopeKey = resolveMemoryIndexManagerScopeKey(params);
+  const previousOperation = INDEX_SCOPE_CLOSES.get(scopeKey) ?? Promise.resolve();
+  const result = previousOperation.then(operation, operation);
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  INDEX_SCOPE_CLOSES.set(scopeKey, tail);
+  try {
+    return await result;
+  } finally {
+    if (INDEX_SCOPE_CLOSES.get(scopeKey) === tail) {
+      INDEX_SCOPE_CLOSES.delete(scopeKey);
+    }
+  }
+}
+
+async function closeMemoryIndexManagersForScopeUnlocked(params: {
+  agentId: string;
+  workspaceDir: string;
+  purpose: MemoryIndexManagerPurpose;
+  exceptKey?: string;
+}): Promise<void> {
+  const isScopedKey = (key: string) =>
+    key !== params.exceptKey && isMemoryIndexManagerCacheKeyInScope(key, params);
+  const pending = Array.from(INDEX_CACHE_PENDING.entries())
+    .filter(([key]) => isScopedKey(key))
+    .map(([, value]) => value);
+  if (pending.length > 0) {
+    await Promise.allSettled(pending);
+  }
+  const entries = Array.from(INDEX_CACHE.entries()).filter(([key]) => isScopedKey(key));
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const [key, manager] of entries) {
+    try {
+      await manager.close();
+      if (INDEX_CACHE.get(key) === manager) {
+        INDEX_CACHE.delete(key);
+      }
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+      log.warn(`failed to close memory index manager for agent ${params.agentId}: ${String(err)}`);
+    }
+  }
+  if (closeFailed) {
+    throw firstError;
+  }
+}
+
 async function closeMemoryIndexManagersForScope(params: {
   agentId: string;
   workspaceDir: string;
   purpose: MemoryIndexManagerPurpose;
   exceptKey?: string;
 }): Promise<void> {
-  const scopeKey = resolveMemoryIndexManagerScopeKey(params);
-  const previousClose = INDEX_SCOPE_CLOSES.get(scopeKey) ?? Promise.resolve();
-  const closePromise = previousClose
-    .catch(() => undefined)
-    .then(async () => {
-      const isScopedKey = (key: string) =>
-        key !== params.exceptKey && isMemoryIndexManagerCacheKeyInScope(key, params);
-      const pending = Array.from(INDEX_CACHE_PENDING.entries())
-        .filter(([key]) => isScopedKey(key))
-        .map(([, value]) => value);
-      if (pending.length > 0) {
-        await Promise.allSettled(pending);
-      }
-      const entries = Array.from(INDEX_CACHE.entries()).filter(([key]) => isScopedKey(key));
-      let firstError: unknown;
-      let closeFailed = false;
-      for (const [key, manager] of entries) {
-        try {
-          await manager.close();
-          if (INDEX_CACHE.get(key) === manager) {
-            INDEX_CACHE.delete(key);
-          }
-        } catch (err) {
-          if (!closeFailed) {
-            firstError = err;
-          }
-          closeFailed = true;
-          log.warn(
-            `failed to close memory index manager for agent ${params.agentId}: ${String(err)}`,
-          );
-        }
-      }
-      if (closeFailed) {
-        throw firstError;
-      }
-    });
-  INDEX_SCOPE_CLOSES.set(scopeKey, closePromise);
-  try {
-    await closePromise;
-  } finally {
-    if (INDEX_SCOPE_CLOSES.get(scopeKey) === closePromise) {
-      INDEX_SCOPE_CLOSES.delete(scopeKey);
-    }
-  }
+  await runMemoryIndexManagerScopeOperation(params, async () => {
+    await closeMemoryIndexManagersForScopeUnlocked(params);
+  });
 }
 
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
@@ -471,16 +507,26 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     purpose?: MemoryIndexManagerPurpose;
     acquireLocalService?: MemoryCoreAcquireLocalService;
   }): Promise<MemoryIndexManager | null> {
-    while (INDEX_GLOBAL_CLOSE.promise) {
-      const pendingGlobalClose = INDEX_GLOBAL_CLOSE.promise;
-      try {
-        await pendingGlobalClose;
-      } catch {
-        if (INDEX_GLOBAL_CLOSE.promise === pendingGlobalClose) {
-          await closeAllMemoryIndexManagers();
+    return await runMemoryIndexManagerGlobalOperation(async () => {
+      if (INDEX_GLOBAL_LIFECYCLE.closeFailed) {
+        try {
+          await closeAllMemoryIndexManagersUnlocked();
+          INDEX_GLOBAL_LIFECYCLE.closeFailed = false;
+        } catch (err) {
+          INDEX_GLOBAL_LIFECYCLE.closeFailed = true;
+          throw err;
         }
       }
-    }
+      return await MemoryIndexManager.getWithinGlobalLifecycle(params);
+    });
+  }
+
+  private static async getWithinGlobalLifecycle(params: {
+    cfg: OpenClawConfig;
+    agentId: string;
+    purpose?: MemoryIndexManagerPurpose;
+    acquireLocalService?: MemoryCoreAcquireLocalService;
+  }): Promise<MemoryIndexManager | null> {
     const { cfg, agentId } = params;
     const settings = resolveMemorySearchConfig(cfg, agentId);
     if (!settings) {
@@ -503,45 +549,53 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       acquireLocalService: params.acquireLocalService,
     });
     const transient = purpose === "status" || purpose === "cli";
-    if (!transient) {
-      const cachedManager = INDEX_CACHE.get(key);
-      await closeMemoryIndexManagersForScope({
-        agentId,
-        workspaceDir,
-        purpose,
-        ...(cachedManager?.closed ? {} : { exceptKey: key }),
+    const getOrCreate = async () =>
+      await getOrCreateManagedCacheEntry({
+        cache: INDEX_CACHE,
+        pending: INDEX_CACHE_PENDING,
+        key,
+        bypassCache: transient,
+        create: async () => {
+          const manager = new MemoryIndexManager({
+            cacheKey: key,
+            cfg,
+            agentId,
+            workspaceDir,
+            settings,
+            providerRequirement,
+            purpose: params.purpose,
+            acquireLocalService: params.acquireLocalService,
+          });
+          // Lightweight dirty-file detection for status mode: check for unindexed
+          // session files on disk without triggering a full sync. This runs before
+          // any caller reads manager.status(), so the dirty flag is accurate when
+          // status() reads sessionsDirty.
+          if (purpose === "status" && manager.sources.has("sessions")) {
+            try {
+              await manager.markSessionStartupCatchupDirtyFiles();
+            } catch (err) {
+              log.warn("memory status session dirty detection failed: " + String(err));
+            }
+          }
+          return manager;
+        },
       });
+    if (transient) {
+      return await getOrCreate();
     }
-    return await getOrCreateManagedCacheEntry({
-      cache: INDEX_CACHE,
-      pending: INDEX_CACHE_PENDING,
-      key,
-      bypassCache: transient,
-      create: async () => {
-        const manager = new MemoryIndexManager({
-          cacheKey: key,
-          cfg,
+    return await runMemoryIndexManagerScopeOperation(
+      { agentId, workspaceDir, purpose },
+      async () => {
+        const cachedManager = INDEX_CACHE.get(key);
+        await closeMemoryIndexManagersForScopeUnlocked({
           agentId,
           workspaceDir,
-          settings,
-          providerRequirement,
-          purpose: params.purpose,
-          acquireLocalService: params.acquireLocalService,
+          purpose,
+          ...(cachedManager?.closed ? {} : { exceptKey: key }),
         });
-        // Lightweight dirty-file detection for status mode: check for unindexed
-        // session files on disk without triggering a full sync. This runs before
-        // any caller reads manager.status(), so the dirty flag is accurate when
-        // status() reads sessionsDirty.
-        if (purpose === "status" && manager.sources.has("sessions")) {
-          try {
-            await manager.markSessionStartupCatchupDirtyFiles();
-          } catch (err) {
-            log.warn("memory status session dirty detection failed: " + String(err));
-          }
-        }
-        return manager;
+        return await getOrCreate();
       },
-    });
+    );
   }
 
   private constructor(params: {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -309,6 +309,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private readonly requestedProvider: EmbeddingProviderRequest;
   private providerInitPromise: Promise<void> | null = null;
   private providerInitialized = false;
+  private providerRetirementPromise: Promise<void> = Promise.resolve();
   protected override fallbackFrom?: EmbeddingProviderId;
   protected override fallbackReason?: string;
   protected providerUnavailableReason?: string;
@@ -551,11 +552,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private applyProviderResult(providerResult: EmbeddingProviderResult): void {
-    if (this.provider?.close) {
-      this.provider.close().catch((err: unknown) => {
-        log.warn(`memory embeddings: failed to close previous provider: ${formatErrorMessage(err)}`);
-      });
-    }
     const providerState = resolveMemoryProviderState(providerResult);
     this.provider = providerState.provider;
     this.fallbackFrom = providerState.fallbackFrom;
@@ -582,6 +578,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     if (!this.providerInitPromise) {
       this.providerInitPromise = (async () => {
+        await this.retireCurrentProvider();
+        if (this.closed) {
+          return;
+        }
         const providerResult = await MemoryIndexManager.loadProviderResult({
           cfg: this.cfg,
           agentId: this.agentId,
@@ -608,10 +608,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   protected resetProviderInitializationForRetry(): void {
-    if (this.provider?.close) {
-      this.provider.close().catch(() => {});
-    }
-    this.provider = null;
+    void this.retireCurrentProvider();
     this.providerInitialized = false;
     this.providerInitPromise = null;
     this.providerUnavailableReason = undefined;
@@ -627,8 +624,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     const message = formatErrorMessage(err);
     const degradedProvider = this.provider;
-    this.provider = null;
-    this.providerRuntime = undefined;
+    void this.retireCurrentProvider();
     this.providerUnavailableReason = `Local embeddings degraded: ${message}`;
     this.providerLifecycle = createDegradedMemoryProviderLifecycle({
       providerId: degradedProvider.id,
@@ -639,12 +635,27 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.providerKey = this.computeProviderKey();
     this.batch = this.resolveBatchConfig();
     this.vector.semanticAvailable = false;
-    void Promise.resolve(degradedProvider.close?.()).catch((errLocal: unknown) => {
-      log.debug(`memory embeddings: failed to close degraded local provider: ${String(errLocal)}`);
-    });
     log.warn("memory embeddings: local provider degraded after worker failure", {
       error: message,
     });
+  }
+
+  protected override retireCurrentProvider(): Promise<void> {
+    const provider = this.provider;
+    if (!provider) {
+      return this.providerRetirementPromise;
+    }
+    this.provider = null;
+    this.providerRuntime = undefined;
+    // Provider replacement must wait for the previous worker to exit; otherwise
+    // repeated retries can accumulate local workers on constrained hosts.
+    const retirement = this.providerRetirementPromise.then(async () => {
+      await provider.close?.();
+    });
+    this.providerRetirementPromise = retirement.catch((err: unknown) => {
+      log.warn(`memory embeddings: failed to close previous provider: ${formatErrorMessage(err)}`);
+    });
+    return this.providerRetirementPromise;
   }
 
   protected isRequiredProviderUnavailable(): boolean {
@@ -1575,6 +1586,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     this.closed = true;
     const pendingProviderInit = this.providerInitPromise;
+    const pendingFallbackInit = this.getPendingFallbackProviderInitialization();
     if (this.watchTimer) {
       clearTimeout(this.watchTimer);
       this.watchTimer = null;
@@ -1653,6 +1665,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     };
     await awaitPendingManagerWork({
       pendingProviderInit,
+      onError: reportPendingWorkError,
+    });
+    await awaitPendingManagerWork({
+      pendingProviderInit: pendingFallbackInit?.then(() => undefined),
+      onError: reportPendingWorkError,
+    });
+    await awaitPendingManagerWork({
+      pendingProviderInit: this.providerRetirementPromise,
       onError: reportPendingWorkError,
     });
     rememberCurrentProvider();

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -655,20 +655,22 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     // Provider replacement must wait for the previous worker to exit; otherwise
     // repeated retries can accumulate local workers on constrained hosts.
-    const retirement = this.providerRetirementPromise.catch(() => {}).then(async () => {
-      let firstError: unknown;
-      for (const pendingProvider of this.providersPendingRetirement) {
-        try {
-          await pendingProvider.close?.();
-          this.providersPendingRetirement.delete(pendingProvider);
-        } catch (err) {
-          firstError ??= err;
+    const retirement = this.providerRetirementPromise
+      .catch(() => {})
+      .then(async () => {
+        let firstError: unknown;
+        for (const pendingProvider of this.providersPendingRetirement) {
+          try {
+            await pendingProvider.close?.();
+            this.providersPendingRetirement.delete(pendingProvider);
+          } catch (err) {
+            firstError ??= err;
+          }
         }
-      }
-      if (firstError) {
-        throw toLintErrorObject(firstError, "Embedding provider retirement failed");
-      }
-    });
+        if (firstError) {
+          throw toLintErrorObject(firstError, "Embedding provider retirement failed");
+        }
+      });
     this.providerRetirementPromise = retirement;
     void retirement.catch((err: unknown) => {
       log.warn(`memory embeddings: failed to close previous provider: ${formatErrorMessage(err)}`);

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1080,6 +1080,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         });
       }
       let semanticProvider = this.provider;
+      let semanticProviderRuntime = this.providerRuntime;
       let vectorProviderIdentity = {
         model: semanticProvider.model,
         aliases: this.resolveProviderIndexIdentities()
@@ -1108,7 +1109,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       try {
         keywordResults = await loadKeywordResults();
         try {
-          queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal, semanticProvider, false);
+          queryVec = await this.embedQueryWithRetry(
+            cleaned,
+            opts?.signal,
+            semanticProvider,
+            false,
+            semanticProviderRuntime,
+          );
         } catch (err) {
           releaseSemanticProvider();
           this.markLocalEmbeddingProviderDegraded(err);
@@ -1138,6 +1145,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
               return [];
             }
             semanticProvider = this.provider;
+            semanticProviderRuntime = this.providerRuntime;
             vectorProviderIdentity = {
               model: semanticProvider.model,
               aliases: this.resolveProviderIndexIdentities()
@@ -1152,6 +1160,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
                 opts?.signal,
                 semanticProvider,
                 false,
+                semanticProviderRuntime,
               );
             } catch (fallbackErr) {
               releaseFallbackProvider();

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1571,7 +1571,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     this.syncing = (async () => {
       await this.ensureProviderInitialized();
-      await this.runSyncWithReadonlyRecovery(params);
+      this.beginSyncProviderGeneration();
+      try {
+        await this.runSyncWithReadonlyRecovery(params);
+      } finally {
+        this.endSyncProviderGeneration();
+      }
     })().finally(() => {
       this.syncing = null;
     });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -762,17 +762,22 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (this.provider?.id !== "local") {
       return;
     }
-    if (!isLocalEmbeddingWorkerFailure(err)) {
+    const workerFailure = isLocalEmbeddingWorkerFailure(err)
+      ? err
+      : err instanceof Error && isLocalEmbeddingWorkerFailure(err.cause)
+        ? err.cause
+        : null;
+    if (!workerFailure) {
       return;
     }
-    const message = formatErrorMessage(err);
+    const message = formatErrorMessage(workerFailure);
     const degradedProvider = this.provider;
     void this.retireCurrentProvider();
     this.providerUnavailableReason = `Local embeddings degraded: ${message}`;
     this.providerLifecycle = createDegradedMemoryProviderLifecycle({
       providerId: degradedProvider.id,
       reason: message,
-      code: err.code,
+      code: workerFailure.code,
     });
     EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
     this.providerKey = this.computeProviderKey();
@@ -1097,58 +1102,81 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
               return [];
             })
           : [];
-      let keywordResults = await loadKeywordResults();
-
+      let keywordResults: Awaited<ReturnType<typeof loadKeywordResults>> = [];
       let queryVec: number[];
+      const releaseSemanticProvider = this.acquireProviderUse(semanticProvider);
       try {
-        queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal, semanticProvider);
-      } catch (err) {
-        // An aborted caller already stopped waiting; skip fallback-provider
-        // activation so the abandoned search stops instead of re-embedding.
-        if (opts?.signal?.aborted) {
-          throw err;
-        }
-        const message = formatErrorMessage(err);
-        const activatedFallback = this.shouldFallbackOnError(err)
-          ? await this.activateFallbackProvider(message).catch((fallbackErr: unknown) => {
-              log.warn(
-                `memory search: failed to activate fallback provider: ${formatErrorMessage(fallbackErr)}`,
+        keywordResults = await loadKeywordResults();
+        try {
+          queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal, semanticProvider, false);
+        } catch (err) {
+          releaseSemanticProvider();
+          this.markLocalEmbeddingProviderDegraded(err);
+          // An aborted caller already stopped waiting; skip fallback-provider
+          // activation so the abandoned search stops instead of re-embedding.
+          if (opts?.signal?.aborted) {
+            throw err;
+          }
+          const message = formatErrorMessage(err);
+          const activatedFallback = this.shouldFallbackOnError(err)
+            ? await this.activateFallbackProvider(message).catch((fallbackErr: unknown) => {
+                log.warn(
+                  `memory search: failed to activate fallback provider: ${formatErrorMessage(fallbackErr)}`,
+                );
+                return false;
+              })
+            : false;
+          if (activatedFallback) {
+            if (
+              this.refreshIndexIdentityDirty({
+                providerKeyKnown: this.providerInitialized,
+              }).status !== "valid"
+            ) {
+              return [];
+            }
+            if (!this.provider) {
+              return [];
+            }
+            semanticProvider = this.provider;
+            vectorProviderIdentity = {
+              model: semanticProvider.model,
+              aliases: this.resolveProviderIndexIdentities()
+                .slice(1)
+                .map((identity) => identity.model),
+            };
+            const releaseFallbackProvider = this.acquireProviderUse(semanticProvider);
+            try {
+              keywordResults = await loadKeywordResults();
+              queryVec = await this.embedQueryWithRetry(
+                cleaned,
+                opts?.signal,
+                semanticProvider,
+                false,
               );
-              return false;
-            })
-          : false;
-        if (activatedFallback) {
-          if (
-            this.refreshIndexIdentityDirty({
-              providerKeyKnown: this.providerInitialized,
-            }).status !== "valid"
-          ) {
-            return [];
+            } catch (fallbackErr) {
+              releaseFallbackProvider();
+              this.markLocalEmbeddingProviderDegraded(fallbackErr);
+              throw fallbackErr;
+            } finally {
+              releaseFallbackProvider();
+            }
+          } else if (!this.provider && this.fts.enabled && this.fts.available) {
+            this.assertRequiredProviderAvailable("search");
+            log.warn(
+              `memory search: embeddings unavailable; using keyword-only results: ${message}`,
+            );
+            return await this.finalizeKeywordOnlyResults({
+              results: keywordResults,
+              temporalDecay: hybrid.temporalDecay,
+              maxResults,
+              minScore,
+            });
+          } else {
+            throw err;
           }
-          keywordResults = await loadKeywordResults();
-          if (!this.provider) {
-            return [];
-          }
-          semanticProvider = this.provider;
-          vectorProviderIdentity = {
-            model: semanticProvider.model,
-            aliases: this.resolveProviderIndexIdentities()
-              .slice(1)
-              .map((identity) => identity.model),
-          };
-          queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal, semanticProvider);
-        } else if (!this.provider && this.fts.enabled && this.fts.available) {
-          this.assertRequiredProviderAvailable("search");
-          log.warn(`memory search: embeddings unavailable; using keyword-only results: ${message}`);
-          return await this.finalizeKeywordOnlyResults({
-            results: keywordResults,
-            temporalDecay: hybrid.temporalDecay,
-            maxResults,
-            minScore,
-          });
-        } else {
-          throw err;
         }
+      } finally {
+        releaseSemanticProvider();
       }
       const hasVector = queryVec.some((v) => v !== 0);
       const vectorResults = hasVector

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -565,7 +565,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
   private async ensureProviderInitialized(): Promise<void> {
     if (this.providerInitialized) {
-      await this.getPendingFallbackProviderInitialization();
+      await this.getPendingFallbackProviderInitialization()?.catch(() => undefined);
       return;
     }
     if (this.settings.provider === "none") {
@@ -580,7 +580,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     if (!this.providerInitPromise) {
       this.providerInitPromise = (async () => {
-        await this.getPendingFallbackProviderInitialization();
+        await this.getPendingFallbackProviderInitialization()?.catch(() => undefined);
         await this.retireCurrentProvider();
         if (this.closed) {
           return;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -564,6 +564,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
   private async ensureProviderInitialized(): Promise<void> {
     if (this.providerInitialized) {
+      await this.getPendingFallbackProviderInitialization();
       return;
     }
     if (this.settings.provider === "none") {
@@ -578,6 +579,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     if (!this.providerInitPromise) {
       this.providerInitPromise = (async () => {
+        await this.getPendingFallbackProviderInitialization();
         await this.retireCurrentProvider();
         if (this.closed) {
           return;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -800,6 +800,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         let closeFailed = false;
         for (const pendingProvider of this.providersPendingRetirement) {
           try {
+            await this.awaitProviderIdle(pendingProvider);
             await pendingProvider.close?.();
             this.providersPendingRetirement.delete(pendingProvider);
           } catch (err) {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -798,6 +798,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         log.warn(`memory sync failed (search): ${String(err)}`);
       },
     });
+    if (
+      preflight.shouldInitializeProvider &&
+      !this.provider &&
+      this.providerLifecycle.mode === "degraded" &&
+      this.providerLifecycle.providerId !== this.settings.provider
+    ) {
+      // A failed fallback must yield ownership back to the configured primary.
+      // Retrying the degraded fallback here can strand a valid existing index.
+      this.resetProviderInitializationForRetry();
+    }
     if (preflight.shouldInitializeProvider) {
       await this.ensureProviderInitialized();
       this.assertRequiredProviderAvailable("search");
@@ -918,6 +928,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         keywordResults = await loadKeywordResults();
         queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
       } else if (!this.provider && this.fts.enabled && this.fts.available) {
+        this.assertRequiredProviderAvailable("search");
         log.warn(`memory search: embeddings unavailable; using keyword-only results: ${message}`);
         return await this.finalizeKeywordOnlyResults({
           results: keywordResults,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -594,7 +594,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     await closeMemoryIndexManagersForScopeUnlocked({
       agentId,
       purpose,
-      ...(cachedManager?.closed ? {} : { exceptKey: key }),
+      ...(cachedManager?.closing || cachedManager?.closed ? {} : { exceptKey: key }),
     });
     return await getOrCreate();
   }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -237,10 +237,8 @@ export async function closeMemoryIndexManagersForAgent(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): Promise<void> {
-  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
   await closeMemoryIndexManagersForScope({
-    agentId: params.agentId,
-    workspaceDir,
+    agentId: normalizeAgentId(params.agentId),
     purpose: "default",
   });
 }
@@ -316,28 +314,22 @@ function isMemoryIndexManagerCacheKeyInScope(
   key: string,
   params: {
     agentId: string;
-    workspaceDir: string;
     purpose: MemoryIndexManagerPurpose;
   },
 ): boolean {
-  return (
-    key.startsWith(`${params.agentId}:${params.workspaceDir}:`) &&
-    key.endsWith(`:${params.purpose}`)
-  );
+  return key.startsWith(`${params.agentId}:`) && key.endsWith(`:${params.purpose}`);
 }
 
 function resolveMemoryIndexManagerScopeKey(params: {
   agentId: string;
-  workspaceDir: string;
   purpose: MemoryIndexManagerPurpose;
 }): string {
-  return JSON.stringify([params.agentId, params.workspaceDir, params.purpose]);
+  return JSON.stringify([params.agentId, params.purpose]);
 }
 
 async function runMemoryIndexManagerScopeOperation<T>(
   params: {
     agentId: string;
-    workspaceDir: string;
     purpose: MemoryIndexManagerPurpose;
   },
   operation: () => Promise<T>,
@@ -371,7 +363,6 @@ async function runMemoryIndexManagerScopeOperation<T>(
 
 async function closeMemoryIndexManagersForScopeUnlocked(params: {
   agentId: string;
-  workspaceDir: string;
   purpose: MemoryIndexManagerPurpose;
   exceptKey?: string;
 }): Promise<void> {
@@ -407,7 +398,6 @@ async function closeMemoryIndexManagersForScopeUnlocked(params: {
 
 async function closeMemoryIndexManagersForScope(params: {
   agentId: string;
-  workspaceDir: string;
   purpose: MemoryIndexManagerPurpose;
   exceptKey?: string;
 }): Promise<void> {
@@ -518,24 +508,21 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     purpose?: MemoryIndexManagerPurpose;
     acquireLocalService?: MemoryCoreAcquireLocalService;
   }): Promise<MemoryIndexManager | null> {
-    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    const agentId = normalizeAgentId(params.agentId);
     const purpose =
       params.purpose === "status" || params.purpose === "cli" ? params.purpose : "default";
-    return await runMemoryIndexManagerScopeOperation(
-      { agentId: params.agentId, workspaceDir, purpose },
-      async () => {
-        if (INDEX_GLOBAL_LIFECYCLE.closeFailed) {
-          try {
-            await closeAllMemoryIndexManagersUnlocked();
-            INDEX_GLOBAL_LIFECYCLE.closeFailed = false;
-          } catch (err) {
-            INDEX_GLOBAL_LIFECYCLE.closeFailed = true;
-            throw err;
-          }
+    return await runMemoryIndexManagerScopeOperation({ agentId, purpose }, async () => {
+      if (INDEX_GLOBAL_LIFECYCLE.closeFailed) {
+        try {
+          await closeAllMemoryIndexManagersUnlocked();
+          INDEX_GLOBAL_LIFECYCLE.closeFailed = false;
+        } catch (err) {
+          INDEX_GLOBAL_LIFECYCLE.closeFailed = true;
+          throw err;
         }
-        return await MemoryIndexManager.getWithinGlobalLifecycle(params);
-      },
-    );
+      }
+      return await MemoryIndexManager.getWithinGlobalLifecycle({ ...params, agentId });
+    });
   }
 
   private static async getWithinGlobalLifecycle(params: {
@@ -603,7 +590,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     const cachedManager = INDEX_CACHE.get(key);
     await closeMemoryIndexManagersForScopeUnlocked({
       agentId,
-      workspaceDir,
       purpose,
       ...(cachedManager?.closed ? {} : { exceptKey: key }),
     });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -551,6 +551,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private applyProviderResult(providerResult: EmbeddingProviderResult): void {
+    if (this.provider?.close) {
+      this.provider.close().catch((err: unknown) => {
+        log.warn(`memory embeddings: failed to close previous provider: ${formatErrorMessage(err)}`);
+      });
+    }
     const providerState = resolveMemoryProviderState(providerResult);
     this.provider = providerState.provider;
     this.fallbackFrom = providerState.fallbackFrom;
@@ -603,6 +608,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   protected resetProviderInitializationForRetry(): void {
+    if (this.provider?.close) {
+      this.provider.close().catch(() => {});
+    }
     this.providerInitialized = false;
     this.providerInitPromise = null;
     this.providerUnavailableReason = undefined;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -7,6 +7,7 @@ import { listRegisteredMemoryEmbeddingProviderAdapters } from "openclaw/plugin-s
 import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   createSubsystemLogger,
+  resolveGlobalSingleton,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveMemorySearchConfig,
@@ -104,6 +105,7 @@ const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const PATH_FTS_TABLE = MEMORY_INDEX_PATHS_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
+const MEMORY_INDEX_MANAGER_SCOPE_CLOSES_KEY = Symbol.for("openclaw.memoryIndexManagerScopeCloses");
 const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const KEYWORD_FALLBACK_SEARCH_TERM_LIMIT = 6;
 const EXACT_PATH_CANDIDATE_LIMIT = 200;
@@ -117,6 +119,10 @@ type MemoryEmbeddingProviderRequirement = {
 
 const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
   resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
+const INDEX_SCOPE_CLOSES = resolveGlobalSingleton<Map<string, Promise<void>>>(
+  MEMORY_INDEX_MANAGER_SCOPE_CLOSES_KEY,
+  () => new Map(),
+);
 
 type EmbeddingProbeCacheEntry = {
   result: MemoryEmbeddingProbeResult;
@@ -271,27 +277,58 @@ function isMemoryIndexManagerCacheKeyInScope(
   );
 }
 
+function resolveMemoryIndexManagerScopeKey(params: {
+  agentId: string;
+  workspaceDir: string;
+  purpose: MemoryIndexManagerPurpose;
+}): string {
+  return JSON.stringify([params.agentId, params.workspaceDir, params.purpose]);
+}
+
 async function closeMemoryIndexManagersForScope(params: {
   agentId: string;
   workspaceDir: string;
   purpose: MemoryIndexManagerPurpose;
   exceptKey?: string;
 }): Promise<void> {
-  const isScopedKey = (key: string) =>
-    key !== params.exceptKey && isMemoryIndexManagerCacheKeyInScope(key, params);
-  const pending = Array.from(INDEX_CACHE_PENDING.entries())
-    .filter(([key]) => isScopedKey(key))
-    .map(([, value]) => value);
-  if (pending.length > 0) {
-    await Promise.allSettled(pending);
-  }
-  const entries = Array.from(INDEX_CACHE.entries()).filter(([key]) => isScopedKey(key));
-  for (const [key, manager] of entries) {
-    INDEX_CACHE.delete(key);
-    try {
-      await manager.close();
-    } catch (err) {
-      log.warn(`failed to close memory index manager for agent ${params.agentId}: ${String(err)}`);
+  const scopeKey = resolveMemoryIndexManagerScopeKey(params);
+  const previousClose = INDEX_SCOPE_CLOSES.get(scopeKey) ?? Promise.resolve();
+  const closePromise = previousClose
+    .catch(() => undefined)
+    .then(async () => {
+      const isScopedKey = (key: string) =>
+        key !== params.exceptKey && isMemoryIndexManagerCacheKeyInScope(key, params);
+      const pending = Array.from(INDEX_CACHE_PENDING.entries())
+        .filter(([key]) => isScopedKey(key))
+        .map(([, value]) => value);
+      if (pending.length > 0) {
+        await Promise.allSettled(pending);
+      }
+      const entries = Array.from(INDEX_CACHE.entries()).filter(([key]) => isScopedKey(key));
+      let firstError: unknown;
+      for (const [key, manager] of entries) {
+        try {
+          await manager.close();
+          if (INDEX_CACHE.get(key) === manager) {
+            INDEX_CACHE.delete(key);
+          }
+        } catch (err) {
+          firstError ??= err;
+          log.warn(
+            `failed to close memory index manager for agent ${params.agentId}: ${String(err)}`,
+          );
+        }
+      }
+      if (firstError) {
+        throw firstError;
+      }
+    });
+  INDEX_SCOPE_CLOSES.set(scopeKey, closePromise);
+  try {
+    await closePromise;
+  } finally {
+    if (INDEX_SCOPE_CLOSES.get(scopeKey) === closePromise) {
+      INDEX_SCOPE_CLOSES.delete(scopeKey);
     }
   }
 }
@@ -311,6 +348,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private providerInitialized = false;
   private providerRetirementPromise: Promise<void> = Promise.resolve();
   private providersPendingRetirement = new Set<EmbeddingProvider>();
+  private closePromise: Promise<void> | null = null;
+  private closeTeardownComplete = false;
   protected override fallbackFrom?: EmbeddingProviderId;
   protected override fallbackReason?: string;
   protected providerUnavailableReason?: string;
@@ -419,11 +458,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     });
     const transient = purpose === "status" || purpose === "cli";
     if (!transient) {
+      const cachedManager = INDEX_CACHE.get(key);
       await closeMemoryIndexManagersForScope({
         agentId,
         workspaceDir,
         purpose,
-        exceptKey: key,
+        ...(cachedManager?.closed ? {} : { exceptKey: key }),
       });
     }
     return await getOrCreateManagedCacheEntry({
@@ -676,6 +716,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       log.warn(`memory embeddings: failed to close previous provider: ${formatErrorMessage(err)}`);
     });
     return retirement;
+  }
+
+  private async drainPendingProviderRetirements(): Promise<unknown[]> {
+    const errors: unknown[] = [];
+    for (
+      let attempt = 0;
+      attempt < 2 && (this.provider !== null || this.providersPendingRetirement.size > 0);
+      attempt += 1
+    ) {
+      try {
+        await this.retireCurrentProvider();
+      } catch (err) {
+        errors.push(err);
+        log.warn(`memory close: pending manager work failed: ${formatErrorMessage(err)}`);
+      }
+    }
+    return errors;
   }
 
   protected isRequiredProviderUnavailable(): boolean {
@@ -1612,9 +1669,34 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   async close(): Promise<void> {
-    if (this.closed) {
+    const existingClose = this.closePromise;
+    if (existingClose) {
+      await existingClose;
       return;
     }
+    const closeOperation = this.closeTeardownComplete ? this.retryFailedClose() : this.closeOnce();
+    this.closePromise = closeOperation;
+    try {
+      await closeOperation;
+    } catch (err) {
+      if (this.closePromise === closeOperation) {
+        this.closePromise = null;
+      }
+      throw err;
+    }
+  }
+
+  private async retryFailedClose(): Promise<void> {
+    const retirementErrors = await this.drainPendingProviderRetirements();
+    if (this.providersPendingRetirement.size > 0) {
+      throw toLintErrorObject(retirementErrors.at(-1), "Embedding provider retirement failed");
+    }
+    if (INDEX_CACHE.get(this.cacheKey) === this) {
+      INDEX_CACHE.delete(this.cacheKey);
+    }
+  }
+
+  private async closeOnce(): Promise<void> {
     this.closed = true;
     const pendingProviderInit = this.providerInitPromise;
     const pendingFallbackInit = this.getPendingFallbackProviderInitialization();
@@ -1684,7 +1766,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     const reportPendingWorkError = (err: unknown) => {
       log.warn(`memory close: pending manager work failed: ${formatErrorMessage(err)}`);
     };
-    const retirementErrors: unknown[] = [];
     const awaitCurrentSync = async () => {
       const pendingSync = this.syncing;
       if (!pendingSync) {
@@ -1704,33 +1785,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       onError: reportPendingWorkError,
     });
     await awaitCurrentSync();
-    for (
-      let attempt = 0;
-      attempt < 2 && (this.provider !== null || this.providersPendingRetirement.size > 0);
-      attempt += 1
-    ) {
-      try {
-        await this.retireCurrentProvider();
-      } catch (err) {
-        retirementErrors.push(err);
-        reportPendingWorkError(err);
-      }
-    }
+    const retirementErrors = await this.drainPendingProviderRetirements();
     rememberCurrentProvider();
     try {
       rememberCurrentProvider();
       await drainTrackedProviders();
     } finally {
       closeMemoryDatabase(this.db);
-      if (INDEX_CACHE.get(this.cacheKey) === this) {
-        INDEX_CACHE.delete(this.cacheKey);
-      }
+      this.closeTeardownComplete = true;
     }
     const closeError =
       (this.providersPendingRetirement.size > 0 ? retirementErrors.at(-1) : undefined) ??
       closeErrors.values().next().value;
     if (closeError) {
       throw toLintErrorObject(closeError, "Non-Error thrown");
+    }
+    if (INDEX_CACHE.get(this.cacheKey) === this) {
+      INDEX_CACHE.delete(this.cacheKey);
     }
   }
 }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -423,6 +423,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private providersPendingRetirement = new Set<EmbeddingProvider>();
   private closePromise: Promise<void> | null = null;
   private closeTeardownComplete = false;
+  private closing = false;
   private activeManagerOperations = 0;
   private managerIdleWaiters = new Set<() => void>();
   protected override fallbackFrom?: EmbeddingProviderId;
@@ -913,7 +914,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private async withManagerOperation<T>(run: () => Promise<T>): Promise<T> {
-    if (this.closed) {
+    if (this.closing || this.closed) {
       throw new Error("Memory index manager is closed");
     }
     this.activeManagerOperations += 1;
@@ -970,7 +971,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           // A fresh process can receive its first search before background watch/session
           // syncs have built the index. Force one synchronous bootstrap so the first
           // lookup after restart does not fail closed with empty results.
-          await this.sync({ reason: "search", force: true });
+          await this.syncAdmitted({ reason: "search", force: true });
         } catch (err) {
           log.warn(`memory sync failed (search-bootstrap): ${String(err)}`);
         }
@@ -989,7 +990,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         enabled: this.settings.sync.onSearch,
         dirty: this.dirty,
         sessionsDirty: this.sessionsDirty,
-        sync: async (params) => await this.sync(params),
+        sync: async (params) => await this.syncAdmitted(params),
         onError: (err) => {
           log.warn(`memory sync failed (search): ${String(err)}`);
         },
@@ -1569,9 +1570,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   async sync(params?: MemorySyncParams): Promise<void> {
-    if (this.closed) {
+    if (this.closing || this.closed) {
       return;
     }
+    return await this.syncAdmitted(params);
+  }
+
+  private async syncAdmitted(params?: MemorySyncParams): Promise<void> {
     if (this.syncing) {
       if (hasTargetedSessionSyncParams(params)) {
         return this.enqueueTargetedSessionSync(params);
@@ -1605,7 +1610,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         setQueuedSessionSync: (value) => {
           this.queuedSessionSync = value;
         },
-        sync: async (params) => await this.sync(params),
+        sync: async (params) => await this.syncAdmitted(params),
       },
       targets,
     );
@@ -1893,8 +1898,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private async closeOnce(): Promise<void> {
-    this.closed = true;
+    this.closing = true;
     await this.awaitManagerIdle();
+    this.closed = true;
     const pendingProviderInit = this.providerInitPromise;
     const pendingFallbackInit = this.getPendingFallbackProviderInitialization();
     if (this.watchTimer) {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -103,7 +103,7 @@ const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
 const MEMORY_INDEX_MANAGER_SCOPE_CLOSES_KEY = Symbol.for("openclaw.memoryIndexManagerScopeCloses");
 const MEMORY_INDEX_MANAGER_GLOBAL_LIFECYCLE_KEY = Symbol.for(
-  "openclaw.memoryIndexManagerGlobalLifecycle.v2",
+  "openclaw.memoryIndexManagerGlobalLifecycle.v3",
 );
 const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const KEYWORD_FALLBACK_SEARCH_TERM_LIMIT = 6;
@@ -123,20 +123,21 @@ const INDEX_SCOPE_CLOSES = resolveGlobalSingleton<Map<string, Promise<void>>>(
   () => new Map(),
 );
 const INDEX_GLOBAL_LIFECYCLE = resolveGlobalSingleton<{
-  tail: Promise<void>;
+  closePromise: Promise<void> | null;
   closeFailed: boolean;
 }>(MEMORY_INDEX_MANAGER_GLOBAL_LIFECYCLE_KEY, () => ({
-  tail: Promise.resolve(),
+  closePromise: null,
   closeFailed: false,
 }));
 
-async function runMemoryIndexManagerGlobalOperation<T>(operation: () => Promise<T>): Promise<T> {
-  const result = INDEX_GLOBAL_LIFECYCLE.tail.then(operation, operation);
-  INDEX_GLOBAL_LIFECYCLE.tail = result.then(
-    () => undefined,
-    () => undefined,
-  );
-  return await result;
+async function runMemoryIndexManagerGlobalClose(operation: () => Promise<void>): Promise<void> {
+  const previous = INDEX_GLOBAL_LIFECYCLE.closePromise ?? Promise.resolve();
+  const closePromise = previous.then(operation, operation);
+  INDEX_GLOBAL_LIFECYCLE.closePromise = closePromise;
+  await closePromise;
+  if (INDEX_GLOBAL_LIFECYCLE.closePromise === closePromise) {
+    INDEX_GLOBAL_LIFECYCLE.closePromise = null;
+  }
 }
 
 async function closeAllMemoryIndexManagersUnlocked(): Promise<void> {
@@ -221,7 +222,7 @@ const EMBEDDING_PROBE_CACHE = new Map<string, EmbeddingProbeCacheEntry>();
 
 export async function closeAllMemoryIndexManagers(): Promise<void> {
   EMBEDDING_PROBE_CACHE.clear();
-  await runMemoryIndexManagerGlobalOperation(async () => {
+  await runMemoryIndexManagerGlobalClose(async () => {
     try {
       await closeAllMemoryIndexManagersUnlocked();
       INDEX_GLOBAL_LIFECYCLE.closeFailed = false;
@@ -341,6 +342,16 @@ async function runMemoryIndexManagerScopeOperation<T>(
   },
   operation: () => Promise<T>,
 ): Promise<T> {
+  while (INDEX_GLOBAL_LIFECYCLE.closePromise) {
+    const globalClose = INDEX_GLOBAL_LIFECYCLE.closePromise;
+    try {
+      await globalClose;
+    } catch {
+      if (INDEX_GLOBAL_LIFECYCLE.closePromise === globalClose) {
+        await closeAllMemoryIndexManagers();
+      }
+    }
+  }
   const scopeKey = resolveMemoryIndexManagerScopeKey(params);
   const previousOperation = INDEX_SCOPE_CLOSES.get(scopeKey) ?? Promise.resolve();
   const result = previousOperation.then(operation, operation);
@@ -507,18 +518,24 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     purpose?: MemoryIndexManagerPurpose;
     acquireLocalService?: MemoryCoreAcquireLocalService;
   }): Promise<MemoryIndexManager | null> {
-    return await runMemoryIndexManagerGlobalOperation(async () => {
-      if (INDEX_GLOBAL_LIFECYCLE.closeFailed) {
-        try {
-          await closeAllMemoryIndexManagersUnlocked();
-          INDEX_GLOBAL_LIFECYCLE.closeFailed = false;
-        } catch (err) {
-          INDEX_GLOBAL_LIFECYCLE.closeFailed = true;
-          throw err;
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    const purpose =
+      params.purpose === "status" || params.purpose === "cli" ? params.purpose : "default";
+    return await runMemoryIndexManagerScopeOperation(
+      { agentId: params.agentId, workspaceDir, purpose },
+      async () => {
+        if (INDEX_GLOBAL_LIFECYCLE.closeFailed) {
+          try {
+            await closeAllMemoryIndexManagersUnlocked();
+            INDEX_GLOBAL_LIFECYCLE.closeFailed = false;
+          } catch (err) {
+            INDEX_GLOBAL_LIFECYCLE.closeFailed = true;
+            throw err;
+          }
         }
-      }
-      return await MemoryIndexManager.getWithinGlobalLifecycle(params);
-    });
+        return await MemoryIndexManager.getWithinGlobalLifecycle(params);
+      },
+    );
   }
 
   private static async getWithinGlobalLifecycle(params: {
@@ -583,19 +600,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (transient) {
       return await getOrCreate();
     }
-    return await runMemoryIndexManagerScopeOperation(
-      { agentId, workspaceDir, purpose },
-      async () => {
-        const cachedManager = INDEX_CACHE.get(key);
-        await closeMemoryIndexManagersForScopeUnlocked({
-          agentId,
-          workspaceDir,
-          purpose,
-          ...(cachedManager?.closed ? {} : { exceptKey: key }),
-        });
-        return await getOrCreate();
-      },
-    );
+    const cachedManager = INDEX_CACHE.get(key);
+    await closeMemoryIndexManagersForScopeUnlocked({
+      agentId,
+      workspaceDir,
+      purpose,
+      ...(cachedManager?.closed ? {} : { exceptKey: key }),
+    });
+    return await getOrCreate();
   }
 
   private constructor(params: {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1074,6 +1074,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           minScore,
         });
       }
+      let semanticProvider = this.provider;
+      let vectorProviderIdentity = {
+        model: semanticProvider.model,
+        aliases: this.resolveProviderIndexIdentities()
+          .slice(1)
+          .map((identity) => identity.model),
+      };
 
       // If FTS isn't available, hybrid mode cannot use keyword search; degrade to vector-only.
       const loadKeywordResults = async () =>
@@ -1094,7 +1101,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
       let queryVec: number[];
       try {
-        queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
+        queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal, semanticProvider);
       } catch (err) {
         // An aborted caller already stopped waiting; skip fallback-provider
         // activation so the abandoned search stops instead of re-embedding.
@@ -1119,7 +1126,17 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
             return [];
           }
           keywordResults = await loadKeywordResults();
-          queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
+          if (!this.provider) {
+            return [];
+          }
+          semanticProvider = this.provider;
+          vectorProviderIdentity = {
+            model: semanticProvider.model,
+            aliases: this.resolveProviderIndexIdentities()
+              .slice(1)
+              .map((identity) => identity.model),
+          };
+          queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal, semanticProvider);
         } else if (!this.provider && this.fts.enabled && this.fts.available) {
           this.assertRequiredProviderAvailable("search");
           log.warn(`memory search: embeddings unavailable; using keyword-only results: ${message}`);
@@ -1135,7 +1152,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       }
       const hasVector = queryVec.some((v) => v !== 0);
       const vectorResults = hasVector
-        ? await this.searchVector(queryVec, candidates, sourceFilterList).catch((err: unknown) => {
+        ? await this.searchVector(
+            queryVec,
+            candidates,
+            sourceFilterList,
+            vectorProviderIdentity,
+          ).catch((err: unknown) => {
             log.warn(`memory search: vector query failed: ${formatErrorMessage(err)}`);
             return [];
           })
@@ -1254,18 +1276,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     queryVec: number[],
     limit: number,
     sourceFilterList: MemorySource[],
+    providerIdentity: { model: string; aliases: string[] },
   ): Promise<Array<MemorySearchResult & { id: string }>> {
-    // This method should never be called without a provider
-    if (!this.provider) {
-      return [];
-    }
     const results = await searchVector({
       db: this.db,
       vectorTable: VECTOR_TABLE,
-      providerModel: this.provider.model,
-      providerModelAliases: this.resolveProviderIndexIdentities()
-        .slice(1)
-        .map((identity) => identity.model),
+      providerModel: providerIdentity.model,
+      providerModelAliases: providerIdentity.aliases,
       queryVec,
       limit,
       snippetMaxChars: SNIPPET_MAX_CHARS,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1795,22 +1795,30 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   async probeVectorAvailability(): Promise<boolean> {
-    if (!this.vector.enabled) {
-      this.vector.semanticAvailable = false;
-      return false;
-    }
-    await this.ensureProviderInitialized();
-    // FTS-only mode: vector search not available
-    if (!this.provider) {
-      this.vector.semanticAvailable = false;
-      return false;
-    }
-    const ready = await this.probeVectorStoreAvailability();
-    this.vector.semanticAvailable = ready;
-    return ready;
+    return await this.withManagerOperation(async () => {
+      if (!this.vector.enabled) {
+        this.vector.semanticAvailable = false;
+        return false;
+      }
+      await this.ensureProviderInitialized();
+      // FTS-only mode: vector search not available
+      if (!this.provider) {
+        this.vector.semanticAvailable = false;
+        return false;
+      }
+      const ready = await this.probeVectorStoreAvailabilityAdmitted();
+      this.vector.semanticAvailable = ready;
+      return ready;
+    });
   }
 
   async probeVectorStoreAvailability(): Promise<boolean> {
+    return await this.withManagerOperation(
+      async () => await this.probeVectorStoreAvailabilityAdmitted(),
+    );
+  }
+
+  private async probeVectorStoreAvailabilityAdmitted(): Promise<boolean> {
     if (!this.vector.enabled) {
       this.vector.available = false;
       return false;
@@ -1848,25 +1856,28 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
-    const cached = this.getCachedEmbeddingAvailability();
-    if (cached) {
-      return cached;
-    }
-    await this.ensureProviderInitialized();
-    // FTS-only mode: embeddings not available but search still works
-    if (!this.provider) {
-      return this.cacheProbeResult({
-        ok: false,
-        error: this.providerUnavailableReason ?? "No embedding provider available (FTS-only mode)",
-      });
-    }
-    try {
-      await this.embedBatchWithRetry(["ping"]);
-      return this.cacheProbeResult({ ok: true });
-    } catch (err) {
-      const message = formatErrorMessage(err);
-      return this.cacheProbeResult({ ok: false, error: message });
-    }
+    return await this.withManagerOperation(async () => {
+      const cached = this.getCachedEmbeddingAvailability();
+      if (cached) {
+        return cached;
+      }
+      await this.ensureProviderInitialized();
+      // FTS-only mode: embeddings not available but search still works
+      if (!this.provider) {
+        return this.cacheProbeResult({
+          ok: false,
+          error:
+            this.providerUnavailableReason ?? "No embedding provider available (FTS-only mode)",
+        });
+      }
+      try {
+        await this.embedBatchWithRetry(["ping"]);
+        return this.cacheProbeResult({ ok: true });
+      } catch (err) {
+        const message = formatErrorMessage(err);
+        return this.cacheProbeResult({ ok: false, error: message });
+      }
+    });
   }
 
   async close(): Promise<void> {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -53,11 +53,7 @@ import {
 } from "./hybrid.js";
 import { awaitPendingManagerWork, startAsyncSearchSync } from "./manager-async-state.js";
 import { MEMORY_BATCH_FAILURE_LIMIT } from "./manager-batch-state.js";
-import {
-  closeManagedCacheEntries,
-  getOrCreateManagedCacheEntry,
-  resolveSingletonManagedCache,
-} from "./manager-cache.js";
+import { getOrCreateManagedCacheEntry, resolveSingletonManagedCache } from "./manager-cache.js";
 import { closeMemoryDatabase } from "./manager-db.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
 import { isLocalEmbeddingWorkerFailure } from "./manager-local-worker-errors.js";
@@ -106,6 +102,7 @@ const PATH_FTS_TABLE = MEMORY_INDEX_PATHS_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
 const MEMORY_INDEX_MANAGER_SCOPE_CLOSES_KEY = Symbol.for("openclaw.memoryIndexManagerScopeCloses");
+const MEMORY_INDEX_MANAGER_GLOBAL_CLOSE_KEY = Symbol.for("openclaw.memoryIndexManagerGlobalClose");
 const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const KEYWORD_FALLBACK_SEARCH_TERM_LIMIT = 6;
 const EXACT_PATH_CANDIDATE_LIMIT = 200;
@@ -122,6 +119,10 @@ const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
 const INDEX_SCOPE_CLOSES = resolveGlobalSingleton<Map<string, Promise<void>>>(
   MEMORY_INDEX_MANAGER_SCOPE_CLOSES_KEY,
   () => new Map(),
+);
+const INDEX_GLOBAL_CLOSE = resolveGlobalSingleton<{ promise: Promise<void> | null }>(
+  MEMORY_INDEX_MANAGER_GLOBAL_CLOSE_KEY,
+  () => ({ promise: null }),
 );
 
 type EmbeddingProbeCacheEntry = {
@@ -175,13 +176,44 @@ const EMBEDDING_PROBE_CACHE = new Map<string, EmbeddingProbeCacheEntry>();
 
 export async function closeAllMemoryIndexManagers(): Promise<void> {
   EMBEDDING_PROBE_CACHE.clear();
-  await closeManagedCacheEntries({
-    cache: INDEX_CACHE,
-    pending: INDEX_CACHE_PENDING,
-    onCloseError: (err) => {
-      log.warn(`failed to close memory index manager: ${String(err)}`);
-    },
-  });
+  const previousClose = INDEX_GLOBAL_CLOSE.promise ?? Promise.resolve();
+  const closePromise = previousClose
+    .catch(() => undefined)
+    .then(async () => {
+      const scopedCloses = Array.from(INDEX_SCOPE_CLOSES.values());
+      if (scopedCloses.length > 0) {
+        await Promise.allSettled(scopedCloses);
+      }
+      const pending = Array.from(INDEX_CACHE_PENDING.values());
+      if (pending.length > 0) {
+        await Promise.allSettled(pending);
+      }
+      const entries = Array.from(INDEX_CACHE.entries());
+      let firstError: unknown;
+      let closeFailed = false;
+      for (const [key, manager] of entries) {
+        try {
+          await manager.close();
+          if (INDEX_CACHE.get(key) === manager) {
+            INDEX_CACHE.delete(key);
+          }
+        } catch (err) {
+          if (!closeFailed) {
+            firstError = err;
+          }
+          closeFailed = true;
+          log.warn(`failed to close memory index manager: ${String(err)}`);
+        }
+      }
+      if (closeFailed) {
+        throw firstError;
+      }
+    });
+  INDEX_GLOBAL_CLOSE.promise = closePromise;
+  await closePromise;
+  if (INDEX_GLOBAL_CLOSE.promise === closePromise) {
+    INDEX_GLOBAL_CLOSE.promise = null;
+  }
 }
 
 export async function closeMemoryIndexManagersForAgent(params: {
@@ -306,6 +338,7 @@ async function closeMemoryIndexManagersForScope(params: {
       }
       const entries = Array.from(INDEX_CACHE.entries()).filter(([key]) => isScopedKey(key));
       let firstError: unknown;
+      let closeFailed = false;
       for (const [key, manager] of entries) {
         try {
           await manager.close();
@@ -313,13 +346,16 @@ async function closeMemoryIndexManagersForScope(params: {
             INDEX_CACHE.delete(key);
           }
         } catch (err) {
-          firstError ??= err;
+          if (!closeFailed) {
+            firstError = err;
+          }
+          closeFailed = true;
           log.warn(
             `failed to close memory index manager for agent ${params.agentId}: ${String(err)}`,
           );
         }
       }
-      if (firstError) {
+      if (closeFailed) {
         throw firstError;
       }
     });
@@ -435,6 +471,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     purpose?: MemoryIndexManagerPurpose;
     acquireLocalService?: MemoryCoreAcquireLocalService;
   }): Promise<MemoryIndexManager | null> {
+    while (INDEX_GLOBAL_CLOSE.promise) {
+      const pendingGlobalClose = INDEX_GLOBAL_CLOSE.promise;
+      try {
+        await pendingGlobalClose;
+      } catch {
+        if (INDEX_GLOBAL_CLOSE.promise === pendingGlobalClose) {
+          await closeAllMemoryIndexManagers();
+        }
+      }
+    }
     const { cfg, agentId } = params;
     const settings = resolveMemorySearchConfig(cfg, agentId);
     if (!settings) {
@@ -699,15 +745,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       .catch(() => {})
       .then(async () => {
         let firstError: unknown;
+        let closeFailed = false;
         for (const pendingProvider of this.providersPendingRetirement) {
           try {
             await pendingProvider.close?.();
             this.providersPendingRetirement.delete(pendingProvider);
           } catch (err) {
-            firstError ??= err;
+            if (!closeFailed) {
+              firstError = err;
+            }
+            closeFailed = true;
           }
         }
-        if (firstError) {
+        if (closeFailed) {
           throw toLintErrorObject(firstError, "Embedding provider retirement failed");
         }
       });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -423,6 +423,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private providersPendingRetirement = new Set<EmbeddingProvider>();
   private closePromise: Promise<void> | null = null;
   private closeTeardownComplete = false;
+  private activeManagerOperations = 0;
+  private managerIdleWaiters = new Set<() => void>();
   protected override fallbackFrom?: EmbeddingProviderId;
   protected override fallbackReason?: string;
   protected providerUnavailableReason?: string;
@@ -905,6 +907,34 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return state;
   }
 
+  private async withManagerOperation<T>(run: () => Promise<T>): Promise<T> {
+    if (this.closed) {
+      throw new Error("Memory index manager is closed");
+    }
+    this.activeManagerOperations += 1;
+    try {
+      return await run();
+    } finally {
+      this.activeManagerOperations -= 1;
+      if (this.activeManagerOperations === 0) {
+        const waiters = Array.from(this.managerIdleWaiters);
+        this.managerIdleWaiters.clear();
+        for (const resolve of waiters) {
+          resolve();
+        }
+      }
+    }
+  }
+
+  private async awaitManagerIdle(): Promise<void> {
+    if (this.activeManagerOperations === 0) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      this.managerIdleWaiters.add(resolve);
+    });
+  }
+
   async search(
     query: string,
     opts?: {
@@ -919,230 +949,234 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       signal?: AbortSignal;
     },
   ): Promise<MemorySearchResult[]> {
-    opts?.onDebug?.({ backend: "builtin" });
-    const normalizedQuery = query.trim();
-    if (!normalizedQuery) {
-      return [];
-    }
-    if (this.providerRequirement.mode === "required") {
-      await this.ensureProviderInitialized();
-      this.assertRequiredProviderAvailable("search");
-    }
-    let hasIndexedContent = this.hasIndexedContent();
-    if (!hasIndexedContent) {
-      try {
-        // A fresh process can receive its first search before background watch/session
-        // syncs have built the index. Force one synchronous bootstrap so the first
-        // lookup after restart does not fail closed with empty results.
-        await this.sync({ reason: "search", force: true });
-      } catch (err) {
-        log.warn(`memory sync failed (search-bootstrap): ${String(err)}`);
-      }
-      hasIndexedContent = this.hasIndexedContent();
-    }
-    const preflight = resolveMemorySearchPreflight({
-      query: normalizedQuery,
-      hasIndexedContent,
-    });
-    if (!preflight.shouldSearch) {
-      return [];
-    }
-    const cleaned = preflight.normalizedQuery;
-    void this.warmSession(opts?.sessionKey);
-    await startAsyncSearchSync({
-      enabled: this.settings.sync.onSearch,
-      dirty: this.dirty,
-      sessionsDirty: this.sessionsDirty,
-      sync: async (params) => await this.sync(params),
-      onError: (err) => {
-        log.warn(`memory sync failed (search): ${String(err)}`);
-      },
-    });
-    if (
-      preflight.shouldInitializeProvider &&
-      !this.provider &&
-      this.providerLifecycle.mode === "degraded" &&
-      this.providerLifecycle.providerId !== this.settings.provider
-    ) {
-      // A failed fallback must yield ownership back to the configured primary.
-      // Retrying the degraded fallback here can strand a valid existing index.
-      this.resetProviderInitializationForRetry();
-    }
-    if (preflight.shouldInitializeProvider) {
-      await this.ensureProviderInitialized();
-      this.assertRequiredProviderAvailable("search");
-    }
-    if (!this.provider && this.providerLifecycle.mode === "degraded") {
-      const activatedFallback = await this.activateFallbackProvider(
-        this.providerLifecycle.reason,
-      ).catch((fallbackErr: unknown) => {
-        log.warn(
-          `memory search: failed to activate fallback provider: ${formatErrorMessage(fallbackErr)}`,
-        );
-        return false;
-      });
-      if (activatedFallback) {
-        this.refreshIndexIdentityDirty({
-          providerKeyKnown: this.providerInitialized,
-        });
-      }
-    }
-    const indexIdentity = this.refreshIndexIdentityDirty({
-      providerKeyKnown: this.providerInitialized,
-    });
-    if (indexIdentity.status !== "valid") {
-      return [];
-    }
-    const minScore = opts?.minScore ?? this.settings.query.minScore;
-    const maxResults = opts?.maxResults ?? this.settings.query.maxResults;
-    const searchSources =
-      opts?.sources && opts.sources.length > 0
-        ? uniqueValues(opts.sources).filter((s) => this.sources.has(s))
-        : undefined;
-    if (
-      opts?.sources &&
-      opts.sources.length > 0 &&
-      (!searchSources || searchSources.length === 0)
-    ) {
-      return [];
-    }
-    // The manager may index recall-only transcripts without making them part of
-    // ordinary searches. Trusted recall passes an explicit source override;
-    // every other caller defaults to the configured search corpus.
-    const sourceFilterList = searchSources ?? this.settings.searchSources;
-    const hybrid = this.settings.query.hybrid;
-    const candidates = Math.min(
-      200,
-      Math.max(1, Math.floor(maxResults * hybrid.candidateMultiplier)),
-    );
-
-    // FTS-only mode: no embedding provider available
-    if (!this.provider) {
-      this.assertRequiredProviderAvailable("search");
-      if (!this.fts.enabled || !this.fts.available) {
-        log.warn("memory search: no provider and FTS unavailable");
+    return await this.withManagerOperation(async () => {
+      opts?.onDebug?.({ backend: "builtin" });
+      const normalizedQuery = query.trim();
+      if (!normalizedQuery) {
         return [];
       }
-
-      const keywordResults = await this.searchKeywordWithFallback(
-        cleaned,
-        candidates,
-        {
-          boostFallbackRanking: true,
+      if (this.providerRequirement.mode === "required") {
+        await this.ensureProviderInitialized();
+        this.assertRequiredProviderAvailable("search");
+      }
+      let hasIndexedContent = this.hasIndexedContent();
+      if (!hasIndexedContent) {
+        try {
+          // A fresh process can receive its first search before background watch/session
+          // syncs have built the index. Force one synchronous bootstrap so the first
+          // lookup after restart does not fail closed with empty results.
+          await this.sync({ reason: "search", force: true });
+        } catch (err) {
+          log.warn(`memory sync failed (search-bootstrap): ${String(err)}`);
+        }
+        hasIndexedContent = this.hasIndexedContent();
+      }
+      const preflight = resolveMemorySearchPreflight({
+        query: normalizedQuery,
+        hasIndexedContent,
+      });
+      if (!preflight.shouldSearch) {
+        return [];
+      }
+      const cleaned = preflight.normalizedQuery;
+      void this.warmSession(opts?.sessionKey);
+      await startAsyncSearchSync({
+        enabled: this.settings.sync.onSearch,
+        dirty: this.dirty,
+        sessionsDirty: this.sessionsDirty,
+        sync: async (params) => await this.sync(params),
+        onError: (err) => {
+          log.warn(`memory sync failed (search): ${String(err)}`);
         },
-        sourceFilterList,
-      ).catch((err: unknown) => {
-        log.warn(`memory search: FTS keyword query failed: ${formatErrorMessage(err)}`);
-        return [];
       });
-
-      return await this.finalizeKeywordOnlyResults({
-        results: keywordResults,
-        temporalDecay: hybrid.temporalDecay,
-        maxResults,
-        minScore,
-      });
-    }
-
-    // If FTS isn't available, hybrid mode cannot use keyword search; degrade to vector-only.
-    const loadKeywordResults = async () =>
-      hybrid.enabled && this.fts.enabled && this.fts.available
-        ? await this.searchKeywordWithFallback(
-            cleaned,
-            candidates,
-            { boostFallbackRanking: true },
-            sourceFilterList,
-          ).catch((err: unknown) => {
-            log.warn(`memory search: FTS hybrid keyword query failed: ${formatErrorMessage(err)}`);
-            return [];
-          })
-        : [];
-    let keywordResults = await loadKeywordResults();
-
-    let queryVec: number[];
-    try {
-      queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
-    } catch (err) {
-      // An aborted caller already stopped waiting; skip fallback-provider
-      // activation so the abandoned search stops instead of re-embedding.
-      if (opts?.signal?.aborted) {
-        throw err;
+      if (
+        preflight.shouldInitializeProvider &&
+        !this.provider &&
+        this.providerLifecycle.mode === "degraded" &&
+        this.providerLifecycle.providerId !== this.settings.provider
+      ) {
+        // A failed fallback must yield ownership back to the configured primary.
+        // Retrying the degraded fallback here can strand a valid existing index.
+        this.resetProviderInitializationForRetry();
       }
-      const message = formatErrorMessage(err);
-      const activatedFallback = this.shouldFallbackOnError(err)
-        ? await this.activateFallbackProvider(message).catch((fallbackErr: unknown) => {
-            log.warn(
-              `memory search: failed to activate fallback provider: ${formatErrorMessage(fallbackErr)}`,
-            );
-            return false;
-          })
-        : false;
-      if (activatedFallback) {
-        if (
+      if (preflight.shouldInitializeProvider) {
+        await this.ensureProviderInitialized();
+        this.assertRequiredProviderAvailable("search");
+      }
+      if (!this.provider && this.providerLifecycle.mode === "degraded") {
+        const activatedFallback = await this.activateFallbackProvider(
+          this.providerLifecycle.reason,
+        ).catch((fallbackErr: unknown) => {
+          log.warn(
+            `memory search: failed to activate fallback provider: ${formatErrorMessage(fallbackErr)}`,
+          );
+          return false;
+        });
+        if (activatedFallback) {
           this.refreshIndexIdentityDirty({
             providerKeyKnown: this.providerInitialized,
-          }).status !== "valid"
-        ) {
+          });
+        }
+      }
+      const indexIdentity = this.refreshIndexIdentityDirty({
+        providerKeyKnown: this.providerInitialized,
+      });
+      if (indexIdentity.status !== "valid") {
+        return [];
+      }
+      const minScore = opts?.minScore ?? this.settings.query.minScore;
+      const maxResults = opts?.maxResults ?? this.settings.query.maxResults;
+      const searchSources =
+        opts?.sources && opts.sources.length > 0
+          ? uniqueValues(opts.sources).filter((s) => this.sources.has(s))
+          : undefined;
+      if (
+        opts?.sources &&
+        opts.sources.length > 0 &&
+        (!searchSources || searchSources.length === 0)
+      ) {
+        return [];
+      }
+      // The manager may index recall-only transcripts without making them part of
+      // ordinary searches. Trusted recall passes an explicit source override;
+      // every other caller defaults to the configured search corpus.
+      const sourceFilterList = searchSources ?? this.settings.searchSources;
+      const hybrid = this.settings.query.hybrid;
+      const candidates = Math.min(
+        200,
+        Math.max(1, Math.floor(maxResults * hybrid.candidateMultiplier)),
+      );
+
+      // FTS-only mode: no embedding provider available
+      if (!this.provider) {
+        this.assertRequiredProviderAvailable("search");
+        if (!this.fts.enabled || !this.fts.available) {
+          log.warn("memory search: no provider and FTS unavailable");
           return [];
         }
-        keywordResults = await loadKeywordResults();
-        queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
-      } else if (!this.provider && this.fts.enabled && this.fts.available) {
-        this.assertRequiredProviderAvailable("search");
-        log.warn(`memory search: embeddings unavailable; using keyword-only results: ${message}`);
+
+        const keywordResults = await this.searchKeywordWithFallback(
+          cleaned,
+          candidates,
+          {
+            boostFallbackRanking: true,
+          },
+          sourceFilterList,
+        ).catch((err: unknown) => {
+          log.warn(`memory search: FTS keyword query failed: ${formatErrorMessage(err)}`);
+          return [];
+        });
+
         return await this.finalizeKeywordOnlyResults({
           results: keywordResults,
           temporalDecay: hybrid.temporalDecay,
           maxResults,
           minScore,
         });
-      } else {
-        throw err;
       }
-    }
-    const hasVector = queryVec.some((v) => v !== 0);
-    const vectorResults = hasVector
-      ? await this.searchVector(queryVec, candidates, sourceFilterList).catch((err: unknown) => {
-          log.warn(`memory search: vector query failed: ${formatErrorMessage(err)}`);
-          return [];
-        })
-      : [];
 
-    if (!hybrid.enabled || !this.fts.enabled || !this.fts.available) {
-      return vectorResults.filter((entry) => entry.score >= minScore).slice(0, maxResults);
-    }
+      // If FTS isn't available, hybrid mode cannot use keyword search; degrade to vector-only.
+      const loadKeywordResults = async () =>
+        hybrid.enabled && this.fts.enabled && this.fts.available
+          ? await this.searchKeywordWithFallback(
+              cleaned,
+              candidates,
+              { boostFallbackRanking: true },
+              sourceFilterList,
+            ).catch((err: unknown) => {
+              log.warn(
+                `memory search: FTS hybrid keyword query failed: ${formatErrorMessage(err)}`,
+              );
+              return [];
+            })
+          : [];
+      let keywordResults = await loadKeywordResults();
 
-    const merged = await this.mergeHybridResults({
-      query: cleaned,
-      vector: vectorResults,
-      keyword: keywordResults,
-      vectorWeight: hybrid.vectorWeight,
-      textWeight: hybrid.textWeight,
-      mmr: hybrid.mmr,
-      temporalDecay: hybrid.temporalDecay,
+      let queryVec: number[];
+      try {
+        queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
+      } catch (err) {
+        // An aborted caller already stopped waiting; skip fallback-provider
+        // activation so the abandoned search stops instead of re-embedding.
+        if (opts?.signal?.aborted) {
+          throw err;
+        }
+        const message = formatErrorMessage(err);
+        const activatedFallback = this.shouldFallbackOnError(err)
+          ? await this.activateFallbackProvider(message).catch((fallbackErr: unknown) => {
+              log.warn(
+                `memory search: failed to activate fallback provider: ${formatErrorMessage(fallbackErr)}`,
+              );
+              return false;
+            })
+          : false;
+        if (activatedFallback) {
+          if (
+            this.refreshIndexIdentityDirty({
+              providerKeyKnown: this.providerInitialized,
+            }).status !== "valid"
+          ) {
+            return [];
+          }
+          keywordResults = await loadKeywordResults();
+          queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
+        } else if (!this.provider && this.fts.enabled && this.fts.available) {
+          this.assertRequiredProviderAvailable("search");
+          log.warn(`memory search: embeddings unavailable; using keyword-only results: ${message}`);
+          return await this.finalizeKeywordOnlyResults({
+            results: keywordResults,
+            temporalDecay: hybrid.temporalDecay,
+            maxResults,
+            minScore,
+          });
+        } else {
+          throw err;
+        }
+      }
+      const hasVector = queryVec.some((v) => v !== 0);
+      const vectorResults = hasVector
+        ? await this.searchVector(queryVec, candidates, sourceFilterList).catch((err: unknown) => {
+            log.warn(`memory search: vector query failed: ${formatErrorMessage(err)}`);
+            return [];
+          })
+        : [];
+
+      if (!hybrid.enabled || !this.fts.enabled || !this.fts.available) {
+        return vectorResults.filter((entry) => entry.score >= minScore).slice(0, maxResults);
+      }
+
+      const merged = await this.mergeHybridResults({
+        query: cleaned,
+        vector: vectorResults,
+        keyword: keywordResults,
+        vectorWeight: hybrid.vectorWeight,
+        textWeight: hybrid.textWeight,
+        mmr: hybrid.mmr,
+        temporalDecay: hybrid.temporalDecay,
+      });
+      const strict = merged.filter((entry) => entry.score >= minScore);
+      if (strict.length > 0 || keywordResults.length === 0) {
+        return strict.slice(0, maxResults);
+      }
+
+      // Hybrid defaults can produce keyword-only matches below minScore after
+      // BM25 normalization and textWeight scaling. Preserve FTS-backed lexical
+      // hits when they are the only relevant results.
+      const relaxedMinScore = 0;
+      const keywordKeys = new Set(
+        keywordResults.map(
+          (entry) => `${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`,
+        ),
+      );
+      return this.selectScoredResults(
+        merged.filter((entry) =>
+          keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`),
+        ),
+        maxResults,
+        minScore,
+        relaxedMinScore,
+      );
     });
-    const strict = merged.filter((entry) => entry.score >= minScore);
-    if (strict.length > 0 || keywordResults.length === 0) {
-      return strict.slice(0, maxResults);
-    }
-
-    // Hybrid defaults can produce keyword-only matches below minScore after
-    // BM25 normalization and textWeight scaling. Preserve FTS-backed lexical
-    // hits when they are the only relevant results.
-    const relaxedMinScore = 0;
-    const keywordKeys = new Set(
-      keywordResults.map(
-        (entry) => `${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`,
-      ),
-    );
-    return this.selectScoredResults(
-      merged.filter((entry) =>
-        keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`),
-      ),
-      maxResults,
-      minScore,
-      relaxedMinScore,
-    );
   }
 
   private selectScoredResults<T extends MemorySearchResult & { score: number }>(
@@ -1801,6 +1835,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
   private async closeOnce(): Promise<void> {
     this.closed = true;
+    await this.awaitManagerIdle();
     const pendingProviderInit = this.providerInitPromise;
     const pendingFallbackInit = this.getPendingFallbackProviderInitialization();
     if (this.watchTimer) {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -310,6 +310,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private providerInitPromise: Promise<void> | null = null;
   private providerInitialized = false;
   private providerRetirementPromise: Promise<void> = Promise.resolve();
+  private providersPendingRetirement = new Set<EmbeddingProvider>();
   protected override fallbackFrom?: EmbeddingProviderId;
   protected override fallbackReason?: string;
   protected providerUnavailableReason?: string;
@@ -644,20 +645,35 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
   protected override retireCurrentProvider(): Promise<void> {
     const provider = this.provider;
-    if (!provider) {
+    if (provider) {
+      this.provider = null;
+      this.providerRuntime = undefined;
+      this.providersPendingRetirement.add(provider);
+    }
+    if (this.providersPendingRetirement.size === 0) {
       return this.providerRetirementPromise;
     }
-    this.provider = null;
-    this.providerRuntime = undefined;
     // Provider replacement must wait for the previous worker to exit; otherwise
     // repeated retries can accumulate local workers on constrained hosts.
-    const retirement = this.providerRetirementPromise.then(async () => {
-      await provider.close?.();
+    const retirement = this.providerRetirementPromise.catch(() => {}).then(async () => {
+      let firstError: unknown;
+      for (const pendingProvider of this.providersPendingRetirement) {
+        try {
+          await pendingProvider.close?.();
+          this.providersPendingRetirement.delete(pendingProvider);
+        } catch (err) {
+          firstError ??= err;
+        }
+      }
+      if (firstError) {
+        throw toLintErrorObject(firstError, "Embedding provider retirement failed");
+      }
     });
-    this.providerRetirementPromise = retirement.catch((err: unknown) => {
+    this.providerRetirementPromise = retirement;
+    void retirement.catch((err: unknown) => {
       log.warn(`memory embeddings: failed to close previous provider: ${formatErrorMessage(err)}`);
     });
-    return this.providerRetirementPromise;
+    return retirement;
   }
 
   protected isRequiredProviderUnavailable(): boolean {
@@ -1675,6 +1691,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     });
     await awaitPendingManagerWork({
       pendingProviderInit: this.providerRetirementPromise,
+      onError: reportPendingWorkError,
+    });
+    await awaitPendingManagerWork({
+      pendingProviderInit: this.retireCurrentProvider(),
       onError: reportPendingWorkError,
     });
     rememberCurrentProvider();

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1671,6 +1671,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     const reportPendingWorkError = (err: unknown) => {
       log.warn(`memory close: pending manager work failed: ${formatErrorMessage(err)}`);
     };
+    const retirementErrors: unknown[] = [];
     const awaitCurrentSync = async () => {
       const pendingSync = this.syncing;
       if (!pendingSync) {
@@ -1689,14 +1690,18 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       pendingProviderInit: pendingFallbackInit?.then(() => undefined),
       onError: reportPendingWorkError,
     });
-    await awaitPendingManagerWork({
-      pendingProviderInit: this.providerRetirementPromise,
-      onError: reportPendingWorkError,
-    });
-    await awaitPendingManagerWork({
-      pendingProviderInit: this.retireCurrentProvider(),
-      onError: reportPendingWorkError,
-    });
+    for (
+      let attempt = 0;
+      attempt < 2 && (this.provider !== null || this.providersPendingRetirement.size > 0);
+      attempt += 1
+    ) {
+      try {
+        await this.retireCurrentProvider();
+      } catch (err) {
+        retirementErrors.push(err);
+        reportPendingWorkError(err);
+      }
+    }
     rememberCurrentProvider();
     try {
       await awaitCurrentSync();
@@ -1708,7 +1713,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         INDEX_CACHE.delete(this.cacheKey);
       }
     }
-    const closeError = closeErrors.values().next().value;
+    const closeError =
+      (this.providersPendingRetirement.size > 0 ? retirementErrors.at(-1) : undefined) ??
+      closeErrors.values().next().value;
     if (closeError) {
       throw toLintErrorObject(closeError, "Non-Error thrown");
     }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -611,6 +611,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (this.provider?.close) {
       this.provider.close().catch(() => {});
     }
+    this.provider = null;
     this.providerInitialized = false;
     this.providerInitPromise = null;
     this.providerUnavailableReason = undefined;

--- a/extensions/memory-core/src/memory/qmd-manager-lifecycle.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-lifecycle.ts
@@ -11,6 +11,8 @@ import {
 } from "./watch-settle.js";
 
 export abstract class QmdManagerLifecycle extends QmdManagerSync {
+  private closePromise: Promise<void> | null = null;
+
   protected ensureWatcher(): void {
     if (!this.syncSettings?.watch || this.watcher || this.closed) {
       return;
@@ -120,9 +122,24 @@ export abstract class QmdManagerLifecycle extends QmdManagerSync {
   }
 
   async close(): Promise<void> {
-    if (this.closed) {
+    const existingClose = this.closePromise;
+    if (existingClose) {
+      await existingClose;
       return;
     }
+    const closeOperation = this.closeOnce();
+    this.closePromise = closeOperation;
+    try {
+      await closeOperation;
+    } catch (err) {
+      if (this.closePromise === closeOperation) {
+        this.closePromise = null;
+      }
+      throw err;
+    }
+  }
+
+  private async closeOnce(): Promise<void> {
     this.closed = true;
     this.resolveCloseSignal();
     this.closeAbortController.abort(new Error("qmd manager closed"));

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -534,6 +534,27 @@ describe("getMemorySearchManager caching", () => {
     expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 
+  it("allows builtin acquisition while failed qmd cleanup remains retained", async () => {
+    const agentId = "retry-agent-retained-cleanup";
+    const qmdCfg = createQmdCfg(agentId);
+    const primary = createQmdManagerInstanceMock();
+    primary.search.mockRejectedValueOnce(new Error("qmd query failed"));
+    primary.close.mockRejectedValue(new Error("qmd close failed"));
+    createQmdManagerMock.mockImplementationOnce(
+      async () => primary as unknown as QmdManagerInstance,
+    );
+
+    const first = requireManager(await getMemorySearchManager({ cfg: qmdCfg, agentId }));
+    await expect(first.search("hello")).resolves.toHaveLength(1);
+    await vi.waitFor(() => expect(primary.close).toHaveBeenCalledTimes(1));
+
+    const builtin = await getMemorySearchManager({ cfg: createBuiltinCfg(agentId), agentId });
+    expect(builtin.manager).toBe(fallbackManager);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
+
+    primary.close.mockResolvedValue(undefined);
+  });
+
   it("falls back immediately when the qmd binary is unavailable", async () => {
     const cfg = createQmdCfg("missing-qmd");
     checkQmdBinaryAvailability.mockResolvedValueOnce({

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -357,6 +357,24 @@ describe("getMemorySearchManager caching", () => {
     }
   });
 
+  it("does not return a failed-close wrapper after a module reload", async () => {
+    const agentId = "reload-failed-close";
+    const cfg = createQmdCfg(agentId);
+    const firstManager = requireManager(await getMemorySearchManager({ cfg, agentId }));
+    mockPrimary.close.mockRejectedValueOnce(new Error("qmd close failed"));
+
+    await expect(closeMemorySearchManager({ cfg, agentId })).rejects.toThrow("qmd close failed");
+
+    vi.resetModules();
+    const freshModule = await import("./search-manager.js");
+    try {
+      const second = await freshModule.getMemorySearchManager({ cfg, agentId, withLease });
+      expect(second.manager).not.toBe(firstManager);
+    } finally {
+      await freshModule.closeAllMemorySearchManagers();
+    }
+  });
+
   it("reuses the same QMD manager instance for repeated calls", async () => {
     const cfg = createQmdCfg("main");
 
@@ -1308,6 +1326,27 @@ describe("getMemorySearchManager caching", () => {
     });
     expect(nextMain.manager).not.toBe(mainManager);
     expect(nextOther.manager).toBe(otherManager);
+  });
+
+  it("blocks qmd replacement while scoped teardown closes its builtin fallback", async () => {
+    const agentId = "scoped-fallback-close-race";
+    const cfg = createQmdCfg(agentId);
+    const firstManager = requireManager(await getMemorySearchManager({ cfg, agentId }));
+    (firstManager as unknown as { fallback: typeof fallbackManager }).fallback = fallbackManager;
+    const fallbackCloseGate = createDeferred<void>();
+    fallbackManager.close.mockImplementationOnce(async () => await fallbackCloseGate.promise);
+
+    const closePromise = closeMemorySearchManager({ cfg, agentId });
+    await vi.waitFor(() => expect(fallbackManager.close).toHaveBeenCalledTimes(1));
+    const secondPromise = getMemorySearchManager({ cfg, agentId });
+    await Promise.resolve();
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
+
+    fallbackCloseGate.resolve();
+    await closePromise;
+    const secondManager = requireManager(await secondPromise);
+    expect(secondManager).not.toBe(firstManager);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 
   it("closes the requested agent builtin index manager on scoped teardown", async () => {

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -357,6 +357,24 @@ describe("getMemorySearchManager caching", () => {
     }
   });
 
+  it("does not return a failed-close wrapper after a module reload", async () => {
+    const agentId = "reload-failed-close";
+    const cfg = createQmdCfg(agentId);
+    const firstManager = requireManager(await getMemorySearchManager({ cfg, agentId }));
+    mockPrimary.close.mockRejectedValueOnce(new Error("qmd close failed"));
+
+    await expect(closeMemorySearchManager({ cfg, agentId })).rejects.toThrow("qmd close failed");
+
+    vi.resetModules();
+    const freshModule = await import("./search-manager.js");
+    try {
+      const second = await freshModule.getMemorySearchManager({ cfg, agentId, withLease });
+      expect(second.manager).not.toBe(firstManager);
+    } finally {
+      await freshModule.closeAllMemorySearchManagers();
+    }
+  });
+
   it("reuses the same QMD manager instance for repeated calls", async () => {
     const cfg = createQmdCfg("main");
 
@@ -804,6 +822,63 @@ describe("getMemorySearchManager caching", () => {
     expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
   });
 
+  it("retains an unused qmd candidate when both replacement closes fail", async () => {
+    const agentId = "cached-qmd-double-close-failure";
+    const firstCfg = createQmdCfg(agentId, "/tmp/workspace-a");
+    const secondCfg = createQmdCfg(agentId, "/tmp/workspace-b");
+    const firstPrimary = createQmdManagerInstanceMock();
+    const secondPrimary = createQmdManagerInstanceMock();
+    const thirdPrimary = createQmdManagerInstanceMock();
+    firstPrimary.close.mockRejectedValueOnce(new Error("old close failed"));
+    secondPrimary.close.mockRejectedValueOnce(new Error("candidate close failed"));
+    createQmdManagerMock
+      .mockImplementationOnce(async () => firstPrimary)
+      .mockImplementationOnce(async () => secondPrimary)
+      .mockImplementationOnce(async () => thirdPrimary);
+
+    await getMemorySearchManager({ cfg: firstCfg, agentId });
+    await expect(getMemorySearchManager({ cfg: secondCfg, agentId })).rejects.toThrow(
+      "old close failed",
+    );
+    expect(secondPrimary.close).toHaveBeenCalledTimes(1);
+
+    const replacement = await getMemorySearchManager({ cfg: secondCfg, agentId });
+    expect(replacement.manager).toBeDefined();
+    expect(secondPrimary.close).toHaveBeenCalledTimes(2);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("continues scoped teardown when retained candidate cleanup still fails", async () => {
+    const agentId = "cached-qmd-persistent-close-failure";
+    const firstCfg = createQmdCfg(agentId, "/tmp/workspace-a");
+    const secondCfg = createQmdCfg(agentId, "/tmp/workspace-b");
+    const firstPrimary = createQmdManagerInstanceMock();
+    const secondPrimary = createQmdManagerInstanceMock();
+    firstPrimary.close.mockRejectedValueOnce(new Error("old close failed"));
+    secondPrimary.close.mockRejectedValue(new Error("candidate close failed"));
+    createQmdManagerMock
+      .mockImplementationOnce(async () => firstPrimary)
+      .mockImplementationOnce(async () => secondPrimary);
+
+    await getMemorySearchManager({ cfg: firstCfg, agentId });
+    await expect(getMemorySearchManager({ cfg: secondCfg, agentId })).rejects.toThrow(
+      "old close failed",
+    );
+
+    await expect(closeMemorySearchManager({ cfg: firstCfg, agentId })).rejects.toThrow(
+      "candidate close failed",
+    );
+    expect(secondPrimary.close).toHaveBeenCalledTimes(2);
+    expect(firstPrimary.close).toHaveBeenCalledTimes(2);
+    expect(mockCloseMemoryIndexManagersForAgent).toHaveBeenCalledWith({
+      cfg: firstCfg,
+      agentId,
+    });
+
+    secondPrimary.close.mockResolvedValue(undefined);
+    await closeMemorySearchManager({ cfg: firstCfg, agentId });
+  });
+
   it("dedupes concurrent full qmd manager creation for the same agent", async () => {
     const agentId = "pending-qmd";
     const cfg = createQmdCfg(agentId);
@@ -1160,6 +1235,49 @@ describe("getMemorySearchManager caching", () => {
     expect(fallbackSearch).toHaveBeenCalledTimes(2);
   });
 
+  it("joins and closes builtin fallback creation during wrapper teardown", async () => {
+    const agentId = "fallback-create-close-race";
+    const { manager } = await createFailedQmdSearchHarness({
+      agentId,
+      errorMessage: "qmd query failed",
+    });
+    const fallbackGate = createDeferred<typeof fallbackManager>();
+    mockMemoryIndexGet.mockImplementationOnce(async () => await fallbackGate.promise);
+
+    const searchPromise = manager.search("hello");
+    await vi.waitFor(() => expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1));
+    const closePromise = manager.close?.() ?? Promise.resolve();
+    fallbackGate.resolve(fallbackManager);
+
+    await closePromise;
+    await expect(searchPromise).rejects.toThrow("memory search manager is closed");
+    expect(fallbackManager.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start fallback creation after wrapper teardown begins", async () => {
+    const agentId = "fallback-after-close-race";
+    const primarySearchGate = createDeferred<void>();
+    mockPrimary.search.mockImplementationOnce(async () => {
+      await primarySearchGate.promise;
+      throw new Error("qmd query failed");
+    });
+    const cfg = createQmdCfg(agentId);
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId }));
+    const primaryCloseGate = createDeferred<void>();
+    mockPrimary.close.mockImplementation(async () => await primaryCloseGate.promise);
+
+    const searchPromise = manager.search("hello");
+    await vi.waitFor(() => expect(mockPrimary.search).toHaveBeenCalledTimes(1));
+    const closePromise = manager.close?.() ?? Promise.resolve();
+    primarySearchGate.resolve();
+    await vi.waitFor(() => expect(mockPrimary.close).toHaveBeenCalled());
+
+    primaryCloseGate.resolve();
+    await closePromise;
+    await expect(searchPromise).rejects.toThrow("memory search manager is closed");
+    expect(mockMemoryIndexGet).not.toHaveBeenCalled();
+  });
+
   it("gives same-call qmd-to-builtin fallback a fresh default deadline", async () => {
     vi.useFakeTimers();
     try {
@@ -1308,6 +1426,27 @@ describe("getMemorySearchManager caching", () => {
     });
     expect(nextMain.manager).not.toBe(mainManager);
     expect(nextOther.manager).toBe(otherManager);
+  });
+
+  it("blocks qmd replacement while scoped teardown closes its builtin fallback", async () => {
+    const agentId = "scoped-fallback-close-race";
+    const cfg = createQmdCfg(agentId);
+    const firstManager = requireManager(await getMemorySearchManager({ cfg, agentId }));
+    (firstManager as unknown as { fallback: typeof fallbackManager }).fallback = fallbackManager;
+    const fallbackCloseGate = createDeferred<void>();
+    fallbackManager.close.mockImplementationOnce(async () => await fallbackCloseGate.promise);
+
+    const closePromise = closeMemorySearchManager({ cfg, agentId });
+    await vi.waitFor(() => expect(fallbackManager.close).toHaveBeenCalledTimes(1));
+    const secondPromise = getMemorySearchManager({ cfg, agentId });
+    await Promise.resolve();
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
+
+    fallbackCloseGate.resolve();
+    await closePromise;
+    const secondManager = requireManager(await secondPromise);
+    expect(secondManager).not.toBe(firstManager);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 
   it("closes the requested agent builtin index manager on scoped teardown", async () => {

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -517,8 +517,8 @@ describe("getMemorySearchManager caching", () => {
     firstPrimary.search.mockRejectedValueOnce(new Error("qmd query failed"));
     firstPrimary.close.mockImplementationOnce(async () => await closeGate.promise);
     createQmdManagerMock
-      .mockImplementationOnce(async () => firstPrimary)
-      .mockImplementationOnce(async () => secondPrimary);
+      .mockImplementationOnce(async () => firstPrimary as unknown as QmdManagerInstance)
+      .mockImplementationOnce(async () => secondPrimary as unknown as QmdManagerInstance);
 
     const first = requireManager(await getMemorySearchManager({ cfg, agentId }));
     await expect(first.search("hello")).resolves.toHaveLength(1);
@@ -858,9 +858,9 @@ describe("getMemorySearchManager caching", () => {
     firstPrimary.close.mockRejectedValueOnce(new Error("old close failed"));
     secondPrimary.close.mockRejectedValueOnce(new Error("candidate close failed"));
     createQmdManagerMock
-      .mockImplementationOnce(async () => firstPrimary)
-      .mockImplementationOnce(async () => secondPrimary)
-      .mockImplementationOnce(async () => thirdPrimary);
+      .mockImplementationOnce(async () => firstPrimary as unknown as QmdManagerInstance)
+      .mockImplementationOnce(async () => secondPrimary as unknown as QmdManagerInstance)
+      .mockImplementationOnce(async () => thirdPrimary as unknown as QmdManagerInstance);
 
     await getMemorySearchManager({ cfg: firstCfg, agentId });
     await expect(getMemorySearchManager({ cfg: secondCfg, agentId })).rejects.toThrow(
@@ -883,8 +883,8 @@ describe("getMemorySearchManager caching", () => {
     firstPrimary.close.mockRejectedValueOnce(new Error("old close failed"));
     secondPrimary.close.mockRejectedValue(new Error("candidate close failed"));
     createQmdManagerMock
-      .mockImplementationOnce(async () => firstPrimary)
-      .mockImplementationOnce(async () => secondPrimary);
+      .mockImplementationOnce(async () => firstPrimary as unknown as QmdManagerInstance)
+      .mockImplementationOnce(async () => secondPrimary as unknown as QmdManagerInstance);
 
     await getMemorySearchManager({ cfg: firstCfg, agentId });
     await expect(getMemorySearchManager({ cfg: secondCfg, agentId })).rejects.toThrow(

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -791,7 +791,7 @@ describe("getMemorySearchManager caching", () => {
     expect(firstPrimary.close).toHaveBeenCalledTimes(1);
   });
 
-  it("retires the cached qmd manager before a replacement attempt", async () => {
+  it("keeps the existing cached full qmd manager when replacement creation fails", async () => {
     const agentId = "cached-qmd-failed-replacement";
     const firstCfg = createQmdCfg(agentId, "/tmp/workspace-a");
     const secondCfg = createQmdCfg(agentId, "/tmp/workspace-b");
@@ -814,14 +814,38 @@ describe("getMemorySearchManager caching", () => {
     const replacementAttempt = await getMemorySearchManager({ cfg: secondCfg, agentId });
 
     expect(replacementAttempt.manager).toBe(fallbackManager);
-    expect(firstPrimary.close).toHaveBeenCalledTimes(1);
-    await expect(firstManager.search("hello")).rejects.toThrow(
-      "memory search manager was replaced by a newer qmd manager",
-    );
+    expect(firstPrimary.close).not.toHaveBeenCalled();
+    await expect(firstManager.search("hello")).resolves.toStrictEqual([]);
 
     const firstAgain = await getMemorySearchManager({ cfg: firstCfg, agentId });
-    expect(firstAgain.manager).not.toBe(firstManager);
-    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
+    expect(firstAgain.manager).toBe(firstManager);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains an unused qmd candidate when both replacement closes fail", async () => {
+    const agentId = "cached-qmd-double-close-failure";
+    const firstCfg = createQmdCfg(agentId, "/tmp/workspace-a");
+    const secondCfg = createQmdCfg(agentId, "/tmp/workspace-b");
+    const firstPrimary = createQmdManagerInstanceMock();
+    const secondPrimary = createQmdManagerInstanceMock();
+    const thirdPrimary = createQmdManagerInstanceMock();
+    firstPrimary.close.mockRejectedValueOnce(new Error("old close failed"));
+    secondPrimary.close.mockRejectedValueOnce(new Error("candidate close failed"));
+    createQmdManagerMock
+      .mockImplementationOnce(async () => firstPrimary)
+      .mockImplementationOnce(async () => secondPrimary)
+      .mockImplementationOnce(async () => thirdPrimary);
+
+    await getMemorySearchManager({ cfg: firstCfg, agentId });
+    await expect(getMemorySearchManager({ cfg: secondCfg, agentId })).rejects.toThrow(
+      "old close failed",
+    );
+    expect(secondPrimary.close).toHaveBeenCalledTimes(1);
+
+    const replacement = await getMemorySearchManager({ cfg: secondCfg, agentId });
+    expect(replacement.manager).toBeDefined();
+    expect(secondPrimary.close).toHaveBeenCalledTimes(2);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(3);
   });
 
   it("dedupes concurrent full qmd manager creation for the same agent", async () => {

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -357,24 +357,6 @@ describe("getMemorySearchManager caching", () => {
     }
   });
 
-  it("does not return a failed-close wrapper after a module reload", async () => {
-    const agentId = "reload-failed-close";
-    const cfg = createQmdCfg(agentId);
-    const firstManager = requireManager(await getMemorySearchManager({ cfg, agentId }));
-    mockPrimary.close.mockRejectedValueOnce(new Error("qmd close failed"));
-
-    await expect(closeMemorySearchManager({ cfg, agentId })).rejects.toThrow("qmd close failed");
-
-    vi.resetModules();
-    const freshModule = await import("./search-manager.js");
-    try {
-      const second = await freshModule.getMemorySearchManager({ cfg, agentId, withLease });
-      expect(second.manager).not.toBe(firstManager);
-    } finally {
-      await freshModule.closeAllMemorySearchManagers();
-    }
-  });
-
   it("reuses the same QMD manager instance for repeated calls", async () => {
     const cfg = createQmdCfg("main");
 
@@ -822,63 +804,6 @@ describe("getMemorySearchManager caching", () => {
     expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
   });
 
-  it("retains an unused qmd candidate when both replacement closes fail", async () => {
-    const agentId = "cached-qmd-double-close-failure";
-    const firstCfg = createQmdCfg(agentId, "/tmp/workspace-a");
-    const secondCfg = createQmdCfg(agentId, "/tmp/workspace-b");
-    const firstPrimary = createQmdManagerInstanceMock();
-    const secondPrimary = createQmdManagerInstanceMock();
-    const thirdPrimary = createQmdManagerInstanceMock();
-    firstPrimary.close.mockRejectedValueOnce(new Error("old close failed"));
-    secondPrimary.close.mockRejectedValueOnce(new Error("candidate close failed"));
-    createQmdManagerMock
-      .mockImplementationOnce(async () => firstPrimary)
-      .mockImplementationOnce(async () => secondPrimary)
-      .mockImplementationOnce(async () => thirdPrimary);
-
-    await getMemorySearchManager({ cfg: firstCfg, agentId });
-    await expect(getMemorySearchManager({ cfg: secondCfg, agentId })).rejects.toThrow(
-      "old close failed",
-    );
-    expect(secondPrimary.close).toHaveBeenCalledTimes(1);
-
-    const replacement = await getMemorySearchManager({ cfg: secondCfg, agentId });
-    expect(replacement.manager).toBeDefined();
-    expect(secondPrimary.close).toHaveBeenCalledTimes(2);
-    expect(createQmdManagerMock).toHaveBeenCalledTimes(3);
-  });
-
-  it("continues scoped teardown when retained candidate cleanup still fails", async () => {
-    const agentId = "cached-qmd-persistent-close-failure";
-    const firstCfg = createQmdCfg(agentId, "/tmp/workspace-a");
-    const secondCfg = createQmdCfg(agentId, "/tmp/workspace-b");
-    const firstPrimary = createQmdManagerInstanceMock();
-    const secondPrimary = createQmdManagerInstanceMock();
-    firstPrimary.close.mockRejectedValueOnce(new Error("old close failed"));
-    secondPrimary.close.mockRejectedValue(new Error("candidate close failed"));
-    createQmdManagerMock
-      .mockImplementationOnce(async () => firstPrimary)
-      .mockImplementationOnce(async () => secondPrimary);
-
-    await getMemorySearchManager({ cfg: firstCfg, agentId });
-    await expect(getMemorySearchManager({ cfg: secondCfg, agentId })).rejects.toThrow(
-      "old close failed",
-    );
-
-    await expect(closeMemorySearchManager({ cfg: firstCfg, agentId })).rejects.toThrow(
-      "candidate close failed",
-    );
-    expect(secondPrimary.close).toHaveBeenCalledTimes(2);
-    expect(firstPrimary.close).toHaveBeenCalledTimes(2);
-    expect(mockCloseMemoryIndexManagersForAgent).toHaveBeenCalledWith({
-      cfg: firstCfg,
-      agentId,
-    });
-
-    secondPrimary.close.mockResolvedValue(undefined);
-    await closeMemorySearchManager({ cfg: firstCfg, agentId });
-  });
-
   it("dedupes concurrent full qmd manager creation for the same agent", async () => {
     const agentId = "pending-qmd";
     const cfg = createQmdCfg(agentId);
@@ -1235,49 +1160,6 @@ describe("getMemorySearchManager caching", () => {
     expect(fallbackSearch).toHaveBeenCalledTimes(2);
   });
 
-  it("joins and closes builtin fallback creation during wrapper teardown", async () => {
-    const agentId = "fallback-create-close-race";
-    const { manager } = await createFailedQmdSearchHarness({
-      agentId,
-      errorMessage: "qmd query failed",
-    });
-    const fallbackGate = createDeferred<typeof fallbackManager>();
-    mockMemoryIndexGet.mockImplementationOnce(async () => await fallbackGate.promise);
-
-    const searchPromise = manager.search("hello");
-    await vi.waitFor(() => expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1));
-    const closePromise = manager.close?.() ?? Promise.resolve();
-    fallbackGate.resolve(fallbackManager);
-
-    await closePromise;
-    await expect(searchPromise).rejects.toThrow("memory search manager is closed");
-    expect(fallbackManager.close).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not start fallback creation after wrapper teardown begins", async () => {
-    const agentId = "fallback-after-close-race";
-    const primarySearchGate = createDeferred<void>();
-    mockPrimary.search.mockImplementationOnce(async () => {
-      await primarySearchGate.promise;
-      throw new Error("qmd query failed");
-    });
-    const cfg = createQmdCfg(agentId);
-    const manager = requireManager(await getMemorySearchManager({ cfg, agentId }));
-    const primaryCloseGate = createDeferred<void>();
-    mockPrimary.close.mockImplementation(async () => await primaryCloseGate.promise);
-
-    const searchPromise = manager.search("hello");
-    await vi.waitFor(() => expect(mockPrimary.search).toHaveBeenCalledTimes(1));
-    const closePromise = manager.close?.() ?? Promise.resolve();
-    primarySearchGate.resolve();
-    await vi.waitFor(() => expect(mockPrimary.close).toHaveBeenCalled());
-
-    primaryCloseGate.resolve();
-    await closePromise;
-    await expect(searchPromise).rejects.toThrow("memory search manager is closed");
-    expect(mockMemoryIndexGet).not.toHaveBeenCalled();
-  });
-
   it("gives same-call qmd-to-builtin fallback a fresh default deadline", async () => {
     vi.useFakeTimers();
     try {
@@ -1426,27 +1308,6 @@ describe("getMemorySearchManager caching", () => {
     });
     expect(nextMain.manager).not.toBe(mainManager);
     expect(nextOther.manager).toBe(otherManager);
-  });
-
-  it("blocks qmd replacement while scoped teardown closes its builtin fallback", async () => {
-    const agentId = "scoped-fallback-close-race";
-    const cfg = createQmdCfg(agentId);
-    const firstManager = requireManager(await getMemorySearchManager({ cfg, agentId }));
-    (firstManager as unknown as { fallback: typeof fallbackManager }).fallback = fallbackManager;
-    const fallbackCloseGate = createDeferred<void>();
-    fallbackManager.close.mockImplementationOnce(async () => await fallbackCloseGate.promise);
-
-    const closePromise = closeMemorySearchManager({ cfg, agentId });
-    await vi.waitFor(() => expect(fallbackManager.close).toHaveBeenCalledTimes(1));
-    const secondPromise = getMemorySearchManager({ cfg, agentId });
-    await Promise.resolve();
-    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
-
-    fallbackCloseGate.resolve();
-    await closePromise;
-    const secondManager = requireManager(await secondPromise);
-    expect(secondManager).not.toBe(firstManager);
-    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 
   it("closes the requested agent builtin index manager on scoped teardown", async () => {

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -791,7 +791,7 @@ describe("getMemorySearchManager caching", () => {
     expect(firstPrimary.close).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the existing cached full qmd manager when replacement creation fails", async () => {
+  it("retires the cached qmd manager before a replacement attempt", async () => {
     const agentId = "cached-qmd-failed-replacement";
     const firstCfg = createQmdCfg(agentId, "/tmp/workspace-a");
     const secondCfg = createQmdCfg(agentId, "/tmp/workspace-b");
@@ -814,12 +814,14 @@ describe("getMemorySearchManager caching", () => {
     const replacementAttempt = await getMemorySearchManager({ cfg: secondCfg, agentId });
 
     expect(replacementAttempt.manager).toBe(fallbackManager);
-    expect(firstPrimary.close).not.toHaveBeenCalled();
-    await expect(firstManager.search("hello")).resolves.toStrictEqual([]);
+    expect(firstPrimary.close).toHaveBeenCalledTimes(1);
+    await expect(firstManager.search("hello")).rejects.toThrow(
+      "memory search manager was replaced by a newer qmd manager",
+    );
 
     const firstAgain = await getMemorySearchManager({ cfg: firstCfg, agentId });
-    expect(firstAgain.manager).toBe(firstManager);
-    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
+    expect(firstAgain.manager).not.toBe(firstManager);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 
   it("dedupes concurrent full qmd manager creation for the same agent", async () => {

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -508,6 +508,32 @@ describe("getMemorySearchManager caching", () => {
     expect(createQmdManagerMock.mock.calls).toHaveLength(2);
   });
 
+  it("blocks qmd reacquisition while a failed primary retires", async () => {
+    const agentId = "retry-agent-retirement";
+    const cfg = createQmdCfg(agentId);
+    const firstPrimary = createQmdManagerInstanceMock();
+    const secondPrimary = createQmdManagerInstanceMock();
+    const closeGate = createDeferred<void>();
+    firstPrimary.search.mockRejectedValueOnce(new Error("qmd query failed"));
+    firstPrimary.close.mockImplementationOnce(async () => await closeGate.promise);
+    createQmdManagerMock
+      .mockImplementationOnce(async () => firstPrimary)
+      .mockImplementationOnce(async () => secondPrimary);
+
+    const first = requireManager(await getMemorySearchManager({ cfg, agentId }));
+    await expect(first.search("hello")).resolves.toHaveLength(1);
+    await vi.waitFor(() => expect(firstPrimary.close).toHaveBeenCalledTimes(1));
+
+    const secondPromise = getMemorySearchManager({ cfg, agentId });
+    await Promise.resolve();
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
+
+    closeGate.resolve();
+    const second = requireManager(await secondPromise);
+    expect(second).not.toBe(first);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
+  });
+
   it("falls back immediately when the qmd binary is unavailable", async () => {
     const cfg = createQmdCfg("missing-qmd");
     checkQmdBinaryAvailability.mockResolvedValueOnce({
@@ -1199,7 +1225,8 @@ describe("getMemorySearchManager caching", () => {
       agentId: retryAgentId,
       errorMessage: "qmd query failed",
     });
-    mockPrimary.close.mockImplementationOnce(async () => await new Promise(() => {}));
+    const retirementGate = createDeferred<void>();
+    mockPrimary.close.mockImplementationOnce(async () => await retirementGate.promise);
     const onDebug = vi.fn();
 
     try {
@@ -1210,6 +1237,7 @@ describe("getMemorySearchManager caching", () => {
       expect(mockPrimary.close).toHaveBeenCalledTimes(1);
       expect(fallbackSearch).toHaveBeenCalledTimes(1);
     } finally {
+      retirementGate.resolve();
       mockPrimary.close.mockImplementation(async () => {});
     }
   });

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -848,6 +848,37 @@ describe("getMemorySearchManager caching", () => {
     expect(createQmdManagerMock).toHaveBeenCalledTimes(3);
   });
 
+  it("continues scoped teardown when retained candidate cleanup still fails", async () => {
+    const agentId = "cached-qmd-persistent-close-failure";
+    const firstCfg = createQmdCfg(agentId, "/tmp/workspace-a");
+    const secondCfg = createQmdCfg(agentId, "/tmp/workspace-b");
+    const firstPrimary = createQmdManagerInstanceMock();
+    const secondPrimary = createQmdManagerInstanceMock();
+    firstPrimary.close.mockRejectedValueOnce(new Error("old close failed"));
+    secondPrimary.close.mockRejectedValue(new Error("candidate close failed"));
+    createQmdManagerMock
+      .mockImplementationOnce(async () => firstPrimary)
+      .mockImplementationOnce(async () => secondPrimary);
+
+    await getMemorySearchManager({ cfg: firstCfg, agentId });
+    await expect(getMemorySearchManager({ cfg: secondCfg, agentId })).rejects.toThrow(
+      "old close failed",
+    );
+
+    await expect(closeMemorySearchManager({ cfg: firstCfg, agentId })).rejects.toThrow(
+      "candidate close failed",
+    );
+    expect(secondPrimary.close).toHaveBeenCalledTimes(2);
+    expect(firstPrimary.close).toHaveBeenCalledTimes(2);
+    expect(mockCloseMemoryIndexManagersForAgent).toHaveBeenCalledWith({
+      cfg: firstCfg,
+      agentId,
+    });
+
+    secondPrimary.close.mockResolvedValue(undefined);
+    await closeMemorySearchManager({ cfg: firstCfg, agentId });
+  });
+
   it("dedupes concurrent full qmd manager creation for the same agent", async () => {
     const agentId = "pending-qmd";
     const cfg = createQmdCfg(agentId);

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -1180,6 +1180,49 @@ describe("getMemorySearchManager caching", () => {
     expect(fallbackSearch).toHaveBeenCalledTimes(2);
   });
 
+  it("joins and closes builtin fallback creation during wrapper teardown", async () => {
+    const agentId = "fallback-create-close-race";
+    const { manager } = await createFailedQmdSearchHarness({
+      agentId,
+      errorMessage: "qmd query failed",
+    });
+    const fallbackGate = createDeferred<typeof fallbackManager>();
+    mockMemoryIndexGet.mockImplementationOnce(async () => await fallbackGate.promise);
+
+    const searchPromise = manager.search("hello");
+    await vi.waitFor(() => expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1));
+    const closePromise = manager.close?.() ?? Promise.resolve();
+    fallbackGate.resolve(fallbackManager);
+
+    await closePromise;
+    await expect(searchPromise).rejects.toThrow("memory search manager is closed");
+    expect(fallbackManager.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start fallback creation after wrapper teardown begins", async () => {
+    const agentId = "fallback-after-close-race";
+    const primarySearchGate = createDeferred<void>();
+    mockPrimary.search.mockImplementationOnce(async () => {
+      await primarySearchGate.promise;
+      throw new Error("qmd query failed");
+    });
+    const cfg = createQmdCfg(agentId);
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId }));
+    const primaryCloseGate = createDeferred<void>();
+    mockPrimary.close.mockImplementation(async () => await primaryCloseGate.promise);
+
+    const searchPromise = manager.search("hello");
+    await vi.waitFor(() => expect(mockPrimary.search).toHaveBeenCalledTimes(1));
+    const closePromise = manager.close?.() ?? Promise.resolve();
+    primarySearchGate.resolve();
+    await vi.waitFor(() => expect(mockPrimary.close).toHaveBeenCalled());
+
+    primaryCloseGate.resolve();
+    await closePromise;
+    await expect(searchPromise).rejects.toThrow("memory search manager is closed");
+    expect(mockMemoryIndexGet).not.toHaveBeenCalled();
+  });
+
   it("gives same-call qmd-to-builtin fallback a fresh default deadline", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -84,6 +84,7 @@ type MemorySearchManagerCacheStore = {
   qmdManagerCache: Map<string, CachedQmdManagerEntry>;
   pendingQmdManagerCreates: Map<string, PendingQmdManagerCreate>;
   qmdManagerOpenFailures: Map<string, QmdManagerOpenFailure>;
+  retainedQmdManagers: Map<string, Set<MemorySearchManager>>;
   scopeLifecycleTails: Map<string, Promise<void>>;
   globalClosePromise: Promise<void> | null;
 };
@@ -95,6 +96,7 @@ function createMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
     qmdManagerCache: new Map<string, CachedQmdManagerEntry>(),
     pendingQmdManagerCreates: new Map<string, PendingQmdManagerCreate>(),
     qmdManagerOpenFailures: new Map<string, QmdManagerOpenFailure>(),
+    retainedQmdManagers: new Map<string, Set<MemorySearchManager>>(),
     scopeLifecycleTails: new Map<string, Promise<void>>(),
     globalClosePromise: null,
   };
@@ -119,6 +121,9 @@ function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
     if (!(cacheStore.scopeLifecycleTails instanceof Map)) {
       cacheStore.scopeLifecycleTails = new Map<string, Promise<void>>();
     }
+    if (!(cacheStore.retainedQmdManagers instanceof Map)) {
+      cacheStore.retainedQmdManagers = new Map<string, Set<MemorySearchManager>>();
+    }
     if (
       cacheStore.globalClosePromise !== null &&
       !(cacheStore.globalClosePromise instanceof Promise)
@@ -140,6 +145,49 @@ const {
   qmdManagerOpenFailures: QMD_MANAGER_OPEN_FAILURES,
 } = MEMORY_SEARCH_MANAGER_CACHE_STORE;
 
+function retainQmdManagerForCleanup(scopeKey: string, manager: MemorySearchManager): void {
+  const retained = MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.get(scopeKey) ?? new Set();
+  retained.add(manager);
+  MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.set(scopeKey, retained);
+}
+
+function releaseRetainedQmdManager(scopeKey: string, manager: MemorySearchManager): void {
+  const retained = MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.get(scopeKey);
+  if (!retained) {
+    return;
+  }
+  retained.delete(manager);
+  if (retained.size === 0) {
+    MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.delete(scopeKey);
+  }
+}
+
+async function drainRetainedQmdManagers(scopeKey: string): Promise<void> {
+  const retained = MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.get(scopeKey);
+  if (!retained) {
+    return;
+  }
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const manager of retained) {
+    try {
+      await manager.close?.();
+      retained.delete(manager);
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (retained.size === 0) {
+    MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.delete(scopeKey);
+  }
+  if (closeFailed) {
+    throw firstError;
+  }
+}
+
 async function runMemorySearchManagerScopeOperation<T>(
   scopeKey: string,
   operation: () => Promise<T>,
@@ -156,7 +204,11 @@ async function runMemorySearchManagerScopeOperation<T>(
   }
   const previous =
     MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.get(scopeKey) ?? Promise.resolve();
-  const result = previous.then(operation, operation);
+  const run = async () => {
+    await drainRetainedQmdManagers(scopeKey);
+    return await operation();
+  };
+  const result = previous.then(run, run);
   const tail = result.then(
     () => undefined,
     () => undefined,
@@ -475,14 +527,27 @@ async function getMemorySearchManagerWithinLifecycle(
     const pendingCreate: PendingQmdManagerCreate = {
       identityKey,
       promise: (async () => {
-        if (cached) {
-          await closeQmdManagerForReplacement(cached.manager);
-        }
         const created = await createFullQmdManager(identityKey);
         if (!created.entry) {
           pendingFailureReason = created.failureReason ?? "qmd memory unavailable";
           recordQmdManagerOpenFailure(scopeKey, identityKey, pendingFailureReason);
           return null;
+        }
+        if (cached) {
+          try {
+            await closeQmdManagerForReplacement(cached.manager);
+          } catch (err) {
+            retainQmdManagerForCleanup(scopeKey, created.entry.manager);
+            try {
+              await created.entry.manager.close?.();
+              releaseRetainedQmdManager(scopeKey, created.entry.manager);
+            } catch (closeErr) {
+              log.warn(
+                `failed to close unused qmd memory manager: ${formatErrorMessage(closeErr)}`,
+              );
+            }
+            throw err;
+          }
         }
         QMD_MANAGER_CACHE.set(scopeKey, created.entry);
         return created.entry.manager;
@@ -614,6 +679,16 @@ async function closeAllMemorySearchManagersWithinLifecycle(): Promise<void> {
   QMD_MANAGER_OPEN_FAILURES.clear();
   let firstError: unknown;
   let closeFailed = false;
+  for (const scopeKey of Array.from(MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.keys())) {
+    try {
+      await drainRetainedQmdManagers(scopeKey);
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
   for (const [scopeKey, entry] of entries) {
     try {
       await entry.manager.close?.();

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -475,23 +475,14 @@ async function getMemorySearchManagerWithinLifecycle(
     const pendingCreate: PendingQmdManagerCreate = {
       identityKey,
       promise: (async () => {
+        if (cached) {
+          await closeQmdManagerForReplacement(cached.manager);
+        }
         const created = await createFullQmdManager(identityKey);
         if (!created.entry) {
           pendingFailureReason = created.failureReason ?? "qmd memory unavailable";
           recordQmdManagerOpenFailure(scopeKey, identityKey, pendingFailureReason);
           return null;
-        }
-        if (cached) {
-          try {
-            await closeQmdManagerForReplacement(cached.manager);
-          } catch (err) {
-            await created.entry.manager.close?.().catch((closeErr: unknown) => {
-              log.warn(
-                `failed to close unused qmd memory manager: ${formatErrorMessage(closeErr)}`,
-              );
-            });
-            throw err;
-          }
         }
         QMD_MANAGER_CACHE.set(scopeKey, created.entry);
         return created.entry.manager;

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -470,7 +470,7 @@ async function getMemorySearchManagerWithinLifecycle(
       cached = undefined;
     }
     const cachedMatchesIdentity = cached?.identityKey === identityKey;
-    if (cachedMatchesIdentity) {
+    if (cachedMatchesIdentity && cached) {
       if (params.purpose === "status") {
         // Status callers often close the manager they receive. Wrap the live
         // full manager with a no-op close so health/status probes do not tear

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -191,6 +191,7 @@ async function drainRetainedQmdManagers(scopeKey: string): Promise<void> {
 async function runMemorySearchManagerScopeOperation<T>(
   scopeKey: string,
   operation: () => Promise<T>,
+  options: { drainRetained?: boolean } = {},
 ): Promise<T> {
   while (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise) {
     const globalClose = MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise;
@@ -205,7 +206,9 @@ async function runMemorySearchManagerScopeOperation<T>(
   const previous =
     MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.get(scopeKey) ?? Promise.resolve();
   const run = async () => {
-    await drainRetainedQmdManagers(scopeKey);
+    if (options.drainRetained !== false) {
+      await drainRetainedQmdManagers(scopeKey);
+    }
     return await operation();
   };
   const result = previous.then(run, run);
@@ -727,6 +730,7 @@ export async function closeMemorySearchManager(params: {
   await runMemorySearchManagerScopeOperation(
     scopeKey,
     async () => await closeMemorySearchManagerWithinLifecycle(params),
+    { drainRetained: false },
   );
 }
 
@@ -736,13 +740,19 @@ async function closeMemorySearchManagerWithinLifecycle(params: {
 }): Promise<void> {
   const normalizedAgentId = normalizeAgentId(params.agentId);
   const scopeKey = buildQmdManagerScopeKey(normalizedAgentId);
+  let closeError: unknown;
+  let closeFailed = false;
+  try {
+    await drainRetainedQmdManagers(scopeKey);
+  } catch (err) {
+    closeError = err;
+    closeFailed = true;
+  }
   const pending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
   if (pending) {
     await Promise.allSettled([pending.promise]);
   }
   const cached = QMD_MANAGER_CACHE.get(scopeKey);
-  let closeError: unknown;
-  let closeFailed = false;
   if (cached) {
     try {
       await cached.manager.close?.();

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -84,6 +84,8 @@ type MemorySearchManagerCacheStore = {
   qmdManagerCache: Map<string, CachedQmdManagerEntry>;
   pendingQmdManagerCreates: Map<string, PendingQmdManagerCreate>;
   qmdManagerOpenFailures: Map<string, QmdManagerOpenFailure>;
+  scopeLifecycleTails: Map<string, Promise<void>>;
+  globalClosePromise: Promise<void> | null;
 };
 
 const QMD_MANAGER_OPEN_FAILURE_COOLDOWN_MS = 60_000;
@@ -93,6 +95,8 @@ function createMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
     qmdManagerCache: new Map<string, CachedQmdManagerEntry>(),
     pendingQmdManagerCreates: new Map<string, PendingQmdManagerCreate>(),
     qmdManagerOpenFailures: new Map<string, QmdManagerOpenFailure>(),
+    scopeLifecycleTails: new Map<string, Promise<void>>(),
+    globalClosePromise: null,
   };
 }
 
@@ -112,6 +116,15 @@ function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
     if (!(cacheStore.qmdManagerOpenFailures instanceof Map)) {
       cacheStore.qmdManagerOpenFailures = new Map<string, QmdManagerOpenFailure>();
     }
+    if (!(cacheStore.scopeLifecycleTails instanceof Map)) {
+      cacheStore.scopeLifecycleTails = new Map<string, Promise<void>>();
+    }
+    if (
+      cacheStore.globalClosePromise !== null &&
+      !(cacheStore.globalClosePromise instanceof Promise)
+    ) {
+      cacheStore.globalClosePromise = null;
+    }
     return cacheStore as MemorySearchManagerCacheStore;
   }
   const repaired = createMemorySearchManagerCacheStore();
@@ -120,11 +133,53 @@ function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
 }
 
 const log = createSubsystemLogger("memory");
+const MEMORY_SEARCH_MANAGER_CACHE_STORE = getMemorySearchManagerCacheStore();
 const {
   qmdManagerCache: QMD_MANAGER_CACHE,
   pendingQmdManagerCreates: PENDING_QMD_MANAGER_CREATES,
   qmdManagerOpenFailures: QMD_MANAGER_OPEN_FAILURES,
-} = getMemorySearchManagerCacheStore();
+} = MEMORY_SEARCH_MANAGER_CACHE_STORE;
+
+async function runMemorySearchManagerScopeOperation<T>(
+  scopeKey: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  while (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise) {
+    const globalClose = MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise;
+    try {
+      await globalClose;
+    } catch {
+      if (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise === globalClose) {
+        await closeAllMemorySearchManagers();
+      }
+    }
+  }
+  const previous =
+    MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.get(scopeKey) ?? Promise.resolve();
+  const result = previous.then(operation, operation);
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.set(scopeKey, tail);
+  try {
+    return await result;
+  } finally {
+    if (MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.get(scopeKey) === tail) {
+      MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.delete(scopeKey);
+    }
+  }
+}
+
+async function runMemorySearchManagerGlobalClose(operation: () => Promise<void>): Promise<void> {
+  const previous = MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise ?? Promise.resolve();
+  const closePromise = previous.then(operation, operation);
+  MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise = closePromise;
+  await closePromise;
+  if (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise === closePromise) {
+    MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise = null;
+  }
+}
 const managerRuntimeLoader = createLazyRuntimeModule(() => import("../../manager-runtime.js"));
 const loadManagerRuntime = managerRuntimeLoader;
 
@@ -144,6 +199,11 @@ type MemorySearchManagerParams = {
   acquireLocalService?: MemoryCoreAcquireLocalService;
   withLease?: PluginStateLeaseRunner;
 };
+
+function isClosedMemorySearchManager(manager: MemorySearchManager): boolean {
+  const isClosed = Reflect.get(manager, "isClosed");
+  return typeof isClosed === "function" && isClosed.call(manager) === true;
+}
 
 function getActiveQmdManagerOpenFailure(
   scopeKey: string,
@@ -202,6 +262,16 @@ function applyManagerDebug(
 }
 
 export async function getMemorySearchManager(
+  params: MemorySearchManagerParams,
+): Promise<MemorySearchManagerResult> {
+  const scopeKey = buildQmdManagerScopeKey(normalizeAgentId(params.agentId));
+  return await runMemorySearchManagerScopeOperation(
+    scopeKey,
+    async () => await getMemorySearchManagerWithinLifecycle(params),
+  );
+}
+
+async function getMemorySearchManagerWithinLifecycle(
   params: MemorySearchManagerParams,
 ): Promise<MemorySearchManagerResult> {
   const acquireStartedAt = Date.now();
@@ -321,7 +391,14 @@ export async function getMemorySearchManager(
       return { entry: cacheEntry };
     };
 
-    const cached = QMD_MANAGER_CACHE.get(scopeKey);
+    let cached = QMD_MANAGER_CACHE.get(scopeKey);
+    if (cached && isClosedMemorySearchManager(cached.manager)) {
+      await cached.manager.close();
+      if (QMD_MANAGER_CACHE.get(scopeKey) === cached) {
+        QMD_MANAGER_CACHE.delete(scopeKey);
+      }
+      cached = undefined;
+    }
     const cachedMatchesIdentity = cached?.identityKey === identityKey;
     if (cachedMatchesIdentity) {
       if (params.purpose === "status") {
@@ -387,7 +464,7 @@ export async function getMemorySearchManager(
     const pending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
     if (pending) {
       await pending.promise;
-      return finish(await getMemorySearchManager(params), {
+      return finish(await getMemorySearchManagerWithinLifecycle(params), {
         backend: "qmd",
         managerCacheState: "pending-create-wait",
         qmdIdentityHash: debugIdentityHash,
@@ -404,12 +481,19 @@ export async function getMemorySearchManager(
           recordQmdManagerOpenFailure(scopeKey, identityKey, pendingFailureReason);
           return null;
         }
-        QMD_MANAGER_CACHE.set(scopeKey, created.entry);
         if (cached) {
-          await closeQmdManagerForReplacement(cached.manager).catch((err: unknown) => {
-            log.warn(`failed to retire replaced qmd memory manager: ${formatErrorMessage(err)}`);
-          });
+          try {
+            await closeQmdManagerForReplacement(cached.manager);
+          } catch (err) {
+            await created.entry.manager.close?.().catch((closeErr: unknown) => {
+              log.warn(
+                `failed to close unused qmd memory manager: ${formatErrorMessage(closeErr)}`,
+              );
+            });
+            throw err;
+          }
         }
+        QMD_MANAGER_CACHE.set(scopeKey, created.entry);
         return created.entry.manager;
       })().finally(() => {
         const currentPending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
@@ -525,26 +609,62 @@ class BorrowedMemoryManager implements MemorySearchManager {
 }
 
 export async function closeAllMemorySearchManagers(): Promise<void> {
+  await runMemorySearchManagerGlobalClose(closeAllMemorySearchManagersWithinLifecycle);
+}
+
+async function closeAllMemorySearchManagersWithinLifecycle(): Promise<void> {
+  const scopeTails = Array.from(MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.values());
+  if (scopeTails.length > 0) {
+    await Promise.allSettled(scopeTails);
+  }
   const pendingCreates = Array.from(PENDING_QMD_MANAGER_CREATES.values(), (entry) => entry.promise);
   await Promise.allSettled(pendingCreates);
-  const managers = Array.from(QMD_MANAGER_CACHE.values(), (entry) => entry.manager);
-  PENDING_QMD_MANAGER_CREATES.clear();
-  QMD_MANAGER_CACHE.clear();
+  const entries = Array.from(QMD_MANAGER_CACHE.entries());
   QMD_MANAGER_OPEN_FAILURES.clear();
-  for (const manager of managers) {
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const [scopeKey, entry] of entries) {
     try {
-      await manager.close?.();
+      await entry.manager.close?.();
+      if (QMD_MANAGER_CACHE.get(scopeKey) === entry) {
+        QMD_MANAGER_CACHE.delete(scopeKey);
+      }
     } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
       log.warn(`failed to close qmd memory manager: ${String(err)}`);
     }
   }
   if (managerRuntimeLoader.peek()) {
-    const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
-    await closeAllMemoryIndexManagers();
+    try {
+      const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
+      await closeAllMemoryIndexManagers();
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (closeFailed) {
+    throw firstError;
   }
 }
 
 export async function closeMemorySearchManager(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+}): Promise<void> {
+  const scopeKey = buildQmdManagerScopeKey(normalizeAgentId(params.agentId));
+  await runMemorySearchManagerScopeOperation(
+    scopeKey,
+    async () => await closeMemorySearchManagerWithinLifecycle(params),
+  );
+}
+
+async function closeMemorySearchManagerWithinLifecycle(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): Promise<void> {
@@ -555,18 +675,34 @@ export async function closeMemorySearchManager(params: {
     await Promise.allSettled([pending.promise]);
   }
   const cached = QMD_MANAGER_CACHE.get(scopeKey);
+  let closeError: unknown;
+  let closeFailed = false;
   if (cached) {
-    QMD_MANAGER_CACHE.delete(scopeKey);
-    QMD_MANAGER_OPEN_FAILURES.delete(scopeKey);
     try {
       await cached.manager.close?.();
+      if (QMD_MANAGER_CACHE.get(scopeKey) === cached) {
+        QMD_MANAGER_CACHE.delete(scopeKey);
+      }
+      QMD_MANAGER_OPEN_FAILURES.delete(scopeKey);
     } catch (err) {
+      closeError = err;
+      closeFailed = true;
       log.warn(`failed to close qmd memory manager for agent ${normalizedAgentId}: ${String(err)}`);
     }
   }
   if (managerRuntimeLoader.peek()) {
-    const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();
-    await closeMemoryIndexManagersForAgent({ cfg: params.cfg, agentId: normalizedAgentId });
+    try {
+      const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();
+      await closeMemoryIndexManagersForAgent({ cfg: params.cfg, agentId: normalizedAgentId });
+    } catch (err) {
+      if (!closeFailed) {
+        closeError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (closeFailed) {
+    throw closeError;
   }
 }
 
@@ -576,6 +712,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   private lastError?: string;
   private cacheEvicted = false;
   private closed = false;
+  private closePromise: Promise<void> | null = null;
   private closeReason = "memory search manager is closed";
 
   constructor(
@@ -736,9 +873,24 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   async close() {
-    if (this.closed) {
+    const existingClose = this.closePromise;
+    if (existingClose) {
+      await existingClose;
       return;
     }
+    const closeOperation = this.closeOnce();
+    this.closePromise = closeOperation;
+    try {
+      await closeOperation;
+    } catch (err) {
+      if (this.closePromise === closeOperation) {
+        this.closePromise = null;
+      }
+      throw err;
+    }
+  }
+
+  private async closeOnce(): Promise<void> {
     this.closed = true;
     await this.deps.primary.close?.();
     await this.fallback?.close?.();
@@ -774,6 +926,10 @@ class FallbackMemoryManager implements MemorySearchManager {
     if (this.closed) {
       throw new Error(this.closeReason);
     }
+  }
+
+  isClosed(): boolean {
+    return this.closed;
   }
 
   private evictCacheEntry(): void {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -699,6 +699,7 @@ async function closeMemorySearchManagerWithinLifecycle(params: {
 
 class FallbackMemoryManager implements MemorySearchManager {
   private fallback: Maybe<MemorySearchManager> = null;
+  private fallbackInitPromise: Promise<Maybe<MemorySearchManager>> | null = null;
   private primaryFailed = false;
   private lastError?: string;
   private cacheEvicted = false;
@@ -883,8 +884,11 @@ class FallbackMemoryManager implements MemorySearchManager {
 
   private async closeOnce(): Promise<void> {
     this.closed = true;
+    const pendingFallback = this.fallbackInitPromise;
     await this.deps.primary.close?.();
+    await pendingFallback;
     await this.fallback?.close?.();
+    this.fallback = null;
     this.evictCacheEntry();
   }
 
@@ -894,23 +898,49 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   private async ensureFallback(): Promise<Maybe<MemorySearchManager>> {
+    this.ensureOpen();
     if (this.fallback) {
       return this.fallback;
     }
-    let fallback: Maybe<MemorySearchManager>;
-    try {
-      fallback = await this.deps.fallbackFactory();
-      if (!fallback) {
-        log.warn("memory fallback requested but builtin index is unavailable");
+    const pending = this.fallbackInitPromise;
+    if (pending) {
+      const fallback = await pending;
+      this.ensureOpen();
+      return fallback;
+    }
+    const initialization = (async (): Promise<Maybe<MemorySearchManager>> => {
+      let fallback: Maybe<MemorySearchManager>;
+      try {
+        fallback = await this.deps.fallbackFactory();
+        if (!fallback) {
+          log.warn("memory fallback requested but builtin index is unavailable");
+          return null;
+        }
+      } catch (err) {
+        const message = formatErrorMessage(err);
+        log.warn(`memory fallback unavailable: ${message}`);
         return null;
       }
-    } catch (err) {
-      const message = formatErrorMessage(err);
-      log.warn(`memory fallback unavailable: ${message}`);
-      return null;
+      this.fallback = fallback;
+      if (this.closed) {
+        await fallback.close?.();
+        if (this.fallback === fallback) {
+          this.fallback = null;
+        }
+        return null;
+      }
+      return fallback;
+    })();
+    this.fallbackInitPromise = initialization;
+    try {
+      const fallback = await initialization;
+      this.ensureOpen();
+      return fallback;
+    } finally {
+      if (this.fallbackInitPromise === initialization) {
+        this.fallbackInitPromise = null;
+      }
     }
-    this.fallback = fallback;
-    return this.fallback;
   }
 
   private ensureOpen(): void {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -334,9 +334,11 @@ export async function getMemorySearchManager(
   params: MemorySearchManagerParams,
 ): Promise<MemorySearchManagerResult> {
   const scopeKey = buildQmdManagerScopeKey(normalizeAgentId(params.agentId));
+  const resolved = resolveMemoryBackendConfig(params);
   return await runMemorySearchManagerScopeOperation(
     scopeKey,
     async () => await getMemorySearchManagerWithinLifecycle(params),
+    { drainRetained: resolved.backend === "qmd" },
   );
 }
 

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -84,6 +84,9 @@ type MemorySearchManagerCacheStore = {
   qmdManagerCache: Map<string, CachedQmdManagerEntry>;
   pendingQmdManagerCreates: Map<string, PendingQmdManagerCreate>;
   qmdManagerOpenFailures: Map<string, QmdManagerOpenFailure>;
+  retainedQmdManagers: Map<string, Set<MemorySearchManager>>;
+  scopeLifecycleTails: Map<string, Promise<void>>;
+  globalClosePromise: Promise<void> | null;
 };
 
 const QMD_MANAGER_OPEN_FAILURE_COOLDOWN_MS = 60_000;
@@ -93,6 +96,9 @@ function createMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
     qmdManagerCache: new Map<string, CachedQmdManagerEntry>(),
     pendingQmdManagerCreates: new Map<string, PendingQmdManagerCreate>(),
     qmdManagerOpenFailures: new Map<string, QmdManagerOpenFailure>(),
+    retainedQmdManagers: new Map<string, Set<MemorySearchManager>>(),
+    scopeLifecycleTails: new Map<string, Promise<void>>(),
+    globalClosePromise: null,
   };
 }
 
@@ -112,6 +118,18 @@ function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
     if (!(cacheStore.qmdManagerOpenFailures instanceof Map)) {
       cacheStore.qmdManagerOpenFailures = new Map<string, QmdManagerOpenFailure>();
     }
+    if (!(cacheStore.scopeLifecycleTails instanceof Map)) {
+      cacheStore.scopeLifecycleTails = new Map<string, Promise<void>>();
+    }
+    if (!(cacheStore.retainedQmdManagers instanceof Map)) {
+      cacheStore.retainedQmdManagers = new Map<string, Set<MemorySearchManager>>();
+    }
+    if (
+      cacheStore.globalClosePromise !== null &&
+      !(cacheStore.globalClosePromise instanceof Promise)
+    ) {
+      cacheStore.globalClosePromise = null;
+    }
     return cacheStore as MemorySearchManagerCacheStore;
   }
   const repaired = createMemorySearchManagerCacheStore();
@@ -120,11 +138,103 @@ function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
 }
 
 const log = createSubsystemLogger("memory");
+const MEMORY_SEARCH_MANAGER_CACHE_STORE = getMemorySearchManagerCacheStore();
 const {
   qmdManagerCache: QMD_MANAGER_CACHE,
   pendingQmdManagerCreates: PENDING_QMD_MANAGER_CREATES,
   qmdManagerOpenFailures: QMD_MANAGER_OPEN_FAILURES,
-} = getMemorySearchManagerCacheStore();
+} = MEMORY_SEARCH_MANAGER_CACHE_STORE;
+
+function retainQmdManagerForCleanup(scopeKey: string, manager: MemorySearchManager): void {
+  const retained = MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.get(scopeKey) ?? new Set();
+  retained.add(manager);
+  MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.set(scopeKey, retained);
+}
+
+function releaseRetainedQmdManager(scopeKey: string, manager: MemorySearchManager): void {
+  const retained = MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.get(scopeKey);
+  if (!retained) {
+    return;
+  }
+  retained.delete(manager);
+  if (retained.size === 0) {
+    MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.delete(scopeKey);
+  }
+}
+
+async function drainRetainedQmdManagers(scopeKey: string): Promise<void> {
+  const retained = MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.get(scopeKey);
+  if (!retained) {
+    return;
+  }
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const manager of retained) {
+    try {
+      await manager.close?.();
+      retained.delete(manager);
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (retained.size === 0) {
+    MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.delete(scopeKey);
+  }
+  if (closeFailed) {
+    throw firstError;
+  }
+}
+
+async function runMemorySearchManagerScopeOperation<T>(
+  scopeKey: string,
+  operation: () => Promise<T>,
+  options: { drainRetained?: boolean } = {},
+): Promise<T> {
+  while (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise) {
+    const globalClose = MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise;
+    try {
+      await globalClose;
+    } catch {
+      if (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise === globalClose) {
+        await closeAllMemorySearchManagers();
+      }
+    }
+  }
+  const previous =
+    MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.get(scopeKey) ?? Promise.resolve();
+  const run = async () => {
+    if (options.drainRetained !== false) {
+      await drainRetainedQmdManagers(scopeKey);
+    }
+    return await operation();
+  };
+  const result = previous.then(run, run);
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.set(scopeKey, tail);
+  try {
+    return await result;
+  } finally {
+    if (MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.get(scopeKey) === tail) {
+      MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.delete(scopeKey);
+    }
+  }
+}
+
+async function runMemorySearchManagerGlobalClose(operation: () => Promise<void>): Promise<void> {
+  const previous = MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise ?? Promise.resolve();
+  const closePromise = previous.then(operation, operation);
+  MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise = closePromise;
+  await closePromise;
+  if (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise === closePromise) {
+    MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise = null;
+  }
+}
 const managerRuntimeLoader = createLazyRuntimeModule(() => import("../../manager-runtime.js"));
 const loadManagerRuntime = managerRuntimeLoader;
 
@@ -144,6 +254,11 @@ type MemorySearchManagerParams = {
   acquireLocalService?: MemoryCoreAcquireLocalService;
   withLease?: PluginStateLeaseRunner;
 };
+
+function isClosedMemorySearchManager(manager: MemorySearchManager): boolean {
+  const isClosed = Reflect.get(manager, "isClosed");
+  return typeof isClosed === "function" && isClosed.call(manager) === true;
+}
 
 function getActiveQmdManagerOpenFailure(
   scopeKey: string,
@@ -202,6 +317,16 @@ function applyManagerDebug(
 }
 
 export async function getMemorySearchManager(
+  params: MemorySearchManagerParams,
+): Promise<MemorySearchManagerResult> {
+  const scopeKey = buildQmdManagerScopeKey(normalizeAgentId(params.agentId));
+  return await runMemorySearchManagerScopeOperation(
+    scopeKey,
+    async () => await getMemorySearchManagerWithinLifecycle(params),
+  );
+}
+
+async function getMemorySearchManagerWithinLifecycle(
   params: MemorySearchManagerParams,
 ): Promise<MemorySearchManagerResult> {
   const acquireStartedAt = Date.now();
@@ -321,7 +446,14 @@ export async function getMemorySearchManager(
       return { entry: cacheEntry };
     };
 
-    const cached = QMD_MANAGER_CACHE.get(scopeKey);
+    let cached = QMD_MANAGER_CACHE.get(scopeKey);
+    if (cached && isClosedMemorySearchManager(cached.manager)) {
+      await cached.manager.close?.();
+      if (QMD_MANAGER_CACHE.get(scopeKey) === cached) {
+        QMD_MANAGER_CACHE.delete(scopeKey);
+      }
+      cached = undefined;
+    }
     const cachedMatchesIdentity = cached?.identityKey === identityKey;
     if (cachedMatchesIdentity) {
       if (params.purpose === "status") {
@@ -387,7 +519,7 @@ export async function getMemorySearchManager(
     const pending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
     if (pending) {
       await pending.promise;
-      return finish(await getMemorySearchManager(params), {
+      return finish(await getMemorySearchManagerWithinLifecycle(params), {
         backend: "qmd",
         managerCacheState: "pending-create-wait",
         qmdIdentityHash: debugIdentityHash,
@@ -404,12 +536,23 @@ export async function getMemorySearchManager(
           recordQmdManagerOpenFailure(scopeKey, identityKey, pendingFailureReason);
           return null;
         }
-        QMD_MANAGER_CACHE.set(scopeKey, created.entry);
         if (cached) {
-          await closeQmdManagerForReplacement(cached.manager).catch((err: unknown) => {
-            log.warn(`failed to retire replaced qmd memory manager: ${formatErrorMessage(err)}`);
-          });
+          try {
+            await closeQmdManagerForReplacement(cached.manager);
+          } catch (err) {
+            retainQmdManagerForCleanup(scopeKey, created.entry.manager);
+            try {
+              await created.entry.manager.close?.();
+              releaseRetainedQmdManager(scopeKey, created.entry.manager);
+            } catch (closeErr) {
+              log.warn(
+                `failed to close unused qmd memory manager: ${formatErrorMessage(closeErr)}`,
+              );
+            }
+            throw err;
+          }
         }
+        QMD_MANAGER_CACHE.set(scopeKey, created.entry);
         return created.entry.manager;
       })().finally(() => {
         const currentPending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
@@ -525,22 +668,57 @@ class BorrowedMemoryManager implements MemorySearchManager {
 }
 
 export async function closeAllMemorySearchManagers(): Promise<void> {
+  await runMemorySearchManagerGlobalClose(closeAllMemorySearchManagersWithinLifecycle);
+}
+
+async function closeAllMemorySearchManagersWithinLifecycle(): Promise<void> {
+  const scopeTails = Array.from(MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.values());
+  if (scopeTails.length > 0) {
+    await Promise.allSettled(scopeTails);
+  }
   const pendingCreates = Array.from(PENDING_QMD_MANAGER_CREATES.values(), (entry) => entry.promise);
   await Promise.allSettled(pendingCreates);
-  const managers = Array.from(QMD_MANAGER_CACHE.values(), (entry) => entry.manager);
-  PENDING_QMD_MANAGER_CREATES.clear();
-  QMD_MANAGER_CACHE.clear();
+  const entries = Array.from(QMD_MANAGER_CACHE.entries());
   QMD_MANAGER_OPEN_FAILURES.clear();
-  for (const manager of managers) {
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const scopeKey of Array.from(MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.keys())) {
     try {
-      await manager.close?.();
+      await drainRetainedQmdManagers(scopeKey);
     } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  for (const [scopeKey, entry] of entries) {
+    try {
+      await entry.manager.close?.();
+      if (QMD_MANAGER_CACHE.get(scopeKey) === entry) {
+        QMD_MANAGER_CACHE.delete(scopeKey);
+      }
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
       log.warn(`failed to close qmd memory manager: ${String(err)}`);
     }
   }
   if (managerRuntimeLoader.peek()) {
-    const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
-    await closeAllMemoryIndexManagers();
+    try {
+      const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
+      await closeAllMemoryIndexManagers();
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (closeFailed) {
+    throw firstError;
   }
 }
 
@@ -548,34 +726,70 @@ export async function closeMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): Promise<void> {
+  const scopeKey = buildQmdManagerScopeKey(normalizeAgentId(params.agentId));
+  await runMemorySearchManagerScopeOperation(
+    scopeKey,
+    async () => await closeMemorySearchManagerWithinLifecycle(params),
+    { drainRetained: false },
+  );
+}
+
+async function closeMemorySearchManagerWithinLifecycle(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+}): Promise<void> {
   const normalizedAgentId = normalizeAgentId(params.agentId);
   const scopeKey = buildQmdManagerScopeKey(normalizedAgentId);
+  let closeError: unknown;
+  let closeFailed = false;
+  try {
+    await drainRetainedQmdManagers(scopeKey);
+  } catch (err) {
+    closeError = err;
+    closeFailed = true;
+  }
   const pending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
   if (pending) {
     await Promise.allSettled([pending.promise]);
   }
   const cached = QMD_MANAGER_CACHE.get(scopeKey);
   if (cached) {
-    QMD_MANAGER_CACHE.delete(scopeKey);
-    QMD_MANAGER_OPEN_FAILURES.delete(scopeKey);
     try {
       await cached.manager.close?.();
+      if (QMD_MANAGER_CACHE.get(scopeKey) === cached) {
+        QMD_MANAGER_CACHE.delete(scopeKey);
+      }
+      QMD_MANAGER_OPEN_FAILURES.delete(scopeKey);
     } catch (err) {
+      closeError = err;
+      closeFailed = true;
       log.warn(`failed to close qmd memory manager for agent ${normalizedAgentId}: ${String(err)}`);
     }
   }
   if (managerRuntimeLoader.peek()) {
-    const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();
-    await closeMemoryIndexManagersForAgent({ cfg: params.cfg, agentId: normalizedAgentId });
+    try {
+      const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();
+      await closeMemoryIndexManagersForAgent({ cfg: params.cfg, agentId: normalizedAgentId });
+    } catch (err) {
+      if (!closeFailed) {
+        closeError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (closeFailed) {
+    throw closeError;
   }
 }
 
 class FallbackMemoryManager implements MemorySearchManager {
   private fallback: Maybe<MemorySearchManager> = null;
+  private fallbackInitPromise: Promise<Maybe<MemorySearchManager>> | null = null;
   private primaryFailed = false;
   private lastError?: string;
   private cacheEvicted = false;
   private closed = false;
+  private closePromise: Promise<void> | null = null;
   private closeReason = "memory search manager is closed";
 
   constructor(
@@ -736,12 +950,30 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   async close() {
-    if (this.closed) {
+    const existingClose = this.closePromise;
+    if (existingClose) {
+      await existingClose;
       return;
     }
+    const closeOperation = this.closeOnce();
+    this.closePromise = closeOperation;
+    try {
+      await closeOperation;
+    } catch (err) {
+      if (this.closePromise === closeOperation) {
+        this.closePromise = null;
+      }
+      throw err;
+    }
+  }
+
+  private async closeOnce(): Promise<void> {
     this.closed = true;
+    const pendingFallback = this.fallbackInitPromise;
     await this.deps.primary.close?.();
+    await pendingFallback;
     await this.fallback?.close?.();
+    this.fallback = null;
     this.evictCacheEntry();
   }
 
@@ -751,29 +983,59 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   private async ensureFallback(): Promise<Maybe<MemorySearchManager>> {
+    this.ensureOpen();
     if (this.fallback) {
       return this.fallback;
     }
-    let fallback: Maybe<MemorySearchManager>;
-    try {
-      fallback = await this.deps.fallbackFactory();
-      if (!fallback) {
-        log.warn("memory fallback requested but builtin index is unavailable");
+    const pending = this.fallbackInitPromise;
+    if (pending) {
+      const fallback = await pending;
+      this.ensureOpen();
+      return fallback;
+    }
+    const initialization = (async (): Promise<Maybe<MemorySearchManager>> => {
+      let fallback: Maybe<MemorySearchManager>;
+      try {
+        fallback = await this.deps.fallbackFactory();
+        if (!fallback) {
+          log.warn("memory fallback requested but builtin index is unavailable");
+          return null;
+        }
+      } catch (err) {
+        const message = formatErrorMessage(err);
+        log.warn(`memory fallback unavailable: ${message}`);
         return null;
       }
-    } catch (err) {
-      const message = formatErrorMessage(err);
-      log.warn(`memory fallback unavailable: ${message}`);
-      return null;
+      this.fallback = fallback;
+      if (this.closed) {
+        await fallback.close?.();
+        if (this.fallback === fallback) {
+          this.fallback = null;
+        }
+        return null;
+      }
+      return fallback;
+    })();
+    this.fallbackInitPromise = initialization;
+    try {
+      const fallback = await initialization;
+      this.ensureOpen();
+      return fallback;
+    } finally {
+      if (this.fallbackInitPromise === initialization) {
+        this.fallbackInitPromise = null;
+      }
     }
-    this.fallback = fallback;
-    return this.fallback;
   }
 
   private ensureOpen(): void {
     if (this.closed) {
       throw new Error(this.closeReason);
     }
+  }
+
+  isClosed(): boolean {
+    return this.closed;
   }
 
   private evictCacheEntry(): void {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -235,6 +235,20 @@ async function runMemorySearchManagerGlobalClose(operation: () => Promise<void>)
     MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise = null;
   }
 }
+
+function retireQmdManagerInScope(scopeKey: string, manager: MemorySearchManager): void {
+  retainQmdManagerForCleanup(scopeKey, manager);
+  void runMemorySearchManagerScopeOperation(
+    scopeKey,
+    async () => {
+      await manager.close?.();
+      releaseRetainedQmdManager(scopeKey, manager);
+    },
+    { drainRetained: false },
+  ).catch((err: unknown) => {
+    log.warn(`failed to retire qmd memory manager: ${formatErrorMessage(err)}`);
+  });
+}
 const managerRuntimeLoader = createLazyRuntimeModule(() => import("../../manager-runtime.js"));
 const loadManagerRuntime = managerRuntimeLoader;
 
@@ -427,6 +441,7 @@ async function getMemorySearchManagerWithinLifecycle(
       const wrapper = new FallbackMemoryManager(
         {
           primary,
+          retirePrimary: () => retireQmdManagerInScope(scopeKey, primary),
           fallbackFactory: async () => {
             const { MemoryIndexManager } = await loadManagerRuntime();
             return await MemoryIndexManager.get(params);
@@ -795,6 +810,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   constructor(
     private readonly deps: {
       primary: MemorySearchManager;
+      retirePrimary: () => void;
       fallbackFactory: () => Promise<Maybe<MemorySearchManager>>;
     },
     private readonly onClose?: () => void,
@@ -825,11 +841,9 @@ class FallbackMemoryManager implements MemorySearchManager {
         this.primaryFailed = true;
         this.lastError = formatErrorMessage(err);
         log.warn(`qmd memory failed; switching to builtin index: ${this.lastError}`);
+        this.deps.retirePrimary();
         // Evict the failed wrapper so the next request can retry QMD with a fresh manager.
         this.evictCacheEntry();
-        // Retirement must not delay the same-call builtin fallback. QMD owns
-        // its internal shutdown bounds; this close is best-effort cleanup.
-        void this.deps.primary.close?.().catch(() => {});
       }
     }
     // The fallback owns a fresh default budget. Release any outer QMD clock

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -84,9 +84,6 @@ type MemorySearchManagerCacheStore = {
   qmdManagerCache: Map<string, CachedQmdManagerEntry>;
   pendingQmdManagerCreates: Map<string, PendingQmdManagerCreate>;
   qmdManagerOpenFailures: Map<string, QmdManagerOpenFailure>;
-  retainedQmdManagers: Map<string, Set<MemorySearchManager>>;
-  scopeLifecycleTails: Map<string, Promise<void>>;
-  globalClosePromise: Promise<void> | null;
 };
 
 const QMD_MANAGER_OPEN_FAILURE_COOLDOWN_MS = 60_000;
@@ -96,9 +93,6 @@ function createMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
     qmdManagerCache: new Map<string, CachedQmdManagerEntry>(),
     pendingQmdManagerCreates: new Map<string, PendingQmdManagerCreate>(),
     qmdManagerOpenFailures: new Map<string, QmdManagerOpenFailure>(),
-    retainedQmdManagers: new Map<string, Set<MemorySearchManager>>(),
-    scopeLifecycleTails: new Map<string, Promise<void>>(),
-    globalClosePromise: null,
   };
 }
 
@@ -118,18 +112,6 @@ function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
     if (!(cacheStore.qmdManagerOpenFailures instanceof Map)) {
       cacheStore.qmdManagerOpenFailures = new Map<string, QmdManagerOpenFailure>();
     }
-    if (!(cacheStore.scopeLifecycleTails instanceof Map)) {
-      cacheStore.scopeLifecycleTails = new Map<string, Promise<void>>();
-    }
-    if (!(cacheStore.retainedQmdManagers instanceof Map)) {
-      cacheStore.retainedQmdManagers = new Map<string, Set<MemorySearchManager>>();
-    }
-    if (
-      cacheStore.globalClosePromise !== null &&
-      !(cacheStore.globalClosePromise instanceof Promise)
-    ) {
-      cacheStore.globalClosePromise = null;
-    }
     return cacheStore as MemorySearchManagerCacheStore;
   }
   const repaired = createMemorySearchManagerCacheStore();
@@ -138,103 +120,11 @@ function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
 }
 
 const log = createSubsystemLogger("memory");
-const MEMORY_SEARCH_MANAGER_CACHE_STORE = getMemorySearchManagerCacheStore();
 const {
   qmdManagerCache: QMD_MANAGER_CACHE,
   pendingQmdManagerCreates: PENDING_QMD_MANAGER_CREATES,
   qmdManagerOpenFailures: QMD_MANAGER_OPEN_FAILURES,
-} = MEMORY_SEARCH_MANAGER_CACHE_STORE;
-
-function retainQmdManagerForCleanup(scopeKey: string, manager: MemorySearchManager): void {
-  const retained = MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.get(scopeKey) ?? new Set();
-  retained.add(manager);
-  MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.set(scopeKey, retained);
-}
-
-function releaseRetainedQmdManager(scopeKey: string, manager: MemorySearchManager): void {
-  const retained = MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.get(scopeKey);
-  if (!retained) {
-    return;
-  }
-  retained.delete(manager);
-  if (retained.size === 0) {
-    MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.delete(scopeKey);
-  }
-}
-
-async function drainRetainedQmdManagers(scopeKey: string): Promise<void> {
-  const retained = MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.get(scopeKey);
-  if (!retained) {
-    return;
-  }
-  let firstError: unknown;
-  let closeFailed = false;
-  for (const manager of retained) {
-    try {
-      await manager.close?.();
-      retained.delete(manager);
-    } catch (err) {
-      if (!closeFailed) {
-        firstError = err;
-      }
-      closeFailed = true;
-    }
-  }
-  if (retained.size === 0) {
-    MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.delete(scopeKey);
-  }
-  if (closeFailed) {
-    throw firstError;
-  }
-}
-
-async function runMemorySearchManagerScopeOperation<T>(
-  scopeKey: string,
-  operation: () => Promise<T>,
-  options: { drainRetained?: boolean } = {},
-): Promise<T> {
-  while (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise) {
-    const globalClose = MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise;
-    try {
-      await globalClose;
-    } catch {
-      if (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise === globalClose) {
-        await closeAllMemorySearchManagers();
-      }
-    }
-  }
-  const previous =
-    MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.get(scopeKey) ?? Promise.resolve();
-  const run = async () => {
-    if (options.drainRetained !== false) {
-      await drainRetainedQmdManagers(scopeKey);
-    }
-    return await operation();
-  };
-  const result = previous.then(run, run);
-  const tail = result.then(
-    () => undefined,
-    () => undefined,
-  );
-  MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.set(scopeKey, tail);
-  try {
-    return await result;
-  } finally {
-    if (MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.get(scopeKey) === tail) {
-      MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.delete(scopeKey);
-    }
-  }
-}
-
-async function runMemorySearchManagerGlobalClose(operation: () => Promise<void>): Promise<void> {
-  const previous = MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise ?? Promise.resolve();
-  const closePromise = previous.then(operation, operation);
-  MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise = closePromise;
-  await closePromise;
-  if (MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise === closePromise) {
-    MEMORY_SEARCH_MANAGER_CACHE_STORE.globalClosePromise = null;
-  }
-}
+} = getMemorySearchManagerCacheStore();
 const managerRuntimeLoader = createLazyRuntimeModule(() => import("../../manager-runtime.js"));
 const loadManagerRuntime = managerRuntimeLoader;
 
@@ -254,11 +144,6 @@ type MemorySearchManagerParams = {
   acquireLocalService?: MemoryCoreAcquireLocalService;
   withLease?: PluginStateLeaseRunner;
 };
-
-function isClosedMemorySearchManager(manager: MemorySearchManager): boolean {
-  const isClosed = Reflect.get(manager, "isClosed");
-  return typeof isClosed === "function" && isClosed.call(manager) === true;
-}
 
 function getActiveQmdManagerOpenFailure(
   scopeKey: string,
@@ -317,16 +202,6 @@ function applyManagerDebug(
 }
 
 export async function getMemorySearchManager(
-  params: MemorySearchManagerParams,
-): Promise<MemorySearchManagerResult> {
-  const scopeKey = buildQmdManagerScopeKey(normalizeAgentId(params.agentId));
-  return await runMemorySearchManagerScopeOperation(
-    scopeKey,
-    async () => await getMemorySearchManagerWithinLifecycle(params),
-  );
-}
-
-async function getMemorySearchManagerWithinLifecycle(
   params: MemorySearchManagerParams,
 ): Promise<MemorySearchManagerResult> {
   const acquireStartedAt = Date.now();
@@ -446,14 +321,7 @@ async function getMemorySearchManagerWithinLifecycle(
       return { entry: cacheEntry };
     };
 
-    let cached = QMD_MANAGER_CACHE.get(scopeKey);
-    if (cached && isClosedMemorySearchManager(cached.manager)) {
-      await cached.manager.close();
-      if (QMD_MANAGER_CACHE.get(scopeKey) === cached) {
-        QMD_MANAGER_CACHE.delete(scopeKey);
-      }
-      cached = undefined;
-    }
+    const cached = QMD_MANAGER_CACHE.get(scopeKey);
     const cachedMatchesIdentity = cached?.identityKey === identityKey;
     if (cachedMatchesIdentity) {
       if (params.purpose === "status") {
@@ -519,7 +387,7 @@ async function getMemorySearchManagerWithinLifecycle(
     const pending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
     if (pending) {
       await pending.promise;
-      return finish(await getMemorySearchManagerWithinLifecycle(params), {
+      return finish(await getMemorySearchManager(params), {
         backend: "qmd",
         managerCacheState: "pending-create-wait",
         qmdIdentityHash: debugIdentityHash,
@@ -536,23 +404,12 @@ async function getMemorySearchManagerWithinLifecycle(
           recordQmdManagerOpenFailure(scopeKey, identityKey, pendingFailureReason);
           return null;
         }
-        if (cached) {
-          try {
-            await closeQmdManagerForReplacement(cached.manager);
-          } catch (err) {
-            retainQmdManagerForCleanup(scopeKey, created.entry.manager);
-            try {
-              await created.entry.manager.close?.();
-              releaseRetainedQmdManager(scopeKey, created.entry.manager);
-            } catch (closeErr) {
-              log.warn(
-                `failed to close unused qmd memory manager: ${formatErrorMessage(closeErr)}`,
-              );
-            }
-            throw err;
-          }
-        }
         QMD_MANAGER_CACHE.set(scopeKey, created.entry);
+        if (cached) {
+          await closeQmdManagerForReplacement(cached.manager).catch((err: unknown) => {
+            log.warn(`failed to retire replaced qmd memory manager: ${formatErrorMessage(err)}`);
+          });
+        }
         return created.entry.manager;
       })().finally(() => {
         const currentPending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
@@ -668,57 +525,22 @@ class BorrowedMemoryManager implements MemorySearchManager {
 }
 
 export async function closeAllMemorySearchManagers(): Promise<void> {
-  await runMemorySearchManagerGlobalClose(closeAllMemorySearchManagersWithinLifecycle);
-}
-
-async function closeAllMemorySearchManagersWithinLifecycle(): Promise<void> {
-  const scopeTails = Array.from(MEMORY_SEARCH_MANAGER_CACHE_STORE.scopeLifecycleTails.values());
-  if (scopeTails.length > 0) {
-    await Promise.allSettled(scopeTails);
-  }
   const pendingCreates = Array.from(PENDING_QMD_MANAGER_CREATES.values(), (entry) => entry.promise);
   await Promise.allSettled(pendingCreates);
-  const entries = Array.from(QMD_MANAGER_CACHE.entries());
+  const managers = Array.from(QMD_MANAGER_CACHE.values(), (entry) => entry.manager);
+  PENDING_QMD_MANAGER_CREATES.clear();
+  QMD_MANAGER_CACHE.clear();
   QMD_MANAGER_OPEN_FAILURES.clear();
-  let firstError: unknown;
-  let closeFailed = false;
-  for (const scopeKey of Array.from(MEMORY_SEARCH_MANAGER_CACHE_STORE.retainedQmdManagers.keys())) {
+  for (const manager of managers) {
     try {
-      await drainRetainedQmdManagers(scopeKey);
+      await manager.close?.();
     } catch (err) {
-      if (!closeFailed) {
-        firstError = err;
-      }
-      closeFailed = true;
-    }
-  }
-  for (const [scopeKey, entry] of entries) {
-    try {
-      await entry.manager.close?.();
-      if (QMD_MANAGER_CACHE.get(scopeKey) === entry) {
-        QMD_MANAGER_CACHE.delete(scopeKey);
-      }
-    } catch (err) {
-      if (!closeFailed) {
-        firstError = err;
-      }
-      closeFailed = true;
       log.warn(`failed to close qmd memory manager: ${String(err)}`);
     }
   }
   if (managerRuntimeLoader.peek()) {
-    try {
-      const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
-      await closeAllMemoryIndexManagers();
-    } catch (err) {
-      if (!closeFailed) {
-        firstError = err;
-      }
-      closeFailed = true;
-    }
-  }
-  if (closeFailed) {
-    throw firstError;
+    const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
+    await closeAllMemoryIndexManagers();
   }
 }
 
@@ -726,70 +548,34 @@ export async function closeMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): Promise<void> {
-  const scopeKey = buildQmdManagerScopeKey(normalizeAgentId(params.agentId));
-  await runMemorySearchManagerScopeOperation(
-    scopeKey,
-    async () => await closeMemorySearchManagerWithinLifecycle(params),
-    { drainRetained: false },
-  );
-}
-
-async function closeMemorySearchManagerWithinLifecycle(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-}): Promise<void> {
   const normalizedAgentId = normalizeAgentId(params.agentId);
   const scopeKey = buildQmdManagerScopeKey(normalizedAgentId);
-  let closeError: unknown;
-  let closeFailed = false;
-  try {
-    await drainRetainedQmdManagers(scopeKey);
-  } catch (err) {
-    closeError = err;
-    closeFailed = true;
-  }
   const pending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
   if (pending) {
     await Promise.allSettled([pending.promise]);
   }
   const cached = QMD_MANAGER_CACHE.get(scopeKey);
   if (cached) {
+    QMD_MANAGER_CACHE.delete(scopeKey);
+    QMD_MANAGER_OPEN_FAILURES.delete(scopeKey);
     try {
       await cached.manager.close?.();
-      if (QMD_MANAGER_CACHE.get(scopeKey) === cached) {
-        QMD_MANAGER_CACHE.delete(scopeKey);
-      }
-      QMD_MANAGER_OPEN_FAILURES.delete(scopeKey);
     } catch (err) {
-      closeError = err;
-      closeFailed = true;
       log.warn(`failed to close qmd memory manager for agent ${normalizedAgentId}: ${String(err)}`);
     }
   }
   if (managerRuntimeLoader.peek()) {
-    try {
-      const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();
-      await closeMemoryIndexManagersForAgent({ cfg: params.cfg, agentId: normalizedAgentId });
-    } catch (err) {
-      if (!closeFailed) {
-        closeError = err;
-      }
-      closeFailed = true;
-    }
-  }
-  if (closeFailed) {
-    throw closeError;
+    const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();
+    await closeMemoryIndexManagersForAgent({ cfg: params.cfg, agentId: normalizedAgentId });
   }
 }
 
 class FallbackMemoryManager implements MemorySearchManager {
   private fallback: Maybe<MemorySearchManager> = null;
-  private fallbackInitPromise: Promise<Maybe<MemorySearchManager>> | null = null;
   private primaryFailed = false;
   private lastError?: string;
   private cacheEvicted = false;
   private closed = false;
-  private closePromise: Promise<void> | null = null;
   private closeReason = "memory search manager is closed";
 
   constructor(
@@ -950,30 +736,12 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   async close() {
-    const existingClose = this.closePromise;
-    if (existingClose) {
-      await existingClose;
+    if (this.closed) {
       return;
     }
-    const closeOperation = this.closeOnce();
-    this.closePromise = closeOperation;
-    try {
-      await closeOperation;
-    } catch (err) {
-      if (this.closePromise === closeOperation) {
-        this.closePromise = null;
-      }
-      throw err;
-    }
-  }
-
-  private async closeOnce(): Promise<void> {
     this.closed = true;
-    const pendingFallback = this.fallbackInitPromise;
     await this.deps.primary.close?.();
-    await pendingFallback;
     await this.fallback?.close?.();
-    this.fallback = null;
     this.evictCacheEntry();
   }
 
@@ -983,59 +751,29 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   private async ensureFallback(): Promise<Maybe<MemorySearchManager>> {
-    this.ensureOpen();
     if (this.fallback) {
       return this.fallback;
     }
-    const pending = this.fallbackInitPromise;
-    if (pending) {
-      const fallback = await pending;
-      this.ensureOpen();
-      return fallback;
-    }
-    const initialization = (async (): Promise<Maybe<MemorySearchManager>> => {
-      let fallback: Maybe<MemorySearchManager>;
-      try {
-        fallback = await this.deps.fallbackFactory();
-        if (!fallback) {
-          log.warn("memory fallback requested but builtin index is unavailable");
-          return null;
-        }
-      } catch (err) {
-        const message = formatErrorMessage(err);
-        log.warn(`memory fallback unavailable: ${message}`);
-        return null;
-      }
-      this.fallback = fallback;
-      if (this.closed) {
-        await fallback.close?.();
-        if (this.fallback === fallback) {
-          this.fallback = null;
-        }
-        return null;
-      }
-      return fallback;
-    })();
-    this.fallbackInitPromise = initialization;
+    let fallback: Maybe<MemorySearchManager>;
     try {
-      const fallback = await initialization;
-      this.ensureOpen();
-      return fallback;
-    } finally {
-      if (this.fallbackInitPromise === initialization) {
-        this.fallbackInitPromise = null;
+      fallback = await this.deps.fallbackFactory();
+      if (!fallback) {
+        log.warn("memory fallback requested but builtin index is unavailable");
+        return null;
       }
+    } catch (err) {
+      const message = formatErrorMessage(err);
+      log.warn(`memory fallback unavailable: ${message}`);
+      return null;
     }
+    this.fallback = fallback;
+    return this.fallback;
   }
 
   private ensureOpen(): void {
     if (this.closed) {
       throw new Error(this.closeReason);
     }
-  }
-
-  isClosed(): boolean {
-    return this.closed;
   }
 
   private evictCacheEntry(): void {

--- a/extensions/memory-lancedb/embeddings.lifecycle.test.ts
+++ b/extensions/memory-lancedb/embeddings.lifecycle.test.ts
@@ -1,0 +1,135 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "./api.js";
+import type { MemoryConfig } from "./config.js";
+
+const providerMocks = vi.hoisted(() => ({
+  getMemoryEmbeddingProvider: vi.fn(),
+  resolveDefaultAgentId: vi.fn(() => "main"),
+}));
+
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
+  getMemoryEmbeddingProvider: providerMocks.getMemoryEmbeddingProvider,
+}));
+
+vi.mock("openclaw/plugin-sdk/memory-host-core", () => ({
+  resolveDefaultAgentId: providerMocks.resolveDefaultAgentId,
+}));
+
+import { createEmbeddings } from "./embeddings.js";
+
+function createApi(): OpenClawPluginApi {
+  const config = {};
+  return {
+    config,
+    runtime: {
+      config: { current: () => config },
+      agent: { resolveAgentDir: () => "/tmp/openclaw-agent" },
+    },
+  } as unknown as OpenClawPluginApi;
+}
+
+const embeddingConfig = {
+  provider: "openai",
+  model: "text-embedding-3-small",
+} as MemoryConfig["embedding"];
+
+describe("memory-lancedb provider lifecycle", () => {
+  it("queues replacement behind close intent while provider creation is pending", async () => {
+    let releaseFirstCreate: () => void = () => {};
+    const firstCreateGate = new Promise<void>((resolve) => {
+      releaseFirstCreate = resolve;
+    });
+    const closeProvider = vi.fn(async () => {});
+    const createProvider = vi.fn(async () => {
+      if (createProvider.mock.calls.length === 1) {
+        await firstCreateGate;
+      }
+      return {
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: vi.fn(async () => [0.1, 0.2, 0.3]),
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+          close: closeProvider,
+        },
+      };
+    });
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: createProvider,
+    });
+
+    const first = createEmbeddings(createApi(), { embedding: embeddingConfig } as MemoryConfig);
+    const firstEmbed = first.embed("first");
+    await vi.waitFor(() => expect(createProvider).toHaveBeenCalledTimes(1));
+
+    const closePromise = first.close?.();
+    const replacement = createEmbeddings(createApi(), {
+      embedding: embeddingConfig,
+    } as MemoryConfig);
+    const replacementEmbed = replacement.embed("replacement");
+    await Promise.resolve();
+    expect(createProvider).toHaveBeenCalledTimes(1);
+
+    releaseFirstCreate();
+    await firstEmbed;
+    await closePromise;
+    await replacementEmbed;
+
+    expect(closeProvider).toHaveBeenCalledTimes(1);
+    expect(createProvider).toHaveBeenCalledTimes(2);
+    expect(
+      expectDefined(closeProvider.mock.invocationCallOrder[0], "pending provider close order"),
+    ).toBeLessThan(
+      expectDefined(createProvider.mock.invocationCallOrder[1], "replacement create order"),
+    );
+    await replacement.close?.();
+  });
+
+  it("does not re-close a provider retired while an older provider still fails", async () => {
+    const closeOlder = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("older close failed once"))
+      .mockRejectedValueOnce(new Error("older close failed twice"))
+      .mockResolvedValue(undefined);
+    const closeCurrent = vi.fn(async () => {});
+    const createProvider = vi
+      .fn()
+      .mockResolvedValueOnce({
+        provider: {
+          id: "openai",
+          model: "older",
+          embedQuery: vi.fn(async () => [0.1]),
+          embedBatch: vi.fn(async () => [[0.1]]),
+          close: closeOlder,
+        },
+      })
+      .mockResolvedValueOnce({
+        provider: {
+          id: "openai",
+          model: "current",
+          embedQuery: vi.fn(async () => [0.2]),
+          embedBatch: vi.fn(async () => [[0.2]]),
+          close: closeCurrent,
+        },
+      });
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: createProvider,
+    });
+
+    const older = createEmbeddings(createApi(), { embedding: embeddingConfig } as MemoryConfig);
+    const current = createEmbeddings(createApi(), { embedding: embeddingConfig } as MemoryConfig);
+    await older.embed("older");
+    await current.embed("current");
+
+    await expect(older.close?.()).rejects.toThrow("older close failed once");
+    await expect(current.close?.()).rejects.toThrow("older close failed twice");
+    expect(closeCurrent).toHaveBeenCalledTimes(1);
+
+    await expect(current.close?.()).resolves.toBeUndefined();
+    expect(closeOlder).toHaveBeenCalledTimes(3);
+    expect(closeCurrent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/memory-lancedb/embeddings.lifecycle.test.ts
+++ b/extensions/memory-lancedb/embeddings.lifecycle.test.ts
@@ -132,4 +132,48 @@ describe("memory-lancedb provider lifecycle", () => {
     expect(closeOlder).toHaveBeenCalledTimes(3);
     expect(closeCurrent).toHaveBeenCalledTimes(1);
   });
+
+  it("drains an admitted embedding before provider close", async () => {
+    let markEmbedStarted: () => void = () => {};
+    const embedStarted = new Promise<void>((resolve) => {
+      markEmbedStarted = resolve;
+    });
+    let releaseEmbed: () => void = () => {};
+    const embedGate = new Promise<void>((resolve) => {
+      releaseEmbed = resolve;
+    });
+    const closeProvider = vi.fn(async () => {});
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: vi.fn(async () => ({
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: vi.fn(async () => {
+            markEmbedStarted();
+            await embedGate;
+            return [0.1, 0.2, 0.3];
+          }),
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+          close: closeProvider,
+        },
+      })),
+    });
+
+    const embeddings = createEmbeddings(createApi(), {
+      embedding: embeddingConfig,
+    } as MemoryConfig);
+    const embedPromise = embeddings.embed("active");
+    await embedStarted;
+    const closePromise = embeddings.close?.();
+    await Promise.resolve();
+
+    expect(closeProvider).not.toHaveBeenCalled();
+    await expect(embeddings.embed("late")).rejects.toThrow("memory-lancedb embeddings are closed");
+
+    releaseEmbed();
+    await expect(embedPromise).resolves.toEqual([0.1, 0.2, 0.3]);
+    await closePromise;
+    expect(closeProvider).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/memory-lancedb/embeddings.ts
+++ b/extensions/memory-lancedb/embeddings.ts
@@ -197,6 +197,8 @@ class ProviderAdapterEmbeddings implements Embeddings {
   private providerPromise: Promise<MemoryEmbeddingProvider> | undefined;
   private closePromise: Promise<void> | null = null;
   private closed = false;
+  private activeUses = 0;
+  private idleWaiters = new Set<() => void>();
 
   constructor(
     private api: OpenClawPluginApi,
@@ -204,9 +206,6 @@ class ProviderAdapterEmbeddings implements Embeddings {
   ) {}
 
   private getProvider(): Promise<MemoryEmbeddingProvider> {
-    if (this.closed) {
-      throw new Error("memory-lancedb embeddings are closed");
-    }
     // Auth profiles and local providers can be repaired while the Gateway stays up.
     // Cache successful setup, but retry after failed provider discovery/auth.
     this.providerPromise ??= this.createProvider().catch((err: unknown) => {
@@ -214,6 +213,37 @@ class ProviderAdapterEmbeddings implements Embeddings {
       throw err;
     });
     return this.providerPromise;
+  }
+
+  private acquireUse(): () => void {
+    if (this.closed) {
+      throw new Error("memory-lancedb embeddings are closed");
+    }
+    this.activeUses += 1;
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.activeUses -= 1;
+      if (this.activeUses === 0) {
+        const waiters = Array.from(this.idleWaiters);
+        this.idleWaiters.clear();
+        for (const resolve of waiters) {
+          resolve();
+        }
+      }
+    };
+  }
+
+  private async awaitIdle(): Promise<void> {
+    if (this.activeUses === 0) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      this.idleWaiters.add(resolve);
+    });
   }
 
   private async createProvider(): Promise<MemoryEmbeddingProvider> {
@@ -259,23 +289,28 @@ class ProviderAdapterEmbeddings implements Embeddings {
   }
 
   async embed(text: string, options?: { timeoutMs?: number }): Promise<number[]> {
-    const provider = await this.getProvider();
-    if (!options?.timeoutMs) {
-      return await provider.embedQuery(text);
-    }
-    const controller = new AbortController();
-    let timer: ReturnType<typeof setTimeout> | undefined;
+    const releaseUse = this.acquireUse();
     try {
-      timer = setTimeout(
-        () => controller.abort(new Error("memory-lancedb embedding timed out")),
-        resolveTimerTimeoutMs(options.timeoutMs, 1),
-      );
-      timer.unref?.();
-      return await provider.embedQuery(text, { signal: controller.signal });
-    } finally {
-      if (timer) {
-        clearTimeout(timer);
+      const provider = await this.getProvider();
+      if (!options?.timeoutMs) {
+        return await provider.embedQuery(text);
       }
+      const controller = new AbortController();
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        timer = setTimeout(
+          () => controller.abort(new Error("memory-lancedb embedding timed out")),
+          resolveTimerTimeoutMs(options.timeoutMs, 1),
+        );
+        timer.unref?.();
+        return await provider.embedQuery(text, { signal: controller.signal });
+      } finally {
+        if (timer) {
+          clearTimeout(timer);
+        }
+      }
+    } finally {
+      releaseUse();
     }
   }
 
@@ -301,6 +336,9 @@ class ProviderAdapterEmbeddings implements Embeddings {
     this.closed = true;
     const providerPromise = this.providerPromise;
     await runProviderAdapterLifecycle(async () => {
+      // Close intent is queued before waiting. Replacement instances therefore remain
+      // behind this owner while already-admitted embeddings drain to completion.
+      await this.awaitIdle();
       const provider = await providerPromise?.catch(() => null);
       if (provider) {
         PROVIDER_ADAPTER_LIFECYCLE.retainedProviders.add(provider);

--- a/extensions/memory-lancedb/embeddings.ts
+++ b/extensions/memory-lancedb/embeddings.ts
@@ -1,6 +1,8 @@
 import { Buffer } from "node:buffer";
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
+import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { MemoryEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
@@ -27,6 +29,46 @@ export type Embeddings = {
   embed(text: string, options?: { timeoutMs?: number }): Promise<number[]>;
   close?(): Promise<void>;
 };
+
+type ProviderAdapterLifecycleState = {
+  retainedProviders: Set<MemoryEmbeddingProvider>;
+  tail: Promise<void>;
+};
+
+const PROVIDER_ADAPTER_LIFECYCLE = resolveGlobalSingleton<ProviderAdapterLifecycleState>(
+  Symbol.for("openclaw.memoryLanceDbEmbeddingProviderLifecycle.v1"),
+  // Plugin reload replaces the service instance. Retain failed closes process-wide so
+  // the next instance cannot create a provider before its predecessor retires.
+  () => ({ retainedProviders: new Set(), tail: Promise.resolve() }),
+);
+
+function runProviderAdapterLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+  const result = PROVIDER_ADAPTER_LIFECYCLE.tail.then(operation, operation);
+  PROVIDER_ADAPTER_LIFECYCLE.tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+async function drainRetainedProviders(): Promise<void> {
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const provider of PROVIDER_ADAPTER_LIFECYCLE.retainedProviders) {
+    try {
+      await provider.close?.();
+      PROVIDER_ADAPTER_LIFECYCLE.retainedProviders.delete(provider);
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (closeFailed) {
+    throw toErrorObject(firstError, "memory-lancedb embedding provider retirement failed");
+  }
+}
 
 class OpenAiCompatibleEmbeddings implements Embeddings {
   private clientPromise: Promise<OpenAiEmbeddingClient>;
@@ -175,6 +217,13 @@ class ProviderAdapterEmbeddings implements Embeddings {
   }
 
   private async createProvider(): Promise<MemoryEmbeddingProvider> {
+    return await runProviderAdapterLifecycle(async () => {
+      await drainRetainedProviders();
+      return await this.createProviderAfterRetirement();
+    });
+  }
+
+  private async createProviderAfterRetirement(): Promise<MemoryEmbeddingProvider> {
     const cfg = (this.api.runtime.config?.current?.() ?? this.api.config) as OpenClawConfig;
     const providerId = this.embedding.provider;
     const { getMemoryEmbeddingProvider } = await loadMemoryEmbeddingProviderModule();
@@ -251,14 +300,21 @@ class ProviderAdapterEmbeddings implements Embeddings {
   private async closeOnce(): Promise<void> {
     this.closed = true;
     const providerPromise = this.providerPromise;
-    if (!providerPromise) {
-      return;
-    }
-    const provider = await providerPromise.catch(() => null);
-    await provider?.close?.();
-    if (this.providerPromise === providerPromise) {
-      this.providerPromise = undefined;
-    }
+    await runProviderAdapterLifecycle(async () => {
+      const provider = await providerPromise?.catch(() => null);
+      if (provider) {
+        PROVIDER_ADAPTER_LIFECYCLE.retainedProviders.add(provider);
+      }
+      try {
+        await drainRetainedProviders();
+      } finally {
+        // Ownership moved to the process-global retained set before draining. Clear the
+        // instance even when another retained provider fails, so successful closes stay final.
+        if (this.providerPromise === providerPromise) {
+          this.providerPromise = undefined;
+        }
+      }
+    });
   }
 }
 

--- a/extensions/memory-lancedb/embeddings.ts
+++ b/extensions/memory-lancedb/embeddings.ts
@@ -25,6 +25,7 @@ const loadMemoryHostCoreModule = createLazyRuntimeModule(
 
 export type Embeddings = {
   embed(text: string, options?: { timeoutMs?: number }): Promise<number[]>;
+  close?(): Promise<void>;
 };
 
 class OpenAiCompatibleEmbeddings implements Embeddings {
@@ -152,6 +153,8 @@ function truncateEmbeddingVector(embedding: number[], dimensions: number, model:
 
 class ProviderAdapterEmbeddings implements Embeddings {
   private providerPromise: Promise<MemoryEmbeddingProvider> | undefined;
+  private closePromise: Promise<void> | null = null;
+  private closed = false;
 
   constructor(
     private api: OpenClawPluginApi,
@@ -159,6 +162,9 @@ class ProviderAdapterEmbeddings implements Embeddings {
   ) {}
 
   private getProvider(): Promise<MemoryEmbeddingProvider> {
+    if (this.closed) {
+      throw new Error("memory-lancedb embeddings are closed");
+    }
     // Auth profiles and local providers can be repaired while the Gateway stays up.
     // Cache successful setup, but retry after failed provider discovery/auth.
     this.providerPromise ??= this.createProvider().catch((err: unknown) => {
@@ -221,6 +227,37 @@ class ProviderAdapterEmbeddings implements Embeddings {
       if (timer) {
         clearTimeout(timer);
       }
+    }
+  }
+
+  async close(): Promise<void> {
+    const existingClose = this.closePromise;
+    if (existingClose) {
+      await existingClose;
+      return;
+    }
+    const closeOperation = this.closeOnce();
+    this.closePromise = closeOperation;
+    try {
+      await closeOperation;
+    } catch (err) {
+      if (this.closePromise === closeOperation) {
+        this.closePromise = null;
+      }
+      throw err;
+    }
+  }
+
+  private async closeOnce(): Promise<void> {
+    this.closed = true;
+    const providerPromise = this.providerPromise;
+    if (!providerPromise) {
+      return;
+    }
+    const provider = await providerPromise.catch(() => null);
+    await provider?.close?.();
+    if (this.providerPromise === providerPromise) {
+      this.providerPromise = undefined;
     }
   }
 }

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -566,7 +566,7 @@ describe("memory plugin e2e", () => {
     ]);
   });
 
-  test("uses provider adapter auth when embedding apiKey is omitted", async () => {
+  test("uses provider adapter auth and drains cleanup before service replacement", async () => {
     const embedQuery = vi.fn(async () => [0.1, 0.2, 0.3]);
     const closeProvider = vi
       .fn<() => Promise<void>>()
@@ -684,14 +684,43 @@ describe("memory plugin e2e", () => {
       expect(providerOptions.fallback).toBe("none");
       expect(providerOptions.model).toBe("text-embedding-3-small");
       expect(providerOptions).not.toHaveProperty("remote");
-      expect(embedQuery).toHaveBeenCalledWith("project memory", {
-        signal: expect.any(AbortSignal),
-      });
       const service = firstObjectArg(registerService as unknown as MockCallSource, "service");
       const stop = service.stop as () => Promise<void>;
       await expect(stop()).rejects.toThrow("provider close failed");
-      await expect(stop()).resolves.toBeUndefined();
+
+      const replacementRegisterTool = vi.fn();
+      const replacementRegisterService = vi.fn();
+      registerTestPlugin(dynamicMemoryPlugin, {
+        ...mockApi,
+        registerTool: replacementRegisterTool,
+        registerService: replacementRegisterService,
+      });
+      const replacementRecallTool = replacementRegisterTool.mock.calls
+        .map(([tool]) => materializeRegisteredTool(tool))
+        .find((tool) => tool.name === "memory_recall");
+      if (!replacementRecallTool) {
+        throw new Error("expected replacement memory_recall tool registration");
+      }
+      await replacementRecallTool.execute("call-2", { query: "replacement memory" });
+
       expect(closeProvider).toHaveBeenCalledTimes(2);
+      expect(createProvider).toHaveBeenCalledTimes(2);
+      expect(embedQuery).toHaveBeenCalledWith("project memory", {
+        signal: expect.any(AbortSignal),
+      });
+      expect(
+        expectDefined(closeProvider.mock.invocationCallOrder[1], "retained provider close order"),
+      ).toBeLessThan(
+        expectDefined(
+          createProvider.mock.invocationCallOrder[1],
+          "replacement provider create order",
+        ),
+      );
+      const replacementService = firstObjectArg(
+        replacementRegisterService as unknown as MockCallSource,
+        "replacement service",
+      );
+      await (replacementService.stop as () => Promise<void>)();
     } finally {
       vi.doUnmock("openclaw/plugin-sdk/memory-core-host-engine-embeddings");
       vi.doUnmock("openai");

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -568,12 +568,17 @@ describe("memory plugin e2e", () => {
 
   test("uses provider adapter auth when embedding apiKey is omitted", async () => {
     const embedQuery = vi.fn(async () => [0.1, 0.2, 0.3]);
+    const closeProvider = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("provider close failed"))
+      .mockResolvedValue(undefined);
     const createProvider = vi.fn(async (options: Record<string, unknown>) => ({
       provider: {
         id: "openai",
         model: options.model,
         embedQuery,
         embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+        close: closeProvider,
       },
     }));
     const getMemoryEmbeddingProvider = vi.fn(() => ({
@@ -586,12 +591,14 @@ describe("memory plugin e2e", () => {
     const loadLanceDbModule = vi.fn(async () => ({
       connect: vi.fn(async () => ({
         tableNames: vi.fn(async () => ["memories"]),
+        close: vi.fn(),
         openTable: vi.fn(async () => ({
           schema: createAgentScopedSchemaMock(),
           vectorSearch,
           countRows: vi.fn(async () => 0),
           add: vi.fn(async () => undefined),
           delete: vi.fn(async () => undefined),
+          close: vi.fn(),
         })),
       })),
     }));
@@ -621,6 +628,7 @@ describe("memory plugin e2e", () => {
         },
       };
       const registerTool = vi.fn();
+      const registerService = vi.fn();
       const mockApi = {
         id: "memory-lancedb",
         name: "Memory (LanceDB)",
@@ -649,7 +657,7 @@ describe("memory plugin e2e", () => {
         },
         registerTool,
         registerCli: vi.fn(),
-        registerService: vi.fn(),
+        registerService,
         on: vi.fn(),
         resolvePath: (filePath: string) => filePath,
       };
@@ -679,6 +687,11 @@ describe("memory plugin e2e", () => {
       expect(embedQuery).toHaveBeenCalledWith("project memory", {
         signal: expect.any(AbortSignal),
       });
+      const service = firstObjectArg(registerService as unknown as MockCallSource, "service");
+      const stop = service.stop as () => Promise<void>;
+      await expect(stop()).rejects.toThrow("provider close failed");
+      await expect(stop()).resolves.toBeUndefined();
+      expect(closeProvider).toHaveBeenCalledTimes(2);
     } finally {
       vi.doUnmock("openclaw/plugin-sdk/memory-core-host-engine-embeddings");
       vi.doUnmock("openai");

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -655,10 +655,14 @@ export default definePluginEntry({
           `memory-lancedb: initialized (db: ${resolvedDbPath}, model: ${cfg.embedding.model})`,
         );
       },
-      stop: () => {
-        db.close();
-        memoryRecallCooldowns.clear();
-        api.logger.info("memory-lancedb: stopped");
+      stop: async () => {
+        try {
+          await embeddings.close?.();
+        } finally {
+          db.close();
+          memoryRecallCooldowns.clear();
+          api.logger.info("memory-lancedb: stopped");
+        }
       },
     });
   },

--- a/extensions/memory-lancedb/memory-cli.test.ts
+++ b/extensions/memory-lancedb/memory-cli.test.ts
@@ -1,0 +1,87 @@
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "./api.js";
+import type { Embeddings } from "./embeddings.js";
+import type { MemoryDB } from "./lancedb-store.js";
+import { registerMemoryCli } from "./memory-cli.js";
+
+function createHarness(params?: { embedError?: unknown; closeError?: Error }) {
+  const registerCli = vi.fn();
+  const closeError = params?.closeError;
+  const close = closeError
+    ? vi.fn(async () => {
+        throw closeError;
+      })
+    : vi.fn(async () => {});
+  const embed =
+    params && Object.hasOwn(params, "embedError")
+      ? vi.fn(async () => {
+          throw params.embedError;
+        })
+      : vi.fn(async () => [0.1, 0.2]);
+  const embeddings: Embeddings = {
+    embed,
+    close,
+  };
+  const search = vi.fn(async () => []);
+  registerMemoryCli(
+    { registerCli } as unknown as OpenClawPluginApi,
+    { search } as unknown as MemoryDB,
+    embeddings,
+    () => "main",
+    undefined,
+  );
+  const registrar = registerCli.mock.calls[0]?.[0] as
+    | ((params: { program: Command }) => void)
+    | undefined;
+  if (!registrar) {
+    throw new Error("expected memory CLI registrar");
+  }
+  const program = new Command();
+  registrar({ program });
+  return { close, embed, program, search };
+}
+
+describe("memory-lancedb CLI embedding lifecycle", () => {
+  it("closes embeddings after search", async () => {
+    const harness = createHarness();
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      await harness.program.parseAsync(["node", "openclaw", "ltm", "search", "hello"]);
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(harness.embed).toHaveBeenCalledTimes(1);
+    expect(harness.search).toHaveBeenCalledTimes(1);
+    expect(harness.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes embeddings without masking search failure", async () => {
+    const harness = createHarness({
+      embedError: new Error("embedding failed"),
+      closeError: new Error("close failed"),
+    });
+
+    await expect(
+      harness.program.parseAsync(["node", "openclaw", "ltm", "search", "hello"]),
+    ).rejects.toThrow("embedding failed");
+    expect(harness.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a falsy search rejection over cleanup failure", async () => {
+    const harness = createHarness({
+      embedError: null,
+      closeError: new Error("close failed"),
+    });
+
+    const rejection = await harness.program
+      .parseAsync(["node", "openclaw", "ltm", "search", "hello"])
+      .then(
+        () => "resolved",
+        (err: unknown) => err,
+      );
+    expect(rejection).toBeNull();
+    expect(harness.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/memory-lancedb/memory-cli.ts
+++ b/extensions/memory-lancedb/memory-cli.ts
@@ -134,18 +134,39 @@ export function registerMemoryCli(
         .option("--agent <id>", "Agent id (default: configured default agent)")
         .option("--limit <n>", "Max results", "5")
         .action(async (query, opts) => {
-          const agentId = resolveCliAgentId(opts.agent);
-          const vector = await embeddings.embed(normalizeRecallQuery(query, recallMaxChars));
-          const limit = parsePositiveIntegerOption(opts.limit, "--limit");
-          const results = await db.search(agentId, vector, limit, 0.3);
-          const output = results.map((r) => ({
-            id: r.entry.id,
-            text: r.entry.text,
-            category: r.entry.category,
-            importance: r.entry.importance,
-            score: r.score,
-          }));
-          console.log(JSON.stringify(output, null, 2));
+          let operationError: unknown;
+          let operationFailed = false;
+          try {
+            const agentId = resolveCliAgentId(opts.agent);
+            const vector = await embeddings.embed(normalizeRecallQuery(query, recallMaxChars));
+            const limit = parsePositiveIntegerOption(opts.limit, "--limit");
+            const results = await db.search(agentId, vector, limit, 0.3);
+            const output = results.map((r) => ({
+              id: r.entry.id,
+              text: r.entry.text,
+              category: r.entry.category,
+              importance: r.entry.importance,
+              score: r.score,
+            }));
+            console.log(JSON.stringify(output, null, 2));
+          } catch (err) {
+            operationError = err;
+            operationFailed = true;
+          }
+          let closeError: unknown;
+          let closeFailed = false;
+          try {
+            await embeddings.close?.();
+          } catch (err) {
+            closeError = err;
+            closeFailed = true;
+          }
+          if (operationFailed) {
+            throw operationError;
+          }
+          if (closeFailed) {
+            throw closeError;
+          }
         });
 
       memory

--- a/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
@@ -188,3 +188,46 @@ it("retries failed construction cleanup without another provider creation", asyn
   expect(forkMock).toHaveBeenCalledTimes(1);
   expect(failedChild.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"], ["SIGTERM"]]);
 });
+
+it("retries failed provider close without another owner call", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    connected: true,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    disconnect: vi.fn(function (this: { connected: boolean }) {
+      this.connected = false;
+    }),
+    kill: vi.fn(function (this: EventEmitter, _signal?: NodeJS.Signals) {
+      queueMicrotask(() => this.emit("error", new Error("kill failed")));
+      return false;
+    }),
+    send: vi.fn(function (
+      this: EventEmitter,
+      message: { id: number },
+      callback: (err?: Error | null) => void,
+    ) {
+      callback();
+      queueMicrotask(() => this.emit("message", { id: message.id, ok: true }));
+      return true;
+    }),
+  });
+  forkMock.mockReturnValue(child);
+  const provider = await createLocalEmbeddingWorkerProvider(
+    { config: {} as never, provider: "local", model: "", fallback: "none" },
+    { workerScriptPath: "/mock/worker.cjs" },
+  );
+
+  await expect(provider.close?.()).rejects.toThrow("did not exit after SIGKILL");
+  child.kill.mockImplementationOnce(function (
+    this: typeof child,
+    signal: NodeJS.Signals = "SIGTERM",
+  ) {
+    this.signalCode = signal;
+    queueMicrotask(() => this.emit("close", null, signal));
+    return true;
+  });
+  await vi.waitFor(() => expect(child.kill).toHaveBeenCalledTimes(3), { timeout: 2_000 });
+
+  expect(forkMock).toHaveBeenCalledTimes(1);
+  expect(child.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"], ["SIGTERM"]]);
+});

--- a/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
@@ -57,3 +57,81 @@ it("terminates a disconnected live worker without forking a replacement", async 
   expect(child.send).toHaveBeenCalledTimes(1);
   expect(child.kill).toHaveBeenCalledExactlyOnceWith("SIGTERM");
 });
+
+it("drains failed construction clients before forking another worker", async () => {
+  const failedChild = Object.assign(new EventEmitter(), {
+    connected: true,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    disconnect: vi.fn(function (this: { connected: boolean }) {
+      this.connected = false;
+    }),
+    kill: vi.fn(function (this: EventEmitter, _signal?: NodeJS.Signals) {
+      queueMicrotask(() => this.emit("error", new Error("kill failed")));
+      return false;
+    }),
+    send: vi.fn(function (
+      this: EventEmitter,
+      message: { id: number; type: string },
+      callback: (err?: Error | null) => void,
+    ) {
+      callback();
+      queueMicrotask(() =>
+        this.emit(
+          "message",
+          message.type === "initialize"
+            ? { id: message.id, ok: false, error: "initialization failed" }
+            : { id: message.id, ok: true },
+        ),
+      );
+      return true;
+    }),
+  });
+  const replacementChild = Object.assign(new EventEmitter(), {
+    connected: true,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    disconnect: vi.fn(function (this: { connected: boolean }) {
+      this.connected = false;
+    }),
+    kill: vi.fn(function (
+      this: EventEmitter & { signalCode: NodeJS.Signals | null },
+      signal: NodeJS.Signals,
+    ) {
+      this.signalCode = signal;
+      queueMicrotask(() => this.emit("close", null, signal));
+      return true;
+    }),
+    send: vi.fn(function (
+      this: EventEmitter,
+      message: { id: number },
+      callback: (err?: Error | null) => void,
+    ) {
+      callback();
+      queueMicrotask(() => this.emit("message", { id: message.id, ok: true }));
+      return true;
+    }),
+  });
+  forkMock.mockReturnValueOnce(failedChild).mockReturnValueOnce(replacementChild);
+  const options = { config: {} as never, provider: "local", model: "", fallback: "none" };
+
+  await expect(
+    createLocalEmbeddingWorkerProvider(options, { workerScriptPath: "/mock/worker.cjs" }),
+  ).rejects.toThrow("initialization failed");
+  expect(forkMock).toHaveBeenCalledTimes(1);
+
+  failedChild.kill.mockImplementationOnce(function (
+    this: typeof failedChild,
+    signal: NodeJS.Signals = "SIGTERM",
+  ) {
+    this.signalCode = signal;
+    queueMicrotask(() => this.emit("close", null, signal));
+    return true;
+  });
+  const provider = await createLocalEmbeddingWorkerProvider(options, {
+    workerScriptPath: "/mock/worker.cjs",
+  });
+  expect(forkMock).toHaveBeenCalledTimes(2);
+
+  await expect(provider.close?.()).resolves.toBeUndefined();
+});

--- a/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
@@ -1,0 +1,59 @@
+// Memory Host SDK tests cover embedding worker process ownership edge cases.
+import { EventEmitter } from "node:events";
+import { beforeEach, expect, it, vi } from "vitest";
+
+const forkMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    fork: forkMock,
+  };
+});
+
+import { createLocalEmbeddingWorkerProvider } from "./embeddings-worker.js";
+
+beforeEach(() => {
+  forkMock.mockReset();
+});
+
+it("terminates a disconnected live worker without forking a replacement", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    connected: true,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    disconnect: vi.fn(function (this: { connected: boolean }) {
+      this.connected = false;
+    }),
+    kill: vi.fn(function (
+      this: EventEmitter & { signalCode: NodeJS.Signals | null },
+      signal: NodeJS.Signals,
+    ) {
+      this.signalCode = signal;
+      queueMicrotask(() => this.emit("close", null, signal));
+      return true;
+    }),
+    send: vi.fn(function (
+      this: EventEmitter,
+      message: { id: number },
+      callback: (err?: Error | null) => void,
+    ) {
+      callback();
+      queueMicrotask(() => this.emit("message", { id: message.id, ok: true }));
+      return true;
+    }),
+  });
+  forkMock.mockReturnValue(child);
+  const provider = await createLocalEmbeddingWorkerProvider(
+    { config: {} as never, provider: "local", model: "", fallback: "none" },
+    { workerScriptPath: "/mock/worker.cjs" },
+  );
+  child.connected = false;
+
+  await expect(provider.close?.()).resolves.toBeUndefined();
+
+  expect(forkMock).toHaveBeenCalledTimes(1);
+  expect(child.send).toHaveBeenCalledTimes(1);
+  expect(child.kill).toHaveBeenCalledExactlyOnceWith("SIGTERM");
+});

--- a/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
@@ -135,3 +135,56 @@ it("drains failed construction clients before forking another worker", async () 
 
   await expect(provider.close?.()).resolves.toBeUndefined();
 });
+
+it("retries failed construction cleanup without another provider creation", async () => {
+  const failedChild = Object.assign(new EventEmitter(), {
+    connected: true,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    disconnect: vi.fn(function (this: { connected: boolean }) {
+      this.connected = false;
+    }),
+    kill: vi.fn(function (this: EventEmitter, _signal?: NodeJS.Signals) {
+      queueMicrotask(() => this.emit("error", new Error("kill failed")));
+      return false;
+    }),
+    send: vi.fn(function (
+      this: EventEmitter,
+      message: { id: number; type: string },
+      callback: (err?: Error | null) => void,
+    ) {
+      callback();
+      queueMicrotask(() =>
+        this.emit(
+          "message",
+          message.type === "initialize"
+            ? { id: message.id, ok: false, error: "initialization failed" }
+            : { id: message.id, ok: true },
+        ),
+      );
+      return true;
+    }),
+  });
+  forkMock.mockReturnValue(failedChild);
+
+  await expect(
+    createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: "/mock/worker.cjs" },
+    ),
+  ).rejects.toThrow("initialization failed");
+  expect(forkMock).toHaveBeenCalledTimes(1);
+
+  failedChild.kill.mockImplementationOnce(function (
+    this: typeof failedChild,
+    signal: NodeJS.Signals = "SIGTERM",
+  ) {
+    this.signalCode = signal;
+    queueMicrotask(() => this.emit("close", null, signal));
+    return true;
+  });
+  await vi.waitFor(() => expect(failedChild.kill).toHaveBeenCalledTimes(3), { timeout: 2_000 });
+
+  expect(forkMock).toHaveBeenCalledTimes(1);
+  expect(failedChild.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"], ["SIGTERM"]]);
+});

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -448,6 +448,7 @@ export async function createLocalEmbeddingWorkerProvider(
     throw err;
   }
   let closed = false;
+  let closePromise: Promise<void> | null = null;
 
   const throwIfClosed = () => {
     if (closed) {
@@ -467,11 +468,11 @@ export async function createLocalEmbeddingWorkerProvider(
       return await client.embedBatch(workerOptions, texts, callOptions);
     },
     close: async () => {
-      if (closed) {
-        return;
+      if (!closePromise) {
+        closed = true;
+        closePromise = client.close();
       }
-      closed = true;
-      await client.close();
+      await closePromise;
     },
   };
   attachLocalEmbeddingRuntimeFacts(provider, () => client.getRuntimeFacts());

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -520,9 +520,12 @@ class LocalEmbeddingWorkerClient {
 }
 
 const FAILED_CONSTRUCTION_CLIENTS = new Set<LocalEmbeddingWorkerClient>();
+const FAILED_CONSTRUCTION_DRAIN_RETRY_MS = 1_000;
 let workerProviderCreationTail: Promise<void> = Promise.resolve();
+let failedConstructionDrainPromise: Promise<void> | null = null;
+let failedConstructionDrainTimer: NodeJS.Timeout | null = null;
 
-async function drainFailedConstructionClients(): Promise<void> {
+async function drainFailedConstructionClientsNow(): Promise<void> {
   let firstError: unknown;
   let closeFailed = false;
   for (const client of FAILED_CONSTRUCTION_CLIENTS) {
@@ -539,6 +542,37 @@ async function drainFailedConstructionClients(): Promise<void> {
   if (closeFailed) {
     throw firstError;
   }
+}
+
+function scheduleFailedConstructionDrain(): void {
+  if (FAILED_CONSTRUCTION_CLIENTS.size === 0 || failedConstructionDrainTimer) {
+    return;
+  }
+  failedConstructionDrainTimer = setTimeout(() => {
+    failedConstructionDrainTimer = null;
+    void drainFailedConstructionClients().catch(() => {});
+  }, FAILED_CONSTRUCTION_DRAIN_RETRY_MS);
+  failedConstructionDrainTimer.unref?.();
+}
+
+async function drainFailedConstructionClients(): Promise<void> {
+  if (failedConstructionDrainPromise) {
+    return await failedConstructionDrainPromise;
+  }
+  if (failedConstructionDrainTimer) {
+    clearTimeout(failedConstructionDrainTimer);
+    failedConstructionDrainTimer = null;
+  }
+  const drain = drainFailedConstructionClientsNow();
+  failedConstructionDrainPromise = drain;
+  const settle = () => {
+    if (failedConstructionDrainPromise === drain) {
+      failedConstructionDrainPromise = null;
+    }
+    scheduleFailedConstructionDrain();
+  };
+  void drain.then(settle, settle);
+  return await drain;
 }
 
 /** Create the public local embedding provider backed by the child worker client. */
@@ -574,6 +608,7 @@ async function createLocalEmbeddingWorkerProviderOnce(
       await client.close();
     } catch {
       FAILED_CONSTRUCTION_CLIENTS.add(client);
+      scheduleFailedConstructionDrain();
     }
     throw err;
   }

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -152,6 +152,55 @@ const WORKER_UNSAFE_EXEC_ARGV_OPTION_PREFIXES = [
 
 const WORKER_CLOSE_GRACE_MS = 250;
 
+type WorkerTerminationWaitResult = {
+  terminated: boolean;
+  error?: unknown;
+};
+
+/** Wait for a confirmed terminal child event while remembering process errors. */
+async function waitForWorkerTermination(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<WorkerTerminationWaitResult> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { terminated: true };
+  }
+  return await new Promise<WorkerTerminationWaitResult>((resolve) => {
+    let processError: unknown;
+    const cleanup = () => {
+      child.off("exit", onTerminated);
+      child.off("close", onTerminated);
+      child.off("error", onError);
+      clearTimeout(timeout);
+    };
+    const settle = (result: WorkerTerminationWaitResult) => {
+      cleanup();
+      resolve(result);
+    };
+    const onTerminated = () => settle({ terminated: true });
+    const onError = (err: unknown) => {
+      processError ??= err;
+    };
+    child.once("exit", onTerminated);
+    child.once("close", onTerminated);
+    child.on("error", onError);
+    const timeout = setTimeout(() => settle({ terminated: false, error: processError }), timeoutMs);
+    timeout.unref?.();
+  });
+}
+
+/** Send a worker signal without letting synchronous or reported failures hang shutdown. */
+function signalWorker(child: ChildProcess, signal: NodeJS.Signals): unknown {
+  try {
+    if (!child.kill(signal)) {
+      return new Error(`Failed to send ${signal} to local embedding worker`);
+    }
+  } catch (err) {
+    return err;
+  }
+  return undefined;
+}
+
 /** Drop execArgv flags that would make forked workers debug/eval stateful or unsafe. */
 function resolveWorkerExecArgv(): string[] {
   const args: string[] = [];
@@ -220,6 +269,9 @@ class LocalEmbeddingWorkerClient {
   async close(): Promise<void> {
     if (this.closed) {
       await this.shutdownPromise;
+      if (this.child) {
+        await this.shutdownChild();
+      }
       return;
     }
     this.closed = true;
@@ -256,7 +308,7 @@ class LocalEmbeddingWorkerClient {
     if (gracefulCloseError) {
       process.emitWarning(
         toErrorObject(gracefulCloseError, "Local embedding worker graceful close failed"),
-        { code: "OPENCLAW_EMBEDDING_WORKER_CLOSE" },
+        { code: "LOCAL_EMBEDDING_WORKER_CLOSE" },
       );
     }
   }
@@ -279,10 +331,16 @@ class LocalEmbeddingWorkerClient {
       }
       this.rejectPending(createWorkerExitError(code, signal));
     });
-    child.on("error", (err) => {
+    child.on("close", () => {
+      // Spawn failures can close without an exit event. Close is terminal, so
+      // the next request may safely create a replacement worker.
       if (this.child === child) {
         this.child = null;
       }
+    });
+    child.on("error", (err) => {
+      // An error does not guarantee that the process exited. Keep the handle so
+      // close can retry termination instead of spawning beside an unknown child.
       this.rejectPending(
         createLocalEmbeddingWorkerFailureError({
           message: `Local embedding worker process failed: ${err.message}`,
@@ -376,11 +434,22 @@ class LocalEmbeddingWorkerClient {
       return this.shutdownPromise;
     }
     const child = this.child;
-    this.child = null;
     if (!child) {
       return Promise.resolve();
     }
-    const shutdown = this.stopChild(child);
+    const shutdown = this.stopChild(child).then(
+      () => {
+        if (this.child === child) {
+          this.child = null;
+        }
+      },
+      (err: unknown) => {
+        // A failed termination leaves ownership with this client. Prevent any
+        // later request from starting a replacement until close succeeds.
+        this.closed = true;
+        throw err;
+      },
+    );
     this.shutdownPromise = shutdown;
     const clearShutdown = () => {
       if (this.shutdownPromise === shutdown) {
@@ -392,13 +461,6 @@ class LocalEmbeddingWorkerClient {
   }
 
   private async stopChild(child: ChildProcess): Promise<void> {
-    const exited = new Promise<void>((resolve) => {
-      if (child.exitCode !== null || child.signalCode !== null) {
-        resolve();
-        return;
-      }
-      child.once("exit", () => resolve());
-    });
     this.rejectPending(
       createLocalEmbeddingWorkerFailureError({
         message: "Local embedding worker exited unexpectedly (shutdown)",
@@ -412,23 +474,24 @@ class LocalEmbeddingWorkerClient {
     if (child.exitCode !== null || child.signalCode !== null) {
       return;
     }
-    child.kill();
-    let timeout: NodeJS.Timeout | undefined;
-    const exitedGracefully = await Promise.race([
-      exited.then(() => true),
-      new Promise<false>((resolve) => {
-        timeout = setTimeout(() => resolve(false), WORKER_CLOSE_GRACE_MS);
-        timeout.unref?.();
-      }),
-    ]);
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-    if (exitedGracefully) {
+    const gracefulWait = waitForWorkerTermination(child, WORKER_CLOSE_GRACE_MS);
+    const gracefulSignalError = signalWorker(child, "SIGTERM");
+    const gracefulResult = await gracefulWait;
+    if (gracefulResult.terminated) {
       return;
     }
-    child.kill("SIGKILL");
-    await exited;
+    const forcedWait = waitForWorkerTermination(child, WORKER_CLOSE_GRACE_MS);
+    const forcedSignalError = signalWorker(child, "SIGKILL");
+    const forcedResult = await forcedWait;
+    if (forcedResult.terminated) {
+      return;
+    }
+    throw createLocalEmbeddingWorkerFailureError({
+      message: "Local embedding worker did not exit after SIGKILL",
+      code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.processError,
+      reason: "process-error",
+      cause: forcedResult.error ?? forcedSignalError ?? gracefulResult.error ?? gracefulSignalError,
+    });
   }
 
   /** Reject all pending requests after child process failure. */
@@ -483,7 +546,15 @@ export async function createLocalEmbeddingWorkerProvider(
         closed = true;
         closePromise = client.close();
       }
-      await closePromise;
+      const pendingClose = closePromise;
+      try {
+        await pendingClose;
+      } catch (err) {
+        if (closePromise === pendingClose) {
+          closePromise = null;
+        }
+        throw err;
+      }
     },
   };
   attachLocalEmbeddingRuntimeFacts(provider, () => client.getRuntimeFacts());

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -519,19 +519,19 @@ class LocalEmbeddingWorkerClient {
   }
 }
 
-const FAILED_CONSTRUCTION_CLIENTS = new Set<LocalEmbeddingWorkerClient>();
-const FAILED_CONSTRUCTION_DRAIN_RETRY_MS = 1_000;
+const RETAINED_WORKER_CLIENTS = new Set<LocalEmbeddingWorkerClient>();
+const RETAINED_WORKER_DRAIN_RETRY_MS = 1_000;
 let workerProviderCreationTail: Promise<void> = Promise.resolve();
-let failedConstructionDrainPromise: Promise<void> | null = null;
-let failedConstructionDrainTimer: NodeJS.Timeout | null = null;
+let retainedWorkerDrainPromise: Promise<void> | null = null;
+let retainedWorkerDrainTimer: NodeJS.Timeout | null = null;
 
-async function drainFailedConstructionClientsNow(): Promise<void> {
+async function drainRetainedWorkerClientsNow(): Promise<void> {
   let firstError: unknown;
   let closeFailed = false;
-  for (const client of FAILED_CONSTRUCTION_CLIENTS) {
+  for (const client of RETAINED_WORKER_CLIENTS) {
     try {
       await client.close();
-      FAILED_CONSTRUCTION_CLIENTS.delete(client);
+      RETAINED_WORKER_CLIENTS.delete(client);
     } catch (err) {
       if (!closeFailed) {
         firstError = err;
@@ -544,32 +544,32 @@ async function drainFailedConstructionClientsNow(): Promise<void> {
   }
 }
 
-function scheduleFailedConstructionDrain(): void {
-  if (FAILED_CONSTRUCTION_CLIENTS.size === 0 || failedConstructionDrainTimer) {
+function scheduleRetainedWorkerDrain(): void {
+  if (RETAINED_WORKER_CLIENTS.size === 0 || retainedWorkerDrainTimer) {
     return;
   }
-  failedConstructionDrainTimer = setTimeout(() => {
-    failedConstructionDrainTimer = null;
-    void drainFailedConstructionClients().catch(() => {});
-  }, FAILED_CONSTRUCTION_DRAIN_RETRY_MS);
-  failedConstructionDrainTimer.unref?.();
+  retainedWorkerDrainTimer = setTimeout(() => {
+    retainedWorkerDrainTimer = null;
+    void drainRetainedWorkerClients().catch(() => {});
+  }, RETAINED_WORKER_DRAIN_RETRY_MS);
+  retainedWorkerDrainTimer.unref?.();
 }
 
-async function drainFailedConstructionClients(): Promise<void> {
-  if (failedConstructionDrainPromise) {
-    return await failedConstructionDrainPromise;
+async function drainRetainedWorkerClients(): Promise<void> {
+  if (retainedWorkerDrainPromise) {
+    return await retainedWorkerDrainPromise;
   }
-  if (failedConstructionDrainTimer) {
-    clearTimeout(failedConstructionDrainTimer);
-    failedConstructionDrainTimer = null;
+  if (retainedWorkerDrainTimer) {
+    clearTimeout(retainedWorkerDrainTimer);
+    retainedWorkerDrainTimer = null;
   }
-  const drain = drainFailedConstructionClientsNow();
-  failedConstructionDrainPromise = drain;
+  const drain = drainRetainedWorkerClientsNow();
+  retainedWorkerDrainPromise = drain;
   const settle = () => {
-    if (failedConstructionDrainPromise === drain) {
-      failedConstructionDrainPromise = null;
+    if (retainedWorkerDrainPromise === drain) {
+      retainedWorkerDrainPromise = null;
     }
-    scheduleFailedConstructionDrain();
+    scheduleRetainedWorkerDrain();
   };
   void drain.then(settle, settle);
   return await drain;
@@ -581,7 +581,7 @@ export async function createLocalEmbeddingWorkerProvider(
   runtimeOptions?: LocalEmbeddingProviderRuntimeOptions,
 ): Promise<EmbeddingProvider> {
   const create = async () => {
-    await drainFailedConstructionClients();
+    await drainRetainedWorkerClients();
     return await createLocalEmbeddingWorkerProviderOnce(options, runtimeOptions);
   };
   const creation = workerProviderCreationTail.then(create, create);
@@ -607,8 +607,8 @@ async function createLocalEmbeddingWorkerProviderOnce(
     try {
       await client.close();
     } catch {
-      FAILED_CONSTRUCTION_CLIENTS.add(client);
-      scheduleFailedConstructionDrain();
+      RETAINED_WORKER_CLIENTS.add(client);
+      scheduleRetainedWorkerDrain();
     }
     throw err;
   }
@@ -640,10 +640,13 @@ async function createLocalEmbeddingWorkerProviderOnce(
       const pendingClose = closePromise;
       try {
         await pendingClose;
+        RETAINED_WORKER_CLIENTS.delete(client);
       } catch (err) {
         if (closePromise === pendingClose) {
           closePromise = null;
         }
+        RETAINED_WORKER_CLIENTS.add(client);
+        scheduleRetainedWorkerDrain();
         throw err;
       }
     },

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -235,7 +235,7 @@ class LocalEmbeddingWorkerClient {
       if (timeout) {
         clearTimeout(timeout);
       }
-      this.shutdownChild();
+      await this.shutdownChild();
     }
   }
 
@@ -288,7 +288,7 @@ class LocalEmbeddingWorkerClient {
       if (options?.signal) {
         const abort = () => {
           this.pending.delete(id);
-          this.shutdownChild();
+          void this.shutdownChild();
           reject(
             toErrorObject(
               options.signal?.reason ?? new Error("Local embedding request aborted"),
@@ -342,12 +342,18 @@ class LocalEmbeddingWorkerClient {
   }
 
   /** Disconnect and kill the current child process if it is still alive. */
-  private shutdownChild(): void {
+  private async shutdownChild(): Promise<void> {
     const child = this.child;
     this.child = null;
     if (!child) {
       return;
     }
+    const exited =
+      child.exitCode !== null || child.signalCode !== null
+        ? Promise.resolve()
+        : new Promise<void>((resolve) => {
+            child.once("exit", () => resolve());
+          });
     this.rejectPending(
       createLocalEmbeddingWorkerFailureError({
         message: "Local embedding worker exited unexpectedly (shutdown)",
@@ -361,6 +367,7 @@ class LocalEmbeddingWorkerClient {
     if (!child.killed) {
       child.kill();
     }
+    await exited;
   }
 
   /** Reject all pending requests after child process failure. */

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -179,6 +179,7 @@ function resolveWorkerExecArgv(): string[] {
 /** IPC client that serializes local embedding calls through one child process. */
 class LocalEmbeddingWorkerClient {
   private child: ChildProcess | null = null;
+  private shutdownPromise: Promise<void> | null = null;
   private nextRequestId = 1;
   private pending = new Map<number, PendingRequest>();
   private lastRuntimeFacts: LocalEmbeddingRuntimeFacts | undefined;
@@ -216,6 +217,10 @@ class LocalEmbeddingWorkerClient {
 
   /** Ask the child to close gracefully, then force shutdown after a short grace period. */
   async close(): Promise<void> {
+    if (this.shutdownPromise) {
+      await this.shutdownPromise;
+      return;
+    }
     const child = this.child;
     if (!child) {
       return;
@@ -279,6 +284,7 @@ class LocalEmbeddingWorkerClient {
     request: LocalEmbeddingWorkerRequestPayload,
     options?: EmbeddingProviderCallOptions,
   ): Promise<number[] | number[][] | undefined> {
+    await this.shutdownPromise;
     options?.signal?.throwIfAborted();
     const child = this.ensureChild();
     const id = this.nextRequestId++;
@@ -342,18 +348,34 @@ class LocalEmbeddingWorkerClient {
   }
 
   /** Disconnect and kill the current child process if it is still alive. */
-  private async shutdownChild(): Promise<void> {
+  private shutdownChild(): Promise<void> {
+    if (this.shutdownPromise) {
+      return this.shutdownPromise;
+    }
     const child = this.child;
     this.child = null;
     if (!child) {
-      return;
+      return Promise.resolve();
     }
-    const exited =
-      child.exitCode !== null || child.signalCode !== null
-        ? Promise.resolve()
-        : new Promise<void>((resolve) => {
-            child.once("exit", () => resolve());
-          });
+    const shutdown = this.stopChild(child);
+    this.shutdownPromise = shutdown;
+    const clearShutdown = () => {
+      if (this.shutdownPromise === shutdown) {
+        this.shutdownPromise = null;
+      }
+    };
+    void shutdown.then(clearShutdown, clearShutdown);
+    return shutdown;
+  }
+
+  private async stopChild(child: ChildProcess): Promise<void> {
+    const exited = new Promise<void>((resolve) => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        resolve();
+        return;
+      }
+      child.once("exit", () => resolve());
+    });
     this.rejectPending(
       createLocalEmbeddingWorkerFailureError({
         message: "Local embedding worker exited unexpectedly (shutdown)",
@@ -364,9 +386,25 @@ class LocalEmbeddingWorkerClient {
     if (child.connected) {
       child.disconnect();
     }
-    if (!child.killed) {
-      child.kill();
+    if (child.exitCode !== null || child.signalCode !== null) {
+      return;
     }
+    child.kill();
+    let timeout: NodeJS.Timeout | undefined;
+    const exitedGracefully = await Promise.race([
+      exited.then(() => true),
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(() => resolve(false), WORKER_CLOSE_GRACE_MS);
+        timeout.unref?.();
+      }),
+    ]);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    if (exitedGracefully) {
+      return;
+    }
+    child.kill("SIGKILL");
     await exited;
   }
 

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -239,16 +239,25 @@ class LocalEmbeddingWorkerClient {
       timeout = setTimeout(() => resolve("timeout"), WORKER_CLOSE_GRACE_MS);
       timeout.unref?.();
     });
+    let gracefulCloseError: unknown;
     try {
       const result = await Promise.race([closeRequest, closeTimeout]);
       if (result === "timeout") {
         closeRequest.catch(() => {});
       }
+    } catch (err) {
+      gracefulCloseError = err;
     } finally {
       if (timeout) {
         clearTimeout(timeout);
       }
       await this.shutdownChild();
+    }
+    if (gracefulCloseError) {
+      process.emitWarning(
+        toErrorObject(gracefulCloseError, "Local embedding worker graceful close failed"),
+        { code: "OPENCLAW_EMBEDDING_WORKER_CLOSE" },
+      );
     }
   }
 

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -302,7 +302,9 @@ class LocalEmbeddingWorkerClient {
     options?: EmbeddingProviderCallOptions,
     allowClosed = false,
   ): Promise<number[] | number[][] | undefined> {
-    await this.shutdownPromise;
+    while (this.shutdownPromise) {
+      await this.shutdownPromise;
+    }
     if (this.closed && !allowClosed) {
       throw new Error("Local embedding worker client has been closed");
     }

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -283,6 +283,10 @@ class LocalEmbeddingWorkerClient {
     if (!child) {
       return;
     }
+    if (!child.connected) {
+      await this.shutdownChild();
+      return;
+    }
     let timeout: NodeJS.Timeout | undefined;
     const closeRequest = this.send({ type: "close" }, undefined, true).then(
       () => "closed" as const,
@@ -315,8 +319,15 @@ class LocalEmbeddingWorkerClient {
 
   /** Ensure the child process exists and has lifecycle failure handlers installed. */
   private ensureChild(): ChildProcess {
-    if (this.child?.connected) {
-      return this.child;
+    const current = this.child;
+    if (current) {
+      if (current.connected) {
+        return current;
+      }
+      if (current.exitCode === null && current.signalCode === null) {
+        throw new Error("Local embedding worker IPC disconnected before process termination");
+      }
+      this.child = null;
     }
 
     const child = fork(this.scriptPath, [], {
@@ -362,6 +373,9 @@ class LocalEmbeddingWorkerClient {
   ): Promise<number[] | number[][] | undefined> {
     while (this.shutdownPromise) {
       await this.shutdownPromise;
+    }
+    if (this.child && !this.child.connected) {
+      await this.shutdownChild();
     }
     if (this.closed && !allowClosed) {
       throw new Error("Local embedding worker client has been closed");

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -519,8 +519,46 @@ class LocalEmbeddingWorkerClient {
   }
 }
 
+const FAILED_CONSTRUCTION_CLIENTS = new Set<LocalEmbeddingWorkerClient>();
+let workerProviderCreationTail: Promise<void> = Promise.resolve();
+
+async function drainFailedConstructionClients(): Promise<void> {
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const client of FAILED_CONSTRUCTION_CLIENTS) {
+    try {
+      await client.close();
+      FAILED_CONSTRUCTION_CLIENTS.delete(client);
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (closeFailed) {
+    throw firstError;
+  }
+}
+
 /** Create the public local embedding provider backed by the child worker client. */
 export async function createLocalEmbeddingWorkerProvider(
+  options: EmbeddingProviderOptions,
+  runtimeOptions?: LocalEmbeddingProviderRuntimeOptions,
+): Promise<EmbeddingProvider> {
+  const create = async () => {
+    await drainFailedConstructionClients();
+    return await createLocalEmbeddingWorkerProviderOnce(options, runtimeOptions);
+  };
+  const creation = workerProviderCreationTail.then(create, create);
+  workerProviderCreationTail = creation.then(
+    () => undefined,
+    () => undefined,
+  );
+  return await creation;
+}
+
+async function createLocalEmbeddingWorkerProviderOnce(
   options: EmbeddingProviderOptions,
   runtimeOptions?: LocalEmbeddingProviderRuntimeOptions,
 ): Promise<EmbeddingProvider> {
@@ -532,7 +570,11 @@ export async function createLocalEmbeddingWorkerProvider(
   try {
     await client.initialize(workerOptions);
   } catch (err) {
-    await client.close().catch(() => {});
+    try {
+      await client.close();
+    } catch {
+      FAILED_CONSTRUCTION_CLIENTS.add(client);
+    }
     throw err;
   }
   let closed = false;

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -179,6 +179,7 @@ function resolveWorkerExecArgv(): string[] {
 /** IPC client that serializes local embedding calls through one child process. */
 class LocalEmbeddingWorkerClient {
   private child: ChildProcess | null = null;
+  private closed = false;
   private shutdownPromise: Promise<void> | null = null;
   private nextRequestId = 1;
   private pending = new Map<number, PendingRequest>();
@@ -217,6 +218,11 @@ class LocalEmbeddingWorkerClient {
 
   /** Ask the child to close gracefully, then force shutdown after a short grace period. */
   async close(): Promise<void> {
+    if (this.closed) {
+      await this.shutdownPromise;
+      return;
+    }
+    this.closed = true;
     if (this.shutdownPromise) {
       await this.shutdownPromise;
       return;
@@ -226,7 +232,9 @@ class LocalEmbeddingWorkerClient {
       return;
     }
     let timeout: NodeJS.Timeout | undefined;
-    const closeRequest = this.send({ type: "close" }).then(() => "closed" as const);
+    const closeRequest = this.send({ type: "close" }, undefined, true).then(
+      () => "closed" as const,
+    );
     const closeTimeout = new Promise<"timeout">((resolve) => {
       timeout = setTimeout(() => resolve("timeout"), WORKER_CLOSE_GRACE_MS);
       timeout.unref?.();
@@ -283,8 +291,12 @@ class LocalEmbeddingWorkerClient {
   private async send(
     request: LocalEmbeddingWorkerRequestPayload,
     options?: EmbeddingProviderCallOptions,
+    allowClosed = false,
   ): Promise<number[] | number[][] | undefined> {
     await this.shutdownPromise;
+    if (this.closed && !allowClosed) {
+      throw new Error("Local embedding worker client has been closed");
+    }
     options?.signal?.throwIfAborted();
     const child = this.ensureChild();
     const id = this.nextRequestId++;

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -633,6 +633,38 @@ process.on("message", (message) => {
     await expect(provider.close?.()).resolves.toBeUndefined();
   });
 
+  it("waits for the local worker process to exit before close resolves", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
+    const workerScript = path.join(tempDir, "worker.cjs");
+    const exitMarker = path.join(tempDir, "worker-exited");
+    await fs.writeFile(
+      workerScript,
+      `
+const fs = require("node:fs");
+const exitMarker = ${JSON.stringify(exitMarker)};
+setInterval(() => {}, 1000);
+process.on("SIGTERM", () => {
+  setTimeout(() => {
+    fs.writeFileSync(exitMarker, "exited");
+    process.exit(0);
+  }, 50);
+});
+process.on("message", (message) => {
+  process.send({ id: message.id, ok: true });
+});
+`,
+      "utf8",
+    );
+    const provider = await createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: workerScript },
+    );
+
+    await expect(provider.close?.()).resolves.toBeUndefined();
+
+    await expect(fs.readFile(exitMarker, "utf8")).resolves.toBe("exited");
+  });
+
   it("rejects pending and queued requests when closing a busy worker", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
     const workerScript = path.join(tempDir, "worker.cjs");

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -660,7 +660,9 @@ process.on("message", (message) => {
       { workerScriptPath: workerScript },
     );
 
-    await expect(provider.close?.()).resolves.toBeUndefined();
+    const firstClose = provider.close?.() ?? Promise.resolve();
+    const secondClose = provider.close?.() ?? Promise.resolve();
+    await expect(Promise.all([firstClose, secondClose])).resolves.toEqual([undefined, undefined]);
 
     await expect(fs.readFile(exitMarker, "utf8")).resolves.toBe("exited");
   });

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -708,8 +708,13 @@ process.on("message", (message) => {
       .toBe("started");
 
     controller.abort(new Error("cancelled"));
+    const queuedEmbedError = provider.embedQuery("queued after cancel").catch((err: unknown) => err);
+    const closePromise = provider.close?.() ?? Promise.resolve();
     await expect(embedPromise).rejects.toThrow("cancelled");
-    await expect(provider.close?.()).resolves.toBeUndefined();
+    await expect(closePromise).resolves.toBeUndefined();
+    await expect(queuedEmbedError).resolves.toMatchObject({
+      message: "Local embedding worker client has been closed",
+    });
 
     await expect(fs.readFile(exitMarker, "utf8")).resolves.toBe("exited");
   });

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -710,7 +710,9 @@ process.on("message", (message) => {
       .toBe("started");
 
     controller.abort(new Error("cancelled"));
-    const queuedEmbedError = provider.embedQuery("queued after cancel").catch((err: unknown) => err);
+    const queuedEmbedError = provider
+      .embedQuery("queued after cancel")
+      .catch((err: unknown) => err);
     const closePromise = provider.close?.() ?? Promise.resolve();
     await expect(embedPromise).rejects.toThrow("cancelled");
     await expect(closePromise).resolves.toBeUndefined();
@@ -772,9 +774,12 @@ process.on("message", (message) => {
 
     await expect(provider.close?.()).resolves.toBeUndefined();
 
-    expect(warning).toHaveBeenCalledWith(expect.objectContaining({ message: "native disposal failed" }), {
-      code: "OPENCLAW_EMBEDDING_WORKER_CLOSE",
-    });
+    expect(warning).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "native disposal failed" }),
+      {
+        code: "OPENCLAW_EMBEDDING_WORKER_CLOSE",
+      },
+    );
   });
 
   it("rejects pending and queued requests when closing a busy worker", async () => {

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -665,6 +665,82 @@ process.on("message", (message) => {
     await expect(fs.readFile(exitMarker, "utf8")).resolves.toBe("exited");
   });
 
+  it("joins cancellation shutdown before a later close resolves", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
+    const workerScript = path.join(tempDir, "worker.cjs");
+    const embedStarted = path.join(tempDir, "embed-started");
+    const exitMarker = path.join(tempDir, "worker-exited");
+    await fs.writeFile(
+      workerScript,
+      `
+const fs = require("node:fs");
+setInterval(() => {}, 1000);
+process.on("SIGTERM", () => {
+  setTimeout(() => {
+    fs.writeFileSync(${JSON.stringify(exitMarker)}, "exited");
+    process.exit(0);
+  }, 50);
+});
+process.on("message", (message) => {
+  if (message.type === "initialize") {
+    process.send({ id: message.id, ok: true });
+  } else if (message.type === "embedQuery") {
+    fs.writeFileSync(${JSON.stringify(embedStarted)}, "started");
+  }
+});
+`,
+      "utf8",
+    );
+    const provider = await createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: workerScript },
+    );
+    const controller = new AbortController();
+    const embedPromise = provider.embedQuery("cancel me", { signal: controller.signal });
+    await expect
+      .poll(async () => {
+        try {
+          return await fs.readFile(embedStarted, "utf8");
+        } catch {
+          return "";
+        }
+      })
+      .toBe("started");
+
+    controller.abort(new Error("cancelled"));
+    await expect(embedPromise).rejects.toThrow("cancelled");
+    await expect(provider.close?.()).resolves.toBeUndefined();
+
+    await expect(fs.readFile(exitMarker, "utf8")).resolves.toBe("exited");
+  });
+
+  it("escalates worker shutdown when the child ignores SIGTERM", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
+    const workerScript = path.join(tempDir, "worker.cjs");
+    await fs.writeFile(
+      workerScript,
+      `
+setInterval(() => {}, 1000);
+process.on("SIGTERM", () => {});
+process.on("message", (message) => {
+  process.send({ id: message.id, ok: true });
+});
+`,
+      "utf8",
+    );
+    const provider = await createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: workerScript },
+    );
+
+    await expect(
+      settleWithin(
+        (provider.close?.() ?? Promise.resolve()).then(() => "closed" as const),
+        1_000,
+      ),
+    ).resolves.toBe("closed");
+  });
+
   it("rejects pending and queued requests when closing a busy worker", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
     const workerScript = path.join(tempDir, "worker.cjs");

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -748,6 +748,35 @@ process.on("message", (message) => {
     ).resolves.toBe("closed");
   });
 
+  it("treats confirmed worker exit as closed after graceful disposal fails", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
+    const workerScript = path.join(tempDir, "worker.cjs");
+    await fs.writeFile(
+      workerScript,
+      `
+process.on("message", (message) => {
+  if (message.type === "close") {
+    process.send({ id: message.id, ok: false, error: "native disposal failed" });
+    return;
+  }
+  process.send({ id: message.id, ok: true });
+});
+`,
+      "utf8",
+    );
+    const warning = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+    const provider = await createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: workerScript },
+    );
+
+    await expect(provider.close?.()).resolves.toBeUndefined();
+
+    expect(warning).toHaveBeenCalledWith(expect.objectContaining({ message: "native disposal failed" }), {
+      code: "OPENCLAW_EMBEDDING_WORKER_CLOSE",
+    });
+  });
+
   it("rejects pending and queued requests when closing a busy worker", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
     const workerScript = path.join(tempDir, "worker.cjs");

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -1,4 +1,5 @@
 // Memory Host SDK tests cover embeddings behavior.
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -14,12 +15,24 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const nodeLlamaMock = vi.hoisted(() => ({
   importNodeLlamaCpp: vi.fn(),
 }));
+const forkMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    fork: forkMock,
+  };
+});
 
 vi.mock("./node-llama.js", () => ({
   importNodeLlamaCpp: nodeLlamaMock.importNodeLlamaCpp,
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  forkMock.mockReset();
+  forkMock.mockImplementation(actual.fork);
   nodeLlamaMock.importNodeLlamaCpp.mockReset();
 });
 
@@ -750,6 +763,57 @@ process.on("message", (message) => {
     ).resolves.toBe("closed");
   });
 
+  it("rejects close when worker signaling errors without a terminal event", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      connected: true,
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      disconnect: vi.fn(function (this: { connected: boolean }) {
+        this.connected = false;
+      }),
+      kill: vi.fn(function (this: EventEmitter) {
+        queueMicrotask(() => this.emit("error", new Error("kill failed")));
+        return false;
+      }),
+      send: vi.fn(function (
+        this: EventEmitter,
+        message: { id: number },
+        callback: (err?: Error | null) => void,
+      ) {
+        callback();
+        queueMicrotask(() => this.emit("message", { id: message.id, ok: true }));
+        return true;
+      }),
+    });
+    forkMock.mockReturnValue(child);
+    const provider = await createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: "/mock/worker.cjs" },
+    );
+
+    const closeResult = await settleWithin(
+      (provider.close?.() ?? Promise.resolve()).then(
+        () => "closed" as const,
+        (err: unknown) => err,
+      ),
+      1_000,
+    );
+
+    expect(closeResult).toMatchObject({
+      code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.processError,
+      message: "Local embedding worker did not exit after SIGKILL",
+    });
+    expect(child.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
+
+    child.kill.mockImplementationOnce(function (this: typeof child) {
+      this.signalCode = "SIGTERM";
+      queueMicrotask(() => this.emit("close", null, "SIGTERM"));
+      return true;
+    });
+    await expect(provider.close?.()).resolves.toBeUndefined();
+    expect(child.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"], ["SIGTERM"]]);
+  });
+
   it("treats confirmed worker exit as closed after graceful disposal fails", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
     const workerScript = path.join(tempDir, "worker.cjs");
@@ -777,7 +841,7 @@ process.on("message", (message) => {
     expect(warning).toHaveBeenCalledWith(
       expect.objectContaining({ message: "native disposal failed" }),
       {
-        code: "OPENCLAW_EMBEDDING_WORKER_CLOSE",
+        code: "LOCAL_EMBEDDING_WORKER_CLOSE",
       },
     );
   });

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -14,6 +14,7 @@ const PNG_1X1_BASE64 =
 
 type LocalAudioSelection = Awaited<ReturnType<typeof inspectLocalAudioSelection>>;
 
+const closeEmbeddingProviderMock = vi.hoisted(() => vi.fn(async () => {}));
 const mocks = vi.hoisted(() => ({
   runtime: {
     log: vi.fn(),
@@ -144,6 +145,7 @@ const mocks = vi.hoisted(() => ({
       model: "text-embedding-3-small",
       embedQuery: async () => [0.1, 0.2],
       embedBatch: async (texts: string[]) => texts.map(() => [0.1, 0.2]),
+      close: closeEmbeddingProviderMock,
     },
   })),
   listMemoryEmbeddingProviders: vi.fn(() => [
@@ -537,6 +539,7 @@ describe("capability cli", () => {
     mocks.inspectLocalAudioSelection.mockReset().mockResolvedValue({ candidates: [], entries: [] });
     mocks.convertHeicToJpeg.mockClear();
     mocks.createEmbeddingProvider.mockClear();
+    closeEmbeddingProviderMock.mockClear();
     mocks.listMemoryEmbeddingProviders
       .mockReset()
       .mockReturnValue([
@@ -3066,6 +3069,32 @@ describe("capability cli", () => {
     expect(firstJsonOutput()?.capability).toBe("embedding.create");
     expect(firstJsonOutput()?.provider).toBe("openai");
     expect(firstJsonOutput()?.model).toBe("text-embedding-3-small");
+    expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the embedding provider without masking embedding failure", async () => {
+    closeEmbeddingProviderMock.mockRejectedValueOnce(new Error("close failed"));
+    mocks.createEmbeddingProvider.mockResolvedValueOnce({
+      provider: {
+        id: "openai",
+        model: "text-embedding-3-small",
+        embedQuery: async () => [0.1, 0.2],
+        embedBatch: async () => {
+          throw new Error("embedding failed");
+        },
+        close: closeEmbeddingProviderMock,
+      },
+    });
+
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: ["capability", "embedding", "create", "--text", "hello", "--json"],
+      }),
+    ).rejects.toThrow("exit 1");
+
+    expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(1);
+    expectRuntimeErrorContains("embedding failed");
   });
 
   it("resolves command SecretRefs before local model capability execution", async () => {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -3093,8 +3093,24 @@ describe("capability cli", () => {
       }),
     ).rejects.toThrow("exit 1");
 
-    expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(1);
+    expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(2);
     expectRuntimeErrorContains("embedding failed");
+  });
+
+  it("retries embedding provider cleanup before reporting close failure", async () => {
+    closeEmbeddingProviderMock
+      .mockRejectedValueOnce(new Error("close failed"))
+      .mockRejectedValueOnce(new Error("close failed"));
+
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: ["capability", "embedding", "create", "--text", "hello", "--json"],
+      }),
+    ).rejects.toThrow("exit 1");
+
+    expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(2);
+    expectRuntimeErrorContains("close failed");
   });
 
   it("resolves command SecretRefs before local model capability execution", async () => {

--- a/src/cli/capability-cli/embedding.ts
+++ b/src/cli/capability-cli/embedding.ts
@@ -41,13 +41,36 @@ async function runMemoryEmbeddingCreate(params: {
   if (!result.provider) {
     throw new Error(result.providerUnavailableReason ?? "No embedding provider available.");
   }
-  const embeddings = await result.provider.embedBatch(params.texts);
+  const provider = result.provider;
+  let embeddings: number[][] = [];
+  let operationError: unknown;
+  let operationFailed = false;
+  try {
+    embeddings = await provider.embedBatch(params.texts);
+  } catch (err) {
+    operationError = err;
+    operationFailed = true;
+  }
+  let closeError: unknown;
+  let closeFailed = false;
+  try {
+    await provider.close?.();
+  } catch (err) {
+    closeError = err;
+    closeFailed = true;
+  }
+  if (operationFailed) {
+    throw operationError;
+  }
+  if (closeFailed) {
+    throw closeError;
+  }
   return {
     ok: true,
     capability: "embedding.create",
     transport: "local" as const,
-    provider: result.provider.id,
-    model: result.provider.model,
+    provider: provider.id,
+    model: provider.model,
     attempts: result.fallbackFrom
       ? [{ provider: result.fallbackFrom, outcome: "failed", error: result.fallbackReason }]
       : [],

--- a/src/cli/capability-cli/embedding.ts
+++ b/src/cli/capability-cli/embedding.ts
@@ -20,6 +20,21 @@ import {
   resolveModelRefOverride,
 } from "./shared.js";
 
+async function closeEmbeddingProviderWithRetry(provider: {
+  close?: () => Promise<void> | void;
+}): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await provider.close?.();
+      return;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
+}
+
 async function runMemoryEmbeddingCreate(params: {
   texts: string[];
   provider?: string;
@@ -54,7 +69,7 @@ async function runMemoryEmbeddingCreate(params: {
   let closeError: unknown;
   let closeFailed = false;
   try {
-    await provider.close?.();
+    await closeEmbeddingProviderWithRetry(provider);
   } catch (err) {
     closeError = err;
     closeFailed = true;

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -29,7 +29,7 @@ let createEmbeddingProviderMock: ReturnType<
         model: string;
         embedQuery: (text: string) => Promise<number[]>;
         embedBatch: (texts: string[]) => Promise<number[][]>;
-        close: () => Promise<void> | void;
+        close?: () => Promise<void> | void;
       };
     }>
   >
@@ -654,5 +654,43 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
     expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
+  });
+
+  it("allows providers without cleanup resources to embed concurrently", async () => {
+    let releaseFirstEmbed: () => void = () => {};
+    const firstEmbedGate = new Promise<void>((resolve) => {
+      releaseFirstEmbed = resolve;
+    });
+    const firstEmbed = vi.fn(async () => {
+      await firstEmbedGate;
+      return [[1, 2]];
+    });
+    const secondEmbed = vi.fn(async () => [[3, 4]]);
+    createEmbeddingProviderMock
+      .mockResolvedValueOnce({
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: async () => [1, 2],
+          embedBatch: firstEmbed,
+        },
+      })
+      .mockResolvedValueOnce({
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: async () => [3, 4],
+          embedBatch: secondEmbed,
+        },
+      });
+
+    const firstPromise = postEmbeddings({ model: "openclaw/default", input: "first" });
+    await vi.waitFor(() => expect(firstEmbed).toHaveBeenCalledTimes(1));
+    const second = await postEmbeddings({ model: "openclaw/default", input: "second" });
+    expect(second.status).toBe(200);
+    expect(secondEmbed).toHaveBeenCalledTimes(1);
+
+    releaseFirstEmbed();
+    expect((await firstPromise).status).toBe(200);
   });
 });

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -29,13 +29,13 @@ let createEmbeddingProviderMock: ReturnType<
         model: string;
         embedQuery: (text: string) => Promise<number[]>;
         embedBatch: (texts: string[]) => Promise<number[][]>;
-        close: () => Promise<void>;
+        close: () => Promise<void> | void;
       };
     }>
   >
 >;
 let embedBatchMock: ReturnType<typeof vi.fn<(texts: string[]) => Promise<number[][]>>>;
-let closeEmbeddingProviderMock: ReturnType<typeof vi.fn<() => Promise<void>>>;
+let closeEmbeddingProviderMock: ReturnType<typeof vi.fn<() => Promise<void> | void>>;
 let clearMemoryEmbeddingProviders: typeof import("../plugins/memory-embedding-providers.js").clearMemoryEmbeddingProviders;
 let registerMemoryEmbeddingProvider: typeof import("../plugins/memory-embedding-providers.js").registerMemoryEmbeddingProvider;
 let clearEmbeddingProviders: typeof import("../plugins/embedding-providers.js").clearEmbeddingProviders;
@@ -594,6 +594,19 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     });
 
     expect(res.status).toBe(500);
+    expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1);
+  });
+
+  it("supports synchronous provider cleanup", async () => {
+    const closesBefore = closeEmbeddingProviderMock.mock.calls.length;
+    closeEmbeddingProviderMock.mockImplementationOnce(() => undefined);
+
+    const res = await postEmbeddings({
+      model: "openclaw/default",
+      input: "hello",
+    });
+
+    expect(res.status).toBe(200);
     expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1);
   });
 });

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -609,4 +609,50 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     expect(res.status).toBe(200);
     expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1);
   });
+
+  it("retains failed cleanup and blocks replacement until retirement succeeds", async () => {
+    const createsBefore = createEmbeddingProviderMock.mock.calls.length;
+    closeEmbeddingProviderMock
+      .mockRejectedValueOnce(new Error("first close failed"))
+      .mockRejectedValueOnce(new Error("retry close failed"));
+
+    const first = await postEmbeddings({ model: "openclaw/default", input: "first" });
+    expect(first.status).toBe(200);
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 1);
+
+    const blocked = await postEmbeddings({ model: "openclaw/default", input: "blocked" });
+    expect(blocked.status).toBe(500);
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 1);
+
+    const recovered = await postEmbeddings({ model: "openclaw/default", input: "recovered" });
+    expect(recovered.status).toBe(200);
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
+  });
+
+  it("does not admit a replacement while provider cleanup is pending", async () => {
+    let releaseClose: () => void = () => {};
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    closeEmbeddingProviderMock.mockImplementationOnce(async () => {
+      await closeGate;
+      throw new Error("close failed");
+    });
+    const createsBefore = createEmbeddingProviderMock.mock.calls.length;
+    const closesBefore = closeEmbeddingProviderMock.mock.calls.length;
+
+    const firstPromise = postEmbeddings({ model: "openclaw/default", input: "first" });
+    await vi.waitFor(() =>
+      expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1),
+    );
+    const secondPromise = postEmbeddings({ model: "openclaw/default", input: "second" });
+    await Promise.resolve();
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 1);
+
+    releaseClose();
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
+  });
 });

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -29,10 +29,13 @@ let createEmbeddingProviderMock: ReturnType<
         model: string;
         embedQuery: (text: string) => Promise<number[]>;
         embedBatch: (texts: string[]) => Promise<number[][]>;
+        close: () => Promise<void>;
       };
     }>
   >
 >;
+let embedBatchMock: ReturnType<typeof vi.fn<(texts: string[]) => Promise<number[][]>>>;
+let closeEmbeddingProviderMock: ReturnType<typeof vi.fn<() => Promise<void>>>;
 let clearMemoryEmbeddingProviders: typeof import("../plugins/memory-embedding-providers.js").clearMemoryEmbeddingProviders;
 let registerMemoryEmbeddingProvider: typeof import("../plugins/memory-embedding-providers.js").registerMemoryEmbeddingProvider;
 let clearEmbeddingProviders: typeof import("../plugins/embedding-providers.js").clearEmbeddingProviders;
@@ -108,14 +111,18 @@ beforeAll(async () => {
   ({ clearMemoryEmbeddingProviders, registerMemoryEmbeddingProvider } =
     await import("../plugins/memory-embedding-providers.js"));
   ({ clearEmbeddingProviders } = await import("../plugins/embedding-providers.js"));
+  embedBatchMock = vi.fn(async (texts: string[]) =>
+    texts.map((_text, index) => [index + 0.1, index + 0.2]),
+  );
+  closeEmbeddingProviderMock = vi.fn(async () => {});
   createEmbeddingProviderMock = vi.fn(
     async (options: { provider: string; model: string; agentDir?: string }) => ({
       provider: {
         id: options.provider,
         model: options.model,
         embedQuery: async () => [0.1, 0.2],
-        embedBatch: async (texts: string[]) =>
-          texts.map((_text, index) => [index + 0.1, index + 0.2]),
+        embedBatch: embedBatchMock,
+        close: closeEmbeddingProviderMock,
       },
     }),
   );
@@ -257,6 +264,7 @@ function latestCreateGenericEmbeddingProviderOptions(): {
 
 describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
   it("embeds string and array inputs", async () => {
+    const closesBefore = closeEmbeddingProviderMock.mock.calls.length;
     const single = await postEmbeddings({
       model: "openclaw/default",
       input: "hello",
@@ -285,6 +293,7 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     const lastCall = latestCreateEmbeddingProviderOptions();
     expect(lastCall.provider).toBe("openai");
     expect(lastCall.model).toBe("text-embedding-3-small");
+    expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 3);
   });
 
   it("supports base64 encoding and agent-scoped auth/config resolution", async () => {
@@ -573,5 +582,18 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
       type: "api_error",
       message: "internal error",
     });
+  });
+
+  it("closes the provider when embedding fails", async () => {
+    const closesBefore = closeEmbeddingProviderMock.mock.calls.length;
+    embedBatchMock.mockRejectedValueOnce(new Error("embedding failed"));
+
+    const res = await postEmbeddings({
+      model: "openclaw/default",
+      input: "hello",
+    });
+
+    expect(res.status).toBe(500);
+    expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1);
   });
 });

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -38,6 +38,8 @@ let embedBatchMock: ReturnType<typeof vi.fn<(texts: string[]) => Promise<number[
 let closeEmbeddingProviderMock: ReturnType<typeof vi.fn<() => Promise<void> | void>>;
 let clearMemoryEmbeddingProviders: typeof import("../plugins/memory-embedding-providers.js").clearMemoryEmbeddingProviders;
 let registerMemoryEmbeddingProvider: typeof import("../plugins/memory-embedding-providers.js").registerMemoryEmbeddingProvider;
+let openAiAdapter: MemoryEmbeddingProviderAdapter;
+let drainRetainedOpenAiEmbeddingProviders: typeof import("./embeddings-http.js").drainRetainedOpenAiEmbeddingProviders;
 let clearEmbeddingProviders: typeof import("../plugins/embedding-providers.js").clearEmbeddingProviders;
 let enabledServer: Awaited<ReturnType<typeof startOpenAiCompatGatewayServer>>;
 let genericEmbeddingServer: { baseUrl: string; close: () => Promise<void> };
@@ -108,6 +110,7 @@ async function startGenericEmbeddingServer(): Promise<{
 }
 
 beforeAll(async () => {
+  ({ drainRetainedOpenAiEmbeddingProviders } = await import("./embeddings-http.js"));
   ({ clearMemoryEmbeddingProviders, registerMemoryEmbeddingProvider } =
     await import("../plugins/memory-embedding-providers.js"));
   ({ clearEmbeddingProviders } = await import("../plugins/embedding-providers.js"));
@@ -130,7 +133,7 @@ beforeAll(async () => {
   clearEmbeddingProviders();
   genericEmbeddingServer = await startGenericEmbeddingServer();
   genericEmbeddingBaseUrl = genericEmbeddingServer.baseUrl;
-  const openAiAdapter: MemoryEmbeddingProviderAdapter = {
+  openAiAdapter = {
     id: "openai",
     defaultModel: "text-embedding-3-small",
     transport: "remote",
@@ -630,6 +633,7 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
   });
 
   it("does not admit a replacement while provider cleanup is pending", async () => {
+    Reflect.set(openAiAdapter, "transport", "local");
     let releaseClose: () => void = () => {};
     const closeGate = new Promise<void>((resolve) => {
       releaseClose = resolve;
@@ -651,6 +655,7 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
 
     releaseClose();
     const [first, second] = await Promise.all([firstPromise, secondPromise]);
+    Reflect.set(openAiAdapter, "transport", "remote");
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
     expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
@@ -673,6 +678,7 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
           model: "text-embedding-3-small",
           embedQuery: async () => [1, 2],
           embedBatch: firstEmbed,
+          close: vi.fn(async () => {}),
         },
       })
       .mockResolvedValueOnce({
@@ -681,6 +687,7 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
           model: "text-embedding-3-small",
           embedQuery: async () => [3, 4],
           embedBatch: secondEmbed,
+          close: vi.fn(async () => {}),
         },
       });
 
@@ -692,5 +699,16 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
 
     releaseFirstEmbed();
     expect((await firstPromise).status).toBe(200);
+  });
+
+  it("drains retained provider cleanup during gateway shutdown", async () => {
+    const closesBefore = closeEmbeddingProviderMock.mock.calls.length;
+    closeEmbeddingProviderMock.mockRejectedValueOnce(new Error("close failed"));
+
+    const res = await postEmbeddings({ model: "openclaw/default", input: "hello" });
+    expect(res.status).toBe(200);
+
+    await drainRetainedOpenAiEmbeddingProviders();
+    expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 2);
   });
 });

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -661,6 +661,40 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
   });
 
+  it("does not bypass local cleanup with a model override", async () => {
+    Reflect.set(openAiAdapter, "transport", "local");
+    let releaseClose: () => void = () => {};
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    closeEmbeddingProviderMock.mockImplementationOnce(async () => {
+      await closeGate;
+    });
+    const createsBefore = createEmbeddingProviderMock.mock.calls.length;
+    const closesBefore = closeEmbeddingProviderMock.mock.calls.length;
+
+    const firstPromise = postEmbeddings(
+      { model: "openclaw/default", input: "first" },
+      { "x-openclaw-model": "openai/model-a" },
+    );
+    await vi.waitFor(() =>
+      expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1),
+    );
+    const secondPromise = postEmbeddings(
+      { model: "openclaw/default", input: "second" },
+      { "x-openclaw-model": "openai/model-b" },
+    );
+    await Promise.resolve();
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 1);
+
+    releaseClose();
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+    Reflect.set(openAiAdapter, "transport", "remote");
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
+  });
+
   it("allows providers without cleanup resources to embed concurrently", async () => {
     let releaseFirstEmbed: () => void = () => {};
     const firstEmbedGate = new Promise<void>((resolve) => {

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -661,6 +661,41 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
   });
 
+  it("serializes cleanup when a remote request creates a local provider", async () => {
+    let releaseClose: () => void = () => {};
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    closeEmbeddingProviderMock.mockImplementationOnce(async () => {
+      await closeGate;
+    });
+    createEmbeddingProviderMock.mockResolvedValueOnce({
+      provider: {
+        id: "local",
+        model: "local-embed",
+        embedQuery: async () => [0.1, 0.2],
+        embedBatch: embedBatchMock,
+        close: closeEmbeddingProviderMock,
+      },
+    });
+    const createsBefore = createEmbeddingProviderMock.mock.calls.length;
+    const closesBefore = closeEmbeddingProviderMock.mock.calls.length;
+
+    const firstPromise = postEmbeddings({ model: "openclaw/default", input: "first" });
+    await vi.waitFor(() =>
+      expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1),
+    );
+    const secondPromise = postEmbeddings({ model: "openclaw/default", input: "second" });
+    await Promise.resolve();
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 1);
+
+    releaseClose();
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
+  });
+
   it("does not bypass local cleanup with a model override", async () => {
     Reflect.set(openAiAdapter, "transport", "local");
     let releaseClose: () => void = () => {};

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -73,13 +73,13 @@ const EMBEDDING_PROVIDER_ADMISSION_TAILS = new Map<string, Promise<void>>();
 async function acquireEmbeddingProviderLease(
   scopeKey: string,
   create: () => Promise<MemoryEmbeddingProvider>,
-  holdForCleanup: boolean,
+  holdForCleanup: (provider: MemoryEmbeddingProvider) => boolean,
 ): Promise<{ provider: MemoryEmbeddingProvider; release: () => void }> {
   const previous = EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) ?? Promise.resolve();
   const createLease = async () => {
     await drainEmbeddingProviderRetirements(scopeKey);
     const provider = await create();
-    if (!holdForCleanup) {
+    if (!holdForCleanup(provider)) {
       return { provider, lifecycle: Promise.resolve(), release: () => {} };
     }
     let release: () => void = () => {};
@@ -445,7 +445,7 @@ export async function handleOpenAiEmbeddingsHttpRequest(
     return true;
   }
   const providerScopeKey = JSON.stringify([agentId, target.provider]);
-  const holdProviderForCleanup = isLocalEmbeddingProvider({
+  const requestedProviderNeedsCleanup = isLocalEmbeddingProvider({
     cfg,
     provider: target.provider,
   });
@@ -469,7 +469,8 @@ export async function handleOpenAiEmbeddingsHttpRequest(
               }
             : undefined,
         }),
-      holdProviderForCleanup,
+      (provider) =>
+        requestedProviderNeedsCleanup || isLocalEmbeddingProvider({ cfg, provider: provider.id }),
     );
     try {
       const embeddings = await provider.embedBatch(texts);

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -67,6 +67,64 @@ type MemorySearchEmbeddingConfig = Pick<
   "local" | "remote" | "outputDimensionality" | "inputType" | "queryInputType" | "documentInputType"
 >;
 
+const EMBEDDING_PROVIDER_RETIREMENTS = new Map<string, Set<MemoryEmbeddingProvider>>();
+const EMBEDDING_PROVIDER_ADMISSION_TAILS = new Map<string, Promise<void>>();
+
+async function runEmbeddingProviderAdmission<T>(
+  scopeKey: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) ?? Promise.resolve();
+  const result = previous.then(operation, operation);
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  EMBEDDING_PROVIDER_ADMISSION_TAILS.set(scopeKey, tail);
+  try {
+    return await result;
+  } finally {
+    if (EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) === tail) {
+      EMBEDDING_PROVIDER_ADMISSION_TAILS.delete(scopeKey);
+    }
+  }
+}
+
+async function drainEmbeddingProviderRetirements(scopeKey: string): Promise<void> {
+  const pending = EMBEDDING_PROVIDER_RETIREMENTS.get(scopeKey);
+  if (!pending || pending.size === 0) {
+    return;
+  }
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const provider of pending) {
+    try {
+      await provider.close?.();
+      pending.delete(provider);
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (pending.size === 0) {
+    EMBEDDING_PROVIDER_RETIREMENTS.delete(scopeKey);
+  }
+  if (closeFailed) {
+    throw firstError;
+  }
+}
+
+function retainEmbeddingProviderForRetirement(
+  scopeKey: string,
+  provider: MemoryEmbeddingProvider,
+): void {
+  const pending = EMBEDDING_PROVIDER_RETIREMENTS.get(scopeKey) ?? new Set();
+  pending.add(provider);
+  EMBEDDING_PROVIDER_RETIREMENTS.set(scopeKey, pending);
+}
+
 function coerceRequest(value: unknown): EmbeddingsRequest {
   return value && typeof value === "object" ? (value as EmbeddingsRequest) : {};
 }
@@ -337,49 +395,54 @@ export async function handleOpenAiEmbeddingsHttpRequest(
     });
     return true;
   }
+  const providerScopeKey = JSON.stringify([agentId, target.provider, target.model]);
 
   try {
-    const provider = await createConfiguredEmbeddingProvider({
-      cfg,
-      agentDir,
-      provider: target.provider,
-      model: target.model,
-      memorySearch: memorySearch
-        ? {
-            ...memorySearch,
-            outputDimensionality:
-              typeof payload.dimensions === "number" && payload.dimensions > 0
-                ? Math.floor(payload.dimensions)
-                : memorySearch.outputDimensionality,
-          }
-        : undefined,
-    });
-    try {
-      const embeddings = await provider.embedBatch(texts);
-      const encodingFormat = payload.encoding_format === "base64" ? "base64" : "float";
-
-      sendJson(res, 200, {
-        object: "list",
-        data: embeddings.map((embedding, index) => ({
-          object: "embedding",
-          index,
-          embedding: encodingFormat === "base64" ? encodeEmbeddingBase64(embedding) : embedding,
-        })),
-        model: requestModel,
-        usage: {
-          prompt_tokens: 0,
-          total_tokens: 0,
-        },
+    await runEmbeddingProviderAdmission(providerScopeKey, async () => {
+      await drainEmbeddingProviderRetirements(providerScopeKey);
+      const provider = await createConfiguredEmbeddingProvider({
+        cfg,
+        agentDir,
+        provider: target.provider,
+        model: target.model,
+        memorySearch: memorySearch
+          ? {
+              ...memorySearch,
+              outputDimensionality:
+                typeof payload.dimensions === "number" && payload.dimensions > 0
+                  ? Math.floor(payload.dimensions)
+                  : memorySearch.outputDimensionality,
+            }
+          : undefined,
       });
-    } finally {
       try {
-        await provider.close?.();
-      } catch (closeErr) {
-        logWarn(
-          `openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`,
-        );
+        const embeddings = await provider.embedBatch(texts);
+        const encodingFormat = payload.encoding_format === "base64" ? "base64" : "float";
+
+        sendJson(res, 200, {
+          object: "list",
+          data: embeddings.map((embedding, index) => ({
+            object: "embedding",
+            index,
+            embedding: encodingFormat === "base64" ? encodeEmbeddingBase64(embedding) : embedding,
+          })),
+          model: requestModel,
+          usage: {
+            prompt_tokens: 0,
+            total_tokens: 0,
+          },
+        });
+      } finally {
+        try {
+          await provider.close?.();
+        } catch (closeErr) {
+          retainEmbeddingProviderForRetirement(providerScopeKey, provider);
+          logWarn(
+            `openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`,
+          );
+        }
       }
-    }
+    });
   } catch (err) {
     logWarn(`openai-compat: embeddings request failed: ${formatErrorMessage(err)}`);
     sendJson(res, 500, {

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -354,22 +354,30 @@ export async function handleOpenAiEmbeddingsHttpRequest(
           }
         : undefined,
     });
-    const embeddings = await provider.embedBatch(texts);
-    const encodingFormat = payload.encoding_format === "base64" ? "base64" : "float";
+    try {
+      const embeddings = await provider.embedBatch(texts);
+      const encodingFormat = payload.encoding_format === "base64" ? "base64" : "float";
 
-    sendJson(res, 200, {
-      object: "list",
-      data: embeddings.map((embedding, index) => ({
-        object: "embedding",
-        index,
-        embedding: encodingFormat === "base64" ? encodeEmbeddingBase64(embedding) : embedding,
-      })),
-      model: requestModel,
-      usage: {
-        prompt_tokens: 0,
-        total_tokens: 0,
-      },
-    });
+      sendJson(res, 200, {
+        object: "list",
+        data: embeddings.map((embedding, index) => ({
+          object: "embedding",
+          index,
+          embedding: encodingFormat === "base64" ? encodeEmbeddingBase64(embedding) : embedding,
+        })),
+        model: requestModel,
+        usage: {
+          prompt_tokens: 0,
+          total_tokens: 0,
+        },
+      });
+    } finally {
+      await provider.close?.().catch((closeErr: unknown) => {
+        logWarn(
+          `openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`,
+        );
+      });
+    }
   } catch (err) {
     logWarn(`openai-compat: embeddings request failed: ${formatErrorMessage(err)}`);
     sendJson(res, 500, {

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -469,8 +469,9 @@ export async function handleOpenAiEmbeddingsHttpRequest(
               }
             : undefined,
         }),
-      (provider) =>
-        requestedProviderNeedsCleanup || isLocalEmbeddingProvider({ cfg, provider: provider.id }),
+      (createdProvider) =>
+        requestedProviderNeedsCleanup ||
+        isLocalEmbeddingProvider({ cfg, provider: createdProvider.id }),
     );
     try {
       const embeddings = await provider.embedBatch(texts);

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -70,24 +70,38 @@ type MemorySearchEmbeddingConfig = Pick<
 const EMBEDDING_PROVIDER_RETIREMENTS = new Map<string, Set<MemoryEmbeddingProvider>>();
 const EMBEDDING_PROVIDER_ADMISSION_TAILS = new Map<string, Promise<void>>();
 
-async function runEmbeddingProviderAdmission<T>(
+async function acquireEmbeddingProviderLease(
   scopeKey: string,
-  operation: () => Promise<T>,
-): Promise<T> {
+  create: () => Promise<MemoryEmbeddingProvider>,
+): Promise<{ provider: MemoryEmbeddingProvider; release: () => void }> {
   const previous = EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) ?? Promise.resolve();
-  const result = previous.then(operation, operation);
-  const tail = result.then(
-    () => undefined,
-    () => undefined,
-  );
+  const createLease = async () => {
+    await drainEmbeddingProviderRetirements(scopeKey);
+    const provider = await create();
+    if (!provider.close) {
+      return { provider, lifecycle: Promise.resolve(), release: () => {} };
+    }
+    let release: () => void = () => {};
+    const lifecycle = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return { provider, lifecycle, release };
+  };
+  const acquired = previous.then(createLease, createLease);
+  const tail = acquired
+    .then(async ({ lifecycle }) => await lifecycle)
+    .then(
+      () => undefined,
+      () => undefined,
+    );
   EMBEDDING_PROVIDER_ADMISSION_TAILS.set(scopeKey, tail);
-  try {
-    return await result;
-  } finally {
+  void tail.then(() => {
     if (EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) === tail) {
       EMBEDDING_PROVIDER_ADMISSION_TAILS.delete(scopeKey);
     }
-  }
+  });
+  const { provider, release } = await acquired;
+  return { provider, release };
 }
 
 async function drainEmbeddingProviderRetirements(scopeKey: string): Promise<void> {
@@ -398,51 +412,54 @@ export async function handleOpenAiEmbeddingsHttpRequest(
   const providerScopeKey = JSON.stringify([agentId, target.provider, target.model]);
 
   try {
-    await runEmbeddingProviderAdmission(providerScopeKey, async () => {
-      await drainEmbeddingProviderRetirements(providerScopeKey);
-      const provider = await createConfiguredEmbeddingProvider({
-        cfg,
-        agentDir,
-        provider: target.provider,
-        model: target.model,
-        memorySearch: memorySearch
-          ? {
-              ...memorySearch,
-              outputDimensionality:
-                typeof payload.dimensions === "number" && payload.dimensions > 0
-                  ? Math.floor(payload.dimensions)
-                  : memorySearch.outputDimensionality,
-            }
-          : undefined,
-      });
-      try {
-        const embeddings = await provider.embedBatch(texts);
-        const encodingFormat = payload.encoding_format === "base64" ? "base64" : "float";
+    const { provider, release } = await acquireEmbeddingProviderLease(
+      providerScopeKey,
+      async () =>
+        await createConfiguredEmbeddingProvider({
+          cfg,
+          agentDir,
+          provider: target.provider,
+          model: target.model,
+          memorySearch: memorySearch
+            ? {
+                ...memorySearch,
+                outputDimensionality:
+                  typeof payload.dimensions === "number" && payload.dimensions > 0
+                    ? Math.floor(payload.dimensions)
+                    : memorySearch.outputDimensionality,
+              }
+            : undefined,
+        }),
+    );
+    try {
+      const embeddings = await provider.embedBatch(texts);
+      const encodingFormat = payload.encoding_format === "base64" ? "base64" : "float";
 
-        sendJson(res, 200, {
-          object: "list",
-          data: embeddings.map((embedding, index) => ({
-            object: "embedding",
-            index,
-            embedding: encodingFormat === "base64" ? encodeEmbeddingBase64(embedding) : embedding,
-          })),
-          model: requestModel,
-          usage: {
-            prompt_tokens: 0,
-            total_tokens: 0,
-          },
-        });
+      sendJson(res, 200, {
+        object: "list",
+        data: embeddings.map((embedding, index) => ({
+          object: "embedding",
+          index,
+          embedding: encodingFormat === "base64" ? encodeEmbeddingBase64(embedding) : embedding,
+        })),
+        model: requestModel,
+        usage: {
+          prompt_tokens: 0,
+          total_tokens: 0,
+        },
+      });
+    } finally {
+      try {
+        await provider.close?.();
+      } catch (closeErr) {
+        retainEmbeddingProviderForRetirement(providerScopeKey, provider);
+        logWarn(
+          `openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`,
+        );
       } finally {
-        try {
-          await provider.close?.();
-        } catch (closeErr) {
-          retainEmbeddingProviderForRetirement(providerScopeKey, provider);
-          logWarn(
-            `openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`,
-          );
-        }
+        release();
       }
-    });
+    }
   } catch (err) {
     logWarn(`openai-compat: embeddings request failed: ${formatErrorMessage(err)}`);
     sendJson(res, 500, {

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -311,7 +311,7 @@ function adaptGenericEmbeddingProvider(
         ...options,
         inputType: "document",
       }),
-    ...(provider.close ? { close: provider.close } : {}),
+    ...(provider.close ? { close: async () => await provider.close?.() } : {}),
   };
 }
 

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -73,12 +73,13 @@ const EMBEDDING_PROVIDER_ADMISSION_TAILS = new Map<string, Promise<void>>();
 async function acquireEmbeddingProviderLease(
   scopeKey: string,
   create: () => Promise<MemoryEmbeddingProvider>,
+  holdForCleanup: boolean,
 ): Promise<{ provider: MemoryEmbeddingProvider; release: () => void }> {
   const previous = EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) ?? Promise.resolve();
   const createLease = async () => {
     await drainEmbeddingProviderRetirements(scopeKey);
     const provider = await create();
-    if (!provider.close) {
+    if (!holdForCleanup) {
       return { provider, lifecycle: Promise.resolve(), release: () => {} };
     }
     let release: () => void = () => {};
@@ -139,6 +140,28 @@ function retainEmbeddingProviderForRetirement(
   EMBEDDING_PROVIDER_RETIREMENTS.set(scopeKey, pending);
 }
 
+export async function drainRetainedOpenAiEmbeddingProviders(): Promise<void> {
+  const activeLifecycles = Array.from(EMBEDDING_PROVIDER_ADMISSION_TAILS.values());
+  if (activeLifecycles.length > 0) {
+    await Promise.allSettled(activeLifecycles);
+  }
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const scopeKey of Array.from(EMBEDDING_PROVIDER_RETIREMENTS.keys())) {
+    try {
+      await drainEmbeddingProviderRetirements(scopeKey);
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (closeFailed) {
+    throw firstError;
+  }
+}
+
 function coerceRequest(value: unknown): EmbeddingsRequest {
   return value && typeof value === "object" ? (value as EmbeddingsRequest) : {};
 }
@@ -189,6 +212,18 @@ function resolveEmbeddingProviderRemoteConfig(remote: MemorySearchEmbeddingConfi
         headers: remote.headers,
       }
     : undefined;
+}
+
+function isLocalEmbeddingProvider(params: {
+  cfg: OpenClawConfig;
+  provider: EmbeddingProviderRequest;
+}): boolean {
+  const providerId =
+    params.provider === "auto" ? DEFAULT_MEMORY_EMBEDDING_PROVIDER : params.provider;
+  return (
+    getMemoryEmbeddingProvider(providerId, params.cfg)?.transport === "local" ||
+    getGenericEmbeddingProvider(providerId, params.cfg)?.transport === "local"
+  );
 }
 
 async function createConfiguredEmbeddingProvider(params: {
@@ -410,6 +445,10 @@ export async function handleOpenAiEmbeddingsHttpRequest(
     return true;
   }
   const providerScopeKey = JSON.stringify([agentId, target.provider, target.model]);
+  const holdProviderForCleanup = isLocalEmbeddingProvider({
+    cfg,
+    provider: target.provider,
+  });
 
   try {
     const { provider, release } = await acquireEmbeddingProviderLease(
@@ -430,6 +469,7 @@ export async function handleOpenAiEmbeddingsHttpRequest(
               }
             : undefined,
         }),
+      holdProviderForCleanup,
     );
     try {
       const embeddings = await provider.embedBatch(texts);

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -444,7 +444,7 @@ export async function handleOpenAiEmbeddingsHttpRequest(
     });
     return true;
   }
-  const providerScopeKey = JSON.stringify([agentId, target.provider, target.model]);
+  const providerScopeKey = JSON.stringify([agentId, target.provider]);
   const holdProviderForCleanup = isLocalEmbeddingProvider({
     cfg,
     provider: target.provider,

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -372,11 +372,13 @@ export async function handleOpenAiEmbeddingsHttpRequest(
         },
       });
     } finally {
-      await provider.close?.().catch((closeErr: unknown) => {
+      try {
+        await provider.close?.();
+      } catch (closeErr) {
         logWarn(
           `openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`,
         );
-      });
+      }
     }
   } catch (err) {
     logWarn(`openai-compat: embeddings request failed: ${formatErrorMessage(err)}`);

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1409,6 +1409,10 @@ describe("createGatewayCloseHandler", () => {
   });
 
   it("unsubscribes lifecycle listeners and disposes bundle runtimes during shutdown", async () => {
+    const closeOrder: string[] = [];
+    mocks.drainRetainedEmbeddingProviders.mockImplementation(async () => {
+      closeOrder.push("embedding-providers");
+    });
     const lifecycleUnsub = vi.fn();
     const taskUnsub = vi.fn();
     const transcriptUnsub = vi.fn();
@@ -1419,6 +1423,13 @@ describe("createGatewayCloseHandler", () => {
         lifecycleUnsub,
         taskUnsub,
         transcriptUnsub,
+        httpServer: {
+          close: (callback: (err?: Error | null) => void) => {
+            closeOrder.push("http-server");
+            callback(null);
+          },
+          closeIdleConnections: vi.fn(),
+        } as never,
       }),
     );
 
@@ -1432,6 +1443,7 @@ describe("createGatewayCloseHandler", () => {
     expect(mocks.disposeAllSessionMcpRuntimes).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAllBundleLspRuntimes).toHaveBeenCalledTimes(1);
     expect(mocks.drainRetainedEmbeddingProviders).toHaveBeenCalledTimes(1);
+    expect(closeOrder).toEqual(["http-server", "embedding-providers"]);
   });
 
   it("starts bundle MCP and LSP runtime disposal concurrently", async () => {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   disposeAllSessionMcpRuntimes: vi.fn(async () => undefined),
   triggerInternalHook: vi.fn<TriggerInternalHookMock>(async (_eventValue) => undefined),
   disposeAllBundleLspRuntimes: vi.fn(async () => undefined),
+  drainRetainedEmbeddingProviders: vi.fn(async () => undefined),
   clearSessionSuspensionTimers: vi.fn(() => 0),
 }));
 const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
@@ -61,6 +62,10 @@ vi.mock("../agents/agent-bundle-lsp-runtime.js", async () => ({
     "../agents/agent-bundle-lsp-runtime.js",
   )),
   disposeAllBundleLspRuntimes: mocks.disposeAllBundleLspRuntimes,
+}));
+
+vi.mock("./embeddings-http.js", () => ({
+  drainRetainedOpenAiEmbeddingProviders: mocks.drainRetainedEmbeddingProviders,
 }));
 
 vi.mock("../agents/session-suspension.js", () => ({
@@ -162,6 +167,8 @@ describe("createGatewayCloseHandler", () => {
     mocks.triggerInternalHook.mockResolvedValue(undefined);
     mocks.disposeAllBundleLspRuntimes.mockClear();
     mocks.disposeAllBundleLspRuntimes.mockResolvedValue(undefined);
+    mocks.drainRetainedEmbeddingProviders.mockClear();
+    mocks.drainRetainedEmbeddingProviders.mockResolvedValue(undefined);
     mocks.clearSessionSuspensionTimers.mockReset();
     mocks.clearSessionSuspensionTimers.mockReturnValue(0);
   });
@@ -1424,6 +1431,7 @@ describe("createGatewayCloseHandler", () => {
     expect(mocks.disposeAgentHarnesses).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAllSessionMcpRuntimes).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAllBundleLspRuntimes).toHaveBeenCalledTimes(1);
+    expect(mocks.drainRetainedEmbeddingProviders).toHaveBeenCalledTimes(1);
   });
 
   it("starts bundle MCP and LSP runtime disposal concurrently", async () => {
@@ -1484,6 +1492,23 @@ describe("createGatewayCloseHandler", () => {
     expect(
       mocks.logWarn.mock.calls.some(([message]) =>
         String(message).includes("bundle-lsp runtime disposal exceeded 5000ms"),
+      ),
+    ).toBe(true);
+  });
+
+  it("continues shutdown when retained embedding provider cleanup hangs", async () => {
+    vi.useFakeTimers();
+    mocks.drainRetainedEmbeddingProviders.mockReturnValue(new Promise(() => {}));
+    const close = createGatewayCloseHandler(createGatewayCloseTestDeps());
+
+    const closePromise = close({ reason: "test shutdown" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await closePromise;
+
+    expect(result.warnings).toContain("embedding-providers");
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes("embedding-providers runtime disposal exceeded 5000ms"),
       ),
     ).toBe(true);
   });

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -866,12 +866,6 @@ export function createGatewayCloseHandler(
         }
       });
       await shutdownStep("agent-harnesses", () => disposeRegisteredAgentHarnesses(), warnings);
-      await disposeRuntimeWithShutdownGrace({
-        label: "embedding-providers",
-        dispose: drainRetainedEmbeddingProvidersOnDemand,
-        graceMs: EMBEDDING_PROVIDER_CLOSE_GRACE_MS,
-        warnings,
-      });
       await measureCloseStep("bundle-runtimes", async () => {
         await Promise.all([
           disposeRuntimeWithShutdownGrace({
@@ -1038,6 +1032,12 @@ export function createGatewayCloseHandler(
             }
           }
         }
+      });
+      await disposeRuntimeWithShutdownGrace({
+        label: "embedding-providers",
+        dispose: drainRetainedEmbeddingProvidersOnDemand,
+        graceMs: EMBEDDING_PROVIDER_CLOSE_GRACE_MS,
+        warnings,
       });
     } finally {
       try {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -43,6 +43,7 @@ const HTTP_CLOSE_GRACE_MS = 1_000;
 const HTTP_CLOSE_FORCE_WAIT_MS = 5_000;
 const MCP_RUNTIME_CLOSE_GRACE_MS = 5_000;
 const LSP_RUNTIME_CLOSE_GRACE_MS = 5_000;
+const EMBEDDING_PROVIDER_CLOSE_GRACE_MS = 5_000;
 const RESTART_REPLY_DRAIN_POLL_MS = 100;
 const RESTART_REPLY_POST_ABORT_DRAIN_TIMEOUT_MS = 1_000;
 const RESTART_REPLY_POST_ABORT_DRAIN_POLL_MS = 50;
@@ -574,7 +575,7 @@ async function triggerGatewayLifecycleHookWithTimeout(params: {
 }
 
 async function disposeRuntimeWithShutdownGrace(params: {
-  label: "bundle-mcp" | "bundle-lsp";
+  label: "bundle-mcp" | "bundle-lsp" | "embedding-providers";
   dispose: () => Promise<void>;
   graceMs: number;
   warnings: string[];
@@ -598,6 +599,11 @@ async function disposeRuntimeWithShutdownGrace(params: {
 async function disposeAllBundleLspRuntimesOnDemand(): Promise<void> {
   const { disposeAllBundleLspRuntimes } = await import("../agents/agent-bundle-lsp-runtime.js");
   await disposeAllBundleLspRuntimes();
+}
+
+async function drainRetainedEmbeddingProvidersOnDemand(): Promise<void> {
+  const { drainRetainedOpenAiEmbeddingProviders } = await import("./embeddings-http.js");
+  await drainRetainedOpenAiEmbeddingProviders();
 }
 
 async function stopGmailWatcherOnDemand(): Promise<void> {
@@ -860,6 +866,12 @@ export function createGatewayCloseHandler(
         }
       });
       await shutdownStep("agent-harnesses", () => disposeRegisteredAgentHarnesses(), warnings);
+      await disposeRuntimeWithShutdownGrace({
+        label: "embedding-providers",
+        dispose: drainRetainedEmbeddingProvidersOnDemand,
+        graceMs: EMBEDDING_PROVIDER_CLOSE_GRACE_MS,
+        warnings,
+      });
       await measureCloseStep("bundle-runtimes", async () => {
         await Promise.all([
           disposeRuntimeWithShutdownGrace({


### PR DESCRIPTION
## What Problem This Solves

Memory Core could start a replacement embedding provider while the previous provider was still closing. For local llama.cpp embeddings, that allowed multiple worker processes to overlap or remain orphaned across degradation, fallback, retry, CLI, and Gateway paths.

## Why This Change Was Made

Provider lifecycle ownership was split across assignment call sites, and the worker client treated “kill signal sent” as equivalent to “child exited.” The final fix centralizes retirement, retains failed retirements for retry, makes worker shutdown joinable and bounded, and carries a leased provider generation through query/index publication so fallback cannot mix provider identities or timeouts.

## Changes

- Serialize provider retirement before primary or fallback initialization.
- Retain failed provider retirements and failed worker-construction clients for later draining.
- Keep provider, runtime, cache key, and identity aliases together through query, embedding-cache, vector, and chunk publication.
- Represent FTS-only sync as an explicit generation so fallback activation cannot create a mixed index.
- Wait for admitted searches, syncs, provider users, Gateway HTTP work, and availability probes before teardown.
- Make worker close joinable, wait for actual child exit, and escalate SIGTERM to SIGKILL within a bounded window.
- Close request-scoped providers in core CLI, LanceDB CLI, Gateway, and LanceDB service consumers; drain retained providers during Gateway shutdown.
- Serialize QMD manager replacement and retain failed QMD cleanup for retry.

## User Impact

Local embedding workers no longer accumulate across provider replacement. Replacement waits for real process exit, successful in-flight work publishes under the provider generation that produced it, and failed cleanup stays retryable rather than being forgotten.

No configuration, public API, persisted-state schema, or changelog change is included.

## Evidence

Defect proof on current main before the fix:

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts -t "waits for degraded provider shutdown before fallback initialization"`
- Failed as expected: replacement creation began while the previous provider close gate was blocked.

Final head: `539b50d373169bd4d97d5398d209b7ff636719d6`

Focused lifecycle proof:

- Memory Core/provider/cache/QMD, worker host, Gateway, CLI, and LanceDB: 513 tests passed on the final runtime tree in Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30188105615.
- Final-head LanceDB provider lifecycle, active-use drain, service replacement, and standalone CLI suites: 143 passed in https://github.com/openclaw/openclaw/actions/runs/30191092698.
- The final active-use owner passed both extension typecheck lanes, formatting, lint, API/boundary guards, and import cycles in https://github.com/openclaw/openclaw/actions/runs/30190850033, followed by a clean structured autoreview.
- Exact-head hosted synthetic-merge CI is green: https://github.com/openclaw/openclaw/actions/runs/30191078329.

Exact-head real llama.cpp/GGUF lifecycle proof:

- Blacksmith Testbox `tbx_01kyehqpz3j3ah8xq3kd8v1m08`, run https://github.com/openclaw/openclaw/actions/runs/30191092698.
- Used the real `extensions/llama-cpp` adapter, `node-llama-cpp`, EmbeddingGemma GGUF, and worker child.
- First provider returned a 768-dimensional embedding in PID 5243.
- PID 5243 was visible during retirement and absent after awaited close.
- Replacement provider returned a 768-dimensional embedding in PID 5325.
- Final worker list was empty: zero orphan workers remained.

Independent adversarial review previously found and drove fixes for generation, admission, and cleanup-proof gaps. The final refuter result is recorded in the maintainer review artifacts.
