### PR TITLE
feat(setup): download-model actions on web and macOS onboarding

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -34363,7 +34363,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 103,
+      "line": 52,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
+      "source": "OpenClaw is preparing a local model.",
+      "surface": "apple",
+      "id": "native.apple.3db546546fbaf38e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 53,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
+      "source": "OpenClaw is completing provider sign-in.",
+      "surface": "apple",
+      "id": "native.apple.c5992a23c991f948"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 175,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "The Gateway setup request failed.",
       "surface": "apple",
@@ -34371,7 +34387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 104,
+      "line": 176,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
       "surface": "apple",
@@ -34379,7 +34395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 188,
+      "line": 260,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "\\(label) couldn’t complete the test.",
       "surface": "apple",
@@ -34387,7 +34403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 261,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
       "surface": "apple",
@@ -34475,7 +34491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 280,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Need help? Chat with OpenClaw",
       "surface": "apple",
@@ -34483,7 +34499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 294,
+      "line": 295,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Your AI is ready",
       "surface": "apple",
@@ -34491,7 +34507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 305,
+      "line": 306,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Setup details",
       "surface": "apple",
@@ -34499,7 +34515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 319,
+      "line": 320,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy setup details",
       "surface": "apple",
@@ -34507,7 +34523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 335,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "No usable AI access found on this Gateway",
       "surface": "apple",
@@ -34515,7 +34531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 337,
+      "line": 338,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect a provider below with an API key or token, then check again.",
       "surface": "apple",
@@ -34523,7 +34539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 338,
+      "line": 339,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Install one of these tools, then check again. You can also connect a provider below.",
       "surface": "apple",
@@ -34531,7 +34547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 343,
+      "line": 344,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Recommended installs",
       "surface": "apple",
@@ -34539,7 +34555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 366,
+      "line": 367,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Detected, but not auto-tested",
       "surface": "apple",
@@ -34547,7 +34563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 374,
+      "line": 375,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "\\(candidate.label) — \\(candidate.detail)",
       "surface": "apple",
@@ -34555,7 +34571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 493,
+      "line": 494,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "No key-based providers are available",
       "surface": "apple",
@@ -34563,7 +34579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 494,
+      "line": 495,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "surface": "apple",
@@ -34571,7 +34587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 496,
+      "line": 497,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Check again",
       "surface": "apple",
@@ -34579,7 +34595,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 510,
+      "line": 511,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "Set up a local model",
+      "surface": "apple",
+      "id": "native.apple.82148c7c60e4fb74"
+    },
+    {
+      "kind": "ui-call",
+      "line": 513,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "Download or prepare a local model on this Gateway.",
+      "surface": "apple",
+      "id": "native.apple.506a932536c642c2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 537,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "Set up / Download model",
+      "surface": "apple",
+      "id": "native.apple.d31411a9f3c68c33"
+    },
+    {
+      "kind": "ui-call",
+      "line": 559,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in with a provider",
       "surface": "apple",
@@ -34587,7 +34627,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 512,
+      "line": 561,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
       "surface": "apple",
@@ -34595,7 +34635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 527,
+      "line": 576,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "More sign-in options",
       "surface": "apple",
@@ -34603,7 +34643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 557,
+      "line": 606,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "API Keys",
       "surface": "apple",
@@ -34611,7 +34651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 597,
+      "line": 646,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Pair",
       "surface": "apple",
@@ -34619,15 +34659,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 597,
+      "line": 646,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in",
       "surface": "apple",
       "id": "native.apple.f431c2a7838e89d7"
     },
     {
-      "kind": "ui-call",
-      "line": 613,
+      "kind": "conditional-branch",
+      "line": 663,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "The model is downloaded and prepared on this Gateway.",
+      "surface": "apple",
+      "id": "native.apple.b62dfd708d5cfb14"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 664,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
       "surface": "apple",
@@ -34635,23 +34683,39 @@
     },
     {
       "kind": "ui-call",
-      "line": 642,
+      "line": 693,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page…",
       "surface": "apple",
       "id": "native.apple.3d5ffc1c8a803630"
     },
     {
-      "kind": "ui-call",
-      "line": 649,
+      "kind": "conditional-branch",
+      "line": 701,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "Starting local model setup…",
+      "surface": "apple",
+      "id": "native.apple.91cd595c858a6ea7"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 702,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Starting secure sign-in…",
       "surface": "apple",
       "id": "native.apple.bb3352787887c424"
     },
     {
-      "kind": "ui-named-argument",
-      "line": 655,
+      "kind": "conditional-branch",
+      "line": 709,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "Model setup didn’t complete",
+      "surface": "apple",
+      "id": "native.apple.ba9a46f1e6c4d477"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 710,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign-in didn’t complete",
       "surface": "apple",
@@ -34659,7 +34723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 665,
+      "line": 720,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -34667,7 +34731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 688,
+      "line": 743,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Finish in your browser",
       "surface": "apple",
@@ -34675,7 +34739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 704,
+      "line": 759,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy",
       "surface": "apple",
@@ -34683,7 +34747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 715,
+      "line": 770,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Expires in \\(minutes) minutes",
       "surface": "apple",
@@ -34691,7 +34755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 722,
+      "line": 777,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page",
       "surface": "apple",
@@ -34699,7 +34763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 750,
+      "line": 805,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Option",
       "surface": "apple",
@@ -34707,7 +34771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 756,
+      "line": 811,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Confirm",
       "surface": "apple",
@@ -34715,7 +34779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 765,
+      "line": 820,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "I've signed in",
       "surface": "apple",
@@ -34723,7 +34787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 767,
+      "line": 822,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Continue",
       "surface": "apple",
@@ -34731,7 +34795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 767,
+      "line": 822,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Submit",
       "surface": "apple",
@@ -34739,7 +34803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 772,
+      "line": 827,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect with an API key or token",
       "surface": "apple",
@@ -34747,7 +34811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 781,
+      "line": 836,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Provider",
       "surface": "apple",
@@ -34755,7 +34819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 789,
+      "line": 844,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "API key or token",
       "surface": "apple",
@@ -34763,7 +34827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 801,
+      "line": 856,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect",
       "surface": "apple",
@@ -34771,7 +34835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 814,
+      "line": 869,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "That key didn’t work",
       "surface": "apple",
@@ -34779,7 +34843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 840,
+      "line": 895,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "OpenClaw — setup helper",
       "surface": "apple",
@@ -34787,7 +34851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 843,
+      "line": 898,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Done",
       "surface": "apple",
@@ -34795,7 +34859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 904,
+      "line": 959,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open help…",
       "surface": "apple",
@@ -34803,7 +34867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 943,
+      "line": 998,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Hide details",
       "surface": "apple",
@@ -34811,7 +34875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 943,
+      "line": 998,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Show details",
       "surface": "apple",
@@ -34819,7 +34883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 966,
+      "line": 1021,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy error",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -764,6 +764,18 @@ extension GatewayConnection {
         return snapshot.supportsServerCapability(capability)
     }
 
+    func supportsServerMethod(
+        _ method: String,
+        ifCurrentServerLease lease: ServerLease) async -> Bool?
+    {
+        guard await self.isCurrentServerLease(lease),
+              self.serverLeaseMatchesCurrentState(lease),
+              let snapshot = lastSnapshot
+        else { return nil }
+        let methods = snapshot.features["methods"]?.value as? [AnyCodable] ?? []
+        return methods.contains { ($0.value as? String) == method }
+    }
+
     func isCurrentServerLease(_ lease: ServerLease) async -> Bool {
         guard let endpoint = try? await currentEndpoint(),
               serverLeaseMatchesCurrentState(lease),

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -25,7 +25,9 @@ final class OnboardingAISetupModel {
             OnboardingController.shared.busyReason = if self.phase == .testing {
                 "OpenClaw is testing your AI connection."
             } else if self.activeAuthOption != nil {
-                "OpenClaw is completing provider sign-in."
+                self.isPreparingModel
+                    ? "OpenClaw is preparing a local model."
+                    : "OpenClaw is completing provider sign-in."
             } else {
                 nil
             }
@@ -37,14 +39,18 @@ final class OnboardingAISetupModel {
     private(set) var manualProviders: [ManualProvider] = []
     private(set) var authOptions: [AuthOption] = []
     private(set) var recommendedInstalls: [RecommendedInstall] = []
+    private(set) var prepareAvailable = false
     private(set) var candidatePresentation: [String: CandidatePresentation] = [:]
     private(set) var activeAuthOption: AuthOption?
+    private(set) var providerWizardKind: ProviderWizardKind?
     private(set) var authStep: WizardStep?
     private(set) var authError: Failure?
     private(set) var authBusy = false {
         didSet {
             if self.activeAuthOption != nil {
-                OnboardingController.shared.busyReason = "OpenClaw is completing provider sign-in."
+                OnboardingController.shared.busyReason = self.isPreparingModel
+                    ? "OpenClaw is preparing a local model."
+                    : "OpenClaw is completing provider sign-in."
             } else if self.phase != .testing {
                 OnboardingController.shared.busyReason = nil
             }
@@ -76,6 +82,19 @@ final class OnboardingAISetupModel {
 
     var selectedManualProvider: ManualProvider? {
         self.manualProviders.first { $0.id == self.manualProviderID }
+    }
+
+    var prepareOptions: [PrepareOption] {
+        guard self.prepareAvailable else { return [] }
+        return Self.prepareOptions(
+            candidates: self.candidates,
+            manualProviders: self.manualProviders,
+            authOptions: self.authOptions,
+            recommendedInstalls: self.recommendedInstalls)
+    }
+
+    var isPreparingModel: Bool {
+        self.providerWizardKind == .prepare
     }
 
     var connected: Bool {
@@ -609,8 +628,10 @@ final class OnboardingAISetupModel {
         self.manualProviders = []
         self.authOptions = []
         self.recommendedInstalls = []
+        self.prepareAvailable = false
         self.candidatePresentation = [:]
         self.activeAuthOption = nil
+        self.providerWizardKind = nil
         self.authStep = nil
         self.authError = nil
         self.authBusy = false
@@ -681,7 +702,15 @@ extension OnboardingAISetupModel {
                   !Task.isCancelled
             else { return }
             let result = try JSONDecoder().decode(DetectResult.self, from: data)
+            let prepareAvailable = await self.gateway.supportsServerMethod(
+                "openclaw.setup.prepare.start",
+                ifCurrentServerLease: lease) == true
+            guard await self.gateway.isCurrentServerLease(lease),
+                  self.isCurrentAttempt(context),
+                  !Task.isCancelled
+            else { return }
             self.serverLease = lease
+            self.prepareAvailable = prepareAvailable
             self.lastDetectedActivationState = result.persistedActivationState
             let manualProviders = result.manualProviders ?? []
             let authOptions = result.authOptions ?? []
@@ -1076,8 +1105,27 @@ extension OnboardingAISetupModel {
 
 extension OnboardingAISetupModel {
     func startProviderAuth(_ option: AuthOption) {
+        self.startProviderWizard(option, kind: .auth)
+    }
+
+    func startProviderPrepare(_ option: PrepareOption) {
+        self.startProviderWizard(
+            AuthOption(
+                id: option.id,
+                label: option.label,
+                hint: option.hint,
+                groupLabel: nil,
+                icon: option.icon,
+                website: option.website,
+                kind: "prepare",
+                featured: false),
+            kind: .prepare)
+    }
+
+    private func startProviderWizard(_ option: AuthOption, kind: ProviderWizardKind) {
         guard !self.isBusy, self.activeAuthOption == nil, let serverLease else { return }
         self.activeAuthOption = option
+        self.providerWizardKind = kind
         self.authStep = nil
         self.authError = nil
         self.authText = ""
@@ -1091,7 +1139,7 @@ extension OnboardingAISetupModel {
         Task {
             do {
                 let data = try await self.gateway.request(
-                    method: "openclaw.setup.auth.start",
+                    method: kind.startMethod,
                     params: [
                         "sessionId": AnyCodable(authSessionID),
                         "authChoice": AnyCodable(option.id),
@@ -1276,7 +1324,7 @@ extension OnboardingAISetupModel {
             return
         }
         if done || status == "done" {
-            self.providerAuthReconciliationPending = true
+            self.providerAuthReconciliationPending = self.providerWizardKind == .auth
             self.clearProviderAuth()
             self.scheduleDetection()
             return
@@ -1343,6 +1391,7 @@ extension OnboardingAISetupModel {
 
     private func clearProviderAuth() {
         self.activeAuthOption = nil
+        self.providerWizardKind = nil
         self.authSessionID = nil
         self.authStep = nil
         self.authError = nil

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
@@ -85,6 +85,78 @@ extension OnboardingAISetupModel {
         let icon: String
     }
 
+    struct PrepareOption: Identifiable, Equatable {
+        let id: String
+        let label: String
+        let hint: String?
+        let icon: String?
+        let website: String?
+    }
+
+    enum ProviderWizardKind: Equatable {
+        case auth
+        case prepare
+
+        var startMethod: String {
+            switch self {
+            case .auth: "openclaw.setup.auth.start"
+            case .prepare: "openclaw.setup.prepare.start"
+            }
+        }
+    }
+
+    static func prepareOptions(
+        candidates: [Candidate],
+        manualProviders: [ManualProvider],
+        authOptions: [AuthOption],
+        recommendedInstalls: [RecommendedInstall]) -> [PrepareOption]
+    {
+        let known = [
+            PrepareOption(
+                id: "ollama",
+                label: "Ollama",
+                hint: "Download a tools-capable model from your Ollama server",
+                icon: nil,
+                website: nil),
+            PrepareOption(
+                id: "llama-cpp",
+                label: "Local model (llama.cpp)",
+                hint: "Download an approximately 5.0 GB local model; requires 16 GB RAM",
+                icon: nil,
+                website: nil),
+        ]
+        return known.compactMap { choice in
+            guard !candidates.contains(where: {
+                $0.kind == "provider-auto:\(choice.id)" || $0.modelRef.hasPrefix("\(choice.id)/")
+            }) else { return nil }
+            if let option = authOptions.first(where: { $0.id == choice.id }) {
+                return PrepareOption(
+                    id: choice.id,
+                    label: option.label,
+                    hint: option.hint,
+                    icon: option.icon,
+                    website: option.website)
+            }
+            if let provider = manualProviders.first(where: { $0.id == choice.id }) {
+                return PrepareOption(
+                    id: choice.id,
+                    label: provider.label,
+                    hint: provider.hint,
+                    icon: provider.icon,
+                    website: provider.website)
+            }
+            if let install = recommendedInstalls.first(where: { $0.id == choice.id }) {
+                return PrepareOption(
+                    id: choice.id,
+                    label: install.label,
+                    hint: install.hint,
+                    icon: install.icon,
+                    website: install.website)
+            }
+            return choice
+        }
+    }
+
     static func canAcceptProviderAuthReconciliation(
         pending: Bool,
         setupComplete: Bool,

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -266,6 +266,7 @@ struct OnboardingAISetupView: View {
         }
 
         if !self.model.connected, self.model.providerCatalogLoaded {
+            self.providerPrepareSection
             self.providerAuthSection
             self.manualSection
         }
@@ -504,6 +505,54 @@ struct OnboardingAISetupView: View {
     }
 
     @ViewBuilder
+    private var providerPrepareSection: some View {
+        if !self.model.prepareOptions.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Set up a local model")
+                    .font(.headline)
+                Text("Download or prepare a local model on this Gateway.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                ForEach(self.model.prepareOptions) { option in
+                    Button {
+                        self.openedProviderAuthURL = nil
+                        self.model.startProviderPrepare(option)
+                    } label: {
+                        HStack(spacing: 10) {
+                            OnboardingProviderArtwork(
+                                icon: option.icon,
+                                fallbackKind: option.id,
+                                fallbackSymbol: "arrow.down.circle")
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(option.label)
+                                    .font(.callout.weight(.semibold))
+                                if let hint = option.hint, !hint.isEmpty {
+                                    Text(hint)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .multilineTextAlignment(.leading)
+                                }
+                            }
+                            Spacer(minLength: 0)
+                            Text("Set up / Download model")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Color.accentColor)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(self.model.isBusy)
+                    .openClawSelectableRowChrome(selected: false)
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(NSColor.controlBackgroundColor)))
+        }
+    }
+
+    @ViewBuilder
     private var providerAuthSection: some View {
         if !self.model.authOptions.isEmpty || !self.model.manualProviders.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
@@ -608,9 +657,11 @@ struct OnboardingAISetupView: View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(self.model.activeAuthOption?.label ?? "Provider sign-in")
+                    Text(self.model.activeAuthOption?.label ?? "Provider setup")
                         .font(.title3.weight(.semibold))
-                    Text("Credentials stay on this Gateway and are saved only after the live test succeeds.")
+                    Text(self.model.isPreparingModel
+                        ? "The model is downloaded and prepared on this Gateway."
+                        : "Credentials stay on this Gateway and are saved only after the live test succeeds.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -646,13 +697,17 @@ struct OnboardingAISetupView: View {
             } else if self.model.authBusy {
                 HStack(spacing: 10) {
                     ProgressView().controlSize(.small)
-                    Text("Starting secure sign-in…")
+                    Text(self.model.isPreparingModel
+                        ? "Starting local model setup…"
+                        : "Starting secure sign-in…")
                 }
             }
 
             if let error = self.model.authError {
                 OnboardingErrorCard(
-                    title: "Sign-in didn’t complete",
+                    title: self.model.isPreparingModel
+                        ? "Model setup didn’t complete"
+                        : "Sign-in didn’t complete",
                     message: error.summary,
                     details: error.detail,
                     docsSlug: "concepts/model-providers",

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -49,12 +49,14 @@ enum GatewayWebSocketTestSupport {
         id: String,
         tickIntervalMs: Int = 30000,
         deviceToken: String? = nil,
-        canvasPluginSurfaceURL: String? = nil) -> Data
+        canvasPluginSurfaceURL: String? = nil,
+        methods: [String] = []) -> Data
     {
         let deviceTokenField = deviceToken.map { #", "deviceToken": "\#($0)""# } ?? ""
         let pluginSurfaceField = canvasPluginSurfaceURL.map {
             #", "pluginSurfaceUrls": { "canvas": "\#($0)" }"#
         } ?? ""
+        let methodsJSON = methods.map { #""\#($0)""# }.joined(separator: ",")
         let json = """
         {
           "type": "res",
@@ -64,7 +66,7 @@ enum GatewayWebSocketTestSupport {
             "type": "hello-ok",
             "protocol": 2,
             "server": { "version": "test", "connId": "test" },
-            "features": { "methods": [], "events": [] }\(pluginSurfaceField),
+            "features": { "methods": [\(methodsJSON)], "events": [] }\(pluginSurfaceField),
             "snapshot": {
               "presence": [ { "ts": 1 } ],
               "health": {},

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -121,6 +121,7 @@ private final class AISetupRouteIdentity: @unchecked Sendable {
 private actor AISetupRequestRecorder {
     private var methods: [String] = []
     private var apiKeys: [String] = []
+    private var authChoices: [String] = []
 
     func record(_ message: URLSessionWebSocketTask.Message) {
         guard let request = aiSetupRequest(from: message) else { return }
@@ -128,10 +129,13 @@ private actor AISetupRequestRecorder {
         if let apiKey = request.params["apiKey"] as? String {
             self.apiKeys.append(apiKey)
         }
+        if let authChoice = request.params["authChoice"] as? String {
+            self.authChoices.append(authChoice)
+        }
     }
 
-    func snapshot() -> (methods: [String], apiKeys: [String]) {
-        (self.methods, self.apiKeys)
+    func snapshot() -> (methods: [String], apiKeys: [String], authChoices: [String]) {
+        (self.methods, self.apiKeys, self.authChoices)
     }
 }
 
@@ -347,7 +351,7 @@ private func configuredModelResponse(id: String) -> Data {
 
 private func waitForAISetupRequests(
     _ recorder: AISetupRequestRecorder,
-    count: Int) async -> (methods: [String], apiKeys: [String])
+    count: Int) async -> (methods: [String], apiKeys: [String], authChoices: [String])
 {
     for _ in 0..<200 {
         let snapshot = await recorder.snapshot()
@@ -357,6 +361,25 @@ private func waitForAISetupRequests(
         try? await Task.sleep(nanoseconds: 5_000_000)
     }
     return await recorder.snapshot()
+}
+
+private func wizardStartResponse(id: String, sessionID: String) -> Data {
+    Data(
+        """
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "sessionId":"\(sessionID)","done":false,"status":"running"
+        }}
+        """.utf8)
+}
+
+private func wizardProgressResponse(id: String, sessionID: String) -> Data {
+    Data(
+        """
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "sessionId":"\(sessionID)","done":false,"status":"running",
+          "step":{"id":"download","type":"progress","message":"Downloading model: 25%"}
+        }}
+        """.utf8)
 }
 
 private func settleQueuedAISetupTasks() async {
@@ -586,6 +609,92 @@ struct OnboardingAISetupTests {
 
     @Test func `provider auth transport outlives device code windows`() {
         #expect(OnboardingAISetupModel.providerAuthRequestTimeoutMs > 15 * 60 * 1000)
+    }
+
+    @Test func `prepare choices use wire presentation and hide usable local models`() throws {
+        let candidates = [OnboardingAISetupModel.Candidate(
+            kind: "provider-auto:ollama",
+            label: "Ollama",
+            detail: "available locally",
+            modelRef: "ollama/qwen3:8b",
+            credentials: true)]
+        let installs = [OnboardingAISetupModel.RecommendedInstall(
+            id: "ollama",
+            label: "Wire Ollama",
+            hint: "Wire hint",
+            website: "https://ollama.com/download",
+            icon: "https://cdn.simpleicons.org/ollama")]
+
+        let options = OnboardingAISetupModel.prepareOptions(
+            candidates: candidates,
+            manualProviders: [],
+            authOptions: [],
+            recommendedInstalls: installs)
+
+        #expect(options.map(\.id) == ["llama-cpp"])
+        #expect(options.first?.label == "Local model (llama.cpp)")
+        #expect(OnboardingAISetupModel.ProviderWizardKind.prepare.startMethod ==
+            "openclaw.setup.prepare.start")
+    }
+
+    @Test func `prepare action starts shared wizard with the local auth choice`() async throws {
+        let recorder = AISetupRequestRecorder()
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(
+                sendHook: { task, message, sendIndex in
+                    guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
+                    if respondToAISetupHealth(task: task, request: request) {
+                        return
+                    }
+                    await recorder.record(message)
+                    switch request.method {
+                    case "openclaw.setup.detect":
+                        task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
+                    case "openclaw.setup.prepare.start":
+                        let sessionID = request.params["sessionId"] as? String ?? "prepare-session"
+                        task.emitReceiveSuccess(.data(wizardStartResponse(
+                            id: request.id,
+                            sessionID: sessionID)))
+                    case "wizard.next":
+                        let sessionID = request.params["sessionId"] as? String ?? "prepare-session"
+                        task.emitReceiveSuccess(.data(wizardProgressResponse(
+                            id: request.id,
+                            sessionID: sessionID)))
+                    default:
+                        break
+                    }
+                },
+                receiveHook: { task, receiveIndex in
+                    if receiveIndex == 0 {
+                        return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                    }
+                    let id = task.snapshotConnectRequestID() ?? "connect"
+                    return .data(GatewayWebSocketTestSupport.connectOkData(
+                        id: id,
+                        methods: ["openclaw.setup.prepare.start"]))
+                })
+        })
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let gateway = GatewayConnection(
+            configProvider: { (url: url, token: nil, password: nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+        let model = OnboardingAISetupModel(
+            gateway: gateway,
+            routeIdentityProvider: { "local" })
+
+        await model.detectAndAutoConnect()
+        let option = try #require(model.prepareOptions.first { $0.id == "llama-cpp" })
+        model.startProviderPrepare(option)
+        let requests = await waitForAISetupRequests(recorder, count: 3)
+
+        #expect(requests.methods == [
+            "openclaw.setup.detect",
+            "openclaw.setup.prepare.start",
+            "wizard.next",
+        ])
+        #expect(requests.authChoices == ["llama-cpp"])
+        #expect(model.isPreparingModel)
+        #expect(model.authStep.map(wizardStepType) == "progress")
     }
 
     @Test func `provider auth opens only safe external links`() {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1889,6 +1889,15 @@ export const en: TranslationMap = {
       pair: "Pair",
       more: "More sign-in options",
     },
+    prepare: {
+      title: "Set up a local model",
+      intro: "Download or prepare a local model on this Gateway.",
+      button: "Set up / Download model",
+      ollamaLabel: "Ollama",
+      ollamaHint: "Download a tools-capable model from your Ollama server",
+      llamaCppLabel: "Local model (llama.cpp)",
+      llamaCppHint: "Download an approximately 5.0 GB local model; requires 16 GB RAM",
+    },
     manual: {
       title: "Connect with an API key or token",
       provider: "Provider",
@@ -1919,8 +1928,11 @@ export const en: TranslationMap = {
     },
     wizard: {
       dialogLabel: "Provider sign-in",
+      prepareDialogLabel: "Local model setup",
       title: "Sign in with a provider",
+      prepareTitle: "Set up a local model",
       starting: "Starting provider sign-in…",
+      prepareStarting: "Starting local model setup…",
       checking: "Checking your model setup…",
       working: "Working…",
       continue: "Continue",

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -39,8 +39,9 @@ const detection: SystemAgentSetupDetectResult = {
   setupComplete: false,
 };
 
-function createContext(): { context: ApplicationContext; client: GatewayBrowserClient } {
-  const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+function createContext() {
+  const request = vi.fn<GatewayBrowserClient["request"]>();
+  const client = { request } as unknown as GatewayBrowserClient;
   const snapshot = {
     client,
     phase: "connected",
@@ -76,6 +77,7 @@ function createContext(): { context: ApplicationContext; client: GatewayBrowserC
   } as unknown as ApplicationGateway;
   return {
     client,
+    request,
     context: {
       gateway,
       basePath: "/openclaw",
@@ -228,8 +230,7 @@ describe("ModelSetupPage catalog icons", () => {
   });
 
   it("starts a prepare wizard from the download affordance", async () => {
-    const { context, client } = createContext();
-    const request = vi.mocked(client.request);
+    const { context, client, request } = createContext();
     request.mockImplementation(async (method: string) => {
       if (method === "openclaw.setup.prepare.start") {
         return { sessionId: "prepare-session", done: false, status: "running" };

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -48,7 +48,9 @@ function createContext(): { context: ApplicationContext; client: GatewayBrowserC
       type: "hello-ok" as const,
       protocol: 1,
       auth: { role: "operator", scopes: ["operator.read", "operator.admin"] },
-      features: { methods: ["openclaw.setup.detect", "openclaw.setup.verify"] },
+      features: {
+        methods: ["openclaw.setup.detect", "openclaw.setup.verify", "openclaw.setup.prepare.start"],
+      },
     },
     assistantAgentId: "main",
     sessionKey: "main",
@@ -223,5 +225,44 @@ describe("ModelSetupPage catalog icons", () => {
       expect.objectContaining({ credentials: "same-origin" }),
     );
     expect(page.querySelector(".model-setup__recommendation [data-provider-icon]")).toBeNull();
+  });
+
+  it("starts a prepare wizard from the download affordance", async () => {
+    const { context, client } = createContext();
+    const request = vi.mocked(client.request);
+    request.mockImplementation(async (method: string) => {
+      if (method === "openclaw.setup.prepare.start") {
+        return { sessionId: "prepare-session", done: false, status: "running" };
+      }
+      if (method === "wizard.next") {
+        return {
+          done: false,
+          status: "running",
+          step: {
+            id: "download",
+            type: "progress",
+            message: "Downloading model: 25%",
+          },
+        };
+      }
+      return {};
+    });
+    const { page } = await mountPage(context, {
+      state: { phase: "ready", result: detection },
+      client,
+      firstRun: false,
+    });
+
+    page.querySelector<HTMLButtonElement>('[data-prepare-choice="llama-cpp"] button')?.click();
+
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        "openclaw.setup.prepare.start",
+        { sessionId: expect.any(String), authChoice: "llama-cpp" },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      expect(page.querySelector("openclaw-modal-dialog")).not.toBeNull();
+      expect(page.textContent).toContain("Downloading model: 25%");
+    });
   });
 });

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -16,6 +16,7 @@ import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { fetchCatalogIconBlobUrl } from "../plugins/icon-loader.ts";
+import type { ModelSetupPrepareOption } from "./prepare-options.ts";
 import { detectModelSetup, verifyModelSetup } from "./rpc.ts";
 import {
   activationTargetId,
@@ -30,6 +31,7 @@ import {
 } from "./state.ts";
 import { renderModelSetup, resolveSetupBrandIcon } from "./view.ts";
 import { ModelSetupWizardRunner } from "./wizard-runner.ts";
+import type { ModelSetupWizardStartMethod } from "./wizard-runner.ts";
 
 type Candidate = SystemAgentSetupDetectResult["candidates"][number];
 type AuthOption = NonNullable<SystemAgentSetupDetectResult["authOptions"]>[number];
@@ -57,6 +59,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   @state() private activationState: ModelSetupActivationState = { phase: "idle" };
   @state() private verifyState: ModelSetupVerifyState = { phase: "idle" };
   @state() private wizardState: ModelSetupWizardState = { phase: "idle" };
+  @state() private wizardMode: "auth" | "prepare" = "auth";
   @state() private wizardValue: unknown;
   @state() private manualProviderId = "";
   @state() private manualApiKey = "";
@@ -90,7 +93,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         this.wizardValue = initialWizardValue(next.step);
       }
     },
-    onDone: () => void this.handleWizardDone(),
+    onDone: (startMethod) => void this.handleWizardDone(startMethod),
     requestFailedMessage: () => t("modelSetup.errors.requestFailed"),
     cancelledMessage: () => t("modelSetup.wizard.cancelled"),
     sessionExpiredMessage: () => t("modelSetup.wizard.sessionExpired"),
@@ -447,20 +450,22 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     );
   }
 
-  private async handleWizardDone(): Promise<void> {
+  private async handleWizardDone(startMethod: ModelSetupWizardStartMethod): Promise<void> {
     const result = await this.detect();
     if (!result) {
       this.wizard.fail(t("modelSetup.errors.requestFailed"));
       return;
     }
-    if (!result.setupComplete) {
+    if (startMethod === "openclaw.setup.auth.start" && !result.setupComplete) {
       this.wizard.fail(t("modelSetup.wizard.notComplete"));
       return;
     }
-    this.activationState = {
-      phase: "success",
-      modelRef: result.configuredModel ?? t("modelSetup.success.configuredModel"),
-    };
+    if (startMethod === "openclaw.setup.auth.start") {
+      this.activationState = {
+        phase: "success",
+        modelRef: result.configuredModel ?? t("modelSetup.success.configuredModel"),
+      };
+    }
     this.wizard.close();
   }
 
@@ -489,9 +494,14 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       activation: this.activationState,
       verify: this.verifyState,
       wizard: this.wizardState,
+      wizardMode: this.wizardMode,
       wizardValue: this.wizardValue,
       canAdmin,
       canVerify,
+      canPrepare:
+        canAdmin &&
+        !gatewayTooOld &&
+        isGatewayMethodAdvertised(snapshot, "openclaw.setup.prepare.start") === true,
       gatewayTooOld,
       actionsDisabled: this.actionsDisabled(),
       manualProviderId: this.manualProviderId,
@@ -502,7 +512,14 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       onDetect: () => void this.detect(),
       onVerify: () => void this.verifyConnection(),
       onActivateCandidate: (candidate) => this.activateCandidate(candidate),
-      onStartAuth: (option: AuthOption) => void this.wizard.start(option.id),
+      onStartAuth: (option: AuthOption) => {
+        this.wizardMode = "auth";
+        void this.wizard.start(option.id);
+      },
+      onStartPrepare: (option: ModelSetupPrepareOption) => {
+        this.wizardMode = "prepare";
+        void this.wizard.start(option.id, "openclaw.setup.prepare.start");
+      },
       onManualProviderChange: (providerId) => {
         this.manualProviderId = providerId;
         this.manualError = null;

--- a/ui/src/pages/model-setup/prepare-options.ts
+++ b/ui/src/pages/model-setup/prepare-options.ts
@@ -1,0 +1,48 @@
+import type { SystemAgentSetupDetectResult } from "../../api/types.ts";
+import { t } from "../../i18n/index.ts";
+
+export type ModelSetupPrepareOption = {
+  id: "ollama" | "llama-cpp";
+  brandId?: string;
+  label: string;
+  hint?: string;
+  icon?: string;
+  website?: string;
+};
+
+export function listModelSetupPrepareOptions(
+  result: SystemAgentSetupDetectResult,
+): ModelSetupPrepareOption[] {
+  const prepareChoices: readonly ModelSetupPrepareOption[] = [
+    {
+      id: "ollama",
+      brandId: "ollama",
+      label: t("modelSetup.prepare.ollamaLabel"),
+      hint: t("modelSetup.prepare.ollamaHint"),
+    },
+    {
+      id: "llama-cpp",
+      brandId: "llama-cpp",
+      label: t("modelSetup.prepare.llamaCppLabel"),
+      hint: t("modelSetup.prepare.llamaCppHint"),
+    },
+  ];
+  const presented = [
+    ...result.manualProviders,
+    ...(result.authOptions ?? []),
+    ...(result.recommendedInstalls ?? []),
+  ];
+  return prepareChoices
+    .filter(
+      (choice) =>
+        !result.candidates.some(
+          (candidate) =>
+            candidate.kind === `provider-auto:${choice.id}` ||
+            candidate.modelRef.startsWith(`${choice.id}/`),
+        ),
+    )
+    .map((choice) => {
+      const wire = presented.find((entry) => entry.id === choice.id);
+      return wire ? { ...choice, ...wire, id: choice.id } : choice;
+    });
+}

--- a/ui/src/pages/model-setup/prepare-options.ts
+++ b/ui/src/pages/model-setup/prepare-options.ts
@@ -43,6 +43,6 @@ export function listModelSetupPrepareOptions(
     )
     .map((choice) => {
       const wire = presented.find((entry) => entry.id === choice.id);
-      return wire ? { ...choice, ...wire, id: choice.id } : choice;
+      return wire ? Object.assign({}, choice, wire, { id: choice.id }) : choice;
     });
 }

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -75,9 +75,11 @@ function props(overrides: Partial<ModelSetupViewProps> = {}): ModelSetupViewProp
     activation: { phase: "idle" },
     verify: { phase: "idle" },
     wizard: { phase: "idle" },
+    wizardMode: "auth",
     wizardValue: undefined,
     canAdmin: true,
     canVerify: true,
+    canPrepare: true,
     gatewayTooOld: false,
     actionsDisabled: false,
     manualProviderId: "openai",
@@ -93,6 +95,7 @@ function props(overrides: Partial<ModelSetupViewProps> = {}): ModelSetupViewProp
     onVerify: vi.fn(),
     onActivateCandidate: vi.fn(),
     onStartAuth: vi.fn(),
+    onStartPrepare: vi.fn(),
     onManualProviderChange: vi.fn(),
     onManualApiKeyChange: vi.fn(),
     onManualConnect: vi.fn(),
@@ -156,6 +159,7 @@ describe("renderModelSetup", () => {
     expect(text(container)).toContain("Detected, but not auto-tested");
     expect(text(container)).toContain("No active login");
     expect(text(container)).toContain("Sign in with a provider");
+    expect(text(container)).toContain("Set up a local model");
     expect(text(container)).toContain("Connect with an API key or token");
     expect(container.querySelector<HTMLSelectElement>(".model-setup__manual select")?.value).toBe(
       "openai",
@@ -176,6 +180,44 @@ describe("renderModelSetup", () => {
         ?.textContent,
     ).toContain("O");
     expect(container.querySelectorAll("img")).toHaveLength(0);
+  });
+
+  it("derives prepare rows from accepted choice ids and hides usable local candidates", () => {
+    const onStartPrepare = vi.fn();
+    const container = mount(props({ onStartPrepare }));
+
+    const ollama = container.querySelector<HTMLButtonElement>(
+      '[data-prepare-choice="ollama"] button',
+    );
+    const llamaCpp = container.querySelector<HTMLButtonElement>(
+      '[data-prepare-choice="llama-cpp"] button',
+    );
+    expect(ollama?.textContent).toContain("Set up / Download model");
+    expect(llamaCpp).not.toBeNull();
+    ollama?.click();
+    expect(onStartPrepare).toHaveBeenCalledWith(expect.objectContaining({ id: "ollama" }));
+
+    const withUsableOllama = mount(
+      props({
+        page: {
+          phase: "ready",
+          result: {
+            ...detected,
+            candidates: [
+              ...detected.candidates,
+              {
+                kind: "provider-auto:ollama",
+                label: "Ollama",
+                detail: "available locally",
+                modelRef: "ollama/qwen3:8b",
+                recommended: false,
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect(withUsableOllama.querySelector('[data-prepare-choice="ollama"]')).toBeNull();
   });
 
   it("renders recommended install cards only when candidates and sign-ins are empty", () => {

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -7,6 +7,7 @@ import {
 } from "../../components/provider-icon.ts";
 import { t } from "../../i18n/index.ts";
 import "../../styles/model-setup.css";
+import { listModelSetupPrepareOptions, type ModelSetupPrepareOption } from "./prepare-options.ts";
 import type {
   ModelSetupActivationState,
   ModelSetupPageState,
@@ -62,9 +63,11 @@ type ModelSetupViewProps = {
   activation: ModelSetupActivationState;
   verify: ModelSetupVerifyState;
   wizard: ModelSetupWizardState;
+  wizardMode: "auth" | "prepare";
   wizardValue: unknown;
   canAdmin: boolean;
   canVerify: boolean;
+  canPrepare: boolean;
   gatewayTooOld: boolean;
   actionsDisabled: boolean;
   manualProviderId: string;
@@ -76,6 +79,7 @@ type ModelSetupViewProps = {
   onVerify: () => void;
   onActivateCandidate: (candidate: Candidate) => void;
   onStartAuth: (option: AuthOption) => void;
+  onStartPrepare: (option: ModelSetupPrepareOption) => void;
   onManualProviderChange: (providerId: string) => void;
   onManualApiKeyChange: (apiKey: string) => void;
   onManualConnect: () => void;
@@ -355,6 +359,47 @@ function renderSignIn(props: ModelSetupViewProps, result: SystemAgentSetupDetect
   `;
 }
 
+function renderPrepare(props: ModelSetupViewProps, result: SystemAgentSetupDetectResult) {
+  if (!props.canPrepare) {
+    return nothing;
+  }
+  const options = listModelSetupPrepareOptions(result);
+  if (options.length === 0) {
+    return nothing;
+  }
+  return html`
+    <section class="settings-section">
+      <div class="settings-section__header">
+        <h2>${t("modelSetup.prepare.title")}</h2>
+      </div>
+      <p class="muted">${t("modelSetup.prepare.intro")}</p>
+      <div class="model-setup__rows">
+        ${options.map(
+          (option) => html`
+            <div class="model-setup__row" data-prepare-choice=${option.id}>
+              <div class="model-setup__provider-copy">
+                ${renderProviderIcon(props, option)}
+                <div>
+                  <strong>${option.label}</strong>
+                  ${option.hint ? html`<div class="muted">${option.hint}</div>` : nothing}
+                </div>
+              </div>
+              <button
+                type="button"
+                class="btn"
+                ?disabled=${props.actionsDisabled}
+                @click=${() => props.onStartPrepare(option)}
+              >
+                ${t("modelSetup.prepare.button")}
+              </button>
+            </div>
+          `,
+        )}
+      </div>
+    </section>
+  `;
+}
+
 function renderManual(props: ModelSetupViewProps, result: SystemAgentSetupDetectResult) {
   const provider = result.manualProviders.find((entry) => entry.id === props.manualProviderId);
   const targetId = `manual:${props.manualProviderId}`;
@@ -448,7 +493,8 @@ function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectR
   }
   return html`
     ${current} ${renderEmptyState(props, result)} ${renderCandidateRows(props, result)}
-    ${renderUnavailable(result)} ${renderSignIn(props, result)} ${renderManual(props, result)}
+    ${renderUnavailable(result)} ${renderPrepare(props, result)} ${renderSignIn(props, result)}
+    ${renderManual(props, result)}
   `;
 }
 
@@ -496,6 +542,7 @@ export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
       ${body}
     </div>
     ${renderModelSetupWizard({
+      mode: props.wizardMode,
       state: props.wizard,
       value: props.wizardValue,
       onValueChange: props.onWizardValueChange,

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -83,6 +83,44 @@ describe("ModelSetupWizardRunner", () => {
     );
   });
 
+  it("uses the prepare start method with the shared wizard transport", async () => {
+    const request = vi.fn((method: string) => {
+      if (method === "openclaw.setup.prepare.start") {
+        return Promise.resolve({ sessionId: "prepare-session", done: false, status: "running" });
+      }
+      if (method === "wizard.next") {
+        return Promise.resolve({
+          done: false,
+          status: "running",
+          step: { id: "pull", type: "progress", message: "Pulling 25%" },
+        });
+      }
+      return Promise.resolve({});
+    });
+    const runner = new ModelSetupWizardRunner({
+      getClient: () => ({ request }) as unknown as GatewayBrowserClient,
+      onChange: () => undefined,
+      onDone: () => undefined,
+      requestFailedMessage: () => "failed",
+      cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "expired",
+    });
+
+    await runner.start("llama-cpp", "openclaw.setup.prepare.start");
+
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "openclaw.setup.prepare.start",
+      { sessionId: expect.any(String), authChoice: "llama-cpp" },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(runner.state).toMatchObject({
+      phase: "step",
+      authChoice: "llama-cpp",
+      step: { type: "progress" },
+    });
+  });
+
   it("clears an expired session and abort without cancelling or replaying the answer", async () => {
     let nextCount = 0;
     let answerSignal: AbortSignal | undefined;

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -8,10 +8,14 @@ import {
   wizardStateFromResult,
 } from "./state.ts";
 
+export type ModelSetupWizardStartMethod =
+  | "openclaw.setup.auth.start"
+  | "openclaw.setup.prepare.start";
+
 type WizardRunnerOptions = {
   getClient: () => GatewayBrowserClient | null;
   onChange: (state: ModelSetupWizardState) => void;
-  onDone: () => void;
+  onDone: (startMethod: ModelSetupWizardStartMethod) => void;
   requestFailedMessage: () => string;
   cancelledMessage: () => string;
   sessionExpiredMessage: () => string;
@@ -22,6 +26,7 @@ export class ModelSetupWizardRunner {
   private sessionId: string | null = null;
   private abortController: AbortController | null = null;
   private generation = 0;
+  private startMethod: ModelSetupWizardStartMethod = "openclaw.setup.auth.start";
 
   constructor(private readonly options: WizardRunnerOptions) {}
 
@@ -29,7 +34,10 @@ export class ModelSetupWizardRunner {
     return this.currentState;
   }
 
-  async start(authChoice: string): Promise<void> {
+  async start(
+    authChoice: string,
+    startMethod: ModelSetupWizardStartMethod = "openclaw.setup.auth.start",
+  ): Promise<void> {
     const client = this.options.getClient();
     if (!client || this.currentState.phase !== "idle") {
       return;
@@ -39,10 +47,11 @@ export class ModelSetupWizardRunner {
     const abortController = new AbortController();
     this.sessionId = sessionId;
     this.abortController = abortController;
+    this.startMethod = startMethod;
     this.setState({ phase: "starting", authChoice });
     try {
       const started = await client.request<SystemAgentSetupAuthStartResult>(
-        "openclaw.setup.auth.start",
+        startMethod,
         { sessionId, authChoice },
         { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS, signal: abortController.signal },
       );
@@ -144,7 +153,7 @@ export class ModelSetupWizardRunner {
     if (next.phase === "done") {
       this.sessionId = null;
       this.abortController = null;
-      this.options.onDone();
+      this.options.onDone(this.startMethod);
     }
   }
 

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -5,6 +5,7 @@ import { copyToClipboard } from "../../lib/clipboard.ts";
 import type { ModelSetupWizardState } from "./state.ts";
 
 type WizardViewProps = {
+  mode: "auth" | "prepare";
   state: ModelSetupWizardState;
   value: unknown;
   onValueChange: (value: unknown) => void;
@@ -241,7 +242,11 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
     props.state.phase === "done";
   return html`
     <openclaw-modal-dialog
-      label=${t("modelSetup.wizard.dialogLabel")}
+      label=${t(
+        props.mode === "prepare"
+          ? "modelSetup.wizard.prepareDialogLabel"
+          : "modelSetup.wizard.dialogLabel",
+      )}
       @modal-cancel=${canCancel ? props.onCancel : props.onClose}
     >
       <div class="model-setup-wizard">
@@ -249,12 +254,22 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
           <h2>
             ${props.state.phase === "step" && props.state.step.title
               ? props.state.step.title
-              : t("modelSetup.wizard.title")}
+              : t(
+                  props.mode === "prepare"
+                    ? "modelSetup.wizard.prepareTitle"
+                    : "modelSetup.wizard.title",
+                )}
           </h2>
         </div>
         <div class="model-setup-wizard__body">
           ${props.state.phase === "starting"
-            ? html`<div role="status">${t("modelSetup.wizard.starting")}</div>`
+            ? html`<div role="status">
+                ${t(
+                  props.mode === "prepare"
+                    ? "modelSetup.wizard.prepareStarting"
+                    : "modelSetup.wizard.starting",
+                )}
+              </div>`
             : props.state.phase === "done"
               ? html`<div role="status">${t("modelSetup.wizard.checking")}</div>`
               : props.state.phase === "error" || props.state.phase === "cancelled"


### PR DESCRIPTION
## What Problem This Solves

The streaming prepare transport (#109764) landed with no UI entry point — web/macOS users see local-model recommendations but must drop to the CLI to pull or download a model.

## Why This Change Was Made

Adds a data-driven "set up local model" affordance to the web model-setup page and macOS onboarding that starts `openclaw.setup.prepare.start` for the two gateway-supported prepare choices (ollama, llama-cpp) and drives the EXISTING wizard progress sheet (web runner parameterized by start method; mac reuses the providerAuthSheet flow). Gated on admin scope + method advertisement (old gateways: hidden); suppressed when a usable detected candidate already covers the provider; prepare completion re-detects without asserting setupComplete (prepare does not set the default model). Presentation enriched from wire icon/website when present. English-only i18n per locale-isolation policy.

## User Impact

One click from "nothing configured" to a streaming model download/pull with live progress on web and macOS.

## Evidence

Web Vitest: 6 files/44 passed (button → prepare method + sheet, runner parameterization, prepare-option suppression); macOS debug build green, 85 OnboardingAISetupTests passed; `ui:i18n:verify` passed; SwiftFormat/SwiftLint clean; autoreview clean.

## Known Limitation

Preparable choice ids mirror the gateway prepare method's own accepted-choice contract client-side; a wire-level capability flag is the natural follow-up when a third preparable provider appears.

Related: #109764, #109681, #109228.
