### PR TITLE
fix: retry Provisioned-Managed throughput throttles

### DIFF
--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -767,6 +767,10 @@ describe("isShortWindowRateLimitMessage", () => {
     ["429 usage limit reached for this billing period", false],
     ["Provider API error (429): Provider returned error", false],
     ["rate limit exceeded", false],
+    [
+      "Requests have exceeded the throughput limit on your Provisioned-Managed deployment. If you continue to exceed your limit, consider increasing the number of provisioned throughput units deployed.",
+      true,
+    ],
   ])("classifies %s", (message, expected) => {
     expect(isShortWindowRateLimitMessage(message)).toBe(expected);
   });

--- a/src/llm/utils/rate-limit-window.ts
+++ b/src/llm/utils/rate-limit-window.ts
@@ -12,7 +12,7 @@ const LONG_WINDOW_RATE_LIMIT_RE =
 const SHORT_RATE_LIMIT_UNIT_RE =
   /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm)\b/i;
 const SHORT_WINDOW_RATE_LIMIT_RE =
-  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown)\b|请求过于频繁|调用频率|频率限制/i;
+  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown|throughput limit on (?:your )?provisioned[- ]managed deployment)\b|请求过于频繁|调用频率|频率限制/i;
 const RETRY_AFTER_VALUE_RE = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
 const RETRY_AFTER_NUMBER_RE = /^(\d+(?:\.\d+)?)\s*([a-z]+)?\b/i;
 const MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS = 60;


### PR DESCRIPTION
Related: #99097

## What Problem This Solves

Fixes an issue where users of Azure Provisioned-Managed deployments could receive an immediate throughput-limit error instead of an automatic same-model retry when allocated throughput was temporarily exhausted.

## Why This Change Was Made

Responses-compatible providers can deliver this Azure throttle in-band as an SSE \`response.failed\` event. At that boundary the event retains the provider code and message, but not the underlying HTTP 429 status or retry headers; the observed OpenClaw failure therefore had \`status=undefined\`. Although Azure documents this condition as a retryable 429, the short-window classifier could not select OpenClaw's bounded same-model backoff from the text alone.

This change recognizes only the canonical \`throughput limit on [your] provisioned[- ]managed deployment\` wording. It intentionally does not generalize generic throughput, rate-limit, or quota messages into short-window throttles.

Azure behavior reference: https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/provisioned-get-started

## User Impact

Temporary Provisioned-Managed throughput saturation now receives OpenClaw's existing bounded same-model backoff before another auth profile is spent or the error is surfaced. Long-window limits, account quota exhaustion, bare \`quota_exceeded\`, and generic rate-limit text remain outside this short-window retry classification.

## Evidence

Redacted live observation before the fix:

\`\`\`text
[openai-transport] [responses] error status=undefined code=rate_limit_reached type=too_many_requests message="Requests have exceeded the throughput limit on your Provisioned-Managed deployment. …"
[agent/embedded] decision=surface_error reason=rate_limit
\`\`\`

Validation on Node 24.15.0:

\`\`\`text
pnpm test src/agents/embedded-agent-runner/run/assistant-failover.test.ts
Test Files  1 passed (1)
Tests       33 passed (33)

OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed -- \
  src/llm/utils/rate-limit-window.ts \
  src/agents/embedded-agent-runner/run/assistant-failover.test.ts
Passed

pnpm build
Passed

pnpm check
Passed
\`\`\`

The focused regression verifies that the canonical Provisioned-Managed message is classified as a short-window throttle. Existing orchestration coverage verifies that short-window failures retry the same model without rotating an auth profile, while quota-style errors, bare \`quota_exceeded\`, generic rate-limit text, and long \`Retry-After\` windows do not spend that retry budget.

A broad \`pnpm test\` run was also attempted. It was stopped after unrelated failures in untouched platform, Gateway, UI timer, and Docker E2E tests; the Docker command was additionally blocked by the host's security policy. The focused shard above remained green after rebasing onto current \`main\`.

No UI changes; screenshots are not applicable.

AI-assisted: Yes — implemented and reviewed with OpenAI Codex. I reviewed the classifier and embedded failover path and understand the behavior changed here.
