### PR TITLE
fix(qa): adjust some qa coverage classifications

### DIFF
--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -5,9 +5,9 @@ scenario:
   surface: subagents
   coverage:
     primary:
-      - agent-runtime.subagent-turns-subagents
-    secondary:
       - agent-runtime.subagent-turns-delivery
+    secondary:
+      - agent-runtime.subagent-turns-subagents
       - channels.qa-channel-final-reply
   objective: Verify a yielded parent still receives a successful subagent result through direct fallback delivery when the dormant announce turn produces no visible reply.
   successCriteria:

--- a/qa/scenarios/agents/subagent-fanout-synthesis.yaml
+++ b/qa/scenarios/agents/subagent-fanout-synthesis.yaml
@@ -6,9 +6,9 @@ scenario:
   runtimePairLane: core
   coverage:
     primary:
-      - agent-runtime.subagent-turns-subagents
-    secondary:
       - agent-runtime.subagent-turns-synthesis
+    secondary:
+      - agent-runtime.subagent-turns-subagents
   objective: Verify the agent can delegate multiple bounded subagent tasks and fold both results back into one parent reply.
   successCriteria:
     - Parent flow launches at least two bounded subagent tasks.

--- a/qa/scenarios/agents/subagent-stale-child-links.yaml
+++ b/qa/scenarios/agents/subagent-stale-child-links.yaml
@@ -7,8 +7,6 @@ scenario:
   coverage:
     primary:
       - gateway.session-apis-subagents
-      - agent-runtime.subagent-turns-subagents
-    secondary:
       - gateway.session-apis-sessions-list
   objective: Verify restarted gateways hide stale persisted subagent child links without hiding live or fresh children.
   successCriteria:

--- a/qa/scenarios/channels/channel-multi-actor-ordering.yaml
+++ b/qa/scenarios/channels/channel-multi-actor-ordering.yaml
@@ -5,8 +5,6 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - agent-runtime.session-turn-ordering
-    secondary:
       - channels.room-allowlist
   objective: Verify blocked secondary-actor traffic does not poison a later allowlisted driver turn.
   successCriteria:

--- a/qa/scenarios/channels/channel-secondary-conversation-isolation.yaml
+++ b/qa/scenarios/channels/channel-secondary-conversation-isolation.yaml
@@ -6,8 +6,6 @@ scenario:
   coverage:
     primary:
       - channels.room-session-group-messages
-    secondary:
-      - agent-runtime.session-turn-ordering
   objective: Verify a reply in a secondary conversation stays isolated from the primary conversation.
   successCriteria:
     - The primary conversation receives only its marker.

--- a/qa/scenarios/channels/group-message-tool-unavailable-fallback.yaml
+++ b/qa/scenarios/channels/group-message-tool-unavailable-fallback.yaml
@@ -6,9 +6,9 @@ scenario:
   coverage:
     primary:
       - channels.group-final-reply
+      - channels.message-final-reply
     secondary:
       - channels.qa-channel-final-reply
-      - channels.message-final-reply
   objective: Reproduce the group-visible-reply bug class where message_tool mode selected tool-only delivery even though group tool policy removed the message tool.
   gatewayConfigPatch:
     messages:

--- a/qa/scenarios/channels/message-tool-stranded-final-reply.yaml
+++ b/qa/scenarios/channels/message-tool-stranded-final-reply.yaml
@@ -5,10 +5,10 @@ scenario:
   surface: channel
   coverage:
     primary:
-      - channels.direct-final-reply
-    secondary:
-      - channels.qa-channel-final-reply
       - channels.message-final-reply
+    secondary:
+      - channels.direct-final-reply
+      - channels.qa-channel-final-reply
   objective: Reproduce #85714 end to end under messages.visibleReplies=message_tool. A long private final reply that never calls the message tool must warn, enqueue one recovery retry by default, and deliver the original reply via message(action=send).
   gatewayConfigPatch:
     messages:

--- a/qa/scenarios/channels/message-tool-stranded-final-retry-failure.yaml
+++ b/qa/scenarios/channels/message-tool-stranded-final-retry-failure.yaml
@@ -5,10 +5,10 @@ scenario:
   surface: channel
   coverage:
     primary:
-      - channels.direct-final-reply
-    secondary:
-      - channels.qa-channel-final-reply
       - channels.message-final-reply
+    secondary:
+      - channels.direct-final-reply
+      - channels.qa-channel-final-reply
   objective: Prove #85714 retry exhaustion is fail-closed and visible. If the one stranded-final recovery retry also omits message(action=send), OpenClaw must deliver only a sanitized diagnostic and must not leak the original private final text.
   gatewayConfigPatch:
     messages:


### PR DESCRIPTION
Closes #113483

## What Problem This Solves

Fixes an issue where maintainers using generic channel QA evidence could see taxonomy features reported as fulfilled even though the passing scenario asserted a different behavior.

## Why This Change Was Made

Retargets eight portable generic channel and subagent scenario declarations to the exact behavior their flows execute. Incidental direct-channel and generic-subagent context stays secondary, unexecuted session-turn attribution is removed, and the channel-specific owner branches plus runtime-tool inventory remain untouched.

The change is YAML-only: `execution.channel` eligibility, run-level channel-driver interchangeability, explicit/implicit selection parity, provider selection, taxonomy, and profile membership are unchanged.

## User Impact

Operators and maintainers get honest QA maturity evidence for sender admission, message-tool fallback/recovery, subagent delivery/synthesis, and gateway sessions-list child filtering. Runtime channel behavior is unchanged.

## Evidence

- Existing-solutions and overlap preflight: reused the existing scenario catalog, taxonomy, evidence writer, and channel-driver seams; excluded Telegram, Matrix, WhatsApp, Slack, Discord, and runtime-tool owner work.
- Focused local contract proof: 5 Vitest files, 93 tests passed, including catalog parsing, scorecard fulfillment, explicit/implicit selection parity, driver membership parity, and provider independence.
- Coverage inventory: exact owner queries resolve to the corrected flows; `agent-runtime.session-turn-ordering` now reports no match instead of receiving padded evidence.
- Executable QA flows: 8 passed, 0 failed, 0 skipped on Blacksmith Testbox `tbx_01kybnp1ynx5qmr6bjq6hk675s` ([run 30142640038](https://github.com/openclaw/openclaw/actions/runs/30142640038)).
- Changed gate: `pnpm check:changed` expanded to all lanes and passed (format, guards, full `tsgo`, all lint shards, import cycles) on the same Testbox.
- Fresh autoreview: clean; no accepted/actionable findings.
- `git diff --check`: passed.
