### PR TITLE
fix(matrix): gateway startup stalls after repeated token rotation

### DIFF
--- a/extensions/matrix/src/matrix/client/storage.test.ts
+++ b/extensions/matrix/src/matrix/client/storage.test.ts
@@ -480,6 +480,59 @@ describe("matrix client storage paths", () => {
     );
   });
 
+  it("does not scan token-history roots when the canonical current-token state is claimed", () => {
+    const logger = createTestLogger();
+    const stateDir = setupStateDir(undefined, logger);
+    const oldCanonicalPaths = resolveMatrixAccountStorageRoot({
+      stateDir,
+      homeserver: defaultStorageAuth.homeserver,
+      userId: defaultStorageAuth.userId,
+      accessToken: "secret-token-old",
+    });
+    const oldStoragePaths = seedExistingStorageRoot({
+      accessToken: "secret-token-old",
+      deviceId: "DEVICE123",
+      storageMeta: {
+        homeserver: defaultStorageAuth.homeserver,
+        userId: defaultStorageAuth.userId,
+        accountId: "default",
+        accessTokenHash: oldCanonicalPaths.tokenHash,
+        deviceId: "DEVICE123",
+      },
+    });
+    fs.mkdirSync(oldStoragePaths.cryptoPath, { recursive: true });
+
+    const canonicalPaths = resolveMatrixAccountStorageRoot({
+      stateDir,
+      homeserver: defaultStorageAuth.homeserver,
+      userId: defaultStorageAuth.userId,
+      accessToken: "secret-token-new",
+    });
+    seedCanonicalStorageRoot({
+      stateDir,
+      accessToken: "secret-token-new",
+      storageMeta: {
+        homeserver: defaultStorageAuth.homeserver,
+        userId: defaultStorageAuth.userId,
+        accountId: "default",
+        accessTokenHash: canonicalPaths.tokenHash,
+        deviceId: "DEVICE123",
+        currentTokenStateClaimed: true,
+      },
+    });
+
+    const readdirSync = vi.spyOn(fs, "readdirSync");
+    const resolvedPaths = resolveDefaultStoragePaths({
+      accessToken: "secret-token-new",
+      deviceId: "DEVICE123",
+    });
+
+    expect(resolvedPaths.rootDir).toBe(canonicalPaths.rootDir);
+    expect(resolvedPaths.tokenHash).toBe(canonicalPaths.tokenHash);
+    expect(readdirSync).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it("reads legacy storage metadata until doctor migrates it to SQLite", () => {
     setupStateDir();
     const oldStoragePaths = resolveDefaultStoragePaths({

--- a/extensions/matrix/src/matrix/client/storage.test.ts
+++ b/extensions/matrix/src/matrix/client/storage.test.ts
@@ -598,7 +598,7 @@ describe("matrix client storage paths", () => {
     },
   );
 
-  it("prefers claimed current-token state over an empty new-token metadata root", () => {
+  it("scans for and prefers claimed current-token state over an unclaimed canonical root", () => {
     const stateDir = setupStateDir();
     const oldStoragePaths = seedCanonicalStorageRoot({
       stateDir,
@@ -624,6 +624,7 @@ describe("matrix client storage paths", () => {
       },
     });
 
+    const readdirSync = vi.spyOn(fs, "readdirSync");
     const rotatedStoragePaths = resolveDefaultStoragePaths({
       accessToken: "secret-token-new",
       deviceId: "DEVICE123",
@@ -631,6 +632,7 @@ describe("matrix client storage paths", () => {
 
     expect(rotatedStoragePaths.rootDir).toBe(oldStoragePaths.rootDir);
     expect(rotatedStoragePaths.tokenHash).toBe(oldStoragePaths.tokenHash);
+    expect(readdirSync).toHaveBeenCalledOnce();
   });
 
   it("does not reuse a populated older token-hash root while deviceId is unknown", () => {

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -64,9 +64,11 @@ function openStorageMetaStore(rootDir: string): PluginStateSyncKeyedStore<Matrix
   );
 }
 
-function scoreStorageRoot(rootDir: string): number {
+function scoreStorageRoot(
+  rootDir: string,
+  metadata: MatrixStorageMetadata = readStoredRootMetadata(rootDir),
+): number {
   let score = 0;
-  const metadata = readStoredRootMetadata(rootDir);
   if (Object.keys(metadata).length > 0) {
     score += 1;
   }
@@ -217,8 +219,32 @@ function resolvePreferredMatrixStorageRoot(params: {
   rootDir: string;
   tokenHash: string;
 } {
+  const canonical = {
+    rootDir: params.canonicalRootDir,
+    tokenHash: params.canonicalTokenHash,
+  };
+  const deviceId = params.deviceId?.trim();
+
+  // Without a confirmed device identity, reusing a populated sibling root after
+  // token rotation can silently bind this run to the wrong Matrix device state.
+  if (!deviceId) {
+    return canonical;
+  }
+
+  const canonicalMetadata = readStoredRootMetadata(params.canonicalRootDir);
+  const canonicalRootOwnsCurrentToken =
+    canonicalMetadata.accessTokenHash === params.canonicalTokenHash &&
+    canonicalMetadata.deviceId?.trim() === deviceId &&
+    canonicalMetadata.currentTokenStateClaimed === true;
+
+  // A claimed canonical root is authoritative. Scanning token-history siblings
+  // would synchronously open and retain every per-root SQLite store during startup.
+  if (canonicalRootOwnsCurrentToken) {
+    return canonical;
+  }
+
   const parentDir = path.dirname(params.canonicalRootDir);
-  const bestCurrentScore = scoreStorageRoot(params.canonicalRootDir);
+  const bestCurrentScore = scoreStorageRoot(params.canonicalRootDir, canonicalMetadata);
   const bestCurrentMtimeMs = resolveStorageRootMtimeMs(params.canonicalRootDir);
   let best = {
     rootDir: params.canonicalRootDir,
@@ -226,15 +252,6 @@ function resolvePreferredMatrixStorageRoot(params: {
     score: bestCurrentScore,
     mtimeMs: bestCurrentMtimeMs,
   };
-
-  // Without a confirmed device identity, reusing a populated sibling root after
-  // token rotation can silently bind this run to the wrong Matrix device state.
-  if (!params.deviceId?.trim()) {
-    return {
-      rootDir: best.rootDir,
-      tokenHash: best.tokenHash,
-    };
-  }
 
   let siblingEntries: fs.Dirent[];
   try {
@@ -262,10 +279,10 @@ function resolvePreferredMatrixStorageRoot(params: {
         homeserver: params.homeserver,
         userId: params.userId,
         accountKey: params.accountKey,
-        deviceId: params.deviceId,
+        deviceId,
         // Once auth resolves a concrete device, only sibling roots that explicitly
         // declare that same device are safe to reuse across token rotations.
-        requireExplicitDeviceMatch: Boolean(params.deviceId),
+        requireExplicitDeviceMatch: true,
       })
     ) {
       continue;
@@ -283,27 +300,19 @@ function resolvePreferredMatrixStorageRoot(params: {
     });
   }
 
-  const canonicalMetadata = readStoredRootMetadata(params.canonicalRootDir);
-  const shouldKeepCanonicalCurrentRoot =
-    canonicalMetadata.accessTokenHash === params.canonicalTokenHash &&
-    canonicalMetadata.deviceId?.trim() === params.deviceId.trim() &&
-    canonicalMetadata.currentTokenStateClaimed === true;
-
-  if (!shouldKeepCanonicalCurrentRoot) {
-    for (const candidate of compatiblePopulatedSiblings) {
-      if (
-        candidate.score > best.score ||
-        (best.rootDir !== params.canonicalRootDir &&
-          candidate.score === best.score &&
-          candidate.mtimeMs > best.mtimeMs)
-      ) {
-        best = {
-          rootDir: candidate.rootDir,
-          tokenHash: candidate.tokenHash,
-          score: candidate.score,
-          mtimeMs: candidate.mtimeMs,
-        };
-      }
+  for (const candidate of compatiblePopulatedSiblings) {
+    if (
+      candidate.score > best.score ||
+      (best.rootDir !== params.canonicalRootDir &&
+        candidate.score === best.score &&
+        candidate.mtimeMs > best.mtimeMs)
+    ) {
+      best = {
+        rootDir: candidate.rootDir,
+        tokenHash: candidate.tokenHash,
+        score: candidate.score,
+        mtimeMs: candidate.mtimeMs,
+      };
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with Matrix enabled could see the gateway, TUI, and CLI RPC commands appear hung during normal startup after historical token-hash storage roots accumulated.

## Why This Change Was Made

When the canonical root already matches the current access-token hash and device ID and has explicitly claimed current state, root selection now treats it as authoritative and returns before scanning token-history siblings. Unsettled roots still use the existing sibling-selection path, and the separate pending encrypted-state restore scan is unchanged.

## User Impact

Normal Matrix restarts no longer synchronously open every historical per-root SQLite database just to keep the already-selected current root. This requires no config change and does not delete or rewrite historical Matrix state; genuine token-rotation recovery behavior remains available when the current root is not settled.

## Evidence

All live evidence below is redacted.

### Before

- The affected installation had six Matrix accounts (`agent1` through `agent6`) and 1,351 historical token-hash roots totaling approximately 3.6 GB.
- Normal root selection opened and retained the historical per-root SQLite stores: approximately 5,404 Matrix SQLite file-descriptor rows were observed before startup settled.
- Gateway RPC readiness was delayed by approximately 90 seconds.
- Every canonical current root already satisfied all three fast-path predicates:

  | Account | Token-hash basename matches | Device ID matches | `currentTokenStateClaimed` |
  | --- | --- | --- | --- |
  | `agent1` | yes | yes | `true` |
  | `agent2` | yes | yes | `true` |
  | `agent3` | yes | yes | `true` |
  | `agent4` | yes | yes | `true` |
  | `agent5` | yes | yes | `true` |
  | `agent6` | yes | yes | `true` |

### After

The same affected installation ran OpenClaw `2026.7.2-beta.3` with the two touched files byte-for-byte identical to this PR. The live core remained pinned to beta-3 for host compatibility; exact-head tests are listed separately below.

Redacted clean-restart capture after the beta-3 one-time startup-migration checkpoint:

```text
launchagent_bootstrap_utc=2026-07-22T00:12:41Z
gateway_ready_utc=2026-07-22T00:12:57.279Z
gateway_ready_from_bootstrap_seconds≈16.3
gateway_ready_from_first_structured_log_seconds=10.096

http_probe_1=200 total=0.043755s
http_probe_2=200 total=0.005532s
http_probe_3=200 total=0.002130s
http_probe_4=200 total=0.002178s
http_probe_5=200 total=0.003896s

matrix_accounts_logged_in=6
matrix_accounts_resumed_sync=6
matrix_main_sqlite_files_open=6
matrix_sqlite_fd_rows=24
listener_sockets=2

migration_pending_lines=0
trusted_plugin_state_errors=0
multiple_populated_root_warnings=0
startup_readiness_refusals=0
database_lock_errors=0
matrix_errors=0
```

No user IDs, account names, homeserver names, room IDs, tokens, device IDs, token hashes, or local storage paths are included in this artifact.

### Upgrade-path scope note

Beta-3 also has a separate one-time doctor-preflight path that recursively inspects historical Matrix databases before its startup-migration checkpoint exists. That path is not the runtime root-selection path changed here. On this installation, six stale legacy credential JSON sources initially blocked that checkpoint; each was validated as older than the authoritative SQLite credential record and collision-safely archived under the product's `.migrated` convention. The after capture above is the subsequent normal restart and therefore isolates the runtime behavior changed by this PR. The doctor-preflight historical-database scan is tracked separately in #112450 rather than conflated with this patch.

## Regression and Exact-Head Validation

- The regression test seeds both a populated historical root and a claimed canonical root, then proves that canonical selection does not call `fs.readdirSync` and emits no accumulated-root warning.
- Exact rebased head `6b43cba73f6d9ca612f4e80aafedcab6e7e608a0`: `node scripts/run-vitest.mjs extensions/matrix/src/matrix/client/storage.test.ts` — 20/20 tests passed.
- `./node_modules/.bin/oxfmt --check extensions/matrix/src/matrix/client/storage.ts extensions/matrix/src/matrix/client/storage.test.ts` — clean.
- `git diff --check origin/main...HEAD` — clean.
- Live/test source equivalence:
  - `storage.ts`: SHA-256 `e2d49f1be5a47b7d54846e2cb63252e47d551842e8de7a383239659d67dfff7f`
  - `storage.test.ts`: SHA-256 `4fedc97d12b27bba6e547e57ed7664f92a37b6ce19c7609f3a9fe61e77967cfc`

### Local ClawSweeper review

- Local-only ClawSweeper review completed against exact head `6b43cba73f6d9ca612f4e80aafedcab6e7e608a0`.
- Decision: keep open for normal maintainer landing; no correctness or security findings.
- Real-behavior proof: sufficient. Overall/proof/patch ratings: A/A/A.

## AI Assistance

AI-assisted: yes, with Codex. The diagnosis, state invariants, implementation, exact-head tests, live timing, and descriptor counts were inspected directly. Evidence is redacted and contains no Matrix secrets.