### PR TITLE
[AI-assisted] docs(mistral): fix broken adjustable-reasoning docs URL

### DIFF
--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -149,7 +149,7 @@ OpenClaw defaults Mistral realtime STT to `pcm_mulaw` at 8 kHz so Voice Call can
 
 <AccordionGroup>
   <Accordion title="Adjustable reasoning">
-    `mistral/mistral-small-latest`, `mistral/mistral-small-2603`, and `mistral/mistral-medium-3-5` support [adjustable reasoning](https://docs.mistral.ai/studio-api/conversations/reasoning/adjustable) on the Chat Completions API via `reasoning_effort` (`none` minimizes extra thinking in the output; `high` surfaces full thinking traces before the final answer).
+    `mistral/mistral-small-latest`, `mistral/mistral-small-2603`, and `mistral/mistral-medium-3-5` support [adjustable reasoning](https://docs.mistral.ai/capabilities/reasoning/) on the Chat Completions API via `reasoning_effort` (`none` minimizes extra thinking in the output; `high` surfaces full thinking traces before the final answer).
 
     OpenClaw maps the session **thinking** level to Mistral's API:
 


### PR DESCRIPTION
## What Problem This Solves

Self-sourced docs fix (no tracking issue — small docs-link correction).

The Mistral provider guide (`docs/providers/mistral.md`) "Adjustable reasoning"
accordion links to
`https://docs.mistral.ai/studio-api/conversations/reasoning/adjustable` for
details on the `reasoning_effort` parameter. That URL returns **HTTP 404** —
Mistral reorganized their docs out of the `studio-api/conversations` path, so
users following the link land on a not-found page instead of the reasoning
reference.

## Why This Change Was Made

Mistral's docs now live under `capabilities/`. The page
`https://docs.mistral.ai/capabilities/reasoning/` documents the same
"adjustable reasoning" feature and the `reasoning_effort` parameter with the
same `none`/`high` semantics this section describes
(`none` = thinks minimally, thinking chunk omitted; `high` = full thinking
chunk before the final answer).

This updates the single link to point at the live page. No code or behavior
changes — pure URL correction in the doc.

## User Impact

Users reading the Mistral provider's "Adjustable reasoning" section can once
again click through to the official Mistral reasoning reference. The previously
documented link was a dead 404.

## Evidence

Verified against the live Mistral docs site (curl, default redirect-follow):

```
$ curl -s -o /dev/null -L -w "%{http_code}\n" https://docs.mistral.ai/studio-api/conversations/reasoning/adjustable
404
$ curl -s -o /dev/null -L -w "%{http_code}\n" https://docs.mistral.ai/capabilities/reasoning/
200
$ curl -s -o /dev/null -L -w "%{http_code}\n" https://docs.mistral.ai/
200
```

The 404 is a hard not-found, not an SPA shell — the Mistral docs root returns
`200` while the old deep path returns `404`. The target page content matches the
section it supports: it documents "adjustable reasoning via the
`reasoning_effort` parameter" with `reasoning_effort = "high"` (response
includes a full thinking chunk before the final answer) and
`reasoning_effort = "none"` (model thinks minimally, thinking chunk omitted) —
the exact `none`/`high` behavior this accordion describes.

Diff is a one-line URL swap in `docs/providers/mistral.md`; the broken URL
occurs only once in the repo.

---

AI-assisted: authored with AI assistance and verified manually as described above.
