### PR TITLE
test(codex): repair app-server CI baselines

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build-state.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build-state.ts
@@ -1,7 +1,10 @@
 type OpenClawCodingToolsFactory =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
+type RuntimeToolNormalizer =
+  (typeof import("openclaw/plugin-sdk/agent-harness-runtime"))["normalizeAgentRuntimeTools"];
 
 /** Mutable dependency seam shared by dynamic-tool construction and its behavioral tests. */
 export const dynamicToolBuildState: {
   openClawCodingToolsFactory?: OpenClawCodingToolsFactory;
+  runtimeToolNormalizer?: RuntimeToolNormalizer;
 } = {};

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -447,7 +447,9 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, messagePolicyParams);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   toolBuildStages.mark("allowlist-filter");
-  const normalizedTools = normalizeAgentRuntimeTools({
+  const normalizeRuntimeTools =
+    dynamicToolBuildState.runtimeToolNormalizer ?? normalizeAgentRuntimeTools;
+  const normalizedTools = normalizeRuntimeTools({
     runtimePlan: input.ignoreRuntimePlan ? undefined : params.runtimePlan,
     tools: filteredTools,
     provider: params.provider,

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -680,6 +680,7 @@ export function setupRunAttemptTestHooks(): void {
     resetCodexAppServerClientFactoryForTest();
     clearRuntimeAuthProfileStoreSnapshots();
     dynamicToolBuildState.openClawCodingToolsFactory = undefined;
+    dynamicToolBuildState.runtimeToolNormalizer = undefined;
     codexWorkspaceDirCache.clear();
     nativeHookRelayUnregisterQueue.clear();
     nativeHookRelayTesting.clearNativeHookRelaysForTests();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -170,6 +170,11 @@ const testing = {
   ): void {
     dynamicToolBuildState.openClawCodingToolsFactory = factory;
   },
+  setRuntimeToolNormalizerForTests(
+    normalizer: NonNullable<typeof dynamicToolBuildState.runtimeToolNormalizer>,
+  ): void {
+    dynamicToolBuildState.runtimeToolNormalizer = normalizer;
+  },
   shouldEnableCodexAppServerNativeToolSurface,
   withCodexStartupTimeout,
 };
@@ -5397,7 +5402,21 @@ describe("runCodexAppServerAttempt", () => {
   });
   it("uses human approval instead of Guardian for auto exec on custom model providers", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
-    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
+    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness(async (method) => {
+      if (method === "thread/start") {
+        const response = threadStartResult();
+        return {
+          ...response,
+          thread: {
+            ...response.thread,
+            modelProvider: "lmstudio",
+          },
+          model: "local-model",
+          modelProvider: "lmstudio",
+        };
+      }
+      return undefined;
+    });
     const params = {
       ...createParams(sessionFile, workspaceDir),
       provider: "lmstudio",
@@ -5609,6 +5628,7 @@ describe("runCodexAppServerAttempt", () => {
     // This test owns review-policy projection, not requester-scoped MCP discovery.
     agentHarnessRuntimeMocks.forceModelToolsUnsupported = true;
     agentHarnessRuntimeMocks.skipRequesterScopedMcpMaterialization = true;
+    testing.setRuntimeToolNormalizerForTests((normalizationParams) => normalizationParams.tools);
     const params = createParams(sessionFile, workspaceDir);
     params.provider = "anthropic";
     params.modelId = "claude-opus-4-6";

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -1634,14 +1634,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
       path.join(tempDir, "session-native-tool-silent.jsonl"),
       path.join(tempDir, "workspace-native-tool-silent"),
     );
-    params.timeoutMs = 100;
+    params.timeoutMs = 1_000;
 
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 20,
       turnAssistantCompletionIdleTimeoutMs: 20,
-      postToolRawAssistantCompletionIdleTimeoutMs: 180,
-      turnTerminalIdleTimeoutMs: 500,
+      postToolRawAssistantCompletionIdleTimeoutMs: 1_800,
+      turnTerminalIdleTimeoutMs: 5_000,
     }).finally(() => {
       settled = true;
     });
@@ -1664,7 +1664,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     );
 
     await new Promise((resolve) => {
-      setTimeout(resolve, 130);
+      setTimeout(resolve, 1_300);
     });
     expect(settled).toBe(false);
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
@@ -1717,14 +1717,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
       path.join(tempDir, "session-buffered-native-tool-silent.jsonl"),
       path.join(tempDir, "workspace-buffered-native-tool-silent"),
     );
-    params.timeoutMs = 100;
+    params.timeoutMs = 1_000;
 
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 20,
       turnAssistantCompletionIdleTimeoutMs: 20,
-      postToolRawAssistantCompletionIdleTimeoutMs: 180,
-      turnTerminalIdleTimeoutMs: 500,
+      postToolRawAssistantCompletionIdleTimeoutMs: 1_800,
+      turnTerminalIdleTimeoutMs: 5_000,
     }).finally(() => {
       settled = true;
     });
@@ -1735,7 +1735,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     );
 
     await new Promise((resolve) => {
-      setTimeout(resolve, 130);
+      setTimeout(resolve, 1_300);
     });
     expect(settled).toBe(false);
     expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -1598,14 +1598,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
       path.join(tempDir, "session-post-tool-silent.jsonl"),
       path.join(tempDir, "workspace-post-tool-silent"),
     );
-    params.timeoutMs = 100;
+    params.timeoutMs = 1_000;
 
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 20,
       turnAssistantCompletionIdleTimeoutMs: 20,
-      postToolRawAssistantCompletionIdleTimeoutMs: 180,
-      turnTerminalIdleTimeoutMs: 500,
+      postToolRawAssistantCompletionIdleTimeoutMs: 1_800,
+      turnTerminalIdleTimeoutMs: 5_000,
     }).finally(() => {
       settled = true;
     });
@@ -1617,7 +1617,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(toolResult.success).toBe(false);
 
     await new Promise((resolve) => {
-      setTimeout(resolve, 130);
+      setTimeout(resolve, 1_300);
     });
     expect(settled).toBe(false);
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);


### PR DESCRIPTION
## Summary

- derive the future-version rejection fixture from the supported Codex app-server ceiling so later version bumps cannot stale it
- make the LM Studio approval fixture confirm the requested provider/model and retain its intended `supportsTools=false` capability
- keep the supervised-model policy test end to end while isolating runtime-tool normalization behind the existing mutable test dependency seam
- provide the required minimal config in the trusted-handoff policy fixture on current `main`
- harden the post-tool turn-watch test against loaded CI runners while preserving its timeout ordering contract

## What Problem This Solves

Five test regressions or instabilities on current `main` surfaced while validating #113429:

1. `MAX_CODEX_APP_SERVER_VERSION` is `0.145.0`, but the rejection test still used `0.145.0` as its unsupported future version. The fixture now increments the configured maximum patch version with `SemVer`, keeping the boundary assertion valid when Codex support advances again.
2. The custom-provider approval test requested LM Studio while its app-server stub returned the default OpenAI provider. It also replaced the base model fixture without preserving `compat.supportsTools=false`, which caused an unrelated dynamic-tool initialization wait.
3. The supervised-model policy test replaces the outer Anthropic model with a synthetic native Codex model, so the outer `supportsTools=false` fixture cannot prevent provider runtime normalization. The existing coding-tool factory seam therefore still allowed an unrelated provider runtime load to consume the test timeout. The seam now also accepts an identity runtime-tool normalizer for focused tests and resets it after every test.
4. Current `main` requires configuration when resolving a trusted internal handoff. The forwarding fixture now supplies the minimal config required to exercise the real resolver without changing the production contract.
5. The post-tool turn-watch test gave the initial tool call only 100 ms to complete before its base timeout. Under CI shard contention, that timer could win before the post-tool deadline was armed. The test now scales all relevant deadlines by 10x while preserving `base timeout < observation point < post-tool timeout < terminal timeout`; runtime behavior is unchanged.

The supervised test still runs the complete attempt and verifies that both `thread/resume` and `turn/start` omit the outer model/provider while selecting `auto_review`. Default production behavior is unchanged because the production normalizer remains the fallback whenever no test override is installed.

## User Impact

There is no production runtime behavior change. Codex test baselines remain aligned with the supported app-server contract and stay stable across future supported-version bumps and loaded CI runners.

## Evidence

- exact head: `1853d56345a7c85e75d2f62bdd5f3f9c38fa89bb`
- base: `upstream/main@a18c31437727c7a319ede155202c435286c6d8c7`
- exact tree: `a3d9f0f0dc138026616aba394a745a87a62cab5d`
- current `upstream/main` reproduction: `client.test.ts` failed exactly the future-version case (`1 failed, 32 passed`) because `0.145.0` resolved instead of rejecting
- updated `client.test.ts`: 33 passed
- `client.test.ts` + `dynamic-tool-build.test.ts` + `run-attempt.test.ts` + `run-attempt.turn-watches.test.ts`: 296 passed on the preceding source diff
- full turn-watch file: 94 passed
- focused supervised-model regression: passed in 1.09 s with its request-level assertions intact
- `oxfmt`, `oxlint`, and `git diff --check`: clean
- autoreview of the dynamic version fixture: clean, no accepted/actionable findings (0.98)
- autoreview of the timing hardening: clean, no accepted/actionable findings (0.93)
- autoreview of the current-main config fixture: clean, no accepted/actionable findings (0.96)
- TruffleHog: clean
- exact-head GitHub CI: green, zero pending checks ([run 30173542848](https://github.com/openclaw/openclaw/actions/runs/30173542848)); this includes the follow-up stabilization of both native post-tool watch cases

The preceding source diff also completed 50 GitHub checks successfully with zero failures.

### Inspectable preceding-head CI proof

GitHub executed preceding head `356dc7d4716aa8496b8bbf949483ff68b04c5901` and completed the following inspectable jobs successfully:

- [checks-node-changed-2](https://github.com/openclaw/openclaw/actions/runs/30150291721/job/89659446154)
- [build-artifacts](https://github.com/openclaw/openclaw/actions/runs/30150291721/job/89659446155)
- [checks-node-changed-1](https://github.com/openclaw/openclaw/actions/runs/30150291721/job/89659446168)
- [check-lint](https://github.com/openclaw/openclaw/actions/runs/30150291721/job/89659446244)
- [check-test-types](https://github.com/openclaw/openclaw/actions/runs/30150291721/job/89659446252)
- [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/30150291721/job/89659880324)
- [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/30150291730)
- [Real behavior proof](https://github.com/openclaw/openclaw/actions/runs/30150331963)

Related: #113429

<!-- AI-assisted: Codex helped diagnose, implement, test, and review this fix. I reviewed the diff and understand the behavior it changes. -->

