### PR TITLE
fix: restore env-var ratchet after response-format change

### DIFF
--- a/packages/ai/src/providers/openai-response-format.ts
+++ b/packages/ai/src/providers/openai-response-format.ts
@@ -1,6 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 
-const OPENCLAW_RESPONSE_FORMAT_NAME = "openclaw_response";
+const JSON_SCHEMA_RESPONSE_FORMAT_NAME = "openclaw_response";
 const OLLAMA_CLOUD_ORIGIN = "https://ollama.com";
 
 export function isKnownOpenAIJsonSchemaModelId(modelId: string | undefined): boolean {
@@ -62,7 +62,7 @@ export function resolveOpenAICompletionsResponseFormat(
   return {
     type: "json_schema",
     json_schema: {
-      name: OPENCLAW_RESPONSE_FORMAT_NAME,
+      name: JSON_SCHEMA_RESPONSE_FORMAT_NAME,
       schema: responseFormat,
     },
   };


### PR DESCRIPTION
Related: #113482, #112838

## What Problem This Solves

Fixes an issue where current `main` fails the environment-variable surface ratchet after the response-format work in #113482, blocking unrelated QA Lab validation.

## Why This Change Was Made

The inventory correctly scans `OPENCLAW_*` production tokens, but #113482 introduced a private TypeScript constant whose identifier looked like an environment variable even though its runtime value is an OpenAI JSON Schema label. Rename that private identifier at the owning `packages/ai` boundary; keep the emitted `"openclaw_response"` value and all response-format behavior unchanged. The budget stays at 521 and QA Lab remains untouched.

## User Impact

Maintainers can run the env-var ratchet and QA Lab validation on current `main` again. There is no runtime, config, or documentation behavior change.

## Evidence

- Before: `node scripts/check-env-var-count.mjs` reported `OPENCLAW_* count 522 exceeds budget 521`.
- After: the same command reports `OPENCLAW_* count 521/521` without changing `config/env-var-count-budget.txt`.
- Blacksmith Testbox: 3 focused files / 74 tests passed, followed by the `core, coreTests` changed gate: https://github.com/openclaw/openclaw/actions/runs/30143781331
- `git diff --check origin/main...HEAD` passed after rebasing onto current `main`.
- Fresh autoreview: clean, no accepted/actionable findings; patch correct at confidence 0.99.

AI-assisted: investigation, implementation, and validation were completed with Codex.
