### PR TITLE
improve(sqlite): prove abrupt writer crash recovery

### DIFF
--- a/scripts/bench-sqlite-reliability.ts
+++ b/scripts/bench-sqlite-reliability.ts
@@ -34,6 +34,12 @@ function printProofLines(report: ReliabilityReport): void {
   console.log(`SQLITE_RELIABILITY_RESTORES_VERIFIED=${report.restoresVerified}`);
   console.log(`SQLITE_RELIABILITY_WRITER_ROWS=${report.writer.rowsCommitted}`);
   console.log(
+    `SQLITE_RELIABILITY_CRASH_RECOVERY=${report.crashRecoveryProof.sourceRecovered && report.crashRecoveryProof.committedStatePreserved && report.crashRecoveryProof.writerRestarted ? "verified" : "missing"}`,
+  );
+  console.log(
+    `SQLITE_RELIABILITY_CRASH_EXIT_SIGNAL=${report.crashRecoveryProof.exit.signal ?? "none"}`,
+  );
+  console.log(
     `SQLITE_RELIABILITY_WAL_SENTINEL=${report.transactionProof.committedWalSentinel ? "verified" : "missing"}`,
   );
   console.log(`SQLITE_RELIABILITY_HELD_BATCH=${report.transactionProof.heldBatch}`);

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -27,6 +27,18 @@ export type ReliabilityStateProof = {
 export type ReliabilityReport = {
   arch: string;
   concurrentRestoresVerified: number;
+  crashRecoveryProof: {
+    committedStatePreserved: true;
+    exit: {
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    };
+    partialVisibleAfterRecovery: false;
+    sourceRecovered: true;
+    stateAfterRecovery: ReliabilityStateProof;
+    stateBeforeKill: ReliabilityStateProof;
+    writerRestarted: true;
+  };
   iterations: number;
   maintenanceProof: {
     bloatBytes: number;

--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -29,11 +29,13 @@ import {
 } from "./sqlite-reliability-contract.js";
 import { monitorSqliteWalDuring } from "./sqlite-reliability-wal-monitor.js";
 import {
+  crashWriter,
   startWriter,
   stopWriter,
   terminateWriter,
   waitForWriterMessage,
   type WriterHandle,
+  type WriterExit,
 } from "./sqlite-reliability-writer.js";
 
 type TargetDatabase = {
@@ -526,6 +528,14 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
     const partial = await waitForWriterMessage(writer, "partial", () => {
       writer?.child.send?.({ kind: "hold-partial" });
     });
+    const stateBeforeKill = verifyRestoredDatabase({
+      identity: target.identity,
+      path: target.path,
+      rowsPerBatch: profile.rowsPerBatch,
+      uncommittedBatch: partial.batch,
+    });
+    let crashExit: WriterExit | undefined;
+    let stateAfterRecovery: ReliabilityStateProof | undefined;
     const metrics: IterationMetric[] = [];
     for (let iteration = 0; iteration < profile.iterations; iteration += 1) {
       const iterationProof = await monitorSqliteWalDuring({
@@ -554,10 +564,20 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
       metrics.push(iterationProof.result);
       peakWalBytes = Math.max(peakWalBytes, iterationProof.peakWalBytes);
       if (iteration === 0) {
-        await waitForWriterMessage(writer, "released", () => {
-          writer?.child.send?.({ action: "rollback", kind: "release-partial" });
+        crashExit = await crashWriter(writer);
+        stateAfterRecovery = verifyRestoredDatabase({
+          expectedState: stateBeforeKill,
+          identity: target.identity,
+          path: target.path,
+          rowsPerBatch: profile.rowsPerBatch,
+          uncommittedBatch: partial.batch,
         });
+        writer = startWriter(target.path, profile);
+        await waitForWriterMessage(writer, "ready");
       }
+    }
+    if (!crashExit || !stateAfterRecovery) {
+      throw new Error("SQLite reliability stress did not execute its crash recovery proof.");
     }
     const writerResult = await stopWriter(writer);
     const maintenanceProof = await runMaintenanceRoundTrip({
@@ -573,6 +593,15 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
     return {
       arch: process.arch,
       concurrentRestoresVerified: metrics.length,
+      crashRecoveryProof: {
+        committedStatePreserved: true,
+        exit: crashExit,
+        partialVisibleAfterRecovery: false,
+        sourceRecovered: true,
+        stateAfterRecovery,
+        stateBeforeKill,
+        writerRestarted: true,
+      },
       iterations: profile.iterations,
       maintenanceProof,
       node: process.version,
@@ -624,8 +653,8 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
         peak: peakWalBytes,
       },
       writer: {
-        batchesCommitted: writerResult.batchesCommitted,
-        rowsCommitted: writerResult.rowsCommitted,
+        batchesCommitted: partial.batchesCommitted + writerResult.batchesCommitted,
+        rowsCommitted: partial.rowsCommitted + writerResult.rowsCommitted,
       },
     };
   } finally {

--- a/scripts/lib/sqlite-reliability-writer.ts
+++ b/scripts/lib/sqlite-reliability-writer.ts
@@ -14,8 +14,10 @@ type WriterReadyMessage = {
 
 type WriterPartialMessage = {
   batch: number;
+  batchesCommitted: number;
   kind: "partial";
   rows: number;
+  rowsCommitted: number;
 };
 
 type WriterReleasedMessage = {
@@ -45,6 +47,11 @@ export type WriterHandle = {
   child: ChildProcess;
   stderr: string[];
   stopped: boolean;
+};
+
+export type WriterExit = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
 };
 
 const WRITER_MESSAGE_TIMEOUT_MS = 30_000;
@@ -143,18 +150,18 @@ export async function stopWriter(writer: WriterHandle): Promise<WriterResultMess
   return result;
 }
 
-async function waitForChildExit(child: ChildProcess): Promise<void> {
+async function waitForChildExit(child: ChildProcess): Promise<WriterExit> {
   if (child.exitCode !== null || child.signalCode !== null) {
-    return;
+    return { code: child.exitCode, signal: child.signalCode };
   }
-  await new Promise<void>((resolve, reject) => {
+  return await new Promise<WriterExit>((resolve, reject) => {
     const timeout = setTimeout(() => {
       cleanup();
-      reject(new Error("SQLite reliability writer did not exit after stopping."));
+      reject(new Error("SQLite reliability writer did not exit after termination was requested."));
     }, WRITER_MESSAGE_TIMEOUT_MS);
-    const onExit = () => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
       cleanup();
-      resolve();
+      resolve({ code, signal });
     };
     const onError = (error: Error) => {
       cleanup();
@@ -170,12 +177,26 @@ async function waitForChildExit(child: ChildProcess): Promise<void> {
   });
 }
 
+export async function crashWriter(writer: WriterHandle): Promise<WriterExit> {
+  if (writer.stopped) {
+    throw new Error("SQLite reliability writer was already stopped.");
+  }
+  if (!writer.child.kill("SIGKILL")) {
+    throw new Error("SQLite reliability writer exited before the crash signal was delivered.");
+  }
+  const exit = await waitForChildExit(writer.child);
+  writer.stopped = true;
+  return exit;
+}
+
 export async function terminateWriter(writer: WriterHandle): Promise<void> {
   if (writer.child.exitCode !== null || writer.child.signalCode !== null) {
+    writer.stopped = true;
     return;
   }
   writer.child.kill();
   await waitForChildExit(writer.child).catch(() => undefined);
+  writer.stopped = true;
 }
 
 function parseWriterChildArgs(argv: string[]): {
@@ -267,9 +288,10 @@ async function runWriterChild(argv: string[]): Promise<void> {
     const insert = database.prepare(
       "INSERT INTO openclaw_reliability_entries (batch, ordinal, payload) VALUES (?, ?, ?)",
     );
-    const insertSentinel = database.prepare(
-      "INSERT INTO openclaw_reliability_sentinel (id, payload) VALUES (1, ?)",
-    );
+    const upsertSentinel = database.prepare(`
+      INSERT INTO openclaw_reliability_sentinel (id, payload) VALUES (1, ?)
+      ON CONFLICT(id) DO UPDATE SET payload = excluded.payload
+    `);
     const deleteExpired = database.prepare(
       "DELETE FROM openclaw_reliability_entries WHERE batch < ?",
     );
@@ -300,7 +322,7 @@ async function runWriterChild(argv: string[]): Promise<void> {
       database.exec("BEGIN IMMEDIATE;");
       try {
         if (includeSentinel) {
-          insertSentinel.run(COMMITTED_WAL_SENTINEL);
+          upsertSentinel.run(COMMITTED_WAL_SENTINEL);
         }
         for (let ordinal = 0; ordinal < options.rowsPerBatch; ordinal += 1) {
           insert.run(nextBatch, ordinal, `${nextBatch}:${ordinal}:${payload}`);
@@ -330,8 +352,10 @@ async function runWriterChild(argv: string[]): Promise<void> {
           }
           sendMessage({
             batch: heldBatch,
+            batchesCommitted,
             kind: "partial",
             rows: heldRows,
+            rowsCommitted,
           } satisfies WriterPartialMessage);
           while (!shouldReleasePartial()) {
             await delay(1);

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -154,9 +154,30 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstResult.stderr).toBe("");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=5");
+    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_CRASH_RECOVERY=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_POST_COMPACT_RESTORE=verified");
     const firstReport = JSON.parse(fs.readFileSync(firstOutput, "utf8")) as {
       concurrentRestoresVerified: number;
+      crashRecoveryProof: {
+        committedStatePreserved: boolean;
+        exit: {
+          code: number | null;
+          signal: string | null;
+        };
+        partialVisibleAfterRecovery: boolean;
+        sourceRecovered: boolean;
+        stateAfterRecovery: {
+          batches: number;
+          rows: number;
+          sha256: string;
+        };
+        stateBeforeKill: {
+          batches: number;
+          rows: number;
+          sha256: string;
+        };
+        writerRestarted: boolean;
+      };
       maintenanceProof: {
         bloatBytes: number;
         compaction: {
@@ -194,6 +215,17 @@ describe("scripts/bench-sqlite-reliability", () => {
     };
     expect(firstReport.concurrentRestoresVerified).toBe(4);
     expect(firstReport.restoresVerified).toBe(5);
+    expect(firstReport.crashRecoveryProof.sourceRecovered).toBe(true);
+    expect(firstReport.crashRecoveryProof.committedStatePreserved).toBe(true);
+    expect(firstReport.crashRecoveryProof.partialVisibleAfterRecovery).toBe(false);
+    expect(firstReport.crashRecoveryProof.writerRestarted).toBe(true);
+    expect(
+      firstReport.crashRecoveryProof.exit.code !== null ||
+        firstReport.crashRecoveryProof.exit.signal !== null,
+    ).toBe(true);
+    expect(firstReport.crashRecoveryProof.stateAfterRecovery).toEqual(
+      firstReport.crashRecoveryProof.stateBeforeKill,
+    );
     expect(firstReport.transactionProof.committedWalSentinel).toBe(true);
     expect(firstReport.transactionProof.heldRows).toBeGreaterThan(0);
     expect(firstReport.transactionProof.visibleAfterRestore).toBe(false);


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Fixes an issue where the SQLite reliability proof used a cooperative rollback, so it did not verify that an abrupt writer-process crash preserves committed state and discards an open transaction.

## Why This Change Was Made

The stress harness now holds a partial WAL transaction, snapshots it, force-terminates the writer, reopens and hash-verifies the source database, proves the partial batch is absent, restarts writing, and then continues through concurrent snapshots, VACUUM, and post-compaction restore. Exit evidence remains portable across Unix and Windows, where forced termination can be reported differently.

## User Impact

Maintainers now get a real process-crash durability signal for both shared and per-agent SQLite databases instead of inferring crash safety from a graceful rollback.

## Evidence

- Blacksmith Testbox `tbx_01kybr6vp5mpznrqzgr2f27e3w`, Linux x64: `pnpm test:serial test/scripts/bench-sqlite-reliability.test.ts` passed all 4 tests.
- Same Testbox, per-agent smoke: 4 concurrent snapshots, 5 verified restores, abrupt writer termination, identical pre/post-crash committed-state hashes, writer restart, 8,658,944 bytes reclaimed by VACUUM, and verified post-compact restore.
- Same Testbox: `pnpm check:changed` passed in 1m51s.
- Fresh `autoreview`: no accepted/actionable findings; correctness confidence 0.88.
- `git diff --check` and targeted `oxfmt --check` passed.
