### PR TITLE
refactor(channels): route bundled command replies

### DIFF
--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -144,6 +144,13 @@ has `visibleReplySent: false`, does not emit `message_sent`, and does not count
 as a visible queued reply. This lets plugins distinguish hook cancellation
 from provider failure without inventing a native message identity.
 
+By default, routed turns record inbound metadata against
+`ctxPayload.SessionKey ?? route.sessionKey`. Set `record.sessionKey` only when a
+native command intentionally executes in one command session while updating a
+different provider-routed target session. The override affects inbound metadata,
+transcript-context merge, and record-stage diagnostics; it does not change dispatch
+routing or hook correlation.
+
 Reject `deliver` or `finalization` when native delivery fails. If no provider
 send was attempted, throw `PlatformMessageNotDispatchedError` from
 `openclaw/plugin-sdk/error-runtime`; core suppresses a false `message_sent`

--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -149,7 +149,8 @@ By default, routed turns record inbound metadata against
 native command intentionally executes in one command session while updating a
 different provider-routed target session. The override affects inbound metadata,
 transcript-context merge, and record-stage diagnostics; it does not change dispatch
-routing or hook correlation.
+routing or hook correlation. An explicit override must be non-empty and contain no
+surrounding whitespace.
 
 Reject `deliver` or `finalization` when native delivery fails. If no provider
 send was attempted, throw `PlatformMessageNotDispatchedError` from

--- a/extensions/discord/src/internal/api.interactions.ts
+++ b/extensions/discord/src/internal/api.interactions.ts
@@ -25,6 +25,15 @@ export async function editWebhookMessage(
     : await rest.patch(Routes.webhookMessage(applicationId, token, messageId), data);
 }
 
+export async function deleteWebhookMessage(
+  rest: RequestClient,
+  applicationId: string,
+  token: string,
+  messageId: string,
+): Promise<unknown> {
+  return await rest.delete(Routes.webhookMessage(applicationId, token, messageId));
+}
+
 export async function getWebhookMessage(
   rest: RequestClient,
   applicationId: string,

--- a/extensions/discord/src/internal/api.test.ts
+++ b/extensions/discord/src/internal/api.test.ts
@@ -13,6 +13,7 @@ import {
   createUserDmChannel,
   deleteChannelMessage,
   deleteOwnMessageReaction,
+  deleteWebhookMessage,
   editApplicationCommand,
   editWebhookMessage,
   getCurrentUser,
@@ -206,7 +207,13 @@ describe("Discord REST API helpers", () => {
   });
 
   it("routes interaction webhook helpers through the typed REST client", async () => {
-    const rest = createFakeRestClient([{ ok: true }, { id: "m1" }, { id: "m2" }, { id: "m3" }]);
+    const rest = createFakeRestClient([
+      { ok: true },
+      { id: "m1" },
+      { id: "m2" },
+      { id: "m3" },
+      undefined,
+    ]);
     const query = { wait: "true" };
 
     await expect(createInteractionCallback(rest, "i1", "itoken", { type: 5 })).resolves.toEqual({
@@ -219,6 +226,7 @@ describe("Discord REST API helpers", () => {
     await expect(
       editWebhookMessage(rest, "app1", "wtoken", "m1", { body: { content: "updated" } }),
     ).resolves.toEqual({ id: "m3" });
+    await expect(deleteWebhookMessage(rest, "app1", "wtoken", "m1")).resolves.toBeUndefined();
     expect(rest.calls).toEqual([
       {
         method: "POST",
@@ -237,6 +245,7 @@ describe("Discord REST API helpers", () => {
         path: Routes.webhookMessage("app1", "wtoken", "m1"),
         data: { body: { content: "updated" } },
       },
+      { method: "DELETE", path: Routes.webhookMessage("app1", "wtoken", "m1") },
     ]);
   });
 

--- a/extensions/discord/src/internal/api.ts
+++ b/extensions/discord/src/internal/api.ts
@@ -32,6 +32,7 @@ export {
 export {
   createInteractionCallback,
   createWebhookMessage,
+  deleteWebhookMessage,
   editWebhookMessage,
   getWebhookMessage,
 } from "./api.interactions.js";

--- a/extensions/discord/src/internal/interaction-response.ts
+++ b/extensions/discord/src/internal/interaction-response.ts
@@ -41,6 +41,10 @@ export class InteractionResponseController {
   recordReplyEdit(): void {
     this.state = "replied";
   }
+
+  recordReplyDelete(): void {
+    this.state = "replied";
+  }
 }
 
 export function needsComponentsV2Query(body: unknown): boolean {

--- a/extensions/discord/src/internal/interactions.test.ts
+++ b/extensions/discord/src/internal/interactions.test.ts
@@ -43,6 +43,24 @@ describe("BaseInteraction", () => {
     });
   });
 
+  it("deletes the original interaction response after defer", async () => {
+    const del = vi.fn(async () => undefined);
+    const post = vi.fn(async () => undefined);
+    const client = createInternalTestClient();
+    attachRestMock(client, { delete: del, post });
+    const interaction = createInteraction(
+      client,
+      createInternalInteractionPayload({ id: "interaction1", token: "token1" }),
+    );
+
+    await interaction.defer();
+    expect(interaction.responseState).toBe("deferred");
+    await interaction.deleteReply();
+
+    expect(del).toHaveBeenCalledWith("/webhooks/app1/token1/messages/%40original");
+    expect(interaction.responseState).toBe("replied");
+  });
+
   it("uses with_components for Components V2 follow-ups", async () => {
     const post = vi.fn(async () => undefined);
     const client = createInternalTestClient();

--- a/extensions/discord/src/internal/interactions.ts
+++ b/extensions/discord/src/internal/interactions.ts
@@ -16,6 +16,7 @@ import {
 import {
   createInteractionCallback,
   createWebhookMessage,
+  deleteWebhookMessage,
   editWebhookMessage,
   getWebhookMessage,
 } from "./api.js";
@@ -202,6 +203,17 @@ class BaseInteraction {
           { body },
         );
     this.response.recordReplyEdit();
+    return result;
+  }
+
+  async deleteReply(): Promise<unknown> {
+    const result = await deleteWebhookMessage(
+      this.client.rest,
+      this.client.options.clientId,
+      this.token,
+      "@original",
+    );
+    this.response.recordReplyDelete();
     return result;
   }
 

--- a/extensions/discord/src/monitor/native-command-agent-reply.ts
+++ b/extensions/discord/src/monitor/native-command-agent-reply.ts
@@ -1,6 +1,9 @@
 // Discord plugin module implements native command agent reply behavior.
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
-import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  hasVisibleInboundReplyDispatch,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelStreamingBlockEnabled } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
@@ -18,7 +21,6 @@ import type { buildDiscordNativeCommandContext } from "./native-command-context.
 import {
   DISCORD_EMPTY_VISIBLE_REPLY_WARNING,
   deliverDiscordInteractionReply,
-  isDiscordUnknownInteraction,
   safeDiscordInteractionCall,
 } from "./native-command-reply.js";
 import { nativeCommandRuntime } from "./native-command.runtime.js";
@@ -27,6 +29,7 @@ import type { DiscordConfig } from "./native-command.types.js";
 type NativeCommandEffectiveRoute = {
   accountId: string;
   agentId: string;
+  sessionKey: string;
 };
 
 export async function dispatchDiscordNativeAgentReply(params: {
@@ -43,71 +46,83 @@ export async function dispatchDiscordNativeAgentReply(params: {
   suppressReplies?: boolean;
   log: ReturnType<typeof createSubsystemLogger>;
 }): Promise<void> {
-  const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
-    cfg: params.cfg,
-    agentId: params.effectiveRoute.agentId,
-    channel: "discord",
-    accountId: params.effectiveRoute.accountId,
-  });
   const blockStreamingEnabled = resolveChannelStreamingBlockEnabled(params.discordConfig);
 
   let didReply = false;
-  const dispatchResult = await nativeCommandRuntime.dispatchReplyWithDispatcher({
-    ctx: params.ctxPayload,
+  let settledWithoutVisibleReply = false;
+  const turnResult = await nativeCommandRuntime.dispatchChannelInboundTurn({
     cfg: params.cfg,
-    dispatcherOptions: {
-      ...replyPipeline,
-      humanDelay: resolveHumanDelayConfig(params.cfg, params.effectiveRoute.agentId),
+    channel: "discord",
+    accountId: params.effectiveRoute.accountId,
+    route: {
+      agentId: params.effectiveRoute.agentId,
+      sessionKey: params.ctxPayload.SessionKey ?? params.effectiveRoute.sessionKey,
+    },
+    ctxPayload: params.ctxPayload,
+    delivery: {
       deliver: async (payload) => {
         if (params.suppressReplies) {
-          return;
+          return {
+            visibleReplySent: false,
+            suppression: { reason: "no_visible_result" as const },
+          };
         }
-        try {
-          await deliverDiscordInteractionReply({
-            interaction: params.interaction,
-            payload,
-            mediaLocalRoots: params.mediaLocalRoots,
-            textLimit: resolveTextChunkLimit(params.cfg, "discord", params.accountId, {
-              fallbackLimit: 2000,
-            }),
-            maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({
-              cfg: params.cfg,
-              discordConfig: params.discordConfig,
-              accountId: params.accountId,
-            }),
-            preferFollowUp: params.preferFollowUp || didReply,
-            responseEphemeral: params.responseEphemeral,
-            chunkMode: resolveChunkMode(params.cfg, "discord", params.accountId),
-          });
-        } catch (error) {
-          if (isDiscordUnknownInteraction(error)) {
-            logVerbose("discord: interaction reply skipped (interaction expired)");
-            return;
-          }
-          throw error;
+        const payloadDelivered = await deliverDiscordInteractionReply({
+          interaction: params.interaction,
+          payload,
+          mediaLocalRoots: params.mediaLocalRoots,
+          textLimit: resolveTextChunkLimit(params.cfg, "discord", params.accountId, {
+            fallbackLimit: 2000,
+          }),
+          maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({
+            cfg: params.cfg,
+            discordConfig: params.discordConfig,
+            accountId: params.accountId,
+          }),
+          preferFollowUp: params.preferFollowUp || didReply,
+          responseEphemeral: params.responseEphemeral,
+          chunkMode: resolveChunkMode(params.cfg, "discord", params.accountId),
+        });
+        didReply ||= payloadDelivered;
+        return payloadDelivered
+          ? { visibleReplySent: true }
+          : {
+              visibleReplySent: false,
+              suppression: { reason: "no_visible_result" as const },
+            };
+      },
+      onDelivered: (_payload, _info, result) => {
+        if (result?.visibleReplySent === false) {
+          settledWithoutVisibleReply = true;
         }
-        didReply = true;
       },
       onError: (err, info) => {
+        if (isChannelPartialDeliveryError(err)) {
+          // Preserve failed delivery accounting while preventing an empty fallback from
+          // obscuring the prefix that Discord already accepted for this payload.
+          didReply = true;
+          logVerbose("discord: interaction reply partially delivered before expiry");
+        }
         const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
         params.log.error(`discord slash ${info.kind} reply failed: ${message}`);
       },
+    },
+    replyPipeline: {},
+    dispatcherOptions: {
+      humanDelay: resolveHumanDelayConfig(params.cfg, params.effectiveRoute.agentId),
     },
     replyOptions: {
       skillFilter: params.channelConfig?.skills,
       disableBlockStreaming:
         typeof blockStreamingEnabled === "boolean" ? !blockStreamingEnabled : undefined,
-      onModelSelected,
     },
   });
 
   if (
     params.suppressReplies ||
     didReply ||
-    dispatchResult.queuedFinal ||
-    dispatchResult.counts.final !== 0 ||
-    dispatchResult.counts.block !== 0 ||
-    dispatchResult.counts.tool !== 0
+    settledWithoutVisibleReply ||
+    (turnResult.dispatched && hasVisibleInboundReplyDispatch(turnResult.dispatchResult))
   ) {
     return;
   }

--- a/extensions/discord/src/monitor/native-command-agent-reply.ts
+++ b/extensions/discord/src/monitor/native-command-agent-reply.ts
@@ -22,6 +22,7 @@ import {
   DISCORD_EMPTY_VISIBLE_REPLY_WARNING,
   deliverDiscordInteractionReply,
   safeDiscordInteractionCall,
+  settleDiscordInteractionWithoutVisibleReply,
 } from "./native-command-reply.js";
 import { nativeCommandRuntime } from "./native-command.runtime.js";
 import type { DiscordConfig } from "./native-command.types.js";
@@ -118,6 +119,10 @@ export async function dispatchDiscordNativeAgentReply(params: {
     },
   });
 
+  if (!didReply && (params.suppressReplies || settledWithoutVisibleReply)) {
+    await settleDiscordInteractionWithoutVisibleReply(params.interaction);
+    return;
+  }
   if (
     params.suppressReplies ||
     didReply ||

--- a/extensions/discord/src/monitor/native-command-reply.test.ts
+++ b/extensions/discord/src/monitor/native-command-reply.test.ts
@@ -4,6 +4,7 @@ import { Container, TextDisplay } from "../internal/discord.js";
 import {
   deliverDiscordInteractionReply,
   hasRenderableReplyPayload,
+  settleDiscordInteractionWithoutVisibleReply,
 } from "./native-command-reply.js";
 
 function createInteraction() {
@@ -66,4 +67,31 @@ describe("deliverDiscordInteractionReply", () => {
     });
     expect(interaction.followUp).not.toHaveBeenCalled();
   });
+});
+
+describe("settleDiscordInteractionWithoutVisibleReply", () => {
+  it("deletes a deferred slash-command loading response", async () => {
+    const interaction = {
+      responseState: "deferred",
+      deleteReply: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await settleDiscordInteractionWithoutVisibleReply(interaction as never);
+
+    expect(interaction.deleteReply).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["unacknowledged", "deferred-update", "replied"])(
+    "does not delete an interaction in the %s state",
+    async (responseState) => {
+      const interaction = {
+        responseState,
+        deleteReply: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await settleDiscordInteractionWithoutVisibleReply(interaction as never);
+
+      expect(interaction.deleteReply).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/extensions/discord/src/monitor/native-command-reply.ts
+++ b/extensions/discord/src/monitor/native-command-reply.ts
@@ -1,4 +1,6 @@
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 // Discord plugin module implements native command reply behavior.
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import {
   resolveSendableOutboundReplyParts,
@@ -16,7 +18,7 @@ import type {
 
 export const DISCORD_EMPTY_VISIBLE_REPLY_WARNING = "⚠️ Command produced no visible reply.";
 
-export function isDiscordUnknownInteraction(error: unknown): boolean {
+function isDiscordUnknownInteraction(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
@@ -75,7 +77,7 @@ export async function deliverDiscordInteractionReply(params: {
   preferFollowUp: boolean;
   responseEphemeral?: boolean;
   chunkMode: "length" | "newline";
-}) {
+}): Promise<boolean> {
   const { interaction, payload, textLimit, maxLinesPerMessage, preferFollowUp, chunkMode } = params;
   const reply = resolveSendableOutboundReplyParts(payload);
   const discordData = payload.channelData?.discord as
@@ -86,7 +88,9 @@ export async function deliverDiscordInteractionReply(params: {
       ? discordData.components
       : undefined;
 
-  let hasReplied = false;
+  // Interaction acknowledgement/defer state is not delivery for this payload. Only a
+  // successful native send in this invocation can make a later expiry partial.
+  let payloadDelivered = false;
   const sendMessage = async (
     content: string,
     files?: { name: string; data: Buffer }[],
@@ -116,17 +120,36 @@ export async function deliverDiscordInteractionReply(params: {
               ? { ephemeral: params.responseEphemeral }
               : {}),
           };
-    await safeDiscordInteractionCall("interaction send", async () => {
-      if (!preferFollowUp && !hasReplied) {
-        await interaction.reply(payloadLocal);
-        hasReplied = true;
+    let result: void | null;
+    try {
+      result = await safeDiscordInteractionCall("interaction send", async () => {
+        if (!preferFollowUp && !payloadDelivered) {
+          await interaction.reply(payloadLocal);
+          payloadDelivered = true;
+          firstMessageComponents = undefined;
+          return;
+        }
+        await interaction.followUp(payloadLocal);
+        payloadDelivered = true;
         firstMessageComponents = undefined;
-        return;
+      });
+    } catch (error) {
+      if (!payloadDelivered) {
+        throw error;
       }
-      await interaction.followUp(payloadLocal);
-      hasReplied = true;
-      firstMessageComponents = undefined;
-    });
+      throw createChannelPartialDeliveryError(error, { visibleReplySent: true });
+    }
+    if (result !== null) {
+      return;
+    }
+    const expiry = new PlatformMessageNotDispatchedError(
+      "Discord interaction expired before message dispatch",
+      { cause: new Error("Unknown interaction") },
+    );
+    if (!payloadDelivered) {
+      throw expiry;
+    }
+    throw createChannelPartialDeliveryError(expiry, { visibleReplySent: true });
   };
 
   if (reply.hasMedia) {
@@ -157,11 +180,11 @@ export async function deliverDiscordInteractionReply(params: {
       }
       await sendMessage(chunk);
     }
-    return;
+    return payloadDelivered;
   }
 
   if (!reply.hasText && !firstMessageComponents) {
-    return;
+    return false;
   }
   let chunks =
     reply.text || firstMessageComponents
@@ -183,4 +206,5 @@ export async function deliverDiscordInteractionReply(params: {
     }
     await sendMessage(chunk, undefined, firstMessageComponents);
   }
+  return payloadDelivered;
 }

--- a/extensions/discord/src/monitor/native-command-reply.ts
+++ b/extensions/discord/src/monitor/native-command-reply.ts
@@ -68,6 +68,19 @@ export async function safeDiscordInteractionCall<T>(
   }
 }
 
+export async function settleDiscordInteractionWithoutVisibleReply(
+  interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction,
+): Promise<void> {
+  // Only slash-command defers create Discord's visible loading response. Component
+  // defers own an existing message, so deleting their original response would erase UI.
+  if (interaction.responseState !== "deferred") {
+    return;
+  }
+  await safeDiscordInteractionCall("interaction delete deferred reply", () =>
+    interaction.deleteReply(),
+  );
+}
+
 export async function deliverDiscordInteractionReply(params: {
   interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction;
   payload: ReplyPayload;

--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -1,5 +1,6 @@
 // Discord tests cover native command.commands allowfrom plugin behavior.
 import { ChannelType } from "discord-api-types/v10";
+import type { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
 import type { NativeCommandSpec } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -80,9 +81,34 @@ function createDispatchSpy() {
       tool: 0,
     },
   } as never);
-  nativeCommandRuntime.dispatchReplyWithDispatcher = dispatcherModule.dispatchReplyWithDispatcher;
+  nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
   return dispatchSpy;
 }
+
+const dispatchChannelInboundTurnForTest: typeof dispatchChannelInboundTurn = async (plan) => {
+  const dispatchResult = await dispatcherModule.dispatchReplyWithDispatcher({
+    ctx: plan.ctxPayload,
+    cfg: plan.cfg,
+    dispatcherOptions: {
+      ...plan.dispatcherOptions,
+      deliver: async (payload, info) => {
+        if (!("deliver" in plan.delivery) || !plan.delivery.deliver) {
+          throw new Error("expected core-managed Discord delivery");
+        }
+        await plan.delivery.deliver(payload, info);
+      },
+      onError: plan.delivery.onError,
+    },
+    replyOptions: plan.replyOptions,
+  });
+  return {
+    admission: { kind: "dispatch" },
+    dispatched: true,
+    ctxPayload: plan.ctxPayload,
+    routeSessionKey: plan.route.sessionKey,
+    dispatchResult,
+  };
+};
 
 function firstDispatchReplyCall(): Parameters<
   typeof dispatcherModule.dispatchReplyWithDispatcher
@@ -141,7 +167,7 @@ function expectChannelNotAllowedReply(interaction: MockCommandInteraction) {
 describe("Discord native slash commands with commands.allowFrom", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    nativeCommandRuntime.dispatchReplyWithDispatcher = dispatcherModule.dispatchReplyWithDispatcher;
+    nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
   });
 
   it("authorizes guild slash commands when commands.allowFrom.discord matches the sender", async () => {

--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -1,8 +1,10 @@
 // Discord tests cover native command.plugin dispatch plugin behavior.
 import { ChannelType } from "discord-api-types/v10";
+import { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
 import type { NativeCommandSpec } from "openclaw/plugin-sdk/command-auth-native";
 import { resolveDirectStatusReplyForSession } from "openclaw/plugin-sdk/command-status-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import {
   clearPluginCommands,
   executePluginCommand,
@@ -13,7 +15,6 @@ import {
   createTestRegistry,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { dispatchReplyWithDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
@@ -37,6 +38,26 @@ const runtimeModuleMocks = vi.hoisted(() => ({
   resolveDirectStatusReplyForSession: vi.fn(),
   getSessionEntry: vi.fn(),
 }));
+
+const dispatchChannelInboundTurnForTest: typeof dispatchChannelInboundTurn = async (plan) => {
+  const dispatchResult = await runtimeModuleMocks.dispatchReplyWithDispatcher({
+    ctx: plan.ctxPayload,
+    cfg: plan.cfg,
+    dispatcherOptions: {
+      ...plan.dispatcherOptions,
+      deliver: "deliver" in plan.delivery ? plan.delivery.deliver : undefined,
+      onError: plan.delivery.onError,
+    },
+    replyOptions: plan.replyOptions,
+  });
+  return {
+    admission: { kind: "dispatch" },
+    dispatched: true,
+    ctxPayload: plan.ctxPayload,
+    routeSessionKey: plan.route.sessionKey,
+    dispatchResult,
+  };
+};
 
 function createConfig(): OpenClawConfig {
   return {
@@ -410,7 +431,7 @@ describe("Discord native plugin command dispatch", () => {
     setActivePluginRegistry(createTestRegistry());
     nativeCommandRuntime.matchPluginCommand = matchPluginCommand;
     nativeCommandRuntime.executePluginCommand = executePluginCommand;
-    nativeCommandRuntime.dispatchReplyWithDispatcher = dispatchReplyWithDispatcher;
+    nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurn;
     nativeCommandRuntime.resolveDirectStatusReplyForSession = resolveDirectStatusReplyForSession;
     nativeCommandRuntime.resolveDiscordNativeInteractionRouteState =
       resolveDiscordNativeInteractionRouteState;
@@ -444,8 +465,7 @@ describe("Discord native plugin command dispatch", () => {
       runtimeModuleMocks.matchPluginCommand as typeof import("openclaw/plugin-sdk/plugin-runtime").matchPluginCommand;
     nativeCommandRuntime.executePluginCommand =
       runtimeModuleMocks.executePluginCommand as typeof import("openclaw/plugin-sdk/plugin-runtime").executePluginCommand;
-    nativeCommandRuntime.dispatchReplyWithDispatcher =
-      runtimeModuleMocks.dispatchReplyWithDispatcher as typeof dispatchReplyWithDispatcher;
+    nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
     nativeCommandRuntime.resolveDirectStatusReplyForSession =
       runtimeModuleMocks.resolveDirectStatusReplyForSession as typeof resolveDirectStatusReplyForSession;
     nativeCommandRuntime.resolveDiscordNativeInteractionRouteState = async (params) =>
@@ -960,6 +980,177 @@ describe("Discord native plugin command dispatch", () => {
       content: "⚠️ Command produced no visible reply.",
       ephemeral: true,
     });
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("does not emit the empty warning when the routed reply hook cancels delivery", async () => {
+    const cfg = createConfig();
+    const interaction = createInteraction();
+    runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
+    nativeCommandRuntime.dispatchChannelInboundTurn = async (plan) => {
+      await plan.delivery.onDelivered?.(
+        { text: "cancelled" },
+        { kind: "final" },
+        {
+          visibleReplySent: false,
+          suppression: { reason: "cancelled_by_reply_payload_sending_hook" },
+        },
+      );
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          counts: { final: 0, block: 0, tool: 0 },
+          queuedFinal: false,
+        },
+      };
+    };
+    const command = await createNativeCommand(cfg, {
+      name: "new",
+      description: "Start a new session.",
+      acceptsArgs: true,
+    });
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expectNoFollowUpContent(interaction, "⚠️ Command produced no visible reply.");
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("keeps a native reply visible when a later Discord chunk expires", async () => {
+    const cfg = createConfig();
+    const interaction = createInteraction();
+    interaction.followUp
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce({ discordCode: 10062, message: "Unknown interaction" });
+    runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
+    runtimeModuleMocks.dispatchReplyWithDispatcher.mockImplementation(async (params: unknown) => {
+      const dispatcherOptions = (
+        params as {
+          dispatcherOptions: {
+            deliver: (payload: { text: string }, info: { kind: "final" }) => Promise<void>;
+            onError?: (error: unknown, info: { kind: "final" }) => void;
+          };
+        }
+      ).dispatcherOptions;
+      try {
+        await dispatcherOptions.deliver({ text: "x".repeat(2500) }, { kind: "final" });
+      } catch (error) {
+        dispatcherOptions.onError?.(error, { kind: "final" });
+      }
+      return {
+        counts: { final: 0, block: 0, tool: 0 },
+        failedCounts: { final: 1, block: 0, tool: 0 },
+        queuedFinal: false,
+      };
+    });
+    const command = await createNativeCommand(cfg, {
+      name: "new",
+      description: "Start a new session.",
+      acceptsArgs: true,
+    });
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(interaction.followUp).toHaveBeenCalledTimes(2);
+    expectNoFollowUpContent(interaction, "⚠️ Command produced no visible reply.");
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("does not classify an already-deferred interaction as partial before this payload sends", async () => {
+    const cfg = createConfig();
+    const interaction = createInteraction();
+    interaction.followUp.mockRejectedValue({
+      discordCode: 10062,
+      message: "Unknown interaction",
+    });
+    runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
+    nativeCommandRuntime.dispatchChannelInboundTurn = async (plan) => {
+      if (!("deliver" in plan.delivery)) {
+        throw new Error("expected direct delivery adapter");
+      }
+      const deliver = plan.delivery.deliver;
+      if (!deliver) {
+        throw new Error("expected direct deliverer");
+      }
+      const payload = { text: "expired before delivery" };
+      const info = { kind: "final" as const };
+      let deliveryError: unknown;
+      try {
+        await deliver(payload, info);
+      } catch (error) {
+        deliveryError = error;
+        plan.delivery.onError?.(error, info);
+      }
+      expect(deliveryError).toBeInstanceOf(PlatformMessageNotDispatchedError);
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          counts: { final: 0, block: 0, tool: 0 },
+          failedCounts: { final: 1, block: 0, tool: 0 },
+          queuedFinal: false,
+        },
+      };
+    };
+    const command = await createNativeCommand(cfg, {
+      name: "new",
+      description: "Start a new session.",
+      acceptsArgs: true,
+    });
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(interaction.followUp).toHaveBeenCalledTimes(2);
+    const fallback = requireRecord(
+      (interaction.followUp as unknown as MockCalls).mock.calls[1]?.[0],
+      "empty fallback",
+    );
+    expect(fallback.content).toBe("⚠️ Command produced no visible reply.");
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("preserves partial delivery when a later Discord chunk fails without expiry", async () => {
+    const cfg = createConfig();
+    const interaction = createInteraction();
+    interaction.followUp
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(new Error("provider connection failed"));
+    runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
+    runtimeModuleMocks.dispatchReplyWithDispatcher.mockImplementation(async (params: unknown) => {
+      const dispatcherOptions = (
+        params as {
+          dispatcherOptions: {
+            deliver: (payload: { text: string }, info: { kind: "final" }) => Promise<void>;
+            onError?: (error: unknown, info: { kind: "final" }) => void;
+          };
+        }
+      ).dispatcherOptions;
+      try {
+        await dispatcherOptions.deliver({ text: "x".repeat(2500) }, { kind: "final" });
+      } catch (error) {
+        dispatcherOptions.onError?.(error, { kind: "final" });
+      }
+      return {
+        counts: { final: 0, block: 0, tool: 0 },
+        failedCounts: { final: 1, block: 0, tool: 0 },
+        queuedFinal: false,
+      };
+    });
+    const command = await createNativeCommand(cfg, {
+      name: "new",
+      description: "Start a new session.",
+      acceptsArgs: true,
+    });
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(interaction.followUp).toHaveBeenCalledTimes(2);
+    expectNoFollowUpContent(interaction, "⚠️ Command produced no visible reply.");
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 

--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -958,6 +958,7 @@ describe("Discord native plugin command dispatch", () => {
     expect(dispatchSpy).not.toHaveBeenCalled();
     expectFollowUpFields(interaction, { content: "direct plugin output" });
     expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.deleteReply).not.toHaveBeenCalled();
   });
 
   it("returns an explicit warning instead of success when dispatch produces zero visible replies", async () => {
@@ -1017,6 +1018,7 @@ describe("Discord native plugin command dispatch", () => {
 
     expectNoFollowUpContent(interaction, "⚠️ Command produced no visible reply.");
     expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.deleteReply).toHaveBeenCalledTimes(1);
   });
 
   it("keeps a native reply visible when a later Discord chunk expires", async () => {
@@ -1057,6 +1059,7 @@ describe("Discord native plugin command dispatch", () => {
     expect(interaction.followUp).toHaveBeenCalledTimes(2);
     expectNoFollowUpContent(interaction, "⚠️ Command produced no visible reply.");
     expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.deleteReply).not.toHaveBeenCalled();
   });
 
   it("does not classify an already-deferred interaction as partial before this payload sends", async () => {
@@ -1112,6 +1115,7 @@ describe("Discord native plugin command dispatch", () => {
     );
     expect(fallback.content).toBe("⚠️ Command produced no visible reply.");
     expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.deleteReply).not.toHaveBeenCalled();
   });
 
   it("preserves partial delivery when a later Discord chunk fails without expiry", async () => {
@@ -1238,6 +1242,7 @@ describe("Discord native plugin command dispatch", () => {
     expect(dispatchSpy).not.toHaveBeenCalled();
     expectNoFollowUpContent(interaction, "⚠️ Command produced no visible reply.");
     expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.deleteReply).toHaveBeenCalledTimes(1);
   });
 
   it("forwards Discord thread metadata into direct plugin command execution", async () => {

--- a/extensions/discord/src/monitor/native-command.runtime.ts
+++ b/extensions/discord/src/monitor/native-command.runtime.ts
@@ -1,14 +1,14 @@
+import { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
 // Discord plugin module implements native command behavior.
 import { resolveDirectStatusReplyForSession } from "openclaw/plugin-sdk/command-status-runtime";
 import * as pluginRuntime from "openclaw/plugin-sdk/plugin-runtime";
-import { dispatchReplyWithDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
 
 export const nativeCommandRuntime = {
   matchPluginCommand: pluginRuntime.matchPluginCommand,
   executePluginCommand: pluginRuntime.executePluginCommand,
-  dispatchReplyWithDispatcher,
+  dispatchChannelInboundTurn,
   resolveDirectStatusReplyForSession,
   resolveDiscordNativeInteractionRouteState,
   getSessionEntry,

--- a/extensions/discord/src/monitor/native-command.status-direct.test.ts
+++ b/extensions/discord/src/monitor/native-command.status-direct.test.ts
@@ -1,5 +1,6 @@
 // Discord tests cover native command.status direct plugin behavior.
 import { ChannelType } from "discord-api-types/v10";
+import type { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { nativeCommandRuntime } from "./native-command.runtime.js";
@@ -31,6 +32,26 @@ vi.mock("openclaw/plugin-sdk/command-status-runtime", () => ({
 vi.mock("openclaw/plugin-sdk/web-media", () => ({
   loadWebMedia: (...args: unknown[]) => runtimeModuleMocks.loadWebMedia(...args),
 }));
+
+const dispatchChannelInboundTurnForTest: typeof dispatchChannelInboundTurn = async (plan) => {
+  const dispatchResult = await runtimeModuleMocks.dispatchReplyWithDispatcher({
+    ctx: plan.ctxPayload,
+    cfg: plan.cfg,
+    dispatcherOptions: {
+      ...plan.dispatcherOptions,
+      deliver: "deliver" in plan.delivery ? plan.delivery.deliver : undefined,
+      onError: plan.delivery.onError,
+    },
+    replyOptions: plan.replyOptions,
+  });
+  return {
+    admission: { kind: "dispatch" },
+    dispatched: true,
+    ctxPayload: plan.ctxPayload,
+    routeSessionKey: plan.route.sessionKey,
+    dispatchResult,
+  };
+};
 
 let createDiscordNativeCommand: typeof import("./native-command.js").createDiscordNativeCommand;
 
@@ -160,8 +181,7 @@ describe("discord native /status", () => {
       buffer: Buffer.from("image"),
       fileName: "status.png",
     });
-    nativeCommandRuntime.dispatchReplyWithDispatcher =
-      runtimeModuleMocks.dispatchReplyWithDispatcher as typeof import("openclaw/plugin-sdk/reply-dispatch-runtime").dispatchReplyWithDispatcher;
+    nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
     nativeCommandRuntime.matchPluginCommand = (() =>
       null) as typeof import("openclaw/plugin-sdk/plugin-runtime").matchPluginCommand;
     setDefaultRouteState();

--- a/extensions/discord/src/monitor/native-command.test-helpers.ts
+++ b/extensions/discord/src/monitor/native-command.test-helpers.ts
@@ -12,7 +12,9 @@ export type MockCommandInteraction = {
     getNumber: ReturnType<typeof vi.fn>;
     getBoolean: ReturnType<typeof vi.fn>;
   };
+  responseState: "unacknowledged" | "deferred" | "deferred-update" | "replied";
   defer: ReturnType<typeof vi.fn>;
+  deleteReply: ReturnType<typeof vi.fn>;
   reply: ReturnType<typeof vi.fn>;
   followUp: ReturnType<typeof vi.fn>;
   client: object;
@@ -36,7 +38,7 @@ export function createMockCommandInteraction(
   const guildId = params.guildId;
   const guild =
     guildId === null || guildId === undefined ? null : { id: guildId, name: params.guildName };
-  return {
+  const interaction: MockCommandInteraction = {
     user: {
       id: params.userId ?? "owner",
       username: params.username ?? "tester",
@@ -57,9 +59,16 @@ export function createMockCommandInteraction(
       getNumber: vi.fn().mockReturnValue(null),
       getBoolean: vi.fn().mockReturnValue(null),
     },
-    defer: vi.fn().mockResolvedValue(undefined),
+    responseState: "unacknowledged",
+    defer: vi.fn(async () => {
+      interaction.responseState = "deferred";
+    }),
+    deleteReply: vi.fn(async () => {
+      interaction.responseState = "replied";
+    }),
     reply: vi.fn().mockResolvedValue({ ok: true }),
     followUp: vi.fn().mockResolvedValue({ ok: true }),
     client: {},
   };
+  return interaction;
 }

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -59,6 +59,7 @@ import {
   deliverDiscordInteractionReply,
   hasRenderableReplyPayload,
   safeDiscordInteractionCall,
+  settleDiscordInteractionWithoutVisibleReply,
 } from "./native-command-reply.js";
 import { maybeDeliverDiscordDirectStatus } from "./native-command-status.js";
 import {
@@ -545,6 +546,7 @@ async function dispatchDiscordCommandInteraction(params: {
 
   if (pluginMatch && commandName !== "status") {
     if (suppressReplies) {
+      await settleDiscordInteractionWithoutVisibleReply(interaction);
       return { accepted: true };
     }
     const messageThreadId = !isDirectMessage && isThreadChannel ? channelId : undefined;
@@ -583,6 +585,7 @@ async function dispatchDiscordCommandInteraction(params: {
       threadParentId: pluginThreadParentId,
     });
     if (pluginReply.suppressReply === true) {
+      await settleDiscordInteractionWithoutVisibleReply(interaction);
       return { accepted: true, effectiveRoute };
     }
     if (!hasRenderableReplyPayload(pluginReply)) {

--- a/extensions/mattermost/src/mattermost/monitor-interactions.ts
+++ b/extensions/mattermost/src/mattermost/monitor-interactions.ts
@@ -16,13 +16,10 @@ import type { MattermostMonitorContext } from "./monitor-types.js";
 import {
   createMattermostReplyDeliveryBarrier,
   deliverMattermostReplyPayload,
+  toMattermostChannelDeliveryResult,
 } from "./reply-delivery.js";
 import type { ReplyPayload } from "./runtime-api.js";
-import {
-  createChannelMessageReplyPipeline,
-  logTypingFailure,
-  registerPluginHttpRoute,
-} from "./runtime-api.js";
+import { logTypingFailure, registerPluginHttpRoute } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
 
 export function registerMattermostInteractions(params: {
@@ -180,12 +177,51 @@ export function registerMattermostInteractions(params: {
           channel: "mattermost",
           accountId: account.accountId,
         });
-        const { onModelSelected, typingCallbacks, ...replyPipeline } =
-          createChannelMessageReplyPipeline({
-            cfg,
+        const deliveryBarrier = createMattermostReplyDeliveryBarrier({
+          isDirect: kind === "direct",
+          dmRetryOptions: account.config.dmChannelRetry,
+        });
+        await core.channel.inbound.dispatch({
+          cfg,
+          channel: "mattermost",
+          accountId: account.accountId,
+          route: {
             agentId: route.agentId,
-            channel: "mattermost",
-            accountId: account.accountId,
+            dmScope: route.dmScope,
+            sessionKey: threadContext.sessionKey,
+          },
+          ctxPayload,
+          delivery: {
+            deliver: async (payload: ReplyPayload) => {
+              const result = toMattermostChannelDeliveryResult(
+                await deliverMattermostReplyPayload({
+                  core,
+                  cfg,
+                  payload,
+                  to,
+                  accountId: account.accountId,
+                  agentId: route.agentId,
+                  replyToId: resolveMattermostReplyRootId({
+                    kind,
+                    threadRootId: threadContext.effectiveReplyToId,
+                    replyToId: payload.replyToId,
+                  }),
+                  textLimit,
+                  tableMode,
+                  sendMessage: sendMessageMattermost,
+                  onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
+                }),
+              );
+              if (result.visibleReplySent) {
+                runtime.log?.(`delivered button-click reply to ${to}`);
+              }
+              return result;
+            },
+            onError: (err, info) => {
+              runtime.error?.(`mattermost button-click ${info.kind} reply failed: ${String(err)}`);
+            },
+          },
+          replyPipeline: {
             typing: {
               start: () => sendTypingIndicator(button.channelId, threadContext.effectiveReplyToId),
               onStartError: (err) => {
@@ -197,48 +233,15 @@ export function registerMattermostInteractions(params: {
                 });
               },
             },
-          });
-        const deliveryBarrier = createMattermostReplyDeliveryBarrier({
-          isDirect: kind === "direct",
-          dmRetryOptions: account.config.dmChannelRetry,
-        });
-        await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
-          ctx: ctxPayload,
-          cfg,
+          },
           dispatcherOptions: {
-            ...replyPipeline,
             resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
             onDeliverySettled: deliveryBarrier.markDeliverySettled,
             humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-            deliver: async (payload: ReplyPayload) => {
-              await deliverMattermostReplyPayload({
-                core,
-                cfg,
-                payload,
-                to,
-                accountId: account.accountId,
-                agentId: route.agentId,
-                replyToId: resolveMattermostReplyRootId({
-                  kind,
-                  threadRootId: threadContext.effectiveReplyToId,
-                  replyToId: payload.replyToId,
-                }),
-                textLimit,
-                tableMode,
-                sendMessage: sendMessageMattermost,
-                onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
-              });
-              runtime.log?.(`delivered button-click reply to ${to}`);
-            },
-            onError: (err, info) => {
-              runtime.error?.(`mattermost button-click ${info.kind} reply failed: ${String(err)}`);
-            },
-            typingCallbacks,
           },
           replyOptions: {
             disableBlockStreaming:
               typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-            onModelSelected,
           },
         });
       },

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.ts
@@ -21,13 +21,10 @@ import type { MattermostMonitorContext } from "./monitor-types.js";
 import {
   createMattermostReplyDeliveryBarrier,
   deliverMattermostReplyPayload,
+  toMattermostChannelDeliveryResult,
 } from "./reply-delivery.js";
 import type { ChatType, ReplyPayload } from "./runtime-api.js";
-import {
-  buildModelsProviderData,
-  createChannelMessageReplyPipeline,
-  logTypingFailure,
-} from "./runtime-api.js";
+import { buildModelsProviderData, logTypingFailure } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
 
 type RunModelPickerCommandParams = {
@@ -120,12 +117,53 @@ export function createMattermostModelPickerInteractionHandler(
       account.accountId,
       { fallbackLimit: account.textChunkLimit ?? 4000 },
     );
-    const { onModelSelected, typingCallbacks, ...replyPipeline } =
-      createChannelMessageReplyPipeline({
-        cfg,
+    const deliveryBarrier = createMattermostReplyDeliveryBarrier({
+      isDirect: params.kind === "direct",
+      dmRetryOptions: account.config.dmChannelRetry,
+    });
+    await core.channel.inbound.dispatch({
+      cfg,
+      channel: "mattermost",
+      accountId: account.accountId,
+      route: {
         agentId: params.route.agentId,
-        channel: "mattermost",
-        accountId: account.accountId,
+        dmScope: params.route.dmScope,
+        sessionKey: params.sessionKey,
+      },
+      ctxPayload,
+      delivery: {
+        // Picker-triggered confirmations should stay immediate.
+        deliver: async (payload: ReplyPayload) => {
+          const trimmedPayload = {
+            ...payload,
+            text: core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode).trim(),
+          };
+          return toMattermostChannelDeliveryResult(
+            await deliverMattermostReplyPayload({
+              core,
+              cfg,
+              payload: trimmedPayload,
+              to,
+              accountId: account.accountId,
+              agentId: params.route.agentId,
+              replyToId: resolveMattermostReplyRootId({
+                kind: params.kind,
+                threadRootId: params.effectiveReplyToId,
+                replyToId: trimmedPayload.replyToId,
+              }),
+              textLimit,
+              // The picker path already converts and trims text before delivery.
+              tableMode: "off",
+              sendMessage: sendMessageMattermost,
+              onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
+            }),
+          );
+        },
+        onError: (err, info) => {
+          runtime.error?.(`mattermost model picker ${info.kind} reply failed: ${String(err)}`);
+        },
+      },
+      replyPipeline: {
         typing: {
           start: () => sendTypingIndicator(params.channelId, params.effectiveReplyToId),
           onStartError: (err) => {
@@ -137,52 +175,14 @@ export function createMattermostModelPickerInteractionHandler(
             });
           },
         },
-      });
-    const deliveryBarrier = createMattermostReplyDeliveryBarrier({
-      isDirect: params.kind === "direct",
-      dmRetryOptions: account.config.dmChannelRetry,
-    });
-    await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
-      ctx: ctxPayload,
-      cfg,
+      },
       dispatcherOptions: {
-        ...replyPipeline,
         resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
         onDeliverySettled: deliveryBarrier.markDeliverySettled,
-        // Picker-triggered confirmations should stay immediate.
-        deliver: async (payload: ReplyPayload) => {
-          const trimmedPayload = {
-            ...payload,
-            text: core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode).trim(),
-          };
-          await deliverMattermostReplyPayload({
-            core,
-            cfg,
-            payload: trimmedPayload,
-            to,
-            accountId: account.accountId,
-            agentId: params.route.agentId,
-            replyToId: resolveMattermostReplyRootId({
-              kind: params.kind,
-              threadRootId: params.effectiveReplyToId,
-              replyToId: trimmedPayload.replyToId,
-            }),
-            textLimit,
-            // The picker path already converts and trims text before delivery.
-            tableMode: "off",
-            sendMessage: sendMessageMattermost,
-            onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
-          });
-        },
-        onError: (err, info) => {
-          runtime.error?.(`mattermost model picker ${info.kind} reply failed: ${String(err)}`);
-        },
-        typingCallbacks,
       },
       replyOptions: {
         disableBlockStreaming:
           typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-        onModelSelected,
       },
     });
   };

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig, PluginRuntime } from "../../runtime-api.js";
 import {
   createMattermostReplyDeliveryBarrier,
   deliverMattermostReplyPayload,
+  toMattermostChannelDeliveryResult,
 } from "./reply-delivery.js";
 
 type DeliverMattermostReplyPayloadParams = Parameters<typeof deliverMattermostReplyPayload>[0];
@@ -39,6 +40,22 @@ function createReplyDeliveryCore(): DeliverMattermostReplyPayloadParams["core"] 
     },
   } as unknown as PluginRuntime;
 }
+
+describe("toMattermostChannelDeliveryResult", () => {
+  it.each(["text", "media"] as const)("marks %s delivery as visible", (outcome) => {
+    expect(toMattermostChannelDeliveryResult(outcome)).toEqual({ visibleReplySent: true });
+  });
+
+  it.each(["reasoning_skipped", "empty"] as const)(
+    "marks %s delivery as intentionally non-visible",
+    (outcome) => {
+      expect(toMattermostChannelDeliveryResult(outcome)).toEqual({
+        visibleReplySent: false,
+        suppression: { reason: "no_visible_result" },
+      });
+    },
+  );
+});
 
 describe("createMattermostReplyDeliveryBarrier", () => {
   it("extends while direct deliveries or DM resolution remain unsettled", async () => {

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -81,12 +81,21 @@ export function createMattermostReplyDeliveryBarrier(params: {
 }
 
 /**
- * Result of `deliverMattermostReplyPayload`. Callers in `monitor.ts` use this
+ * Result of `deliverMattermostReplyPayload`. Inbound delivery adapters use this
  * to distinguish a successful visible send from an intentionally suppressed
  * reasoning payload from a substantive payload that ended up sending nothing
  * (the silent-completion symptom in #80501).
  */
 export type MattermostReplyDeliveryOutcome = "reasoning_skipped" | "empty" | "text" | "media";
+
+export function toMattermostChannelDeliveryResult(outcome: MattermostReplyDeliveryOutcome) {
+  return outcome === "text" || outcome === "media"
+    ? { visibleReplySent: true as const }
+    : {
+        visibleReplySent: false as const,
+        suppression: { reason: "no_visible_result" as const },
+      };
+}
 
 export async function deliverMattermostReplyPayload(params: {
   core: PluginRuntime;

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -37,15 +37,14 @@ import {
 import {
   createMattermostReplyDeliveryBarrier,
   deliverMattermostReplyPayload,
+  toMattermostChannelDeliveryResult,
 } from "./reply-delivery.js";
 import {
   buildModelsProviderData,
-  createChannelMessageReplyPipeline,
   isRequestBodyLimitError,
   logTypingFailure,
   readRequestBodyWithLimit,
   type OpenClawConfig,
-  type ReplyPayload,
   type RuntimeEnv,
 } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
@@ -871,63 +870,70 @@ async function handleSlashCommandAsync(params: {
     accountId: account.accountId,
   });
 
-  const { onModelSelected, typingCallbacks, ...replyPipeline } = createChannelMessageReplyPipeline({
-    cfg,
-    agentId: route.agentId,
-    channel: "mattermost",
-    accountId: account.accountId,
-    typing: {
-      start: () => sendMattermostTyping(client, { channelId }),
-      onStartError: (err) => {
-        logTypingFailure({
-          log: (message) => log?.(message),
-          channel: "mattermost",
-          target: channelId,
-          error: err,
-        });
-      },
-    },
-  });
   const humanDelay = resolveHumanDelayConfig(cfg, route.agentId);
   const deliveryBarrier = createMattermostReplyDeliveryBarrier({
     isDirect: kind === "direct",
     dmRetryOptions: account.config.dmChannelRetry,
   });
 
-  await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
-    ctx: ctxPayload,
+  await core.channel.inbound.dispatch({
     cfg,
-    dispatcherOptions: {
-      ...replyPipeline,
-      resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
-      onDeliverySettled: deliveryBarrier.markDeliverySettled,
-      humanDelay,
-      deliver: async (payload: ReplyPayload) => {
-        await deliverMattermostReplyPayload({
-          core,
-          cfg,
-          payload,
-          to,
-          accountId: account.accountId,
-          agentId: route.agentId,
-          textLimit,
-          tableMode,
-          sendMessage: sendMessageMattermost,
-          onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
-        });
-        runtime.log?.(`delivered slash reply to ${to}`);
+    channel: "mattermost",
+    accountId: account.accountId,
+    route: {
+      agentId: route.agentId,
+      dmScope: route.dmScope,
+      sessionKey: route.sessionKey,
+    },
+    ctxPayload,
+    delivery: {
+      deliver: async (payload) => {
+        const result = toMattermostChannelDeliveryResult(
+          await deliverMattermostReplyPayload({
+            core,
+            cfg,
+            payload,
+            to,
+            accountId: account.accountId,
+            agentId: route.agentId,
+            textLimit,
+            tableMode,
+            sendMessage: sendMessageMattermost,
+            onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
+          }),
+        );
+        if (result.visibleReplySent) {
+          runtime.log?.(`delivered slash reply to ${to}`);
+        }
+        return result;
       },
       onError: (err, info) => {
         runtime.error?.(
           `mattermost slash ${info.kind} reply failed: ${sanitizeCommandLookupError(err)}`,
         );
       },
-      typingCallbacks,
+    },
+    replyPipeline: {
+      typing: {
+        start: () => sendMattermostTyping(client, { channelId }),
+        onStartError: (err) => {
+          logTypingFailure({
+            log: (message) => log?.(message),
+            channel: "mattermost",
+            target: channelId,
+            error: err,
+          });
+        },
+      },
+    },
+    dispatcherOptions: {
+      resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
+      onDeliverySettled: deliveryBarrier.markDeliverySettled,
+      humanDelay,
     },
     replyOptions: {
       disableBlockStreaming:
         typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-      onModelSelected,
     },
   });
 }

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -1,6 +1,7 @@
 // Slack plugin module implements replies behavior.
 import type { MessageMetadata } from "@slack/types";
 import type { Block, KnownBlock } from "@slack/web-api";
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -374,6 +375,11 @@ export async function deliverSlackSlashReplies(params: {
   isGroup?: boolean;
   groupId?: string;
   responseBudget?: SlackResponseUrlBudget;
+  onReplySettled?: (settlement: {
+    replyIndex: number;
+    visibleReplySent: boolean;
+    error?: unknown;
+  }) => void;
 }) {
   type SlashReplyMessage = {
     text: string;
@@ -386,6 +392,7 @@ export async function deliverSlackSlashReplies(params: {
     skipOriginalBlocks?: true;
   };
   type SlashReplyDelivery = {
+    replyIndex: number;
     hookContent: string;
     messages: PlannedSlashReplyMessage[];
   };
@@ -411,7 +418,7 @@ export async function deliverSlackSlashReplies(params: {
     };
   };
 
-  for (const payload of params.replies) {
+  for (const [replyIndex, payload] of params.replies.entries()) {
     if (payload.isReasoning === true) {
       continue;
     }
@@ -479,7 +486,11 @@ export async function deliverSlackSlashReplies(params: {
         );
       }
       if (messages.length > 0) {
-        deliveries.push({ hookContent: hookParts.filter(Boolean).join("\n\n"), messages });
+        deliveries.push({
+          replyIndex,
+          hookContent: hookParts.filter(Boolean).join("\n\n"),
+          messages,
+        });
       }
       continue;
     }
@@ -497,9 +508,17 @@ export async function deliverSlackSlashReplies(params: {
       markdownToSlackMrkdwnChunks(markdown, chunkLimit, { tableMode: params.tableMode }),
     );
     deliveries.push({
+      replyIndex,
       hookContent: textRaw ?? resolveSlackMediaHookSpokenText(payload) ?? combined,
       messages: (chunks.length > 0 ? chunks : [combined]).map((text) => ({ message: { text } })),
     });
+  }
+
+  const plannedReplyIndexes = new Set(deliveries.map((delivery) => delivery.replyIndex));
+  for (const replyIndex of params.replies.keys()) {
+    if (!plannedReplyIndexes.has(replyIndex)) {
+      params.onReplySettled?.({ replyIndex, visibleReplySent: false });
+    }
   }
 
   if (deliveries.length === 0) {
@@ -554,6 +573,11 @@ export async function deliverSlackSlashReplies(params: {
     }
     for (const delivery of deliveries) {
       emitDeliveryFailure(delivery, failure);
+      params.onReplySettled?.({
+        replyIndex: delivery.replyIndex,
+        visibleReplySent: false,
+        error: failure,
+      });
     }
     throw failure;
   };
@@ -563,17 +587,25 @@ export async function deliverSlackSlashReplies(params: {
     await failOversizedDelivery();
   }
 
-  const deliverNativeFallback = async (messages: readonly SlackFormattingDisabledMessage[]) => {
+  const deliverNativeFallback = async (
+    messages: readonly SlackFormattingDisabledMessage[],
+    onVisible: () => void,
+  ) => {
     for (const message of messages) {
       const response = await respond(message);
       if (await isSlackInvalidBlocksResponse(response)) {
         throw new Error("Slack rejected the native-data fallback blocks with invalid_blocks.");
       }
+      onVisible();
     }
   };
 
   let plannedIndex = 0;
   for (const delivery of deliveries) {
+    let visibleReplySent = false;
+    const markVisible = () => {
+      visibleReplySent = true;
+    };
     try {
       for (const planned of delivery.messages) {
         const minimumAfter = minimumRemainingCalls[plannedIndex + 1] ?? 0;
@@ -581,6 +613,7 @@ export async function deliverSlackSlashReplies(params: {
         const fallback = planned.nativeFallback;
         if (!fallback) {
           await respond(planned.message);
+          markVisible();
           continue;
         }
         const remaining = responseBudget.remaining();
@@ -588,13 +621,16 @@ export async function deliverSlackSlashReplies(params: {
           !planned.skipOriginalBlocks &&
           (remaining === undefined || 1 + fallback.length + minimumAfter <= remaining);
         if (!canAttemptNative) {
-          await deliverNativeFallback(fallback);
+          await deliverNativeFallback(fallback, markVisible);
           continue;
         }
         let rejectedNativeBlocks = false;
         try {
           const response = await respond(planned.message);
           rejectedNativeBlocks = await isSlackInvalidBlocksResponse(response);
+          if (!rejectedNativeBlocks) {
+            markVisible();
+          }
         } catch (error) {
           if (!isSlackNativeResponseUrlRejection(error)) {
             throw error;
@@ -602,12 +638,23 @@ export async function deliverSlackSlashReplies(params: {
           rejectedNativeBlocks = true;
         }
         if (rejectedNativeBlocks) {
-          await deliverNativeFallback(fallback);
+          await deliverNativeFallback(fallback, markVisible);
         }
       }
     } catch (error) {
-      emitDeliveryFailure(delivery, error);
-      throw error;
+      const deliveryError = visibleReplySent
+        ? createChannelPartialDeliveryError(error, {
+            content: delivery.hookContent,
+            visibleReplySent: true,
+          })
+        : error;
+      emitDeliveryFailure(delivery, deliveryError);
+      params.onReplySettled?.({
+        replyIndex: delivery.replyIndex,
+        visibleReplySent,
+        error: deliveryError,
+      });
+      throw deliveryError;
     }
     if (params.messageSentHookTarget) {
       emitSlackMessageSentHooks({
@@ -620,5 +667,6 @@ export async function deliverSlackSlashReplies(params: {
         groupId: params.groupId,
       });
     }
+    params.onReplySettled?.({ replyIndex: delivery.replyIndex, visibleReplySent: true });
   }
 }

--- a/extensions/slack/src/monitor/slash-dispatch.runtime.ts
+++ b/extensions/slack/src/monitor/slash-dispatch.runtime.ts
@@ -1,11 +1,11 @@
 // Slack plugin module implements slash dispatch behavior.
 import {
-  recordInboundSessionMetaSafe as recordInboundSessionMetaSafeImpl,
-  resolveConversationLabel as resolveConversationLabelImpl,
-} from "openclaw/plugin-sdk/conversation-runtime";
+  dispatchChannelInboundTurn as dispatchChannelInboundTurnImpl,
+  isChannelPartialDeliveryError as isChannelPartialDeliveryErrorImpl,
+} from "openclaw/plugin-sdk/channel-inbound";
+import { resolveConversationLabel as resolveConversationLabelImpl } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveMarkdownTableMode as resolveMarkdownTableModeImpl } from "openclaw/plugin-sdk/markdown-table-runtime";
 import {
-  dispatchReplyWithDispatcher as dispatchReplyWithDispatcherImpl,
   finalizeInboundContext as finalizeInboundContextImpl,
   resolveChunkMode as resolveChunkModeImpl,
 } from "openclaw/plugin-sdk/reply-runtime";
@@ -15,12 +15,12 @@ import { deliverSlackSlashReplies as deliverSlackSlashRepliesImpl } from "./repl
 type ResolveChunkMode = typeof import("openclaw/plugin-sdk/reply-runtime").resolveChunkMode;
 type FinalizeInboundContext =
   typeof import("openclaw/plugin-sdk/reply-runtime").finalizeInboundContext;
-type DispatchReplyWithDispatcher =
-  typeof import("openclaw/plugin-sdk/reply-runtime").dispatchReplyWithDispatcher;
+type DispatchChannelInboundTurn =
+  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
+type IsChannelPartialDeliveryError =
+  typeof import("openclaw/plugin-sdk/channel-inbound").isChannelPartialDeliveryError;
 type ResolveConversationLabel =
   typeof import("openclaw/plugin-sdk/conversation-runtime").resolveConversationLabel;
-type RecordInboundSessionMetaSafe =
-  typeof import("openclaw/plugin-sdk/conversation-runtime").recordInboundSessionMetaSafe;
 type ResolveMarkdownTableMode =
   typeof import("openclaw/plugin-sdk/markdown-table-runtime").resolveMarkdownTableMode;
 type ResolveAgentRoute = typeof import("openclaw/plugin-sdk/routing").resolveAgentRoute;
@@ -38,22 +38,22 @@ export function finalizeInboundContext(
   return finalizeInboundContextImpl(...args);
 }
 
-export function dispatchReplyWithDispatcher(
-  ...args: Parameters<DispatchReplyWithDispatcher>
-): ReturnType<DispatchReplyWithDispatcher> {
-  return dispatchReplyWithDispatcherImpl(...args);
+export function dispatchChannelInboundTurn(
+  ...args: Parameters<DispatchChannelInboundTurn>
+): ReturnType<DispatchChannelInboundTurn> {
+  return dispatchChannelInboundTurnImpl(...args);
+}
+
+export function isChannelPartialDeliveryError(
+  ...args: Parameters<IsChannelPartialDeliveryError>
+): ReturnType<IsChannelPartialDeliveryError> {
+  return isChannelPartialDeliveryErrorImpl(...args);
 }
 
 export function resolveConversationLabel(
   ...args: Parameters<ResolveConversationLabel>
 ): ReturnType<ResolveConversationLabel> {
   return resolveConversationLabelImpl(...args);
-}
-
-export function recordInboundSessionMetaSafe(
-  ...args: Parameters<RecordInboundSessionMetaSafe>
-): ReturnType<RecordInboundSessionMetaSafe> {
-  return recordInboundSessionMetaSafeImpl(...args);
 }
 
 export function resolveMarkdownTableMode(

--- a/extensions/slack/src/monitor/slash.test-harness.ts
+++ b/extensions/slack/src/monitor/slash.test-harness.ts
@@ -5,6 +5,7 @@ type AsyncMock = ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown
 
 const mocks = vi.hoisted(() => ({
   dispatchMock: vi.fn(),
+  turnPlanMock: vi.fn(),
   readAllowFromStoreMock: vi.fn(),
   upsertPairingRequestMock: vi.fn(),
   resolveAgentRouteMock: vi.fn(),
@@ -12,25 +13,85 @@ const mocks = vi.hoisted(() => ({
   resolveConversationLabelMock: vi.fn(),
   recordSessionMetaFromInboundMock: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   resolveStorePathMock: vi.fn(),
-  deliverSlackSlashRepliesMock: vi.fn<(params: unknown) => Promise<unknown>>(async () => {}),
+  deliverSlackSlashRepliesMock: vi.fn<(params: unknown) => Promise<unknown>>(async (params) => {
+    const delivery = params as {
+      replies?: unknown[];
+      onReplySettled?: (settlement: { replyIndex: number; visibleReplySent: boolean }) => void;
+    };
+    delivery.replies?.forEach((_reply, replyIndex) =>
+      delivery.onReplySettled?.({ replyIndex, visibleReplySent: true }),
+    );
+  }),
 }));
 
 vi.mock("./slash-dispatch.runtime.js", () => {
   return {
     deliverSlackSlashReplies: (params: unknown) => mocks.deliverSlackSlashRepliesMock(params),
-    dispatchReplyWithDispatcher: (...args: unknown[]) => mocks.dispatchMock(...args),
+    dispatchChannelInboundTurn: async (plan: {
+      cfg: unknown;
+      ctxPayload: unknown;
+      route: { sessionKey: string };
+      dispatcherOptions?: { onSettled?: () => unknown };
+      delivery: { deliver?: unknown; onError?: unknown };
+      replyOptions?: unknown;
+    }) => {
+      mocks.turnPlanMock(plan);
+      void mocks.recordSessionMetaFromInboundMock({
+        sessionKey:
+          (plan.ctxPayload as { SessionKey?: string }).SessionKey ?? plan.route.sessionKey,
+        ctx: plan.ctxPayload,
+      });
+      let dispatchResult: unknown;
+      try {
+        const deliver = async (...args: unknown[]) => {
+          const result = await (
+            plan.delivery.deliver as (...deliveryArgs: unknown[]) => Promise<{
+              finalization?: Promise<unknown>;
+            } | void>
+          )(...args);
+          // Routed core observes deferred rejection immediately, then awaits the same
+          // finalization during settlement. Mirror that ownership in this legacy-shaped shim.
+          void result?.finalization?.catch(() => undefined);
+          return result;
+        };
+        dispatchResult = await mocks.dispatchMock({
+          ctx: plan.ctxPayload,
+          cfg: plan.cfg,
+          dispatcherOptions: {
+            ...plan.dispatcherOptions,
+            deliver,
+            onError: plan.delivery.onError,
+          },
+          replyOptions: plan.replyOptions,
+        });
+      } finally {
+        await plan.dispatcherOptions?.onSettled?.();
+      }
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult,
+      };
+    },
     finalizeInboundContext: (...args: unknown[]) => mocks.finalizeInboundContextMock(...args),
+    isChannelPartialDeliveryError: (error: unknown) =>
+      Boolean(
+        error &&
+        typeof error === "object" &&
+        (error as { code?: unknown }).code === "CHANNEL_PARTIAL_DELIVERY",
+      ),
     resolveAgentRoute: (...args: unknown[]) => mocks.resolveAgentRouteMock(...args),
     resolveChunkMode: vi.fn(() => "auto"),
     resolveConversationLabel: (...args: unknown[]) => mocks.resolveConversationLabelMock(...args),
     resolveMarkdownTableMode: vi.fn(() => "auto"),
-    recordInboundSessionMetaSafe: (...args: unknown[]) =>
-      mocks.recordSessionMetaFromInboundMock(...args),
   };
 });
 
 type SlashHarnessMocks = {
   dispatchMock: ReturnType<typeof vi.fn>;
+  turnPlanMock: ReturnType<typeof vi.fn>;
   readAllowFromStoreMock: ReturnType<typeof vi.fn>;
   upsertPairingRequestMock: ReturnType<typeof vi.fn>;
   resolveAgentRouteMock: ReturnType<typeof vi.fn>;
@@ -47,6 +108,7 @@ export function getSlackSlashMocks(): SlashHarnessMocks {
 
 export function resetSlackSlashMocks() {
   mocks.dispatchMock.mockReset().mockResolvedValue({ counts: { final: 1, tool: 0, block: 0 } });
+  mocks.turnPlanMock.mockReset();
   mocks.readAllowFromStoreMock.mockReset().mockResolvedValue([]);
   mocks.upsertPairingRequestMock.mockReset().mockResolvedValue({ code: "PAIRCODE", created: true });
   mocks.resolveAgentRouteMock.mockReset().mockReturnValue({
@@ -58,5 +120,13 @@ export function resetSlackSlashMocks() {
   mocks.resolveConversationLabelMock.mockReset().mockReturnValue(undefined);
   mocks.recordSessionMetaFromInboundMock.mockReset().mockResolvedValue(undefined);
   mocks.resolveStorePathMock.mockReset().mockReturnValue("/tmp/openclaw-sessions.json");
-  mocks.deliverSlackSlashRepliesMock.mockReset().mockResolvedValue(undefined);
+  mocks.deliverSlackSlashRepliesMock.mockReset().mockImplementation(async (params: unknown) => {
+    const delivery = params as {
+      replies?: unknown[];
+      onReplySettled?: (settlement: { replyIndex: number; visibleReplySent: boolean }) => void;
+    };
+    delivery.replies?.forEach((_reply, replyIndex) =>
+      delivery.onReplySettled?.({ replyIndex, visibleReplySent: true }),
+    );
+  });
 }

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -764,6 +764,74 @@ describe("Slack native command argument menus", () => {
     );
   });
 
+  it("batches accepted payloads in order while omitting a hook-cancelled payload", async () => {
+    const { deliverSlackSlashRepliesMock, turnPlanMock } = getSlackSlashMocks();
+    const asyncDispatchMock = dispatchMock as unknown as {
+      mockImplementation: (
+        implementation: (params: unknown) => Promise<unknown>,
+      ) => typeof dispatchMock;
+    };
+    asyncDispatchMock.mockImplementation(async (params: unknown) => {
+      const deliver = (
+        params as {
+          dispatcherOptions: {
+            deliver: (payload: { text: string }, info: { kind: "final" }) => Promise<void>;
+          };
+        }
+      ).dispatcherOptions.deliver;
+      const plan = turnPlanMock.mock.calls.at(-1)?.[0] as {
+        delivery: {
+          onDelivered?: (payload: unknown, info: unknown, result: unknown) => Promise<void> | void;
+        };
+      };
+      await deliver({ text: "first" }, { kind: "final" });
+      await plan.delivery.onDelivered?.(
+        { text: "cancelled" },
+        { kind: "final" },
+        {
+          visibleReplySent: false,
+          suppression: { reason: "cancelled_by_reply_payload_sending_hook" },
+        },
+      );
+      await deliver({ text: "third" }, { kind: "final" });
+      return { counts: { final: 2, tool: 0, block: 0 } };
+    });
+
+    await runCommandHandler(agentStatusHandler);
+
+    expect(deliverSlackSlashRepliesMock).toHaveBeenCalledOnce();
+    expect(deliverSlackSlashRepliesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ replies: [{ text: "first" }, { text: "third" }] }),
+    );
+  });
+
+  it("does not call the response URL when every payload is hook-cancelled", async () => {
+    const { deliverSlackSlashRepliesMock, turnPlanMock } = getSlackSlashMocks();
+    const asyncDispatchMock = dispatchMock as unknown as {
+      mockImplementation: (implementation: () => Promise<unknown>) => typeof dispatchMock;
+    };
+    asyncDispatchMock.mockImplementation(async () => {
+      const plan = turnPlanMock.mock.calls.at(-1)?.[0] as {
+        delivery: {
+          onDelivered?: (payload: unknown, info: unknown, result: unknown) => Promise<void> | void;
+        };
+      };
+      await plan.delivery.onDelivered?.(
+        { text: "cancelled" },
+        { kind: "final" },
+        {
+          visibleReplySent: false,
+          suppression: { reason: "cancelled_by_reply_payload_sending_hook" },
+        },
+      );
+      return { counts: { final: 0, tool: 0, block: 0 } };
+    });
+
+    await runCommandHandler(agentStatusHandler);
+
+    expect(deliverSlackSlashRepliesMock).not.toHaveBeenCalled();
+  });
+
   it("prefers the configured slash command over native commands", async () => {
     const configuredHarness = createArgMenusHarness();
     (
@@ -1759,7 +1827,7 @@ describe("slack slash command session metadata", () => {
     );
   });
 
-  it("awaits session metadata persistence before dispatch", async () => {
+  it("starts routed session metadata recording before dispatch without blocking delivery", async () => {
     const recordStarted = createDeferred<void>();
     const deferred = createDeferred<void>();
     recordSessionMetaFromInboundMock.mockClear().mockImplementation(() => {
@@ -1780,12 +1848,12 @@ describe("slack slash command session metadata", () => {
 
     await recordStarted.promise;
     expect(recordSessionMetaFromInboundMock).toHaveBeenCalledTimes(1);
-    expect(dispatchMock).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
 
     deferred.resolve();
     await runPromise;
-
-    expect(dispatchMock).toHaveBeenCalledTimes(1);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -6,7 +6,6 @@ import {
   resolveAgentDir,
   resolveDefaultModelForAgent,
 } from "openclaw/plugin-sdk/agent-runtime";
-import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
 import {
   formatCommandArgMenuTitle,
   resolveEffectiveAgentRuntime,
@@ -18,12 +17,12 @@ import {
   resolveNativeCommandSessionTargets,
 } from "openclaw/plugin-sdk/command-auth-native";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   resolveNativeCommandsEnabled,
   resolveNativeSkillsEnabled,
 } from "openclaw/plugin-sdk/native-command-config-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
@@ -667,9 +666,9 @@ export async function registerSlackMonitorSlashCommands(params: {
       const roomLabel = channelName ? `#${channelName}` : `#${command.channel_id}`;
       const {
         deliverSlackSlashReplies,
-        dispatchReplyWithDispatcher,
+        dispatchChannelInboundTurn,
         finalizeInboundContext,
-        recordInboundSessionMetaSafe,
+        isChannelPartialDeliveryError,
         resolveAgentRoute,
         resolveChunkMode,
         resolveConversationLabel,
@@ -750,34 +749,11 @@ export async function registerSlackMonitorSlashCommands(params: {
         OriginatingTo: slashReplyTarget,
       });
 
-      await recordInboundSessionMetaSafe({
-        cfg,
-        agentId: route.agentId,
-        sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
-        ctx: ctxPayload,
-        onError: (err) =>
-          runtime.error?.(
-            danger(`slack slash: failed updating session meta: ${formatErrorMessage(err)}`),
-          ),
-      });
-
-      const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
-        cfg,
-        agentId: route.agentId,
-        channel: "slack",
-        accountId: route.accountId,
-        transformReplyPayload: (payload) => {
-          if (payload.isReasoning === true) {
-            return null;
-          }
-          return isSlackInteractiveRepliesEnabled({ cfg, accountId: route.accountId })
-            ? compileSlackInteractiveReplies(payload)
-            : payload;
-        },
-      });
-
       const messageSentHookTarget = ctxPayload.OriginatingTo ?? ctxPayload.To ?? slashReplyTarget;
-      const deliverSlashPayloads = async (replies: ReplyPayload[]) => {
+      const deliverSlashPayloads = async (
+        replies: Parameters<typeof deliverSlackSlashReplies>[0]["replies"],
+        onReplySettled?: Parameters<typeof deliverSlackSlashReplies>[0]["onReplySettled"],
+      ) => {
         await deliverSlackSlashReplies({
           replies,
           respond,
@@ -795,24 +771,91 @@ export async function registerSlackMonitorSlashCommands(params: {
             accountId: route.accountId,
           }),
           responseBudget,
+          onReplySettled,
         });
       };
-      const pendingSlashReplies: ReplyPayload[] = [];
+      const pendingSlashReplies: Array<{
+        payload: Parameters<typeof deliverSlackSlashReplies>[0]["replies"][number];
+        finalization: ReturnType<typeof createDeferred<{ visibleReplySent: boolean }>>;
+      }> = [];
       const shouldDeliverBlockImmediately = commandDefinition?.key === "login";
 
-      const { counts } = await dispatchReplyWithDispatcher({
-        ctx: ctxPayload,
+      await dispatchChannelInboundTurn({
         cfg,
+        channel: "slack",
+        accountId: route.accountId,
+        route: {
+          agentId: route.agentId,
+          sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+        },
+        ctxPayload,
+        replyPipeline: {
+          transformReplyPayload: (payload) => {
+            if (payload.isReasoning === true) {
+              return null;
+            }
+            return isSlackInteractiveRepliesEnabled({ cfg, accountId: route.accountId })
+              ? compileSlackInteractiveReplies(payload)
+              : payload;
+          },
+        },
         dispatcherOptions: {
-          ...replyPipeline,
           // /login must expose its device code before the auth flow can finish. Other block
           // streams stay batched so the response_url planner can honor Slack's five-call cap.
-          deliver: async (payload, info) => {
-            if (info.kind === "block" && shouldDeliverBlockImmediately) {
-              await deliverSlashPayloads([payload]);
+          onSettled: async () => {
+            if (pendingSlashReplies.length === 0) {
               return;
             }
-            pendingSlashReplies.push(payload);
+            const pending = pendingSlashReplies.splice(0);
+            const settled = new Set<number>();
+            try {
+              await deliverSlashPayloads(
+                pending.map((entry) => entry.payload),
+                ({ replyIndex, visibleReplySent, error }) => {
+                  const entry = pending[replyIndex];
+                  if (!entry || settled.has(replyIndex)) {
+                    return;
+                  }
+                  settled.add(replyIndex);
+                  if (error !== undefined) {
+                    entry.finalization.reject(error);
+                    return;
+                  }
+                  entry.finalization.resolve({ visibleReplySent });
+                },
+              );
+            } catch (error) {
+              const unsettledError = isChannelPartialDeliveryError(error)
+                ? ((error as Error).cause ?? error)
+                : error;
+              for (const [replyIndex, entry] of pending.entries()) {
+                if (!settled.has(replyIndex)) {
+                  entry.finalization.reject(unsettledError);
+                }
+              }
+              throw error;
+            }
+          },
+        },
+        delivery: {
+          // The response_url helper owns provider-finalized message_sent emission. Keep
+          // observeMessageSent unset or core would emit a second lifecycle event.
+          deliver: async (payload, info) => {
+            if (info.kind === "block" && shouldDeliverBlockImmediately) {
+              let visibleReplySent = false;
+              await deliverSlashPayloads([payload], (settlement) => {
+                visibleReplySent = settlement.visibleReplySent;
+              });
+              return visibleReplySent
+                ? { visibleReplySent: true }
+                : {
+                    visibleReplySent: false,
+                    suppression: { reason: "no_visible_result" as const },
+                  };
+            }
+            const finalization = createDeferred<{ visibleReplySent: boolean }>();
+            pendingSlashReplies.push({ payload, finalization });
+            return { visibleReplySent: false, finalization: finalization.promise };
           },
           onError: (err, info) => {
             runtime.error?.(
@@ -822,14 +865,8 @@ export async function registerSlackMonitorSlashCommands(params: {
         },
         replyOptions: {
           skillFilter: channelConfig?.skills,
-          onModelSelected,
         },
       });
-      if (pendingSlashReplies.length > 0) {
-        await deliverSlashPayloads(pendingSlashReplies);
-      } else if (counts.final + counts.tool + counts.block === 0) {
-        await deliverSlashPayloads([]);
-      }
     } catch (err) {
       runtime.error?.(danger(`slack slash handler failed: ${formatErrorMessage(err)}`));
       if (!isSlackResponseAlreadyReportedError(err) && responseBudget.remaining() !== 0) {

--- a/extensions/telegram/src/bot-native-command-deps.runtime.ts
+++ b/extensions/telegram/src/bot-native-command-deps.runtime.ts
@@ -1,3 +1,4 @@
+import { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
 import { readChannelAllowFromStore } from "openclaw/plugin-sdk/conversation-runtime";
 import { getPluginCommandSpecs } from "openclaw/plugin-sdk/plugin-runtime";
 // Telegram plugin module implements bot native command deps behavior.
@@ -5,7 +6,6 @@ import type {
   ModelsAuthLoginFlowOptions,
   ModelsAuthLoginFlowResult,
 } from "openclaw/plugin-sdk/provider-auth-login-flow-runtime";
-import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { listSkillCommandsForAgents } from "openclaw/plugin-sdk/skill-commands-runtime";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -14,26 +14,28 @@ import { loadTelegramSendModule } from "./send-runtime.js";
 
 export type TelegramNativeCommandDeps = Pick<
   TelegramBotDeps,
-  | "dispatchReplyWithBufferedBlockDispatcher"
   | "editMessageTelegram"
   | "getRuntimeConfig"
   | "listSkillCommandsForAgents"
   | "readChannelAllowFromStore"
   | "syncTelegramMenuCommands"
 > & {
+  dispatchChannelInboundTurn?: typeof dispatchChannelInboundTurn;
   getPluginCommandSpecs?: typeof getPluginCommandSpecs;
   runModelsAuthLoginFlow?: (opts: ModelsAuthLoginFlowOptions) => Promise<ModelsAuthLoginFlowResult>;
 };
 
-export const defaultTelegramNativeCommandDeps: TelegramNativeCommandDeps = {
+export const defaultTelegramNativeCommandDeps: TelegramNativeCommandDeps & {
+  dispatchChannelInboundTurn: typeof dispatchChannelInboundTurn;
+} = {
   get getRuntimeConfig() {
     return getRuntimeConfig;
   },
   get readChannelAllowFromStore() {
     return readChannelAllowFromStore;
   },
-  get dispatchReplyWithBufferedBlockDispatcher() {
-    return dispatchReplyWithBufferedBlockDispatcher;
+  get dispatchChannelInboundTurn() {
+    return dispatchChannelInboundTurn;
   },
   get listSkillCommandsForAgents() {
     return listSkillCommandsForAgents;

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -94,20 +94,21 @@ export function createNativeCommandTestParams(
   cfg: OpenClawConfig,
   params: Partial<RegisterTelegramNativeCommandsParams> = {},
 ): RegisterTelegramNativeCommandsParams {
-  const dispatchResult: Awaited<
-    ReturnType<TelegramNativeCommandDeps["dispatchReplyWithBufferedBlockDispatcher"]>
-  > = {
-    queuedFinal: false,
-    counts: { block: 0, final: 0, tool: 0 },
-  };
   const telegramDeps: TelegramNativeCommandDeps = {
     getRuntimeConfig: vi.fn(() => cfg) as TelegramNativeCommandDeps["getRuntimeConfig"],
     readChannelAllowFromStore: vi.fn(
       async () => [],
     ) as TelegramNativeCommandDeps["readChannelAllowFromStore"],
-    dispatchReplyWithBufferedBlockDispatcher: vi.fn(
-      async () => dispatchResult,
-    ) as TelegramNativeCommandDeps["dispatchReplyWithBufferedBlockDispatcher"],
+    dispatchChannelInboundTurn: vi.fn(async (plan) => ({
+      admission: { kind: "dispatch" },
+      dispatched: true,
+      ctxPayload: plan.ctxPayload,
+      routeSessionKey: plan.route.sessionKey,
+      dispatchResult: {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+      },
+    })) as TelegramNativeCommandDeps["dispatchChannelInboundTurn"],
     listSkillCommandsForAgents,
     syncTelegramMenuCommands: vi.fn(({ bot, commandsToRegister }) => {
       if (commandsToRegister.length === 0) {

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -29,6 +29,8 @@ type DispatchReplyWithBufferedBlockDispatcherParams =
 type DispatchReplyWithBufferedBlockDispatcherResult = Awaited<
   ReturnType<DispatchReplyWithBufferedBlockDispatcherFn>
 >;
+type DispatchChannelInboundTurnFn =
+  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
 type ResolveCommandArgMenuFn =
   typeof import("openclaw/plugin-sdk/command-auth-native").resolveCommandArgMenu;
 type DeliverRepliesFn = typeof import("./bot/delivery.js").deliverReplies;
@@ -85,6 +87,48 @@ const replyMocks = vi.hoisted(() => ({
 const deliveryMocks = vi.hoisted(() => ({
   deliverReplies: vi.fn<DeliverRepliesFn>(async () => ({ delivered: true })),
 }));
+const dispatchChannelInboundTurnMock = vi.fn<DispatchChannelInboundTurnFn>(async (plan) => {
+  const recordTask = sessionMocks.recordSessionMetaFromInbound({
+    storePath: sessionMocks.resolveStorePath(plan.cfg.session?.store, {
+      agentId: plan.route.agentId,
+    }),
+    sessionKey: plan.record?.sessionKey ?? plan.ctxPayload.SessionKey ?? plan.route.sessionKey,
+    ctx: plan.ctxPayload,
+  });
+  void Promise.resolve(recordTask).catch((error: unknown) => plan.record?.onRecordError?.(error));
+  const deliver = async (
+    payload: Parameters<
+      DispatchReplyWithBufferedBlockDispatcherParams["dispatcherOptions"]["deliver"]
+    >[0],
+    info: Parameters<
+      DispatchReplyWithBufferedBlockDispatcherParams["dispatcherOptions"]["deliver"]
+    >[1],
+  ) => {
+    const result =
+      "deliverWithProviderMessageSending" in plan.delivery
+        ? await plan.delivery.deliverWithProviderMessageSending(payload, info)
+        : await plan.delivery.deliver(payload, info);
+    await plan.delivery.onDelivered?.(payload, info, result);
+    return result;
+  };
+  const dispatchResult = await replyMocks.dispatchReplyWithBufferedBlockDispatcher({
+    ctx: plan.ctxPayload,
+    cfg: plan.cfg,
+    dispatcherOptions: {
+      ...plan.dispatcherOptions,
+      deliver,
+      onError: plan.delivery.onError,
+    },
+    replyOptions: plan.replyOptions,
+  });
+  return {
+    admission: { kind: "dispatch" },
+    dispatched: true,
+    ctxPayload: plan.ctxPayload,
+    routeSessionKey: plan.route.sessionKey,
+    dispatchResult,
+  };
+});
 const sessionBindingMocks = vi.hoisted(() => ({
   resolveByConversation: vi.fn<
     (ref: unknown) => { bindingId: string; targetSessionKey: string } | null
@@ -236,7 +280,9 @@ vi.mock("./bot-native-commands.runtime.js", () => {
     ),
     resolveChunkMode,
     resolveThreadSessionKeys,
-    dispatchReplyWithBufferedBlockDispatcher: replyMocks.dispatchReplyWithBufferedBlockDispatcher,
+    dispatchChannelInboundTurn: dispatchChannelInboundTurnMock as unknown as NonNullable<
+      TelegramNativeCommandDeps["dispatchChannelInboundTurn"]
+    >,
   };
 });
 vi.mock("openclaw/plugin-sdk/plugin-runtime", async () => {
@@ -332,7 +378,9 @@ function registerAndResolveCommandHandlerBase(params: {
   const telegramDeps: TelegramNativeCommandDeps = {
     getRuntimeConfig: vi.fn(() => commandRuntimeCfg),
     readChannelAllowFromStore: vi.fn(async () => storeAllowFrom ?? []),
-    dispatchReplyWithBufferedBlockDispatcher: replyMocks.dispatchReplyWithBufferedBlockDispatcher,
+    dispatchChannelInboundTurn: dispatchChannelInboundTurnMock as unknown as NonNullable<
+      TelegramNativeCommandDeps["dispatchChannelInboundTurn"]
+    >,
     getPluginCommandSpecs: vi.fn(() => pluginCommandSpecs ?? []),
     listSkillCommandsForAgents: vi.fn(() => []),
     syncTelegramMenuCommands: vi.fn(),
@@ -645,6 +693,7 @@ function resetSessionMetaMocks() {
   replyMocks.dispatchReplyWithBufferedBlockDispatcher
     .mockClear()
     .mockResolvedValue(dispatchReplyResult);
+  dispatchChannelInboundTurnMock.mockClear();
   sessionBindingMocks.resolveByConversation.mockReset().mockReturnValue(null);
   sessionBindingMocks.touch.mockReset();
   deliveryMocks.deliverReplies.mockClear().mockResolvedValue({ delivered: true });
@@ -666,11 +715,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     await handler(createTelegramPrivateCommandContext());
 
     expect(sessionMocks.recordSessionMetaFromInbound).toHaveBeenCalledTimes(1);
-    const dispatchCall = (
-      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-        [{ ctx?: { CommandTargetSessionKey?: string } }]
-      >
-    )[0]?.[0];
+    const turnPlan = dispatchChannelInboundTurnMock.mock.calls[0]?.[0];
     const call = (
       sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
         [{ sessionKey?: string; ctx?: { OriginatingChannel?: string; Provider?: string } }]
@@ -678,7 +723,8 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     )[0]?.[0];
     expect(call?.ctx?.OriginatingChannel).toBe("telegram");
     expect(call?.ctx?.Provider).toBe("telegram");
-    expect(call?.sessionKey).toBe(dispatchCall?.ctx?.CommandTargetSessionKey);
+    expect(call?.sessionKey).toBe(turnPlan?.ctxPayload.CommandTargetSessionKey);
+    expect(turnPlan?.record?.sessionKey).toBe(turnPlan?.ctxPayload.CommandTargetSessionKey);
   });
 
   it("keeps one live config snapshot through native command execution", async () => {
@@ -1169,7 +1215,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it("awaits session metadata persistence before dispatch", async () => {
+  it("starts routed session metadata persistence without blocking command dispatch", async () => {
     const deferred = createDeferred<void>();
     sessionMocks.recordSessionMetaFromInbound.mockReturnValue(deferred.promise);
 
@@ -1180,12 +1226,13 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     await vi.waitFor(() => {
       expect(sessionMocks.recordSessionMetaFromInbound).toHaveBeenCalledTimes(1);
     });
-    expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    });
 
     deferred.resolve();
     await runPromise;
 
-    expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
     const dispatcherOptions = requireRecord(
       requireRecord(
         firstMockArg(
@@ -1274,6 +1321,60 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     await handler(createTelegramPrivateCommandContext());
 
     expect(deliveryMocks.deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("does not emit the empty fallback when reply-payload hooks cancel a native reply", async () => {
+    dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
+      await plan.delivery.onDelivered?.(
+        { text: "cancelled" },
+        { kind: "final" },
+        {
+          visibleReplySent: false,
+          suppression: { reason: "cancelled_by_reply_payload_sending_hook" },
+        },
+      );
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        },
+      };
+    });
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(deliveryMocks.deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("retains the empty fallback for a true non-silent metadata-only native reply", async () => {
+    dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
+      plan.dispatcherOptions?.onSkip?.({}, { kind: "final", reason: "empty" });
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        },
+      };
+    });
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledOnce();
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [{ text: "No response generated. Please try again." }],
+      }),
+    );
   });
 
   it("sends native command error replies silently when silentErrorReplies is enabled", async () => {

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -95,7 +95,11 @@ const dispatchChannelInboundTurnMock = vi.fn<DispatchChannelInboundTurnFn>(async
     sessionKey: plan.record?.sessionKey ?? plan.ctxPayload.SessionKey ?? plan.route.sessionKey,
     ctx: plan.ctxPayload,
   });
-  void Promise.resolve(recordTask).catch((error: unknown) => plan.record?.onRecordError?.(error));
+  const trackedRecordTask = Promise.resolve(recordTask).catch((error: unknown) =>
+    plan.record?.onRecordError?.(error),
+  );
+  plan.record?.trackSessionMetaTask?.(trackedRecordTask);
+  await plan.afterRecord?.();
   const deliver = async (
     payload: Parameters<
       DispatchReplyWithBufferedBlockDispatcherParams["dispatcherOptions"]["deliver"]
@@ -1215,7 +1219,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it("starts routed session metadata persistence without blocking command dispatch", async () => {
+  it("awaits routed session metadata persistence before command dispatch", async () => {
     const deferred = createDeferred<void>();
     sessionMocks.recordSessionMetaFromInbound.mockReturnValue(deferred.promise);
 
@@ -1226,12 +1230,11 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     await vi.waitFor(() => {
       expect(sessionMocks.recordSessionMetaFromInbound).toHaveBeenCalledTimes(1);
     });
-    await vi.waitFor(() => {
-      expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
-    });
+    expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
 
     deferred.resolve();
     await runPromise;
+    expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
 
     const dispatcherOptions = requireRecord(
       requireRecord(

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -20,8 +20,6 @@ type DispatchReplyWithBufferedBlockDispatcherFn =
 type DispatchReplyWithBufferedBlockDispatcherResult = Awaited<
   ReturnType<DispatchReplyWithBufferedBlockDispatcherFn>
 >;
-type RecordInboundSessionMetaSafeFn =
-  typeof import("./bot-native-commands.runtime.js").recordInboundSessionMetaSafe;
 type ResolveChunkModeFn = typeof import("./bot-native-commands.runtime.js").resolveChunkMode;
 type EnsureConfiguredBindingRouteReadyFn =
   typeof import("./bot-native-commands.runtime.js").ensureConfiguredBindingRouteReady;
@@ -29,8 +27,6 @@ type GetAgentScopedMediaLocalRootsFn =
   typeof import("./bot-native-commands.runtime.js").getAgentScopedMediaLocalRoots;
 type ResolveThreadSessionKeysFn =
   typeof import("./bot-native-commands.runtime.js").resolveThreadSessionKeys;
-type CreateChannelReplyPipelineFn =
-  typeof import("./bot-native-commands.delivery.runtime.js").createChannelMessageReplyPipeline;
 type AnyMock = MockFn<(...args: unknown[]) => unknown>;
 type AnyAsyncMock = MockFn<(...args: unknown[]) => Promise<unknown>>;
 type NativeCommandHarness = {
@@ -63,11 +59,6 @@ const replyPipelineMocks = vi.hoisted(() => {
     dispatchReplyWithBufferedBlockDispatcher: vi.fn(
       (async () => dispatchReplyResult) as DispatchReplyWithBufferedBlockDispatcherFn,
     ),
-    createChannelMessageReplyPipeline: vi.fn((() => ({
-      onModelSelected: () => {},
-      responsePrefixContextProvider: () => undefined,
-    })) as unknown as CreateChannelReplyPipelineFn),
-    recordInboundSessionMetaSafe: vi.fn<RecordInboundSessionMetaSafeFn>(async () => undefined),
     resolveChunkMode: vi.fn((() => "length") as unknown as ResolveChunkModeFn),
     ensureConfiguredBindingRouteReady: vi.fn((async () => ({
       ok: true,
@@ -89,22 +80,44 @@ const replyPipelineMocks = vi.hoisted(() => {
   };
 });
 const deliveryMocks = vi.hoisted(() => ({
-  deliverReplies: vi.fn(async () => {}),
+  deliverReplies: vi.fn(async () => ({ delivered: true })),
 }));
+
+const dispatchChannelInboundTurnForTest: TelegramNativeCommandDeps["dispatchChannelInboundTurn"] =
+  async (plan) => {
+    const dispatchResult = await replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher({
+      ctx: plan.ctxPayload,
+      cfg: plan.cfg,
+      dispatcherOptions: {
+        ...plan.dispatcherOptions,
+        deliver:
+          "deliverWithProviderMessageSending" in plan.delivery
+            ? plan.delivery.deliverWithProviderMessageSending
+            : plan.delivery.deliver,
+        onError: plan.delivery.onError,
+      },
+      replyOptions: plan.replyOptions,
+    });
+    return {
+      admission: { kind: "dispatch" },
+      dispatched: true,
+      ctxPayload: plan.ctxPayload,
+      routeSessionKey: plan.route.sessionKey,
+      dispatchResult,
+    };
+  };
 
 vi.mock("./bot-native-commands.runtime.js", () => ({
   getPluginCommandSpecs: pluginCommandMocks.getPluginCommandSpecs,
   matchPluginCommand: pluginCommandMocks.matchPluginCommand,
   executePluginCommand: pluginCommandMocks.executePluginCommand,
   finalizeInboundContext: replyPipelineMocks.finalizeInboundContext,
-  recordInboundSessionMetaSafe: replyPipelineMocks.recordInboundSessionMetaSafe,
   resolveChunkMode: replyPipelineMocks.resolveChunkMode,
   ensureConfiguredBindingRouteReady: replyPipelineMocks.ensureConfiguredBindingRouteReady,
   getAgentScopedMediaLocalRoots: replyPipelineMocks.getAgentScopedMediaLocalRoots,
   resolveThreadSessionKeys: replyPipelineMocks.resolveThreadSessionKeys,
 }));
 vi.mock("./bot-native-commands.delivery.runtime.js", () => ({
-  createChannelMessageReplyPipeline: replyPipelineMocks.createChannelMessageReplyPipeline,
   deliverReplies: deliveryMocks.deliverReplies,
   emitTelegramMessageSentHooks: vi.fn(),
 }));
@@ -163,8 +176,7 @@ export function createNativeCommandsHarness(params?: {
     getRuntimeConfig: vi.fn(() => cfg),
     readChannelAllowFromStore:
       readChannelAllowFromStore as TelegramNativeCommandDeps["readChannelAllowFromStore"],
-    dispatchReplyWithBufferedBlockDispatcher:
-      replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher,
+    dispatchChannelInboundTurn: dispatchChannelInboundTurnForTest,
     getPluginCommandSpecs: pluginCommandMocks.getPluginCommandSpecs,
     listSkillCommandsForAgents: vi.fn(() => []),
     syncTelegramMenuCommands: vi.fn(),

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -8,6 +8,7 @@ import {
   resolveDefaultModelForAgent,
   resolveThinkingDefaultWithRuntimeCatalog,
 } from "openclaw/plugin-sdk/agent-runtime";
+import type { ChannelInboundTurnPlan } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelStreamingBlockEnabled } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveNativeCommandSessionTargets } from "openclaw/plugin-sdk/command-auth-native";
 import {
@@ -1650,38 +1651,43 @@ export const registerTelegramNativeCommands = ({
           OriginatingChannel: "telegram" as const,
           OriginatingTo: originatingTo,
         });
-        await nativeCommandRuntime.recordInboundSessionMetaSafe({
-          cfg: runtimeCfg,
-          agentId: route.agentId,
-          sessionKey: commandTargetSessionKey,
-          ctx: ctxPayload,
-          onError: (err) =>
-            runtime.error?.(danger(`telegram slash: failed updating session meta: ${String(err)}`)),
-        });
-
         const disableBlockStreaming =
           resolveTelegramNativeCommandDisableBlockStreaming(runtimeTelegramCfg);
         const deliveryState = {
           delivered: false,
+          intentionallySuppressed: false,
           skippedNonSilent: 0,
         };
 
-        const { createChannelMessageReplyPipeline, deliverReplies } =
-          await loadTelegramNativeCommandDeliveryRuntime();
-        const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
+        const { deliverReplies } = await loadTelegramNativeCommandDeliveryRuntime();
+
+        const turnPlan: ChannelInboundTurnPlan<"provider_message_sending"> = {
           cfg: runtimeCfg,
-          agentId: route.agentId,
           channel: "telegram",
           accountId: route.accountId,
-        });
-
-        await telegramDeps.dispatchReplyWithBufferedBlockDispatcher({
-          ctx: ctxPayload,
-          cfg: runtimeCfg,
+          route: {
+            agentId: route.agentId,
+            sessionKey: commandSessionKey,
+          },
+          ctxPayload,
+          record: {
+            sessionKey: commandTargetSessionKey,
+            onRecordError: (err) =>
+              runtime.error?.(
+                danger(`telegram slash: failed updating session meta: ${String(err)}`),
+              ),
+          },
+          replyPipeline: {},
           dispatcherOptions: {
-            ...replyPipeline,
             beforeDeliver: async (payload) => payload,
-            deliver: async (payload, _info) => {
+            onSkip: (_payload, info) => {
+              if (info.reason !== "silent") {
+                deliveryState.skippedNonSilent += 1;
+              }
+            },
+          },
+          delivery: {
+            deliverWithProviderMessageSending: async (payload) => {
               if (
                 shouldSuppressLocalTelegramExecApprovalPrompt({
                   cfg: runtimeCfg,
@@ -1690,7 +1696,10 @@ export const registerTelegramNativeCommands = ({
                 })
               ) {
                 deliveryState.delivered = true;
-                return;
+                return {
+                  visibleReplySent: false,
+                  suppression: { reason: "no_visible_result" },
+                };
               }
               const result = await deliverReplies({
                 replies: [
@@ -1707,10 +1716,20 @@ export const registerTelegramNativeCommands = ({
               if (result.delivered) {
                 deliveryState.delivered = true;
               }
+              return result.delivered
+                ? { visibleReplySent: true }
+                : {
+                    visibleReplySent: false,
+                    suppression: { reason: "no_visible_result" as const },
+                  };
             },
-            onSkip: (_payload, info) => {
-              if (info.reason !== "silent") {
-                deliveryState.skippedNonSilent += 1;
+            onDelivered: (_payload, _info, result) => {
+              const reason = result?.suppression?.reason;
+              if (
+                reason === "cancelled_by_reply_payload_sending_hook" ||
+                reason === "empty_after_reply_payload_sending_hook"
+              ) {
+                deliveryState.intentionallySuppressed = true;
               }
             },
             onError: (err, info) => {
@@ -1720,10 +1739,17 @@ export const registerTelegramNativeCommands = ({
           replyOptions: {
             skillFilter,
             disableBlockStreaming,
-            onModelSelected,
           },
-        });
-        if (!deliveryState.delivered && deliveryState.skippedNonSilent > 0) {
+        };
+        await (
+          telegramDeps.dispatchChannelInboundTurn ??
+          defaultTelegramNativeCommandDeps.dispatchChannelInboundTurn
+        )(turnPlan);
+        if (
+          !deliveryState.delivered &&
+          !deliveryState.intentionallySuppressed &&
+          deliveryState.skippedNonSilent > 0
+        ) {
           await deliverReplies({
             replies: [{ text: EMPTY_RESPONSE_FALLBACK }],
             ...deliveryBaseOptions,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1660,6 +1660,7 @@ export const registerTelegramNativeCommands = ({
         };
 
         const { deliverReplies } = await loadTelegramNativeCommandDeliveryRuntime();
+        let recordSessionMetaTask: Promise<unknown> | undefined;
 
         const turnPlan: ChannelInboundTurnPlan<"provider_message_sending"> = {
           cfg: runtimeCfg,
@@ -1672,10 +1673,18 @@ export const registerTelegramNativeCommands = ({
           ctxPayload,
           record: {
             sessionKey: commandTargetSessionKey,
+            trackSessionMetaTask: (task) => {
+              recordSessionMetaTask = task;
+            },
             onRecordError: (err) =>
               runtime.error?.(
                 danger(`telegram slash: failed updating session meta: ${String(err)}`),
               ),
+          },
+          // Native commands historically persisted target metadata before dispatch.
+          // Preserve that ordering while the shared recorder owns the write.
+          afterRecord: async () => {
+            await recordSessionMetaTask;
           },
           replyPipeline: {},
           dispatcherOptions: {

--- a/src/channels/turn/execution.ts
+++ b/src/channels/turn/execution.ts
@@ -217,13 +217,17 @@ async function runPreparedChannelTurnCoreInTrace<
     await params.runDispatchLifecycle?.onDispatchSkipped("botLoopProtection");
     return botLoopDrop;
   }
+  // Native commands can execute in an isolated command session while updating the
+  // provider-routed target session. Keep that record target separate from dispatch.
+  const recordSessionKey =
+    params.record?.sessionKey ?? params.ctxPayload.SessionKey ?? params.routeSessionKey;
   if (params.ctxPayload.SessionTranscriptContext) {
     const { mergeSessionTranscriptContext } =
       await import("../inbound-event/session-transcript-context.runtime.js");
     await mergeSessionTranscriptContext({
       agentId: params.ctxPayload.AgentId,
       ctx: params.ctxPayload,
-      sessionKey: params.ctxPayload.SessionKey ?? params.routeSessionKey,
+      sessionKey: recordSessionKey,
       storePath: params.storePath,
     });
   }
@@ -233,14 +237,14 @@ async function runPreparedChannelTurnCoreInTrace<
       stage: "record",
       event: "start",
       messageId: params.messageId,
-      sessionKey: params.ctxPayload.SessionKey ?? params.routeSessionKey,
+      sessionKey: recordSessionKey,
       admission: admission.kind,
     },
   });
   try {
     await params.recordInboundSession({
       storePath: params.storePath,
-      sessionKey: params.ctxPayload.SessionKey ?? params.routeSessionKey,
+      sessionKey: recordSessionKey,
       ctx: params.ctxPayload,
       groupResolution: params.record?.groupResolution,
       createIfMissing: params.record?.createIfMissing,
@@ -254,7 +258,7 @@ async function runPreparedChannelTurnCoreInTrace<
         stage: "record",
         event: "done",
         messageId: params.messageId,
-        sessionKey: params.ctxPayload.SessionKey ?? params.routeSessionKey,
+        sessionKey: recordSessionKey,
         admission: admission.kind,
       },
     });
@@ -266,7 +270,7 @@ async function runPreparedChannelTurnCoreInTrace<
         stage: "record",
         event: "error",
         messageId: params.messageId,
-        sessionKey: params.ctxPayload.SessionKey ?? params.routeSessionKey,
+        sessionKey: recordSessionKey,
         admission: admission.kind,
         error: err,
       },

--- a/src/channels/turn/execution.ts
+++ b/src/channels/turn/execution.ts
@@ -64,6 +64,23 @@ function isSystemChannelTurn(ctx: FinalizedMsgContext): boolean {
   );
 }
 
+function resolveRecordSessionKey<TDispatchResult>(
+  params: PreparedChannelTurn<TDispatchResult>,
+): string {
+  const explicitSessionKey = params.record?.sessionKey;
+  if (explicitSessionKey === undefined) {
+    return params.ctxPayload.SessionKey ?? params.routeSessionKey;
+  }
+  const normalizedSessionKey = explicitSessionKey.trim();
+  if (!normalizedSessionKey) {
+    throw new Error("Channel turn record.sessionKey must be non-empty.");
+  }
+  if (normalizedSessionKey !== explicitSessionKey) {
+    throw new Error("Channel turn record.sessionKey must not include surrounding whitespace.");
+  }
+  return explicitSessionKey;
+}
+
 function maybeWarnZeroCountVisibleDispatch<TDispatchResult>(
   params: Pick<
     PreparedChannelTurn<TDispatchResult>,
@@ -219,8 +236,7 @@ async function runPreparedChannelTurnCoreInTrace<
   }
   // Native commands can execute in an isolated command session while updating the
   // provider-routed target session. Keep that record target separate from dispatch.
-  const recordSessionKey =
-    params.record?.sessionKey ?? params.ctxPayload.SessionKey ?? params.routeSessionKey;
+  const recordSessionKey = resolveRecordSessionKey(params);
   if (params.ctxPayload.SessionTranscriptContext) {
     const { mergeSessionTranscriptContext } =
       await import("../inbound-event/session-transcript-context.runtime.js");

--- a/src/channels/turn/kernel.test.ts
+++ b/src/channels/turn/kernel.test.ts
@@ -1422,6 +1422,50 @@ describe("channel turn kernel", () => {
     expect(deliver).toHaveBeenCalledWith({ text: "reply" }, { kind: "final" });
   });
 
+  it("can record a target session without changing the command dispatch session", async () => {
+    const log = vi.fn();
+    const recordInboundSession = createRecordInboundSession();
+    const dispatchReplyWithBufferedBlockDispatcher = createDispatch();
+    const commandSessionKey = "agent:main:command:telegram:42";
+    const targetSessionKey = "agent:main:telegram:group:42:topic:7";
+
+    const result = await dispatchAssembledChannelTurn({
+      cfg,
+      channel: "telegram",
+      agentId: "main",
+      routeSessionKey: commandSessionKey,
+      storePath: "/tmp/sessions.json",
+      ctxPayload: createCtx({
+        SessionKey: commandSessionKey,
+        CommandTargetSessionKey: targetSessionKey,
+      }),
+      recordInboundSession,
+      dispatchReplyWithBufferedBlockDispatcher,
+      delivery: { deliver: async () => ({ visibleReplySent: true }) },
+      record: { sessionKey: targetSessionKey },
+      log,
+    });
+
+    expectDispatched(result);
+    expect(result.routeSessionKey).toBe(commandSessionKey);
+    expect(result.ctxPayload.SessionKey).toBe(commandSessionKey);
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: targetSessionKey }),
+    );
+    const recordEvents = log.mock.calls
+      .map(([event]) => event as TurnLogEvent)
+      .filter((event) => event.stage === "record");
+    expect(recordEvents).toEqual([
+      expect.objectContaining({ event: "start", sessionKey: targetSessionKey }),
+      expect.objectContaining({ event: "done", sessionKey: targetSessionKey }),
+    ]);
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({ SessionKey: commandSessionKey }),
+      }),
+    );
+  });
+
   it("runs prepared dispatches after recording session metadata", async () => {
     const events: string[] = [];
     const log = vi.fn();

--- a/src/channels/turn/kernel.test.ts
+++ b/src/channels/turn/kernel.test.ts
@@ -51,6 +51,7 @@ const getGlobalHookRunner = vi.hoisted(() => vi.fn());
 const createMessageSentEmitter = vi.hoisted(() =>
   vi.fn(() => ({ emitMessageSent, hasMessageSentHooks: true })),
 );
+const readRecentUserAssistantTextForSession = vi.hoisted(() => vi.fn());
 
 vi.mock("../../auto-reply/reply/provider-dispatcher.js", async (importOriginal) => {
   const actual =
@@ -99,6 +100,10 @@ vi.mock("../../plugins/hook-runner-global.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../plugins/hook-runner-global.js")>();
   return { ...actual, getGlobalHookRunner };
 });
+
+vi.mock("../../config/sessions/transcript.js", () => ({
+  readRecentUserAssistantTextForSession,
+}));
 
 const cfg = {} as OpenClawConfig;
 
@@ -260,6 +265,7 @@ describe("channel turn kernel", () => {
       hasMessageSentHooks: true,
     }));
     getGlobalHookRunner.mockReturnValue(null);
+    readRecentUserAssistantTextForSession.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -1436,8 +1442,10 @@ describe("channel turn kernel", () => {
       routeSessionKey: commandSessionKey,
       storePath: "/tmp/sessions.json",
       ctxPayload: createCtx({
+        AgentId: "main",
         SessionKey: commandSessionKey,
         CommandTargetSessionKey: targetSessionKey,
+        SessionTranscriptContext: { historyLimit: 1 },
       }),
       recordInboundSession,
       dispatchReplyWithBufferedBlockDispatcher,
@@ -1452,6 +1460,13 @@ describe("channel turn kernel", () => {
     expect(recordInboundSession).toHaveBeenCalledWith(
       expect.objectContaining({ sessionKey: targetSessionKey }),
     );
+    expect(readRecentUserAssistantTextForSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: targetSessionKey,
+        storePath: "/tmp/sessions.json",
+      }),
+    );
     const recordEvents = log.mock.calls
       .map(([event]) => event as TurnLogEvent)
       .filter((event) => event.stage === "record");
@@ -1464,6 +1479,45 @@ describe("channel turn kernel", () => {
         ctx: expect.objectContaining({ SessionKey: commandSessionKey }),
       }),
     );
+  });
+
+  it("rejects an empty explicit record session before recording or dispatch", async () => {
+    const recordInboundSession = createRecordInboundSession();
+    const dispatchReplyWithBufferedBlockDispatcher = createDispatch();
+
+    await expect(
+      dispatchAssembledChannelTurn({
+        cfg,
+        channel: "telegram",
+        agentId: "main",
+        routeSessionKey: "agent:main:command:telegram:42",
+        storePath: "/tmp/sessions.json",
+        ctxPayload: createCtx(),
+        recordInboundSession,
+        dispatchReplyWithBufferedBlockDispatcher,
+        delivery: { deliver: async () => ({ visibleReplySent: true }) },
+        record: { sessionKey: "  " },
+      }),
+    ).rejects.toThrow("Channel turn record.sessionKey must be non-empty.");
+    expect(recordInboundSession).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("rejects surrounding whitespace in an explicit record session", async () => {
+    await expect(
+      dispatchAssembledChannelTurn({
+        cfg,
+        channel: "telegram",
+        agentId: "main",
+        routeSessionKey: "agent:main:command:telegram:42",
+        storePath: "/tmp/sessions.json",
+        ctxPayload: createCtx(),
+        recordInboundSession: createRecordInboundSession(),
+        dispatchReplyWithBufferedBlockDispatcher: createDispatch(),
+        delivery: { deliver: async () => ({ visibleReplySent: true }) },
+        record: { sessionKey: " agent:main:telegram:group:42 " },
+      }),
+    ).rejects.toThrow("Channel turn record.sessionKey must not include surrounding whitespace.");
   });
 
   it("runs prepared dispatches after recording session metadata", async () => {

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -259,6 +259,8 @@ export type ChannelTurnDeliveryAdapter =
 
 /** Options for recording inbound session route state around a turn. */
 export type ChannelTurnRecordOptions = {
+  /** Override the session receiving inbound metadata without changing dispatch routing. */
+  sessionKey?: string;
   groupResolution?: GroupKeyResolution | null;
   createIfMissing?: boolean;
   updateLastRoute?: InboundLastRouteUpdate;

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -259,7 +259,10 @@ export type ChannelTurnDeliveryAdapter =
 
 /** Options for recording inbound session route state around a turn. */
 export type ChannelTurnRecordOptions = {
-  /** Override the session receiving inbound metadata without changing dispatch routing. */
+  /**
+   * Override the session used for metadata and transcript context.
+   * Must be non-empty and contain no surrounding whitespace.
+   */
   sessionKey?: string;
   groupResolution?: GroupKeyResolution | null;
   createIfMissing?: boolean;


### PR DESCRIPTION
Related: #113448

## What Problem This Solves

Bundled native-command reply paths in Mattermost, Discord, Slack, and Telegram could bypass the routed channel-turn lifecycle. Depending on the wrapper and payload, `message_sending` could be omitted for media-only replies or applied twice to Telegram text replies.

## Why This Change Was Made

Routes the six affected wrapper sites through the existing channel-turn owner while preserving provider-owned delivery and finalization. An optional record-session target lets Telegram keep execution routing separate from target-session bookkeeping. This adds no config, protocol, storage, batch subsystem, or compatibility shim.

AI-assisted: Codex was used for implementation and validation; lifecycle ownership and evidence were manually directed and reviewed.

## SDK Contract Decision

The narrow public SDK contract is approved for this PR. `record.sessionKey` is an additive, optional target for a routed turn whose execution session intentionally differs from the session that owns inbound metadata and transcript context. The selected key owns inbound metadata, transcript-context merge, and record-stage diagnostics; it does not change dispatch routing or hook correlation.

The override must be non-empty and contain no surrounding whitespace. Its default remains `ctxPayload.SessionKey ?? route.sessionKey`, so existing callers and sibling native-command paths do not change behavior. Keeping this generic SDK seam is intentional: bundled plugins use the same typed boundary as external plugins, rather than a Telegram-specific core exception.

## User Impact

Outbound modifying hooks now run exactly once per logical native-command payload on these paths, including media-only payloads. Cancellation remains non-visible and does not emit a false terminal delivery event. Legacy dispatcher behavior remains available to unchanged callers.

## Evidence\n\n### Inspectable live evidence

The attached bundle contains sanitized JSON/JSONL hook traces, per-channel summaries,
current-head reconciliation, SHA-256 checksums, and the redacted UI crops linked below.
It contains no credentials, raw destination/account identifiers, invite URLs, private
message bodies, or unrelated contacts.

- [Download the complete redacted evidence bundle](https://github.com/user-attachments/files/30398757/pr-113500-live-evidence-0bcec9e5.zip)
- Bundle SHA-256: `3e9bd8c4dcd8e01173c38c537daca8159dc639d36e1c8365e1337cd4d88922e7`
- Reconciliation target: `0bcec9e5e14b831abb6d9fd48caf5486a6047990`. The live rows came from the accepted D2B-M candidate lineage, were reconciled through stable-patch-equivalent head `9bf7463`, and then audited across the bounded `9bf7463..0bcec9e5` hardening delta. That delta does not change the Discord, Mattermost, or Slack delivery code, or Telegram's hook, cancellation, provider-send, or terminal-event implementation; exact-head gates and affected tests passed.

| Channel | Live result | Inspectable attachment |
| --- | --- | --- |
| Discord | `LIVE_EXTERNAL`: cancellation reached both modifiers once, sent no final reply, and emitted no false `message_sent`. | [Redacted cancellation UI](https://github.com/user-attachments/assets/03c402ad-930b-4536-a077-33d0f107822c); `discord-cancel-trace.jsonl` in the bundle |
| Mattermost | `LIVE_DISPOSABLE`: one registered native slash produced one provider-visible transformed post; the accepted provider-finalization exclusion remains explicit. | [Redacted provider UI](https://github.com/user-attachments/assets/e32fe5bb-1118-44dc-ba80-972666474174); `mattermost-slash-summary.json` and `mattermost-slash-trace.jsonl` in the bundle |
| Slack | `LIVE_EXTERNAL`: the first payload was cancelled without a terminal event; the second payload delivered once with one `message_sent`. | `slack-batch-summary.json` and `slack-batch-trace.jsonl` in the bundle |
| Telegram | `LIVE_EXTERNAL`: success followed `reply_payload_sending -> message_sending -> message_sent` once each with provider ID 451; cancellation produced no send or terminal event and remained absent in Desktop readback. | [Redacted success UI](https://github.com/user-attachments/assets/0425c689-431f-4ae2-b9c3-88761f3ce774), [redacted cancellation search](https://github.com/user-attachments/assets/8fc93b52-4964-4668-a3eb-7815486fe00c); success/cancellation traces and summary in the bundle |


- Rebased onto frozen integration base `c66ca2fbb2b038f4796abfa76bd52dcc3b675b02`; current head is `0bcec9e5e14b831abb6d9fd48caf5486a6047990` and contains three commits. This branch intentionally does not chase later `main` movement.
- The final SDK hardening delta passed 104 affected assertions: Telegram 43 and core channel-turn 61. The core contract test proves the explicit key drives transcript lookup, metadata recording, and diagnostics without changing dispatch; validation tests cover empty and whitespace-padded overrides; Telegram proves target metadata persistence completes before command dispatch.
- Exact-final-head remote validation passed the full changed gate (core/core-test/extension/extension-test typechecks, formatting, plugin SDK contracts and boundaries, full core and extension lint, and repository guards), `plugin-sdk:surface:check`, and the full build on Blacksmith Testbox `tbx_01kygrdcjjrbqcp1e2f4kr7h5e` ([run](https://github.com/openclaw/openclaw/actions/runs/30233619588)).
- Exact-head GitHub CI passed with 81 successful checks, 34 expected skips, and no failures or pending checks ([run](https://github.com/openclaw/openclaw/actions/runs/30234678635)).
- Fresh exact-final uncommitted autoreview found no accepted/actionable findings (0.93 confidence). Its one earlier concern about silently trimming opaque identifiers was accepted and fixed by rejecting surrounding whitespace instead.
- Mattermost `LIVE_DISPOSABLE`: a patch-identical pre-rewrite native slash traversed the production plugin/Gateway with exact `reply_payload_sending -> message_sending` order, one modifier each, and provider-finalized content plus a real post ID (`run_e8cc37627156`). The current preview image redirected browser automation to its `/landing` interstitial; the earlier patch-identical row includes matching browser UI (`run_8eb492bb7de5`). Missing `message_sent` is the separately accepted provider-finalization boundary.
- Slack `LIVE_EXTERNAL`: one real slash execution produced two payloads; cancellation suppressed the first without a terminal event, while the second completed once and matched Chrome (`run_007ed624deed`).
- Telegram `LIVE_EXTERNAL`: native success produced exact `reply_payload_sending -> message_sending -> message_sent` order with provider message ID 451 (`run_79da707733fd`); cancellation produced no provider send or terminal event and remained absent in Telegram Desktop (`run_3bf25ec262ae`).
- Discord `LIVE_EXTERNAL`: native-command cancellation settled the deferred interaction without a visible final message or false terminal event (`run_bf58efcdf18b`).
- A diagnostic Mattermost button no-reply observation was reproduced unchanged on the frozen base (`run_2468b916264d`), so it is not a regression introduced by this PR.
