### PR TITLE
docs: add incident-response to Security navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1723,7 +1723,8 @@
                   "security/network-proxy",
                   "security/formal-verification",
                   "security/THREAT-MODEL-ATLAS",
-                  "security/CONTRIBUTING-THREAT-MODEL"
+                  "security/CONTRIBUTING-THREAT-MODEL",
+                  "security/incident-response"
                 ]
               },
               {


### PR DESCRIPTION
AI-assisted: prepared with an AI coding agent.

## What Problem This Solves

`docs/security/incident-response.md` exists and is linked from sibling Security docs and `docs/docs_map.md`, but it is missing from the Security navigation group in `docs/docs.json`, so it does not appear in the Mintlify sidebar.

## Why This Change Was Made

Adds `security/incident-response` to the `pages` array in the Security group.

## User Impact

Readers can now reach the incident response guide from the docs navigation under Security.

## Evidence

- `docs/security/incident-response.md` exists and is referenced by `docs/security/formal-verification.md`, `docs/security/THREAT-MODEL-ATLAS.md`, and `docs/security/CONTRIBUTING-THREAT-MODEL.md`.
- `docs/docs_map.md` lists the route `/security/incident-response`.
- `python3 -m json.tool docs/docs.json` passes with the added entry.
- `git diff` is limited to the new `pages` array item.
