### PR TITLE
docs: use absolute docs URLs in SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ For coordinated change sets that genuinely need more than 20 PRs, join the **#cl
 
 ## Before You PR
 
-- Use **Node 24.15+** for source checkouts when possible. OpenClaw also supports Node 22.22.3+ and Node 25.9+, but Node 23, Node 22 before 22.22.3, and Node 24 before 24.15 are below the repository engine floor and can fail before `pnpm` commands run. See [Node install guidance](docs/install/node.md) if your local version is too old.
+- Use **Node 24.15+** for source checkouts when possible. OpenClaw also supports Node 22.22.3+ and Node 25.9+, but Node 23, Node 22 before 22.22.3, and Node 24 before 24.15 are below the repository engine floor and can fail before `pnpm` commands run. See [Node install guidance](https://docs.openclaw.ai/install/node) if your local version is too old.
 - Test locally with your OpenClaw instance
 - External PRs must describe the user, product, or operational problem in **What Problem This Solves** and include useful validation in **Evidence**. Focused tests, CI results, screenshots, recordings, terminal output, live observations, redacted logs, and artifact links all count. Reviewers will inspect the code, tests, and CI; use the PR body to explain intent and make validation easy to understand.
 - When ClawSweeper, Barnacle, or a maintainer asks for more context or evidence, edit the PR description instead of only replying in a new comment. Keep **What Problem This Solves**, **Why This Change Was Made**, **User Impact**, and **Evidence** current; a short comment can point reviewers to the update, but the PR body should remain the durable explanation for maintainers and bots.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ For OpenClaw core issues, submit through a private [GitHub Security Advisory](ht
 Maintainers may close, hide, delete, or otherwise take down public issues and PRs that disclose vulnerabilities or active security issues. We will redirect those reports through the private disclosure process so the issue can be triaged and fixed without giving attackers a public playbook.
 
 For full reporting instructions see our [Trust page](https://trust.openclaw.ai).
-For maintainer response workflow, see the [incident response plan](docs/security/incident-response.md).
+For maintainer response workflow, see the [incident response plan](https://docs.openclaw.ai/security/incident-response).
 
 OpenClaw does not currently run a paid bug bounty program. Please still disclose responsibly so we can fix real issues quickly. The best way to help the project right now is to send high-signal reports and, when practical, focused PRs.
 


### PR DESCRIPTION
*AI-assisted edit.*

## What Problem This Solves

Fixes broken reader paths for two docs links. On GitHub-rendered `SECURITY.md` and `CONTRIBUTING.md`, the relative `docs/...` paths do not resolve to the published docs site, so maintainers/contributors following the links reach non-existent or incorrect pages.

## Why This Change Was Made

Replaced the two relative markdown link targets with the canonical `https://docs.openclaw.ai/...` URLs that the repo's docs host uses. This keeps GitHub-rendered files consistent with absolute docs links elsewhere in the repository.

## User Impact

Readers clicking the "incident response plan" or "Node install guidance" links from GitHub will now land on the correct public docs pages.

## Evidence

- `python3 ../scripts/preflight_ship.py` (run for both `SECURITY.md` and `CONTRIBUTING.md`) confirmed the relative-path markers are still present on `upstream/main` and the absolute URLs are not yet present.
- `git diff` shows only the two markdown link targets changed:
  - `docs/security/incident-response.md` → `https://docs.openclaw.ai/security/incident-response`
  - `docs/install/node.md` → `https://docs.openclaw.ai/install/node