### PR TITLE
fix(agents): restore Qwen thinking compatibility routing

### DIFF
--- a/src/agents/embedded-agent-runner/model.compat.ts
+++ b/src/agents/embedded-agent-runner/model.compat.ts
@@ -1,5 +1,12 @@
 import type { ModelCompatConfig, ModelMediaInputConfig } from "../../config/types.models.js";
 import { normalizeProviderId } from "../model-selection.js";
+import { isQwenThinkingCapableModelId } from "../qwen-thinking-compat.js";
+
+export {
+  applyInferredQwenThinkingCompat,
+  isQwenThinkingCapableModelId,
+  resolveQwenThinkingFormatForRoute,
+} from "../qwen-thinking-compat.js";
 
 export function mergeModelMediaInput(
   base: ModelMediaInputConfig | undefined,
@@ -26,6 +33,7 @@ export function mergeModelMediaInput(
 
 export function resolveConfiguredFallbackReasoning(params: {
   provider: string;
+  modelId?: string;
   compat?: unknown;
   reasoning?: boolean;
 }): boolean {
@@ -34,17 +42,22 @@ export function resolveConfiguredFallbackReasoning(params: {
 
 export function resolveConfiguredModelReasoning(params: {
   provider: string;
+  modelId?: string;
   compat?: unknown;
   reasoning?: boolean;
 }): boolean | undefined {
   if (params.reasoning !== undefined) {
     return params.reasoning;
   }
-  return isVllmQwenThinkingCompat(params) ? true : undefined;
+  if (isVllmQwenThinkingCompat(params)) {
+    return true;
+  }
+  return params.modelId && isQwenThinkingCapableModelId(params.modelId) ? true : undefined;
 }
 
 export function resolveMergedConfiguredModelReasoning(params: {
   provider: string;
+  modelId?: string;
   configuredCompat?: unknown;
   resolvedCompat?: unknown;
   configuredReasoning?: boolean;
@@ -56,9 +69,13 @@ export function resolveMergedConfiguredModelReasoning(params: {
   if (isVllmQwenThinkingCompat({ provider: params.provider, compat: params.configuredCompat })) {
     return true;
   }
+  if (params.modelId && isQwenThinkingCapableModelId(params.modelId)) {
+    return true;
+  }
   return (
     resolveConfiguredModelReasoning({
       provider: params.provider,
+      modelId: params.modelId,
       compat: params.resolvedCompat,
       reasoning: params.discoveredReasoning,
     }) ?? false

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2991,6 +2991,58 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
+  it("infers reasoning and thinkingFormat for custom Qwen3.6 model ids", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://127.0.0.1:8080/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "Qwen3.6-27B",
+                name: "Qwen3.6-27B",
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "Qwen3.6-27B", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.reasoning).toBe(true);
+    expect(result.model?.compat).toEqual(
+      expect.objectContaining({ thinkingFormat: "qwen-chat-template" }),
+    );
+  });
+
+  it("preserves explicit reasoning false for custom Qwen3.6 model ids", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.com/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "qwen3.6-27b",
+                name: "qwen3.6-27b",
+                reasoning: false,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "qwen3.6-27b", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.reasoning).toBe(false);
+  });
+
   it("propagates image input capability from matching configured fallback model", () => {
     const cfg = {
       models: {

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -52,6 +52,7 @@ import {
   type ModelRegistry,
 } from "../sessions/index.js";
 import {
+  applyInferredQwenThinkingCompat,
   mergeModelCompat,
   mergeModelMediaInput,
   resolveConfiguredFallbackReasoning,
@@ -850,6 +851,7 @@ function applyConfiguredProviderOverrides(params: {
   });
   const resolvedReasoning = resolveMergedConfiguredModelReasoning({
     provider: params.provider,
+    modelId: discoveredModel.id,
     configuredCompat: resolvedCompat,
     resolvedCompat,
     configuredReasoning: metadataOverrideModel?.reasoning,
@@ -873,6 +875,13 @@ function applyConfiguredProviderOverrides(params: {
     capability: "llm",
     transport: "stream",
   });
+  const inferredQwen = applyInferredQwenThinkingCompat({
+    provider: params.provider,
+    modelId: discoveredModel.id,
+    baseUrl: requestConfig.baseUrl ?? discoveredModel.baseUrl,
+    reasoning: resolvedReasoning,
+    compat: resolvedCompat,
+  });
   return attachModelProviderLocalService(
     attachModelProviderRequestTransport(
       {
@@ -880,7 +889,7 @@ function applyConfiguredProviderOverrides(params: {
         provider: params.provider,
         api: requestConfig.api ?? "openai-responses",
         baseUrl: requestConfig.baseUrl ?? discoveredModel.baseUrl,
-        reasoning: resolvedReasoning,
+        reasoning: inferredQwen.reasoning ?? resolvedReasoning,
         input: normalizedInput,
         cost: metadataOverrideModel?.cost ?? discoveredModel.cost,
         contextWindow: resolvedContextWindow ?? discoveredModel.contextWindow,
@@ -903,7 +912,7 @@ function applyConfiguredProviderOverrides(params: {
         ...(providerConfig.authHeader !== undefined
           ? { authHeader: providerConfig.authHeader }
           : {}),
-        compat: resolvedCompat,
+        compat: inferredQwen.compat ?? resolvedCompat,
         mediaInput: mergeModelMediaInput(
           mergeModelMediaInput(
             configuredStaticCatalogModel?.mediaInput,
@@ -1095,6 +1104,13 @@ function resolveExplicitModelWithRegistry(params: {
       providerParams: providerConfig?.params,
       configuredParams: fallbackInlineMatch.params,
     });
+    const inferredInline = applyInferredQwenThinkingCompat({
+      provider,
+      modelId,
+      baseUrl: fallbackInlineMatch.baseUrl ?? providerConfig?.baseUrl,
+      reasoning: fallbackInlineMatch.reasoning,
+      compat: fallbackInlineMatch.compat,
+    });
     return {
       kind: "resolved",
       source: "configured",
@@ -1110,9 +1126,11 @@ function resolveExplicitModelWithRegistry(params: {
             : {}),
           reasoning: resolveConfiguredModelReasoning({
             provider,
-            compat: fallbackInlineMatch.compat,
-            reasoning: fallbackInlineMatch.reasoning,
+            modelId,
+            compat: inferredInline.compat ?? fallbackInlineMatch.compat,
+            reasoning: inferredInline.reasoning ?? fallbackInlineMatch.reasoning,
           }),
+          ...(inferredInline.compat ? { compat: inferredInline.compat } : {}),
           ...(resolvedParams ? { params: resolvedParams } : {}),
           ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
         } as Model,

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -36,6 +36,7 @@ import {
   normalizeProviderId,
 } from "./model-ref-shared.js";
 import { findNormalizedProviderValue, parseModelRef } from "./model-selection-normalize.js";
+import { applyInferredQwenThinkingCompat } from "./qwen-thinking-compat.js";
 
 // Shared model-selection helpers for config aliases, allowlists, provider
 // inference, and configured catalog rows used by CLI and runtime selectors.
@@ -1402,27 +1403,33 @@ export function buildConfiguredModelCatalog(params: {
       const input = Array.isArray(model?.input) ? model.input : undefined;
       const modelParams =
         model?.params && typeof model.params === "object" ? model.params : undefined;
-      const compat = model?.compat && typeof model.compat === "object" ? model.compat : undefined;
-      const reasoning =
-        typeof model?.reasoning === "boolean"
-          ? model.reasoning
-          : isVllmQwenThinkingCompat(providerId, compat)
-            ? true
-            : undefined;
+      const configuredCompat =
+        model?.compat && typeof model.compat === "object" ? model.compat : undefined;
+      const baseUrl = model?.baseUrl ?? provider.baseUrl;
+      const inferred = applyInferredQwenThinkingCompat({
+        provider: providerId,
+        modelId: id,
+        baseUrl,
+        reasoning:
+          typeof model?.reasoning === "boolean"
+            ? model.reasoning
+            : isVllmQwenThinkingCompat(providerId, configuredCompat)
+              ? true
+              : undefined,
+        compat: configuredCompat,
+      });
       catalog.push({
         provider: providerId,
         id,
         name,
         api: model.api ?? provider.api,
-        ...((model.baseUrl ?? provider.baseUrl)
-          ? { baseUrl: model.baseUrl ?? provider.baseUrl }
-          : {}),
+        ...(baseUrl ? { baseUrl } : {}),
         contextWindow,
         contextTokens,
-        reasoning,
+        reasoning: inferred.reasoning,
         input,
         ...(modelParams ? { params: modelParams } : {}),
-        compat,
+        ...(inferred.compat ? { compat: inferred.compat } : {}),
       });
     }
   }

--- a/src/agents/qwen-thinking-compat.test.ts
+++ b/src/agents/qwen-thinking-compat.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyInferredQwenThinkingCompat,
+  isQwenThinkingCapableModelId,
+  resolveQwenThinkingFormatForRoute,
+} from "./qwen-thinking-compat.js";
+
+describe("qwen-thinking-compat", () => {
+  it.each([
+    "qwen3.6-27b",
+    "Qwen3.6-27B",
+    "qwen3.5-plus",
+    "qwen3.7-max",
+    "qwen3-6-27b",
+    "org/qwen3.6-flash",
+  ])("detects thinking-capable id %s", (id) => {
+    expect(isQwenThinkingCapableModelId(id)).toBe(true);
+  });
+
+  it.each(["qwen3-8b", "qwen2.5-coder", "llama3.1", "qwen3"])(
+    "does not detect non-thinking id %s",
+    (id) => {
+      expect(isQwenThinkingCapableModelId(id)).toBe(false);
+    },
+  );
+
+  it("infers reasoning and qwen format for custom remote routes", () => {
+    expect(
+      applyInferredQwenThinkingCompat({
+        provider: "my-qwen",
+        modelId: "Qwen3.6-27B",
+        baseUrl: "https://example.com/v1",
+      }),
+    ).toEqual({
+      reasoning: true,
+      compat: { thinkingFormat: "qwen" },
+    });
+  });
+
+  it("infers qwen-chat-template for local endpoints", () => {
+    expect(
+      resolveQwenThinkingFormatForRoute({
+        provider: "custom",
+        baseUrl: "http://127.0.0.1:1234/v1",
+      }),
+    ).toBe("qwen-chat-template");
+    expect(
+      applyInferredQwenThinkingCompat({
+        provider: "lmstudio",
+        modelId: "qwen3.6-27b",
+        baseUrl: "http://localhost:1234/v1",
+      }).compat,
+    ).toEqual({ thinkingFormat: "qwen-chat-template" });
+  });
+
+  it("preserves explicit reasoning false and thinkingFormat", () => {
+    expect(
+      applyInferredQwenThinkingCompat({
+        provider: "custom",
+        modelId: "qwen3.6-27b",
+        reasoning: false,
+        compat: { thinkingFormat: "openai" },
+      }),
+    ).toEqual({
+      reasoning: false,
+      compat: { thinkingFormat: "openai" },
+    });
+  });
+});

--- a/src/agents/qwen-thinking-compat.ts
+++ b/src/agents/qwen-thinking-compat.ts
@@ -1,0 +1,95 @@
+/**
+ * Infer reasoning + thinkingFormat for Qwen 3.5+ custom openai-completions rows
+ * when the operator omitted those fields.
+ */
+import type { ModelCompatConfig } from "../config/types.models.js";
+import { normalizeProviderId } from "./model-ref-shared.js";
+
+export type QwenThinkingFormat = "qwen" | "qwen-chat-template";
+
+/**
+ * Qwen 3.5+ thinking family ids (plus/flash/max and local weights like
+ * qwen3.6-27b). Older plain qwen3-8b rows stay opt-in via explicit config.
+ */
+export function isQwenThinkingCapableModelId(modelId: string): boolean {
+  const normalized = modelId.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const leaf = normalized.includes("/")
+    ? normalized.slice(normalized.lastIndexOf("/") + 1)
+    : normalized;
+  // qwen3.5+ / qwen3.6-27b / qwen3-6-27b. Dash form only accepts minor 5–7 so
+  // size tags like qwen3-8b stay opt-in.
+  return /^qwen3(?:\.[5-9]|[-_][5-7](?:\D|$))/.test(leaf);
+}
+
+export function resolveQwenThinkingFormatForRoute(params: {
+  provider: string;
+  baseUrl?: string | null;
+}): QwenThinkingFormat {
+  const providerId = normalizeProviderId(params.provider);
+  if (
+    providerId === "vllm" ||
+    providerId === "lmstudio" ||
+    providerId === "ollama" ||
+    providerId === "sglang"
+  ) {
+    return "qwen-chat-template";
+  }
+  const baseUrl = typeof params.baseUrl === "string" ? params.baseUrl.trim().toLowerCase() : "";
+  if (
+    baseUrl.includes("localhost") ||
+    baseUrl.includes("127.0.0.1") ||
+    baseUrl.includes("[::1]") ||
+    baseUrl.includes("0.0.0.0")
+  ) {
+    return "qwen-chat-template";
+  }
+  return "qwen";
+}
+
+function mergeCompat(
+  base: ModelCompatConfig | undefined,
+  override: ModelCompatConfig | undefined,
+): ModelCompatConfig | undefined {
+  if (!base) {
+    return override;
+  }
+  if (!override) {
+    return base;
+  }
+  return { ...base, ...override };
+}
+
+/** Fill omitted reasoning / thinkingFormat for Qwen3.5+ custom openai-completions rows. */
+export function applyInferredQwenThinkingCompat(params: {
+  provider: string;
+  modelId: string;
+  baseUrl?: string | null;
+  reasoning?: boolean;
+  compat?: ModelCompatConfig;
+}): { reasoning?: boolean; compat?: ModelCompatConfig } {
+  if (!isQwenThinkingCapableModelId(params.modelId)) {
+    return {
+      ...(params.reasoning !== undefined ? { reasoning: params.reasoning } : {}),
+      ...(params.compat ? { compat: params.compat } : {}),
+    };
+  }
+  const reasoning = params.reasoning ?? true;
+  const existingFormat = params.compat?.thinkingFormat;
+  if (existingFormat) {
+    return {
+      reasoning,
+      ...(params.compat ? { compat: params.compat } : {}),
+    };
+  }
+  const thinkingFormat = resolveQwenThinkingFormatForRoute({
+    provider: params.provider,
+    baseUrl: params.baseUrl,
+  });
+  return {
+    reasoning,
+    compat: mergeCompat(params.compat, { thinkingFormat }),
+  };
+}

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -27,6 +27,7 @@ import {
   listPluginModelCatalogFiles,
   type PluginModelCatalogMetadataSnapshot,
 } from "../plugin-model-catalog.js";
+import { applyInferredQwenThinkingCompat } from "../qwen-thinking-compat.js";
 import { getAuthStorageOAuthProviderRegistry } from "./auth-storage-oauth-registry.js";
 import type { AuthStatus, AuthStorage } from "./auth-storage.js";
 import {
@@ -634,7 +635,14 @@ export class ModelRegistry {
           continue;
         }
 
-        const compat = mergeCompat(providerConfig.compat, modelDef.compat);
+        const mergedCompat = mergeCompat(providerConfig.compat, modelDef.compat);
+        const inferred = applyInferredQwenThinkingCompat({
+          provider: providerName,
+          modelId: modelDef.id,
+          baseUrl,
+          reasoning: modelDef.reasoning,
+          compat: mergedCompat,
+        });
         this.storeModelHeaders(providerName, modelDef.id, modelDef.headers);
         const defaultCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
         models.push({
@@ -643,7 +651,7 @@ export class ModelRegistry {
           api: api as Api,
           provider: providerName,
           baseUrl,
-          reasoning: modelDef.reasoning ?? false,
+          reasoning: inferred.reasoning ?? false,
           thinkingLevelMap: modelDef.thinkingLevelMap,
           input: runtimeInput,
           cost: modelDef.cost ?? defaultCost,
@@ -652,7 +660,7 @@ export class ModelRegistry {
           ...(modelDef.maxTokens !== undefined ? { maxTokensSource } : {}),
           params: modelDef.params,
           headers: undefined,
-          compat,
+          compat: inferred.compat ?? mergedCompat,
         } as Model);
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Qwen thinking-capable models could be routed without the inferred thinking compatibility settings needed for correct reasoning behavior.

## Why This Change Was Made

Adds a dedicated Qwen thinking-compat helper and wires it through model selection / embedded runner model compat so thinking-capable Qwen routes get consistent format inference.

## User Impact

Qwen models that support thinking behave more consistently in OpenClaw agent runs.

## Evidence

- Unit tests in `src/agents/qwen-thinking-compat.test.ts` and model runner coverage
