### PR TITLE
fix(agents): align compaction reserve with usage gate and harden flush

### DIFF
--- a/src/agents/agent-compaction-constants.ts
+++ b/src/agents/agent-compaction-constants.ts
@@ -10,3 +10,9 @@ export const MIN_PROMPT_BUDGET_TOKENS = 8_000;
  * content after reserve tokens are subtracted.
  */
 export const MIN_PROMPT_BUDGET_RATIO = 0.5;
+
+/**
+ * Preflight and threshold maintenance compact once projected usage reaches
+ * this share of the model context window.
+ */
+export const COMPACTION_CONTEXT_USAGE_RATIO = 0.85;

--- a/src/agents/agent-settings.test.ts
+++ b/src/agents/agent-settings.test.ts
@@ -37,19 +37,20 @@ describe("applyAgentCompactionSettingsFromConfig", () => {
       }),
     };
 
+    // 100k window → reserve = 100_000 - floor(100_000 * 0.85) = 15_000.
     const first = applyAgentCompactionSettingsFromConfig({
       settingsManager,
       contextTokenBudget: 100_000,
     });
-    expect(first.compaction.reserveTokens).toBe(DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR);
+    expect(first.compaction.reserveTokens).toBe(15_000);
 
     reserve = 16_384;
     const second = applyAgentCompactionSettingsFromConfig({
       settingsManager,
       contextTokenBudget: 100_000,
     });
-    expect(second.compaction.reserveTokens).toBe(DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR);
-    expect(reserve).toBe(DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR);
+    expect(second.compaction.reserveTokens).toBe(15_000);
+    expect(reserve).toBe(15_000);
   });
 
   it("does not override when already above floor and not in safeguard mode", () => {
@@ -129,7 +130,7 @@ describe("applyAgentCompactionSettingsFromConfig", () => {
 
   it("caps the effective reserve so small-context models do not compact at token one", () => {
     // Embedded runner default reserveTokens is 16 384. With a 16 384 context window
-    // both the default reserve and floor exceed the safe maximum of 8 384.
+    // align reserve to ~15% (2 458) while still keeping the min-prompt-budget cap.
     const settingsManager = SettingsManager.inMemory();
     const applyOverrides = vi.spyOn(settingsManager, "applyOverrides");
 
@@ -138,14 +139,14 @@ describe("applyAgentCompactionSettingsFromConfig", () => {
       contextTokenBudget: 16_384,
     });
 
-    expect(result.compaction).toEqual({ reserveTokens: 8_384, keepRecentTokens: 20_000 });
+    expect(result.compaction).toEqual({ reserveTokens: 2_458, keepRecentTokens: 20_000 });
     expect(result.didOverride).toBe(true);
     expect(applyOverrides).toHaveBeenCalledWith({
-      compaction: { reserveTokens: 8_384 },
+      compaction: { reserveTokens: 2_458 },
     });
     expect(settingsManager.getCompactionSettings()).toEqual({
       enabled: true,
-      reserveTokens: 8_384,
+      reserveTokens: 2_458,
       keepRecentTokens: 20_000,
     });
     expect(shouldCompact(1, 16_384, { enabled: true, ...result.compaction })).toBe(false);
@@ -153,8 +154,7 @@ describe("applyAgentCompactionSettingsFromConfig", () => {
 
   it("applies capped floor when current reserve is below it on small-context models", () => {
     // Simulate an embedded runner default of 4 096 with a 16 384 context window.
-    // minPromptBudget = min(8_000, floor(16_384 * 0.5)) = 8_000.
-    // maxReserve = 16_384 - 8_000 = 8_384.
+    // ratioReserve = ceil(16_384 * 0.15) = 2_458; maxReserve = 8_384 → 2_458.
     const settingsManager = {
       getCompactionReserveTokens: () => 4_096,
       getCompactionKeepRecentTokens: () => 20_000,
@@ -167,50 +167,48 @@ describe("applyAgentCompactionSettingsFromConfig", () => {
     });
 
     expect(result.didOverride).toBe(true);
-    expect(result.compaction.reserveTokens).toBe(8_384);
+    expect(result.compaction.reserveTokens).toBe(2_458);
     expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
-      compaction: { reserveTokens: 8_384 },
+      compaction: { reserveTokens: 2_458 },
     });
   });
 
-  it("does not cap the reserve floor for a mid-size context", () => {
+  it("aligns mid-size context reserve to ~15% of the window", () => {
     const settingsManager = {
       getCompactionReserveTokens: () => 16_384,
       getCompactionKeepRecentTokens: () => 20_000,
       applyOverrides: vi.fn(),
     };
 
-    // 32 768 context window → minPromptBudget = min(8_000, floor(32_768 * 0.5)) = 8_000.
-    // maxReserve = 32_768 - 8_000 = 24_768, so the 20 000 floor remains intact.
+    // 32 768 context → ceil(32_768 * 0.15) = 4_916 (~15% free for the 85% gate).
     const result = applyAgentCompactionSettingsFromConfig({
       settingsManager,
       contextTokenBudget: 32_768,
     });
 
-    expect(result.compaction.reserveTokens).toBe(DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR);
+    expect(result.compaction.reserveTokens).toBe(4_916);
     expect(result.compaction.keepRecentTokens).toBe(20_000);
     expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
-      compaction: { reserveTokens: DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR },
+      compaction: { reserveTokens: 4_916 },
     });
   });
 
-  it("does not cap floor when context window is large enough", () => {
+  it("aligns large context reserve to ~15% of the window", () => {
     const settingsManager = {
       getCompactionReserveTokens: () => 16_384,
       getCompactionKeepRecentTokens: () => 20_000,
       applyOverrides: vi.fn(),
     };
 
-    // 200 000 context window → maxReserve = 200_000 - 8_000 = 192_000.
-    // floor (20 000) is well within that cap.
+    // 200 000 context → ceil(200_000 * 0.15) = 30_000.
     const result = applyAgentCompactionSettingsFromConfig({
       settingsManager,
       contextTokenBudget: 200_000,
     });
 
-    expect(result.compaction.reserveTokens).toBe(DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR);
+    expect(result.compaction.reserveTokens).toBe(30_000);
     expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
-      compaction: { reserveTokens: DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR },
+      compaction: { reserveTokens: 30_000 },
     });
   });
 

--- a/src/agents/agent-settings.ts
+++ b/src/agents/agent-settings.ts
@@ -3,7 +3,11 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { AgentCompactionMode } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ContextEngineInfo } from "../context-engine/types.js";
-import { MIN_PROMPT_BUDGET_RATIO, MIN_PROMPT_BUDGET_TOKENS } from "./agent-compaction-constants.js";
+import {
+  MIN_PROMPT_BUDGET_RATIO,
+  MIN_PROMPT_BUDGET_TOKENS,
+  COMPACTION_CONTEXT_USAGE_RATIO,
+} from "./agent-compaction-constants.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 
 export const DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
@@ -42,29 +46,28 @@ export function applyAgentCompactionSettingsFromConfig(params: {
   const compactionCfg = params.cfg?.agents?.defaults?.compaction;
 
   const configuredKeepRecentTokens = toPositiveInt(compactionCfg?.keepRecentTokens);
-  let reserveTokensFloor = DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR;
-  let maxReserveTokens: number | undefined;
+  let targetReserveTokens: number;
 
-  // Cap the floor to a safe fraction of the context window so that
-  // small-context models (e.g. Ollama with 16 K tokens) are not starved of
-  // prompt budget.  Without this cap the default floor of 20 000 can exceed
-  // the entire context window, causing every prompt to be classified as an
-  // overflow and triggering an infinite compaction loop.
+  // Cap reserve so small-context models (e.g. Ollama with 16 K tokens) keep a
+  // usable prompt budget. When the window is known, align reserve to ~15% so
+  // threshold maintenance matches the preflight ~85% usage gate.
   const contextTokenBudget = toPositiveInt(params.contextTokenBudget);
   if (contextTokenBudget !== undefined) {
     const minPromptBudget = Math.min(
       MIN_PROMPT_BUDGET_TOKENS,
       Math.max(1, Math.floor(contextTokenBudget * MIN_PROMPT_BUDGET_RATIO)),
     );
-    maxReserveTokens = Math.max(0, contextTokenBudget - minPromptBudget);
-    reserveTokensFloor = Math.min(reserveTokensFloor, maxReserveTokens);
-  }
-
-  let targetReserveTokens = Math.max(currentReserveTokens, reserveTokensFloor);
-  if (maxReserveTokens !== undefined) {
-    // Cap the effective value too: the harness default or explicit config can otherwise
-    // undo the floor cap and make shouldCompact() true from the first token.
-    targetReserveTokens = Math.min(targetReserveTokens, maxReserveTokens);
+    const maxReserveTokens = Math.max(0, contextTokenBudget - minPromptBudget);
+    // Pair reserve with the 85% usage gate (window - floor(window * 0.85)).
+    // Avoid `ceil(window * 0.15)` — `1 - 0.85` float noise can off-by-one.
+    const ratioReserve =
+      contextTokenBudget - Math.floor(contextTokenBudget * COMPACTION_CONTEXT_USAGE_RATIO);
+    targetReserveTokens = Math.min(ratioReserve, maxReserveTokens);
+  } else {
+    targetReserveTokens = Math.max(
+      currentReserveTokens,
+      DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR,
+    );
   }
   const targetKeepRecentTokens = configuredKeepRecentTokens ?? currentKeepRecentTokens;
 

--- a/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
+++ b/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
@@ -7,6 +7,18 @@ import {
   resolveCompactionTimeoutMs,
 } from "./embedded-agent-runner/compaction-safety-timeout.js";
 
+const emitAgentEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../infra/agent-events.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/agent-events.js")>(
+    "../infra/agent-events.js",
+  );
+  return {
+    ...actual,
+    emitAgentEvent: (...args: unknown[]) => emitAgentEventMock(...args),
+  };
+});
+
 const EMBEDDED_COMPACTION_TIMEOUT_MS = 180_000;
 
 describe("compactWithSafetyTimeout", () => {
@@ -190,11 +202,74 @@ describe("compactContextEngineWithSafetyTimeout", () => {
   beforeEach(() => {
     vi.useRealTimers();
     vi.clearAllTimers();
+    emitAgentEventMock.mockClear();
   });
 
   afterEach(() => {
     vi.clearAllTimers();
     vi.useRealTimers();
+  });
+
+  it("emits compaction start/end agent events around a successful compact()", async () => {
+    const result: CompactResult = {
+      ok: true,
+      compacted: true,
+      result: { tokensBefore: 1000, tokensAfter: 200 },
+    };
+    const compact = vi.fn<CompactFn>(async () => result);
+
+    await expect(compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30)).resolves.toBe(
+      result,
+    );
+
+    expect(emitAgentEventMock.mock.calls.map((call) => call[0])).toEqual([
+      {
+        runId: "context-engine-compact:agent:main:session-1:session-1",
+        stream: "compaction",
+        sessionKey: "agent:main:session-1",
+        data: { phase: "start" },
+      },
+      {
+        runId: "context-engine-compact:agent:main:session-1:session-1",
+        stream: "compaction",
+        sessionKey: "agent:main:session-1",
+        data: { phase: "end", completed: true },
+      },
+    ]);
+  });
+
+  it("prefers runtimeContext.runId for compaction agent events", async () => {
+    const result: CompactResult = {
+      ok: true,
+      compacted: false,
+      reason: "already compact",
+    };
+    const compact = vi.fn<CompactFn>(async () => result);
+
+    await compactContextEngineWithSafetyTimeout(
+      { compact },
+      {
+        ...baseParams,
+        agentId: "main",
+        runtimeContext: { runId: "chat-run-42" },
+      },
+      30,
+    );
+
+    expect(emitAgentEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "chat-run-42",
+        stream: "compaction",
+        agentId: "main",
+        data: { phase: "start" },
+      }),
+    );
+    expect(emitAgentEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "chat-run-42",
+        data: { phase: "end", completed: false },
+      }),
+    );
   });
 
   it("bounds a hung plugin compact() and rejects with a timeout error", async () => {
@@ -207,6 +282,12 @@ describe("compactContextEngineWithSafetyTimeout", () => {
     await vi.advanceTimersByTimeAsync(30);
     await assertion;
     expect(vi.getTimerCount()).toBe(0);
+    expect(emitAgentEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "compaction",
+        data: { phase: "end", completed: false },
+      }),
+    );
   });
 
   it("returns the plugin compact() result when it settles in time", async () => {
@@ -304,6 +385,12 @@ describe("compactContextEngineWithSafetyTimeout", () => {
 
     await expect(compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30)).rejects.toBe(
       error,
+    );
+    expect(emitAgentEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "compaction",
+        data: { phase: "end", completed: false },
+      }),
     );
   });
 });

--- a/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
+++ b/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
@@ -5,6 +5,7 @@ import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-co
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CompactResult, ContextEngine } from "../../context-engine/types.js";
 import { createAbortError } from "../../infra/abort-signal.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";
 import { withTimeout } from "../../node-host/with-timeout.js";
 
 const EMBEDDED_COMPACTION_TIMEOUT_MS = 180_000;
@@ -102,6 +103,30 @@ export async function compactWithSafetyTimeout<T>(
 /** Parameters for a single {@link ContextEngine.compact} invocation. */
 type ContextEngineCompactParams = Parameters<ContextEngine["compact"]>[0];
 
+function resolveContextEngineCompactionEventRunId(params: ContextEngineCompactParams): string {
+  const runtimeRunId = params.runtimeContext?.runId;
+  if (typeof runtimeRunId === "string" && runtimeRunId.trim()) {
+    return runtimeRunId.trim();
+  }
+  // Engine-owned compaction bypasses AgentSession compaction_start/end, so the
+  // Control UI never learns the run is compacting unless we emit here. Prefer a
+  // stable synthetic id when the caller did not thread the active chat runId.
+  return `context-engine-compact:${params.sessionKey}:${params.sessionId}`;
+}
+
+function emitContextEngineCompactionAgentEvent(
+  params: ContextEngineCompactParams,
+  data: { phase: "start" } | { phase: "end"; completed: boolean },
+): void {
+  emitAgentEvent({
+    runId: resolveContextEngineCompactionEventRunId(params),
+    stream: "compaction",
+    sessionKey: params.sessionKey,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    data,
+  });
+}
+
 /**
  * Invoke a plugin-owned {@link ContextEngine.compact} bounded by the same
  * finite safety timeout that protects native runtime compaction.
@@ -117,23 +142,36 @@ type ContextEngineCompactParams = Parameters<ContextEngine["compact"]>[0];
  *  - the timeout signal and caller `abortSignal` are both raced against the
  *    call (so a non-cooperating engine is still bounded) and threaded into the
  *    `compact()` params (so cooperating engines can cancel their own in-flight
- *    work).
+ *    work);
+ *  - start/end `stream: "compaction"` agent events are emitted so Control UI
+ *    can show the compacting indicator (AgentSession never fires for this path).
  *
  * Callers keep their existing try/catch — a timeout or abort surfaces as a
  * thrown error, never a silent hang.
  */
-export function compactContextEngineWithSafetyTimeout(
+export async function compactContextEngineWithSafetyTimeout(
   contextEngine: Pick<ContextEngine, "compact">,
   params: ContextEngineCompactParams,
   timeoutMs: number = EMBEDDED_COMPACTION_TIMEOUT_MS,
   abortSignal?: AbortSignal,
 ): Promise<CompactResult> {
-  return compactWithSafetyTimeout(
-    (compactAbortSignal) =>
-      contextEngine.compact(
-        compactAbortSignal ? { ...params, abortSignal: compactAbortSignal } : params,
-      ),
-    timeoutMs,
-    abortSignal ? { abortSignal } : undefined,
-  );
+  emitContextEngineCompactionAgentEvent(params, { phase: "start" });
+  try {
+    const result = await compactWithSafetyTimeout(
+      (compactAbortSignal) =>
+        contextEngine.compact(
+          compactAbortSignal ? { ...params, abortSignal: compactAbortSignal } : params,
+        ),
+      timeoutMs,
+      abortSignal ? { abortSignal } : undefined,
+    );
+    emitContextEngineCompactionAgentEvent(params, {
+      phase: "end",
+      completed: Boolean(result.ok && result.compacted),
+    });
+    return result;
+  } catch (err) {
+    emitContextEngineCompactionAgentEvent(params, { phase: "end", completed: false });
+    throw err;
+  }
 }

--- a/src/auto-reply/reply/agent-runner-execute.ts
+++ b/src/auto-reply/reply/agent-runner-execute.ts
@@ -235,6 +235,7 @@ export async function executePreparedReplyAgentRun(
         storePath,
         isHeartbeat,
         replyOperation,
+        runId: normalizeOptionalString(opts?.runId),
         onCompactionNotice: sendDirectCompactionNotice,
       }),
     );

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -11,6 +11,10 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { classifyCompactionReason } from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
+import {
+  resolveLiveToolResultAggregateMaxChars,
+  truncateToolResultMessage,
+} from "../../agents/embedded-agent-runner/tool-result-truncation.js";
 import { isCliRuntimeAliasForProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
@@ -24,6 +28,7 @@ import {
   resolveCandidateThinkingLevel,
   resolveEffectiveAgentRuntime,
 } from "../../agents/thinking-runtime.js";
+import { resolveLiveToolResultMaxChars } from "../../agents/tool-result-limits.js";
 import {
   deriveContextPromptTokens,
   hasNonzeroUsage,
@@ -67,6 +72,7 @@ import {
   hasAlreadyFlushedForCurrentCompaction,
   resolveMaxActiveTranscriptBytes,
   resolveMemoryFlushContextWindowTokens,
+  resolvePreflightCompactionThreshold,
   resolveResponsesServerCompactionThreshold,
   shouldRunMemoryFlush,
   shouldRunPreflightCompaction,
@@ -651,11 +657,82 @@ type TranscriptTokenEstimate = {
   transcriptBytesTokens?: number;
 };
 
+function toolResultTextLength(message: AgentMessage): number {
+  if ((message as { role?: string }).role !== "toolResult") {
+    return 0;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+  let total = 0;
+  for (const block of content) {
+    if (
+      block &&
+      typeof block === "object" &&
+      "text" in block &&
+      typeof (block as { text?: unknown }).text === "string"
+    ) {
+      total += (block as { text: string }).text.length;
+    }
+  }
+  return total;
+}
+
+/**
+ * Estimate transcript tokens the way the live prompt sees them: apply per-result
+ * and aggregate tool-result caps before counting. Raw disk tool dumps otherwise
+ * massively over-trigger preflight compaction.
+ */
+function estimateModelVisibleTranscriptTokens(
+  messages: AgentMessage[],
+  contextWindowTokens: number,
+): number | undefined {
+  if (messages.length === 0) {
+    return undefined;
+  }
+  const windowTokens = Math.max(1, Math.floor(contextWindowTokens));
+  const perResultMaxChars = resolveLiveToolResultMaxChars({
+    contextWindowTokens: windowTokens,
+  });
+  const aggregateMaxChars = resolveLiveToolResultAggregateMaxChars({
+    contextWindowTokens: windowTokens,
+    perResultMaxChars,
+  });
+
+  let capped = messages.map((message) =>
+    (message as { role?: string }).role === "toolResult"
+      ? truncateToolResultMessage(message, perResultMaxChars)
+      : message,
+  );
+
+  let toolChars = capped.reduce((sum, message) => sum + toolResultTextLength(message), 0);
+  if (toolChars > aggregateMaxChars) {
+    let remaining = toolChars - aggregateMaxChars;
+    capped = capped.map((message) => {
+      if (remaining <= 0 || (message as { role?: string }).role !== "toolResult") {
+        return message;
+      }
+      const length = toolResultTextLength(message);
+      if (length <= 0) {
+        return message;
+      }
+      const reduceBy = Math.min(length, remaining);
+      remaining -= reduceBy;
+      return truncateToolResultMessage(message, Math.max(0, length - reduceBy));
+    });
+  }
+
+  const tokens = estimateMessagesTokens(capped);
+  return Number.isFinite(tokens) && tokens > 0 ? Math.ceil(tokens) : undefined;
+}
+
 async function estimatePromptTokensFromSessionTranscript(params: {
   sessionId?: string;
   sessionEntry?: SessionEntry;
   sessionKey?: string;
   storePath?: string;
+  contextWindowTokens: number;
 }): Promise<TranscriptTokenEstimate | undefined> {
   const sessionId = normalizeOptionalString(params.sessionId);
   if (!sessionId) {
@@ -670,6 +747,8 @@ async function estimatePromptTokensFromSessionTranscript(params: {
       includeByteSize: true,
       includeUsage: true,
     });
+    // Byte/4 is only diagnostic for the optional maxActiveTranscriptBytes path —
+    // never treat it as a prompt-token estimate (JSON overhead false-triggers).
     const transcriptBytesTokens =
       typeof snapshot.byteSize === "number" &&
       Number.isFinite(snapshot.byteSize) &&
@@ -705,13 +784,10 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         maxBytes: 1024 * 1024,
       },
     )) as AgentMessage[];
-    const estimatedMessageTokens = (() => {
-      if (messages.length === 0) {
-        return undefined;
-      }
-      const tokens = estimateMessagesTokens(messages);
-      return Number.isFinite(tokens) && tokens > 0 ? Math.ceil(tokens) : undefined;
-    })();
+    const estimatedMessageTokens = estimateModelVisibleTranscriptTokens(
+      messages,
+      params.contextWindowTokens,
+    );
     if (typeof promptTokens === "number" && Number.isFinite(promptTokens) && promptTokens > 0) {
       const usagePromptTokens = Math.ceil(promptTokens) + (trailingBytesTokens ?? 0);
       return {
@@ -724,12 +800,11 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         transcriptBytesTokens,
       };
     }
-    const estimatedTokens = estimatedMessageTokens ?? transcriptBytesTokens;
-    if (estimatedTokens === undefined) {
+    if (estimatedMessageTokens === undefined) {
       return undefined;
     }
     return {
-      promptTokens: Math.ceil(estimatedTokens),
+      promptTokens: estimatedMessageTokens,
       transcriptByteSize: snapshot.byteSize,
       transcriptBytesTokens,
     };
@@ -752,6 +827,8 @@ export async function runPreflightCompactionIfNeeded(params: {
   storePath?: string;
   isHeartbeat: boolean;
   replyOperation: ReplyOperation;
+  /** Active chat/agent run id so Control UI compaction events correlate to the turn. */
+  runId?: string;
   onCompactionNotice?: (phase: CompactionNoticePhase) => Promise<void> | void;
 }): Promise<SessionEntry | undefined> {
   const deps = {
@@ -825,10 +902,10 @@ export async function runPreflightCompactionIfNeeded(params: {
     provider: params.followupRun.run.provider,
     modelId: params.followupRun.run.model ?? params.defaultModel,
   });
-  const threshold = Math.max(
-    contextWindowTokens - reserveTokensFloor - softThresholdTokens,
-    serverCompactionThreshold ?? 0,
-  );
+  const threshold = resolvePreflightCompactionThreshold({
+    contextWindowTokens,
+    minimumThresholdTokens: serverCompactionThreshold,
+  });
   const freshNeedsOutputRead =
     typeof freshPersistedTokens === "number" &&
     typeof promptTokenEstimate === "number" &&
@@ -844,6 +921,7 @@ export async function runPreflightCompactionIfNeeded(params: {
           sessionEntry: entry,
           sessionKey: params.sessionKey ?? params.followupRun.run.sessionKey,
           storePath: params.storePath,
+          contextWindowTokens,
         });
   const transcriptSizeSnapshot =
     shouldCheckActiveTranscriptBytes && transcriptUsageTokens?.transcriptByteSize === undefined
@@ -1004,6 +1082,7 @@ export async function runPreflightCompactionIfNeeded(params: {
       currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
       ownerNumbers: params.followupRun.run.ownerNumbers,
       abortSignal: params.replyOperation.abortSignal,
+      ...(params.runId ? { runId: params.runId } : {}),
     });
 
     if (!result?.ok) {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -828,6 +828,7 @@ export function createFollowupRunner(params: {
           storePath,
           isHeartbeat: opts?.isHeartbeat === true,
           replyOperation,
+          runId,
           onCompactionNotice: notifyPreflightCompaction,
         });
         preflightCompactionApplied =

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,10 +1,12 @@
-// Builds memory flush prompts when conversation context exceeds model budget.
+import { COMPACTION_CONTEXT_USAGE_RATIO } from "../../agents/agent-compaction-constants.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { legacyModelKey, modelKey } from "../../agents/model-ref-shared.js";
 import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+export { COMPACTION_CONTEXT_USAGE_RATIO };
 
 export function resolveMemoryFlushContextWindowTokens(params: {
   modelId?: string;
@@ -98,6 +100,8 @@ export function resolveResponsesServerCompactionThreshold(params: {
   return resolvePositiveIntegerParam(sources, "responsesCompactThreshold");
 }
 
+/** Preflight/threshold compaction fires once projected usage reaches this share of the window. */
+
 function resolveMemoryFlushGateState<
   TEntry extends Pick<SessionEntry, "totalTokens" | "totalTokensFresh">,
 >(params: {
@@ -131,6 +135,18 @@ function resolveMemoryFlushGateState<
   }
 
   return { entry: params.entry, totalTokens, threshold };
+}
+
+/** Token threshold for preflight compaction (~85% of the model context window). */
+export function resolvePreflightCompactionThreshold(params: {
+  contextWindowTokens: number;
+  minimumThresholdTokens?: number;
+}): number {
+  const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
+  return Math.max(
+    Math.floor(contextWindow * COMPACTION_CONTEXT_USAGE_RATIO),
+    Math.floor(params.minimumThresholdTokens ?? 0),
+  );
 }
 
 export function shouldRunMemoryFlush(params: {
@@ -169,12 +185,32 @@ export function shouldRunPreflightCompaction(params: {
    */
   tokenCount?: number;
   contextWindowTokens: number;
-  reserveTokensFloor: number;
-  softThresholdTokens: number;
+  /**
+   * @deprecated Unused for preflight compaction. Kept so call sites can share
+   * the memory-flush plan fields without a separate shape. Soft threshold only
+   * gates memory flush, not compaction.
+   */
+  reserveTokensFloor?: number;
+  /**
+   * @deprecated Unused for preflight compaction. Soft threshold only gates
+   * memory flush so compaction does not fire earlier than ~85% of the window.
+   */
+  softThresholdTokens?: number;
   minimumThresholdTokens?: number;
 }): boolean {
-  const state = resolveMemoryFlushGateState(params);
-  return Boolean(state && state.totalTokens >= state.threshold);
+  if (!params.entry) {
+    return false;
+  }
+  const totalTokens =
+    resolvePositiveTokenCount(params.tokenCount) ?? resolveFreshSessionTotalTokens(params.entry);
+  if (!totalTokens || totalTokens <= 0) {
+    return false;
+  }
+  const threshold = resolvePreflightCompactionThreshold({
+    contextWindowTokens: params.contextWindowTokens,
+    minimumThresholdTokens: params.minimumThresholdTokens,
+  });
+  return threshold > 0 && totalTokens >= threshold;
 }
 
 /**

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -398,16 +398,42 @@ describe("shouldRunPreflightCompaction", () => {
     ).toBe(false);
   });
 
-  it("triggers when a projected token count crosses the threshold", () => {
+  it("triggers when a projected token count crosses the 85% threshold", () => {
     expect(
       shouldRunPreflightCompaction({
         entry: { totalTokens: 10, totalTokensFresh: false },
-        tokenCount: 93_000,
+        tokenCount: 85_000,
         contextWindowTokens: 100_000,
         reserveTokensFloor: 5_000,
         softThresholdTokens: 2_000,
       }),
     ).toBe(true);
+  });
+
+  it("does not trigger below the 85% threshold", () => {
+    expect(
+      shouldRunPreflightCompaction({
+        entry: { totalTokens: 10, totalTokensFresh: false },
+        tokenCount: 84_999,
+        contextWindowTokens: 100_000,
+        reserveTokensFloor: 5_000,
+        softThresholdTokens: 2_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores softThresholdTokens for compaction gating", () => {
+    // Old formula window - reserve - soft would fire much earlier; soft must
+    // only affect memory flush, not preflight compaction.
+    expect(
+      shouldRunPreflightCompaction({
+        entry: { totalTokens: 10, totalTokensFresh: false },
+        tokenCount: 84_999,
+        contextWindowTokens: 100_000,
+        reserveTokensFloor: 1,
+        softThresholdTokens: 50_000,
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where compaction reserve tokens could disagree with the ~85% preflight usage gate, and context-engine compaction could hang or fail to surface a compacting state in Control UI.

## Why This Change Was Made

Aligns reserve calculation with `COMPACTION_CONTEXT_USAGE_RATIO`, hardens memory-flush / preflight compaction threshold helpers, and emits compaction start/end agent events from the context-engine safety-timeout path.

## User Impact

Compaction should trigger more predictably near context limits, and the UI can show when context-engine compaction is active.

## Evidence

- Compaction safety-timeout tests and reply-state / agent-settings coverage on the branch
