### PR TITLE
feat(agents): stream provisional tool progress for write and edit

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -31,6 +31,7 @@ import type {
   EmbeddedAgentSubscribeState,
 } from "./embedded-agent-subscribe.handlers.types.js";
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
+import { maybeEmitProvisionalMutationToolProgress } from "./embedded-agent-subscribe.provisional-tool-progress.js";
 import { appendRawStream } from "./embedded-agent-subscribe.raw-stream.js";
 import { warnIfAssistantEmittedSuspiciousText } from "./embedded-agent-subscribe.tool-text-diagnostics.js";
 import {
@@ -731,6 +732,17 @@ export function handleMessageUpdate(
       ? (assistantEvent as Record<string, unknown>)
       : undefined;
   const evtType = typeof assistantRecord?.type === "string" ? assistantRecord.type : "";
+
+  // Provisional write/edit progress must run even when commentary text is
+  // suppressed — otherwise long content streaming looks like a freeze.
+  if (evtType === "toolcall_start" || evtType === "toolcall_delta") {
+    maybeEmitProvisionalMutationToolProgress(ctx, {
+      message: msg,
+      assistantMessageEvent: assistantRecord,
+    });
+    return;
+  }
+
   const eventAssistantMessage =
     assistantRecord?.partial && typeof assistantRecord.partial === "object"
       ? (assistantRecord.partial as AssistantMessage)

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -82,6 +82,16 @@ export type EmbeddedAgentSubscribeState = {
   toolMetaById: Map<string, ToolCallSummary>;
   toolSummaryById: Set<string>;
   execLiveUpdateStateById?: Map<string, { lastEmittedAtMs: number }>;
+  /** Throttle/state for provisional write/edit tool-stream emits during arg streaming. */
+  provisionalToolStreamStateById?: Map<
+    string,
+    {
+      lastEmittedAtMs: number;
+      lastContentLength?: number;
+      started: boolean;
+      lastPath?: string;
+    }
+  >;
   itemActiveIds: Set<string>;
   itemStartedCount: number;
   itemCompletedCount: number;

--- a/src/agents/embedded-agent-subscribe.provisional-tool-progress.test.ts
+++ b/src/agents/embedded-agent-subscribe.provisional-tool-progress.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
+import * as agentEvents from "../infra/agent-events.js";
+import { handleMessageUpdate } from "./embedded-agent-subscribe.handlers.messages.js";
+import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
+import type { AgentMessage } from "./runtime/index.js";
+
+function createContext(
+  params: {
+    onAgentEvent?: ReturnType<typeof vi.fn>;
+    toolMetaById?: Map<string, unknown>;
+  } = {},
+): EmbeddedAgentSubscribeContext {
+  return {
+    params: {
+      runId: "run-1",
+      session: { id: "session-1" },
+      ...(params.onAgentEvent ? { onAgentEvent: params.onAgentEvent } : {}),
+    },
+    state: {
+      deterministicApprovalPromptPending: false,
+      deterministicApprovalPromptSent: false,
+      reasoningStreamOpen: false,
+      streamReasoning: false,
+      deltaBuffer: "",
+      blockBuffer: "",
+      partialBlockState: {
+        thinking: false,
+        final: false,
+        inlineCode: createInlineCodeState(),
+      },
+      lastStreamedAssistant: undefined,
+      lastStreamedAssistantCleaned: undefined,
+      emittedAssistantUpdate: false,
+      shouldEmitPartialReplies: true,
+      blockReplyBreak: "text_end",
+      assistantMessageIndex: 0,
+      assistantTexts: [],
+      toolMetaById: (params.toolMetaById ??
+        new Map()) as EmbeddedAgentSubscribeContext["state"]["toolMetaById"],
+      toolSummaryById: new Set(),
+      itemActiveIds: new Set(),
+      itemStartedCount: 0,
+      itemCompletedCount: 0,
+    },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+    noteLastAssistant: vi.fn(),
+    noteCompletedAssistant: vi.fn(),
+    stripBlockTags: vi.fn((text: string) => text),
+    consumePartialReplyDirectives: vi.fn(() => undefined),
+    emitAssistantStreamData: vi.fn(),
+    emitReasoningStream: vi.fn(),
+    shouldEmitToolResult: () => false,
+    emitToolSummary: vi.fn(),
+    flushBlockReplyBuffer: vi.fn(),
+    resetAssistantMessageState: vi.fn(),
+    recordAssistantUsage: vi.fn(),
+    commitAssistantUsage: vi.fn(),
+  } as unknown as EmbeddedAgentSubscribeContext;
+}
+
+function writePartialMessage(params: {
+  id: string;
+  path?: string;
+  content?: string;
+}): AgentMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "toolCall",
+        id: params.id,
+        name: "write",
+        arguments: {
+          ...(params.path ? { path: params.path } : {}),
+          ...(params.content !== undefined ? { content: params.content } : {}),
+        },
+      },
+    ],
+    stopReason: "stop",
+  } as AgentMessage;
+}
+
+describe("provisional mutation tool progress", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("emits start as soon as write tool name is known, before path appears", () => {
+    const emitSpy = vi.spyOn(agentEvents, "emitAgentEvent").mockImplementation(() => undefined);
+    const ctx = createContext();
+
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-write-early",
+            name: "write",
+            arguments: { content: "partial…" },
+          },
+        ],
+        stopReason: "stop",
+      },
+      assistantMessageEvent: { type: "toolcall_delta", contentIndex: 0 },
+    } as never);
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          phase: "start",
+          name: "write",
+          toolCallId: "call-write-early",
+          args: { content: "partial…" },
+        },
+      }),
+    );
+  });
+
+  it("emits start with path and content preview while write args stream", () => {
+    const emitSpy = vi.spyOn(agentEvents, "emitAgentEvent").mockImplementation(() => undefined);
+    const onAgentEvent = vi.fn();
+    const ctx = createContext({ onAgentEvent });
+
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: writePartialMessage({
+        id: "call-write-1",
+        path: "/tmp/foo.md",
+        content: "hello world",
+      }),
+      assistantMessageEvent: { type: "toolcall_delta", contentIndex: 0, delta: "…" },
+    } as never);
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "write",
+          toolCallId: "call-write-1",
+          args: { path: "/tmp/foo.md", content: "hello world" },
+        },
+      }),
+    );
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "tool",
+        data: expect.objectContaining({
+          phase: "start",
+          args: { path: "/tmp/foo.md", content: "hello world" },
+        }),
+      }),
+    );
+  });
+
+  it("throttles content updates and skips after real tool start", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-25T00:00:00.000Z"));
+    const emitSpy = vi.spyOn(agentEvents, "emitAgentEvent").mockImplementation(() => undefined);
+    const ctx = createContext();
+
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: writePartialMessage({
+        id: "call-write-2",
+        path: "/repo/a.md",
+        content: "a",
+      }),
+      assistantMessageEvent: { type: "toolcall_delta", contentIndex: 0 },
+    } as never);
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: writePartialMessage({
+        id: "call-write-2",
+        path: "/repo/a.md",
+        content: "ab",
+      }),
+      assistantMessageEvent: { type: "toolcall_delta", contentIndex: 0 },
+    } as never);
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(80);
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: writePartialMessage({
+        id: "call-write-2",
+        path: "/repo/a.md",
+        content: "abcd",
+      }),
+      assistantMessageEvent: { type: "toolcall_delta", contentIndex: 0 },
+    } as never);
+    expect(emitSpy).toHaveBeenCalledTimes(2);
+    expect(emitSpy.mock.calls[1]?.[0]?.data).toEqual({
+      phase: "update",
+      name: "write",
+      toolCallId: "call-write-2",
+      args: { path: "/repo/a.md", content: "abcd" },
+    });
+
+    ctx.state.toolMetaById.set("call-write-2", {
+      instanceReplaySafe: true,
+      replaySafe: true,
+      mutatingAction: true,
+    });
+    vi.advanceTimersByTime(80);
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: writePartialMessage({
+        id: "call-write-2",
+        path: "/repo/a.md",
+        content: "abcdef",
+      }),
+      assistantMessageEvent: { type: "toolcall_delta", contentIndex: 0 },
+    } as never);
+    expect(emitSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/embedded-agent-subscribe.provisional-tool-progress.ts
+++ b/src/agents/embedded-agent-subscribe.provisional-tool-progress.ts
@@ -1,0 +1,241 @@
+/**
+ * Emits throttled provisional `stream: "tool"` events while mutation-tool
+ * arguments are still streaming. Real `tool_execution_start` later replaces
+ * these with full sanitized args. Surfaces path + a bounded content preview
+ * so Control UI can show "Writing foo.md +N" and a live +diff viewport before
+ * disk I/O starts. Never emit contentLength — that leaks into KV tool shells.
+ */
+import { asOptionalObjectRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
+import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
+import type { AgentMessage } from "./runtime/index.js";
+import { normalizeToolName } from "./tool-policy.js";
+
+// Keep updates frequent enough for a typewriter feel without flooding WS.
+const LIVE_PROVISIONAL_TOOL_UPDATE_MIN_INTERVAL_MS = 80;
+// Prefer full content when small; otherwise send a trailing window so the
+// latest characters stay visible without shipping multi-MB arg payloads.
+const PROVISIONAL_CONTENT_PREVIEW_MAX_CHARS = 24_000;
+
+const MUTATION_STREAM_TOOL_NAMES = new Set([
+  "write",
+  "write_file",
+  "create_file",
+  "edit",
+  "edit_file",
+  "multiedit",
+  "multi_edit",
+  "apply_patch",
+  "applypatch",
+  "patch",
+  "str_replace_editor",
+  "str_replace_based_edit_tool",
+]);
+
+const CONTENT_LENGTH_ARG_KEYS = [
+  "content",
+  "newText",
+  "new_string",
+  "file_text",
+  "patch",
+  "input",
+] as const;
+
+export type ProvisionalToolStreamState = {
+  lastEmittedAtMs: number;
+  lastContentLength?: number;
+  started: boolean;
+  lastPath?: string;
+};
+
+function resolvePathArg(args: Record<string, unknown>): string | undefined {
+  return (
+    normalizeOptionalString(args.path) ??
+    normalizeOptionalString(args.file_path) ??
+    normalizeOptionalString(args.filePath) ??
+    normalizeOptionalString(args.file) ??
+    normalizeOptionalString(args.filepath) ??
+    normalizeOptionalString(args.filename) ??
+    normalizeOptionalString(args.notebook_path)
+  );
+}
+
+function resolveStreamingContentText(args: Record<string, unknown>): string | undefined {
+  for (const key of CONTENT_LENGTH_ARG_KEYS) {
+    const value = args[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function truncateProvisionalContentPreview(content: string): string {
+  if (content.length <= PROVISIONAL_CONTENT_PREVIEW_MAX_CHARS) {
+    return content;
+  }
+  return sliceUtf16Safe(content, -PROVISIONAL_CONTENT_PREVIEW_MAX_CHARS);
+}
+
+function resolveStreamingContentLength(args: Record<string, unknown>): number | undefined {
+  const explicit = args.contentLength;
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return Math.floor(explicit);
+  }
+  const content = resolveStreamingContentText(args);
+  if (content) {
+    return content.length;
+  }
+  return undefined;
+}
+
+function resolveStreamingToolCallBlock(
+  message: AgentMessage,
+  contentIndex: unknown,
+): { id: string; name: string; arguments: Record<string, unknown> } | undefined {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const index =
+    typeof contentIndex === "number" && Number.isInteger(contentIndex) && contentIndex >= 0
+      ? contentIndex
+      : undefined;
+  const candidates = index !== undefined ? [content[index]] : content.filter(Boolean).toReversed();
+  for (const block of candidates) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as {
+      type?: unknown;
+      id?: unknown;
+      name?: unknown;
+      arguments?: unknown;
+    };
+    if (record.type !== "toolCall" && record.type !== "functionCall") {
+      continue;
+    }
+    const id = normalizeOptionalString(record.id);
+    const name = normalizeOptionalString(record.name);
+    if (!id || !name) {
+      continue;
+    }
+    const args = asRecord(record.arguments) ?? {};
+    return { id, name, arguments: args };
+  }
+  return undefined;
+}
+
+function buildProvisionalMutationArgs(args: Record<string, unknown>): {
+  path?: string;
+  content?: string;
+} {
+  const path = resolvePathArg(args);
+  const contentText = resolveStreamingContentText(args);
+  // Do not ship contentLength — UI derives +N lines from content and must not
+  // fall through to a contentLength key/value dump.
+  return {
+    ...(path ? { path } : {}),
+    ...(contentText ? { content: truncateProvisionalContentPreview(contentText) } : {}),
+  };
+}
+
+function shouldEmitProvisionalUpdate(
+  previous: ProvisionalToolStreamState | undefined,
+  next: { path?: string; content?: string },
+  now: number,
+): boolean {
+  // toolcall_start / first delta: show Writing/Editing as soon as the tool name
+  // is known, even before path/content appear in partial JSON.
+  if (!previous?.started) {
+    return true;
+  }
+  if (next.path && previous.lastPath !== next.path) {
+    return true;
+  }
+  const nextLen = next.content?.length;
+  if (nextLen !== undefined && nextLen !== previous.lastContentLength) {
+    return now - previous.lastEmittedAtMs >= LIVE_PROVISIONAL_TOOL_UPDATE_MIN_INTERVAL_MS;
+  }
+  return false;
+}
+
+/** Emit provisional tool-stream progress for streaming write/edit/patch args. */
+export function maybeEmitProvisionalMutationToolProgress(
+  ctx: EmbeddedAgentSubscribeContext,
+  params: {
+    message: AgentMessage;
+    assistantMessageEvent?: Record<string, unknown>;
+  },
+): void {
+  const evtType =
+    typeof params.assistantMessageEvent?.type === "string" ? params.assistantMessageEvent.type : "";
+  if (evtType !== "toolcall_start" && evtType !== "toolcall_delta") {
+    return;
+  }
+
+  const toolCall = resolveStreamingToolCallBlock(
+    params.message,
+    params.assistantMessageEvent?.contentIndex,
+  );
+  if (!toolCall) {
+    return;
+  }
+
+  const toolName = normalizeToolName(toolCall.name);
+  if (!MUTATION_STREAM_TOOL_NAMES.has(toolName)) {
+    return;
+  }
+
+  // Real execution start already owns this call — do not race provisional args.
+  if (ctx.state.toolMetaById.has(toolCall.id)) {
+    return;
+  }
+
+  const provisional = buildProvisionalMutationArgs(toolCall.arguments);
+
+  const now = Date.now();
+  const state =
+    ctx.state.provisionalToolStreamStateById ?? new Map<string, ProvisionalToolStreamState>();
+  ctx.state.provisionalToolStreamStateById = state;
+  const previous = state.get(toolCall.id);
+  if (!shouldEmitProvisionalUpdate(previous, provisional, now)) {
+    return;
+  }
+
+  const phase = previous?.started ? "update" : "start";
+  state.set(toolCall.id, {
+    lastEmittedAtMs: now,
+    lastContentLength: provisional.content?.length ?? previous?.lastContentLength,
+    started: true,
+    lastPath: provisional.path ?? previous?.lastPath,
+  });
+
+  emitAgentEvent({
+    runId: ctx.params.runId,
+    stream: "tool",
+    data: {
+      phase,
+      name: toolName,
+      toolCallId: toolCall.id,
+      args: provisional,
+    },
+  });
+  runBestEffortCallback({
+    label: "provisional tool agent event",
+    log: ctx.log,
+    callback: () =>
+      ctx.params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          phase,
+          name: toolName,
+          toolCallId: toolCall.id,
+          args: provisional,
+        },
+      }),
+  });
+}

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -59,11 +59,12 @@ const replaceEditSchema = Type.Object(
 const editSchema = Type.Object(
   {
     path: Type.String({
-      description: "File path; relative/absolute.",
+      description:
+        "File path; relative/absolute. Emit this key first in the tool-call JSON (before edits) so the UI can show the target while edits stream.",
     }),
     edits: Type.Array(replaceEditSchema, {
       description:
-        "Targeted replacements against original file; no overlap/nesting. Merge nearby changes.",
+        "Targeted replacements against original file; no overlap/nesting. Merge nearby changes. Stream after path.",
     }),
   },
   {},
@@ -398,9 +399,10 @@ export function createEditToolDefinition(
     name: "edit",
     label: "edit",
     description:
-      "Exact single-file replacements. oldText unique/non-overlapping against original. Merge nearby changes; omit large unchanged spans.",
+      "Exact single-file replacements. oldText unique/non-overlapping against original. Merge nearby changes; omit large unchanged spans. Emit path before edits in the arguments JSON; the file is written only when the tool call completes.",
     promptSnippet: "Exact file edits; multiple disjoint edits per call",
     promptGuidelines: [
+      "In edit arguments JSON, emit path before edits so the target file is known while edits stream.",
       "oldText must match exactly",
       "Multiple disjoint locations: one call, multiple edits[]",
       "Match original file; no overlap/nesting; merge nearby",

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -33,9 +33,13 @@ import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const writeSchema = Type.Object({
   path: Type.String({
-    description: "File path; relative/absolute.",
+    description:
+      "File path; relative/absolute. Emit this key first in the tool-call JSON (before content) so the UI can show the target while content streams.",
   }),
-  content: Type.String({ description: "File content." }),
+  content: Type.String({
+    description:
+      "File content. Stream after path; the file is written only when the tool call completes.",
+  }),
 });
 
 const WriteToolOutputSchema = Type.Union([
@@ -534,9 +538,13 @@ export function createWriteToolDefinition(
   return {
     name: "write",
     label: "write",
-    description: "Write/overwrite file; creates parent directories.",
+    description:
+      "Write/overwrite file; creates parent directories. Emit path before content in the arguments JSON; the file is written only when the tool call completes.",
     promptSnippet: "Create/overwrite files",
-    promptGuidelines: ["Use only new files/complete rewrites."],
+    promptGuidelines: [
+      "Use only new files/complete rewrites.",
+      "In write arguments JSON, emit path before content so the target file is known while content streams.",
+    ],
     parameters: writeSchema,
     outputSchema: WriteToolOutputSchema,
     async execute(

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -274,6 +274,8 @@ function resolveWriteDetail(toolKey: string, args: unknown): string | undefined 
 
   const path = resolvePathArg(record) ?? normalizeOptionalString(record.url);
   if (!path) {
+    // Path-less streaming write/edit: the row/diff viewport owns progress.
+    // Do not emit "N chars" / contentLength details that leak into tool shells.
     return undefined;
   }
 
@@ -281,20 +283,8 @@ function resolveWriteDetail(toolKey: string, args: unknown): string | undefined 
     return `from ${path}`;
   }
 
+  // Path owns the detail; +N / live diff viewport carry content progress.
   const destinationPrefix = toolKey === "edit" ? "in" : "to";
-  const content =
-    typeof record.content === "string"
-      ? record.content
-      : typeof record.newText === "string"
-        ? record.newText
-        : typeof record.new_string === "string"
-          ? record.new_string
-          : undefined;
-
-  if (content && content.length > 0) {
-    return `${destinationPrefix} ${path} (${content.length} chars)`;
-  }
-
   return `${destinationPrefix} ${path}`;
 }
 

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -137,8 +137,37 @@ describe("tool display details", () => {
     );
 
     expect(readDetail).toBe("lines 2-3 from /tmp/a.txt");
-    expect(writeDetail).toBe("to /tmp/a.txt (3 chars)");
-    expect(editDetail).toBe("in /tmp/a.txt (4 chars)");
+    expect(writeDetail).toBe("to /tmp/a.txt");
+    expect(editDetail).toBe("in /tmp/a.txt");
+  });
+
+  it("omits contentLength from write/edit details (viewport owns progress)", () => {
+    const writeDetail = formatToolDetail(
+      resolveToolDisplay({
+        name: "write",
+        args: { path: "/tmp/a.txt", contentLength: 12_000 },
+      }),
+    );
+    const editDetail = formatToolDetail(
+      resolveToolDisplay({
+        name: "edit",
+        args: { path: "/tmp/a.txt", contentLength: 4 },
+      }),
+    );
+
+    expect(writeDetail).toBe("to /tmp/a.txt");
+    expect(editDetail).toBe("in /tmp/a.txt");
+  });
+
+  it("omits write details before path arrives", () => {
+    expect(
+      formatToolDetail(
+        resolveToolDisplay({
+          name: "write",
+          args: { contentLength: 1089, content: "partial…" },
+        }),
+      ),
+    ).toBeUndefined();
   });
 
   it("formats web_search query with quotes", () => {


### PR DESCRIPTION
## What Problem This Solves

Long-running write/edit tool calls often stayed opaque until completion, so users could not see provisional progress while files were being streamed.

## Why This Change Was Made

Adds provisional tool-progress handling in the embedded agent subscribe path and streams live write/edit argument updates so tool cards can show in-progress mutation state.

## User Impact

Write/edit tool activity can surface live progress in Control UI instead of only a final result.

## Evidence

- Tests in `embedded-agent-subscribe.provisional-tool-progress.test.ts` and tool-display coverage

## Notes

Pairs with Control UI PR https://github.com/openclaw/openclaw/pull/113511