### PR TITLE
refactor(net): extract guarded one-hop dispatch boundary

### DIFF
--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -22,7 +22,11 @@ import {
 } from "./one-hop-fetch-dispatcher.js";
 import { shouldUseEnvHttpProxyForUrl } from "./proxy-env.js";
 import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } from "./redirect-headers.js";
-import { fetchWithRuntimeDispatcher, isMockedFetch } from "./runtime-fetch.js";
+import {
+  fetchWithRuntimeDispatcher,
+  isMockedFetch,
+  type DispatcherAwareRequestInit,
+} from "./runtime-fetch.js";
 import {
   assertHostnameAllowedWithPolicy,
   buildNetworkGuardProfileV1,
@@ -650,7 +654,6 @@ async function fetchWithSsrFGuardInternal(
       const init: OneHopFetchRequest["init"] = {
         ...(currentInit ? { ...currentInit } : {}),
         redirect: "manual",
-        ...(dispatcher ? { dispatcher } : {}),
         ...(signal ? { signal } : {}),
       };
 
@@ -666,9 +669,18 @@ async function fetchWithSsrFGuardInternal(
       // because the default global fetch path will not honor per-request
       // dispatchers.
       const shouldUseRuntimeFetch = Boolean(dispatcher) && !supportsDispatcherInit;
-      const oneHopDispatcher: OneHopFetchDispatcher = createLocalOneHopFetchDispatcher(
-        shouldUseRuntimeFetch ? fetchWithRuntimeDispatcher : defaultFetch,
-      );
+      const localFetch = async (url: string, requestInit: OneHopFetchRequest["init"]) => {
+        const localInit: DispatcherAwareRequestInit = {
+          ...requestInit,
+          ...(dispatcher ? { dispatcher } : {}),
+        };
+        return shouldUseRuntimeFetch
+          ? await fetchWithRuntimeDispatcher(url, localInit)
+          : await defaultFetch(url, localInit);
+      };
+      const oneHopDispatcher: OneHopFetchDispatcher = createLocalOneHopFetchDispatcher(localFetch, {
+        hasPreparedDispatcher: Boolean(dispatcher),
+      });
       const response = await oneHopDispatcher.dispatch({
         url: parsedUrl.toString(),
         init,

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -25,6 +25,7 @@ import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } 
 import { fetchWithRuntimeDispatcher, isMockedFetch } from "./runtime-fetch.js";
 import {
   assertHostnameAllowedWithPolicy,
+  buildNetworkGuardProfileV1,
   closeDispatcher,
   createPinnedDispatcher,
   matchesHostnameAllowlist,
@@ -581,6 +582,8 @@ async function fetchWithSsrFGuardInternal(
         !usesTrustedExplicitProxyMode &&
         params.pinDns !== false;
       const timeoutMs = resolveDispatcherTimeoutMs(params.timeoutMs);
+      let routeMode: Parameters<typeof buildNetworkGuardProfileV1>[0]["routeMode"];
+      let resolutionMode: Parameters<typeof buildNetworkGuardProfileV1>[0]["resolutionMode"];
 
       // Trusted env-proxy, managed proxy, and pinDns=false can skip local DNS
       // pinning, so keep the pre-DNS hostname/IP policy checks from the pinned path.
@@ -589,36 +592,60 @@ async function fetchWithSsrFGuardInternal(
       }
 
       if (canUseTrustedEnvProxy) {
+        routeMode = "environment-proxy";
+        resolutionMode = "proxy";
         dispatcher = createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
       } else if (canUseManagedProxy) {
+        routeMode = "managed-proxy";
+        resolutionMode = "proxy";
         if (shouldCheckManagedProxyBypass) {
           const pinned = await resolvePinnedHostname();
-          dispatcher = shouldUseConfiguredLocalOriginManagedProxyBypass({
+          const useDirectBypass = shouldUseConfiguredLocalOriginManagedProxyBypass({
             url: parsedUrl,
             managedProxyBypass: params.managedProxyBypass,
             resolvedAddresses: pinned.addresses,
-          })
-            ? createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs)
-            : createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
+          });
+          if (useDirectBypass) {
+            routeMode = "direct";
+            resolutionMode = "pinned";
+            dispatcher = createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
+          } else {
+            dispatcher = createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
+          }
         } else {
           dispatcher = createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
         }
       } else if (usesTrustedExplicitProxyMode) {
+        routeMode = "explicit-proxy";
+        resolutionMode = "proxy";
         // Explicit proxy targets are still checked against the caller's hostname
         // policy, but the proxy does the DNS resolution for the final target.
         assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl);
         dispatcher = createPolicyDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
       } else if (canUseMockedFetchWithoutDns) {
+        routeMode = "direct";
+        resolutionMode = "caller";
         // Test-installed fetch mocks should stay hermetic. Host/IP policy still runs;
         // real fetches continue through pinned DNS below.
         assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl);
       } else if (params.pinDns === false) {
+        routeMode = "direct";
+        resolutionMode = "caller";
         await resolvePinnedHostname();
         dispatcher = createPolicyDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
       } else {
+        routeMode = "direct";
+        resolutionMode = "pinned";
         const pinned = await resolvePinnedHostname();
         dispatcher = createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
       }
+
+      const networkGuard = buildNetworkGuardProfileV1({
+        url: parsedUrl,
+        policy: policyForUrl,
+        routeMode,
+        resolutionMode,
+      });
 
       const init: OneHopFetchRequest["init"] = {
         ...(currentInit ? { ...currentInit } : {}),
@@ -645,6 +672,7 @@ async function fetchWithSsrFGuardInternal(
       const response = await oneHopDispatcher.dispatch({
         url: parsedUrl.toString(),
         init,
+        networkGuard,
       });
       const capturedByGlobalFetchPatch =
         !shouldUseRuntimeFetch &&

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -14,13 +14,15 @@ import {
   shouldResolveConfiguredLocalOriginManagedProxyBypass,
   type ConfiguredLocalOriginManagedProxyBypass,
 } from "./configured-local-origin-bypass.js";
+import {
+  createLocalOneHopFetchDispatcher,
+  type FetchLike,
+  type OneHopFetchDispatcher,
+  type OneHopFetchRequest,
+} from "./one-hop-fetch-dispatcher.js";
 import { shouldUseEnvHttpProxyForUrl } from "./proxy-env.js";
 import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } from "./redirect-headers.js";
-import {
-  fetchWithRuntimeDispatcher,
-  isMockedFetch,
-  type DispatcherAwareRequestInit,
-} from "./runtime-fetch.js";
+import { fetchWithRuntimeDispatcher, isMockedFetch } from "./runtime-fetch.js";
 import {
   assertHostnameAllowedWithPolicy,
   closeDispatcher,
@@ -51,8 +53,6 @@ function resolveDispatcherTimeoutMs(fromParams: number | undefined): number | un
   }
   return undefined;
 }
-
-type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
 export const GUARDED_FETCH_MODE = {
   STRICT: "strict",
@@ -620,7 +620,7 @@ async function fetchWithSsrFGuardInternal(
         dispatcher = createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
       }
 
-      const init: DispatcherAwareRequestInit = {
+      const init: OneHopFetchRequest["init"] = {
         ...(currentInit ? { ...currentInit } : {}),
         redirect: "manual",
         ...(dispatcher ? { dispatcher } : {}),
@@ -639,9 +639,13 @@ async function fetchWithSsrFGuardInternal(
       // because the default global fetch path will not honor per-request
       // dispatchers.
       const shouldUseRuntimeFetch = Boolean(dispatcher) && !supportsDispatcherInit;
-      const response = shouldUseRuntimeFetch
-        ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
-        : await defaultFetch(parsedUrl.toString(), init);
+      const oneHopDispatcher: OneHopFetchDispatcher = createLocalOneHopFetchDispatcher(
+        shouldUseRuntimeFetch ? fetchWithRuntimeDispatcher : defaultFetch,
+      );
+      const response = await oneHopDispatcher.dispatch({
+        url: parsedUrl.toString(),
+        init,
+      });
       const capturedByGlobalFetchPatch =
         !shouldUseRuntimeFetch &&
         isAmbientGlobalFetch({

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -14,7 +14,10 @@ import {
   shouldResolveConfiguredLocalOriginManagedProxyBypass,
   type ConfiguredLocalOriginManagedProxyBypass,
 } from "./configured-local-origin-bypass.js";
-import { buildNetworkGuardProfileV1 } from "./network-guard-profile-builder.js";
+import {
+  buildNetworkGuardProfileV1,
+  resolvePinnedNetworkGuardRouteV1,
+} from "./network-guard-profile-builder.js";
 import {
   createLocalOneHopFetchDispatcher,
   type FetchLike,
@@ -638,8 +641,7 @@ async function fetchWithSsrFGuardInternal(
         await resolvePinnedHostname();
         dispatcher = createPolicyDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
       } else {
-        routeMode = "direct";
-        resolutionMode = "pinned";
+        ({ routeMode, resolutionMode } = resolvePinnedNetworkGuardRouteV1(dispatcherPolicy));
         const pinned = await resolvePinnedHostname();
         dispatcher = createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
       }

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -14,6 +14,7 @@ import {
   shouldResolveConfiguredLocalOriginManagedProxyBypass,
   type ConfiguredLocalOriginManagedProxyBypass,
 } from "./configured-local-origin-bypass.js";
+import { buildNetworkGuardProfileV1 } from "./network-guard-profile-builder.js";
 import {
   createLocalOneHopFetchDispatcher,
   type FetchLike,
@@ -29,7 +30,6 @@ import {
 } from "./runtime-fetch.js";
 import {
   assertHostnameAllowedWithPolicy,
-  buildNetworkGuardProfileV1,
   closeDispatcher,
   createPinnedDispatcher,
   matchesHostnameAllowlist,

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -16,7 +16,7 @@ import {
 } from "./configured-local-origin-bypass.js";
 import {
   buildNetworkGuardProfileV1,
-  resolvePinnedNetworkGuardRouteV1,
+  resolveNetworkGuardRouteV1,
 } from "./network-guard-profile-builder.js";
 import {
   createLocalOneHopFetchDispatcher,
@@ -636,12 +636,11 @@ async function fetchWithSsrFGuardInternal(
         // real fetches continue through pinned DNS below.
         assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl);
       } else if (params.pinDns === false) {
-        routeMode = "direct";
-        resolutionMode = "caller";
+        ({ routeMode, resolutionMode } = resolveNetworkGuardRouteV1(dispatcherPolicy, "caller"));
         await resolvePinnedHostname();
         dispatcher = createPolicyDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
       } else {
-        ({ routeMode, resolutionMode } = resolvePinnedNetworkGuardRouteV1(dispatcherPolicy));
+        ({ routeMode, resolutionMode } = resolveNetworkGuardRouteV1(dispatcherPolicy, "pinned"));
         const pinned = await resolvePinnedHostname();
         dispatcher = createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
       }

--- a/src/infra/net/network-guard-profile-builder.ts
+++ b/src/infra/net/network-guard-profile-builder.ts
@@ -18,19 +18,20 @@ function normalizePolicyHostnames(values?: string[]): string[] {
   return normalizeUniqueStringEntries(values?.map((value) => normalizeHostname(value)));
 }
 
-export function resolvePinnedNetworkGuardRouteV1(
-  dispatcherPolicy?: Pick<PinnedDispatcherPolicy, "mode">,
+export function resolveNetworkGuardRouteV1(
+  dispatcherPolicy: Pick<PinnedDispatcherPolicy, "mode"> | undefined,
+  resolutionMode: NetworkGuardResolutionMode,
 ): {
   routeMode: NetworkGuardRouteMode;
   resolutionMode: NetworkGuardResolutionMode;
 } {
   if (dispatcherPolicy?.mode === "env-proxy") {
-    return { routeMode: "environment-proxy", resolutionMode: "pinned" };
+    return { routeMode: "environment-proxy", resolutionMode };
   }
   if (dispatcherPolicy?.mode === "explicit-proxy") {
-    return { routeMode: "explicit-proxy", resolutionMode: "pinned" };
+    return { routeMode: "explicit-proxy", resolutionMode };
   }
-  return { routeMode: "direct", resolutionMode: "pinned" };
+  return { routeMode: "direct", resolutionMode };
 }
 
 export function buildNetworkGuardProfileV1(params: {

--- a/src/infra/net/network-guard-profile-builder.ts
+++ b/src/infra/net/network-guard-profile-builder.ts
@@ -10,11 +10,27 @@ import {
 import {
   isPrivateNetworkAllowedByPolicy,
   normalizeHostnameAllowlist,
+  type PinnedDispatcherPolicy,
   type SsrFPolicy,
 } from "./ssrf.js";
 
 function normalizePolicyHostnames(values?: string[]): string[] {
   return normalizeUniqueStringEntries(values?.map((value) => normalizeHostname(value)));
+}
+
+export function resolvePinnedNetworkGuardRouteV1(
+  dispatcherPolicy?: Pick<PinnedDispatcherPolicy, "mode">,
+): {
+  routeMode: NetworkGuardRouteMode;
+  resolutionMode: NetworkGuardResolutionMode;
+} {
+  if (dispatcherPolicy?.mode === "env-proxy") {
+    return { routeMode: "environment-proxy", resolutionMode: "proxy" };
+  }
+  if (dispatcherPolicy?.mode === "explicit-proxy") {
+    return { routeMode: "explicit-proxy", resolutionMode: "proxy" };
+  }
+  return { routeMode: "direct", resolutionMode: "pinned" };
 }
 
 export function buildNetworkGuardProfileV1(params: {

--- a/src/infra/net/network-guard-profile-builder.ts
+++ b/src/infra/net/network-guard-profile-builder.ts
@@ -25,10 +25,10 @@ export function resolvePinnedNetworkGuardRouteV1(
   resolutionMode: NetworkGuardResolutionMode;
 } {
   if (dispatcherPolicy?.mode === "env-proxy") {
-    return { routeMode: "environment-proxy", resolutionMode: "proxy" };
+    return { routeMode: "environment-proxy", resolutionMode: "pinned" };
   }
   if (dispatcherPolicy?.mode === "explicit-proxy") {
-    return { routeMode: "explicit-proxy", resolutionMode: "proxy" };
+    return { routeMode: "explicit-proxy", resolutionMode: "pinned" };
   }
   return { routeMode: "direct", resolutionMode: "pinned" };
 }

--- a/src/infra/net/network-guard-profile-builder.ts
+++ b/src/infra/net/network-guard-profile-builder.ts
@@ -1,0 +1,74 @@
+import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { normalizeHostname } from "./hostname.js";
+import {
+  NETWORK_GUARD_PROFILE_VERSION,
+  type NetworkGuardAddressMode,
+  type NetworkGuardProfileV1,
+  type NetworkGuardResolutionMode,
+  type NetworkGuardRouteMode,
+} from "./network-guard-profile.js";
+import {
+  isPrivateNetworkAllowedByPolicy,
+  normalizeHostnameAllowlist,
+  type SsrFPolicy,
+} from "./ssrf.js";
+
+function normalizePolicyHostnames(values?: string[]): string[] {
+  return normalizeUniqueStringEntries(values?.map((value) => normalizeHostname(value)));
+}
+
+export function buildNetworkGuardProfileV1(params: {
+  url: URL;
+  policy?: SsrFPolicy;
+  routeMode: NetworkGuardRouteMode;
+  resolutionMode: NetworkGuardResolutionMode;
+  allowedPrivateCidrs?: string[];
+}): NetworkGuardProfileV1 {
+  const hostname = normalizeHostname(params.url.hostname);
+  if (!hostname) {
+    throw new Error("Invalid network guard profile hostname");
+  }
+  const trustedHostnames = normalizePolicyHostnames(params.policy?.allowedHostnames);
+  const addressMode: NetworkGuardAddressMode = isPrivateNetworkAllowedByPolicy(params.policy)
+    ? "allow-private-network"
+    : trustedHostnames.includes(hostname)
+      ? "trusted-host"
+      : "public-only";
+  return {
+    version: NETWORK_GUARD_PROFILE_VERSION,
+    target: {
+      protocol: params.url.protocol as "http:" | "https:",
+      origin: params.url.origin,
+      hostname,
+      port: params.url.port
+        ? Number.parseInt(params.url.port, 10)
+        : params.url.protocol === "https:"
+          ? 443
+          : 80,
+    },
+    route: {
+      mode: params.routeMode,
+      resolution: params.resolutionMode,
+      tls: params.url.protocol === "https:" ? "required" : "cleartext",
+    },
+    addressPolicy: {
+      mode: addressMode,
+      trustedHostnames,
+      hostnameAllowlist: [
+        ...normalizeHostnameAllowlist(params.policy?.hostnameAllowlist),
+      ].toSorted(),
+      allowedPrivateCidrs: normalizeUniqueStringEntries(params.allowedPrivateCidrs).toSorted(),
+      allowRfc2544BenchmarkRange: params.policy?.allowRfc2544BenchmarkRange === true,
+      allowIpv6UniqueLocalRange: params.policy?.allowIpv6UniqueLocalRange === true,
+      dnsRebinding: {
+        policy: "reject",
+        enforcement:
+          params.resolutionMode === "pinned"
+            ? "local-pinned"
+            : params.resolutionMode === "proxy"
+              ? "connection-owner-required"
+              : "not-enforced",
+      },
+    },
+  };
+}

--- a/src/infra/net/network-guard-profile.fixtures.test.ts
+++ b/src/infra/net/network-guard-profile.fixtures.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import networkGuardFixtures from "../../../test/fixtures/network-guard-profile-v1.json" with { type: "json" };
 import {
+  assertNetworkGuardProfileV1,
+  NETWORK_GUARD_PROFILE_VERSION,
+} from "./network-guard-profile.js";
+import {
+  buildNetworkGuardProfileV1,
   resolvePinnedHostnameWithPolicy,
   resolveSsrFPolicyForUrl,
   type LookupFn,
@@ -25,10 +30,24 @@ function createLookup(addresses: string[]): LookupFn {
 }
 
 describe("network guard profile v1 fixtures", () => {
+  it("declares the supported serialized profile version", () => {
+    expect(networkGuardFixtures.version).toBe(NETWORK_GUARD_PROFILE_VERSION);
+  });
+
   for (const fixture of networkGuardFixtures.cases as FixtureCase[]) {
     it(fixture.id, async () => {
       const url = new URL(fixture.url);
       const policy = resolveSsrFPolicyForUrl(url, fixture.policy);
+      const encodedProfile = JSON.stringify(
+        buildNetworkGuardProfileV1({
+          url,
+          policy,
+          routeMode: "direct",
+          resolutionMode: "pinned",
+        }),
+      );
+      const serializedProfile: unknown = JSON.parse(encodedProfile);
+      expect(() => assertNetworkGuardProfileV1(serializedProfile)).not.toThrow();
       const attempts = fixture.resolutionSequence.map((addresses) =>
         resolvePinnedHostnameWithPolicy(url.hostname, {
           lookupFn: createLookup(addresses),

--- a/src/infra/net/network-guard-profile.fixtures.test.ts
+++ b/src/infra/net/network-guard-profile.fixtures.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import networkGuardFixtures from "../../../test/fixtures/network-guard-profile-v1.json" with { type: "json" };
+import {
+  resolvePinnedHostnameWithPolicy,
+  resolveSsrFPolicyForUrl,
+  type LookupFn,
+  type SsrFPolicy,
+} from "./ssrf.js";
+
+type FixtureCase = {
+  id: string;
+  url: string;
+  policy: SsrFPolicy;
+  resolutionSequence: string[][];
+  expected: "allow" | "deny" | "deny-on-second-resolution";
+};
+
+function createLookup(addresses: string[]): LookupFn {
+  return vi.fn(async () =>
+    addresses.map((address) => ({
+      address,
+      family: address.includes(":") ? 6 : 4,
+    })),
+  ) as unknown as LookupFn;
+}
+
+describe("network guard profile v1 fixtures", () => {
+  for (const fixture of networkGuardFixtures.cases as FixtureCase[]) {
+    it(fixture.id, async () => {
+      const url = new URL(fixture.url);
+      const policy = resolveSsrFPolicyForUrl(url, fixture.policy);
+      const attempts = fixture.resolutionSequence.map((addresses) =>
+        resolvePinnedHostnameWithPolicy(url.hostname, {
+          lookupFn: createLookup(addresses),
+          policy,
+        }),
+      );
+
+      if (fixture.expected === "allow") {
+        await expect(attempts[0]).resolves.toBeDefined();
+        return;
+      }
+      if (fixture.expected === "deny") {
+        await expect(attempts[0]).rejects.toThrow(/blocked|private|internal/i);
+        return;
+      }
+      await expect(attempts[0]).resolves.toBeDefined();
+      await expect(attempts[1]).rejects.toThrow(/blocked|private|internal/i);
+    });
+  }
+});

--- a/src/infra/net/network-guard-profile.fixtures.test.ts
+++ b/src/infra/net/network-guard-profile.fixtures.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import networkGuardFixtures from "../../../test/fixtures/network-guard-profile-v1.json" with { type: "json" };
+import { buildNetworkGuardProfileV1 } from "./network-guard-profile-builder.js";
 import {
   assertNetworkGuardProfileV1,
   NETWORK_GUARD_PROFILE_VERSION,
 } from "./network-guard-profile.js";
 import {
-  buildNetworkGuardProfileV1,
   resolvePinnedHostnameWithPolicy,
   resolveSsrFPolicyForUrl,
   type LookupFn,

--- a/src/infra/net/network-guard-profile.test.ts
+++ b/src/infra/net/network-guard-profile.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   assertLocalNetworkGuardPrepared,
+  assertNetworkGuardProfileV1,
   assertNetworkGuardProfileTarget,
   NETWORK_GUARD_PROFILE_VERSION,
   type NetworkGuardProfileV1,
@@ -34,6 +35,11 @@ function createProfile(): NetworkGuardProfileV1 {
       },
     },
   };
+}
+
+function serializeProfile(): Record<string, unknown> {
+  const encoded = JSON.stringify(createProfile());
+  return JSON.parse(encoded) as Record<string, unknown>;
 }
 
 describe("network guard profile", () => {
@@ -127,6 +133,54 @@ describe("network guard profile", () => {
     ).toThrow(/does not match/i);
   });
 
+  it("accepts a complete serialized v1 profile", () => {
+    expect(() => assertNetworkGuardProfileV1(serializeProfile())).not.toThrow();
+  });
+
+  it.each([
+    {
+      name: "unknown fields",
+      mutate: (profile: Record<string, unknown>) => {
+        profile.futureField = true;
+      },
+      expected: /unsupported network guard profile shape/i,
+    },
+    {
+      name: "target TLS mismatch",
+      mutate: (profile: Record<string, unknown>) => {
+        (profile.route as Record<string, unknown>).tls = "cleartext";
+      },
+      expected: /TLS posture is inconsistent/i,
+    },
+    {
+      name: "route and resolution mismatch",
+      mutate: (profile: Record<string, unknown>) => {
+        (profile.route as Record<string, unknown>).mode = "explicit-proxy";
+      },
+      expected: /resolution is inconsistent with the route/i,
+    },
+    {
+      name: "non-string policy arrays",
+      mutate: (profile: Record<string, unknown>) => {
+        (profile.addressPolicy as Record<string, unknown>).allowedPrivateCidrs = [10];
+      },
+      expected: /invalid network guard allowed private CIDRs/i,
+    },
+    {
+      name: "DNS enforcement mismatch",
+      mutate: (profile: Record<string, unknown>) => {
+        const policy = profile.addressPolicy as Record<string, unknown>;
+        (policy.dnsRebinding as Record<string, unknown>).enforcement = "connection-owner-required";
+      },
+      expected: /DNS rebinding enforcement is inconsistent/i,
+    },
+  ])("rejects serialized profiles with $name", ({ mutate, expected }) => {
+    const profile = serializeProfile();
+    mutate(profile);
+
+    expect(() => assertNetworkGuardProfileV1(profile)).toThrow(expected);
+  });
+
   it("requires prepared pinned dispatch state for local execution", () => {
     const profile = createProfile();
     expect(() =>
@@ -155,6 +209,6 @@ describe("network guard profile", () => {
         requestUrl: "https://api.example.com/v1",
         hasDispatcher: true,
       }),
-    ).toThrow(/does not match resolution mode/i);
+    ).toThrow(/DNS rebinding enforcement is inconsistent/i);
   });
 });

--- a/src/infra/net/network-guard-profile.test.ts
+++ b/src/infra/net/network-guard-profile.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertLocalNetworkGuardPrepared,
+  assertNetworkGuardProfileTarget,
+  NETWORK_GUARD_PROFILE_VERSION,
+  type NetworkGuardProfileV1,
+} from "./network-guard-profile.js";
+import { buildNetworkGuardProfileV1, resolveSsrFPolicyForUrl } from "./ssrf.js";
+
+function createProfile(): NetworkGuardProfileV1 {
+  return {
+    version: NETWORK_GUARD_PROFILE_VERSION,
+    target: {
+      protocol: "https:",
+      origin: "https://api.example.com",
+      hostname: "api.example.com",
+      port: 443,
+    },
+    route: {
+      mode: "direct",
+      resolution: "pinned",
+      tls: "required",
+    },
+    addressPolicy: {
+      mode: "public-only",
+      trustedHostnames: [],
+      hostnameAllowlist: ["api.example.com"],
+      allowedPrivateCidrs: [],
+      allowRfc2544BenchmarkRange: false,
+      allowIpv6UniqueLocalRange: false,
+      dnsRebinding: {
+        policy: "reject",
+        enforcement: "local-pinned",
+      },
+    },
+  };
+}
+
+describe("network guard profile", () => {
+  it("derives a fixed public profile for the local pinned path", () => {
+    const profile = buildNetworkGuardProfileV1({
+      url: new URL("https://API.EXAMPLE.COM/v1"),
+      policy: { hostnameAllowlist: ["api.example.com"] },
+      routeMode: "direct",
+      resolutionMode: "pinned",
+    });
+
+    expect(profile).toEqual({
+      version: NETWORK_GUARD_PROFILE_VERSION,
+      target: {
+        protocol: "https:",
+        origin: "https://api.example.com",
+        hostname: "api.example.com",
+        port: 443,
+      },
+      route: {
+        mode: "direct",
+        resolution: "pinned",
+        tls: "required",
+      },
+      addressPolicy: {
+        mode: "public-only",
+        trustedHostnames: [],
+        hostnameAllowlist: ["api.example.com"],
+        allowedPrivateCidrs: [],
+        allowRfc2544BenchmarkRange: false,
+        allowIpv6UniqueLocalRange: false,
+        dnsRebinding: {
+          policy: "reject",
+          enforcement: "local-pinned",
+        },
+      },
+    });
+  });
+
+  it("limits exact-origin private trust to the matching redirect hop", () => {
+    const policy = { allowedOrigins: ["http://10.0.0.5:11434"] };
+    const firstUrl = new URL("http://10.0.0.5:11434/v1");
+    const firstProfile = buildNetworkGuardProfileV1({
+      url: firstUrl,
+      policy: resolveSsrFPolicyForUrl(firstUrl, policy),
+      routeMode: "direct",
+      resolutionMode: "pinned",
+    });
+    const redirectedUrl = new URL("http://10.0.0.6:11434/v1");
+    const redirectedProfile = buildNetworkGuardProfileV1({
+      url: redirectedUrl,
+      policy: resolveSsrFPolicyForUrl(redirectedUrl, policy),
+      routeMode: "direct",
+      resolutionMode: "pinned",
+    });
+
+    expect(firstProfile.addressPolicy.mode).toBe("trusted-host");
+    expect(redirectedProfile.addressPolicy.mode).toBe("public-only");
+  });
+
+  it("represents proxy resolution, TLS, and managed private CIDRs without executable policy", () => {
+    const profile = buildNetworkGuardProfileV1({
+      url: new URL("https://private.example:8443/v1"),
+      policy: { allowPrivateNetwork: true },
+      routeMode: "explicit-proxy",
+      resolutionMode: "proxy",
+      allowedPrivateCidrs: ["10.20.0.0/16", " 10.10.0.0/16 "],
+    });
+
+    expect(profile.route).toEqual({
+      mode: "explicit-proxy",
+      resolution: "proxy",
+      tls: "required",
+    });
+    expect(profile.addressPolicy).toMatchObject({
+      mode: "allow-private-network",
+      allowedPrivateCidrs: ["10.10.0.0/16", "10.20.0.0/16"],
+      dnsRebinding: {
+        policy: "reject",
+        enforcement: "connection-owner-required",
+      },
+    });
+  });
+  it("binds the profile to the exact request origin and normalized hostname", () => {
+    const profile = createProfile();
+    expect(() =>
+      assertNetworkGuardProfileTarget(profile, "https://API.EXAMPLE.COM/v1"),
+    ).not.toThrow();
+    expect(() =>
+      assertNetworkGuardProfileTarget(profile, "https://api.example.com:8443/v1"),
+    ).toThrow(/does not match/i);
+  });
+
+  it("requires prepared pinned dispatch state for local execution", () => {
+    const profile = createProfile();
+    expect(() =>
+      assertLocalNetworkGuardPrepared({
+        profile,
+        requestUrl: "https://api.example.com/v1",
+        hasDispatcher: false,
+      }),
+    ).toThrow(/prepared local dispatcher/i);
+    expect(() =>
+      assertLocalNetworkGuardPrepared({
+        profile,
+        requestUrl: "https://api.example.com/v1",
+        hasDispatcher: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects rebinding enforcement claims that do not match resolution ownership", () => {
+    const profile = createProfile();
+    profile.addressPolicy.dnsRebinding.enforcement = "connection-owner-required";
+
+    expect(() =>
+      assertLocalNetworkGuardPrepared({
+        profile,
+        requestUrl: "https://api.example.com/v1",
+        hasDispatcher: true,
+      }),
+    ).toThrow(/does not match resolution mode/i);
+  });
+});

--- a/src/infra/net/network-guard-profile.test.ts
+++ b/src/infra/net/network-guard-profile.test.ts
@@ -205,6 +205,13 @@ describe("network guard profile", () => {
       expected: /unsupported network guard profile shape/i,
     },
     {
+      name: "non-normalized target hostname",
+      mutate: (profile: Record<string, unknown>) => {
+        (profile.target as Record<string, unknown>).hostname = "API.EXAMPLE.COM.";
+      },
+      expected: /hostname must be normalized/i,
+    },
+    {
       name: "target TLS mismatch",
       mutate: (profile: Record<string, unknown>) => {
         (profile.route as Record<string, unknown>).tls = "cleartext";

--- a/src/infra/net/network-guard-profile.test.ts
+++ b/src/infra/net/network-guard-profile.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { buildNetworkGuardProfileV1 } from "./network-guard-profile-builder.js";
 import {
   assertLocalNetworkGuardPrepared,
   assertNetworkGuardProfileV1,
@@ -6,7 +7,7 @@ import {
   NETWORK_GUARD_PROFILE_VERSION,
   type NetworkGuardProfileV1,
 } from "./network-guard-profile.js";
-import { buildNetworkGuardProfileV1, resolveSsrFPolicyForUrl } from "./ssrf.js";
+import { resolveSsrFPolicyForUrl } from "./ssrf.js";
 
 function createProfile(): NetworkGuardProfileV1 {
   return {

--- a/src/infra/net/network-guard-profile.test.ts
+++ b/src/infra/net/network-guard-profile.test.ts
@@ -138,14 +138,31 @@ describe("network guard profile", () => {
     },
     {
       dispatcherPolicy: { mode: "env-proxy" as const },
-      expected: { routeMode: "environment-proxy", resolutionMode: "proxy" },
+      expected: { routeMode: "environment-proxy", resolutionMode: "pinned" },
     },
     {
       dispatcherPolicy: { mode: "explicit-proxy" as const },
-      expected: { routeMode: "explicit-proxy", resolutionMode: "proxy" },
+      expected: { routeMode: "explicit-proxy", resolutionMode: "pinned" },
     },
   ])("derives pinned route ownership for $expected.routeMode", ({ dispatcherPolicy, expected }) => {
     expect(resolvePinnedNetworkGuardRouteV1(dispatcherPolicy)).toEqual(expected);
+  });
+
+  it("accepts proxy routing with locally pinned target resolution", () => {
+    const profile = buildNetworkGuardProfileV1({
+      url: new URL("https://api.example.com/v1"),
+      routeMode: "explicit-proxy",
+      resolutionMode: "pinned",
+    });
+
+    expect(() => assertNetworkGuardProfileV1(profile)).not.toThrow();
+    expect(() =>
+      assertLocalNetworkGuardPrepared({
+        profile,
+        requestUrl: "https://api.example.com/v1",
+        hasDispatcher: true,
+      }),
+    ).not.toThrow();
   });
 
   it("binds the profile to the exact request origin and normalized hostname", () => {
@@ -180,7 +197,7 @@ describe("network guard profile", () => {
     {
       name: "route and resolution mismatch",
       mutate: (profile: Record<string, unknown>) => {
-        (profile.route as Record<string, unknown>).mode = "explicit-proxy";
+        (profile.route as Record<string, unknown>).resolution = "proxy";
       },
       expected: /resolution is inconsistent with the route/i,
     },

--- a/src/infra/net/network-guard-profile.test.ts
+++ b/src/infra/net/network-guard-profile.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildNetworkGuardProfileV1,
-  resolvePinnedNetworkGuardRouteV1,
+  resolveNetworkGuardRouteV1,
 } from "./network-guard-profile-builder.js";
 import {
   assertLocalNetworkGuardPrepared,
@@ -130,23 +130,30 @@ describe("network guard profile", () => {
   it.each([
     {
       dispatcherPolicy: undefined,
+      resolutionMode: "pinned" as const,
       expected: { routeMode: "direct", resolutionMode: "pinned" },
     },
     {
       dispatcherPolicy: { mode: "direct" as const },
-      expected: { routeMode: "direct", resolutionMode: "pinned" },
+      resolutionMode: "caller" as const,
+      expected: { routeMode: "direct", resolutionMode: "caller" },
     },
     {
       dispatcherPolicy: { mode: "env-proxy" as const },
+      resolutionMode: "pinned" as const,
       expected: { routeMode: "environment-proxy", resolutionMode: "pinned" },
     },
     {
       dispatcherPolicy: { mode: "explicit-proxy" as const },
-      expected: { routeMode: "explicit-proxy", resolutionMode: "pinned" },
+      resolutionMode: "caller" as const,
+      expected: { routeMode: "explicit-proxy", resolutionMode: "caller" },
     },
-  ])("derives pinned route ownership for $expected.routeMode", ({ dispatcherPolicy, expected }) => {
-    expect(resolvePinnedNetworkGuardRouteV1(dispatcherPolicy)).toEqual(expected);
-  });
+  ])(
+    "derives independent route and resolution ownership for $expected.routeMode",
+    ({ dispatcherPolicy, resolutionMode, expected }) => {
+      expect(resolveNetworkGuardRouteV1(dispatcherPolicy, resolutionMode)).toEqual(expected);
+    },
+  );
 
   it("accepts proxy routing with locally pinned target resolution", () => {
     const profile = buildNetworkGuardProfileV1({
@@ -163,6 +170,16 @@ describe("network guard profile", () => {
         hasDispatcher: true,
       }),
     ).not.toThrow();
+  });
+
+  it("accepts proxy routing with caller-owned target resolution", () => {
+    const profile = buildNetworkGuardProfileV1({
+      url: new URL("https://api.example.com/v1"),
+      routeMode: "explicit-proxy",
+      resolutionMode: "caller",
+    });
+
+    expect(() => assertNetworkGuardProfileV1(profile)).not.toThrow();
   });
 
   it("binds the profile to the exact request origin and normalized hostname", () => {

--- a/src/infra/net/network-guard-profile.test.ts
+++ b/src/infra/net/network-guard-profile.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildNetworkGuardProfileV1 } from "./network-guard-profile-builder.js";
+import {
+  buildNetworkGuardProfileV1,
+  resolvePinnedNetworkGuardRouteV1,
+} from "./network-guard-profile-builder.js";
 import {
   assertLocalNetworkGuardPrepared,
   assertNetworkGuardProfileV1,
@@ -124,6 +127,27 @@ describe("network guard profile", () => {
       },
     });
   });
+  it.each([
+    {
+      dispatcherPolicy: undefined,
+      expected: { routeMode: "direct", resolutionMode: "pinned" },
+    },
+    {
+      dispatcherPolicy: { mode: "direct" as const },
+      expected: { routeMode: "direct", resolutionMode: "pinned" },
+    },
+    {
+      dispatcherPolicy: { mode: "env-proxy" as const },
+      expected: { routeMode: "environment-proxy", resolutionMode: "proxy" },
+    },
+    {
+      dispatcherPolicy: { mode: "explicit-proxy" as const },
+      expected: { routeMode: "explicit-proxy", resolutionMode: "proxy" },
+    },
+  ])("derives pinned route ownership for $expected.routeMode", ({ dispatcherPolicy, expected }) => {
+    expect(resolvePinnedNetworkGuardRouteV1(dispatcherPolicy)).toEqual(expected);
+  });
+
   it("binds the profile to the exact request origin and normalized hostname", () => {
     const profile = createProfile();
     expect(() =>

--- a/src/infra/net/network-guard-profile.ts
+++ b/src/infra/net/network-guard-profile.ts
@@ -1,0 +1,86 @@
+import { normalizeHostname } from "./hostname.js";
+
+export const NETWORK_GUARD_PROFILE_VERSION = "network-guard/v1" as const;
+
+export type NetworkGuardRouteMode =
+  | "direct"
+  | "environment-proxy"
+  | "explicit-proxy"
+  | "managed-proxy";
+
+export type NetworkGuardResolutionMode = "pinned" | "proxy" | "caller";
+
+export type NetworkGuardAddressMode = "public-only" | "trusted-host" | "allow-private-network";
+
+export type NetworkGuardProfileV1 = {
+  version: typeof NETWORK_GUARD_PROFILE_VERSION;
+  target: {
+    protocol: "http:" | "https:";
+    origin: string;
+    hostname: string;
+    port: number;
+  };
+  route: {
+    mode: NetworkGuardRouteMode;
+    resolution: NetworkGuardResolutionMode;
+    tls: "required" | "cleartext";
+  };
+  addressPolicy: {
+    mode: NetworkGuardAddressMode;
+    trustedHostnames: string[];
+    hostnameAllowlist: string[];
+    allowedPrivateCidrs: string[];
+    allowRfc2544BenchmarkRange: boolean;
+    allowIpv6UniqueLocalRange: boolean;
+    dnsRebinding: {
+      policy: "reject";
+      enforcement: "local-pinned" | "connection-owner-required" | "not-enforced";
+    };
+  };
+};
+
+function resolveUrlPort(url: URL): number {
+  if (url.port) {
+    return Number.parseInt(url.port, 10);
+  }
+  return url.protocol === "https:" ? 443 : 80;
+}
+
+export function assertNetworkGuardProfileTarget(
+  profile: NetworkGuardProfileV1,
+  requestUrl: string,
+): void {
+  if (profile.version !== NETWORK_GUARD_PROFILE_VERSION) {
+    throw new Error(`Unsupported network guard profile version: ${profile.version}`);
+  }
+  const parsed = new URL(requestUrl);
+  const hostname = normalizeHostname(parsed.hostname);
+  if (
+    parsed.protocol !== profile.target.protocol ||
+    parsed.origin !== profile.target.origin ||
+    hostname !== profile.target.hostname ||
+    resolveUrlPort(parsed) !== profile.target.port
+  ) {
+    throw new Error("Network guard profile target does not match one-hop request URL");
+  }
+}
+
+export function assertLocalNetworkGuardPrepared(params: {
+  profile: NetworkGuardProfileV1;
+  requestUrl: string;
+  hasDispatcher: boolean;
+}): void {
+  assertNetworkGuardProfileTarget(params.profile, params.requestUrl);
+  const expectedEnforcement =
+    params.profile.route.resolution === "pinned"
+      ? "local-pinned"
+      : params.profile.route.resolution === "proxy"
+        ? "connection-owner-required"
+        : "not-enforced";
+  if (params.profile.addressPolicy.dnsRebinding.enforcement !== expectedEnforcement) {
+    throw new Error("Network guard DNS rebinding enforcement does not match resolution mode");
+  }
+  if (expectedEnforcement === "local-pinned" && !params.hasDispatcher) {
+    throw new Error("Pinned network guard profile requires a prepared local dispatcher");
+  }
+}

--- a/src/infra/net/network-guard-profile.ts
+++ b/src/infra/net/network-guard-profile.ts
@@ -39,6 +39,59 @@ export type NetworkGuardProfileV1 = {
   };
 };
 
+const PROFILE_KEYS = ["version", "target", "route", "addressPolicy"] as const;
+const TARGET_KEYS = ["protocol", "origin", "hostname", "port"] as const;
+const ROUTE_KEYS = ["mode", "resolution", "tls"] as const;
+const ADDRESS_POLICY_KEYS = [
+  "mode",
+  "trustedHostnames",
+  "hostnameAllowlist",
+  "allowedPrivateCidrs",
+  "allowRfc2544BenchmarkRange",
+  "allowIpv6UniqueLocalRange",
+  "dnsRebinding",
+] as const;
+const DNS_REBINDING_KEYS = ["policy", "enforcement"] as const;
+
+function assertRecord(value: unknown, label: string): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Unsupported ${label} shape`);
+  }
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[],
+  label: string,
+): void {
+  const actualKeys = Object.keys(value).toSorted();
+  const sortedExpectedKeys = [...expectedKeys].toSorted();
+  if (
+    actualKeys.length !== sortedExpectedKeys.length ||
+    actualKeys.some((key, index) => key !== sortedExpectedKeys[index])
+  ) {
+    throw new Error(`Unsupported ${label} shape`);
+  }
+}
+
+function assertNonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Invalid ${label}`);
+  }
+}
+
+function assertStringArray(value: unknown, label: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error(`Invalid ${label}`);
+  }
+}
+
+function assertBoolean(value: unknown, label: string): asserts value is boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`Invalid ${label}`);
+  }
+}
+
 function resolveUrlPort(url: URL): number {
   if (url.port) {
     return Number.parseInt(url.port, 10);
@@ -46,13 +99,118 @@ function resolveUrlPort(url: URL): number {
   return url.protocol === "https:" ? 443 : 80;
 }
 
+export function assertNetworkGuardProfileV1(
+  profile: unknown,
+): asserts profile is NetworkGuardProfileV1 {
+  assertRecord(profile, "network guard profile");
+  assertExactKeys(profile, PROFILE_KEYS, "network guard profile");
+  if (profile.version !== NETWORK_GUARD_PROFILE_VERSION) {
+    throw new Error(`Unsupported network guard profile version: ${String(profile.version)}`);
+  }
+
+  assertRecord(profile.target, "network guard target");
+  assertExactKeys(profile.target, TARGET_KEYS, "network guard target");
+  if (profile.target.protocol !== "http:" && profile.target.protocol !== "https:") {
+    throw new Error("Invalid network guard target protocol");
+  }
+  assertNonEmptyString(profile.target.origin, "network guard target origin");
+  assertNonEmptyString(profile.target.hostname, "network guard target hostname");
+  if (
+    typeof profile.target.port !== "number" ||
+    !Number.isInteger(profile.target.port) ||
+    profile.target.port < 1 ||
+    profile.target.port > 65_535
+  ) {
+    throw new Error("Invalid network guard target port");
+  }
+  let parsedOrigin: URL;
+  try {
+    parsedOrigin = new URL(profile.target.origin);
+  } catch {
+    throw new Error("Invalid network guard target origin");
+  }
+  if (
+    parsedOrigin.origin !== profile.target.origin ||
+    parsedOrigin.protocol !== profile.target.protocol ||
+    normalizeHostname(parsedOrigin.hostname) !== normalizeHostname(profile.target.hostname) ||
+    resolveUrlPort(parsedOrigin) !== profile.target.port
+  ) {
+    throw new Error("Network guard target origin is inconsistent");
+  }
+
+  assertRecord(profile.route, "network guard route");
+  assertExactKeys(profile.route, ROUTE_KEYS, "network guard route");
+  const routeModes: readonly unknown[] = [
+    "direct",
+    "environment-proxy",
+    "explicit-proxy",
+    "managed-proxy",
+  ];
+  if (!routeModes.includes(profile.route.mode)) {
+    throw new Error("Invalid network guard route mode");
+  }
+  const resolutionModes: readonly unknown[] = ["pinned", "proxy", "caller"];
+  if (!resolutionModes.includes(profile.route.resolution)) {
+    throw new Error("Invalid network guard resolution mode");
+  }
+  if (profile.route.tls !== "required" && profile.route.tls !== "cleartext") {
+    throw new Error("Invalid network guard TLS posture");
+  }
+  const expectedTls = profile.target.protocol === "https:" ? "required" : "cleartext";
+  if (profile.route.tls !== expectedTls) {
+    throw new Error("Network guard route TLS posture is inconsistent with the target");
+  }
+  const usesProxyRoute = profile.route.mode !== "direct";
+  if ((profile.route.resolution === "proxy") !== usesProxyRoute) {
+    throw new Error("Network guard resolution is inconsistent with the route");
+  }
+
+  assertRecord(profile.addressPolicy, "network guard address policy");
+  assertExactKeys(profile.addressPolicy, ADDRESS_POLICY_KEYS, "network guard address policy");
+  const addressModes: readonly unknown[] = ["public-only", "trusted-host", "allow-private-network"];
+  if (!addressModes.includes(profile.addressPolicy.mode)) {
+    throw new Error("Invalid network guard address policy mode");
+  }
+  assertStringArray(profile.addressPolicy.trustedHostnames, "network guard trusted hostnames");
+  assertStringArray(profile.addressPolicy.hostnameAllowlist, "network guard hostname allowlist");
+  assertStringArray(
+    profile.addressPolicy.allowedPrivateCidrs,
+    "network guard allowed private CIDRs",
+  );
+  assertBoolean(
+    profile.addressPolicy.allowRfc2544BenchmarkRange,
+    "network guard RFC 2544 benchmark-range flag",
+  );
+  assertBoolean(
+    profile.addressPolicy.allowIpv6UniqueLocalRange,
+    "network guard IPv6 unique-local-range flag",
+  );
+
+  assertRecord(profile.addressPolicy.dnsRebinding, "network guard DNS rebinding policy");
+  assertExactKeys(
+    profile.addressPolicy.dnsRebinding,
+    DNS_REBINDING_KEYS,
+    "network guard DNS rebinding policy",
+  );
+  if (profile.addressPolicy.dnsRebinding.policy !== "reject") {
+    throw new Error("Invalid network guard DNS rebinding policy");
+  }
+  const expectedEnforcement =
+    profile.route.resolution === "pinned"
+      ? "local-pinned"
+      : profile.route.resolution === "proxy"
+        ? "connection-owner-required"
+        : "not-enforced";
+  if (profile.addressPolicy.dnsRebinding.enforcement !== expectedEnforcement) {
+    throw new Error("Network guard DNS rebinding enforcement is inconsistent");
+  }
+}
+
 export function assertNetworkGuardProfileTarget(
   profile: NetworkGuardProfileV1,
   requestUrl: string,
 ): void {
-  if (profile.version !== NETWORK_GUARD_PROFILE_VERSION) {
-    throw new Error(`Unsupported network guard profile version: ${profile.version}`);
-  }
+  assertNetworkGuardProfileV1(profile);
   const parsed = new URL(requestUrl);
   const hostname = normalizeHostname(parsed.hostname);
   if (

--- a/src/infra/net/network-guard-profile.ts
+++ b/src/infra/net/network-guard-profile.ts
@@ -161,10 +161,7 @@ export function assertNetworkGuardProfileV1(
     throw new Error("Network guard route TLS posture is inconsistent with the target");
   }
   const usesProxyRoute = profile.route.mode !== "direct";
-  if (
-    (profile.route.resolution === "proxy" && !usesProxyRoute) ||
-    (profile.route.resolution === "caller" && usesProxyRoute)
-  ) {
+  if (profile.route.resolution === "proxy" && !usesProxyRoute) {
     throw new Error("Network guard resolution is inconsistent with the route");
   }
 

--- a/src/infra/net/network-guard-profile.ts
+++ b/src/infra/net/network-guard-profile.ts
@@ -115,6 +115,10 @@ export function assertNetworkGuardProfileV1(
   }
   assertNonEmptyString(profile.target.origin, "network guard target origin");
   assertNonEmptyString(profile.target.hostname, "network guard target hostname");
+  const normalizedTargetHostname = normalizeHostname(profile.target.hostname);
+  if (normalizedTargetHostname !== profile.target.hostname) {
+    throw new Error("Network guard target hostname must be normalized");
+  }
   if (
     typeof profile.target.port !== "number" ||
     !Number.isInteger(profile.target.port) ||
@@ -132,7 +136,7 @@ export function assertNetworkGuardProfileV1(
   if (
     parsedOrigin.origin !== profile.target.origin ||
     parsedOrigin.protocol !== profile.target.protocol ||
-    normalizeHostname(parsedOrigin.hostname) !== normalizeHostname(profile.target.hostname) ||
+    normalizeHostname(parsedOrigin.hostname) !== normalizedTargetHostname ||
     resolveUrlPort(parsedOrigin) !== profile.target.port
   ) {
     throw new Error("Network guard target origin is inconsistent");

--- a/src/infra/net/network-guard-profile.ts
+++ b/src/infra/net/network-guard-profile.ts
@@ -161,7 +161,10 @@ export function assertNetworkGuardProfileV1(
     throw new Error("Network guard route TLS posture is inconsistent with the target");
   }
   const usesProxyRoute = profile.route.mode !== "direct";
-  if ((profile.route.resolution === "proxy") !== usesProxyRoute) {
+  if (
+    (profile.route.resolution === "proxy" && !usesProxyRoute) ||
+    (profile.route.resolution === "caller" && usesProxyRoute)
+  ) {
     throw new Error("Network guard resolution is inconsistent with the route");
   }
 

--- a/src/infra/net/one-hop-fetch-dispatcher.test.ts
+++ b/src/infra/net/one-hop-fetch-dispatcher.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLocalOneHopFetchDispatcher } from "./one-hop-fetch-dispatcher.js";
+
+describe("createLocalOneHopFetchDispatcher", () => {
+  it("delegates one manual-redirect exchange and preserves HTTP responses", async () => {
+    const response = new Response("rate limited", { status: 429 });
+    const fetchImpl = vi.fn().mockResolvedValue(response);
+    const dispatcher = createLocalOneHopFetchDispatcher(fetchImpl);
+    const signal = new AbortController().signal;
+
+    await expect(
+      dispatcher.dispatch({
+        url: "https://public.example/resource",
+        init: {
+          method: "POST",
+          redirect: "manual",
+          signal,
+        },
+      }),
+    ).resolves.toBe(response);
+    expect(fetchImpl).toHaveBeenCalledWith("https://public.example/resource", {
+      method: "POST",
+      redirect: "manual",
+      signal,
+    });
+  });
+
+  it("propagates transport failures unchanged", async () => {
+    const transportError = new Error("socket closed");
+    const dispatcher = createLocalOneHopFetchDispatcher(vi.fn().mockRejectedValue(transportError));
+
+    await expect(
+      dispatcher.dispatch({
+        url: "https://public.example/resource",
+        init: { redirect: "manual" },
+      }),
+    ).rejects.toBe(transportError);
+  });
+});

--- a/src/infra/net/one-hop-fetch-dispatcher.test.ts
+++ b/src/infra/net/one-hop-fetch-dispatcher.test.ts
@@ -74,4 +74,21 @@ describe("createLocalOneHopFetchDispatcher", () => {
       }),
     ).rejects.toBe(transportError);
   });
+
+  it("keeps local dispatcher state outside the portable request", async () => {
+    const fetchImpl = vi.fn(async () => new Response("ok"));
+    const dispatcher = createLocalOneHopFetchDispatcher(fetchImpl, {
+      hasPreparedDispatcher: true,
+    });
+    const request = {
+      url: "https://public.example/resource",
+      init: { redirect: "manual" as const },
+      networkGuard: createNetworkGuard("pinned"),
+    };
+
+    await dispatcher.dispatch(request);
+
+    expect(request.init).toEqual({ redirect: "manual" });
+    expect(fetchImpl).toHaveBeenCalledWith(request.url, request.init);
+  });
 });

--- a/src/infra/net/one-hop-fetch-dispatcher.test.ts
+++ b/src/infra/net/one-hop-fetch-dispatcher.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  NETWORK_GUARD_PROFILE_VERSION,
+  type NetworkGuardProfileV1,
+} from "./network-guard-profile.js";
 import { createLocalOneHopFetchDispatcher } from "./one-hop-fetch-dispatcher.js";
+
+function createNetworkGuard(
+  resolution: NetworkGuardProfileV1["route"]["resolution"] = "caller",
+): NetworkGuardProfileV1 {
+  return {
+    version: NETWORK_GUARD_PROFILE_VERSION,
+    target: {
+      protocol: "https:",
+      origin: "https://public.example",
+      hostname: "public.example",
+      port: 443,
+    },
+    route: { mode: "direct", resolution, tls: "required" },
+    addressPolicy: {
+      mode: "public-only",
+      trustedHostnames: [],
+      hostnameAllowlist: [],
+      allowedPrivateCidrs: [],
+      allowRfc2544BenchmarkRange: false,
+      allowIpv6UniqueLocalRange: false,
+      dnsRebinding: {
+        policy: "reject",
+        enforcement:
+          resolution === "pinned"
+            ? "local-pinned"
+            : resolution === "proxy"
+              ? "connection-owner-required"
+              : "not-enforced",
+      },
+    },
+  };
+}
 
 describe("createLocalOneHopFetchDispatcher", () => {
   it("delegates one manual-redirect exchange and preserves HTTP responses", async () => {
@@ -16,6 +52,7 @@ describe("createLocalOneHopFetchDispatcher", () => {
           redirect: "manual",
           signal,
         },
+        networkGuard: createNetworkGuard(),
       }),
     ).resolves.toBe(response);
     expect(fetchImpl).toHaveBeenCalledWith("https://public.example/resource", {
@@ -33,6 +70,7 @@ describe("createLocalOneHopFetchDispatcher", () => {
       dispatcher.dispatch({
         url: "https://public.example/resource",
         init: { redirect: "manual" },
+        networkGuard: createNetworkGuard(),
       }),
     ).rejects.toBe(transportError);
   });

--- a/src/infra/net/one-hop-fetch-dispatcher.ts
+++ b/src/infra/net/one-hop-fetch-dispatcher.ts
@@ -1,0 +1,22 @@
+import type { DispatcherAwareRequestInit } from "./runtime-fetch.js";
+
+export type OneHopFetchRequest = {
+  url: string;
+  init: DispatcherAwareRequestInit & { redirect: "manual" };
+};
+
+export type OneHopFetchDispatcher = {
+  dispatch: (request: OneHopFetchRequest) => Promise<Response>;
+};
+
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type LocalOneHopFetch = (url: string, init: OneHopFetchRequest["init"]) => Promise<Response>;
+
+export function createLocalOneHopFetchDispatcher(
+  fetchImpl: LocalOneHopFetch,
+): OneHopFetchDispatcher {
+  return {
+    dispatch: async ({ url, init }) => await fetchImpl(url, init),
+  };
+}

--- a/src/infra/net/one-hop-fetch-dispatcher.ts
+++ b/src/infra/net/one-hop-fetch-dispatcher.ts
@@ -2,11 +2,10 @@ import {
   assertLocalNetworkGuardPrepared,
   type NetworkGuardProfileV1,
 } from "./network-guard-profile.js";
-import type { DispatcherAwareRequestInit } from "./runtime-fetch.js";
 
 export type OneHopFetchRequest = {
   url: string;
-  init: DispatcherAwareRequestInit & { redirect: "manual" };
+  init: RequestInit & { redirect: "manual" };
   networkGuard: NetworkGuardProfileV1;
 };
 
@@ -20,13 +19,14 @@ type LocalOneHopFetch = (url: string, init: OneHopFetchRequest["init"]) => Promi
 
 export function createLocalOneHopFetchDispatcher(
   fetchImpl: LocalOneHopFetch,
+  options: { hasPreparedDispatcher?: boolean } = {},
 ): OneHopFetchDispatcher {
   return {
     dispatch: async ({ url, init, networkGuard }) => {
       assertLocalNetworkGuardPrepared({
         profile: networkGuard,
         requestUrl: url,
-        hasDispatcher: Boolean(init.dispatcher),
+        hasDispatcher: options.hasPreparedDispatcher === true,
       });
       return await fetchImpl(url, init);
     },

--- a/src/infra/net/one-hop-fetch-dispatcher.ts
+++ b/src/infra/net/one-hop-fetch-dispatcher.ts
@@ -1,8 +1,13 @@
+import {
+  assertLocalNetworkGuardPrepared,
+  type NetworkGuardProfileV1,
+} from "./network-guard-profile.js";
 import type { DispatcherAwareRequestInit } from "./runtime-fetch.js";
 
 export type OneHopFetchRequest = {
   url: string;
   init: DispatcherAwareRequestInit & { redirect: "manual" };
+  networkGuard: NetworkGuardProfileV1;
 };
 
 export type OneHopFetchDispatcher = {
@@ -17,6 +22,13 @@ export function createLocalOneHopFetchDispatcher(
   fetchImpl: LocalOneHopFetch,
 ): OneHopFetchDispatcher {
   return {
-    dispatch: async ({ url, init }) => await fetchImpl(url, init),
+    dispatch: async ({ url, init, networkGuard }) => {
+      assertLocalNetworkGuardPrepared({
+        profile: networkGuard,
+        requestUrl: url,
+        hasDispatcher: Boolean(init.dispatcher),
+      });
+      return await fetchImpl(url, init);
+    },
   };
 }

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -22,6 +22,13 @@ import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/strin
 import type { Dispatcher } from "undici";
 import { normalizeHostname } from "./hostname.js";
 import {
+  NETWORK_GUARD_PROFILE_VERSION,
+  type NetworkGuardAddressMode,
+  type NetworkGuardProfileV1,
+  type NetworkGuardResolutionMode,
+  type NetworkGuardRouteMode,
+} from "./network-guard-profile.js";
+import {
   createHttp1Agent,
   createHttp1EnvHttpProxyAgent,
   createHttp1ProxyAgent,
@@ -253,6 +260,62 @@ export function resolveSsrFPolicyForUrl(url: URL, policy?: SsrFPolicy): SsrFPoli
     allowedHostnames: Array.from(
       new Set([...(policy.allowedHostnames ?? []), normalizeHostname(url.hostname)]),
     ),
+  };
+}
+
+export function buildNetworkGuardProfileV1(params: {
+  url: URL;
+  policy?: SsrFPolicy;
+  routeMode: NetworkGuardRouteMode;
+  resolutionMode: NetworkGuardResolutionMode;
+  allowedPrivateCidrs?: string[];
+}): NetworkGuardProfileV1 {
+  const hostname = normalizeHostname(params.url.hostname);
+  if (!hostname) {
+    throw new Error("Invalid network guard profile hostname");
+  }
+  const trustedHostnames = normalizeSsrFPolicyHostnames(params.policy?.allowedHostnames);
+  const addressMode: NetworkGuardAddressMode = isPrivateNetworkAllowedByPolicy(params.policy)
+    ? "allow-private-network"
+    : trustedHostnames.includes(hostname)
+      ? "trusted-host"
+      : "public-only";
+  return {
+    version: NETWORK_GUARD_PROFILE_VERSION,
+    target: {
+      protocol: params.url.protocol as "http:" | "https:",
+      origin: params.url.origin,
+      hostname,
+      port: params.url.port
+        ? Number.parseInt(params.url.port, 10)
+        : params.url.protocol === "https:"
+          ? 443
+          : 80,
+    },
+    route: {
+      mode: params.routeMode,
+      resolution: params.resolutionMode,
+      tls: params.url.protocol === "https:" ? "required" : "cleartext",
+    },
+    addressPolicy: {
+      mode: addressMode,
+      trustedHostnames,
+      hostnameAllowlist: [
+        ...normalizeHostnameAllowlist(params.policy?.hostnameAllowlist),
+      ].toSorted(),
+      allowedPrivateCidrs: normalizeUniqueStringEntries(params.allowedPrivateCidrs).toSorted(),
+      allowRfc2544BenchmarkRange: params.policy?.allowRfc2544BenchmarkRange === true,
+      allowIpv6UniqueLocalRange: params.policy?.allowIpv6UniqueLocalRange === true,
+      dnsRebinding: {
+        policy: "reject",
+        enforcement:
+          params.resolutionMode === "pinned"
+            ? "local-pinned"
+            : params.resolutionMode === "proxy"
+              ? "connection-owner-required"
+              : "not-enforced",
+      },
+    },
   };
 }
 

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -22,13 +22,6 @@ import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/strin
 import type { Dispatcher } from "undici";
 import { normalizeHostname } from "./hostname.js";
 import {
-  NETWORK_GUARD_PROFILE_VERSION,
-  type NetworkGuardAddressMode,
-  type NetworkGuardProfileV1,
-  type NetworkGuardResolutionMode,
-  type NetworkGuardRouteMode,
-} from "./network-guard-profile.js";
-import {
   createHttp1Agent,
   createHttp1EnvHttpProxyAgent,
   createHttp1ProxyAgent,
@@ -260,62 +253,6 @@ export function resolveSsrFPolicyForUrl(url: URL, policy?: SsrFPolicy): SsrFPoli
     allowedHostnames: Array.from(
       new Set([...(policy.allowedHostnames ?? []), normalizeHostname(url.hostname)]),
     ),
-  };
-}
-
-export function buildNetworkGuardProfileV1(params: {
-  url: URL;
-  policy?: SsrFPolicy;
-  routeMode: NetworkGuardRouteMode;
-  resolutionMode: NetworkGuardResolutionMode;
-  allowedPrivateCidrs?: string[];
-}): NetworkGuardProfileV1 {
-  const hostname = normalizeHostname(params.url.hostname);
-  if (!hostname) {
-    throw new Error("Invalid network guard profile hostname");
-  }
-  const trustedHostnames = normalizeSsrFPolicyHostnames(params.policy?.allowedHostnames);
-  const addressMode: NetworkGuardAddressMode = isPrivateNetworkAllowedByPolicy(params.policy)
-    ? "allow-private-network"
-    : trustedHostnames.includes(hostname)
-      ? "trusted-host"
-      : "public-only";
-  return {
-    version: NETWORK_GUARD_PROFILE_VERSION,
-    target: {
-      protocol: params.url.protocol as "http:" | "https:",
-      origin: params.url.origin,
-      hostname,
-      port: params.url.port
-        ? Number.parseInt(params.url.port, 10)
-        : params.url.protocol === "https:"
-          ? 443
-          : 80,
-    },
-    route: {
-      mode: params.routeMode,
-      resolution: params.resolutionMode,
-      tls: params.url.protocol === "https:" ? "required" : "cleartext",
-    },
-    addressPolicy: {
-      mode: addressMode,
-      trustedHostnames,
-      hostnameAllowlist: [
-        ...normalizeHostnameAllowlist(params.policy?.hostnameAllowlist),
-      ].toSorted(),
-      allowedPrivateCidrs: normalizeUniqueStringEntries(params.allowedPrivateCidrs).toSorted(),
-      allowRfc2544BenchmarkRange: params.policy?.allowRfc2544BenchmarkRange === true,
-      allowIpv6UniqueLocalRange: params.policy?.allowIpv6UniqueLocalRange === true,
-      dnsRebinding: {
-        policy: "reject",
-        enforcement:
-          params.resolutionMode === "pinned"
-            ? "local-pinned"
-            : params.resolutionMode === "proxy"
-              ? "connection-owner-required"
-              : "not-enforced",
-      },
-    },
   };
 }
 

--- a/test/fixtures/network-guard-profile-v1.json
+++ b/test/fixtures/network-guard-profile-v1.json
@@ -1,0 +1,69 @@
+{
+  "version": "network-guard/v1",
+  "cases": [
+    {
+      "id": "public-ipv4",
+      "url": "https://api.dispatch.test/v1",
+      "policy": {},
+      "resolutionSequence": [["93.184.216.34"]],
+      "expected": "allow"
+    },
+    {
+      "id": "private-ipv4",
+      "url": "https://api.dispatch.test/v1",
+      "policy": {},
+      "resolutionSequence": [["10.0.0.8"]],
+      "expected": "deny"
+    },
+    {
+      "id": "mixed-public-private",
+      "url": "https://api.dispatch.test/v1",
+      "policy": {},
+      "resolutionSequence": [["93.184.216.34", "10.0.0.8"]],
+      "expected": "deny"
+    },
+    {
+      "id": "dns-rebinding",
+      "url": "https://rebind.dispatch.test/v1",
+      "policy": {},
+      "resolutionSequence": [["93.184.216.34"], ["127.0.0.1"]],
+      "expected": "deny-on-second-resolution"
+    },
+    {
+      "id": "exact-origin-private",
+      "url": "https://private.dispatch.test/v1",
+      "policy": {
+        "allowedOrigins": ["https://private.dispatch.test"]
+      },
+      "resolutionSequence": [["10.0.0.8"]],
+      "expected": "allow"
+    },
+    {
+      "id": "trusted-origin-link-local",
+      "url": "https://private.dispatch.test/v1",
+      "policy": {
+        "allowedOrigins": ["https://private.dispatch.test"]
+      },
+      "resolutionSequence": [["169.254.169.254"]],
+      "expected": "deny"
+    },
+    {
+      "id": "redirect-origin-private",
+      "url": "https://redirected.dispatch.test/v1",
+      "policy": {
+        "allowedOrigins": ["https://private.dispatch.test"]
+      },
+      "resolutionSequence": [["10.0.0.8"]],
+      "expected": "deny"
+    },
+    {
+      "id": "rfc2544-fake-ip",
+      "url": "https://api.dispatch.test/v1",
+      "policy": {
+        "allowRfc2544BenchmarkRange": true
+      },
+      "resolutionSequence": [["198.18.0.153"]],
+      "expected": "allow"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

`fetchWithSsrFGuard` currently owns both the security decision and the physical one-hop fetch. That makes it difficult for another connection owner to preserve the exact SSRF decision across the dispatch boundary without reinterpreting policy.

## Change

- Extract the existing redirect-manual physical fetch into a local one-hop dispatcher.
- Add a fixed `network-guard/v1` profile describing the target, route, DNS-resolution ownership, TLS posture, and address-policy decision.
- Validate the profile and exact request target before local dispatch.
- Add fixture and unit coverage for direct, environment-proxy, explicit-proxy, managed-proxy, caller-resolved, proxy-resolved, and locally pinned routes.

## Boundaries

This is behavior-preserving infrastructure. It does **not** add hosted execution, credential transport, a Gateway endpoint, new configuration/environment flags, private-network authority, or a Plugin SDK API. The profile builder remains internal so Lobster or another host can validate the boundary before any future public promotion.

Maintainer note: this does introduce an internal versioned `network-guard/v1` data contract under `src/infra/net`. Please confirm that versioning and ownership are appropriate at this layer.

## Related work

This is compatible with and separate from #92190: that PR owns app-level fetch/redirect transport selection, while this PR extracts one already-guarded physical hop inside the SSRF redirect loop.

Motivated by the boundary problems visible in #103710 and #94166, but this PR does not claim to fix or close either issue.

## Validation

- 130 focused tests passed across the guard profile, fixtures, one-hop dispatcher, and existing fetch-guard SSRF suite.
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm plugin-sdk:api:check` (baseline unchanged)
- Type-aware Oxlint on all changed TypeScript files: 0 warnings, 0 errors.
- `codex review --base upstream/main`: no actionable correctness regressions.
- Lobster-owned real-runtime proof: [giodl/lobster#30](https://microsoft.ghe.com/giodl/lobster/pull/30). At OpenClaw `c85d52bfff5f2e170bbb905d04bc452275c9d5e1`, the harness imports production `fetchWithSsrFGuard` and uses real ephemeral loopback origin/proxy TCP servers. It starts with hostile inherited upper- and lower-case proxy variables and emits only redacted route counters/statuses:

```text
{"proof":"lobster-openclaw-guarded-dispatch","lane":"direct","status":200,"originHits":1,"proxyHits":0}
{"proof":"lobster-openclaw-guarded-dispatch","lane":"explicit-proxy","resolution":"caller","status":200,"originHits":2,"proxyHits":1}
{"proof":"lobster-openclaw-guarded-dispatch","lane":"managed-proxy","resolution":"proxy","status":200,"originHits":3,"proxyHits":2}
{"proof":"lobster-openclaw-guarded-dispatch","result":"pass","openclawHead":"c85d52bfff5f2e170bbb905d04bc452275c9d5e1","lobsterHead":"dc48f43dad"}
```

The aggregate `check-changed` wrapper progressed through its cheap guards and SDK check but exceeded the Windows host timeout during the repository-wide core lint sweep; the changed files were subsequently checked with type-aware Oxlint directly.
