### PR TITLE
fix(memory): keep QMD file hints after stale docid misses (issue #113041)

### DIFF
--- a/extensions/memory-core/src/memory/qmd-document-resolver.ts
+++ b/extensions/memory-core/src/memory/qmd-document-resolver.ts
@@ -91,15 +91,16 @@ export class QmdDocumentResolver {
       }
       throw err;
     }
-    // QMD hits can include both docid and file; keep the file hint usable when
-    // OpenClaw's local hash lookup is stale or missing so valid hits survive.
-    const location =
-      (rows.length > 0 ? this.pickDocLocation(rows, normalizedHints) : null) ??
-      this.resolveDocLocationFromHints(normalizedHints);
-    if (location) {
-      this.docPathCache.set(cacheKey, location);
+    if (rows.length > 0) {
+      const dbLocation = this.pickDocLocation(rows, normalizedHints);
+      if (dbLocation) {
+        this.docPathCache.set(cacheKey, dbLocation);
+        return dbLocation;
+      }
     }
-    return location;
+    // 当索引查询无结果或无匹配时，使用 QMD 文件提示回退
+    // 不要缓存 hint-derived 位置，以便索引恢复时可以重新建立权威路径
+    return this.resolveDocLocationFromHints(normalizedHints);
   }
 
   normalizeDocHints(hints?: QmdDocHints): QmdDocHints {

--- a/extensions/memory-core/src/memory/qmd-document-resolver.ts
+++ b/extensions/memory-core/src/memory/qmd-document-resolver.ts
@@ -91,7 +91,11 @@ export class QmdDocumentResolver {
       }
       throw err;
     }
-    const location = rows.length > 0 ? this.pickDocLocation(rows, normalizedHints) : null;
+    // QMD hits can include both docid and file; keep the file hint usable when
+    // OpenClaw's local hash lookup is stale or missing so valid hits survive.
+    const location =
+      (rows.length > 0 ? this.pickDocLocation(rows, normalizedHints) : null) ??
+      this.resolveDocLocationFromHints(normalizedHints);
     if (location) {
       this.docPathCache.set(cacheKey, location);
     }

--- a/extensions/memory-core/src/memory/qmd-document-resolver.ts
+++ b/extensions/memory-core/src/memory/qmd-document-resolver.ts
@@ -98,8 +98,8 @@ export class QmdDocumentResolver {
         return dbLocation;
       }
     }
-    // 当索引查询无结果或无匹配时，使用 QMD 文件提示回退
-    // 不要缓存 hint-derived 位置，以便索引恢复时可以重新建立权威路径
+    // Keep hint-only locations out of the docid cache so a recovered index row
+    // can become authoritative on the next lookup.
     return this.resolveDocLocationFromHints(normalizedHints);
   }
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -6105,6 +6105,80 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("uses index record after index recovery, not stale hint-only cache", async () => {
+    const searchDocid = "recovered-doc-after-empty-index";
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            {
+              docid: searchDocid,
+              file: "qmd://workspace-main/notes/welcome.md",
+              score: 0.91,
+              snippet: "@@ -3,1\nQMD activation",
+            },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const inner = manager as unknown as {
+      db: {
+        prepare: () => { all: (arg: unknown) => unknown[] };
+        close: () => void;
+      } | null;
+    };
+
+    // 第一次搜索：索引为空，使用 QMD 文件提示回退
+    inner.db = {
+      prepare: () => ({
+        all: () => [],
+      }),
+      close: () => {},
+    };
+
+    await expect(
+      manager.search("QMD activation", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).resolves.toEqual([
+      {
+        path: "notes/welcome.md",
+        startLine: 3,
+        endLine: 3,
+        score: 0.91,
+        snippet: "@@ -3,1\nQMD activation",
+        source: "memory",
+      },
+    ]);
+
+    // 第二次搜索：索引恢复后，应该使用索引中的记录而不是缓存的回退位置
+    inner.db = {
+      prepare: () => ({
+        all: () => [{ collection: "workspace-main", path: "indexed/path.md" }],
+      }),
+      close: () => {},
+    };
+
+    await expect(
+      manager.search("QMD activation", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).resolves.toEqual([
+      {
+        path: "indexed/path.md",
+        startLine: 3,
+        endLine: 3,
+        score: 0.91,
+        snippet: "@@ -3,1\nQMD activation",
+        source: "memory",
+      },
+    ]);
+    await manager.close();
+  });
+
   it("throws when stdout is empty without the no-results marker", async () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -6058,6 +6058,53 @@ describe("QmdMemoryManager", () => {
     }
   });
 
+  it("uses qmd file hints when docid lookup misses", async () => {
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            {
+              docid: "missing-from-openclaw-index",
+              file: "qmd://workspace-main/notes/welcome.md",
+              score: 0.91,
+              snippet: "@@ -3,1\nQMD activation",
+            },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const inner = manager as unknown as {
+      db: { prepare: () => { all: () => unknown[] }; close: () => void };
+    };
+    inner.db = {
+      prepare: () => ({
+        all: () => [],
+      }),
+      close: () => {},
+    };
+
+    await expect(
+      manager.search("QMD activation", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).resolves.toEqual([
+      {
+        path: "notes/welcome.md",
+        startLine: 3,
+        endLine: 3,
+        score: 0.91,
+        snippet: "@@ -3,1\nQMD activation",
+        source: "memory",
+      },
+    ]);
+    await manager.close();
+  });
+
   it("throws when stdout is empty without the no-results marker", async () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -6100,6 +6100,7 @@ describe("QmdMemoryManager", () => {
         score: 0.91,
         snippet: "@@ -3,1\nQMD activation",
         source: "memory",
+        provenance: expectedQmdProvenance("untrusted"),
       },
     ]);
     await manager.close();
@@ -6153,6 +6154,7 @@ describe("QmdMemoryManager", () => {
         score: 0.91,
         snippet: "@@ -3,1\nQMD activation",
         source: "memory",
+        provenance: expectedQmdProvenance("untrusted"),
       },
     ]);
 
@@ -6174,6 +6176,7 @@ describe("QmdMemoryManager", () => {
         score: 0.91,
         snippet: "@@ -3,1\nQMD activation",
         source: "memory",
+        provenance: expectedQmdProvenance("untrusted"),
       },
     ]);
     await manager.close();

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -6136,7 +6136,6 @@ describe("QmdMemoryManager", () => {
       } | null;
     };
 
-    // 第一次搜索：索引为空，使用 QMD 文件提示回退
     inner.db = {
       prepare: () => ({
         all: () => [],
@@ -6158,7 +6157,6 @@ describe("QmdMemoryManager", () => {
       },
     ]);
 
-    // 第二次搜索：索引恢复后，应该使用索引中的记录而不是缓存的回退位置
     inner.db = {
       prepare: () => ({
         all: () => [{ collection: "workspace-main", path: "indexed/path.md" }],


### PR DESCRIPTION
Closes #113041

## What Problem This Solves

Fixes an issue where QMD-backed `memory_search` could drop a hit when QMD returned a `docid` that OpenClaw could not resolve locally, even though QMD also supplied a `qmd://` file hint.

## Why This Change Was Made

The resolver now falls back to normalized QMD file and collection hints when docid lookup misses. It still caches only index-backed locations, so a later recovered index can become authoritative again instead of staying pinned to a hint-only path.

## User Impact

Users relying on the QMD memory backend can keep valid memory-search hits even when OpenClaw's local document index temporarily cannot resolve QMD's `docid`; once the index recovers, search results use the recovered authoritative indexed path.
## Evidence

- Branch refreshed against current `main` `ad1dc602594b0193501099ad930162baa25eef46`; current PR head is `f4e65e17cbf273ace5353560f17643f6163baaa1`.
- Current-head runtime proof on `f4e65e17cbf273ace5353560f17643f6163baaa1`: `node --import tsx --input-type=module` ran the PR head's `QmdDocumentResolver` with an empty `documents` lookup and the QMD file hint `qmd://workspace-main/notes/welcome.md`, then inserted a recovered index row for the same docid. Inspectable output:

```json
{
  "head": "f4e65e17cbf273ace5353560f17643f6163baaa1",
  "docid": "recovered-doc-after-empty-index",
  "hint": "qmd://workspace-main/notes/welcome.md",
  "firstSearch": {
    "resolvedPath": "notes/welcome.md",
    "collection": "workspace-main",
    "collectionRelativePath": "notes/welcome.md",
    "source": "memory"
  },
  "afterIndexRecovery": {
    "resolvedPath": "indexed/path.md",
    "collection": "workspace-main",
    "collectionRelativePath": "indexed/path.md",
    "source": "memory"
  }
}
```

- Supporting regression coverage on `f4e65e17cbf273ace5353560f17643f6163baaa1`: `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/memory-core/src/memory/qmd-manager.test.ts -t "uses qmd file hints|uses index record after index recovery|resolves search hits when qmd returns qmd:// file URIs without docid|preserves multi-collection qmd search hits when results only include file URIs"` passed: 1 file passed; 4 tests passed; 160 skipped.
- Targeted formatting and whitespace checks on `f4e65e17cbf273ace5353560f17643f6163baaa1` passed:
  - `git diff --check upstream/main...HEAD`
  - `oxfmt --check extensions/memory-core/src/memory/qmd-document-resolver.ts extensions/memory-core/src/memory/qmd-manager.test.ts`
- Proof boundary: the runtime transcript directly proves the QMD document-location resolver path that user-visible QMD memory search uses after QMD returns a hit, including the unresolved-docid fallback and the no-stale-hint-cache invariant. It does not require a live external QMD index because the failing boundary is the OpenClaw resolver's handling of QMD result metadata after the QMD subprocess has already returned hits.