### PR TITLE
feat(approvals): add external verification contract

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18049,6 +18049,19 @@ public struct StandingGrantApprovalScope: Codable, Sendable {
     }
 }
 
+public struct PluginApprovalExternalResolution: Codable, Sendable {
+    public let label: String
+    public let decisions: [ApprovalAllowDecision]
+
+    public init(
+        label: String,
+        decisions: [ApprovalAllowDecision])
+    {
+        self.label = label
+        self.decisions = decisions
+    }
+}
+
 public struct ExecApprovalPresentation: Codable, Sendable {
     public let kind: String
     public let commandtext: String
@@ -18106,6 +18119,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
     public let agentid: AnyCodable?
     public let scope: ApprovalScope?
     public let alloweddecisions: [ApprovalDecision]
+    public let externalresolution: PluginApprovalExternalResolution?
 
     public init(
         kind: String,
@@ -18117,7 +18131,8 @@ public struct PluginApprovalPresentation: Codable, Sendable {
         toolname: AnyCodable? = nil,
         agentid: AnyCodable? = nil,
         scope: ApprovalScope? = nil,
-        alloweddecisions: [ApprovalDecision])
+        alloweddecisions: [ApprovalDecision],
+        externalresolution: PluginApprovalExternalResolution? = nil)
     {
         self.kind = kind
         self.title = title
@@ -18129,6 +18144,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
         self.agentid = agentid
         self.scope = scope
         self.alloweddecisions = alloweddecisions
+        self.externalresolution = externalresolution
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -18142,6 +18158,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
         case agentid = "agentId"
         case scope
         case alloweddecisions = "allowedDecisions"
+        case externalresolution = "externalResolution"
     }
 }
 

--- a/packages/gateway-protocol/src/approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/approvals-validators.test.ts
@@ -63,12 +63,60 @@ describe("unified approval protocol validators", () => {
     expect(validateApprovalPresentation(execPresentation)).toBe(true);
     expect(validateApprovalPresentation(pluginPresentation)).toBe(true);
     expect(validateApprovalPresentation(systemAgentPresentation)).toBe(true);
+    expect(
+      validateApprovalPresentation({
+        ...pluginPresentation,
+        allowedDecisions: ["deny"],
+        externalResolution: {
+          label: "Verify with World",
+          decisions: ["allow-once", "allow-always"],
+        },
+      }),
+    ).toBe(true);
     expect(validateApprovalPresentation({ ...pluginPresentation, detail: "full tool input" })).toBe(
       true,
     );
     expect(validateApprovalPresentation({ ...pluginPresentation, detail: "" })).toBe(false);
     expect(
       validateApprovalPresentation({ ...pluginPresentation, detail: "x".repeat(16_385) }),
+    ).toBe(false);
+    expect(
+      validateApprovalPresentation({
+        ...pluginPresentation,
+        externalResolution: { label: "", decisions: ["allow-once"] },
+      }),
+    ).toBe(false);
+    const astralLabel = String.fromCodePoint(0x1f680).repeat(80);
+    expect(
+      validateApprovalPresentation({
+        ...pluginPresentation,
+        externalResolution: { label: astralLabel, decisions: ["allow-once"] },
+      }),
+    ).toBe(true);
+    expect(
+      validateApprovalPresentation({
+        ...pluginPresentation,
+        externalResolution: {
+          label: `${astralLabel}${String.fromCodePoint(0x1f680)}`,
+          decisions: ["allow-once"],
+        },
+      }),
+    ).toBe(false);
+    expect(
+      validateApprovalPresentation({
+        ...pluginPresentation,
+        externalResolution: { label: "Verify", decisions: ["deny"] },
+      }),
+    ).toBe(false);
+    expect(
+      validateApprovalPresentation({
+        ...pluginPresentation,
+        externalResolution: {
+          label: "Verify",
+          decisions: ["allow-once"],
+          proof: "private",
+        },
+      }),
     ).toBe(false);
 
     for (const forbiddenField of ["cwd", "env", "systemRunBinding", "systemRunPlan"] as const) {

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -121,6 +121,16 @@ export const ApprovalScopeSchema = Type.Union([
   StandingGrantApprovalScopeSchema,
 ]);
 
+/** Reviewer-safe projection of a plugin-owned external verification choice. */
+export const PluginApprovalExternalResolutionSchema = closedObject({
+  label: Type.String({ minLength: 1, maxLength: 80 }),
+  decisions: Type.Array(ApprovalAllowDecisionSchema, {
+    minItems: 1,
+    maxItems: 2,
+    uniqueItems: true,
+  }),
+});
+
 const ApprovalAllowedDecisionsSchema = Type.Array(ApprovalDecisionSchema, {
   minItems: 1,
   maxItems: 3,
@@ -167,6 +177,7 @@ export const PluginApprovalPresentationSchema = closedObject({
   agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   scope: Type.Optional(ApprovalScopeSchema),
   allowedDecisions: ApprovalAllowedDecisionsSchema,
+  externalResolution: Type.Optional(PluginApprovalExternalResolutionSchema),
 });
 
 /** Reviewer-safe OpenClaw system change. Exact operation stays host-local. */
@@ -370,6 +381,9 @@ export type ApprovalAllowDecision = Static<typeof ApprovalAllowDecisionSchema>;
 export type ApprovalTerminalReason = Static<typeof ApprovalTerminalReasonSchema>;
 export type PluginApprovalSeverity = Static<typeof PluginApprovalSeveritySchema>;
 export type ApprovalScope = Static<typeof ApprovalScopeSchema>;
+export type PluginApprovalExternalResolution = Static<
+  typeof PluginApprovalExternalResolutionSchema
+>;
 export type ExecApprovalPresentation = Static<typeof ExecApprovalPresentationSchema>;
 export type PluginApprovalPresentation = Static<typeof PluginApprovalPresentationSchema>;
 export type SystemAgentApprovalPresentation = Static<typeof SystemAgentApprovalPresentationSchema>;

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-approvals.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-approvals.ts
@@ -16,6 +16,7 @@ export const ApprovalProtocolSchemas = {
   ExternalPostApprovalScope: approvals.ExternalPostApprovalScopeSchema,
   StandingGrantApprovalScope: approvals.StandingGrantApprovalScopeSchema,
   ApprovalScope: approvals.ApprovalScopeSchema,
+  PluginApprovalExternalResolution: approvals.PluginApprovalExternalResolutionSchema,
   ExecApprovalPresentation: approvals.ExecApprovalPresentationSchema,
   PluginApprovalPresentation: approvals.PluginApprovalPresentationSchema,
   SystemAgentApprovalPresentation: approvals.SystemAgentApprovalPresentationSchema,

--- a/src/infra/approval-presentation.test.ts
+++ b/src/infra/approval-presentation.test.ts
@@ -21,6 +21,10 @@ function buildPluginPresentation(request: {
   pluginId?: string;
   toolName?: string;
   agentId?: string;
+  externalResolution?: {
+    label: string;
+    decisions?: readonly ("allow-once" | "allow-always")[];
+  };
 }) {
   return buildApprovalPresentation({ kind: "plugin", request, allowedDecisions });
 }
@@ -165,6 +169,101 @@ describe("buildApprovalPresentation", () => {
       throw new Error("expected plugin detail");
     }
     expect(Array.from(presentation.detail)).toHaveLength(PLUGIN_APPROVAL_DETAIL_MAX_LENGTH);
+  });
+
+  it("projects only bounded reviewer-safe external verification metadata", () => {
+    expect(
+      buildApprovalPresentation({
+        kind: "plugin",
+        request: {
+          title: "World verification",
+          description: "Verify personhood before continuing.",
+          pluginId: "agentkit",
+          externalResolution: {
+            label: "Verify with World\u202E",
+            decisions: ["allow-once", "allow-always"],
+          },
+        },
+        allowedDecisions: ["deny"],
+      }),
+    ).toMatchObject({
+      kind: "plugin",
+      pluginId: "agentkit",
+      allowedDecisions: ["deny"],
+      externalResolution: {
+        label: "Verify with World\\u{202E}",
+        decisions: ["allow-once", "allow-always"],
+      },
+    });
+  });
+
+  it("rejects an external label that exceeds its limit after spoof-resistant escaping", () => {
+    expect(
+      buildApprovalPresentation({
+        kind: "plugin",
+        request: {
+          title: "World verification",
+          description: "Verify personhood before continuing.",
+          pluginId: "agentkit",
+          externalResolution: {
+            label: "\u202E".repeat(11),
+            decisions: ["allow-once"],
+          },
+        },
+        allowedDecisions: ["deny"],
+      }),
+    ).toBeNull();
+  });
+
+  it("applies the external label limit by Unicode code point", () => {
+    const label = String.fromCodePoint(0x1f680).repeat(80);
+    const buildWithLabel = (value: string) =>
+      buildApprovalPresentation({
+        kind: "plugin",
+        request: {
+          title: "World verification",
+          description: "Verify personhood before continuing.",
+          externalResolution: { label: value, decisions: ["allow-once"] },
+        },
+        allowedDecisions: ["deny"],
+      });
+
+    expect(buildWithLabel(label)).toMatchObject({
+      kind: "plugin",
+      externalResolution: { label },
+    });
+    expect(buildWithLabel(`${label}${String.fromCodePoint(0x1f680)}`)).toBeNull();
+  });
+
+  it.each([
+    { label: " ", decisions: undefined },
+    { label: "Verify", decisions: [] },
+    { label: "Verify", decisions: ["allow-once", "allow-once"] as const },
+  ])("rejects malformed external verification metadata", (externalResolution) => {
+    expect(
+      buildPluginPresentation({
+        title: "World verification",
+        description: "Verify personhood before continuing.",
+        pluginId: "agentkit",
+        externalResolution,
+      }),
+    ).toBeNull();
+  });
+
+  it("defaults external verification to allow once", () => {
+    expect(
+      buildPluginPresentation({
+        title: "World verification",
+        description: "Verify personhood before continuing.",
+        pluginId: "agentkit",
+        externalResolution: { label: " Verify\nwith World " },
+      }),
+    ).toMatchObject({
+      externalResolution: {
+        label: "Verify\\u{A}with World",
+        decisions: ["allow-once"],
+      },
+    });
   });
 });
 

--- a/src/infra/approval-presentation.ts
+++ b/src/infra/approval-presentation.ts
@@ -23,6 +23,8 @@ import {
 } from "./plugin-approvals.js";
 import type { SystemAgentApprovalRequestPayload } from "./system-agent-approvals.js";
 
+const PLUGIN_EXTERNAL_RESOLUTION_LABEL_MAX_LENGTH = 80;
+
 function normalizeDecisionList(decisions: readonly ApprovalDecision[]): ApprovalDecision[] {
   const result: ApprovalDecision[] = [];
   for (const decision of decisions) {
@@ -39,6 +41,29 @@ function normalizeDecisionList(decisions: readonly ApprovalDecision[]): Approval
 function sanitizeOptionalSingleLine(value: unknown): string | null {
   const normalized = normalizeOptionalString(value);
   return normalized ? sanitizeExecApprovalDisplayText(normalized) : null;
+}
+
+function normalizePluginExternalResolution(
+  value: PluginApprovalRequestPayload["externalResolution"],
+): NonNullable<PluginApprovalRequestPayload["externalResolution"]> | null {
+  if (!value) {
+    return null;
+  }
+  const rawLabel = value.label?.trim();
+  const label = rawLabel ? sanitizeExecApprovalDisplayText(rawLabel) : "";
+  if (!label || exceedsApprovalTextLimit(label, PLUGIN_EXTERNAL_RESOLUTION_LABEL_MAX_LENGTH)) {
+    throw new Error("invalid external approval label");
+  }
+  const decisions = value.decisions ?? ["allow-once"];
+  if (
+    decisions.length < 1 ||
+    decisions.length > 2 ||
+    decisions.some((decision) => decision !== "allow-once" && decision !== "allow-always") ||
+    new Set(decisions).size !== decisions.length
+  ) {
+    throw new Error("invalid external approval decisions");
+  }
+  return { label, decisions: [...decisions] };
 }
 
 function buildExecApprovalPresentation(params: {
@@ -103,6 +128,12 @@ function buildPluginApprovalPresentation(params: {
     ? truncatePluginApprovalDetail(sanitizeExecApprovalWarningText(rawDetail))
     : null;
   const scope = request.scope ? sanitizeApprovalScope(request.scope) : null;
+  let externalResolution: ReturnType<typeof normalizePluginExternalResolution>;
+  try {
+    externalResolution = normalizePluginExternalResolution(request.externalResolution);
+  } catch {
+    return null;
+  }
   return {
     kind: "plugin",
     title,
@@ -114,6 +145,14 @@ function buildPluginApprovalPresentation(params: {
     agentId: sanitizeOptionalSingleLine(request.agentId),
     ...(scope ? { scope } : {}),
     allowedDecisions: normalizeDecisionList(params.allowedDecisions),
+    ...(externalResolution
+      ? {
+          externalResolution: {
+            label: externalResolution.label,
+            decisions: [...(externalResolution.decisions ?? ["allow-once"])],
+          },
+        }
+      : {}),
   };
 }
 

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -26,6 +26,11 @@ export type PluginApprovalRequestPayload = {
   toolName?: string | null;
   toolCallId?: string | null;
   allowedDecisions?: readonly ExecApprovalDecision[] | null;
+  /** Trusted in-process metadata; public Gateway callers cannot submit this field. */
+  externalResolution?: {
+    label: string;
+    decisions?: readonly ("allow-once" | "allow-always")[];
+  } | null;
   actions?: readonly PluginApprovalActionView[] | null;
   agentId?: string | null;
   sessionKey?: string | null;


### PR DESCRIPTION
## What Problem This Solves

[RFC #15](https://github.com/openclaw/rfcs/pull/15) accepts a provider-neutral external verification boundary: core owns approval lifecycle and plugins own provider policy and proof handling.

This PR adds the bounded presentation contract only:

- an optional external verification label and closed `allow-once` / `allow-always` decision model
- fail-closed normalization and spoof-resistant display sanitization
- aligned Gateway schema and generated Swift model
- no provider ids, proof payloads, secrets, policy, or runtime defaults in core

## scope

7 files: 59 production-source lines, 23 generated Swift lines, and 147 test lines. Existing approval resolution behavior is unchanged.

The runtime ledger, trusted producer/resolver seam, native and TUI interaction, and AgentKit provider implementation remain tracked by [#82336](https://github.com/openclaw/openclaw/issues/82336).

## staging decision

The latest ClawSweeper review correctly notes that the official plugin hook cannot yet produce or resolve this field. This PR does not claim otherwise.

Maintainer approval records the decision to land this bounded contract first. The executable host runtime, resolver lifecycle, native/TUI interaction, and AgentKit integration remain follow-up work.

## CI repair

The previous head failed `checks-node-compact-small-46` because the SDK diff cleanup test incorrectly required the whole runner temporary directory to be empty. Main already fixes this in #134422 (`dfb9f1f9e910be9db7adee15c360dfe271040aff`): assert that the CLI-owned directory is removed while unrelated runner files survive. Head `fa89123aab8b6a3608e4e5f0f238790e465556d4` rebases the unchanged PR patch onto `1363c4744796e7e18ace354efb70ebbdd00bef2c`, which includes that fix. `git range-diff` confirms the feature patch is identical. Current-head CI must pass before merge.

## Evidence

### Current CI repair

- Published head: `fa89123aab8b6a3608e4e5f0f238790e465556d4`.
- The existing upstream test fix is included; the PR feature patch is unchanged. The previously failing `checks-node-compact-small-46` shard now passes.
- Fresh exact-commit autoreview passed with no P0 findings and a clean secret scan.
- [Current-head CI](https://github.com/openclaw/openclaw/actions/runs/33447644876) passed: 250 successful checks, 36 skips, one neutral, and no failures or pending checks. The required `openclaw/ci-gate` is green.

### Historical validation

Head `6eb514992dc4d5ecca5ea8e5fa3fda59a40bec59`, based on `ddf73d4ca2ef0b12818d7913f3ab68027ad58101`:

- protocol registry and Swift generation checks passed
- 22 focused protocol and presentation tests passed across 2 Vitest shards
- plugin SDK surface check and `git diff --check` passed
- autoreview: secret scan clean, no P0 findings, patch correct at 0.99 confidence

GitHub CI for that earlier head was green: 184 successful jobs, 13 intentional skips, and 0 failures, including `security-fast`, the SDK API diff, the final iOS build, and `openclaw/ci-gate`.

## end-to-end status

The prepared implementation stack was previously exercised in an isolated OpenClaw root with the AgentKit plugin, a physical Android device, and the production World App. Deny, allow-once, session trust, expiry, dismissal, supersession, and late completion all stayed fail-closed where required.

That is historical semantic proof, not exact-head runtime proof for this contract-only PR. After the maintainer staging decision, the smaller runtime follow-ups will be rebuilt on current `main`, then the automated matrix and physical ceremony will be rerun on their exact heads as required by #82336.

