### PR TITLE
improve(sqlite): prove killed VACUUM recovery

### DIFF
--- a/scripts/bench-sqlite-reliability.ts
+++ b/scripts/bench-sqlite-reliability.ts
@@ -53,6 +53,9 @@ function printProofLines(report: ReliabilityReport): void {
     `SQLITE_RELIABILITY_COMPACT_RECLAIMED_BYTES=${report.maintenanceProof.compaction.reclaimedBytes}`,
   );
   console.log(
+    `SQLITE_RELIABILITY_VACUUM_INTERRUPTION=${report.maintenanceProof.vacuumInterruption.recoveryVerified ? "verified" : "missing"}`,
+  );
+  console.log(
     `SQLITE_RELIABILITY_POST_COMPACT_RESTORE=${report.maintenanceProof.postCompact.restoreVerified ? "verified" : "missing"}`,
   );
   console.log(`SQLITE_RELIABILITY_FINAL_ROWS=${report.maintenanceProof.postCompact.state.rows}`);

--- a/scripts/lib/sqlite-reliability-compaction-worker.ts
+++ b/scripts/lib/sqlite-reliability-compaction-worker.ts
@@ -1,0 +1,48 @@
+import { pathToFileURL } from "node:url";
+import { compactDoctorSessionSqliteTarget } from "../../src/commands/doctor-session-sqlite-compact.js";
+import { runDoctorStateSqliteCompact } from "../../src/commands/doctor-state-sqlite-compact.js";
+
+type CompactionTarget =
+  | { role: "agent"; agentId: string; path: string }
+  | { role: "global"; path: string };
+
+function parseTarget(argv: string[]): CompactionTarget {
+  const [role, databasePath, agentId, ...extra] = argv;
+  if (extra.length > 0 || !databasePath) {
+    throw new Error("invalid SQLite compaction worker arguments");
+  }
+  if (role === "global" && !agentId) {
+    return { role, path: databasePath };
+  }
+  if (role === "agent" && agentId) {
+    return { role, agentId, path: databasePath };
+  }
+  throw new Error("invalid SQLite compaction worker target");
+}
+
+async function main(argv: string[]): Promise<void> {
+  const target = parseTarget(argv);
+  process.send?.({ kind: "ready" });
+  if (target.role === "global") {
+    const report = await runDoctorStateSqliteCompact({ env: process.env });
+    if (report.skipped) {
+      throw new Error(`global compaction unexpectedly skipped ${target.path}`);
+    }
+  } else {
+    const report = compactDoctorSessionSqliteTarget(
+      {
+        agentId: target.agentId,
+        storePath: target.path,
+      },
+      { env: process.env },
+    );
+    if (report.skipped) {
+      throw new Error(`agent compaction unexpectedly skipped ${target.path}`);
+    }
+  }
+  process.send?.({ kind: "completed" });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main(process.argv.slice(2));
+}

--- a/scripts/lib/sqlite-reliability-compaction.ts
+++ b/scripts/lib/sqlite-reliability-compaction.ts
@@ -1,0 +1,271 @@
+import { fork, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import type { SnapshotDatabaseIdentity } from "../../src/snapshot/snapshot-provider.js";
+import type { ReliabilityReport, ReliabilityStateProof } from "./sqlite-reliability-contract.js";
+
+type CompactionPayloadProof = {
+  bytes: number;
+  idSum: number;
+  rows: number;
+};
+
+type CompactionTarget = {
+  identity: SnapshotDatabaseIdentity;
+  path: string;
+};
+
+type CompactionExit = ReliabilityReport["maintenanceProof"]["vacuumInterruption"]["exit"];
+
+const COMPACTION_WORKER_PATH = fileURLToPath(
+  new URL("./sqlite-reliability-compaction-worker.ts", import.meta.url),
+);
+const COMPACTION_TIMEOUT_MS = 120_000;
+const MIN_ACTIVE_SIDECAR_BYTES = 1024 * 1024;
+
+function fileSize(filePath: string): number {
+  try {
+    return fs.statSync(filePath).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return 0;
+    }
+    throw error;
+  }
+}
+
+function assertSameState(
+  actual: ReliabilityStateProof,
+  expected: ReliabilityStateProof,
+  label: string,
+): void {
+  if (
+    actual.batches !== expected.batches ||
+    actual.rows !== expected.rows ||
+    actual.sha256 !== expected.sha256
+  ) {
+    throw new Error(
+      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
+    );
+  }
+}
+
+function assertSamePayload(
+  actual: CompactionPayloadProof,
+  expected: CompactionPayloadProof,
+  label: string,
+): void {
+  if (
+    actual.bytes !== expected.bytes ||
+    actual.idSum !== expected.idSum ||
+    actual.rows !== expected.rows
+  ) {
+    throw new Error(
+      `${label} changed compaction payload: expected rows=${expected.rows} bytes=${expected.bytes} idSum=${expected.idSum}, got rows=${actual.rows} bytes=${actual.bytes} idSum=${actual.idSum}`,
+    );
+  }
+}
+
+function workerArgs(target: CompactionTarget): string[] {
+  if (target.identity.role === "global") {
+    return ["global", target.path, ""];
+  }
+  if (target.identity.role === "agent") {
+    return ["agent", target.path, target.identity.agentId];
+  }
+  throw new Error(`unsupported reliability target role: ${target.identity.role}`);
+}
+
+function formatWorkerStderr(stderr: string): string {
+  const text = stderr.trim();
+  return text ? ` stderr=${JSON.stringify(text)}` : "";
+}
+
+async function waitForWorkerReady(params: {
+  child: ChildProcess;
+  readStderr: () => string;
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `SQLite compaction worker did not become ready.${formatWorkerStderr(params.readStderr())}`,
+        ),
+      );
+    }, 30_000);
+    const onMessage = (message: unknown) => {
+      if (
+        message &&
+        typeof message === "object" &&
+        (message as { kind?: unknown }).kind === "ready"
+      ) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `SQLite compaction worker exited before ready: code=${String(code)} signal=${String(signal)}.${formatWorkerStderr(params.readStderr())}`,
+        ),
+      );
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      params.child.off("message", onMessage);
+      params.child.off("error", onError);
+      params.child.off("exit", onExit);
+    };
+    params.child.on("message", onMessage);
+    params.child.on("error", onError);
+    params.child.on("exit", onExit);
+  });
+}
+
+async function waitForChildExit(child: ChildProcess): Promise<CompactionExit> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  return await new Promise<CompactionExit>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("SQLite compaction worker did not exit after forced termination."));
+    }, 30_000);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    child.on("exit", onExit);
+    child.on("error", onError);
+  });
+}
+
+async function waitForActiveVacuum(params: {
+  child: ChildProcess;
+  databasePath: string;
+  readStderr: () => string;
+}): Promise<{ journalBytes: number; walBytes: number }> {
+  const deadline = Date.now() + COMPACTION_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const journalBytes = fileSize(`${params.databasePath}-journal`);
+    const walBytes = fileSize(`${params.databasePath}-wal`);
+    if (journalBytes >= MIN_ACTIVE_SIDECAR_BYTES || walBytes >= MIN_ACTIVE_SIDECAR_BYTES) {
+      return { journalBytes, walBytes };
+    }
+    if (params.child.exitCode !== null || params.child.signalCode !== null) {
+      throw new Error(
+        `SQLite compaction completed before interruption evidence was observed.${formatWorkerStderr(params.readStderr())}`,
+      );
+    }
+    await delay(2);
+  }
+  throw new Error(
+    `SQLite compaction did not produce ${MIN_ACTIVE_SIDECAR_BYTES} bytes of active journal evidence within 120 seconds.`,
+  );
+}
+
+function assertForcedExit(exit: CompactionExit): void {
+  if (exit.code === 0) {
+    throw new Error("SQLite compaction worker exited cleanly before forced termination.");
+  }
+  if (process.platform === "win32") {
+    if (exit.code === null && exit.signal === null) {
+      throw new Error("SQLite compaction worker reported no forced Windows exit.");
+    }
+    return;
+  }
+  if (exit.signal !== "SIGKILL") {
+    throw new Error(
+      `SQLite compaction worker exited without SIGKILL: code=${String(exit.code)} signal=${String(exit.signal)}`,
+    );
+  }
+}
+
+export async function runVacuumInterruptionProof(params: {
+  env: NodeJS.ProcessEnv;
+  expectedAutoVacuum: number;
+  expectedPayload: CompactionPayloadProof;
+  expectedState: ReliabilityStateProof;
+  readAutoVacuum: () => number;
+  readPayload: () => CompactionPayloadProof;
+  recoverAndVerifyDatabase: () => ReliabilityStateProof;
+  target: CompactionTarget;
+}): Promise<ReliabilityReport["maintenanceProof"]["vacuumInterruption"]> {
+  let stderr = "";
+  const child = fork(COMPACTION_WORKER_PATH, workerArgs(params.target), {
+    env: params.env,
+    execArgv: ["--import", "tsx"],
+    serialization: "json",
+    stdio: ["ignore", "ignore", "pipe", "ipc"],
+  });
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  try {
+    await waitForWorkerReady({ child, readStderr: () => stderr });
+    const observed = await waitForActiveVacuum({
+      child,
+      databasePath: params.target.path,
+      readStderr: () => stderr,
+    });
+    if (!child.kill("SIGKILL")) {
+      throw new Error("SQLite compaction worker exited before the crash signal was delivered.");
+    }
+    const exit = await waitForChildExit(child);
+    assertForcedExit(exit);
+
+    const stateAfterRecovery = params.recoverAndVerifyDatabase();
+    assertSameState(stateAfterRecovery, params.expectedState, "vacuum crash recovery");
+    const autoVacuumAfterRecovery = params.readAutoVacuum();
+    if (autoVacuumAfterRecovery !== params.expectedAutoVacuum) {
+      throw new Error(
+        `SQLite VACUUM committed before forced termination: expected auto_vacuum=${params.expectedAutoVacuum}, got ${autoVacuumAfterRecovery}`,
+      );
+    }
+    const payloadAfterRecovery = params.readPayload();
+    assertSamePayload(payloadAfterRecovery, params.expectedPayload, "vacuum crash recovery");
+    const journalBytesAfterRecovery = fileSize(`${params.target.path}-journal`);
+    const walBytesAfterRecovery = fileSize(`${params.target.path}-wal`);
+    if (journalBytesAfterRecovery !== 0 || walBytesAfterRecovery !== 0) {
+      throw new Error(
+        `SQLite recovery left active compaction sidecars: journal=${journalBytesAfterRecovery} wal=${walBytesAfterRecovery}`,
+      );
+    }
+
+    return {
+      autoVacuumAfterRecovery,
+      autoVacuumBeforeKill: params.expectedAutoVacuum,
+      exit,
+      journalBytesObserved: observed.journalBytes,
+      payloadAfterRecovery,
+      payloadBeforeKill: params.expectedPayload,
+      recoveryVerified: true,
+      stateAfterRecovery,
+      stateBeforeKill: params.expectedState,
+      walBytesObserved: observed.walBytes,
+    };
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+      await waitForChildExit(child).catch(() => undefined);
+    }
+  }
+}

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -61,6 +61,29 @@ export type ReliabilityReport = {
         before: number;
       };
     };
+    vacuumInterruption: {
+      autoVacuumAfterRecovery: number;
+      autoVacuumBeforeKill: number;
+      exit: {
+        code: number | null;
+        signal: NodeJS.Signals | null;
+      };
+      journalBytesObserved: number;
+      payloadAfterRecovery: {
+        bytes: number;
+        idSum: number;
+        rows: number;
+      };
+      payloadBeforeKill: {
+        bytes: number;
+        idSum: number;
+        rows: number;
+      };
+      recoveryVerified: true;
+      stateAfterRecovery: ReliabilityStateProof;
+      stateBeforeKill: ReliabilityStateProof;
+      walBytesObserved: number;
+    };
     postCompact: {
       restoreMs: number;
       restoreVerified: true;

--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -19,6 +19,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../src/state/openclaw-state-db.js";
+import { runVacuumInterruptionProof } from "./sqlite-reliability-compaction.js";
 import {
   COMMITTED_WAL_SENTINEL,
   PROFILES,
@@ -53,8 +54,8 @@ type IterationMetric = {
 
 type CompactionProof = ReliabilityReport["maintenanceProof"]["compaction"];
 
-const COMPACTION_BLOAT_ROWS = 512;
-const COMPACTION_BLOAT_PAYLOAD_BYTES = 16 * 1024;
+const COMPACTION_BLOAT_ROWS = 256;
+const COMPACTION_BLOAT_PAYLOAD_BYTES = 256 * 1024;
 
 function nowMs(): number {
   return Number(process.hrtime.bigint()) / 1e6;
@@ -205,11 +206,12 @@ function verifyRestoredDatabase(params: {
   expectedState?: ReliabilityStateProof;
   identity: SnapshotDatabaseIdentity;
   path: string;
+  readOnly?: boolean;
   rowsPerBatch: number;
   uncommittedBatch: number | null;
 }): ReliabilityStateProof {
   const { DatabaseSync } = requireNodeSqlite();
-  const database = new DatabaseSync(params.path, { readOnly: true });
+  const database = new DatabaseSync(params.path, { readOnly: params.readOnly ?? true });
   try {
     database.exec("PRAGMA trusted_schema = OFF;");
     assertPragmaOk(database, "quick_check");
@@ -280,8 +282,48 @@ function createCompactionBloat(databasePath: string): number {
       database.exec("ROLLBACK;");
       throw error;
     }
-    database.exec("DELETE FROM openclaw_reliability_compaction_bloat;");
+    database.exec("PRAGMA wal_checkpoint(TRUNCATE);");
     return COMPACTION_BLOAT_ROWS * COMPACTION_BLOAT_PAYLOAD_BYTES;
+  } finally {
+    database.close();
+  }
+}
+
+function readCompactionPayload(databasePath: string): {
+  bytes: number;
+  idSum: number;
+  rows: number;
+} {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const row = database
+      .prepare(
+        `SELECT
+           COUNT(*) AS rows,
+           COALESCE(SUM(id), 0) AS id_sum,
+           COALESCE(SUM(length(payload)), 0) AS bytes
+         FROM openclaw_reliability_compaction_bloat`,
+      )
+      .get() as { bytes?: unknown; id_sum?: unknown; rows?: unknown };
+    return {
+      bytes: sqliteSafeInteger(row.bytes, "compaction payload bytes"),
+      idSum: sqliteSafeInteger(row.id_sum, "compaction payload id sum"),
+      rows: sqliteSafeInteger(row.rows, "compaction payload rows"),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function deleteCompactionBloat(databasePath: string): void {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      DELETE FROM openclaw_reliability_compaction_bloat;
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
   } finally {
     database.close();
   }
@@ -301,6 +343,29 @@ function readAutoVacuum(databasePath: string): number {
   } finally {
     database.close();
   }
+}
+
+function prepareVacuumRollbackSentinel(databasePath: string): number {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      PRAGMA busy_timeout = 30000;
+      PRAGMA wal_checkpoint(TRUNCATE);
+      PRAGMA journal_mode = DELETE;
+      PRAGMA auto_vacuum = NONE;
+      VACUUM;
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+  } finally {
+    database.close();
+  }
+  const autoVacuum = readAutoVacuum(databasePath);
+  if (autoVacuum !== 0) {
+    throw new Error(`failed to prepare VACUUM rollback sentinel: auto_vacuum=${autoVacuum}`);
+  }
+  return autoVacuum;
 }
 
 function assertCompactionProof(proof: {
@@ -405,6 +470,7 @@ async function runMaintenanceRoundTrip(params: {
   syncedRepository: string;
   target: TargetDatabase;
 }): Promise<ReliabilityReport["maintenanceProof"]> {
+  const autoVacuumBeforeKill = prepareVacuumRollbackSentinel(params.target.path);
   const bloatBytes = createCompactionBloat(params.target.path);
   const expectedState = verifyRestoredDatabase({
     identity: params.target.identity,
@@ -412,6 +478,31 @@ async function runMaintenanceRoundTrip(params: {
     rowsPerBatch: params.rowsPerBatch,
     uncommittedBatch: null,
   });
+  const expectedPayload = readCompactionPayload(params.target.path);
+  if (expectedPayload.rows !== COMPACTION_BLOAT_ROWS || expectedPayload.bytes !== bloatBytes) {
+    throw new Error(
+      `compaction payload setup failed: rows=${expectedPayload.rows} bytes=${expectedPayload.bytes}`,
+    );
+  }
+  const vacuumInterruption = await runVacuumInterruptionProof({
+    env: params.env,
+    expectedAutoVacuum: autoVacuumBeforeKill,
+    expectedPayload,
+    expectedState,
+    readAutoVacuum: () => readAutoVacuum(params.target.path),
+    readPayload: () => readCompactionPayload(params.target.path),
+    recoverAndVerifyDatabase: () =>
+      verifyRestoredDatabase({
+        expectedState,
+        identity: params.target.identity,
+        path: params.target.path,
+        readOnly: false,
+        rowsPerBatch: params.rowsPerBatch,
+        uncommittedBatch: null,
+      }),
+    target: params.target,
+  });
+  deleteCompactionBloat(params.target.path);
   const compaction = await compactTargetDatabase(params.target, params.env);
   verifyRestoredDatabase({
     expectedState,
@@ -451,6 +542,7 @@ async function runMaintenanceRoundTrip(params: {
       snapshotMs: Number(snapshotMs.toFixed(3)),
       state,
     },
+    vacuumInterruption,
   };
 }
 

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -156,6 +156,7 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=5");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_CRASH_RECOVERY=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_PUBLICATION_INTERRUPTION=verified");
+    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_VACUUM_INTERRUPTION=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_POST_COMPACT_RESTORE=verified");
     const firstReport = JSON.parse(fs.readFileSync(firstOutput, "utf8")) as {
       concurrentRestoresVerified: number;
@@ -186,6 +187,37 @@ describe("scripts/bench-sqlite-reliability", () => {
           freelistPages: { after: number; before: number };
           reclaimedBytes: number;
           walBytes: { after: number };
+        };
+        vacuumInterruption: {
+          autoVacuumAfterRecovery: number;
+          autoVacuumBeforeKill: number;
+          exit: {
+            code: number | null;
+            signal: string | null;
+          };
+          journalBytesObserved: number;
+          payloadAfterRecovery: {
+            bytes: number;
+            idSum: number;
+            rows: number;
+          };
+          payloadBeforeKill: {
+            bytes: number;
+            idSum: number;
+            rows: number;
+          };
+          recoveryVerified: boolean;
+          stateAfterRecovery: {
+            batches: number;
+            rows: number;
+            sha256: string;
+          };
+          stateBeforeKill: {
+            batches: number;
+            rows: number;
+            sha256: string;
+          };
+          walBytesObserved: number;
         };
         postCompact: {
           restoreVerified: boolean;
@@ -289,6 +321,23 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstReport.maintenanceProof.compaction.freelistPages.after).toBe(0);
     expect(firstReport.maintenanceProof.compaction.reclaimedBytes).toBeGreaterThan(0);
     expect(firstReport.maintenanceProof.compaction.walBytes.after).toBe(0);
+    expect(firstReport.maintenanceProof.vacuumInterruption.recoveryVerified).toBe(true);
+    expect(firstReport.maintenanceProof.vacuumInterruption.autoVacuumBeforeKill).toBe(0);
+    expect(firstReport.maintenanceProof.vacuumInterruption.autoVacuumAfterRecovery).toBe(0);
+    expect(
+      firstReport.maintenanceProof.vacuumInterruption.exit.code !== null ||
+        firstReport.maintenanceProof.vacuumInterruption.exit.signal !== null,
+    ).toBe(true);
+    expect(
+      firstReport.maintenanceProof.vacuumInterruption.journalBytesObserved > 0 ||
+        firstReport.maintenanceProof.vacuumInterruption.walBytesObserved > 0,
+    ).toBe(true);
+    expect(firstReport.maintenanceProof.vacuumInterruption.payloadAfterRecovery).toEqual(
+      firstReport.maintenanceProof.vacuumInterruption.payloadBeforeKill,
+    );
+    expect(firstReport.maintenanceProof.vacuumInterruption.stateAfterRecovery).toEqual(
+      firstReport.maintenanceProof.vacuumInterruption.stateBeforeKill,
+    );
     expect(firstReport.maintenanceProof.postCompact.restoreVerified).toBe(true);
     expect(firstReport.maintenanceProof.postCompact.state.batches).toBeGreaterThan(0);
     expect(firstReport.maintenanceProof.postCompact.state.rows).toBeGreaterThan(0);


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Resolves a reliability-proof gap where OpenClaw's SQLite stress harness exercised normal compaction but did not demonstrate that a database remains intact when the process is force-killed during `VACUUM`.

## Why This Change Was Made

The harness now creates a 64 MiB retained payload, runs the real global or per-agent doctor compaction path in a child process, waits for active SQLite sidecar writes, and force-terminates the worker. Recovery must preserve application rows and the exact payload, clear active sidecars, and retain an `auto_vacuum = NONE` rollback sentinel; a committed VACUUM would change that value to `INCREMENTAL`, so post-commit kills cannot pass as recovery proof.

## User Impact

No runtime behavior changes. Maintainers get deterministic evidence that global and per-agent SQLite databases survive an interrupted full VACUUM and remain snapshot/restore capable afterward.

## Evidence

- `pnpm test:serial test/scripts/bench-sqlite-reliability.test.ts` - 4/4 passed on Linux x64 Testbox.
- `pnpm check:changed` - passed scripts, test-root typecheck, formatting, and lint lanes.
- Testbox lease: `tbx_01kybwkbm3mny5dvzba1yrhdxq`.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30146158691
- Global and per-agent smoke runs preserved 256 rows / 64 MiB payload through forced termination and verified post-compaction snapshot restore.
- `autoreview` - clean after correcting WAL-only and phase-timing false-positive risks.

AI-assisted; implementation and proof were reviewed and understood. No transcript attached.
