### PR TITLE
ci(env): ratchet production variable count

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-521
+520


### PR DESCRIPTION
## What Problem This Solves

The merge of #112678 reduced the production `OPENCLAW_*` variable count from 521 to 520 without lowering the ratchet budget. As a result, `pnpm check:changed` fails on current `main` before reaching change-specific validation.

## Why This Change Was Made

Lower the checked-in budget to the measured production count. This follows the ratchet policy in the file and keeps the repair isolated from unrelated cleanup branches.

## User Impact

No runtime behavior changes. Repository changed-file validation works again on current `main`.

## Evidence

- `node scripts/check-env-var-count.mjs --base origin/main`
- `OPENCLAW_TESTBOX=1` path-scoped `pnpm check:changed -- config/env-var-count-budget.txt`
- Testbox: `tbx_01kybwyerdechedzbs98cekye0`
- Autoreview: clean, no actionable findings
