### PR TITLE
fix: MEDIA leak, large-video aspect, steered webchat takeover

### DIFF
--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -323,7 +323,7 @@ describe("createBlockReplyDeliveryHandler", () => {
     expect(normalized.payload.mediaUrls).toEqual([]);
   });
 
-  it("leaves media-looking text alone when media directive parsing is disabled", () => {
+  it("strips MEDIA directives from visible text when attachment extraction is disabled", () => {
     const normalized = normalizeReplyPayloadDirectives({
       payload: { text: "Result\nMEDIA: ./image.png" },
       trimLeadingWhitespace: true,
@@ -331,7 +331,8 @@ describe("createBlockReplyDeliveryHandler", () => {
       extractMediaDirectives: false,
     });
 
-    expect(normalized.payload.text).toBe("Result\nMEDIA: ./image.png");
+    // Block streaming disables mid-stream attach, but the directive must not leak as text.
+    expect(normalized.payload.text).toBe("Result");
     expect(normalized.payload.mediaUrl).toBeUndefined();
     expect(normalized.payload.mediaUrls).toBeUndefined();
   });

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -30,7 +30,9 @@ export function normalizeReplyPayloadDirectives(params: {
     parseMode === "always" ||
     (parseMode === "auto" &&
       (sourceText.includes("[[") ||
-        (params.extractMediaDirectives !== false && /media:/i.test(sourceText)) ||
+        // Always parse MEDIA: so block streaming can strip the directive from visible
+        // text even when extractMediaDirectives is false (no mid-stream attach).
+        /media:/i.test(sourceText) ||
         (params.extractMarkdownImages === true && /!\[[^\]]*]\(/.test(sourceText)) ||
         sourceText.includes(silentToken)));
 

--- a/src/gateway/server-methods/chat-send-active-run-ownership.test.ts
+++ b/src/gateway/server-methods/chat-send-active-run-ownership.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { createChatSendActiveRunOwnership } from "./chat-send-active-run-ownership.js";
+
+describe("createChatSendActiveRunOwnership", () => {
+  it("keeps gateway fallback for plain non-agent replies", () => {
+    const ownership = createChatSendActiveRunOwnership();
+    expect(ownership.shouldFinalizeAsNonAgent(false)).toBe(true);
+    expect(ownership.shouldTerminalize()).toBe(false);
+  });
+
+  it("skips fallback after a steered turn is adopted by the active run", () => {
+    const ownership = createChatSendActiveRunOwnership();
+    ownership.markActiveRunTurnAdopted();
+    expect(ownership.shouldFinalizeAsNonAgent(false)).toBe(false);
+    expect(ownership.shouldTerminalize()).toBe(true);
+  });
+
+  it("skips fallback when a followup was queued behind the active run", () => {
+    const ownership = createChatSendActiveRunOwnership();
+    ownership.markQueuedFollowupEnqueued();
+    expect(ownership.shouldFinalizeAsNonAgent(false)).toBe(false);
+    expect(ownership.shouldTerminalize()).toBe(true);
+  });
+
+  it("skips fallback once an agent run owns the turn", () => {
+    const ownership = createChatSendActiveRunOwnership();
+    expect(ownership.shouldFinalizeAsNonAgent(true)).toBe(false);
+  });
+});

--- a/src/gateway/server-methods/chat-send-active-run-ownership.ts
+++ b/src/gateway/server-methods/chat-send-active-run-ownership.ts
@@ -1,0 +1,50 @@
+/**
+ * Decide whether chat.send still owns user-turn fallback persistence.
+ *
+ * Steered and queued followups are already owned by the active runtime or a
+ * later aggregate turn. Writing through the gateway fallback while an embedded
+ * prompt lock is released appends a foreign user turn and kills the active run
+ * with EmbeddedAttemptSessionTakeoverError (#113194).
+ */
+function shouldFinalizeChatSendAsNonAgent(params: {
+  agentRunStarted: boolean;
+  queuedFollowupEnqueued: boolean;
+  activeRunTurnAdopted: boolean;
+}): boolean {
+  return !params.agentRunStarted && !params.queuedFollowupEnqueued && !params.activeRunTurnAdopted;
+}
+
+/** Successful steer/queue admission ends this client run; a later turn owns work. */
+function shouldTerminalizeDeferredChatSend(params: {
+  queuedFollowupEnqueued: boolean;
+  activeRunTurnAdopted: boolean;
+}): boolean {
+  return params.queuedFollowupEnqueued || params.activeRunTurnAdopted;
+}
+
+/** Track steer vs followup ownership for chat.send post-dispatch. */
+export function createChatSendActiveRunOwnership() {
+  let queuedFollowupEnqueued = false;
+  let activeRunTurnAdopted = false;
+  return {
+    markQueuedFollowupEnqueued: () => {
+      queuedFollowupEnqueued = true;
+    },
+    markActiveRunTurnAdopted: () => {
+      activeRunTurnAdopted = true;
+    },
+    isQueuedFollowupEnqueued: () => queuedFollowupEnqueued,
+    isActiveRunTurnAdopted: () => activeRunTurnAdopted,
+    shouldFinalizeAsNonAgent: (agentRunStarted: boolean) =>
+      shouldFinalizeChatSendAsNonAgent({
+        agentRunStarted,
+        queuedFollowupEnqueued,
+        activeRunTurnAdopted,
+      }),
+    shouldTerminalize: () =>
+      shouldTerminalizeDeferredChatSend({
+        queuedFollowupEnqueued,
+        activeRunTurnAdopted,
+      }),
+  };
+}

--- a/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
@@ -67,6 +67,68 @@ describe("createChatSendDispatchErrorLifecycle", () => {
     expect(removeChatRun).toHaveBeenCalledWith("run-1", "run-1", "agent:main:main");
   });
 
+  it("terminalizes an admitted steered turn as successful despite later dispatch failure", async () => {
+    const broadcast = vi.fn();
+    const cleanupAdmittedRun = vi.fn();
+    const removeChatRun = vi.fn();
+    const warn = vi.fn();
+    const dedupe = new Map();
+    const lifecycle = createChatSendDispatchErrorLifecycle({
+      admission: {
+        activeRunAbort: {
+          cleanup: vi.fn(),
+          controller: new AbortController(),
+          entry: undefined,
+          registered: true,
+        } as never,
+        cleanupAdmittedRun,
+        lifecycleGeneration: "test-generation",
+        restartSafeAdmission: undefined,
+      },
+      context: {
+        agentRunSeq: new Map(),
+        broadcast,
+        chatRunState: createChatRunState(),
+        dedupe,
+        getRuntimeConfig: () => ({}),
+        logGateway: { warn },
+        nodeSendToSession: vi.fn(),
+        removeChatRun,
+      } as never,
+      isActiveRunTurnAdopted: () => true,
+      isQueuedFollowupEnqueued: () => false,
+      persistUserTurnTranscript: vi.fn(),
+      session: {
+        agentId: "main",
+        backingSessionId: undefined,
+        cfg: {},
+        clientRunId: "run-2",
+        now: 1,
+        rawSessionKey: "agent:main:main",
+        sessionKey: "agent:main:main",
+      },
+      terminalizeRestartSafeAdmission: vi.fn(),
+      userTurnRecorder: { hasPersisted: () => false, isBlocked: () => false },
+    });
+
+    await lifecycle.handleError(new Error("late failure after steer"));
+    lifecycle.finalize();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("dispatch failed after active-run steer adoption"),
+    );
+    expect(dedupe.get("chat:run-2")).toMatchObject({
+      ok: true,
+      payload: { runId: "run-2", status: "ok" },
+    });
+    expect(broadcast).toHaveBeenCalledWith(
+      "chat",
+      expect.objectContaining({ runId: "run-2", state: "final" }),
+      { sessionKeys: ["agent:main:main"] },
+    );
+    expect(cleanupAdmittedRun).toHaveBeenCalledOnce();
+  });
+
   it("preserves an explicitly aborted terminal when its dispatch later rejects", async () => {
     const runId = "explicit-abort-before-dispatch-rejection";
     const sessionKey = "agent:main:main";

--- a/src/gateway/server-methods/chat-send-dispatch-errors.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.ts
@@ -29,6 +29,7 @@ export function createChatSendDispatchErrorLifecycle(params: {
     "activeRunAbort" | "cleanupAdmittedRun" | "lifecycleGeneration" | "restartSafeAdmission"
   >;
   context: GatewayRequestContext;
+  isActiveRunTurnAdopted?: () => boolean;
   isQueuedFollowupEnqueued: () => boolean;
   persistUserTurnTranscript: () => Promise<unknown>;
   session: Pick<
@@ -44,6 +45,7 @@ export function createChatSendDispatchErrorLifecycle(params: {
   const {
     admission,
     context,
+    isActiveRunTurnAdopted,
     isQueuedFollowupEnqueued,
     persistUserTurnTranscript,
     session,
@@ -58,10 +60,14 @@ export function createChatSendDispatchErrorLifecycle(params: {
 
   const handleError = async (err: unknown) => {
     const errorMessage = String(err);
+    const activeRunTurnAdopted = isActiveRunTurnAdopted?.() === true;
     const queuedFollowupEnqueued = isQueuedFollowupEnqueued();
-    if (queuedFollowupEnqueued) {
+    const ownedByActiveRun = activeRunTurnAdopted || queuedFollowupEnqueued;
+    if (ownedByActiveRun) {
       context.logGateway.warn(
-        `webchat dispatch failed after followup queue admission: ${formatForLog(err)}`,
+        activeRunTurnAdopted
+          ? `webchat dispatch failed after active-run steer adoption: ${formatForLog(err)}`
+          : `webchat dispatch failed after followup queue admission: ${formatForLog(err)}`,
       );
       if (!context.chatRunState.hasAbortMarker(clientRunId)) {
         setGatewayDedupeEntry({

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -32,6 +32,7 @@ import { ensureChatQueuedTurns } from "./chat-abort-runtime.js";
 import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
 import { hasGatewayAdminScope } from "./chat-origin-routing.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
+import { createChatSendActiveRunOwnership } from "./chat-send-active-run-ownership.js";
 import { admitChatSend } from "./chat-send-admission.js";
 import { prepareChatSendAttachments } from "./chat-send-attachments.js";
 import {
@@ -39,7 +40,7 @@ import {
   scheduleChatDashboardSessionTitle,
 } from "./chat-send-background.js";
 import { createChatSendDispatchErrorLifecycle } from "./chat-send-dispatch-errors.js";
-import { finalizeChatSendNonAgentReplies } from "./chat-send-nonagent-finalization.js";
+import { finalizeChatSendPostDispatch } from "./chat-send-post-dispatch.js";
 import {
   respondChatSessionRoutingChanged,
   runChatSendPreAdmission,
@@ -51,7 +52,6 @@ import {
 import { createChatSendReplyDispatch } from "./chat-send-reply-dispatch.js";
 import { normalizeChatSendRequest } from "./chat-send-request.js";
 import { prepareChatSendSession } from "./chat-send-session.js";
-import { finalizeChatSendSourceReplies } from "./chat-send-source-finalization.js";
 import { applyChatSendManagedMedia, prepareChatSendUserTurn } from "./chat-send-user-turn.js";
 import {
   chatSendAckServerTimingAttributes,
@@ -339,11 +339,12 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
       session: preparedSession.value,
       userTurnRecorder,
     });
-    let queuedFollowupEnqueued = false;
+    const activeRunOwnership = createChatSendActiveRunOwnership();
     const dispatchErrorLifecycle = createChatSendDispatchErrorLifecycle({
       admission: admitted.value,
       context,
-      isQueuedFollowupEnqueued: () => queuedFollowupEnqueued,
+      isActiveRunTurnAdopted: activeRunOwnership.isActiveRunTurnAdopted,
+      isQueuedFollowupEnqueued: activeRunOwnership.isQueuedFollowupEnqueued,
       persistUserTurnTranscript: persistGatewayUserTurnTranscript,
       session: preparedSession.value,
       terminalizeRestartSafeAdmission,
@@ -441,19 +442,26 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
                   // Gateway cancel identity only — share collect key via ownerKey.
                   admission: "cancel-only",
                   ownerKey: queuedFollowupOwnerKey,
-                  onAdopted: async () => {},
+                  onAdopted: async () => {
+                    activeRunOwnership.markActiveRunTurnAdopted();
+                  },
                   onDeferred: () => {
-                    queuedFollowupEnqueued = registerQueuedChatTurn({
-                      chatQueuedTurns: ensureChatQueuedTurns(context),
-                      runId: clientRunId,
-                      controller: activeRunAbort.controller,
-                      sessionId: backingSessionId ?? clientRunId,
-                      sessionKey,
-                      agentId: selectedAgent.agentId,
-                      ownerConnId: normalizeOptionalText(client?.connId),
-                      ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
-                    });
-                    return queuedFollowupEnqueued;
+                    if (
+                      !registerQueuedChatTurn({
+                        chatQueuedTurns: ensureChatQueuedTurns(context),
+                        runId: clientRunId,
+                        controller: activeRunAbort.controller,
+                        sessionId: backingSessionId ?? clientRunId,
+                        sessionKey,
+                        agentId: selectedAgent.agentId,
+                        ownerConnId: normalizeOptionalText(client?.connId),
+                        ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
+                      })
+                    ) {
+                      return false;
+                    }
+                    activeRunOwnership.markQueuedFollowupEnqueued();
+                    return true;
                   },
                   onCancellationRetired: () => {
                     retireQueuedChatTurnCancellation(
@@ -557,96 +565,22 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
         await measureDiagnosticsTimelineSpan(
           "gateway.chat_send.post_dispatch",
           async () => {
-            const returnedAgentErrorPayloads = agentRunStarted
-              ? replyDispatch.deliveredReplies
-                  .map((entryInner) => entryInner.payload)
-                  .filter((payload) => payload.isError)
-              : [];
-            const returnedAgentErrorMessage =
-              returnedAgentErrorPayloads
-                .map((payload) => payload.text?.trim())
-                .filter((text): text is string => Boolean(text))
-                .join(" | ") || undefined;
-            if (
-              agentRunStarted &&
-              returnedAgentErrorPayloads.length > 0 &&
-              !userTurnRecorder.hasPersisted() &&
-              !userTurnRecorder.isBlocked()
-            ) {
-              await persistGatewayUserTurnTranscriptBestEffort();
-            }
-            if (
-              agentRunStarted &&
-              returnedAgentErrorPayloads.length === 0 &&
-              !userTurnRecorder.hasPersisted() &&
-              !userTurnRecorder.isBlocked() &&
-              userTurnRecorder.hasRuntimePersistencePending()
-            ) {
-              await persistGatewayUserTurnTranscriptBestEffort();
-            }
-            let broadcastedSourceReplyFinal = false;
-            // WebChat persistence has two owners. Agent runs persist model-visible turns
-            // through OpenClaw runtime's SessionManager; this dispatcher only owns live delivery payloads.
-            // Do not blindly mirror agent-run final payloads into JSONL or chat.history can
-            // duplicate normal embedded-agent assistant turns. The non-agent branch below has no
-            // runtime-owned assistant turn, so it appends a gateway-injected assistant entry before
-            // broadcasting the final UI event.
-            if (!agentRunStarted && !queuedFollowupEnqueued) {
-              await finalizeChatSendNonAgentReplies({
-                accountId,
-                context,
-                deliveredReplies: replyDispatch.deliveredReplies,
-                emitFirstAssistantServerTiming,
-                foldCommandBlocks: isInternalTextSlashCommandTurn,
-                persistUserTurnTranscript: persistGatewayUserTurnTranscriptBestEffort,
-                session: preparedSession.value,
-                suppressReplies: replyDispatch.hasAppendedWebchatAgentMedia(),
-              });
-            } else {
-              broadcastedSourceReplyFinal = await finalizeChatSendSourceReplies({
-                accountId,
-                context,
-                deliveredReplies: replyDispatch.deliveredReplies,
-                emitFirstAssistantServerTiming,
-                hasReturnedAgentErrorPayloads: returnedAgentErrorPayloads.length > 0,
-                session: preparedSession.value,
-              });
-            }
-            const shouldBroadcastAgentError =
-              returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;
-            if (shouldBroadcastAgentError) {
-              broadcastChatError({
-                context,
-                runId: clientRunId,
-                sessionKey,
-                agentId,
-                errorMessage: returnedAgentErrorMessage,
-              });
-            }
-            if (!context.chatRunState.hasAbortMarker(clientRunId)) {
-              const returnedAgentError = shouldBroadcastAgentError
-                ? errorShape(
-                    ErrorCodes.UNAVAILABLE,
-                    returnedAgentErrorMessage ?? "agent returned an error payload",
-                  )
-                : undefined;
-              setGatewayDedupeEntry({
-                dedupe: context.dedupe,
-                key: `chat:${clientRunId}`,
-                entry: {
-                  ts: Date.now(),
-                  ok: !shouldBroadcastAgentError,
-                  payload: shouldBroadcastAgentError
-                    ? {
-                        runId: clientRunId,
-                        status: "error" as const,
-                        summary: returnedAgentErrorMessage ?? "agent returned an error payload",
-                      }
-                    : { runId: clientRunId, status: "ok" as const },
-                  ...(returnedAgentError ? { error: returnedAgentError } : {}),
-                },
-              });
-            }
+            await finalizeChatSendPostDispatch({
+              accountId,
+              activeRunOwnership,
+              agentId,
+              agentRunStarted,
+              clientRunId,
+              context,
+              deliveredReplies: replyDispatch.deliveredReplies,
+              emitFirstAssistantServerTiming,
+              foldCommandBlocks: isInternalTextSlashCommandTurn,
+              hasAppendedWebchatAgentMedia: replyDispatch.hasAppendedWebchatAgentMedia,
+              persistUserTurnTranscriptBestEffort: persistGatewayUserTurnTranscriptBestEffort,
+              session: preparedSession.value,
+              sessionKey,
+              userTurnRecorder,
+            });
           },
           {
             phase: "agent-turn",
@@ -661,9 +595,11 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
           },
           dispatchStartedAtMs,
         );
-        if (queuedFollowupEnqueued && !context.chatRunState.hasAbortMarker(clientRunId)) {
-          // Successful queue admission ends this client run. The later
-          // aggregate/followup owns its own run id.
+        if (
+          activeRunOwnership.shouldTerminalize() &&
+          !context.chatRunState.hasAbortMarker(clientRunId)
+        ) {
+          // Successful steer/queue admission ends this client run.
           broadcastChatFinal({
             context,
             runId: clientRunId,

--- a/src/gateway/server-methods/chat-send-post-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-post-dispatch.ts
@@ -1,0 +1,135 @@
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import { setGatewayDedupeEntry } from "./agent-job.js";
+import { broadcastChatError } from "./chat-broadcast.js";
+import type { createChatSendActiveRunOwnership } from "./chat-send-active-run-ownership.js";
+import { finalizeChatSendNonAgentReplies } from "./chat-send-nonagent-finalization.js";
+import type { createChatSendReplyDispatch } from "./chat-send-reply-dispatch.js";
+import type { PreparedChatSendSession } from "./chat-send-session.js";
+import { finalizeChatSendSourceReplies } from "./chat-send-source-finalization.js";
+import type { GatewayRequestContext } from "./types.js";
+
+type DeliveredReply = ReturnType<typeof createChatSendReplyDispatch>["deliveredReplies"][number];
+type ActiveRunOwnership = ReturnType<typeof createChatSendActiveRunOwnership>;
+
+/** Finalize chat.send after inbound dispatch without re-owning steered turns. */
+export async function finalizeChatSendPostDispatch(params: {
+  accountId: string | undefined;
+  activeRunOwnership: ActiveRunOwnership;
+  agentId: string | undefined;
+  agentRunStarted: boolean;
+  clientRunId: string;
+  context: GatewayRequestContext;
+  deliveredReplies: readonly DeliveredReply[];
+  emitFirstAssistantServerTiming: () => void;
+  foldCommandBlocks: boolean;
+  hasAppendedWebchatAgentMedia: () => boolean;
+  persistUserTurnTranscriptBestEffort: () => Promise<void>;
+  session: PreparedChatSendSession;
+  sessionKey: string;
+  userTurnRecorder: Pick<
+    UserTurnTranscriptRecorder,
+    "hasPersisted" | "hasRuntimePersistencePending" | "isBlocked"
+  >;
+}): Promise<void> {
+  const {
+    accountId,
+    activeRunOwnership,
+    agentId,
+    agentRunStarted,
+    clientRunId,
+    context,
+    deliveredReplies,
+    emitFirstAssistantServerTiming,
+    foldCommandBlocks,
+    hasAppendedWebchatAgentMedia,
+    persistUserTurnTranscriptBestEffort,
+    session,
+    sessionKey,
+    userTurnRecorder,
+  } = params;
+  const returnedAgentErrorPayloads = agentRunStarted
+    ? deliveredReplies.map((entry) => entry.payload).filter((payload) => payload.isError)
+    : [];
+  const returnedAgentErrorMessage =
+    returnedAgentErrorPayloads
+      .map((payload) => payload.text?.trim())
+      .filter((text): text is string => Boolean(text))
+      .join(" | ") || undefined;
+  if (
+    agentRunStarted &&
+    returnedAgentErrorPayloads.length > 0 &&
+    !userTurnRecorder.hasPersisted() &&
+    !userTurnRecorder.isBlocked()
+  ) {
+    await persistUserTurnTranscriptBestEffort();
+  }
+  if (
+    agentRunStarted &&
+    returnedAgentErrorPayloads.length === 0 &&
+    !userTurnRecorder.hasPersisted() &&
+    !userTurnRecorder.isBlocked() &&
+    userTurnRecorder.hasRuntimePersistencePending()
+  ) {
+    await persistUserTurnTranscriptBestEffort();
+  }
+  let broadcastedSourceReplyFinal = false;
+  // Agent runs persist through SessionManager; non-agent turns use gateway fallback.
+  // Steered/queued turns already have a runtime owner — do not append again.
+  if (activeRunOwnership.shouldFinalizeAsNonAgent(agentRunStarted)) {
+    await finalizeChatSendNonAgentReplies({
+      accountId,
+      context,
+      deliveredReplies,
+      emitFirstAssistantServerTiming,
+      foldCommandBlocks,
+      persistUserTurnTranscript: persistUserTurnTranscriptBestEffort,
+      session,
+      suppressReplies: hasAppendedWebchatAgentMedia(),
+    });
+  } else {
+    broadcastedSourceReplyFinal = await finalizeChatSendSourceReplies({
+      accountId,
+      context,
+      deliveredReplies,
+      emitFirstAssistantServerTiming,
+      hasReturnedAgentErrorPayloads: returnedAgentErrorPayloads.length > 0,
+      session,
+    });
+  }
+  const shouldBroadcastAgentError =
+    returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;
+  if (shouldBroadcastAgentError) {
+    broadcastChatError({
+      context,
+      runId: clientRunId,
+      sessionKey,
+      agentId,
+      errorMessage: returnedAgentErrorMessage,
+    });
+  }
+  if (!context.chatRunState.hasAbortMarker(clientRunId)) {
+    const returnedAgentError = shouldBroadcastAgentError
+      ? errorShape(
+          ErrorCodes.UNAVAILABLE,
+          returnedAgentErrorMessage ?? "agent returned an error payload",
+        )
+      : undefined;
+    setGatewayDedupeEntry({
+      dedupe: context.dedupe,
+      key: `chat:${clientRunId}`,
+      entry: {
+        ts: Date.now(),
+        ok: !shouldBroadcastAgentError,
+        payload: shouldBroadcastAgentError
+          ? {
+              runId: clientRunId,
+              status: "error" as const,
+              summary: returnedAgentErrorMessage ?? "agent returned an error payload",
+            }
+          : { runId: clientRunId, status: "ok" as const },
+        ...(returnedAgentError ? { error: returnedAgentError } : {}),
+      },
+    });
+  }
+}

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -9,12 +9,22 @@ import {
 } from "./media-probe.js";
 import type { MediaProbeKind, MediaProbeResult } from "./media-probe.js";
 
-const { runFfprobe } = vi.hoisted(() => ({
+const { runFfprobe, withTempWorkspace, resolvePreferredOpenClawTmpDir } = vi.hoisted(() => ({
   runFfprobe: vi.fn(),
+  withTempWorkspace: vi.fn(),
+  resolvePreferredOpenClawTmpDir: vi.fn(),
 }));
 
 vi.mock("./ffmpeg-exec.js", () => ({
   runFfprobe,
+}));
+
+vi.mock("../infra/private-temp-workspace.js", () => ({
+  withTempWorkspace,
+}));
+
+vi.mock("../infra/tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir,
 }));
 
 let testDir = "";
@@ -40,6 +50,13 @@ afterAll(async () => {
 
 beforeEach(() => {
   runFfprobe.mockReset();
+  resolvePreferredOpenClawTmpDir.mockReturnValue("/tmp/openclaw");
+  withTempWorkspace.mockImplementation(async (_opts, run) => {
+    const workspace = {
+      write: vi.fn(async (name: string) => `/tmp/openclaw/ws/${name}`),
+    };
+    return await run(workspace);
+  });
 });
 
 async function probeMediaFile(filePath: string, kind: MediaProbeKind): Promise<MediaProbeResult> {
@@ -192,11 +209,22 @@ describe("probeMediaFilesWithinBudget", () => {
 });
 
 describe("probeVideoDimensions", () => {
-  it("keeps buffer callers on the canonical probe path", async () => {
+  it("writes buffer to seekable temp file then probes path", async () => {
     const buffer = Buffer.from("video");
+    const write = vi.fn(async (name: string) => `/tmp/openclaw/ws/${name}`);
+    withTempWorkspace.mockImplementationOnce(async (_opts, run) => await run({ write }));
     runFfprobe.mockResolvedValueOnce(JSON.stringify({ streams: [{ width: 720, height: 1280 }] }));
 
     await expect(probeVideoDimensions(buffer)).resolves.toEqual({ width: 720, height: 1280 });
+
+    expect(write).toHaveBeenCalledWith("video.bin", buffer);
+    expect(withTempWorkspace).toHaveBeenCalledWith(
+      {
+        rootDir: "/tmp/openclaw",
+        prefix: "openclaw-ffprobe-",
+      },
+      expect.any(Function),
+    );
     expect(runFfprobe).toHaveBeenCalledWith(
       [
         "-v",
@@ -204,14 +232,31 @@ describe("probeVideoDimensions", () => {
         "-select_streams",
         "v:0",
         "-protocol_whitelist",
-        "pipe",
+        "fd",
         "-show_entries",
         "format=duration:stream=duration,width,height",
         "-of",
         "json",
-        "pipe:0",
+        "-fd",
+        "0",
+        "fd:",
       ],
-      { input: buffer },
+      { stdinFileDescriptor: expect.any(Number) },
     );
+  });
+
+  it("falls back when ffprobe fails or returns malformed output", async () => {
+    const buffer = Buffer.from("video");
+
+    runFfprobe.mockRejectedValueOnce(new Error("missing ffprobe"));
+    await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+
+    runFfprobe.mockResolvedValueOnce("{");
+    await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+  });
+
+  it("falls back when the temp workspace write rejects", async () => {
+    withTempWorkspace.mockRejectedValueOnce(new Error("disk full"));
+    await expect(probeVideoDimensions(Buffer.from("video"))).resolves.toBeUndefined();
   });
 });

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -51,9 +51,15 @@ afterAll(async () => {
 beforeEach(() => {
   runFfprobe.mockReset();
   resolvePreferredOpenClawTmpDir.mockReturnValue("/tmp/openclaw");
+  // Write a real seekable file so probeVideoDimensions can fs.open it (same
+  // path production uses after withTempWorkspace.write).
   withTempWorkspace.mockImplementation(async (_opts, run) => {
     const workspace = {
-      write: vi.fn(async (name: string) => `/tmp/openclaw/ws/${name}`),
+      write: vi.fn(async (name: string, buffer: Buffer) => {
+        const filePath = path.join(testDir, name);
+        await fs.writeFile(filePath, buffer);
+        return filePath;
+      }),
     };
     return await run(workspace);
   });
@@ -211,8 +217,15 @@ describe("probeMediaFilesWithinBudget", () => {
 describe("probeVideoDimensions", () => {
   it("writes buffer to seekable temp file then probes path", async () => {
     const buffer = Buffer.from("video");
-    const write = vi.fn(async (name: string) => `/tmp/openclaw/ws/${name}`);
-    withTempWorkspace.mockImplementationOnce(async (_opts, run) => await run({ write }));
+    let write: ReturnType<typeof vi.fn> | undefined;
+    withTempWorkspace.mockImplementationOnce(async (_opts, run) => {
+      write = vi.fn(async (name: string, data: Buffer) => {
+        const filePath = path.join(testDir, name);
+        await fs.writeFile(filePath, data);
+        return filePath;
+      });
+      return await run({ write });
+    });
     runFfprobe.mockResolvedValueOnce(JSON.stringify({ streams: [{ width: 720, height: 1280 }] }));
 
     await expect(probeVideoDimensions(buffer)).resolves.toEqual({ width: 720, height: 1280 });

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
 import type { MediaKind } from "@openclaw/media-core/constants";
+import { withTempWorkspace } from "../infra/private-temp-workspace.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfprobe } from "./ffmpeg-exec.js";
 
 export type MediaProbeKind = Extract<MediaKind, "audio" | "video">;
@@ -189,8 +191,25 @@ type VideoDimensions = {
   height: number;
 };
 
-/** Probes a video buffer while preserving the existing public media-runtime API. */
+/**
+ * Probes a video buffer via a seekable temp file. Pipe:0 probing fails for
+ * large MP4s because ffprobe needs to seek the MOOV atom (often at the end for
+ * faststart files), which is impossible over a non-seekable stdin pipe.
+ */
 export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensions | undefined> {
-  const { width, height } = await probeMediaSource({ kind: "buffer", buffer }, "video");
-  return width && height ? { width, height } : undefined;
+  try {
+    return await withTempWorkspace(
+      {
+        rootDir: resolvePreferredOpenClawTmpDir(),
+        prefix: "openclaw-ffprobe-",
+      },
+      async (workspace) => {
+        const tempPath = await workspace.write("video.bin", buffer);
+        const { width, height } = await probeMediaFile(tempPath, "video");
+        return width && height ? { width, height } : undefined;
+      },
+    );
+  } catch {
+    return undefined;
+  }
 }

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -143,6 +143,35 @@ describe("splitMediaFromOutput", () => {
     ]);
   });
 
+  it("strips MEDIA lines from visible text when attachment extraction is disabled", () => {
+    expectParsedMediaOutputCase(
+      "Caption\nMEDIA:./screenshot.png\nDone",
+      {
+        text: "Caption\nDone",
+        mediaUrls: undefined,
+      },
+      { extractMediaDirectives: false },
+    );
+  });
+
+  it("strips mixed valid/invalid MEDIA leftovers when extraction is disabled", () => {
+    expectParsedMediaOutputCase(
+      "Caption\nMEDIA:./ok.png leftover-words\nDone",
+      {
+        text: "Caption\nDone",
+        mediaUrls: undefined,
+      },
+      { extractMediaDirectives: false },
+    );
+  });
+
+  it("still extracts MEDIA attachments when extraction remains enabled", () => {
+    expectParsedMediaOutputCase("Caption\nMEDIA:./screenshot.png\nDone", {
+      text: "Caption\nDone",
+      mediaUrls: ["./screenshot.png"],
+    });
+  });
+
   const extractMarkdownImages = { extractMarkdownImages: true } as const;
 
   it("keeps markdown image urls as text by default", () => {

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -317,3 +317,19 @@ describe("splitMediaFromOutput", () => {
     );
   });
 });
+
+describe("strip-only MEDIA text preservation", () => {
+  it("preserves paragraph breaks, indentation, and repeated spaces", () => {
+    const input = "First\n\n  Second  paragraph\nMEDIA:./image.png\n    code  example";
+    expect(splitMediaFromOutput(input, { extractMediaDirectives: false }).text).toBe(
+      "First\n\n  Second  paragraph\n    code  example",
+    );
+  });
+
+  it("preserves fenced text containing MEDIA examples", () => {
+    const input = "Before\n\n```text\nMEDIA:./example.png\n  keep  spaces\n```\nMEDIA:./image.png";
+    expect(splitMediaFromOutput(input, { extractMediaDirectives: false }).text).toBe(
+      "Before\n\n```text\nMEDIA:./example.png\n  keep  spaces\n```",
+    );
+  });
+});

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -500,7 +500,9 @@ export function splitMediaFromOutput(
   }
   const extractMarkdownImages = options.extractMarkdownImages === true;
   const extractMediaDirectives = options.extractMediaDirectives !== false;
-  const mayContainMediaToken = extractMediaDirectives && /media:/i.test(trimmedRaw);
+  // Always detect MEDIA: lines so block-streaming (extractMediaDirectives:false) can
+  // still strip the directive from visible text without attaching mid-stream.
+  const mayContainMediaToken = /media:/i.test(trimmedRaw);
   const mayContainMarkdownImage = extractMarkdownImages && /!\[[^\]]*]\(/.test(trimmedRaw);
   const mayContainAudioTag = trimmedRaw.includes("[[");
   if (!mayContainMediaToken && !mayContainMarkdownImage && !mayContainAudioTag) {
@@ -542,7 +544,7 @@ export function splitMediaFromOutput(
     }
 
     const trimmedStart = line.trimStart();
-    if (!extractMediaDirectives || !trimmedStart.toUpperCase().startsWith("MEDIA:")) {
+    if (!trimmedStart.toUpperCase().startsWith("MEDIA:")) {
       const markdownImageResult = extractMarkdownImages
         ? collectMarkdownImageSegments({ line, media })
         : { lineSegments: [], foundMedia: false };
@@ -593,7 +595,11 @@ export function splitMediaFromOutput(
       for (const part of parts) {
         const candidate = normalizeMediaSource(cleanCandidate(part));
         if (isValidMedia(candidate, unwrapped ? { allowSpaces: true } : undefined)) {
-          media.push(candidate);
+          // Collect attachments only when extraction is enabled; always mark handled so
+          // the directive line is stripped from visible text during block streaming.
+          if (extractMediaDirectives) {
+            media.push(candidate);
+          }
           hasValidMedia = true;
           foundMediaToken = true;
           validCount += 1;
@@ -615,7 +621,9 @@ export function splitMediaFromOutput(
         // A single valid split plus invalid leftovers can be one local path containing spaces.
         const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
         if (isValidMedia(fallback, { allowSpaces: true })) {
-          media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
+          if (extractMediaDirectives) {
+            media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
+          }
           hasValidMedia = true;
           foundMediaToken = true;
           validCount = 1;
@@ -626,7 +634,9 @@ export function splitMediaFromOutput(
       if (!hasValidMedia && !unwrapped && /\s/.test(payloadValue)) {
         const spacedFallback = normalizeMediaSource(cleanCandidate(payloadValue));
         if (isValidMedia(spacedFallback, { allowSpaces: true, allowBareFilename: true })) {
-          media.splice(mediaStartIndex, media.length - mediaStartIndex, spacedFallback);
+          if (extractMediaDirectives) {
+            media.splice(mediaStartIndex, media.length - mediaStartIndex, spacedFallback);
+          }
           hasValidMedia = true;
           foundMediaToken = true;
           validCount = 1;
@@ -637,7 +647,9 @@ export function splitMediaFromOutput(
       if (!hasValidMedia) {
         const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
         if (isValidMedia(fallback, { allowSpaces: true, allowBareFilename: true })) {
-          media.push(fallback);
+          if (extractMediaDirectives) {
+            media.push(fallback);
+          }
           hasValidMedia = true;
           foundMediaToken = true;
           invalidParts.length = 0;
@@ -650,11 +662,15 @@ export function splitMediaFromOutput(
           lineSegments.push({ type: "text", text: beforeText });
         }
         pieces.length = 0;
-        for (const url of media.slice(mediaStartIndex, mediaStartIndex + validCount)) {
-          lineSegments.push({ type: "media", url });
-        }
-        if (invalidParts.length > 0) {
-          pieces.push(invalidParts.join(" "));
+        if (extractMediaDirectives) {
+          for (const url of media.slice(mediaStartIndex, mediaStartIndex + validCount)) {
+            lineSegments.push({ type: "media", url });
+          }
+          // Keep invalid leftovers visible only when attaching; strip-only mode drops
+          // the whole MEDIA directive from streamed text.
+          if (invalidParts.length > 0) {
+            pieces.push(invalidParts.join(" "));
+          }
         }
       } else if (looksLikeLocalPath) {
         // Strip MEDIA: lines with local paths even when invalid (e.g. absolute paths

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -703,19 +703,10 @@ export function splitMediaFromOutput(
     lineOffset += line.length + 1; // +1 for newline
   }
 
-  let cleanedText = keptLines
-    .join("\n")
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/[ \t]{2,}/g, " ")
-    .replace(/\n{2,}/g, "\n")
-    .trim();
-
-  // Detect and strip [[audio_as_voice]] tag
-  const audioTagResult = parseAudioTag(cleanedText);
+  const visibleText = keptLines.join("\n").replace(/^(?:[ \t]*\n)+/, "");
+  const audioTagResult = parseAudioTag(visibleText);
   const hasAudioAsVoice = audioTagResult.audioAsVoice;
-  if (audioTagResult.hadTag) {
-    cleanedText = audioTagResult.text.replace(/\n{2,}/g, "\n").trim();
-  }
+  const cleanedText = (audioTagResult.hadTag ? audioTagResult.text : visibleText).trimEnd();
 
   if (media.length === 0) {
     const parsedText = foundMediaToken || hasAudioAsVoice ? cleanedText : trimmedRaw;


### PR DESCRIPTION
Closes #113014
Closes #97826
Closes #113194

## What Problem This Solves

Fixes three delivery bugs:

1. Webchat/block-streamed replies leak raw `MEDIA:/path` lines into visible text ("Outside allowed folders").
2. Large Telegram videos omit width/height because ffprobe stdin probing fails on non-seekable pipes, so playback stretches.
3. A second webchat message steered into an in-flight run can kill that run with `EmbeddedAttemptSessionTakeoverError`.

## Why This Change Was Made

- Always strip `MEDIA:` directives from visible text during block streaming while still deferring attachment extraction to the final pass.
- Probe video dimensions via a seekable temp workspace instead of `pipe:0`.
- Steered/queued followups are already owned by the active runtime; skip the gateway non-agent user-turn fallback (and terminalize the client run) once adoption/queue admission happens.

## User Impact

- Webchat image replies no longer show broken local-path chips for stripped MEDIA directives.
- Large videos keep correct aspect ratio when dimensions can be probed.
- Steering a second webchat message into an active run no longer aborts that run via session takeover.

## Evidence

Focused tests (Node 24.15): 92 passed across parse/video/delivery/ownership/dispatch-error shards.

```text
node scripts/run-vitest.mjs \
  src/media/parse.test.ts \
  src/media/video-dimensions.test.ts \
  src/auto-reply/reply/reply-delivery.test.ts \
  src/gateway/server-methods/chat-send-active-run-ownership.test.ts \
  src/gateway/server-methods/chat-send-dispatch-errors.test.ts
```

Autoreview (claude-fable-5): clean.

### After-fix runtime proofs (local process, redacted)

Block-stream MEDIA strip (`extractMediaDirectives: false`):

```text
before:
Here is the screenshot.
MEDIA:/home/user/.openclaw/media/browser/snap-abc.png
Done.

after.text: "Here is the screenshot.\nDone."
after.mediaUrl: undefined
after.mediaUrls: undefined
stripped: true
```

Large landscape video probe (moov-at-end 1920x1080 MP4; non-seekable truncated pipe fails with `moov atom not found`; production `probeVideoDimensions` on the full buffer returns dimensions):

```text
truncated pipe:0 -> moov atom not found / Invalid data
probeVideoDimensions(5.1MB buffer) -> { width: 1920, height: 1080, aspect: 1.778 }
```

Steered/queued `chat.send` ownership (gateway skips non-agent user-turn fallback after adoption/queue):

```text
plain: shouldFinalizeAsNonAgent=true, shouldTerminalize=false
after active-run steer adoption: shouldFinalizeAsNonAgent=false, shouldTerminalize=true
after followup queued: shouldFinalizeAsNonAgent=false, shouldTerminalize=true
```

Telegram Desktop visible playback proof still needs a live bot delivery capture (Mantis requested).

CI: earlier `checks-node-compact-small-7` failure was unrelated `help-exit.process.test.ts` `--help` timeout flake; empty commit retriggers exact-head CI.

AI-assisted.

### September 12 parser review follow-up

Fixed the review finding that stripping MEDIA directives collapsed retained paragraph breaks, indentation, repeated spaces, and fenced examples. Two new regression tests failed on the prior head; all 66 parser tests now pass using an isolated Vitest 5 runner against the actual source and dependencies. Oxfmt 0.60.0 and git diff --check pass; scoped Sol autoreview reports no actionable findings. This validates the parser correction only.

The separate direct-run onAdopted/steering finding remains unresolved. Live Telegram playback evidence and the broader gateway steering runtime validation are still outstanding; this PR is not ready to merge. Earlier 92-test evidence above is historical and was not rerun for this narrow follow-up.
