### PR TITLE
refactor(wizard): share migration config canonicalization

### DIFF
--- a/src/wizard/setup.migration-canonical.ts
+++ b/src/wizard/setup.migration-canonical.ts
@@ -1,0 +1,25 @@
+import crypto from "node:crypto";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+export function canonicalizeSetupMigrationValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeSetupMigrationValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .toSorted()
+      .filter((key) => record[key] !== undefined)
+      .map((key) => [key, canonicalizeSetupMigrationValue(record[key])]),
+  );
+}
+
+export function hashSetupMigrationConfig(config: OpenClawConfig): string {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(canonicalizeSetupMigrationValue(config)))
+    .digest("hex");
+}

--- a/src/wizard/setup.migration-promotion.ts
+++ b/src/wizard/setup.migration-promotion.ts
@@ -1,11 +1,11 @@
 // Setup migration promotion owns durable journals, rollback, and path validation.
-import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readDurableJsonFile, writeJsonAtomic } from "../infra/json-files.js";
 import { isNotFoundPathError } from "../infra/path-guards.js";
 import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
+import { hashSetupMigrationConfig } from "./setup.migration-canonical.js";
 
 export const PROMOTION_JOURNAL_FILE = "onboarding-promotion.json";
 export const PROMOTION_JOURNAL_VERSION = 1;
@@ -65,29 +65,6 @@ export type SetupMigrationPromotionResume = {
   acknowledge: () => Promise<void>;
   cleanup: () => Promise<void>;
 };
-
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(canonicalize);
-  }
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-  const record = value as Record<string, unknown>;
-  return Object.fromEntries(
-    Object.keys(record)
-      .toSorted()
-      .filter((key) => record[key] !== undefined)
-      .map((key) => [key, canonicalize(record[key])]),
-  );
-}
-
-function hashConfig(config: OpenClawConfig): string {
-  return crypto
-    .createHash("sha256")
-    .update(JSON.stringify(canonicalize(config)))
-    .digest("hex");
-}
 
 async function pathExists(candidate: string): Promise<boolean> {
   try {
@@ -308,7 +285,7 @@ export async function recoverSetupMigrationPromotion(params: {
       `An onboarding migration promotion is indeterminate. Review ${found.path} and run openclaw doctor before retrying.`,
     );
   }
-  const currentConfigHash = hashConfig(await params.readConfigFile());
+  const currentConfigHash = hashSetupMigrationConfig(await params.readConfigFile());
   const allFinal = (
     await Promise.all(journal.components.map((component) => pathExists(component.finalPath)))
   ).every(Boolean);

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -8,6 +8,7 @@ import { withFileLock } from "../infra/file-lock.js";
 import { isNotFoundPathError } from "../infra/path-guards.js";
 import type { MigrationPlan } from "../plugins/types.js";
 import { resolveUserPath } from "../utils.js";
+import { canonicalizeSetupMigrationValue } from "./setup.migration-canonical.js";
 
 const SETUP_MIGRATION_LOCK_OPTIONS = {
   retries: { retries: 60, factor: 1, minTimeout: 500, maxTimeout: 500 },
@@ -25,22 +26,6 @@ const MEANINGFUL_WORKSPACE_ENTRIES = [
   "skills",
 ] as const;
 const MEANINGFUL_STATE_ENTRIES = ["credentials", "sessions", "agents", "state"] as const;
-
-function canonicalizeJsonValue(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(canonicalizeJsonValue);
-  }
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-  const record = value as Record<string, unknown>;
-  return Object.fromEntries(
-    Object.keys(record)
-      .toSorted()
-      .filter((key) => record[key] !== undefined)
-      .map((key) => [key, canonicalizeJsonValue(record[key])]),
-  );
-}
 
 async function exists(candidate: string): Promise<boolean> {
   try {
@@ -245,7 +230,7 @@ export async function buildSetupMigrationTargetSnapshot(params: {
 }): Promise<string> {
   const hash = crypto.createHash("sha256");
   const targetConfig = buildSetupMigrationSnapshotConfig(params.config);
-  hash.update(`config:${JSON.stringify(canonicalizeJsonValue(targetConfig))}\0`);
+  hash.update(`config:${JSON.stringify(canonicalizeSetupMigrationValue(targetConfig))}\0`);
   await hashTargetPath(hash, params.workspaceDir, "workspace");
   for (const entry of MEANINGFUL_STATE_ENTRIES) {
     await hashTargetPath(hash, path.join(params.stateDir, entry), `state/${entry}`);

--- a/src/wizard/setup.migration-stage.ts
+++ b/src/wizard/setup.migration-stage.ts
@@ -1,5 +1,4 @@
 // Setup migration staging keeps provider writes isolated until verified promotion.
-import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveAgentDir } from "../agents/agent-scope-config.js";
@@ -21,6 +20,7 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { hashSetupMigrationConfig } from "./setup.migration-canonical.js";
 import {
   assertDisjointPromotionTargets,
   assertSupportedStagedStateTree,
@@ -75,29 +75,6 @@ type SetupMigrationStage = {
   }) => Promise<{ config: OpenClawConfig; resume: SetupMigrationPromotionResume }>;
   cleanup: () => Promise<void>;
 };
-
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(canonicalize);
-  }
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-  const record = value as Record<string, unknown>;
-  return Object.fromEntries(
-    Object.keys(record)
-      .toSorted()
-      .filter((key) => record[key] !== undefined)
-      .map((key) => [key, canonicalize(record[key])]),
-  );
-}
-
-function hashConfig(config: OpenClawConfig): string {
-  return crypto
-    .createHash("sha256")
-    .update(JSON.stringify(canonicalize(config)))
-    .digest("hex");
-}
 
 async function pathExists(candidate: string): Promise<boolean> {
   try {
@@ -378,7 +355,7 @@ export async function createSetupMigrationStage(params: {
     async promote({ expectedConfig, continuation, readConfigFile, commitConfigFile }) {
       disposeDatabases();
       const configBefore = await readConfigFile();
-      if (hashConfig(configBefore) !== hashConfig(expectedConfig)) {
+      if (hashSetupMigrationConfig(configBefore) !== hashSetupMigrationConfig(expectedConfig)) {
         throw new Error("Migration config changed before promotion. Review it and retry.");
       }
       const configTarget = configs.getFinalConfig();
@@ -429,8 +406,8 @@ export async function createSetupMigrationStage(params: {
         version: PROMOTION_JOURNAL_VERSION,
         status: "prepared",
         providerId: params.providerId,
-        configHashBefore: hashConfig(configBefore),
-        configHashTarget: hashConfig(configTarget),
+        configHashBefore: hashSetupMigrationConfig(configBefore),
+        configHashTarget: hashSetupMigrationConfig(configTarget),
         components: existingComponents,
         continuation: {
           ...continuation,
@@ -461,9 +438,9 @@ export async function createSetupMigrationStage(params: {
           committed = await commitConfigFile(configTarget, expectedConfig);
         } catch (error) {
           const current = await readConfigFile().catch(() => undefined);
-          if (current && hashConfig(current) === journal.configHashTarget) {
+          if (current && hashSetupMigrationConfig(current) === journal.configHashTarget) {
             committed = current;
-          } else if (current && hashConfig(current) === journal.configHashBefore) {
+          } else if (current && hashSetupMigrationConfig(current) === journal.configHashBefore) {
             throw error;
           } else {
             journal.status = "indeterminate";
@@ -475,7 +452,7 @@ export async function createSetupMigrationStage(params: {
             );
           }
         }
-        journal.configHashTarget = hashConfig(committed);
+        journal.configHashTarget = hashSetupMigrationConfig(committed);
         journal.status = "committed";
         retainForRecovery = true;
         await writePromotionJournal(journalPath, journal);


### PR DESCRIPTION
## What Problem This Solves

Setup migration staging, promotion recovery, and target snapshots each carried their own copy of the same stable JSON canonicalization logic. Staging and promotion also duplicated the same SHA-256 config hashing wrapper.

## Why This Change Was Made

Move the exact shared behavior into one setup-migration-owned module and update all three callers. This removes duplicate recovery-critical logic without widening the utility into an unrelated generic serializer.

## User Impact

No intended behavior change. Setup migration hashes and snapshot fingerprints keep the same key ordering and `undefined` filtering semantics.

## Evidence

- Hosted focused tests: 35 passing across setup migration stage, transaction, and import suites
- Hosted current-base `pnpm check:changed`: passed on Testbox `tbx_01kyby7khhk9g7ervt0gb61aj3`
- Current-base Testbox workflow: `30146992004`
- Autoreview: clean, no actionable findings
- Net production change: 36 additions, 72 deletions
