### PR TITLE
refactor(plugins): rely on shared alias resolution

### DIFF
--- a/src/realtime-transcription/provider-registry.ts
+++ b/src/realtime-transcription/provider-registry.ts
@@ -51,15 +51,11 @@ export function getRealtimeTranscriptionProvider(
   if (!normalized) {
     return undefined;
   }
-  const directProvider = resolvePluginCapabilityProvider({
+  return resolvePluginCapabilityProvider({
     key: "realtimeTranscriptionProviders",
     providerId: normalized,
     cfg,
   });
-  if (directProvider) {
-    return directProvider;
-  }
-  return buildProviderMaps(cfg).aliases.get(normalized);
 }
 
 /** Canonicalizes a configured provider id while preserving unknown ids. */

--- a/src/talk/provider-registry.ts
+++ b/src/talk/provider-registry.ts
@@ -54,17 +54,11 @@ export function getRealtimeVoiceProvider(
   if (!normalized) {
     return undefined;
   }
-  // Prefer the capability runtime's direct provider lookup; alias maps are a secondary
-  // Talk-level convenience for user config and gateway requests.
-  const directProvider = resolvePluginCapabilityProvider({
+  return resolvePluginCapabilityProvider({
     key: "realtimeVoiceProviders",
     providerId: normalized,
     cfg,
   });
-  if (directProvider) {
-    return directProvider;
-  }
-  return buildProviderMaps(cfg).aliases.get(normalized);
 }
 
 /**

--- a/src/transcripts/provider-registry.ts
+++ b/src/transcripts/provider-registry.ts
@@ -14,7 +14,7 @@ import type { TranscriptSourceProvider } from "./provider-types.js";
  * Transcript source provider registry.
  *
  * Transcript providers are plugin capability providers; this module exposes
- * canonical/alias lookup and keeps direct plugin resolution ahead of map fallback.
+ * canonical/alias lookup through the shared capability runtime.
  */
 /** Normalize transcript source provider ids for registry lookup. */
 export function normalizeTranscriptSourceProviderId(
@@ -51,13 +51,9 @@ export function getTranscriptSourceProvider(
   if (!normalized) {
     return undefined;
   }
-  const directProvider = resolvePluginCapabilityProvider({
+  return resolvePluginCapabilityProvider({
     key: "transcriptSourceProviders",
     providerId: normalized,
     cfg,
   });
-  if (directProvider) {
-    return directProvider;
-  }
-  return buildProviderMaps(cfg).aliases.get(normalized);
 }


### PR DESCRIPTION
## What Problem This Solves

The realtime voice, realtime transcription, and transcript source registries each retried provider lookup through a locally rebuilt alias map after the shared capability runtime returned no provider.

The shared runtime already resolves canonical IDs and runtime aliases, including cold-loaded providers, so the fallback repeated discovery work without adding behavior.

## Why This Change Was Made

Delegate lookup entirely to the canonical capability resolver while preserving the existing canonical-list map behavior.

## User Impact

No intended behavior change. Configured provider aliases continue to resolve through the shared plugin capability runtime.

## Evidence

- Hosted focused tests: 55 passing across capability-provider alias resolution and Talk provider selection
- Hosted current-base `pnpm check:changed`: passed on Testbox `tbx_01kyby7khhk9g7ervt0gb61aj3`
- Autoreview: clean, no actionable findings
- Net production change: 4 additions, 18 deletions
