### PR TITLE
fix(ui): status labels in Control UI fail WCAG AA contrast on their own tint

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -82,6 +82,9 @@
    * WCAG 2.1 AA audit (label on own subtle tint, worst of --card / --bg):
    *   --ok     #22c55e  6.66:1 ✓    --warn  #f59e0b  6.93:1 ✓
    *   --danger #f87171  5.52:1 ✓    --info  #60a5fa  5.97:1 ✓
+   *
+   * Bounded to --card and --bg. A status label can also land on --bg-hover,
+   * --bg-muted, --panel-hover or --input, which this audit does not cover.
    */
   --ok: #22c55e;
   --ok-muted: rgba(34, 197, 94, 0.75);
@@ -242,6 +245,11 @@
    * WCAG 2.1 AA audit (label on own subtle tint, worst of --card / --bg):
    *   --ok     #166534  5.70:1 ✓    --warn  #92400e  5.66:1 ✓
    *   --danger #b91c1c  5.10:1 ✓    --info  #1d4ed8  5.34:1 ✓
+   *
+   * Bounded to --card and --bg. Hover and input surfaces are not covered, and
+   * one gap is reachable: .plugins-row-message--error sits on --danger-subtle
+   * over a hovered row, which is 4.28:1 under dash-light. That is an
+   * improvement on the 3.23:1 it replaced, not a regression, but it is not AA.
    */
   --ok: #166534;
   --ok-muted: rgba(22, 101, 52, 0.75);

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -66,7 +66,23 @@
   --accent-2-muted: rgba(20, 184, 166, 0.7);
   --accent-2-subtle: rgba(20, 184, 166, 0.1);
 
-  /* Semantic */
+  /*
+   * Semantic status
+   *
+   * Each `--x` doubles as label text on its own `--x-subtle` tint, so the pair
+   * is one contrast decision: the 8% tint composites onto the surface and the
+   * label must still clear WCAG AA 4.5:1 on the lightest dark surface
+   * (dash `--card` #221a16, worse than claw `--card` #161920). Keep every
+   * `-subtle`/`-muted` rgba in sync with its base hex — they are the same
+   * color at 8%/75%, and re-tinting one without the other silently drops the
+   * pair below AA. Bases stay literal hex: `widget-theme.ts` publishes them to
+   * MCP app guest documents, where a `color-mix(... var(--x) ...)` string
+   * would not resolve.
+   *
+   * WCAG 2.1 AA audit (label on own subtle tint, worst of --card / --bg):
+   *   --ok     #22c55e  6.66:1 ✓    --warn  #f59e0b  6.93:1 ✓
+   *   --danger #f87171  5.52:1 ✓    --info  #60a5fa  5.97:1 ✓
+   */
   --ok: #22c55e;
   --ok-muted: rgba(34, 197, 94, 0.75);
   --ok-subtle: rgba(34, 197, 94, 0.08);
@@ -75,10 +91,11 @@
   --warn: #f59e0b;
   --warn-muted: rgba(245, 158, 11, 0.75);
   --warn-subtle: rgba(245, 158, 11, 0.08);
-  --danger: #ef4444;
-  --danger-muted: rgba(239, 68, 68, 0.75);
-  --danger-subtle: rgba(239, 68, 68, 0.08);
-  --info: #3b82f6;
+  --danger: #f87171;
+  --danger-muted: rgba(248, 113, 113, 0.75);
+  --danger-subtle: rgba(248, 113, 113, 0.08);
+  --info: #60a5fa;
+  --info-subtle: rgba(96, 165, 250, 0.08);
 
   /* Focus */
   --focus: rgba(255, 92, 92, 0.2);
@@ -216,18 +233,29 @@
   --accent-2-muted: rgba(13, 148, 136, 0.75);
   --accent-2-subtle: rgba(13, 148, 136, 0.08);
 
-  --ok: #15803d;
-  --ok-muted: rgba(21, 128, 61, 0.75);
-  --ok-subtle: rgba(21, 128, 61, 0.08);
+  /*
+   * Semantic status — see the `:root` block for the pairing rule. Light mode
+   * is bounded by `--bg` (#faf9f7, and the darker dash-light #f7f2ec) rather
+   * than the white `--card`, so a token that passes on a card can still fail
+   * on the page behind it.
+   *
+   * WCAG 2.1 AA audit (label on own subtle tint, worst of --card / --bg):
+   *   --ok     #166534  5.70:1 ✓    --warn  #92400e  5.66:1 ✓
+   *   --danger #b91c1c  5.10:1 ✓    --info  #1d4ed8  5.34:1 ✓
+   */
+  --ok: #166534;
+  --ok-muted: rgba(22, 101, 52, 0.75);
+  --ok-subtle: rgba(22, 101, 52, 0.08);
   --destructive: #dc2626;
   --destructive-foreground: #fafafa;
-  --warn: #b45309;
-  --warn-muted: rgba(180, 83, 9, 0.75);
-  --warn-subtle: rgba(180, 83, 9, 0.08);
-  --danger: #dc2626;
-  --danger-muted: rgba(220, 38, 38, 0.75);
-  --danger-subtle: rgba(220, 38, 38, 0.08);
-  --info: #2563eb;
+  --warn: #92400e;
+  --warn-muted: rgba(146, 64, 14, 0.75);
+  --warn-subtle: rgba(146, 64, 14, 0.08);
+  --danger: #b91c1c;
+  --danger-muted: rgba(185, 28, 28, 0.75);
+  --danger-subtle: rgba(185, 28, 28, 0.08);
+  --info: #1d4ed8;
+  --info-subtle: rgba(29, 78, 216, 0.08);
 
   --focus: rgba(189, 69, 49, 0.15);
   --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 70%, transparent);

--- a/ui/src/styles/sessions.css
+++ b/ui/src/styles/sessions.css
@@ -512,7 +512,7 @@
 
 .session-avatar--group {
   color: var(--info);
-  background: rgba(59, 130, 246, 0.1);
+  background: var(--info-subtle);
 }
 
 .session-avatar--global {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where status labels in Control UI — "failed", "blocked", "offline", "pending", log-level chips, session-kind badges, plugin and config status pills — render as low-contrast text that is hard to read for users with reduced vision, and unreadable in bright ambient light.

These labels are drawn as a colored word sitting on a faint wash of the same color (`--danger` text on `--danger-subtle`, and so on). That pairing is a single contrast decision, and most of the pairs did not clear the WCAG 2.1 AA 4.5:1 minimum for body text:

- **Light mode: every status token failed** against `--bg`, the page surface behind most panels. `--ok` and `--warn` reached only 4.29:1, `--danger` 4.07:1, `--info` 4.41:1.
- **Dark mode: `--danger` (4.35:1) and `--info` (4.37:1) failed** on `--card`.
- `--info` had **no `--info-subtle` token at all**, so every surface needing an info wash hardcoded `rgba(59, 130, 246, ...)` — the dark-mode blue, pasted verbatim into light mode where it does not belong.

Worst affected is the light theme, where a token passing on a white card still failed on the page behind it — so the same badge was compliant in a dialog and non-compliant in the list underneath.

## Why This Change Was Made

The failing bases move one step along their existing color ramp (hue family unchanged), and each token's `-subtle`/`-muted` companions are re-derived from the new base so the pair stays internally consistent. `--info-subtle` is added to both declaring blocks, completing the `ok`/`warn`/`danger`/`info` family, and replaces the hardcoded literal in `.session-avatar--group` — whose `--ok`/`--warn` siblings were already tokenized and where the missing token was the only reason a raw value was used.

Boundaries:

- **`--destructive` is deliberately untouched.** It is the separate token for solid destructive *fills* that carry light text, where the contrast requirement runs the other way. Keeping the two apart is what lets `--danger` be tuned purely as a status/label color.
- Status tokens are declared in exactly two blocks, `:root` and `[data-theme-mode="light"]` (verified: `openknot`, `openknot-light`, `dash`, `dash-light` do not redeclare them), so both modes are fixed at their single source and all six theme families inherit the result.
- Bases stay literal hex rather than `color-mix()`, because `ui/src/pages/chat/components/widget-theme.ts` publishes `--ok`/`--warn`/`--danger`/`--info` into MCP app guest documents, where a `color-mix(... var(--x) ...)` string would not resolve.

## User Impact

Status text on `--card` and `--bg` now meets WCAG AA in both modes across all six theme families. Every failing pair clears 4.5:1 with margin (worst case 5.10:1, up from 3.85:1). Colors shift by one ramp step, so the visual language is unchanged — reds still read as red, ambers as amber — but labels are legibly darker in light mode and lighter in dark mode.

Nothing regresses: status dots, meters, progress bars and chart segments use these tokens as non-text graphics against the page surface, and all of them *gain* contrast, since the change moves each token away from its surrounding surface. The one place `--danger` is a solid fill under white text improves from 4.83:1 to 6.47:1.

## Evidence

Contrast computed by compositing the `-subtle` tint over each surface with source-over in gamma space (matching CSS), then applying the WCAG 2.1 relative-luminance formula. Values are parsed out of the committed `base.css`, not hand-transcribed.

### Before / after — label on its own subtle tint (worst of `--card` / `--bg`)

| Mode | Token | Before | After | Before ratio | After ratio |
|---|---|---|---|---|---|
| Light | `--ok` | `#15803d` | `#166534` | 4.07 FAIL | **5.70 PASS** |
| Light | `--warn` | `#b45309` | `#92400e` | 4.07 FAIL | **5.66 PASS** |
| Light | `--danger` | `#dc2626` | `#b91c1c` | 3.85 FAIL | **5.10 PASS** |
| Light | `--info` | `#2563eb` | `#1d4ed8` | 4.17 FAIL | **5.34 PASS** |
| Dark | `--ok` | `#22c55e` | `#22c55e` (kept) | 6.66 PASS | 6.66 PASS |
| Dark | `--warn` | `#f59e0b` | `#f59e0b` (kept) | 6.93 PASS | 6.93 PASS |
| Dark | `--danger` | `#ef4444` | `#f87171` | 4.19 FAIL | **5.52 PASS** |
| Dark | `--info` | `#3b82f6` | `#60a5fa` | 4.27 FAIL | **5.97 PASS** |

Binding surface is `dash-light`/`bg` in light mode and `dash`/`card` in dark mode — both worse than the claw defaults, so the numbers above hold for every family. Per-family detail for the claw theme: light `--ok` 4.51 card / 4.29 bg, `--danger` 4.27 / 4.07, `--info` 4.63 / 4.41; dark `--danger` 4.35 card, `--info` 4.37 card.

### Direction check — the cases where the requirement flips

| Case | Requirement | Before | After |
|---|---|---|---|
| `.chat-delete-confirm__yes` — `background: var(--danger)` with `color: #fff` (light-mode fall-through; all dark families already override to `--destructive`) | 4.5:1 | 4.83 | **6.47** |
| Status dots / meters / chart bars vs adjacent surface (18 combinations, incl. `dash bg-hover`) | 3:1 non-text | 3.61 min | **4.84 min** |
| `-muted` (75% alpha) as text | — | 2.99 min | **3.74 min** (improved everywhere, none regressed) |

### Consumer audit

352 `var(--ok|warn|danger|info…)` references across `ui/src` were swept. Every rule setting a status token as a background *and* a text color (31 blocks) was inspected individually. All but one are tint-background + status-colored-text — the pattern this PR fixes. The single solid-fill-with-light-text case is in the table above.

### Checks

- `lightningcss` parse of both changed files: OK, 0 warnings.
- Token audit parsed from committed `base.css`: all 8 pairs PASS, every `-subtle` rgba in sync with its base hex; exactly 2 declarations per token, confirming no other theme block redeclares them.
- `oxfmt --check`: clean. `git diff --check`: clean.
- No `.ts` files touched, so the typecheck surface is unchanged. No test asserts these token values (the four browser tests that load `base.css` assert layout properties, not colors).

## Known follow-ups (deliberately not in this PR)

1. **`MODE_TOKEN_ORDER` in `ui/src/app/custom-theme.ts` omits `ok*`, `warn*`, `info*`** while `danger*` is present. This is *not* an oversight to patch blindly: `danger` is mapped from tweakcn's `destructive` source token (`custom-theme.ts:367`), and tweakcn has no source token for success/warning/info. Adding them would mean inventing colors with no upstream source, so it is left alone. Consequence, worth knowing: imported custom themes inherit `--ok`/`--warn`/`--info` from the base blocks and therefore pick up this fix, but their `--danger` comes from the imported `destructive` and is not guaranteed AA by this change.
2. **Five hardcoded `rgba(59, 130, 246, …)` literals remain** in `components.css` (`.callout.info`, `.compaction-indicator--active`, `.log-level.info`, `.log-chip.info`). These are theme-drift, not contrast failures — they compute to acceptable ratios in both modes — and converting them touches sibling rules (`.callout.success` has the same issue with green) that belong in a focused tokenization pass.
3. **Light-mode `-muted` variants remain below 4.5:1** (best 4.11:1). At 75% alpha they are inherently lossy; reaching AA needs an alpha or design decision beyond this contrast fix. They improve materially here and none regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



### Audit bound (added after review)

The measurements above are bounded to `--card` and `--bg`. Status labels can also land on `--bg-hover`, `--bg-muted`, `--panel-hover` and `--input`, which this pass does not cover. One gap there is reachable with real text: `.plugins-row-message--error` renders on `--danger-subtle` over a hovered row, which is 4.28:1 under `dash-light` — an improvement on the 3.23:1 it replaced, but not AA. It is recorded in the follow-ups rather than fixed here, because closing it means darkening the label everywhere else, which is a design call.

Also worth folding into the existing literal-drift follow-up: `rgba(239, 68, 68, …)` copies of the old dark `--danger` in `components.css` and `layout.css` are now desynced from the token, alongside the blue literals already listed.