### PR TITLE
refactor(anthropic-vertex): share catalog runtime

### DIFF
--- a/extensions/anthropic-vertex/api.ts
+++ b/extensions/anthropic-vertex/api.ts
@@ -11,6 +11,10 @@ export {
   buildAnthropicVertexProvider,
 } from "./provider-catalog.js";
 export {
+  mergeImplicitAnthropicVertexProvider,
+  resolveImplicitAnthropicVertexProvider,
+} from "./provider-catalog-runtime.js";
+export {
   hasAnthropicVertexAvailableAuth,
   hasAnthropicVertexCredentials,
   resolveAnthropicVertexClientRegion,
@@ -19,39 +23,8 @@ export {
   resolveAnthropicVertexRegion,
   resolveAnthropicVertexRegionFromBaseUrl,
 } from "./region.js";
-import { buildAnthropicVertexProvider } from "./provider-catalog.js";
-import { hasAnthropicVertexAvailableAuth } from "./region.js";
 
 const loadStreamRuntimeModule = createLazyRuntimeModule(() => import("./stream-runtime.js"));
-
-/** Merge an implicit Anthropic Vertex provider with explicit user config. */
-export function mergeImplicitAnthropicVertexProvider(params: {
-  existing?: ReturnType<typeof buildAnthropicVertexProvider>;
-  implicit: ReturnType<typeof buildAnthropicVertexProvider>;
-}) {
-  const { existing, implicit } = params;
-  if (!existing) {
-    return implicit;
-  }
-  return {
-    ...implicit,
-    ...existing,
-    models:
-      Array.isArray(existing.models) && existing.models.length > 0
-        ? existing.models
-        : implicit.models,
-  };
-}
-
-/** Resolve an implicit Anthropic Vertex provider when ADC credentials are available. */
-export function resolveImplicitAnthropicVertexProvider(params?: { env?: NodeJS.ProcessEnv }) {
-  const env = params?.env ?? process.env;
-  if (!hasAnthropicVertexAvailableAuth(env)) {
-    return null;
-  }
-
-  return buildAnthropicVertexProvider({ env });
-}
 
 /** Create a lazy Anthropic Vertex stream function for a known project/region/base URL. */
 export function createAnthropicVertexStreamFn(

--- a/extensions/anthropic-vertex/index.ts
+++ b/extensions/anthropic-vertex/index.ts
@@ -8,12 +8,8 @@ import {
   buildProviderReplayFamilyHooks,
   resolveClaudeThinkingProfile,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import {
-  hasAnthropicVertexAvailableAuth,
-  mergeImplicitAnthropicVertexProvider,
-  resolveAnthropicVertexConfigApiKey,
-  resolveImplicitAnthropicVertexProvider,
-} from "./api.js";
+import { hasAnthropicVertexAvailableAuth, resolveAnthropicVertexConfigApiKey } from "./api.js";
+import { runAnthropicVertexCatalog } from "./provider-catalog-runtime.js";
 import { normalizeAnthropicVertexResolvedModel } from "./provider-catalog.js";
 
 const PROVIDER_ID = "anthropic-vertex";
@@ -32,20 +28,7 @@ export default definePluginEntry({
       auth: [],
       catalog: {
         order: "simple",
-        run: async (ctx) => {
-          const implicit = resolveImplicitAnthropicVertexProvider({
-            env: ctx.env,
-          });
-          if (!implicit) {
-            return null;
-          }
-          return {
-            provider: mergeImplicitAnthropicVertexProvider({
-              existing: ctx.config.models?.providers?.[PROVIDER_ID],
-              implicit,
-            }),
-          };
-        },
+        run: runAnthropicVertexCatalog,
       },
       resolveConfigApiKey: ({ env }) => resolveAnthropicVertexConfigApiKey(env),
       ...buildProviderReplayFamilyHooks({ family: "native-anthropic-by-model" }),

--- a/extensions/anthropic-vertex/provider-catalog-runtime.ts
+++ b/extensions/anthropic-vertex/provider-catalog-runtime.ts
@@ -1,0 +1,51 @@
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildAnthropicVertexProvider } from "./provider-catalog.js";
+import { hasAnthropicVertexAvailableAuth } from "./region.js";
+
+const PROVIDER_ID = "anthropic-vertex";
+
+/** Merge an implicit Anthropic Vertex provider with explicit user config. */
+export function mergeImplicitAnthropicVertexProvider(params: {
+  existing?: ModelProviderConfig;
+  implicit: ModelProviderConfig;
+}): ModelProviderConfig {
+  const { existing, implicit } = params;
+  if (!existing) {
+    return implicit;
+  }
+  return {
+    ...implicit,
+    ...existing,
+    models:
+      Array.isArray(existing.models) && existing.models.length > 0
+        ? existing.models
+        : implicit.models,
+  };
+}
+
+/** Resolve an implicit Anthropic Vertex provider when ADC credentials are available. */
+export function resolveImplicitAnthropicVertexProvider(params?: { env?: NodeJS.ProcessEnv }) {
+  const env = params?.env ?? process.env;
+  if (!hasAnthropicVertexAvailableAuth(env)) {
+    return null;
+  }
+
+  return buildAnthropicVertexProvider({ env });
+}
+
+/** Build the shared catalog result used by discovery and the full plugin entry. */
+export async function runAnthropicVertexCatalog(ctx: ProviderCatalogContext) {
+  const implicit = resolveImplicitAnthropicVertexProvider({
+    env: ctx.env,
+  });
+  if (!implicit) {
+    return null;
+  }
+  return {
+    provider: mergeImplicitAnthropicVertexProvider({
+      existing: ctx.config.models?.providers?.[PROVIDER_ID],
+      implicit,
+    }),
+  };
+}

--- a/extensions/anthropic-vertex/provider-discovery.ts
+++ b/extensions/anthropic-vertex/provider-discovery.ts
@@ -3,8 +3,7 @@
  * catalog surfaces that need the provider contract without full plugin entry setup.
  */
 import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
-import { buildAnthropicVertexProvider } from "./provider-catalog.js";
+import { runAnthropicVertexCatalog } from "./provider-catalog-runtime.js";
 import { hasAnthropicVertexAvailableAuth, resolveAnthropicVertexConfigApiKey } from "./region.js";
 
 const PROVIDER_ID = "anthropic-vertex";
@@ -28,48 +27,6 @@ type AnthropicVertexProviderPlugin = {
       }
     | undefined;
 };
-
-function mergeImplicitAnthropicVertexProvider(params: {
-  existing?: ModelProviderConfig;
-  implicit: ModelProviderConfig;
-}) {
-  const { existing, implicit } = params;
-  if (!existing) {
-    return implicit;
-  }
-  return {
-    ...implicit,
-    ...existing,
-    models:
-      Array.isArray(existing.models) && existing.models.length > 0
-        ? existing.models
-        : implicit.models,
-  };
-}
-
-function resolveImplicitAnthropicVertexProvider(params?: { env?: NodeJS.ProcessEnv }) {
-  const env = params?.env ?? process.env;
-  if (!hasAnthropicVertexAvailableAuth(env)) {
-    return null;
-  }
-
-  return buildAnthropicVertexProvider({ env });
-}
-
-async function runAnthropicVertexCatalog(ctx: ProviderCatalogContext) {
-  const implicit = resolveImplicitAnthropicVertexProvider({
-    env: ctx.env,
-  });
-  if (!implicit) {
-    return null;
-  }
-  return {
-    provider: mergeImplicitAnthropicVertexProvider({
-      existing: ctx.config.models?.providers?.[PROVIDER_ID],
-      implicit,
-    }),
-  };
-}
 
 /** Anthropic Vertex provider discovery descriptor. */
 export const anthropicVertexProviderDiscovery: AnthropicVertexProviderPlugin = {


### PR DESCRIPTION
## What Problem This Solves

The Anthropic Vertex plugin repeated ADC resolution, explicit-provider merging, and catalog runner setup across its API and discovery surfaces.

## Why This Change Was Made

Move that shared runtime into one plugin-owned module while preserving the public API exports and the discovery path's lazy stream import boundary.

## User Impact

No intended behavior change. Catalog discovery and plugin API calls now share one implementation, removing 36 net production lines.

## Evidence

- Hosted focused tests: 27 passed across `provider-discovery.import-guard.test.ts`, `index.test.ts`, and `api.test.ts`
- Import guard verifies the discovery path remains isolated from the streaming runtime
- Fresh autoreview: no actionable findings
- `git diff --check`
- Current-main hosted `pnpm check:changed`: passed in Blacksmith Testbox `tbx_01kyby7khhk9g7ervt0gb61aj3`
