### PR TITLE
refactor(packages): reuse shared error coercion

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -26,6 +26,7 @@ function loadNodeOs(): typeof NodeOs | null {
 // NEVER convert to top-level runtime imports - breaks browser/Vite builds
 const os = loadNodeOs();
 
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import {
   resolveTimerTimeoutMs,
   clampTimerTimeoutMs,
@@ -440,7 +441,7 @@ export const streamOpenAICodexResponses: StreamFunction<
             }
           }
           const tlsCertificateError = inspectTlsCertificateError(error);
-          lastError = toLintErrorObject(error, String(error));
+          lastError = toErrorObject(error, String(error));
           // Deterministic certificate failures cannot recover through backoff.
           if (
             attempt < maxRetries &&
@@ -1364,7 +1365,7 @@ async function* parseWebSocket(
     }
 
     if (failed) {
-      throw toLintErrorObject(failed, "Non-Error thrown");
+      throw toErrorObject(failed, "Non-Error thrown");
     }
     if (!sawCompletion) {
       throw new Error("WebSocket stream closed before response.completed");
@@ -1710,17 +1711,4 @@ function buildWebSocketHeaders(
   return headers;
 }
 
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -2,6 +2,7 @@
 import { fork, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { DEFAULT_LOCAL_MODEL } from "./embedding-defaults.js";
 import {
@@ -289,7 +290,7 @@ class LocalEmbeddingWorkerClient {
           this.pending.delete(id);
           this.shutdownChild();
           reject(
-            toLintErrorObject(
+            toErrorObject(
               options.signal?.reason ?? new Error("Local embedding request aborted"),
               "Non-Error rejection",
             ),
@@ -418,19 +419,4 @@ export async function createLocalEmbeddingWorkerProvider(
   };
   attachLocalEmbeddingRuntimeFacts(provider, () => client.getRuntimeFacts());
   return provider;
-}
-
-/** Convert abort reasons or arbitrary thrown values into lint-safe Error objects. */
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }


### PR DESCRIPTION
## What Problem This Solves

Two package runtimes carried identical local error-coercion helpers even though `@openclaw/normalization-core` already owns the canonical `toErrorObject` implementation.

## Why This Change Was Made

Reuse the shared package helper and retain each caller's existing fallback message. This removes duplicated coercion branches without changing error text or control flow.

## User Impact

No intended behavior change. The package runtimes now share the established error normalization path, removing 26 net production lines.

## Evidence

- Hosted focused tests: 71 passed across OpenAI ChatGPT responses, retry handling, and memory-host embeddings
- Fresh autoreview: no actionable findings
- `git diff --check`
- Current-main hosted `pnpm check:changed`: passed in Blacksmith Testbox `tbx_01kyby7khhk9g7ervt0gb61aj3`
