### PR TITLE
improve(sqlite): prove restore interruption recovery

### DIFF
--- a/scripts/bench-sqlite-reliability.ts
+++ b/scripts/bench-sqlite-reliability.ts
@@ -43,6 +43,9 @@ function printProofLines(report: ReliabilityReport): void {
     `SQLITE_RELIABILITY_PUBLICATION_INTERRUPTION=${report.publicationInterruptionProof.beforePublish.recoveryVerified && report.publicationInterruptionProof.afterPublish.targetVerifiedAfterCrash && report.publicationInterruptionProof.afterPublish.recoveryVerified ? "verified" : "missing"}`,
   );
   console.log(
+    `SQLITE_RELIABILITY_RESTORE_INTERRUPTION=${report.maintenanceProof.restoreInterruption.beforePublish.recoveryVerified && report.maintenanceProof.restoreInterruption.beforePublish.retryRestored && report.maintenanceProof.restoreInterruption.afterPublish.targetVerifiedAfterCrash && report.maintenanceProof.restoreInterruption.afterPublish.existingTargetPreserved ? "verified" : "missing"}`,
+  );
+  console.log(
     `SQLITE_RELIABILITY_WAL_SENTINEL=${report.transactionProof.committedWalSentinel ? "verified" : "missing"}`,
   );
   console.log(`SQLITE_RELIABILITY_HELD_BATCH=${report.transactionProof.heldBatch}`);

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -91,6 +91,47 @@ export type ReliabilityReport = {
       snapshotMs: number;
       state: ReliabilityStateProof;
     };
+    restoreInterruption: {
+      afterPublish: {
+        existingTargetPreserved: true;
+        exit: {
+          code: number | null;
+          signal: NodeJS.Signals | null;
+        };
+        payloadAfterRecovery: {
+          bytes: number;
+          idSum: number;
+          rows: number;
+        };
+        recoveryVerified: true;
+        repositoryVerified: true;
+        retryRestored: false;
+        stagingEntries: number;
+        stateAfterRecovery: ReliabilityStateProof;
+        targetVerifiedAfterCrash: true;
+        targetVisibleAfterCrash: true;
+      };
+      beforePublish: {
+        existingTargetPreserved: false;
+        exit: {
+          code: number | null;
+          signal: NodeJS.Signals | null;
+        };
+        payloadAfterRecovery: {
+          bytes: number;
+          idSum: number;
+          rows: number;
+        };
+        recoveryVerified: true;
+        repositoryVerified: true;
+        retryRestored: true;
+        stagingEntries: number;
+        stateAfterRecovery: ReliabilityStateProof;
+        targetVerifiedAfterCrash: false;
+        targetVisibleAfterCrash: false;
+      };
+      snapshotBytes: number;
+    };
   };
   node: string;
   paths: {

--- a/scripts/lib/sqlite-reliability-restore-worker.ts
+++ b/scripts/lib/sqlite-reliability-restore-worker.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type RestoreCrashPoint = "after-publish" | "before-publish";
+
+const SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
+
+function parseCrashPoint(value: string | undefined): RestoreCrashPoint {
+  if (value === "after-publish" || value === "before-publish") {
+    return value;
+  }
+  throw new Error(`invalid SQLite restore crash point: ${String(value)}`);
+}
+
+function holdAtCrashPoint(crashPoint: RestoreCrashPoint): never {
+  process.send?.({ crashPoint, kind: "crash-point" });
+  while (true) {
+    Atomics.wait(SLEEP_BUFFER, 0, 0, 60_000);
+  }
+}
+
+async function main(argv: string[]): Promise<void> {
+  const [crashPointValue, repositoryPath, validationRootPath, snapshotPath, targetPath, ...extra] =
+    argv;
+  if (extra.length > 0 || !repositoryPath || !validationRootPath || !snapshotPath || !targetPath) {
+    throw new Error("invalid SQLite restore interruption worker arguments");
+  }
+  const crashPoint = parseCrashPoint(crashPointValue);
+  const resolvedTargetPath = path.resolve(targetPath);
+
+  if (crashPoint === "before-publish") {
+    const originalLink = fs.link.bind(fs);
+    Object.defineProperty(fs, "link", {
+      configurable: true,
+      enumerable: true,
+      value: async (sourcePath: string, publishedPath: string) => {
+        const resolvedSourcePath = path.resolve(sourcePath);
+        if (
+          path.resolve(publishedPath) === resolvedTargetPath &&
+          path.basename(resolvedSourcePath) === "database.sqlite" &&
+          path.basename(path.dirname(resolvedSourcePath)).startsWith(".sqlite-publish-")
+        ) {
+          holdAtCrashPoint(crashPoint);
+        }
+        await originalLink(sourcePath, publishedPath);
+      },
+      writable: true,
+    });
+  } else {
+    const originalRmdir = fs.rmdir.bind(fs);
+    const restoreParentPath = path.resolve(path.dirname(targetPath));
+    Object.defineProperty(fs, "rmdir", {
+      configurable: true,
+      enumerable: true,
+      value: async (directoryPath: string) => {
+        const resolvedDirectoryPath = path.resolve(directoryPath);
+        if (
+          path.dirname(resolvedDirectoryPath) === restoreParentPath &&
+          path.basename(resolvedDirectoryPath).startsWith(".tmp-restore-")
+        ) {
+          holdAtCrashPoint(crashPoint);
+        }
+        await originalRmdir(directoryPath);
+      },
+      writable: true,
+    });
+  }
+
+  const { createLocalSqliteSnapshotProvider } =
+    await import("../../src/snapshot/local-repository.js");
+  const provider = createLocalSqliteSnapshotProvider({
+    repositoryPath,
+    validationRootPath,
+  });
+  process.send?.({ kind: "ready" });
+  await provider.restoreFresh({ path: snapshotPath }, targetPath);
+  throw new Error(`SQLite restore worker passed ${crashPoint} without being terminated.`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main(process.argv.slice(2));
+}

--- a/scripts/lib/sqlite-reliability-restore.ts
+++ b/scripts/lib/sqlite-reliability-restore.ts
@@ -1,0 +1,481 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createLocalSqliteSnapshotProvider } from "../../src/snapshot/local-repository.js";
+import type { ReliabilityReport, ReliabilityStateProof } from "./sqlite-reliability-contract.js";
+
+type RestoreCrashPoint = "after-publish" | "before-publish";
+type RestoreExit =
+  ReliabilityReport["maintenanceProof"]["restoreInterruption"]["beforePublish"]["exit"];
+type RestorePayloadProof =
+  ReliabilityReport["maintenanceProof"]["restoreInterruption"]["beforePublish"]["payloadAfterRecovery"];
+type RestoreCrashResult = {
+  existingTargetPreserved: boolean;
+  exit: RestoreExit;
+  payloadAfterRecovery: RestorePayloadProof;
+  recoveryVerified: true;
+  repositoryVerified: true;
+  retryRestored: boolean;
+  stagingEntries: number;
+  stateAfterRecovery: ReliabilityStateProof;
+  targetVerifiedAfterCrash: boolean;
+  targetVisibleAfterCrash: boolean;
+};
+
+const RESTORE_WORKER_PATH = fileURLToPath(
+  new URL("./sqlite-reliability-restore-worker.ts", import.meta.url),
+);
+const RESTORE_TIMEOUT_MS = 120_000;
+const MIN_STAGED_RESTORE_BYTES = 1024 * 1024;
+
+function hashFile(filePath: string): string {
+  return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function assertSameState(
+  actual: ReliabilityStateProof,
+  expected: ReliabilityStateProof,
+  label: string,
+): void {
+  if (
+    actual.batches !== expected.batches ||
+    actual.rows !== expected.rows ||
+    actual.sha256 !== expected.sha256
+  ) {
+    throw new Error(
+      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
+    );
+  }
+}
+
+function assertSamePayload(
+  actual: RestorePayloadProof,
+  expected: RestorePayloadProof,
+  label: string,
+): void {
+  if (
+    actual.bytes !== expected.bytes ||
+    actual.idSum !== expected.idSum ||
+    actual.rows !== expected.rows
+  ) {
+    throw new Error(
+      `${label} changed compaction payload: expected rows=${expected.rows} bytes=${expected.bytes} idSum=${expected.idSum}, got rows=${actual.rows} bytes=${actual.bytes} idSum=${actual.idSum}`,
+    );
+  }
+}
+
+function assertNoSqliteSidecars(targetPath: string): void {
+  for (const suffix of ["-journal", "-shm", "-wal"]) {
+    if (fs.existsSync(`${targetPath}${suffix}`)) {
+      throw new Error(`restore crash left an unexpected SQLite sidecar: ${targetPath}${suffix}`);
+    }
+  }
+}
+
+function listRestoreStagingEntries(scratchPath: string): string[] {
+  return fs
+    .readdirSync(scratchPath)
+    .filter((entry) => entry.startsWith(".sqlite-publish-") || entry.startsWith(".tmp-restore-"));
+}
+
+function listOuterRestoreStagingEntries(scratchPath: string): string[] {
+  return listRestoreStagingEntries(scratchPath).filter((entry) =>
+    entry.startsWith(".tmp-restore-"),
+  );
+}
+
+function hasPublicationStaging(scratchPath: string): boolean {
+  return listRestoreStagingEntries(scratchPath).some((entry) =>
+    entry.startsWith(".sqlite-publish-"),
+  );
+}
+
+function formatWorkerStderr(stderr: string): string {
+  const text = stderr.trim();
+  return text ? ` stderr=${JSON.stringify(text)}` : "";
+}
+
+async function waitForWorkerReady(params: {
+  child: ChildProcess;
+  readStderr: () => string;
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `SQLite restore worker did not become ready.${formatWorkerStderr(params.readStderr())}`,
+        ),
+      );
+    }, 30_000);
+    const onMessage = (message: unknown) => {
+      if (
+        message &&
+        typeof message === "object" &&
+        (message as { kind?: unknown }).kind === "ready"
+      ) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `SQLite restore worker exited before ready: code=${String(code)} signal=${String(signal)}.${formatWorkerStderr(params.readStderr())}`,
+        ),
+      );
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      params.child.off("message", onMessage);
+      params.child.off("error", onError);
+      params.child.off("exit", onExit);
+    };
+    params.child.on("message", onMessage);
+    params.child.on("error", onError);
+    params.child.on("exit", onExit);
+  });
+}
+
+async function waitForChildExit(child: ChildProcess): Promise<RestoreExit> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  return await new Promise<RestoreExit>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("SQLite restore worker did not exit after forced termination."));
+    }, 30_000);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    child.on("exit", onExit);
+    child.on("error", onError);
+  });
+}
+
+function assertForcedExit(exit: RestoreExit): void {
+  if (exit.code === 0) {
+    throw new Error("SQLite restore worker exited cleanly before forced termination.");
+  }
+  if (process.platform === "win32") {
+    if (exit.code === null && exit.signal === null) {
+      throw new Error("SQLite restore worker reported no forced Windows exit.");
+    }
+    return;
+  }
+  if (exit.signal !== "SIGKILL") {
+    throw new Error(
+      `SQLite restore worker exited without SIGKILL: code=${String(exit.code)} signal=${String(exit.signal)}`,
+    );
+  }
+}
+
+async function waitForCrashPoint(params: {
+  child: ChildProcess;
+  crashPoint: RestoreCrashPoint;
+  readStderr: () => string;
+  scratchPath: string;
+  targetPath: string;
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `SQLite restore worker did not reach ${params.crashPoint}.${formatWorkerStderr(params.readStderr())}`,
+        ),
+      );
+    }, RESTORE_TIMEOUT_MS);
+    const onMessage = (message: unknown) => {
+      const event = message as { crashPoint?: unknown; kind?: unknown } | undefined;
+      if (event?.kind === "crash-point" && event.crashPoint === params.crashPoint) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `SQLite restore worker exited before ${params.crashPoint}: code=${String(code)} signal=${String(signal)}.${formatWorkerStderr(params.readStderr())}`,
+        ),
+      );
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      params.child.off("message", onMessage);
+      params.child.off("error", onError);
+      params.child.off("exit", onExit);
+    };
+    params.child.on("message", onMessage);
+    params.child.on("error", onError);
+    params.child.on("exit", onExit);
+  });
+
+  const outerStagingEntries = listOuterRestoreStagingEntries(params.scratchPath);
+  const targetVisible = fs.existsSync(params.targetPath);
+  const publicationStagingVisible = hasPublicationStaging(params.scratchPath);
+  const barrierValid =
+    outerStagingEntries.length > 0 &&
+    (params.crashPoint === "before-publish"
+      ? !targetVisible && publicationStagingVisible
+      : targetVisible && !publicationStagingVisible);
+  if (!barrierValid) {
+    throw new Error(`SQLite restore worker reported an invalid ${params.crashPoint} barrier.`);
+  }
+}
+
+async function assertRepositorySnapshotAvailable(params: {
+  expectedSnapshotBytes: number;
+  provider: ReturnType<typeof createLocalSqliteSnapshotProvider>;
+  snapshotPath: string;
+}): Promise<void> {
+  const verification = await params.provider.verify({ path: params.snapshotPath });
+  if (verification.manifest.artifact.sizeBytes !== params.expectedSnapshotBytes) {
+    throw new Error(
+      `SQLite restore source changed: expected ${params.expectedSnapshotBytes} bytes, got ${verification.manifest.artifact.sizeBytes}`,
+    );
+  }
+  const resolvedSnapshotPath = path.resolve(params.snapshotPath);
+  const snapshots = await params.provider.list();
+  if (!snapshots.some((snapshot) => path.resolve(snapshot.ref.path) === resolvedSnapshotPath)) {
+    throw new Error(`SQLite restore source disappeared from repository: ${params.snapshotPath}`);
+  }
+}
+
+async function runCrashPoint(params: {
+  crashPoint: RestoreCrashPoint;
+  expectedPayload: RestorePayloadProof;
+  expectedSnapshotBytes: number;
+  expectedState: ReliabilityStateProof;
+  provider: ReturnType<typeof createLocalSqliteSnapshotProvider>;
+  repositoryPath: string;
+  scratchPath: string;
+  snapshotPath: string;
+  validationRootPath: string;
+  verifyPayload: (databasePath: string) => RestorePayloadProof;
+  verifyState: (databasePath: string) => ReliabilityStateProof;
+}): Promise<RestoreCrashResult> {
+  const targetPath = path.join(params.scratchPath, `${params.crashPoint}.sqlite`);
+  let stderr = "";
+  const child = fork(
+    RESTORE_WORKER_PATH,
+    [
+      params.crashPoint,
+      params.repositoryPath,
+      params.validationRootPath,
+      params.snapshotPath,
+      targetPath,
+    ],
+    {
+      cwd: process.cwd(),
+      execArgv: ["--import", "tsx"],
+      serialization: "json",
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    },
+  );
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  let crashStagingEntries: string[];
+  try {
+    await waitForWorkerReady({ child, readStderr: () => stderr });
+    await waitForCrashPoint({
+      child,
+      crashPoint: params.crashPoint,
+      readStderr: () => stderr,
+      scratchPath: params.scratchPath,
+      targetPath,
+    });
+    if (!child.kill("SIGKILL")) {
+      throw new Error(
+        `SQLite restore worker exited before the ${params.crashPoint} crash signal was delivered.`,
+      );
+    }
+    const exit = await waitForChildExit(child);
+    assertForcedExit(exit);
+
+    crashStagingEntries = listRestoreStagingEntries(params.scratchPath);
+    if (!crashStagingEntries.some((entry) => entry.startsWith(".tmp-restore-"))) {
+      throw new Error(`SQLite restore worker left no owned staging at ${params.crashPoint}.`);
+    }
+    await assertRepositorySnapshotAvailable({
+      expectedSnapshotBytes: params.expectedSnapshotBytes,
+      provider: params.provider,
+      snapshotPath: params.snapshotPath,
+    });
+
+    const targetVisibleAfterCrash = fs.existsSync(targetPath);
+    let retryRestored = false;
+    let existingTargetPreserved = false;
+    if (params.crashPoint === "before-publish") {
+      if (targetVisibleAfterCrash) {
+        throw new Error("SQLite restore target became visible before publication.");
+      }
+      await params.provider.restoreFresh({ path: params.snapshotPath }, targetPath);
+      retryRestored = true;
+    } else {
+      if (!targetVisibleAfterCrash) {
+        throw new Error("SQLite restore target disappeared after durable publication.");
+      }
+      if (fs.statSync(targetPath).nlink !== 1) {
+        throw new Error("SQLite restore target retained a publication hard link after commit.");
+      }
+      const targetHash = hashFile(targetPath);
+      let retryError: unknown;
+      try {
+        await params.provider.restoreFresh({ path: params.snapshotPath }, targetPath);
+      } catch (error) {
+        retryError = error;
+      }
+      if (
+        !(retryError instanceof Error) ||
+        !/Fresh SQLite restore path already exists/iu.test(retryError.message)
+      ) {
+        throw new Error("SQLite restore retry did not preserve the published target.", {
+          cause: retryError,
+        });
+      }
+      if (hashFile(targetPath) !== targetHash) {
+        throw new Error("SQLite restore retry changed the published target.");
+      }
+      existingTargetPreserved = true;
+    }
+
+    assertNoSqliteSidecars(targetPath);
+    const stateAfterRecovery = params.verifyState(targetPath);
+    assertSameState(stateAfterRecovery, params.expectedState, `${params.crashPoint} restore`);
+    const payloadAfterRecovery = params.verifyPayload(targetPath);
+    assertSamePayload(payloadAfterRecovery, params.expectedPayload, `${params.crashPoint} restore`);
+    await assertRepositorySnapshotAvailable({
+      expectedSnapshotBytes: params.expectedSnapshotBytes,
+      provider: params.provider,
+      snapshotPath: params.snapshotPath,
+    });
+    for (const entry of crashStagingEntries) {
+      if (!fs.existsSync(path.join(params.scratchPath, entry))) {
+        throw new Error(`SQLite restore retry removed crash staging it did not own: ${entry}`);
+      }
+    }
+
+    return {
+      existingTargetPreserved,
+      exit,
+      payloadAfterRecovery,
+      recoveryVerified: true,
+      repositoryVerified: true,
+      retryRestored,
+      stagingEntries: crashStagingEntries.length,
+      stateAfterRecovery,
+      targetVerifiedAfterCrash: params.crashPoint === "after-publish",
+      targetVisibleAfterCrash,
+    };
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+      await waitForChildExit(child).catch(() => undefined);
+    }
+    fs.rmSync(targetPath, { force: true });
+    for (const entry of listRestoreStagingEntries(params.scratchPath)) {
+      fs.rmSync(path.join(params.scratchPath, entry), { force: true, recursive: true });
+    }
+  }
+}
+
+export async function runRestoreInterruptionProof(params: {
+  expectedPayload: RestorePayloadProof;
+  expectedSnapshotBytes: number;
+  expectedState: ReliabilityStateProof;
+  repositoryPath: string;
+  scratchPath: string;
+  snapshotPath: string;
+  validationRootPath: string;
+  verifyPayload: (databasePath: string) => RestorePayloadProof;
+  verifyState: (databasePath: string) => ReliabilityStateProof;
+}): Promise<ReliabilityReport["maintenanceProof"]["restoreInterruption"]> {
+  if (params.expectedSnapshotBytes < MIN_STAGED_RESTORE_BYTES * 2) {
+    throw new Error(
+      `SQLite restore interruption snapshot is too small: ${params.expectedSnapshotBytes} bytes`,
+    );
+  }
+  fs.mkdirSync(params.scratchPath, { recursive: true, mode: 0o700 });
+  const provider = createLocalSqliteSnapshotProvider({
+    repositoryPath: params.repositoryPath,
+    validationRootPath: params.validationRootPath,
+  });
+  await assertRepositorySnapshotAvailable({
+    expectedSnapshotBytes: params.expectedSnapshotBytes,
+    provider,
+    snapshotPath: params.snapshotPath,
+  });
+
+  const beforePublish = await runCrashPoint({
+    ...params,
+    crashPoint: "before-publish",
+    provider,
+  });
+  if (
+    beforePublish.targetVisibleAfterCrash ||
+    beforePublish.targetVerifiedAfterCrash ||
+    !beforePublish.retryRestored ||
+    beforePublish.existingTargetPreserved
+  ) {
+    throw new Error("SQLite restore before-publication recovery reported an invalid outcome.");
+  }
+
+  const afterPublish = await runCrashPoint({
+    ...params,
+    crashPoint: "after-publish",
+    provider,
+  });
+  if (
+    !afterPublish.targetVisibleAfterCrash ||
+    !afterPublish.targetVerifiedAfterCrash ||
+    afterPublish.retryRestored ||
+    !afterPublish.existingTargetPreserved
+  ) {
+    throw new Error("SQLite restore after-publication recovery reported an invalid outcome.");
+  }
+
+  return {
+    afterPublish: {
+      ...afterPublish,
+      existingTargetPreserved: true,
+      retryRestored: false,
+      targetVerifiedAfterCrash: true,
+      targetVisibleAfterCrash: true,
+    },
+    beforePublish: {
+      ...beforePublish,
+      existingTargetPreserved: false,
+      retryRestored: true,
+      targetVerifiedAfterCrash: false,
+      targetVisibleAfterCrash: false,
+    },
+    snapshotBytes: params.expectedSnapshotBytes,
+  };
+}

--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -29,6 +29,7 @@ import {
   type ReliabilityStateProof,
 } from "./sqlite-reliability-contract.js";
 import { runPublicationInterruptionProof } from "./sqlite-reliability-publication.js";
+import { runRestoreInterruptionProof } from "./sqlite-reliability-restore.js";
 import { monitorSqliteWalDuring } from "./sqlite-reliability-wal-monitor.js";
 import {
   crashWriter,
@@ -469,6 +470,7 @@ async function runMaintenanceRoundTrip(params: {
   syncedProvider: ReturnType<typeof createLocalSqliteSnapshotProvider>;
   syncedRepository: string;
   target: TargetDatabase;
+  validationRoot: string;
 }): Promise<ReliabilityReport["maintenanceProof"]> {
   const autoVacuumBeforeKill = prepareVacuumRollbackSentinel(params.target.path);
   const bloatBytes = createCompactionBloat(params.target.path);
@@ -484,6 +486,32 @@ async function runMaintenanceRoundTrip(params: {
       `compaction payload setup failed: rows=${expectedPayload.rows} bytes=${expectedPayload.bytes}`,
     );
   }
+  const interruptedSnapshot = await params.repositoryProvider.create({
+    identity: params.target.identity,
+    path: params.target.path,
+  });
+  const interruptedCopiedPath = copySnapshotDirectory(
+    interruptedSnapshot.ref.path,
+    params.syncedRepository,
+  );
+  const restoreInterruption = await runRestoreInterruptionProof({
+    expectedPayload,
+    expectedSnapshotBytes: interruptedSnapshot.manifest.artifact.sizeBytes,
+    expectedState,
+    repositoryPath: params.syncedRepository,
+    scratchPath: path.join(params.restoreRoot, "interrupted"),
+    snapshotPath: interruptedCopiedPath,
+    validationRootPath: params.validationRoot,
+    verifyPayload: readCompactionPayload,
+    verifyState: (databasePath) =>
+      verifyRestoredDatabase({
+        expectedState,
+        identity: params.target.identity,
+        path: databasePath,
+        rowsPerBatch: params.rowsPerBatch,
+        uncommittedBatch: null,
+      }),
+  });
   const vacuumInterruption = await runVacuumInterruptionProof({
     env: params.env,
     expectedAutoVacuum: autoVacuumBeforeKill,
@@ -542,6 +570,7 @@ async function runMaintenanceRoundTrip(params: {
       snapshotMs: Number(snapshotMs.toFixed(3)),
       state,
     },
+    restoreInterruption,
     vacuumInterruption,
   };
 }
@@ -700,6 +729,7 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
       syncedProvider,
       syncedRepository,
       target,
+      validationRoot,
     });
     const snapshotBytes = metrics.map((metric) => metric.snapshotBytes);
     return {
@@ -727,7 +757,7 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
       profile: options.profile,
       publicationInterruptionProof,
       retainedBatches: profile.retainedBatches,
-      restoresVerified: metrics.length + 1,
+      restoresVerified: metrics.length + 3,
       rowsPerBatch: profile.rowsPerBatch,
       snapshotBytes: {
         max: Math.max(...snapshotBytes),

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseSqliteReliabilityCli } from "../../scripts/lib/sqlite-reliability-cli.js";
+import type { ReliabilityReport } from "../../scripts/lib/sqlite-reliability-contract.js";
 import { monitorSqliteWalDuring } from "../../scripts/lib/sqlite-reliability-wal-monitor.js";
 
 const tempDirs: string[] = [];
@@ -153,127 +154,15 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstResult.status, firstResult.stderr).toBe(0);
     expect(firstResult.stderr).toBe("");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=5");
+    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=7");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_CRASH_RECOVERY=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_PUBLICATION_INTERRUPTION=verified");
+    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORE_INTERRUPTION=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_VACUUM_INTERRUPTION=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_POST_COMPACT_RESTORE=verified");
-    const firstReport = JSON.parse(fs.readFileSync(firstOutput, "utf8")) as {
-      concurrentRestoresVerified: number;
-      crashRecoveryProof: {
-        committedStatePreserved: boolean;
-        exit: {
-          code: number | null;
-          signal: string | null;
-        };
-        partialVisibleAfterRecovery: boolean;
-        sourceRecovered: boolean;
-        stateAfterRecovery: {
-          batches: number;
-          rows: number;
-          sha256: string;
-        };
-        stateBeforeKill: {
-          batches: number;
-          rows: number;
-          sha256: string;
-        };
-        writerRestarted: boolean;
-      };
-      maintenanceProof: {
-        bloatBytes: number;
-        compaction: {
-          autoVacuum: { after: number };
-          freelistPages: { after: number; before: number };
-          reclaimedBytes: number;
-          walBytes: { after: number };
-        };
-        vacuumInterruption: {
-          autoVacuumAfterRecovery: number;
-          autoVacuumBeforeKill: number;
-          exit: {
-            code: number | null;
-            signal: string | null;
-          };
-          journalBytesObserved: number;
-          payloadAfterRecovery: {
-            bytes: number;
-            idSum: number;
-            rows: number;
-          };
-          payloadBeforeKill: {
-            bytes: number;
-            idSum: number;
-            rows: number;
-          };
-          recoveryVerified: boolean;
-          stateAfterRecovery: {
-            batches: number;
-            rows: number;
-            sha256: string;
-          };
-          stateBeforeKill: {
-            batches: number;
-            rows: number;
-            sha256: string;
-          };
-          walBytesObserved: number;
-        };
-        postCompact: {
-          restoreVerified: boolean;
-          state: {
-            batches: number;
-            rows: number;
-            sha256: string;
-          };
-        };
-      };
-      paths: {
-        sourceDatabase: string;
-        syncedRepository: string;
-      };
-      publicationInterruptionProof: {
-        afterPublish: {
-          existingTargetPreserved: boolean;
-          exit: {
-            code: number | null;
-            signal: string | null;
-          };
-          recoveryVerified: boolean;
-          sourceStatePreserved: boolean;
-          stagingEntries: number;
-          targetVerifiedAfterCrash: boolean;
-          targetVisibleAfterCrash: boolean;
-        };
-        beforePublish: {
-          exit: {
-            code: number | null;
-            signal: string | null;
-          };
-          recoveryVerified: boolean;
-          retryPublished: boolean;
-          sourceStatePreserved: boolean;
-          stagingEntries: number;
-          targetVerifiedAfterCrash: boolean;
-          targetVisibleAfterCrash: boolean;
-        };
-      };
-      restoresVerified: number;
-      transactionProof: {
-        committedWalSentinel: boolean;
-        heldRows: number;
-        visibleAfterRestore: boolean;
-      };
-      walBytes: {
-        limit: number;
-        peak: number;
-      };
-      writer: {
-        rowsCommitted: number;
-      };
-    };
+    const firstReport = JSON.parse(fs.readFileSync(firstOutput, "utf8")) as ReliabilityReport;
     expect(firstReport.concurrentRestoresVerified).toBe(4);
-    expect(firstReport.restoresVerified).toBe(5);
+    expect(firstReport.restoresVerified).toBe(7);
     expect(firstReport.crashRecoveryProof.sourceRecovered).toBe(true);
     expect(firstReport.crashRecoveryProof.committedStatePreserved).toBe(true);
     expect(firstReport.crashRecoveryProof.partialVisibleAfterRecovery).toBe(false);
@@ -338,6 +227,51 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstReport.maintenanceProof.vacuumInterruption.stateAfterRecovery).toEqual(
       firstReport.maintenanceProof.vacuumInterruption.stateBeforeKill,
     );
+    expect(firstReport.maintenanceProof.restoreInterruption.snapshotBytes).toBeGreaterThan(
+      64 * 1024 * 1024,
+    );
+    expect(firstReport.maintenanceProof.restoreInterruption.beforePublish).toMatchObject({
+      existingTargetPreserved: false,
+      recoveryVerified: true,
+      repositoryVerified: true,
+      retryRestored: true,
+      targetVerifiedAfterCrash: false,
+      targetVisibleAfterCrash: false,
+    });
+    expect(
+      firstReport.maintenanceProof.restoreInterruption.beforePublish.stagingEntries,
+    ).toBeGreaterThan(0);
+    expect(
+      firstReport.maintenanceProof.restoreInterruption.beforePublish.exit.code !== null ||
+        firstReport.maintenanceProof.restoreInterruption.beforePublish.exit.signal !== null,
+    ).toBe(true);
+    expect(
+      firstReport.maintenanceProof.restoreInterruption.beforePublish.stateAfterRecovery,
+    ).toEqual(firstReport.maintenanceProof.postCompact.state);
+    expect(
+      firstReport.maintenanceProof.restoreInterruption.beforePublish.payloadAfterRecovery,
+    ).toEqual(firstReport.maintenanceProof.vacuumInterruption.payloadBeforeKill);
+    expect(firstReport.maintenanceProof.restoreInterruption.afterPublish).toMatchObject({
+      existingTargetPreserved: true,
+      recoveryVerified: true,
+      repositoryVerified: true,
+      retryRestored: false,
+      targetVerifiedAfterCrash: true,
+      targetVisibleAfterCrash: true,
+    });
+    expect(
+      firstReport.maintenanceProof.restoreInterruption.afterPublish.stagingEntries,
+    ).toBeGreaterThan(0);
+    expect(
+      firstReport.maintenanceProof.restoreInterruption.afterPublish.exit.code !== null ||
+        firstReport.maintenanceProof.restoreInterruption.afterPublish.exit.signal !== null,
+    ).toBe(true);
+    expect(
+      firstReport.maintenanceProof.restoreInterruption.afterPublish.stateAfterRecovery,
+    ).toEqual(firstReport.maintenanceProof.restoreInterruption.beforePublish.stateAfterRecovery);
+    expect(
+      firstReport.maintenanceProof.restoreInterruption.afterPublish.payloadAfterRecovery,
+    ).toEqual(firstReport.maintenanceProof.restoreInterruption.beforePublish.payloadAfterRecovery);
     expect(firstReport.maintenanceProof.postCompact.restoreVerified).toBe(true);
     expect(firstReport.maintenanceProof.postCompact.state.batches).toBeGreaterThan(0);
     expect(firstReport.maintenanceProof.postCompact.state.rows).toBeGreaterThan(0);
@@ -371,7 +305,7 @@ describe("scripts/bench-sqlite-reliability", () => {
       paths: { syncedRepository: string };
       restoresVerified: number;
     };
-    expect(secondReport.restoresVerified).toBe(5);
+    expect(secondReport.restoresVerified).toBe(7);
     expect(secondReport.paths.syncedRepository).not.toBe(firstReport.paths.syncedRepository);
   });
 


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Resolves a reliability-proof gap where `restoreFresh` had extensive injected-fault coverage but no real process-termination test around its publication boundary. A restore process could die before the target became visible or after durable publication, and the stress suite did not prove the repository, target, retry behavior, and stale staging remained safe in both states.

## Why This Change Was Made

The SQLite reliability runner now snapshots a database containing more than 64 MiB of retained payload and runs two deterministic worker barriers. One pauses immediately before the target hard link is created; the other pauses after the target is durably published and verified but before outer staging cleanup. The parent force-terminates each worker, validates exact application and payload state, verifies repository listing and integrity, proves sidecars are absent, and checks retry containment.

The barriers live only in the reliability worker. Production snapshot and restore code is unchanged.

## User Impact

No direct user-facing behavior changes. Maintainers now have repeatable evidence that interrupted fresh restores either leave no target and retry successfully, or leave a complete durable target that retries preserve without deleting staging owned by the crashed process.

AI-assisted: yes. The final diff passed structured autoreview with no accepted or actionable findings.

## Evidence

- Blacksmith Testbox `tbx_01kybxpqmc5d5ry7frj99w3wpc`, workflow run https://github.com/openclaw/openclaw/actions/runs/30146711946
- `pnpm test test/scripts/bench-sqlite-reliability.test.ts -- --reporter=verbose`: 4 tests passed, including two complete global smoke cycles.
- `node --import tsx scripts/bench-sqlite-reliability.ts --profile smoke --agent sqlite-reliability-agent`: 7 restores verified; crash recovery, publication interruption, restore interruption, killed VACUUM recovery, and post-compaction restore all verified.
- Scoped `pnpm check:changed -- <six touched files>`: formatting, dependency guards, script declarations, scripts and root-test typechecks, boundary checks, and lint passed.
- `autoreview --mode local`: clean after replacing both timing-based crash observations with deterministic IPC barriers.
