### PR TITLE
refactor: deduplicate micro helpers onto canonical homes

### DIFF
--- a/extensions/feishu/src/security-audit-shared.ts
+++ b/extensions/feishu/src/security-audit-shared.ts
@@ -1,16 +1,10 @@
 // Feishu plugin module implements security audit shared behavior.
 import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
+import {
+  asOptionalRecord as asRecord,
+  hasNonEmptyString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawConfig } from "../runtime-api.js";
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function hasNonEmptyString(value: unknown): boolean {
-  return typeof value === "string" && value.trim().length > 0;
-}
 
 function isFeishuDocToolEnabled(cfg: OpenClawConfig): boolean {
   const channels = asRecord(cfg.channels);

--- a/extensions/ollama/src/node-inference.ts
+++ b/extensions/ollama/src/node-inference.ts
@@ -1,4 +1,5 @@
 import { jsonResult } from "openclaw/plugin-sdk/channel-actions";
+import { formatErrorMessage as errorMessage } from "openclaw/plugin-sdk/error-runtime";
 // Ollama node inference exposes local models to agents through paired node hosts.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import {
@@ -92,10 +93,6 @@ function readNodeCommandParams(paramsJSON?: string | null): Record<string, unkno
     throw new Error("node inference params must be a JSON object");
   }
   return parsed;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error && error.message ? error.message : String(error);
 }
 
 function durationMs(value: unknown): number | undefined {

--- a/packages/ai/src/transports/openai-compatible-conversation-turn.ts
+++ b/packages/ai/src/transports/openai-compatible-conversation-turn.ts
@@ -4,9 +4,7 @@
  * Some providers reject requests without a non-empty user/assistant turn; this
  * helper checks the loose message payload shape before transport submission.
  */
-function hasNonEmptyString(value: unknown): boolean {
-  return typeof value === "string" && value.trim().length > 0;
-}
+import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 
 function hasNonEmptyContentPart(part: unknown): boolean {
   if (!part || typeof part !== "object") {

--- a/packages/ai/src/transports/openai-responses-transport.ts
+++ b/packages/ai/src/transports/openai-responses-transport.ts
@@ -51,6 +51,7 @@ import {
   stripSystemPromptCacheBoundary,
 } from "../internal/shared.js";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
+import { shortHash } from "../utils/hash.js";
 import {
   buildGuardedModelFetch,
   resolveOpenAIStrictToolSetting,
@@ -97,7 +98,7 @@ import {
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,
 } from "./transport-stream-shared.js";
-import { redactIdentifier, redactSensitiveText, sha256HexPrefix } from "./transport-utils.js";
+import { redactIdentifier, redactSensitiveText } from "./transport-utils.js";
 
 const DEFAULT_AZURE_OPENAI_API_VERSION = "preview";
 const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
@@ -858,10 +859,6 @@ async function createResponsesStreamWithEncryptedContentRetry(params: {
 
 function resolveAzureOpenAIApiVersion(env = process.env): string {
   return env.AZURE_OPENAI_API_VERSION?.trim() || DEFAULT_AZURE_OPENAI_API_VERSION;
-}
-
-function shortHash(value: string): string {
-  return sha256HexPrefix(value, 16);
 }
 
 function normalizeResponsesReplayItemId(

--- a/packages/ai/src/transports/transport-utils.ts
+++ b/packages/ai/src/transports/transport-utils.ts
@@ -21,7 +21,7 @@ export function sha256Hex(value: string | Uint8Array): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-export function sha256HexPrefix(value: string | Uint8Array, length: number): string {
+function sha256HexPrefix(value: string | Uint8Array, length: number): string {
   return sha256Hex(value).slice(0, length);
 }
 

--- a/packages/memory-host-sdk/src/host/secret-input-utils.ts
+++ b/packages/memory-host-sdk/src/host/secret-input-utils.ts
@@ -1,4 +1,6 @@
 // Secret input parsing shared by memory provider config and gateway-resolved snapshots.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 
 /** Supported secret reference backing stores. */
 type SecretRefSource = "env" | "file" | "exec";
@@ -16,11 +18,6 @@ const LEGACY_SECRETREF_ENV_MARKER_PREFIX = "secretref-env:";
 const ENV_SECRET_TEMPLATE_RE = /^\$\{([A-Z][A-Z0-9_]{0,127})\}$/;
 const SECRET_REF_SOURCES = new Set<SecretRefSource>(["env", "file", "exec"]);
 
-/** Narrow unknown JSON config values to plain records. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 /** Normalize literal secret strings and reject empty placeholders. */
 function normalizeSecretInputString(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -33,11 +30,6 @@ function normalizeSecretInputString(value: unknown): string | undefined {
 /** Narrow a string to a supported SecretRef source. */
 function hasSecretRefSource(value: unknown): value is SecretRefSource {
   return typeof value === "string" && SECRET_REF_SOURCES.has(value as SecretRefSource);
-}
-
-/** Narrow unknown values to non-empty strings. */
-function hasNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
 }
 
 /** Detect canonical three-field SecretRef objects. */

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -1,6 +1,7 @@
 /**
  * Normalizes and delivers agent command results to outbound channels.
  */
+import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
@@ -182,10 +183,6 @@ function logNestedOutput(
     }
     runtime.log(`${prefix} ${line}`);
   }
-}
-
-function hasNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
 }
 
 function hasNonEmptyStringArray(value: unknown): value is string[] {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -2,6 +2,7 @@
  * Handles embedded-agent assistant message events, block replies, reasoning
  * streams, reply directives, and pending tool media attachment handoff.
  */
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -158,12 +159,6 @@ export function resetPendingAssistantUsage(
   }
   ctx.state.pendingAssistantUsage = undefined;
   ctx.state.assistantUsageCommitted = false;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function extractStandaloneMessageToolText(

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -3,6 +3,8 @@
  * Protects runtime-generated prompt blocks from user text and removes old
  * context formats before replaying or comparing messages.
  */
+import { escapeRegExp } from "../shared/regexp.js";
+
 /** Opening delimiter for protected OpenClaw runtime context blocks. */
 export const INTERNAL_RUNTIME_CONTEXT_BEGIN = "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>";
 /** Closing delimiter for protected OpenClaw runtime context blocks. */
@@ -35,10 +37,6 @@ export function escapeInternalRuntimeContextDelimiters(value: string): string {
   return value
     .replaceAll(INTERNAL_RUNTIME_CONTEXT_BEGIN, ESCAPED_INTERNAL_RUNTIME_CONTEXT_BEGIN)
     .replaceAll(INTERNAL_RUNTIME_CONTEXT_END, ESCAPED_INTERNAL_RUNTIME_CONTEXT_END);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function findDelimitedTokenIndex(text: string, token: string, from: number): number {

--- a/src/agents/mcp-auth-profile.ts
+++ b/src/agents/mcp-auth-profile.ts
@@ -3,6 +3,7 @@
  */
 import crypto from "node:crypto";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { BundleMcpConfig, BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
 import { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
@@ -19,10 +20,6 @@ type McpAuthProfileOptions = {
   cfg?: OpenClawConfig;
   agentDir?: string;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
 
 function normalizeStringHeaders(value: unknown): Record<string, string> | undefined {
   if (!isRecord(value)) {

--- a/src/agents/mcp-oauth-store.ts
+++ b/src/agents/mcp-oauth-store.ts
@@ -12,6 +12,7 @@ import {
   type OAuthClientInformationMixed,
   type OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -56,10 +57,6 @@ class McpOAuthStoreCorruptionError extends Error {
     super(`MCP OAuth store ${storeKey} is invalid: ${detail}`, options);
     this.name = "McpOAuthStoreCorruptionError";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function assertOptionalString(

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
 import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-runtime.js";
@@ -147,12 +148,6 @@ function assertBoundedViewDescriptor(value: {
   ) {
     throw new Error("MCP App preview descriptor exceeds safe limits");
   }
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function normalizePermissions(value: unknown): McpAppPermissions | undefined {

--- a/src/agents/node-plugin-tools.ts
+++ b/src/agents/node-plugin-tools.ts
@@ -1,4 +1,5 @@
 /** Materializes connected node-hosted plugin tools for agent runs. */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { listConnectedNodePluginTools } from "../gateway/node-plugin-tool-snapshot.js";
 import {
   NODE_MCP_TOOL_CALL_GATEWAY_TIMEOUT_MS,
@@ -21,10 +22,6 @@ type MaterializedNodeToolEntry = ReturnType<typeof listConnectedNodePluginTools>
   command: string;
   normalizedName: string;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
 
 function isAgentToolResult(value: unknown): value is AgentToolResult<unknown> {
   return isRecord(value) && Array.isArray(value.content);

--- a/src/agents/sandbox-host.ts
+++ b/src/agents/sandbox-host.ts
@@ -1,3 +1,5 @@
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+
 export type SandboxHostCsp = {
   connectDomains?: string[];
   resourceDomains?: string[];
@@ -72,12 +74,6 @@ const RESOLVE_LEADING_DOCTYPE_END_SOURCE = `(html) => {
   }
   return 0;
 }`;
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
 
 function normalizeDomains(
   value: unknown,

--- a/src/agents/tool-terminal-outcome.ts
+++ b/src/agents/tool-terminal-outcome.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   consumeTrackedToolExecutionStarted,
   peekAdjustedParamsForToolCall,
@@ -7,12 +8,6 @@ import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types
 import { createToolErrorState } from "./tool-error-state.js";
 import type { ToolErrorSummary } from "./tool-error-summary.js";
 import { buildToolMutationState } from "./tool-mutation.js";
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
 
 /** Build one attempt-scoped facts-in/state-out terminal observer for every harness. */
 export function createToolTerminalObserver(

--- a/src/agents/worktrees/run-lease.ts
+++ b/src/agents/worktrees/run-lease.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { formatErrorMessage as errorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getFileLockProcessStartTime } from "../../shared/pid-alive.js";
 import { lockWorktreeForProcess, unlockWorktree } from "./git-lock.js";
@@ -51,10 +52,6 @@ type LeaseCleanup = {
 };
 const pendingLeaseCleanups = new Set<LeaseCleanup>();
 let exitCleanupRegistered = false;
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 async function withGitLockTransition<T>(id: string, operation: () => Promise<T>): Promise<T> {
   const previous = gitLockTransitionTails.get(id) ?? Promise.resolve();

--- a/src/auto-reply/reply/commands-export-common.ts
+++ b/src/auto-reply/reply/commands-export-common.ts
@@ -8,6 +8,7 @@ import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { escapeRegExp } from "../../shared/regexp.js";
 import type { ReplyPayload } from "../types.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
@@ -22,10 +23,6 @@ interface ExportCommandSessionTarget {
 }
 
 const MAX_EXPORT_COMMAND_OUTPUT_PATH_CHARS = 512;
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 /** Parses an optional non-flag output path from export command text. */
 export function parseExportCommandOutputPath(

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import { readAcpSessionMetaForEntry } from "../../acp/runtime/session-meta.js";
 import {
   migrateSessionEntries,
@@ -41,10 +42,6 @@ interface SessionData {
 
 const BACKEND_DELEGATED_WARNING =
   "This session was handled by a backend runtime (e.g. CLI/ACP). Assistant replies, tool calls, and usage data are stored in the backend transcript and are not included in this export.";
-
-function hasNonEmptyString(value: unknown): boolean {
-  return typeof value === "string" && value.trim().length > 0;
-}
 
 function hasBackendSession(entry: StoredSessionEntry, hasStoredAcpSession: boolean): boolean {
   return (

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,4 +1,5 @@
 // Builds memory flush prompts when conversation context exceeds model budget.
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { legacyModelKey, modelKey } from "../../agents/model-ref-shared.js";
@@ -35,12 +36,6 @@ export function resolveMaxActiveTranscriptBytes(cfg?: OpenClawConfig): number | 
 function resolvePositiveTokenCount(value: number | undefined): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.floor(value)
-    : undefined;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
     : undefined;
 }
 

--- a/src/channels/plugins/outbound/direct-text-media.ts
+++ b/src/channels/plugins/outbound/direct-text-media.ts
@@ -3,6 +3,7 @@
  *
  * Builds lightweight SDK-backed send adapters with chunking, sanitization, and media limits.
  */
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
 import { chunkText } from "../../../auto-reply/chunk.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
@@ -30,12 +31,6 @@ type DirectSendFn<TOpts extends Record<string, unknown>, TResult extends DirectS
   text: string,
   opts: TOpts,
 ) => Promise<TResult>;
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value != null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
 
 function readNumberField(record: Record<string, unknown> | undefined, key: string) {
   const value = record?.[key];

--- a/src/channels/plugins/setup-contract.ts
+++ b/src/channels/plugins/setup-contract.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { Option } from "commander";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { parseStrictNonNegativeInteger } from "../../infra/parse-finite-number.js";
@@ -251,10 +252,6 @@ export function resolveChannelSetupExecutionAdapter(plugin: {
     namedAccountPromotionKeys: legacy.namedAccountPromotionKeys,
     resolveSingleAccountPromotionTarget: legacy.resolveSingleAccountPromotionTarget,
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function parseStringList(value: unknown): string[] | undefined {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import { expectDefined } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Command } from "commander";
@@ -180,10 +181,6 @@ function isNativeApprovalsSnapshot(
   snapshot: ExecApprovalsSnapshot,
 ): snapshot is NativeExecApprovalsSnapshot {
   return "enabled" in snapshot;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseNativeAction(value: unknown, label: string): NativeExecApprovalAction {

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringifiedOptionalString,
@@ -196,12 +197,6 @@ const SENSITIVE_HEADER_NAMES = new Set([
 
 const SENSITIVE_KEY_PATTERN =
   /(?:^|[_-])(api[_-]?key|authorization|bearer|password|secret|token)$/i;
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 function issue(level: McpDoctorIssue["level"], message: string): McpDoctorIssue {
   return { level, message };

--- a/src/commands/doctor-heartbeat-cadence-migration.ts
+++ b/src/commands/doctor-heartbeat-cadence-migration.ts
@@ -15,6 +15,7 @@ import {
 } from "../cron/store.js";
 import type { CronJob, CronJobCreate } from "../cron/types.js";
 import type { HealthFinding } from "../flows/health-checks.js";
+import { formatErrorMessage as errorMessage } from "../infra/errors.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.js";
 import { resolveHeartbeatSchedulerSeed } from "../infra/heartbeat-runner.js";
 import { shortenHomePath } from "../utils.js";
@@ -33,10 +34,6 @@ type HeartbeatMonitorChange =
 type HeartbeatMonitorPlan = {
   changes: HeartbeatMonitorChange[];
 };
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 function createDoctorCronService(storePath: string, cfg: OpenClawConfig): CronService {
   const noop = () => {};

--- a/src/commands/doctor-heartbeat-scratch-migration.ts
+++ b/src/commands/doctor-heartbeat-scratch-migration.ts
@@ -18,6 +18,7 @@ import {
 import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import type { CronJob } from "../cron/types.js";
 import type { HealthFinding } from "../flows/health-checks.js";
+import { formatErrorMessage as errorMessage } from "../infra/errors.js";
 import { resolveHeartbeatAgents } from "../infra/heartbeat-runner.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { readRegularFile } from "../infra/regular-file.js";
@@ -40,10 +41,6 @@ type HeartbeatSource = {
   content: string;
   sha256: string;
 };
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 async function readHeartbeatSource(
   cfg: OpenClawConfig,

--- a/src/commands/doctor-heartbeat-task-migration.ts
+++ b/src/commands/doctor-heartbeat-task-migration.ts
@@ -24,6 +24,7 @@ import {
 import { getCronStoreKysely } from "../cron/store/schema.js";
 import type { CronJob } from "../cron/types.js";
 import type { HealthFinding } from "../flows/health-checks.js";
+import { formatErrorMessage as errorMessage } from "../infra/errors.js";
 import { resolveHeartbeatAgents, resolveHeartbeatSession } from "../infra/heartbeat-runner.js";
 import { executeSqliteQuerySync } from "../infra/kysely-sync.js";
 import {
@@ -36,10 +37,6 @@ import { analyzeLegacyHeartbeatTasks, type LegacyHeartbeatTask } from "./heartbe
 const HEARTBEAT_TASK_MIGRATION_CHECK_ID = "core/doctor/heartbeat-task-cron-migration";
 
 type HeartbeatTaskMigrationResult = { changes: string[]; warnings: string[] };
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 type ValidatedHeartbeatTask = {
   task: LegacyHeartbeatTask;

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -4,6 +4,7 @@ import { formatCliCommand } from "../../../cli/command-format.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { loadCronQuarantineFile, resolveCronJobsStorePath } from "../../../cron/store.js";
 import type { HealthFinding } from "../../../flows/health-checks.js";
+import { formatErrorMessage as errorMessage } from "../../../infra/errors.js";
 import { shortenHomePath } from "../../../utils.js";
 import type { DoctorPrompter, DoctorOptions } from "../../doctor-prompter.js";
 import { countStaleDreamingJobs } from "./dreaming-payload-migration.js";
@@ -29,10 +30,6 @@ export {
 
 function pluralize(count: number, noun: string) {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
-}
-
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 function readLegacyCronStorePath(cfg: OpenClawConfig): string | undefined {

--- a/src/commands/doctor/cron/legacy-repair.ts
+++ b/src/commands/doctor/cron/legacy-repair.ts
@@ -12,6 +12,7 @@ import {
   saveCronQuarantineFile,
 } from "../../../cron/store.js";
 import type { CronJob } from "../../../cron/types.js";
+import { formatErrorMessage as errorMessage } from "../../../infra/errors.js";
 import { shortenHomePath } from "../../../utils.js";
 import type { LegacyCodexModelIdentity } from "../shared/codex-route-model-ref.js";
 import { migrateLegacyDreamingPayloadShape } from "./dreaming-payload-migration.js";
@@ -72,10 +73,6 @@ function formatRunLogMigrationNote(importedFiles: number): string {
   return importedFiles > 0
     ? ` Imported ${pluralize(importedFiles, "legacy cron run log")} into SQLite.`
     : "";
-}
-
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 function readLegacyCronStorePath(cfg: OpenClawConfig): string | undefined {

--- a/src/commands/doctor/shared/stale-agent-model-ref-repair.ts
+++ b/src/commands/doctor/shared/stale-agent-model-ref-repair.ts
@@ -1,6 +1,7 @@
 // Doctor-only repair for agent model refs whose provider is no longer available.
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -27,10 +28,6 @@ type RepairOptions = {
 };
 
 const DEFAULT_MODEL_REF = `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}`;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
 
 function providerFromModelRef(ref: string): string | undefined {
   const trimmed = ref.trim();

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { extractAssistantVisibleText } from "../../shared/chat-message-content.js";
 import {
@@ -450,12 +451,6 @@ function extractEditorText(content: unknown): string | undefined {
     })
     .join("");
   return text || undefined;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function isSessionHeader(event: unknown): boolean {

--- a/src/config/sessions/session-accessor.sqlite-parent-fork.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-fork.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { derivePromptTokens, normalizeUsage } from "../../agents/usage.js";
 import type {
   SessionParentForkDecision,
@@ -152,10 +153,6 @@ function selectParentForkTokenEstimateEvents(
     appendPath,
     appendParentId: tree.appendParentId,
   }).nodes.flatMap((node) => node.entry);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function normalizePositiveTokenCount(value: unknown): number | undefined {

--- a/src/fleet/backup.runtime.ts
+++ b/src/fleet/backup.runtime.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import * as tar from "tar";
+import { formatErrorMessage as errorMessage } from "../infra/errors.js";
 import { root as fsSafeRoot } from "../infra/fs-safe.js";
 import {
   cellAuthSecretDir,
@@ -79,10 +80,6 @@ type FleetRestoreResult = {
   started: boolean;
   url: string;
 };
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 function timestampBasename(tenant: string, nowMs: number): string {
   const stamp = new Date(nowMs)

--- a/src/fleet/containers.runtime.ts
+++ b/src/fleet/containers.runtime.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { attachChildProcessBridge } from "../process/child-process-bridge.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import {
@@ -104,10 +105,6 @@ class InvalidInspectOutputError extends Error {
   constructor() {
     super("container inspect returned an invalid response");
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function requireRecord(value: unknown): Record<string, unknown> {

--- a/src/gateway/mcp-app-reconstruction.ts
+++ b/src/gateway/mcp-app-reconstruction.ts
@@ -1,4 +1,5 @@
 import { type CallToolResult, ContentBlockSchema } from "@modelcontextprotocol/sdk/types.js";
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { BoardMcpAppDescriptor } from "../../packages/gateway-protocol/src/index.js";
 import { getOrCreateSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
 import type { SessionMcpRuntime } from "../agents/agent-bundle-mcp-types.js";
@@ -42,12 +43,6 @@ type TranscriptResult = Omit<ReconstructionData, "toolInput"> & { modelToolName:
 type TranscriptResultRead =
   | { kind: "restorable"; value: TranscriptResult }
   | { kind: "unavailable" };
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
 
 function readString(record: Record<string, unknown> | undefined, key: string): string | undefined {
   const value = record?.[key];

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -1,4 +1,5 @@
 // Unified operator approval lookup and first-answer resolution handlers.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
@@ -57,10 +58,6 @@ type CreateApprovalHandlersParams = {
   pluginIosPushDelivery?: PluginApprovalIosPushDelivery;
   databaseOptions?: OpenClawStateDatabaseOptions;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function buildApprovalSnapshot(
   record: OperatorApprovalRecord,

--- a/src/gateway/server-methods/channel-pairing.ts
+++ b/src/gateway/server-methods/channel-pairing.ts
@@ -1,4 +1,5 @@
 // Gateway RPC handlers for DM sender access requests on pairing-policy channels.
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
@@ -42,12 +43,6 @@ class InvalidPairingTargetError extends Error {}
 
 function normalizeFilter(value: string | undefined): string | undefined {
   return normalizeOptionalString(value)?.toLowerCase();
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function resolvePairingPolicy(params: {

--- a/src/gateway/server-methods/migrations.ts
+++ b/src/gateway/server-methods/migrations.ts
@@ -18,6 +18,7 @@ import {
   planProviderMemoryImport,
 } from "../../commands/migrate/memory-import.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage as errorMessage } from "../../infra/errors.js";
 import { summarizeMigrationItems } from "../../plugin-sdk/migration.js";
 import type { MigrationItem, MigrationPlan, MigrationProviderPlugin } from "../../plugins/types.js";
 import { isValidAgentId, normalizeAgentId } from "../../routing/session-key.js";
@@ -29,10 +30,6 @@ const activeApplies = new Set<string>();
 
 function emptySummary() {
   return summarizeMigrationItems([]);
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 type CachedMemoryApply = {

--- a/src/gateway/server-methods/secrets.ts
+++ b/src/gateway/server-methods/secrets.ts
@@ -7,12 +7,9 @@ import {
   validateSecretsResolveParams,
   validateSecretsResolveResult,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { formatErrorMessage as errorMessage } from "../../infra/errors.js";
 import { isKnownCoreSecretTargetId, isKnownSecretTargetId } from "../../secrets/target-registry.js";
 import type { GatewayRequestHandlers } from "./types.js";
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 function invalidSecretsResolveField(
   errors: ValidationError[] | null | undefined,

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -1,4 +1,5 @@
 import { normalizeCodexResponsesBaseUrlForOpenAISdk } from "@openclaw/ai/transports";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { TSchema } from "typebox";
 import type {
   WorkerInferenceContext,
@@ -151,10 +152,6 @@ function inferenceError(
     message: ERROR_MESSAGES[reason],
     ...(usage ? { usage: structuredClone(usage) } : {}),
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function copyTool(tool: NonNullable<WorkerInferenceContext["tools"]>[number]): Tool | undefined {

--- a/src/gateway/worker-environments/service-validation.ts
+++ b/src/gateway/worker-environments/service-validation.ts
@@ -1,12 +1,9 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { redactSensitiveText } from "../../logging/redact.js";
 import type { WorkerLease, WorkerLeaseStatus, WorkerSshEndpoint } from "../../plugins/types.js";
 import { normalizeWorkerSshEndpoint } from "./store.js";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export function inspectionStatus(value: unknown): WorkerLeaseStatus["status"] {
   if (!isRecord(value)) {

--- a/src/gateway/worker-environments/transcript-commit-store.ts
+++ b/src/gateway/worker-environments/transcript-commit-store.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { Insertable, Selectable } from "kysely";
 import type {
   WorkerTranscriptCommitErrorReason,
@@ -82,10 +83,6 @@ function normalizeRequestHash(value: unknown): string {
     throw new Error("Worker transcript commit request hash must be lowercase SHA-256 hex");
   }
   return value;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isNonEmptyStringArray(value: unknown): value is string[] {

--- a/src/infra/approval-presentation.ts
+++ b/src/infra/approval-presentation.ts
@@ -1,4 +1,5 @@
 // Builds the canonical reviewer-safe projection for durable approvals.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
@@ -19,10 +20,6 @@ import {
   type PluginApprovalRequestPayload,
 } from "./plugin-approvals.js";
 import type { SystemAgentApprovalRequestPayload } from "./system-agent-approvals.js";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function normalizeDecisionList(decisions: readonly ApprovalDecision[]): ApprovalDecision[] {
   const result: ApprovalDecision[] = [];

--- a/src/infra/device-identity-legacy.ts
+++ b/src/infra/device-identity-legacy.ts
@@ -1,5 +1,6 @@
 // Canonicalizes retired Node and Swift identity payloads for Doctor import.
 import { createHash } from "node:crypto";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   validateStoredDeviceIdentity,
   type StoredDeviceIdentity,
@@ -16,10 +17,6 @@ export type NormalizedLegacyDeviceIdentity = StoredDeviceIdentity;
 
 function fingerprintPublicKey(publicKeyPem: string): string {
   return createHash("sha256").update(deriveEd25519PublicKeyRaw(publicKeyPem)).digest("hex");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function isValidCreatedAtMs(value: unknown): value is number {

--- a/src/infra/exec-allowlist-pattern.ts
+++ b/src/infra/exec-allowlist-pattern.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { escapeRegExp as escapeRegExpLiteral } from "../shared/regexp.js";
 import { expandHomePrefix } from "./home-dir.js";
 
 const GLOB_REGEX_CACHE_LIMIT = 512;
@@ -43,10 +44,6 @@ function normalizeDotPathSegments(value: string): string {
   const normalized =
     process.platform === "win32" ? path.win32.normalize(value) : path.posix.normalize(value);
   return normalizeMatchTarget(normalized);
-}
-
-function escapeRegExpLiteral(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function compileGlobRegex(pattern: string): RegExp {

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { escapeRegExp as escapeRegExpLiteral } from "../shared/regexp.js";
 import { isInterpreterLikeAllowlistPattern } from "./command-analysis/inline-eval.js";
 import { detectInlineEvalArgv } from "./command-analysis/risks.js";
 import { explainShellCommand } from "./command-explainer/extract.js";
@@ -1207,10 +1208,6 @@ export type AllowAlwaysPattern = {
   pattern: string;
   argPattern?: string;
 };
-
-function escapeRegExpLiteral(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 function buildScriptArgPatternFromArgv(
   argv: string[],

--- a/src/infra/outbound/protocol-scaffolding.ts
+++ b/src/infra/outbound/protocol-scaffolding.ts
@@ -1,4 +1,5 @@
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
+import { escapeRegExp } from "../../shared/regexp.js";
 
 const INTERNAL_RUNTIME_SCAFFOLDING_TAGS = ["system-reminder", "previous_response"] as const;
 const INTERNAL_RUNTIME_SCAFFOLDING_TAG_PATTERN = INTERNAL_RUNTIME_SCAFFOLDING_TAGS.join("|");
@@ -22,10 +23,6 @@ const INTERNAL_RUNTIME_MARKER_LINES = [
   "<<<END_UNTRUSTED_CHILD_RESULT>>>",
 ] as const;
 const PROMPT_DATA_TAG_NAMES = ["prompt-data", "untrusted-text"] as const;
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 function standaloneLinePattern(token: string): string {
   return `(?:^|\\r?\\n)[ \\t]*${escapeRegExp(token)}[ \\t]*(?=\\r?\\n|$)`;

--- a/src/infra/outbound/source-reply-mirror.ts
+++ b/src/infra/outbound/source-reply-mirror.ts
@@ -1,5 +1,6 @@
 // Source reply mirroring records successful same-conversation message-tool
 // sends back into the owning session transcript.
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -51,12 +52,6 @@ type SourceReplyThreadPlacement = "match" | "mismatch" | "unknown";
 // Mirror only enough delivered payload detail to preserve transcript context.
 function readStringArray(value: unknown): string[] | undefined {
   return normalizeOptionalTrimmedStringList(value);
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function readFirstString(

--- a/src/infra/package-dist-inventory.ts
+++ b/src/infra/package-dist-inventory.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import pLimit, { type LimitFunction } from "p-limit";
 import { isLocalBuildMetadataDistPath } from "../../scripts/lib/local-build-metadata-paths.mjs";
+import { escapeRegExp } from "../shared/regexp.js";
 import { readJsonIfExists } from "./json-files.js";
 
 export const PACKAGE_DIST_INVENTORY_RELATIVE_PATH = "dist/postinstall-inventory.json";
@@ -114,10 +115,6 @@ function isLegacyPluginDependencyDirPath(relativePath: string): boolean {
 
   const pluginDependencyDir = parts[3] ?? "";
   return pluginDependencyDir.toLowerCase() === "node_modules";
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[\\^$+?.()|[\]{}]/g, "\\$&");
 }
 
 function compilePackageFilesExclusionPattern(pattern: string): RegExp {

--- a/src/infra/state-migrations.meeting-transcripts-detection.ts
+++ b/src/infra/state-migrations.meeting-transcripts-detection.ts
@@ -1,6 +1,7 @@
 // Doctor detection for legacy meeting transcript files and interrupted imports.
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import {
@@ -29,10 +30,6 @@ const TRANSCRIPT_ARTIFACT_NAMES = new Set([
   "summary.md",
   "transcript.jsonl",
 ]);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
 
 function hasLegacyArtifactsSync(directory: string): boolean {
   const entries = fs.readdirSync(directory, { withFileTypes: true });

--- a/src/infra/state-migrations.meeting-transcripts-files.ts
+++ b/src/infra/state-migrations.meeting-transcripts-files.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import type { DatabaseSync } from "node:sqlite";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type {
   TranscriptSessionDescriptor,
   TranscriptUtterance,
@@ -36,10 +37,6 @@ export type LegacyMeetingTranscriptSnapshot = {
   sourceHash: string;
   sourceSizeBytes: number;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
 
 function sha256FileSync(filePath: string): string {
   const digest = createHash("sha256");

--- a/src/logging/secret-redaction-registry.ts
+++ b/src/logging/secret-redaction-registry.ts
@@ -1,13 +1,11 @@
+import { escapeRegExp } from "../shared/regexp.js";
+
 const MIN_SECRET_VALUE_LENGTH = 6;
 const MAX_SECRET_VALUES = 512;
 
 const registeredValues = new Map<string, true>();
 let compiledMatcher: RegExp | undefined;
 let firstChars = new Set<string>();
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 function rebuildProbe(): void {
   firstChars = new Set([...registeredValues.keys()].map((value) => value.charAt(0)));

--- a/src/memory-host-sdk/event-store.ts
+++ b/src/memory-host-sdk/event-store.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-store.js";
 import {
   pluginStateEntriesInKeyRange,
@@ -87,10 +88,6 @@ function truncateUtf8(value: string, maxBytes: number): { value: string; truncat
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 /** Validate and bound one diagnostic event before storing it in plugin state. */

--- a/src/node-host/invoke-agent-cli-claude-params.ts
+++ b/src/node-host/invoke-agent-cli-claude-params.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 
 const MAX_ARG_COUNT = 128;
@@ -124,12 +125,6 @@ export type ClaudeCliNodeRunResult = {
   truncated: boolean;
   timeoutKind?: "hard" | "idle";
 };
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 function decodeJson(raw?: string | null): unknown {
   if (!raw) {

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { ContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -834,10 +835,6 @@ async function dispatchInvoke(
     },
     preferMacAppExecHost,
   });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function decodeMcpToolsCallParams(raw?: string | null): McpToolsCallParams {

--- a/src/node-host/worker-support.ts
+++ b/src/node-host/worker-support.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayClientRequestOptions } from "../gateway/client.js";
 import type { NodeHostClient } from "./client.js";
 import type { NodeInvokeRequestPayload } from "./invoke.js";
@@ -12,12 +13,6 @@ type NodeHostWorkerInput =
   | { type: "invoke-cancel"; invokeId: string }
   | NodeHostWorkerGatewayResponse
   | { type: "stop" };
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 export function parseNodeHostWorkerInput(line: string): NodeHostWorkerInput | null {
   try {

--- a/src/plugin-sdk/session-transcript-runtime.ts
+++ b/src/plugin-sdk/session-transcript-runtime.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { redactTranscriptMessage } from "../agents/transcript-redact.js";
 import {
   appendTranscriptMessage,
@@ -485,10 +486,6 @@ function extractAssistantMirrorComparableText(
 
 function isDeliveryMirrorAssistantMessage(message: SessionTranscriptAssistantMessage): boolean {
   return message.provider === "openclaw" && message.model === "delivery-mirror";
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function readNonEmptyString(value: unknown): string | undefined {

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -1,5 +1,6 @@
 // Builds OpenAI-compatible embedding provider entries for plugins.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import type {
@@ -255,12 +256,6 @@ function embeddingInputToText(input: EmbeddingInput): string {
     textParts.push(part.text);
   }
   return textParts.join("");
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function malformedEmbeddingResponse(): Error {

--- a/src/security/audit-gateway-config.ts
+++ b/src/security/audit-gateway-config.ts
@@ -1,6 +1,7 @@
 // Audits gateway config for bind, auth, and exposure risks.
 import { isIP } from "node:net";
 import {
+  hasNonEmptyString,
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
@@ -21,10 +22,6 @@ type CollectGatewayConfigFindingsOptions = {
   collectDangerousConfigFlags?: CollectDangerousConfigFlags;
   gatewayAuthOverride?: Pick<GatewayAuthConfig, "mode" | "token" | "password">;
 };
-
-function hasNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
 
 export function collectGatewayConfigFindings(
   cfg: OpenClawConfig,

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { escapeRegExp } from "../shared/regexp.js";
 
 export type ParsedAgentSessionKey = {
   agentId: string;
@@ -122,10 +123,6 @@ export function normalizeSessionPeerId(params: {
   return isCasePreservingPeer(params.channel, params.peerKind)
     ? peerId
     : normalizeLowercaseStringOrEmpty(peerId);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 type PreservedSpan = { start: number; end: number; trim: boolean };

--- a/src/worker/launch-descriptor.ts
+++ b/src/worker/launch-descriptor.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { Value } from "typebox/value";
 import {
   GATEWAY_CLIENT_IDS,
@@ -59,10 +60,6 @@ export type WorkerLaunchDescriptor = {
   admission: WorkerLaunchAdmission;
   assignment: WorkerLaunchAssignment;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function hasExactKeys(value: Record<string, unknown>, required: string[], optional: string[] = []) {
   const allowed = new Set([...required, ...optional]);

--- a/ui/src/lib/chat/heartbeat-display.ts
+++ b/ui/src/lib/chat/heartbeat-display.ts
@@ -1,12 +1,9 @@
 // Control UI chat module implements heartbeat display behavior.
+import { escapeRegExp } from "../../../../src/shared/regexp.js";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 
 const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 export function stripHeartbeatTokenForDisplay(
   raw: string,

--- a/ui/src/lib/gateway-errors.ts
+++ b/ui/src/lib/gateway-errors.ts
@@ -4,14 +4,9 @@ import {
   GatewayErrorDetailCodes,
   readMissingScopeError,
 } from "@openclaw/gateway-client/browser";
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { resolveGatewayErrorDetailCode } from "../api/gateway.ts";
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 /** Identifies an expired process-local wizard session without parsing public copy. */
 export function isWizardNotFoundError(err: unknown): boolean {

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -5,6 +5,7 @@ import {
   isToolResultContentType,
   resolveToolUseId,
 } from "../../../../src/chat/tool-content.js";
+import { escapeRegExp } from "../../../../src/shared/regexp.js";
 import type { QuestionPrompt } from "../../app/question-prompt.ts";
 import type {
   ChatItem,
@@ -1011,10 +1012,6 @@ function prefersNativeChatSurface(message: unknown): boolean {
   }
   const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
   return (role === "user" || role === "assistant") && !(normalized.senderLabel ?? "").trim();
-}
-
-function escapeRegExp(text: string): string {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function stripSenderLabelPrefix(text: string, senderLabel: string): string {

--- a/ui/src/pages/model-providers/data.ts
+++ b/ui/src/pages/model-providers/data.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveUsageProviderId } from "../../../../src/infra/provider-usage.shared.js";
 // Merges gateway provider signals (auth status, live usage/quota, local session
 // cost) into one card list for the Model Providers settings page.
@@ -391,12 +392,6 @@ export function buildSelectableDefaultModels(
     });
   }
   return selectable;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
 }
 
 export function readModelProviderConfig(config: Record<string, unknown> | null): {


### PR DESCRIPTION
## What Problem This Solves

Small error, regular-expression, non-empty-string, and record-shape helpers had accumulated across 63 files, creating multiple owners for the same invariants.

## Why This Change Was Made

This AI-assisted refactor moves callers to the existing canonical helper homes while retaining intentional UI, test, and Code Mode variants whose fallback semantics differ.

## User Impact

No intended behavior change. The production tree loses 225 duplicate lines and future fixes land in one canonical implementation.

Release-note context: none; this is a behavior-neutral internal refactor.

## Evidence

- Focused Vitest batches: 1,321 passed and 19 skipped; Code Mode passed 79/79 after preserving its formatter semantics.
- Changed gate: Blacksmith Testbox `tbx_01kybbapk4tfxpr7qejd0f2eet`, Actions run 30136744869.
- Autoreview: clean, no actionable findings (confidence 0.91).
- `git diff --check` passed.
