### PR TITLE
refactor(plugin-sdk): share doctor key-move builder

### DIFF
--- a/extensions/discord/src/doctor-contract.ts
+++ b/extensions/discord/src/doctor-contract.ts
@@ -11,6 +11,7 @@ import {
 import {
   asObjectRecord,
   defineChannelAliasMigration,
+  defineKeyMoveMigration,
   hasLegacyAccountStreamingAliases,
   normalizeChannelAccounts,
   stripRetiredChannelKeys,
@@ -70,21 +71,11 @@ function hasLegacyTtsProviderKeys(value: unknown): boolean {
   return LEGACY_TTS_PROVIDER_KEYS.some((key) => Object.hasOwn(tts, key));
 }
 
-function hasLegacyDiscordGuildChannelAllowAlias(value: unknown): boolean {
-  const guilds = asObjectRecord(asObjectRecord(value)?.guilds);
-  if (!guilds) {
-    return false;
-  }
-  return Object.values(guilds).some((guildValue) => {
-    const channels = asObjectRecord(asObjectRecord(guildValue)?.channels);
-    if (!channels) {
-      return false;
-    }
-    return Object.values(channels).some((channel) =>
-      Object.hasOwn(asObjectRecord(channel) ?? {}, "allow"),
-    );
-  });
-}
+const guildChannelAllowMigration = defineKeyMoveMigration({
+  scope: ["guilds", "*", "channels", "*"],
+  from: ["allow"],
+  to: ["enabled"],
+});
 
 function hasLegacyDiscordGuildChannelAgentId(value: unknown): boolean {
   const guilds = asObjectRecord(asObjectRecord(value)?.guilds);
@@ -275,58 +266,6 @@ function normalizeUnsupportedRealtimeWakeNames(
   };
 }
 
-function normalizeDiscordGuildChannelAllowAliases(params: {
-  entry: Record<string, unknown>;
-  pathPrefix: string;
-  changes: string[];
-}): { entry: Record<string, unknown>; changed: boolean } {
-  const guilds = asObjectRecord(params.entry.guilds);
-  if (!guilds) {
-    return { entry: params.entry, changed: false };
-  }
-
-  let changed = false;
-  const nextGuilds = { ...guilds };
-  for (const [guildId, guildValue] of Object.entries(guilds)) {
-    const guild = asObjectRecord(guildValue);
-    const channels = asObjectRecord(guild?.channels);
-    if (!guild || !channels) {
-      continue;
-    }
-    let channelsChanged = false;
-    const nextChannels = { ...channels };
-    for (const [channelId, channelValue] of Object.entries(channels)) {
-      const channel = asObjectRecord(channelValue);
-      if (!channel || !Object.hasOwn(channel, "allow")) {
-        continue;
-      }
-      const nextChannel = { ...channel };
-      if (nextChannel.enabled === undefined) {
-        nextChannel.enabled = channel.allow;
-        params.changes.push(
-          `Moved ${params.pathPrefix}.guilds.${guildId}.channels.${channelId}.allow → ${params.pathPrefix}.guilds.${guildId}.channels.${channelId}.enabled.`,
-        );
-      } else {
-        params.changes.push(
-          `Removed ${params.pathPrefix}.guilds.${guildId}.channels.${channelId}.allow (${params.pathPrefix}.guilds.${guildId}.channels.${channelId}.enabled already set).`,
-        );
-      }
-      delete nextChannel.allow;
-      nextChannels[channelId] = nextChannel;
-      channelsChanged = true;
-    }
-    if (!channelsChanged) {
-      continue;
-    }
-    nextGuilds[guildId] = { ...guild, channels: nextChannels };
-    changed = true;
-  }
-
-  return changed
-    ? { entry: { ...params.entry, guilds: nextGuilds }, changed: true }
-    : { entry: params.entry, changed: false };
-}
-
 function isDiscordChannelAgentBinding(
   value: unknown,
   match: { accountId?: string; guildId: string; channelId: string },
@@ -450,14 +389,13 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "discord"],
     message:
       'channels.discord.guilds.<id>.channels.<id>.allow is legacy; use channels.discord.guilds.<id>.channels.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: hasLegacyDiscordGuildChannelAllowAlias,
+    match: guildChannelAllowMigration.hasLegacy,
   },
   {
     path: ["channels", "discord", "accounts"],
     message:
       'channels.discord.accounts.<id>.guilds.<id>.channels.<id>.allow is legacy; use channels.discord.accounts.<id>.guilds.<id>.channels.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: (value) =>
-      hasLegacyAccountStreamingAliases(value, hasLegacyDiscordGuildChannelAllowAlias),
+    match: (value) => hasLegacyAccountStreamingAliases(value, guildChannelAllowMigration.hasLegacy),
   },
   {
     path: ["channels", "discord"],
@@ -514,7 +452,7 @@ export function normalizeCompatibilityConfig({
     changes.push("Removed retired Discord tuning knobs.");
   }
 
-  const guildAliases = normalizeDiscordGuildChannelAllowAliases({
+  const guildAliases = guildChannelAllowMigration.normalize({
     entry: updated,
     pathPrefix: "channels.discord",
     changes,
@@ -537,7 +475,7 @@ export function normalizeCompatibilityConfig({
     pathPrefix: "channels.discord",
     changes,
     normalizeAccount: ({ account, accountId, pathPrefix, changes: accountChanges }) => {
-      const guilds = normalizeDiscordGuildChannelAllowAliases({
+      const guilds = guildChannelAllowMigration.normalize({
         entry: account,
         pathPrefix,
         changes: accountChanges,

--- a/extensions/googlechat/src/doctor-contract.ts
+++ b/extensions/googlechat/src/doctor-contract.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   asObjectRecord,
   defineChannelAliasMigration,
+  defineKeyMoveMigration,
   hasLegacyAccountStreamingAliases,
   normalizeChannelConfigEntries,
 } from "openclaw/plugin-sdk/runtime-doctor";
@@ -30,43 +31,11 @@ function hasRetiredReactions(value: unknown): boolean {
   return Object.hasOwn(asObjectRecord(asObjectRecord(value)?.actions) ?? {}, "reactions");
 }
 
-function hasLegacyGoogleChatGroupAllowAlias(value: unknown): boolean {
-  const groups = asObjectRecord(asObjectRecord(value)?.groups);
-  if (!groups) {
-    return false;
-  }
-  return Object.values(groups).some((group) => Object.hasOwn(asObjectRecord(group) ?? {}, "allow"));
-}
-
-function normalizeGoogleChatGroups(params: {
-  groups: Record<string, unknown>;
-  pathPrefix: string;
-  changes: string[];
-}): { groups: Record<string, unknown>; changed: boolean } {
-  let changed = false;
-  const nextGroups = { ...params.groups };
-  for (const [groupId, groupValue] of Object.entries(params.groups)) {
-    const group = asObjectRecord(groupValue);
-    if (!group || !Object.hasOwn(group, "allow")) {
-      continue;
-    }
-    const nextGroup = { ...group };
-    if (nextGroup.enabled === undefined) {
-      nextGroup.enabled = group.allow;
-      params.changes.push(
-        `Moved ${params.pathPrefix}.${groupId}.allow → ${params.pathPrefix}.${groupId}.enabled.`,
-      );
-    } else {
-      params.changes.push(
-        `Removed ${params.pathPrefix}.${groupId}.allow (${params.pathPrefix}.${groupId}.enabled already set).`,
-      );
-    }
-    delete nextGroup.allow;
-    nextGroups[groupId] = nextGroup;
-    changed = true;
-  }
-  return { groups: nextGroups, changed };
-}
+const groupAllowMigration = defineKeyMoveMigration({
+  scope: ["groups", "*"],
+  from: ["allow"],
+  to: ["enabled"],
+});
 
 function normalizeGoogleChatEntry(params: {
   entry: Record<string, unknown>;
@@ -98,18 +67,9 @@ function normalizeGoogleChatEntry(params: {
     changed = true;
   }
 
-  const groups = asObjectRecord(updated.groups);
-  if (groups) {
-    const normalized = normalizeGoogleChatGroups({
-      groups,
-      pathPrefix: `${params.pathPrefix}.groups`,
-      changes: params.changes,
-    });
-    if (normalized.changed) {
-      updated = { ...updated, groups: normalized.groups };
-      changed = true;
-    }
-  }
+  const groups = groupAllowMigration.normalize({ ...params, entry: updated });
+  updated = groups.entry;
+  changed = changed || groups.changed;
 
   return { entry: updated, changed };
 }
@@ -142,13 +102,13 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "googlechat"],
     message:
       'channels.googlechat.groups.<id>.allow is legacy; use channels.googlechat.groups.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: hasLegacyGoogleChatGroupAllowAlias,
+    match: groupAllowMigration.hasLegacy,
   },
   {
     path: ["channels", "googlechat", "accounts"],
     message:
       'channels.googlechat.accounts.<id>.groups.<id>.allow is legacy; use channels.googlechat.accounts.<id>.groups.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacyGoogleChatGroupAllowAlias),
+    match: (value) => hasLegacyAccountStreamingAliases(value, groupAllowMigration.hasLegacy),
   },
   ...streamingAliasMigration.legacyConfigRules,
 ];

--- a/extensions/matrix/src/doctor-contract.ts
+++ b/extensions/matrix/src/doctor-contract.ts
@@ -6,6 +6,7 @@ import type {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   defineChannelAliasMigration,
+  defineKeyMoveMigration,
   hasLegacyAccountStreamingAliases,
   normalizeChannelConfigEntries,
   stripRetiredChannelKeys,
@@ -55,15 +56,18 @@ const streamingAliasMigration = defineChannelAliasMigration<MatrixStreamingMode>
   accountStreamingReplacesRoot: true,
 });
 
-function hasLegacyMatrixRoomAllowAlias(value: unknown): boolean {
-  const room = isRecord(value) ? value : null;
-  return Boolean(room && typeof room.allow === "boolean");
-}
-
-function hasLegacyMatrixRoomMapAllowAliases(value: unknown): boolean {
-  const rooms = isRecord(value) ? value : null;
-  return Boolean(rooms && Object.values(rooms).some((room) => hasLegacyMatrixRoomAllowAlias(room)));
-}
+const roomAllowMigration = defineKeyMoveMigration({
+  scope: ["*"],
+  from: ["allow"],
+  to: ["enabled"],
+  sourceOwn: false,
+  match: (value) => typeof value === "boolean",
+  targetIsSet: (value) => typeof value === "boolean",
+  movedMessage: ({ sourcePath, targetPath, mappedValue }) =>
+    `Moved ${sourcePath} → ${targetPath} (${String(mappedValue)}).`,
+  existingMessage: ({ sourcePath, targetPath, targetValue }) =>
+    `Moved ${sourcePath} → ${targetPath} (${String(targetValue)}).`,
+});
 
 function hasLegacyTrustedDmPolicy(value: unknown): boolean {
   const root = isRecord(value) ? value : null;
@@ -104,32 +108,6 @@ function migrateLegacyTrustedDmPolicy(params: {
   return { entry: { ...params.entry, dm: nextDm }, changed: true };
 }
 
-function normalizeMatrixRoomAllowAliases(params: {
-  rooms: Record<string, unknown>;
-  pathPrefix: string;
-  changes: string[];
-}): { rooms: Record<string, unknown>; changed: boolean } {
-  let changed = false;
-  const nextRooms: Record<string, unknown> = { ...params.rooms };
-  for (const [roomId, roomValue] of Object.entries(params.rooms)) {
-    const room = isRecord(roomValue) ? roomValue : null;
-    if (!room || typeof room.allow !== "boolean") {
-      continue;
-    }
-    const nextRoom = { ...room };
-    if (typeof nextRoom.enabled !== "boolean") {
-      nextRoom.enabled = room.allow;
-    }
-    delete nextRoom.allow;
-    nextRooms[roomId] = nextRoom;
-    changed = true;
-    params.changes.push(
-      `Moved ${params.pathPrefix}.${roomId}.allow → ${params.pathPrefix}.${roomId}.enabled (${String(nextRoom.enabled)}).`,
-    );
-  }
-  return { rooms: nextRooms, changed };
-}
-
 export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
   ...streamingAliasMigration.legacyConfigRules,
   {
@@ -151,13 +129,13 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "matrix", "groups"],
     message:
       'channels.matrix.groups.<room>.allow is legacy; use channels.matrix.groups.<room>.enabled instead. Run "openclaw doctor --fix".',
-    match: hasLegacyMatrixRoomMapAllowAliases,
+    match: roomAllowMigration.hasLegacy,
   },
   {
     path: ["channels", "matrix", "rooms"],
     message:
       'channels.matrix.rooms.<room>.allow is legacy; use channels.matrix.rooms.<room>.enabled instead. Run "openclaw doctor --fix".',
-    match: hasLegacyMatrixRoomMapAllowAliases,
+    match: roomAllowMigration.hasLegacy,
   },
   {
     path: ["channels", "matrix", "accounts"],
@@ -169,8 +147,8 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
           return false;
         }
         return (
-          hasLegacyMatrixRoomMapAllowAliases(account.groups) ||
-          hasLegacyMatrixRoomMapAllowAliases(account.rooms)
+          roomAllowMigration.hasLegacy(account.groups) ||
+          roomAllowMigration.hasLegacy(account.rooms)
         );
       }),
   },
@@ -197,22 +175,25 @@ function normalizeMatrixEntry(params: {
   const dmPolicy = migrateLegacyTrustedDmPolicy({ ...params, entry: network.entry });
   let entry = dmPolicy.entry;
   let changed = network.changed || dmPolicy.changed;
-  for (const key of ["groups", "rooms"] as const) {
-    const rooms = isRecord(entry[key]) ? entry[key] : null;
-    if (!rooms) {
+  for (const section of ["groups", "rooms"] as const) {
+    const roomMap = isRecord(entry[section]) ? entry[section] : null;
+    if (!roomMap) {
       continue;
     }
-    const normalized = normalizeMatrixRoomAllowAliases({
-      rooms,
-      pathPrefix: `${params.pathPrefix}.${key}`,
+    const normalized = roomAllowMigration.normalize({
+      entry: roomMap,
+      pathPrefix: `${params.pathPrefix}.${section}`,
       changes: params.changes,
     });
     if (normalized.changed) {
-      entry = Object.assign({}, entry, { [key]: normalized.rooms });
+      entry = Object.assign({}, entry, { [section]: normalized.entry });
       changed = true;
     }
   }
-  return { entry, changed };
+  return {
+    entry,
+    changed,
+  };
 }
 
 export function normalizeCompatibilityConfig({

--- a/extensions/qqbot/src/doctor-contract.ts
+++ b/extensions/qqbot/src/doctor-contract.ts
@@ -7,6 +7,7 @@ import type { GroupToolPolicyConfig } from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   asObjectRecord,
+  defineKeyMoveMigration,
   hasLegacyAccountStreamingAliases,
   normalizeChannelConfigEntries,
 } from "openclaw/plugin-sdk/runtime-doctor";
@@ -14,6 +15,13 @@ import {
 const RESTRICTED_GROUP_TOOLS: GroupToolPolicyConfig = {
   deny: ["exec", "read", "write"],
 };
+
+const streamingTransportMigration = defineKeyMoveMigration({
+  from: ["streaming", "c2cStreamApi"],
+  to: ["streaming", "nativeTransport"],
+  match: (value) => value !== undefined,
+  sourceOwn: false,
+});
 
 // QQBot's legacy scalar `streaming` is not a plain mode alias: `true` enabled
 // block streaming AND the official C2C stream API (shouldUseOfficialC2cStream
@@ -28,10 +36,7 @@ function hasLegacyStreamingValue(value: unknown): boolean {
   if (!entry) {
     return false;
   }
-  return (
-    typeof entry.streaming === "boolean" ||
-    asObjectRecord(entry.streaming)?.c2cStreamApi !== undefined
-  );
+  return typeof entry.streaming === "boolean" || streamingTransportMigration.hasLegacy(entry);
 }
 
 function migrateStreamingValue(params: {
@@ -52,27 +57,7 @@ function migrateStreamingValue(params: {
     }
     return { entry: { ...params.entry, streaming: next }, changed: true };
   }
-  const streamingRecord = asObjectRecord(streaming);
-  if (!streamingRecord || streamingRecord.c2cStreamApi === undefined) {
-    return { entry: params.entry, changed: false };
-  }
-  const { c2cStreamApi, ...rest } = streamingRecord;
-  const next: Record<string, unknown> = { ...rest };
-  if (next.nativeTransport === undefined) {
-    next.nativeTransport = c2cStreamApi;
-    params.changes.push(`Moved ${path}.c2cStreamApi → ${path}.nativeTransport.`);
-  } else {
-    params.changes.push(`Removed ${path}.c2cStreamApi (${path}.nativeTransport already set).`);
-  }
-  return { entry: { ...params.entry, streaming: next }, changed: true };
-}
-
-function hasLegacyGroupToolPolicy(value: unknown): boolean {
-  const groups = asObjectRecord(value);
-  if (!groups) {
-    return false;
-  }
-  return Object.values(groups).some((group) => asObjectRecord(group)?.toolPolicy !== undefined);
+  return streamingTransportMigration.normalize(params);
 }
 
 function migrateToolPolicy(value: unknown): GroupToolPolicyConfig | undefined {
@@ -92,39 +77,23 @@ function describeToolPolicy(value: unknown): string {
   return typeof value === "string" ? value : String(value);
 }
 
-function migrateGroups(params: {
-  groups: Record<string, unknown>;
-  pathPrefix: string;
-  changes: string[];
-}): { groups: Record<string, unknown>; changed: boolean } {
-  let changed = false;
-  const nextGroups = { ...params.groups };
-  for (const [groupId, rawGroup] of Object.entries(params.groups)) {
-    const group = asObjectRecord(rawGroup);
-    if (!group || group.toolPolicy === undefined) {
-      continue;
-    }
-    const { toolPolicy, ...rest } = group;
-    const nextGroup = { ...rest };
-    const policy = migrateToolPolicy(toolPolicy);
-    const path = `${params.pathPrefix}.${groupId}`;
-    if (nextGroup.tools !== undefined) {
-      params.changes.push(`Removed ${path}.toolPolicy (${path}.tools already exists).`);
-    } else if (policy) {
-      nextGroup.tools = policy;
-      params.changes.push(
-        `Moved ${path}.toolPolicy=${describeToolPolicy(toolPolicy)} to ${path}.tools.`,
-      );
-    } else {
-      params.changes.push(
-        `Removed unsupported ${path}.toolPolicy=${describeToolPolicy(toolPolicy)}.`,
-      );
-    }
-    nextGroups[groupId] = nextGroup;
-    changed = true;
-  }
-  return { groups: nextGroups, changed };
-}
+const groupToolPolicyMigration = defineKeyMoveMigration({
+  scope: ["*"],
+  from: ["toolPolicy"],
+  to: ["tools"],
+  match: (value) => value !== undefined,
+  sourceOwn: false,
+  map: (value) => {
+    const policy = migrateToolPolicy(value);
+    return policy ? { value: policy } : null;
+  },
+  movedMessage: ({ sourcePath, targetPath, sourceValue }) =>
+    `Moved ${sourcePath}=${describeToolPolicy(sourceValue)} to ${targetPath}.`,
+  existingMessage: ({ sourcePath, targetPath }) =>
+    `Removed ${sourcePath} (${targetPath} already exists).`,
+  invalidMessage: ({ sourcePath, sourceValue }) =>
+    `Removed unsupported ${sourcePath}=${describeToolPolicy(sourceValue)}.`,
+});
 
 export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
   {
@@ -143,7 +112,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "qqbot", "groups"],
     message:
       'channels.qqbot.groups.<id>.toolPolicy is legacy and was ignored by QQBot group tool enforcement; use channels.qqbot.groups.<id>.tools instead. Run "openclaw doctor --fix".',
-    match: hasLegacyGroupToolPolicy,
+    match: groupToolPolicyMigration.hasLegacy,
   },
   {
     path: ["channels", "qqbot", "accounts"],
@@ -151,7 +120,7 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
       'channels.qqbot.accounts.<id>.groups.<groupId>.toolPolicy is legacy and was ignored by QQBot group tool enforcement; use channels.qqbot.accounts.<id>.groups.<groupId>.tools instead. Run "openclaw doctor --fix".',
     match: (value) =>
       hasLegacyAccountStreamingAliases(value, (account) =>
-        hasLegacyGroupToolPolicy(asObjectRecord(account)?.groups),
+        groupToolPolicyMigration.hasLegacy(asObjectRecord(account)?.groups),
       ),
   },
 ];
@@ -166,13 +135,13 @@ function normalizeQqbotEntry(params: {
   if (!groups) {
     return streaming;
   }
-  const migrated = migrateGroups({
-    groups,
+  const migrated = groupToolPolicyMigration.normalize({
+    entry: groups,
     pathPrefix: `${params.pathPrefix}.groups`,
     changes: params.changes,
   });
   return migrated.changed
-    ? { entry: { ...streaming.entry, groups: migrated.groups }, changed: true }
+    ? { entry: { ...streaming.entry, groups: migrated.entry }, changed: true }
     : streaming;
 }
 

--- a/extensions/slack/src/doctor-contract.ts
+++ b/extensions/slack/src/doctor-contract.ts
@@ -5,8 +5,8 @@ import type {
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
-  asObjectRecord,
   defineChannelAliasMigration,
+  defineKeyMoveMigration,
   hasLegacyAccountStreamingAliases,
   normalizeChannelConfigEntries,
 } from "openclaw/plugin-sdk/runtime-doctor";
@@ -24,119 +24,27 @@ const streamingAliasMigration = defineChannelAliasMigration({
   dm: { root: true, accounts: true },
 });
 
-function hasLegacySlackChannelAllowAlias(value: unknown): boolean {
-  const channels = asObjectRecord(asObjectRecord(value)?.channels);
-  if (!channels) {
-    return false;
-  }
-  return Object.values(channels).some((channel) =>
-    Object.hasOwn(asObjectRecord(channel) ?? {}, "allow"),
-  );
-}
+const dmReplyModeMigration = defineKeyMoveMigration({
+  from: ["dm", "replyToMode"],
+  to: ["replyToModeByChatType", "direct"],
+});
 
-function hasLegacySlackThreadMentionPolicy(value: unknown): boolean {
-  const thread = asObjectRecord(asObjectRecord(value)?.thread);
-  return Boolean(thread && Object.hasOwn(thread, "requireExplicitMention"));
-}
+const threadMentionPolicyMigration = defineKeyMoveMigration({
+  from: ["thread", "requireExplicitMention"],
+  to: ["implicitMentions", "threadParticipation"],
+  // The retired boolean controlled only participated threads; the canonical
+  // setting expresses the inverse while reply-to-bot policy stays independent.
+  map: (value) => (typeof value === "boolean" ? { value: !value } : null),
+  pruneEmptySource: true,
+  movedMessage: ({ sourcePath, targetPath, mappedValue }) =>
+    `Moved ${sourcePath} → ${targetPath} (${String(mappedValue)}).`,
+});
 
-function hasLegacyDmReplyMode(value: unknown): boolean {
-  return Object.hasOwn(asObjectRecord(asObjectRecord(value)?.dm) ?? {}, "replyToMode");
-}
-
-function migrateDmReplyMode(
-  entry: Record<string, unknown>,
-  path: string,
-  changes: string[],
-): boolean {
-  const dm = asObjectRecord(entry.dm);
-  if (!dm || !Object.hasOwn(dm, "replyToMode")) {
-    return false;
-  }
-  const byType = asObjectRecord(entry.replyToModeByChatType) ?? {};
-  if (byType.direct === undefined) {
-    byType.direct = dm.replyToMode;
-    entry.replyToModeByChatType = byType;
-    changes.push(`Moved ${path}.dm.replyToMode → ${path}.replyToModeByChatType.direct.`);
-  } else {
-    changes.push(`Removed ${path}.dm.replyToMode (replyToModeByChatType.direct already set).`);
-  }
-  delete dm.replyToMode;
-  return true;
-}
-
-function normalizeSlackThreadMentionPolicy(params: {
-  value: Record<string, unknown>;
-  pathPrefix: string;
-  changes: string[];
-}): { value: Record<string, unknown>; changed: boolean } {
-  const thread = asObjectRecord(params.value.thread);
-  if (!thread || !Object.hasOwn(thread, "requireExplicitMention")) {
-    return { value: params.value, changed: false };
-  }
-
-  const next = { ...params.value };
-  const nextThread = { ...thread };
-  const implicitMentions = asObjectRecord(params.value.implicitMentions) ?? {};
-  const nextImplicitMentions = { ...implicitMentions };
-  const legacyValue = thread.requireExplicitMention;
-  const targetPath = `${params.pathPrefix}.implicitMentions.threadParticipation`;
-  if (nextImplicitMentions.threadParticipation !== undefined) {
-    params.changes.push(
-      `Removed ${params.pathPrefix}.thread.requireExplicitMention (${targetPath} already set).`,
-    );
-  } else if (typeof legacyValue === "boolean") {
-    // The retired key maps only the participated-thread fact. Replies to the bot
-    // remain independently governed by the canonical replyToBot policy.
-    nextImplicitMentions.threadParticipation = !legacyValue;
-    params.changes.push(
-      `Moved ${params.pathPrefix}.thread.requireExplicitMention → ${targetPath} (${String(!legacyValue)}).`,
-    );
-  } else {
-    params.changes.push(
-      `Removed invalid ${params.pathPrefix}.thread.requireExplicitMention value.`,
-    );
-  }
-  delete nextThread.requireExplicitMention;
-  if (Object.keys(nextThread).length > 0) {
-    next.thread = nextThread;
-  } else {
-    delete next.thread;
-  }
-  if (Object.keys(nextImplicitMentions).length > 0) {
-    next.implicitMentions = nextImplicitMentions;
-  }
-  return { value: next, changed: true };
-}
-
-function normalizeSlackChannelAllowAliases(params: {
-  channels: Record<string, unknown>;
-  pathPrefix: string;
-  changes: string[];
-}): { channels: Record<string, unknown>; changed: boolean } {
-  let changed = false;
-  const nextChannels = { ...params.channels };
-  for (const [channelId, channelValue] of Object.entries(params.channels)) {
-    const channel = asObjectRecord(channelValue);
-    if (!channel || !Object.hasOwn(channel, "allow")) {
-      continue;
-    }
-    const nextChannel = { ...channel };
-    if (nextChannel.enabled === undefined) {
-      nextChannel.enabled = channel.allow;
-      params.changes.push(
-        `Moved ${params.pathPrefix}.${channelId}.allow → ${params.pathPrefix}.${channelId}.enabled.`,
-      );
-    } else {
-      params.changes.push(
-        `Removed ${params.pathPrefix}.${channelId}.allow (${params.pathPrefix}.${channelId}.enabled already set).`,
-      );
-    }
-    delete nextChannel.allow;
-    nextChannels[channelId] = nextChannel;
-    changed = true;
-  }
-  return { channels: nextChannels, changed };
-}
+const channelAllowMigration = defineKeyMoveMigration({
+  scope: ["channels", "*"],
+  from: ["allow"],
+  to: ["enabled"],
+});
 
 export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
   ...streamingAliasMigration.legacyConfigRules,
@@ -144,37 +52,38 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
     path: ["channels", "slack"],
     message:
       'channels.slack.dm.replyToMode moved to replyToModeByChatType.direct. Run "openclaw doctor --fix".',
-    match: hasLegacyDmReplyMode,
+    match: dmReplyModeMigration.hasLegacy,
   },
   {
     path: ["channels", "slack", "accounts"],
     message:
       'channels.slack.accounts.<id>.dm.replyToMode moved to replyToModeByChatType.direct. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacyDmReplyMode),
+    match: (value) => hasLegacyAccountStreamingAliases(value, dmReplyModeMigration.hasLegacy),
   },
   {
     path: ["channels", "slack"],
     message:
       'channels.slack.thread.requireExplicitMention is legacy; use channels.slack.implicitMentions.threadParticipation instead. Run "openclaw doctor --fix".',
-    match: hasLegacySlackThreadMentionPolicy,
+    match: threadMentionPolicyMigration.hasLegacy,
   },
   {
     path: ["channels", "slack", "accounts"],
     message:
       'channels.slack.accounts.<id>.thread.requireExplicitMention is legacy; use channels.slack.accounts.<id>.implicitMentions.threadParticipation instead. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacySlackThreadMentionPolicy),
+    match: (value) =>
+      hasLegacyAccountStreamingAliases(value, threadMentionPolicyMigration.hasLegacy),
   },
   {
     path: ["channels", "slack"],
     message:
       'channels.slack.channels.<id>.allow is legacy; use channels.slack.channels.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: hasLegacySlackChannelAllowAlias,
+    match: channelAllowMigration.hasLegacy,
   },
   {
     path: ["channels", "slack", "accounts"],
     message:
       'channels.slack.accounts.<id>.channels.<id>.allow is legacy; use channels.slack.accounts.<id>.channels.<id>.enabled instead. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyAccountStreamingAliases(value, hasLegacySlackChannelAllowAlias),
+    match: (value) => hasLegacyAccountStreamingAliases(value, channelAllowMigration.hasLegacy),
   },
 ];
 
@@ -183,28 +92,13 @@ function normalizeSlackEntry(params: {
   pathPrefix: string;
   changes: string[];
 }): { entry: Record<string, unknown>; changed: boolean } {
-  let entry = params.entry;
-  let changed = migrateDmReplyMode(entry, params.pathPrefix, params.changes);
-  const threadPolicy = normalizeSlackThreadMentionPolicy({
-    value: entry,
-    pathPrefix: params.pathPrefix,
-    changes: params.changes,
-  });
-  entry = threadPolicy.value;
-  changed = changed || threadPolicy.changed;
-  const channels = asObjectRecord(entry.channels);
-  if (channels) {
-    const normalized = normalizeSlackChannelAllowAliases({
-      channels,
-      pathPrefix: `${params.pathPrefix}.channels`,
-      changes: params.changes,
-    });
-    if (normalized.changed) {
-      entry = { ...entry, channels: normalized.channels };
-      changed = true;
-    }
-  }
-  return { entry, changed };
+  const dm = dmReplyModeMigration.normalize(params);
+  const thread = threadMentionPolicyMigration.normalize({ ...params, entry: dm.entry });
+  const channels = channelAllowMigration.normalize({ ...params, entry: thread.entry });
+  return {
+    entry: channels.entry,
+    changed: dm.changed || thread.changed || channels.changed,
+  };
 }
 
 export function normalizeCompatibilityConfig({

--- a/src/plugin-sdk/runtime-doctor.test.ts
+++ b/src/plugin-sdk/runtime-doctor.test.ts
@@ -1,12 +1,75 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "./config-contracts.js";
-import { normalizeChannelConfigEntries, stripRetiredChannelKeys } from "./runtime-doctor.js";
+import {
+  defineKeyMoveMigration,
+  normalizeChannelConfigEntries,
+  stripRetiredChannelKeys,
+} from "./runtime-doctor.js";
 
 function cfgWith(entry: Record<string, unknown>): OpenClawConfig {
   return { channels: { sample: entry } } as never;
 }
 
 describe("runtime-doctor channel helpers", () => {
+  it("moves nested keys across wildcard entries and preserves canonical values", () => {
+    const migration = defineKeyMoveMigration({
+      scope: ["groups", "*"],
+      from: ["allow"],
+      to: ["enabled"],
+    });
+    const entry = {
+      groups: {
+        first: { allow: true },
+        second: { allow: true, enabled: false },
+        invalid: "skip",
+      },
+    };
+    const changes: string[] = [];
+
+    expect(migration.hasLegacy(entry)).toBe(true);
+    expect(migration.normalize({ entry, pathPrefix: "channels.sample", changes })).toEqual({
+      entry: {
+        groups: {
+          first: { enabled: true },
+          second: { enabled: false },
+          invalid: "skip",
+        },
+      },
+      changed: true,
+    });
+    expect(changes).toEqual([
+      "Moved channels.sample.groups.first.allow → channels.sample.groups.first.enabled.",
+      "Removed channels.sample.groups.second.allow (channels.sample.groups.second.enabled already set).",
+    ]);
+  });
+
+  it("supports mapped values, invalid removal, and empty-parent pruning", () => {
+    const migration = defineKeyMoveMigration({
+      from: ["thread", "requireExplicitMention"],
+      to: ["implicitMentions", "threadParticipation"],
+      map: (value) => (typeof value === "boolean" ? { value: !value } : null),
+      pruneEmptySource: true,
+    });
+    const changes: string[] = [];
+    const moved = migration.normalize({
+      entry: { thread: { requireExplicitMention: true } },
+      pathPrefix: "channels.sample",
+      changes,
+    });
+    expect(moved.entry).toEqual({ implicitMentions: { threadParticipation: false } });
+    expect(
+      migration.normalize({
+        entry: { thread: { requireExplicitMention: "yes" } },
+        pathPrefix: "channels.sample",
+        changes,
+      }).entry,
+    ).toEqual({});
+    expect(changes).toEqual([
+      "Moved channels.sample.thread.requireExplicitMention → channels.sample.implicitMentions.threadParticipation.",
+      "Removed invalid channels.sample.thread.requireExplicitMention value.",
+    ]);
+  });
+
   it("normalizes the root and every object-shaped account in order", () => {
     const changeLog: string[] = [];
     const result = normalizeChannelConfigEntries({

--- a/src/plugin-sdk/runtime-doctor.ts
+++ b/src/plugin-sdk/runtime-doctor.ts
@@ -1,6 +1,9 @@
 /**
  * Runtime SDK subpath for plugin doctor migrations, compat checks, and uninstall helpers.
  */
+import { asObjectRecord } from "../config/channel-compat-normalization.js";
+import type { CompatMutationResult } from "../config/channel-compat-normalization.js";
+
 export { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
 export { defineChannelAliasMigration } from "../config/channel-alias-migration.js";
 export type {
@@ -53,3 +56,200 @@ export {
   legacyStateFileExists,
 } from "../plugins/doctor-state-migration-fs.js";
 export type { DoctorSessionRouteStateOwner } from "../plugins/doctor-session-route-state-owner-types.js";
+
+type KeyMoveValue = { value: unknown };
+type KeyMoveChangeContext = {
+  sourcePath: string;
+  targetPath: string;
+  sourceValue: unknown;
+  targetValue: unknown;
+  mappedValue: unknown;
+};
+
+function readKeyMovePath(entry: Record<string, unknown>, path: readonly string[], own = true) {
+  let current = entry;
+  for (const segment of path.slice(0, -1)) {
+    const next = asObjectRecord(current[segment]);
+    if (!next) {
+      return null;
+    }
+    current = next;
+  }
+  const key = path.at(-1);
+  return key && (own ? Object.hasOwn(current, key) : key in current)
+    ? { value: current[key] }
+    : null;
+}
+
+function setKeyMovePath(
+  entry: Record<string, unknown>,
+  path: readonly string[],
+  value: unknown,
+): Record<string, unknown> {
+  const [key, ...rest] = path;
+  if (!key) {
+    return entry;
+  }
+  if (rest.length === 0) {
+    return { ...entry, [key]: value };
+  }
+  return {
+    ...entry,
+    [key]: setKeyMovePath(asObjectRecord(entry[key]) ?? {}, rest, value),
+  };
+}
+
+function deleteKeyMovePath(
+  entry: Record<string, unknown>,
+  path: readonly string[],
+  pruneEmpty: boolean,
+): Record<string, unknown> {
+  const [key, ...rest] = path;
+  if (!key) {
+    return entry;
+  }
+  const next = { ...entry };
+  if (rest.length === 0) {
+    delete next[key];
+    return next;
+  }
+  const child = asObjectRecord(entry[key]);
+  if (!child) {
+    return entry;
+  }
+  const updatedChild = deleteKeyMovePath(child, rest, pruneEmpty);
+  if (pruneEmpty && Object.keys(updatedChild).length === 0) {
+    delete next[key];
+  } else {
+    next[key] = updatedChild;
+  }
+  return next;
+}
+
+/** Defines an immutable legacy-key move across fixed or `*`-mapped object paths. */
+export function defineKeyMoveMigration(params: {
+  scope?: readonly string[];
+  from: readonly string[];
+  to: readonly string[];
+  match?: (value: unknown) => boolean;
+  sourceOwn?: boolean;
+  map?: (value: unknown) => KeyMoveValue | null;
+  targetIsSet?: (value: unknown) => boolean;
+  pruneEmptySource?: boolean;
+  movedMessage?: (context: KeyMoveChangeContext) => string;
+  existingMessage?: (context: KeyMoveChangeContext) => string;
+  invalidMessage?: (context: KeyMoveChangeContext) => string;
+}): {
+  hasLegacy: (value: unknown) => boolean;
+  normalize: (params: {
+    entry: Record<string, unknown>;
+    pathPrefix: string;
+    changes: string[];
+  }) => CompatMutationResult;
+} {
+  const visitScopes = (
+    entry: Record<string, unknown>,
+    scope: readonly string[],
+    visit: (scopeEntry: Record<string, unknown>, scopePath: readonly string[]) => boolean,
+    scopePath: readonly string[] = [],
+  ): boolean => {
+    const [segment, ...rest] = scope;
+    if (!segment) {
+      return visit(entry, scopePath);
+    }
+    if (segment === "*") {
+      return Object.entries(entry).some(([key, value]) => {
+        const child = asObjectRecord(value);
+        return child ? visitScopes(child, rest, visit, [...scopePath, key]) : false;
+      });
+    }
+    const child = asObjectRecord(entry[segment]);
+    return child ? visitScopes(child, rest, visit, [...scopePath, segment]) : false;
+  };
+
+  const hasLegacy = (value: unknown): boolean => {
+    const entry = asObjectRecord(value);
+    return entry
+      ? visitScopes(entry, params.scope ?? [], (scopeEntry) => {
+          const source = readKeyMovePath(scopeEntry, params.from, params.sourceOwn);
+          return Boolean(source && (params.match?.(source.value) ?? true));
+        })
+      : false;
+  };
+
+  const normalizeScope = (
+    scopeEntry: Record<string, unknown>,
+    scopePath: readonly string[],
+    pathPrefix: string,
+    changes: string[],
+  ): CompatMutationResult => {
+    const source = readKeyMovePath(scopeEntry, params.from, params.sourceOwn);
+    if (!source || !(params.match?.(source.value) ?? true)) {
+      return { entry: scopeEntry, changed: false };
+    }
+    const target = readKeyMovePath(scopeEntry, params.to);
+    const mapped = params.map ? params.map(source.value) : { value: source.value };
+    const context: KeyMoveChangeContext = {
+      sourcePath: [pathPrefix, ...scopePath, ...params.from].join("."),
+      targetPath: [pathPrefix, ...scopePath, ...params.to].join("."),
+      sourceValue: source.value,
+      targetValue: target?.value,
+      mappedValue: mapped?.value,
+    };
+    const targetSet = params.targetIsSet?.(target?.value) ?? target?.value !== undefined;
+    let updated = scopeEntry;
+    if (targetSet) {
+      changes.push(
+        params.existingMessage?.(context) ??
+          `Removed ${context.sourcePath} (${context.targetPath} already set).`,
+      );
+    } else if (mapped) {
+      updated = setKeyMovePath(updated, params.to, mapped.value);
+      changes.push(
+        params.movedMessage?.(context) ?? `Moved ${context.sourcePath} → ${context.targetPath}.`,
+      );
+    } else {
+      changes.push(
+        params.invalidMessage?.(context) ?? `Removed invalid ${context.sourcePath} value.`,
+      );
+    }
+    return {
+      entry: deleteKeyMovePath(updated, params.from, params.pruneEmptySource ?? false),
+      changed: true,
+    };
+  };
+
+  const normalizeScopes = (
+    entry: Record<string, unknown>,
+    scope: readonly string[],
+    pathPrefix: string,
+    changes: string[],
+    scopePath: readonly string[] = [],
+  ): CompatMutationResult => {
+    const [segment, ...rest] = scope;
+    if (!segment) {
+      return normalizeScope(entry, scopePath, pathPrefix, changes);
+    }
+    let changed = false;
+    const updated = { ...entry };
+    const keys = segment === "*" ? Object.keys(entry) : [segment];
+    for (const key of keys) {
+      const child = asObjectRecord(entry[key]);
+      if (!child) {
+        continue;
+      }
+      const normalized = normalizeScopes(child, rest, pathPrefix, changes, [...scopePath, key]);
+      if (normalized.changed) {
+        updated[key] = normalized.entry;
+        changed = true;
+      }
+    }
+    return changed ? { entry: updated, changed: true } : { entry, changed: false };
+  };
+
+  return {
+    hasLegacy,
+    normalize: ({ entry, pathPrefix, changes }) =>
+      normalizeScopes(entry, params.scope ?? [], pathPrefix, changes),
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Five plugin doctor contracts repeated the same key-move migration construction and reporting mechanics.

## Why This Change Was Made

This AI-assisted refactor adds a generic `defineKeyMoveMigration` owner in the plugin SDK and migrates Discord, Google Chat, Matrix, QQBot, and Slack while removing the broader directory-builder experiment from this branch.

## User Impact

No intended behavior change. Plugin doctor repairs keep their existing keys and outcomes with 58 fewer production lines.

Release-note context: none; this is an internal plugin doctor refactor.

## Evidence

- Doctor proof: 57 tests across five shards passed.
- Plugin SDK surface check passed with no public export-budget delta.
- `git diff --check` passed.
- Autoreview: clean.
