### PR TITLE
refactor: share channel probe runner

### DIFF
--- a/extensions/discord/src/probe.ts
+++ b/extensions/discord/src/probe.ts
@@ -3,7 +3,7 @@ import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import { fetchWithTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
+import { fetchWithTimeout, runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { DiscordApiError, fetchDiscord } from "./api.js";
 import { normalizeDiscordToken } from "./token.js";
 
@@ -140,72 +140,67 @@ export async function probeDiscord(
   timeoutMs: number,
   opts?: { fetcher?: typeof fetch; includeApplication?: boolean },
 ): Promise<DiscordProbe> {
-  const started = Date.now();
-  const fetcher = opts?.fetcher ?? fetch;
-  const includeApplication = opts?.includeApplication === true;
-  const normalized = normalizeDiscordToken(token, "channels.discord.token");
-  const result: DiscordProbe = {
-    ok: false,
-    status: null,
-    error: null,
-    elapsedMs: 0,
-  };
-  if (!normalized) {
-    return {
-      ...result,
-      error: "missing token",
-      elapsedMs: Date.now() - started,
-    };
-  }
-  let res: Response | undefined;
-  try {
-    const getMeUrl = `${DISCORD_API_BASE}/users/@me`;
-    const getMeDeadlineMs = Date.now() + timeoutMs;
-    res = await fetchWithTimeout(
-      getMeUrl,
-      { headers: { Authorization: `Bot ${normalized}` } },
-      timeoutMs,
-      getResolvedFetch(fetcher),
-    );
-    if (!res.ok) {
-      result.status = res.status;
-      result.error = `getMe failed (${res.status})`;
-      return { ...result, elapsedMs: Date.now() - started };
-    }
-    const json = await readDiscordProbeGetMeJson(res, timeoutMs, getMeDeadlineMs);
-    result.ok = true;
-    result.bot = {
-      id: json.id ?? null,
-      username: json.username ?? null,
-    };
-    if (includeApplication) {
-      // Application metadata is optional. Keep its deadline inside the outer status budget so a
-      // stalled secondary response cannot discard the already-resolved bot identity.
-      const elapsedMs = Math.max(0, Date.now() - started);
-      const completionReserveMs = Math.min(
-        DISCORD_PROBE_COMPLETION_RESERVE_MAX_MS,
-        Math.max(1, Math.floor(timeoutMs / 10)),
-      );
-      const applicationTimeoutMs = Math.floor(timeoutMs - elapsedMs - completionReserveMs);
-      if (applicationTimeoutMs > 0) {
-        result.application =
-          (await fetchDiscordApplicationSummary(normalized, applicationTimeoutMs, fetcher)) ??
-          undefined;
+  return await runChannelProbe(
+    undefined,
+    async ({ startedAt }) => {
+      const fetcher = opts?.fetcher ?? fetch;
+      const includeApplication = opts?.includeApplication === true;
+      const normalized = normalizeDiscordToken(token, "channels.discord.token");
+      const result: Omit<DiscordProbe, "elapsedMs"> = {
+        ok: false,
+        status: null,
+        error: null,
+      };
+      if (!normalized) {
+        return { ...result, error: "missing token" };
       }
-    }
-    return { ...result, elapsedMs: Date.now() - started };
-  } catch (err) {
-    return {
-      ...result,
-      status: err instanceof Response ? err.status : result.status,
-      error: formatErrorMessage(err),
-      elapsedMs: Date.now() - started,
-    };
-  } finally {
-    if (res?.bodyUsed !== true) {
-      await res?.body?.cancel().catch(() => undefined);
-    }
-  }
+      let res: Response | undefined;
+      try {
+        const getMeUrl = `${DISCORD_API_BASE}/users/@me`;
+        const getMeDeadlineMs = Date.now() + timeoutMs;
+        res = await fetchWithTimeout(
+          getMeUrl,
+          { headers: { Authorization: `Bot ${normalized}` } },
+          timeoutMs,
+          getResolvedFetch(fetcher),
+        );
+        if (!res.ok) {
+          return { ...result, status: res.status, error: `getMe failed (${res.status})` };
+        }
+        const json = await readDiscordProbeGetMeJson(res, timeoutMs, getMeDeadlineMs);
+        result.ok = true;
+        result.bot = {
+          id: json.id ?? null,
+          username: json.username ?? null,
+        };
+        if (includeApplication) {
+          // Application metadata is optional. Keep its deadline inside the outer status budget so a
+          // stalled secondary response cannot discard the already-resolved bot identity.
+          const elapsedMs = Math.max(0, Date.now() - startedAt);
+          const completionReserveMs = Math.min(
+            DISCORD_PROBE_COMPLETION_RESERVE_MAX_MS,
+            Math.max(1, Math.floor(timeoutMs / 10)),
+          );
+          const applicationTimeoutMs = Math.floor(timeoutMs - elapsedMs - completionReserveMs);
+          if (applicationTimeoutMs > 0) {
+            result.application =
+              (await fetchDiscordApplicationSummary(normalized, applicationTimeoutMs, fetcher)) ??
+              undefined;
+          }
+        }
+        return result;
+      } finally {
+        if (res?.bodyUsed !== true) {
+          await res?.body?.cancel().catch(() => undefined);
+        }
+      }
+    },
+    (error) => ({
+      ok: false,
+      status: error instanceof Response ? error.status : null,
+      error: formatErrorMessage(error),
+    }),
+  );
 }
 
 /**

--- a/extensions/matrix/src/matrix/probe.ts
+++ b/extensions/matrix/src/matrix/probe.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/ssrf-dispatcher";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { SsrFPolicy } from "../runtime-api.js";
 import type { BaseProbeResult } from "../runtime-api.js";
 import { isBunRuntime } from "./client/runtime.js";
@@ -30,65 +31,47 @@ export async function probeMatrix(params: {
   ssrfPolicy?: SsrFPolicy;
   dispatcherPolicy?: PinnedDispatcherPolicy;
 }): Promise<MatrixProbe> {
-  const started = Date.now();
-  const result: MatrixProbe = {
-    ok: false,
-    status: null,
-    error: null,
-    elapsedMs: 0,
-  };
-  if (isBunRuntime()) {
-    return {
-      ...result,
-      error: "Matrix probe requires Node (bun runtime not supported)",
-      elapsedMs: Date.now() - started,
-    };
-  }
-  if (!params.homeserver?.trim()) {
-    return {
-      ...result,
-      error: "missing homeserver",
-      elapsedMs: Date.now() - started,
-    };
-  }
-  if (!params.accessToken?.trim()) {
-    return {
-      ...result,
-      error: "missing access token",
-      elapsedMs: Date.now() - started,
-    };
-  }
-  try {
-    const { createMatrixClient } = await loadMatrixProbeRuntimeDeps();
-    const inputUserId = normalizeOptionalString(params.userId);
-    const client = await createMatrixClient({
-      homeserver: params.homeserver,
-      userId: inputUserId,
-      accessToken: params.accessToken,
-      deviceId: params.deviceId,
-      persistStorage: false,
-      localTimeoutMs: params.timeoutMs,
-      accountId: params.accountId,
-      allowPrivateNetwork: params.allowPrivateNetwork,
-      ssrfPolicy: params.ssrfPolicy,
-      dispatcherPolicy: params.dispatcherPolicy,
-    });
-    // The client wrapper resolves user ID via whoami when needed.
-    const userId = await client.getUserId();
-    result.ok = true;
-    result.userId = userId ?? null;
-
-    result.elapsedMs = Date.now() - started;
-    return result;
-  } catch (err) {
-    return {
-      ...result,
+  return await runChannelProbe(
+    undefined,
+    async () => {
+      const result: Omit<MatrixProbe, "elapsedMs"> = {
+        ok: false,
+        status: null,
+        error: null,
+      };
+      if (isBunRuntime()) {
+        return { ...result, error: "Matrix probe requires Node (bun runtime not supported)" };
+      }
+      if (!params.homeserver?.trim()) {
+        return { ...result, error: "missing homeserver" };
+      }
+      if (!params.accessToken?.trim()) {
+        return { ...result, error: "missing access token" };
+      }
+      const { createMatrixClient } = await loadMatrixProbeRuntimeDeps();
+      const inputUserId = normalizeOptionalString(params.userId);
+      const client = await createMatrixClient({
+        homeserver: params.homeserver,
+        userId: inputUserId,
+        accessToken: params.accessToken,
+        deviceId: params.deviceId,
+        persistStorage: false,
+        localTimeoutMs: params.timeoutMs,
+        accountId: params.accountId,
+        allowPrivateNetwork: params.allowPrivateNetwork,
+        ssrfPolicy: params.ssrfPolicy,
+        dispatcherPolicy: params.dispatcherPolicy,
+      });
+      // The client wrapper resolves user ID via whoami when needed.
+      return { ...result, ok: true, userId: (await client.getUserId()) ?? null };
+    },
+    (error) => ({
+      ok: false,
       status:
-        typeof err === "object" && err && "statusCode" in err
-          ? Number((err as { statusCode?: number }).statusCode)
-          : result.status,
-      error: formatErrorMessage(err),
-      elapsedMs: Date.now() - started,
-    };
-  }
+        typeof error === "object" && error && "statusCode" in error
+          ? Number((error as { statusCode?: number }).statusCode)
+          : null,
+      error: formatErrorMessage(error),
+    }),
+  );
 }

--- a/extensions/mattermost/src/mattermost/probe.ts
+++ b/extensions/mattermost/src/mattermost/probe.ts
@@ -7,6 +7,7 @@ import {
   ssrfPolicyFromPrivateNetworkOptIn,
   type LookupFn,
 } from "openclaw/plugin-sdk/ssrf-runtime";
+import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeMattermostBaseUrl, readMattermostError, type MattermostUser } from "./client.js";
 import type { BaseProbeResult } from "./runtime-api.js";
 
@@ -34,49 +35,51 @@ export async function probeMattermost(
     return { ok: false, error: "baseUrl missing" };
   }
   const url = `${normalized}/api/v4/users/me`;
-  const start = Date.now();
-  // Guard-owned timeoutMs covers DNS/proxy preflight; init.signal alone does not.
-  const resolvedTimeoutMs = timeoutMs > 0 ? resolveTimerTimeoutMs(timeoutMs, 2500) : undefined;
-  try {
-    const { response: res, release } = await fetchWithSsrFGuard({
-      url,
-      init: {
-        headers: { Authorization: `Bearer ${botToken}` },
-      },
-      auditContext: "mattermost-probe",
-      policy: ssrfPolicyFromPrivateNetworkOptIn(allowPrivateNetwork),
-      ...(resolvedTimeoutMs !== undefined ? { timeoutMs: resolvedTimeoutMs } : {}),
-      ...(deps?.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
-      ...(deps?.lookupFn ? { lookupFn: deps.lookupFn } : {}),
-    });
-    try {
-      const elapsedMs = Date.now() - start;
-      if (!res.ok) {
-        const detail = await readMattermostError(res);
+  return await runChannelProbe(
+    undefined,
+    async ({ elapsedMs }) => {
+      // Guard-owned timeoutMs covers DNS/proxy preflight; init.signal alone does not.
+      const resolvedTimeoutMs = timeoutMs > 0 ? resolveTimerTimeoutMs(timeoutMs, 2500) : undefined;
+      const { response: res, release } = await fetchWithSsrFGuard({
+        url,
+        init: {
+          headers: { Authorization: `Bearer ${botToken}` },
+        },
+        auditContext: "mattermost-probe",
+        policy: ssrfPolicyFromPrivateNetworkOptIn(allowPrivateNetwork),
+        ...(resolvedTimeoutMs !== undefined ? { timeoutMs: resolvedTimeoutMs } : {}),
+        ...(deps?.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+        ...(deps?.lookupFn ? { lookupFn: deps.lookupFn } : {}),
+      });
+      const requestElapsedMs = elapsedMs();
+      try {
+        if (!res.ok) {
+          const detail = await readMattermostError(res);
+          return {
+            ok: false,
+            status: res.status,
+            error: detail || res.statusText,
+            elapsedMs: requestElapsedMs,
+          };
+        }
+        const bot = await readProviderJsonResponse<MattermostUser>(
+          res,
+          "Mattermost probe /users/me",
+        );
         return {
-          ok: false,
+          ok: true,
           status: res.status,
-          error: detail || res.statusText,
-          elapsedMs,
+          elapsedMs: requestElapsedMs,
+          bot,
         };
+      } finally {
+        await release();
       }
-      const bot = await readProviderJsonResponse<MattermostUser>(res, "Mattermost probe /users/me");
-      return {
-        ok: true,
-        status: res.status,
-        elapsedMs,
-        bot,
-      };
-    } finally {
-      await release();
-    }
-  } catch (err) {
-    const message = formatErrorMessage(err);
-    return {
+    },
+    (error) => ({
       ok: false,
       status: null,
-      error: message,
-      elapsedMs: Date.now() - start,
-    };
-  }
+      error: formatErrorMessage(error),
+    }),
+  );
 }

--- a/extensions/signal/src/probe.ts
+++ b/extensions/signal/src/probe.ts
@@ -1,6 +1,7 @@
 // Signal plugin module implements probe behavior.
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { type SignalTransportKind, signalCheck, signalRpcRequest } from "./client-adapter.js";
 import { detectSignalTransport } from "./transport-detection.js";
 
@@ -32,49 +33,39 @@ export async function probeSignal(
     apiMode?: "auto" | "native" | "container";
   } = {},
 ): Promise<SignalProbe> {
-  const started = Date.now();
-  const result: SignalProbe = {
-    ok: false,
-    status: null,
-    error: null,
-    elapsedMs: 0,
-    version: null,
-  };
-  let transportKind: SignalTransportKind;
-  try {
-    transportKind = await resolveProbeTransportKind(baseUrl, timeoutMs, options);
-  } catch (error) {
-    return {
-      ...result,
-      error: formatErrorMessage(error),
-      elapsedMs: Date.now() - started,
+  return await runChannelProbe(undefined, async () => {
+    const result: Omit<SignalProbe, "elapsedMs"> = {
+      ok: false,
+      status: null,
+      error: null,
+      version: null,
     };
-  }
-  const check = await signalCheck(baseUrl, timeoutMs, { transportKind });
-  if (!check.ok) {
-    return {
-      ...result,
-      status: check.status ?? null,
-      error: check.error ?? "unreachable",
-      elapsedMs: Date.now() - started,
-    };
-  }
-  try {
-    const version = await signalRpcRequest("version", undefined, {
-      baseUrl,
-      timeoutMs,
-      transportKind,
-    });
-    result.version = parseSignalVersion(version);
-  } catch (err) {
-    result.error = formatErrorMessage(err);
-  }
-  return {
-    ...result,
-    ok: true,
-    status: check.status ?? null,
-    elapsedMs: Date.now() - started,
-  };
+    let transportKind: SignalTransportKind;
+    try {
+      transportKind = await resolveProbeTransportKind(baseUrl, timeoutMs, options);
+    } catch (error) {
+      return { ...result, error: formatErrorMessage(error) };
+    }
+    const check = await signalCheck(baseUrl, timeoutMs, { transportKind });
+    if (!check.ok) {
+      return {
+        ...result,
+        status: check.status ?? null,
+        error: check.error ?? "unreachable",
+      };
+    }
+    try {
+      const version = await signalRpcRequest("version", undefined, {
+        baseUrl,
+        timeoutMs,
+        transportKind,
+      });
+      result.version = parseSignalVersion(version);
+    } catch (error) {
+      result.error = formatErrorMessage(error);
+    }
+    return { ...result, ok: true, status: check.status ?? null };
+  });
 }
 
 async function resolveProbeTransportKind(

--- a/extensions/slack/src/probe.test.ts
+++ b/extensions/slack/src/probe.test.ts
@@ -4,36 +4,21 @@ import { probeSlack } from "./probe.js";
 
 const authTestMock = vi.hoisted(() => vi.fn());
 const createSlackWebClientMock = vi.hoisted(() => vi.fn());
-const withTimeoutMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
   createSlackWebClient: createSlackWebClientMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/text-utility-runtime", () => ({
-  withTimeout: withTimeoutMock,
-}));
-
-function requireFirstTimeoutCall() {
-  const [call] = withTimeoutMock.mock.calls;
-  if (!call) {
-    throw new Error("expected withTimeout call");
-  }
-  return call;
-}
-
 describe("probeSlack", () => {
   beforeEach(() => {
     authTestMock.mockReset();
     createSlackWebClientMock.mockReset();
-    withTimeoutMock.mockReset();
 
     createSlackWebClientMock.mockReturnValue({
       auth: {
         test: authTestMock,
       },
     });
-    withTimeoutMock.mockImplementation(async (promise: Promise<unknown>) => await promise);
   });
 
   it("maps Slack auth metadata on success", async () => {
@@ -55,10 +40,6 @@ describe("probeSlack", () => {
       team: { id: "T123", name: "OpenClaw" },
     });
     expect(createSlackWebClientMock).toHaveBeenCalledWith("xoxb-test");
-    expect(withTimeoutMock).toHaveBeenCalledTimes(1);
-    const [promise, timeoutMs] = requireFirstTimeoutCall();
-    expect(promise).toBeInstanceOf(Promise);
-    expect(timeoutMs).toBe(2500);
   });
 
   it("warns when auth.test looks like a user token in the bot token slot", async () => {

--- a/extensions/slack/src/probe.ts
+++ b/extensions/slack/src/probe.ts
@@ -1,6 +1,6 @@
 // Slack plugin module implements probe behavior.
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
-import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
+import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createSlackWebClient } from "./client.js";
 import { formatSlackError } from "./errors.js";
 import { formatSlackBotTokenIdentityWarning } from "./token.js";
@@ -20,68 +20,61 @@ export async function probeSlack(
   opts?: { accountId?: string | null; identity?: "bot" | "user" },
 ): Promise<SlackProbe> {
   const client = createSlackWebClient(token);
-  const start = Date.now();
-  try {
-    const result = await withTimeout(client.auth.test(), timeoutMs);
-    if (!result.ok) {
-      return {
-        ok: false,
-        status: 200,
-        error: result.error ?? "unknown",
-        elapsedMs: Date.now() - start,
-      };
-    }
-    if (opts?.identity === "user") {
-      if (result.bot_id?.trim()) {
+  return await runChannelProbe(
+    timeoutMs,
+    async () => {
+      const result = await client.auth.test();
+      if (!result.ok) {
         return {
           ok: false,
           status: 200,
-          error:
-            "Slack auth.test identified a bot token; user identity requires a user OAuth token",
-          elapsedMs: Date.now() - start,
+          error: result.error ?? "unknown",
         };
       }
-      const userId = result.user_id?.trim();
-      if (!userId) {
+      if (opts?.identity === "user") {
+        if (result.bot_id?.trim()) {
+          return {
+            ok: false,
+            status: 200,
+            error:
+              "Slack auth.test identified a bot token; user identity requires a user OAuth token",
+          };
+        }
+        const userId = result.user_id?.trim();
+        if (!userId) {
+          return {
+            ok: false,
+            status: 200,
+            error: "Slack auth.test returned no human user_id for user identity",
+          };
+        }
         return {
-          ok: false,
+          ok: true,
           status: 200,
-          error: "Slack auth.test returned no human user_id for user identity",
-          elapsedMs: Date.now() - start,
+          user: { id: userId, name: result.user },
+          team: { id: result.team_id, name: result.team },
         };
       }
+      const warning = formatSlackBotTokenIdentityWarning({
+        auth: result,
+        accountId: opts?.accountId,
+      });
+      const authIdentity = { id: result.user_id, name: result.user };
       return {
         ok: true,
         status: 200,
-        elapsedMs: Date.now() - start,
-        user: { id: userId, name: result.user },
+        bot: authIdentity,
         team: { id: result.team_id, name: result.team },
+        ...(warning ? { warning } : {}),
       };
-    }
-    const warning = formatSlackBotTokenIdentityWarning({
-      auth: result,
-      accountId: opts?.accountId,
-    });
-    const authIdentity = { id: result.user_id, name: result.user };
-    return {
-      ok: true,
-      status: 200,
-      elapsedMs: Date.now() - start,
-      bot: authIdentity,
-      team: { id: result.team_id, name: result.team },
-      ...(warning ? { warning } : {}),
-    };
-  } catch (err) {
-    const message = formatSlackError(err);
-    const status =
-      typeof (err as { statusCode?: number }).statusCode === "number"
-        ? (err as { statusCode?: number }).statusCode
-        : null;
-    return {
+    },
+    (error) => ({
       ok: false,
-      status,
-      error: message,
-      elapsedMs: Date.now() - start,
-    };
-  }
+      status:
+        typeof (error as { statusCode?: number }).statusCode === "number"
+          ? (error as { statusCode?: number }).statusCode
+          : null,
+      error: formatSlackError(error),
+    }),
+  );
 }

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -4,7 +4,7 @@ import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
-import { fetchWithTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
+import { fetchWithTimeout, runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeTelegramBotInfo, type TelegramBotInfo } from "./bot-info.js";
 import {
   resolveTelegramApiBase,
@@ -139,163 +139,159 @@ export async function probeTelegram(
   timeoutMs: number,
   proxyOrOptions?: string | TelegramProbeOptions,
 ): Promise<TelegramProbe> {
-  const started = Date.now();
-  const timeoutBudgetMs = Math.max(1, Math.floor(timeoutMs));
-  const deadlineMs = started + timeoutBudgetMs;
-  const options = resolveProbeOptions(proxyOrOptions);
-  const abortSignal = options?.abortSignal;
-  const includeWebhookInfo = options?.includeWebhookInfo !== false;
-  const transport = resolveProbeTransport(token, options);
-  const fetcher = transport.fetch;
-  const apiBase = resolveTelegramApiBase(options?.apiRoot);
-  const base = `${apiBase}/bot${token}`;
-  const retryDelayMs = Math.max(50, Math.min(1000, Math.floor(timeoutBudgetMs / 5)));
-  const resolveRemainingBudgetMs = () => Math.max(0, deadlineMs - Date.now());
+  return await runChannelProbe(
+    undefined,
+    async ({ startedAt }) => {
+      const timeoutBudgetMs = Math.max(1, Math.floor(timeoutMs));
+      const deadlineMs = startedAt + timeoutBudgetMs;
+      const options = resolveProbeOptions(proxyOrOptions);
+      const abortSignal = options?.abortSignal;
+      const includeWebhookInfo = options?.includeWebhookInfo !== false;
+      const transport = resolveProbeTransport(token, options);
+      const fetcher = transport.fetch;
+      const apiBase = resolveTelegramApiBase(options?.apiRoot);
+      const base = `${apiBase}/bot${token}`;
+      const retryDelayMs = Math.max(50, Math.min(1000, Math.floor(timeoutBudgetMs / 5)));
+      const resolveRemainingBudgetMs = () => Math.max(0, deadlineMs - Date.now());
+      const result: Omit<TelegramProbe, "elapsedMs"> = {
+        ok: false,
+        status: null,
+        error: null,
+      };
+      let meRes: Response | null = null;
+      let fetchError: unknown = null;
 
-  const result: TelegramProbe = {
-    ok: false,
-    status: null,
-    error: null,
-    elapsedMs: 0,
-  };
-
-  try {
-    let meRes: Response | null = null;
-    let fetchError: unknown = null;
-
-    // Retry loop for initial connection (handles network/DNS startup races)
-    for (let i = 0; i < 3; i++) {
-      const remainingBudgetMs = resolveRemainingBudgetMs();
-      if (remainingBudgetMs <= 0 || abortSignal?.aborted) {
-        break;
-      }
-      try {
-        meRes = await fetchWithTimeout(
-          `${base}/getMe`,
-          { signal: abortSignal },
-          Math.max(1, Math.min(timeoutBudgetMs, remainingBudgetMs)),
-          fetcher,
-        );
-        break;
-      } catch (err) {
-        fetchError = err;
-        if (abortSignal?.aborted) {
-          throw err;
+      // Retry loop for initial connection (handles network/DNS startup races)
+      for (let i = 0; i < 3; i++) {
+        const remainingBudgetMs = resolveRemainingBudgetMs();
+        if (remainingBudgetMs <= 0 || abortSignal?.aborted) {
+          break;
         }
-        // On timeout or network error, promote the transport to its IPv4
-        // fallback dispatcher so the next retry (and all future probes
-        // sharing this cached transport) skip the stalled IPv6 path.
-        // Keep the original socket code in transport fallback diagnostics.
-        transport.forceFallback?.("probe timeout/network error", err);
-        if (i < 2) {
-          const remainingAfterAttemptMs = resolveRemainingBudgetMs();
-          if (remainingAfterAttemptMs <= 0) {
-            break;
-          }
-          const delayMs = Math.min(retryDelayMs, remainingAfterAttemptMs);
-          if (delayMs > 0) {
-            await sleepWithAbort(delayMs, abortSignal);
-          }
-        }
-      }
-    }
-
-    if (!meRes) {
-      throw toLintErrorObject(
-        fetchError ?? new Error(`probe timed out after ${timeoutBudgetMs}ms`),
-        "Non-Error thrown",
-      );
-    }
-
-    const meJson = JSON.parse(
-      (
-        await readTelegramDiagnosticBody(
-          meRes,
-          Math.min(timeoutBudgetMs, resolveRemainingBudgetMs()),
-        )
-      ).toString("utf8"),
-    ) as {
-      ok?: boolean;
-      description?: string;
-      result?: unknown;
-    };
-    if (!meRes.ok || !meJson?.ok) {
-      result.status = meRes.status;
-      result.error = meJson?.description ?? `getMe failed (${meRes.status})`;
-      return { ...result, elapsedMs: Date.now() - started };
-    }
-
-    const botInfo = normalizeTelegramBotInfo(meJson.result);
-    const rawBot = meJson.result && typeof meJson.result === "object" ? meJson.result : {};
-    const bot = rawBot as Record<string, unknown>;
-    if (botInfo) {
-      result.botInfo = botInfo;
-    }
-    result.bot = {
-      id: typeof bot.id === "number" ? bot.id : null,
-      isBot: normalizeBoolean(bot.is_bot),
-      firstName: typeof bot.first_name === "string" ? bot.first_name : null,
-      username: typeof bot.username === "string" ? bot.username : null,
-      canJoinGroups: normalizeBoolean(bot.can_join_groups),
-      canReadAllGroupMessages: normalizeBoolean(bot.can_read_all_group_messages),
-      canManageBots: normalizeBoolean(bot.can_manage_bots),
-      supportsInlineQueries: normalizeBoolean(bot.supports_inline_queries),
-      canConnectToBusiness: normalizeBoolean(bot.can_connect_to_business),
-      hasMainWebApp: normalizeBoolean(bot.has_main_web_app),
-      hasTopicsEnabled: normalizeBoolean(bot.has_topics_enabled),
-      allowsUsersToCreateTopics: normalizeBoolean(bot.allows_users_to_create_topics),
-    };
-
-    if (includeWebhookInfo) {
-      // Try to fetch webhook info, but don't fail health if it errors.
-      try {
-        const webhookRemainingBudgetMs = resolveRemainingBudgetMs();
-        if (webhookRemainingBudgetMs > 0) {
-          const webhookRes = await fetchWithTimeout(
-            `${base}/getWebhookInfo`,
+        try {
+          meRes = await fetchWithTimeout(
+            `${base}/getMe`,
             { signal: abortSignal },
-            Math.max(1, Math.min(timeoutBudgetMs, webhookRemainingBudgetMs)),
+            Math.max(1, Math.min(timeoutBudgetMs, remainingBudgetMs)),
             fetcher,
           );
-          const webhookJson = JSON.parse(
-            (
-              await readTelegramDiagnosticBody(
-                webhookRes,
-                Math.min(timeoutBudgetMs, resolveRemainingBudgetMs()),
-              )
-            ).toString("utf8"),
-          ) as {
-            ok?: boolean;
-            result?: { url?: string; has_custom_certificate?: boolean };
-          };
-          if (webhookRes.ok && webhookJson?.ok) {
-            result.webhook = {
-              url: webhookJson.result?.url ?? null,
-              hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
-            };
+          break;
+        } catch (err) {
+          fetchError = err;
+          if (abortSignal?.aborted) {
+            throw err;
+          }
+          // On timeout or network error, promote the transport to its IPv4
+          // fallback dispatcher so the next retry (and all future probes
+          // sharing this cached transport) skip the stalled IPv6 path.
+          // Keep the original socket code in transport fallback diagnostics.
+          transport.forceFallback?.("probe timeout/network error", err);
+          if (i < 2) {
+            const remainingAfterAttemptMs = resolveRemainingBudgetMs();
+            if (remainingAfterAttemptMs <= 0) {
+              break;
+            }
+            const delayMs = Math.min(retryDelayMs, remainingAfterAttemptMs);
+            if (delayMs > 0) {
+              await sleepWithAbort(delayMs, abortSignal);
+            }
           }
         }
-      } catch (err) {
-        if (abortSignal?.aborted) {
-          throw err;
-        }
-        // ignore webhook errors for probe
       }
-    }
 
-    result.ok = true;
-    result.status = null;
-    result.error = null;
-    result.elapsedMs = Date.now() - started;
-    return result;
-  } catch (err) {
-    return {
-      ...result,
-      status: err instanceof Response ? err.status : result.status,
-      error: formatErrorMessage(err),
-      elapsedMs: Date.now() - started,
-    };
-  }
+      if (!meRes) {
+        throw toLintErrorObject(
+          fetchError ?? new Error(`probe timed out after ${timeoutBudgetMs}ms`),
+          "Non-Error thrown",
+        );
+      }
+
+      const meJson = JSON.parse(
+        (
+          await readTelegramDiagnosticBody(
+            meRes,
+            Math.min(timeoutBudgetMs, resolveRemainingBudgetMs()),
+          )
+        ).toString("utf8"),
+      ) as {
+        ok?: boolean;
+        description?: string;
+        result?: unknown;
+      };
+      if (!meRes.ok || !meJson?.ok) {
+        result.status = meRes.status;
+        result.error = meJson?.description ?? `getMe failed (${meRes.status})`;
+        return result;
+      }
+
+      const botInfo = normalizeTelegramBotInfo(meJson.result);
+      const rawBot = meJson.result && typeof meJson.result === "object" ? meJson.result : {};
+      const bot = rawBot as Record<string, unknown>;
+      if (botInfo) {
+        result.botInfo = botInfo;
+      }
+      result.bot = {
+        id: typeof bot.id === "number" ? bot.id : null,
+        isBot: normalizeBoolean(bot.is_bot),
+        firstName: typeof bot.first_name === "string" ? bot.first_name : null,
+        username: typeof bot.username === "string" ? bot.username : null,
+        canJoinGroups: normalizeBoolean(bot.can_join_groups),
+        canReadAllGroupMessages: normalizeBoolean(bot.can_read_all_group_messages),
+        canManageBots: normalizeBoolean(bot.can_manage_bots),
+        supportsInlineQueries: normalizeBoolean(bot.supports_inline_queries),
+        canConnectToBusiness: normalizeBoolean(bot.can_connect_to_business),
+        hasMainWebApp: normalizeBoolean(bot.has_main_web_app),
+        hasTopicsEnabled: normalizeBoolean(bot.has_topics_enabled),
+        allowsUsersToCreateTopics: normalizeBoolean(bot.allows_users_to_create_topics),
+      };
+
+      if (includeWebhookInfo) {
+        // Try to fetch webhook info, but don't fail health if it errors.
+        try {
+          const webhookRemainingBudgetMs = resolveRemainingBudgetMs();
+          if (webhookRemainingBudgetMs > 0) {
+            const webhookRes = await fetchWithTimeout(
+              `${base}/getWebhookInfo`,
+              { signal: abortSignal },
+              Math.max(1, Math.min(timeoutBudgetMs, webhookRemainingBudgetMs)),
+              fetcher,
+            );
+            const webhookJson = JSON.parse(
+              (
+                await readTelegramDiagnosticBody(
+                  webhookRes,
+                  Math.min(timeoutBudgetMs, resolveRemainingBudgetMs()),
+                )
+              ).toString("utf8"),
+            ) as {
+              ok?: boolean;
+              result?: { url?: string; has_custom_certificate?: boolean };
+            };
+            if (webhookRes.ok && webhookJson?.ok) {
+              result.webhook = {
+                url: webhookJson.result?.url ?? null,
+                hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
+              };
+            }
+          }
+        } catch (err) {
+          if (abortSignal?.aborted) {
+            throw err;
+          }
+          // ignore webhook errors for probe
+        }
+      }
+
+      result.ok = true;
+      result.status = null;
+      result.error = null;
+      return result;
+    },
+    (error) => ({
+      ok: false,
+      status: error instanceof Response ? error.status : null,
+      error: formatErrorMessage(error),
+    }),
+  );
 }
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/src/plugin-sdk/text-utility-runtime.test.ts
+++ b/src/plugin-sdk/text-utility-runtime.test.ts
@@ -1,9 +1,57 @@
-import { describe, expect, it } from "vitest";
-import { escapeHtml } from "./text-utility-runtime.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { escapeHtml, runChannelProbe } from "./text-utility-runtime.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 describe("escapeHtml", () => {
   it("escapes five HTML-sensitive characters and existing entity markers", () => {
     expect(escapeHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
     expect(escapeHtml("already &amp; escaped")).toBe("already &amp;amp; escaped");
+  });
+});
+
+describe("runChannelProbe", () => {
+  it("adds elapsed time to successful results", async () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(100).mockReturnValueOnce(145);
+
+    await expect(
+      runChannelProbe(
+        undefined,
+        async ({ startedAt }) => ({ ok: startedAt === 100 }),
+        (error) => ({ ok: false, error: String(error) }),
+      ),
+    ).resolves.toEqual({ ok: true, elapsedMs: 45 });
+  });
+
+  it("preserves an explicit timing snapshot", async () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(100).mockReturnValueOnce(120);
+
+    await expect(
+      runChannelProbe(
+        undefined,
+        async ({ elapsedMs }) => ({ ok: true, elapsedMs: elapsedMs() }),
+        (error) => ({ ok: false, error: String(error) }),
+      ),
+    ).resolves.toEqual({ ok: true, elapsedMs: 20 });
+  });
+
+  it("applies the timeout before shaping the error result", async () => {
+    vi.useFakeTimers();
+    const resultPromise = runChannelProbe(
+      50,
+      async () => await new Promise<never>(() => {}),
+      (error) => ({ ok: false, error: String(error) }),
+    );
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      error: "Error: timeout",
+      elapsedMs: 50,
+    });
   });
 });

--- a/src/plugin-sdk/text-utility-runtime.ts
+++ b/src/plugin-sdk/text-utility-runtime.ts
@@ -1,4 +1,33 @@
 // Focused low-level text/runtime helpers used by bundled plugins.
+import type { BaseProbeResult } from "../channels/plugins/types.public.js";
+import { withTimeout } from "../utils/with-timeout.js";
+
+type ChannelProbeResult = BaseProbeResult & { elapsedMs?: number };
+
+/** Run a channel probe with shared timeout, elapsed-time, and error-result handling. */
+export async function runChannelProbe<
+  TResult extends ChannelProbeResult,
+  TErrorResult extends ChannelProbeResult = never,
+>(
+  timeoutMs: number | undefined,
+  run: (context: { startedAt: number; elapsedMs: () => number }) => Promise<TResult>,
+  onError?: (error: unknown) => TErrorResult,
+): Promise<(TResult | TErrorResult) & { elapsedMs: number }> {
+  const startedAt = Date.now();
+  const elapsedMs = () => Date.now() - startedAt;
+  const finish = <T extends ChannelProbeResult>(result: T) => ({
+    ...result,
+    elapsedMs: result.elapsedMs ?? elapsedMs(),
+  });
+  try {
+    return finish(await withTimeout(run({ startedAt, elapsedMs }), timeoutMs ?? 0));
+  } catch (error) {
+    if (!onError) {
+      throw error;
+    }
+    return finish(onError(error));
+  }
+}
 
 /** Escapes text for safe insertion into HTML text and quoted attribute values. */
 export function escapeHtml(value: string): string {
@@ -32,4 +61,4 @@ export {
   truncateUtf16Safe,
 } from "../utils.js";
 export { fetchWithTimeout } from "../utils/fetch-timeout.js";
-export { withTimeout } from "../utils/with-timeout.js";
+export { withTimeout };


### PR DESCRIPTION
## What Problem This Solves

Six channel probes duplicated timing, exception normalization, and result scaffolding around their channel-specific checks.

## Why This Change Was Made

This AI-assisted refactor introduces `runChannelProbe` as the shared runner while leaving each channel's transport and status interpretation local.

## User Impact

Probe behavior and channel-specific results are preserved, with one owner for timing and error handling.

Release-note context: none; this is a behavior-neutral channel probe refactor.

## Evidence

- 136 focused tests passed across the SDK helper and Slack, Discord, Matrix, Mattermost, Signal, and Telegram probes.
- Changed gate: Blacksmith Testbox `tbx_01kybbcywd4a36reg515fzw0ps`, Actions run 30136794596.
- Plugin SDK surface check and `git diff --check` passed.
- Autoreview: clean, no actionable findings.
