### PR TITLE
refactor: share feishu docx/broadcast and telegram send bookkeeping

### DIFF
--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -108,6 +108,7 @@ function createReplayClaim(key: string): FeishuMessageProcessingClaim {
 describe("broadcast dispatch", () => {
   const mockGetChatInfo = vi.fn();
   const mockShouldComputeCommandAuthorized = vi.fn(() => false);
+  const resolvedTurnCalls: Array<Record<string, unknown>> = [];
   const mockSaveMediaBuffer = vi.fn().mockResolvedValue({
     path: "/tmp/inbound-clip.mp4",
     contentType: "video/mp4",
@@ -149,6 +150,7 @@ describe("broadcast dispatch", () => {
           if (!("route" in turn) || !("delivery" in turn)) {
             throw new Error("expected assembled Feishu channel turn plan");
           }
+          resolvedTurnCalls.push(turn as unknown as Record<string, unknown>);
           const routeSessionKey = turn.route.sessionKey;
           await mockRecordInboundSession({
             storePath: mockResolveStorePath(),
@@ -251,6 +253,7 @@ describe("broadcast dispatch", () => {
     mockResolveStorePath.mockReset().mockReturnValue("/tmp/feishu-session-store.json");
     feishuGroupNameCache.clear();
     builtInboundContextCalls.length = 0;
+    resolvedTurnCalls.length = 0;
     mockResolveAgentRoute.mockReturnValue({
       agentId: "main",
       channel: "feishu",
@@ -371,6 +374,37 @@ describe("broadcast dispatch", () => {
       | { agentId?: string }
       | undefined;
     expect(dispatcherParams?.agentId).toBe("main");
+  });
+
+  it("keeps the observer adapter isolated from active delivery", async () => {
+    const activeDeliver = vi.fn(async () => undefined);
+    mockCreateFeishuReplyDispatcher.mockReturnValueOnce({
+      dispatcherOptions: {},
+      delivery: { deliver: activeDeliver },
+      replyOptions: {},
+      ensureNoVisibleReplyFallback: vi.fn(),
+    });
+
+    await handleFeishuMessage({
+      cfg: createBroadcastConfig(),
+      event: createBroadcastEvent({
+        messageId: "msg-broadcast-observer-isolation",
+        text: "hello @bot",
+        botMentioned: true,
+      }),
+      botOpenId: "bot-open-id",
+      runtime: createRuntimeEnv(),
+    });
+
+    const observerTurn = resolvedTurnCalls.find(
+      (turn) => (turn["admission"] as { kind?: string } | undefined)?.kind === "observeOnly",
+    );
+    const observerDelivery = observerTurn?.["delivery"] as
+      | { deliver: (payload: unknown, context: unknown) => Promise<unknown> }
+      | undefined;
+    expect(observerDelivery?.deliver).not.toBe(activeDeliver);
+    await expect(observerDelivery?.deliver({}, {})).resolves.toEqual({ visibleReplySent: false });
+    expect(activeDeliver).not.toHaveBeenCalled();
   });
 
   it("sends no-visible-reply fallback for active broadcast zero-final dispatch", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1557,6 +1557,52 @@ export async function handleFeishuMessage(params: {
         `feishu[${account.accountId}]: broadcasting to ${broadcastAgents.length} agents (strategy=${strategy}, active=${activeAgentId ?? "none"})`,
       );
 
+      type BroadcastInboundVariant =
+        | { kind: "observeOnly" }
+        | { kind: "active"; dispatcher: ReturnType<typeof createFeishuReplyDispatcher> };
+      const createBroadcastInboundAdapter = (paramsLocal: {
+        agentId: string;
+        sessionKey: string;
+        ctxPayload: Awaited<ReturnType<typeof buildCtxPayloadForAgent>>;
+        record: {
+          updateLastRoute: ReturnType<typeof buildFeishuInboundLastRouteUpdate>;
+          onRecordError: (err: unknown) => void;
+        };
+        lifecycle: FeishuIngressLifecycle;
+        variant: BroadcastInboundVariant;
+      }) => ({
+        ingest: () => ({
+          id: ctx.messageId,
+          timestamp: messageCreateTimeMs,
+          rawText: ctx.content,
+          textForAgent: paramsLocal.ctxPayload.BodyForAgent,
+          textForCommands: paramsLocal.ctxPayload.CommandBody,
+          raw: ctx,
+        }),
+        resolveTurn: () => ({
+          cfg,
+          channel: "feishu" as const,
+          accountId: route.accountId,
+          route: { agentId: paramsLocal.agentId, sessionKey: paramsLocal.sessionKey },
+          ctxPayload: paramsLocal.ctxPayload,
+          record: paramsLocal.record,
+          ...(paramsLocal.variant.kind === "observeOnly"
+            ? {
+                admission: { kind: "observeOnly" as const, reason: "broadcast-observer" },
+                delivery: { deliver: async () => ({ visibleReplySent: false }) },
+                replyOptions: bindIngressLifecycleToReplyOptions(paramsLocal.lifecycle),
+              }
+            : {
+                dispatcherOptions: paramsLocal.variant.dispatcher.dispatcherOptions,
+                delivery: paramsLocal.variant.dispatcher.delivery,
+                replyOptions: {
+                  ...paramsLocal.variant.dispatcher.replyOptions,
+                  ...bindIngressLifecycleToReplyOptions(paramsLocal.lifecycle),
+                },
+              }),
+        }),
+      });
+
       const dispatchForAgent = async (agentId: string) => {
         const normalizedAgentId = normalizeAgentId(agentId);
         if (hasKnownAgents && !agentIds.includes(normalizedAgentId)) {
@@ -1626,11 +1672,13 @@ export async function handleFeishuMessage(params: {
             ctx.mentionedBot && agentId === activeAgentId,
           );
 
+          let variant: BroadcastInboundVariant;
           if (agentId === activeAgentId) {
             // Active agent: real Feishu dispatcher (responds on Feishu)
             const identity = resolveAgentOutboundIdentity(cfg, agentId);
-            const { dispatcherOptions, delivery, replyOptions, ensureNoVisibleReplyFallback } =
-              createFeishuReplyDispatcher({
+            variant = {
+              kind: "active",
+              dispatcher: createFeishuReplyDispatcher({
                 cfg,
                 agentId,
                 runtime: runtime as RuntimeEnv,
@@ -1649,85 +1697,46 @@ export async function handleFeishuMessage(params: {
                 requiredMentionTargets,
                 messageCreateTimeMs,
                 sessionKey: agentSessionKey,
-              });
+              }),
+            };
 
             log(
               `feishu[${account.accountId}]: broadcast active dispatch agent=${agentId} (session=${agentSessionKey})`,
             );
-            const turnResult = await core.channel.inbound.run({
-              channel: "feishu",
-              accountId: route.accountId,
-              raw: ctx,
-              adapter: {
-                ingest: () => ({
-                  id: ctx.messageId,
-                  timestamp: messageCreateTimeMs,
-                  rawText: ctx.content,
-                  textForAgent: agentCtx.BodyForAgent,
-                  textForCommands: agentCtx.CommandBody,
-                  raw: ctx,
-                }),
-                resolveTurn: () => ({
-                  cfg,
-                  channel: "feishu",
-                  accountId: route.accountId,
-                  route: { agentId, sessionKey: agentSessionKey },
-                  ctxPayload: agentCtx,
-                  record: agentRecord,
-                  dispatcherOptions,
-                  delivery,
-                  replyOptions: {
-                    ...replyOptions,
-                    ...bindIngressLifecycleToReplyOptions(lane.lifecycle),
-                  },
-                }),
-              },
-            });
-            if (
-              turnResult.dispatched &&
-              shouldSendNoVisibleReplyFallback(turnResult.dispatchResult)
-            ) {
-              await ensureNoVisibleReplyFallback("broadcast-dispatch-complete-no-visible-reply");
-            }
-            await lane.onDispatchComplete(turnResult.dispatched);
           } else {
             // Observer agent: no-op dispatcher (session entry + inference, no Feishu reply).
             // Strip CommandAuthorized so slash commands (e.g. /reset) don't silently
             // mutate observer sessions — only the active agent should execute commands.
             delete (agentCtx as Record<string, unknown>).CommandAuthorized;
+            variant = { kind: "observeOnly" };
             log(
               `feishu[${account.accountId}]: broadcast observer dispatch agent=${agentId} (session=${agentSessionKey})`,
             );
-            const turnResult = await core.channel.inbound.run({
-              channel: "feishu",
-              accountId: route.accountId,
-              raw: ctx,
-              adapter: {
-                ingest: () => ({
-                  id: ctx.messageId,
-                  timestamp: messageCreateTimeMs,
-                  rawText: ctx.content,
-                  textForAgent: agentCtx.BodyForAgent,
-                  textForCommands: agentCtx.CommandBody,
-                  raw: ctx,
-                }),
-                resolveTurn: () => ({
-                  cfg,
-                  channel: "feishu",
-                  accountId: route.accountId,
-                  route: { agentId, sessionKey: agentSessionKey },
-                  ctxPayload: agentCtx,
-                  record: agentRecord,
-                  admission: { kind: "observeOnly", reason: "broadcast-observer" },
-                  delivery: {
-                    deliver: async () => ({ visibleReplySent: false }),
-                  },
-                  replyOptions: bindIngressLifecycleToReplyOptions(lane.lifecycle),
-                }),
-              },
-            });
-            await lane.onDispatchComplete(turnResult.dispatched);
           }
+
+          const turnResult = await core.channel.inbound.run({
+            channel: "feishu",
+            accountId: route.accountId,
+            raw: ctx,
+            adapter: createBroadcastInboundAdapter({
+              agentId,
+              sessionKey: agentSessionKey,
+              ctxPayload: agentCtx,
+              record: agentRecord,
+              lifecycle: lane.lifecycle,
+              variant,
+            }),
+          });
+          if (
+            variant.kind === "active" &&
+            turnResult.dispatched &&
+            shouldSendNoVisibleReplyFallback(turnResult.dispatchResult)
+          ) {
+            await variant.dispatcher.ensureNoVisibleReplyFallback(
+              "broadcast-dispatch-complete-no-visible-reply",
+            );
+          }
+          await lane.onDispatchComplete(turnResult.dispatched);
         } catch (err) {
           await lane.onDispatchFailed(err);
           throw err;

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -486,6 +486,56 @@ async function processImages(
   return processed;
 }
 
+async function convertInsertAndProcessDocx(params: {
+  client: Lark.Client;
+  docToken: string;
+  markdown: string;
+  maxBytes: number;
+  imageReadTimeoutMs: number;
+  logger?: Logger;
+  target?: { parentBlockId: string; index: number };
+  onConverted: (blockCount: number) => Promise<void> | void;
+}) {
+  const { client, docToken, logger, target } = params;
+  logger?.info?.("feishu_doc: Converting markdown...");
+  const { blocks, firstLevelBlockIds, images } = await chunkedConvertMarkdown(
+    client,
+    createDocxMarkdownPlan(params.markdown).chunks,
+  );
+  await params.onConverted(blocks.length);
+  if (blocks.length === 0) {
+    return { blocks, inserted: [], imagesProcessed: 0 };
+  }
+
+  const { orderedBlocks, rootIds } = normalizeConvertedBlockTree(blocks, firstLevelBlockIds);
+  logger?.info?.(
+    `feishu_doc: Converted to ${blocks.length} blocks, inserting${target ? ` at index ${target.index}` : ""}...`,
+  );
+  const { children: inserted } =
+    blocks.length > BATCH_SIZE
+      ? await insertBlocksInBatches(
+          client,
+          docToken,
+          orderedBlocks,
+          rootIds,
+          logger,
+          target?.parentBlockId,
+          target?.index,
+        )
+      : await insertBlocksWithDescendant(client, docToken, orderedBlocks, rootIds, target);
+  const imagesProcessed = await processImages(
+    client,
+    docToken,
+    images,
+    inserted,
+    params.maxBytes,
+    params.imageReadTimeoutMs,
+  );
+  logger?.info?.(`feishu_doc: Done (${blocks.length} blocks, ${imagesProcessed} images)`);
+
+  return { blocks, inserted, imagesProcessed };
+}
+
 async function uploadImageBlock(
   client: Lark.Client,
   docToken: string,
@@ -748,34 +798,20 @@ async function writeDoc(
   imageReadTimeoutMs: number,
   logger?: Logger,
 ) {
-  const markdownPlan = createDocxMarkdownPlan(markdown);
-  logger?.info?.("feishu_doc: Converting markdown...");
-  const { blocks, firstLevelBlockIds, images } = await chunkedConvertMarkdown(
-    client,
-    markdownPlan.chunks,
-  );
-  // Complete fallible conversion before deleting existing content so an
-  // unsupported oversized construct cannot leave the document empty.
-  const deleted = await clearDocumentContent(client, docToken);
-  if (blocks.length === 0) {
-    return { success: true, blocks_deleted: deleted, blocks_added: 0, images_processed: 0 };
-  }
-
-  logger?.info?.(`feishu_doc: Converted to ${blocks.length} blocks, inserting...`);
-  const { orderedBlocks, rootIds } = normalizeConvertedBlockTree(blocks, firstLevelBlockIds);
-  const { children: inserted } =
-    blocks.length > BATCH_SIZE
-      ? await insertBlocksInBatches(client, docToken, orderedBlocks, rootIds, logger)
-      : await insertBlocksWithDescendant(client, docToken, orderedBlocks, rootIds);
-  const imagesProcessed = await processImages(
+  let deleted = 0;
+  const { blocks, imagesProcessed } = await convertInsertAndProcessDocx({
     client,
     docToken,
-    images,
-    inserted,
+    markdown,
     maxBytes,
     imageReadTimeoutMs,
-  );
-  logger?.info?.(`feishu_doc: Done (${blocks.length} blocks, ${imagesProcessed} images)`);
+    logger,
+    // Complete fallible conversion before deleting existing content so an
+    // unsupported oversized construct cannot leave the document empty.
+    onConverted: async () => {
+      deleted = await clearDocumentContent(client, docToken);
+    },
+  });
 
   return {
     success: true,
@@ -793,31 +829,19 @@ async function appendDoc(
   imageReadTimeoutMs: number,
   logger?: Logger,
 ) {
-  const markdownPlan = createDocxMarkdownPlan(markdown);
-  logger?.info?.("feishu_doc: Converting markdown...");
-  const { blocks, firstLevelBlockIds, images } = await chunkedConvertMarkdown(
-    client,
-    markdownPlan.chunks,
-  );
-  if (blocks.length === 0) {
-    throw new Error("Content is empty");
-  }
-
-  logger?.info?.(`feishu_doc: Converted to ${blocks.length} blocks, inserting...`);
-  const { orderedBlocks, rootIds } = normalizeConvertedBlockTree(blocks, firstLevelBlockIds);
-  const { children: inserted } =
-    blocks.length > BATCH_SIZE
-      ? await insertBlocksInBatches(client, docToken, orderedBlocks, rootIds, logger)
-      : await insertBlocksWithDescendant(client, docToken, orderedBlocks, rootIds);
-  const imagesProcessed = await processImages(
+  const { blocks, inserted, imagesProcessed } = await convertInsertAndProcessDocx({
     client,
     docToken,
-    images,
-    inserted,
+    markdown,
     maxBytes,
     imageReadTimeoutMs,
-  );
-  logger?.info?.(`feishu_doc: Done (${blocks.length} blocks, ${imagesProcessed} images)`);
+    logger,
+    onConverted: (blockCount) => {
+      if (blockCount === 0) {
+        throw new Error("Content is empty");
+      }
+    },
+  });
 
   return {
     success: true,
@@ -836,7 +860,6 @@ async function insertDoc(
   imageReadTimeoutMs: number,
   logger?: Logger,
 ) {
-  const markdownPlan = createDocxMarkdownPlan(markdown);
   const blockInfo = await client.docx.documentBlock.get({
     path: { document_id: docToken, block_id: afterBlockId },
   });
@@ -872,44 +895,20 @@ async function insertDoc(
   }
   const insertIndex = blockIndex + 1;
 
-  logger?.info?.("feishu_doc: Converting markdown...");
-  const { blocks, firstLevelBlockIds, images } = await chunkedConvertMarkdown(
-    client,
-    markdownPlan.chunks,
-  );
-  if (blocks.length === 0) {
-    throw new Error("Content is empty");
-  }
-  const { orderedBlocks, rootIds } = normalizeConvertedBlockTree(blocks, firstLevelBlockIds);
-
-  logger?.info?.(
-    `feishu_doc: Converted to ${blocks.length} blocks, inserting at index ${insertIndex}...`,
-  );
-  const { children: inserted } =
-    blocks.length > BATCH_SIZE
-      ? await insertBlocksInBatches(
-          client,
-          docToken,
-          orderedBlocks,
-          rootIds,
-          logger,
-          parentId,
-          insertIndex,
-        )
-      : await insertBlocksWithDescendant(client, docToken, orderedBlocks, rootIds, {
-          parentBlockId: parentId,
-          index: insertIndex,
-        });
-
-  const imagesProcessed = await processImages(
+  const { blocks, inserted, imagesProcessed } = await convertInsertAndProcessDocx({
     client,
     docToken,
-    images,
-    inserted,
+    markdown,
     maxBytes,
     imageReadTimeoutMs,
-  );
-  logger?.info?.(`feishu_doc: Done (${blocks.length} blocks, ${imagesProcessed} images)`);
+    logger,
+    target: { parentBlockId: parentId, index: insertIndex },
+    onConverted: (blockCount) => {
+      if (blockCount === 0) {
+        throw new Error("Content is empty");
+      }
+    },
+  });
 
   return {
     success: true,

--- a/extensions/telegram/src/send-actions.ts
+++ b/extensions/telegram/src/send-actions.ts
@@ -15,6 +15,7 @@ import {
   type TelegramApiContext,
   type TelegramApiOverride,
 } from "./send-context.js";
+import { prepareTelegramOutbound } from "./send-outbound.js";
 import type { OpenClawConfig } from "./send.runtime.js";
 import { parseTelegramTarget } from "./targets.js";
 
@@ -226,24 +227,15 @@ async function pinMessageTelegramWithContext(
   opts: TelegramDeleteOpts,
   context: TelegramApiContext,
 ): Promise<{ ok: true; messageId: string; chatId: string }> {
-  const { cfg, account, api } = context;
-  const rawTarget = String(chatIdInput);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: rawTarget,
-    persistTarget: rawTarget,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
+  const { api } = context;
+  const { chatId, messageId, request } = await prepareTelegramOutbound({
+    to: chatIdInput,
+    context,
+    opts,
+    messageIdInput,
+    request: { kind: "standard" },
   });
-  const messageId = normalizeMessageId(messageIdInput);
-  const requestWithDiag = createTelegramRequestWithDiag({
-    cfg,
-    account,
-    retry: opts.retry,
-    verbose: opts.verbose,
-  });
-  await requestWithDiag(
+  await request(
     () =>
       api.pinChatMessage(chatId, messageId, {
         disable_notification: opts.notify !== true,

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -14,11 +14,8 @@ import {
   warnTelegramRichBlocksDegradations,
 } from "./rich-plain-fallback.js";
 import {
-  createTelegramRequestWithDiag,
   isTelegramMessageHasNoTextError,
   isTelegramMessageNotModifiedError,
-  normalizeMessageId,
-  resolveAndPersistChatId,
   resolveTelegramApiContext,
   sendLogger,
   withTelegramApiContextLease,
@@ -26,6 +23,7 @@ import {
   type TelegramApiContext,
   type TelegramApiOverride,
 } from "./send-context.js";
+import { prepareTelegramOutbound } from "./send-outbound.js";
 import type { OpenClawConfig } from "./send.runtime.js";
 import { resolveMarkdownTableMode } from "./send.runtime.js";
 
@@ -85,26 +83,17 @@ async function editMessageReplyMarkupTelegramWithContext(
   opts: TelegramEditReplyMarkupOpts,
   context: TelegramApiContext,
 ): Promise<{ ok: true; messageId: string; chatId: string }> {
-  const { cfg, account, api } = context;
-  const rawTarget = String(chatIdInput);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: rawTarget,
-    persistTarget: rawTarget,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
-  });
-  const messageId = normalizeMessageId(messageIdInput);
-  const requestWithDiag = createTelegramRequestWithDiag({
-    cfg,
-    account,
-    retry: opts.retry,
-    verbose: opts.verbose,
+  const { api } = context;
+  const { chatId, messageId, request } = await prepareTelegramOutbound({
+    to: chatIdInput,
+    context,
+    opts,
+    messageIdInput,
+    request: { kind: "standard" },
   });
   const replyMarkup = buildInlineKeyboard(buttons) ?? { inline_keyboard: [] };
   try {
-    await requestWithDiag(
+    await request(
       () => api.editMessageReplyMarkup(chatId, messageId, { reply_markup: replyMarkup }),
       "editMessageReplyMarkup",
       {
@@ -141,29 +130,22 @@ async function editMessageTelegramWithContext(
   context: TelegramApiContext,
 ): Promise<{ ok: true; messageId: string; chatId: string }> {
   const { cfg, account, api } = context;
-  const rawTarget = String(chatIdInput);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: rawTarget,
-    persistTarget: rawTarget,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
-  });
-  const messageId = normalizeMessageId(messageIdInput);
-  const requestWithDiag = createTelegramRequestWithDiag({
-    cfg,
-    account,
-    retry: opts.retry,
-    verbose: opts.verbose,
-    shouldRetry: (err) =>
-      isRecoverableTelegramNetworkError(err, { context: "edit" }) || isTelegramServerError(err),
+  const { chatId, messageId, request } = await prepareTelegramOutbound({
+    to: chatIdInput,
+    context,
+    opts,
+    messageIdInput,
+    request: {
+      kind: "standard",
+      shouldRetry: (err) =>
+        isRecoverableTelegramNetworkError(err, { context: "edit" }) || isTelegramServerError(err),
+    },
   });
   const requestWithEditShouldLog = <T>(
     fn: () => Promise<T>,
     label?: string,
     shouldLog?: (err: unknown) => boolean,
-  ) => requestWithDiag(fn, label, shouldLog ? { shouldLog } : undefined);
+  ) => request(fn, label, shouldLog ? { shouldLog } : undefined);
 
   const textMode = opts.textMode ?? "markdown";
   // Caller-authored HTML edits keep legacy parse_mode HTML semantics too.

--- a/extensions/telegram/src/send-location.ts
+++ b/extensions/telegram/src/send-location.ts
@@ -1,30 +1,19 @@
-import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import {
   formatLocationText,
   normalizeOutboundLocation,
   type OutboundLocation,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
-import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import {
-  buildTelegramThreadReplyParams,
-  resolveTelegramSendThreadSpec,
-} from "./reply-parameters.js";
-import {
-  createRequestWithChatNotFound,
-  createTelegramNonIdempotentRequestWithDiag,
   logTelegramOutboundSendOk,
-  resolveAndPersistChatId,
   resolveTelegramApiContext,
-  resolveTelegramMessageIdOrThrow,
   toAcceptedThreadScopedParams,
   withTelegramApiContextLease,
   withTelegramNativeQuoteFallback,
   type TelegramApiContext,
 } from "./send-context.js";
 import type { TelegramLocationSendOpts, TelegramSendResult } from "./send-message-types.js";
-import { recordSentMessage } from "./sent-message-cache.js";
-import { parseTelegramTarget } from "./targets.js";
+import { finalizeTelegramOutbound, prepareTelegramOutbound } from "./send-outbound.js";
 import { resolveTelegramBotUserIdFromToken } from "./token.js";
 
 type TelegramSendLocationParams = Parameters<TelegramApiContext["api"]["sendLocation"]>[3];
@@ -59,61 +48,43 @@ async function sendLocationTelegramWithContext(
     throw new Error("Telegram venues require both location.name and location.address.");
   }
 
-  const { cfg, account, api } = context;
+  const { account, api } = context;
   const botUserId = resolveTelegramBotUserIdFromToken(opts.token || account.token);
-  const target = parseTelegramTarget(to);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: target.chatId,
-    persistTarget: to,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
-  });
-  const threadSpec = resolveTelegramSendThreadSpec({
-    targetMessageThreadId: target.messageThreadId,
-    messageThreadId: opts.messageThreadId,
-    chatType: target.chatType,
-  });
-  const threadParams = buildTelegramThreadReplyParams({
-    thread: threadSpec,
-    replyToMessageId: opts.replyToMessageId,
-    replyQuoteText: opts.quoteText,
-    useReplyIdAsQuoteSource: true,
+  const prepared = await prepareTelegramOutbound({
+    to,
+    context,
+    opts,
+    thread: {
+      messageThreadId: opts.messageThreadId,
+      replyToMessageId: opts.replyToMessageId,
+      replyQuoteText: opts.quoteText,
+      useReplyIdAsQuoteSource: true,
+    },
+    request: { kind: "nonIdempotent" },
   });
   const replyMarkup = buildInlineKeyboard(opts.buttons);
   const commonParams = {
-    ...threadParams,
+    ...prepared.threadParams,
     ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
     ...(opts.silent === true ? { disable_notification: true } : {}),
   };
-  const requestWithChatNotFound = createRequestWithChatNotFound({
-    requestWithDiag: createTelegramNonIdempotentRequestWithDiag({
-      cfg,
-      account,
-      retry: opts.retry,
-      verbose: opts.verbose,
-    }),
-    chatId,
-    input: to,
-  });
   const label = hasName ? "venue" : "location";
   const delivery = await withTelegramNativeQuoteFallback({
     label,
     requestParams: commonParams,
     request: (effectiveParams, retryLabel) =>
-      requestWithChatNotFound(
+      prepared.request(
         () =>
           hasName
             ? api.sendVenue(
-                chatId,
+                prepared.chatId,
                 location.latitude,
                 location.longitude,
                 location.name ?? "",
                 location.address ?? "",
                 effectiveParams as TelegramSendVenueParams,
               )
-            : api.sendLocation(chatId, location.latitude, location.longitude, {
+            : api.sendLocation(prepared.chatId, location.latitude, location.longitude, {
                 ...effectiveParams,
                 ...(location.accuracy !== undefined
                   ? { horizontal_accuracy: location.accuracy }
@@ -124,44 +95,28 @@ async function sendLocationTelegramWithContext(
   });
   const result = delivery.result;
   const acceptedParams = toAcceptedThreadScopedParams(delivery.acceptedParams);
-  const messageId = resolveTelegramMessageIdOrThrow(result, `${label} send`);
-  const resolvedChatId = String(result?.chat?.id ?? chatId);
-  recordSentMessage(chatId, messageId, cfg);
-  await opts.onDeliveryResult?.({ messageId: String(messageId), chatId: resolvedChatId });
-  const projectionPlan = opts.promptContextProjectionPlan;
-  const projection = projectionPlan?.cursor.take(projectionPlan.finalPart);
-  const recorded = await recordOutboundMessageForPromptContext({
-    cfg,
-    account,
+  return finalizeTelegramOutbound({
+    context,
+    prepared,
+    result,
+    resultContext: `${label} send`,
     ...(botUserId !== undefined ? { botUserId } : {}),
-    chatId,
-    message: result,
-    messageId,
     text: formatLocationText(location),
-    ...(threadSpec?.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
-    ...(threadSpec ? { successfulSendThread: threadSpec } : {}),
     ...(acceptedParams?.message_thread_id !== undefined
       ? { messageThreadId: acceptedParams.message_thread_id }
       : {}),
-    promptContextProjection: projection,
+    promptContextProjectionPlan: opts.promptContextProjectionPlan,
+    onDeliveryResult: opts.onDeliveryResult,
+    beforeActivity: ({ messageId, chatId }) =>
+      logTelegramOutboundSendOk({
+        accountId: account.accountId,
+        chatId,
+        messageId,
+        operation: hasName ? "sendVenue" : "sendLocation",
+        deliveryKind: label,
+        messageThreadId: acceptedParams?.message_thread_id,
+        replyToMessageId: opts.replyToMessageId,
+        silent: opts.silent,
+      }),
   });
-  if (projection && !recorded) {
-    projectionPlan?.cursor.invalidate();
-  }
-  logTelegramOutboundSendOk({
-    accountId: account.accountId,
-    chatId: resolvedChatId,
-    messageId: String(messageId),
-    operation: hasName ? "sendVenue" : "sendLocation",
-    deliveryKind: label,
-    messageThreadId: acceptedParams?.message_thread_id,
-    replyToMessageId: opts.replyToMessageId,
-    silent: opts.silent,
-  });
-  recordChannelActivity({
-    channel: "telegram",
-    accountId: account.accountId,
-    direction: "outbound",
-  });
-  return { messageId: String(messageId), chatId: resolvedChatId };
 }

--- a/extensions/telegram/src/send-outbound.ts
+++ b/extensions/telegram/src/send-outbound.ts
@@ -1,0 +1,145 @@
+import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
+import {
+  buildTelegramThreadReplyParams,
+  resolveTelegramSendThreadSpec,
+} from "./reply-parameters.js";
+import {
+  createRequestWithChatNotFound,
+  createTelegramNonIdempotentRequestWithDiag,
+  createTelegramRequestWithDiag,
+  normalizeMessageId,
+  resolveAndPersistChatId,
+  resolveTelegramMessageIdOrThrow,
+  type TelegramApiContext,
+} from "./send-context.js";
+import type { TelegramSendOpts } from "./send-message-types.js";
+import { recordSentMessage } from "./sent-message-cache.js";
+import { parseTelegramTarget } from "./targets.js";
+
+type PreparedTelegramOutbound = {
+  chatId: string;
+  threadSpec?: ReturnType<typeof resolveTelegramSendThreadSpec>;
+  threadParams: ReturnType<typeof buildTelegramThreadReplyParams>;
+  request: ReturnType<typeof createTelegramRequestWithDiag>;
+};
+
+type PreparedTelegramOutboundWithMessageId<T> = PreparedTelegramOutbound &
+  (T extends string | number ? { messageId: number } : { messageId?: undefined });
+
+export async function prepareTelegramOutbound<T extends string | number | undefined>(params: {
+  to: string | number;
+  context: TelegramApiContext;
+  opts: Pick<TelegramSendOpts, "verbose" | "retry" | "gatewayClientScopes">;
+  messageIdInput?: T;
+  thread?: {
+    messageThreadId?: number;
+    replyToMessageId?: number;
+    replyQuoteText?: string;
+    useReplyIdAsQuoteSource?: boolean;
+  };
+  request:
+    | { kind: "nonIdempotent"; useApiErrorLogging?: boolean }
+    | { kind: "standard"; shouldRetry?: (err: unknown) => boolean };
+}): Promise<PreparedTelegramOutboundWithMessageId<T>> {
+  const { cfg, account, api } = params.context;
+  const rawTarget = String(params.to);
+  const target = parseTelegramTarget(rawTarget);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: target.chatId,
+    persistTarget: rawTarget,
+    verbose: params.opts.verbose,
+    gatewayClientScopes: params.opts.gatewayClientScopes,
+  });
+  const threadSpec = params.thread
+    ? resolveTelegramSendThreadSpec({
+        targetMessageThreadId: target.messageThreadId,
+        messageThreadId: params.thread.messageThreadId,
+        chatType: target.chatType,
+      })
+    : undefined;
+  const threadParams = buildTelegramThreadReplyParams({
+    thread: threadSpec,
+    replyToMessageId: params.thread?.replyToMessageId,
+    replyQuoteText: params.thread?.replyQuoteText,
+    useReplyIdAsQuoteSource: params.thread?.useReplyIdAsQuoteSource,
+  });
+  const requestWithDiag =
+    params.request.kind === "nonIdempotent"
+      ? createTelegramNonIdempotentRequestWithDiag({
+          cfg,
+          account,
+          retry: params.opts.retry,
+          verbose: params.opts.verbose,
+          useApiErrorLogging: params.request.useApiErrorLogging,
+        })
+      : createTelegramRequestWithDiag({
+          cfg,
+          account,
+          retry: params.opts.retry,
+          verbose: params.opts.verbose,
+          shouldRetry: params.request.shouldRetry,
+        });
+  const request =
+    params.request.kind === "nonIdempotent"
+      ? createRequestWithChatNotFound({ requestWithDiag, chatId, input: rawTarget })
+      : requestWithDiag;
+  return {
+    chatId,
+    ...(params.messageIdInput !== undefined
+      ? { messageId: normalizeMessageId(params.messageIdInput) }
+      : {}),
+    threadSpec,
+    threadParams,
+    request,
+  } as PreparedTelegramOutboundWithMessageId<T>;
+}
+
+export async function finalizeTelegramOutbound(params: {
+  context: TelegramApiContext;
+  prepared: Pick<PreparedTelegramOutbound, "chatId" | "threadSpec">;
+  result: Parameters<typeof recordOutboundMessageForPromptContext>[0]["message"];
+  resultContext: string;
+  botUserId?: number;
+  text?: string;
+  messageThreadId?: number;
+  promptContextProjectionPlan?: TelegramSendOpts["promptContextProjectionPlan"];
+  onDeliveryResult?: TelegramSendOpts["onDeliveryResult"];
+  beforeActivity?: (result: { messageId: string; chatId: string }) => void;
+}): Promise<{ messageId: string; chatId: string }> {
+  const { cfg, account } = params.context;
+  const messageId = resolveTelegramMessageIdOrThrow(params.result, params.resultContext);
+  const resultIds = {
+    messageId: String(messageId),
+    chatId: String(params.result.chat?.id ?? params.prepared.chatId),
+  };
+  recordSentMessage(params.prepared.chatId, messageId, cfg);
+  await params.onDeliveryResult?.(resultIds);
+  const projection = params.promptContextProjectionPlan?.cursor.take(
+    params.promptContextProjectionPlan.finalPart,
+  );
+  const recorded = await recordOutboundMessageForPromptContext({
+    cfg,
+    account,
+    botUserId: params.botUserId,
+    chatId: params.prepared.chatId,
+    message: params.result,
+    messageId,
+    text: params.text,
+    messageThreadId: params.messageThreadId ?? params.prepared.threadSpec?.id,
+    successfulSendThread: params.prepared.threadSpec,
+    promptContextProjection: projection,
+  });
+  if (projection && !recorded) {
+    params.promptContextProjectionPlan?.cursor.invalidate();
+  }
+  params.beforeActivity?.(resultIds);
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+  return resultIds;
+}

--- a/extensions/telegram/src/send-special.ts
+++ b/extensions/telegram/src/send-special.ts
@@ -1,24 +1,13 @@
-import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
-import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import {
-  buildTelegramThreadReplyParams,
-  resolveTelegramSendThreadSpec,
-} from "./reply-parameters.js";
-import {
-  createRequestWithChatNotFound,
-  createTelegramNonIdempotentRequestWithDiag,
-  resolveAndPersistChatId,
   resolveTelegramApiContext,
-  resolveTelegramMessageIdOrThrow,
   withTelegramApiContextLease,
   type TelegramApiContext,
   type TelegramApiOverride,
 } from "./send-context.js";
 import type { TelegramSendResult } from "./send-message-types.js";
+import { finalizeTelegramOutbound, prepareTelegramOutbound } from "./send-outbound.js";
 import { normalizePollInput, type OpenClawConfig, type PollInput } from "./send.runtime.js";
-import { recordSentMessage } from "./sent-message-cache.js";
-import { parseTelegramTarget } from "./targets.js";
 
 type TelegramSendPollParams = Parameters<TelegramApiContext["api"]["sendPoll"]>[3];
 
@@ -64,66 +53,30 @@ async function sendStickerTelegramWithContext(
   opts: TelegramStickerOpts,
   context: TelegramApiContext,
 ): Promise<TelegramSendResult> {
-  const { cfg, account, api } = context;
-  const target = parseTelegramTarget(to);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: target.chatId,
-    persistTarget: to,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
+  const { api } = context;
+  const prepared = await prepareTelegramOutbound({
+    to,
+    context,
+    opts,
+    thread: {
+      messageThreadId: opts.messageThreadId,
+      replyToMessageId: opts.replyToMessageId,
+    },
+    request: { kind: "nonIdempotent", useApiErrorLogging: false },
   });
-  const threadSpec = resolveTelegramSendThreadSpec({
-    targetMessageThreadId: target.messageThreadId,
-    messageThreadId: opts.messageThreadId,
-    chatType: target.chatType,
-  });
-  const threadParams = buildTelegramThreadReplyParams({
-    thread: threadSpec,
-    replyToMessageId: opts.replyToMessageId,
-  });
-  const hasThreadParams = Object.keys(threadParams).length > 0;
+  const stickerParams =
+    Object.keys(prepared.threadParams).length > 0 ? prepared.threadParams : undefined;
 
-  const requestWithDiag = createTelegramNonIdempotentRequestWithDiag({
-    cfg,
-    account,
-    retry: opts.retry,
-    verbose: opts.verbose,
-    useApiErrorLogging: false,
-  });
-  const requestWithChatNotFound = createRequestWithChatNotFound({
-    requestWithDiag,
-    chatId,
-    input: to,
-  });
-
-  const stickerParams = hasThreadParams ? threadParams : undefined;
-
-  const result = await requestWithChatNotFound(
-    () => api.sendSticker(chatId, fileId.trim(), stickerParams),
+  const result = await prepared.request(
+    () => api.sendSticker(prepared.chatId, fileId.trim(), stickerParams),
     "sticker",
   );
-
-  const messageId = resolveTelegramMessageIdOrThrow(result, "sticker send");
-  const resolvedChatId = String(result?.chat?.id ?? chatId);
-  recordSentMessage(chatId, messageId, opts.cfg);
-  await recordOutboundMessageForPromptContext({
-    cfg,
-    account,
-    chatId,
-    message: result,
-    messageId,
-    ...(threadSpec?.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
-    ...(threadSpec ? { successfulSendThread: threadSpec } : {}),
+  return finalizeTelegramOutbound({
+    context,
+    prepared,
+    result,
+    resultContext: "sticker send",
   });
-  recordChannelActivity({
-    channel: "telegram",
-    accountId: account.accountId,
-    direction: "outbound",
-  });
-
-  return { messageId: String(messageId), chatId: resolvedChatId };
 }
 
 type TelegramPollOpts = {
@@ -165,43 +118,19 @@ async function sendPollTelegramWithContext(
   opts: TelegramPollOpts,
   context: TelegramApiContext,
 ): Promise<{ messageId: string; chatId: string; pollId?: string }> {
-  const { cfg, account, api } = context;
-  const target = parseTelegramTarget(to);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: target.chatId,
-    persistTarget: to,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
+  const { api } = context;
+  const prepared = await prepareTelegramOutbound({
+    to,
+    context,
+    opts,
+    thread: {
+      messageThreadId: opts.messageThreadId,
+      replyToMessageId: opts.replyToMessageId,
+    },
+    request: { kind: "nonIdempotent" },
   });
 
-  // Normalize the poll input (validates question, options, maxSelections)
   const normalizedPoll = normalizePollInput(poll, { maxOptions: 12 });
-  const threadSpec = resolveTelegramSendThreadSpec({
-    targetMessageThreadId: target.messageThreadId,
-    messageThreadId: opts.messageThreadId,
-    chatType: target.chatType,
-  });
-  const threadParams = buildTelegramThreadReplyParams({
-    thread: threadSpec,
-    replyToMessageId: opts.replyToMessageId,
-  });
-
-  // Build poll options as simple strings (Grammy accepts string[] or InputPollOption[])
-  const pollOptions = normalizedPoll.options;
-
-  const requestWithDiag = createTelegramNonIdempotentRequestWithDiag({
-    cfg,
-    account,
-    retry: opts.retry,
-    verbose: opts.verbose,
-  });
-  const requestWithChatNotFound = createRequestWithChatNotFound({
-    requestWithDiag,
-    chatId,
-    input: to,
-  });
 
   const durationSeconds = normalizedPoll.durationSeconds;
   if (durationSeconds === undefined && normalizedPoll.durationHours !== undefined) {
@@ -213,40 +142,27 @@ async function sendPollTelegramWithContext(
     throw new Error("Telegram poll durationSeconds must be between 5 and 600");
   }
 
-  // Build poll parameters following Grammy's api.sendPoll signature
-  // sendPoll(chat_id, question, options, other?, signal?)
   const pollParams: TelegramSendPollParams = {
     allows_multiple_answers: normalizedPoll.maxSelections > 1,
     is_anonymous: opts.isAnonymous ?? true,
     ...(durationSeconds !== undefined ? { open_period: durationSeconds } : {}),
-    ...(Object.keys(threadParams).length > 0 ? threadParams : {}),
+    ...(Object.keys(prepared.threadParams).length > 0 ? prepared.threadParams : {}),
     ...(opts.silent === true ? { disable_notification: true } : {}),
   };
 
-  const result = await requestWithChatNotFound(
-    () => api.sendPoll(chatId, normalizedPoll.question, pollOptions, pollParams),
+  const result = await prepared.request(
+    () =>
+      api.sendPoll(prepared.chatId, normalizedPoll.question, normalizedPoll.options, pollParams),
     "poll",
   );
-
-  const messageId = resolveTelegramMessageIdOrThrow(result, "poll send");
-  const resolvedChatId = String(result?.chat?.id ?? chatId);
   const pollId = result?.poll?.id;
-  recordSentMessage(chatId, messageId, opts.cfg);
-  await recordOutboundMessageForPromptContext({
-    cfg,
-    account,
-    chatId,
-    message: result,
-    messageId,
-    ...(threadSpec?.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
-    ...(threadSpec ? { successfulSendThread: threadSpec } : {}),
-  });
-
-  recordChannelActivity({
-    channel: "telegram",
-    accountId: account.accountId,
-    direction: "outbound",
-  });
-
-  return { messageId: String(messageId), chatId: resolvedChatId, pollId };
+  return {
+    ...(await finalizeTelegramOutbound({
+      context,
+      prepared,
+      result,
+      resultContext: "poll send",
+    })),
+    pollId,
+  };
 }

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2539,6 +2539,8 @@ describe("sendMessageTelegram", () => {
       "Champ de Mars",
       expect.any(Object),
     );
+    expect(wasSentByBot(chatId, 301)).toBe(true);
+    expect(wasSentByBot(chatId, 302)).toBe(true);
   });
 
   it("rejects incomplete Telegram venues", async () => {
@@ -3911,6 +3913,7 @@ describe("sendStickerTelegram", () => {
       expect(sendSticker).toHaveBeenCalledWith(chatId, testCase.expectedFileId, undefined);
       expect(res.messageId).toBe(String(testCase.expectedMessageId));
       expect(res.chatId).toBe(chatId);
+      expect(wasSentByBot(chatId, testCase.expectedMessageId)).toBe(true);
     });
   }
 
@@ -4658,6 +4661,7 @@ describe("sendPollTelegram", () => {
     expect(sendPollCall[1]).toBe("Q");
     expect(sendPollCall[2]).toEqual(["A", "B"]);
     expect(requireRecord(sendPollCall[3], "send poll params").open_period).toBe(60);
+    expect(wasSentByBot("123", 123)).toBe(true);
   });
 
   it("fails poll sends instead of retrying without message_thread_id", async () => {


### PR DESCRIPTION
## What Problem This Solves

Feishu document insertion and broadcast adaptation, plus Telegram outbound bookkeeping, each had multiple implementations of ordering-sensitive internal behavior.

## Why This Change Was Made

This AI-assisted refactor establishes shared Feishu stages and a Telegram prepare/finalize bookkeeping owner. Telegram observer isolation is encoded by the API shape and covered as a contract, while transport-specific retry and recovery policies stay at their call sites.

## User Impact

No intended output change. Telegram sent-message bookkeeping now has one ordering contract, and Feishu document/broadcast paths are less likely to drift.

Release-note context: internal channel behavior is preserved; the notable hardening is that observer failures cannot interfere with successful Telegram send bookkeeping.

## Evidence

- Telegram extension: 176 files / 2,914 tests passed; Feishu extension: 89 files / 1,327 tests passed.
- Changed gate: Blacksmith Testbox `tbx_01kybcdz4k4pbnrwe0gynxhw09`, Actions run 30137472711.
- Item-level and final branch autoreviews were clean.
- Focused Feishu docx/broadcast and Telegram send contract tests all passed before and after their refactors.
