### PR TITLE
test(markdown): lock discord/feishu/qqbot output contracts

### DIFF
--- a/extensions/discord/src/markdown.test.ts
+++ b/extensions/discord/src/markdown.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { renderDiscordMarkdown } from "./markdown.js";
+
+describe("renderDiscordMarkdown", () => {
+  it("preserves Discord markdown source while normalizing CommonMark underscore bold", () => {
+    const input = [
+      "~~~ts",
+      "const value = `inline`;",
+      "~~~",
+      "",
+      "[docs](https://example.test/a_(b)) <@123> ||spoiler||",
+      "> quote",
+      "* parent",
+      "  1. child",
+      String.raw`\*literal\* __bold__`,
+    ].join("\n");
+
+    expect(renderDiscordMarkdown(input, "off")).toBe(input.replace("__bold__", "**bold**"));
+  });
+
+  it("converts tables only when requested and leaves length enforcement to chunking", () => {
+    const table = "| A | B |\n| - | - |\n| x | y |";
+    expect(renderDiscordMarkdown(table, "code")).toBe(
+      "```\n| A | B |\n| --- | --- |\n| x | y |\n```",
+    );
+
+    const oversized = "x".repeat(2_001);
+    expect(renderDiscordMarkdown(oversized, "off")).toBe(oversized);
+  });
+});

--- a/extensions/feishu/src/markdown.test.ts
+++ b/extensions/feishu/src/markdown.test.ts
@@ -4,7 +4,45 @@ import {
   chunkFeishuMarkdown,
   chunkFeishuPostMarkdown,
   materializeFeishuPostMarkdownSoftBreaks,
+  parseFeishuMarkdown,
 } from "./markdown.js";
+
+describe("parseFeishuMarkdown", () => {
+  it("retains the block tree needed by rich-post and document consumers", () => {
+    const root = parseFeishuMarkdown(
+      [
+        "> quote",
+        "",
+        "- parent",
+        "  1. child",
+        "",
+        "```ts",
+        "const value = `inline`;",
+        "```",
+        "",
+        "| A | B |",
+        "| - | - |",
+        '| [docs](https://example.test) | <at user_id="ou_1"></at> ||spoiler|| |',
+      ].join("\n"),
+    );
+
+    expect(root.children?.map((node) => node.type)).toEqual([
+      "blockquote",
+      "list",
+      "code",
+      "table",
+    ]);
+  });
+
+  it("serializes authored markdown bytes unchanged in the Feishu rich-post element", () => {
+    const markdown = String.raw`\*literal\* [docs](https://example.test) <at user_id="ou_1"></at> ||spoiler||`;
+    const content = JSON.parse(buildFeishuPostMessageContent({ messageText: markdown })) as {
+      zh_cn: { content: Array<Array<{ tag: string; text?: string }>> };
+    };
+
+    expect(content.zh_cn.content[0]?.at(-1)).toEqual({ tag: "md", text: markdown });
+  });
+});
 
 describe("materializeFeishuPostMarkdownSoftBreaks", () => {
   it.each([


### PR DESCRIPTION
## What Problem This Solves

A proposed shared Markdown IR migration would silently change Discord, Feishu, and QQBot output contracts because those paths depend on authored bytes, parser structure, or stateful streaming details that the current IR does not retain.

## Why This Change Was Made

This AI-assisted test-only change locks the byte-preservation and chunking contracts and documents why shared-IR migration is intentionally out of scope instead of forcing a lossy abstraction.

## User Impact

No runtime behavior changes. The tests protect existing Markdown rendering, escaping, spacing, table, and streaming behavior from future accidental normalization.

Release-note context: none; this is maintainer-requested contract coverage for existing behavior.

## Evidence

- Full extension proof: Discord 204 files / 2,319 tests; Feishu 89 files / 1,328 tests; QQBot messaging 9 files / 113 tests.
- Focused byte-contract and chunking suites also passed, including 66 Discord send tests, 26 Feishu parser/docx tests, and 57 QQBot chunking tests.
- Changed gate passed on Blacksmith Testbox `tbx_01kybazs2kw452xmrbaetvxt82`.
- Autoreview: clean, no accepted/actionable findings.
