### PR TITLE
refactor(signal): reuse shared error coercion

### DIFF
--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -7,6 +7,7 @@
  */
 
 import nodePath from "node:path";
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { detectMime, parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
 import {
@@ -461,7 +462,7 @@ export async function streamContainerEvents(params: {
       }
       settled = true;
       cleanup();
-      reject(toLintErrorObject(error, "Signal WebSocket receive handler failed"));
+      reject(toErrorObject(error, "Signal WebSocket receive handler failed"));
     };
 
     try {
@@ -470,7 +471,7 @@ export async function streamContainerEvents(params: {
       logError(
         `[signal-ws] failed to create WebSocket: ${err instanceof Error ? err.message : String(err)}`,
       );
-      reject(toLintErrorObject(err, "Non-Error rejection"));
+      reject(toErrorObject(err, "Non-Error rejection"));
       return;
     }
 
@@ -947,19 +948,5 @@ export async function containerRpcRequest<T = unknown>(
     default:
       throw new Error(`Unsupported container RPC method: ${method}`);
   }
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -3,7 +3,7 @@ import { Buffer } from "node:buffer";
 import http, { type ClientRequest, type IncomingMessage } from "node:http";
 import https from "node:https";
 import { generateSecureUuid } from "openclaw/plugin-sdk/core";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 
 export type SignalRpcOptions = {
@@ -145,7 +145,7 @@ function requestSignalHttpText(
       }
       settled = true;
       cleanup();
-      reject(toLintErrorObject(error, "Non-Error rejection"));
+      reject(toErrorObject(error, "Non-Error rejection"));
     };
     const resolveOnce = (response: SignalHttpResponse) => {
       if (settled) {
@@ -297,7 +297,7 @@ function openSignalEventStream(
       }
       settled = true;
       cleanup();
-      reject(toLintErrorObject(error, "Non-Error rejection"));
+      reject(toErrorObject(error, "Non-Error rejection"));
     };
     const request: ClientRequest = client.request(
       url,
@@ -440,18 +440,4 @@ export async function streamSignalEvents(params: {
   }
 
   await flushEvent();
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }


### PR DESCRIPTION
## What Problem This Solves

Signal carried two byte-equivalent local helpers for converting arbitrary rejection values into `Error` objects, even though the Plugin SDK already exposes the canonical normalization-core implementation.

## Why This Change Was Made

Use `toErrorObject` from `openclaw/plugin-sdk/error-runtime` at all four Signal call sites while preserving each existing fallback string and structured error field.

## User Impact

No intended behavior change. Signal client and container failures now share the established error-coercion contract, removing 27 net production lines.

## Evidence

- Hosted Signal extension suite: 43 files and 728 tests passed
- Fresh autoreview: no actionable findings
- `git diff --check`
- Current-main hosted `pnpm check:changed`: passed in Blacksmith Testbox `tbx_01kyby7khhk9g7ervt0gb61aj3`
