### PR TITLE
[AI-assisted] docs(chutes): fix broken API keys URL in provider guide

### DIFF
--- a/docs/providers/chutes.md
+++ b/docs/providers/chutes.md
@@ -51,7 +51,7 @@ the Chutes catalog.
     <Steps>
       <Step title="Get an API key">
         Create a key at
-        [chutes.ai/settings/api-keys](https://chutes.ai/settings/api-keys).
+        [chutes.ai/app/settings/api-keys](https://chutes.ai/app/settings/api-keys).
       </Step>
       <Step title="Run the API key onboarding flow">
         ```bash
@@ -146,7 +146,7 @@ Run `openclaw models list --all --provider chutes` for the full list.
   <Card title="Chutes" href="https://chutes.ai" icon="arrow-up-right-from-square">
     Chutes dashboard and API docs.
   </Card>
-  <Card title="Chutes API keys" href="https://chutes.ai/settings/api-keys" icon="key">
+  <Card title="Chutes API keys" href="https://chutes.ai/app/settings/api-keys" icon="key">
     Create and manage Chutes API keys.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## What Problem This Solves

Self-sourced docs fix (no tracking issue — small docs-link correction).

The Chutes provider guide (`docs/providers/chutes.md`) tells users to create an API key at `https://chutes.ai/settings/api-keys` (in the API-key onboarding step and in the **Related** "Chutes API keys" Card). That URL returns **HTTP 404** — users following either link land on a not-found page instead of the key-management screen.

## Why This Change Was Made

The live Chutes app serves API keys under `/app/settings/...`, not `/settings/...`. This updates both references to `https://chutes.ai/app/settings/api-keys`:

- Onboarding prose link (and its visible link text).
- The `<Card href>` in the Related section.

No code or behavior changes — pure URL correction in the doc.

## User Impact

Users setting up Chutes via the API-key path can once again click through to the real key-management page. The previously documented deep link was a dead 404.

## Evidence

Verified against the live site (curl, default redirect-follow), re-checked today against `upstream/main`:

```
$ curl -s -o /dev/null -L -w "%{http_code}\n" https://chutes.ai/settings/api-keys
404
$ curl -s -o /dev/null -L -w "%{http_code}\n" https://chutes.ai/app/settings/api-keys
200
```

`https://chutes.ai/robots.txt` confirms `/app/settings` is the authenticated app area (not the top-level `/settings`):

```
Disallow: /app/settings
Disallow: /app/settings/
```

The two routes are distinct real routes (not an SPA catch-all): `/app/settings/keys` returns 404 while `/app/settings/api-keys` returns 200. The broken URL occurs only at these two spots in `docs/providers/chutes.md`; no other occurrences exist under `docs/`.

## Prior work

A prior PR (#113485) was closed by me based on an incorrect assumption that the target file had been removed in a repo restructuring. On re-verification, `docs/providers/chutes.md` still exists on the current tip and the broken link still sits at lines 54 and 149. GitHub does not allow reopening a PR whose branch was force-pushed while closed, so this is a fresh PR rebased onto current `main` with the identical two-line fix.

---

AI-assisted: authored with AI assistance and verified manually as described above.
