### PR TITLE
improve(sqlite): prove snapshot repository interruption recovery

### DIFF
--- a/scripts/bench-sqlite-reliability.ts
+++ b/scripts/bench-sqlite-reliability.ts
@@ -46,6 +46,9 @@ function printProofLines(report: ReliabilityReport): void {
     `SQLITE_RELIABILITY_RESTORE_INTERRUPTION=${report.maintenanceProof.restoreInterruption.beforePublish.recoveryVerified && report.maintenanceProof.restoreInterruption.beforePublish.retryRestored && report.maintenanceProof.restoreInterruption.afterPublish.targetVerifiedAfterCrash && report.maintenanceProof.restoreInterruption.afterPublish.existingTargetPreserved ? "verified" : "missing"}`,
   );
   console.log(
+    `SQLITE_RELIABILITY_REPOSITORY_INTERRUPTION=${report.maintenanceProof.repositoryInterruption.beforePending.repositoryVerified && report.maintenanceProof.repositoryInterruption.beforePending.retryCreated && report.maintenanceProof.repositoryInterruption.pending.repositoryVerified && report.maintenanceProof.repositoryInterruption.pending.retryCreated && report.maintenanceProof.repositoryInterruption.afterCommit.crashSnapshotVerifiedAfterCrash && report.maintenanceProof.repositoryInterruption.afterCommit.retryCreated ? "verified" : "missing"}`,
+  );
+  console.log(
     `SQLITE_RELIABILITY_WAL_SENTINEL=${report.transactionProof.committedWalSentinel ? "verified" : "missing"}`,
   );
   console.log(`SQLITE_RELIABILITY_HELD_BATCH=${report.transactionProof.heldBatch}`);

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -91,6 +91,71 @@ export type ReliabilityReport = {
       snapshotMs: number;
       state: ReliabilityStateProof;
     };
+    repositoryInterruption: {
+      afterCommit: {
+        crashSnapshotVerifiedAfterCrash: true;
+        crashSnapshotVisibleAfterCrash: true;
+        exit: {
+          code: number | null;
+          signal: NodeJS.Signals | null;
+        };
+        incompleteEntries: 0;
+        payload: {
+          bytes: number;
+          idSum: number;
+          rows: number;
+        };
+        repositoryVerified: true;
+        retryCreated: true;
+        sourcePayloadPreserved: true;
+        sourceStatePreserved: true;
+        stagingEntries: number;
+        state: ReliabilityStateProof;
+        visibleSnapshotsAfterCrash: number;
+      };
+      beforePending: {
+        crashSnapshotVerifiedAfterCrash: false;
+        crashSnapshotVisibleAfterCrash: false;
+        exit: {
+          code: number | null;
+          signal: NodeJS.Signals | null;
+        };
+        incompleteEntries: 1;
+        payload: {
+          bytes: number;
+          idSum: number;
+          rows: number;
+        };
+        repositoryVerified: true;
+        retryCreated: true;
+        sourcePayloadPreserved: true;
+        sourceStatePreserved: true;
+        stagingEntries: number;
+        state: ReliabilityStateProof;
+        visibleSnapshotsAfterCrash: number;
+      };
+      pending: {
+        crashSnapshotVerifiedAfterCrash: false;
+        crashSnapshotVisibleAfterCrash: false;
+        exit: {
+          code: number | null;
+          signal: NodeJS.Signals | null;
+        };
+        incompleteEntries: 1;
+        payload: {
+          bytes: number;
+          idSum: number;
+          rows: number;
+        };
+        repositoryVerified: true;
+        retryCreated: true;
+        sourcePayloadPreserved: true;
+        sourceStatePreserved: true;
+        stagingEntries: number;
+        state: ReliabilityStateProof;
+        visibleSnapshotsAfterCrash: number;
+      };
+    };
     restoreInterruption: {
       afterPublish: {
         existingTargetPreserved: true;

--- a/scripts/lib/sqlite-reliability-repository-worker.ts
+++ b/scripts/lib/sqlite-reliability-repository-worker.ts
@@ -1,0 +1,121 @@
+import fsSync, { type PathLike } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { SnapshotDatabaseIdentity } from "../../src/snapshot/snapshot-provider.js";
+
+type RepositoryCrashPoint = "after-commit" | "before-pending" | "pending";
+
+const SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
+
+function parseCrashPoint(value: string | undefined): RepositoryCrashPoint {
+  if (value === "after-commit" || value === "before-pending" || value === "pending") {
+    return value;
+  }
+  throw new Error(`invalid SQLite repository crash point: ${String(value)}`);
+}
+
+function parseIdentity(value: string): SnapshotDatabaseIdentity {
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("invalid SQLite repository worker identity");
+  }
+  const record = parsed as Record<string, unknown>;
+  if (record.role === "global") {
+    return { role: "global" };
+  }
+  if (record.role === "agent" && typeof record.agentId === "string") {
+    return { role: "agent", agentId: record.agentId };
+  }
+  if (record.role === "generic" && typeof record.id === "string") {
+    return { role: "generic", id: record.id };
+  }
+  throw new Error("invalid SQLite repository worker identity");
+}
+
+function holdAtCrashPoint(crashPoint: RepositoryCrashPoint): never {
+  process.send?.({ crashPoint, kind: "crash-point" });
+  while (true) {
+    Atomics.wait(SLEEP_BUFFER, 0, 0, 60_000);
+  }
+}
+
+function isPendingPath(filePath: unknown, repositoryPath: string): boolean {
+  const resolvedPath = path.resolve(String(filePath));
+  return (
+    path.basename(resolvedPath) === ".pending" &&
+    path.dirname(path.dirname(resolvedPath)) === repositoryPath
+  );
+}
+
+function installCrashBarrier(crashPoint: RepositoryCrashPoint, repositoryPath: string): void {
+  if (crashPoint === "before-pending") {
+    const originalOpen = fs.open.bind(fs);
+    Object.defineProperty(fs, "open", {
+      configurable: true,
+      enumerable: true,
+      value: (async (...args: unknown[]) => {
+        if (args[1] === "wx+" && isPendingPath(args[0], repositoryPath)) {
+          holdAtCrashPoint(crashPoint);
+        }
+        return await (originalOpen as (...openArgs: unknown[]) => Promise<unknown>)(...args);
+      }) as typeof fs.open,
+      writable: true,
+    });
+    return;
+  }
+
+  const originalUnlinkSync = fsSync.unlinkSync.bind(fsSync);
+  Object.defineProperty(fsSync, "unlinkSync", {
+    configurable: true,
+    enumerable: true,
+    value: ((filePath: PathLike) => {
+      if (!isPendingPath(filePath, repositoryPath)) {
+        return originalUnlinkSync(filePath);
+      }
+      if (crashPoint === "after-commit") {
+        originalUnlinkSync(filePath);
+      }
+      holdAtCrashPoint(crashPoint);
+    }) as typeof fsSync.unlinkSync,
+    writable: true,
+  });
+}
+
+async function main(argv: string[]): Promise<void> {
+  const [
+    crashPointValue,
+    repositoryPathValue,
+    validationRootPath,
+    sourcePath,
+    identityValue,
+    ...extra
+  ] = argv;
+  if (
+    extra.length > 0 ||
+    !repositoryPathValue ||
+    !validationRootPath ||
+    !sourcePath ||
+    !identityValue
+  ) {
+    throw new Error("invalid SQLite repository interruption worker arguments");
+  }
+  const crashPoint = parseCrashPoint(crashPointValue);
+  const repositoryPath = path.resolve(repositoryPathValue);
+  const identity = parseIdentity(identityValue);
+  installCrashBarrier(crashPoint, repositoryPath);
+
+  const { createLocalSqliteSnapshotProvider } =
+    await import("../../src/snapshot/local-repository.js");
+  const provider = createLocalSqliteSnapshotProvider({
+    repositoryPath,
+    validationRootPath,
+  });
+  process.send?.({ kind: "ready" });
+  await provider.create({ identity, path: sourcePath });
+  throw new Error(`SQLite repository worker passed ${crashPoint} without being terminated.`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main(process.argv.slice(2));
+}

--- a/scripts/lib/sqlite-reliability-repository.ts
+++ b/scripts/lib/sqlite-reliability-repository.ts
@@ -1,0 +1,378 @@
+import { fork, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createLocalSqliteSnapshotProvider } from "../../src/snapshot/local-repository.js";
+import {
+  SNAPSHOT_SQLITE_FILENAME,
+  type SnapshotDatabaseIdentity,
+  type SnapshotSummary,
+} from "../../src/snapshot/snapshot-provider.js";
+import type { ReliabilityReport, ReliabilityStateProof } from "./sqlite-reliability-contract.js";
+
+type RepositoryCrashPoint = "after-commit" | "before-pending" | "pending";
+type RepositoryExit =
+  ReliabilityReport["maintenanceProof"]["repositoryInterruption"]["beforePending"]["exit"];
+type RepositoryPayload =
+  ReliabilityReport["maintenanceProof"]["repositoryInterruption"]["beforePending"]["payload"];
+type CrashPointResult = {
+  crashSnapshotVerifiedAfterCrash: boolean;
+  crashSnapshotVisibleAfterCrash: boolean;
+  exit: RepositoryExit;
+  incompleteEntries: number;
+  payload: RepositoryPayload;
+  stagingEntries: number;
+  state: ReliabilityStateProof;
+  visibleSnapshotsAfterCrash: number;
+};
+
+const REPOSITORY_WORKER_PATH = fileURLToPath(
+  new URL("./sqlite-reliability-repository-worker.ts", import.meta.url),
+);
+const REPOSITORY_TIMEOUT_MS = 120_000;
+
+function assertSameState(
+  actual: ReliabilityStateProof,
+  expected: ReliabilityStateProof,
+  label: string,
+): void {
+  if (
+    actual.batches !== expected.batches ||
+    actual.rows !== expected.rows ||
+    actual.sha256 !== expected.sha256
+  ) {
+    throw new Error(
+      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
+    );
+  }
+}
+
+function assertSamePayload(
+  actual: RepositoryPayload,
+  expected: RepositoryPayload,
+  label: string,
+): void {
+  if (
+    actual.bytes !== expected.bytes ||
+    actual.idSum !== expected.idSum ||
+    actual.rows !== expected.rows
+  ) {
+    throw new Error(
+      `${label} changed compaction payload: expected rows=${expected.rows} bytes=${expected.bytes} idSum=${expected.idSum}, got rows=${actual.rows} bytes=${actual.bytes} idSum=${actual.idSum}`,
+    );
+  }
+}
+
+function formatWorkerStderr(stderr: string): string {
+  const text = stderr.trim();
+  return text ? ` stderr=${JSON.stringify(text)}` : "";
+}
+
+async function waitForCrashPoint(params: {
+  child: ChildProcess;
+  crashPoint: RepositoryCrashPoint;
+  readStderr: () => string;
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `SQLite repository worker did not reach ${params.crashPoint}.${formatWorkerStderr(params.readStderr())}`,
+        ),
+      );
+    }, REPOSITORY_TIMEOUT_MS);
+    const onMessage = (message: unknown) => {
+      const event = message as { crashPoint?: unknown; kind?: unknown } | undefined;
+      if (event?.kind === "crash-point" && event.crashPoint === params.crashPoint) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `SQLite repository worker exited before ${params.crashPoint}: code=${String(code)} signal=${String(signal)}.${formatWorkerStderr(params.readStderr())}`,
+        ),
+      );
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      params.child.off("message", onMessage);
+      params.child.off("error", onError);
+      params.child.off("exit", onExit);
+    };
+    params.child.on("message", onMessage);
+    params.child.on("error", onError);
+    params.child.on("exit", onExit);
+  });
+}
+
+async function waitForChildExit(child: ChildProcess): Promise<RepositoryExit> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  return await new Promise<RepositoryExit>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("SQLite repository worker did not exit after forced termination."));
+    }, 30_000);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    child.on("exit", onExit);
+    child.on("error", onError);
+  });
+}
+
+function assertForcedExit(exit: RepositoryExit): void {
+  if (exit.code === 0) {
+    throw new Error("SQLite repository worker exited cleanly before forced termination.");
+  }
+  if (process.platform === "win32") {
+    if (exit.code === null && exit.signal === null) {
+      throw new Error("SQLite repository worker reported no forced Windows exit.");
+    }
+    return;
+  }
+  if (exit.signal !== "SIGKILL") {
+    throw new Error(
+      `SQLite repository worker exited without SIGKILL: code=${String(exit.code)} signal=${String(exit.signal)}`,
+    );
+  }
+}
+
+async function verifySnapshot(params: {
+  expectedPayload: RepositoryPayload;
+  expectedState: ReliabilityStateProof;
+  provider: ReturnType<typeof createLocalSqliteSnapshotProvider>;
+  snapshot: SnapshotSummary;
+  verifyPayload: (databasePath: string) => RepositoryPayload;
+  verifyState: (databasePath: string) => ReliabilityStateProof;
+}): Promise<void> {
+  await params.provider.verify(params.snapshot.ref);
+  const artifactPath = path.join(params.snapshot.ref.path, SNAPSHOT_SQLITE_FILENAME);
+  assertSameState(params.verifyState(artifactPath), params.expectedState, artifactPath);
+  assertSamePayload(params.verifyPayload(artifactPath), params.expectedPayload, artifactPath);
+}
+
+function listRepositoryEntries(repositoryPath: string): string[] {
+  return fs.existsSync(repositoryPath) ? fs.readdirSync(repositoryPath) : [];
+}
+
+async function runCrashPoint(params: {
+  crashPoint: RepositoryCrashPoint;
+  expectedPayload: RepositoryPayload;
+  expectedState: ReliabilityStateProof;
+  identity: SnapshotDatabaseIdentity;
+  provider: ReturnType<typeof createLocalSqliteSnapshotProvider>;
+  repositoryPath: string;
+  sourcePath: string;
+  validationRootPath: string;
+  verifyPayload: (databasePath: string) => RepositoryPayload;
+  verifyState: (databasePath: string) => ReliabilityStateProof;
+}): Promise<CrashPointResult> {
+  const visibleBefore = await params.provider.list();
+  const visiblePathsBefore = new Set(
+    visibleBefore.map((snapshot) => path.resolve(snapshot.ref.path)),
+  );
+  const entriesBefore = new Set(listRepositoryEntries(params.repositoryPath));
+  let stderr = "";
+  const child = fork(
+    REPOSITORY_WORKER_PATH,
+    [
+      params.crashPoint,
+      params.repositoryPath,
+      params.validationRootPath,
+      params.sourcePath,
+      JSON.stringify(params.identity),
+    ],
+    {
+      cwd: process.cwd(),
+      execArgv: ["--import", "tsx"],
+      serialization: "json",
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    },
+  );
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  try {
+    await waitForCrashPoint({
+      child,
+      crashPoint: params.crashPoint,
+      readStderr: () => stderr,
+    });
+    if (!child.kill("SIGKILL")) {
+      throw new Error(
+        `SQLite repository worker exited before the ${params.crashPoint} crash signal was delivered.`,
+      );
+    }
+    const exit = await waitForChildExit(child);
+    assertForcedExit(exit);
+
+    const createdEntries = listRepositoryEntries(params.repositoryPath).filter(
+      (entry) => !entriesBefore.has(entry),
+    );
+    const visibleAfter = await params.provider.list();
+    const crashSnapshots = visibleAfter.filter(
+      (snapshot) => !visiblePathsBefore.has(path.resolve(snapshot.ref.path)),
+    );
+    const expectedVisibleCrashSnapshots = params.crashPoint === "after-commit" ? 1 : 0;
+    if (crashSnapshots.length !== expectedVisibleCrashSnapshots) {
+      throw new Error(
+        `SQLite repository exposed ${crashSnapshots.length} snapshot(s) at ${params.crashPoint}; expected ${expectedVisibleCrashSnapshots}.`,
+      );
+    }
+    for (const snapshot of visibleAfter) {
+      await verifySnapshot({ ...params, snapshot });
+    }
+
+    const sourceState = params.verifyState(params.sourcePath);
+    assertSameState(sourceState, params.expectedState, `${params.crashPoint} source`);
+    const sourcePayload = params.verifyPayload(params.sourcePath);
+    assertSamePayload(sourcePayload, params.expectedPayload, `${params.crashPoint} source`);
+
+    const crashSnapshotNames = new Set(
+      crashSnapshots.map((snapshot) => path.basename(snapshot.ref.path)),
+    );
+    const residueEntries = createdEntries.filter((entry) => !crashSnapshotNames.has(entry));
+    const stagingEntries = residueEntries.filter((entry) => entry.startsWith(".tmp-")).length;
+    const incompleteEntries = residueEntries.length - stagingEntries;
+    if (stagingEntries === 0) {
+      throw new Error(`SQLite repository worker left no staging at ${params.crashPoint}.`);
+    }
+    const expectedIncompleteEntries = params.crashPoint === "after-commit" ? 0 : 1;
+    if (incompleteEntries !== expectedIncompleteEntries) {
+      throw new Error(
+        `SQLite repository left ${incompleteEntries} incomplete final entries at ${params.crashPoint}; expected ${expectedIncompleteEntries}.`,
+      );
+    }
+
+    const retry = await params.provider.create({
+      identity: params.identity,
+      path: params.sourcePath,
+    });
+    const retrySnapshot = (await params.provider.list()).find(
+      (snapshot) => path.resolve(snapshot.ref.path) === path.resolve(retry.ref.path),
+    );
+    if (!retrySnapshot) {
+      throw new Error(`SQLite repository retry was not visible after ${params.crashPoint}.`);
+    }
+    await verifySnapshot({ ...params, snapshot: retrySnapshot });
+    for (const entry of createdEntries) {
+      if (!fs.existsSync(path.join(params.repositoryPath, entry))) {
+        throw new Error(`SQLite repository retry removed crash residue it did not own: ${entry}`);
+      }
+    }
+
+    return {
+      crashSnapshotVerifiedAfterCrash: crashSnapshots.length === 1,
+      crashSnapshotVisibleAfterCrash: crashSnapshots.length === 1,
+      exit,
+      incompleteEntries,
+      payload: sourcePayload,
+      stagingEntries,
+      state: sourceState,
+      visibleSnapshotsAfterCrash: visibleAfter.length,
+    };
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+      await waitForChildExit(child).catch(() => undefined);
+    }
+  }
+}
+
+export async function runRepositoryInterruptionProof(params: {
+  expectedPayload: RepositoryPayload;
+  expectedState: ReliabilityStateProof;
+  identity: SnapshotDatabaseIdentity;
+  repositoryPath: string;
+  sourcePath: string;
+  validationRootPath: string;
+  verifyPayload: (databasePath: string) => RepositoryPayload;
+  verifyState: (databasePath: string) => ReliabilityStateProof;
+}): Promise<ReliabilityReport["maintenanceProof"]["repositoryInterruption"]> {
+  const provider = createLocalSqliteSnapshotProvider({
+    repositoryPath: params.repositoryPath,
+    validationRootPath: params.validationRootPath,
+  });
+  const baseline = await provider.create({
+    identity: params.identity,
+    path: params.sourcePath,
+  });
+  const baselineSnapshot = (await provider.list()).find(
+    (snapshot) => path.resolve(snapshot.ref.path) === path.resolve(baseline.ref.path),
+  );
+  if (!baselineSnapshot) {
+    throw new Error("SQLite repository baseline snapshot was not visible.");
+  }
+  await verifySnapshot({ ...params, provider, snapshot: baselineSnapshot });
+
+  const beforePending = await runCrashPoint({
+    ...params,
+    crashPoint: "before-pending",
+    provider,
+  });
+  const pending = await runCrashPoint({
+    ...params,
+    crashPoint: "pending",
+    provider,
+  });
+  const afterCommit = await runCrashPoint({
+    ...params,
+    crashPoint: "after-commit",
+    provider,
+  });
+
+  return {
+    afterCommit: {
+      ...afterCommit,
+      crashSnapshotVerifiedAfterCrash: true,
+      crashSnapshotVisibleAfterCrash: true,
+      incompleteEntries: 0,
+      repositoryVerified: true,
+      retryCreated: true,
+      sourcePayloadPreserved: true,
+      sourceStatePreserved: true,
+    },
+    beforePending: {
+      ...beforePending,
+      crashSnapshotVerifiedAfterCrash: false,
+      crashSnapshotVisibleAfterCrash: false,
+      incompleteEntries: 1,
+      repositoryVerified: true,
+      retryCreated: true,
+      sourcePayloadPreserved: true,
+      sourceStatePreserved: true,
+    },
+    pending: {
+      ...pending,
+      crashSnapshotVerifiedAfterCrash: false,
+      crashSnapshotVisibleAfterCrash: false,
+      incompleteEntries: 1,
+      repositoryVerified: true,
+      retryCreated: true,
+      sourcePayloadPreserved: true,
+      sourceStatePreserved: true,
+    },
+  };
+}

--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -29,6 +29,7 @@ import {
   type ReliabilityStateProof,
 } from "./sqlite-reliability-contract.js";
 import { runPublicationInterruptionProof } from "./sqlite-reliability-publication.js";
+import { runRepositoryInterruptionProof } from "./sqlite-reliability-repository.js";
 import { runRestoreInterruptionProof } from "./sqlite-reliability-restore.js";
 import { monitorSqliteWalDuring } from "./sqlite-reliability-wal-monitor.js";
 import {
@@ -486,6 +487,23 @@ async function runMaintenanceRoundTrip(params: {
       `compaction payload setup failed: rows=${expectedPayload.rows} bytes=${expectedPayload.bytes}`,
     );
   }
+  const repositoryInterruption = await runRepositoryInterruptionProof({
+    expectedPayload,
+    expectedState,
+    identity: params.target.identity,
+    repositoryPath: path.join(params.restoreRoot, "repository-interruptions"),
+    sourcePath: params.target.path,
+    validationRootPath: params.validationRoot,
+    verifyPayload: readCompactionPayload,
+    verifyState: (databasePath) =>
+      verifyRestoredDatabase({
+        expectedState,
+        identity: params.target.identity,
+        path: databasePath,
+        rowsPerBatch: params.rowsPerBatch,
+        uncommittedBatch: null,
+      }),
+  });
   const interruptedSnapshot = await params.repositoryProvider.create({
     identity: params.target.identity,
     path: params.target.path,
@@ -570,6 +588,7 @@ async function runMaintenanceRoundTrip(params: {
       snapshotMs: Number(snapshotMs.toFixed(3)),
       state,
     },
+    repositoryInterruption,
     restoreInterruption,
     vacuumInterruption,
   };

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -158,6 +158,7 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_CRASH_RECOVERY=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_PUBLICATION_INTERRUPTION=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORE_INTERRUPTION=verified");
+    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_REPOSITORY_INTERRUPTION=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_VACUUM_INTERRUPTION=verified");
     expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_POST_COMPACT_RESTORE=verified");
     const firstReport = JSON.parse(fs.readFileSync(firstOutput, "utf8")) as ReliabilityReport;
@@ -226,6 +227,69 @@ describe("scripts/bench-sqlite-reliability", () => {
     );
     expect(firstReport.maintenanceProof.vacuumInterruption.stateAfterRecovery).toEqual(
       firstReport.maintenanceProof.vacuumInterruption.stateBeforeKill,
+    );
+    expect(firstReport.maintenanceProof.repositoryInterruption.beforePending).toMatchObject({
+      crashSnapshotVerifiedAfterCrash: false,
+      crashSnapshotVisibleAfterCrash: false,
+      incompleteEntries: 1,
+      repositoryVerified: true,
+      retryCreated: true,
+      sourcePayloadPreserved: true,
+      sourceStatePreserved: true,
+      visibleSnapshotsAfterCrash: 1,
+    });
+    expect(
+      firstReport.maintenanceProof.repositoryInterruption.beforePending.stagingEntries,
+    ).toBeGreaterThan(0);
+    expect(
+      firstReport.maintenanceProof.repositoryInterruption.beforePending.exit.code !== null ||
+        firstReport.maintenanceProof.repositoryInterruption.beforePending.exit.signal !== null,
+    ).toBe(true);
+    expect(firstReport.maintenanceProof.repositoryInterruption.pending).toMatchObject({
+      crashSnapshotVerifiedAfterCrash: false,
+      crashSnapshotVisibleAfterCrash: false,
+      incompleteEntries: 1,
+      repositoryVerified: true,
+      retryCreated: true,
+      sourcePayloadPreserved: true,
+      sourceStatePreserved: true,
+      visibleSnapshotsAfterCrash: 2,
+    });
+    expect(
+      firstReport.maintenanceProof.repositoryInterruption.pending.stagingEntries,
+    ).toBeGreaterThan(0);
+    expect(
+      firstReport.maintenanceProof.repositoryInterruption.pending.exit.code !== null ||
+        firstReport.maintenanceProof.repositoryInterruption.pending.exit.signal !== null,
+    ).toBe(true);
+    expect(firstReport.maintenanceProof.repositoryInterruption.afterCommit).toMatchObject({
+      crashSnapshotVerifiedAfterCrash: true,
+      crashSnapshotVisibleAfterCrash: true,
+      incompleteEntries: 0,
+      repositoryVerified: true,
+      retryCreated: true,
+      sourcePayloadPreserved: true,
+      sourceStatePreserved: true,
+      visibleSnapshotsAfterCrash: 4,
+    });
+    expect(
+      firstReport.maintenanceProof.repositoryInterruption.afterCommit.stagingEntries,
+    ).toBeGreaterThan(0);
+    expect(
+      firstReport.maintenanceProof.repositoryInterruption.afterCommit.exit.code !== null ||
+        firstReport.maintenanceProof.repositoryInterruption.afterCommit.exit.signal !== null,
+    ).toBe(true);
+    expect(firstReport.maintenanceProof.repositoryInterruption.beforePending.state).toEqual(
+      firstReport.maintenanceProof.repositoryInterruption.pending.state,
+    );
+    expect(firstReport.maintenanceProof.repositoryInterruption.pending.state).toEqual(
+      firstReport.maintenanceProof.repositoryInterruption.afterCommit.state,
+    );
+    expect(firstReport.maintenanceProof.repositoryInterruption.beforePending.payload).toEqual(
+      firstReport.maintenanceProof.repositoryInterruption.pending.payload,
+    );
+    expect(firstReport.maintenanceProof.repositoryInterruption.pending.payload).toEqual(
+      firstReport.maintenanceProof.repositoryInterruption.afterCommit.payload,
     );
     expect(firstReport.maintenanceProof.restoreInterruption.snapshotBytes).toBeGreaterThan(
       64 * 1024 * 1024,


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Resolves a reliability proof gap where snapshot repository behavior after a process dies during directory publication was covered only by synthetic directory fixtures, not by terminating the real provider at each commit-marker boundary.

## Why This Change Was Made

The SQLite reliability harness now runs the production snapshot provider in a child process and kills it before `.pending` creation, while `.pending` protects a complete snapshot, and immediately after marker removal. Each lane uses a 64+ MiB database, verifies source state and payload integrity, checks repository visibility, creates a subsequent snapshot, and proves that retry work does not delete residue it cannot prove it owns.

## User Impact

No direct user-facing behavior changes. Maintainers now have deterministic process-interruption proof that incomplete snapshots stay hidden, committed snapshots stay visible and verifiable, and later snapshot creation remains reliable.

## Evidence

- Blacksmith Testbox `tbx_01kyc2bks8s19bvewr1rsyv10f`
- `pnpm test:serial test/scripts/bench-sqlite-reliability.test.ts`: 4/4 passed in 44.49s
- `pnpm check:changed`: passed script/test typechecks, formatting, lint, and boundary guards
- `autoreview --mode local`: clean, no accepted/actionable findings
- `git diff --check`: passed

AI-assisted: yes. The implementation and proof were reviewed and validated by the maintainer before submission.
