### PR TITLE
refactor(media): consolidate generated media byte limits

### DIFF
--- a/extensions/azure-speech/speech-provider.ts
+++ b/extensions/azure-speech/speech-provider.ts
@@ -2,6 +2,7 @@
  * Azure Speech provider descriptor. It reads config/env defaults, parses speech
  * directives, lists voices, and calls the Azure TTS runtime helper.
  */
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
   SpeechDirectiveTokenParseContext,
@@ -27,8 +28,6 @@ import {
   listAzureSpeechVoices,
   normalizeAzureSpeechBaseUrl,
 } from "./tts.js";
-
-const DEFAULT_GENERATED_AUDIO_MAX_BYTES = 16 * 1024 * 1024;
 
 type AzureSpeechProviderConfig = {
   apiKey?: string;
@@ -188,16 +187,6 @@ function resolveTimeoutMs(config: AzureSpeechProviderConfig, timeoutMs: number):
   return config.timeoutMs ?? timeoutMs;
 }
 
-function resolveGeneratedAudioMaxBytes(req: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-}): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_AUDIO_MAX_BYTES;
-}
-
 /** Build the Azure Speech provider descriptor for the speech-core runtime. */
 export function buildAzureSpeechProvider(): SpeechProviderPlugin {
   return {
@@ -295,7 +284,7 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
         lang: overrides.lang ?? config.lang,
         outputFormat,
         timeoutMs: resolveTimeoutMs(config, req.timeoutMs),
-        maxBytes: resolveGeneratedAudioMaxBytes(req),
+        maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
       });
       return {
         audioBuffer,
@@ -322,7 +311,7 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
         lang: overrides.lang ?? config.lang,
         outputFormat: DEFAULT_AZURE_SPEECH_TELEPHONY_FORMAT,
         timeoutMs: resolveTimeoutMs(config, req.timeoutMs),
-        maxBytes: resolveGeneratedAudioMaxBytes(req),
+        maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
       });
       return {
         audioBuffer,

--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -2,6 +2,7 @@
  * BytePlus Seedance video generation provider implementation.
  */
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -37,7 +38,6 @@ const MAX_POLL_ATTEMPTS = 120;
 const BYTEPLUS_SEED_MAX = 2_147_483_647;
 const BYTEPLUS_MIN_DURATION_SECONDS = 2;
 const BYTEPLUS_MAX_DURATION_SECONDS = 12;
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 
 type BytePlusTaskCreateResponse = {
   id?: unknown;
@@ -105,14 +105,6 @@ function resolveBytePlusVideoBaseUrl(req: VideoGenerationRequest): string {
   return (
     normalizeOptionalString(req.cfg?.models?.providers?.byteplus?.baseUrl) ?? BYTEPLUS_BASE_URL
   );
-}
-
-function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
 function resolveBytePlusImageUrl(req: VideoGenerationRequest): string | undefined {
@@ -386,7 +378,7 @@ export function buildBytePlusVideoGenerationProvider(): VideoGenerationProvider 
             defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
           }),
           fetchFn,
-          maxBytes: resolveGeneratedVideoMaxBytes(req),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "video"),
         });
         return {
           videos: [video],

--- a/extensions/codex/src/app-server/event-projector-media.ts
+++ b/extensions/codex/src/app-server/event-projector-media.ts
@@ -3,13 +3,12 @@ import {
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { generatedImageAssetFromBase64 } from "openclaw/plugin-sdk/image-generation";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import { readItemString, readString } from "./event-projector-values.js";
 import type { CodexThreadItem, JsonObject } from "./protocol.js";
 
 const GENERATED_IMAGE_MEDIA_SUBDIR = "tool-image-generation";
-const BYTES_PER_MB = 1024 * 1024;
-const DEFAULT_GENERATED_IMAGE_MAX_BYTES = 6 * BYTES_PER_MB;
 
 export class CodexGeneratedMediaProjection {
   private readonly itemIds = new Set<string>();
@@ -41,7 +40,7 @@ export class CodexGeneratedMediaProjection {
     }
     const itemId = readString(item, "id") ?? `raw-image-${this.itemIds.size}`;
     this.itemIds.add(itemId);
-    const maxBytes = resolveGeneratedImageMaxBytes(this.config);
+    const maxBytes = resolveGeneratedMediaMaxBytes(this.config, "image");
     const estimatedDecodedBytes = estimateBase64DecodedBytes(result);
     if (estimatedDecodedBytes !== undefined && estimatedDecodedBytes > maxBytes) {
       embeddedAgentLog.warn("codex app-server raw image generation result exceeds media limit", {
@@ -138,12 +137,4 @@ function estimateBase64DecodedBytes(base64: string): number | undefined {
 
 function isBase64WhitespaceCode(code: number): boolean {
   return code === 0x20 || code === 0x09 || code === 0x0a || code === 0x0d;
-}
-
-function resolveGeneratedImageMaxBytes(config: EmbeddedRunAttemptParams["config"]): number {
-  const configured = config?.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * BYTES_PER_MB);
-  }
-  return DEFAULT_GENERATED_IMAGE_MAX_BYTES;
 }

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/extension-shared";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
@@ -42,8 +43,6 @@ const DEFAULT_PROMPT_INPUT_NAME = "text";
 const DEFAULT_INPUT_IMAGE_INPUT_NAME = "image";
 const DEFAULT_POLL_INTERVAL_MS = 1_500;
 const DEFAULT_TIMEOUT_MS = 5 * 60_000;
-const DEFAULT_GENERATED_IMAGE_MAX_BYTES = 6 * 1024 * 1024;
-const DEFAULT_GENERATED_MEDIA_MAX_BYTES = 16 * 1024 * 1024;
 
 export const DEFAULT_COMFY_MODEL = "workflow";
 
@@ -123,19 +122,6 @@ if (process.env.VITEST === "true") {
     getConfig: getComfyConfig,
     setFetchGuard: setComfyFetchGuardForTesting,
   });
-}
-
-function resolveComfyGeneratedOutputMaxBytes(params: {
-  cfg: OpenClawConfig;
-  capability: ComfyCapability;
-}): number {
-  const configured = params.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return params.capability === "image"
-    ? DEFAULT_GENERATED_IMAGE_MAX_BYTES
-    : DEFAULT_GENERATED_MEDIA_MAX_BYTES;
 }
 
 function readConfigBoolean(config: ComfyProviderConfig, key: string): boolean | undefined {
@@ -847,10 +833,8 @@ export async function runComfyWorkflow(params: {
   }
 
   const assets: ComfyGeneratedAsset[] = [];
-  const maxOutputBytes = resolveComfyGeneratedOutputMaxBytes({
-    cfg: params.cfg,
-    capability: params.capability,
-  });
+  const outputKind = params.capability === "music" ? "audio" : params.capability;
+  const maxOutputBytes = resolveGeneratedMediaMaxBytes(params.cfg, outputKind);
   let assetIndex = 0;
   for (const output of outputFiles) {
     const downloaded = await downloadOutputFile({

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -8,6 +8,7 @@ import {
   imageFileExtensionForMimeType,
   toImageDataUrl,
 } from "openclaw/plugin-sdk/image-generation";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
   assertOkOrThrowHttpError,
@@ -589,16 +590,6 @@ function formatFalReferenceLimitError(
   return `${schema.referenceLimitLabel} supports at most ${limit} ${noun} (requested ${inputImageCount})`;
 }
 
-function resolveGeneratedImageMaxBytes(req: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-}): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_IMAGE_MAX_BYTES;
-}
-
 async function fetchImageBuffer(
   url: string,
   deadline: ProviderOperationDeadline,
@@ -755,7 +746,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
       const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
         await resolveFalHttpRequestConfig({ req, capability: "image" });
       const networkPolicy = resolveFalNetworkPolicy({ baseUrl, allowPrivateNetwork });
-      const maxImageBytes = resolveGeneratedImageMaxBytes(req);
+      const maxImageBytes = resolveGeneratedMediaMaxBytes(req.cfg, "image");
       const requestBody: Record<string, unknown> = {
         prompt: req.prompt,
         ...(schema.supportsCount ? { num_images: req.count ?? 1 } : {}),

--- a/extensions/fal/music-generation-provider.ts
+++ b/extensions/fal/music-generation-provider.ts
@@ -1,4 +1,5 @@
 // Fal provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import {
   downloadGeneratedMusicAsset,
   extractGeneratedMusicFileCandidates,
@@ -18,7 +19,6 @@ const DEFAULT_FAL_MUSIC_MODEL = "fal-ai/minimax-music/v2.6";
 const FAL_ACE_STEP_MODEL = "fal-ai/ace-step/prompt-to-audio";
 const FAL_STABLE_AUDIO_MODEL = "fal-ai/stable-audio-25/text-to-audio";
 const DEFAULT_TIMEOUT_MS = 180_000;
-const DEFAULT_GENERATED_MUSIC_MAX_BYTES = 16 * 1024 * 1024;
 
 const FAL_MUSIC_MODELS = [
   DEFAULT_FAL_MUSIC_MODEL,
@@ -28,14 +28,6 @@ const FAL_MUSIC_MODELS = [
 
 function resolveFalMusicModel(model: string | undefined): string {
   return normalizeOptionalString(model) ?? DEFAULT_FAL_MUSIC_MODEL;
-}
-
-function resolveGeneratedMusicMaxBytes(req: MusicGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_MUSIC_MAX_BYTES;
 }
 
 function buildFalMinimaxBody(req: MusicGenerationRequest): Record<string, unknown> {
@@ -176,7 +168,7 @@ export function buildFalMusicGenerationProvider(): MusicGenerationProvider {
           fetchFn: fetch,
           provider: "fal",
           requestFailedMessage: "fal generated music download failed",
-          maxBytes: resolveGeneratedMusicMaxBytes(req),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
         });
         const lyrics =
           typeof payload === "object" && payload && !Array.isArray(payload)

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Fal provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
@@ -59,7 +60,6 @@ const SEEDANCE_REFERENCE_MAX_AUDIOS_BY_MODEL = Object.fromEntries(
 );
 const DEFAULT_HTTP_TIMEOUT_MS = 30_000;
 const DEFAULT_OPERATION_TIMEOUT_MS = 1_200_000;
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 const POLL_INTERVAL_MS = 5_000;
 const FAL_VIDEO_MALFORMED_RESPONSE = "fal video generation response malformed";
 const FAL_VIDEO_PENDING_STATUSES = new Set([
@@ -201,14 +201,6 @@ function extractFalVideoEntry(payload: FalVideoResponse) {
     return payload.video;
   }
   return payload.videos?.find((entry) => normalizeOptionalString(entry.url));
-}
-
-function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
 async function downloadFalVideo(
@@ -703,7 +695,11 @@ export function buildFalVideoGenerationProvider(): VideoGenerationProvider {
       if (!url) {
         throw new Error("fal video generation response missing output URL");
       }
-      const video = await downloadFalVideo(url, policy, resolveGeneratedVideoMaxBytes(req));
+      const video = await downloadFalVideo(
+        url,
+        policy,
+        resolveGeneratedMediaMaxBytes(req.cfg, "video"),
+      );
       return {
         videos: [video],
         model,

--- a/extensions/google/image-generation-provider.ts
+++ b/extensions/google/image-generation-provider.ts
@@ -5,7 +5,7 @@ import {
   type GeneratedImageAsset,
   type ImageGenerationProvider,
 } from "openclaw/plugin-sdk/image-generation";
-import { MAX_IMAGE_BYTES } from "openclaw/plugin-sdk/media-runtime";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
   hasConfiguredSecretInput,
@@ -29,7 +29,6 @@ const DEFAULT_GOOGLE_IMAGE_MODEL = "gemini-3.1-flash-image";
 const DEFAULT_IMAGE_TIMEOUT_MS = 180_000;
 const DEFAULT_OUTPUT_MIME = "image/png";
 const GOOGLE_MAX_IMAGE_RESULTS = 4;
-const MB = 1024 * 1024;
 const GOOGLE_SUPPORTED_SIZES = [
   "1024x1024",
   "1024x1536",
@@ -55,16 +54,6 @@ const GOOGLE_IMAGE_MALFORMED_RESPONSE = "Google image generation response malfor
 function normalizeGoogleImageModel(model: string | undefined): string {
   const trimmed = model?.trim();
   return normalizeGoogleModelId(trimmed || DEFAULT_GOOGLE_IMAGE_MODEL);
-}
-
-function resolveGeneratedImageMaxBytes(req: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-}): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * MB);
-  }
-  return MAX_IMAGE_BYTES;
 }
 
 function mapSizeToImageConfig(
@@ -256,7 +245,7 @@ export function buildGoogleImageGenerationProvider(): ImageGenerationProvider {
         const payload = await readProviderJsonResponse(res, "google.image-generation", {
           maxBytes: resolveInlineImageJsonResponseMaxBytes(
             GOOGLE_MAX_IMAGE_RESULTS,
-            resolveGeneratedImageMaxBytes(req),
+            resolveGeneratedMediaMaxBytes(req.cfg, "image"),
           ),
         });
         let imageIndex = 0;

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Google provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   createProviderOperationDeadline,
@@ -28,7 +29,6 @@ import { createGoogleGenAI, type GoogleGenAIClient } from "./google-genai-runtim
 const DEFAULT_TIMEOUT_MS = 180_000;
 const POLL_INTERVAL_MS = 10_000;
 const MAX_POLL_ATTEMPTS = 120;
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 const GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE =
   "Google video generation response missing generated videos";
@@ -36,14 +36,6 @@ const GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE =
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
   return configured ? resolveGoogleGenerativeAiApiOrigin(configured) : undefined;
-}
-
-function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
 function assertGeneratedVideoBufferWithinLimit(buffer: Buffer, maxBytes: number): void {
@@ -565,7 +557,7 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
       if (generatedVideos.length === 0) {
         throw new Error(GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE);
       }
-      const maxVideoBytes = resolveGeneratedVideoMaxBytes(req);
+      const maxVideoBytes = resolveGeneratedMediaMaxBytes(req.cfg, "video");
       const videos = await Promise.all(
         generatedVideos.map(async (entry, index) => {
           const inline = entry.video as

--- a/extensions/gradium/speech-provider.ts
+++ b/extensions/gradium/speech-provider.ts
@@ -1,4 +1,5 @@
 // Gradium provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
   SpeechDirectiveTokenParseContext,
@@ -9,8 +10,6 @@ import { asObject, trimToUndefined } from "openclaw/plugin-sdk/speech";
 import { resolveSpeechProviderApiKey } from "openclaw/plugin-sdk/speech-core";
 import { DEFAULT_GRADIUM_VOICE_ID, GRADIUM_VOICES, normalizeGradiumBaseUrl } from "./shared.js";
 import { gradiumTTS } from "./tts.js";
-
-const DEFAULT_GENERATED_AUDIO_MAX_BYTES = 16 * 1024 * 1024;
 
 type GradiumProviderConfig = {
   apiKey?: string;
@@ -56,16 +55,6 @@ function isGradiumProviderConfigured(config: SpeechProviderConfig): boolean {
     // Provider selection is a predicate; synthesis reports the precise URL error.
     return false;
   }
-}
-
-function resolveGeneratedAudioMaxBytes(req: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-}): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_AUDIO_MAX_BYTES;
 }
 
 function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
@@ -117,7 +106,7 @@ export function buildGradiumSpeechProvider(): SpeechProviderPlugin {
         voiceId: trimToUndefined(overrides.voiceId) ?? config.voiceId,
         outputFormat,
         timeoutMs: req.timeoutMs,
-        maxBytes: resolveGeneratedAudioMaxBytes(req),
+        maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
       });
       return {
         audioBuffer,
@@ -142,7 +131,7 @@ export function buildGradiumSpeechProvider(): SpeechProviderPlugin {
         voiceId: trimToUndefined(overrides.voiceId) ?? config.voiceId,
         outputFormat,
         timeoutMs: req.timeoutMs,
-        maxBytes: resolveGeneratedAudioMaxBytes(req),
+        maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
       });
       return { audioBuffer, outputFormat, sampleRate };
     },

--- a/extensions/microsoft-foundry/image-generation-provider.ts
+++ b/extensions/microsoft-foundry/image-generation-provider.ts
@@ -13,7 +13,7 @@ import {
   parseOpenAiCompatibleImageResponse,
   resolveInlineImageJsonResponseMaxBytes,
 } from "openclaw/plugin-sdk/image-generation";
-import { MAX_IMAGE_BYTES } from "openclaw/plugin-sdk/media-runtime";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
@@ -46,7 +46,6 @@ const MAI_MAX_IMAGE_PIXELS = 1_048_576;
 const MAI_IMAGE_BASE_PATH = "/mai/v1";
 const MAI_IMAGE_MAX_RESULTS = 1;
 const MAI_IMAGE_OUTPUT_MIME = "image/png";
-const MB = 1024 * 1024;
 const MAI_IMAGE_UPLOAD_MIME_TYPES = new Set(["image/jpeg", "image/jpg", "image/png"]);
 
 type ModelProviderConfig = NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]>[string];
@@ -112,16 +111,6 @@ function resolveMaiImageSize(size: string | undefined): { width: number; height:
     );
   }
   return { width, height };
-}
-
-function resolveGeneratedImageMaxBytes(req: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-}): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * MB);
-  }
-  return MAX_IMAGE_BYTES;
 }
 
 function assertSingleImageCount(count: number | undefined): void {
@@ -389,7 +378,7 @@ export function buildMicrosoftFoundryImageGenerationProvider(): ImageGenerationP
           {
             maxBytes: resolveInlineImageJsonResponseMaxBytes(
               MAI_IMAGE_MAX_RESULTS,
-              resolveGeneratedImageMaxBytes(req),
+              resolveGeneratedMediaMaxBytes(req.cfg, "image"),
             ),
           },
         );

--- a/extensions/minimax/image-generation-provider.ts
+++ b/extensions/minimax/image-generation-provider.ts
@@ -3,7 +3,8 @@ import {
   resolveInlineImageJsonResponseMaxBytes,
   type ImageGenerationProvider,
 } from "openclaw/plugin-sdk/image-generation";
-import { canonicalizeBase64, MAX_IMAGE_BYTES } from "openclaw/plugin-sdk/media-runtime";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
@@ -19,7 +20,6 @@ const CN_MINIMAX_IMAGE_BASE_URL = "https://api.minimaxi.com";
 const DEFAULT_MODEL = "image-01";
 const DEFAULT_OUTPUT_MIME = "image/png";
 const MINIMAX_MAX_IMAGE_RESULTS = 9;
-const MB = 1024 * 1024;
 const MINIMAX_SUPPORTED_ASPECT_RATIOS = [
   "1:1",
   "16:9",
@@ -77,16 +77,6 @@ function resolveMinimaxImageBaseUrl(
     return CN_MINIMAX_IMAGE_BASE_URL;
   }
   return DEFAULT_MINIMAX_IMAGE_BASE_URL;
-}
-
-function resolveGeneratedImageMaxBytes(req: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-}): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * MB);
-  }
-  return MAX_IMAGE_BYTES;
 }
 
 function buildMinimaxImageProvider(providerId: string): ImageGenerationProvider {
@@ -188,7 +178,7 @@ function buildMinimaxImageProvider(providerId: string): ImageGenerationProvider 
           {
             maxBytes: resolveInlineImageJsonResponseMaxBytes(
               MINIMAX_MAX_IMAGE_RESULTS,
-              resolveGeneratedImageMaxBytes(req),
+              resolveGeneratedMediaMaxBytes(req.cfg, "image"),
             ),
           },
         );

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -1,9 +1,9 @@
 // Minimax provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import type {
   GeneratedMusicAsset,
   MusicGenerationProvider,
-  MusicGenerationRequest,
 } from "openclaw/plugin-sdk/music-generation";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -26,7 +26,6 @@ const DEFAULT_MINIMAX_MUSIC_BASE_URL = "https://api.minimax.io";
 const DEFAULT_MINIMAX_MUSIC_MODEL = "music-2.6";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
-const DEFAULT_GENERATED_MUSIC_MAX_BYTES = 16 * 1024 * 1024;
 const STREAM_ENVELOPE_MAX_BYTES_MULTIPLIER = 5;
 const STREAM_ENVELOPE_OVERHEAD_BYTES = 64 * 1024;
 
@@ -125,14 +124,6 @@ function decodePossibleText(data: string): string {
 function isLikelyRemoteUrl(value: string | undefined): boolean {
   const trimmed = normalizeOptionalString(value);
   return Boolean(trimmed && /^https?:\/\//iu.test(trimmed));
-}
-
-function resolveGeneratedMusicMaxBytes(req: MusicGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_MUSIC_MAX_BYTES;
 }
 
 async function downloadTrackFromUrl(params: {
@@ -404,7 +395,7 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
         await assertOkOrThrowHttpError(res, "MiniMax music generation failed");
         const contentType = normalizeOptionalString(res.headers.get("content-type")) ?? "";
         const lowerContentType = contentType.toLowerCase();
-        const maxGeneratedMusicBytes = resolveGeneratedMusicMaxBytes(req);
+        const maxGeneratedMusicBytes = resolveGeneratedMediaMaxBytes(req.cfg, "audio");
         const payload =
           lowerContentType.includes("text/event-stream") || lowerContentType.startsWith("audio/")
             ? null
@@ -438,7 +429,7 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
                 defaultTimeoutMs: req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
               }),
               fetchFn,
-              maxBytes: resolveGeneratedMusicMaxBytes(req),
+              maxBytes: maxGeneratedMusicBytes,
               policy: requestPolicy,
             })
           : inlineAudio

--- a/extensions/minimax/video-generation-provider.ts
+++ b/extensions/minimax/video-generation-provider.ts
@@ -1,5 +1,6 @@
 // Minimax provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -33,7 +34,6 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_OPERATION_TIMEOUT_MS = 1_200_000;
 const POLL_INTERVAL_MS = 10_000;
 const MAX_POLL_ATTEMPTS = 120;
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 const MINIMAX_MODEL_ALLOWED_DURATIONS: Readonly<Record<string, readonly number[]>> = {
   "MiniMax-Hailuo-2.3": [6, 10],
   "MiniMax-Hailuo-02": [6, 10],
@@ -94,14 +94,6 @@ function resolveMinimaxVideoBaseUrl(
   } catch {
     return DEFAULT_MINIMAX_VIDEO_BASE_URL;
   }
-}
-
-function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
 function assertMinimaxBaseResp(baseResp: MinimaxBaseResp | undefined, context: string): void {
@@ -570,6 +562,7 @@ function buildMinimaxVideoProvider(providerId: string): VideoGenerationProvider 
         });
         const videoUrl = normalizeOptionalString(completed.video_url);
         const fileId = normalizeOptionalString(completed.file_id);
+        const maxVideoBytes = resolveGeneratedMediaMaxBytes(req.cfg, "video");
         const video = videoUrl
           ? await downloadVideoFromUrl({
               url: videoUrl,
@@ -578,7 +571,7 @@ function buildMinimaxVideoProvider(providerId: string): VideoGenerationProvider 
                 defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
               }),
               fetchFn,
-              maxBytes: resolveGeneratedVideoMaxBytes(req),
+              maxBytes: maxVideoBytes,
               policy: requestPolicy,
             })
           : fileId
@@ -591,7 +584,7 @@ function buildMinimaxVideoProvider(providerId: string): VideoGenerationProvider 
                 }),
                 baseUrl,
                 fetchFn,
-                maxBytes: resolveGeneratedVideoMaxBytes(req),
+                maxBytes: maxVideoBytes,
                 policy: requestPolicy,
               })
             : (() => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -12,9 +12,12 @@ import {
   toImageDataUrl,
 } from "openclaw/plugin-sdk/image-generation";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
-import { resolveClosestSize } from "openclaw/plugin-sdk/media-generation-runtime";
+import {
+  resolveClosestSize,
+  resolveGeneratedMediaMaxBytes,
+} from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
-import { canonicalizeBase64, MAX_IMAGE_BYTES } from "openclaw/plugin-sdk/media-runtime";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import {
   ensureAuthProfileStore,
   hasConfiguredSecretInput,
@@ -72,7 +75,6 @@ const MOCK_OPENAI_PROVIDER_ID = "mock-openai";
 const OPENAI_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const OPENAI_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
 const OPENAI_QUALITIES = ["low", "medium", "high", "auto"] as const;
-const MB = 1024 * 1024;
 const OPENAI_IMAGE_MODELS = [
   DEFAULT_OPENAI_IMAGE_MODEL,
   OPENAI_TRANSPARENT_BACKGROUND_IMAGE_MODEL,
@@ -125,14 +127,6 @@ function resolveOpenAIImageCount(count: number | undefined): number {
     return 1;
   }
   return Math.max(1, Math.min(OPENAI_MAX_IMAGE_RESULTS, Math.trunc(count)));
-}
-
-function resolveGeneratedImageMaxBytes(cfg: OpenClawConfig): number {
-  const configured = cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * MB);
-  }
-  return MAX_IMAGE_BYTES;
 }
 
 function isPublicOpenAIImageBaseUrl(baseUrl: string): boolean {
@@ -1060,7 +1054,7 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
         const data = await readProviderJsonResponse(response, "openai.image-generation", {
           maxBytes: resolveInlineImageJsonResponseMaxBytes(
             count,
-            resolveGeneratedImageMaxBytes(req.cfg),
+            resolveGeneratedMediaMaxBytes(req.cfg, "image"),
           ),
         });
         const output = resolveOutputMime(req.outputFormat);

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -1,4 +1,5 @@
 // Openai provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { isVoiceMessageCompatibleAudio } from "openclaw/plugin-sdk/media-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
@@ -29,7 +30,6 @@ import {
 } from "./tts.js";
 
 const OPENAI_SPEECH_RESPONSE_FORMATS = ["mp3", "opus", "wav"] as const;
-const DEFAULT_GENERATED_AUDIO_MAX_BYTES = 16 * 1024 * 1024;
 
 type OpenAiSpeechResponseFormat = (typeof OPENAI_SPEECH_RESPONSE_FORMATS)[number];
 
@@ -182,16 +182,6 @@ function readOpenAIOverrides(
   };
 }
 
-function resolveGeneratedAudioMaxBytes(req: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-}): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_AUDIO_MAX_BYTES;
-}
-
 function isCustomOpenAITtsBaseUrl(baseUrl: string | undefined): boolean {
   if (baseUrl !== undefined) {
     return normalizeOpenAITtsBaseUrl(baseUrl) !== DEFAULT_OPENAI_BASE_URL;
@@ -319,7 +309,7 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
         responseFormat,
         extraBody: config.extraBody,
         timeoutMs: req.timeoutMs,
-        maxBytes: resolveGeneratedAudioMaxBytes(req),
+        maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
       });
       const fileExtension = responseFormatToFileExtension(responseFormat);
       return {
@@ -351,7 +341,7 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
         responseFormat: outputFormat,
         extraBody: config.extraBody,
         timeoutMs: req.timeoutMs,
-        maxBytes: resolveGeneratedAudioMaxBytes(req),
+        maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
       });
       return { audioBuffer, outputFormat, sampleRate };
     },

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -1,5 +1,6 @@
 // Openai provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime, type MediaKind } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -33,7 +34,6 @@ const DEFAULT_OPENAI_VIDEO_MODEL = "sora-2";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 2_500;
 const MAX_POLL_ATTEMPTS = 120;
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 const OPENAI_VIDEO_SECONDS = [4, 8, 12] as const;
 const OPENAI_VIDEO_SIZES = ["720x1280", "1280x720", "1024x1792", "1792x1024"] as const;
 
@@ -79,14 +79,6 @@ function resolveDurationSeconds(durationSeconds: number | undefined): "4" | "8" 
     Math.abs(current - rounded) < Math.abs(best - rounded) ? current : best,
   );
   return String(nearest) as "4" | "8" | "12";
-}
-
-function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
 function resolveSize(params: {
@@ -467,7 +459,7 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
           fetchFn,
           allowPrivateNetwork,
           dispatcherPolicy,
-          maxBytes: resolveGeneratedVideoMaxBytes(req),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "video"),
         });
         return {
           videos: [video],

--- a/extensions/openrouter/image-generation-provider.ts
+++ b/extensions/openrouter/image-generation-provider.ts
@@ -10,7 +10,7 @@ import {
   resolveInlineImageJsonResponseMaxBytes,
   toImageDataUrl,
 } from "openclaw/plugin-sdk/image-generation";
-import { MAX_IMAGE_BYTES } from "openclaw/plugin-sdk/media-runtime";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
@@ -25,7 +25,6 @@ import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
 const DEFAULT_MODEL = "google/gemini-3.1-flash-image-preview";
 const DEFAULT_TIMEOUT_MS = 180_000;
 const MAX_IMAGE_RESULTS = 4;
-const MB = 1024 * 1024;
 const SUPPORTED_MODELS = [
   DEFAULT_MODEL,
   "google/gemini-3-pro-image-preview",
@@ -217,16 +216,6 @@ function resolveImageCount(count: number | undefined): number {
   return Math.max(1, Math.min(MAX_IMAGE_RESULTS, Math.trunc(count)));
 }
 
-function resolveGeneratedImageMaxBytes(req: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-}): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * MB);
-  }
-  return MAX_IMAGE_BYTES;
-}
-
 function isGeminiImageModel(model: string): boolean {
   return model.startsWith("google/gemini-");
 }
@@ -344,7 +333,7 @@ export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvide
         const payload = await readProviderJsonResponse(response, "openrouter.image-generation", {
           maxBytes: resolveInlineImageJsonResponseMaxBytes(
             count,
-            resolveGeneratedImageMaxBytes(req),
+            resolveGeneratedMediaMaxBytes(req.cfg, "image"),
           ),
         });
         const images = extractOpenRouterImagesFromResponse(payload, {

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -1,6 +1,6 @@
 // Openrouter provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
-import { maxBytesForKind } from "openclaw/plugin-sdk/media-runtime";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import type {
   MusicGenerationProvider,
   MusicGenerationRequest,
@@ -24,7 +24,6 @@ import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
 const DEFAULT_OPENROUTER_MUSIC_MODEL = "google/lyria-3-pro-preview";
 const OPENROUTER_CLIP_MUSIC_MODEL = "google/lyria-3-clip-preview";
 const DEFAULT_TIMEOUT_MS = 180_000;
-const MB = 1024 * 1024;
 const OPENROUTER_SSE_ENVELOPE_OVERHEAD_BYTES = 64 * 1024;
 const OPENROUTER_MUSIC_MODELS = [
   DEFAULT_OPENROUTER_MUSIC_MODEL,
@@ -123,14 +122,6 @@ function readDeltaAudio(part: unknown): { data?: string; transcript?: string } |
     data: normalizeOptionalString(audio.data),
     transcript: typeof audio.transcript === "string" ? audio.transcript : undefined,
   };
-}
-
-function resolveGeneratedMusicMaxBytes(req: MusicGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * MB);
-  }
-  return maxBytesForKind("audio");
 }
 
 function resolveOpenRouterSseEventMaxBytes(maxBytes: number): number {
@@ -432,7 +423,7 @@ export function buildOpenRouterMusicGenerationProvider(): MusicGenerationProvide
         const streamResult = await readOpenRouterAudioStream(
           response,
           streamDeadline,
-          resolveGeneratedMusicMaxBytes(req),
+          resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
         );
         if (streamResult.audioBuffer.byteLength === 0) {
           throw new Error("OpenRouter music generation response missing audio data");

--- a/extensions/openrouter/video-generation-provider.ts
+++ b/extensions/openrouter/video-generation-provider.ts
@@ -1,5 +1,6 @@
 // Openrouter provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -36,7 +37,6 @@ const DEFAULT_TIMEOUT_MS = 600_000;
 const DEFAULT_HTTP_TIMEOUT_MS = 60_000;
 const POLL_INTERVAL_MS = 5_000;
 const MAX_POLL_ATTEMPTS = 120;
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 const SUPPORTED_ASPECT_RATIOS = ["16:9", "9:16"] as const;
 const OPENROUTER_VIDEO_MALFORMED_RESPONSE = "OpenRouter video generation response malformed";
 const SUPPORTED_DURATION_SECONDS = [4, 6, 8] as const;
@@ -369,14 +369,6 @@ function resolveDeliverableOpenRouterVideoUrl(value: string | undefined): string
   }
 }
 
-function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
-}
-
 async function downloadOpenRouterVideo(params: {
   url: string;
   deliveryUrl?: string;
@@ -567,7 +559,7 @@ export function buildOpenRouterVideoGenerationProvider(): VideoGenerationProvide
           }),
           allowPrivateNetwork,
           dispatcherPolicy,
-          maxBytes: resolveGeneratedVideoMaxBytes(req),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "video"),
         });
 
         return {

--- a/extensions/runway/video-generation-provider.ts
+++ b/extensions/runway/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Runway provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -35,7 +36,6 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 5_000;
 const MAX_POLL_ATTEMPTS = 120;
 const MAX_DURATION_SECONDS = 10;
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 
 type RunwayTaskStatus = "PENDING" | "RUNNING" | "THROTTLED" | "SUCCEEDED" | "FAILED" | "CANCELLED";
 
@@ -122,14 +122,6 @@ function resolveRunwayBaseUrl(req: VideoGenerationRequest): string {
   return (
     normalizeOptionalString(req.cfg?.models?.providers?.runway?.baseUrl) ?? DEFAULT_RUNWAY_BASE_URL
   );
-}
-
-function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
 function toDataUrl(buffer: Buffer, mimeType: string): string {
@@ -448,7 +440,7 @@ export function buildRunwayVideoGenerationProvider(): VideoGenerationProvider {
             defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
           }),
           fetchFn,
-          maxBytes: resolveGeneratedVideoMaxBytes(req),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "video"),
         });
         return {
           videos,

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -1,5 +1,6 @@
 // Together provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -35,7 +36,6 @@ const POLL_INTERVAL_MS = 5_000;
 const MAX_POLL_ATTEMPTS = 120;
 const TOGETHER_MIN_DURATION_SECONDS = 1;
 const TOGETHER_MAX_DURATION_SECONDS = 10;
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 
 type TogetherVideoResponse = {
   id?: string;
@@ -108,14 +108,6 @@ function resolveTogetherDurationSeconds(value: unknown): string | undefined {
     max: TOGETHER_MAX_DURATION_SECONDS,
   });
   return duration === undefined ? undefined : String(duration);
-}
-
-function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
 async function pollTogetherVideo(params: {
@@ -326,7 +318,7 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
             defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
           }),
           fetchFn,
-          maxBytes: resolveGeneratedVideoMaxBytes(req),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "video"),
         });
         return {
           videos: [video],

--- a/extensions/vydra/image-generation-provider.ts
+++ b/extensions/vydra/image-generation-provider.ts
@@ -1,5 +1,6 @@
 // Vydra provider module implements model/runtime integration.
 import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
   assertOkOrThrowHttpError,
@@ -11,7 +12,6 @@ import {
   downloadVydraAsset,
   extractVydraResultUrls,
   resolveCompletedVydraPayload,
-  resolveVydraGeneratedMediaMaxBytes,
   resolveVydraResponseJobId,
   resolveVydraResponseStatus,
   resolveVydraRequestContext,
@@ -98,7 +98,7 @@ export function buildVydraImageGenerationProvider(): ImageGenerationProvider {
           kind: "image",
           timeoutMs: req.timeoutMs,
           fetchFn,
-          maxBytes: resolveVydraGeneratedMediaMaxBytes({ cfg: req.cfg, kind: "image" }),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "image"),
           requestPolicy,
         });
         return {

--- a/extensions/vydra/shared.ts
+++ b/extensions/vydra/shared.ts
@@ -26,9 +26,6 @@ export const DEFAULT_VYDRA_VIDEO_MODEL = "veo3";
 export const DEFAULT_VYDRA_SPEECH_MODEL = "elevenlabs/tts";
 export const DEFAULT_VYDRA_VOICE_ID = "21m00Tcm4TlvDq8ikWAM";
 const DEFAULT_HTTP_TIMEOUT_MS = 120_000;
-const DEFAULT_GENERATED_IMAGE_MAX_BYTES = 6 * 1024 * 1024;
-const DEFAULT_GENERATED_AUDIO_MAX_BYTES = 16 * 1024 * 1024;
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 const POLL_INTERVAL_MS = 2_500;
 const MAX_POLL_ATTEMPTS = 120;
 type VydraAuthStore = Parameters<typeof resolveApiKeyForProvider>[0]["store"];
@@ -259,23 +256,6 @@ function resolveVydraAssetRequestHeaders(
   } catch {
     return undefined;
   }
-}
-
-export function resolveVydraGeneratedMediaMaxBytes(params: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-  kind: VydraMediaKind;
-}): number {
-  const configured = params.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  if (params.kind === "image") {
-    return DEFAULT_GENERATED_IMAGE_MAX_BYTES;
-  }
-  if (params.kind === "audio") {
-    return DEFAULT_GENERATED_AUDIO_MAX_BYTES;
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
 export async function downloadVydraAsset(params: {

--- a/extensions/vydra/speech-provider.ts
+++ b/extensions/vydra/speech-provider.ts
@@ -1,4 +1,5 @@
 // Vydra provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import {
   assertOkOrThrowHttpError,
   postJsonRequest,
@@ -19,7 +20,6 @@ import {
   downloadVydraAsset,
   extractVydraResultUrls,
   normalizeVydraBaseUrl,
-  resolveVydraGeneratedMediaMaxBytes,
   trimToUndefined,
 } from "./shared.js";
 
@@ -145,7 +145,7 @@ export function buildVydraSpeechProvider(): SpeechProviderPlugin {
           kind: "audio",
           timeoutMs: req.timeoutMs,
           fetchFn,
-          maxBytes: resolveVydraGeneratedMediaMaxBytes({ cfg: req.cfg, kind: "audio" }),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
           requestPolicy: {
             allowPrivateNetwork,
             dispatcherPolicy,

--- a/extensions/vydra/video-generation-provider.ts
+++ b/extensions/vydra/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Vydra provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
   assertOkOrThrowHttpError,
@@ -14,7 +15,6 @@ import {
   downloadVydraAsset,
   extractVydraResultUrls,
   resolveCompletedVydraPayload,
-  resolveVydraGeneratedMediaMaxBytes,
   resolveVydraResponseJobId,
   resolveVydraResponseStatus,
   resolveVydraRequestContext,
@@ -136,7 +136,7 @@ export function buildVydraVideoGenerationProvider(): VideoGenerationProvider {
             defaultTimeoutMs: DEFAULT_VYDRA_VIDEO_TIMEOUT_MS,
           }),
           fetchFn,
-          maxBytes: resolveVydraGeneratedMediaMaxBytes({ cfg: req.cfg, kind: "video" }),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "video"),
           requestPolicy,
         });
         return {

--- a/extensions/xai/speech-provider.ts
+++ b/extensions/xai/speech-provider.ts
@@ -1,4 +1,5 @@
 // Xai provider module implements model/runtime integration.
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import {
   isProviderAuthProfileConfigured,
   type OpenClawConfig,
@@ -30,7 +31,6 @@ import {
 } from "./tts.js";
 
 const XAI_SPEECH_RESPONSE_FORMATS = ["mp3", "wav", "pcm", "mulaw", "alaw"] as const;
-const DEFAULT_GENERATED_AUDIO_MAX_BYTES = 16 * 1024 * 1024;
 
 type XaiSpeechResponseFormat = (typeof XAI_SPEECH_RESPONSE_FORMATS)[number];
 
@@ -139,16 +139,6 @@ function readXaiOverrides(overrides: SpeechProviderOverrides | undefined): XaiTt
 
 function resolveDirectXaiAudioApiKey(configApiKey?: string): string | undefined {
   return resolveSpeechProviderApiKey(configApiKey, process.env.XAI_API_KEY);
-}
-
-function resolveGeneratedAudioMaxBytes(req: {
-  cfg: { agents?: { defaults?: { mediaMaxMb?: number } } };
-}): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_AUDIO_MAX_BYTES;
 }
 
 function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
@@ -261,7 +251,7 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
         speed: overrides.speed ?? config.speed,
         responseFormat,
         timeoutMs: req.timeoutMs,
-        maxBytes: resolveGeneratedAudioMaxBytes(req),
+        maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
       });
       return {
         audioBuffer,
@@ -284,7 +274,7 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
         speed: overrides.speed ?? config.speed,
         responseFormat,
         timeoutMs: req.timeoutMs,
-        maxBytes: resolveGeneratedAudioMaxBytes(req),
+        maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
       });
       return {
         audioStream: stream.audioStream,
@@ -309,7 +299,7 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
         speed: overrides.speed ?? config.speed,
         responseFormat: outputFormat,
         timeoutMs: req.timeoutMs,
-        maxBytes: resolveGeneratedAudioMaxBytes(req),
+        maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
       });
       return { audioBuffer, outputFormat, sampleRate };
     },

--- a/extensions/xai/video-generation-provider.ts
+++ b/extensions/xai/video-generation-provider.ts
@@ -1,5 +1,6 @@
 // Xai provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
+import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
@@ -59,7 +60,6 @@ const XAI_VIDEO_TERMINAL_FAILURE_STATUSES = new Set(["failed", "error", "expired
 const XAI_VIDEO_DEFAULT_DURATION_SECONDS = 8;
 const XAI_VIDEO_DEFAULT_ASPECT_RATIO = "16:9";
 const XAI_VIDEO_DEFAULT_RESOLUTION = "480p";
-const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 
 type XaiVideoCreateResponse = {
   request_id?: string;
@@ -141,14 +141,6 @@ function resolveXaiVideoBaseUrl(req: VideoGenerationRequest): string {
   return (
     normalizeOptionalString(req.cfg?.models?.providers?.xai?.baseUrl) ?? DEFAULT_XAI_VIDEO_BASE_URL
   );
-}
-
-function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
-  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
-  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured * 1024 * 1024);
-  }
-  return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
 function resolveImageUrl(input: VideoGenerationSourceInput | undefined): string | undefined {
@@ -561,7 +553,7 @@ export function buildXaiVideoGenerationProvider(): VideoGenerationProvider {
           allowPrivateNetwork,
           dispatcherPolicy,
           fetchFn,
-          maxBytes: resolveGeneratedVideoMaxBytes(req),
+          maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "video"),
         });
         return {
           videos: [video],

--- a/src/media/configured-max-bytes.test.ts
+++ b/src/media/configured-max-bytes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveGeneratedMediaMaxBytes } from "../plugin-sdk/media-generation-runtime.js";
+
+const MB = 1024 * 1024;
+
+function configWithMediaMaxMb(mediaMaxMb: number): OpenClawConfig {
+  return { agents: { defaults: { mediaMaxMb } } } as OpenClawConfig;
+}
+
+describe("resolveGeneratedMediaMaxBytes", () => {
+  it.each([
+    { kind: "image" as const, expected: 6 * MB },
+    { kind: "audio" as const, expected: 16 * MB },
+    { kind: "video" as const, expected: 16 * MB },
+  ])("uses the $kind default when mediaMaxMb is unset", ({ kind, expected }) => {
+    expect(resolveGeneratedMediaMaxBytes(undefined, kind)).toBe(expected);
+  });
+
+  it.each([
+    { label: "zero", value: 0 },
+    { label: "negative", value: -1 },
+    { label: "NaN", value: Number.NaN },
+    { label: "positive infinity", value: Number.POSITIVE_INFINITY },
+  ])("uses the per-kind default for $label mediaMaxMb", ({ value }) => {
+    expect(resolveGeneratedMediaMaxBytes(configWithMediaMaxMb(value), "image")).toBe(6 * MB);
+  });
+
+  it("floors fractional configured megabytes to whole bytes", () => {
+    const mediaMaxMb = 1.000_001;
+
+    expect(resolveGeneratedMediaMaxBytes(configWithMediaMaxMb(mediaMaxMb), "audio")).toBe(
+      Math.floor(mediaMaxMb * MB),
+    );
+  });
+});

--- a/src/media/configured-max-bytes.ts
+++ b/src/media/configured-max-bytes.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { MEDIA_MAX_BYTES } from "./store.js";
 
 const MB = 1024 * 1024;
+type GeneratedMediaKind = Extract<MediaKind, "audio" | "image" | "video">;
 
 /** Resolves the global generated-media byte cap from the user-facing MB config value. */
 export function resolveConfiguredMediaMaxBytes(cfg?: OpenClawConfig): number | undefined {
@@ -15,7 +16,10 @@ export function resolveConfiguredMediaMaxBytes(cfg?: OpenClawConfig): number | u
 }
 
 /** Returns the configured media cap, falling back to the media-core per-kind default. */
-export function resolveGeneratedMediaMaxBytes(cfg: OpenClawConfig | undefined, kind: MediaKind) {
+export function resolveGeneratedMediaMaxBytes(
+  cfg: OpenClawConfig | undefined,
+  kind: GeneratedMediaKind,
+) {
   return resolveConfiguredMediaMaxBytes(cfg) ?? maxBytesForKind(kind);
 }
 

--- a/src/plugin-sdk/media-generation-runtime.ts
+++ b/src/plugin-sdk/media-generation-runtime.ts
@@ -1,3 +1,4 @@
 // Narrow shared media-generation runtime helpers for bundled and third-party plugins.
 
 export { resolveClosestSize } from "../media-generation/runtime-shared.js";
+export { resolveGeneratedMediaMaxBytes } from "../media/configured-max-bytes.js";


### PR DESCRIPTION
## What Problem This Solves

Twenty-five generated-media provider paths independently interpreted `agents.defaults.mediaMaxMb` with the same validation, binary-MiB conversion, flooring, and per-kind fallback policy.

## Why This Change Was Made

Expose the existing `resolveGeneratedMediaMaxBytes` helper through the private local media-generation Plugin SDK runtime and migrate image, speech, video, music, Comfy, Vydra, and Codex callers. Provider-specific envelope, response, download, and persistence caps remain separate.

## User Impact

No intended behavior change. Generated-media providers now share one config policy, removing 233 net production lines. Invalid, non-finite, zero, or negative values still fall back by kind; fractional values still floor; music still uses the audio default.

## Evidence

- Added table-driven config contract coverage for invalid values, fractional flooring, and image/audio/video defaults
- Fresh autoreview against `origin/main`: no actionable findings, confidence 0.93
- `git diff --check`
- Direct Codex contract inspection:
  - `codex-rs/protocol/src/models.rs:990` keeps the image result as a required string
  - `codex-rs/core/src/event_mapping.rs:233` initially maps no saved path
  - `codex-rs/ext/image-generation/src/tool.rs:160` reads the base64 result
  - `codex-rs/ext/image-generation/src/tool.rs:182` persists decoded bytes and emits result plus optional path
  - `codex-rs/app-server-protocol/src/protocol/v2/item.rs:913` forwards both fields
  - `codex-rs/app-server/tests/suite/v2/imagegen_extension.rs:116` verifies result, saved path, and persisted bytes
- Testbox `tbx_01kyby7khhk9g7ervt0gb61aj3`: `pnpm check:changed` passed in 18m55s, including core/extension typechecks, extension tests, Plugin SDK contracts, boundaries, import-cycle checks, and media guards
- Same Testbox: `pnpm build` passed in 1m46s
