### PR TITLE
fix(ui): dashboard no longer flashes white before dark theme loads

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -66,6 +66,46 @@
       })();
     </script>
     <style>
+      /* Paint before the app stylesheet arrives so WebKit never exposes a white
+         document between its native dark canvas and the persisted UI theme. */
+      html,
+      body {
+        min-height: 100%;
+      }
+
+      html {
+        background: #0e1015;
+        color-scheme: dark;
+      }
+
+      html[data-theme-mode="light"] {
+        background: #faf9f7;
+        color-scheme: light;
+      }
+
+      html[data-theme="openknot"] {
+        background: #080808;
+      }
+
+      html[data-theme="openknot-light"] {
+        background: #f9f9fb;
+      }
+
+      html[data-theme="dash"] {
+        background: #1a1210;
+      }
+
+      html[data-theme="dash-light"] {
+        background: #f7f2ec;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100%;
+        background: inherit;
+        color-scheme: inherit;
+      }
+
       body.openclaw-mount-fallback-active {
         margin: 0;
         min-width: 320px;

--- a/ui/src/app/mount-fallback.test.ts
+++ b/ui/src/app/mount-fallback.test.ts
@@ -33,6 +33,20 @@ function createIsolatedWindow(): TestWindow {
   return frameWindow;
 }
 
+function installStartupPaintShell(window: TestWindow, html: string): void {
+  const parsed = new window.DOMParser().parseFromString(html, "text/html");
+  window.document.head.innerHTML = parsed.head.innerHTML;
+  window.document.body.innerHTML = parsed.body.innerHTML;
+
+  const startupScript = Array.from(
+    parsed.querySelectorAll<HTMLScriptElement>("script:not([src])"),
+  ).find((script) => script.textContent?.includes("var THEMES = { claw: 1, knot: 1, dash: 1 }"));
+  if (!startupScript?.textContent) {
+    throw new Error("Expected inline startup theme script in index.html");
+  }
+  window.eval(startupScript.textContent);
+}
+
 function installFallbackShell(window: TestWindow, html: string): void {
   const parsed = new window.DOMParser().parseFromString(html, "text/html");
   window.document.head.innerHTML = parsed.head.innerHTML;
@@ -64,6 +78,28 @@ describe("Control UI mount fallback", () => {
   afterEach(() => {
     document.body.innerHTML = "";
   });
+
+  it.each([
+    ["claw dark", { theme: "claw", themeMode: "dark" }, "dark", "rgb(14, 16, 21)"],
+    ["OpenKnot dark", { theme: "knot", themeMode: "dark" }, "openknot", "rgb(8, 8, 8)"],
+    ["Dash light", { theme: "dash", themeMode: "light" }, "dash-light", "rgb(247, 242, 236)"],
+  ])(
+    "paints %s before the app stylesheet loads",
+    async (_name, settings, expectedTheme, expectedBackground) => {
+      const frameWindow = createIsolatedWindow();
+      frameWindow.localStorage.clear();
+      frameWindow.localStorage.setItem("openclaw.control.settings.v1", JSON.stringify(settings));
+      installStartupPaintShell(frameWindow, await readIndexHtmlWithDelay(1));
+
+      expect(frameWindow.document.documentElement.dataset.theme).toBe(expectedTheme);
+      expect(
+        frameWindow.getComputedStyle(frameWindow.document.documentElement).backgroundColor,
+      ).toBe(expectedBackground);
+      expect(frameWindow.getComputedStyle(frameWindow.document.body).backgroundColor).toBe(
+        expectedBackground,
+      );
+    },
+  );
 
   it("shows the static troubleshooting panel when the app element is never registered", async () => {
     const frameWindow = createIsolatedWindow();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Dashboard with a persisted dark theme could briefly see a white document while the Control UI stylesheet and application bundle were loading.

## Why This Change Was Made

The document now applies a minimal theme-aware startup paint immediately after resolving the persisted theme, before external styles load. The normal Control UI stylesheet remains authoritative after startup, and focused coverage verifies representative dark and light theme families.

## User Impact

The Dashboard opens against the selected theme background instead of briefly flashing white. Light, OpenKnot, and Dash themes retain their intended initial colors.

## Evidence

- `node scripts/run-vitest.mjs ui/src/app/mount-fallback.test.ts` — 8 tests passed.
- `git diff --check` — passed.
- Codex autoreview — clean, no accepted/actionable findings.
- A universal Developer-ID-signed macOS candidate passed strict nested code-signature verification and Gatekeeper assessment.
- The first-paint regression is temporal; a static screenshot would not meaningfully capture it. The test parses only the inline document head, resolves persisted themes, and checks computed root/body backgrounds before the external application stylesheet mounts.

AI-assisted change; implementation and final diff were manually reviewed.
