### PR TITLE
fix(agents): keep relocated auth and shared sessions discoverable

### DIFF
--- a/src/agents/auth-profiles/path-resolve.ts
+++ b/src/agents/auth-profiles/path-resolve.ts
@@ -11,19 +11,14 @@ import {
   AUTH_STATE_FILENAME,
   LEGACY_AUTH_FILENAME,
 } from "./path-constants.js";
+import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
 import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 
 function resolveAuthAgentDir(agentDir?: string): string {
   if (agentDir) {
     return resolveUserPath(agentDir);
   }
-  const configuredMainAgentDir = process.env.OPENCLAW_AGENT_DIR?.trim();
-  if (configuredMainAgentDir) {
-    return resolveUserPath(configuredMainAgentDir);
-  }
-  // The no-argument auth-store API names the shipped shared main store, not a
-  // configured-agent fallback. Roster-aware callers pass their resolved dir.
-  return path.join(resolveStateDir(), "agents", "main", "agent");
+  return resolveSharedMainAuthAgentDir();
 }
 
 /** Resolve the persisted auth profile store path for an agent dir. */

--- a/src/agents/auth-profiles/shared-main-dir.ts
+++ b/src/agents/auth-profiles/shared-main-dir.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
+import { LEGACY_IMPLICIT_AGENT_ID } from "../../routing/session-key.js";
+import { resolveUserPath } from "../../utils.js";
+
+/** Resolve the shipped shared-main auth store, including its supported relocation. */
+export function resolveSharedMainAuthAgentDir(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.OPENCLAW_AGENT_DIR?.trim();
+  return configured
+    ? resolveUserPath(configured, env)
+    : path.join(resolveStateDir(env), "agents", LEGACY_IMPLICIT_AGENT_ID, "agent");
+}

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -6,7 +6,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { resolveStateDir } from "../../config/paths.js";
 import { sha256HexPrefix } from "../../infra/crypto-digest.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
@@ -26,6 +25,7 @@ import {
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../../state/openclaw-state-db.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveRegisteredAgentIdForDir } from "../agent-dir-registry.js";
+import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
 
 type AuthProfileDatabase = Pick<
   OpenClawAgentKyselyDatabase,
@@ -40,10 +40,7 @@ function resolveAgentDir(agentDir?: string): string {
   if (agentDir) {
     return resolveUserPath(agentDir);
   }
-  const configuredMainAgentDir = process.env.OPENCLAW_AGENT_DIR?.trim();
-  return configuredMainAgentDir
-    ? resolveUserPath(configuredMainAgentDir)
-    : path.join(resolveStateDir(), "agents", "main", "agent");
+  return resolveSharedMainAuthAgentDir();
 }
 
 function inferAgentIdFromDir(agentDir: string): string {

--- a/src/commands/doctor/shared/stale-auth-order.test.ts
+++ b/src/commands/doctor/shared/stale-auth-order.test.ts
@@ -683,6 +683,34 @@ describe("repairStaleConfiguredAuthOrders", () => {
     },
   );
 
+  it("uses OPENCLAW_AGENT_DIR as the inherited shared-main auth store", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-main-auth-order-"));
+    try {
+      const sharedMainAgentDir = path.join(stateDir, "relocated-main-agent");
+      writePersistedAuthProfileStoreRaw(
+        tokenStore({ profileId: "anthropic:relocated-main", provider: "anthropic" }),
+        sharedMainAgentDir,
+      );
+      const cfg = {
+        auth: { order: { anthropic: ["anthropic:missing"] } },
+      } satisfies OpenClawConfig;
+
+      const result = maybeRepairStaleConfiguredAuthOrders({
+        cfg,
+        env: {
+          OPENCLAW_AGENT_DIR: sharedMainAgentDir,
+          OPENCLAW_STATE_DIR: stateDir,
+        },
+      });
+
+      expect(result.config.auth?.order?.anthropic).toBeUndefined();
+      expect(result.changes).toHaveLength(1);
+      expect(result.warnings).toBeUndefined();
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves an order that selects a runtime-only external profile", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-runtime-auth-order-"));
     try {

--- a/src/commands/doctor/shared/stale-auth-order.ts
+++ b/src/commands/doctor/shared/stale-auth-order.ts
@@ -13,6 +13,7 @@ import {
   coercePersistedAuthProfileStore,
   mergeAuthProfileStores,
 } from "../../../agents/auth-profiles/persisted.js";
+import { resolveSharedMainAuthAgentDir } from "../../../agents/auth-profiles/shared-main-dir.js";
 import {
   inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
@@ -28,10 +29,7 @@ import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
 import { resolveProviderIdForAuth } from "../../../agents/provider-auth-aliases.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import {
-  LEGACY_IMPLICIT_AGENT_ID as DEFAULT_AGENT_ID,
-  normalizeAgentId,
-} from "../../../routing/session-key.js";
+import { normalizeAgentId } from "../../../routing/session-key.js";
 import {
   inspectOpenClawAgentDatabaseOwner,
   listOpenClawRegisteredAgentDatabases,
@@ -290,7 +288,7 @@ function loadConfiguredAgentAuthStores(
   }
   // Every secondary agent inherits the legacy main store at runtime, even when
   // `agents.list` names a different default agent.
-  const mainAgentDir = path.join(resolveStateDir(env), "agents", DEFAULT_AGENT_ID, "agent");
+  const mainAgentDir = path.resolve(resolveSharedMainAuthAgentDir(env));
   const activeAgentDirs = new Set<string>();
   const expectedAgentIdsByDir = new Map<string, Set<string>>();
   const addExpectedAgentDir = (agentDir: string, agentId: string) => {
@@ -298,7 +296,7 @@ function loadConfiguredAgentAuthStores(
     owners.add(normalizeAgentId(agentId));
     expectedAgentIdsByDir.set(agentDir, owners);
   };
-  addExpectedAgentDir(mainAgentDir, DEFAULT_AGENT_ID);
+  addExpectedAgentDir(mainAgentDir, resolveAuthProfileDatabaseOwnerId(mainAgentDir));
   for (const agentId of listAgentIds(cfg)) {
     const agentDir = path.resolve(resolveAgentDir(cfg, agentId, env));
     activeAgentDirs.add(agentDir);

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
@@ -55,7 +55,7 @@ async function writeRawAuthStore(agentDir: string, store: unknown): Promise<void
 }
 
 describe("stale OAuth profile shadow doctor repair", () => {
-  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_HOME"]);
+  const envSnapshot = captureEnv(["OPENCLAW_AGENT_DIR", "OPENCLAW_STATE_DIR", "OPENCLAW_HOME"]);
   let tempRoot = "";
   let stateDir = "";
 
@@ -217,6 +217,52 @@ describe("stale OAuth profile shadow doctor repair", () => {
         profileId,
       }),
     ]);
+  });
+
+  it("repairs shadows against the OPENCLAW_AGENT_DIR shared-main store", async () => {
+    const profileId = "anthropic:default";
+    const now = Date.now();
+    const relocatedMainAgentDir = path.join(tempRoot, "relocated-main-agent");
+    const childAgentDir = path.join(stateDir, "agents", "telegram", "agent");
+    const env = {
+      ...process.env,
+      OPENCLAW_AGENT_DIR: relocatedMainAgentDir,
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    await writeRawAuthStore(
+      relocatedMainAgentDir,
+      storeWith(
+        profileId,
+        oauthCredential({
+          access: "main-access",
+          refresh: "main-refresh",
+          expires: now + 60 * 60 * 1000,
+          accountId: "acct-shared",
+        }),
+      ),
+    );
+    await writeRawAuthStore(
+      childAgentDir,
+      storeWith(
+        profileId,
+        oauthCredential({
+          access: "child-access",
+          refresh: "child-refresh",
+          expires: now - 60_000,
+          accountId: "acct-shared",
+        }),
+      ),
+    );
+
+    const result = await repairStaleOAuthProfileShadows({
+      cfg: { agents: { entries: { telegram: { default: true } } } } satisfies OpenClawConfig,
+      env,
+      now,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(1);
+    expect(loadPersistedAuthProfileStore(childAgentDir)?.profiles[profileId]).toBeUndefined();
   });
 
   it("leaves legacy sidecar-backed OAuth profiles for the sidecar migration repair", async () => {

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
@@ -15,11 +15,11 @@ import {
 } from "../../../agents/auth-profiles/oauth-shared.js";
 import { resolveAuthStorePath } from "../../../agents/auth-profiles/paths.js";
 import { loadPersistedAuthProfileStore } from "../../../agents/auth-profiles/persisted.js";
+import { resolveSharedMainAuthAgentDir } from "../../../agents/auth-profiles/shared-main-dir.js";
 import { updateAuthProfileStoreWithLock } from "../../../agents/auth-profiles/store.js";
 import type { AuthProfileStore, OAuthCredential } from "../../../agents/auth-profiles/types.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { LEGACY_IMPLICIT_AGENT_ID } from "../../../routing/session-key.js";
 import { shortenHomePath } from "../../../utils.js";
 
 type StaleOAuthProfileShadow = {
@@ -113,7 +113,7 @@ export async function scanStaleOAuthProfileShadows(params: {
 }): Promise<StaleOAuthProfileShadow[]> {
   const env = params.env ?? process.env;
   const now = params.now ?? Date.now();
-  const mainAgentDir = path.join(resolveStateDir(env), "agents", LEGACY_IMPLICIT_AGENT_ID, "agent");
+  const mainAgentDir = resolveSharedMainAuthAgentDir(env);
   const mainAuthPath = path.resolve(resolveAuthStorePath(mainAgentDir));
   const mainStore = loadPersistedAuthProfileStore(mainAgentDir);
   if (!mainStore) {
@@ -294,9 +294,7 @@ export async function repairStaleOAuthProfileShadows(params: {
     byAgentDir.set(hit.agentDir, existing);
   }
   for (const [agentDir, agentHits] of byAgentDir) {
-    const mainStore = loadPersistedAuthProfileStore(
-      path.join(resolveStateDir(env), "agents", LEGACY_IMPLICIT_AGENT_ID, "agent"),
-    );
+    const mainStore = loadPersistedAuthProfileStore(resolveSharedMainAuthAgentDir(env));
     if (!mainStore) {
       continue;
     }

--- a/src/config/sessions/targets-collision.ts
+++ b/src/config/sessions/targets-collision.ts
@@ -46,7 +46,7 @@ export function dedupeSessionStoreTargetsBySqliteTarget(
   const registeredDatabases = listOpenClawRegisteredAgentDatabases({ env: options.env });
   const grouped = new Map<
     string,
-    Array<{ target: SessionStoreTarget; databaseOwnerAgentId?: string }>
+    Array<{ target: SessionStoreTarget; databaseOwnerAgentId?: string; shared: boolean }>
   >();
   const logicalGroups = new Map<
     string,
@@ -73,6 +73,7 @@ export function dedupeSessionStoreTargetsBySqliteTarget(
     const group = grouped.get(sqlitePath) ?? [];
     group.push({
       target,
+      shared: resolved.shared === true,
       ...(resolved.agentId ? { databaseOwnerAgentId: normalizeAgentId(resolved.agentId) } : {}),
     });
     grouped.set(sqlitePath, group);
@@ -155,11 +156,19 @@ export function dedupeSessionStoreTargetsBySqliteTarget(
         registeredOwners[0] ??
         (collision ? options.defaultAgentId : group[0]!.target.agentId),
     );
-    const selected = byAgentId.get(ownerAgentId);
+    const ownerTarget = byAgentId.get(ownerAgentId);
+    // An exact shared database can outlive its schema owner's roster entry. Keep one
+    // configured claimant so the accessor can reopen the path under its durable owner.
+    const selected =
+      ownerTarget ??
+      (group.some((entry) => entry.shared)
+        ? (byAgentId.get(normalizeAgentId(options.defaultAgentId)) ?? group[0]?.target)
+        : undefined);
     if (selected) {
       deduped.push(selected);
     }
-    const ignoredAgentIds = [...byAgentId.keys()].filter((agentId) => agentId !== ownerAgentId);
+    const selectedAgentId = selected ? normalizeAgentId(selected.agentId) : ownerAgentId;
+    const ignoredAgentIds = [...byAgentId.keys()].filter((agentId) => agentId !== selectedAgentId);
     if (!selected || ignoredAgentIds.length > 0) {
       const effectiveIgnoredAgentIds = selected ? ignoredAgentIds : [...byAgentId.keys()];
       const diagnostic: SessionStoreTargetCollisionDiagnostic = {

--- a/src/config/sessions/targets.test.ts
+++ b/src/config/sessions/targets.test.ts
@@ -370,6 +370,44 @@ describe("resolveSessionStoreTargets", () => {
     },
   );
 
+  it("retains a shared-store claimant when the physical owner left the roster", async () => {
+    await withTempHome(async (home) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(home, ".openclaw") };
+      const storePath = path.join(home, "shared.sqlite");
+      await replaceSessionEntry(
+        {
+          agentId: "main",
+          defaultAgentId: "main",
+          env,
+          storePath,
+          sessionKey: "agent:main:main",
+        },
+        { sessionId: "main-session", updatedAt: 1 },
+      );
+      await replaceSessionEntry(
+        {
+          agentId: "ops",
+          defaultAgentId: "main",
+          env,
+          storePath,
+          sessionKey: "agent:ops:main",
+        },
+        { sessionId: "ops-session", updatedAt: 2 },
+      );
+      const cfg: OpenClawConfig = {
+        session: { store: storePath },
+        agents: { entries: { ops: { default: true } } },
+      };
+
+      expect(resolveSessionStoreTargets(cfg, { allAgents: true }, { env })).toEqual([
+        { agentId: "ops", storePath },
+      ]);
+      expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "ops", { env })).toEqual([
+        { agentId: "ops", storePath },
+      ]);
+    });
+  });
+
   it("honors a registered owner over the configured default for a fixed-store collision", async () => {
     await withTempHome(async (home) => {
       const stateDir = path.join(home, ".openclaw");

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -74,14 +74,8 @@ function areAsciiCaseVariants(left: string | undefined, right: string | undefine
 }
 
 function shouldProbeUnicodeCaseVariants(left: string, right: string): boolean {
-  const hasNonAscii = (value: string) => {
-    for (let index = 0; index < value.length; index += 1) {
-      if (value.charCodeAt(index) > 0x7f) {
-        return true;
-      }
-    }
-    return false;
-  };
+  const hasNonAscii = (value: string) =>
+    value.split("").some((character) => character.charCodeAt(0) > 0x7f);
   if (!hasNonAscii(left) && !hasNonAscii(right)) {
     return false;
   }

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -73,6 +73,24 @@ function areAsciiCaseVariants(left: string | undefined, right: string | undefine
   return left !== undefined && right !== undefined && foldAsciiCase(left) === foldAsciiCase(right);
 }
 
+function shouldProbeUnicodeCaseVariants(left: string, right: string): boolean {
+  if (!/[^\x00-\x7F]/u.test(`${left}${right}`)) {
+    return false;
+  }
+  const lowercaseEquivalent = left.toLowerCase() === right.toLowerCase();
+  const uppercaseEquivalent = left.toUpperCase() === right.toUpperCase();
+  if (!lowercaseEquivalent && !uppercaseEquivalent) {
+    return false;
+  }
+  // Keep dotted-I expansions distinct even on filesystems that collapse them.
+  // That existing isolation contract avoids locale-sensitive owner aliasing.
+  return !(
+    Array.from(left).length !== Array.from(right).length &&
+    lowercaseEquivalent &&
+    !uppercaseEquivalent
+  );
+}
+
 function isWindowsReservedPathComponent(value: string): boolean {
   const stem = value
     .split(".", 1)[0]!
@@ -282,9 +300,6 @@ function areMissingSuffixAliases(params: {
   if (params.left === params.right) {
     return true;
   }
-  if (!areAsciiCaseVariants(params.left.normalize("NFC"), params.right.normalize("NFC"))) {
-    return false;
-  }
   const leftSegments = params.left.split(path.sep);
   const rightSegments = params.right.split(path.sep);
   if (
@@ -318,11 +333,6 @@ function areMissingSuffixAliases(params: {
       const rightSegment = rightSegments[index]!;
       const normalizedLeft = leftSegment.normalize("NFC");
       const normalizedRight = rightSegment.normalize("NFC");
-      if (!areAsciiCaseVariants(normalizedLeft, normalizedRight)) {
-        missingSuffixAliasCache.set(cacheKey, false);
-        return false;
-      }
-
       const availableProbeNameLength =
         maxProbePathLength - probeParent.length - (probeParent.endsWith(path.sep) ? 0 : 1);
       const componentProbeNameLength = Math.max(
@@ -333,9 +343,30 @@ function areMissingSuffixAliases(params: {
 
       let nextProbeParent: string | undefined;
       if (normalizedLeft !== normalizedRight) {
+        // Case and normalization are independent gates. A synthetic ASCII case
+        // probe here never bypasses the raw-spelling normalization probe below.
+        let caseProbeParent = probeParent;
+        let caseProbePairs = createAsciiCaseProbePairs(componentProbeNameLength, forbiddenNames);
+        if (!areAsciiCaseVariants(normalizedLeft, normalizedRight)) {
+          if (!shouldProbeUnicodeCaseVariants(normalizedLeft, normalizedRight)) {
+            missingSuffixAliasCache.set(cacheKey, false);
+            return false;
+          }
+          const privateParent = createNeutralProbeDirectory({
+            parentPath: probeParent,
+            createdPaths,
+            forbiddenNames,
+            nameLength: componentProbeNameLength,
+          });
+          if (!privateParent) {
+            return true;
+          }
+          caseProbeParent = privateParent;
+          caseProbePairs = [[leftSegment, rightSegment]];
+        }
         const caseProbe = createDirectoryAliasProbe({
-          parentPath: probeParent,
-          pairs: createAsciiCaseProbePairs(componentProbeNameLength, forbiddenNames),
+          parentPath: caseProbeParent,
+          pairs: caseProbePairs,
           createdPaths,
         });
         if (!caseProbe) {

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -74,7 +74,15 @@ function areAsciiCaseVariants(left: string | undefined, right: string | undefine
 }
 
 function shouldProbeUnicodeCaseVariants(left: string, right: string): boolean {
-  if (!/[^\x00-\x7F]/u.test(`${left}${right}`)) {
+  const hasNonAscii = (value: string) => {
+    for (let index = 0; index < value.length; index += 1) {
+      if (value.charCodeAt(index) > 0x7f) {
+        return true;
+      }
+    }
+    return false;
+  };
+  if (!hasNonAscii(left) && !hasNonAscii(right)) {
     return false;
   }
   const lowercaseEquivalent = left.toLowerCase() === right.toLowerCase();

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -1794,6 +1794,100 @@ describe("openclaw agent database", () => {
     },
   );
 
+  it("matches volume semantics for non-ASCII case aliases", () => {
+    const stateDir = fs.realpathSync(createTempStateDir());
+    const upperPath = path.join(stateDir, "É.sqlite");
+    const lowerPath = path.join(stateDir, "é.sqlite");
+    fs.writeFileSync(upperPath, "probe");
+    let aliases = false;
+    try {
+      const upperStat = fs.lstatSync(upperPath, { bigint: true });
+      const lowerStat = fs.lstatSync(lowerPath, { bigint: true });
+      aliases = upperStat.dev === lowerStat.dev && upperStat.ino === lowerStat.ino;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    } finally {
+      fs.unlinkSync(upperPath);
+    }
+
+    expect(isSameOpenClawAgentDatabasePath(upperPath, lowerPath)).toBe(aliases);
+  });
+
+  it("matches volume semantics for Unicode simple case-fold aliases", () => {
+    const stateDir = fs.realpathSync(createTempStateDir());
+    const sigmaPath = path.join(stateDir, "σ.sqlite");
+    const finalSigmaPath = path.join(stateDir, "ς.sqlite");
+    fs.writeFileSync(sigmaPath, "probe");
+    let aliases = false;
+    try {
+      const sigmaStat = fs.lstatSync(sigmaPath, { bigint: true });
+      const finalSigmaStat = fs.lstatSync(finalSigmaPath, { bigint: true });
+      aliases = sigmaStat.dev === finalSigmaStat.dev && sigmaStat.ino === finalSigmaStat.ino;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    } finally {
+      fs.unlinkSync(sigmaPath);
+    }
+
+    expect(isSameOpenClawAgentDatabasePath(sigmaPath, finalSigmaPath)).toBe(aliases);
+  });
+
+  it("does not probe unrelated Unicode spellings as case aliases", () => {
+    const stateDir = fs.realpathSync(createTempStateDir());
+    expect(
+      isSameOpenClawAgentDatabasePath(
+        path.join(stateDir, "猫.sqlite"),
+        path.join(stateDir, "犬.sqlite"),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps case and normalization semantics distinct for missing aliases", () => {
+    const stateDir = fs.realpathSync(createTempStateDir());
+    const composedUpperPath = path.join(stateDir, "É.sqlite");
+    const decomposedLowerPath = path.join(stateDir, "é.sqlite");
+    fs.writeFileSync(composedUpperPath, "probe");
+    let aliases = false;
+    try {
+      const upperStat = fs.lstatSync(composedUpperPath, { bigint: true });
+      const lowerStat = fs.lstatSync(decomposedLowerPath, { bigint: true });
+      aliases = upperStat.dev === lowerStat.dev && upperStat.ino === lowerStat.ino;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    } finally {
+      fs.unlinkSync(composedUpperPath);
+    }
+
+    expect(isSameOpenClawAgentDatabasePath(composedUpperPath, decomposedLowerPath)).toBe(aliases);
+  });
+
+  it("requires raw normalization after an ASCII-only case difference", () => {
+    const stateDir = fs.realpathSync(createTempStateDir());
+    const composedUpperPath = path.join(stateDir, "ÉA.sqlite");
+    const decomposedMixedPath = path.join(stateDir, "Éa.sqlite");
+    fs.writeFileSync(composedUpperPath, "probe");
+    let aliases = false;
+    try {
+      const upperStat = fs.lstatSync(composedUpperPath, { bigint: true });
+      const mixedStat = fs.lstatSync(decomposedMixedPath, { bigint: true });
+      aliases = upperStat.dev === mixedStat.dev && upperStat.ino === mixedStat.ino;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    } finally {
+      fs.unlinkSync(composedUpperPath);
+    }
+
+    expect(isSameOpenClawAgentDatabasePath(composedUpperPath, decomposedMixedPath)).toBe(aliases);
+  });
+
   it.runIf(tempVolumeIsCaseInsensitive)(
     "matches nested missing aliases using exact component case semantics",
     () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where operators using `OPENCLAW_AGENT_DIR` could have live shared-main credentials omitted by Doctor repairs, and where sessions in a shared exact SQLite store could disappear from all-agent discovery after its physical owner left the roster. It also prevents case-insensitive filesystems from registering Unicode case aliases such as `É.sqlite` and `é.sqlite` as separate agent databases.

## Why This Change Was Made

Shared-main auth directory resolution now has one env-aware owner used by both runtime path APIs and Doctor diagnostics. Shared exact-store deduplication retains a configured logical claimant even when the durable schema owner is no longer configured, while SQLite access still resolves that physical owner. Missing database paths use candidate-aware Unicode case probes, with independent normalization checks and the existing dotted-I isolation contract.

## User Impact

Relocated auth stores remain visible to `openclaw doctor --fix`, valid `auth.order` entries are preserved, retired physical owners no longer hide surviving agents' shared sessions, and database ownership stays isolated on case-insensitive Unicode filesystems. No operator action is required.

## Evidence

- Four full affected Vitest files on Blacksmith Testbox: 180 passed, 6 platform skips.
- `node scripts/check-changed.mjs` on all 11 touched files: passed in 17m14s, including core/core-test typechecks, full core lint, SDK boundaries, database-first guards, and import-cycle checks.
- Final branch-scoped Codex autoreview: clean, no accepted/actionable findings.
- Regression coverage includes relocated shared-main auth order repair, relocated OAuth shadow repair, shared-store discovery after `main` leaves the roster, composed/decomposed Unicode cases, sigma/final-sigma folding, unrelated Unicode spellings, dotted-I isolation, and combined case-plus-normalization behavior.

## ClawSweeper Rank-up Moves

The exact-head ClawSweeper workflow completed successfully, but its durable comment remained at the `review started` placeholder and published no rank-up moves. There were therefore no moves to apply or skip; this is recorded here so the landing does not pass the review surface silently.
