### PR TITLE
fix(slack): seed outbound-only thread context

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -14,6 +14,7 @@ import {
 
 describe("resolveSlackThreadContextData", () => {
   const storeFixture = createSlackSessionStoreFixture("openclaw-slack-thread-context-");
+  const threadSessionKey = "agent:main:slack:channel:c123:thread:100.000";
 
   beforeAll(() => {
     storeFixture.setup();
@@ -62,6 +63,7 @@ describe("resolveSlackThreadContextData", () => {
     allowFromLower: string[];
     allowNameMatching: boolean;
     sessionState?: "missing" | "fresh" | "stale";
+    sessionLastInteractionAt?: number;
   }) {
     const { storePath } = storeFixture.makeTmpStorePath();
     const replies = vi.fn().mockResolvedValue({
@@ -73,7 +75,17 @@ describe("resolveSlackThreadContextData", () => {
       ctx.channelRuntime = {
         ...ctx.channelRuntime!,
         session: {
-          resolveEntryResetFreshness: () => ({ state: params.sessionState }),
+          resolveEntryResetFreshness: () =>
+            params.sessionState === "missing"
+              ? { state: "missing", entry: undefined }
+              : {
+                  state: params.sessionState,
+                  entry: {
+                    ...(params.sessionLastInteractionAt !== undefined
+                      ? { lastInteractionAt: params.sessionLastInteractionAt }
+                      : {}),
+                  },
+                },
         },
       };
     }
@@ -92,7 +104,7 @@ describe("resolveSlackThreadContextData", () => {
       threadStarter: params.threadStarter,
       roomLabel: "#general",
       storePath,
-      sessionKey: "thread-session",
+      sessionKey: threadSessionKey,
       allowFromLower: params.allowFromLower,
       allowNameMatching: params.allowNameMatching,
       contextVisibilityMode: "allowlist",
@@ -128,14 +140,20 @@ describe("resolveSlackThreadContextData", () => {
     {
       title: "does not hydrate starter media for an existing thread session",
       sessionState: "fresh" as const,
+      sessionLastInteractionAt: 100,
       hydrates: false,
+    },
+    {
+      title: "hydrates starter media for an outbound-only thread session",
+      sessionState: "fresh" as const,
+      hydrates: true,
     },
     {
       title: "hydrates starter media after a thread session reset",
       sessionState: "stale" as const,
       hydrates: true,
     },
-  ])("$title", async ({ sessionState, hydrates }) => {
+  ])("$title", async ({ sessionState, sessionLastInteractionAt, hydrates }) => {
     const resolveSlackMedia = vi
       .spyOn(mediaModule, "resolveSlackMedia")
       .mockResolvedValue(starterMedia);
@@ -145,10 +163,38 @@ describe("resolveSlackThreadContextData", () => {
       allowFromLower: ["u1"],
       allowNameMatching: false,
       sessionState,
+      sessionLastInteractionAt,
     });
 
     expect(result.threadStarterMedia).toEqual(hydrates ? starterMedia : null);
     expect(resolveSlackMedia).toHaveBeenCalledTimes(hydrates ? 1 : 0);
+  });
+
+  it("hydrates the visible conversation for an outbound-only thread session", async () => {
+    const { replies, result } = await resolveAllowlistedThreadContext({
+      repliesMessages: [
+        { text: "starter from Alice", user: "U1", ts: "100.000" },
+        { text: "assistant answer", bot_id: "B1", ts: "100.200" },
+        { text: "untagged follow-up", user: "U1", ts: "100.800" },
+        { text: "current message", user: "U1", ts: "101.000" },
+      ],
+      threadStarter: {
+        text: "starter from Alice",
+        userId: "U1",
+        ts: "100.000",
+      },
+      allowFromLower: ["u1"],
+      allowNameMatching: false,
+      sessionState: "fresh",
+    });
+
+    expect(result.shouldSeedInitialThreadContext).toBe(true);
+    expect(result.threadStarterBody).toBe("starter from Alice");
+    expect(result.threadHistoryBody).toContain("starter from Alice");
+    expect(result.threadHistoryBody).toContain("untagged follow-up");
+    expect(result.threadHistoryBody).not.toContain("assistant answer");
+    expect(result.threadHistoryBody).not.toContain("current message");
+    expect(replies).toHaveBeenCalledTimes(1);
   });
 
   it("omits non-allowlisted starter, follow-ups, and unrelated current-bot replies", async () => {
@@ -294,7 +340,7 @@ describe("resolveSlackThreadContextData", () => {
       },
       roomLabel: "#general",
       storePath,
-      sessionKey: "thread-session",
+      sessionKey: threadSessionKey,
       allowFromLower: ["u1"],
       allowNameMatching: false,
       contextVisibilityMode: "allowlist",
@@ -340,7 +386,7 @@ describe("resolveSlackThreadContextData", () => {
       },
       roomLabel: "#general",
       storePath,
-      sessionKey: "thread-session",
+      sessionKey: threadSessionKey,
       allowFromLower: ["u1"],
       allowNameMatching: false,
       contextVisibilityMode: "allowlist",
@@ -464,7 +510,7 @@ describe("resolveSlackThreadContextData", () => {
       },
       roomLabel: "DM",
       storePath,
-      sessionKey: "thread-session",
+      sessionKey: threadSessionKey,
       allowFromLower: [],
       allowNameMatching: false,
       contextVisibilityMode: "all",

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -43,9 +43,17 @@ type SlackThreadContextData = {
 
 const SLACK_THREAD_CONTEXT_USER_LOOKUP_CONCURRENCY = 4;
 
-type SlackSessionResetFreshness = {
-  state: "missing" | "fresh" | "stale";
-};
+type SlackSessionResetFreshness =
+  | {
+      state: "missing";
+      entry: undefined;
+    }
+  | {
+      state: "fresh" | "stale";
+      entry: {
+        lastInteractionAt?: number;
+      };
+    };
 
 type SlackSessionFreshnessRuntime = {
   session?: {
@@ -188,11 +196,14 @@ export async function resolveSlackThreadContextData(params: {
           sessionKey: params.sessionKey,
         })
       : undefined;
+  // Outbound delivery mirroring can create a fresh thread session before its
+  // first inbound turn. Seed that session or the root conversation is lost.
   const shouldSeedInitialThreadContext = Boolean(
     params.isThreadReply &&
     params.threadTs &&
     (threadSessionFreshness
-      ? threadSessionFreshness.state !== "fresh"
+      ? threadSessionFreshness.state !== "fresh" ||
+        threadSessionFreshness.entry.lastInteractionAt === undefined
       : threadSessionPreviousTimestamp === undefined),
   );
   const shouldLoadInitialThreadHistory =


### PR DESCRIPTION
## Summary

- treat a fresh Slack thread session with no inbound interaction as uninitialized
- seed the bounded, visible thread root, prior human context, and starter media on the first inbound turn after an outbound delivery mirror
- add regression coverage for outbound-only thread sessions and use canonical Slack session keys in the affected tests

## Root cause

When OpenClaw sends into a Slack thread through outbound delivery, delivery mirroring can create the thread session before the first human follow-up. The thread-context freshness check treated that entry as an established fresh session based only on its reset state, so it skipped initial thread hydration.

Slack's thread-participation routing can correctly promote the untagged follow-up to a user request, but the model then receives a new thread session without the visible root or preceding human context.

## User impact

Bot-participating Slack threads keep the context users can see in Slack when the first follow-up arrives without an explicit mention. Existing sessions that already have an inbound interaction remain unchanged. Existing allowlist and context-visibility filtering still applies, and prior bot output/current-message duplication remains excluded.

## Validation

- reproduced the regression on current `main`: the outbound-only case returned `shouldSeedInitialThreadContext=false`
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts` — 16/16 passed after the fix
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` — passed
- `git diff --check origin/main...HEAD` — passed