### PR TITLE
fix(cron): close browser tabs after isolated runs

### DIFF
--- a/src/cron/isolated-agent/run.session-key-isolation.test.ts
+++ b/src/cron/isolated-agent/run.session-key-isolation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
+  cleanupBrowserSessionsForLifecycleEndMock,
   isCliProviderMock,
   loadSessionEntryMock,
   loadRunCronIsolatedAgentTurn,
@@ -76,6 +77,12 @@ describe("runCronIsolatedAgentTurn isolated session identity", () => {
     expect(runRequest.promptCacheKey).not.toContain("daily-monitor");
     expect(runRequest.bootstrapContextMode).toBe("lightweight");
     expect(runRequest.bootstrapContextRunKind).toBe("cron");
+    expect(cleanupBrowserSessionsForLifecycleEndMock).toHaveBeenCalledOnce();
+    expect(cleanupBrowserSessionsForLifecycleEndMock).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      sessionKeys: ["agent:default:cron:daily-monitor:run:isolated-run-1"],
+      onWarn: expect.any(Function),
+    });
     const embeddedRunOrder = runEmbeddedAgentMock.mock.invocationCallOrder[0];
     if (embeddedRunOrder === undefined) {
       throw new Error("Expected embedded cron execution order");

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -97,6 +97,7 @@ export const resolveSessionAuthProfileOverrideMock = createMock();
 export const resolveFastModeStateMock = createMock();
 export const getChannelPluginMock = createMock();
 export const retireSessionMcpRuntimeMock = createMock();
+export const cleanupBrowserSessionsForLifecycleEndMock = createMock();
 export const callGatewayMock = createMock();
 export const ensureRuntimePluginsLoadedMock = createMock();
 export const hasUsableWebSearchProviderMock = createMock();
@@ -353,6 +354,10 @@ vi.mock("../../agents/cli-runner.runtime.js", () => ({
 
 vi.mock("../../agents/agent-bundle-mcp-tools.js", () => ({
   retireSessionMcpRuntime: retireSessionMcpRuntimeMock,
+}));
+
+vi.mock("../../browser-lifecycle-cleanup.js", () => ({
+  cleanupBrowserSessionsForLifecycleEnd: cleanupBrowserSessionsForLifecycleEndMock,
 }));
 
 vi.mock("../../gateway/call.runtime.js", () => ({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -12,6 +12,7 @@ import { expandToolGroups, normalizeToolName } from "../../agents/tool-policy.js
 import { deriveContextPromptTokens } from "../../agents/usage.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { HEARTBEAT_TOKEN, isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
+import { cleanupBrowserSessionsForLifecycleEnd } from "../../browser-lifecycle-cleanup.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -1953,6 +1954,12 @@ export async function runCronIsolatedAgentTurn(params: {
         });
       } finally {
         prepared.context.sessionWorkAdmission.release();
+        // Browser ownership follows the detached run identity, not the stable cron job key.
+        await cleanupBrowserSessionsForLifecycleEnd({
+          cfg: prepared.context.cfgWithAgentDefaults,
+          sessionKeys: [prepared.context.runSessionKey],
+          onWarn: (message) => logWarn(`[cron:${params.job.id}] ${message}`),
+        });
       }
     }
   }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -27,7 +27,6 @@ const {
   fetchWithSsrFGuardMock,
   sendCronAnnouncePayloadStrictMock,
   runCronIsolatedAgentTurnMock,
-  cleanupBrowserSessionsForLifecycleEndMock,
   getGlobalHookRunnerMock,
   runCronChangedMock,
   abortAndDrainEmbeddedAgentRunMock,
@@ -52,7 +51,6 @@ const {
     status: "ok",
     summary: "ok",
   })),
-  cleanupBrowserSessionsForLifecycleEndMock: vi.fn(async () => {}),
   runCronChangedMock: vi.fn(async (_event: unknown, _context?: unknown) => {}),
   getGlobalHookRunnerMock: vi.fn(() => ({
     hasHooks: (hookName: string) => hookName === "cron_changed",
@@ -193,10 +191,6 @@ vi.mock("../cron/isolated-agent.js", () => ({
   runCronIsolatedAgentTurn: runCronIsolatedAgentTurnMock,
 }));
 
-vi.mock("../browser-lifecycle-cleanup.js", () => ({
-  cleanupBrowserSessionsForLifecycleEnd: cleanupBrowserSessionsForLifecycleEndMock,
-}));
-
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: getGlobalHookRunnerMock,
 }));
@@ -321,16 +315,6 @@ function expectIsolatedRunFields(fields: Record<string, unknown>) {
   return options;
 }
 
-function expectCleanupForSessionKeys(sessionKeys: string[]) {
-  expect(cleanupBrowserSessionsForLifecycleEndMock).toHaveBeenCalledTimes(1);
-  const options = requireRecord(
-    callArg(cleanupBrowserSessionsForLifecycleEndMock, 0, 0, "cleanup options"),
-    "cleanup options",
-  );
-  expect(options.sessionKeys).toEqual(sessionKeys);
-  expect(options.onWarn).toBeTypeOf("function");
-}
-
 describe("buildGatewayCronService", () => {
   beforeEach(() => {
     resetActiveCronTaskRunsForTests();
@@ -342,7 +326,6 @@ describe("buildGatewayCronService", () => {
     fetchWithSsrFGuardMock.mockClear();
     sendCronAnnouncePayloadStrictMock.mockClear();
     runCronIsolatedAgentTurnMock.mockClear();
-    cleanupBrowserSessionsForLifecycleEndMock.mockClear();
     runCronChangedMock.mockClear();
     getGlobalHookRunnerMock.mockClear();
     abortAndDrainEmbeddedAgentRunMock.mockClear();
@@ -2563,7 +2546,6 @@ describe("buildGatewayCronService", () => {
 
       const options = expectIsolatedRunFields({ sessionKey });
       expect(requireRecord(options.job, "isolated job").id).toBe(job.id);
-      expectCleanupForSessionKeys([sessionKey]);
     } finally {
       state.cron.stop();
     }
@@ -2604,7 +2586,6 @@ describe("buildGatewayCronService", () => {
           return record.sessionKey === "main";
         }),
       ).toBe(false);
-      expectCleanupForSessionKeys([`cron:${job.id}`]);
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -5,7 +5,6 @@ import { isAgentDeletionBlocked } from "../agents/agent-lifecycle-registry.js";
 import { listAgentEntries, listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-import { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { getRuntimeConfig } from "../config/io.js";
 import {
@@ -721,26 +720,19 @@ export function buildGatewayCronService(params: {
     }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       const sessionKey = resolveCronSessionTargetSessionKey(job.sessionTarget) ?? `cron:${job.id}`;
-      try {
-        return await runCronIsolatedAgentTurn({
-          cfg: runtimeConfig,
-          deps: params.deps,
-          job,
-          message,
-          abortSignal,
-          onExecutionStarted,
-          onExecutionPhase,
-          onLaneWait,
-          agentId,
-          sessionKey,
-          lane: "cron",
-        });
-      } finally {
-        await cleanupBrowserSessionsForLifecycleEnd({
-          sessionKeys: [sessionKey],
-          onWarn: (msg) => cronLogger.warn({ jobId: job.id }, msg),
-        });
-      }
+      return await runCronIsolatedAgentTurn({
+        cfg: runtimeConfig,
+        deps: params.deps,
+        job,
+        message,
+        abortSignal,
+        onExecutionStarted,
+        onExecutionPhase,
+        onLaneWait,
+        agentId,
+        sessionKey,
+        lane: "cron",
+      });
     },
     runCommandJob: async ({ job, abortSignal }) => {
       const result = await runCronCommandJob({


### PR DESCRIPTION
## What problem does this solve?

Isolated cron and hook agent runs could leave browser tabs open after completion. Browser tabs are owned by the canonical run-scoped session key, while gateway cron cleanup used the stable job key. The exact-key lookup therefore missed every detached run. Hook-triggered isolated runs bypassed that gateway wrapper entirely.

Closes #113564.

## How does this solve it?

- Move browser cleanup to `runCronIsolatedAgentTurn`, the lifecycle owner shared by scheduled and hook-triggered isolated runs.
- Clean the canonical `runSessionKey` in the existing final cleanup path, covering success, error, and timeout exits.
- Remove the gateway-only wrapper and its tests so ownership is expressed once.
- Add a regression assertion for the exact detached run key.

## User impact

Browser tabs opened by isolated scheduled or hook agent runs now close when the run ends instead of accumulating across runs.

## Real behavior proof

Redacted transcript from a disposable Docker gateway built from exact rebased head `59c9caac14cd55029d3d6904034d2965108062d1`. It used isolated state and browser data; no production deployment or live-state mutation.

<details>
<summary>Scheduled isolated cron run</summary>

```text
baseline: browser tabs=0
run: model=openai/gpt-5.6-sol, sessionTarget=isolated
during run:
  title="Example Domain"
  url="https://example.com/?openclaw-proof=cron-113566-rebase"
terminal:
  status="ok"
  summary="CRON_REBASE_PROOF_DONE"
  sessionKey="agent:main:cron:<job>:run:<session>"
after run:
  browser tabs=0
  matching proof tabs=0
  browser.session-tabs rows=0
```

</details>

<details>
<summary>Hook-triggered isolated run</summary>

```text
POST /hooks/agent -> {"ok":true,"runId":"<redacted>"}
during run:
  title="Example Domain"
  url="https://example.com/?openclaw-proof=hook-113566-rebase"
  durable owner="agent:main:cron:<hook-job>:run:<session>"
gateway log: "hook agent run completed without announcement"
after run:
  matching proof tabs=0
  browser.session-tabs rows=0
```

</details>

## Validation

- Regression test failed before the fix: browser cleanup received zero calls.
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.session-key-isolation.test.ts src/gateway/server-cron.test.ts src/browser-lifecycle-cleanup.test.ts` — 71 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed` — passed (`core`, `coreTests`; includes formatting, lint, both core typechecks, API/boundary guards, and import-cycle checks).
- Autoreview secret scan — clean. Local AI review engine unavailable; independent PR review requested from ClawSweeper.

AI-assisted: Codex investigated the production symptom, implemented the fix, and ran validation; the diff and tests were manually inspected.
