### PR TITLE
test: consolidate Slack and QMD matrices

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -973,6 +973,160 @@ describe("QmdMemoryManager", () => {
     return { manager: requireValue(manager, "manager missing"), resolved };
   }
 
+  function createAbortChildHarness() {
+    let child: MockChild | undefined;
+    let kill: ReturnType<typeof vi.fn> | undefined;
+
+    return {
+      createChild(): MockChild {
+        const current = createMockChild({ autoClose: false });
+        const currentKill = vi.fn(() => {
+          // Closing only after SIGKILL proves the caller abort reached this child.
+          queueMicrotask(() => current.emit("close", null));
+          return true;
+        });
+        Object.assign(current, { kill: currentKill });
+        child ??= current;
+        kill ??= currentKill;
+        return current;
+      },
+      async waitForSpawn(): Promise<void> {
+        await waitUntil(() => kill !== undefined);
+      },
+      expectKilled(): void {
+        expect(child).toBeDefined();
+        expect(kill).toHaveBeenCalledWith("SIGKILL");
+      },
+    };
+  }
+
+  type AbortSearchScenario = {
+    name: string;
+    qmd: QmdTestConfig | (() => QmdTestConfig);
+    isTarget: (cmd: string, args: string[]) => boolean;
+    preAborted?: boolean;
+    outputFor?: (
+      cmd: string,
+      args: string[],
+    ) => { stream: "stdout" | "stderr"; data: string; code?: number } | undefined;
+    neverSpawns?: (cmd: string, args: string[]) => boolean;
+  };
+
+  async function runAbortSearchScenario(scenario: AbortSearchScenario): Promise<void> {
+    configureQmd(typeof scenario.qmd === "function" ? scenario.qmd() : scenario.qmd);
+    const abortChild = createAbortChildHarness();
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      if (scenario.isTarget(cmd, args)) {
+        return abortChild.createChild();
+      }
+      const output = scenario.outputFor?.(cmd, args);
+      if (output) {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, output.stream, output.data, output.code);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const controller = new AbortController();
+    if (scenario.preAborted) {
+      controller.abort(new Error("memory_search timed out after 15s"));
+    }
+    const targetCallsBefore = spawnMock.mock.calls.filter((call: unknown[]) =>
+      scenario.isTarget(String(call[0]), call[1] as string[]),
+    ).length;
+    const searchPromise = manager.search("test", {
+      sessionKey: "agent:main:slack:dm:u123",
+      signal: controller.signal,
+    });
+    searchPromise.catch(() => undefined);
+
+    if (scenario.preAborted) {
+      await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
+      const targetCallsAfter = spawnMock.mock.calls.filter((call: unknown[]) =>
+        scenario.isTarget(String(call[0]), call[1] as string[]),
+      ).length;
+      expect(targetCallsAfter).toBe(targetCallsBefore);
+      await manager.close();
+      return;
+    }
+
+    await abortChild.waitForSpawn();
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
+    abortChild.expectKilled();
+    if (scenario.neverSpawns) {
+      expect(
+        spawnMock.mock.calls.some((call: unknown[]) =>
+          scenario.neverSpawns?.(String(call[0]), call[1] as string[]),
+        ),
+      ).toBe(false);
+    }
+    await manager.close();
+  }
+
+  type QmdCommandMatrixScenario = {
+    name: string;
+    configure: () => void | Promise<void>;
+    supportsMultiCollection?: boolean;
+    rejectSearchFlags?: boolean;
+    expectedCommands: (maxResults: number) => string[][];
+  };
+
+  function qmdQueryArgs(
+    command: "query" | "search",
+    maxResults: number,
+    ...collections: string[]
+  ): string[] {
+    return [
+      command,
+      "test",
+      "--json",
+      "-n",
+      String(maxResults),
+      ...collections.flatMap((collection) => ["-c", collection]),
+    ];
+  }
+
+  async function runQmdCommandMatrixScenario(scenario: QmdCommandMatrixScenario): Promise<void> {
+    await scenario.configure();
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "--help" && scenario.supportsMultiCollection) {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          "-c, --collection <name>    Filter by one or more collections",
+        );
+        return child;
+      }
+      if (args[0] === "search" && scenario.rejectSearchFlags) {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stderr", "unknown flag: --json", 2);
+        return child;
+      }
+      if (args[0] === "search" || args[0] === "query") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager, resolved } = await createManager();
+    const maxResults = requireValue(resolved.qmd?.limits.maxResults, "qmd maxResults missing");
+    await expect(
+      manager.search("test", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).resolves.toStrictEqual([]);
+    const commandCalls = qmdCommandCalls().filter(
+      (args) => args[0] === "search" || args[0] === "query",
+    );
+    expect(commandCalls).toEqual(scenario.expectedCommands(maxResults));
+    await manager.close();
+  }
+
   beforeAll(async () => {
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qmd-manager-test-fixtures-"));
   });
@@ -2889,254 +3043,63 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("aborts the in-flight qmd search subprocess when the caller signal aborts", async () => {
-    configureQmd({ searchMode: "query" });
-
-    // The query child never closes on its own so the only way the search can
-    // settle is the caller-owned abort signal killing the subprocess.
-    let queryChildKill: ReturnType<typeof vi.fn> | undefined;
-    let queryChild: MockChild | undefined;
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
-        const kill = vi.fn(() => {
-          // Mirror a real child exiting after SIGKILL so the close handler runs.
-          queueMicrotask(() => child.emit("close", null));
-        });
-        Object.assign(child, { kill });
-        queryChildKill = kill;
-        queryChild = child;
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager } = await createManager();
-    const controller = new AbortController();
-
-    const searchPromise = manager.search("test", {
-      sessionKey: "agent:main:slack:dm:u123",
-      signal: controller.signal,
-    });
-    searchPromise.catch(() => undefined);
-
-    await waitUntil(() => queryChildKill !== undefined);
-    expect(queryChild).toBeDefined();
-
-    controller.abort(new Error("memory_search timed out after 15s"));
-
-    await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
-    expect(queryChildKill).toHaveBeenCalledWith("SIGKILL");
-    await manager.close();
-  });
-
-  it("rejects the qmd search before spawning when the caller signal is already aborted", async () => {
-    configureQmd({ searchMode: "query" });
-
-    const { manager } = await createManager();
-    const controller = new AbortController();
-    controller.abort(new Error("memory_search timed out after 15s"));
-
-    const callsBefore = spawnMock.mock.calls.filter(
-      (call: unknown[]) => (call[1] as string[])?.[0] === "query",
-    ).length;
-
-    await expect(
-      manager.search("test", {
-        sessionKey: "agent:main:slack:dm:u123",
-        signal: controller.signal,
+  const abortSearchScenarios = [
+    {
+      name: "aborts the in-flight qmd search subprocess when the caller signal aborts",
+      qmd: { searchMode: "query" },
+      isTarget: (_cmd, args) => args[0] === "query",
+    },
+    {
+      name: "rejects the qmd search before spawning when the caller signal is already aborted",
+      qmd: { searchMode: "query" },
+      isTarget: (_cmd, args) => args[0] === "query",
+      preAborted: true,
+    },
+    {
+      name: "aborts the in-flight grouped qmd search subprocess when the caller signal aborts",
+      qmd: { sessions: { enabled: true } },
+      isTarget: (_cmd, args) => args[0] === "search",
+      outputFor: (_cmd, args) =>
+        args[0] === "--help"
+          ? {
+              stream: "stdout",
+              data: "-c, --collection <name>    Filter by one or more collections",
+            }
+          : undefined,
+    },
+    {
+      name: "aborts the multi-collection capability probe without caching a failure",
+      qmd: () => ({
+        paths: [
+          { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+          { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+        ],
       }),
-    ).rejects.toThrow("memory_search timed out after 15s");
+      isTarget: (_cmd, args) => args[0] === "--help",
+      outputFor: (_cmd, args) =>
+        args[0] === "search" ? { stream: "stdout", data: "[]" } : undefined,
+      neverSpawns: (_cmd, args) => args[0] === "search",
+    },
+    {
+      name: "aborts the in-flight mcporter search subprocess when the caller signal aborts",
+      qmd: {
+        searchMode: "query",
+        mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+      },
+      isTarget: (cmd, args) => isMcporterCommand(cmd) && args[0] === "call",
+    },
+    {
+      name: "rejects the mcporter search before spawning a call subprocess when the caller signal is already aborted",
+      qmd: {
+        searchMode: "query",
+        mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+      },
+      isTarget: (cmd, args) => isMcporterCommand(cmd) && args[0] === "call",
+      preAborted: true,
+    },
+  ] satisfies AbortSearchScenario[];
 
-    const callsAfter = spawnMock.mock.calls.filter(
-      (call: unknown[]) => (call[1] as string[])?.[0] === "query",
-    ).length;
-    expect(callsAfter).toBe(callsBefore);
-    await manager.close();
-  });
-
-  it("aborts the in-flight grouped qmd search subprocess when the caller signal aborts", async () => {
-    configureQmd({ sessions: { enabled: true } });
-
-    // Mixed memory/session sources route the search through
-    // runQueryAcrossCollectionGroups. The first grouped search child never
-    // closes on its own, so the only way the search can settle is the
-    // caller-owned abort signal reaching the grouped subprocess and killing it.
-    let groupedChildKill: ReturnType<typeof vi.fn> | undefined;
-    let groupedChild: MockChild | undefined;
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "--help") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          "-c, --collection <name>    Filter by one or more collections",
-        );
-        return child;
-      }
-      if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        const kill = vi.fn(() => {
-          // Mirror a real child exiting after SIGKILL so the close handler runs.
-          queueMicrotask(() => child.emit("close", null));
-        });
-        Object.assign(child, { kill });
-        if (!groupedChildKill) {
-          groupedChildKill = kill;
-          groupedChild = child;
-        }
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager } = await createManager();
-    const controller = new AbortController();
-
-    const searchPromise = manager.search("test", {
-      sessionKey: "agent:main:slack:dm:u123",
-      signal: controller.signal,
-    });
-    searchPromise.catch(() => undefined);
-
-    await waitUntil(() => groupedChildKill !== undefined);
-    expect(groupedChild).toBeDefined();
-
-    controller.abort(new Error("memory_search timed out after 15s"));
-
-    await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
-    expect(groupedChildKill).toHaveBeenCalledWith("SIGKILL");
-    await manager.close();
-  });
-
-  it("aborts the multi-collection capability probe without caching a failure", async () => {
-    configureQmd({
-      paths: [
-        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
-      ],
-    });
-
-    let helpChildKill: ReturnType<typeof vi.fn> | undefined;
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "--help") {
-        const child = createMockChild({ autoClose: false });
-        const kill = vi.fn(() => {
-          queueMicrotask(() => child.emit("close", null));
-        });
-        Object.assign(child, { kill });
-        helpChildKill = kill;
-        return child;
-      }
-      if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager } = await createManager();
-    const controller = new AbortController();
-    const searchPromise = manager.search("test", {
-      sessionKey: "agent:main:slack:dm:u123",
-      signal: controller.signal,
-    });
-    searchPromise.catch(() => undefined);
-
-    await waitUntil(() => helpChildKill !== undefined);
-    controller.abort(new Error("memory_search timed out after 15s"));
-
-    await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
-    expect(helpChildKill).toHaveBeenCalledWith("SIGKILL");
-    expect(
-      spawnMock.mock.calls.some((call: unknown[]) => (call[1] as string[])?.[0] === "search"),
-    ).toBe(false);
-    await manager.close();
-  });
-
-  it("aborts the in-flight mcporter search subprocess when the caller signal aborts", async () => {
-    configureQmd({
-      searchMode: "query",
-      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-    });
-
-    // The mcporter `call` child never closes on its own, so the only way the
-    // search can settle is the caller-owned abort signal reaching the mcporter
-    // subprocess via runMcporter -> runCliCommand and killing it.
-    let mcporterCallKill: ReturnType<typeof vi.fn> | undefined;
-    let mcporterCallChild: MockChild | undefined;
-    spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      if (isMcporterCommand(cmd) && args[0] === "call") {
-        const child = createMockChild({ autoClose: false });
-        const kill = vi.fn(() => {
-          // Mirror a real child exiting after SIGKILL so the close handler runs.
-          queueMicrotask(() => child.emit("close", null));
-        });
-        Object.assign(child, { kill });
-        mcporterCallKill = kill;
-        mcporterCallChild = child;
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager } = await createManager();
-    const controller = new AbortController();
-
-    const searchPromise = manager.search("test", {
-      sessionKey: "agent:main:slack:dm:u123",
-      signal: controller.signal,
-    });
-    searchPromise.catch(() => undefined);
-
-    await waitUntil(() => mcporterCallKill !== undefined);
-    expect(mcporterCallChild).toBeDefined();
-
-    controller.abort(new Error("memory_search timed out after 15s"));
-
-    await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
-    expect(mcporterCallKill).toHaveBeenCalledWith("SIGKILL");
-    await manager.close();
-  });
-
-  it("rejects the mcporter search before spawning a call subprocess when the caller signal is already aborted", async () => {
-    configureQmd({
-      searchMode: "query",
-      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
-    });
-
-    spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
-      if (isMcporterCommand(cmd) && args[0] === "call") {
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
-      }
-      emitAndClose(child, "stdout", "[]");
-      return child;
-    });
-
-    const { manager } = await createManager();
-    const controller = new AbortController();
-    controller.abort(new Error("memory_search timed out after 15s"));
-
-    const callsBefore = spawnMock.mock.calls.filter(
-      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])?.[0] === "call",
-    ).length;
-
-    await expect(
-      manager.search("test", {
-        sessionKey: "agent:main:slack:dm:u123",
-        signal: controller.signal,
-      }),
-    ).rejects.toThrow("memory_search timed out after 15s");
-
-    const callsAfter = spawnMock.mock.calls.filter(
-      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])?.[0] === "call",
-    ).length;
-    expect(callsAfter).toBe(callsBefore);
-    await manager.close();
-  });
+  it.each(abortSearchScenarios)("$name", runAbortSearchScenario);
 
   it("does not pass --no-rerank to direct query fallback from search mode", async () => {
     configureQmd({ searchMode: "search", rerank: false });
@@ -3271,273 +3234,101 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("scopes qmd queries to managed collections", async () => {
-    configureQmd({
-      paths: [
-        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+  const qmdCommandMatrixScenarios = [
+    {
+      name: "scopes qmd queries to managed collections",
+      configure: () =>
+        configureQmd({
+          paths: [
+            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+          ],
+        }),
+      expectedCommands: (maxResults) => [
+        qmdQueryArgs("search", maxResults, "workspace-main"),
+        qmdQueryArgs("search", maxResults, "notes-main"),
       ],
-    });
-
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager, resolved } = await createManager();
-
-    await manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
-    const maxResults = resolved.qmd?.limits.maxResults;
-    if (!maxResults) {
-      throw new Error("qmd maxResults missing");
-    }
-    const searchCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "search");
-    expect(searchCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
-    ]);
-    await manager.close();
-  });
-
-  it("groups same-source qmd queries when the installed qmd supports multiple collection filters", async () => {
-    configureQmd({
-      paths: [
-        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+    },
+    {
+      name: "groups same-source qmd queries when the installed qmd supports multiple collection filters",
+      configure: () =>
+        configureQmd({
+          paths: [
+            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+          ],
+        }),
+      supportsMultiCollection: true,
+      expectedCommands: (maxResults) => [
+        qmdQueryArgs("search", maxResults, "workspace-main", "notes-main"),
       ],
-    });
-
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "--help") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          "-c, --collection <name>    Filter by one or more collections",
-        );
-        return child;
-      }
-      if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager, resolved } = await createManager();
-
-    await manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
-    const maxResults = resolved.qmd?.limits.maxResults;
-    if (!maxResults) {
-      throw new Error("qmd maxResults missing");
-    }
-    const searchCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "search");
-    expect(searchCalls).toEqual([
-      [
-        "search",
-        "test",
-        "--json",
-        "-n",
-        String(maxResults),
-        "-c",
-        "workspace-main",
-        "-c",
-        "notes-main",
+    },
+    {
+      name: "keeps mixed-source qmd queries in separate source groups",
+      configure: () => configureQmd({ sessions: { enabled: true } }),
+      supportsMultiCollection: true,
+      expectedCommands: (maxResults) => [
+        qmdQueryArgs("search", maxResults, "workspace-main"),
+        qmdQueryArgs("search", maxResults, "sessions-main"),
       ],
-    ]);
-    await manager.close();
-  });
-
-  it("keeps mixed-source qmd queries in separate source groups", async () => {
-    configureQmd({ sessions: { enabled: true } });
-
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "--help") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          "-c, --collection <name>    Filter by one or more collections",
-        );
-        return child;
-      }
-      if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager, resolved } = await createManager();
-
-    await manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
-    const maxResults = resolved.qmd?.limits.maxResults;
-    if (!maxResults) {
-      throw new Error("qmd maxResults missing");
-    }
-    const searchCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "search");
-    expect(searchCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "sessions-main"],
-    ]);
-    await manager.close();
-  });
-
-  it("does not query phantom memory-alt collections when MEMORY.md exists", async () => {
-    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# canonical root");
-    configureQmd({ includeDefaultMemory: true, paths: [] });
-
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager, resolved } = await createManager();
-
-    await manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
-    const maxResults = resolved.qmd?.limits.maxResults;
-    if (!maxResults) {
-      throw new Error("qmd maxResults missing");
-    }
-    const searchCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "search");
-    expect(searchCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "memory-root-main"],
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "memory-dir-main"],
-    ]);
-    await manager.close();
-  });
-
-  it("uses explicit external custom collection names verbatim at query time", async () => {
-    const sharedMirrorDir = path.join(tmpRoot, "shared-notion-mirror");
-    await fs.mkdir(sharedMirrorDir);
-    configureQmd({
-      paths: [{ path: sharedMirrorDir, pattern: "**/*.md", name: "notion-mirror" }],
-    });
-
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager, resolved } = await createManager();
-
-    await manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
-    const maxResults = resolved.qmd?.limits.maxResults;
-    if (!maxResults) {
-      throw new Error("qmd maxResults missing");
-    }
-    const searchCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "search");
-    expect(searchCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "notion-mirror"],
-    ]);
-    await manager.close();
-  });
-
-  it("runs qmd query per collection when query mode has multiple collection filters", async () => {
-    configureQmd({
-      searchMode: "query",
-      paths: [
-        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+    },
+    {
+      name: "does not query phantom memory-alt collections when MEMORY.md exists",
+      configure: async () => {
+        await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# canonical root");
+        configureQmd({ includeDefaultMemory: true, paths: [] });
+      },
+      expectedCommands: (maxResults) => [
+        qmdQueryArgs("search", maxResults, "memory-root-main"),
+        qmdQueryArgs("search", maxResults, "memory-dir-main"),
       ],
-    });
-
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager, resolved } = await createManager();
-    const maxResults = resolved.qmd?.limits.maxResults;
-    if (!maxResults) {
-      throw new Error("qmd maxResults missing");
-    }
-
-    await expect(
-      manager.search("test", { sessionKey: "agent:main:slack:dm:u123" }),
-    ).resolves.toStrictEqual([]);
-
-    const queryCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "query");
-    expect(queryCalls).toEqual([
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
-    ]);
-    await manager.close();
-  });
-
-  it("uses per-collection query fallback when search mode rejects flags", async () => {
-    configureQmd({
-      searchMode: "search",
-      paths: [
-        { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
-        { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+    },
+    {
+      name: "uses explicit external custom collection names verbatim at query time",
+      configure: async () => {
+        const sharedMirrorDir = path.join(tmpRoot, "shared-notion-mirror");
+        await fs.mkdir(sharedMirrorDir);
+        configureQmd({
+          paths: [{ path: sharedMirrorDir, pattern: "**/*.md", name: "notion-mirror" }],
+        });
+      },
+      expectedCommands: (maxResults) => [qmdQueryArgs("search", maxResults, "notion-mirror")],
+    },
+    {
+      name: "runs qmd query per collection when query mode has multiple collection filters",
+      configure: () =>
+        configureQmd({
+          searchMode: "query",
+          paths: [
+            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+          ],
+        }),
+      expectedCommands: (maxResults) => [
+        qmdQueryArgs("query", maxResults, "workspace-main"),
+        qmdQueryArgs("query", maxResults, "notes-main"),
       ],
-    });
+    },
+    {
+      name: "uses per-collection query fallback when search mode rejects flags",
+      configure: () =>
+        configureQmd({
+          searchMode: "search",
+          paths: [
+            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+          ],
+        }),
+      rejectSearchFlags: true,
+      expectedCommands: (maxResults) => [
+        qmdQueryArgs("search", maxResults, "workspace-main"),
+        qmdQueryArgs("query", maxResults, "workspace-main"),
+        qmdQueryArgs("query", maxResults, "notes-main"),
+      ],
+    },
+  ] satisfies QmdCommandMatrixScenario[];
 
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stderr", "unknown flag: --json", 2);
-        return child;
-      }
-      if (args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
-      }
-      return createMockChild();
-    });
-
-    const { manager, resolved } = await createManager();
-    const maxResults = resolved.qmd?.limits.maxResults;
-    if (!maxResults) {
-      throw new Error("qmd maxResults missing");
-    }
-
-    await expect(
-      manager.search("test", { sessionKey: "agent:main:slack:dm:u123" }),
-    ).resolves.toStrictEqual([]);
-
-    const searchAndQueryCalls = spawnMock.mock.calls
-      .map((call: unknown[]) => call[1] as string[])
-      .filter((args: string[]) => args[0] === "search" || args[0] === "query");
-    expect(searchAndQueryCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
-    ]);
-    await manager.close();
-  });
+  it.each(qmdCommandMatrixScenarios)("$name", runQmdCommandMatrixScenario);
 
   it("runs qmd searches via mcporter and warns when startDaemon=false", async () => {
     configureQmd({

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -881,6 +881,164 @@ describe("slack prepareSlackMessage inbound contract", () => {
     return prepareMessageWith(ctx, createThreadAccount(), createThreadReplyMessage(overrides));
   }
 
+  type ThreadRouteScenario = {
+    name: string;
+    source: "app_mention" | "message";
+    mentionType: "explicit" | "implicit" | "regex";
+    bindingOwner: "none" | "plugin" | "runtime";
+    expectRootMentioned?: boolean;
+    expectFollowUpMentioned?: boolean;
+  };
+
+  async function runThreadRouteScenario(scenario: ThreadRouteScenario) {
+    const implicit = scenario.mentionType === "implicit";
+    const channelId = implicit ? "C0AGG76CP1S" : "C0AHZFCAS1K";
+    const userId = implicit ? "U_TRAJCHE" : "U_BEK";
+    const rootTs = implicit ? "1778073105.769279" : "1777244692.409919";
+    const replyToMode = implicit ? "first" : "all";
+    const rootText = implicit
+      ? "What day is it?"
+      : scenario.bindingOwner === "runtime"
+        ? "reviewbot please review GitHub issue #50621"
+        : scenario.mentionType === "explicit"
+          ? "<@B1> send a subagent to review GitHub issue #50621"
+          : "Bill send a subagent to review GitHub issue #50621";
+    const expectedSessionKey =
+      scenario.bindingOwner === "runtime"
+        ? "agent:review:slack:channel:c0ahzfcas1k"
+        : `agent:main:slack:channel:${channelId.toLowerCase()}:thread:${rootTs}`;
+    const { storePath } = storeFixture.makeTmpStorePath();
+    const channelsConfig = implicit
+      ? { [channelId]: { enabled: true, requireMention: false } }
+      : undefined;
+    const replies = vi.fn().mockResolvedValue({
+      messages: [{ text: rootText, user: userId, ts: rootTs }],
+      response_metadata: { next_cursor: "" },
+    });
+    const cfg = {
+      session: { store: storePath },
+      ...(scenario.mentionType === "regex" && scenario.bindingOwner !== "runtime"
+        ? { messages: { groupChat: { mentionPatterns: ["\\bbill\\b"] } } }
+        : {}),
+      ...(scenario.bindingOwner === "runtime"
+        ? {
+            agents: {
+              list: [
+                { id: "main", default: true },
+                { id: "review", groupChat: { mentionPatterns: ["\\breviewbot\\b"] } },
+              ],
+            },
+          }
+        : {}),
+      channels: {
+        slack: {
+          enabled: true,
+          replyToMode,
+          groupPolicy: "open",
+          ...(channelsConfig ? { channels: channelsConfig } : {}),
+        },
+      },
+    } as OpenClawConfig;
+    const slackCtx = createInboundSlackCtx({
+      cfg,
+      appClient: { conversations: { replies } } as unknown as App["client"],
+      defaultRequireMention: true,
+      replyToMode,
+      ...(channelsConfig ? { channelsConfig } : {}),
+    });
+    slackCtx.resolveChannelName = async () => ({
+      name: implicit ? "genai" : "proj-openclaw",
+      type: "channel",
+    });
+    slackCtx.resolveUserName = async () => ({ name: implicit ? "Trajche" : "Bek" });
+
+    const bindingTarget =
+      scenario.bindingOwner === "runtime"
+        ? expectedSessionKey
+        : "agent:plugin:slack:channel:c0ahzfcas1k";
+    const binding: SessionBindingRecord | undefined =
+      scenario.bindingOwner === "none"
+        ? undefined
+        : {
+            bindingId: `${scenario.bindingOwner}-slack-binding`,
+            targetSessionKey: bindingTarget,
+            targetKind: "session",
+            conversation: {
+              channel: "slack",
+              accountId: "default",
+              conversationId: channelId,
+            },
+            status: "active",
+            boundAt: 1,
+            ...(scenario.bindingOwner === "plugin"
+              ? {
+                  metadata: {
+                    pluginBindingOwner: "plugin",
+                    pluginId: "demo-plugin",
+                    pluginRoot: "/tmp/demo-plugin",
+                  },
+                }
+              : {}),
+          };
+    const adapter: SessionBindingAdapter | undefined = binding
+      ? {
+          channel: "slack",
+          accountId: "default",
+          listBySession: () => [],
+          resolveByConversation: (ref) => (ref.conversationId === channelId ? binding : null),
+        }
+      : undefined;
+    if (adapter) {
+      registerSessionBindingAdapter(adapter);
+    }
+
+    try {
+      const account = createSlackAccount({ replyToMode });
+      const root = await prepareSlackMessage({
+        ctx: slackCtx,
+        account,
+        message: {
+          type: "message",
+          channel: channelId,
+          channel_type: "channel",
+          user: userId,
+          text: rootText,
+          ts: rootTs,
+        } as SlackMessageEvent,
+        opts: {
+          source: scenario.source,
+          ...(scenario.source === "app_mention" ? { wasMentioned: true } : {}),
+        },
+      });
+      recordSlackThreadParticipation("default", channelId, rootTs);
+      const followUp = await prepareSlackMessage({
+        ctx: slackCtx,
+        account,
+        message: {
+          type: "message",
+          channel: channelId,
+          channel_type: "channel",
+          user: userId,
+          text: implicit ? "and the time?" : "https://github.com/openclaw/openclaw/issues/50621",
+          ts: "1777244714.000100",
+          thread_ts: rootTs,
+        } as SlackMessageEvent,
+        opts: { source: "message" },
+      });
+      const expectedAgentId =
+        scenario.bindingOwner === "runtime"
+          ? "review"
+          : scenario.bindingOwner === "plugin"
+            ? "main"
+            : undefined;
+      return { root, followUp, expectedSessionKey, expectedAgentId };
+    } finally {
+      if (adapter) {
+        unregisterSessionBindingAdapter({ channel: "slack", accountId: "default", adapter });
+      }
+    }
+  }
+
   type ThreadContextAllowlistCaseParams = {
     channel: string;
     channelType: SlackMessageEvent["channel_type"];
@@ -3223,133 +3381,72 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     }
   });
 
-  it("keeps a root app mention and URL-only Slack thread follow-up on one parent session", async () => {
-    const { storePath } = storeFixture.makeTmpStorePath();
-    const rootTs = "1777244692.409919";
-    const expectedSessionKey = "agent:main:slack:channel:c0ahzfcas1k:thread:1777244692.409919";
-    const replies = vi.fn().mockResolvedValue({
-      messages: [
-        {
-          text: "<@B1> send a subagent to review GitHub issue #50621",
-          user: "U_BEK",
-          ts: rootTs,
-        },
-      ],
-      response_metadata: { next_cursor: "" },
-    });
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        session: { store: storePath },
-        channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
-      } as OpenClawConfig,
-      appClient: { conversations: { replies } } as unknown as App["client"],
-      defaultRequireMention: true,
-      replyToMode: "all",
-    });
-    slackCtx.resolveChannelName = async () => ({ name: "proj-openclaw", type: "channel" });
-    slackCtx.resolveUserName = async () => ({ name: "Bek" });
+  const threadRouteScenarios = [
+    {
+      name: "keeps a root app mention and URL-only Slack thread follow-up on one parent session",
+      source: "app_mention",
+      mentionType: "explicit",
+      bindingOwner: "none",
+      expectFollowUpMentioned: true,
+    },
+    {
+      name: "keeps a message-first root mention and URL-only Slack thread follow-up on one parent session",
+      source: "message",
+      mentionType: "explicit",
+      bindingOwner: "none",
+      expectRootMentioned: true,
+      expectFollowUpMentioned: true,
+    },
+    {
+      name: "keeps an implicit-conversation root and its Slack thread follow-up on one parent session in `requireMention: false` channels (#78505)",
+      source: "message",
+      mentionType: "implicit",
+      bindingOwner: "none",
+    },
+    {
+      name: "keeps a regex-mentioned Slack thread root and URL-only follow-up on one parent session",
+      source: "message",
+      mentionType: "regex",
+      bindingOwner: "none",
+      expectRootMentioned: true,
+      expectFollowUpMentioned: true,
+    },
+    {
+      name: "keeps runtime-bound regex mentions on the bound parent session",
+      source: "message",
+      mentionType: "regex",
+      bindingOwner: "runtime",
+      expectRootMentioned: true,
+      expectFollowUpMentioned: true,
+    },
+    {
+      name: "still seeds regex mentions when plugin-owned bindings do not rewrite the route",
+      source: "message",
+      mentionType: "regex",
+      bindingOwner: "plugin",
+    },
+  ] satisfies ThreadRouteScenario[];
 
-    const root = await prepareSlackMessage({
-      ctx: slackCtx,
-      account: createSlackAccount({ replyToMode: "all" }),
-      message: {
-        type: "message",
-        channel: "C0AHZFCAS1K",
-        channel_type: "channel",
-        user: "U_BEK",
-        text: "<@B1> send a subagent to review GitHub issue #50621",
-        ts: rootTs,
-      } as SlackMessageEvent,
-      opts: { source: "app_mention", wasMentioned: true },
-    });
-    recordSlackThreadParticipation("default", "C0AHZFCAS1K", rootTs);
-
-    const followUp = await prepareSlackMessage({
-      ctx: slackCtx,
-      account: createSlackAccount({ replyToMode: "all" }),
-      message: {
-        type: "message",
-        channel: "C0AHZFCAS1K",
-        channel_type: "channel",
-        user: "U_BEK",
-        text: "https://github.com/openclaw/openclaw/issues/50621",
-        ts: "1777244714.000100",
-        thread_ts: rootTs,
-      } as SlackMessageEvent,
-      opts: { source: "message" },
-    });
+  it.each(threadRouteScenarios)("$name", async (scenario) => {
+    const { root, followUp, expectedSessionKey, expectedAgentId } =
+      await runThreadRouteScenario(scenario);
 
     assertPrepared(root, "root message");
     assertPrepared(followUp, "follow-up message");
+    // Root preparation must seed the eventual thread route; otherwise the
+    // follow-up silently splits into a second session.
     expect(root.ctxPayload.SessionKey).toBe(expectedSessionKey);
     expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(followUp.ctxPayload.WasMentioned).toBe(true);
     expect(new Set([root.ctxPayload.SessionKey, followUp.ctxPayload.SessionKey]).size).toBe(1);
-  });
-
-  it("keeps a message-first root mention and URL-only Slack thread follow-up on one parent session", async () => {
-    const { storePath } = storeFixture.makeTmpStorePath();
-    const rootTs = "1777244692.409919";
-    const expectedSessionKey = "agent:main:slack:channel:c0ahzfcas1k:thread:1777244692.409919";
-    const replies = vi.fn().mockResolvedValue({
-      messages: [
-        {
-          text: "<@B1> send a subagent to review GitHub issue #50621",
-          user: "U_BEK",
-          ts: rootTs,
-        },
-      ],
-      response_metadata: { next_cursor: "" },
-    });
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        session: { store: storePath },
-        channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
-      } as OpenClawConfig,
-      appClient: { conversations: { replies } } as unknown as App["client"],
-      defaultRequireMention: true,
-      replyToMode: "all",
-    });
-    slackCtx.resolveChannelName = async () => ({ name: "proj-openclaw", type: "channel" });
-    slackCtx.resolveUserName = async () => ({ name: "Bek" });
-
-    const root = await prepareSlackMessage({
-      ctx: slackCtx,
-      account: createSlackAccount({ replyToMode: "all" }),
-      message: {
-        type: "message",
-        channel: "C0AHZFCAS1K",
-        channel_type: "channel",
-        user: "U_BEK",
-        text: "<@B1> send a subagent to review GitHub issue #50621",
-        ts: rootTs,
-      } as SlackMessageEvent,
-      opts: { source: "message" },
-    });
-    recordSlackThreadParticipation("default", "C0AHZFCAS1K", rootTs);
-
-    const followUp = await prepareSlackMessage({
-      ctx: slackCtx,
-      account: createSlackAccount({ replyToMode: "all" }),
-      message: {
-        type: "message",
-        channel: "C0AHZFCAS1K",
-        channel_type: "channel",
-        user: "U_BEK",
-        text: "https://github.com/openclaw/openclaw/issues/50621",
-        ts: "1777244714.000100",
-        thread_ts: rootTs,
-      } as SlackMessageEvent,
-      opts: { source: "message" },
-    });
-
-    assertPrepared(root, "root message");
-    assertPrepared(followUp, "follow-up message");
-    expect(root.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(root.ctxPayload.WasMentioned).toBe(true);
-    expect(followUp.ctxPayload.WasMentioned).toBe(true);
-    expect(new Set([root.ctxPayload.SessionKey, followUp.ctxPayload.SessionKey]).size).toBe(1);
+    if (expectedAgentId) {
+      expect(root.route.agentId).toBe(expectedAgentId);
+    }
+    if (scenario.expectRootMentioned !== undefined) {
+      expect(root.ctxPayload.WasMentioned).toBe(scenario.expectRootMentioned);
+    }
+    if (scenario.expectFollowUpMentioned !== undefined) {
+      expect(followUp.ctxPayload.WasMentioned).toBe(scenario.expectFollowUpMentioned);
+    }
   });
 
   it("preserves explicit Slack mention targets when an implicit thread wake mentions someone else", async () => {
@@ -3678,84 +3775,21 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.MentionSource).toBe("command_bypass");
   });
 
-  it("keeps an implicit-conversation root and its Slack thread follow-up on one parent session in `requireMention: false` channels (#78505)", async () => {
-    const { storePath } = storeFixture.makeTmpStorePath();
-    const rootTs = "1778073105.769279";
-    const expectedSessionKey = `agent:main:slack:channel:c0agg76cp1s:thread:${rootTs}`;
-    const replies = vi.fn().mockResolvedValue({
-      messages: [
-        {
-          text: "What day is it?",
-          user: "U_TRAJCHE",
-          ts: rootTs,
-        },
-      ],
-      response_metadata: { next_cursor: "" },
-    });
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        session: { store: storePath },
-        channels: {
-          slack: {
-            enabled: true,
-            replyToMode: "first",
-            groupPolicy: "open",
-            channels: { C0AGG76CP1S: { enabled: true, requireMention: false } },
-          },
-        },
-      } as OpenClawConfig,
-      appClient: { conversations: { replies } } as unknown as App["client"],
-      defaultRequireMention: true,
-      replyToMode: "first",
-      channelsConfig: { C0AGG76CP1S: { enabled: true, requireMention: false } },
-    });
-    slackCtx.resolveChannelName = async () => ({ name: "genai", type: "channel" });
-    slackCtx.resolveUserName = async () => ({ name: "Trajche" });
-
-    const root = await prepareSlackMessage({
-      ctx: slackCtx,
-      account: createSlackAccount({ replyToMode: "first" }),
-      message: {
-        type: "message",
-        channel: "C0AGG76CP1S",
-        channel_type: "channel",
-        user: "U_TRAJCHE",
-        text: "What day is it?",
-        ts: rootTs,
-      } as SlackMessageEvent,
-      opts: { source: "message" },
-    });
-    recordSlackThreadParticipation("default", "C0AGG76CP1S", rootTs);
-
-    const followUp = await prepareSlackMessage({
-      ctx: slackCtx,
-      account: createSlackAccount({ replyToMode: "first" }),
-      message: {
-        type: "message",
-        channel: "C0AGG76CP1S",
-        channel_type: "channel",
-        user: "U_TRAJCHE",
-        text: "and the time?",
-        ts: "1778073128.229409",
-        thread_ts: rootTs,
-      } as SlackMessageEvent,
-      opts: { source: "message" },
-    });
-
-    assertPrepared(root, "root message");
-    assertPrepared(followUp, "follow-up message");
-    // Without the seeding fix, root would land on `agent:main:slack:channel:c0agg76cp1s`
-    // while followUp would land on `:thread:<rootTs>`, splitting the conversation
-    // across two sessions. Both must share one session key.
-    expect(root.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(new Set([root.ctxPayload.SessionKey, followUp.ctxPayload.SessionKey]).size).toBe(1);
-  });
-
-  it("treats Slack user-group mentions as explicit mentions when the bot is a member", async () => {
+  it.each([
+    {
+      name: "treats Slack user-group mentions as explicit mentions when the bot is a member",
+      users: ["U_OTHER", "B1"],
+      admitted: true,
+    },
+    {
+      name: "drops Slack user-group mentions when the bot is not a member",
+      users: ["U_OTHER"],
+      admitted: false,
+    },
+  ])("$name", async ({ users, admitted }) => {
     const usergroupsUsersList = vi.fn().mockResolvedValue({
       ok: true,
-      users: ["U_OTHER", "B1"],
+      users,
     });
     const slackCtx = createInboundSlackCtx({
       cfg: {
@@ -3793,55 +3827,15 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       usergroup: "S0AGENTS",
       team_id: "T1",
     });
+    if (!admitted) {
+      expect(prepared).toBeNull();
+      return;
+    }
     assertPrepared(prepared);
     expect(prepared.ctxPayload.WasMentioned).toBe(true);
     expect(prepared.ctxPayload.ExplicitlyMentionedBot).toBe(true);
     expect(prepared.ctxPayload.MentionedSubteamIds).toEqual(["S0AGENTS"]);
     expect(prepared.ctxPayload.MentionSource).toBe("subteam");
-  });
-
-  it("drops Slack user-group mentions when the bot is not a member", async () => {
-    const usergroupsUsersList = vi.fn().mockResolvedValue({
-      ok: true,
-      users: ["U_OTHER"],
-    });
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: {
-          slack: {
-            enabled: true,
-            groupPolicy: "open",
-            channels: { C0AGENTS: { requireMention: true } },
-          },
-        },
-      } as OpenClawConfig,
-      appClient: {
-        usergroups: { users: { list: usergroupsUsersList } },
-      } as unknown as App["client"],
-      defaultRequireMention: true,
-    });
-    slackCtx.resolveChannelName = async () => ({ name: "agents", type: "channel" });
-    slackCtx.resolveUserName = async () => ({ name: "Bek" });
-
-    const prepared = await prepareSlackMessage({
-      ctx: slackCtx,
-      account: createSlackAccount(),
-      message: {
-        type: "message",
-        channel: "C0AGENTS",
-        channel_type: "channel",
-        user: "U_BEK",
-        text: "<!subteam^S0AGENTS|agents> triage this",
-        ts: "1777244692.409920",
-      } as SlackMessageEvent,
-      opts: { source: "message" },
-    });
-
-    expect(usergroupsUsersList).toHaveBeenCalledWith({
-      usergroup: "S0AGENTS",
-      team_id: "T1",
-    });
-    expect(prepared).toBeNull();
   });
 
   function createCaptionlessSlackAudioMessage(
@@ -4095,71 +4089,6 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     }
   });
 
-  it("keeps a regex-mentioned Slack thread root and URL-only follow-up on one parent session", async () => {
-    const { storePath } = storeFixture.makeTmpStorePath();
-    const rootTs = "1777244692.409919";
-    const expectedSessionKey = "agent:main:slack:channel:c0ahzfcas1k:thread:1777244692.409919";
-    const replies = vi.fn().mockResolvedValue({
-      messages: [
-        {
-          text: "Bill send a subagent to review GitHub issue #50621",
-          user: "U_BEK",
-          ts: rootTs,
-        },
-      ],
-      response_metadata: { next_cursor: "" },
-    });
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        session: { store: storePath },
-        messages: { groupChat: { mentionPatterns: ["\\bbill\\b"] } },
-        channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
-      } as OpenClawConfig,
-      appClient: { conversations: { replies } } as unknown as App["client"],
-      defaultRequireMention: true,
-      replyToMode: "all",
-    });
-    slackCtx.resolveChannelName = async () => ({ name: "proj-openclaw", type: "channel" });
-    slackCtx.resolveUserName = async () => ({ name: "Bek" });
-
-    const root = await prepareSlackMessage({
-      ctx: slackCtx,
-      account: createSlackAccount({ replyToMode: "all" }),
-      message: {
-        type: "message",
-        channel: "C0AHZFCAS1K",
-        channel_type: "channel",
-        user: "U_BEK",
-        text: "Bill send a subagent to review GitHub issue #50621",
-        ts: rootTs,
-      } as SlackMessageEvent,
-      opts: { source: "message" },
-    });
-    recordSlackThreadParticipation("default", "C0AHZFCAS1K", rootTs);
-
-    const followUp = await prepareSlackMessage({
-      ctx: slackCtx,
-      account: createSlackAccount({ replyToMode: "all" }),
-      message: {
-        type: "message",
-        channel: "C0AHZFCAS1K",
-        channel_type: "channel",
-        user: "U_BEK",
-        text: "https://github.com/openclaw/openclaw/issues/50621",
-        ts: "1777244714.000100",
-        thread_ts: rootTs,
-      } as SlackMessageEvent,
-      opts: { source: "message" },
-    });
-
-    assertPrepared(root, "root message");
-    assertPrepared(followUp, "follow-up message");
-    expect(root.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(root.ctxPayload.WasMentioned).toBe(true);
-    expect(followUp.ctxPayload.WasMentioned).toBe(true);
-  });
-
   it("keeps per-channel replyToMode during regex mention reroute", async () => {
     const rootTs = "1777244692.409919";
     const slackCtx = createInboundSlackCtx({
@@ -4199,180 +4128,6 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.WasMentioned).toBe(true);
     expect(prepared.ctxPayload.MessageThreadId).toBeUndefined();
     expect(prepared.ctxPayload.SessionKey).toBe("agent:main:slack:channel:c0ahzfcas1k");
-  });
-
-  it("keeps runtime-bound regex mentions on the bound parent session", async () => {
-    const { storePath } = storeFixture.makeTmpStorePath();
-    const rootTs = "1777244692.409919";
-    const expectedSessionKey = "agent:review:slack:channel:c0ahzfcas1k";
-    const binding: SessionBindingRecord = {
-      bindingId: "slack-review-binding",
-      targetSessionKey: "agent:review:slack:channel:c0ahzfcas1k",
-      targetKind: "session",
-      conversation: {
-        channel: "slack",
-        accountId: "default",
-        conversationId: "C0AHZFCAS1K",
-      },
-      status: "active",
-      boundAt: 1,
-    };
-    const resolveByConversation = vi.fn<SessionBindingAdapter["resolveByConversation"]>((ref) =>
-      ref.conversationId === "C0AHZFCAS1K" ? binding : null,
-    );
-    const adapter: SessionBindingAdapter = {
-      channel: "slack",
-      accountId: "default",
-      listBySession: () => [],
-      resolveByConversation,
-    };
-    registerSessionBindingAdapter(adapter);
-    try {
-      const slackCtx = createInboundSlackCtx({
-        cfg: {
-          session: { store: storePath },
-          agents: {
-            list: [
-              { id: "main", default: true },
-              { id: "review", groupChat: { mentionPatterns: ["\\breviewbot\\b"] } },
-            ],
-          },
-          channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
-        } as OpenClawConfig,
-        defaultRequireMention: true,
-        replyToMode: "all",
-      });
-      slackCtx.resolveChannelName = async () => ({ name: "proj-openclaw", type: "channel" });
-      slackCtx.resolveUserName = async () => ({ name: "Bek" });
-
-      const prepared = await prepareSlackMessage({
-        ctx: slackCtx,
-        account: createSlackAccount({ replyToMode: "all" }),
-        message: {
-          type: "message",
-          channel: "C0AHZFCAS1K",
-          channel_type: "channel",
-          user: "U_BEK",
-          text: "reviewbot please review GitHub issue #50621",
-          ts: rootTs,
-        } as SlackMessageEvent,
-        opts: { source: "message" },
-      });
-      recordSlackThreadParticipation("default", "C0AHZFCAS1K", rootTs);
-
-      const followUp = await prepareSlackMessage({
-        ctx: slackCtx,
-        account: createSlackAccount({ replyToMode: "all" }),
-        message: {
-          type: "message",
-          channel: "C0AHZFCAS1K",
-          channel_type: "channel",
-          user: "U_BEK",
-          text: "https://github.com/openclaw/openclaw/issues/50621",
-          ts: "1777244714.000100",
-          thread_ts: rootTs,
-        } as SlackMessageEvent,
-        opts: { source: "message" },
-      });
-
-      assertPrepared(prepared);
-      assertPrepared(followUp, "follow-up message");
-      expect(prepared.route.agentId).toBe("review");
-      expect(prepared.ctxPayload.SessionKey).toBe(expectedSessionKey);
-      expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
-      expect(prepared.ctxPayload.WasMentioned).toBe(true);
-      expect(followUp.ctxPayload.WasMentioned).toBe(true);
-      expect(new Set([prepared.ctxPayload.SessionKey, followUp.ctxPayload.SessionKey]).size).toBe(
-        1,
-      );
-    } finally {
-      unregisterSessionBindingAdapter({ channel: "slack", accountId: "default", adapter });
-    }
-  });
-
-  it("still seeds regex mentions when plugin-owned bindings do not rewrite the route", async () => {
-    const { storePath } = storeFixture.makeTmpStorePath();
-    const rootTs = "1777244692.409919";
-    const expectedSessionKey = "agent:main:slack:channel:c0ahzfcas1k:thread:1777244692.409919";
-    const binding: SessionBindingRecord = {
-      bindingId: "plugin-owned-slack-binding",
-      targetSessionKey: "agent:plugin:slack:channel:c0ahzfcas1k",
-      targetKind: "session",
-      conversation: {
-        channel: "slack",
-        accountId: "default",
-        conversationId: "C0AHZFCAS1K",
-      },
-      status: "active",
-      boundAt: 1,
-      metadata: {
-        pluginBindingOwner: "plugin",
-        pluginId: "demo-plugin",
-        pluginRoot: "/tmp/demo-plugin",
-      },
-    };
-    const resolveByConversation = vi.fn<SessionBindingAdapter["resolveByConversation"]>((ref) =>
-      ref.conversationId === "C0AHZFCAS1K" ? binding : null,
-    );
-    const adapter: SessionBindingAdapter = {
-      channel: "slack",
-      accountId: "default",
-      listBySession: () => [],
-      resolveByConversation,
-    };
-    registerSessionBindingAdapter(adapter);
-    try {
-      const slackCtx = createInboundSlackCtx({
-        cfg: {
-          session: { store: storePath },
-          messages: { groupChat: { mentionPatterns: ["\\bbill\\b"] } },
-          channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
-        } as OpenClawConfig,
-        defaultRequireMention: true,
-        replyToMode: "all",
-      });
-      slackCtx.resolveChannelName = async () => ({ name: "proj-openclaw", type: "channel" });
-      slackCtx.resolveUserName = async () => ({ name: "Bek" });
-
-      const root = await prepareSlackMessage({
-        ctx: slackCtx,
-        account: createSlackAccount({ replyToMode: "all" }),
-        message: {
-          type: "message",
-          channel: "C0AHZFCAS1K",
-          channel_type: "channel",
-          user: "U_BEK",
-          text: "Bill send a subagent to review GitHub issue #50621",
-          ts: rootTs,
-        } as SlackMessageEvent,
-        opts: { source: "message" },
-      });
-      recordSlackThreadParticipation("default", "C0AHZFCAS1K", rootTs);
-
-      const followUp = await prepareSlackMessage({
-        ctx: slackCtx,
-        account: createSlackAccount({ replyToMode: "all" }),
-        message: {
-          type: "message",
-          channel: "C0AHZFCAS1K",
-          channel_type: "channel",
-          user: "U_BEK",
-          text: "https://github.com/openclaw/openclaw/issues/50621",
-          ts: "1777244714.000100",
-          thread_ts: rootTs,
-        } as SlackMessageEvent,
-        opts: { source: "message" },
-      });
-
-      assertPrepared(root, "root message");
-      assertPrepared(followUp, "follow-up message");
-      expect(root.route.agentId).toBe("main");
-      expect(root.ctxPayload.SessionKey).toBe(expectedSessionKey);
-      expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
-      expect(new Set([root.ctxPayload.SessionKey, followUp.ctxPayload.SessionKey]).size).toBe(1);
-    } finally {
-      unregisterSessionBindingAdapter({ channel: "slack", accountId: "default", adapter });
-    }
   });
 
   it("prepares bare-ping Slack thread replies with the parent thread timestamp", async () => {


### PR DESCRIPTION
## What Problem This Solves

The Slack message-preparation and memory QMD manager suites repeated large scenario matrices that obscured the distinct contracts each case was proving.

## Why This Change Was Made

This consolidates equivalent cases into shared matrices while retaining every original test name and behavior in both suites.

## User Impact

No user-visible behavior changes. The Slack suite remains at 130 tests and QMD remains at 162 tests while the combined test code shrinks by 454 lines.

## Evidence

- Both focused suites passed before and after: Slack 130/130 and QMD 162/162.
- Formatting and \`git diff --check\` passed.
- \`node scripts/check-changed.mjs\` passed on Blacksmith Testbox \`tbx_01kyc0tsb396y8xhkgw91srysk\`.
- Autoreview completed with no actionable findings.
- Diff total: +608/-1,062 (net -454 LOC).
