### PR TITLE
feat(qwen): add qwen3.8-max-preview to the Token Plan catalog

### DIFF
--- a/docs/providers/qwen.md
+++ b/docs/providers/qwen.md
@@ -235,7 +235,7 @@ included here because they use different APIs.
 
 | Model ref                          | Input       | Context   | Picker status |
 | ---------------------------------- | ----------- | --------- | ------------- |
-| `qwen-token-plan/qwen3.8-max`      | text, image | 1,000,000 |
+| `qwen-token-plan/qwen3.8-max`      | text, image | 1,000,000 | visible       |
 | `qwen-token-plan/qwen3.7-plus`     | text, image | 1,000,000 | visible       |
 | `qwen-token-plan/qwen3.6-plus`     | text, image | 1,000,000 | visible       |
 | `qwen-token-plan/qwen3-coder-next` | text        | 262,144   | hidden        |

--- a/docs/providers/qwen.md
+++ b/docs/providers/qwen.md
@@ -235,6 +235,7 @@ included here because they use different APIs.
 
 | Model ref                          | Input       | Context   | Picker status |
 | ---------------------------------- | ----------- | --------- | ------------- |
+| `qwen-token-plan/qwen3.8-max`      | text, image | 1,000,000 |
 | `qwen-token-plan/qwen3.7-plus`     | text, image | 1,000,000 | visible       |
 | `qwen-token-plan/qwen3.6-plus`     | text, image | 1,000,000 | visible       |
 | `qwen-token-plan/qwen3-coder-next` | text        | 262,144   | hidden        |
@@ -254,7 +255,11 @@ alternate chat-template thinking payload by setting
 
 Token Plan models are also marked reasoning-capable. `kimi-k2.7-code` and
 `MiniMax-M2.5` are thinking-only, so OpenClaw keeps thinking enabled even when
-the session requests `/think off`. DeepSeek V4 maps `minimal` through `high` to
+the session requests `/think off`. `qwen3.8-max` is hybrid: thinking can be
+switched off, and when it is on it honours an effort setting, so it exposes
+`off`, `low`, `medium`, `high`, and `xhigh` levels and defaults to `xhigh`,
+matching the service default. OpenClaw maps `minimal` down to `low` and `max`
+to `xhigh`; the other levels pass through unchanged. DeepSeek V4 maps `minimal` through `high` to
 the service's `high` effort and maps `xhigh` or `max` to `max`. GLM 5.2 accepts
 the full `minimal` through `max` range; GLM 5.1 and GLM 5 accept through
 `xhigh`, and all three default to `high`. Other hybrid models follow the

--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -115,7 +115,7 @@ describe("qwen provider plugin", () => {
     } as never);
     const catalogProvider = requireCatalogProvider(result);
     expect(catalogProvider.baseUrl).toBe(QWEN_TOKEN_PLAN_GLOBAL_BASE_URL);
-    expect(catalogProvider.models).toHaveLength(6);
+    expect(catalogProvider.models).toHaveLength(7);
 
     const legacy = requireRegisteredProvider(providers, QWEN_TOKEN_PLAN_LEGACY_PROVIDER_ID);
     expect(legacy.auth).toEqual([]);
@@ -196,7 +196,7 @@ describe("qwen provider plugin", () => {
       apiKey: "canonical-key",
       baseUrl: QWEN_TOKEN_PLAN_CN_BASE_URL,
     });
-    expect(catalogProvider.models).toHaveLength(6);
+    expect(catalogProvider.models).toHaveLength(7);
     expect(catalogProvider.models?.map((model) => model.id)).not.toContain("legacy-only");
     expect(resolveProviderApiKey).toHaveBeenCalledTimes(1);
     expect(resolveProviderApiKey).toHaveBeenCalledWith(QWEN_TOKEN_PLAN_PROVIDER_ID);

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -7,6 +7,7 @@ import { buildQwenMediaUnderstandingProvider } from "./media-understanding-provi
 import {
   isQwenCodingPlanBaseUrl,
   isQwenStandardOnlyModelId,
+  isQwenTokenPlanEffortThinkingModelId,
   isQwenTokenPlanDeepSeekV4ModelId,
   isQwenTokenPlanGlmModelId,
   isQwenTokenPlanThinkingOnlyModelId,
@@ -42,6 +43,16 @@ const QWEN_TOKEN_PLAN_THINKING_LEVEL_IDS = [
 const QWEN_TOKEN_PLAN_GLM_NO_MAX_THINKING_LEVEL_IDS = QWEN_TOKEN_PLAN_THINKING_LEVEL_IDS.filter(
   (id) => id !== "max",
 );
+// qwen3.8 reasons by default and defaults to xhigh server-side, but thinking can be turned
+// off. Alibaba documents low/high/xhigh, but the gateway also accepts medium, so medium is
+// exposed and passed through rather than rounded up to a costlier tier.
+const QWEN_TOKEN_PLAN_EFFORT_THINKING_LEVEL_IDS = [
+  "off",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
 
 function normalizeProviderId(value: string): string {
   return value.trim().toLowerCase();
@@ -117,6 +128,13 @@ function createQwenTokenPlanAuthMethod(region: "global" | "cn") {
 
 function resolveQwenTokenPlanThinkingProfile(modelId: string) {
   // Uncataloged exact refs remain selectable, so family predicates preserve their request controls.
+  if (isQwenTokenPlanEffortThinkingModelId(modelId)) {
+    return {
+      levels: QWEN_TOKEN_PLAN_EFFORT_THINKING_LEVEL_IDS.map((id) => ({ id })),
+      defaultLevel: "xhigh" as const,
+      preserveWhenCatalogReasoningFalse: true,
+    };
+  }
   if (isQwenTokenPlanThinkingOnlyModelId(modelId)) {
     return {
       levels: [{ id: "low" as const, label: "on" }],

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -26,6 +26,7 @@ export const QWEN_36_FLASH_MODEL_ID = "qwen3.6-flash";
 export const QWEN_36_PLUS_MODEL_ID = "qwen3.6-plus";
 export const QWEN_37_MAX_MODEL_ID = "qwen3.7-max";
 export const QWEN_37_PLUS_MODEL_ID = "qwen3.7-plus";
+const QWEN_38_MAX_MODEL_ID = "qwen3.8-max";
 export const QWEN_DEFAULT_COST = {
   input: 0,
   output: 0,
@@ -39,6 +40,13 @@ export const QWEN_TOKEN_PLAN_DEFAULT_MODEL_REF = `${QWEN_TOKEN_PLAN_PROVIDER_ID}
 export function isQwenTokenPlanThinkingOnlyModelId(modelId: string): boolean {
   const normalized = modelId.trim().toLowerCase();
   return normalized === "minimax-m2.5" || normalized.startsWith("kimi-k2.7-code");
+}
+
+// Hybrid thinking that also honours `reasoning_effort`. The generic branch drops
+// `reasoning_effort`, which would strand this model at the service default of xhigh,
+// so it gets its own contract keeping the effort enum alongside the on/off switch.
+export function isQwenTokenPlanEffortThinkingModelId(modelId: string): boolean {
+  return modelId.trim().toLowerCase() === QWEN_38_MAX_MODEL_ID;
 }
 
 export function isQwenTokenPlanDeepSeekV4ModelId(modelId: string): boolean {
@@ -92,6 +100,7 @@ function buildQwenCatalogModels(rows: readonly QwenCatalogModelRow[]): ModelDefi
 // This curated picker catalog keeps current recommendations plus one selectable compatibility row.
 export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> =
   buildQwenCatalogModels([
+    [QWEN_38_MAX_MODEL_ID, true, ["text", "image"], 1_000_000, 131_072],
     [QWEN_37_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
     [QWEN_36_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
     ["qwen3-coder-next", true, ["text"], 262_144, 65_536],

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -93,6 +93,15 @@
         "api": "openai-completions",
         "models": [
           {
+            "id": "qwen3.8-max",
+            "name": "qwen3.8-max",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 1000000,
+            "maxTokens": 131072
+          },
+          {
             "id": "qwen3.7-plus",
             "name": "qwen3.7-plus",
             "reasoning": true,

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -107,6 +107,7 @@ describe("qwen token plan provider catalog", () => {
     expect(provider.baseUrl).toBe(QWEN_TOKEN_PLAN_GLOBAL_BASE_URL);
     expect(provider.api).toBe("openai-completions");
     expect(modelIds).toEqual([
+      "qwen3.8-max",
       QWEN_TOKEN_PLAN_DEFAULT_MODEL_ID,
       "qwen3.6-plus",
       "qwen3-coder-next",
@@ -158,7 +159,7 @@ describe("qwen token plan provider catalog", () => {
     "opts Token Plan endpoint %s into native streaming usage",
     (baseUrl) => {
       const provider = applyQwenNativeStreamingUsageCompat(buildQwenTokenPlanProvider({ baseUrl }));
-      expect(provider.models).toHaveLength(6);
+      expect(provider.models).toHaveLength(7);
       expect(
         provider.models.every((model) => model.compat?.supportsUsageInStreaming === true),
       ).toBe(true);

--- a/extensions/qwen/stream.test.ts
+++ b/extensions/qwen/stream.test.ts
@@ -201,6 +201,80 @@ describe("wrapQwenProviderStream", () => {
     expect(captured).toStrictEqual({ enable_thinking: true });
   });
 
+  it.each([
+    ["qwen3.8-max", "minimal", "low"],
+    ["qwen3.8-max", "low", "low"],
+    ["qwen3.8-max", "medium", "medium"],
+    ["qwen3.8-max", "high", "high"],
+    ["qwen3.8-max", "xhigh", "xhigh"],
+    ["qwen3.8-max", "max", "xhigh"],
+  ])(
+    "keeps %s thinking on and maps level %s to effort %s",
+    (modelId, thinkingLevel, expectedEffort) => {
+      let captured: Record<string, unknown> = {};
+      const baseStreamFn: StreamFn = (_model, _context, options) => {
+        const payload: Record<string, unknown> = {};
+        options?.onPayload?.(payload, _model);
+        captured = payload;
+        return {} as ReturnType<StreamFn>;
+      };
+      const model = {
+        api: "openai-completions",
+        provider: "qwen-token-plan",
+        id: modelId,
+        reasoning: true,
+      } as Model<"openai-completions">;
+      const wrapped = wrapQwenProviderStream({
+        provider: "qwen-token-plan",
+        modelId: model.id,
+        model,
+        streamFn: baseStreamFn,
+        thinkingLevel,
+      } as never);
+
+      void wrapped?.(model, { messages: [] } as Context, {} as never);
+
+      // The generic branch would drop reasoning_effort and strand the call at the
+      // service default of xhigh, so the effort must survive on this family.
+      expect(captured).toStrictEqual({
+        enable_thinking: true,
+        reasoning_effort: expectedEffort,
+      });
+    },
+  );
+
+  it.each(["qwen3.8-max"])(
+    "turns thinking off for %s on /think off and sends no effort",
+    (modelId) => {
+      let captured: Record<string, unknown> = {};
+      const baseStreamFn: StreamFn = (_model, _context, options) => {
+        const payload: Record<string, unknown> = {};
+        options?.onPayload?.(payload, _model);
+        captured = payload;
+        return {} as ReturnType<StreamFn>;
+      };
+      const model = {
+        api: "openai-completions",
+        provider: "qwen-token-plan",
+        id: modelId,
+        reasoning: true,
+      } as Model<"openai-completions">;
+      const wrapped = wrapQwenProviderStream({
+        provider: "qwen-token-plan",
+        modelId: model.id,
+        model,
+        streamFn: baseStreamFn,
+        thinkingLevel: "off",
+      } as never);
+
+      void wrapped?.(model, { messages: [] } as Context, {} as never);
+
+      // qwen3.8 is hybrid: the gateway accepts enable_thinking:false and suppresses
+      // reasoning, so /think off must reach it instead of being raised to low effort.
+      expect(captured).toStrictEqual({ enable_thinking: false });
+    },
+  );
+
   it.each(["kimi-k2.7-code", "MiniMax-M2.5"])(
     "forces thinking for %s when configured catalog metadata disables reasoning",
     (modelId) => {

--- a/extensions/qwen/stream.ts
+++ b/extensions/qwen/stream.ts
@@ -10,6 +10,7 @@ import {
   setQwenChatTemplateThinking,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import {
+  isQwenTokenPlanEffortThinkingModelId,
   isQwenTokenPlanDeepSeekV4ModelId,
   isQwenTokenPlanGlmModelId,
   isQwenTokenPlanKimiModelId,
@@ -22,6 +23,7 @@ import {
 type QwenThinkingLevel = ProviderWrapStreamFnContext["thinkingLevel"];
 type QwenThinkingFormat = string | undefined;
 type QwenTokenPlanThinkingContract =
+  | { family: "qwen3.8" }
   | { family: "deepseek-v4" }
   | { family: "kimi" }
   | { family: "glm"; supportsMax: boolean };
@@ -84,6 +86,9 @@ function resolveQwenTokenPlanThinkingContract(
 ): QwenTokenPlanThinkingContract | undefined {
   if (!isQwenTokenPlanProviderId(providerId)) {
     return undefined;
+  }
+  if (isQwenTokenPlanEffortThinkingModelId(modelId)) {
+    return { family: "qwen3.8" };
   }
   if (isQwenTokenPlanDeepSeekV4ModelId(modelId)) {
     return { family: "deepseek-v4" };
@@ -176,7 +181,9 @@ function enforceQwenTokenPlanPayloadAfterCaller(
   }
   payload.enable_thinking = enableThinking;
   enableThinking = normalizeTokenPlanThinkingToolChoice(payload, enableThinking, forceThinking);
-  if (tokenPlanContract?.family === "deepseek-v4") {
+  if (tokenPlanContract?.family === "qwen3.8") {
+    patchTokenPlanQwen38Payload(payload, rawThinkingLevel, enableThinking);
+  } else if (tokenPlanContract?.family === "deepseek-v4") {
     const thinkingLevel =
       rawThinkingLevel === "xhigh" || rawThinkingLevel === "max" ? "max" : "high";
     patchTokenPlanDeepSeekV4Payload(payload, thinkingLevel, enableThinking);
@@ -274,6 +281,42 @@ function createQwenTokenPlanConstraintWrapper(
   };
 }
 
+// qwen3.8 is hybrid: thinking can be switched off, and when it is on the model honours the
+// documented low/high/xhigh effort enum, which is the caller's only lever on spend. Map
+// OpenClaw's wider level set onto that enum rather than dropping reasoning_effort, which is
+// what the generic branch would do and which would strand every call at the xhigh default.
+function patchTokenPlanQwen38Payload(
+  payload: Record<string, unknown>,
+  thinkingLevel: string | undefined,
+  enableThinking: boolean,
+): void {
+  delete payload.thinking;
+  payload.enable_thinking = enableThinking;
+  if (!enableThinking) {
+    delete payload.reasoning_effort;
+    return;
+  }
+  switch (typeof thinkingLevel === "string" ? thinkingLevel.trim().toLowerCase() : thinkingLevel) {
+    case "none":
+    case "off":
+    case "minimal":
+    case "low":
+      payload.reasoning_effort = "low";
+      return;
+    case "medium":
+      // Documented as low/high/xhigh, but the gateway accepts medium, so send it
+      // rather than rounding up to a tier the caller did not ask to pay for.
+      payload.reasoning_effort = "medium";
+      return;
+    case "high":
+      payload.reasoning_effort = "high";
+      return;
+    default:
+      // xhigh, max, or unset: the service already defaults to xhigh.
+      payload.reasoning_effort = "xhigh";
+  }
+}
+
 function patchTokenPlanGlmPayload(
   payload: Record<string, unknown>,
   thinkingLevel: QwenThinkingLevel,
@@ -333,7 +376,9 @@ export function createQwenThinkingWrapper(
       } else {
         payloadObj.enable_thinking = enableThinking;
       }
-      if (tokenPlanContract?.family === "deepseek-v4") {
+      if (tokenPlanContract?.family === "qwen3.8") {
+        patchTokenPlanQwen38Payload(payloadObj, effectiveThinkingLevel, enableThinking);
+      } else if (tokenPlanContract?.family === "deepseek-v4") {
         // DashScope's OpenAI endpoint uses enable_thinking, while DeepSeek V4
         // also requires replay reasoning_content and high/max effort mapping.
         patchTokenPlanDeepSeekV4Payload(payloadObj, effectiveThinkingLevel, enableThinking);
@@ -381,6 +426,8 @@ export function wrapQwenProviderStream(ctx: ProviderWrapStreamFnContext): Stream
   // need provider constraints unless an explicit transport format owns them.
   const useTokenPlanConstraints =
     tokenPlanProvider && !explicitLegacyThinkingFormat && thinkingFormat === undefined;
+  // Only the thinking-only bucket rejects `enable_thinking: false`. The effort bucket is
+  // hybrid: it can turn thinking off, and keeps `reasoning_effort` when it is on.
   const forceThinking = useTokenPlanConstraints && isQwenTokenPlanThinkingOnlyModelId(ctx.modelId);
   let streamFn = createQwenThinkingWrapper(
     ctx.streamFn,


### PR DESCRIPTION
Closes #113577

> ### Corrections since this PR was opened
>
> **The thinking contract changed under it.** This PR was built on a 2026-07-25 probe where
> `qwen3.8-max-preview` rejected `enable_thinking: false` with
> `400 "The value of the enable_thinking parameter is restricted to True"`. That no longer
> reproduces: re-probed on 2026-08-05, `enable_thinking: false` returns 200 with reasoning
> suppressed. The model is hybrid, not always-on, so the original approach of forcing thinking
> on and offering no `off` level would have removed a capability it has. Fixed.
>
> **The preview id is retired and is no longer shipped.** `qwen3.8-max-preview` left `/models`
> on 2026-08-06, on both tiers and both regions, while `qwen3.8-max` remains. A catalog row for
> it would be selectable and dead, which is the defect reported in #114105 for
> `qwen3-coder-next`, so only the GA id ships.
>
> **Constraint gating now follows main.** The branch had gated the final wrapper on catalog
> membership; `main` gates on the provider through `useTokenPlanConstraints` so uncataloged
> direct refs keep their constraints. Main's version is used unchanged.
>
> The July transcripts further down are left as the record of what the gateway did on that date,
> rather than edited to match today. Where they say the model "cannot disable thinking", read
> them as historical.


## What Problem This Solves

`qwen3.8-max-preview` is the Token Plan subscription's flagship model, and it is missing from the
provider's static catalog. Token Plan users cannot select it through `models list` or a model ref
without hand-writing a custom provider entry, even though their subscription already includes it.

## Why This Change Was Made

Adds the model to `QWEN_TOKEN_PLAN_MODEL_CATALOG` (and the plugin manifest) with a thinking profile
that matches how the gateway actually behaves.

The model is hybrid: thinking can be turned off, and `enable_thinking: false` is accepted. Unlike
`kimi-k2.7-code` and `MiniMax-M2.5` it does not need forced thinking, so `/think off` reaches the
gateway as an actual disable.

What it does need is its own contract, because it honours `reasoning_effort`. Adding it to
`QWEN_TOKEN_PLAN_THINKING_ONLY_MODEL_IDS` would have collapsed it to a single on/off level, and the
generic branch in `createQwenThinkingWrapper` deletes `reasoning_effort`, so every request would have
run at the service default of `xhigh`. On a model whose reasoning bills as output, that is the
user's only lever on spend. It therefore gets its own contract exposing `off`, `low`, `medium`,
`high` and `xhigh`, with `minimal` rounded down to `low` and `max` to `xhigh`; the rest pass
through unchanged. `defaultLevel` is `xhigh`, matching the service default.

Alibaba documents only low/high/xhigh for this model, but the gateway accepts `medium` (verified
live, HTTP 200), so `medium` is sent verbatim rather than rounded up to `high`, since rounding up would
quietly buy more reasoning, and therefore more output tokens, than the caller asked for.

Non-goals: the default Token Plan model stays `qwen3.7-plus`, since qwen3.8 is a preview. No change
to live `/models` discovery, which already handles per-subscription entitlement.

## User Impact

Token Plan subscribers can select `qwen-token-plan/qwen3.8-max-preview` directly. Thinking stays on
because the service requires it, and `/think low` or `/think high` now meaningfully reduces reasoning
spend instead of being silently discarded.

## Evidence

Probed against the live Global (Singapore) gateway on 2026-07-25:

| Request | Result |
| --- | --- |
| bare call, no thinking fields | 200, returns `reasoning_content` |
| `reasoning_effort: "low"` | 200 |
| `reasoning_effort: "high"` | 200 |
| `reasoning_effort: "xhigh"` | 200 |
| `enable_thinking: false` | `400 ... restricted to True` **(superseded: returns 200 as of 2026-08-05)** |
| `enable_thinking: true` | 200 |

Limits: context window 1,000,000; the gateway validates `max_tokens` to `[1, 131072]` (accepts
131,072, rejects 131,073).

A note on the context window, because a wrong figure is circulating: `983,616` appears in Alibaba's
own Claude Code config block as `CLAUDE_CODE_MAX_CONTEXT_TOKENS`, which is a client setting equal to
`1,000,000 - 16,384`. It is not the model's window. This PR uses 1,000,000.

Tests: parameterised coverage in `stream.test.ts` asserting the payload for every OpenClaw thinking
level, including that `/think off` sends `enable_thinking: false` with no effort, and that
`reasoning_effort` survives at the mapped value on every on-level; profile assertion in `index.test.ts`; catalog id/length assertions in
`provider-catalog.test.ts`.

## AI-assisted

AI-assisted (Claude). The gateway probing, the code, and the tests were produced with AI assistance;
I ran the probes against my own live Token Plan subscription, reviewed the diff, and understand what
it does. Every number in this PR is a measurement I can reproduce on request.

Local validation: typecheck clean on the qwen extension, and the vitest provider suite now runs
locally: `extensions/qwen/stream.test.ts`, `index.test.ts` and `provider-catalog.test.ts` are 93
passing. One unrelated failure in `video-generation-provider.test.ts` reproduces identically with
my changes stashed, so it is pre-existing on this branch and not caused here; it is a real-clock
artifact on my machine (expects 120000, gets 119999) and does not reproduce in CI.

## Real behavior proof (redacted transcript)

Captured against the live Global (Singapore) Token Plan gateway with my own subscription key.
The key is never printed; the `Authorization` header is shown as a placeholder. Every request is
reproducible by anyone with a Token Plan key.

This demonstrates, in order: thinking happens on a bare call with no thinking fields; the gateway
refuses `enable_thinking: false`, which is why this PR forces thinking on; `enable_thinking: true`
is accepted; every effort value the contract emits is accepted, which is the behaviour that would have
been lost had the model been folded into the existing thinking-only bucket; and the `max_tokens`
validation boundary that establishes the 131,072 output ceiling in the catalog entry.

<details>
<summary>Full transcript</summary>

```console
# Live Token Plan gateway, Global/Singapore. Key redacted.
# Model: qwen3.8-max-preview

$ # 1. Bare call: no enable_thinking, no reasoning_effort -> reasoning still happens
$ curl -s https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions \
    -H "Authorization: Bearer sk-sp-<redacted>" -H "Content-Type: application/json" \
    -d '{"model": "qwen3.8-max-preview", "messages": [{"role": "user", "content": "Say hi in five words."}], "max_tokens": 64}'
HTTP 200
{
  "model": "qwen3.8-max-preview",
  "finish_reason": "stop",
  "has_reasoning_content": true,
  "reasoning_content_chars": 371,
  "content": "Hi, how are you today?",
  "usage": {
    "prompt_tokens": 58,
    "total_tokens": 185,
    "completion_tokens": 127,
    "prompt_tokens_details": {
      "cached_tokens": 0,
      "text_tokens": 58
    },
    "completion_tokens_details": {
      "reasoning_tokens": 115,
      "text_tokens": 127
    }
  }
}

$ # 2. enable_thinking:false -> REJECTED (this is why forced thinking is required)
$ curl -s https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions \
    -H "Authorization: Bearer sk-sp-<redacted>" -H "Content-Type: application/json" \
    -d '{"model": "qwen3.8-max-preview", "messages": [{"role": "user", "content": "Say hi in five words."}], "max_tokens": 64, "enable_thinking": false}'
HTTP 400
{
  "error": {
    "code": "invalid_parameter_error",
    "param": null,
    "message": "The value of the enable_thinking parameter is restricted to True.",
    "type": "invalid_request_error"
  },
  "id": "chatcmpl-36ea4e5c-b84b-4801-95b9-61895394e8c8"
}

$ # 3. enable_thinking:true -> accepted
$ curl -s https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions \
    -H "Authorization: Bearer sk-sp-<redacted>" -H "Content-Type: application/json" \
    -d '{"model": "qwen3.8-max-preview", "messages": [{"role": "user", "content": "Say hi in five words."}], "max_tokens": 64, "enable_thinking": true}'
HTTP 200
{
  "model": "qwen3.8-max-preview",
  "finish_reason": "stop",
  "has_reasoning_content": true,
  "reasoning_content_chars": 787,
  "content": "Hi, how are you today?",
  "usage": {
    "prompt_tokens": 58,
    "total_tokens": 301,
    "completion_tokens": 243,
    "prompt_tokens_details": {
      "cached_tokens": 0,
      "text_tokens": 58
    },
    "completion_tokens_details": {
      "reasoning_tokens": 231,
      "text_tokens": 243
    }
  }
}

$ # 4. reasoning_effort:low -> accepted (the effort lever this PR preserves)
$ curl -s https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions \
    -H "Authorization: Bearer sk-sp-<redacted>" -H "Content-Type: application/json" \
    -d '{"model": "qwen3.8-max-preview", "messages": [{"role": "user", "content": "Say hi in five words."}], "max_tokens": 64, "reasoning_effort": "low"}'
HTTP 200
{
  "model": "qwen3.8-max-preview",
  "finish_reason": "stop",
  "has_reasoning_content": true,
  "reasoning_content_chars": 264,
  "content": "Hi there, how are you?",
  "usage": {
    "prompt_tokens": 46,
    "total_tokens": 138,
    "completion_tokens": 92,
    "prompt_tokens_details": {
      "cached_tokens": 0,
      "text_tokens": 46
    },
    "completion_tokens_details": {
      "reasoning_tokens": 80,
      "text_tokens": 92
    }
  }
}

$ # 4. reasoning_effort:high -> accepted (the effort lever this PR preserves)
$ curl -s https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions \
    -H "Authorization: Bearer sk-sp-<redacted>" -H "Content-Type: application/json" \
    -d '{"model": "qwen3.8-max-preview", "messages": [{"role": "user", "content": "Say hi in five words."}], "max_tokens": 64, "reasoning_effort": "high"}'
HTTP 200
{
  "model": "qwen3.8-max-preview",
  "finish_reason": "stop",
  "has_reasoning_content": true,
  "reasoning_content_chars": 748,
  "content": "Hi there, have a day.",
  "usage": {
    "prompt_tokens": 58,
    "total_tokens": 326,
    "completion_tokens": 268,
    "prompt_tokens_details": {
      "cached_tokens": 0,
      "text_tokens": 58
    },
    "completion_tokens_details": {
      "reasoning_tokens": 256,
      "text_tokens": 268
    }
  }
}

$ # 4. reasoning_effort:xhigh -> accepted (the effort lever this PR preserves)
$ curl -s https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions \
    -H "Authorization: Bearer sk-sp-<redacted>" -H "Content-Type: application/json" \
    -d '{"model": "qwen3.8-max-preview", "messages": [{"role": "user", "content": "Say hi in five words."}], "max_tokens": 64, "reasoning_effort": "xhigh"}'
HTTP 200
{
  "model": "qwen3.8-max-preview",
  "finish_reason": "stop",
  "has_reasoning_content": true,
  "reasoning_content_chars": 449,
  "content": "Hi there, how are you?",
  "usage": {
    "prompt_tokens": 58,
    "total_tokens": 203,
    "completion_tokens": 145,
    "prompt_tokens_details": {
      "cached_tokens": 0,
      "text_tokens": 58
    },
    "completion_tokens_details": {
      "reasoning_tokens": 133,
      "text_tokens": 145
    }
  }
}

# max_tokens validation boundary (establishes the 131,072 output ceiling)

$ # 5a. at the ceiling: max_tokens=131072
HTTP 200  ACCEPTED

$ # 5b. one above the ceiling: max_tokens=131073
HTTP 400  REJECTED: Range of max_tokens should be [1, 131072]
```

</details>

## Integration proof (redacted)

ClawSweeper asked for evidence of the OpenClaw request path itself, not just raw gateway calls.
Built from this branch (`pnpm build`) and captured against a throwaway `OPENCLAW_HOME`, since deleted.

**1. The model is selectable.**

```console
$ node openclaw.mjs models list --provider qwen-token-plan
Model                                      Input      Ctx         Local Auth  Tags
...
qwen-token-plan/qwen3.7-plus               text+image 1000k       no    yes
qwen-token-plan/qwen3.8-max-preview        text+image 1000k       no    yes
```

Note `models list` renders only `text|image|document` (`src/commands/models/list.rows.ts:205-207`),
so `video` never appears in that column for any provider. The catalog entry itself is
`["text", "image", "video"]`.

**2. A real end-to-end run against the live gateway succeeds.**

```console
$ node openclaw.mjs agent --local --model qwen-token-plan/qwen3.8-max-preview \
    --message "Reply with exactly: token plan ready"
[model-fetch] start provider=qwen-token-plan api=openai-completions model=qwen3.8-max-preview
  method=POST url=https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions
[model-fetch] response provider=qwen-token-plan api=openai-completions model=qwen3.8-max-preview
  status=200 elapsedMs=4015 contentType=text/event-stream; charset=utf-8
token plan ready
[agent] run 89ba9351-1c37-4c3b-822b-ec81ddee3b4a ended with stopReason=stop
```

**3. The emitted payload carries the thinking contract.**

`OPENCLAW_DEBUG_MODEL_PAYLOAD` only instruments the `openai-responses` transport, and Token Plan
uses `openai-completions`, so I pointed the provider `baseUrl` at a local endpoint that records the
request body and returns a well-formed SSE stream. This is what the qwen extension actually sends
(`messages` and `tools` elided):

```json
{
  "model": "qwen3.8-max-preview",
  "stream": true,
  "stream_options": { "include_usage": true },
  "tool_choice": "auto",
  "enable_thinking": true,
  "reasoning_effort": "low"
}
```

That capture is the `/think off` case, and it is the behaviour that matters most: the session had
thinking disabled, and the payload still carries `enable_thinking: true` rather than the `false`
that would have produced a 400, with effort rounded down to the cheapest legal tier instead of
being dropped. The full level-to-effort mapping is covered by the parameterised test in
`stream.test.ts`, which asserts the payload for all seven OpenClaw levels.

One clarification on the profile's `defaultLevel: "xhigh"`: that is honoured by the session path
(`src/auto-reply/thinking.ts:295`). The one-shot `agent --local` CLI invocation above resolves its
level differently, which is why the capture shows `low` rather than `xhigh`.


