### PR TITLE
refactor(slack): reuse shared error coercion

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -43,7 +43,7 @@ import {
   resolveChannelStreamingSuppressDefaultToolProgressMessages,
   type ChannelProgressDraftLine,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
 import {
   buildTtsSupplementMediaPayload,
@@ -2364,7 +2364,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     });
   }
   if (dispatchError) {
-    throw toLintErrorObject(dispatchError, "Slack dispatch failed");
+    throw toErrorObject(dispatchError, "Slack dispatch failed");
   }
   if (!anyReplyDelivered && !draftPreviewCommitted) {
     await draftStream?.clear();
@@ -2377,19 +2377,5 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       `slack: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${prepared.replyTarget}`,
     );
   }
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/slack/src/monitor/provider-support.ts
+++ b/extensions/slack/src/monitor/provider-support.ts
@@ -1,4 +1,5 @@
 // Slack provider module implements model/runtime integration.
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { asOptionalRecord as asRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SlackChannelResolution } from "../resolve-channels.js";
 import type { SlackUserResolution } from "../resolve-users.js";
@@ -103,7 +104,7 @@ function installSlackNativeReconnectFailureObserver(receiver: unknown) {
               resolve(undefined);
               return;
             }
-            reject(toLintErrorObject(error, "Non-Error rejection"));
+            reject(toErrorObject(error, "Non-Error rejection"));
           });
         }, delayMs);
       });
@@ -405,7 +406,7 @@ export async function startSlackSocketAndWaitForDisconnect(params: {
     const disconnect = disconnectWaiter.getLatest();
     disconnectWaiter.cancel();
     if (isMissingSocketStartErrorDetail(err) && disconnect?.error !== undefined) {
-      throw toLintErrorObject(disconnect.error, "Non-Error thrown");
+      throw toErrorObject(disconnect.error, "Non-Error thrown");
     }
     if (isMissingSocketStartErrorDetail(err)) {
       const suffix = disconnect ? ` after ${disconnect.event}` : "";
@@ -487,18 +488,4 @@ export function formatSlackUserResolved(entry: SlackUserResolution): string | nu
     name: entry.name,
     extra: entry.note ? [entry.note] : [],
   });
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }


### PR DESCRIPTION
## What Problem This Solves

Slack maintained two identical copies of its non-Error coercion helper across message dispatch and Socket Mode provider support. Keeping the same structured-error behavior in multiple monitor modules creates avoidable drift and repeated maintenance.

## Why This Change Was Made

Replace both local helpers with the existing public `toErrorObject` Plugin SDK contract. The shared implementation is byte-for-byte equivalent for Error passthrough, string conversion, fallback messages, causes, and enumerable structured fields.

## User Impact

No user-visible behavior changes. Slack keeps the same dispatch and reconnect error semantics with 27 fewer production lines and one canonical coercion path.

## Evidence

- Blacksmith Testbox `tbx_01kyc5qpbma3mkg6dz2p5m2kk4` passed 156 focused tests:
  - normalization-core error coercion: 8
  - Slack preview fallback: 118
  - Slack provider interop: 15
  - Slack provider reconnect: 15
- The same Testbox passed `pnpm check:changed` in 3m35s across extension production and extension-test lanes.
- Hosted extension typecheck and Plugin SDK boundary checks passed.
- Fresh post-rebase autoreview: clean, 0.99 confidence.

AI-assisted: yes. The maintainer reviewed the implementation and proof.
