### PR TITLE
refactor(matrix): reuse shared error coercion

### DIFF
--- a/extensions/matrix/src/matrix/sdk/idb-persistence.test-helpers.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.test-helpers.ts
@@ -1,4 +1,6 @@
 // Matrix helper module supports idb persistence helpers behavior.
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
+
 export async function clearAllIndexedDbState(params?: { databasePrefix?: string }): Promise<void> {
   const databases = await indexedDB.databases();
   const expectedPrefix = params?.databasePrefix ? `${params.databasePrefix}::` : null;
@@ -14,7 +16,7 @@ export async function clearAllIndexedDbState(params?: { databasePrefix?: string 
             req.addEventListener("success", () => resolve(), { once: true });
             req.addEventListener(
               "error",
-              () => reject(toLintErrorObject(req.error, "Non-Error rejection")),
+              () => reject(toErrorObject(req.error, "Non-Error rejection")),
               { once: true },
             );
             req.addEventListener("blocked", () => resolve(), { once: true });
@@ -48,17 +50,13 @@ export async function seedDatabase(params: {
         db.close();
         resolve();
       });
-      tx.addEventListener(
-        "error",
-        () => reject(toLintErrorObject(tx.error, "Non-Error rejection")),
-        { once: true },
-      );
+      tx.addEventListener("error", () => reject(toErrorObject(tx.error, "Non-Error rejection")), {
+        once: true,
+      });
     });
-    req.addEventListener(
-      "error",
-      () => reject(toLintErrorObject(req.error, "Non-Error rejection")),
-      { once: true },
-    );
+    req.addEventListener("error", () => reject(toErrorObject(req.error, "Non-Error rejection")), {
+      once: true,
+    });
   });
 }
 
@@ -97,33 +95,17 @@ export async function readDatabaseRecords(params: {
       });
       keysReq.addEventListener(
         "error",
-        () => reject(toLintErrorObject(keysReq.error, "Non-Error rejection")),
+        () => reject(toErrorObject(keysReq.error, "Non-Error rejection")),
         { once: true },
       );
       valuesReq.addEventListener(
         "error",
-        () => reject(toLintErrorObject(valuesReq.error, "Non-Error rejection")),
+        () => reject(toErrorObject(valuesReq.error, "Non-Error rejection")),
         { once: true },
       );
     });
-    req.addEventListener(
-      "error",
-      () => reject(toLintErrorObject(req.error, "Non-Error rejection")),
-      { once: true },
-    );
+    req.addEventListener("error", () => reject(toErrorObject(req.error, "Non-Error rejection")), {
+      once: true,
+    });
   });
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { indexedDB as fakeIndexedDB } from "fake-indexeddb";
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { withFileLock } from "openclaw/plugin-sdk/file-lock";
 import {
   MATRIX_IDB_SNAPSHOT_FILENAME,
@@ -133,11 +134,9 @@ export function isValidMatrixIdbSnapshotJson(data: string): boolean {
 function idbReq<T>(req: IDBRequest<T>): Promise<T> {
   return new Promise((resolve, reject) => {
     req.addEventListener("success", () => resolve(req.result), { once: true });
-    req.addEventListener(
-      "error",
-      () => reject(toLintErrorObject(req.error, "Non-Error rejection")),
-      { once: true },
-    );
+    req.addEventListener("error", () => reject(toErrorObject(req.error, "Non-Error rejection")), {
+      once: true,
+    });
   });
 }
 
@@ -157,7 +156,7 @@ async function dumpIndexedDatabases(databasePrefix?: string): Promise<IdbDatabas
     const db: IDBDatabase = await new Promise((resolve, reject) => {
       const r = idb.open(name, version);
       r.addEventListener("success", () => resolve(r.result), { once: true });
-      r.addEventListener("error", () => reject(toLintErrorObject(r.error, "Non-Error rejection")), {
+      r.addEventListener("error", () => reject(toErrorObject(r.error, "Non-Error rejection")), {
         once: true,
       });
     });
@@ -245,7 +244,7 @@ async function restoreIndexedDatabases(snapshot: IdbDatabaseSnapshot[]): Promise
         },
         { once: true },
       );
-      r.addEventListener("error", () => reject(toLintErrorObject(r.error, "Non-Error rejection")), {
+      r.addEventListener("error", () => reject(toErrorObject(r.error, "Non-Error rejection")), {
         once: true,
       });
     });
@@ -389,18 +388,4 @@ function throwIfLegacySnapshotNeedsDoctor(
 function throwLegacySnapshotMigrationRequired(): never {
   LogService.warn("IdbPersistence", LEGACY_SNAPSHOT_DIAGNOSTIC);
   throw new MatrixIdbSnapshotMigrationRequiredError();
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }

--- a/extensions/matrix/src/matrix/startup-abort.ts
+++ b/extensions/matrix/src/matrix/startup-abort.ts
@@ -1,4 +1,6 @@
 // Matrix plugin module implements startup abort behavior.
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
+
 export function createMatrixStartupAbortError(): Error {
   const error = new Error("Matrix startup aborted");
   error.name = "AbortError";
@@ -38,22 +40,8 @@ export async function awaitMatrixStartupWithAbort<T>(
       },
       (error: unknown) => {
         abortSignal.removeEventListener("abort", onAbort);
-        reject(toLintErrorObject(error, "Non-Error rejection"));
+        reject(toErrorObject(error, "Non-Error rejection"));
       },
     );
   });
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }


### PR DESCRIPTION
## What Problem This Solves

Matrix startup and IndexedDB persistence carried three exact copies of the same error-coercion behavior, including one in the test helper. Keeping those copies separate increases drift risk whenever structured rejection handling changes.

This is a maintainer-requested cleanup from the current duplicate/dead-code sweep.

## Why This Change Was Made

The Matrix plugin now uses the existing public `openclaw/plugin-sdk/error-runtime` helper for all three paths. The shared helper preserves existing `Error` identity, string handling, fallback messages, causes, and enumerable structured fields.

The change stays inside the Matrix owner boundary and removes 27 production lines, 45 lines overall.

## User Impact

No user-visible behavior changes. Matrix startup and IndexedDB errors now follow the same canonical coercion path as other plugin surfaces, reducing future drift.

AI-assisted: yes. The implementation and proof were reviewed against the current source contracts.

## Evidence

- Blacksmith Testbox `tbx_01kyc714z3xm119xrgp81xbfc0`
- `corepack pnpm test:serial packages/normalization-core/src/error-coercion.test.ts extensions/matrix/src/matrix/client/shared.test.ts extensions/matrix/src/matrix/sdk/idb-persistence.test.ts`
  - 22 tests passed across 3 files
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
  - extension production/test typechecks, lint, SDK contracts, boundaries, and import-cycle checks passed
- `oxfmt --check` and `git diff --check` passed
- Fresh post-rebase autoreview: clean, 0.99 confidence
