### PR TITLE
fix: restore plugin bindings and macOS test stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Plugin conversation binding agent scope:** resolve opaque plugin-owned session keys against the configured default agent in channel binding adapters, restoring current-conversation binds after implicit `main` fallback removal.
 - **Cron local-provider preflight:** report the guarded-fetch deadline as a bounded preflight timeout, preserve concrete nested non-timeout errors, and carry the failure reason into fallback warnings. Thanks @shakkernerd.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Plugin conversation binding agent scope:** resolve opaque plugin-owned session keys against the configured default agent in channel binding adapters, restoring current-conversation binds after implicit `main` fallback removal.
 - **Cron local-provider preflight:** report the guarded-fetch deadline as a bounded preflight timeout, preserve concrete nested non-timeout errors, and carry the failure reason into fallback warnings. Thanks @shakkernerd.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -1249,6 +1249,9 @@ describe("thread binding lifecycle", () => {
   it("binds current Discord DMs as direct conversation bindings", async () => {
     createTestThreadBindingManager({
       accountId: "default",
+      cfg: {
+        agents: { list: [{ id: "codex", default: true }] },
+      },
       persist: false,
       enableSweeper: false,
       idleTimeoutMs: 24 * 60 * 60 * 1000,
@@ -1285,7 +1288,7 @@ describe("thread binding lifecycle", () => {
       parentConversationId: "user:1177378744822943744",
     });
     expectFields(requireRecord(bound, "bound session").metadata, "bound metadata", {
-      agentId: "main",
+      agentId: "codex",
     });
     const resolved = requireRecord(
       getSessionBindingService().resolveByConversation({

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -1284,6 +1284,9 @@ describe("thread binding lifecycle", () => {
       conversationId: "user:1177378744822943744",
       parentConversationId: "user:1177378744822943744",
     });
+    expectFields(requireRecord(bound, "bound session").metadata, "bound metadata", {
+      agentId: "main",
+    });
     const resolved = requireRecord(
       getSessionBindingService().resolveByConversation({
         channel: "discord",

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -1,3 +1,4 @@
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 // Discord plugin module implements thread bindings.manager behavior.
 import {
   registerSessionBindingAdapter,
@@ -383,7 +384,7 @@ export function createThreadBindingManager(params: {
         agentId:
           normalizeOptionalString(bindParams.agentId) ??
           normalizeOptionalString(existingValue?.agentId) ??
-          resolveAgentIdFromSessionKey(targetSessionKey),
+          resolveAgentIdFromSessionKey(targetSessionKey, resolveDefaultAgentId(cfg)),
         label:
           normalizeOptionalString(bindParams.label) ??
           normalizeOptionalString(existingValue?.label),

--- a/extensions/feishu/src/thread-bindings.ts
+++ b/extensions/feishu/src/thread-bindings.ts
@@ -1,3 +1,4 @@
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 // Feishu plugin module implements thread bindings behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -186,7 +187,11 @@ export function createFeishuThreadBindingManager(params: {
         agentId:
           typeof metadata?.agentId === "string" && metadata.agentId.trim()
             ? metadata.agentId.trim()
-            : (existingLocal?.agentId ?? resolveAgentIdFromSessionKey(normalizedTargetSessionKey)),
+            : (existingLocal?.agentId ??
+              resolveAgentIdFromSessionKey(
+                normalizedTargetSessionKey,
+                resolveDefaultAgentId(params.cfg),
+              )),
         label:
           typeof metadata?.label === "string" && metadata.label.trim()
             ? metadata.label.trim()

--- a/extensions/matrix/src/matrix/thread-bindings.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { readJsonFileWithFallback } from "openclaw/plugin-sdk/json-store";
 import { resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/session-key-runtime";
@@ -586,7 +587,7 @@ export async function createMatrixThreadBindingManager(params: {
         targetSessionKey,
         agentId:
           normalizeOptionalString(input.metadata?.agentId) ||
-          resolveAgentIdFromSessionKey(targetSessionKey),
+          resolveAgentIdFromSessionKey(targetSessionKey, resolveDefaultAgentId(params.cfg)),
         label: normalizeOptionalString(input.metadata?.label) || undefined,
         boundBy: normalizeOptionalString(input.metadata?.boundBy) || "system",
         boundAt: now,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -94,7 +94,9 @@ async function withTempSessionStore<T>(
     return await run({ dir, storePath: path.join(dir, "sessions.json") });
   } finally {
     closeOpenClawAgentDatabasesForTest();
-    await fs.rm(dir, { recursive: true, force: true });
+    // SQLite teardown can race fixture removal on loaded CI hosts. Keep the
+    // retries bounded so persistent cleanup failures still surface.
+    await fs.rm(dir, { recursive: true, force: true, maxRetries: 20, retryDelay: 25 });
   }
 }
 

--- a/src/infra/outbound/account-scoped-conversation-bindings.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.ts
@@ -1,3 +1,4 @@
+import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 // Account-scoped conversation binding managers adapt channel-local thread maps
 // into the shared session binding service.
 import { resolveThreadBindingConversationIdFromBindingId } from "../../channels/thread-binding-id.js";
@@ -175,7 +176,11 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
         agentId:
           typeof metadata?.agentId === "string" && metadata.agentId.trim()
             ? metadata.agentId.trim()
-            : (existingLocal?.agentId ?? resolveAgentIdFromSessionKey(normalizedTargetSessionKey)),
+            : (existingLocal?.agentId ??
+              resolveAgentIdFromSessionKey(
+                normalizedTargetSessionKey,
+                resolveDefaultAgentId(params.cfg),
+              )),
         label:
           typeof metadata?.label === "string" && metadata.label.trim()
             ? metadata.label.trim()

--- a/src/plugin-sdk/memory-host-core.test.ts
+++ b/src/plugin-sdk/memory-host-core.test.ts
@@ -22,6 +22,10 @@ import {
 } from "./memory-host-core.js";
 import { appendMemoryHostEvent } from "./memory-host-events.js";
 
+async function createFixtureRoot(prefix: string): Promise<string> {
+  return await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), prefix)));
+}
+
 describe("memory-host-core helpers", () => {
   afterEach(() => {
     clearMemoryPluginState();
@@ -92,7 +96,7 @@ describe("memory-host-core helpers", () => {
   });
 
   it("lists readable workspaces without requiring workspace-root writes", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-readonly-workspace-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-readonly-workspace-");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     try {
       vi.stubEnv("OPENCLAW_STATE_DIR", path.join(fixtureRoot, "state"));
@@ -131,9 +135,7 @@ describe("memory-host-core helpers", () => {
   it.runIf(process.platform !== "win32")(
     "propagates failures reading an existing event export",
     async () => {
-      const fixtureRoot = await fs.mkdtemp(
-        path.join(os.tmpdir(), "memory-host-unreadable-export-"),
-      );
+      const fixtureRoot = await createFixtureRoot("memory-host-unreadable-export-");
       const workspaceDir = path.join(fixtureRoot, "workspace");
       let eventExportPath: string | undefined;
       try {
@@ -182,7 +184,7 @@ describe("memory-host-core helpers", () => {
   it.runIf(process.platform !== "win32")(
     "does not delete an event export through a symlinked parent",
     async () => {
-      const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-export-symlink-"));
+      const fixtureRoot = await createFixtureRoot("memory-host-export-symlink-");
       const workspaceDir = path.join(fixtureRoot, "workspace");
       const externalMemoryDir = path.join(fixtureRoot, "external-memory");
       const stateDir = path.join(fixtureRoot, "state");
@@ -227,7 +229,7 @@ describe("memory-host-core helpers", () => {
   );
 
   it("does not replace or delete an unowned event export path", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-unowned-export-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-unowned-export-");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     try {
       vi.stubEnv("OPENCLAW_STATE_DIR", fixtureRoot);
@@ -274,7 +276,7 @@ describe("memory-host-core helpers", () => {
   });
 
   it("does not let an orphaned owner marker authorize a later workspace file", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-orphan-owner-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-orphan-owner-");
     const stateDir = path.join(fixtureRoot, "state");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     try {
@@ -331,7 +333,7 @@ describe("memory-host-core helpers", () => {
   });
 
   it("does not claim a same-content inode that replaces an exclusive export", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-create-replace-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-create-replace-");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     const cfg = {
       agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
@@ -393,7 +395,7 @@ describe("memory-host-core helpers", () => {
   });
 
   it("does not claim a hash-only pending event export after interruption", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-pending-owner-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-pending-owner-");
     const stateDir = path.join(fixtureRoot, "state");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     const firstEvent = {
@@ -464,7 +466,7 @@ describe("memory-host-core helpers", () => {
   });
 
   it("omits the event export when a workspace path component is a file", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-blocked-export-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-blocked-export-");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     try {
       vi.stubEnv("OPENCLAW_STATE_DIR", path.join(fixtureRoot, "state"));
@@ -495,7 +497,7 @@ describe("memory-host-core helpers", () => {
   });
 
   it("lists shared public artifacts from memory workspaces", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-public-artifacts-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-public-artifacts-");
     try {
       vi.stubEnv("OPENCLAW_STATE_DIR", fixtureRoot);
       const workspaceDir = path.join(fixtureRoot, "workspace");
@@ -620,7 +622,7 @@ describe("memory-host-core helpers", () => {
   it.runIf(process.platform !== "win32")(
     "does not let a workspace alias overwrite a newer event export",
     async () => {
-      const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-export-race-"));
+      const fixtureRoot = await createFixtureRoot("memory-host-export-race-");
       const workspaceDir = path.join(fixtureRoot, "workspace");
       const workspaceAlias = path.join(fixtureRoot, "workspace-alias");
       const cfg = {
@@ -710,7 +712,7 @@ describe("memory-host-core helpers", () => {
     { name: "refresh", clearEvents: false },
     { name: "retirement", clearEvents: true },
   ])("preserves a replacement installed during event export $name", async ({ clearEvents }) => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-export-replace-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-export-replace-");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     const cfg = {
       agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
@@ -776,7 +778,7 @@ describe("memory-host-core helpers", () => {
     { name: "refresh", clearEvents: false },
     { name: "retirement", clearEvents: true },
   ])("keeps ownership through same-inode event export $name", async ({ clearEvents }) => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-export-inode-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-export-inode-");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     const cfg = {
       agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
@@ -848,7 +850,7 @@ describe("memory-host-core helpers", () => {
   });
 
   it("retries an owned event export after a same-inode post-write race", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-export-retry-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-export-retry-");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     const cfg = {
       agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
@@ -911,7 +913,7 @@ describe("memory-host-core helpers", () => {
   });
 
   it("repairs an oversized owned event export by inode", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-export-oversized-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-export-oversized-");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     const cfg = {
       agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
@@ -953,7 +955,7 @@ describe("memory-host-core helpers", () => {
   });
 
   it("keeps public event exports isolated across state directories", async () => {
-    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-export-owner-"));
+    const fixtureRoot = await createFixtureRoot("memory-host-export-owner-");
     const workspaceDir = path.join(fixtureRoot, "workspace");
     const cfg = {
       agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },


### PR DESCRIPTION
## What Problem This Solves

Fixes two current-`main` regressions found on macOS: the memory-host SDK suite failed three tests because resolver paths canonicalized `/var` to `/private/var`, and plugin-owned current-conversation bindings failed when their opaque session keys did not encode an agent ID after implicit `main` fallback removal.

## Why This Change Was Made

Memory-host fixtures now canonicalize every temporary root before resolver assertions and race interception. Channel binding owners now pass their configured default agent into opaque-key resolution, covering Discord and the sibling Feishu, Matrix, and account-scoped adapters without restoring a global implicit fallback. The Discord regression configures `codex` as a non-`main` default and verifies that exact agent is stored.

Required full CI also exposed a pre-existing session-store fixture teardown race twice. Its database-first cleanup now uses the repository's bounded recursive-removal retry policy so transient `ENOTEMPTY` does not fail an otherwise green 2,109-test shard.

AI-assisted with Codex. The patch was manually traced through the binding service, channel adapters, memory export owner, and filesystem-safe publication path, then reviewed with the repository autoreview workflow.

## User Impact

Plugin-owned conversation bindings work again when the plugin session key is intentionally opaque, and contributors can run the memory-host SDK suite on macOS without false path mismatches or a 120-second race timeout.

## Evidence

Before the fix on macOS at current `main`:

- `src/plugin-sdk/memory-host-core.test.ts`: 3 failed / 20, including the `/var` vs `/private/var` assertion and a 120-second timeout; `OPENCLAW_VITEST_MAX_WORKERS=1` reproduced the same three failures.
- `extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts`: 1 failed / 34 with `Session key does not contain an agent id`.

After the fix on the rebased branch:

- `node scripts/run-vitest.mjs src/plugin-sdk/memory-host-core.test.ts` — 20/20 passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugin-sdk/memory-host-core.test.ts` — 20/20 passed.
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts` — 34/34 passed; the opaque plugin key resolved to configured default `codex`, and the direct binding made zero Discord REST calls.
- `node scripts/run-vitest.mjs extensions/feishu/src/thread-bindings.test.ts` — 4/4 passed.
- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/thread-bindings.test.ts` — 11/11 passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/command/session-store.test.ts` — 58/58 passed.
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox `tbx_01kyc6cx7m0p01qj18tpcd3hdw` (Actions run `30151252223`).
- Autoreview — clean, no accepted/actionable findings, overall correctness 0.99.

Live transport proof is intentionally skipped. Current-placement direct binding is a local adapter operation whose contract explicitly makes no Discord REST call; a credentialed live run would mutate a real persisted conversation binding without exercising an additional transport path. The configured non-`main` actual-adapter regression above is the closest safe proof and directly covers the risk identified by ClawSweeper.
