### PR TITLE
refactor(telegram): reuse shared error coercion

### DIFF
--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -1,7 +1,7 @@
 // Telegram plugin module implements probe behavior.
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithTimeout, runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -199,7 +199,7 @@ export async function probeTelegram(
       }
 
       if (!meRes) {
-        throw toLintErrorObject(
+        throw toErrorObject(
           fetchError ?? new Error(`probe timed out after ${timeoutBudgetMs}ms`),
           "Non-Error thrown",
         );
@@ -292,18 +292,4 @@ export async function probeTelegram(
       error: formatErrorMessage(error),
     }),
   );
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }


### PR DESCRIPTION
## What Problem This Solves

Telegram probe failures had a private error-coercion implementation that exactly duplicated the existing Plugin SDK contract. Keeping the copy created an unnecessary drift point in a channel reliability path.

## Why This Change Was Made

The probe now imports `toErrorObject` from `openclaw/plugin-sdk/error-runtime` and deletes the Telegram-local clone. The shared helper preserves the same error identity, fallback message, cause, and enumerable structured fields.

## User Impact

No user-visible behavior changes. Telegram probe errors keep the same messages and structured details while using the canonical SDK implementation.

## Evidence

- Blacksmith Testbox `tbx_01kyc7pj3m3yq8krwkah2mctf4`: 21 focused tests passed across normalization-core error coercion and Telegram probe behavior.
- The same Testbox passed the one-file `pnpm check:changed` plan, including extension production/test typechecks, lint, SDK contracts, plugin boundaries, database-first guards, and import-cycle checks.
- `oxfmt --check` and `git diff --check` passed.
- Fresh post-rebase autoreview reported no actionable findings at 0.99 confidence.
- Final diff: 1 file, 2 insertions, 16 deletions.

AI-assisted: yes. I reviewed the implementation and validation results. No agent transcript is included.
