### PR TITLE
refactor(models): share config ref flattening

### DIFF
--- a/packages/model-catalog-core/src/configured-model-refs.test.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.test.ts
@@ -3,9 +3,22 @@ import { describe, expect, it } from "vitest";
 import {
   collectConfiguredModelRefs,
   collectConfiguredModelRefValues,
+  listModelRefsFromConfigValue,
 } from "./configured-model-refs.js";
 
 describe("configured model refs", () => {
+  it("lists raw refs from one model selector without normalizing them", () => {
+    expect(listModelRefsFromConfigValue("  openai/gpt-5.5  ")).toEqual(["  openai/gpt-5.5  "]);
+    expect(
+      listModelRefsFromConfigValue({
+        primary: " primary/model ",
+        fallbacks: ["", "fallback/model", 42, "fallback/model"],
+      }),
+    ).toEqual([" primary/model ", "", "fallback/model", "fallback/model"]);
+    expect(listModelRefsFromConfigValue(["openai/gpt-5.5"])).toEqual([]);
+    expect(listModelRefsFromConfigValue({ primary: 42, fallbacks: "openai/gpt-5.5" })).toEqual([]);
+  });
+
   it("collects agent, hook, message, and channel model refs with config paths", () => {
     expect(
       collectConfiguredModelRefs({

--- a/packages/model-catalog-core/src/configured-model-refs.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.ts
@@ -20,6 +20,28 @@ export const AGENT_MODEL_CONFIG_KEYS = [
   "pdfModel",
 ] as const;
 
+/** List raw refs from one string or primary/fallback model selector. */
+export function listModelRefsFromConfigValue(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (!isRecord(value)) {
+    return [];
+  }
+  const refs: string[] = [];
+  if (typeof value.primary === "string") {
+    refs.push(value.primary);
+  }
+  if (Array.isArray(value.fallbacks)) {
+    for (const fallback of value.fallbacks) {
+      if (typeof fallback === "string") {
+        refs.push(fallback);
+      }
+    }
+  }
+  return refs;
+}
+
 /** Collect configured model references from agents, channels, hooks, and message config. */
 export function collectConfiguredModelRefs(
   config: unknown,

--- a/src/agents/harness-runtimes.test.ts
+++ b/src/agents/harness-runtimes.test.ts
@@ -30,6 +30,18 @@ describe("collectConfiguredAgentHarnessRuntimes", () => {
     expect(collectConfiguredAgentHarnessRuntimes(config)).toEqual(["codex"]);
   });
 
+  it("requires Codex when OpenAI is only a default model fallback", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { fallbacks: ["openai/gpt-5.5"] },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(collectConfiguredAgentHarnessRuntimes(config)).toEqual(["codex"]);
+  });
+
   it("can ignore implicit OpenAI Codex runtime preferences", () => {
     const config = {
       agents: {

--- a/src/agents/harness-runtimes.ts
+++ b/src/agents/harness-runtimes.ts
@@ -1,6 +1,7 @@
 /**
  * Collects configured native harness runtime ids from model provider config.
  */
+import { listModelRefsFromConfigValue } from "@openclaw/model-catalog-core/configured-model-refs";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isRecord } from "../utils.js";
@@ -21,35 +22,6 @@ function isSelectablePluginRuntime(runtime: string | undefined): runtime is stri
     !isDefaultAgentRuntimeId(runtime) &&
     normalizeOptionalAgentRuntimeId(runtime) !== OPENCLAW_AGENT_RUNTIME_ID
   );
-}
-
-// Agent model config accepts a direct string or primary/fallback object. Collect
-// all refs so fallback-only harness preferences still preload their plugin.
-function listAgentModelRefs(value: unknown): string[] {
-  if (typeof value === "string") {
-    return [value];
-  }
-  if (!isRecord(value)) {
-    return [];
-  }
-  const refs: string[] = [];
-  if (typeof value.primary === "string") {
-    refs.push(value.primary);
-  }
-  if (Array.isArray(value.fallbacks)) {
-    for (const fallback of value.fallbacks) {
-      if (typeof fallback === "string") {
-        refs.push(fallback);
-      }
-    }
-  }
-  return refs;
-}
-
-function pushAgentModelRefs(refs: string[], value: unknown): void {
-  for (const ref of listAgentModelRefs(value)) {
-    refs.push(ref);
-  }
 }
 
 // Parses provider/model refs used in config maps before asking harness policy
@@ -148,9 +120,7 @@ function pushConfiguredAgentModelRuntimeIds(
   };
 
   const defaultsModel = config.agents?.defaults?.model;
-  const defaultsModelRefs: string[] = [];
-  pushAgentModelRefs(defaultsModelRefs, defaultsModel);
-  pushModelRefs(defaultsModelRefs);
+  pushModelRefs(listModelRefsFromConfigValue(defaultsModel));
   pushModelMapRefs(config.agents?.defaults?.models);
 
   for (const agent of listAgentEntries(config)) {
@@ -158,9 +128,7 @@ function pushConfiguredAgentModelRuntimeIds(
       continue;
     }
     const agentId = typeof agent.id === "string" ? agent.id : undefined;
-    const selectedModelRefs: string[] = [];
-    pushAgentModelRefs(selectedModelRefs, agent.model ?? defaultsModel);
-    pushModelRefs(selectedModelRefs, agentId);
+    pushModelRefs(listModelRefsFromConfigValue(agent.model ?? defaultsModel), agentId);
     pushModelMapRefs(agent.models, agentId);
   }
 }

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -805,6 +805,19 @@ describe("resolveGatewayStartupPluginIds", () => {
       ["demo-channel", "browser", "amazon-bedrock", "memory-core"],
     ],
     [
+      "includes bundled model providers selected only as agent fallbacks at startup",
+      {
+        agents: {
+          defaults: {
+            model: {
+              fallbacks: ["amazon-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0"],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      ["demo-channel", "browser", "amazon-bedrock", "memory-core"],
+    ],
+    [
       "honors explicit plugin disablement for selected model providers",
       {
         agents: {

--- a/src/plugins/gateway-startup-plugin-providers.ts
+++ b/src/plugins/gateway-startup-plugin-providers.ts
@@ -1,4 +1,5 @@
 // Collects configured model, generation, voice, and memory provider ownership.
+import { listModelRefsFromConfigValue } from "@openclaw/model-catalog-core/configured-model-refs";
 import {
   buildModelCatalogMergeKey,
   parseModelCatalogRef,
@@ -58,29 +59,8 @@ export function manifestOwnsConfiguredWebSearchProvider(params: {
   });
 }
 
-function listModelProviderRefs(value: unknown): string[] {
-  if (typeof value === "string") {
-    return [value];
-  }
-  if (!isRecord(value)) {
-    return [];
-  }
-  const refs: string[] = [];
-  if (typeof value.primary === "string") {
-    refs.push(value.primary);
-  }
-  if (Array.isArray(value.fallbacks)) {
-    for (const fallback of value.fallbacks) {
-      if (typeof fallback === "string") {
-        refs.push(fallback);
-      }
-    }
-  }
-  return refs;
-}
-
 function listModelProviderRefParts(value: unknown): Array<{ providerId: string; modelId: string }> {
-  return listModelProviderRefs(value)
+  return listModelRefsFromConfigValue(value)
     .map(parseModelCatalogRef)
     .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
     .map(({ provider, modelId }) => ({ providerId: provider, modelId }));
@@ -88,7 +68,7 @@ function listModelProviderRefParts(value: unknown): Array<{ providerId: string; 
 
 function collectModelProviderIds(value: unknown): ReadonlySet<string> {
   return new Set(
-    listModelProviderRefs(value)
+    listModelRefsFromConfigValue(value)
       .map((ref) => {
         const slashIndex = ref.indexOf("/");
         return slashIndex > 0 ? normalizeProviderId(ref.slice(0, slashIndex)) : "";


### PR DESCRIPTION
## What Problem This Solves

Gateway provider startup and agent harness discovery independently flattened the same string-or-primary/fallback model selector shape. The duplicate implementations could drift and make fallback-only configuration activate different owners on adjacent startup paths.

## Why This Change Was Made

`model-catalog-core` now owns one narrow raw selector flattener. Both callers use it while keeping their higher-level provider parsing, harness policy, inheritance, and scope unchanged. The helper intentionally preserves whitespace, blanks, duplicates, and primary-before-fallback order.

## User Impact

No configuration behavior changes. Model providers and agent harness plugins continue to preload from primary and fallback refs consistently, with one canonical implementation behind both paths.

## Evidence

- Blacksmith Testbox `tbx_01kyc8a7nszenvsdy23pnc6db8`: 179 focused tests passed across model-catalog-core, harness runtime discovery, and gateway startup planning.
- The same Testbox passed `pnpm check:changed`, including core production/test typechecks, lint, package and Plugin SDK contracts, plugin boundaries, database-first guards, and import-cycle checks.
- Added direct raw-value semantics coverage plus fallback-only provider and harness regression tests.
- `oxfmt --check` and `git diff --check` passed.
- Fresh post-rebase autoreview reported no actionable findings at 0.98 confidence.
- Production diff: 28 net lines removed.

AI-assisted: yes. I reviewed the implementation and validation results. No agent transcript is included.
