### PR TITLE
[AI-assisted] docs(mistral): fix broken adjustable-reasoning docs URL

### DIFF
--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -147,7 +147,7 @@ OpenClaw defaults Mistral realtime STT to `pcm_mulaw` at 8 kHz so Voice Call can
 
 <AccordionGroup>
   <Accordion title="Adjustable reasoning">
-    `mistral/mistral-small-latest`, `mistral/mistral-small-2603`, and `mistral/mistral-medium-3-5` support [adjustable reasoning](https://docs.mistral.ai/studio-api/conversations/reasoning/adjustable) on the Chat Completions API via `reasoning_effort` (`none` minimizes extra thinking in the output; `high` surfaces full thinking traces before the final answer).
+    `mistral/mistral-small-latest`, `mistral/mistral-small-2603`, and `mistral/mistral-medium-3-5` support [adjustable reasoning](https://docs.mistral.ai/capabilities/reasoning) on the Chat Completions API via `reasoning_effort` (`none` minimizes extra thinking in the output; `high` surfaces full thinking traces before the final answer).
 
     OpenClaw maps the session **thinking** level to Mistral's API:
 


### PR DESCRIPTION
## What Problem This Solves

`docs/providers/mistral.md` links the phrase "adjustable reasoning" (line 152) to `https://docs.mistral.ai/studio-api/conversations/reasoning/adjustable`, which now returns **404**. Mistral reorganized their documentation and moved the reasoning guide under `/capabilities/`, so the link OpenClaw ships in the Mistral provider guide is dead for anyone reading the "Adjustable reasoning" section.

## Triage / Root cause

Mistral's docs site was restructured: the old `studio-api/conversations/reasoning/adjustable` path is gone. The OpenClaw provider doc still points at the pre-restructure URL.

## Fix

Point the link at the current `https://docs.mistral.ai/capabilities/reasoning`, which documents the same `reasoning_effort` parameter (`none` / `high` on the Chat Completions API) that the surrounding paragraph describes. Minimal one-URL change; no prose logic touched.

## Evidence

```
$ curl -s -o /dev/null -L -w "%{http_code}\n" https://docs.mistral.ai/studio-api/conversations/reasoning/adjustable
404
$ curl -s -o /dev/null -L -w "%{http_code}\n" https://docs.mistral.ai/capabilities/reasoning
200
$ curl -s -o /dev/null -L -w "%{http_code}\n" https://docs.mistral.ai/capabilities/this-does-not-exist-xyz
404
```

The 404 on the old URL is a real "page does not exist", not an SPA catch-all shell — a fabricated `/capabilities/this-does-not-exist-xyz` path also returns 404, while the genuine `/capabilities/reasoning` page returns 200. Content of the replacement page was verified to document `reasoning_effort` with `none`/`high` values on the Chat Completions API (matching the section's prose).

## Verification

- `git diff` is a single-line URL swap on `docs/providers/mistral.md`.
- Preflight (`scripts/preflight_ship.py`) against current `upstream/main`: bug marker still present, fix marker absent, no open duplicate PRs.
- CI `check-docs` / `Real behavior proof` on this PR is the authoritative link/render check.

## Notes / Risks

- Self-sourced docs-drift fix (broken external link). This is the same verified broken link previously closed in error as #113490 (a prior run wrongly closed it on a false "files restructured" claim; the file and the 404 link both persist on `upstream/main`). This is a fresh branch rebased on current `upstream/main` (`21667ef`).
- Different file and different provider than #113545 (chutes API-key URL), so this does not stack on top of that PR.
- AI-assisted; authored and verified by me.
