### PR TITLE
refactor(outbound): share audit history projection

### DIFF
--- a/src/infra/outbound/outbound-audit.test.ts
+++ b/src/infra/outbound/outbound-audit.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { TrustedMessageAuditEvent } from "../../audit/message-audit-events.js";
 import { onTrustedMessageAuditEventForTest as onTrustedMessageAuditEvent } from "../../audit/message-audit-events.test-support.js";
+import type { OutboundPayloadDeliveryOutcome } from "./deliver-types.js";
 import {
   completedOutboundAuditTerminals,
   emitOutboundAuditTerminals,
+  failedOutboundAuditTerminals,
   uniformOutboundAuditTerminals,
 } from "./outbound-audit.js";
 
@@ -163,6 +165,56 @@ describe("outbound audit projection", () => {
     });
     expect(events[0]).not.toHaveProperty("reasonCode");
     expect(events[0]).not.toHaveProperty("deliveryKind");
+  });
+
+  it.each([
+    {
+      kind: "completed",
+      project: (payloadOutcomes: OutboundPayloadDeliveryOutcome[]) =>
+        completedOutboundAuditTerminals({
+          payloadCount: 1,
+          results: [],
+          payloadOutcomes,
+        }),
+    },
+    {
+      kind: "failed",
+      project: (payloadOutcomes: OutboundPayloadDeliveryOutcome[]) =>
+        failedOutboundAuditTerminals({
+          payloadCount: 1,
+          results: [],
+          payloadOutcomes,
+          failureStage: "platform_send",
+        }),
+    },
+  ])("projects recorded history consistently for $kind runs", ({ project }) => {
+    const result = { channel: "matrix" as const, messageId: "platform-1" };
+
+    expect(
+      project([
+        { index: 0, status: "suppressed", reason: "adapter_returned_no_identity" },
+        { index: 0, status: "sent", results: [result] },
+      ]),
+    ).toEqual([
+      {
+        payloadIndex: 0,
+        terminal: { outcome: "unknown", failureStage: "platform_send" },
+      },
+    ]);
+    expect(
+      project([{ index: 0, status: "sent", results: [result], deliveryKind: "media" }]),
+    ).toEqual([
+      {
+        payloadIndex: 0,
+        terminal: { outcome: "sent", results: [result], deliveryKind: "media" },
+      },
+    ]);
+    expect(project([{ index: 0, status: "suppressed", reason: "no_visible_payload" }])).toEqual([
+      {
+        payloadIndex: 0,
+        terminal: { outcome: "suppressed", reasonCode: "no_visible_payload" },
+      },
+    ]);
   });
 
   it("counts physical sends once across receipt representations and result fallbacks", () => {

--- a/src/infra/outbound/outbound-audit.ts
+++ b/src/infra/outbound/outbound-audit.ts
@@ -94,11 +94,34 @@ function sentResults(
   return sent?.results ?? [];
 }
 
-function hasUnknownAdapterSideEffect(history: readonly OutboundPayloadDeliveryOutcome[]): boolean {
-  return history.some(
-    (outcome) =>
-      outcome.status === "suppressed" && outcome.reason === "adapter_returned_no_identity",
-  );
+function projectRecordedOutboundAuditTerminal(
+  history: readonly OutboundPayloadDeliveryOutcome[],
+): OutboundAuditTerminal | undefined {
+  // A missing adapter identity leaves the whole payload history uncertain,
+  // even if a later retry reports another terminal outcome.
+  if (
+    history.some(
+      (outcome) =>
+        outcome.status === "suppressed" && outcome.reason === "adapter_returned_no_identity",
+    )
+  ) {
+    return { outcome: "unknown", failureStage: "platform_send" };
+  }
+  const latest = history.at(-1);
+  if (latest?.status === "sent") {
+    return {
+      outcome: "sent",
+      results: latest.results,
+      ...(latest.deliveryKind ? { deliveryKind: latest.deliveryKind } : {}),
+    };
+  }
+  if (latest?.status === "suppressed") {
+    if (latest.reason === "adapter_returned_no_identity") {
+      return { outcome: "unknown", failureStage: "platform_send" };
+    }
+    return { outcome: "suppressed", reasonCode: latest.reason };
+  }
+  return undefined;
 }
 
 export function completedOutboundAuditTerminals(params: {
@@ -109,34 +132,9 @@ export function completedOutboundAuditTerminals(params: {
   const indexed = outcomesByPayload(params.payloadOutcomes);
   return Array.from({ length: params.payloadCount }, (_, payloadIndex) => {
     const history = indexed.get(payloadIndex) ?? [];
-    const latest = history.at(-1);
-    if (hasUnknownAdapterSideEffect(history)) {
-      return {
-        payloadIndex,
-        terminal: { outcome: "unknown", failureStage: "platform_send" },
-      };
-    }
-    if (latest?.status === "sent") {
-      return {
-        payloadIndex,
-        terminal: {
-          outcome: "sent",
-          results: latest.results,
-          ...(latest.deliveryKind ? { deliveryKind: latest.deliveryKind } : {}),
-        },
-      };
-    }
-    if (latest?.status === "suppressed") {
-      if (latest.reason === "adapter_returned_no_identity") {
-        return {
-          payloadIndex,
-          terminal: { outcome: "unknown", failureStage: "platform_send" },
-        };
-      }
-      return {
-        payloadIndex,
-        terminal: { outcome: "suppressed", reasonCode: latest.reason },
-      };
+    const recordedTerminal = projectRecordedOutboundAuditTerminal(history);
+    if (recordedTerminal) {
+      return { payloadIndex, terminal: recordedTerminal };
     }
     // Core delivery reports every original payload, including normalization
     // suppressions. The single-payload fallback supports legacy recovery senders.
@@ -159,35 +157,11 @@ export function failedOutboundAuditTerminals(params: {
   const indexed = outcomesByPayload(params.payloadOutcomes);
   return Array.from({ length: params.payloadCount }, (_, payloadIndex) => {
     const history = indexed.get(payloadIndex) ?? [];
+    const recordedTerminal = projectRecordedOutboundAuditTerminal(history);
+    if (recordedTerminal) {
+      return { payloadIndex, terminal: recordedTerminal };
+    }
     const latest = history.at(-1);
-    if (hasUnknownAdapterSideEffect(history)) {
-      return {
-        payloadIndex,
-        terminal: { outcome: "unknown", failureStage: "platform_send" },
-      };
-    }
-    if (latest?.status === "sent") {
-      return {
-        payloadIndex,
-        terminal: {
-          outcome: "sent",
-          results: latest.results,
-          ...(latest.deliveryKind ? { deliveryKind: latest.deliveryKind } : {}),
-        },
-      };
-    }
-    if (latest?.status === "suppressed") {
-      if (latest.reason === "adapter_returned_no_identity") {
-        return {
-          payloadIndex,
-          terminal: { outcome: "unknown", failureStage: "platform_send" },
-        };
-      }
-      return {
-        payloadIndex,
-        terminal: { outcome: "suppressed", reasonCode: latest.reason },
-      };
-    }
     const failedResults = latest?.status === "failed" ? (latest.results ?? []) : [];
     const payloadResults = failedResults.length > 0 ? failedResults : sentResults(history);
     const fallbackResults = params.payloadCount === 1 ? params.results : [];


### PR DESCRIPTION
## What Problem This Solves

Completed and failed outbound audit projection repeated the same terminal-history classification. The two copies also carried separate unreachable adapter-identity branches, making a security-sensitive metadata projection harder to reason about and easier to drift.

## Why This Change Was Made

One private projector now owns recorded-history precedence: uncertain adapter side effects, successful sends, then ordinary suppressions. Completed and failed flows retain their distinct fallback behavior after that shared decision.

## User Impact

No intentional behavior change. Outbound audit events preserve the same outcome, failure-stage, delivery-kind, result, and suppression metadata with one canonical projection path.

## Evidence

- Outbound audit projector tests: 12 passed; baseline was 10 tests.
- Four targeted delivery-audit scenarios passed, including durable terminals and unknown adapter side effects.
- Sparse-safe exact-surface `check:changed` passed: https://github.com/openclaw/openclaw/actions/runs/30153261013
- Fresh post-rebase autoreview passed at 0.98 confidence with no actionable findings.
- `oxfmt --check` and `git diff --check` passed.
- Production code is net 26 lines smaller.
