### PR TITLE
fix(onboard): rebase non-interactive commit onto first-agent write

### DIFF
--- a/src/commands/onboard-agent.test.ts
+++ b/src/commands/onboard-agent.test.ts
@@ -31,6 +31,7 @@ describe("onboarding main-agent creation", () => {
       .mockResolvedValueOnce({
         exists: true,
         valid: true,
+        hash: "hash-after-create",
         sourceConfig: {
           agents: { list: [{ id: "main", default: true }] },
           gateway: { controlUi: { enabled: true } },
@@ -79,6 +80,30 @@ describe("onboarding main-agent creation", () => {
       }),
     ).resolves.toEqual({ config, agentId: "main", bootstrapPending: false });
     expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+    expect(mocks.createAgent).not.toHaveBeenCalled();
+  });
+  it("reports the post-create config hash so callers can rebase their commit", async () => {
+    // Regression (#112678): creating the first roster agent writes the config
+    // file, so a caller holding a pre-create hash would fail its own optimistic
+    // write with ConfigMutationConflictError and leave onboarding half-applied.
+    const result = await ensureOnboardingAgent({
+      config: { agents: { defaults: { model: "openai/gpt-5.5" } } },
+      workspace: "/tmp/work",
+    });
+
+    expect(result.configHash).toBe("hash-after-create");
+  });
+
+  it("omits the config hash when no agent had to be created", async () => {
+    const config = { agents: { list: [{ id: "main", default: true }] } };
+
+    const result = await ensureOnboardingAgent({
+      config,
+      workspace: "/tmp/work",
+      preserveCandidateRoster: true,
+    });
+
+    expect(result.configHash).toBeUndefined();
     expect(mocks.createAgent).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/onboard-agent.ts
+++ b/src/commands/onboard-agent.ts
@@ -45,7 +45,18 @@ export async function ensureOnboardingAgent(params: {
   workspace: string;
   preserveCandidateRoster?: boolean;
   baseConfig?: OpenClawConfig;
-}): Promise<{ config: OpenClawConfig; agentId: string; bootstrapPending: boolean }> {
+}): Promise<{
+  config: OpenClawConfig;
+  agentId: string;
+  bootstrapPending: boolean;
+  /**
+   * Config hash observed after this helper created the first roster agent.
+   * Callers that captured a hash before calling must adopt it for their own
+   * commit: the create wrote the file, so their baseline is stale but not
+   * foreign, and the optimistic guard would otherwise reject their write.
+   */
+  configHash?: string;
+}> {
   const candidateRoster = listAgentEntries(params.config);
   if (
     candidateRoster.length > 0 &&
@@ -99,6 +110,7 @@ export async function ensureOnboardingAgent(params: {
     }),
     agentId: created.agentId,
     bootstrapPending: created.bootstrapPending,
+    ...(after.hash !== undefined ? { configHash: after.hash } : {}),
   };
 }
 

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -206,6 +206,10 @@ export async function runNonInteractiveLocalSetup(params: {
     baseConfig,
   });
   nextConfig = applyLocalSetupWorkspaceConfig(created.config, requestedWorkspaceDir);
+  // Creating the first roster agent writes the config file, so the hash captured
+  // before this step no longer matches. Adopt the post-create hash; foreign
+  // writes are still rejected because we only trust the write we just made.
+  const effectiveBaseHash = created.configHash ?? baseHash;
   if (opts.skipBootstrap) {
     nextConfig = applySkipBootstrapConfig(nextConfig);
   }
@@ -271,7 +275,7 @@ export async function runNonInteractiveLocalSetup(params: {
   nextConfig = await commitNonInteractiveOnboardConfig({
     nextConfig,
     baseConfig,
-    baseHash,
+    baseHash: effectiveBaseHash,
     reset: opts.reset,
   });
   logConfigUpdated(runtime);


### PR DESCRIPTION
## What Problem This Solves

`openclaw onboard --non-interactive` (any auth choice) fails on a fresh install with `ConfigMutationConflictError: config changed since last load` and leaves a HALF-WRITTEN config — only the agent roster entry, no model, no provider, no gateway. Found by live testing on current main; reproduced deterministically on fresh state dirs.

## Why This Change Was Made

#112678 (roster-only refactor) made onboarding create the first roster agent through `createAgent`, which WRITES the config file mid-flow. `runNonInteractiveSetup` captures `snapshot.hash` before that and passes it as the optimistic-concurrency baseline to the final commit, so the guard rejects onboarding's own write. `ensureOnboardingAgent` now reports the post-create config hash (only on the path where it actually created the agent), and non-interactive local setup adopts it as the effective baseline. Foreign-write protection is preserved: the baseline is only advanced past a write we made ourselves; every other path keeps the original hash and the original guard semantics.

## User Impact

Fresh non-interactive onboarding completes again and writes a full config; no more half-configured installs from a failed first run. Regression window is #112678 (2026-07-24) to now.

## Evidence

Live reproduction on current main (fresh `OPENCLAW_STATE_DIR`, `--auth-choice ollama`): before = `ConfigMutationConflictError` + partial config containing only `agents.entries.main`; after = "Updated config" and a complete config (model `ollama/gemma4:latest`, provider `ollama`, roster `main`, gateway port).

Bisected to #112678 by running the same command on its parent (`5f63f744ead` — succeeds) vs the commit itself (fails). Config-write tracing pinned the intermediate writer to agent-create's `transformConfigFileWithRetry`.

Tests: `node scripts/run-vitest.mjs src/commands/onboard-agent.test.ts src/commands/onboard-non-interactive` — 9 files / 57 passed, including two new regression tests (post-create hash reported; hash omitted when nothing was created); `node scripts/run-vitest.mjs src/config/mutate` — 46 passed. Autoreview clean (0.94).

Follow-up, intentionally not fixed here: `src/commands/setup.ts` calls `ensureOnboardingAgent` and then writes with the pre-create `snapshot`; it does not pass a `baseHash`, so it does not throw, but the stale snapshot is a latent hazard.

Related: #112678.
