### PR TITLE
refactor(config): share legacy migration traversal

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -207,13 +207,11 @@ describe("legacy MCP server config migrate", () => {
       command: "example-mcp",
       cwd: "/node-legacy",
     });
-    expect(res.changes).toEqual(
-      expect.arrayContaining([
-        "Canonicalized legacy aliases in mcp.servers.legacy.",
-        "Canonicalized legacy aliases in mcp.servers.canonical.",
-        "Canonicalized legacy aliases in nodeHost.mcp.servers.legacy.",
-      ]),
-    );
+    expect(res.changes).toEqual([
+      "Canonicalized legacy aliases in mcp.servers.legacy.",
+      "Canonicalized legacy aliases in mcp.servers.canonical.",
+      "Canonicalized legacy aliases in nodeHost.mcp.servers.legacy.",
+    ]);
     expect(migrateLegacyConfigForTest(res.config)).toEqual({ config: null, changes: [] });
   });
 });

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.config-tranche.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.config-tranche.ts
@@ -1,29 +1,7 @@
 // Config-tranche migrations move legacy aliases before canonical validation.
 import { ensureRecord, getRecord } from "../../../config/legacy.shared.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../routing/account-id.js";
-
-function deletePath(owner: unknown, path: readonly string[], index = 0): boolean {
-  const record = getRecord(owner);
-  const key = path[index];
-  if (!record || !key) {
-    return false;
-  }
-  if (index === path.length - 1) {
-    if (!Object.hasOwn(record, key)) {
-      return false;
-    }
-    delete record[key];
-    return true;
-  }
-  const child = getRecord(record[key]);
-  if (!child || !deletePath(child, path, index + 1)) {
-    return false;
-  }
-  if (Object.keys(child).length === 0) {
-    delete record[key];
-  }
-  return true;
-}
+import { deleteRetiredPath } from "./legacy-config-record-shared.js";
 
 function visitAgentEntries(
   raw: Record<string, unknown>,
@@ -81,7 +59,8 @@ function stripRetiredAgentConfig(raw: Record<string, unknown>, changes: string[]
   let removedContextLimits = false;
   const stripContextLimits = (owner: Record<string, unknown>) => {
     for (const key of ["memoryGetDefaultLines", "toolResultMaxChars"]) {
-      removedContextLimits = deletePath(owner, ["contextLimits", key]) || removedContextLimits;
+      removedContextLimits =
+        deleteRetiredPath(owner, ["contextLimits", key]) || removedContextLimits;
     }
   };
   if (defaults) {
@@ -203,7 +182,7 @@ function migrateWhatsAppDebounce(raw: Record<string, unknown>, changes: string[]
 
 export function migrateConfigTranche(raw: Record<string, unknown>, changes: string[]): void {
   stripRetiredPresentationPrefs(raw, changes);
-  if (deletePath(raw, ["skills", "load", "watchDebounceMs"])) {
+  if (deleteRetiredPath(raw, ["skills", "load", "watchDebounceMs"])) {
     changes.push("Removed skills.load.watchDebounceMs; the watcher now uses the 250 ms default.");
   }
   stripRetiredAgentConfig(raw, changes);

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired-media.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired-media.ts
@@ -1,5 +1,6 @@
 // Media and voice compatibility migrations retired from canonical runtime config.
 import { getRecord } from "../../../config/legacy.shared.js";
+import { deleteRetiredPath } from "./legacy-config-record-shared.js";
 
 export function moveVoice(owner: Record<string, unknown>, path: string, changes: string[]): void {
   if (!Object.hasOwn(owner, "voice")) {
@@ -241,39 +242,6 @@ const RETIRED_AGENT_TUNING_PATHS = [
   ["tools", "loopDetection", "detectors"],
   ["tools", "loopDetection", "postCompactionGuard"],
 ] as const;
-
-function deleteRetiredPath(owner: unknown, path: readonly string[], index = 0): boolean {
-  const record = getRecord(owner);
-  if (!record) {
-    return false;
-  }
-  const key = path[index];
-  if (!key) {
-    return false;
-  }
-  if (key === "*") {
-    let changed = false;
-    for (const value of Object.values(record)) {
-      changed = deleteRetiredPath(value, path, index + 1) || changed;
-    }
-    return changed;
-  }
-  if (index === path.length - 1) {
-    if (!Object.hasOwn(record, key)) {
-      return false;
-    }
-    delete record[key];
-    return true;
-  }
-  const child = getRecord(record[key]);
-  if (!child || !deleteRetiredPath(child, path, index + 1)) {
-    return false;
-  }
-  if (Object.keys(child).length === 0) {
-    delete record[key];
-  }
-  return true;
-}
 
 export function stripRetiredTuningKnobs(raw: Record<string, unknown>): boolean {
   let changed = false;

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts
@@ -276,6 +276,121 @@ describe("retired runtime config migrations", () => {
     );
   });
 
+  it("preserves wildcard entries while pruning emptied named descendants", () => {
+    const result = applyAll({
+      cloudWorkers: {
+        profiles: {
+          keep: { lifetime: "1h", region: "eu" },
+          prune: { lifetime: "1h" },
+          malformed: "keep",
+        },
+      },
+      agents: {
+        defaults: {
+          cliBackends: {
+            keep: { reliability: { outputLimits: { maxChars: 1 }, enabled: true } },
+            prune: { reliability: { outputLimits: { maxChars: 1 } } },
+            malformed: null,
+          },
+        },
+      },
+    });
+
+    expect(result.raw).toMatchObject({
+      cloudWorkers: {
+        profiles: {
+          keep: { region: "eu" },
+          prune: {},
+          malformed: "keep",
+        },
+      },
+      agents: {
+        defaults: {
+          cliBackends: {
+            keep: { reliability: { enabled: true } },
+            prune: {},
+            malformed: null,
+          },
+        },
+      },
+    });
+    expect(result.changes).toEqual([
+      "Applied tier-eval tranche retirements; canonical settings and built-in defaults now apply.",
+      "Removed retired runtime tuning knobs; built-in defaults now apply.",
+    ]);
+  });
+
+  it("visits channel roots before ordered object-shaped accounts", () => {
+    const result = applyAll({
+      channels: {
+        googlechat: {
+          serviceAccountRef: "root-google",
+          accounts: {
+            z: { serviceAccountRef: "z-google" },
+            malformed: "keep-google",
+            a: { serviceAccountRef: "a-google" },
+          },
+        },
+        slack: {
+          identity: "root-slack",
+          accounts: {
+            z: { identity: "z-slack", postAs: "canonical-z" },
+            malformed: 42,
+            a: { identity: "a-slack" },
+          },
+        },
+        imessage: {
+          coalesceSameSenderDms: true,
+          accounts: {
+            z: { coalesceSameSenderDms: true },
+            malformed: false,
+            a: { coalesceSameSenderDms: true },
+          },
+        },
+      },
+    });
+
+    expect(result.raw).toMatchObject({
+      channels: {
+        googlechat: {
+          serviceAccount: "root-google",
+          accounts: {
+            z: { serviceAccount: "z-google" },
+            malformed: "keep-google",
+            a: { serviceAccount: "a-google" },
+          },
+        },
+        slack: {
+          postAs: "root-slack",
+          accounts: {
+            z: { postAs: "canonical-z" },
+            malformed: 42,
+            a: { postAs: "a-slack" },
+          },
+        },
+        imessage: {
+          accounts: {
+            z: {},
+            malformed: false,
+            a: {},
+          },
+        },
+      },
+    });
+    expect(result.changes).toEqual([
+      "Moved channels.googlechat.serviceAccountRef → channels.googlechat.serviceAccount.",
+      "Moved channels.googlechat.accounts.z.serviceAccountRef → channels.googlechat.accounts.z.serviceAccount.",
+      "Moved channels.googlechat.accounts.a.serviceAccountRef → channels.googlechat.accounts.a.serviceAccount.",
+      "Applied tier-eval tranche retirements; canonical settings and built-in defaults now apply.",
+      "Moved channels.slack.identity → channels.slack.postAs.",
+      "Removed channels.slack.accounts.z.identity (channels.slack.accounts.z.postAs already set).",
+      "Moved channels.slack.accounts.a.identity → channels.slack.accounts.a.postAs.",
+      "Removed channels.imessage.coalesceSameSenderDms.",
+      "Removed channels.imessage.accounts.z.coalesceSameSenderDms.",
+      "Removed channels.imessage.accounts.a.coalesceSameSenderDms.",
+    ]);
+  });
+
   it("migrates the config tranche while preserving canonical settings", () => {
     const result = applyAll({
       ui: {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
@@ -22,6 +22,7 @@ import {
   stripRetiredTuningKnobs,
 } from "./legacy-config-migrations.runtime.retired-media.js";
 import { migrateTierEvalTranche } from "./legacy-config-migrations.runtime.tier-eval.js";
+import { visitChannelEntries } from "./legacy-config-record-shared.js";
 
 const rule = (
   path: string[],
@@ -198,42 +199,9 @@ function migrateFinalLayoutRenames(raw: Record<string, unknown>, changes: string
     }
   }
 
-  const slack = getRecord(getRecord(raw.channels)?.slack);
-  moveKey(slack, "identity", "postAs", "channels.slack", changes);
-  const slackAccounts = getRecord(slack?.accounts);
-  if (slackAccounts) {
-    for (const [accountId, value] of Object.entries(slackAccounts)) {
-      moveKey(
-        getRecord(value),
-        "identity",
-        "postAs",
-        `channels.slack.accounts.${accountId}`,
-        changes,
-      );
-    }
-  }
-}
-
-function visitChannelEntries(
-  raw: Record<string, unknown>,
-  channelId: string,
-  visitor: (entry: Record<string, unknown>, path: string) => void,
-): void {
-  const channel = getRecord(getRecord(raw.channels)?.[channelId]);
-  if (!channel) {
-    return;
-  }
-  visitor(channel, `channels.${channelId}`);
-  const accounts = getRecord(channel.accounts);
-  if (!accounts) {
-    return;
-  }
-  for (const [accountId, value] of Object.entries(accounts)) {
-    const account = getRecord(value);
-    if (account) {
-      visitor(account, `channels.${channelId}.accounts.${accountId}`);
-    }
-  }
+  visitChannelEntries(raw, "slack", (entry, path) => {
+    moveKey(entry, "identity", "postAs", path, changes);
+  });
 }
 
 function migrateFinalLayoutKills(raw: Record<string, unknown>, changes: string[]): void {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.tier-eval.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.tier-eval.ts
@@ -1,60 +1,6 @@
 // Tier-eval config compatibility migration and its scoped traversal helpers.
 import { ensureRecord, getRecord } from "../../../config/legacy.shared.js";
-
-function deleteRetiredPath(owner: unknown, path: readonly string[], index = 0): boolean {
-  const record = getRecord(owner);
-  if (!record) {
-    return false;
-  }
-  const key = path[index];
-  if (!key) {
-    return false;
-  }
-  if (key === "*") {
-    let changed = false;
-    for (const value of Object.values(record)) {
-      changed = deleteRetiredPath(value, path, index + 1) || changed;
-    }
-    return changed;
-  }
-  if (index === path.length - 1) {
-    if (!Object.hasOwn(record, key)) {
-      return false;
-    }
-    delete record[key];
-    return true;
-  }
-  const child = getRecord(record[key]);
-  if (!child || !deleteRetiredPath(child, path, index + 1)) {
-    return false;
-  }
-  if (Object.keys(child).length === 0) {
-    delete record[key];
-  }
-  return true;
-}
-
-function visitChannelEntries(
-  raw: Record<string, unknown>,
-  channelId: string,
-  visitor: (entry: Record<string, unknown>, path: string) => void,
-): void {
-  const channel = getRecord(getRecord(raw.channels)?.[channelId]);
-  if (!channel) {
-    return;
-  }
-  visitor(channel, `channels.${channelId}`);
-  const accounts = getRecord(channel.accounts);
-  if (!accounts) {
-    return;
-  }
-  for (const [accountId, value] of Object.entries(accounts)) {
-    const account = getRecord(value);
-    if (account) {
-      visitor(account, `channels.${channelId}.accounts.${accountId}`);
-    }
-  }
-}
+import { deleteRetiredPath, visitChannelEntries } from "./legacy-config-record-shared.js";
 
 const TIER_EVAL_RETIRED_ROOT_PATHS = [
   ["cloudWorkers", "profiles", "*", "lifetime"],

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.tier-eval.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.tier-eval.ts
@@ -56,25 +56,6 @@ function visitChannelEntries(
   }
 }
 
-function moveKey(
-  owner: Record<string, unknown> | null | undefined,
-  legacyKey: string,
-  canonicalKey: string,
-  path: string,
-  changes: string[],
-): void {
-  if (!owner || !Object.hasOwn(owner, legacyKey)) {
-    return;
-  }
-  if (owner[canonicalKey] === undefined) {
-    owner[canonicalKey] = owner[legacyKey];
-    changes.push(`Moved ${path}.${legacyKey} → ${path}.${canonicalKey}.`);
-  } else {
-    changes.push(`Removed ${path}.${legacyKey} (${path}.${canonicalKey} already set).`);
-  }
-  delete owner[legacyKey];
-}
-
 const TIER_EVAL_RETIRED_ROOT_PATHS = [
   ["cloudWorkers", "profiles", "*", "lifetime"],
   ["meta", "lastTouchedAt"],
@@ -247,20 +228,6 @@ function migrateCliBackendSessionArgs(
       );
     }
     delete backend.sessionArg;
-  }
-}
-
-function moveMcpWorkingDirectory(raw: Record<string, unknown>, changes: string[]): void {
-  for (const [ownerPath, servers] of [
-    ["mcp.servers", getRecord(getRecord(raw.mcp)?.servers)],
-    ["nodeHost.mcp.servers", getRecord(getRecord(getRecord(raw.nodeHost)?.mcp)?.servers)],
-  ] as const) {
-    if (!servers) {
-      continue;
-    }
-    for (const [serverId, value] of Object.entries(servers)) {
-      moveKey(getRecord(value), "workingDirectory", "cwd", `${ownerPath}.${serverId}`, changes);
-    }
   }
 }
 
@@ -527,7 +494,6 @@ export function migrateTierEvalTranche(raw: Record<string, unknown>, changes: st
   let stripped = false;
   stripTtsPersonaPrompts(raw, changes);
   stripped = migratePresenceEnabled(raw, changes) || stripped;
-  moveMcpWorkingDirectory(raw, changes);
   migrateChannelAliases(raw, changes);
   const session = getRecord(raw.session);
   if (session && Object.hasOwn(session, "idleMinutes")) {

--- a/src/commands/doctor/shared/legacy-config-record-shared.ts
+++ b/src/commands/doctor/shared/legacy-config-record-shared.ts
@@ -26,3 +26,61 @@ export function ensureRecord(target: JsonRecord, key: string): JsonRecord {
 export function hasOwnKey(target: JsonRecord, key: string): boolean {
   return Object.hasOwn(target, key);
 }
+
+/** Delete a nested retired config path, with `*` matching record entries. */
+export function deleteRetiredPath(owner: unknown, path: readonly string[], index = 0): boolean {
+  if (!isRecord(owner)) {
+    return false;
+  }
+  const key = path[index];
+  if (!key) {
+    return false;
+  }
+  if (key === "*") {
+    let changed = false;
+    for (const value of Object.values(owner)) {
+      changed = deleteRetiredPath(value, path, index + 1) || changed;
+    }
+    return changed;
+  }
+  if (index === path.length - 1) {
+    if (!Object.hasOwn(owner, key)) {
+      return false;
+    }
+    delete owner[key];
+    return true;
+  }
+  const child = owner[key];
+  if (!isRecord(child) || !deleteRetiredPath(child, path, index + 1)) {
+    return false;
+  }
+  if (Object.keys(child).length === 0) {
+    delete owner[key];
+  }
+  return true;
+}
+
+/** Visit a channel root followed by its object-shaped accounts in config order. */
+export function visitChannelEntries(
+  raw: JsonRecord,
+  channelId: string,
+  visitor: (entry: JsonRecord, path: string) => void,
+): void {
+  const channels = raw.channels;
+  if (!isRecord(channels)) {
+    return;
+  }
+  const channel = channels[channelId];
+  if (!isRecord(channel)) {
+    return;
+  }
+  visitor(channel, `channels.${channelId}`);
+  if (!isRecord(channel.accounts)) {
+    return;
+  }
+  for (const [accountId, account] of Object.entries(channel.accounts)) {
+    if (isRecord(account)) {
+      visitor(account, `channels.${channelId}.accounts.${accountId}`);
+    }
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Doctor's legacy-config migrations retained three copies of nested path deletion, two copies of channel/account traversal, and a second MCP `workingDirectory` repair path after the dedicated MCP migration had already canonicalized it.

That duplicate ownership made upgrade behavior and diagnostic ordering easier to drift.

## Why This Change Was Made

This removes the unreachable tier-eval MCP fallback and centralizes the shared path-deletion and channel-traversal invariants in the existing legacy-record helper. Caller-specific migration policy stays local, including final-layout key moves and migration summaries.

Focused regressions lock down wildcard pruning, malformed account preservation, root-before-account traversal, exact diagnostic order, and MCP-only diagnostics.

## User Impact

No intended user-visible behavior change. `openclaw doctor --fix` preserves the same canonical config and diagnostics while the implementation has one owner per shared traversal rule.

Production code is net 115 lines smaller.

## Evidence

- Blacksmith Testbox: 238 focused unit tests and 3 migration E2E tests passed ([run 30153629711](https://github.com/openclaw/openclaw/actions/runs/30153629711)).
- Sparse-safe `pnpm check:changed` passed in Testbox `tbx_01kycbhm6hd1qb7zq373dwy2w3` ([run 30153744017](https://github.com/openclaw/openclaw/actions/runs/30153744017)).
- `oxfmt --check` and `git diff --check` passed.
- Fresh post-rebase autoreview passed at 0.96 confidence with no actionable findings.
- No open duplicate PR found for this doctor migration cleanup.

AI-assisted: yes.
