### PR TITLE
refactor(discord): share handle normalization

### DIFF
--- a/extensions/discord/src/directory-cache.ts
+++ b/extensions/discord/src/directory-cache.ts
@@ -23,7 +23,7 @@ function normalizeSnowflake(value: string | number | bigint): string | null {
   return text;
 }
 
-function normalizeHandleKey(raw: string): string | null {
+export function normalizeDiscordHandleKey(raw: string): string | null {
   let handle = normalizeOptionalString(raw) ?? "";
   if (!handle) {
     return null;
@@ -76,7 +76,7 @@ export function rememberDiscordDirectoryUser(params: {
     if (typeof candidate !== "string") {
       continue;
     }
-    const handle = normalizeHandleKey(candidate);
+    const handle = normalizeDiscordHandleKey(candidate);
     if (!handle) {
       continue;
     }
@@ -98,7 +98,7 @@ export function resolveDiscordDirectoryUserId(params: {
   if (!cache) {
     return undefined;
   }
-  const handle = normalizeHandleKey(params.handle);
+  const handle = normalizeDiscordHandleKey(params.handle);
   if (!handle) {
     return undefined;
   }

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -5,7 +5,7 @@ import {
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveDiscordDirectoryUserId } from "./directory-cache.js";
+import { normalizeDiscordHandleKey, resolveDiscordDirectoryUserId } from "./directory-cache.js";
 
 type DiscordMentionAliasesConfig = Record<string, string>;
 
@@ -48,31 +48,17 @@ export function formatMention(params: {
   return `<#${target.id}>`;
 }
 
-function normalizeHandleKey(raw: string): string | null {
-  let handle = normalizeOptionalString(raw) ?? "";
-  if (!handle) {
-    return null;
-  }
-  if (handle.startsWith("@")) {
-    handle = normalizeOptionalString(handle.slice(1)) ?? "";
-  }
-  if (!handle || /\s/.test(handle)) {
-    return null;
-  }
-  return normalizeLowercaseStringOrEmpty(handle);
-}
-
 function resolveConfiguredMentionAlias(
   handle: string,
   mentionAliases?: DiscordMentionAliasesConfig | null,
 ): string | undefined {
-  const key = normalizeHandleKey(handle);
+  const key = normalizeDiscordHandleKey(handle);
   if (!key || !mentionAliases) {
     return undefined;
   }
   const withoutDiscriminator = key.replace(DISCORD_DISCRIMINATOR_SUFFIX, "");
   for (const [rawAlias, rawUserId] of Object.entries(mentionAliases)) {
-    const alias = normalizeHandleKey(rawAlias);
+    const alias = normalizeDiscordHandleKey(rawAlias);
     if (!alias) {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Discord directory matching and mention resolution maintained separate copies of the same handle-normalization rule. That duplication could let cache keys and mention aliases drift apart.

## Why This Change Was Made

The directory cache now owns and exports the canonical normalization helper, and mention resolution reuses it. This keeps the existing exact/base-key matching behavior while deleting the second implementation.

## User Impact

No intended user-visible behavior change. Discord handle lookup and mention expansion keep the same case-folding, prefix stripping, and discriminator handling with one source of truth.

## Evidence

- 100 focused Discord tests passed in Blacksmith Testbox (`30153996390`)
- sparse-safe `pnpm check:changed` passed in Blacksmith Testbox (`30154391512`)
- `oxfmt --check` and `git diff --check` passed
- fresh post-rebase autoreview found no actionable findings, confidence 0.98
- production diff: 6 additions, 20 deletions (`-14` lines)

AI-assisted: yes
