### PR TITLE
fix(gateway): return 404 for disabled OpenAI API routes

### DIFF
--- a/src/gateway/control-ui-routing.test.ts
+++ b/src/gateway/control-ui-routing.test.ts
@@ -96,6 +96,48 @@ describe("classifyControlUiRequest", () => {
         expected: { kind: "not-control-ui" as const },
       },
       {
+        name: "keeps the OpenAI-compatible API root outside the SPA catch-all",
+        pathname: "/v1",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps the OpenAI-compatible API root slash outside the SPA catch-all",
+        pathname: "/v1/",
+        method: "HEAD",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps OpenAI-compatible model discovery outside the SPA catch-all",
+        pathname: "/v1/models",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps OpenAI-compatible model details outside the SPA catch-all",
+        pathname: "/v1/models/openclaw",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps OpenAI-compatible responses outside the SPA catch-all",
+        pathname: "/v1/responses",
+        method: "HEAD",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "preserves the SPA root that only resembles the OpenAI-compatible API",
+        pathname: "/v12",
+        method: "GET",
+        expected: { kind: "serve" as const },
+      },
+      {
+        name: "preserves SPA routes that only resemble the OpenAI-compatible API",
+        pathname: "/v12/models",
+        method: "GET",
+        expected: { kind: "serve" as const },
+      },
+      {
         name: "returns not-found for legacy ui routes",
         pathname: "/ui/settings",
         method: "GET",

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -65,6 +65,10 @@ export function classifyControlUiRequest(params: {
     if (pathname === "/api" || pathname.startsWith("/api/")) {
       return { kind: "not-control-ui" };
     }
+    // Disabled OpenAI-compatible endpoints must return 404, not the SPA HTML.
+    if (pathname === "/v1" || pathname.startsWith("/v1/")) {
+      return { kind: "not-control-ui" };
+    }
     if (!isReadHttpMethod(method)) {
       return { kind: "not-control-ui" };
     }

--- a/src/gateway/server-http.probe.test.ts
+++ b/src/gateway/server-http.probe.test.ts
@@ -52,6 +52,64 @@ describe("gateway OpenAI-compatible disabled HTTP routes", () => {
       },
     });
   });
+
+  it("returns 404 for disabled GET routes when the Control UI is root-mounted", async () => {
+    await withGatewayServer({
+      prefix: "openai-compat-disabled-root-control-ui",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        controlUiEnabled: true,
+        controlUiBasePath: "",
+      },
+      run: async (server) => {
+        for (const path of [
+          "/v1",
+          "/v1/",
+          "/v1/models",
+          "/v1/models/openclaw",
+          "/v1/chat/completions",
+          "/v1/responses",
+          "/v1/embeddings",
+        ]) {
+          const { res, getBody } = await sendGatewayRequest(server, {
+            path,
+            method: "GET",
+          });
+
+          expect(res.statusCode, path).toBe(404);
+          expect(getBody(), path).toBe("Not Found");
+        }
+      },
+    });
+  });
+
+  it.each([
+    { name: "chat completions", enabled: { openAiChatCompletionsEnabled: true } },
+    { name: "responses", enabled: { openResponsesEnabled: true } },
+  ])("keeps $name model discovery ahead of a root-mounted Control UI", async ({ enabled }) => {
+    await withGatewayServer({
+      prefix: "openai-compat-enabled-root-control-ui",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        controlUiEnabled: true,
+        controlUiBasePath: "",
+        ...enabled,
+      },
+      run: async (server) => {
+        const { res, getBody } = await sendGatewayRequest(server, {
+          path: "/v1/models",
+          method: "GET",
+          headers: { "x-openclaw-scopes": "operator.read" },
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(getBody())).toMatchObject({
+          object: "list",
+          data: expect.arrayContaining([expect.objectContaining({ id: "openclaw/default" })]),
+        });
+      },
+    });
+  });
 });
 
 describe("gateway probe endpoints", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users probing disabled OpenAI-compatible endpoints received an HTTP 200 Control UI HTML document instead of HTTP 404 when the Control UI was mounted at the gateway root.

## Why This Change Was Made

Reserve only the exact `/v1` API namespace before root SPA fallback. Preserve similarly named SPA paths such as `/v12` and preserve model discovery when either compatible API is enabled.

## User Impact

OpenAI clients can reliably distinguish disabled APIs from enabled endpoints without parsing false-success HTML. Existing Control UI routes and enabled chat-completions or responses discovery continue to work.

## Evidence

Actual isolated, running published OpenClaw gateways. The original signed-release runtime on port 54918 remains unchanged; the after-fix release runtime on ports 54928 and 54929 contains exactly the reviewed `/v1` classifier change. This is real HTTP traffic to root-mounted production Control UI, not a mock or test-harness response:

```text
original disabled GET /v1/models            HTTP 200 text/html        14406 bytes
patched  GET /                              HTTP 200 text/html        14406 bytes
patched  GET /healthz                       HTTP 200 application/json    27 bytes
patched  disabled GET /v1                   HTTP 404 text/plain           9 bytes
patched  disabled GET /v1/models            HTTP 404 text/plain           9 bytes
patched  disabled GET /v1/responses         HTTP 404 text/plain           9 bytes
patched  disabled GET /v1/chat/completions  HTTP 404 text/plain           9 bytes
patched  lookalike GET /v12                 HTTP 200 text/html        14406 bytes
patched  enabled GET /v1/models             HTTP 200 application/json   294 bytes
```

The actual enabled discovery response is:

```json
{"object":"list","data":[{"id":"openclaw","object":"model"},{"id":"openclaw/default","object":"model"},{"id":"openclaw/main","object":"model"}]}
```

- Remote focused gateway proof: 53 passing tests across the root route classifier and real HTTP probe harness, including `/v12`, all disabled paths, and model discovery with both enabled API modes.
- Complete remote `pnpm check:changed -- src/gateway/control-ui-routing.ts src/gateway/control-ui-routing.test.ts src/gateway/server-http.probe.test.ts` passed, including formatting, core and core-test typechecks, import-cycle, dependency, plugin-boundary, state and security guards.
- All applicable exact-head GitHub checks passed. Repository-native hosted-proof preparation passed without changing the reviewed head.
- Fresh independent structured autoreview and official TruffleHog secret scan: clean.
