### PR TITLE
fix(control-ui): keep polling gateway-driven setup progress

### DIFF
--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -174,4 +174,52 @@ describe("ModelSetupWizardRunner", () => {
     expect(request.mock.calls.filter(([method]) => method === "wizard.next")).toHaveLength(2);
     expect(request.mock.calls.filter(([method]) => method === "wizard.cancel")).toEqual([]);
   });
+
+  it("keeps polling gateway-executed progress steps without user input", async () => {
+    // Regression: download/pull progress steps carry no controls, so nothing
+    // asked for the next one and the sheet froze on the first frame while the
+    // gateway kept downloading (observed live: "Preparing…" stuck at 900 MB).
+    const messages = ["Preparing model download…", "Downloading… 7%", "Downloading… 16%"];
+    let nextIndex = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "openclaw.setup.prepare.start") {
+        return Promise.resolve({ sessionId: "session-progress", done: false, status: "running" });
+      }
+      if (method === "wizard.next") {
+        const message = messages[nextIndex];
+        nextIndex += 1;
+        if (message === undefined) {
+          return Promise.resolve({ done: true, status: "done" });
+        }
+        return Promise.resolve({
+          done: false,
+          status: "running",
+          step: { id: `progress-${nextIndex}`, type: "progress", message, executor: "gateway" },
+        });
+      }
+      return Promise.resolve({});
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const seen: string[] = [];
+    const onDone = vi.fn();
+    const runner = new ModelSetupWizardRunner({
+      getClient: () => client,
+      onChange: (state) => {
+        if (state.phase === "step" && state.step.type === "progress") {
+          seen.push(state.step.message ?? "");
+        }
+      },
+      onDone,
+      requestFailedMessage: () => "failed",
+      cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "expired",
+    });
+
+    await runner.start("llama-cpp", "openclaw.setup.prepare.start");
+    await vi.waitFor(() => {
+      expect(onDone).toHaveBeenCalledWith("openclaw.setup.prepare.start");
+    });
+
+    expect(seen).toEqual(messages);
+  });
 });

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -154,6 +154,17 @@ export class ModelSetupWizardRunner {
       this.sessionId = null;
       this.abortController = null;
       this.options.onDone(this.startMethod);
+      return;
+    }
+    // Gateway-executed steps (download/pull progress) carry no input controls,
+    // so nothing would ever ask for the next one. Keep polling: the session
+    // long-polls until the next update or the terminal result, so this renders
+    // live progress instead of freezing on the first frame.
+    if (next.phase === "step" && next.step.executor === "gateway") {
+      const generation = this.generation;
+      void this.requestNext(authChoice, undefined, generation).catch((error: unknown) => {
+        this.handleError(error, generation);
+      });
     }
   }
 


### PR DESCRIPTION
Related: #113476, #109764

## What Problem This Solves

In the web Model Setup sheet, a local-model download or pull started via "Set up / Download model" froze on its first progress frame ("Preparing Gemma 4 E4B model download…") and never updated or closed, even though the gateway kept downloading. Found by live testing on current main: the browser sat on the initial label while the model directory grew past 900 MB, and the gateway logged only two `wizard.next` calls for the whole session.

## Why This Change Was Made

The model-setup wizard runner is request/response driven: it only asks for the next step after `start()` or after the user answers one. Gateway-executed steps (`executor: "gateway"`, which is what the wizard session stamps on progress) carry no input controls, so nothing ever requested the next step. The runner now continues polling immediately after applying a gateway-executed step; the session long-polls until the next update or terminal result, so there is no busy loop, and the existing generation/abort guards plus `handleError` still own cancellation and failures. Auth flows benefit identically because the trigger is the generic `executor` discriminator rather than a prepare-specific branch.

## User Impact

Local-model downloads and Ollama pulls now show live progress (percent, GB, MB/s) in the browser and finish or close on their own, instead of appearing stuck.

## Evidence

Live before/after on a real gateway with the real 5 GB Gemma download:

- Before: message stuck at "Preparing Gemma 4 E4B model download…" with 913 MB on disk and 2 `wizard.next` RPCs total.
- After (Control UI rebuilt with the fix): "Downloading Gemma 4 E4B… 7% (0.4/5.0 GB, 7 MB/s)" advancing to "16% (0.8/5.0 GB, 13 MB/s)" and 301 `wizard.next` RPCs, then a clean Cancel.

Tests: `node scripts/run-vitest.mjs ui/src/pages/model-setup` — 6 files / 45 passed, including a new regression test that drives three gateway progress frames through completion. Verified the new test fails with the fix reverted (1 failed / 4 passed) and passes with it. Autoreview clean (0.93).

## Follow-up

The macOS onboarding sheet has the same shape: `applyAuthWizardResult` in `apps/macos/Sources/OpenClaw/OnboardingAISetup.swift` stores the step without requesting the next one, so gateway-executed progress will freeze there too. Tracked separately because it needs a Mac build and live app verification this PR cannot provide.
