### PR TITLE
fix(ci): restore packaged OpenWebUI and update validation

### DIFF
--- a/scripts/e2e/lib/fixtures/workspace.mjs
+++ b/scripts/e2e/lib/fixtures/workspace.mjs
@@ -29,10 +29,8 @@ function writeOpenWebUiWorkspace() {
     path.join(workspace, "IDENTITY.md"),
     "# Identity\n\n- Name: OpenClaw\n- Purpose: Open WebUI Docker compatibility smoke test assistant.\n",
   );
-  writeJson(path.join(workspace, ".openclaw", "workspace-state.json"), {
-    version: 1,
-    setupCompletedAt: "2026-01-01T00:00:00.000Z",
-  });
+  fs.rmSync(path.join(workspace, ".openclaw", "workspace-state.json"), { force: true });
+  fs.rmSync(path.join(workspace, "openclaw-workspace-state.json"), { force: true });
   fs.rmSync(path.join(workspace, "BOOTSTRAP.md"), { force: true });
 }
 

--- a/scripts/e2e/lib/package-git-fixture.mjs
+++ b/scripts/e2e/lib/package-git-fixture.mjs
@@ -26,7 +26,21 @@ function withoutAiRuntimeDependency(value) {
   return next.length > 0 ? next : undefined;
 }
 
+function ensureDependencyIgnores(root) {
+  const gitignorePath = path.join(root, ".gitignore");
+  const existing = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
+  const lines = new Set(existing.split(/\r?\n/u));
+  const required = ["node_modules", "**/node_modules/", "pnpm-lock.yaml"];
+  const missing = required.filter((entry) => !lines.has(entry));
+  if (missing.length === 0) {
+    return;
+  }
+  const prefix = existing.length === 0 || existing.endsWith("\n") ? existing : `${existing}\n`;
+  fs.writeFileSync(gitignorePath, `${prefix}${missing.join("\n")}\n`);
+}
+
 function prepare(root) {
+  ensureDependencyIgnores(root);
   const packageJsonPath = path.join(root, "package.json");
   const packageJson = readJson(packageJsonPath);
   const aiRuntimeSource = path.join(root, "node_modules", "@openclaw", "ai");

--- a/test/scripts/fixtures-workspace.test.ts
+++ b/test/scripts/fixtures-workspace.test.ts
@@ -1,6 +1,6 @@
 // Fixtures Workspace tests cover shared E2E workspace fixture assertions.
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -19,7 +19,39 @@ function runAgentsDeleteAssert(root: string, outputPath: string, env: Record<str
   });
 }
 
+function runOpenWebUiWorkspace(workspaceDir: string) {
+  return spawnSync(process.execPath, [FIXTURE_SCRIPT, "openwebui-workspace"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      OPENCLAW_WORKSPACE_DIR: workspaceDir,
+    },
+  });
+}
+
 describe("workspace fixture assertions", () => {
+  it("prepares Open WebUI without retired workspace setup state", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-fixture-workspace-"));
+    const workspaceDir = path.join(root, "workspace");
+    const nestedStatePath = path.join(workspaceDir, ".openclaw", "workspace-state.json");
+    const rootStatePath = path.join(workspaceDir, "openclaw-workspace-state.json");
+    try {
+      mkdirSync(path.dirname(nestedStatePath), { recursive: true });
+      writeFileSync(nestedStatePath, "{}\n");
+      writeFileSync(rootStatePath, "{}\n");
+      const result = runOpenWebUiWorkspace(workspaceDir);
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(path.join(workspaceDir, "IDENTITY.md"), "utf8")).toContain(
+        "Open WebUI Docker compatibility smoke test assistant.",
+      );
+      expect(existsSync(nestedStatePath)).toBe(false);
+      expect(existsSync(rootStatePath)).toBe(false);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("rejects oversized agents delete output before parsing it", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-fixture-workspace-"));
     const outputPath = path.join(root, "agents-delete.json");

--- a/test/scripts/package-git-fixture.test.ts
+++ b/test/scripts/package-git-fixture.test.ts
@@ -10,6 +10,7 @@ describe("package git fixture", () => {
 
   it("stages bundled ai runtime as a local file dependency", async () => {
     const root = tempDirs.make("openclaw-package-git-fixture-");
+    writeFileSync(path.join(root, ".gitignore"), "dist/\n");
     mkdirSync(path.join(root, "node_modules", "@openclaw", "ai"), { recursive: true });
     writeFileSync(
       path.join(root, "package.json"),
@@ -35,6 +36,9 @@ describe("package git fixture", () => {
     );
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(readFileSync(path.join(root, ".gitignore"), "utf8").split(/\r?\n/u)).toEqual(
+      expect.arrayContaining(["dist/", "node_modules", "**/node_modules/", "pnpm-lock.yaml"]),
+    );
     const packageJson = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
     expect(packageJson.dependencies["@openclaw/ai"]).toBe("file:.openclaw-fixture/packages/ai");
     expect(packageJson.bundleDependencies).toEqual(["chalk"]);
@@ -47,5 +51,24 @@ describe("package git fixture", () => {
         ),
       ).name,
     ).toBe("@openclaw/ai");
+
+    mkdirSync(path.join(root, "node_modules", "chalk"), { recursive: true });
+    writeFileSync(path.join(root, "node_modules", "chalk", "package.json"), "{}\n");
+    mkdirSync(path.join(root, ".openclaw-fixture", "packages", "ai", "node_modules", "zod"), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(root, ".openclaw-fixture", "packages", "ai", "node_modules", "zod", "package.json"),
+      "{}\n",
+    );
+    writeFileSync(path.join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+    expect(spawnSync("git", ["init", "-q", root], { encoding: "utf8" }).status).toBe(0);
+    expect(spawnSync("git", ["-C", root, "add", "-A"], { encoding: "utf8" }).status).toBe(0);
+    const staged = spawnSync("git", ["-C", root, "diff", "--cached", "--name-only"], {
+      encoding: "utf8",
+    });
+    expect(staged.status).toBe(0);
+    expect(staged.stdout).not.toContain("node_modules");
+    expect(staged.stdout).not.toContain("pnpm-lock.yaml");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where packaged OpenWebUI chat returned HTTP 500 and package-to-git development updates failed with a dirty-worktree error during full release validation.

## Why This Change Was Made

Use the existing canonical SQLite workspace lifecycle instead of creating retired workspace-state sidecars. Preserve existing fixture `.gitignore` content while excluding root and nested installed dependencies and the generated package-manager lockfile. This ports the existing maintainer-owned fixture repair and makes reused workspaces safe.

## User Impact

Release validation can exercise an actual OpenWebUI conversation and packaged channel switching without false failures or bypassing real workspace and clean-worktree safety checks. Existing user-defined ignore entries survive.

## Evidence

- Independently reproduced both failures twice in real Docker package-acceptance runs, including exact current selected product `91b5b43d788`: run `30154513668`, jobs `89671003911` and `89671003914`.
- Verified the existing owner implementation in maintainer commit `e08212c574d` and preserved its SQLite-first and existing-ignore contracts.
- Remote focused proof: `pnpm test test/scripts/fixtures-workspace.test.ts test/scripts/package-git-fixture.test.ts` passed all four tests, including actual fixture subprocesses, preexisting retired state, actual Git staging, and existing `.gitignore` preservation.
- Remote four-file formatting and focused oxlint passed; both canonical script and root-test tsgo projects passed on the trusted Testbox.
- Fresh independent `gpt-5.6-sol` structured autoreview and official TruffleHog scan passed after strengthening reused-workspace regression.
