### PR TITLE
fix(openai): align Codex discovery client version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **OpenAI Codex model discovery:** align the catalog request's client version with the managed Codex package and guard dependency bumps against future drift.
 - **Cron local-provider preflight:** report the guarded-fetch deadline as a bounded preflight timeout, preserve concrete nested non-timeout errors, and carry the failure reason into fallback warnings. Thanks @shakkernerd.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **OpenAI Codex model discovery:** align the catalog request's client version with the managed Codex package and guard dependency bumps against future drift.
 - **Cron local-provider preflight:** report the guarded-fetch deadline as a bounded preflight timeout, preserve concrete nested non-timeout errors, and carry the failure reason into fallback warnings. Thanks @shakkernerd.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -84,7 +84,7 @@ function classifyOpenAiFailoverCode(code: string | undefined) {
 const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
 // Keep synchronized with extensions/codex's exact @openai/codex dependency;
 // the provider contract test fails when that managed-runtime pin changes.
-const OPENAI_CODEX_CLIENT_VERSION = "0.144.6";
+const OPENAI_CODEX_CLIENT_VERSION = "0.145.0";
 const OPENAI_CODEX_MODELS_ENDPOINT = `${OPENAI_CODEX_RESPONSES_BASE_URL}/models?client_version=${OPENAI_CODEX_CLIENT_VERSION}`;
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
 const OPENAI_CODEX_MODELS_CACHE_TTL_MS = 60_000;

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -2350,6 +2350,7 @@ const APPCAST_TEST_TARGETS = ["test/appcast.test.ts", "test/scripts/make-appcast
 const CODEX_VERSION_CONTRACT_TEST_TARGETS = [
   "extensions/codex/src/manifest.test.ts",
   "extensions/openai/openai-provider.test.ts",
+  "test/scripts/codex-client-version-contract.test.ts",
 ];
 const SOURCE_TEST_TARGETS = new Map([
   ...PRECISE_SOURCE_TEST_TARGETS,

--- a/test/scripts/codex-client-version-contract.test.ts
+++ b/test/scripts/codex-client-version-contract.test.ts
@@ -1,0 +1,33 @@
+// Codex Client Version Contract tests cover cross-plugin managed version alignment.
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const CODEX_PACKAGE_JSON_URL = new URL("../../extensions/codex/package.json", import.meta.url);
+const OPENAI_PROVIDER_URL = new URL("../../extensions/openai/openai-provider.ts", import.meta.url);
+const OPENAI_CODEX_CLIENT_VERSION_PATTERN = /^const OPENAI_CODEX_CLIENT_VERSION = "([^"]+)";$/mu;
+
+function readManagedCodexVersion(): string {
+  const packageJson = JSON.parse(fs.readFileSync(CODEX_PACKAGE_JSON_URL, "utf8")) as {
+    dependencies?: Record<string, unknown>;
+  };
+  const version = packageJson.dependencies?.["@openai/codex"];
+  if (typeof version !== "string") {
+    throw new Error("extensions/codex/package.json must pin @openai/codex exactly");
+  }
+  return version;
+}
+
+function readOpenAICodexClientVersion(): string {
+  const providerSource = fs.readFileSync(OPENAI_PROVIDER_URL, "utf8");
+  const version = OPENAI_CODEX_CLIENT_VERSION_PATTERN.exec(providerSource)?.[1];
+  if (!version) {
+    throw new Error("extensions/openai/openai-provider.ts must declare the Codex client version");
+  }
+  return version;
+}
+
+describe("Codex client version contract", () => {
+  it("matches OpenAI model discovery to the managed Codex package", () => {
+    expect(readOpenAICodexClientVersion()).toBe(readManagedCodexVersion());
+  });
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -298,6 +298,7 @@ describe("scripts/test-projects changed-target routing", () => {
         targets: [
           "extensions/codex/src/manifest.test.ts",
           "extensions/openai/openai-provider.test.ts",
+          "test/scripts/codex-client-version-contract.test.ts",
         ],
       });
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OAuth model discovery advertised Codex client version 0.144.6 after the managed Codex package moved to 0.145.0, causing the provider version and catalog URL contract tests to fail.

## Why This Change Was Made

Align the OpenAI provider's catalog client version with the exact managed Codex package. Add a lightweight tooling contract and route Codex version changes through it so the invariant still runs when broad dependency updates select CI's compact fallback and omit the extension batch.

## User Impact

Codex OAuth model discovery now identifies itself with the same version as the managed Codex runtime, keeping catalog eligibility and version-gated model metadata consistent.

## Evidence

- `node scripts/run-vitest.mjs extensions/openai/openai-provider.test.ts` — 61 tests passed on Blacksmith Testbox.
- `node scripts/run-vitest.mjs test/scripts/codex-client-version-contract.test.ts test/scripts/test-projects.test.ts` — 220 tests passed.
- `pnpm check:changed` — passed all selected format, guard, typecheck, lint, boundary, and import-cycle lanes.
- Autoreview: clean, no accepted or actionable findings.
- Exact-head hosted CI: [run 30155403162](https://github.com/openclaw/openclaw/actions/runs/30155403162) passed.

### Direct Codex contract

Verified the exact managed source at `openai/codex` tag `rust-v0.145.0`:

- [`codex-rs/Cargo.toml:131`](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/Cargo.toml#L131) declares workspace version 0.145.0.
- [`codex-rs/models-manager/src/lib.rs:18`](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/models-manager/src/lib.rs#L18-L26) derives the whole client version from the Cargo package version.
- [`codex-rs/models-manager/src/manager.rs:394`](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/models-manager/src/manager.rs#L394-L407) passes that version into model discovery.
- [`codex-rs/model-provider/src/models_endpoint.rs:75`](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/model-provider/src/models_endpoint.rs#L75-L88) builds the authenticated model-list URL with it.
- [`codex-rs/codex-api/src/endpoint/models.rs:35`](https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/codex-api/src/endpoint/models.rs#L35-L43) appends `client_version` to the models endpoint.

### Redacted live OAuth discovery

Ran an account-scoped request using the existing Codex CLI ChatGPT login. The access token and account identifier stayed in process memory and were not printed or written.

```json
{
  "request": {
    "origin": "https://chatgpt.com",
    "path": "/backend-api/codex/models",
    "clientVersion": "0.145.0",
    "accountScoped": true
  },
  "credential": {
    "source": "Codex CLI saved ChatGPT login",
    "tokenExposed": false
  },
  "response": {
    "status": 200,
    "ok": true,
    "modelCount": 8,
    "modelIds": [
      "gpt-5.6-sol",
      "gpt-5.6-terra",
      "gpt-5.6-luna",
      "gpt-5.5",
      "gpt-5.4",
      "gpt-5.4-mini",
      "gpt-5.3-codex-spark",
      "codex-auto-review"
    ]
  }
}
```

Owner review: the OpenAI/Codex maintainer accepts the narrow synchronized-constant design after direct source verification and live catalog proof. Runtime derivation from the Codex plugin was rejected because the OpenAI plugin is an independently publishable owner boundary and may not have the Codex plugin package beside it.
