### PR TITLE
refactor(workboard): share claim token redaction

### DIFF
--- a/extensions/workboard/src/card-redaction.test.ts
+++ b/extensions/workboard/src/card-redaction.test.ts
@@ -1,0 +1,45 @@
+import type { WorkboardCard } from "@openclaw/workboard-contract";
+import { describe, expect, it } from "vitest";
+import { redactClaimToken } from "./card-redaction.js";
+
+function createCard(metadata?: WorkboardCard["metadata"]): WorkboardCard {
+  return {
+    id: "card-1",
+    title: "Ship cleanup",
+    status: "running",
+    priority: "normal",
+    labels: ["cleanup"],
+    position: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    metadata,
+  };
+}
+
+describe("redactClaimToken", () => {
+  it("preserves card identity when there is no claim", () => {
+    const card = createCard({ archivedAt: 1 });
+
+    expect(redactClaimToken(card)).toBe(card);
+  });
+
+  it("redacts the token without mutating the card", () => {
+    const card = createCard({
+      claim: {
+        ownerId: "worker",
+        token: "secret-token",
+        claimedAt: 1,
+        lastHeartbeatAt: 2,
+      },
+    });
+
+    const redacted = redactClaimToken(card);
+
+    expect(redacted).not.toBe(card);
+    expect(redacted.labels).toBe(card.labels);
+    expect(redacted.metadata).not.toBe(card.metadata);
+    expect(redacted.metadata?.claim).not.toBe(card.metadata?.claim);
+    expect(redacted.metadata?.claim?.token).toBe("[redacted]");
+    expect(card.metadata?.claim?.token).toBe("secret-token");
+  });
+});

--- a/extensions/workboard/src/card-redaction.ts
+++ b/extensions/workboard/src/card-redaction.ts
@@ -1,0 +1,18 @@
+import type { WorkboardCard } from "@openclaw/workboard-contract";
+
+export function redactClaimToken(card: WorkboardCard): WorkboardCard {
+  const claim = card.metadata?.claim;
+  if (!claim) {
+    return card;
+  }
+  return {
+    ...card,
+    metadata: {
+      ...card.metadata,
+      claim: {
+        ...claim,
+        token: "[redacted]",
+      },
+    },
+  };
+}

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -11,6 +11,7 @@ import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveWorkboardCardByIdOrPrefix } from "./card-lookup.js";
+import { redactClaimToken } from "./card-redaction.js";
 import type { WorkboardDispatchResult, WorkboardStore } from "./store.js";
 
 type JsonOptions = {
@@ -69,23 +70,6 @@ function formatCardLine(card: WorkboardCard): string {
   const boardId = card.metadata?.automation?.boardId ?? "default";
   const agent = card.agentId ? ` ${card.agentId}` : "";
   return `${card.id.slice(0, 8)}  ${card.status.padEnd(8)}  ${card.priority.padEnd(6)}  ${boardId}${agent}  ${card.title}`;
-}
-
-function redactClaimToken(card: WorkboardCard): WorkboardCard {
-  const claim = card.metadata?.claim;
-  if (!claim) {
-    return card;
-  }
-  return {
-    ...card,
-    metadata: {
-      ...card.metadata,
-      claim: {
-        ...claim,
-        token: "[redacted]",
-      },
-    },
-  };
 }
 
 function redactDispatchResult(result: WorkboardDispatchResult): WorkboardDispatchResult {

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -1,6 +1,6 @@
-import type { WorkboardCard } from "@openclaw/workboard-contract";
 // Workboard plugin module implements gateway behavior.
 import type { OpenClawPluginApi } from "../api.js";
+import { redactClaimToken } from "./card-redaction.js";
 import {
   assertNoCursorAdvance,
   createWorkboardDispatchHandler,
@@ -18,20 +18,6 @@ import { WorkboardStore } from "./store.js";
 
 const READ_SCOPE = "operator.read" as const;
 const WRITE_SCOPE = "operator.write" as const;
-
-function redactClaimToken(card: WorkboardCard): WorkboardCard {
-  const claim = card.metadata?.claim;
-  if (!claim) {
-    return card;
-  }
-  return {
-    ...card,
-    metadata: {
-      ...card.metadata,
-      claim: { ...claim, token: "[redacted]" },
-    },
-  };
-}
 
 function redactDiagnosticsRows(result: Awaited<ReturnType<WorkboardStore["diagnostics"]>>) {
   return {

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -5,6 +5,7 @@ import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/plugin
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { Type } from "typebox";
+import { redactClaimToken } from "./card-redaction.js";
 import { WorkboardStore } from "./store.js";
 import { cardIdField, claimTokenField, createWorkboardMoveTool } from "./tools-card-mutations.js";
 
@@ -107,23 +108,6 @@ function summarizeCard(card: WorkboardCard) {
     diagnostics: card.metadata?.diagnostics,
     archivedAt: card.metadata?.archivedAt,
     updatedAt: card.updatedAt,
-  };
-}
-
-function redactClaimToken(card: WorkboardCard): WorkboardCard {
-  const claim = card.metadata?.claim;
-  if (!claim) {
-    return card;
-  }
-  return {
-    ...card,
-    metadata: {
-      ...card.metadata,
-      claim: {
-        ...claim,
-        token: "[redacted]",
-      },
-    },
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Workboard's CLI, agent tools, and gateway each carried their own copy of claim-token redaction. Keeping the same security-sensitive presentation rule in three places made future drift easy.

## Why This Change Was Made

Moves the existing behavior into one Workboard-owned leaf helper and migrates all three callers. The helper preserves the existing no-claim identity fast path, shallow-copy behavior, and exact `[redacted]` marker.

## User Impact

No user-visible behavior change. Workboard claim tokens remain hidden consistently across CLI JSON, tool results, and gateway responses, with one canonical implementation.

## Evidence

- Hosted focused tests: 37 passed across `card-redaction.test.ts`, `cli.test.ts`, `tools.test.ts`, and `gateway.test.ts` (`30155079128`).
- Hosted sparse-safe `pnpm check:changed`: passed (`30155367475`), including extension production/test typechecks, lint, formatting, plugin boundaries, and import-cycle checks.
- Fresh autoreview: clean, confidence `0.99`.
- Production code: net `-28` lines.
