### PR TITLE
perf: multi-select archiving no longer stalls a second per row

### DIFF
--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -47,13 +47,17 @@ export async function patchSession(
   session: SidebarRecentSession,
   patch: SidebarSessionPatch,
   scope: SidebarSessionMutationScope,
+  refresh: { deferListRefresh?: boolean } = {},
 ): Promise<SidebarSessionMutationResult> {
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
     return "stale";
   }
-  const agentId = parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
+  const agentId = sessionRowAgentId(session, scope);
   try {
-    const patched = await scope.sessions.patch(session.key, patch, { agentId });
+    const patched = await scope.sessions.patch(session.key, patch, {
+      agentId,
+      ...(refresh.deferListRefresh ? { deferListRefresh: true } : {}),
+    });
     if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
       return "stale";
     }
@@ -70,7 +74,7 @@ export async function patchSession(
     if (patch.pinned === false || (patch.archived === true && session.pinned)) {
       host.pruneSidebarSessionEntry(session.key);
     }
-    if (host.sidebarSessionStatusFilter() !== "active") {
+    if (!refresh.deferListRefresh && host.sidebarSessionStatusFilter() !== "active") {
       await host.sessionData.refreshSidebarSessions(agentId);
       if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
         return "stale";
@@ -98,6 +102,47 @@ export async function patchSession(
   }
 }
 
+function sessionRowAgentId(
+  session: SidebarRecentSession,
+  scope: SidebarSessionMutationScope,
+): string {
+  return parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
+}
+
+/**
+ * One list refresh per owning agent, replacing the per-row refreshes a batch
+ * defers; each deferred row skipped a full `sessions.list` round trip and rode
+ * pushed `sessions.changed` events instead. Agents come from the rows, not the
+ * scope, because `patchSession` routes every mutation by its own key. The
+ * result carries the stale/failed reporting the per-row refresh owed its caller.
+ */
+async function refreshSessionsAfterBatch(
+  host: SessionOrganizerControllerHost,
+  scope: SidebarSessionMutationScope,
+  rows: readonly SidebarRecentSession[],
+): Promise<SidebarSessionMutationResult> {
+  const agentIds = [...new Set(rows.map((row) => sessionRowAgentId(row, scope)))];
+  const refreshSidebar = host.sidebarSessionStatusFilter() !== "active";
+  for (const agentId of agentIds) {
+    if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+      return "stale";
+    }
+    try {
+      await scope.sessions.refreshReplacement(agentId);
+      if (refreshSidebar && host.sessionData.isSessionMutationScopeCurrent(scope)) {
+        await host.sessionData.refreshSidebarSessions(agentId);
+      }
+    } catch (error) {
+      if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+        return "stale";
+      }
+      host.sessionData.publishSessionMutationError(scope, error);
+      return "failed";
+    }
+  }
+  return host.sessionData.isSessionMutationScopeCurrent(scope) ? "completed" : "stale";
+}
+
 export async function patchSessions(
   host: SessionOrganizerControllerHost,
   rows: readonly SidebarRecentSession[],
@@ -107,11 +152,14 @@ export async function patchSessions(
   if (!scope) {
     return "stale";
   }
+  if (rows.length === 0) {
+    return "completed";
+  }
   let result: SidebarSessionMutationResult = "completed";
   // Sequential like deleteMany: parallel patches would race the shared
   // session-state publishes inside the capability.
   for (const row of rows) {
-    const rowResult = await patchSession(host, row, patch, scope);
+    const rowResult = await patchSession(host, row, patch, scope, { deferListRefresh: true });
     if (rowResult === "stale") {
       return "stale";
     }
@@ -119,7 +167,8 @@ export async function patchSessions(
       result = "failed";
     }
   }
-  return result;
+  const refreshed = await refreshSessionsAfterBatch(host, scope, rows);
+  return refreshed === "completed" ? result : refreshed;
 }
 
 export async function archiveSessionWithUndo(
@@ -145,9 +194,14 @@ async function archiveSessionsWithUndo(
   rows: readonly SidebarRecentSession[],
   scope: SidebarSessionMutationScope,
 ) {
+  if (rows.length === 0) {
+    return;
+  }
   const archived: Array<{ session: SidebarRecentSession; pinned: boolean }> = [];
   for (const session of rows) {
-    const result = await patchSession(host, session, { archived: true }, scope);
+    const result = await patchSession(host, session, { archived: true }, scope, {
+      deferListRefresh: true,
+    });
     if (result === "stale") {
       return;
     }
@@ -155,7 +209,8 @@ async function archiveSessionsWithUndo(
       archived.push({ session, pinned: session.pinned });
     }
   }
-  if (archived.length === 0 || !host.sessionData.isSessionMutationScopeCurrent(scope)) {
+  const refreshed = await refreshSessionsAfterBatch(host, scope, rows);
+  if (archived.length === 0 || refreshed === "stale") {
     return;
   }
   showToast({
@@ -183,6 +238,7 @@ async function restoreArchivedSessions(
       session,
       { archived: false, ...(pinned ? { pinned: true } : {}) },
       scope,
+      { deferListRefresh: true },
     );
     if (result === "stale") {
       return;
@@ -191,7 +247,12 @@ async function restoreArchivedSessions(
       restoredActiveKey = session.key;
     }
   }
-  if (restoredActiveKey && host.sessionData.isSessionMutationScopeCurrent(scope)) {
+  const refreshed = await refreshSessionsAfterBatch(
+    host,
+    scope,
+    archived.map((entry) => entry.session),
+  );
+  if (restoredActiveKey && refreshed !== "stale") {
     host.replaceCurrentSession(restoredActiveKey);
   }
 }

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -734,6 +734,71 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     }
   });
 
+  // Batch archiving used to force one canonical sessions.list per row, which is
+  // what made a multi-select stall. The whole selection must archive on one
+  // refresh and leave the sidebar settled with the rows gone.
+  it("archives a sidebar multi-select with one canonical list refresh", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+    const batchKeys = ["agent:main:batch-a", "agent:main:batch-b", "agent:main:batch-c"] as const;
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", baseTime),
+          sessionRow(batchKeys[0], "Batch A", baseTime - 1_000),
+          sessionRow(batchKeys[1], "Batch B", baseTime - 2_000),
+          sessionRow(batchKeys[2], "Batch C", baseTime - 3_000),
+        ]),
+        "sessions.patch": {},
+      },
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const sidebar = page.locator("openclaw-app-sidebar");
+      const rowFor = (key: string) =>
+        sidebar.locator(`.sidebar-recent-session[data-session-key="${key}"]`);
+      await rowFor(batchKeys[0]).waitFor({ state: "visible", timeout: 10_000 });
+      for (const key of batchKeys.slice(1)) {
+        await rowFor(key).waitFor({ state: "visible" });
+      }
+      const listCountBeforeBatch = (await gateway.getRequests("sessions.list")).length;
+
+      for (const key of batchKeys) {
+        await rowFor(key).click({ modifiers: ["Meta"] });
+      }
+      await rowFor(batchKeys[0]).click({ button: "right" });
+      const batchMenu = page.locator("openclaw-session-menu");
+      const archiveItem = batchMenu.getByRole("menuitem", { name: `Archive ${batchKeys.length}` });
+      await archiveItem.waitFor({ state: "visible", timeout: 10_000 });
+      await captureUiProof(page, "sidebar-multi-select-archive-menu.png");
+      await activateMenuItem(archiveItem);
+
+      for (const key of batchKeys) {
+        await waitForPatch(gateway, (params) => params.key === key && params.archived === true);
+      }
+
+      const patches = await gateway.getRequests("sessions.patch");
+      expect(patches.map((request) => requireRecord(request.params).key)).toEqual([...batchKeys]);
+      // The whole selection costs one canonical refresh, not one per archived row.
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length, { timeout: 10_000 })
+        .toBe(listCountBeforeBatch + 1);
+      await captureUiProof(page, "sidebar-multi-select-archive-settled.png");
+      // Hold past the batch so a late per-row refresh would still be caught.
+      await page.waitForTimeout(500);
+      expect((await gateway.getRequests("sessions.list")).length).toBe(listCountBeforeBatch + 1);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps a session row when the Gateway reports no deletion", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -1375,10 +1375,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         restoreModelOverride();
         return null;
       }
-      await refreshReplacement(options.agentId);
-      if (!isCurrentConnection(scope)) {
-        restoreModelOverride();
-        return null;
+      if (!options.deferListRefresh) {
+        await refreshReplacement(options.agentId);
+        if (!isCurrentConnection(scope)) {
+          restoreModelOverride();
+          return null;
+        }
       }
       if (pendingModelPatches.get(normalizedKey)?.token === modelPatchToken) {
         pendingModelPatches.delete(normalizedKey);

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -227,4 +227,39 @@ describe("session list replacement options", () => {
     expect(listCalls[2]?.[1]).not.toHaveProperty("offset");
     sessions.dispose();
   });
+
+  it("defers the canonical refresh for batch patches until the caller asks for it", async () => {
+    const keys = ["agent:main:one", "agent:main:two", "agent:main:three"];
+    const request = vi.fn(async (method: string, _params?: unknown) => {
+      if (method === "sessions.list") {
+        return sessionsResult(
+          keys.map((key) => ({ key, kind: "direct" as const, updatedAt: 1 })),
+          1,
+        );
+      }
+      if (method === "sessions.patch") {
+        return { ok: true };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const sessions = createSessions(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:one",
+    );
+
+    await sessions.refresh({ agentId: "main", limit: 60, includeDerivedTitles: true, force: true });
+    for (const key of keys) {
+      await sessions.patch(key, { archived: true }, { agentId: "main", deferListRefresh: true });
+    }
+    const listCallsBeforeTail = request.mock.calls.filter(
+      ([method]) => method === "sessions.list",
+    ).length;
+    await sessions.refreshReplacement("main");
+
+    // One seeding list, none from the patches, one authoritative tail refresh.
+    expect(listCallsBeforeTail).toBe(1);
+    expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(2);
+    expect(request.mock.calls.filter(([method]) => method === "sessions.patch")).toHaveLength(3);
+    sessions.dispose();
+  });
 });

--- a/ui/src/lib/sessions/patch.ts
+++ b/ui/src/lib/sessions/patch.ts
@@ -18,6 +18,12 @@ export type SessionPatchOptions = {
   agentId?: string;
   /** Capture the current connection now, but dispatch only after this tail settles. */
   waitFor?: Promise<unknown>;
+  /**
+   * Skips the canonical list refresh this patch forces. Batch callers own one
+   * refresh after their last row; otherwise an N-row batch pays N full
+   * `sessions.list` round trips while `sessions.changed` already reconciles.
+   */
+  deferListRefresh?: boolean;
 };
 
 export type SessionPatchRoute = (

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -134,18 +134,22 @@ describe("AppSidebar multi-select", () => {
     menu.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
 
     await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(2));
+    // Each row defers its canonical list refresh; the batch pays one refresh at
+    // the end instead of a full sessions.list round trip per archived row.
     expect(harness.patch).toHaveBeenNthCalledWith(
       1,
       "agent:main:a",
       { archived: true },
-      { agentId: "main" },
+      { agentId: "main", deferListRefresh: true },
     );
     expect(harness.patch).toHaveBeenNthCalledWith(
       2,
       "agent:main:b",
       { archived: true },
-      { agentId: "main" },
+      { agentId: "main", deferListRefresh: true },
     );
+    await waitForFast(() => expect(harness.refreshReplacement).toHaveBeenCalledTimes(1));
+    expect(harness.refreshReplacement).toHaveBeenCalledWith("main");
   });
 
   it("deletes the selection in one batch after a single confirm", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -480,10 +480,11 @@ describe("AppSidebar session mutation feedback", () => {
 
     await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledTimes(2));
     await vi.waitFor(() => expect(setSessionKey).toHaveBeenLastCalledWith(archivedRow.key));
+    // Undo restores through the batch helper, which refreshes once at the end.
     expect(harness.patch).toHaveBeenLastCalledWith(
       archivedRow.key,
       { archived: false, pinned: true },
-      { agentId: "main" },
+      { agentId: "main", deferListRefresh: true },
     );
     expect(navigate).toHaveBeenLastCalledWith("chat", {
       search: "?session=agent%3Amain%3Aa",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators archiving a multi-select in the Control UI sidebar
would wait roughly two seconds per row before the selection cleared. Archiving
nine threads from the context menu (`Archive 9`) took the better part of twenty
seconds, and the same stall applied to the other batch actions — mark
read/unread, move to group, and undoing a batch archive.

## Why This Change Was Made

Every row in a batch went through `sessions.patch`, and the session capability
force-refreshes the canonical `sessions.list` after each patch. A nine-row
archive therefore paid nine full list round trips on top of nine patches, and in
the archived/all sidebar view it paid a second sidebar list per row as well.

Batch callers now pass a `deferListRefresh` option so their rows skip that
per-row replacement, and each batch helper (`patchSessions`,
`archiveSessionsWithUndo`, `restoreArchivedSessions`) issues one authoritative
refresh per owning agent after its last row. The Gateway still pushes a
`sessions.changed` per committed patch, and the batch's single canonical refresh
settles the final sidebar state. Single-row actions are untouched: they keep
patching and refreshing exactly as before. No Gateway protocol change.

The tail refresh keeps the stale-scope and failure reporting the per-row refresh
owed its caller, and derives its agents from the row keys so per-row routing is
preserved.

## User Impact

Multi-select archive (and the other batch menu actions) now cost one list
refresh for the whole selection instead of one per row, so the marginal cost of
each extra selected thread drops to a single small patch call. A nine-row
archive goes from nine patch+list pairs to nine patches plus one list.

`sessions.list` is by far the more expensive of the two calls. On a 60-session
store the handler benchmark below measured ~176 ms per `sessions.patch` against
~2.9 s per `sessions.list` — roughly 17x. Those absolutes come from a loaded
machine (an identical re-run was ~3.5x faster across the board), so read the
ratio rather than the milliseconds; the win is removing N-1 of the expensive
call regardless of what it costs on a given host.

## Evidence

Gateway-level measurement of the two RPCs a batch archive issues, taken with a
throwaway harness test against the real `sessions` handlers with a 60-session
store (avg of 5 list calls / 9 patch calls, per-call ms):

```
rows=60
sessions.list  (includeDerivedTitles: true)  avg 2900.8  [3369, 3257, 2917, 2579, 2382]
sessions.list  (includeDerivedTitles: false) avg 3124.7  [2457, 3203, 3697, 3607, 2660]
sessions.patch (archived: true)              avg  175.7  [173, 178, 157, 161, 175, 169, 182, 231, 155]
```

The list call is ~17x the cost of the patch it was chasing, and derived titles
are not the reason — the plain list costs the same, so the per-row refresh was
pure overhead.

Real Control UI behavior, in Chromium against the mocked Gateway
(`ui/src/e2e/session-management.e2e.test.ts`, run via
`test/vitest/vitest.ui-e2e.config.ts`): the new case cmd-clicks three sidebar
rows, opens the batch menu, activates **Archive 3**, and asserts the Gateway saw
three `sessions.patch` calls in row order plus **exactly one** `sessions.list`.
It then holds past the batch so a late per-row refresh would still be caught, and
re-asserts the count. Before this change that same flow issued one full
`sessions.list` per archived row.

Screenshots captured by the run (`OPENCLAW_CAPTURE_UI_PROOF=1`):
`sidebar-multi-select-archive-menu.png` shows the three selected rows with the
batch menu open; `sidebar-multi-select-archive-settled.png` is the settled
sidebar after the single refresh.

Focused tests (`node scripts/run-vitest.mjs`):

- `ui/src/lib/sessions/list-options.test.ts` — new case proves a deferred batch
  issues its patches with zero intervening `sessions.list` calls and exactly one
  on the tail refresh (5 passed).
- `ui/src/components/app-sidebar.test.ts` — batch-menu archive now asserts the
  deferred option per row plus a single `refreshReplacement`; the single-session
  archive/undo case is updated for the shared batch helper (166 passed).

Also green locally: UI typecheck (`scripts/run-tsgo.mjs -p tsconfig.ui.json`),
`oxlint` on the touched files, and the UI boundary-guard lint lane.
