### PR TITLE
fix(auto-reply): gate execution-phase typing in message mode (#111547)

### DIFF
--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -867,8 +867,8 @@ describe("createTypingSignaler", () => {
     }
   });
 
-  it("starts typing on execution activity for active reply modes", async () => {
-    for (const mode of ["instant", "message", "thinking"] as const) {
+  it("starts typing on execution activity for instant and thinking modes", async () => {
+    for (const mode of ["instant", "thinking"] as const) {
       const typing = createMockTypingController();
       const signaler = createTypingSignaler({ typing, mode, isHeartbeat: false });
 
@@ -878,6 +878,27 @@ describe("createTypingSignaler", () => {
       expect(typing.refreshTypingTtl, `mode=${mode}`).toHaveBeenCalledTimes(1);
       expect(typing.startTypingOnText, `mode=${mode}`).not.toHaveBeenCalled();
     }
+  });
+
+  it("does not start typing on execution activity in message mode before renderable text", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({ typing, mode: "message", isHeartbeat: false });
+
+    await signaler.signalExecutionActivity?.();
+
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
+  });
+
+  it("starts typing on execution activity in message mode after renderable text", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({ typing, mode: "message", isHeartbeat: false });
+
+    await signaler.signalTextDelta("hello");
+    await signaler.signalExecutionActivity?.();
+
+    expect(typing.startTypingLoop).toHaveBeenCalledTimes(1);
+    expect(typing.refreshTypingTtl).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses typing when disabled", async () => {

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -162,6 +162,13 @@ export function createTypingSignaler(params: {
       return;
     }
     if (!typing.isActive()) {
+      // In message mode, typing must wait for renderable reply text, matching
+      // signalToolStart(). Otherwise execution-phase activity (tool calls,
+      // reasoning) starts the indicator before any message exists, making
+      // "message" behave like "instant".
+      if (shouldStartOnMessageStart && !hasRenderableText) {
+        return;
+      }
       await typing.startTypingLoop();
     }
     typing.refreshTypingTtl();


### PR DESCRIPTION
Closes #111547

## What Problem This Solves

With `typingMode: "message"` configured, the typing indicator (WhatsApp "composing", etc.) still started **immediately when a run began** — before any renderable assistant text existed. The execution-phase typing path bypassed the mode's gating, so `"message"` behaved like `"instant"` in practice. Only `"never"` actually prevented early typing.

## Why This Change Was Made

`signalToolStart()` already enforces the message-mode guard:

```ts
if (shouldStartOnMessageStart && !hasRenderableText) {
  return;
}
```

but `signalExecutionActivity()` (called from the execution phase at `agent-runner-execution.ts`) did **not**, so it started the typing loop unconditionally for any non-`never` mode. This is an inconsistency between the two execution-phase typing paths, not a deliberate boundary: the same "wait for renderable text" rule now applies to both.

The fix mirrors the existing `signalToolStart()` guard exactly — no new state, no behavior change for `instant` / `thinking` / `never` modes.

## User Impact

Channels driven by the core typing controller (WhatsApp, Telegram, etc.) no longer show a typing bubble during the execution phase before the assistant has produced any reply text when `typingMode: "message"` is set. The indicator now starts only when renderable text arrives, matching the documented `"message"` semantics.

## Evidence

Red/green terminal proof (real code on this branch vs `upstream/main` `typing-mode.ts`):

**RED — `upstream/main` + the new tests:**
```
❯ auto-reply ../../src/auto-reply/reply/reply-utils.test.ts (79 tests | 1 failed | 76 skipped) 27ms
     × does not start typing on execution activity in message mode before renderable text
     ✓ starts typing on execution activity in message mode after renderable text
```
The failure is the reported defect: in `message` mode, `signalExecutionActivity()` started the typing loop before any renderable text existed.

**GREEN — this PR:**
```
✓ auto-reply ../../src/auto-reply/reply/reply-utils.test.ts (79 tests | 76 skipped) 22ms
 Test Files  1 passed (1)
      Tests  3 passed (79)
```
All three `signalExecutionActivity` cases pass: `instant`/`thinking` still start typing, `message` waits for renderable text, and `message` starts after `signalTextDelta("hello")`. `agent-runner-execution-lifecycle.test.ts` (16 tests) also passes — it only asserts `signalExecutionActivity` is invoked, not typing state.

## Notes

A previous attempt (#111601) was closed by its author ("Will not pursue further"), not for a technical objection. This change keeps the validated direction and adds explicit before/after-renderable-text coverage for the message path.