### PR TITLE
fix(gateway): close failed Responses streams without false completion

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -106,7 +106,12 @@ async function writeGatewayConfig(config: Record<string, unknown>) {
   await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
 }
 
-async function postResponses(port: number, body: unknown, headers?: Record<string, string>) {
+async function postResponses(
+  port: number,
+  body: unknown,
+  headers?: Record<string, string>,
+  signal?: AbortSignal,
+) {
   const res = await fetch(`http://127.0.0.1:${port}/v1/responses`, {
     method: "POST",
     headers: {
@@ -115,6 +120,7 @@ async function postResponses(port: number, body: unknown, headers?: Record<strin
       ...headers,
     },
     body: JSON.stringify(body),
+    ...(signal ? { signal } : {}),
   });
   return res;
 }
@@ -195,6 +201,36 @@ const WEATHER_TOOL = [
     type: "function",
     name: "get_weather",
     description: "Get weather",
+  },
+] as const;
+
+const STREAM_FAILURE_CASES = [
+  {
+    name: "a reserved client tool",
+    createError: () => createClientToolNameConflictError(["read"]),
+    tools: [{ type: "function", name: "read" }],
+    expectedCode: "invalid_request_error",
+    expectedMessage: "invalid tool configuration",
+  },
+  {
+    name: "a mapped provider failure",
+    createError: () =>
+      new FailoverError("The provider rejected the request.", {
+        reason: "format",
+        status: 400,
+        code: "decimal_above_max_value",
+        rawError: "Invalid top_p: expected a value less than or equal to 1.",
+      }),
+    tools: [],
+    expectedCode: "invalid_request_error",
+    expectedMessage: "Invalid top_p",
+  },
+  {
+    name: "an unmapped provider failure",
+    createError: () => new Error("provider failed"),
+    tools: [],
+    expectedCode: "api_error",
+    expectedMessage: "internal error",
   },
 ] as const;
 
@@ -1027,6 +1063,67 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(json.error?.message).toContain("Invalid 'top_p'");
     expect(agentCommand).toHaveBeenCalledTimes(1);
   });
+
+  it.each(
+    STREAM_FAILURE_CASES.flatMap((failure) =>
+      [false, true].map((emitErrorLifecycle) => ({
+        name: failure.name,
+        createError: failure.createError,
+        tools: failure.tools,
+        expectedCode: failure.expectedCode,
+        expectedMessage: failure.expectedMessage,
+        emitErrorLifecycle,
+        label: `${failure.name} ${emitErrorLifecycle ? "after" : "without"} an error lifecycle`,
+      })),
+    ),
+  )(
+    "closes the response stream for $label without reporting completion",
+    async ({ createError, emitErrorLifecycle, expectedCode, expectedMessage, tools }) => {
+      const idleRootCount = getActiveGatewayRootWorkCount();
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce((async (opts: unknown) => {
+        if (emitErrorLifecycle) {
+          const runId = (opts as { runId?: string }).runId;
+          if (!runId) {
+            throw new Error("expected a streaming response run ID");
+          }
+          emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "error" } });
+        }
+        throw createError();
+      }) as never);
+
+      const res = await postResponses(
+        enabledPort,
+        {
+          stream: true,
+          model: "openclaw",
+          input: "hi",
+          tools,
+        },
+        undefined,
+        AbortSignal.timeout(5_000),
+      );
+      expect(res.status).toBe(200);
+
+      const events = parseSseEvents(await res.text());
+      const failedEvents = events.filter((event) => event.event === "response.failed");
+      expect(failedEvents).toHaveLength(1);
+      expect(events.filter((event) => event.event === "response.completed")).toHaveLength(0);
+      expect(events.filter((event) => event.data === "[DONE]")).toHaveLength(1);
+      expect(events.at(-1)?.data).toBe("[DONE]");
+
+      const failedResponse = (
+        parseSseData(findSseEvent(events, "response.failed")) as {
+          response?: { status?: string; error?: { code?: string; message?: string } };
+        }
+      ).response;
+      expect(failedResponse?.status).toBe("failed");
+      expect(failedResponse?.error?.code).toBe(expectedCode);
+      expect(failedResponse?.error?.message).toContain(expectedMessage);
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(idleRootCount));
+    },
+  );
 
   it("accepts write-scoped and admin-scoped HTTP callers", async () => {
     const port = enabledPort;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -992,6 +992,19 @@ export async function handleOpenResponsesHttpRequest(
     maybeFinalize();
   };
 
+  const finalizeFailedResponse = (response: ResponseResource) => {
+    if (closed) {
+      return;
+    }
+    // Failure is terminal even when an earlier lifecycle event is waiting for usage.
+    closed = true;
+    stopWatchingDisconnect();
+    unsubscribe();
+    writeSseEvent(res, { type: "response.failed", response });
+    writeDone(res);
+    res.end();
+  };
+
   // Send initial events
   const initialResponse = createResponseResource({
     id: responseId,
@@ -1312,7 +1325,7 @@ export async function handleOpenResponsesHttpRequest(
           usage: finalUsage,
         });
 
-        writeSseEvent(res, { type: "response.failed", response: errorResponse });
+        finalizeFailedResponse(errorResponse);
         emitAgentEvent({
           runId: responseId,
           stream: "lifecycle",
@@ -1343,7 +1356,7 @@ export async function handleOpenResponsesHttpRequest(
           usage: finalUsage,
         });
         rememberResponseSession();
-        writeSseEvent(res, { type: "response.failed", response: mappedResponse });
+        finalizeFailedResponse(mappedResponse);
         emitAgentEvent({
           runId: responseId,
           stream: "lifecycle",
@@ -1352,7 +1365,7 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
       rememberResponseSession();
-      writeSseEvent(res, { type: "response.failed", response: errorResponse });
+      finalizeFailedResponse(errorResponse);
       emitAgentEvent({
         runId: responseId,
         stream: "lifecycle",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users streaming OpenAI-compatible Responses requests could wait indefinitely after a provider or client-tool failure, or receive a contradictory `response.completed` event after `response.failed`. The failure is reachable on shipped `v2026.7.1` and current main when the Responses endpoint is explicitly enabled and authenticated.

## Why This Change Was Made

Terminate every failed Responses stream through one existing-protocol-compliant path: stop disconnect observation, release its subscription, emit exactly one `response.failed`, write `[DONE]`, and end the response. Preserve successful streams, normal cancellation, existing error redaction/mapping, and Gateway work-admission cleanup. Authentication and configuration are unchanged.

## User Impact

OpenAI-compatible clients receive a prompt, correct failure and a closed stream instead of hanging or observing false successful completion. Reserved-tool conflicts, mapped provider failures, and ordinary provider exceptions are handled consistently.

## Evidence

- Independently reproduced and traced the shipped and current source against the pinned official OpenAI Responses protocol.
- Six real HTTP streaming regressions: reserved `read` client tool, mapped provider failure, and unmapped provider failure, each both with and without an earlier lifecycle-error event.
- Each regression asserts one `response.failed`, zero `response.completed`, one final `[DONE]`, bounded HTTP stream termination, correct error mapping, and Gateway root-work cleanup.
- Trusted remote Linux Testbox: all **39/39** `src/gateway/openresponses-http.test.ts` regressions pass.
- Targeted format, core oxlint, core typecheck, and gateway-test typecheck all pass.
- Fresh independent autoreview: clean (0.96); verified TruffleHog: clean.
- AI-assisted; reviewed and validated against the actual endpoint, current/shipped source, sibling Chat Completions behavior and upstream protocol.
