### PR TITLE
feat(ui): syntax-highlight read-only automation scripts in Control UI

### DIFF
--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -83,7 +83,8 @@ export function handleMarkdownCodeBlockCopy(event: Event): void {
   });
 }
 
-function highlightCode(text: string, lang: string): string {
+/** Highlight a snippet; output is escaped hljs markup safe for unsafeHTML in a code block. */
+export function highlightCodeHtml(text: string, lang: string): string {
   const language = lang.trim().toLowerCase();
   try {
     if (language && hljs.getLanguage(language)) {
@@ -103,7 +104,7 @@ function highlightCode(text: string, lang: string): string {
 
 /** Highlight a JSON/JSON5 snippet; output is escaped hljs markup safe for unsafeHTML in a code block. */
 export function highlightJsonHtml(text: string): string {
-  return highlightCode(text, "json");
+  return highlightCodeHtml(text, "json");
 }
 
 function codeClassAttribute(lang: string, highlighted: string): string {
@@ -122,7 +123,7 @@ function renderCodeElement(
   if (options.blockArt || isMarkdownBlockArtText(text)) {
     return `<pre><code class="markdown-block-art">${escapeMarkdownHtml(text)}</code></pre>`;
   }
-  const highlighted = highlightCode(text, lang);
+  const highlighted = highlightCodeHtml(text, lang);
   const classAttr = codeClassAttribute(lang, highlighted);
   return `<pre><code${classAttr}>${highlighted}</code></pre>`;
 }

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -842,7 +842,7 @@ describe("cron view editor", () => {
     expect(systemEvent.querySelector("#cron-payload-model")).toBeNull();
   });
 
-  it("renders script payloads as read-only without exposing script authoring", () => {
+  it("renders script payloads as highlighted read-only code without exposing script authoring", () => {
     const script = "const result = await agent('check status')";
     const job = createJob("job-script", {
       name: "Status script",
@@ -860,15 +860,51 @@ describe("cron view editor", () => {
       },
     });
 
-    const payload = getElement(container, "#cron-payload-text", HTMLTextAreaElement);
-    expect(payload.readOnly).toBe(true);
-    expect(payload.value).toBe(script);
+    const payload = getElement(container, "#cron-payload-text", HTMLPreElement);
+    expect(payload.textContent).toBe(script);
+    expect(payload.querySelector(".hljs-keyword")?.textContent).toBe("const");
+    expect(payload.querySelector(".hljs-string")?.textContent).toBe("'check status'");
+    expect(container.querySelector("textarea#cron-payload-text")).toBeNull();
     expect(container.querySelector("#cron-payload-kind")?.getAttribute("value")).toBeNull();
     expect((container.querySelector("#cron-payload-kind") as HTMLInputElement).value).toBe(
       "Script",
     );
     expect(container.textContent).toContain("contents stay read-only");
     expect(container.querySelector('option[value="script"]')).toBeNull();
+  });
+
+  it("highlights locked command payloads as shell and keeps heartbeat payloads plain", () => {
+    const job = createJob("job-command", {
+      name: "Backup",
+      payload: { kind: "script", script: "" },
+    });
+    const command = renderView({
+      jobs: [job],
+      editingJobId: job.id,
+      form: {
+        ...DEFAULT_CRON_FORM,
+        name: job.name,
+        payloadKind: "command",
+        payloadLocked: true,
+        payloadText: "echo $HOME",
+      },
+    });
+    const payload = getElement(command, "#cron-payload-text", HTMLPreElement);
+    expect(payload.textContent).toBe("echo $HOME");
+    expect(payload.querySelector(".hljs-built_in")?.textContent).toBe("echo");
+
+    const heartbeat = renderView({
+      jobs: [job],
+      editingJobId: job.id,
+      form: {
+        ...DEFAULT_CRON_FORM,
+        name: job.name,
+        payloadKind: "heartbeat",
+        payloadLocked: true,
+        payloadText: "",
+      },
+    });
+    expect(heartbeat.querySelector("#cron-payload-text")).toBeInstanceOf(HTMLTextAreaElement);
   });
 
   it("disables submit and lists blocking fields when validation fails", () => {

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -3,6 +3,7 @@
 import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { repeat } from "lit/directives/repeat.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { ChannelUiMetaEntry, CronJob, CronRunLogEntry, CronStatus } from "../../api/types.ts";
 import "../../styles/chat/text.css";
 import "../../styles/cron.css";
@@ -14,6 +15,7 @@ import type {
   CronSortDir,
 } from "../../api/types.ts";
 import { icon, icons } from "../../components/icons.ts";
+import { highlightCodeHtml } from "../../components/markdown-code-blocks.ts";
 import {
   renderSettingsPage,
   renderSettingsRow,
@@ -311,6 +313,8 @@ function renderRequiredTitle(label: string) {
 // wrapped control its accessible name (including the visually-hidden required marker).
 function renderFieldRow(params: {
   label: string;
+  // Blank when the control is not labelable (e.g. a code block); the label then
+  // has no `for` target and the control carries its own aria-label.
   controlId: string;
   control: unknown;
   required?: boolean;
@@ -328,7 +332,7 @@ function renderFieldRow(params: {
     : html`<div class=${controlClass}>${params.control}</div>`;
   return html`
     <div class=${params.stacked ? "settings-row settings-row--stacked" : "settings-row"}>
-      <label class="settings-row__text" for=${params.controlId}>
+      <label class="settings-row__text" for=${ifDefined(params.controlId || undefined)}>
         <span class="settings-row__title">
           ${params.required ? renderRequiredTitle(params.label) : params.label}
         </span>
@@ -1047,6 +1051,16 @@ function renderMenuItem(
 
 // ── Editor sections ──
 
+// Only the read-only payload kinds carry source text; the rest are prose prompts,
+// so an empty language keeps them on the plain editable textarea.
+const CRON_PAYLOAD_CODE_LANGUAGES: Record<CronFormState["payloadKind"], string> = {
+  script: "javascript",
+  command: "bash",
+  heartbeat: "",
+  systemEvent: "",
+  agentTurn: "",
+};
+
 function renderPromptSection(
   props: CronProps,
   ctx: { payloadLocked: boolean; isAgentTurn: boolean },
@@ -1063,32 +1077,49 @@ function renderPromptSection(
     : props.form.payloadKind === "systemEvent"
       ? t("cron.form.systemEventHelp")
       : t("cron.form.agentTurnHelp");
+  // Script/command payloads are always read-only here, so they render as a highlighted
+  // code block instead of a textarea; every other kind stays an editable field. The code
+  // block carries no aria-invalid/describedby because validateCronForm skips payloadText
+  // for locked payloads, so this branch can never render a payload error.
+  const codeLanguage = ctx.payloadLocked ? CRON_PAYLOAD_CODE_LANGUAGES[props.form.payloadKind] : "";
   const promptRow = renderFieldRow({
     label: promptLabel,
-    controlId: "cron-payload-text",
+    controlId: codeLanguage ? "" : "cron-payload-text",
     required: true,
     help: promptHelp,
     stacked: true,
     wide: true,
     error: props.fieldErrors.payloadText,
     errorId: errorIdForField("payloadText"),
-    control: html`
-      <textarea
-        id="cron-payload-text"
-        class="settings-input"
-        rows="6"
-        .value=${props.form.payloadText}
-        ?readonly=${ctx.payloadLocked}
-        aria-required="true"
-        placeholder=${t("cron.form.promptPlaceholder")}
-        aria-invalid=${props.fieldErrors.payloadText ? "true" : "false"}
-        aria-describedby=${ifDefined(
-          props.fieldErrors.payloadText ? errorIdForField("payloadText") : undefined,
-        )}
-        @input=${(e: Event) =>
-          props.onFormChange({ payloadText: (e.target as HTMLTextAreaElement).value })}
-      ></textarea>
-    `,
+    control: codeLanguage
+      ? html`
+          <pre
+            id="cron-payload-text"
+            class="code-block cron-payload-code"
+            data-test-id="cron-payload-code"
+            tabindex="0"
+            aria-label=${promptLabel}
+          ><code class="hljs">${unsafeHTML(
+            highlightCodeHtml(props.form.payloadText, codeLanguage),
+          )}</code></pre>
+        `
+      : html`
+          <textarea
+            id="cron-payload-text"
+            class="settings-input"
+            rows="6"
+            .value=${props.form.payloadText}
+            ?readonly=${ctx.payloadLocked}
+            aria-required="true"
+            placeholder=${t("cron.form.promptPlaceholder")}
+            aria-invalid=${props.fieldErrors.payloadText ? "true" : "false"}
+            aria-describedby=${ifDefined(
+              props.fieldErrors.payloadText ? errorIdForField("payloadText") : undefined,
+            )}
+            @input=${(e: Event) =>
+              props.onFormChange({ payloadText: (e.target as HTMLTextAreaElement).value })}
+          ></textarea>
+        `,
   });
   const actionRow = renderFieldRow({
     label: t("cron.form.action"),

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -595,6 +595,27 @@
   text-align: left;
 }
 
+/* Read-only script/command payload: a highlighted code block sized like the
+   textarea it replaces, scrollable and focusable so keyboard users can reach it.
+   `resize` needs an explicit height (not max-height) as the resize origin, so the
+   drag handle keeps working for long scripts the way the old textarea did. */
+.cron-payload-code {
+  margin: 0;
+  width: 100%;
+  height: 240px;
+  max-height: none;
+  min-height: 96px;
+  resize: vertical;
+  overflow: auto;
+  white-space: pre;
+  tab-size: 2;
+}
+
+.cron-payload-code:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .cron-inline-controls {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);


### PR DESCRIPTION
## What Problem This Solves

Automations created outside Control UI (Code Mode scripts and shell commands) show their source
on the automation detail page, but it rendered as a plain monospace textarea. A hundred-line Code
Mode script was an undifferentiated wall of text: no keyword, string, or comment contrast, a fixed
six-row viewport, and no way to grow the field to read more of it at once.

## Why This Change Was Made

Script and command payloads are already read-only in Control UI (`validateCronForm` skips them and
`buildCronPayload` refuses to author them), so the field never needed to be an input. It now renders
as a highlighted `<pre class="code-block">` — JavaScript for `script`, shell for `command` — reusing
the highlight.js path that chat code blocks and the JSON viewers already use, so the palette and
light/dark theming come for free and no new dependency or highlighter is introduced. The block is
`resize: vertical` with a 240px default height, matching the `textarea.settings-input` convention
elsewhere in settings. Heartbeat, system-event, and agent-turn payloads are unchanged and stay
editable textareas.

Accessibility: the block is focusable so keyboard users can scroll it, and it carries its own
`aria-label` instead of a `for` target, since `<pre>` is not a labelable element.

## User Impact

Reading a Code Mode automation in Control UI is now practical — keywords, strings, and comments are
distinguishable at a glance, and the view can be dragged taller for longer scripts. No behavior
change for editable automations, and script payloads remain read-only exactly as before.

## Evidence

### Real behavior proof (running gateway, real automations)

Ran a session-owned dev gateway on an isolated state dir and port (`OPENCLAW_STATE_DIR=<tmp>`,
`--port 18999`; the operator's own gateway on 18789 was untouched), created two real automations
through the CLI, and drove the actual Control UI served by that gateway with Playwright:

```
openclaw cron add --name "ClawSweeper dashboard Code Mode refresh" --every 10m --script <file>
openclaw cron add --name "Nightly log rotate" --every 1h --command 'find "$HOME/logs" -name "*.log" -mtime +7 -print0 | xargs -0 gzip --best'
```

Observed on the real automation detail view (`/cron` -> job -> Settings), both dark and light theme:

- **Script payload** renders as `pre.cron-payload-code` with highlighted `const`/`async`/`function`
  keywords, string literals, template literals, and an italic comment line. The read-only help text
  ("This payload was created outside Control UI...") and the `Action: Script` row are unchanged.
- **Command payload** renders the same way with shell highlighting.
- **Resize verified by dragging the handle**, measured via `boundingBox()`:
  `{height: 240}` before the drag, `{height: 504}` after — the full script becomes visible without
  scrolling. Width is unchanged (`vertical` only), as intended.
- Heartbeat/system-event/agent-turn payloads still render a plain editable textarea.

Screenshots (dark script view, dark script view resized to 504px, command/shell view, light script
view) were captured as PNGs during this run. I could not attach them to the PR from the agent
session: the sanctioned artifact path (Mantis/R2 publishing) needs `MANTIS_ARTIFACT_R2_*`
credentials I did not want to pull and use unprompted for a screenshot, and repo policy forbids
committing proof images to a product-repo branch. The files were handed to the maintainer directly;
say the word and I will attach them here.

### Automated proof

- `node scripts/run-vitest.mjs ui/src/pages/cron` — 47 passed. The script-payload test now asserts
  the highlighted read-only block (`.hljs-keyword` = `const`, `.hljs-string` = `'check status'`, no
  `textarea#cron-payload-text`); added coverage for shell highlighting of locked `command` payloads
  and for heartbeat payloads staying a plain textarea.
- `node scripts/run-vitest.mjs ui/src/components/markdown` — 111 passed (shared highlighter export).
- `tsgo --noEmit -p tsconfig.ui.json` clean; `oxlint` clean; `oxfmt` applied.
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings. Its one finding
  (missing `aria-invalid`/`aria-describedby` on the new branch) was verified unreachable —
  `validateCronForm` gates `errors.payloadText` behind `!form.payloadLocked` — and documented inline.
