### PR TITLE
feat(anthropic): complete Claude Opus 5 runtime support

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7865,7 +7865,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Getting started
   - H2: Claude sessions across computers
   - H2: Thinking defaults (Claude Opus 5, Sonnet 5, Mythos 5, Fable 5, 4.8, and 4.6)
-  - H2: Safety refusal fallback (Claude Fable 5)
+  - H2: Safety refusal fallback (Claude Opus 5 and Fable 5)
   - H3: Why this exists
   - H3: How it works
   - H3: Observability and billing

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -342,72 +342,62 @@ Related Anthropic docs:
 
 </Note>
 
-## Safety refusal fallback (Claude Fable 5)
+## Safety refusal fallback (Claude Opus 5 and Fable 5)
 
 <Warning>
-Using Claude Fable 5 means also using Claude Opus 4.8. Fable 5 ships with
-safety classifiers that can decline a request, and Anthropic's sanctioned
-recovery is to have `claude-opus-4-8` serve that turn. OpenClaw opts into this
-automatically for direct API-key requests, so some Fable turns are answered
-and billed as Claude Opus 4.8. If your policy or budget cannot accept
-Opus-served turns, do not select `anthropic/claude-fable-5`.
+Claude Opus 5 and Fable 5 can route a safety-classifier refusal to another
+Claude model. OpenClaw opts into Anthropic's recommended per-category routing
+for direct API-key requests. A fallback-served turn is billed at the model
+that answered. If your policy requires every turn to stay on the requested
+model, do not use these models through the automatic fallback path.
 </Warning>
 
 ### Why this exists
 
-Fable 5 classifiers return `stop_reason: "refusal"` on requests in restricted
-domains, and they also false-positive on benign-adjacent work (security
-tooling, life sciences, or even asking the model to reproduce its raw
-reasoning). Without a fallback, the turn dies with an error even though
-another Claude model would happily serve it - Anthropic's own refusal message
-tells API integrators to configure a fallback model.
+Opus 5 and Fable 5 classifiers return `stop_reason: "refusal"` on requests in
+restricted domains. Without a fallback, the turn ends with an error even when
+Anthropic has a recommended model for that refusal category.
 
 ### How it works
 
-1. For every direct API-key request to `anthropic/claude-fable-5`, OpenClaw
-   sends Anthropic's server-side fallback opt-in: the
-   `server-side-fallback-2026-06-01` beta header plus
-   `fallbacks: [{"model": "claude-opus-4-8"}]`. Claude Opus 4.8 is the only
-   fallback target Anthropic permits for Fable 5.
+1. For every direct API-key request to `anthropic/claude-opus-5` or
+   `anthropic/claude-fable-5`, OpenClaw sends the
+   `server-side-fallback-2026-07-01` beta header plus
+   `fallbacks: "default"`. Anthropic selects the recommended model for the
+   reported refusal category.
 2. Only a safety-classifier decline triggers the fallback. Rate limits,
    overloads, and server errors behave exactly as before and go through
    OpenClaw's normal [model failover](/concepts/model-failover).
 3. The rescue happens inside the same call. A decline before any output is
-   invisible apart from latency; the whole answer comes from Opus 4.8. On a
+   invisible apart from latency; the whole answer comes from the serving
+   model. On a
    mid-stream decline the partial text is kept as the prefix the fallback
    model continues from, while the declined model's reasoning and tool calls
    are discarded per Anthropic's replay rules (they must not be echoed back or
    executed).
-4. If Claude Opus 4.8 declines as well, the turn surfaces the refusal as an
-   error, exactly like before this feature.
+4. If the recommended model declines as well, the turn surfaces the refusal
+   as an error.
 
-The fallback happens at the Anthropic API level, so `claude-opus-4-8` does not
-need to be in your configured model list or fallback chain - a Fable-capable
-API key can always serve Opus.
+The fallback happens at the Anthropic API level, so the serving model does not
+need to be in your configured OpenClaw fallback chain.
 
 ### Observability and billing
 
 - A fallback-served turn records a `provider_fallback` diagnostic on the
   assistant message naming `fromModel` and `toModel`, and the message's
-  `responseModel` reports `claude-opus-4-8`.
-- Anthropic bills per attempt: a decline before output is free, and the rescue
-  bills at Claude Opus 4.8 rates (currently half of Fable 5 rates). OpenClaw's
-  per-turn cost estimate prices fallback-served turns at Opus rates to match.
-- A mid-stream decline additionally bills the already-streamed Fable partial
+  `responseModel` reports the model that answered.
+- Anthropic bills the fallback attempt at the serving model's rates. OpenClaw
+  prices known Opus 4.8 fallback-served turns at Opus 4.8 rates.
+- A mid-stream decline additionally bills the already-streamed primary-model partial
   on Anthropic's side; that portion is reported in the API's per-attempt
   usage but not folded into OpenClaw's per-turn estimate.
 
 ### Scope
 
-Applies to `anthropic/claude-fable-5` with API-key auth against
-`api.anthropic.com`. OAuth (Claude CLI subscription reuse), proxy base URLs,
-Bedrock, Vertex, and Foundry requests are unchanged and still surface
-refusals as errors there.
-
-Verified live: a benign prompt asking Fable 5 to reproduce its raw chain of
-thought is declined with `category: "reasoning_extraction"` when sent without
-fallbacks, and the same prompt through OpenClaw returns a normal Opus-served
-answer with the `provider_fallback` diagnostic attached.
+Applies to `anthropic/claude-opus-5` and `anthropic/claude-fable-5` with
+API-key auth against `api.anthropic.com`. OAuth (including Claude CLI
+subscription reuse), proxy base URLs, Bedrock, Vertex, and Foundry requests
+are unchanged and still surface refusals as errors there.
 
 See Anthropic's [refusals and fallback
 guide](https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback)
@@ -481,19 +471,20 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
 
 <AccordionGroup>
   <Accordion title="Fast mode">
-    OpenClaw's shared `/fast` toggle sets Anthropic's `service_tier` field for direct API-key traffic to `api.anthropic.com`.
+    For Claude Opus 5 and Opus 4.8, OpenClaw's shared `/fast` toggle uses
+    Anthropic's native fast mode for direct API-key traffic to `api.anthropic.com`.
 
     | Command | Maps to |
-    |---------|---------|
-    | `/fast on` | `service_tier: "auto"` |
-    | `/fast off` | `service_tier: "standard_only"` |
+    | --- | --- |
+    | `/fast on` | `speed: "fast"` plus `fast-mode-2026-02-01` |
+    | `/fast off` | Standard speed; no `speed` field |
 
     ```json5
     {
       agents: {
         defaults: {
           models: {
-            "anthropic/claude-sonnet-4-6": {
+            "anthropic/claude-opus-5": {
               params: { fastMode: true },
             },
           },
@@ -503,10 +494,12 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
     ```
 
     <Note>
-    - Only applies to direct `api.anthropic.com` requests made with an API key. OAuth/subscription-token requests and proxy routes never get a `service_tier` field.
+    - Native fast mode is a research preview for Claude Opus 5 and Opus 4.8. It can deliver up to 2.5x higher output-token throughput and is billed at `$10/$50` per million input/output tokens. OpenClaw applies the same 2x multiplier to cache pricing in its cost estimate.
+    - Native fast mode only applies to direct `api.anthropic.com` requests made with an API key. OAuth/subscription-token requests, Claude CLI, proxies, Bedrock, Vertex, and Foundry never receive the beta or `speed` field.
+    - Accounts need fast-mode access and a non-zero fast-mode rate limit. Anthropic returns a fast-specific `429` when the separate fast quota is exhausted or zero.
+    - For other direct Anthropic models, `/fast` retains the existing Priority Tier mapping: on uses `service_tier: "auto"` and off uses `service_tier: "standard_only"`.
     - Explicit `serviceTier` or `service_tier` params override `/fast` when both are set.
-    - Claude Opus 5 and Sonnet 5 do not support Priority Tier, so OpenClaw omits `service_tier` for those models.
-    - On accounts without Priority Tier capacity, `service_tier: "auto"` may resolve to `standard`.
+    - Claude Sonnet 5 supports neither native fast mode nor Priority Tier, so OpenClaw omits both fields.
 
     </Note>
 

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -38,6 +38,7 @@ import {
   resolveClaudeOpus5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
   resolveClaudeThinkingProfile,
+  supportsClaude1MContext,
   supportsClaudeAdaptiveThinking,
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
@@ -431,7 +432,7 @@ function resolveAnthropicForwardCompatModel(
 }
 
 function isAnthropicGa1MModel(modelId: string): boolean {
-  return supportsClaudeAdaptiveThinking({ id: modelId });
+  return supportsClaude1MContext({ id: modelId });
 }
 
 function isAnthropicFable5Model(modelId: string): boolean {

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -101,6 +101,46 @@ function runPayloadWrapper(
   return captured.payload;
 }
 
+function runNativeFastModeWrapper(params?: {
+  apiKey?: string;
+  provider?: string;
+  api?: string;
+  baseUrl?: string;
+  enabled?: boolean;
+  headers?: Record<string, string>;
+  modelId?: string;
+}) {
+  const captured: {
+    headers?: Record<string, string>;
+    model?: { cost: { input: number; output: number; cacheRead: number; cacheWrite: number } };
+    payload?: Record<string, unknown>;
+  } = {};
+  const base: StreamFn = (model, _context, options) => {
+    captured.headers = options?.headers;
+    captured.model = model as typeof captured.model;
+    const payload = {} as Record<string, unknown>;
+    options?.onPayload?.(payload as never, model as never);
+    captured.payload = payload;
+    return {} as never;
+  };
+  const wrapper = createAnthropicFastModeWrapper(base, params?.enabled ?? true);
+  void wrapper(
+    {
+      provider: params?.provider ?? "anthropic",
+      api: params?.api ?? "anthropic-messages",
+      baseUrl: params?.baseUrl,
+      id: params?.modelId ?? "claude-opus-5",
+      cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+    } as never,
+    {} as never,
+    {
+      apiKey: params?.apiKey ?? "sk-ant-api03-test-key",
+      headers: params?.headers,
+    } as never,
+  );
+  return captured;
+}
+
 describe("anthropic stream wrappers", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -216,6 +256,87 @@ describe("anthropic stream wrappers", () => {
 
   it("ignores unresolved auto fast mode at the provider boundary", () => {
     expect(resolveAnthropicFastMode({ fastMode: "auto" })).toBeUndefined();
+  });
+
+  it("uses native fast mode and premium pricing for Claude Opus 5", () => {
+    const captured = runNativeFastModeWrapper({
+      headers: { "anthropic-beta": "files-api-2025-04-14" },
+    });
+
+    expect(captured.headers?.["anthropic-beta"]).toBe("files-api-2025-04-14,fast-mode-2026-02-01");
+    expect(captured.payload).toEqual({ speed: "fast" });
+    expect(captured.model?.cost).toEqual({
+      input: 10,
+      output: 50,
+      cacheRead: 1,
+      cacheWrite: 12.5,
+    });
+  });
+
+  it("uses native fast mode for Claude Opus 4.8", () => {
+    const captured = runNativeFastModeWrapper({ modelId: "claude-opus-4.8" });
+
+    expect(captured.payload).toEqual({ speed: "fast" });
+    expect(captured.model?.cost.output).toBe(50);
+  });
+
+  it("keeps standard Opus 5 payload and pricing when fast mode is disabled", () => {
+    const captured = runNativeFastModeWrapper({ enabled: false });
+
+    expect(captured.headers).toBeUndefined();
+    expect(captured.payload).toEqual({});
+    expect(captured.model?.cost).toEqual({
+      input: 5,
+      output: 25,
+      cacheRead: 0.5,
+      cacheWrite: 6.25,
+    });
+  });
+
+  it.each([
+    {
+      label: "OAuth",
+      params: { apiKey: "sk-ant-oat01-test-token" },
+    },
+    {
+      label: "proxy",
+      params: { baseUrl: "https://proxy.example.com/v1" },
+    },
+    {
+      label: "Vertex",
+      params: {
+        provider: "anthropic-vertex",
+        baseUrl: "https://us-east5-aiplatform.googleapis.com",
+      },
+    },
+  ])("does not send native fast mode over $label routes", ({ params }) => {
+    const captured = runNativeFastModeWrapper(params);
+
+    expect(captured.headers).toBeUndefined();
+    expect(captured.payload).toEqual({});
+    expect(captured.model?.cost.input).toBe(5);
+  });
+
+  it("lets explicit service tier configuration override fast mode", () => {
+    const captured: { headers?: Record<string, string>; payload?: Record<string, unknown> } = {};
+    const wrapped = wrapAnthropicProviderStream({
+      streamFn: createPayloadCapturingBaseStream(captured),
+      modelId: "claude-opus-5",
+      extraParams: { fastMode: true, serviceTier: "standard_only" },
+    } as never);
+
+    void wrapped?.(
+      {
+        provider: "anthropic",
+        api: "anthropic-messages",
+        id: "claude-opus-5",
+      } as never,
+      {} as never,
+      { apiKey: "sk-ant-api03-test-key" } as never,
+    );
+
+    expect(captured.headers).toBeUndefined();
+    expect(captured.payload).toEqual({});
   });
 });
 

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -280,6 +280,14 @@ describe("anthropic stream wrappers", () => {
     expect(captured.model?.cost.output).toBe(50);
   });
 
+  it.each(["opus", "opus-5"])("uses native fast mode for the %s alias", (modelId) => {
+    const captured = runNativeFastModeWrapper({ modelId });
+
+    expect(captured.headers?.["anthropic-beta"]).toContain("fast-mode-2026-02-01");
+    expect(captured.payload).toEqual({ speed: "fast" });
+    expect(captured.model?.cost.output).toBe(50);
+  });
+
   it("keeps standard Opus 5 payload and pricing when fast mode is disabled", () => {
     const captured = runNativeFastModeWrapper({ enabled: false });
 

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -6,9 +6,11 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { streamSimple } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
+  resolveProviderEndpoint,
   resolveClaudeOpus5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
   supportsClaude1MContext,
+  supportsClaudeFastMode,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   applyAnthropicPayloadPolicyToParams,
@@ -27,6 +29,8 @@ import {
 const log = createSubsystemLogger("anthropic-stream");
 
 const ANTHROPIC_CONTEXT_1M_BETA_LEGACY = "context-1m-2025-08-07";
+const ANTHROPIC_FAST_MODE_BETA = "fast-mode-2026-02-01";
+const ANTHROPIC_FAST_MODE_COST_MULTIPLIER = 2;
 const OPENCLAW_DEFAULT_ANTHROPIC_BETAS = [
   "fine-grained-tool-streaming-2025-05-14",
   "interleaved-thinking-2025-05-14",
@@ -75,6 +79,29 @@ function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
 
 function resolveAnthropicFastServiceTier(enabled: boolean): AnthropicServiceTier {
   return enabled ? "auto" : "standard_only";
+}
+
+function isDirectAnthropicApiModel(model: Parameters<StreamFn>[0]): boolean {
+  if (
+    normalizeLowercaseStringOrEmpty(model.provider) !== "anthropic" ||
+    normalizeLowercaseStringOrEmpty(model.api) !== "anthropic-messages"
+  ) {
+    return false;
+  }
+  const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
+  return endpointClass === "default" || endpointClass === "anthropic-public";
+}
+
+function applyAnthropicFastModePricing(model: Parameters<StreamFn>[0]): Parameters<StreamFn>[0] {
+  return {
+    ...model,
+    cost: {
+      input: model.cost.input * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+      output: model.cost.output * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+      cacheRead: model.cost.cacheRead * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+      cacheWrite: model.cost.cacheWrite * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+    },
+  };
 }
 
 function normalizeAnthropicServiceTier(value: unknown): AnthropicServiceTier | undefined {
@@ -148,7 +175,7 @@ export function createAnthropicBetaHeadersWrapper(
   };
 }
 
-/** Wrap a stream function with the Anthropic fast-mode service tier. */
+/** Wrap a stream function with native fast mode or the legacy Priority Tier mapping. */
 export function createAnthropicFastModeWrapper(
   baseStreamFn: StreamFn | undefined,
   enabled: DynamicFastMode,
@@ -158,6 +185,28 @@ export function createAnthropicFastModeWrapper(
     const resolved = typeof enabled === "function" ? enabled() : enabled;
     if (resolved === undefined) {
       return underlying(model, context, options);
+    }
+    if (supportsClaudeFastMode(model)) {
+      if (
+        !resolved ||
+        isAnthropicOAuthApiKey(options?.apiKey) ||
+        !isDirectAnthropicApiModel(model)
+      ) {
+        return underlying(model, context, options);
+      }
+      return streamWithPayloadPatch(
+        underlying,
+        applyAnthropicFastModePricing(model),
+        context,
+        {
+          ...options,
+          headers: mergeAnthropicBetaHeader(options?.headers, [ANTHROPIC_FAST_MODE_BETA]),
+        },
+        (payloadObj) => {
+          delete payloadObj.service_tier;
+          payloadObj.speed = "fast";
+        },
+      );
     }
     return createAnthropicServiceTierWrapper(underlying, resolveAnthropicFastServiceTier(resolved))(
       model,
@@ -254,7 +303,7 @@ export function wrapAnthropicProviderStream(
     serviceTier
       ? (streamFn) => createAnthropicServiceTierWrapper(streamFn, serviceTier)
       : undefined,
-    hasFastModeParam
+    hasFastModeParam && serviceTier === undefined
       ? (streamFn) =>
           createAnthropicFastModeWrapper(streamFn, () => resolveAnthropicFastMode(ctx.extraParams))
       : undefined,

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -6,9 +6,9 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { streamSimple } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
-  resolveClaudeFable5ModelIdentity,
   resolveClaudeOpus5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
+  supportsClaude1MContext,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   applyAnthropicPayloadPolicyToParams,
@@ -27,16 +27,6 @@ import {
 const log = createSubsystemLogger("anthropic-stream");
 
 const ANTHROPIC_CONTEXT_1M_BETA_LEGACY = "context-1m-2025-08-07";
-const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
-  "claude-opus-4-8",
-  "claude-opus-4.8",
-  "claude-opus-4-6",
-  "claude-opus-4.6",
-  "claude-opus-4-7",
-  "claude-opus-4.7",
-  "claude-sonnet-4-6",
-  "claude-sonnet-4.6",
-] as const;
 const OPENCLAW_DEFAULT_ANTHROPIC_BETAS = [
   "fine-grained-tool-streaming-2025-05-14",
   "interleaved-thinking-2025-05-14",
@@ -51,15 +41,7 @@ type AnthropicServiceTier = "auto" | "standard_only";
 type DynamicFastMode = boolean | (() => boolean | undefined);
 
 function isAnthropic1MModel(modelId: string): boolean {
-  if (
-    resolveClaudeFable5ModelIdentity({ id: modelId }) !== undefined ||
-    resolveClaudeOpus5ModelIdentity({ id: modelId }) !== undefined ||
-    resolveClaudeSonnet5ModelIdentity({ id: modelId }) !== undefined
-  ) {
-    return true;
-  }
-  const normalized = normalizeLowercaseStringOrEmpty(modelId);
-  return ANTHROPIC_GA_1M_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+  return supportsClaude1MContext({ id: modelId });
 }
 
 function parseHeaderList(value: unknown): string[] {

--- a/packages/ai/src/providers/anthropic-server-fallback.test.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.test.ts
@@ -21,14 +21,15 @@ describe("Anthropic server-side fallback", () => {
     },
   );
 
-  it("preserves fast-mode pricing when Opus 5 falls back to Opus 4.8", () => {
+  it("preserves requested pricing when Opus 5 falls back to Opus 4.8", () => {
+    const customOpusCost = { input: 12, output: 60, cacheRead: 1.2, cacheWrite: 15 };
     expect(
       resolveAnthropicFallbackServingModelCost({
         requestedModelId: "claude-opus-5",
         servingModelId: "claude-opus-4-8",
-        requestedCost: OPUS_FAST_COST,
+        requestedCost: customOpusCost,
       }),
-    ).toEqual(OPUS_FAST_COST);
+    ).toBe(customOpusCost);
   });
 
   it("keeps requested pricing for an unknown future fallback target", () => {

--- a/packages/ai/src/providers/anthropic-server-fallback.test.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.test.ts
@@ -54,9 +54,19 @@ describe("Anthropic server-side fallback", () => {
     });
     expect(
       resolveAnthropicPreOutputFallbackBoundary({
-        requestedModelId: "claude-opus-5",
+        requestedModelId: "anthropic/claude-opus-5@20260701",
         servingModelId: "claude-opus-5",
       }),
     ).toBeNull();
+  });
+
+  it("preserves fast pricing when an Opus 5 alias resolves to its canonical id", () => {
+    expect(
+      resolveAnthropicFallbackServingModelCost({
+        requestedModelId: "opus",
+        servingModelId: "claude-opus-5",
+        requestedCost: OPUS_FAST_COST,
+      }),
+    ).toBe(OPUS_FAST_COST);
   });
 });

--- a/packages/ai/src/providers/anthropic-server-fallback.test.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLAUDE_OPUS_FALLBACK_MODEL_COST,
+  resolveAnthropicFallbackServingModelCost,
+  resolveAnthropicPreOutputFallbackBoundary,
+} from "./anthropic-server-fallback.js";
+
+const FABLE_COST = { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 };
+const OPUS_FAST_COST = { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 };
+
+describe("Anthropic server-side fallback", () => {
+  it.each(["claude-opus-5", "claude-opus-4-8"])(
+    "uses standard Opus pricing when Fable falls back to %s",
+    (servingModelId) => {
+      expect(
+        resolveAnthropicFallbackServingModelCost({
+          requestedModelId: "claude-fable-5",
+          servingModelId,
+          requestedCost: FABLE_COST,
+        }),
+      ).toEqual(CLAUDE_OPUS_FALLBACK_MODEL_COST);
+    },
+  );
+
+  it("preserves fast-mode pricing when Opus 5 falls back to Opus 4.8", () => {
+    expect(
+      resolveAnthropicFallbackServingModelCost({
+        requestedModelId: "claude-opus-5",
+        servingModelId: "claude-opus-4-8",
+        requestedCost: OPUS_FAST_COST,
+      }),
+    ).toEqual(OPUS_FAST_COST);
+  });
+
+  it("keeps requested pricing for an unknown future fallback target", () => {
+    expect(
+      resolveAnthropicFallbackServingModelCost({
+        requestedModelId: "claude-fable-5",
+        servingModelId: "claude-future-6",
+        requestedCost: FABLE_COST,
+      }),
+    ).toBe(FABLE_COST);
+  });
+
+  it("detects pre-output fallback only when the serving model changed", () => {
+    expect(
+      resolveAnthropicPreOutputFallbackBoundary({
+        requestedModelId: "claude-fable-5",
+        servingModelId: "claude-opus-5",
+      }),
+    ).toEqual({
+      fromModel: "claude-fable-5",
+      toModel: "claude-opus-5",
+    });
+    expect(
+      resolveAnthropicPreOutputFallbackBoundary({
+        requestedModelId: "claude-opus-5",
+        servingModelId: "claude-opus-5",
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/ai/src/providers/anthropic-server-fallback.test.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   CLAUDE_OPUS_FALLBACK_MODEL_COST,
   resolveAnthropicFallbackServingModelCost,
-  resolveAnthropicPreOutputFallbackBoundary,
 } from "./anthropic-server-fallback.js";
 
 const FABLE_COST = { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 };
@@ -40,24 +39,6 @@ describe("Anthropic server-side fallback", () => {
         requestedCost: FABLE_COST,
       }),
     ).toBe(FABLE_COST);
-  });
-
-  it("detects pre-output fallback only when the serving model changed", () => {
-    expect(
-      resolveAnthropicPreOutputFallbackBoundary({
-        requestedModelId: "claude-fable-5",
-        servingModelId: "claude-opus-5",
-      }),
-    ).toEqual({
-      fromModel: "claude-fable-5",
-      toModel: "claude-opus-5",
-    });
-    expect(
-      resolveAnthropicPreOutputFallbackBoundary({
-        requestedModelId: "anthropic/claude-opus-5@20260701",
-        servingModelId: "claude-opus-5",
-      }),
-    ).toBeNull();
   });
 
   it("preserves fast pricing when an Opus 5 alias resolves to its canonical id", () => {

--- a/packages/ai/src/providers/anthropic-server-fallback.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.ts
@@ -1,4 +1,9 @@
 import type { AssistantMessageDiagnostic, Model } from "../types.js";
+import {
+  resolveClaudeFable5ModelIdentity,
+  resolveClaudeModelIdentity,
+  resolveClaudeOpus5ModelIdentity,
+} from "./anthropic-model-contract.js";
 
 /** Anthropic beta that re-serves safety refusals on an allowed fallback model. */
 export const ANTHROPIC_SERVER_SIDE_FALLBACK_BETA = "server-side-fallback-2026-07-01";
@@ -36,13 +41,26 @@ function isModelCostEqual(left: Model["cost"], right: Model["cost"]): boolean {
   );
 }
 
-function normalizeModelId(modelId: string | null): string | null {
-  const normalized = modelId?.trim().toLowerCase();
+function resolveFallbackModelIdentity(modelId: string | null): string | null {
+  if (!modelId?.trim()) {
+    return null;
+  }
+  const ref = { id: modelId };
+  const normalized = resolveClaudeModelIdentity(ref);
+  if (normalized === "opus" || normalized === "opus-5" || resolveClaudeOpus5ModelIdentity(ref)) {
+    return "claude-opus-5";
+  }
+  if (resolveClaudeFable5ModelIdentity(ref)) {
+    return "claude-fable-5";
+  }
+  if (/^claude-opus-4-8(?=$|[^a-z0-9])/.test(normalized)) {
+    return "claude-opus-4-8";
+  }
   return normalized || null;
 }
 
 function isClaudeOpusFallbackModel(modelId: string): boolean {
-  return /^claude-opus-(?:5|4-8)$/.test(modelId);
+  return modelId === "claude-opus-5" || modelId === "claude-opus-4-8";
 }
 
 /** Detect a fallback that completed before the requested model emitted any content. */
@@ -50,8 +68,8 @@ export function resolveAnthropicPreOutputFallbackBoundary(params: {
   requestedModelId: string;
   servingModelId: string | null;
 }): AnthropicFallbackBoundary | null {
-  const requestedModelId = normalizeModelId(params.requestedModelId);
-  const servingModelId = normalizeModelId(params.servingModelId);
+  const requestedModelId = resolveFallbackModelIdentity(params.requestedModelId);
+  const servingModelId = resolveFallbackModelIdentity(params.servingModelId);
   if (!requestedModelId || !servingModelId || servingModelId === requestedModelId) {
     return null;
   }
@@ -67,8 +85,8 @@ export function resolveAnthropicFallbackServingModelCost(params: {
   servingModelId: string | null;
   requestedCost: Model["cost"];
 }): Model["cost"] {
-  const requestedModelId = normalizeModelId(params.requestedModelId);
-  const servingModelId = normalizeModelId(params.servingModelId);
+  const requestedModelId = resolveFallbackModelIdentity(params.requestedModelId);
+  const servingModelId = resolveFallbackModelIdentity(params.servingModelId);
   if (
     !servingModelId ||
     servingModelId === requestedModelId ||

--- a/packages/ai/src/providers/anthropic-server-fallback.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.ts
@@ -45,6 +45,22 @@ function isClaudeOpusFallbackModel(modelId: string): boolean {
   return /^claude-opus-(?:5|4-8)$/.test(modelId);
 }
 
+/** Detect a fallback that completed before the requested model emitted any content. */
+export function resolveAnthropicPreOutputFallbackBoundary(params: {
+  requestedModelId: string;
+  servingModelId: string | null;
+}): AnthropicFallbackBoundary | null {
+  const requestedModelId = normalizeModelId(params.requestedModelId);
+  const servingModelId = normalizeModelId(params.servingModelId);
+  if (!requestedModelId || !servingModelId || servingModelId === requestedModelId) {
+    return null;
+  }
+  return {
+    fromModel: requestedModelId,
+    toModel: servingModelId,
+  };
+}
+
 /** Resolve billed rates from the serving model reported by Anthropic's fallback stream. */
 export function resolveAnthropicFallbackServingModelCost(params: {
   requestedModelId: string;

--- a/packages/ai/src/providers/anthropic-server-fallback.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.ts
@@ -63,22 +63,6 @@ function isClaudeOpusFallbackModel(modelId: string): boolean {
   return modelId === "claude-opus-5" || modelId === "claude-opus-4-8";
 }
 
-/** Detect a fallback that completed before the requested model emitted any content. */
-export function resolveAnthropicPreOutputFallbackBoundary(params: {
-  requestedModelId: string;
-  servingModelId: string | null;
-}): AnthropicFallbackBoundary | null {
-  const requestedModelId = resolveFallbackModelIdentity(params.requestedModelId);
-  const servingModelId = resolveFallbackModelIdentity(params.servingModelId);
-  if (!requestedModelId || !servingModelId || servingModelId === requestedModelId) {
-    return null;
-  }
-  return {
-    fromModel: requestedModelId,
-    toModel: servingModelId,
-  };
-}
-
 /** Resolve billed rates from the serving model reported by Anthropic's fallback stream. */
 export function resolveAnthropicFallbackServingModelCost(params: {
   requestedModelId: string;

--- a/packages/ai/src/providers/anthropic-server-fallback.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.ts
@@ -20,26 +20,10 @@ export const CLAUDE_OPUS_FALLBACK_MODEL_COST = {
   cacheWrite: 6.25,
 } as const;
 
-const CLAUDE_OPUS_FAST_FALLBACK_MODEL_COST = {
-  input: 10,
-  output: 50,
-  cacheRead: 1,
-  cacheWrite: 12.5,
-} as const;
-
 export type AnthropicFallbackBoundary = {
   fromModel: string | null;
   toModel: string | null;
 };
-
-function isModelCostEqual(left: Model["cost"], right: Model["cost"]): boolean {
-  return (
-    left.input === right.input &&
-    left.output === right.output &&
-    left.cacheRead === right.cacheRead &&
-    left.cacheWrite === right.cacheWrite
-  );
-}
 
 function resolveFallbackModelIdentity(modelId: string | null): string | null {
   if (!modelId?.trim()) {
@@ -78,11 +62,8 @@ export function resolveAnthropicFallbackServingModelCost(params: {
   ) {
     return params.requestedCost;
   }
-  if (
-    requestedModelId === "claude-opus-5" &&
-    isModelCostEqual(params.requestedCost, CLAUDE_OPUS_FAST_FALLBACK_MODEL_COST)
-  ) {
-    return CLAUDE_OPUS_FAST_FALLBACK_MODEL_COST;
+  if (requestedModelId && isClaudeOpusFallbackModel(requestedModelId)) {
+    return params.requestedCost;
   }
   return CLAUDE_OPUS_FALLBACK_MODEL_COST;
 }

--- a/packages/ai/src/providers/anthropic-server-fallback.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessageDiagnostic } from "../types.js";
+import type { AssistantMessageDiagnostic, Model } from "../types.js";
 
 /** Anthropic beta that re-serves safety refusals on an allowed fallback model. */
 export const ANTHROPIC_SERVER_SIDE_FALLBACK_BETA = "server-side-fallback-2026-07-01";
@@ -6,18 +6,68 @@ export const ANTHROPIC_SERVER_SIDE_FALLBACK_BETA = "server-side-fallback-2026-07
 /** Let Anthropic select the recommended model for each refusal category. */
 export const ANTHROPIC_SERVER_SIDE_FALLBACKS = "default" as const;
 
-// Fallback-served turns bill at the serving model's rates.
-export const CLAUDE_OPUS_48_FALLBACK_MODEL_COST = {
+// Anthropic's current default routes serve fallback output on Opus 5 or 4.8,
+// which share the same standard and fast-mode rates.
+export const CLAUDE_OPUS_FALLBACK_MODEL_COST = {
   input: 5,
   output: 25,
   cacheRead: 0.5,
   cacheWrite: 6.25,
 } as const;
 
+const CLAUDE_OPUS_FAST_FALLBACK_MODEL_COST = {
+  input: 10,
+  output: 50,
+  cacheRead: 1,
+  cacheWrite: 12.5,
+} as const;
+
 export type AnthropicFallbackBoundary = {
   fromModel: string | null;
   toModel: string | null;
 };
+
+function isModelCostEqual(left: Model["cost"], right: Model["cost"]): boolean {
+  return (
+    left.input === right.input &&
+    left.output === right.output &&
+    left.cacheRead === right.cacheRead &&
+    left.cacheWrite === right.cacheWrite
+  );
+}
+
+function normalizeModelId(modelId: string | null): string | null {
+  const normalized = modelId?.trim().toLowerCase();
+  return normalized || null;
+}
+
+function isClaudeOpusFallbackModel(modelId: string): boolean {
+  return /^claude-opus-(?:5|4-8)$/.test(modelId);
+}
+
+/** Resolve billed rates from the serving model reported by Anthropic's fallback stream. */
+export function resolveAnthropicFallbackServingModelCost(params: {
+  requestedModelId: string;
+  servingModelId: string | null;
+  requestedCost: Model["cost"];
+}): Model["cost"] {
+  const requestedModelId = normalizeModelId(params.requestedModelId);
+  const servingModelId = normalizeModelId(params.servingModelId);
+  if (
+    !servingModelId ||
+    servingModelId === requestedModelId ||
+    !isClaudeOpusFallbackModel(servingModelId)
+  ) {
+    return params.requestedCost;
+  }
+  if (
+    requestedModelId === "claude-opus-5" &&
+    isModelCostEqual(params.requestedCost, CLAUDE_OPUS_FAST_FALLBACK_MODEL_COST)
+  ) {
+    return CLAUDE_OPUS_FAST_FALLBACK_MODEL_COST;
+  }
+  return CLAUDE_OPUS_FALLBACK_MODEL_COST;
+}
 
 function readBoundaryModel(value: unknown): string | null {
   if (!value || typeof value !== "object") {

--- a/packages/ai/src/providers/anthropic-server-fallback.ts
+++ b/packages/ai/src/providers/anthropic-server-fallback.ts
@@ -1,22 +1,18 @@
 import type { AssistantMessageDiagnostic } from "../types.js";
 
 /** Anthropic beta that re-serves safety refusals on an allowed fallback model. */
-export const ANTHROPIC_SERVER_SIDE_FALLBACK_BETA = "server-side-fallback-2026-06-01";
+export const ANTHROPIC_SERVER_SIDE_FALLBACK_BETA = "server-side-fallback-2026-07-01";
 
-// Anthropic documents claude-opus-4-8 as the allowed fallback for claude-fable-5.
-export const CLAUDE_FABLE_5_FALLBACK_MODEL = "claude-opus-4-8";
+/** Let Anthropic select the recommended model for each refusal category. */
+export const ANTHROPIC_SERVER_SIDE_FALLBACKS = "default" as const;
 
 // Fallback-served turns bill at the serving model's rates.
-export const CLAUDE_FABLE_5_FALLBACK_MODEL_COST = {
+export const CLAUDE_OPUS_48_FALLBACK_MODEL_COST = {
   input: 5,
   output: 25,
   cacheRead: 0.5,
   cacheWrite: 6.25,
 } as const;
-
-export function buildAnthropicServerSideFallbacks(): Array<{ model: string }> {
-  return [{ model: CLAUDE_FABLE_5_FALLBACK_MODEL }];
-}
 
 export type AnthropicFallbackBoundary = {
   fromModel: string | null;

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1779,7 +1779,7 @@ describe("Anthropic provider", () => {
                   type: "message_start",
                   message: {
                     id: "msg_fallback",
-                    // Pre-output declines: message_start names the fallback model.
+                    // Pre-output fallback has no boundary block; message_start names the serving model.
                     model: "claude-opus-4-8",
                     usage: { input_tokens: 5, output_tokens: 0 },
                   },
@@ -1787,24 +1787,14 @@ describe("Anthropic provider", () => {
                 {
                   type: "content_block_start",
                   index: 0,
-                  content_block: {
-                    type: "fallback",
-                    from: { model: "claude-fable-5" },
-                    to: { model: "claude-opus-4-8" },
-                  },
-                },
-                { type: "content_block_stop", index: 0 },
-                {
-                  type: "content_block_start",
-                  index: 1,
                   content_block: { type: "text", text: "" },
                 },
                 {
                   type: "content_block_delta",
-                  index: 1,
+                  index: 0,
                   delta: { type: "text_delta", text: "Hi!" },
                 },
-                { type: "content_block_stop", index: 1 },
+                { type: "content_block_stop", index: 0 },
                 {
                   type: "message_delta",
                   delta: { stop_reason: "end_turn" },
@@ -1827,7 +1817,17 @@ describe("Anthropic provider", () => {
     expect(result.stopReason).toBe("stop");
     expect(result.content).toEqual([{ type: "text", text: "Hi!" }]);
     expect(result.responseModel).toBe("claude-opus-4-8");
-    expect(result.diagnostics).toEqual([expect.objectContaining({ type: "provider_fallback" })]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        type: "provider_fallback",
+        details: {
+          provider: "anthropic",
+          fromModel: "claude-fable-5",
+          toModel: "claude-opus-4-8",
+        },
+      }),
+    ]);
+    expect(result.usage.cost.total).toBeCloseTo(0.000075, 10);
   });
 
   it("routes interleaved active content blocks by their event indexes", async () => {

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1583,30 +1583,36 @@ describe("Anthropic provider", () => {
     ]);
   });
 
-  it("sends server-side fallback params for direct Fable API-key requests", async () => {
-    let capturedPayload: unknown;
-    const stream = streamAnthropic(
-      makeAnthropicModel({ id: "claude-fable-5", name: "Claude Fable 5" }),
-      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
-      {
-        apiKey: "sk-ant-provider",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
+  it.each([
+    { id: "claude-fable-5", name: "Claude Fable 5" },
+    { id: "claude-opus-5", name: "Claude Opus 5" },
+  ])(
+    "sends default server-side fallback params for direct $name API-key requests",
+    async (model) => {
+      let capturedPayload: unknown;
+      const stream = streamAnthropic(
+        makeAnthropicModel(model),
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+        {
+          apiKey: "sk-ant-provider",
+          onPayload: (payload) => {
+            capturedPayload = payload;
+            throw new Error("stop before network");
+          },
         },
-      },
-    );
-    await stream.result();
+      );
+      await stream.result();
 
-    expect((capturedPayload as { fallbacks?: unknown }).fallbacks).toEqual([
-      { model: "claude-opus-4-8" },
-    ]);
-    await vi.waitFor(() => expect(anthropicMockState.configs).toHaveLength(1));
-    const config = anthropicMockState.configs[0] as {
-      defaultHeaders?: Record<string, string>;
-    };
-    expect(config.defaultHeaders?.["anthropic-beta"]).toContain("server-side-fallback-2026-06-01");
-  });
+      expect((capturedPayload as { fallbacks?: unknown }).fallbacks).toBe("default");
+      await vi.waitFor(() => expect(anthropicMockState.configs).toHaveLength(1));
+      const config = anthropicMockState.configs[0] as {
+        defaultHeaders?: Record<string, string>;
+      };
+      expect(config.defaultHeaders?.["anthropic-beta"]).toContain(
+        "server-side-fallback-2026-07-01",
+      );
+    },
+  );
 
   it.each([
     { label: "OAuth tokens", overrides: {}, apiKey: "sk-ant-oat01-token" },
@@ -1621,8 +1627,8 @@ describe("Anthropic provider", () => {
       apiKey: "vertex-token",
     },
     {
-      label: "non-Fable models",
-      overrides: { id: "claude-opus-4-8", name: "Claude Opus 4.8" },
+      label: "unsupported models",
+      overrides: { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
       apiKey: "sk-ant-provider",
     },
   ])("omits server-side fallback params for $label", async ({ overrides, apiKey }) => {

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1779,22 +1779,31 @@ describe("Anthropic provider", () => {
                   type: "message_start",
                   message: {
                     id: "msg_fallback",
-                    // Pre-output fallback has no boundary block; message_start names the serving model.
-                    model: "claude-opus-4-8",
+                    model: "claude-fable-5",
                     usage: { input_tokens: 5, output_tokens: 0 },
                   },
                 },
                 {
                   type: "content_block_start",
                   index: 0,
+                  content_block: {
+                    type: "fallback",
+                    from: { model: "claude-fable-5" },
+                    to: { model: "claude-opus-4-8" },
+                  },
+                },
+                { type: "content_block_stop", index: 0 },
+                {
+                  type: "content_block_start",
+                  index: 1,
                   content_block: { type: "text", text: "" },
                 },
                 {
                   type: "content_block_delta",
-                  index: 0,
+                  index: 1,
                   delta: { type: "text_delta", text: "Hi!" },
                 },
-                { type: "content_block_stop", index: 0 },
+                { type: "content_block_stop", index: 1 },
                 {
                   type: "message_delta",
                   delta: { stop_reason: "end_turn" },

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -71,6 +71,7 @@ import {
   applyAnthropicFallbackBoundary,
   readAnthropicFallbackBoundary,
   resolveAnthropicFallbackServingModelCost,
+  resolveAnthropicPreOutputFallbackBoundary,
 } from "./anthropic-server-fallback.js";
 import {
   ANTHROPIC_OMITTED_REASONING_TEXT,
@@ -493,6 +494,17 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
           output.responseId = event.message.id;
           output.responseModel = event.message.model;
           if (refusalBuffer) {
+            const preOutputFallback = resolveAnthropicPreOutputFallbackBoundary({
+              requestedModelId: model.id,
+              servingModelId: event.message.model,
+            });
+            if (preOutputFallback) {
+              applyAnthropicFallbackBoundary({
+                output,
+                boundary: preOutputFallback,
+                provider: model.provider,
+              });
+            }
             costModel = {
               ...model,
               cost: resolveAnthropicFallbackServingModelCost({

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -71,7 +71,6 @@ import {
   applyAnthropicFallbackBoundary,
   readAnthropicFallbackBoundary,
   resolveAnthropicFallbackServingModelCost,
-  resolveAnthropicPreOutputFallbackBoundary,
 } from "./anthropic-server-fallback.js";
 import {
   ANTHROPIC_OMITTED_REASONING_TEXT,
@@ -493,27 +492,6 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         if (event.type === "message_start") {
           output.responseId = event.message.id;
           output.responseModel = event.message.model;
-          if (refusalBuffer) {
-            const preOutputFallback = resolveAnthropicPreOutputFallbackBoundary({
-              requestedModelId: model.id,
-              servingModelId: event.message.model,
-            });
-            if (preOutputFallback) {
-              applyAnthropicFallbackBoundary({
-                output,
-                boundary: preOutputFallback,
-                provider: model.provider,
-              });
-            }
-            costModel = {
-              ...model,
-              cost: resolveAnthropicFallbackServingModelCost({
-                requestedModelId: model.id,
-                servingModelId: event.message.model,
-                requestedCost: model.cost,
-              }),
-            };
-          }
           const promptUsage = readAnthropicPromptUsageSnapshot(event.message.usage);
           const messageStartPromptTokens = promptUsage
             ? promptUsage.input + promptUsage.cacheRead + promptUsage.cacheWrite

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -67,9 +67,9 @@ import {
 import { applyAnthropicRefusal } from "./anthropic-refusal.js";
 import {
   ANTHROPIC_SERVER_SIDE_FALLBACK_BETA,
-  CLAUDE_FABLE_5_FALLBACK_MODEL_COST,
+  ANTHROPIC_SERVER_SIDE_FALLBACKS,
+  CLAUDE_OPUS_48_FALLBACK_MODEL_COST,
   applyAnthropicFallbackBoundary,
-  buildAnthropicServerSideFallbacks,
   readAnthropicFallbackBoundary,
 } from "./anthropic-server-fallback.js";
 import {
@@ -560,7 +560,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
             // Cost intentionally mirrors top-level usage (serving attempt at
             // serving-model rates). A mid-stream decline's billed partial is
             // only in usage.iterations and is not folded in here.
-            costModel = { ...model, cost: CLAUDE_FABLE_5_FALLBACK_MODEL_COST };
+            costModel = { ...model, cost: CLAUDE_OPUS_48_FALLBACK_MODEL_COST };
             calculateCost(costModel, output.usage);
             eventSink.push({ type: "start", partial: output });
             for (const [i, block] of blocks.entries()) {
@@ -1019,7 +1019,11 @@ function isAnthropicPublicEndpoint(baseUrl: string | undefined): boolean {
  * identity) requests are excluded until the beta is verified there.
  */
 function supportsAnthropicServerSideFallback(model: Model<"anthropic-messages">): boolean {
-  if (!usesClaudeFable5MessagesContract(model) || model.provider !== "anthropic") {
+  if (
+    (!usesClaudeFable5MessagesContract(model) &&
+      resolveClaudeOpus5ModelIdentity(model) === undefined) ||
+    model.provider !== "anthropic"
+  ) {
     return false;
   }
   return isAnthropicPublicEndpoint(model.baseUrl);
@@ -1228,12 +1232,11 @@ async function buildParams(
     params.system = system;
   }
 
-  // Fable safety classifiers can decline benign-adjacent work; server-side
-  // fallback re-serves the same call on claude-opus-4-8 instead of failing
-  // the turn. Only set when createClient added the matching beta header.
+  // Fable 5 and Opus 5 safety classifiers can decline benign-adjacent work.
+  // Anthropic owns the per-category fallback recommendation so routing can
+  // evolve without a client release.
   if (serverSideFallback) {
-    (params as { fallbacks?: Array<{ model: string }> }).fallbacks =
-      buildAnthropicServerSideFallbacks();
+    (params as { fallbacks?: "default" }).fallbacks = ANTHROPIC_SERVER_SIDE_FALLBACKS;
   }
 
   // Thinking and post-4.6 Claude models reject custom temperature values.

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -68,9 +68,9 @@ import { applyAnthropicRefusal } from "./anthropic-refusal.js";
 import {
   ANTHROPIC_SERVER_SIDE_FALLBACK_BETA,
   ANTHROPIC_SERVER_SIDE_FALLBACKS,
-  CLAUDE_OPUS_48_FALLBACK_MODEL_COST,
   applyAnthropicFallbackBoundary,
   readAnthropicFallbackBoundary,
+  resolveAnthropicFallbackServingModelCost,
 } from "./anthropic-server-fallback.js";
 import {
   ANTHROPIC_OMITTED_REASONING_TEXT,
@@ -492,6 +492,16 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         if (event.type === "message_start") {
           output.responseId = event.message.id;
           output.responseModel = event.message.model;
+          if (refusalBuffer) {
+            costModel = {
+              ...model,
+              cost: resolveAnthropicFallbackServingModelCost({
+                requestedModelId: model.id,
+                servingModelId: event.message.model,
+                requestedCost: model.cost,
+              }),
+            };
+          }
           const promptUsage = readAnthropicPromptUsageSnapshot(event.message.usage);
           const messageStartPromptTokens = promptUsage
             ? promptUsage.input + promptUsage.cacheRead + promptUsage.cacheWrite
@@ -560,7 +570,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
             // Cost intentionally mirrors top-level usage (serving attempt at
             // serving-model rates). A mid-stream decline's billed partial is
             // only in usage.iterations and is not folded in here.
-            costModel = { ...model, cost: CLAUDE_OPUS_48_FALLBACK_MODEL_COST };
+            costModel = {
+              ...model,
+              cost: resolveAnthropicFallbackServingModelCost({
+                requestedModelId: model.id,
+                servingModelId: fallbackBoundary.toModel,
+                requestedCost: model.cost,
+              }),
+            };
             calculateCost(costModel, output.usage);
             eventSink.push({ type: "start", partial: output });
             for (const [i, block] of blocks.entries()) {

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -753,37 +753,43 @@ describe("anthropic transport stream", () => {
     );
   });
 
-  it("sends server-side fallback params for direct Fable API-key requests", async () => {
-    guardedFetchMock.mockResolvedValueOnce(
-      createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_fb", usage: { input_tokens: 1, output_tokens: 0 } },
-        },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 1, output_tokens: 1 },
-        },
-        { type: "message_stop" },
-      ]),
-    );
+  it.each([
+    { id: "claude-fable-5", name: "Claude Fable 5" },
+    { id: "claude-opus-5", name: "Claude Opus 5" },
+  ])(
+    "sends default server-side fallback params for direct $name API-key requests",
+    async (model) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        createSseResponse([
+          {
+            type: "message_start",
+            message: { id: "msg_fb", usage: { input_tokens: 1, output_tokens: 0 } },
+          },
+          {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn" },
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+          { type: "message_stop" },
+        ]),
+      );
 
-    await runTransportStream(
-      makeAnthropicTransportModel({ id: "claude-fable-5", name: "Claude Fable 5" }),
-      {
-        messages: [{ role: "user", content: "hello" }],
-      } as AnthropicStreamContext,
-      {
-        apiKey: "sk-ant-api",
-      } as AnthropicStreamOptions,
-    );
+      await runTransportStream(
+        makeAnthropicTransportModel(model),
+        {
+          messages: [{ role: "user", content: "hello" }],
+        } as AnthropicStreamContext,
+        {
+          apiKey: "sk-ant-api",
+        } as AnthropicStreamOptions,
+      );
 
-    expect(latestAnthropicRequest().payload.fallbacks).toEqual([{ model: "claude-opus-4-8" }]);
-    expect(latestAnthropicRequestHeaders().get("anthropic-beta")).toBe(
-      "fine-grained-tool-streaming-2025-05-14,server-side-fallback-2026-06-01",
-    );
-  });
+      expect(latestAnthropicRequest().payload.fallbacks).toBe("default");
+      expect(latestAnthropicRequestHeaders().get("anthropic-beta")).toBe(
+        "fine-grained-tool-streaming-2025-05-14,server-side-fallback-2026-07-01",
+      );
+    },
+  );
 
   it.each([
     {
@@ -801,8 +807,8 @@ describe("anthropic transport stream", () => {
       apiKey: "sk-ant-api",
     },
     {
-      label: "non-Fable models",
-      model: { id: "claude-opus-4-8", name: "Claude Opus 4.8" },
+      label: "unsupported models",
+      model: { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
       apiKey: "sk-ant-api",
     },
   ])("omits server-side fallback params for $label", async ({ model, apiKey }) => {

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -946,6 +946,63 @@ describe("anthropic transport stream", () => {
     expect(result.usage.cost.total).toBeCloseTo(0.00025, 10);
   });
 
+  it("records and prices a pre-output server-side fallback without a boundary block", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: {
+            id: "msg_pre_output_fb",
+            model: "claude-opus-5",
+            usage: { input_tokens: 5, output_tokens: 0 },
+          },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "continued" },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 5, output_tokens: 2 },
+        },
+        { type: "message_stop" },
+      ]),
+    );
+
+    const model = makeAnthropicTransportModel({ id: "claude-fable-5", name: "Claude Fable 5" });
+    model.cost = { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 };
+    const result = await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.responseModel).toBe("claude-opus-5");
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        type: "provider_fallback",
+        details: {
+          provider: "anthropic",
+          fromModel: "claude-fable-5",
+          toModel: "claude-opus-5",
+        },
+      }),
+    ]);
+    expect(result.usage.cost.total).toBeCloseTo(0.000075, 10);
+  });
+
   it("uses bearer auth for Microsoft Foundry Anthropic transport requests", async () => {
     const model = makeAnthropicTransportModel({
       provider: "microsoft-foundry",

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -946,28 +946,38 @@ describe("anthropic transport stream", () => {
     expect(result.usage.cost.total).toBeCloseTo(0.00025, 10);
   });
 
-  it("records and prices a pre-output server-side fallback without a boundary block", async () => {
+  it("records and prices a pre-output server-side fallback boundary", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
         {
           type: "message_start",
           message: {
             id: "msg_pre_output_fb",
-            model: "claude-opus-5",
+            model: "claude-fable-5",
             usage: { input_tokens: 5, output_tokens: 0 },
           },
         },
         {
           type: "content_block_start",
           index: 0,
+          content_block: {
+            type: "fallback",
+            from: { model: "claude-fable-5" },
+            to: { model: "claude-opus-5" },
+          },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "content_block_start",
+          index: 1,
           content_block: { type: "text", text: "" },
         },
         {
           type: "content_block_delta",
-          index: 0,
+          index: 1,
           delta: { type: "text_delta", text: "continued" },
         },
-        { type: "content_block_stop", index: 0 },
+        { type: "content_block_stop", index: 1 },
         {
           type: "message_delta",
           delta: { stop_reason: "end_turn" },

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -46,7 +46,6 @@ import {
   readAnthropicUsageTokenCount,
   readLastAnthropicIterationUsage,
   resolveAnthropicFallbackServingModelCost,
-  resolveAnthropicPreOutputFallbackBoundary,
   supportsClaudeAdaptiveThinking,
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
@@ -1443,27 +1442,6 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             const usage = message?.usage ?? {};
             output.responseId = typeof message?.id === "string" ? message.id : undefined;
             output.responseModel = typeof message?.model === "string" ? message.model : undefined;
-            if (refusalBuffer) {
-              const preOutputFallback = resolveAnthropicPreOutputFallbackBoundary({
-                requestedModelId: model.id,
-                servingModelId: output.responseModel ?? null,
-              });
-              if (preOutputFallback) {
-                applyAnthropicFallbackBoundary({
-                  output,
-                  boundary: preOutputFallback,
-                  provider: model.provider,
-                });
-              }
-              costModel = {
-                ...model,
-                cost: resolveAnthropicFallbackServingModelCost({
-                  requestedModelId: model.id,
-                  servingModelId: output.responseModel ?? null,
-                  requestedCost: model.cost,
-                }),
-              };
-            }
             const promptUsage = readAnthropicPromptUsageSnapshot(usage);
             const messageStartPromptTokens = promptUsage
               ? promptUsage.input + promptUsage.cacheRead + promptUsage.cacheWrite

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -26,10 +26,10 @@ import {
 import {
   ANTHROPIC_OMITTED_REASONING_TEXT,
   ANTHROPIC_SERVER_SIDE_FALLBACK_BETA,
-  CLAUDE_FABLE_5_FALLBACK_MODEL_COST,
+  ANTHROPIC_SERVER_SIDE_FALLBACKS,
+  CLAUDE_OPUS_48_FALLBACK_MODEL_COST,
   applyClaudeRequestContract,
   applyAnthropicFallbackBoundary,
-  buildAnthropicServerSideFallbacks,
   defaultsClaudeAdaptiveThinking,
   applyAnthropicRefusal,
   findActiveAnthropicToolTurnAssistantIndex,
@@ -345,7 +345,11 @@ function isKimiAnthropicProvider(provider: string | undefined): boolean {
  * identity) requests are excluded until the beta is verified there.
  */
 function useAnthropicServerSideFallback(model: AnthropicTransportModel): boolean {
-  return usesClaudeFable5MessagesContract(model) && isDirectAnthropicModel(model);
+  return (
+    (usesClaudeFable5MessagesContract(model) ||
+      resolveClaudeOpus5ModelIdentity(model) !== undefined) &&
+    isDirectAnthropicModel(model)
+  );
 }
 
 function supportsReasoningContentReplay(
@@ -1073,11 +1077,11 @@ async function buildAnthropicParams(
     max_tokens: maxTokens,
     stream: true,
   };
-  // Fable safety classifiers can decline benign-adjacent work; server-side
-  // fallback re-serves the same call on claude-opus-4-8 instead of failing
-  // the turn. Requires the matching beta header from the transport client.
+  // Fable 5 and Opus 5 safety classifiers can decline benign-adjacent work.
+  // Anthropic owns the per-category fallback recommendation so routing can
+  // evolve without a client release.
   if (!isOAuthToken && useAnthropicServerSideFallback(model)) {
-    params.fallbacks = buildAnthropicServerSideFallbacks();
+    params.fallbacks = ANTHROPIC_SERVER_SIDE_FALLBACKS;
   }
   if (isOAuthToken) {
     params.system = [
@@ -1512,7 +1516,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               // Cost intentionally mirrors top-level usage (serving attempt at
               // serving-model rates). A mid-stream decline's billed partial is
               // only in usage.iterations and is not folded in here.
-              costModel = { ...model, cost: CLAUDE_FABLE_5_FALLBACK_MODEL_COST };
+              costModel = { ...model, cost: CLAUDE_OPUS_48_FALLBACK_MODEL_COST };
               calculateCost(costModel, output.usage);
               eventSink.push({ type: "start", partial: output as never });
               for (const [i, block] of output.content.entries()) {

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -27,7 +27,6 @@ import {
   ANTHROPIC_OMITTED_REASONING_TEXT,
   ANTHROPIC_SERVER_SIDE_FALLBACK_BETA,
   ANTHROPIC_SERVER_SIDE_FALLBACKS,
-  CLAUDE_OPUS_48_FALLBACK_MODEL_COST,
   applyClaudeRequestContract,
   applyAnthropicFallbackBoundary,
   defaultsClaudeAdaptiveThinking,
@@ -46,6 +45,7 @@ import {
   readAnthropicPromptUsageSnapshot,
   readAnthropicUsageTokenCount,
   readLastAnthropicIterationUsage,
+  resolveAnthropicFallbackServingModelCost,
   supportsClaudeAdaptiveThinking,
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
@@ -1442,6 +1442,16 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             const usage = message?.usage ?? {};
             output.responseId = typeof message?.id === "string" ? message.id : undefined;
             output.responseModel = typeof message?.model === "string" ? message.model : undefined;
+            if (refusalBuffer) {
+              costModel = {
+                ...model,
+                cost: resolveAnthropicFallbackServingModelCost({
+                  requestedModelId: model.id,
+                  servingModelId: output.responseModel ?? null,
+                  requestedCost: model.cost,
+                }),
+              };
+            }
             const promptUsage = readAnthropicPromptUsageSnapshot(usage);
             const messageStartPromptTokens = promptUsage
               ? promptUsage.input + promptUsage.cacheRead + promptUsage.cacheWrite
@@ -1516,7 +1526,14 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               // Cost intentionally mirrors top-level usage (serving attempt at
               // serving-model rates). A mid-stream decline's billed partial is
               // only in usage.iterations and is not folded in here.
-              costModel = { ...model, cost: CLAUDE_OPUS_48_FALLBACK_MODEL_COST };
+              costModel = {
+                ...model,
+                cost: resolveAnthropicFallbackServingModelCost({
+                  requestedModelId: model.id,
+                  servingModelId: fallbackBoundary.toModel,
+                  requestedCost: model.cost,
+                }),
+              };
               calculateCost(costModel, output.usage);
               eventSink.push({ type: "start", partial: output as never });
               for (const [i, block] of output.content.entries()) {

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -46,6 +46,7 @@ import {
   readAnthropicUsageTokenCount,
   readLastAnthropicIterationUsage,
   resolveAnthropicFallbackServingModelCost,
+  resolveAnthropicPreOutputFallbackBoundary,
   supportsClaudeAdaptiveThinking,
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
@@ -1443,6 +1444,17 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             output.responseId = typeof message?.id === "string" ? message.id : undefined;
             output.responseModel = typeof message?.model === "string" ? message.model : undefined;
             if (refusalBuffer) {
+              const preOutputFallback = resolveAnthropicPreOutputFallbackBoundary({
+                requestedModelId: model.id,
+                servingModelId: output.responseModel ?? null,
+              });
+              if (preOutputFallback) {
+                applyAnthropicFallbackBoundary({
+                  output,
+                  boundary: preOutputFallback,
+                  provider: model.provider,
+                });
+              }
               costModel = {
                 ...model,
                 cost: resolveAnthropicFallbackServingModelCost({

--- a/packages/llm-core/src/model-contracts/anthropic.ts
+++ b/packages/llm-core/src/model-contracts/anthropic.ts
@@ -99,9 +99,12 @@ export function resolveClaudeSonnet5ModelIdentity(ref: ClaudeModelRef): string |
   return normalized.slice((match.index ?? 0) + (match[0].startsWith("-") ? 1 : 0));
 }
 
-/** Resolve Claude Opus 5 through direct ids, cloud ids, or deployment metadata. */
+/** Resolve Claude Opus 5 through aliases, direct ids, cloud ids, or deployment metadata. */
 export function resolveClaudeOpus5ModelIdentity(ref: ClaudeModelRef): string | undefined {
   const normalized = resolveClaudeModelIdentity(ref);
+  if (normalized === "opus" || normalized === "opus-5") {
+    return "claude-opus-5";
+  }
   const match = /(?:^|-)claude-opus-5(?=$|[^a-z0-9])/.exec(normalized);
   if (!match) {
     return undefined;
@@ -112,38 +115,51 @@ export function resolveClaudeOpus5ModelIdentity(ref: ClaudeModelRef): string | u
 /** Return whether a Claude model supports adaptive thinking. */
 export function supportsClaudeAdaptiveThinking(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|mythos-(?:5|preview)|opus-(?:4-(?:6|7|8)|5)|sonnet-(?:5|4-6))(?=$|[^a-z0-9])/.test(
-    modelId,
+  return (
+    resolveClaudeOpus5ModelIdentity(ref) !== undefined ||
+    /(?:^|-)claude-(?:fable-5|mythos-(?:5|preview)|opus-4-(?:6|7|8)|sonnet-(?:5|4-6))(?=$|[^a-z0-9])/.test(
+      modelId,
+    )
   );
 }
 
 /** Return whether a Claude model has a native 1M-token context window. */
 export function supportsClaude1MContext(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|mythos-(?:5|preview)|opus-(?:4-(?:6|7|8)|5)|sonnet-(?:5|4-6))(?=$|[^a-z0-9])/.test(
-    modelId,
+  return (
+    resolveClaudeOpus5ModelIdentity(ref) !== undefined ||
+    /(?:^|-)claude-(?:fable-5|mythos-(?:5|preview)|opus-4-(?:6|7|8)|sonnet-(?:5|4-6))(?=$|[^a-z0-9])/.test(
+      modelId,
+    )
   );
 }
 
 /** Return whether a Claude model supports Anthropic's native fast mode. */
 export function supportsClaudeFastMode(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-opus-(?:4-8|5)(?=$|[^a-z0-9])/.test(modelId);
+  return (
+    resolveClaudeOpus5ModelIdentity(ref) !== undefined ||
+    /(?:^|-)claude-opus-4-8(?=$|[^a-z0-9])/.test(modelId)
+  );
 }
 
 /** Return whether a Claude model supports native max effort. */
 export function supportsClaudeNativeMaxEffort(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|mythos-5|opus-(?:4-(?:6|7|8)|5)|sonnet-(?:5|4-6))(?=$|[^a-z0-9])/.test(
-    modelId,
+  return (
+    resolveClaudeOpus5ModelIdentity(ref) !== undefined ||
+    /(?:^|-)claude-(?:fable-5|mythos-5|opus-4-(?:6|7|8)|sonnet-(?:5|4-6))(?=$|[^a-z0-9])/.test(
+      modelId,
+    )
   );
 }
 
 /** Return whether a Claude model supports native xhigh effort. */
 export function supportsClaudeNativeXhighEffort(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|mythos-5|opus-(?:4-(?:7|8)|5)|sonnet-5)(?=$|[^a-z0-9])/.test(
-    modelId,
+  return (
+    resolveClaudeOpus5ModelIdentity(ref) !== undefined ||
+    /(?:^|-)claude-(?:fable-5|mythos-5|opus-4-(?:7|8)|sonnet-5)(?=$|[^a-z0-9])/.test(modelId)
   );
 }
 

--- a/packages/llm-core/src/model-contracts/anthropic.ts
+++ b/packages/llm-core/src/model-contracts/anthropic.ts
@@ -117,6 +117,14 @@ export function supportsClaudeAdaptiveThinking(ref: ClaudeModelRef): boolean {
   );
 }
 
+/** Return whether a Claude model has a native 1M-token context window. */
+export function supportsClaude1MContext(ref: ClaudeModelRef): boolean {
+  const modelId = resolveClaudeModelIdentity(ref);
+  return /(?:^|-)claude-(?:fable-5|mythos-(?:5|preview)|opus-(?:4-(?:6|7|8)|5)|sonnet-(?:5|4-6))(?=$|[^a-z0-9])/.test(
+    modelId,
+  );
+}
+
 /** Return whether a Claude model supports native max effort. */
 export function supportsClaudeNativeMaxEffort(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);

--- a/packages/llm-core/src/model-contracts/anthropic.ts
+++ b/packages/llm-core/src/model-contracts/anthropic.ts
@@ -125,6 +125,12 @@ export function supportsClaude1MContext(ref: ClaudeModelRef): boolean {
   );
 }
 
+/** Return whether a Claude model supports Anthropic's native fast mode. */
+export function supportsClaudeFastMode(ref: ClaudeModelRef): boolean {
+  const modelId = resolveClaudeModelIdentity(ref);
+  return /(?:^|-)claude-opus-(?:4-8|5)(?=$|[^a-z0-9])/.test(modelId);
+}
+
 /** Return whether a Claude model supports native max effort. */
 export function supportsClaudeNativeMaxEffort(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -201,6 +201,8 @@ export function resolveAnthropicFixedContextWindow(
   ) {
     return ANTHROPIC_MYTHOS_5_CONTEXT_TOKENS;
   }
+  // Opus 5 is natively 1M on every runtime, including Claude CLI. Keep this
+  // ahead of the legacy CLI opt-in gate used by older 1M variants below.
   if (resolveClaudeOpus5ModelIdentity({ id: modelId })) {
     return ANTHROPIC_OPUS_5_CONTEXT_TOKENS;
   }

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -1,6 +1,7 @@
 import {
   resolveClaudeOpus5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
+  supportsClaude1MContext,
 } from "@openclaw/llm-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -37,16 +38,6 @@ export type ContextTokenResolutionParams = {
   allowUnscopedModelLookup?: boolean;
 };
 
-const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
-  "claude-opus-4-8",
-  "claude-opus-4.8",
-  "claude-opus-4-6",
-  "claude-opus-4.6",
-  "claude-opus-4-7",
-  "claude-opus-4.7",
-  "claude-sonnet-4-6",
-  "claude-sonnet-4.6",
-] as const;
 export const ANTHROPIC_CONTEXT_1M_TOKENS = 1_000_000;
 export const ANTHROPIC_VERTEX_CONTEXT_1M_TOKENS = 1_000_000;
 export const ANTHROPIC_FABLE_CONTEXT_TOKENS = 1_000_000;
@@ -216,11 +207,7 @@ export function resolveAnthropicFixedContextWindow(
   if (resolveClaudeSonnet5ModelIdentity({ id: modelId })) {
     return ANTHROPIC_SONNET_5_CONTEXT_TOKENS;
   }
-  // Opus 5 ships 1M as the model default (not a [1m] opt-in like Opus 4.x).
-  if (resolveClaudeOpus5ModelIdentity({ id: modelId })) {
-    return ANTHROPIC_OPUS_5_CONTEXT_TOKENS;
-  }
-  if (!ANTHROPIC_GA_1M_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix))) {
+  if (!supportsClaude1MContext({ id: modelId })) {
     return undefined;
   }
   if (provider === "claude-cli" && !modelId.endsWith("[1m]") && options?.claudeCli1M !== true) {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -710,6 +710,7 @@ describe("resolveContextTokensForModel", () => {
     ["anthropic", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["anthropic-vertex", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["claude-cli", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
+    ["claude-cli", "claude-opus-5", ANTHROPIC_OPUS_5_CONTEXT_TOKENS],
     ["anthropic", "claude-sonnet-4-6", ANTHROPIC_CONTEXT_1M_TOKENS],
     ["anthropic-vertex", "claude-sonnet-4-6", ANTHROPIC_VERTEX_CONTEXT_1M_TOKENS],
   ])(

--- a/src/agents/embedded-agent-runner-extraparams.live.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.live.test.ts
@@ -170,9 +170,13 @@ describeAnthropicLive("embedded agent extra params (anthropic live)", () => {
     };
 
     if (!res.ok) {
-      expect(res.status).toBe(429);
-      expect(json.error?.type).toBe("rate_limit_error");
-      expect(json.error?.message).toContain("fast mode");
+      if (res.status === 429) {
+        expect(json.error?.type).toBe("rate_limit_error");
+        expect(json.error?.message).toContain("fast mode");
+        return;
+      }
+      expect(res.status).toBe(529);
+      expect(json.error?.type).toBe("overloaded_error");
       return;
     }
 

--- a/src/agents/embedded-agent-runner-extraparams.live.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.live.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { applyExtraParamsToAgent } from "./embedded-agent-runner/extra-params.js";
 import { isLiveTestEnabled } from "./live-test-helpers.js";
-import { isLiveAuthDrift, isLiveBillingDrift } from "./live-test-provider-drift.test-support.js";
 
 const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
 const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
@@ -119,56 +118,65 @@ describeLive("embedded agent extra params (live)", () => {
 });
 
 describeAnthropicLive("embedded agent extra params (anthropic live)", () => {
-  it("verifies Anthropic fast-mode service_tier semantics against the live API", async () => {
+  it("verifies Claude Opus 5 default fallback against the live API", async () => {
     const headers = {
       "content-type": "application/json",
       "x-api-key": ANTHROPIC_KEY,
       "anthropic-version": "2023-06-01",
+      "anthropic-beta": "server-side-fallback-2026-07-01",
     };
 
-    const runProbe = async (serviceTier: "auto" | "standard_only") => {
-      const res = await fetch("https://api.anthropic.com/v1/messages", {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          model: "claude-sonnet-4-6",
-          max_tokens: 32,
-          service_tier: serviceTier,
-          messages: [{ role: "user", content: "Reply with OK." }],
-        }),
-      });
-      const json = (await res.json()) as {
-        error?: { message?: string };
-        stop_reason?: string;
-        usage?: { service_tier?: string };
-      };
-      const errorMessage = json.error?.message ?? `HTTP ${res.status}`;
-      if (!res.ok) {
-        if (isLiveBillingDrift(errorMessage)) {
-          console.warn(`[anthropic:live] skip service_tier ${serviceTier}: billing drift`);
-          return null;
-        }
-        if (isLiveAuthDrift(errorMessage)) {
-          console.warn(`[anthropic:live] skip service_tier ${serviceTier}: auth drift`);
-          return null;
-        }
-      }
-      expect(res.ok, errorMessage).toBe(true);
-      return json;
+    const res = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "claude-opus-5",
+        max_tokens: 32,
+        fallbacks: "default",
+        messages: [{ role: "user", content: "Reply with OK." }],
+      }),
+    });
+    const json = (await res.json()) as {
+      error?: { message?: string };
+      model?: string;
+      stop_reason?: string;
     };
 
-    const standard = await runProbe("standard_only");
-    if (!standard) {
-      return;
-    }
-    expect(standard.usage?.service_tier).toBe("standard");
-    expect(standard.stop_reason).toBe("end_turn");
+    expect(res.ok, json.error?.message ?? `HTTP ${res.status}`).toBe(true);
+    expect(json.model).toBe("claude-opus-5");
+    expect(json.stop_reason).toBe("end_turn");
+  }, 45_000);
 
-    const fast = await runProbe("auto");
-    if (!fast) {
+  it("verifies Claude Opus 5 native fast-mode contract against the live API", async () => {
+    const res = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": ANTHROPIC_KEY,
+        "anthropic-version": "2023-06-01",
+        "anthropic-beta": "fast-mode-2026-02-01",
+      },
+      body: JSON.stringify({
+        model: "claude-opus-5",
+        max_tokens: 32,
+        speed: "fast",
+        messages: [{ role: "user", content: "Reply with OK." }],
+      }),
+    });
+    const json = (await res.json()) as {
+      error?: { message?: string; type?: string };
+      stop_reason?: string;
+      usage?: { speed?: string };
+    };
+
+    if (!res.ok) {
+      expect(res.status).toBe(429);
+      expect(json.error?.type).toBe("rate_limit_error");
+      expect(json.error?.message).toContain("fast mode");
       return;
     }
-    expect(["standard", "priority"]).toContain(fast.usage?.service_tier);
-    expect(fast.stop_reason).toBe("end_turn");
+
+    expect(json.usage?.speed).toBe("fast");
+    expect(json.stop_reason).toBe("end_turn");
   }, 45_000);
 });

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -75,6 +75,8 @@ describe("Claude model contracts", () => {
 
   it.each([
     ["Anthropic API", { id: "claude-opus-5" }, "claude-opus-5"],
+    ["Anthropic alias", { id: "opus" }, "claude-opus-5"],
+    ["Anthropic version alias", { id: "opus-5" }, "claude-opus-5"],
     ["Claude CLI", { id: "claude-opus-5" }, "claude-opus-5"],
     ["Vertex AI", { id: "claude-opus-5@20260701" }, "claude-opus-5@20260701"],
     ["Amazon Bedrock", { id: "global.anthropic.claude-opus-5" }, "claude-opus-5"],
@@ -108,6 +110,8 @@ describe("Claude model contracts", () => {
 
   it("recognizes native fast-mode Claude models", () => {
     expect(supportsClaudeFastMode({ id: "claude-opus-5" })).toBe(true);
+    expect(supportsClaudeFastMode({ id: "opus" })).toBe(true);
+    expect(supportsClaudeFastMode({ id: "opus-5" })).toBe(true);
     expect(supportsClaudeFastMode({ id: "global.anthropic.claude-opus-5" })).toBe(true);
     expect(supportsClaudeFastMode({ id: "claude-opus-4.8" })).toBe(true);
     expect(supportsClaudeFastMode({ id: "claude-opus-4-7" })).toBe(false);

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -18,6 +18,7 @@ import {
   selectPreferredLocalModelId,
   supportsClaude1MContext,
   supportsClaudeAdaptiveThinking,
+  supportsClaudeFastMode,
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
 } from "./provider-model-shared.js";
@@ -89,6 +90,14 @@ describe("Claude model contracts", () => {
     expect(supportsClaude1MContext({ id: "us.anthropic.claude-sonnet-4-6-v1:0" })).toBe(true);
     expect(supportsClaude1MContext({ id: "claude-opus-50" })).toBe(false);
     expect(supportsClaude1MContext({ id: "claude-haiku-4-5" })).toBe(false);
+  });
+
+  it("recognizes native fast-mode Claude models", () => {
+    expect(supportsClaudeFastMode({ id: "claude-opus-5" })).toBe(true);
+    expect(supportsClaudeFastMode({ id: "global.anthropic.claude-opus-5" })).toBe(true);
+    expect(supportsClaudeFastMode({ id: "claude-opus-4.8" })).toBe(true);
+    expect(supportsClaudeFastMode({ id: "claude-opus-4-7" })).toBe(false);
+    expect(supportsClaudeFastMode({ id: "claude-opus-50" })).toBe(false);
   });
 
   it("does not classify later numeric model versions as supported aliases", () => {

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -73,15 +73,29 @@ describe("Claude model contracts", () => {
     expect(requiresClaudeDefaultSampling({ id: "claude-mythos-5" })).toBe(true);
   });
 
-  it("recognizes Claude Opus 5 across direct and cloud model ids", () => {
-    expect(resolveClaudeOpus5ModelIdentity({ id: "claude-opus-5" })).toBe("claude-opus-5");
-    expect(resolveClaudeOpus5ModelIdentity({ id: "global.anthropic.claude-opus-5" })).toBe(
+  it.each([
+    ["Anthropic API", { id: "claude-opus-5" }, "claude-opus-5"],
+    ["Claude CLI", { id: "claude-opus-5" }, "claude-opus-5"],
+    ["Vertex AI", { id: "claude-opus-5@20260701" }, "claude-opus-5@20260701"],
+    ["Amazon Bedrock", { id: "global.anthropic.claude-opus-5" }, "claude-opus-5"],
+    [
+      "Amazon Bedrock Mantle",
+      { id: "anthropic.claude-opus-5", params: { canonicalModelId: "claude-opus-5" } },
       "claude-opus-5",
-    );
-    expect(supportsClaudeAdaptiveThinking({ id: "claude-opus-5" })).toBe(true);
-    expect(supportsClaudeNativeMaxEffort({ id: "claude-opus-5" })).toBe(true);
-    expect(supportsClaudeNativeXhighEffort({ id: "anthropic.claude-opus-5" })).toBe(true);
-    expect(requiresClaudeDefaultSampling({ id: "claude-opus-5" })).toBe(true);
+    ],
+    [
+      "Microsoft Foundry",
+      { id: "prod-opus", params: { canonicalModelId: "claude-opus-5" } },
+      "claude-opus-5",
+    ],
+    ["OpenRouter", { id: "anthropic/claude-opus-5" }, "claude-opus-5"],
+  ] as const)("recognizes the Claude Opus 5 contract through %s", (_provider, ref, identity) => {
+    expect(resolveClaudeOpus5ModelIdentity(ref)).toBe(identity);
+    expect(supportsClaude1MContext(ref)).toBe(true);
+    expect(supportsClaudeAdaptiveThinking(ref)).toBe(true);
+    expect(supportsClaudeNativeMaxEffort(ref)).toBe(true);
+    expect(supportsClaudeNativeXhighEffort(ref)).toBe(true);
+    expect(requiresClaudeDefaultSampling(ref)).toBe(true);
   });
 
   it("recognizes native 1M Claude model families independently", () => {

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -16,6 +16,7 @@ import {
   resolveClaudeThinkingProfile,
   requiresClaudeDefaultSampling,
   selectPreferredLocalModelId,
+  supportsClaude1MContext,
   supportsClaudeAdaptiveThinking,
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
@@ -80,6 +81,14 @@ describe("Claude model contracts", () => {
     expect(supportsClaudeNativeMaxEffort({ id: "claude-opus-5" })).toBe(true);
     expect(supportsClaudeNativeXhighEffort({ id: "anthropic.claude-opus-5" })).toBe(true);
     expect(requiresClaudeDefaultSampling({ id: "claude-opus-5" })).toBe(true);
+  });
+
+  it("recognizes native 1M Claude model families independently", () => {
+    expect(supportsClaude1MContext({ id: "claude-opus-5" })).toBe(true);
+    expect(supportsClaude1MContext({ id: "anthropic/claude-opus-4.8" })).toBe(true);
+    expect(supportsClaude1MContext({ id: "us.anthropic.claude-sonnet-4-6-v1:0" })).toBe(true);
+    expect(supportsClaude1MContext({ id: "claude-opus-50" })).toBe(false);
+    expect(supportsClaude1MContext({ id: "claude-haiku-4-5" })).toBe(false);
   });
 
   it("does not classify later numeric model versions as supported aliases", () => {

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -36,6 +36,7 @@ export {
   resolveClaudeSonnet5ModelIdentity,
   requiresClaudeDefaultSampling,
   requiresClaudeMandatoryAdaptiveThinking,
+  supportsClaude1MContext,
   supportsClaudeAdaptiveThinking,
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -38,6 +38,7 @@ export {
   requiresClaudeMandatoryAdaptiveThinking,
   supportsClaude1MContext,
   supportsClaudeAdaptiveThinking,
+  supportsClaudeFastMode,
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
 } from "@openclaw/llm-core";


### PR DESCRIPTION
Closes #113412
Related: #113598

## What Problem This Solves

Claude Opus 5 support was incomplete across OpenClaw's Anthropic paths. Direct Anthropic requests did not opt into the current server-side fallback contract, native fast mode was not wired consistently, fallback serving-model costs could be misattributed, aliases did not inherit the full model contract, and provider-specific capability checks had drifted.

## Why This Change Was Made

Centralize the Opus 5 capability contract, then apply Anthropic-owned request behavior only at the direct API-key boundary. OAuth, Claude CLI subscription auth, proxy routes, Bedrock, Vertex, and Foundry remain excluded from Anthropic-only beta request parameters. Fallback boundary events now drive serving-model identity and cost accounting without duplicate inference.

Maintainer decisions:

- Anthropic-managed default fallback is intentional for direct API-key Opus 5 and Fable 5 requests. A selected model may be served by another model in the same category; docs call out the routing and billing implication.
- `supportsClaude1MContext` and `supportsClaudeFastMode` are intended stable shared plugin SDK contracts.
- Native fast mode remains quota-dependent. OpenClaw sends Anthropic's current fast-mode contract and preserves standard behavior when fast mode is disabled or excluded.

## User Impact

Users can use Claude Opus 5 with the full supported contract: 1M context capability, adaptive/max/xhigh reasoning support, direct-Anthropic refusal fallback, native fast mode, aliases, Claude CLI, and routed provider identities. Usage and cost reporting follow the model that actually served a fallback response.

## Evidence

Live, redacted provider proof:

- Direct Anthropic standard request with `claude-opus-5` and default fallback: HTTP 200, final serving model `claude-opus-5`, stop reason `end_turn`, usage returned by Anthropic.
- Direct Anthropic native fast request: Anthropic accepted the beta/payload contract and returned HTTP 429 `rate_limit_error` identifying fast-mode quota. This account has zero fast quota, so no serving model or generation usage exists for that rejected request. The live test also accepts Anthropic's documented 529 capacity outcome.
- Claude CLI v2.1.220: exact Opus 5 output passed with a valid API key; the OpenClaw Gateway `claude-cli/claude-opus-5` route passed both fresh-session and same-session resume.
- OpenRouter `anthropic/claude-opus-5`: HTTP 200.
- Provider identity tests cover Anthropic, Claude CLI, Vertex, Bedrock, Mantle, Foundry, and OpenRouter without leaking Anthropic-only request parameters into routed providers.

Validation:

- Focused shared-contract, Anthropic wrapper, provider, transport, fallback-accounting, and context tests passed.
- Core, plugin, package, and source type lanes; focused lint; and production build passed on Blacksmith Testbox.
- Fresh autoreview found no accepted or actionable findings after iterative fixes.
- Exact-head hosted CI and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 113633` passed for `8879903651e4060d26bd788a4e7dfe273614b220`.