### PR TITLE
fix(qa): repair stale scenario source and documentation references

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveQaParityPackScenarioIds } from "./agentic-parity.js";
+import { resolveQaRepoPath } from "./repo-path.js";
 import {
   listQaScenarioYamlPaths,
   readQaBootstrapScenarioCatalog,
@@ -89,6 +90,24 @@ describe("qa scenario catalog", () => {
     ).toBe(true);
     const recall = readQaScenarioById("memory-recall");
     expect(recall.coverage?.primary).toContain(`${memory}.memory-recall`);
+  });
+
+  it("keeps scenario documentation and code references backed by the repository", () => {
+    for (const scenario of readQaScenarioPack().scenarios) {
+      const referenceGroups = [
+        ["docsRefs", scenario.docsRefs],
+        ["codeRefs", scenario.codeRefs],
+      ] as const;
+
+      for (const [kind, references] of referenceGroups) {
+        for (const reference of references ?? []) {
+          const resolvedReference =
+            resolveQaRepoPath(import.meta.dirname, reference, "file") ??
+            resolveQaRepoPath(import.meta.dirname, reference, "directory");
+          expect(resolvedReference, `${scenario.id} ${kind} ${reference} exists`).not.toBeNull();
+        }
+      }
+    }
   });
 
   it("exposes bootstrap data from the YAML pack", () => {

--- a/qa/scenarios/agents/instruction-followthrough-repo-contract.yaml
+++ b/qa/scenarios/agents/instruction-followthrough-repo-contract.yaml
@@ -21,7 +21,7 @@ scenario:
   codeRefs:
     - src/agents/system-prompt.ts
     - src/agents/embedded-agent-runner/run/incomplete-turn.ts
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
     summary: Verify the agent reads repo instructions first, then completes the first bounded followthrough task without stalling.

--- a/qa/scenarios/channels/telegram-reply-chain-exact-marker.yaml
+++ b/qa/scenarios/channels/telegram-reply-chain-exact-marker.yaml
@@ -12,7 +12,7 @@ scenario:
     - The model returns the requested exact marker through the reply path.
     - Exactly one outbound message contains the marker.
   codeRefs:
-    - src/auto-reply/reply/reply-payload.ts
+    - src/auto-reply/reply-payload.ts
     - extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
   execution:
     profiles: { "telegram:adapter": 13, "telegram:all": 12 }

--- a/qa/scenarios/channels/telegram-tools-compact-command.yaml
+++ b/qa/scenarios/channels/telegram-tools-compact-command.yaml
@@ -12,7 +12,7 @@ scenario:
     - The compact tools command reaches native command dispatch.
     - The joined reply includes exec and the verbose-mode hint.
   codeRefs:
-    - src/auto-reply/reply/commands-tools.ts
+    - src/auto-reply/reply/commands-info.ts
     - extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
   execution:
     profiles:

--- a/qa/scenarios/channels/whatsapp-access-control-dm-disabled.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-dm-disabled.yaml
@@ -18,7 +18,7 @@ scenario:
   docsRefs:
     - docs/channels/whatsapp.md
   codeRefs:
-    - extensions/whatsapp/src/monitor.ts
+    - extensions/whatsapp/src/inbound/access-control.ts
   execution:
     kind: flow
     channel: whatsapp

--- a/qa/scenarios/channels/whatsapp-access-control-dm-open.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-dm-open.yaml
@@ -18,7 +18,7 @@ scenario:
   docsRefs:
     - docs/channels/whatsapp.md
   codeRefs:
-    - extensions/whatsapp/src/monitor.ts
+    - extensions/whatsapp/src/inbound/access-control.ts
   execution:
     kind: flow
     channel: whatsapp

--- a/qa/scenarios/channels/whatsapp-access-control-group-disabled.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-group-disabled.yaml
@@ -18,7 +18,7 @@ scenario:
   docsRefs:
     - docs/channels/whatsapp.md
   codeRefs:
-    - extensions/whatsapp/src/monitor.ts
+    - extensions/whatsapp/src/inbound/access-control.ts
   execution:
     kind: flow
     channel: whatsapp

--- a/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
@@ -18,7 +18,7 @@ scenario:
   docsRefs:
     - docs/channels/whatsapp.md
   codeRefs:
-    - extensions/whatsapp/src/monitor.ts
+    - extensions/whatsapp/src/inbound/access-control.ts
   execution:
     kind: flow
     channel: whatsapp

--- a/qa/scenarios/channels/whatsapp-pairing-block.yaml
+++ b/qa/scenarios/channels/whatsapp-pairing-block.yaml
@@ -21,7 +21,7 @@ scenario:
   docsRefs:
     - docs/channels/whatsapp.md
   codeRefs:
-    - extensions/whatsapp/src/monitor.ts
+    - extensions/whatsapp/src/inbound/access-control.ts
   execution:
     kind: flow
     channel: whatsapp

--- a/qa/scenarios/channels/whatsapp-tools-compact-command.yaml
+++ b/qa/scenarios/channels/whatsapp-tools-compact-command.yaml
@@ -12,7 +12,7 @@ scenario:
     - The compact tools command reaches native command dispatch.
     - The joined reply includes exec and the verbose-mode hint.
   codeRefs:
-    - src/auto-reply/reply/commands-tools.ts
+    - src/auto-reply/reply/commands-info.ts
     - extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
   execution:
     profiles: { "whatsapp:mock-default": 34 }

--- a/qa/scenarios/media/image-generation-roundtrip.yaml
+++ b/qa/scenarios/media/image-generation-roundtrip.yaml
@@ -20,7 +20,7 @@ scenario:
   codeRefs:
     - src/agents/tools/image-generate-tool.ts
     - src/gateway/chat-attachments.ts
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
     summary: Verify a generated image is saved as media, reattached on the next turn, and described correctly through the vision path.

--- a/qa/scenarios/media/image-understanding-attachment.yaml
+++ b/qa/scenarios/media/image-understanding-attachment.yaml
@@ -20,7 +20,7 @@ scenario:
   codeRefs:
     - src/gateway/server-methods/agent.ts
     - extensions/qa-lab/src/suite.ts
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
     summary: Verify an attached image reaches the agent model and the agent can describe what it sees.

--- a/qa/scenarios/media/native-image-generation.yaml
+++ b/qa/scenarios/media/native-image-generation.yaml
@@ -19,7 +19,7 @@ scenario:
     - docs/providers/openai.md
   codeRefs:
     - src/agents/tools/image-generate-tool.ts
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
     summary: Verify image_generate appears when configured and returns a real saved media artifact.

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -38,7 +38,7 @@ scenario:
     - extensions/active-memory/index.ts
     - extensions/active-memory/doctor-contract-api.ts
     - extensions/qa-lab/src/suite.ts
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
     summary: Verify Active Memory stays off when session-toggled off, runs memory search/get when enabled, and helps a live model answer with the recalled preference in the first visible reply.

--- a/qa/scenarios/models/model-switch-tool-continuity.yaml
+++ b/qa/scenarios/models/model-switch-tool-continuity.yaml
@@ -19,7 +19,7 @@ scenario:
     - docs/concepts/model-failover.md
   codeRefs:
     - extensions/qa-lab/src/suite.ts
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
     summary: Verify switching models preserves session context and tool use instead of dropping into plain-text only behavior.

--- a/qa/scenarios/plugins/bundled-plugin-skill-runtime.yaml
+++ b/qa/scenarios/plugins/bundled-plugin-skill-runtime.yaml
@@ -18,8 +18,8 @@ scenario:
     - docs/plugins/manifest.md
   codeRefs:
     - scripts/stage-bundled-plugin-runtime.mjs
-    - src/agents/skills/workspace.ts
-    - src/agents/skills/plugin-skills.ts
+    - src/skills/loading/workspace.ts
+    - src/skills/loading/plugin-skills.ts
   execution:
     kind: flow
     summary: Force the packaged dist-runtime plugin tree and verify an enabled bundled plugin skill survives discovery.

--- a/qa/scenarios/plugins/plugin-lifecycle-hot-reload.yaml
+++ b/qa/scenarios/plugins/plugin-lifecycle-hot-reload.yaml
@@ -19,7 +19,7 @@ scenario:
     - docs/gateway/configuration.md
     - docs/plugins/manifest.md
   codeRefs:
-    - src/agents/skills-status.ts
+    - src/skills/discovery/status.ts
     - src/gateway/server-methods/config.ts
     - extensions/qa-lab/src/suite-runtime-agent-tools.ts
   execution:

--- a/qa/scenarios/plugins/skill-install-hot-availability.yaml
+++ b/qa/scenarios/plugins/skill-install-hot-availability.yaml
@@ -17,7 +17,7 @@ scenario:
     - docs/tools/skills.md
     - docs/gateway/configuration.md
   codeRefs:
-    - src/agents/skills-status.ts
+    - src/skills/discovery/status.ts
     - extensions/qa-lab/src/suite.ts
   execution:
     kind: flow

--- a/qa/scenarios/plugins/skill-visibility-invocation.yaml
+++ b/qa/scenarios/plugins/skill-visibility-invocation.yaml
@@ -17,7 +17,7 @@ scenario:
     - docs/tools/skills.md
     - docs/gateway/protocol.md
   codeRefs:
-    - src/agents/skills-status.ts
+    - src/skills/discovery/status.ts
     - extensions/qa-lab/src/suite.ts
   execution:
     kind: flow

--- a/qa/scenarios/runtime/approval-turn-tool-followthrough.yaml
+++ b/qa/scenarios/runtime/approval-turn-tool-followthrough.yaml
@@ -19,7 +19,7 @@ scenario:
     - docs/channels/qa-channel.md
   codeRefs:
     - extensions/qa-lab/src/suite.ts
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
     - src/agents/embedded-agent-runner/run/incomplete-turn.ts
   execution:
     kind: flow

--- a/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
+++ b/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
@@ -19,7 +19,7 @@ scenario:
     - docs/help/testing.md
   codeRefs:
     - extensions/qa-lab/src/suite.ts
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
     - src/agents/embedded-agent-subscribe.ts
     - src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
   execution:

--- a/qa/scenarios/runtime/docker-prometheus-smoke.yaml
+++ b/qa/scenarios/runtime/docker-prometheus-smoke.yaml
@@ -27,7 +27,7 @@ scenario:
     - docs/concepts/qa-e2e-automation.md
   codeRefs:
     - extensions/diagnostics-prometheus/src/service.ts
-    - src/diagnostics/internal-diagnostics.ts
+    - src/infra/diagnostic-events.ts
     - extensions/qa-lab/src/suite.ts
   execution:
     kind: flow

--- a/qa/scenarios/runtime/empty-response-recovery-replay-safe-read.yaml
+++ b/qa/scenarios/runtime/empty-response-recovery-replay-safe-read.yaml
@@ -17,7 +17,7 @@ scenario:
   docsRefs:
     - docs/help/testing.md
   codeRefs:
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
     - src/agents/embedded-agent-runner/run/incomplete-turn.ts
   execution:
     kind: flow

--- a/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
+++ b/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
@@ -16,7 +16,7 @@ scenario:
   docsRefs:
     - docs/help/testing.md
   codeRefs:
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
     - src/agents/embedded-agent-runner/run/incomplete-turn.ts
   execution:
     kind: flow

--- a/qa/scenarios/runtime/gateway-restart-multi-live.yaml
+++ b/qa/scenarios/runtime/gateway-restart-multi-live.yaml
@@ -26,7 +26,7 @@ scenario:
     - The Gateway child and qa-channel recover after every replacement without a user follow-up.
     - Restart-safe policy remains active, the unsafe probe stays unavailable, and the completed audit is delivered exactly once.
   docsRefs:
-    - docs/reference/code-mode.md
+    - docs/tools/code-mode.md
     - docs/channels/qa-channel.md
   codeRefs:
     - extensions/qa-lab/src/suite-runtime-agent-session.ts

--- a/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
+++ b/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
@@ -17,7 +17,7 @@ scenario:
   docsRefs:
     - docs/help/testing.md
   codeRefs:
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
     - src/agents/embedded-agent-runner/run/incomplete-turn.ts
   execution:
     kind: flow

--- a/qa/scenarios/runtime/reasoning-only-recovery-replay-safe-read.yaml
+++ b/qa/scenarios/runtime/reasoning-only-recovery-replay-safe-read.yaml
@@ -17,7 +17,7 @@ scenario:
   docsRefs:
     - docs/help/testing.md
   codeRefs:
-    - extensions/qa-lab/src/mock-openai-server.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
     - src/agents/embedded-agent-runner/run/incomplete-turn.ts
   execution:
     kind: flow

--- a/qa/scenarios/runtime/tools/skill-invocation.yaml
+++ b/qa/scenarios/runtime/tools/skill-invocation.yaml
@@ -14,7 +14,7 @@ scenario:
   docsRefs:
     - docs/tools/skills.md
   codeRefs:
-    - src/agents/skills-clawhub.ts
+    - src/skills/runtime/tool-dispatch.ts
     - extensions/qa-lab/src/runtime-tool-fixture.ts
   execution:
     kind: flow

--- a/qa/scenarios/scheduling/cron-natural-fire-no-duplicate.yaml
+++ b/qa/scenarios/scheduling/cron-natural-fire-no-duplicate.yaml
@@ -21,7 +21,7 @@ scenario:
   codeRefs:
     - src/cron/service.ts
     - src/cron/service/timer.ts
-    - src/cron/run-log.ts
+    - src/cron/task-run-history.ts
     - extensions/qa-lab/src/cron-run-wait.ts
     - extensions/qa-lab/src/suite-runtime-transport.ts
   execution:

--- a/qa/scenarios/scheduling/cron-single-run-no-duplicate.yaml
+++ b/qa/scenarios/scheduling/cron-single-run-no-duplicate.yaml
@@ -20,7 +20,7 @@ scenario:
     - docs/channels/qa-channel.md
   codeRefs:
     - src/cron/service.ts
-    - src/cron/run-log.ts
+    - src/cron/task-run-history.ts
     - extensions/qa-lab/src/cron-run-wait.ts
     - extensions/qa-lab/src/suite-runtime-transport.ts
   execution:

--- a/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
+++ b/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
@@ -24,7 +24,7 @@ scenario:
     - extensions/qa-lab/src/scenario-runtime-api.ts
     - extensions/qa-lab/src/suite.ts
     - extensions/qa-lab/src/web-runtime.ts
-    - ui/src/ui/views/chat.ts
+    - ui/src/pages/chat/chat-view.ts
   gatewayRuntime:
     forwardHostHome: true
   execution:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA operators and agent bootstrap instructions followed source or documentation references that no longer exist. Real scenario discovery, evidence and coverage navigation consequently directed investigators to moved or deleted code.

## Why This Change Was Made

Update each stale scenario reference to its verified current repository owner and add an actual catalog regression using the same module-anchored repository resolver as production. The regression accepts both valid file and directory references and is independent of the test working directory.

## User Impact

QA scenarios, coverage reports and agent-generated investigation plans now point to real current source and documentation. Future stale references fail focused QA validation instead of silently producing false evidence.

## Evidence

- Independently parsed all 361 scenario YAML files and audited all 963 documentation/source references, including the valid directory reference: 963/963 exist and zero are missing.
- Remote Linux: all 36 real scenario catalog tests passed.
- Full formatting scan of all 362 changed/test and scenario paths passed; focused QA oxlint and remote command exited zero.
- Reproduced and corrected the real repository-root and directory-reference contracts before publication.
- Fresh independent Codex autoreview and secret scan passed with zero actionable findings.
- AI-assisted and independently reviewed; preserves current taxonomy and does not revert newer main behavior.
