### PR TITLE
fix(workboard): enforce fail-closed completion gates

### DIFF
--- a/extensions/workboard/src/gateway.test.ts
+++ b/extensions/workboard/src/gateway.test.ts
@@ -642,7 +642,15 @@ describe("workboard gateway methods", () => {
 
     const completeRespond = vi.fn();
     await methods.get("workboard.cards.complete")?.handler({
-      params: { id: cardId, summary: "Operator closed it." },
+      params: {
+        id: cardId,
+        summary: "Operator closed it.",
+        proof: {
+          status: "passed",
+          command: "pnpm test extensions/workboard/src/gateway.test.ts",
+          note: "Gateway lifecycle test passed.",
+        },
+      },
       respond: completeRespond,
     } as never);
     expect(completeRespond.mock.calls[0]?.[1]).toMatchObject({

--- a/extensions/workboard/src/store-card-helpers.ts
+++ b/extensions/workboard/src/store-card-helpers.ts
@@ -11,6 +11,7 @@ import {
   type WorkboardExecution,
   type WorkboardMetadata,
   type WorkboardNotification,
+  type WorkboardProof,
   type WorkboardRunAttempt,
   type WorkboardStatus,
 } from "@openclaw/workboard-contract";
@@ -48,6 +49,22 @@ export function cardSessionKey(card: WorkboardCard): string | undefined {
 
 export function cardRunId(card: WorkboardCard): string | undefined {
   return card.runId ?? card.execution?.runId;
+}
+
+export function isStructuredPassedProof(proof: WorkboardProof | undefined): boolean {
+  if (proof?.status !== "passed") {
+    return false;
+  }
+  const source = proof.command?.trim() || proof.url?.trim();
+  const note = proof.note?.trim();
+  return Boolean(source && note && !/^(?:ok|done|complete|verified)$/i.test(note));
+}
+
+export function pullRequestUrls(card: WorkboardCard): string[] {
+  const urls = [card.sourceUrl, ...(card.metadata?.links ?? []).map((link) => link.url)].filter(
+    (url): url is string => Boolean(url),
+  );
+  return urls.filter((url) => /github\.com\/[^/]+\/[^/]+\/pull\/\d+(?:[/?#]|$)/i.test(url));
 }
 
 function executionAttemptStatus(execution: WorkboardExecution): WorkboardAttemptStatus {

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -3,6 +3,7 @@ import type {
   WorkboardBoardMetadata,
   WorkboardChange,
   WorkboardCard,
+  WorkboardCompletionSource,
   WorkboardLink,
   WorkboardMetadata,
   WorkboardStatus,
@@ -66,6 +67,7 @@ import {
   normalizeTemplateId,
   normalizeTimestamp,
   normalizeTitle,
+  removeUndefinedMetadataFields,
   syncExecutionSessionKey,
   trimMetadataToBudget,
 } from "./store-normalizers.js";
@@ -472,6 +474,8 @@ export class WorkboardCoreStore {
       allowMetadataDependencyLinks?: boolean;
       enforceStatusHolds?: boolean;
       preserveProofId?: string;
+      completionSource?: WorkboardCompletionSource;
+      completionReason?: string;
     } = {},
   ): Promise<WorkboardCard> {
     const existing = await this.get(id);
@@ -532,6 +536,19 @@ export class WorkboardCoreStore {
       allowDependencyLinks: options.allowMetadataDependencyLinks !== false,
       preserveProofId: options.preserveProofId,
     });
+    if (status === "done" && options.completionSource) {
+      metadata = removeUndefinedMetadataFields({
+        ...metadata,
+        completionSource: options.completionSource,
+        completionReason: options.completionReason,
+      });
+    } else if (status !== "done") {
+      metadata = removeUndefinedMetadataFields({
+        ...metadata,
+        completionSource: undefined,
+        completionReason: undefined,
+      });
+    }
     if (status !== existing.status && !hasFreshLifecycleStatusSource) {
       // Status patches often spread existing metadata. Only a newly supplied
       // lifecycle source is provenance; copied markers must not survive a manual transition.
@@ -614,7 +631,7 @@ export class WorkboardCoreStore {
     );
     next.events = appendEvent(next, updateEvent(existing, next), now);
     if (options.enforceStatusHolds && effectivePatch.status !== undefined) {
-      await this.assertActiveStatusAllowed(existing, next, now);
+      await this.assertActiveStatusAllowed(existing, next, now, options.completionSource);
     }
     if (status !== "done") {
       delete next.completedAt;
@@ -637,6 +654,7 @@ export class WorkboardCoreStore {
     existing: WorkboardCard,
     next: WorkboardCard,
     now: number,
+    completionSource: WorkboardCompletionSource = "automated",
   ): Promise<void> {
     if (
       next.status !== "ready" &&
@@ -656,6 +674,11 @@ export class WorkboardCoreStore {
       throw new Error("card dependencies are not done.");
     }
     if (next.status === "done") {
+      // The direct operator move path preserves the documented manual acceptance
+      // workflow. Automated/agent completion still uses the fail-closed gate below.
+      if (completionSource === "operator") {
+        return;
+      }
       await this.assertDoneTransitionAllowed(existing, next);
       return;
     }

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -18,16 +18,19 @@ import { normalizeAutomationPatch, normalizeCardAutomation } from "./store-autom
 import {
   assertCanMutateClaimedCard,
   cardBoardId,
+  cardChildIds,
   cardParentIds,
   compareCards,
   isActiveDependencyTarget,
   isDependencyPromotableStatus,
+  isStructuredPassedProof,
   lifecycleStatusSourceUpdatedAtFromPatch,
   removeUndefinedCardFields,
   shouldSkipPersistedLifecycleStatusUpdate,
   syncExecutionAttemptMetadata,
   updateEvent,
   appendEvent,
+  pullRequestUrls,
 } from "./store-card-helpers.js";
 import { WorkboardChangeTracker } from "./store-change-tracker.js";
 import { MAX_CARD_COMMENTS, MAX_CARD_WORKER_LOGS, POSITION_STEP } from "./store-constants.js";
@@ -433,6 +436,9 @@ export class WorkboardCoreStore {
       ...(completedAt ? { completedAt } : {}),
       ...(!metadataIsEmpty(syncedMetadata) ? { metadata: syncedMetadata } : {}),
     };
+    if (card.status === "done") {
+      await this.assertDoneTransitionAllowed(undefined, card);
+    }
     await this.store.register(card.id, { version: 1, card });
     try {
       for (const parent of parentCards) {
@@ -650,11 +656,67 @@ export class WorkboardCoreStore {
       throw new Error("card dependencies are not done.");
     }
     if (next.status === "done") {
+      await this.assertDoneTransitionAllowed(existing, next);
       return;
     }
     const scheduledAt = next.metadata?.automation?.scheduledAt;
     if ((scheduledAt && scheduledAt > now) || (existing.status === "scheduled" && !scheduledAt)) {
       throw new Error("card is scheduled for later.");
+    }
+  }
+
+  private async assertDoneTransitionAllowed(
+    existing: WorkboardCard | undefined,
+    next: WorkboardCard,
+  ): Promise<void> {
+    const proof = next.metadata?.proof?.findLast(isStructuredPassedProof);
+    if (!proof) {
+      throw new Error(
+        "done gate: a passed structured proof with an exact command or URL and result note is required.",
+      );
+    }
+    if (next.metadata?.workflowState === "decomposed") {
+      throw new Error(
+        "done gate: a decomposed/planning card must remain open until execution is complete.",
+      );
+    }
+    const cardsById = new Map((await this.list()).map((card) => [card.id, card]));
+    if (existing) {
+      cardsById.set(existing.id, next);
+    }
+    for (const parentId of cardParentIds(next)) {
+      if (cardsById.get(parentId)?.status !== "done") {
+        throw new Error(`done gate: dependency ${parentId} is not done.`);
+      }
+    }
+    for (const childId of cardChildIds(next)) {
+      const child = cardsById.get(childId);
+      if (!child) {
+        throw new Error(`done gate: required child ${childId} is missing.`);
+      }
+      if (child.status !== "done" && (next.metadata?.completionWaiver?.trim().length ?? 0) < 12) {
+        throw new Error(`done gate: required child ${childId} is ${child.status}, not done.`);
+      }
+    }
+    for (const link of next.metadata?.links ?? []) {
+      if (link.type !== "blocked_by") {
+        continue;
+      }
+      const blocker = link.targetCardId ? cardsById.get(link.targetCardId) : undefined;
+      if (!blocker || blocker.status !== "done") {
+        throw new Error(
+          `done gate: unresolved blocker ${link.targetCardId ?? link.url ?? "(unknown)"}.`,
+        );
+      }
+    }
+    if (pullRequestUrls(next).length > 0) {
+      const note = proof.note?.toLowerCase() ?? "";
+      const hasCommit = /\b[0-9a-f]{7,40}\b/i.test(proof.note ?? "");
+      if (!/\bmerged\b/.test(note) || !/\breview(?:ed)?\b/.test(note) || !hasCommit) {
+        throw new Error(
+          "done gate: a pull request remains in review until merged exact-head/review proof includes the commit SHA.",
+        );
+      }
     }
   }
 

--- a/extensions/workboard/src/store-inputs.ts
+++ b/extensions/workboard/src/store-inputs.ts
@@ -113,6 +113,7 @@ export type WorkboardCompleteInput = {
   proofId?: unknown;
   artifacts?: unknown;
   createdCardIds?: unknown;
+  completionWaiver?: unknown;
 };
 export type WorkboardBlockInput = {
   ownerId?: unknown;
@@ -170,6 +171,8 @@ export type WorkboardDecomposeInput = {
   summary?: unknown;
   children?: unknown;
   completeParent?: unknown;
+  proof?: unknown;
+  completionWaiver?: unknown;
 };
 export type WorkboardNotificationSubscribeInput = {
   boardId?: unknown;

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -1039,6 +1039,8 @@ export function normalizeMetadata(
   const hasLifecycleStatusSourceUpdatedAt = Object.hasOwn(record, "lifecycleStatusSourceUpdatedAt");
   const hasWorkflowState = Object.hasOwn(record, "workflowState");
   const hasCompletionWaiver = Object.hasOwn(record, "completionWaiver");
+  const hasCompletionSource = Object.hasOwn(record, "completionSource");
+  const hasCompletionReason = Object.hasOwn(record, "completionReason");
   const links = Array.isArray(record.links)
     ? record.links.map(normalizeLink).filter((link): link is WorkboardLink => link !== null)
     : undefined;
@@ -1150,6 +1152,14 @@ export function normalizeMetadata(
     completionWaiver: hasCompletionWaiver
       ? normalizeBoundedString(record.completionWaiver, undefined, 2000, "completion waiver")
       : fallback.completionWaiver,
+    completionSource: hasCompletionSource
+      ? record.completionSource === "operator" || record.completionSource === "automated"
+        ? record.completionSource
+        : undefined
+      : fallback.completionSource,
+    completionReason: hasCompletionReason
+      ? normalizeBoundedString(record.completionReason, undefined, 2000, "completion reason")
+      : fallback.completionReason,
   };
   return trimMetadataToBudget(normalized, options);
 }
@@ -1269,6 +1279,8 @@ export function removeUndefinedMetadataFields(metadata: WorkboardMetadata): Work
     "failureCount",
     "workflowState",
     "completionWaiver",
+    "completionSource",
+    "completionReason",
   ] as const) {
     const value = next[key];
     if (

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -1037,6 +1037,8 @@ export function normalizeMetadata(
   const hasArchivedAt = Object.hasOwn(record, "archivedAt");
   const hasStale = Object.hasOwn(record, "stale");
   const hasLifecycleStatusSourceUpdatedAt = Object.hasOwn(record, "lifecycleStatusSourceUpdatedAt");
+  const hasWorkflowState = Object.hasOwn(record, "workflowState");
+  const hasCompletionWaiver = Object.hasOwn(record, "completionWaiver");
   const links = Array.isArray(record.links)
     ? record.links.map(normalizeLink).filter((link): link is WorkboardLink => link !== null)
     : undefined;
@@ -1140,6 +1142,14 @@ export function normalizeMetadata(
       typeof record.failureCount === "number" && Number.isFinite(record.failureCount)
         ? Math.max(0, Math.trunc(record.failureCount))
         : fallback.failureCount,
+    workflowState: hasWorkflowState
+      ? record.workflowState === "planned" || record.workflowState === "decomposed"
+        ? record.workflowState
+        : undefined
+      : fallback.workflowState,
+    completionWaiver: hasCompletionWaiver
+      ? normalizeBoundedString(record.completionWaiver, undefined, 2000, "completion waiver")
+      : fallback.completionWaiver,
   };
   return trimMetadataToBudget(normalized, options);
 }
@@ -1257,6 +1267,8 @@ export function removeUndefinedMetadataFields(metadata: WorkboardMetadata): Work
     "stale",
     "lifecycleStatusSourceUpdatedAt",
     "failureCount",
+    "workflowState",
+    "completionWaiver",
   ] as const) {
     const value = next[key];
     if (

--- a/extensions/workboard/src/store-promote.ts
+++ b/extensions/workboard/src/store-promote.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { WorkboardCard } from "@openclaw/workboard-contract";
+import type { WorkboardCard, WorkboardCompletionSource } from "@openclaw/workboard-contract";
 import { assertCanMutateClaimedCard } from "./store-card-helpers.js";
 import { MAX_CARD_COMMENTS } from "./store-constants.js";
 import { WorkboardEnrichmentStore } from "./store-enrichment.js";
@@ -25,6 +25,7 @@ export class WorkboardPromoteStore extends WorkboardEnrichmentStore {
     status: unknown,
     position: unknown,
     scope?: WorkboardMutationScope,
+    reason?: unknown,
   ): Promise<WorkboardCard> {
     return await this.enqueueMutation(async () => {
       const existing = await this.get(id);
@@ -34,12 +35,21 @@ export class WorkboardPromoteStore extends WorkboardEnrichmentStore {
       // Operator surfaces omit scope and may override claims. Agent tools pass scope so a
       // worker cannot move another worker's claimed card between the preflight and this write.
       assertCanMutateClaimedCard(existing, scope);
+      const operatorCompletion = status === "done" && scope == null;
+      const completionSource: WorkboardCompletionSource | undefined =
+        status === "done" ? (operatorCompletion ? "operator" : "automated") : undefined;
+      const completionReason = operatorCompletion
+        ? normalizeBoundedString(reason, undefined, 2000, "completion reason") ??
+          "Operator accepted completion via direct status move."
+        : undefined;
       return await this.updateCard(
         id,
         { status, position },
         {
           allowMetadataDependencyLinks: false,
           enforceStatusHolds: true,
+          ...(completionSource ? { completionSource } : {}),
+          ...(completionReason ? { completionReason } : {}),
         },
       );
     });

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -244,6 +244,12 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
       }
     }
     const summary = normalizeBoundedString(input.summary, undefined, 2000, "summary");
+    const completionWaiver = normalizeBoundedString(
+      input.completionWaiver,
+      undefined,
+      2000,
+      "completion waiver",
+    );
     const proofInput =
       input.proof && typeof input.proof === "object" && !Array.isArray(input.proof)
         ? (input.proof as WorkboardProofInput)
@@ -286,6 +292,8 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
           claim: undefined,
           attempts: closeRunningAttempts(metadata.attempts, now, "succeeded"),
           failureCount: 0,
+          workflowState: undefined,
+          ...(completionWaiver ? { completionWaiver } : {}),
           automation: normalizeAutomation(
             {
               ...metadata.automation,
@@ -545,12 +553,26 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
       const existingCardIds = new Set((await this.list()).map((card) => card.id));
       const children: WorkboardCard[] = [];
       const reusedChildSnapshots = new Map<string, WorkboardCard>();
+      const childIdempotencyKeys = new Set<string>();
       try {
         for (const rawChild of childrenInput) {
           if (!rawChild || typeof rawChild !== "object" || Array.isArray(rawChild)) {
             throw new Error("children must be objects.");
           }
           const child = rawChild as WorkboardDecomposeChildInput;
+          const childIdempotencyKey = normalizeBoundedString(
+            child.idempotencyKey ??
+              deriveChildIdempotencyKey(parentAutomation?.idempotencyKey, children.length + 1),
+            undefined,
+            160,
+            "idempotency key",
+          );
+          if (childIdempotencyKey) {
+            if (childIdempotencyKeys.has(childIdempotencyKey)) {
+              throw new Error(`duplicate child idempotency key: ${childIdempotencyKey}`);
+            }
+            childIdempotencyKeys.add(childIdempotencyKey);
+          }
           const created = await this.createDirect(
             {
               ...child,
@@ -558,9 +580,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
               boardId: child.boardId ?? parentAutomation?.boardId,
               tenant: child.tenant ?? parentAutomation?.tenant,
               createdByCardId: parent.id,
-              idempotencyKey:
-                child.idempotencyKey ??
-                deriveChildIdempotencyKey(parentAutomation?.idempotencyKey, children.length + 1),
+              idempotencyKey: childIdempotencyKey,
             },
             scope === null ? undefined : scope,
           );
@@ -579,11 +599,22 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
           );
         }
         const summary = normalizeBoundedString(input.summary, undefined, 2000, "decompose summary");
-        const completeParent = input.completeParent !== false;
+        const completionWaiver = normalizeBoundedString(
+          input.completionWaiver,
+          undefined,
+          2000,
+          "completion waiver",
+        );
+        const completeParent = input.completeParent === true;
         const updatedParent = completeParent
           ? await this.completeDirect(
               parent.id,
-              { summary, createdCardIds: children.map((child) => child.id) },
+              {
+                summary,
+                proof: input.proof,
+                createdCardIds: children.map((child) => child.id),
+                ...(completionWaiver ? { completionWaiver } : {}),
+              },
               scope,
             )
           : await (async () => {
@@ -597,6 +628,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
                       : latestParent.status,
                   metadata: {
                     ...latestParent.metadata,
+                    workflowState: "decomposed",
                     automation: normalizeAutomation(
                       {
                         ...latestParent.metadata?.automation,
@@ -605,6 +637,16 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
                       },
                       latestParent.metadata?.automation,
                     ),
+                    notifications: [
+                      ...(latestParent.metadata?.notifications ?? []),
+                      {
+                        id: randomUUID(),
+                        kind: "decomposed",
+                        createdAt: Date.now(),
+                        sequence: this.nextNotificationSequence(Date.now()),
+                        message: capText(summary, 240) ?? "Workboard card decomposed.",
+                      } satisfies WorkboardNotification,
+                    ].slice(-MAX_CARD_NOTIFICATIONS),
                   },
                 },
                 { enforceStatusHolds: true },

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -319,6 +319,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
       },
       {
         enforceStatusHolds: true,
+        completionSource: "automated",
         ...(proof ? { preserveProofId: proofId ?? proof.id } : {}),
       },
     );

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -614,6 +614,11 @@ describe("WorkboardStore", () => {
       toStatus: "running",
     });
 
+    await store.addProof(card.id, {
+      status: "passed",
+      command: "pnpm test",
+      note: "Tests passed.",
+    });
     const done = await store.update(card.id, { status: "done" });
     expect(done.completedAt).toBeGreaterThanOrEqual(done.startedAt ?? 0);
 
@@ -1103,10 +1108,7 @@ describe("WorkboardStore", () => {
       },
     });
 
-    const failed = await store.complete(card.id, {
-      summary: "A later run failed.",
-      proof: { ...proofInput, status: "failed" },
-    });
+    const failed = await store.addProof(card.id, { ...proofInput, status: "failed" });
 
     expect(failed.metadata?.proof?.map((entry) => [entry.id, entry.status])).toEqual([
       ["proof-unknown", "unknown"],
@@ -1146,6 +1148,7 @@ describe("WorkboardStore", () => {
       status: "passed" as const,
       createdAt: 1_000,
       command: "pnpm test extensions/workboard",
+      note: "Tests passed.",
     };
     const card = await store.create({
       title: "Reuse terminal proof",
@@ -1155,7 +1158,7 @@ describe("WorkboardStore", () => {
     const completed = await store.complete(card.id, {
       summary: "Already passed.",
       proofId: proof.id,
-      proof: { status: "passed", command: proof.command },
+      proof: { status: "passed", command: proof.command, note: "Tests passed." },
     });
 
     expect(completed.metadata?.proof).toEqual([proof]);
@@ -1531,7 +1534,21 @@ describe("WorkboardStore", () => {
 
   it("reports an active claim after a dependency-backed card starts running", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const parent = await store.create({ title: "Parent", status: "done" });
+    const parent = await store.create({
+      title: "Parent",
+      status: "done",
+      metadata: {
+        proof: [
+          {
+            id: "parent-proof",
+            status: "passed",
+            createdAt: 1,
+            command: "pnpm test",
+            note: "Tests passed.",
+          },
+        ],
+      },
+    });
     const child = await store.create({ title: "Child", parents: [parent.id] });
 
     await store.claim(child.id, { ownerId: "main", ttlSeconds: 60 });
@@ -1650,7 +1667,12 @@ describe("WorkboardStore", () => {
       store.create({ title: "Unscoped child", idempotencyKey: "fanout:1" }),
     ).resolves.toMatchObject({ title: "Unscoped child" });
 
-    await store.complete(parent.id, { summary: "Parent done." });
+    await store.complete(parent.id, {
+      summary: "Parent done.",
+      proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      completionWaiver:
+        "Child cards are intentionally follow-up work promoted after parent completion.",
+    });
     const promoted = await store.promoteReady();
 
     expect(promoted.cards).toEqual([expect.objectContaining({ id: child.id, status: "ready" })]);
@@ -1728,7 +1750,7 @@ describe("WorkboardStore", () => {
   it("keeps future scheduled cards scheduled until their time arrives", async () => {
     vi.useFakeTimers();
     try {
-      vi.setSystemTime(0);
+      vi.setSystemTime(1);
       const store = new WorkboardStore(createMemoryStore());
       const card = await store.create({
         title: "Later",
@@ -1779,7 +1801,12 @@ describe("WorkboardStore", () => {
       await expect(store.claim(implicit.id, { ownerId: "main" })).rejects.toThrow(/scheduled/);
       await expect(store.move(manual.id, "running", manual.position)).rejects.toThrow(/scheduled/);
 
-      await store.complete(parent.id, { summary: "Parent done." });
+      await store.complete(parent.id, {
+        summary: "Parent done.",
+        proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+        completionWaiver:
+          "Child cards are intentionally follow-up work promoted after parent completion.",
+      });
       expect((await store.dispatch(5_000)).promoted).toEqual([]);
       await expect(store.get(dependent.id)).resolves.toMatchObject({ status: "scheduled" });
 
@@ -1847,7 +1874,12 @@ describe("WorkboardStore", () => {
     );
     await expect(store.claim(child.id, { ownerId: "main" })).rejects.toThrow(/dependencies/);
 
-    await store.complete(parent.id, { summary: "Parent done." });
+    await store.complete(parent.id, {
+      summary: "Parent done.",
+      proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      completionWaiver:
+        "Child cards are intentionally follow-up work promoted after parent completion.",
+    });
     const dispatch = await store.dispatch();
 
     expect(dispatch.promoted).toEqual([expect.objectContaining({ id: child.id, status: "ready" })]);
@@ -1884,7 +1916,12 @@ describe("WorkboardStore", () => {
       ),
     );
 
-    await store.complete(parent.id, { summary: "Parent done." });
+    await store.complete(parent.id, {
+      summary: "Parent done.",
+      proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      completionWaiver:
+        "Child cards are intentionally follow-up work promoted after parent completion.",
+    });
     entriesSpy.mockClear();
     const dispatch = await store.dispatch();
 
@@ -1903,14 +1940,57 @@ describe("WorkboardStore", () => {
   it("rejects terminal children with incomplete dependency parents", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const runningParent = await store.create({ title: "Running parent", status: "running" });
-    const doneChild = await store.create({ title: "Done child", status: "done" });
+    const doneChild = await store.create({
+      title: "Done child",
+      status: "done",
+      metadata: {
+        proof: [
+          {
+            id: "child-proof",
+            status: "passed",
+            createdAt: 1,
+            command: "pnpm test",
+            note: "Tests passed.",
+          },
+        ],
+      },
+    });
 
     await expect(store.linkCards(runningParent.id, doneChild.id)).rejects.toThrow(/terminal child/);
     await expect(
-      store.create({ title: "Already done", status: "done", parents: [runningParent.id] }),
+      store.create({
+        title: "Already done",
+        status: "done",
+        parents: [runningParent.id],
+        metadata: {
+          proof: [
+            {
+              id: "already-proof",
+              status: "passed",
+              createdAt: 1,
+              command: "pnpm test",
+              note: "Tests passed.",
+            },
+          ],
+        },
+      }),
     ).rejects.toThrow(/terminal child/);
 
-    const doneParent = await store.create({ title: "Done parent", status: "done" });
+    const doneParent = await store.create({
+      title: "Done parent",
+      status: "done",
+      metadata: {
+        proof: [
+          {
+            id: "done-parent-proof",
+            status: "passed",
+            createdAt: 1,
+            command: "pnpm test",
+            note: "Tests passed.",
+          },
+        ],
+      },
+    });
     await expect(store.linkCards(doneParent.id, doneChild.id)).resolves.toMatchObject({
       id: doneChild.id,
       status: "done",
@@ -2022,7 +2102,13 @@ describe("WorkboardStore", () => {
       ownerId: "main",
       token: "token-1",
       summary: "Implemented and verified.",
-      proof: { status: "passed", command: "pnpm test extensions/workboard" },
+      proof: {
+        status: "passed",
+        command: "pnpm test extensions/workboard",
+        note: "Tests passed.",
+      },
+      completionWaiver:
+        "Follow-up child is intentionally tracked as separate post-completion work.",
       artifacts: [{ path: "/tmp/log.txt", label: "log" }],
       createdCardIds: [child.id],
     });
@@ -2085,7 +2171,10 @@ describe("WorkboardStore", () => {
           metadata: { failureCount: 2 },
         })
       ).id,
-      { summary: "Recovered." },
+      {
+        summary: "Recovered.",
+        proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      },
     );
     expect(recovered.metadata?.failureCount).toBeUndefined();
   });
@@ -2097,7 +2186,10 @@ describe("WorkboardStore", () => {
     const longSummary = "x".repeat(1000);
     const longReason = "y".repeat(1000);
 
-    const completed = await store.complete(completeCard.id, { summary: longSummary });
+    const completed = await store.complete(completeCard.id, {
+      summary: longSummary,
+      proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+    });
     const blocked = await store.block(blockCard.id, { reason: longReason });
 
     expect(completed.metadata?.comments?.[0]?.body).toBe(longSummary);
@@ -2263,7 +2355,12 @@ describe("WorkboardStore", () => {
       maxRetries: 1,
       metadata: { failureCount: 2 },
     });
-    await store.complete(parent.id, { summary: "Parent done." });
+    await store.complete(parent.id, {
+      summary: "Parent done.",
+      proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      completionWaiver:
+        "Child cards are intentionally follow-up work promoted after parent completion.",
+    });
 
     const dependentDispatch = await store.dispatch();
 
@@ -2396,6 +2493,15 @@ describe("WorkboardStore", () => {
       title: "Needs proof",
       status: "done",
       metadata: {
+        proof: [
+          {
+            id: "needs-proof-seed",
+            status: "passed",
+            createdAt: 1,
+            command: "pnpm test",
+            note: "Tests passed.",
+          },
+        ],
         diagnostics: [
           {
             kind: "missing_proof",
@@ -2411,7 +2517,9 @@ describe("WorkboardStore", () => {
 
     const updated = await store.addProof(card.id, { status: "passed", label: "CI" });
 
-    expect(updated.metadata?.proof).toEqual([expect.objectContaining({ label: "CI" })]);
+    expect(updated.metadata?.proof).toEqual(
+      expect.arrayContaining([expect.objectContaining({ label: "CI" })]),
+    );
     expect(updated.metadata?.diagnostics).toBeUndefined();
   });
 
@@ -2421,6 +2529,15 @@ describe("WorkboardStore", () => {
       title: "Needs artifact",
       status: "done",
       metadata: {
+        proof: [
+          {
+            id: "needs-artifact-seed",
+            status: "passed",
+            createdAt: 1,
+            command: "pnpm test",
+            note: "Tests passed.",
+          },
+        ],
         diagnostics: [
           {
             kind: "missing_proof",
@@ -2474,6 +2591,15 @@ describe("WorkboardStore", () => {
       title: "Done with attachment",
       status: "done",
       metadata: {
+        proof: [
+          {
+            id: "attachment-proof-seed",
+            status: "passed",
+            createdAt: 1,
+            command: "pnpm test",
+            note: "Tests passed.",
+          },
+        ],
         attachments: [
           {
             id: "attachment-proof",
@@ -2659,7 +2785,16 @@ describe("WorkboardStore", () => {
     const child = await store.create({ title: "Child", parents: [parent.id] });
 
     await expect(
-      store.complete(parent.id, { createdCardIds: [child.id], summary: "done" }, null),
+      store.complete(
+        parent.id,
+        {
+          createdCardIds: [child.id],
+          summary: "done",
+          proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+          completionWaiver: "Child cards remain as separately tracked follow-up work.",
+        },
+        null,
+      ),
     ).resolves.toMatchObject({
       status: "done",
       metadata: { automation: { createdCardIds: [child.id] } },
@@ -2724,12 +2859,30 @@ describe("WorkboardStore", () => {
       status: "running",
       agentId: "agent-a",
     });
-    await store.complete(parent.id, { summary: "Use board-scoped queues." }, null);
+    await store.complete(
+      parent.id,
+      {
+        summary: "Use board-scoped queues.",
+        proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      },
+      null,
+    );
     await store.create({
       title: "Older task",
       status: "done",
       agentId: "agent-a",
-      metadata: { automation: { summary: "Finished related cleanup." } },
+      metadata: {
+        automation: { summary: "Finished related cleanup." },
+        proof: [
+          {
+            id: "older-proof",
+            status: "passed",
+            createdAt: 1,
+            command: "pnpm test",
+            note: "Tests passed.",
+          },
+        ],
+      },
     });
     const child = await store.create({
       title: "Implement",
@@ -2813,7 +2966,10 @@ describe("WorkboardStore", () => {
       eventKinds: ["completed"],
     });
 
-    await store.complete(card.id, { summary: "Done." });
+    await store.complete(card.id, {
+      summary: "Done.",
+      proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+    });
 
     const preview = await store.notificationEvents({ subscriptionId: subscription.id });
     expect(preview.events).toEqual([expect.objectContaining({ kind: "completed" })]);
@@ -2976,8 +3132,14 @@ describe("WorkboardStore", () => {
       target: "session:operator",
     });
 
-    await store.complete(unrelated.id, { summary: "Other done." });
-    await store.complete(matching.id, { summary: "Matching done." });
+    await store.complete(unrelated.id, {
+      summary: "Other done.",
+      proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+    });
+    await store.complete(matching.id, {
+      summary: "Matching done.",
+      proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+    });
 
     await expect(store.notificationEvents({ subscriptionId: subscription.id })).resolves.toEqual({
       subscription: expect.objectContaining({ id: subscription.id }),
@@ -2999,7 +3161,10 @@ describe("WorkboardStore", () => {
       eventKinds: ["completed"],
     });
 
-    await store.complete(card.id, { summary: "Ops done." });
+    await store.complete(card.id, {
+      summary: "Ops done.",
+      proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+    });
 
     await expect(store.notificationEvents({ subscriptionId: subscription.id })).resolves.toEqual({
       subscription: expect.objectContaining({ id: subscription.id, cardId: card.id }),
@@ -3213,7 +3378,8 @@ describe("WorkboardStore", () => {
       ],
     });
 
-    expect(result.parent.status).toBe("done");
+    expect(result.parent.status).toBe("todo");
+    expect(result.parent.metadata?.workflowState).toBe("decomposed");
     expect(result.parent.events?.at(-1)).toMatchObject({ kind: "decomposed" });
     expect(result.parent.metadata?.automation?.createdCardIds).toEqual(
       result.children.map((child) => child.id),
@@ -3328,8 +3494,38 @@ describe("WorkboardStore", () => {
       store.complete(parent.id, {
         createdCardIds: result.children.map((child) => child.id),
         summary: "Children recorded.",
+        proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
       }),
-    ).resolves.toMatchObject({ status: "done" });
+    ).rejects.toThrow(/required child/);
+    await expect(store.get(parent.id)).resolves.toMatchObject({
+      status: "todo",
+      metadata: { workflowState: "decomposed" },
+    });
+  });
+
+  it("requires explicit proof and waiver when decomposition completes an open parent", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({ title: "Parent" });
+
+    await expect(
+      store.decompose(parent.id, {
+        completeParent: true,
+        children: [{ title: "Child" }],
+      }),
+    ).rejects.toThrow(/structured proof/);
+    await expect(store.list()).resolves.toEqual([expect.objectContaining({ id: parent.id })]);
+
+    const result = await store.decompose(parent.id, {
+      completeParent: true,
+      proof: { status: "passed", command: "pnpm test", note: "Decomposition gate passed." },
+      completionWaiver: "Child execution is intentionally tracked as follow-up work.",
+      children: [{ title: "Child" }],
+    });
+
+    expect(result.parent.status).toBe("done");
+    expect(result.parent.metadata?.automation?.createdCardIds).toEqual(
+      result.children.map((child) => child.id),
+    );
   });
 
   it("omits derived child idempotency keys when the parent key is already at the limit", async () => {
@@ -3358,7 +3554,8 @@ describe("WorkboardStore", () => {
       children: [{ title: "Ignored duplicate", idempotencyKey: "child-key" }],
     });
 
-    expect(result.parent.status).toBe("done");
+    expect(result.parent.status).toBe("todo");
+    expect(result.parent.metadata?.workflowState).toBe("decomposed");
     expect(result.children).toEqual([expect.objectContaining({ id: existingChild.id })]);
     expect(result.parent.metadata?.automation?.createdCardIds).toEqual([existingChild.id]);
     await expect(store.get(existingChild.id)).resolves.toMatchObject({
@@ -3370,11 +3567,84 @@ describe("WorkboardStore", () => {
     });
   });
 
+  it("rejects duplicate child idempotency keys within one decomposition", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({ title: "Parent" });
+
+    await expect(
+      store.decompose(parent.id, {
+        children: [
+          { title: "First child", idempotencyKey: "same-child" },
+          { title: "Duplicate child", idempotencyKey: "same-child" },
+        ],
+      }),
+    ).rejects.toThrow("duplicate child idempotency key: same-child");
+
+    await expect(store.list()).resolves.toEqual([expect.objectContaining({ id: parent.id })]);
+  });
+
   it("rejects invalid status values", async () => {
     const store = new WorkboardStore(createMemoryStore());
     await expect(store.create({ title: "Bad card", status: "later" })).rejects.toThrow(
       /status must be one of/,
     );
+  });
+
+  it("requires strong proof before any card can become done", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({ title: "Proof gate" });
+
+    await expect(store.update(card.id, { status: "done" })).rejects.toThrow(/structured proof/);
+    await expect(
+      store.complete(card.id, { proof: { status: "passed", note: "done" } }),
+    ).rejects.toThrow(/structured proof/);
+    await expect(
+      store.complete(card.id, {
+        proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      }),
+    ).resolves.toMatchObject({ status: "done" });
+  });
+
+  it("rejects completion while required children or blockers remain", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({ title: "Parent" });
+    await store.create({ title: "Child", parents: [parent.id] });
+    await expect(
+      store.complete(parent.id, {
+        proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      }),
+    ).rejects.toThrow(/required child/);
+
+    const blocker = await store.create({ title: "Blocker" });
+    const blocked = await store.create({ title: "Blocked" });
+    await store.addLink(blocked.id, { type: "blocked_by", targetCardId: blocker.id });
+    await expect(
+      store.complete(blocked.id, {
+        proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      }),
+    ).rejects.toThrow(/unresolved blocker/);
+  });
+
+  it("keeps pull-request cards in review until merged exact-head proof exists", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Review PR",
+      sourceUrl: "https://github.com/acme/project/pull/42",
+    });
+    await expect(
+      store.complete(card.id, {
+        proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
+      }),
+    ).rejects.toThrow(/pull request remains in review/);
+    await expect(
+      store.complete(card.id, {
+        proof: {
+          status: "passed",
+          command: "pnpm test",
+          note: "PR merged and reviewed at commit abcdef1234567.",
+        },
+      }),
+    ).resolves.toMatchObject({ status: "done" });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -3590,7 +3590,7 @@ describe("WorkboardStore", () => {
     );
   });
 
-  it("requires strong proof before any card can become done", async () => {
+  it("gates automated completion while preserving audited operator acceptance", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({ title: "Proof gate" });
 
@@ -3598,11 +3598,28 @@ describe("WorkboardStore", () => {
     await expect(
       store.complete(card.id, { proof: { status: "passed", note: "done" } }),
     ).rejects.toThrow(/structured proof/);
+
+    const operatorAccepted = await store.move(card.id, "done", undefined);
+    expect(operatorAccepted).toMatchObject({
+      status: "done",
+      metadata: {
+        completionSource: "operator",
+        completionReason: "Operator accepted completion via direct status move.",
+      },
+    });
+
+    const automatedCard = await store.create({ title: "Automated proof gate" });
     await expect(
-      store.complete(card.id, {
+      store.move(automatedCard.id, "done", undefined, { ownerId: "agent-worker" }),
+    ).rejects.toThrow(/structured proof/);
+    await expect(
+      store.complete(automatedCard.id, {
         proof: { status: "passed", command: "pnpm test", note: "Tests passed." },
       }),
-    ).resolves.toMatchObject({ status: "done" });
+    ).resolves.toMatchObject({
+      status: "done",
+      metadata: { completionSource: "automated" },
+    });
   });
 
   it("rejects completion while required children or blockers remain", async () => {

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -414,6 +414,7 @@ describe("workboard tools", () => {
         id: parent.id,
         token,
         command: "pnpm test extensions/workboard",
+        note: "Tests passed.",
       }),
     );
     expect(pendingProof.proofId).toEqual(expect.any(String));
@@ -423,8 +424,13 @@ describe("workboard tools", () => {
         token,
         summary: "Done.",
         createdCardIds: [child.id],
+        completionWaiver: "Child is intentionally promoted as separate follow-up work.",
         proofId: pendingProof.proofId,
-        proof: { status: "passed", command: "pnpm test extensions/workboard" },
+        proof: {
+          status: "passed",
+          command: "pnpm test extensions/workboard",
+          note: "Tests passed.",
+        },
       }),
     );
     expect(completed.card).toMatchObject({
@@ -541,7 +547,10 @@ describe("workboard tools", () => {
         children: [{ title: "Child A" }, { title: "Child B" }],
       }),
     );
-    expect(decomposed.parent).toMatchObject({ status: "done" });
+    expect(decomposed.parent).toMatchObject({
+      status: "todo",
+      metadata: { workflowState: "decomposed" },
+    });
     expect(decomposed.children).toEqual([
       expect.objectContaining({ title: "Child A" }),
       expect.objectContaining({ title: "Child B" }),
@@ -581,7 +590,7 @@ describe("workboard tools", () => {
         subscriptionId: (subscription.subscription as { id: string }).id,
       }),
     );
-    expect(events.events).toEqual([expect.objectContaining({ kind: "completed" })]);
+    expect(events.events).toEqual([]);
 
     const attached = readPayload(
       await tools.get("workboard_attachment_add")?.execute("call-attach", {

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -632,6 +632,14 @@ describe("workboard tools", () => {
     );
     expect(unclaimed.card).toMatchObject({ status: "ready" });
 
+    const automatedDone = await store.create({ title: "Automated move card", status: "todo" });
+    await expect(
+      tools.get("workboard_move")?.execute("move-automated-done", {
+        id: automatedDone.id,
+        status: "done",
+      }),
+    ).rejects.toThrow(/structured proof/);
+
     await store.claim(card.id, { ownerId: "agent-a", token: "test-auth-token" });
     await expect(
       tools.get("workboard_move")?.execute("move-denied", {

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -518,6 +518,11 @@ export function createWorkboardTools(params: {
           createdCardIds: Type.Optional(
             Type.Array(Type.String(), { description: "Cards created during this run." }),
           ),
+          completionWaiver: Type.Optional(
+            Type.String({
+              description: "Documented reason required child work is intentionally still open.",
+            }),
+          ),
         },
         { additionalProperties: false },
       ),
@@ -776,7 +781,27 @@ export function createWorkboardTools(params: {
           summary: Type.Optional(Type.String({ description: "Decomposition summary." })),
           completeParent: Type.Optional(
             Type.Boolean({
-              description: "Complete the parent after child creation. Default true.",
+              description:
+                "Complete the parent after child creation. Default false; decomposition is planning until explicitly completed.",
+            }),
+          ),
+          proof: Type.Optional(
+            Type.Object(
+              {
+                status: Type.Optional(
+                  Type.String({ description: "passed, failed, skipped, or unknown." }),
+                ),
+                label: Type.Optional(Type.String({ description: "Proof label." })),
+                command: Type.Optional(Type.String({ description: "Command or step run." })),
+                url: Type.Optional(Type.String({ description: "Proof URL." })),
+                note: Type.Optional(Type.String({ description: "Proof note." })),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+          completionWaiver: Type.Optional(
+            Type.String({
+              description: "Documented reason required child work is intentionally still open.",
             }),
           ),
           children: Type.Array(

--- a/packages/workboard-contract/src/index.ts
+++ b/packages/workboard-contract/src/index.ts
@@ -73,7 +73,7 @@ export const WORKBOARD_DIAGNOSTIC_KINDS = [
   "orphaned_session",
 ] as const;
 export const WORKBOARD_DIAGNOSTIC_SEVERITIES = ["warning", "error", "critical"] as const;
-export const WORKBOARD_NOTIFICATION_KINDS = ["completed", "failed", "stale"] as const;
+export const WORKBOARD_NOTIFICATION_KINDS = ["completed", "decomposed", "failed", "stale"] as const;
 export const WORKBOARD_BOARD_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,79}$/;
 
 export function isValidWorkboardBoardId(value: unknown): value is string {
@@ -336,6 +336,10 @@ export type WorkboardMetadata = {
   stale?: WorkboardStaleState;
   lifecycleStatusSourceUpdatedAt?: number;
   failureCount?: number;
+  /** Explicit, documented reason why required child work remains open. */
+  completionWaiver?: string;
+  /** Planning/decomposition is not execution completion. */
+  workflowState?: "planned" | "decomposed";
 };
 
 export type WorkboardCard = {

--- a/packages/workboard-contract/src/index.ts
+++ b/packages/workboard-contract/src/index.ts
@@ -89,6 +89,7 @@ export type WorkboardEventKind = (typeof WORKBOARD_EVENT_KINDS)[number];
 export type WorkboardAttemptStatus = (typeof WORKBOARD_ATTEMPT_STATUSES)[number];
 export type WorkboardLinkType = (typeof WORKBOARD_LINK_TYPES)[number];
 export type WorkboardProofStatus = (typeof WORKBOARD_PROOF_STATUSES)[number];
+export type WorkboardCompletionSource = "operator" | "automated";
 export type WorkboardTemplateId = (typeof WORKBOARD_TEMPLATE_IDS)[number];
 export type WorkboardDiagnosticKind = (typeof WORKBOARD_DIAGNOSTIC_KINDS)[number];
 export type WorkboardDiagnosticSeverity = (typeof WORKBOARD_DIAGNOSTIC_SEVERITIES)[number];
@@ -338,6 +339,10 @@ export type WorkboardMetadata = {
   failureCount?: number;
   /** Explicit, documented reason why required child work remains open. */
   completionWaiver?: string;
+  /** Authority that performed the terminal completion transition. */
+  completionSource?: WorkboardCompletionSource;
+  /** Audit reason for a manual operator completion, when supplied. */
+  completionReason?: string;
   /** Planning/decomposition is not execution completion. */
   workflowState?: "planned" | "decomposed";
 };


### PR DESCRIPTION
Closes #113582

## What Problem This Solves
Automated Workboard completion could mark cards done without complete, structured proof, while the original implementation also blocked the documented direct operator-acceptance path. This change keeps manual operator acceptance compatible and makes automated/agent completion fail closed.

## Summary
- preserve direct operator moves to `done`
- record operator completion source and audit reason metadata
- keep `workboard_complete`, scoped agent moves, and automated paths behind structured proof and lifecycle gates
- retain dependency, child, blocker, and exact-head PR checks for automated completion
- add regression coverage for both manual acceptance and automated rejection

## Evidence
- focused Workboard tests: 122 passed
- extension source typecheck passed
- extension test typecheck passed
- extension lint completed without reported findings
- `git diff --check` passed
- exact published head: `b8224c6774`

## Compatibility Decision
Manual operator acceptance is intentionally preserved. Automated and agent-driven completion remains proof-gated and fail-closed, with operator completion recorded explicitly for auditability.
