### PR TITLE
fix(qa): run channel message flows on both supported drivers

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -100,10 +100,12 @@ describe("qa scenario catalog channel contracts", () => {
     expect(flow).toContain("String(memoryAfter) === config.seededMemory");
   });
 
-  it("enables Telegram previews for channel streaming evidence", () => {
-    const scenario = readQaScenarioById("channel-message-flows");
+  it("keeps channel streaming evidence portable across QA Channel and Crabline Telegram", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("channel-message-flows"));
 
-    expect(scenario.coverage?.primary).toEqual([`${agentRuntime}.streaming-replies`]);
+    expect(scenario.execution.channel).toBeUndefined();
+    expect(scenario.execution.channels).toEqual(["qa-channel", "telegram"]);
+    expect(scenario.coverage?.primary).toEqual(["channels.streaming-final-reply"]);
     expect(scenario.coverage?.secondary).toEqual([`${agentRuntime}.streaming-replies-delivery`]);
     expect(scenario.gatewayConfigPatch).toMatchObject({
       channels: { telegram: { streaming: { mode: "partial" } } },

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -85,6 +85,13 @@ const qaFlowScenarioExecutionSchema = z
     kind: z.literal("flow").default("flow"),
     summary: z.string().trim().min(1).optional(),
     channel: qaScenarioChannelSchema.optional(),
+    channels: z
+      .array(qaScenarioChannelSchema)
+      .min(1)
+      .refine((channels) => new Set(channels).size === channels.length, {
+        message: "scenario execution channel ids must be unique",
+      })
+      .optional(),
     profiles: z.record(qaScenarioProfileSchema, z.number().int().nonnegative()).optional(),
     suiteIsolation: z.literal("isolated").optional(),
     isolationReason: z.string().trim().min(1).optional(),

--- a/extensions/qa-lab/src/scenario-lane.test.ts
+++ b/extensions/qa-lab/src/scenario-lane.test.ts
@@ -1,6 +1,6 @@
 // Qa Lab tests cover canonical scenario lane matching behavior.
 import { describe, expect, it } from "vitest";
-import { readQaScenarioPack } from "./scenario-catalog.js";
+import { readQaScenarioById, readQaScenarioPack } from "./scenario-catalog.js";
 import {
   describeQaProviderLaneMismatches,
   scenarioMatchesQaProviderLane,
@@ -106,6 +106,27 @@ describe("QA scenario lane matching", () => {
       }),
     ).toBe(false);
   });
+
+  it.each([
+    { channelDriver: "qa-channel" as const, channel: undefined, matches: true },
+    { channelDriver: "crabline" as const, channel: "telegram", matches: true },
+    { channelDriver: "crabline" as const, channel: "discord", matches: false },
+  ])(
+    "matches channel streaming evidence for $channelDriver channel $channel: $matches",
+    ({ channelDriver, channel, matches }) => {
+      const scenario = readQaScenarioById("channel-message-flows");
+
+      expect(
+        scenarioMatchesQaProviderLane({
+          scenario,
+          providerMode: "mock-openai",
+          primaryModel: "mock-openai/gpt-5.6-luna",
+          channelDriver,
+          channel,
+        }),
+      ).toBe(matches);
+    },
+  );
 
   it("accepts a mock lane only when its selected provider and model satisfy the contract", () => {
     const scenario = makeQaSuiteTestScenario("mock-anthropic", {

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -32,6 +32,11 @@ export function describeQaProviderLaneMismatches(params: {
   if (scenarioChannel && effectiveChannel !== scenarioChannel) {
     mismatches.push(`channel=${scenarioChannel}`);
   }
+  const allowedChannels =
+    params.scenario.execution.kind === "flow" ? params.scenario.execution.channels : undefined;
+  if (allowedChannels && !allowedChannels.includes(effectiveChannel ?? "")) {
+    mismatches.push(`channel=${allowedChannels.join("|")}`);
+  }
   const selected = splitQaModelRef(params.primaryModel);
   const requiredProvider = normalizeQaConfigString(config.requiredProvider);
   if (requiredProvider && selected?.provider !== requiredProvider) {

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -394,6 +394,50 @@ describe("qa suite planning helpers", () => {
     ).toEqual(["strict-live-lane"]);
   });
 
+  it.each([
+    { channelDriver: "qa-channel" as const, channel: undefined, expectedChannel: "qa-channel" },
+    { channelDriver: "crabline" as const, channel: "telegram", expectedChannel: "telegram" },
+  ])(
+    "selects the real channel streaming scenario for the $channelDriver driver",
+    ({ channelDriver, channel, expectedChannel }) => {
+      const scenario = readQaScenarioById("channel-message-flows");
+      const selected = selectQaFlowSuiteScenarios({
+        scenarios: [scenario],
+        scenarioIds: [scenario.id],
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        channelDriver,
+        channel,
+      });
+
+      expect(selected).toEqual([scenario]);
+      expect(
+        resolveQaSuiteScenarioChannel({
+          defaultChannel: expectedChannel,
+          explicitChannel: channel,
+          scenarios: selected,
+        }),
+      ).toBe(expectedChannel);
+    },
+  );
+
+  it("rejects channel streaming evidence on unsupported Crabline channels", () => {
+    const scenario = readQaScenarioById("channel-message-flows");
+
+    expect(() =>
+      selectQaFlowSuiteScenarios({
+        scenarios: [scenario],
+        scenarioIds: [scenario.id],
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        channelDriver: "crabline",
+        channel: "discord",
+      }),
+    ).toThrow(
+      "selected QA scenario(s) do not match the current QA lane: channel-message-flows (channel=qa-channel|telegram)",
+    );
+  });
+
   it("keeps explicitly requested scenarios in request order", () => {
     const scenarios = [
       makeQaSuiteTestScenario("first"),

--- a/qa/scenarios/channels/channel-message-flows.yaml
+++ b/qa/scenarios/channels/channel-message-flows.yaml
@@ -5,7 +5,7 @@ scenario:
   surface: channels
   coverage:
     primary:
-      - agent-runtime.streaming-replies
+      - channels.streaming-final-reply
     secondary:
       - agent-runtime.streaming-replies-delivery
   objective: Verify streaming channel replies produce visible previews that resolve to one final answer.
@@ -29,7 +29,9 @@ scenario:
     - extensions/telegram/src/draft-stream.ts
   execution:
     kind: flow
-    channel: telegram
+    channels:
+      - qa-channel
+      - telegram
     summary: Stream a deterministic answer through QA Channel or Crabline Telegram and assert its preview lifecycle.
     config:
       requiredProviderMode: mock-openai


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the documented channel-message-flows QA scenario was rejected on the built-in QA channel because its fixture accepted only Telegram, despite the official QA workflow requiring the same real message-flow scenario to run against both QA Channel and Crabline Telegram.

## Why This Change Was Made

Use a validated, nonempty, duplicate-free internal scenario channel allowlist and preserve the existing singular channel contract. Explicitly admit only the two supported QA Channel and Telegram lanes, retaining canonical streaming coverage and rejecting unsupported Crabline Discord.

## User Impact

Developers and CI can execute the documented message-flow suite against both supported drivers. Unsupported real channel combinations remain rejected rather than silently widening routing.

## Evidence

- Remote Linux actual product: built private QA distribution and ran the exact documented QA Channel flow, 1 passed, 0 failed.
- Actual Crabline Telegram product flow on a separately launched QA Gateway, 1 passed, 0 failed.
- All 57 real-catalog, lane-match and suite-planning regressions passed, including actual Discord rejection.
- Exact six-file format and targeted lint gates passed.
- Fresh independent Codex review and secret scan passed with no actionable findings.
- AI-assisted and independently reviewed; no core routing, channel policy or authentication change.
