### PR TITLE
fix(tui): complete approved terminal operator scope upgrades

### DIFF
--- a/src/tui/gateway-chat.scopes.test.ts
+++ b/src/tui/gateway-chat.scopes.test.ts
@@ -1,0 +1,280 @@
+// Covers TUI device pairing and operator scope upgrades through the real Gateway client.
+import { Buffer } from "node:buffer";
+import { generateKeyPairSync } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
+import { ErrorCodes, PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
+import { deriveDeviceIdFromPublicKey } from "../infra/device-identity.js";
+import type { GatewayChatClient } from "./gateway-chat.js";
+
+type GatewayRequestFrame = {
+  type: "req";
+  id: string;
+  method: string;
+  params?: {
+    client?: { id?: string };
+    role?: string;
+    scopes?: string[];
+    auth?: { token?: string; deviceToken?: string };
+    device?: { id?: string; nonce?: string; signature?: string };
+    [key: string]: unknown;
+  };
+};
+
+describe("GatewayChatClient operator scopes", () => {
+  it("requests and completes an approved TUI scope upgrade through the real Gateway client", async () => {
+    const requestedScopes = [
+      "operator.admin",
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+    ];
+    const sharedGatewayToken = "test-shared-gateway-token";
+    let cachedDeviceAuth = {
+      token: "cached-read-only-device-token",
+      scopes: ["operator.read"],
+    };
+    const loadDeviceAuthToken = vi.fn(() => cachedDeviceAuth);
+    const storeDeviceAuthToken = vi.fn((record: { token: string; scopes: string[] }) => {
+      cachedDeviceAuth = { token: record.token, scopes: [...record.scopes] };
+    });
+    const clearDeviceAuthToken = vi.fn();
+    const sockets: ScopeUpgradeWebSocket[] = [];
+    const clients: GatewayChatClient[] = [];
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+    const publicKeyPem = publicKey.export({ type: "spki", format: "pem" });
+    const deviceId = deriveDeviceIdFromPublicKey(publicKeyPem);
+    if (!deviceId) {
+      throw new Error("expected a valid isolated TUI device identity");
+    }
+    const deviceIdentity = {
+      deviceId,
+      privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+      publicKeyPem,
+    };
+
+    class ScopeUpgradeWebSocket extends EventEmitter {
+      static readonly OPEN = 1;
+      readyState = 0;
+      readonly sent: GatewayRequestFrame[] = [];
+
+      constructor(_url: string, _options?: unknown) {
+        super();
+        sockets.push(this);
+      }
+
+      send(data: string): void {
+        this.sent.push(JSON.parse(data) as GatewayRequestFrame);
+      }
+
+      close(code = 1000, reason = ""): void {
+        this.readyState = 3;
+        this.emit("close", code, Buffer.from(reason));
+      }
+
+      terminate(): void {
+        this.close();
+      }
+
+      open(): void {
+        this.readyState = ScopeUpgradeWebSocket.OPEN;
+        this.emit("open");
+      }
+
+      receive(frame: unknown): void {
+        this.emit("message", JSON.stringify(frame));
+      }
+    }
+
+    vi.resetModules();
+    vi.doMock("ws", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("ws")>();
+      return { ...actual, WebSocket: ScopeUpgradeWebSocket };
+    });
+    vi.doMock("../gateway/client.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../gateway/client.js")>();
+      class IsolatedGatewayClient extends actual.GatewayClient {
+        constructor(options: ConstructorParameters<typeof actual.GatewayClient>[0]) {
+          super({
+            ...options,
+            hostDeps: {
+              ...options.hostDeps,
+              loadOrCreateDeviceIdentity: () => deviceIdentity,
+              loadDeviceAuthToken,
+              storeDeviceAuthToken,
+              clearDeviceAuthToken,
+              beforeConnect: () => {},
+              registerGatewayLoopbackBypass: () => undefined,
+              logDebug: () => {},
+              logError: () => {},
+              redactForLog: (message) => message,
+            },
+          });
+        }
+      }
+      return { ...actual, GatewayClient: IsolatedGatewayClient };
+    });
+
+    try {
+      const { GatewayChatClient: RealGatewayChatClient } = await import("./gateway-chat.js");
+      const openConnection = async (token?: string) => {
+        const client = new RealGatewayChatClient({
+          url: "ws://127.0.0.1:18789",
+          ...(token ? { token } : {}),
+          allowInsecureLocalOperatorUi: false,
+        });
+        clients.push(client);
+        const socketCount = sockets.length;
+        client.start();
+        await vi.waitFor(() => expect(sockets).toHaveLength(socketCount + 1));
+        const socket = sockets.at(-1);
+        if (!socket) {
+          throw new Error("expected isolated TUI WebSocket");
+        }
+        socket.open();
+        const nonce = `tui-scope-upgrade-${socketCount}`;
+        socket.receive({
+          type: "event",
+          event: "connect.challenge",
+          payload: { nonce },
+        });
+        const connect = socket.sent.find((frame) => frame.method === "connect");
+        if (!connect) {
+          throw new Error("expected real TUI Gateway connect frame");
+        }
+        expect(connect.params).toMatchObject({
+          client: { id: "openclaw-tui" },
+          role: "operator",
+          scopes: requestedScopes,
+          device: { id: deviceIdentity.deviceId, nonce },
+          auth: token
+            ? { token }
+            : {
+                token: cachedDeviceAuth.token,
+                deviceToken: cachedDeviceAuth.token,
+              },
+        });
+        if (token) {
+          expect(connect.params?.auth?.deviceToken).toBeUndefined();
+        }
+        expect(connect.params?.device?.signature).toEqual(expect.any(String));
+        return { client, socket, connect };
+      };
+
+      const readOnly = await openConnection();
+      const onReadOnlyDisconnected = vi.fn();
+      readOnly.client.onDisconnected = onReadOnlyDisconnected;
+      readOnly.socket.receive({
+        type: "res",
+        id: readOnly.connect.id,
+        ok: false,
+        error: {
+          code: ErrorCodes.INVALID_REQUEST,
+          message: "device token scope mismatch",
+          details: {
+            code: ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH,
+            authReason: "scope_mismatch",
+          },
+        },
+      });
+      await vi.waitFor(() => expect(onReadOnlyDisconnected).toHaveBeenCalledWith("connect failed"));
+      expect(cachedDeviceAuth.scopes).toEqual(["operator.read"]);
+      expect(storeDeviceAuthToken).not.toHaveBeenCalled();
+      expect(clearDeviceAuthToken).not.toHaveBeenCalled();
+      await readOnly.client.stop();
+
+      const rejected = await openConnection(sharedGatewayToken);
+      const onDisconnected = vi.fn();
+      rejected.client.onDisconnected = onDisconnected;
+      rejected.socket.receive({
+        type: "res",
+        id: rejected.connect.id,
+        ok: false,
+        error: {
+          code: ErrorCodes.NOT_PAIRED,
+          message: "pairing required",
+          details: {
+            code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+            reason: "scope-upgrade",
+            requestId: "tui-scope-upgrade-request",
+            requestedRole: "operator",
+            requestedScopes,
+            approvedScopes: ["operator.read"],
+          },
+        },
+      });
+      await vi.waitFor(() => expect(onDisconnected).toHaveBeenCalledWith("connect failed"));
+      expect(cachedDeviceAuth.scopes).toEqual(["operator.read"]);
+      expect(storeDeviceAuthToken).not.toHaveBeenCalled();
+      expect(clearDeviceAuthToken).not.toHaveBeenCalled();
+      await expect(
+        rejected.client.sendChat({ sessionKey: "main", message: "not yet approved" }),
+      ).rejects.toThrow("gateway not connected");
+      await rejected.client.stop();
+
+      const approved = await openConnection(sharedGatewayToken);
+      approved.socket.receive({
+        type: "res",
+        id: approved.connect.id,
+        ok: true,
+        payload: {
+          type: "hello-ok",
+          protocol: PROTOCOL_VERSION,
+          features: { methods: ["chat.history", "chat.send"], events: [] },
+          auth: {
+            role: "operator",
+            scopes: requestedScopes,
+            deviceToken: "approved-tui-device-token",
+          },
+        },
+      });
+      await approved.client.waitForReady();
+      expect(storeDeviceAuthToken).toHaveBeenCalledWith({
+        deviceId: deviceIdentity.deviceId,
+        role: "operator",
+        token: "approved-tui-device-token",
+        scopes: requestedScopes,
+        env: undefined,
+      });
+
+      const history = approved.client.loadHistory({ sessionKey: "main", limit: 20 });
+      const historyRequest = approved.socket.sent.find((frame) => frame.method === "chat.history");
+      expect(historyRequest?.params).toMatchObject({ sessionKey: "main", limit: 20 });
+      approved.socket.receive({
+        type: "res",
+        id: historyRequest?.id,
+        ok: true,
+        payload: { messages: [] },
+      });
+      await expect(history).resolves.toEqual({ messages: [] });
+
+      const chat = approved.client.sendChat({
+        sessionKey: "main",
+        message: "approved chat message",
+        runId: "tui-scope-upgrade-run",
+      });
+      const chatRequest = approved.socket.sent.find((frame) => frame.method === "chat.send");
+      expect(chatRequest?.params).toMatchObject({
+        sessionKey: "main",
+        message: "approved chat message",
+        idempotencyKey: "tui-scope-upgrade-run",
+      });
+      approved.socket.receive({
+        type: "res",
+        id: chatRequest?.id,
+        ok: true,
+        payload: { runId: "tui-scope-upgrade-run", status: "started" },
+      });
+      await expect(chat).resolves.toEqual({
+        runId: "tui-scope-upgrade-run",
+        status: "started",
+      });
+    } finally {
+      await Promise.all(clients.map((client) => client.stop()));
+      vi.doUnmock("ws");
+      vi.doUnmock("../gateway/client.js");
+      vi.resetModules();
+    }
+  });
+});

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -700,6 +700,7 @@ describe("GatewayChatClient", () => {
         clientName: "openclaw-tui",
         caps: ["agent-kind", "plugin-approvals", "task-suggestions", "tool-events"],
         mode: "ui",
+        scopes: ["operator.admin", "operator.read", "operator.write", "operator.approvals"],
         preauthHandshakeTimeoutMs: 30_000,
         tlsFingerprint: "sha256:11:22:33:44",
         deviceIdentity: null,

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -158,6 +158,7 @@ export class GatewayChatClient implements TuiBackend {
       clientVersion: VERSION,
       platform: process.platform,
       mode: GATEWAY_CLIENT_MODES.UI,
+      scopes: ["operator.admin", "operator.read", "operator.write", "operator.approvals"],
       deviceIdentity: connection.allowInsecureLocalOperatorUi ? null : undefined,
       caps: [
         GATEWAY_CLIENT_CAPS.AGENT_KIND,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening the terminal UI with an existing cached read-only device token failed with `missing scope: operator.write`, leaving real users unable to send messages, reset sessions or approve terminal actions.

## Why This Change Was Made

Explicitly request the existing canonical operator admin, read, write and approvals scopes in the real Gateway client. Preserve ordinary pairing-required behavior: an old lower-scope token must be rejected, a human/device-approved upgrade must complete, and only the approved replacement token is stored.

## User Impact

TUI users can send chats and use supported administrative/approval actions after a real approved device-scope upgrade. The fix never grants scopes without authorization or bypasses pairing.

## Evidence

- Actual official terminal in a real PTY against a dedicated token-auth Gateway completed live OpenAI GPT-5.4 chat with exact expected response.
- Remote Linux: all 42 TUI tests pass, including a dedicated real GatewayClient/in-memory-WebSocket regression proving Ed25519 device identity, challenge signing, stale read-only denial, pairing-required response, approved token persistence, and successful real history/send RPCs.
- Existing and new test files comply with line-length policy; targeted oxlint, full core and core-test tsgo and formatting all pass.
- Fresh independent Codex review, complete regression scan and secret scan passed with zero actionable findings.
- AI-assisted and independently reviewed.
