### PR TITLE
fix(ui): keep the sidebar run indicator on the left

### DIFF
--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -20,6 +20,7 @@ import type { AppSidebarSessionNavigationElement } from "./app-sidebar-session-n
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 import type { SidebarWorkboardBoard } from "./app-sidebar-workboard.ts";
 import { icons } from "./icons.ts";
+import { renderSessionGlyph, renderSessionUnreadBadge } from "./session-glyph.ts";
 import { renderSessionRowBadges } from "./session-row-badges.ts";
 
 type AppSidebarRenderHost = AppSidebarSessionNavigationElement & {
@@ -90,21 +91,15 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
   const outboxCount = host.outboxCountForSessionKey(mainKey);
   const active =
     host.activeRouteId === "chat" && areUiSessionKeysEquivalent(host.getRouteSessionKey(), mainKey);
-  const stateBadge = mainRow?.hasActiveRun
-    ? html`<openclaw-tooltip .content=${t("sessionsView.activeRun")}>
-        <span
-          class="session-run-spinner"
-          role="img"
-          aria-label=${t("sessionsView.activeRun")}
-        ></span>
-      </openclaw-tooltip>`
-    : mainRow?.unread === true && !active
-      ? html`<span
-          class="session-unread-dot"
-          role="img"
-          aria-label=${t("sessionsView.unread")}
-        ></span>`
-      : nothing;
+  const running = mainRow?.hasActiveRun === true;
+  const unread = mainRow?.unread === true && !active;
+  // Home shares the sidebar's leading-slot contract: run state rings its icon
+  // instead of drifting to the row edge, which stays reserved for counts.
+  const homeGlyph = renderSessionGlyph({
+    content: html`<span class="nav-item__icon" aria-hidden="true">${icons.home}</span>`,
+    running,
+    badge: unread ? renderSessionUnreadBadge() : nothing,
+  });
   return html`
     <a
       href=${`${pathForRoute("chat", host.basePath)}${searchForSession(mainKey)}`}
@@ -118,7 +113,11 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
         host.openMainSession(agentId);
       }}
     >
-      <span class="nav-item__icon" aria-hidden="true">${icons.home}</span>
+      ${running
+        ? html`<openclaw-tooltip .content=${t("sessionsView.activeRun")}
+            >${homeGlyph}</openclaw-tooltip
+          >`
+        : homeGlyph}
       <span class="nav-item__text">${t("nav.home")}</span>
       ${sessionHasBoard(mainKey)
         ? html`<openclaw-tooltip .content=${t("sessionsView.dashboardAvailable")}>
@@ -130,9 +129,8 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
             >
           </openclaw-tooltip>`
         : nothing}
-      ${stateBadge !== nothing || approvalNeeded || outboxCount > 0
+      ${approvalNeeded || outboxCount > 0
         ? html`<span class="nav-item__state sidebar-home-session-states">
-            ${stateBadge}
             ${approvalNeeded
               ? html`<openclaw-tooltip .content=${t("sessionsView.approvalNeeded")}>
                   <span

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -155,7 +155,7 @@ export function renderRecentSession(params: {
       ? session.archivedBy
       : session.createdActor
     : undefined;
-  const { running, pinnedState, leadingIndicator } = renderSessionLeadingState(
+  const { running, leadingIndicator } = renderSessionLeadingState(
     session,
     pullRequestState,
     ownerActor,
@@ -274,7 +274,6 @@ export function renderRecentSession(params: {
             session.key,
           ),
         })}
-        ${pinnedState}
       </a>
       ${session.childSessionKeys.length > 0
         ? html`<button

--- a/ui/src/components/session-glyph.ts
+++ b/ui/src/components/session-glyph.ts
@@ -1,0 +1,40 @@
+import { html, nothing, type TemplateResult } from "lit";
+import { t } from "../i18n/index.ts";
+
+export type SessionGlyphContent = TemplateResult | typeof nothing;
+
+/**
+ * The sidebar's leading slot. Every row kind (owner avatar, page icon,
+ * attention glyph) renders its own artwork here and carries run state as a ring
+ * around it, so the run indicator never migrates to the row's trailing edge.
+ * Circular content already fits the ring; arbitrary square icons and thumbnails
+ * scale down so their corners stay inside it.
+ */
+export function renderSessionGlyph(options: {
+  content: SessionGlyphContent;
+  running: boolean;
+  circular?: boolean;
+  badge?: SessionGlyphContent;
+}): TemplateResult {
+  const { content, running, circular = false, badge = nothing } = options;
+  const modifiers = `${circular ? " session-glyph--circular" : ""}${running ? " session-glyph--running" : ""}`;
+  return html`<span class="session-glyph${modifiers}">
+    <span class="session-glyph__content">${content}</span>
+    ${running
+      ? html`<span
+          class="session-glyph__ring"
+          role="img"
+          aria-label=${t("sessionsView.activeRun")}
+        ></span>`
+      : nothing}
+    ${badge}
+  </span>`;
+}
+
+export function renderSessionUnreadBadge(): TemplateResult {
+  return html`<span
+    class="session-glyph__badge session-glyph__badge--unread"
+    role="img"
+    aria-label=${t("sessionsView.unread")}
+  ></span>`;
+}

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -6,9 +6,35 @@ import {
   renderSessionAttentionIcon,
   renderSessionState,
 } from "./session-attention-presentation.ts";
+import {
+  renderSessionGlyph,
+  renderSessionUnreadBadge,
+  type SessionGlyphContent,
+} from "./session-glyph.ts";
 import { resolveSessionIcon } from "./session-icon-registry.ts";
 import type { SessionPullRequestIndicatorState } from "./session-menu-work.ts";
 import { renderSessionOwnerChip, type SessionCreatedActor } from "./session-owner-chip.ts";
+
+function renderGlyphBadge(
+  session: SidebarRecentSession,
+  pullRequestState: SessionPullRequestIndicatorState,
+): SessionGlyphContent {
+  if (session.unread) {
+    return renderSessionUnreadBadge();
+  }
+  if (pullRequestState === "none") {
+    return nothing;
+  }
+  const label =
+    pullRequestState === "open" ? t("sessionsView.openPullRequest") : t("chat.pullRequests.merged");
+  return html`<span
+    class="session-glyph__badge sidebar-session-pr-indicator--${pullRequestState}"
+    data-session-pr-state=${pullRequestState}
+    role="img"
+    aria-label=${label}
+    title=${label}
+  ></span>`;
+}
 
 export function renderSessionLeadingState(
   session: SidebarRecentSession,
@@ -17,70 +43,45 @@ export function renderSessionLeadingState(
   attribution: "created" | "archived",
 ) {
   const running = session.hasActiveRun || session.status === "running";
-  const sessionState = renderSessionState(session);
-  // Pinned rows keep their custom icon in the fixed leading slot and place
-  // transient run/unread/terminal state at the row edge.
-  const pinnedState =
-    session.pinned && sessionState !== nothing
-      ? html`<span class="nav-item__state">${sessionState}</span>`
-      : nothing;
 
   if (session.attention.kind !== "none") {
     return {
       running,
-      pinnedState,
-      leadingIndicator: renderSessionAttentionIcon(session.attention),
+      leadingIndicator: renderSessionGlyph({
+        content: renderSessionAttentionIcon(session.attention),
+        running,
+        // Attention does not replace unread: a row waiting on the user can also
+        // hold output the user has not seen.
+        badge: renderGlyphBadge(session, pullRequestState),
+      }),
     };
   }
   if (session.pinned) {
     return {
       running,
-      pinnedState,
-      leadingIndicator: html`<span class="sidebar-pinned-session__icon" aria-hidden="true"
-        >${resolveSessionIcon(session.icon)}</span
-      >`,
+      leadingIndicator: renderSessionGlyph({
+        content: html`<span class="sidebar-pinned-session__icon" aria-hidden="true"
+          >${resolveSessionIcon(session.icon)}</span
+        >`,
+        running,
+        badge: renderGlyphBadge(session, pullRequestState),
+      }),
     };
   }
   if (!session.isChild && ownerActor?.id?.trim()) {
-    const label =
-      pullRequestState === "open"
-        ? t("sessionsView.openPullRequest")
-        : t("chat.pullRequests.merged");
     return {
       running,
-      pinnedState,
-      leadingIndicator: html`<span
-        class="sidebar-session-avatar ${running ? "sidebar-session-avatar--running" : ""}"
-      >
-        ${renderSessionOwnerChip(ownerActor, "row", attribution)}
-        ${running
-          ? html`<span
-              class="sidebar-session-avatar__running-ring"
-              role="img"
-              aria-label=${t("sessionsView.activeRun")}
-              title=${t("sessionsView.activeRun")}
-            ></span>`
-          : nothing}
-        ${session.unread
-          ? html`<span
-              class="sidebar-session-avatar__badge sidebar-session-avatar__badge--unread"
-              role="img"
-              aria-label=${t("sessionsView.unread")}
-            ></span>`
-          : pullRequestState !== "none"
-            ? html`<span
-                class="sidebar-session-avatar__badge sidebar-session-pr-indicator--${pullRequestState}"
-                data-session-pr-state=${pullRequestState}
-                role="img"
-                aria-label=${label}
-                title=${label}
-              ></span>`
-            : nothing}
-      </span>`,
+      leadingIndicator: renderSessionGlyph({
+        content: renderSessionOwnerChip(ownerActor, "row", attribution),
+        running,
+        circular: true,
+        badge: renderGlyphBadge(session, pullRequestState),
+      }),
     };
   }
+  // No artwork to ring: the bare spinner already sits in the leading slot.
   if (running) {
-    return { running, pinnedState, leadingIndicator: sessionState };
+    return { running, leadingIndicator: renderSessionState(session) };
   }
   if (pullRequestState !== "none") {
     const label =
@@ -89,7 +90,6 @@ export function renderSessionLeadingState(
         : t("chat.pullRequests.merged");
     return {
       running,
-      pinnedState,
       leadingIndicator: html`<span
         class="sidebar-session-pr-indicator sidebar-session-pr-indicator--${pullRequestState}"
         data-session-pr-state=${pullRequestState}
@@ -100,9 +100,9 @@ export function renderSessionLeadingState(
       >`,
     };
   }
+  const sessionState = renderSessionState(session);
   return {
     running,
-    pinnedState,
     leadingIndicator:
       sessionState !== nothing
         ? sessionState

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -45,7 +45,9 @@ openclaw-session-owner-chip {
   font-size: 10px;
 }
 
-.sidebar-session-avatar {
+/* Leading slot shared by every sidebar row: the row's own artwork plus a run
+   ring and corner badge, so run state always reads at the row's left edge. */
+.session-glyph {
   position: relative;
   display: inline-flex;
   width: 16px;
@@ -53,7 +55,27 @@ openclaw-session-owner-chip {
   flex: 0 0 16px;
 }
 
-.sidebar-session-avatar__running-ring {
+.session-glyph__content {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  transition: transform var(--duration-fast) ease;
+}
+
+/* The ring is a circle, so square artwork (page icons, thumbnails, arbitrary
+   SVGs) must shrink to keep its corners inside it. Circular avatars already
+   fit. A 16px square scaled below 0.75 clears the ring's 17px inner circle. */
+.session-glyph--running .session-glyph__content {
+  transform: scale(0.72);
+}
+
+.session-glyph--circular.session-glyph--running .session-glyph__content {
+  transform: none;
+}
+
+.session-glyph__ring {
   position: absolute;
   inset: -2px;
   box-sizing: border-box;
@@ -63,7 +85,7 @@ openclaw-session-owner-chip {
   pointer-events: none;
 }
 
-.sidebar-session-avatar__badge {
+.session-glyph__badge {
   position: absolute;
   z-index: 1;
   top: -2px;
@@ -75,7 +97,7 @@ openclaw-session-owner-chip {
   box-shadow: 0 0 0 1.5px var(--bg);
 }
 
-.sidebar-session-avatar__badge--unread {
+.session-glyph__badge--unread {
   color: var(--accent);
 }
 
@@ -5698,7 +5720,7 @@ td.data-table-key-col {
 }
 
 .session-run-spinner,
-.sidebar-session-avatar__running-ring {
+.session-glyph__ring {
   animation: session-run-spin 0.8s linear infinite;
 }
 
@@ -5710,7 +5732,7 @@ td.data-table-key-col {
 
 @media (prefers-reduced-motion: reduce) {
   .session-run-spinner,
-  .sidebar-session-avatar__running-ring {
+  .session-glyph__ring {
     animation: none;
     border-color: var(--accent);
   }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3004,7 +3004,8 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   stroke-linejoin: round;
 }
 
-/* Home carries the main session's unread/running state at the row's edge. */
+/* Home carries approval and outbox counts at the row's edge; run/unread state
+   rings the leading icon instead (see .session-glyph). */
 .nav-item__state {
   flex: none;
   margin-left: auto;

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -403,11 +403,16 @@ describe("AppSidebar agent chip", () => {
     expect(sidebar.querySelector(".sidebar-agent-card__subtitle")?.textContent).toContain(
       "Working",
     );
-    const spinner = sidebar.querySelector(".nav-item--home .session-run-spinner");
-    expect(spinner?.hasAttribute("title")).toBe(false);
+    // Run state rings the Home icon in the leading slot; the row edge keeps
+    // only approval/outbox counts.
+    const ring = sidebar.querySelector(
+      ".nav-item--home .session-glyph--running .session-glyph__ring",
+    );
+    expect(ring).not.toBeNull();
+    expect(sidebar.querySelector(".nav-item--home .nav-item__state")).toBeNull();
+    expect(ring?.hasAttribute("title")).toBe(false);
     expect(
-      (spinner?.closest("openclaw-tooltip") as (HTMLElement & { content?: string }) | null)
-        ?.content,
+      (ring?.closest("openclaw-tooltip") as (HTMLElement & { content?: string }) | null)?.content,
     ).toBe("Active run");
   });
 
@@ -539,7 +544,7 @@ describe("AppSidebar agent chip", () => {
     // the global row's unread state.
     expect(sidebar.querySelector('[data-session-key="global"]')).toBeNull();
     expect(sidebar.querySelector('[data-session-key="agent:main:side-quest"]')).not.toBeNull();
-    expect(sidebar.querySelector(".nav-item--home .session-unread-dot")).not.toBeNull();
+    expect(sidebar.querySelector(".nav-item--home .session-glyph__badge--unread")).not.toBeNull();
   });
 
   it("promotes main-session children to top-level threads, including alias parent keys", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -357,12 +357,8 @@ describe("AppSidebar session ownership", () => {
     await sidebar.updateComplete;
 
     const row = sidebar.querySelector(`[data-session-key="${key}"]`);
-    expect(
-      row?.querySelector(".sidebar-session-avatar openclaw-session-owner-chip"),
-    ).not.toBeNull();
-    expect(
-      row?.querySelector('.sidebar-session-avatar__badge[aria-label="Unread"]'),
-    ).not.toBeNull();
+    expect(row?.querySelector(".session-glyph openclaw-session-owner-chip")).not.toBeNull();
+    expect(row?.querySelector('.session-glyph__badge[aria-label="Unread"]')).not.toBeNull();
     expect(row?.querySelector(".sidebar-recent-session__unread")).toBeNull();
     expect(row?.querySelector(".sidebar-session-indicator__dot")).toBeNull();
   });

--- a/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
@@ -156,6 +156,61 @@ describe("AppSidebar interleaved zone", () => {
     expect(iconFor("agent:main:unknown")?.querySelector('path[d^="M21 15"]')).not.toBeNull();
   });
 
+  it("rings a running pinned icon instead of trailing the row", async () => {
+    const keys = ["agent:main:main", "agent:main:page"];
+    const sessions = createSessionsHarness("main", keys);
+    const result = sessions.sessions.state.result;
+    expect(result).not.toBeNull();
+    if (!result) {
+      return;
+    }
+    for (const row of result.sessions) {
+      if (row.key === "agent:main:page") {
+        Object.assign(row, { pinned: true, icon: "🦞", hasActiveRun: true, unread: true });
+      }
+    }
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, sessions.sessions);
+
+    const row = sidebar.querySelector('[data-session-key="agent:main:page"]');
+    const glyph = row?.querySelector(".sidebar-session-indicator .session-glyph--running");
+    expect(glyph?.querySelector(".sidebar-pinned-session__icon")?.textContent).toContain("🦞");
+    expect(glyph?.querySelector(".session-glyph__ring")).not.toBeNull();
+    expect(glyph?.querySelector(".session-glyph__badge--unread")).not.toBeNull();
+    expect(row?.querySelector(".nav-item__state")).toBeNull();
+    expect(row?.querySelector(".sidebar-recent-session__state")).toBeNull();
+  });
+
+  it("keeps unread on a pinned attention row's glyph", async () => {
+    const keys = ["agent:main:main", "agent:main:page"];
+    const sessions = createSessionsHarness("main", keys);
+    const result = sessions.sessions.state.result;
+    expect(result).not.toBeNull();
+    if (!result) {
+      return;
+    }
+    for (const row of result.sessions) {
+      if (row.key === "agent:main:page") {
+        Object.assign(row, {
+          pinned: true,
+          icon: "🦞",
+          unread: true,
+          status: "failed",
+          lastRunError: "boom",
+          updatedAt: 10,
+        });
+      }
+    }
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, sessions.sessions);
+
+    const row = sidebar.querySelector('[data-session-key="agent:main:page"]');
+    const glyph = row?.querySelector(".sidebar-session-indicator .session-glyph");
+    expect(glyph?.querySelector(".sidebar-session-attention__icon")).not.toBeNull();
+    expect(glyph?.querySelector(".session-glyph__badge--unread")).not.toBeNull();
+    expect(row?.querySelector(".nav-item__state")).toBeNull();
+  });
+
   it("keeps many pinned sessions always visible", async () => {
     const keys = [
       "agent:main:pinned-0",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a running page in the sidebar showed its loading indicator at the row's right edge, while a running thread showed it on the left. Home behaved like the pages. The result was that the same "this is running" signal appeared in two different places depending on which section of the sidebar you were looking at, so the eye had no single column to scan.

## Why This Change Was Made

The split was structural, not cosmetic: the leading-slot renderer had a dedicated `pinnedState` branch that pulled run/unread state out of the leading slot and re-emitted it at the row's trailing edge (`nav-item__state`, `margin-left: auto`). Threads with an owner avatar already had the nicer treatment — a spinning ring drawn around the 16px avatar — but that markup was hard-wired to the avatar branch.

This promotes that ring into a shared leading slot (`session-glyph.ts`): row artwork, optional run ring, optional corner badge. Attention icons, page icons, owner avatars, and Home all render through it, and `pinnedState` is deleted, so there is now exactly one place run state can appear.

The one real design problem is that the ring is a circle while page icons are square — named SVGs, emoji, sanitized arbitrary SVGs, thumbnails. Growing the ring to circumscribe a 16px square needs roughly 26px, which overflows the slot into the row text. So the content scales instead while running (`scale(0.72)`, transitioned): an 11.5px square has a half-diagonal of 8.14px, inside the ring's 8.5px inner radius. Circular avatars opt out via `--circular` and render exactly as before.

Unread state on pages moves from the right edge to the same corner badge threads already use. Home's trailing cluster keeps approval and outbox counts, which are counts rather than run state.

## User Impact

The sidebar has one indicator column. A running page, thread, or Home row shows the same spinning ring around its own icon, in the same position, instead of the indicator jumping to the right edge for pages. Nothing is lost: unread state moves to the icon's corner badge, and page icons stay recognizable while running.

## Evidence

Before/after of the sidebar leading slot (rendered from the shipped row markup and CSS, generic labels):

| | before | after |
|---|---|---|
| Home, running | spinner at right edge | ring around the home icon |
| Page, running | spinner right of the badge cluster | ring around the page icon |
| Page, unread | dot at right edge | corner badge on the page icon |
| Thread with avatar | ring around avatar | unchanged |
| Thread, no avatar | spinner in leading slot | unchanged |

Geometry was verified by rendering the running state across emoji, gradient thumbnail, arbitrary square SVG, and circular avatar; no artwork crosses the ring.

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 168/168 green, including two new regression tests: a running pinned page rings its icon and carries no `.nav-item__state`/`.sidebar-recent-session__state`, and a pinned attention row keeps its unread badge on the glyph.
- `node scripts/check-changed.mjs` — exit 0 on Blacksmith Testbox (oxlint core/ui/packages clean, typecheck lanes included).
- Codex autoreview (`gpt-5.6-sol`, xhigh) — clean; its first pass caught that pinned attention rows lost their unread indicator, which is fixed and covered by the second test above.
