### PR TITLE
refactor(channels): finish factory migrations for line/tlon/zalouser

### DIFF
--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -2,6 +2,7 @@
 import type { webhook } from "@line/bot-sdk";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import {
+  buildChannelInboundEventContext,
   formatInboundMediaUnavailableText,
   formatInboundEnvelope,
   formatLocationText,
@@ -17,7 +18,6 @@ import {
   resolveConfiguredBindingRoute,
   resolveRuntimeConversationBindingRoute,
 } from "openclaw/plugin-sdk/conversation-runtime";
-import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute, resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -247,40 +247,6 @@ function extractNativeMediaKind(
 type LineRouteInfo = ReturnType<typeof resolveAgentRoute>;
 type LineSourceInfoWithPeerId = LineSourceInfo & { peerId: string };
 
-function resolveLineConversationLabel(params: {
-  isGroup: boolean;
-  groupId?: string;
-  roomId?: string;
-  senderLabel: string;
-}): string {
-  return params.isGroup
-    ? params.groupId
-      ? `group:${params.groupId}`
-      : params.roomId
-        ? `room:${params.roomId}`
-        : "unknown-group"
-    : params.senderLabel;
-}
-
-function resolveLineAddresses(params: {
-  isGroup: boolean;
-  groupId?: string;
-  roomId?: string;
-  userId?: string;
-  peerId: string;
-}): { fromAddress: string; toAddress: string; originatingTo: string } {
-  const fromAddress = params.isGroup
-    ? params.groupId
-      ? `line:group:${params.groupId}`
-      : params.roomId
-        ? `line:room:${params.roomId}`
-        : `line:${params.peerId}`
-    : `line:${params.userId ?? params.peerId}`;
-  const toAddress = params.isGroup ? fromAddress : `line:${params.userId ?? params.peerId}`;
-  const originatingTo = params.isGroup ? fromAddress : `line:${params.userId ?? params.peerId}`;
-  return { fromAddress, toAddress, originatingTo };
-}
-
 async function finalizeLineInboundContext(params: {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
@@ -297,22 +263,20 @@ async function finalizeLineInboundContext(params: {
   verboseLog: { kind: "inbound" | "postback"; mediaCount?: number };
   inboundHistory?: Pick<HistoryEntry, "sender" | "body" | "timestamp">[];
 }) {
-  const { fromAddress, toAddress, originatingTo } = resolveLineAddresses({
-    isGroup: params.source.isGroup,
-    groupId: params.source.groupId,
-    roomId: params.source.roomId,
-    userId: params.source.userId,
-    peerId: params.source.peerId,
-  });
-
   const senderId = params.source.userId ?? "unknown";
   const senderLabel = params.source.userId ? `user:${params.source.userId}` : "unknown";
-  const conversationLabel = resolveLineConversationLabel({
-    isGroup: params.source.isGroup,
-    groupId: params.source.groupId,
-    roomId: params.source.roomId,
-    senderLabel,
-  });
+  const conversationLabel = params.source.isGroup
+    ? params.source.groupId
+      ? `group:${params.source.groupId}`
+      : params.source.roomId
+        ? `room:${params.source.roomId}`
+        : "unknown-group"
+    : senderLabel;
+  const address = params.source.groupId
+    ? `line:group:${params.source.groupId}`
+    : params.source.roomId
+      ? `line:room:${params.source.roomId}`
+      : `line:${params.source.userId ?? params.source.peerId}`;
 
   const { storePath, envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
     cfg: params.cfg,
@@ -335,40 +299,48 @@ async function finalizeLineInboundContext(params: {
     envelope: envelopeOptions,
   });
 
-  const ctxPayload = finalizeInboundContext({
-    Body: body,
-    BodyForAgent: agentBody,
-    RawBody: params.rawBody,
-    CommandBody: params.rawBody,
-    From: fromAddress,
-    To: toAddress,
-    SessionKey: params.route.sessionKey,
-    DmScope: params.route.dmScope,
-    AccountId: params.route.accountId,
-    ChatType: params.source.isGroup ? "group" : "direct",
-    ConversationLabel: conversationLabel,
-    GroupSubject: params.source.isGroup
-      ? (params.source.groupId ?? params.source.roomId)
-      : undefined,
-    SenderId: senderId,
-    Provider: "line",
-    Surface: "line",
-    MessageSid: params.messageSid,
-    Timestamp: params.timestamp,
+  const ctxPayload = buildChannelInboundEventContext({
+    channel: "line",
+    accountId: params.route.accountId,
+    messageId: params.messageSid,
+    timestamp: params.timestamp,
+    from: address,
+    sender: { id: senderId },
+    conversation: {
+      kind: params.source.isGroup ? "group" : "direct",
+      id: params.source.peerId,
+      label: conversationLabel,
+    },
+    route: {
+      agentId: params.route.agentId,
+      dmScope: params.route.dmScope,
+      accountId: params.route.accountId,
+      routeSessionKey: params.route.sessionKey,
+    },
+    reply: { to: address, originatingTo: address },
+    message: {
+      body,
+      bodyForAgent: agentBody,
+      rawBody: params.rawBody,
+      commandBody: params.rawBody,
+      inboundHistory: params.inboundHistory,
+    },
+    access: { commands: { authorized: params.commandAuthorized } },
     media,
-    ...params.locationContext,
-    CommandAuthorized: params.commandAuthorized,
-    OriginatingChannel: "line" as const,
-    OriginatingTo: originatingTo,
-    GroupSystemPrompt: params.source.isGroup
-      ? normalizeOptionalString(
-          resolveLineGroupConfigEntry(params.account.config.groups, {
-            groupId: params.source.groupId,
-            roomId: params.source.roomId,
-          })?.systemPrompt,
-        )
-      : undefined,
-    InboundHistory: params.inboundHistory,
+    extra: {
+      ...params.locationContext,
+      GroupSubject: params.source.isGroup
+        ? (params.source.groupId ?? params.source.roomId)
+        : undefined,
+      GroupSystemPrompt: params.source.isGroup
+        ? normalizeOptionalString(
+            resolveLineGroupConfigEntry(params.account.config.groups, {
+              groupId: params.source.groupId,
+              roomId: params.source.roomId,
+            })?.systemPrompt,
+          )
+        : undefined,
+    },
   });
 
   const pinnedMainDmOwner = !params.source.isGroup

--- a/extensions/line/src/probe.ts
+++ b/extensions/line/src/probe.ts
@@ -1,7 +1,7 @@
 // Line plugin module implements probe behavior.
 import { messagingApi } from "@line/bot-sdk";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
+import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { LineProbeResult } from "./types.js";
 
 export async function probeLineBot(
@@ -16,20 +16,20 @@ export async function probeLineBot(
     channelAccessToken: channelAccessToken.trim(),
   });
 
-  try {
-    const profile = await withTimeout(client.getBotInfo(), timeoutMs);
-
-    return {
-      ok: true,
-      bot: {
-        displayName: profile.displayName,
-        userId: profile.userId,
-        basicId: profile.basicId,
-        pictureUrl: profile.pictureUrl,
-      },
-    };
-  } catch (err) {
-    const message = formatErrorMessage(err);
-    return { ok: false, error: message };
-  }
+  return await runChannelProbe(
+    timeoutMs,
+    async () => {
+      const profile = await client.getBotInfo();
+      return {
+        ok: true,
+        bot: {
+          displayName: profile.displayName,
+          userId: profile.userId,
+          basicId: profile.basicId,
+          pictureUrl: profile.pictureUrl,
+        },
+      };
+    },
+    (error) => ({ ok: false, error: formatErrorMessage(error) }),
+  );
 }

--- a/extensions/line/src/setup-runtime-api.ts
+++ b/extensions/line/src/setup-runtime-api.ts
@@ -5,6 +5,6 @@ export {
   setSetupChannelEnabled,
   splitSetupEntries,
 } from "openclaw/plugin-sdk/setup";
-export type { ChannelSetupDmPolicy, ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+export type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
 export { listLineAccountIds, normalizeAccountId, resolveLineAccount } from "./accounts.js";
 export type { LineConfig } from "./types.js";

--- a/extensions/line/src/setup-surface.test.ts
+++ b/extensions/line/src/setup-surface.test.ts
@@ -375,9 +375,11 @@ describe("linePlugin status.probeAccount", () => {
       timeoutMs: 50,
     };
 
-    await expect(lineStatusAdapter.probeAccount!(params)).resolves.toEqual(
-      await probeLineBot("token", 50),
-    );
+    const directResult = await probeLineBot("token", 50);
+    await expect(lineStatusAdapter.probeAccount!(params)).resolves.toEqual({
+      ...directResult,
+      elapsedMs: expect.any(Number),
+    });
   });
 });
 

--- a/extensions/line/src/setup-surface.ts
+++ b/extensions/line/src/setup-surface.ts
@@ -1,10 +1,12 @@
 // Line plugin module implements setup surface behavior.
+import { createChannelDmPolicy } from "openclaw/plugin-sdk/channel-dm-policy";
 import {
   createAllowFromSection,
+  createPromptParsedAllowFromForAccount,
   createStandardChannelSetupStatus,
-  defineTokenCredential,
-  mergeAllowFromEntries,
   createSetupTranslator,
+  defineTokenCredential,
+  parseSetupEntriesWithParser,
 } from "openclaw/plugin-sdk/setup";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveDefaultLineAccountId } from "./accounts.js";
@@ -20,7 +22,6 @@ import {
   resolveLineAccount,
   setSetupChannelEnabled,
   splitSetupEntries,
-  type ChannelSetupDmPolicy,
   type ChannelSetupWizard,
 } from "./setup-runtime-api.js";
 
@@ -46,45 +47,44 @@ const LINE_ALLOW_FROM_HELP_LINES = [
   t("wizard.channels.docs", { link: formatDocsLink("/channels/line", "channels/line") }),
 ];
 
-const lineDmPolicy: ChannelSetupDmPolicy = {
-  label: "LINE",
-  channel,
-  policyKey: "channels.line.dmPolicy",
-  allowFromKey: "channels.line.allowFrom",
-  resolveConfigKeys: (cfg, accountId) =>
-    (accountId ?? resolveDefaultLineAccountId(cfg)) !== DEFAULT_ACCOUNT_ID
-      ? {
-          policyKey: `channels.line.accounts.${accountId ?? resolveDefaultLineAccountId(cfg)}.dmPolicy`,
-          allowFromKey: `channels.line.accounts.${accountId ?? resolveDefaultLineAccountId(cfg)}.allowFrom`,
-        }
-      : {
-          policyKey: "channels.line.dmPolicy",
-          allowFromKey: "channels.line.allowFrom",
-        },
-  getCurrent: (cfg, accountId) =>
-    resolveLineAccount({ cfg, accountId: accountId ?? resolveDefaultLineAccountId(cfg) }).config
-      .dmPolicy ?? "pairing",
-  setPolicy: (cfg, policy, accountId) =>
+const promptLineAllowFrom = createPromptParsedAllowFromForAccount({
+  defaultAccountId: resolveDefaultLineAccountId,
+  noteTitle: t("wizard.line.allowlistTitle"),
+  noteLines: LINE_ALLOW_FROM_HELP_LINES,
+  message: t("wizard.line.allowFromPrompt"),
+  placeholder: "U1234567890abcdef1234567890abcdef",
+  parseEntries: (raw) =>
+    parseSetupEntriesWithParser(raw, (entry) => {
+      const id = parseLineAllowFromId(entry);
+      return id ? { value: id } : { error: t("wizard.line.allowFromInvalid") };
+    }),
+  getExistingAllowFrom: ({ cfg, accountId }) =>
+    resolveLineAccount({ cfg, accountId }).config.allowFrom ?? [],
+  applyAllowFrom: ({ cfg, accountId, allowFrom }) =>
     patchLineAccountConfig({
       cfg,
-      accountId: accountId ?? resolveDefaultLineAccountId(cfg),
+      accountId,
       enabled: true,
-      patch:
-        policy === "open"
-          ? {
-              dmPolicy: "open",
-              allowFrom: mergeAllowFromEntries(
-                resolveLineAccount({
-                  cfg,
-                  accountId: accountId ?? resolveDefaultLineAccountId(cfg),
-                }).config.allowFrom,
-                ["*"],
-              ),
-            }
-          : { dmPolicy: policy },
-      clearFields: policy === "pairing" || policy === "disabled" ? ["allowFrom"] : undefined,
+      patch: { allowFrom },
     }),
-};
+});
+
+const lineDmPolicy = createChannelDmPolicy({
+  label: "LINE",
+  channel,
+  resolveAccount: (cfg, accountId) =>
+    resolveLineAccount({ cfg, accountId: accountId ?? resolveDefaultLineAccountId(cfg) }),
+  applyPatch: ({ cfg, account, patch }) =>
+    patchLineAccountConfig({
+      cfg,
+      accountId: account.accountId,
+      enabled: true,
+      patch,
+      clearFields:
+        patch.dmPolicy === "pairing" || patch.dmPolicy === "disabled" ? ["allowFrom"] : undefined,
+    }),
+  promptAllowFrom: promptLineAllowFrom,
+});
 
 export const lineSetupWizard: ChannelSetupWizard = {
   channel,

--- a/extensions/line/src/types.ts
+++ b/extensions/line/src/types.ts
@@ -72,6 +72,7 @@ export interface LineSendResult {
 }
 
 export type LineProbeResult = BaseProbeResult<string> & {
+  elapsedMs?: number;
   bot?: {
     displayName?: string;
     userId?: string;

--- a/extensions/tlon/src/channel.runtime.test.ts
+++ b/extensions/tlon/src/channel.runtime.test.ts
@@ -1,5 +1,5 @@
 // Tlon tests cover channel runtime behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { authenticate } from "./urbit/auth.js";
 import { urbitFetch } from "./urbit/fetch.js";
 
@@ -34,6 +34,10 @@ function responseWithCancelableBody(
 }
 
 describe("probeTlonAccount", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.mocked(authenticate).mockReset();
     vi.mocked(urbitFetch).mockReset();
@@ -58,7 +62,10 @@ describe("probeTlonAccount", () => {
       refreshTimeout: vi.fn(),
     });
 
-    await expect(probeTlonAccount(account)).resolves.toEqual(expected);
+    await expect(probeTlonAccount(account)).resolves.toEqual({
+      ...expected,
+      elapsedMs: expect.any(Number),
+    });
 
     expect(cancelBody).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
@@ -82,9 +89,22 @@ describe("probeTlonAccount", () => {
       refreshTimeout: vi.fn(),
     });
 
-    await expect(probeTlonAccount(account)).resolves.toEqual({ ok: true });
+    await expect(probeTlonAccount(account)).resolves.toEqual({
+      ok: true,
+      elapsedMs: expect.any(Number),
+    });
     expect(cancel).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
     expect(events).toEqual(["cancel", "release"]);
+  });
+
+  it("honors the status adapter timeout", async () => {
+    vi.useFakeTimers();
+    vi.mocked(authenticate).mockReturnValueOnce(new Promise(() => {}));
+
+    const pending = probeTlonAccount(account, 50);
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(pending).resolves.toEqual({ ok: false, error: "timeout", elapsedMs: 50 });
   });
 });

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { monitorTlonProvider } from "./monitor/index.js";
 import { tlonSetupWizard } from "./setup-surface.js";
 import {
@@ -210,39 +211,44 @@ export const tlonRuntimeOutbound: ChannelOutboundAdapter = {
   },
 };
 
-export async function probeTlonAccount(account: ConfiguredTlonAccount) {
-  try {
-    const ssrfPolicy = ssrfPolicyFromDangerouslyAllowPrivateNetwork(
-      account.dangerouslyAllowPrivateNetwork,
-    );
-    const cookie = await authenticate(account.url, account.code, { ssrfPolicy });
-    const { response, release } = await urbitFetch({
-      baseUrl: account.url,
-      path: "/~/name",
-      init: {
-        method: "GET",
-        headers: { Cookie: cookie },
-      },
-      ssrfPolicy,
-      timeoutMs: 30_000,
-      auditContext: "tlon-probe-account",
-    });
-    try {
-      if (!response.ok) {
-        return { ok: false, error: `Name request failed: ${response.status}` };
+export async function probeTlonAccount(account: ConfiguredTlonAccount, timeoutMs?: number) {
+  return await runChannelProbe(
+    timeoutMs,
+    async () => {
+      const ssrfPolicy = ssrfPolicyFromDangerouslyAllowPrivateNetwork(
+        account.dangerouslyAllowPrivateNetwork,
+      );
+      const cookie = await authenticate(account.url, account.code, { ssrfPolicy });
+      const { response, release } = await urbitFetch({
+        baseUrl: account.url,
+        path: "/~/name",
+        init: {
+          method: "GET",
+          headers: { Cookie: cookie },
+        },
+        ssrfPolicy,
+        timeoutMs: 30_000,
+        auditContext: "tlon-probe-account",
+      });
+      try {
+        if (!response.ok) {
+          return { ok: false, error: `Name request failed: ${response.status}` };
+        }
+        return { ok: true };
+      } finally {
+        // Guard release does not settle unread response streams; cancel first so
+        // the probe cannot leave its pinned connection open.
+        if (!response.bodyUsed) {
+          await response.body?.cancel().catch(() => undefined);
+        }
+        await release();
       }
-      return { ok: true };
-    } finally {
-      // Guard release does not settle unread response streams; cancel first so
-      // the probe cannot leave its pinned connection open.
-      if (!response.bodyUsed) {
-        await response.body?.cancel().catch(() => undefined);
-      }
-      await release();
-    }
-  } catch (error) {
-    return { ok: false, error: (error as { message?: string })?.message ?? String(error) };
-  }
+    },
+    (error) => ({
+      ok: false,
+      error: (error as { message?: string })?.message ?? String(error),
+    }),
+  );
 }
 
 export async function startTlonGatewayAccount(

--- a/extensions/tlon/src/channel.ts
+++ b/extensions/tlon/src/channel.ts
@@ -170,11 +170,11 @@ export const tlonPlugin = createChatChannelPlugin({
           url: s.url ?? null,
         };
       },
-      probeAccount: async ({ account }) => {
+      probeAccount: async ({ account, timeoutMs }) => {
         if (!account.configured || !account.ship || !account.url || !account.code) {
           return { ok: false, error: "Not configured" };
         }
-        return await (await loadTlonChannelRuntime()).probeTlonAccount(account as never);
+        return await (await loadTlonChannelRuntime()).probeTlonAccount(account as never, timeoutMs);
       },
       resolveAccountSnapshot: ({ account }) => ({
         accountId: account.accountId,

--- a/extensions/zalouser/src/probe.test.ts
+++ b/extensions/zalouser/src/probe.test.ts
@@ -28,6 +28,7 @@ describe("probeZalouser", () => {
     await expect(probeZalouser("default")).resolves.toEqual({
       ok: true,
       user: { userId: "123", displayName: "Alice" },
+      elapsedMs: expect.any(Number),
     });
   });
 
@@ -36,6 +37,7 @@ describe("probeZalouser", () => {
     await expect(probeZalouser("default")).resolves.toEqual({
       ok: false,
       error: "Not authenticated",
+      elapsedMs: expect.any(Number),
     });
   });
 
@@ -44,6 +46,7 @@ describe("probeZalouser", () => {
     await expect(probeZalouser("default")).resolves.toEqual({
       ok: false,
       error: "network down",
+      elapsedMs: expect.any(Number),
     });
   });
 
@@ -57,6 +60,7 @@ describe("probeZalouser", () => {
     await expect(pending).resolves.toEqual({
       ok: false,
       error: "Not authenticated",
+      elapsedMs: expect.any(Number),
     });
   });
 
@@ -71,6 +75,7 @@ describe("probeZalouser", () => {
     await expect(probeZalouser("default", 10)).resolves.toEqual({
       ok: true,
       user: { userId: "123", displayName: "Alice" },
+      elapsedMs: expect.any(Number),
     });
 
     expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);

--- a/extensions/zalouser/src/probe.ts
+++ b/extensions/zalouser/src/probe.ts
@@ -2,46 +2,29 @@
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ZcaUserInfo } from "./types.js";
 import { getZaloUserInfo } from "./zalo-js.js";
 
 export type ZalouserProbeResult = BaseProbeResult<string> & {
   user?: ZcaUserInfo;
+  elapsedMs?: number;
 };
 
 export async function probeZalouser(
   profile: string,
   timeoutMs?: number,
 ): Promise<ZalouserProbeResult> {
-  try {
-    let user: ZcaUserInfo | null;
-    if (timeoutMs) {
-      let timeout: ReturnType<typeof setTimeout> | undefined;
+  return await runChannelProbe(
+    timeoutMs ? resolveTimerTimeoutMs(timeoutMs, 1000, 1000) : undefined,
+    async () => {
       try {
-        user = await Promise.race([
-          getZaloUserInfo(profile),
-          new Promise<null>((resolve) => {
-            timeout = setTimeout(() => resolve(null), resolveTimerTimeoutMs(timeoutMs, 1000, 1000));
-          }),
-        ]);
-      } finally {
-        if (timeout) {
-          clearTimeout(timeout);
-        }
+        const user = await getZaloUserInfo(profile);
+        return user ? { ok: true, user } : { ok: false, error: "Not authenticated" };
+      } catch (error) {
+        return { ok: false, error: formatErrorMessage(error) };
       }
-    } else {
-      user = await getZaloUserInfo(profile);
-    }
-
-    if (!user) {
-      return { ok: false, error: "Not authenticated" };
-    }
-
-    return { ok: true, user };
-  } catch (error) {
-    return {
-      ok: false,
-      error: formatErrorMessage(error),
-    };
-  }
+    },
+    () => ({ ok: false, error: "Not authenticated" }),
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

LINE, Tlon, and Zalo Personal still carried plugin-local DM-policy, probe, and inbound-context scaffolding after the shared channel factories were available. Tlon's probe also ignored the adapter-provided timeout and could wait for the wrong duration.

## Why This Change Was Made

This finishes those migrations onto the canonical DM-policy factory, channel probe runner, and inbound context builder. Zalo retains its exact `Not authenticated` result, while Tlon now passes `timeoutMs` through the shared probe contract.

## User Impact

Most of the change is behavior-neutral consolidation. Tlon operators now get probe timeout behavior that honors the adapter's configured/requested `timeoutMs` instead of the previous fixed behavior.

Release-note context: Tlon channel probes now honor the adapter-provided timeout while LINE and Zalo Personal move to the shared channel lifecycle factories without intended behavior changes.

## Evidence

- Focused channel proof passed: 43 tests.
- `node scripts/check-changed.mjs` passed on Testbox.
- The Tlon timeout propagation has focused regression coverage.
- Final branch autoreview reported no accepted or actionable findings.
- `git diff --check` is clean at `ef553dbb177bcbd94956c94c055e98f215e6715b`.

