### PR TITLE
refactor(ui): mechanical dedup batch

### DIFF
--- a/ui/src/components/lobster-pet-contract.ts
+++ b/ui/src/components/lobster-pet-contract.ts
@@ -76,21 +76,12 @@ export type LobsterPetLook = {
   glint: string | null;
 };
 
-function fnv1a(value: string): number {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < value.length; i++) {
-    hash ^= value.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return hash >>> 0;
-}
-
 // One salt per page load: revisiting the UI re-rolls every session's lobster,
 // while re-renders within a load stay stable for a given session key.
 const LOAD_SALT = Math.trunc(Math.random() * 0xffffffff);
 
 export function lobsterPetSeed(sessionKey: string): number {
-  return (fnv1a(sessionKey) ^ LOAD_SALT) >>> 0;
+  return (fnv1aUtf16(sessionKey) ^ LOAD_SALT) >>> 0;
 }
 
 // The most recently active session with a terminal status decides how the
@@ -136,3 +127,4 @@ export function resolveLobsterPetMode(
   }
   return sessions?.some((row) => row.hasActiveRun === true) ? "busy" : "idle";
 }
+import { fnv1aUtf16 } from "../lib/fnv1a.ts";

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -208,15 +208,16 @@ export function renderSettingsToggleRow(props: {
 
 export function renderSettingsSegmented<T extends string>(props: {
   value: T;
-  options: ReadonlyArray<{ value: T; label: unknown; title?: string }>;
+  options: ReadonlyArray<{ value: T; label: unknown; title?: string; testId?: string }>;
   /** The selected radio is passed so callers can anchor visual transitions. */
   onChange: (value: T, element: HTMLElement) => void;
   disabled?: boolean;
   ariaLabel?: string;
+  className?: string;
 }): TemplateResult {
   return html`
     <wa-radio-group
-      class="settings-segmented"
+      class="settings-segmented ${props.className ?? ""}"
       size="s"
       orientation="horizontal"
       .value=${props.value}
@@ -245,6 +246,7 @@ export function renderSettingsSegmented<T extends string>(props: {
             value=${option.value}
             .checked=${option.value === props.value}
             title=${option.title ?? nothing}
+            data-test-id=${option.testId ?? nothing}
           >
             ${option.label}
           </wa-radio>

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -72,7 +72,7 @@ export interface SidebarMenusControllerHost
   ) => void;
   readonly onPairMobile?: () => void;
   readonly onRetryConnect?: () => void;
-  readonly onUpdateSidebarEntries?: (entries: readonly string[]) => void;
+  readonly onUpdateSidebarEntries?: (entries: string[]) => void;
   readonly onPreloadRoute?: (routeId: NavigationRouteId) => Promise<void>;
   readonly pinnedAgentIds: readonly string[];
   readonly selectedSessionKeys: ReadonlySet<string>;

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -56,7 +56,7 @@ type SidebarMenusRenderer = {
   renderSidebarSessionSortMenuForController(controller: SidebarMenusController): unknown;
 };
 
-interface SidebarMenusControllerHost
+export interface SidebarMenusControllerHost
   extends ReactiveControllerHost, SessionOrganizerControllerHost {
   readonly activeRouteId?: NavigationRouteId;
   readonly activeWorkboardBoardId: string;
@@ -72,6 +72,7 @@ interface SidebarMenusControllerHost
   ) => void;
   readonly onPairMobile?: () => void;
   readonly onRetryConnect?: () => void;
+  readonly onUpdateSidebarEntries?: (entries: readonly string[]) => void;
   readonly onPreloadRoute?: (routeId: NavigationRouteId) => Promise<void>;
   readonly pinnedAgentIds: readonly string[];
   readonly selectedSessionKeys: ReadonlySet<string>;

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -1,14 +1,6 @@
-import { html, nothing, type ReactiveControllerHost } from "lit";
+import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
-import {
-  DEFAULT_SIDEBAR_ENTRIES,
-  serializeSidebarEntry,
-  type NavigationRouteId,
-  type SidebarZoneEntry,
-} from "../app-navigation.ts";
-import type { RouteId } from "../app-route-paths.ts";
-import type { ApplicationContext, ApplicationNavigationOptions } from "../app/context.ts";
-import type { ThemeMode } from "../app/theme.ts";
+import { DEFAULT_SIDEBAR_ENTRIES, serializeSidebarEntry } from "../app-navigation.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../app/user-profile.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
 import { openEditor } from "../lib/editor-links.ts";
@@ -25,105 +17,13 @@ import {
   renderSidebarSessionGroupMenu,
   renderSidebarSessionSortMenu,
 } from "./app-sidebar-session-menu-renderers.ts";
+import type { SessionMenuAction } from "./session-menu.ts";
 import type {
-  SidebarRecentSession,
-  SidebarSessionGroupMenuState,
-  SidebarSessionMenuState,
-  SidebarSessionSortMode,
-} from "./app-sidebar-session-types.ts";
-import type { SidebarWorkboardBoard, SidebarWorkboardRenderers } from "./app-sidebar-workboard.ts";
-import type { SessionDataController } from "./session-data-controller.ts";
-import type { SessionMenuAction, SessionMenuWork } from "./session-menu.ts";
-import type { SessionOrganizerController } from "./session-organizer-controller.ts";
-import type { SessionOrganizerControllerHost } from "./session-organizer-operations.runtime.ts";
-import type { SessionCreatorOption } from "./session-owner-chip.ts";
+  SidebarMenusController,
+  SidebarMenusControllerHost,
+} from "./sidebar-menus-controller.ts";
 
-type SidebarMenuAgent = {
-  id: string;
-  name?: string;
-  identity?: { name?: string; emoji?: string; avatar?: string; avatarUrl?: string };
-};
-
-interface SidebarMenusRenderHost extends ReactiveControllerHost, SessionOrganizerControllerHost {
-  readonly activeRouteId?: NavigationRouteId;
-  readonly activeWorkboardBoardId: string;
-  readonly basePath: string;
-  readonly canPairDevice: boolean;
-  readonly connected: boolean;
-  readonly offline: boolean;
-  readonly gatewayVersion: string | null;
-  readonly onNavigate?: (
-    routeId: NavigationRouteId,
-    options?: ApplicationNavigationOptions,
-  ) => void;
-  readonly onPairMobile?: () => void;
-  readonly onRetryConnect?: () => void;
-  readonly pinnedAgentIds: readonly string[];
-  readonly sessionData: SessionOrganizerControllerHost["sessionData"] &
-    Pick<
-      SessionDataController,
-      "approvalBadgeSnapshot" | "presenceInstanceId" | "presencePayload" | "sessionsLoading"
-    >;
-  readonly sessionDataContext: ApplicationContext<RouteId> | undefined;
-  readonly sessionOrganizer: SessionOrganizerController;
-  readonly sessionCreatorFilterActive: boolean;
-  sessionCreatorFilterId: string | null;
-  readonly sessionCreatorOptions: readonly SessionCreatorOption[];
-  readonly sessionOwnershipVisible: boolean;
-  readonly sidebarEntries: readonly string[];
-  sessionSortMode: SidebarSessionSortMode;
-  readonly themeMode: ThemeMode;
-  readonly workboardBoards: readonly SidebarWorkboardBoard[];
-  readonly workboardRenderers?: SidebarWorkboardRenderers;
-  activeChipAgent(): {
-    activeId: string;
-    agent: SidebarMenuAgent | undefined;
-    agents: readonly SidebarMenuAgent[];
-  };
-  agentUnreadCount(agentId: string): number;
-  askAgentCapabilities(agentId: string): void;
-  onUpdateSidebarEntries?(entries: readonly string[]): void;
-  reconciledSidebarZone(): {
-    entries: readonly SidebarZoneEntry[];
-    sidebarEntries: readonly string[];
-  };
-  selectedVisibleSessions(): SidebarRecentSession[];
-  switchChipAgent(agentId: string): void;
-}
-
-interface SidebarMenusRenderController {
-  readonly host: SidebarMenusRenderHost;
-  readonly agentMenuFilter: string;
-  readonly agentMenuPosition: { x: number; bottom: number } | null;
-  readonly agentMenuTrigger: HTMLElement | null;
-  readonly customizeMenuPosition: { x: number; y: number } | null;
-  readonly customizeMenuTrigger: HTMLElement | null;
-  readonly identityMenuPosition: { x: number; bottom: number; width: number } | null;
-  readonly identityMenuTrigger: HTMLElement | null;
-  readonly moreMenuPosition: { x: number; y: number } | null;
-  readonly moreMenuTrigger: HTMLElement | null;
-  readonly sessionGroupMenu: SidebarSessionGroupMenuState | null;
-  readonly sessionGroupMenuTrigger: HTMLElement | null;
-  readonly sessionMenu: SidebarSessionMenuState | null;
-  readonly sessionMenuTrigger: HTMLElement | null;
-  readonly sessionMenuWork: SessionMenuWork | null;
-  readonly sessionSortMenuPosition: { x: number; y: number } | null;
-  readonly sessionSortMenuTrigger: HTMLElement | null;
-  cancelPreload(event: Event): void;
-  closeAgentMenu(options?: { restoreFocus?: boolean }): void;
-  closeCustomizeMenu(options?: { restoreFocus?: boolean }): void;
-  closeIdentityMenu(options?: { restoreFocus?: boolean }): void;
-  closeMoreMenu(options?: { restoreFocus?: boolean }): void;
-  closeSessionGroupMenu(options?: { restoreFocus?: boolean }): void;
-  closeSessionMenu(): void;
-  closeSessionSortMenu(options?: { restoreFocus?: boolean }): void;
-  isRouteEnabled(routeId: NavigationRouteId): boolean;
-  openCustomizeMenu(x: number, y: number, trigger?: HTMLElement | null): void;
-  preloadRoute(routeId: NavigationRouteId, event: Event, immediate?: boolean): void;
-  setAgentMenuFilter(next: string): void;
-}
-
-export function renderSidebarCustomizeMenuForController(controller: SidebarMenusRenderController) {
+export function renderSidebarCustomizeMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.customizeMenuPosition;
   const trigger = controller.customizeMenuTrigger;
@@ -168,7 +68,7 @@ export function renderSidebarCustomizeMenuForController(controller: SidebarMenus
   });
 }
 
-export function renderSidebarAgentMenuForController(controller: SidebarMenusRenderController) {
+export function renderSidebarAgentMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.agentMenuPosition;
   const trigger = controller.agentMenuTrigger;
@@ -198,7 +98,7 @@ export function renderSidebarAgentMenuForController(controller: SidebarMenusRend
   });
 }
 
-export function renderSidebarIdentityMenuForController(controller: SidebarMenusRenderController) {
+export function renderSidebarIdentityMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.identityMenuPosition;
   const trigger = controller.identityMenuTrigger;
@@ -230,7 +130,7 @@ export function renderSidebarIdentityMenuForController(controller: SidebarMenusR
   });
 }
 
-export function renderSidebarSessionMenuForController(controller: SidebarMenusRenderController) {
+export function renderSidebarSessionMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const menu = controller.sessionMenu;
   if (!menu) {
@@ -347,9 +247,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusRe
   );
 }
 
-export function renderSidebarSessionGroupMenuForController(
-  controller: SidebarMenusRenderController,
-) {
+export function renderSidebarSessionGroupMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const menu = controller.sessionGroupMenu;
   return renderSidebarSessionGroupMenu({
@@ -379,9 +277,7 @@ export function renderSidebarSessionGroupMenuForController(
   });
 }
 
-export function renderSidebarSessionSortMenuForController(
-  controller: SidebarMenusRenderController,
-) {
+export function renderSidebarSessionSortMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.sessionSortMenuPosition;
   return renderSidebarSessionSortMenu({
@@ -423,7 +319,7 @@ export function renderSidebarSessionSortMenuForController(
   });
 }
 
-export function renderSidebarMoreMenuForController(controller: SidebarMenusRenderController) {
+export function renderSidebarMoreMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.moreMenuPosition;
   const trigger = controller.moreMenuTrigger;
@@ -457,7 +353,7 @@ export function renderSidebarMoreMenuForController(controller: SidebarMenusRende
   });
 }
 
-function activeWorkboardBoardIsPinned(host: SidebarMenusRenderHost): boolean {
+function activeWorkboardBoardIsPinned(host: SidebarMenusControllerHost): boolean {
   return Boolean(
     host.activeWorkboardBoardId &&
     host

--- a/ui/src/components/terminal/terminal-panel-styles.ts
+++ b/ui/src/components/terminal/terminal-panel-styles.ts
@@ -208,13 +208,9 @@ export const terminalPanelStyles = css`
     border-radius: 50%;
     animation: tp-spin 0.8s linear infinite;
   }
-  .tp-empty,
   .tp-error {
     padding: 10px 12px;
     font-size: 12px;
-    color: var(--muted, #8a919e);
-  }
-  .tp-error {
     color: var(--danger, #ff6b6b);
   }
   @keyframes tp-spin {

--- a/ui/src/components/working-phrase.ts
+++ b/ui/src/components/working-phrase.ts
@@ -5,6 +5,7 @@
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
+import { fnv1aUtf16 } from "../lib/fnv1a.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { PollController } from "../lit/poll-controller.ts";
 
@@ -36,16 +37,6 @@ const WORKING_PHRASE_SHOW_AFTER_MS = 30_000;
 /** How long each phrase holds before rotating to the next. */
 const WORKING_PHRASE_ROTATE_EVERY_MS = 45_000;
 
-// FNV-1a, matching the stance picker: deterministic per seed.
-function fnvHash(key: string): number {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < key.length; i++) {
-    hash ^= key.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return hash >>> 0;
-}
-
 /** Constant-time stride walk over the phrase list: any stride in
  * [1, len-1] guarantees adjacent buckets differ, and with a prime-length
  * list (currently 19) every stride cycles through all phrases before
@@ -53,8 +44,8 @@ function fnvHash(key: string): number {
  * arbitrarily old timestamp, and this runs on a one-second poll. */
 function displayedPhraseIndex(seed: string, bucket: number): number {
   const length = PHRASE_KEYS.length;
-  const offset = fnvHash(`${seed}:offset`) % length;
-  const stride = 1 + (fnvHash(`${seed}:stride`) % (length - 1));
+  const offset = fnv1aUtf16(`${seed}:offset`) % length;
+  const stride = 1 + (fnv1aUtf16(`${seed}:stride`) % (length - 1));
   return (offset + bucket * stride) % length;
 }
 

--- a/ui/src/lib/fnv1a.ts
+++ b/ui/src/lib/fnv1a.ts
@@ -1,0 +1,9 @@
+/** FNV-1a over JavaScript UTF-16 code units. */
+export function fnv1aUtf16(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}

--- a/ui/src/lib/identity-avatar.ts
+++ b/ui/src/lib/identity-avatar.ts
@@ -1,4 +1,5 @@
 import { formatSenderLabel, type SenderIdentity } from "./chat/sender-label.ts";
+import { fnv1aUtf16 } from "./fnv1a.ts";
 
 // NOTE: this is sender-controlled metadata. It must never carry the trusted
 // gateway origin — that comes only from the app connection via
@@ -70,15 +71,6 @@ function initialsFromLabel(label: string): string {
   return initials.toUpperCase() || "?";
 }
 
-function stableColorSeed(value: string): number {
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return hash >>> 0;
-}
-
 export function resolveAvatarInitials(
   input: IdentityAvatarInput,
 ): Extract<ResolvedIdentityAvatar, { kind: "initials" }> {
@@ -87,7 +79,7 @@ export function resolveAvatarInitials(
   return {
     kind: "initials",
     initials: initialsFromLabel(label),
-    colorSeed: stableColorSeed(id || label),
+    colorSeed: fnv1aUtf16(id || label),
   };
 }
 

--- a/ui/src/lib/workboard/index.ts
+++ b/ui/src/lib/workboard/index.ts
@@ -23,7 +23,7 @@ export {
   workboardCardMatchesHealthKey,
 } from "./derived.ts";
 export { captureSessionToWorkboard } from "./session-capture.ts";
-export { getWorkboardDependencyState } from "./card-state.ts";
+export { getWorkboardDependencyState, resetDraftState } from "./card-state.ts";
 export { loadWorkboard, refreshWorkboard } from "./loading.ts";
 export {
   configureWorkboardLiveRefresh,

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -37,6 +37,7 @@ import {
   extractToolPreview,
   isToolCardError,
 } from "../../lib/chat/tool-cards.ts";
+import { fnv1aUtf16 } from "../../lib/fnv1a.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import {
@@ -956,12 +957,7 @@ function messageProjectionDigest(message: unknown): string {
     typeof record?.toolCallId === "string" ? record.toolCallId : "",
     record ? extractTextCached(message) : "",
   ].join("\u0000");
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < source.length; index += 1) {
-    hash ^= source.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  const digest = `p${(hash >>> 0).toString(36)}${source.length.toString(36)}`;
+  const digest = `p${fnv1aUtf16(source).toString(36)}${source.length.toString(36)}`;
   if (message && typeof message === "object") {
     messageProjectionDigests.set(message, digest);
   }

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -41,11 +41,52 @@ import {
   markComposerInputIntent,
   suppressStaleSubmittedDraftReplay,
 } from "./chat-composer-state.ts";
-import type { ChatComposerProps } from "./chat-composer-types.ts";
+import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
 import { renderChatComposerView } from "./chat-composer-view.ts";
 import { createGatewayQuestionPanelProps } from "./chat-question-card.ts";
 
 export { isChatRunWorking, resetChatComposerState } from "./chat-composer-state.ts";
+
+function handleSlashMenuKeyDown<T>(
+  event: KeyboardEvent,
+  state: ChatComposerState,
+  items: readonly T[],
+  paneId: string,
+  requestUpdate: () => void,
+  onSelect: (item: T, submit: boolean) => void,
+): boolean {
+  switch (event.key) {
+    case "ArrowDown":
+      event.preventDefault();
+      state.slashMenuIndex = (state.slashMenuIndex + 1) % items.length;
+      requestUpdate();
+      scrollActiveSlashMenuOptionIntoView(state, paneId);
+      return true;
+    case "ArrowUp":
+      event.preventDefault();
+      state.slashMenuIndex = (state.slashMenuIndex - 1 + items.length) % items.length;
+      requestUpdate();
+      scrollActiveSlashMenuOptionIntoView(state, paneId);
+      return true;
+    case "Tab":
+    case "Enter": {
+      event.preventDefault();
+      const item = items[state.slashMenuIndex];
+      if (item !== undefined) {
+        onSelect(item, event.key === "Enter");
+      }
+      return true;
+    }
+    case "Escape":
+      event.preventDefault();
+      state.slashMenuOpen = false;
+      resetSlashMenuState(state);
+      requestUpdate();
+      return true;
+    default:
+      return false;
+  }
+}
 
 export function renderChatComposer(props: ChatComposerProps) {
   const state = getChatComposerState(props.paneId);
@@ -249,86 +290,35 @@ export function renderChatComposer(props: ChatComposerProps) {
       state.slashMenuMode === "args" &&
       state.slashMenuArgItems.length > 0
     ) {
-      const len = state.slashMenuArgItems.length;
-      switch (event.key) {
-        case "ArrowDown":
-          event.preventDefault();
-          state.slashMenuIndex = (state.slashMenuIndex + 1) % len;
-          requestUpdate();
-          scrollActiveSlashMenuOptionIntoView(state, props.paneId);
-          return;
-        case "ArrowUp":
-          event.preventDefault();
-          state.slashMenuIndex = (state.slashMenuIndex - 1 + len) % len;
-          requestUpdate();
-          scrollActiveSlashMenuOptionIntoView(state, props.paneId);
-          return;
-        case "Tab":
-          event.preventDefault();
-          {
-            const arg = state.slashMenuArgItems[state.slashMenuIndex];
-            if (arg !== undefined) {
-              selectSlashArg(arg, props, requestUpdate, false);
-            }
-          }
-          return;
-        case "Enter":
-          event.preventDefault();
-          {
-            const arg = state.slashMenuArgItems[state.slashMenuIndex];
-            if (arg !== undefined) {
-              selectSlashArg(arg, props, requestUpdate, true);
-            }
-          }
-          return;
-        case "Escape":
-          event.preventDefault();
-          state.slashMenuOpen = false;
-          resetSlashMenuState(state);
-          requestUpdate();
-          return;
+      if (
+        handleSlashMenuKeyDown(
+          event,
+          state,
+          state.slashMenuArgItems,
+          props.paneId,
+          requestUpdate,
+          (arg, submit) => selectSlashArg(arg, props, requestUpdate, submit),
+        )
+      ) {
+        return;
       }
     }
 
     if (props.connected && state.slashMenuOpen && state.slashMenuItems.length > 0) {
-      const len = state.slashMenuItems.length;
-      switch (event.key) {
-        case "ArrowDown":
-          event.preventDefault();
-          state.slashMenuIndex = (state.slashMenuIndex + 1) % len;
-          requestUpdate();
-          scrollActiveSlashMenuOptionIntoView(state, props.paneId);
-          return;
-        case "ArrowUp":
-          event.preventDefault();
-          state.slashMenuIndex = (state.slashMenuIndex - 1 + len) % len;
-          requestUpdate();
-          scrollActiveSlashMenuOptionIntoView(state, props.paneId);
-          return;
-        case "Tab":
-          event.preventDefault();
-          {
-            const command = state.slashMenuItems[state.slashMenuIndex];
-            if (command) {
-              tabCompleteSlashCommand(command, props, requestUpdate);
-            }
-          }
-          return;
-        case "Enter":
-          event.preventDefault();
-          {
-            const command = state.slashMenuItems[state.slashMenuIndex];
-            if (command) {
-              selectSlashCommand(command, props, requestUpdate);
-            }
-          }
-          return;
-        case "Escape":
-          event.preventDefault();
-          state.slashMenuOpen = false;
-          resetSlashMenuState(state);
-          requestUpdate();
-          return;
+      if (
+        handleSlashMenuKeyDown(
+          event,
+          state,
+          state.slashMenuItems,
+          props.paneId,
+          requestUpdate,
+          (command, submit) =>
+            submit
+              ? selectSlashCommand(command, props, requestUpdate)
+              : tabCompleteSlashCommand(command, props, requestUpdate),
+        )
+      ) {
+        return;
       }
     }
 

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -38,6 +38,7 @@ import {
 } from "../../../lib/chat/side-question.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
+import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import {
   areUiSessionKeysEquivalent,
   isUiGlobalScopeConfigured,
@@ -751,12 +752,7 @@ function removeReplyContextMenu(paneId?: string) {
 
 function stableReplyMessageId(senderLabel: string | undefined, text: string): string {
   const source = `${senderLabel ?? ""}\n${text}`;
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < source.length; index += 1) {
-    hash ^= source.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return `reply:${(hash >>> 0).toString(16)}`;
+  return `reply:${fnv1aUtf16(source).toString(16)}`;
 }
 
 function createReplyContextMenuButton(onClick: () => void): HTMLButtonElement {

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -4,6 +4,7 @@ import { icons } from "../../../components/icons.ts";
 import "../../../components/working-phrase.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
+import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import { formatCompactTokenCount, formatDurationCompact } from "../../../lib/format.ts";
 import type { TurnRecap } from "../chat-progress.ts";
 import type { ChatRunStartupPhase } from "../chat-run-startup.ts";
@@ -46,13 +47,8 @@ function renderLiveOutputTokens(outputTokens: number | null | undefined) {
 }
 
 function stanceClass(key: string): string {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < key.length; i++) {
-    hash ^= key.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
   const total = STANCES.reduce((sum, [, weight]) => sum + weight, 0);
-  let roll = ((((hash ^ STANCE_SALT) >>> 0) % 1000) / 1000) * total;
+  let roll = ((((fnv1aUtf16(key) ^ STANCE_SALT) >>> 0) % 1000) / 1000) * total;
   for (const [stance, weight] of STANCES) {
     roll -= weight;
     if (roll <= 0) {

--- a/ui/src/pages/chat/deleted-messages.ts
+++ b/ui/src/pages/chat/deleted-messages.ts
@@ -1,56 +1,18 @@
 // Control UI chat module implements deleted messages behavior.
-import { getSafeLocalStorage } from "../../local-storage.ts";
+import { PersistedSet } from "./persisted-set.ts";
 
 const PREFIX = "openclaw:deleted:";
 
-export class DeletedMessages {
-  private key: string;
-  private keys = new Set<string>();
-
+export class DeletedMessages extends PersistedSet<string> {
   constructor(sessionKey: string) {
-    this.key = PREFIX + sessionKey;
-    this.load();
-  }
-
-  has(key: string): boolean {
-    return this.keys.has(key);
+    super(PREFIX + sessionKey, (value): value is string => typeof value === "string");
   }
 
   delete(key: string): void {
-    this.keys.add(key);
-    this.save();
+    this.add(key);
   }
 
   restore(key: string): void {
-    this.keys.delete(key);
-    this.save();
-  }
-
-  clear(): void {
-    this.keys.clear();
-    this.save();
-  }
-
-  private load(): void {
-    try {
-      const raw = getSafeLocalStorage()?.getItem(this.key);
-      if (!raw) {
-        return;
-      }
-      const arr = JSON.parse(raw);
-      if (Array.isArray(arr)) {
-        this.keys = new Set(arr.filter((s) => typeof s === "string"));
-      }
-    } catch {
-      // ignore
-    }
-  }
-
-  private save(): void {
-    try {
-      getSafeLocalStorage()?.setItem(this.key, JSON.stringify([...this.keys]));
-    } catch {
-      // ignore
-    }
+    this.remove(key);
   }
 }

--- a/ui/src/pages/chat/persisted-set.ts
+++ b/ui/src/pages/chat/persisted-set.ts
@@ -1,0 +1,46 @@
+import { getSafeLocalStorage } from "../../local-storage.ts";
+
+export class PersistedSet<T> {
+  protected values = new Set<T>();
+
+  constructor(
+    private readonly key: string,
+    isValue: (value: unknown) => value is T,
+  ) {
+    try {
+      const parsed: unknown = JSON.parse(getSafeLocalStorage()?.getItem(key) ?? "");
+      if (Array.isArray(parsed)) {
+        this.values = new Set(parsed.filter(isValue));
+      }
+    } catch {
+      // Storage is optional and corrupt entries are ignored.
+    }
+  }
+
+  has(value: T): boolean {
+    return this.values.has(value);
+  }
+
+  protected add(value: T): void {
+    this.values.add(value);
+    this.save();
+  }
+
+  protected remove(value: T): void {
+    this.values.delete(value);
+    this.save();
+  }
+
+  clear(): void {
+    this.values.clear();
+    this.save();
+  }
+
+  private save(): void {
+    try {
+      getSafeLocalStorage()?.setItem(this.key, JSON.stringify([...this.values]));
+    } catch {
+      // Storage is optional.
+    }
+  }
+}

--- a/ui/src/pages/chat/pinned-messages.ts
+++ b/ui/src/pages/chat/pinned-messages.ts
@@ -1,68 +1,30 @@
 // Control UI chat module implements pinned messages behavior.
-import { getSafeLocalStorage } from "../../local-storage.ts";
+import { PersistedSet } from "./persisted-set.ts";
 
 const PREFIX = "openclaw:pinned:";
 
-export class PinnedMessages {
-  private key: string;
-  private pinnedIndices = new Set<number>();
-
+export class PinnedMessages extends PersistedSet<number> {
   constructor(sessionKey: string) {
-    this.key = PREFIX + sessionKey;
-    this.load();
+    super(PREFIX + sessionKey, (value): value is number => typeof value === "number");
   }
 
   get indices(): Set<number> {
-    return this.pinnedIndices;
-  }
-
-  has(index: number): boolean {
-    return this.pinnedIndices.has(index);
+    return this.values;
   }
 
   pin(index: number): void {
-    this.pinnedIndices.add(index);
-    this.save();
+    this.add(index);
   }
 
   unpin(index: number): void {
-    this.pinnedIndices.delete(index);
-    this.save();
+    this.remove(index);
   }
 
   toggle(index: number): void {
-    if (this.pinnedIndices.has(index)) {
+    if (this.has(index)) {
       this.unpin(index);
     } else {
       this.pin(index);
-    }
-  }
-
-  clear(): void {
-    this.pinnedIndices.clear();
-    this.save();
-  }
-
-  private load(): void {
-    try {
-      const raw = getSafeLocalStorage()?.getItem(this.key);
-      if (!raw) {
-        return;
-      }
-      const arr = JSON.parse(raw);
-      if (Array.isArray(arr)) {
-        this.pinnedIndices = new Set(arr.filter((n) => typeof n === "number"));
-      }
-    } catch {
-      // ignore
-    }
-  }
-
-  private save(): void {
-    try {
-      getSafeLocalStorage()?.setItem(this.key, JSON.stringify([...this.pinnedIndices]));
-    } catch {
-      // ignore
     }
   }
 }

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -11,6 +11,7 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { resolveToolCallKind, unwrapShellWrapperCommand } from "../../lib/chat/tool-call-view.ts";
+import { fnv1aUtf16 } from "../../lib/fnv1a.ts";
 
 const MAX_TITLE_INPUT_CHARS = 2_000;
 const MAX_ITEMS_PER_REQUEST = 24;
@@ -56,12 +57,7 @@ let notifyUpdate: (() => void) | null = null;
 /** FNV-1a over name + serialized args; stable across renders of one call. */
 function digest(name: string, input: string): string {
   const source = `${name}\u0000${input}`;
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < source.length; index += 1) {
-    hash ^= source.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return `t${(hash >>> 0).toString(36)}${source.length.toString(36)}`;
+  return `t${fnv1aUtf16(source).toString(36)}${source.length.toString(36)}`;
 }
 
 function serializeArgs(args: unknown): string | null {

--- a/ui/src/pages/cron/segmented-control.ts
+++ b/ui/src/pages/cron/segmented-control.ts
@@ -1,5 +1,6 @@
 import { html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { renderSettingsSegmented } from "../../components/settings-ui.ts";
 import "../../components/web-awesome-tabs.ts";
 
 export function renderSegmented<T extends string>(params: {
@@ -38,33 +39,10 @@ export function renderSegmented<T extends string>(params: {
       </wa-tab-group>
     `;
   }
-  return html`
-    <wa-radio-group
-      class="settings-segmented"
-      size="s"
-      orientation="horizontal"
-      label=${ifDefined(params.ariaLabel)}
-      .value=${params.value}
-      @change=${(event: Event) => {
-        const value = (event.currentTarget as HTMLElement & { value?: string }).value;
-        if (value !== undefined) {
-          params.onChange(value as T);
-        }
-      }}
-    >
-      ${params.options.map(
-        (option) => html`
-          <wa-radio
-            class="settings-segmented__btn"
-            appearance="button"
-            value=${option.value}
-            .checked=${option.value === params.value}
-            data-test-id=${ifDefined(option.testId)}
-          >
-            ${option.label}
-          </wa-radio>
-        `,
-      )}
-    </wa-radio-group>
-  `;
+  return renderSettingsSegmented({
+    value: params.value,
+    options: params.options,
+    ariaLabel: params.ariaLabel,
+    onChange: (value) => params.onChange(value),
+  });
 }

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -188,7 +188,9 @@ describe("cron view list pane", () => {
       HTMLElement,
     ) as HTMLElement & { checked: boolean };
     expect(active.checked).toBe(true);
-    expect(active.closest("wa-radio-group")?.getAttribute("label")).toBe("Automation status");
+    expect(active.closest("wa-radio-group")?.querySelector('[slot="label"]')?.textContent).toBe(
+      "Automation status",
+    );
 
     selectSegmented(getElement(container, '[data-test-id="cron-tab-disabled"]', HTMLElement));
     expect(onJobsFiltersChange).toHaveBeenCalledWith({ cronJobsEnabledFilter: "disabled" });

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -215,14 +215,24 @@ describe("sessions page lifecycle", () => {
     });
 
     const archived = [
-      ...page.querySelectorAll<HTMLButtonElement>(".sessions-view-segment button"),
-    ].find((button) => button.textContent?.trim() === "Archived");
-    archived?.click();
+      ...page.querySelectorAll<HTMLElement & { checked: boolean }>(
+        ".sessions-view-segment wa-radio",
+      ),
+    ].find((radio) => radio.textContent?.trim() === "Archived");
+    const group = archived?.closest<HTMLElement & { value: string }>("wa-radio-group");
+    if (group) {
+      group.value = "archived";
+      group.dispatchEvent(new Event("change", { bubbles: true }));
+    }
     await page.updateComplete;
 
     expect(page.statusFilter).toBe("archived");
     expect(context.navigate).toHaveBeenCalledWith("sessions", { search: "?status=archived" });
-    expect(archived?.getAttribute("aria-pressed")).toBe("true");
+    expect(
+      [...page.querySelectorAll<HTMLElement & { checked: boolean }>("wa-radio")].find(
+        (radio) => radio.textContent?.trim() === "Archived",
+      )?.checked,
+    ).toBe(true);
   });
 
   it("re-enumerates all archived sessions before bulk deletion", async () => {

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -226,17 +226,21 @@ describe("sessions view", () => {
     );
     await Promise.resolve();
 
-    const buttons = container.querySelectorAll<HTMLButtonElement>(".sessions-view-segment button");
-    expect([...buttons].map((button) => button.textContent?.trim())).toEqual([
+    const radios = container.querySelectorAll<HTMLElement & { checked: boolean }>(
+      ".sessions-view-segment wa-radio",
+    );
+    expect([...radios].map((radio) => radio.textContent?.trim())).toEqual([
       "Active",
       "Archived",
       "All",
     ]);
-    expect(buttons[0]?.getAttribute("aria-pressed")).toBe("true");
-    expect(buttons[1]?.getAttribute("aria-pressed")).toBe("false");
-    expect(buttons[2]?.getAttribute("aria-pressed")).toBe("false");
+    expect([...radios].map((radio) => radio.checked)).toEqual([true, false, false]);
 
-    buttons[2]?.click();
+    const group = radios[2]?.closest<HTMLElement & { value: string }>("wa-radio-group");
+    if (group) {
+      group.value = "all";
+      group.dispatchEvent(new Event("change", { bubbles: true }));
+    }
 
     expect(onStatusFilterChange).toHaveBeenCalledWith("all");
   });

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -15,6 +15,7 @@ import { pathForRoute } from "../../app-route-paths.ts";
 import { icons } from "../../components/icons.ts";
 import {
   renderSettingsPage,
+  renderSettingsSegmented,
   renderSettingsSection,
   renderSettingsStatus,
 } from "../../components/settings-ui.ts";
@@ -1302,33 +1303,21 @@ function renderSessionsTable(props: SessionsProps, ctx: SessionsTableContext) {
               includeUnknown: checked,
             }),
         })}
-        <div
-          class="settings-segmented sessions-view-segment"
-          role="group"
-          aria-label=${t("sessionsView.sessionState")}
-        >
-          ${(["active", "archived", "all"] as const).map(
-            (statusFilter) => html`
-              <button
-                type="button"
-                class="settings-segmented__btn ${props.statusFilter === statusFilter
-                  ? "settings-segmented__btn--active"
-                  : ""}"
-                aria-pressed=${String(props.statusFilter === statusFilter)}
-                title=${statusFilter === "archived"
-                  ? t("sessionsView.archivedOnlyTooltip")
-                  : nothing}
-                @click=${() => props.onStatusFilterChange(statusFilter)}
-              >
-                ${statusFilter === "active"
-                  ? t("common.active")
-                  : statusFilter === "archived"
-                    ? t("sessionsView.archived")
-                    : t("sessionsView.all")}
-              </button>
-            `,
-          )}
-        </div>
+        ${renderSettingsSegmented<SessionArchivedFilter>({
+          value: props.statusFilter,
+          ariaLabel: t("sessionsView.sessionState"),
+          className: "sessions-view-segment",
+          options: [
+            { value: "active", label: t("common.active") },
+            {
+              value: "archived",
+              label: t("sessionsView.archived"),
+              title: t("sessionsView.archivedOnlyTooltip"),
+            },
+            { value: "all", label: t("sessionsView.all") },
+          ],
+          onChange: (value) => props.onStatusFilterChange(value),
+        })}
       </div>
       <span class="sessions-toolbar__divider" aria-hidden="true"></span>
       <label class="session-groupby">

--- a/ui/src/pages/workboard/view.ts
+++ b/ui/src/pages/workboard/view.ts
@@ -1,6 +1,5 @@
 // Control UI view renders workboard screen content.
 
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing, type TemplateResult } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult, GatewaySessionRow } from "../../api/types.ts";
@@ -10,7 +9,12 @@ import { icons } from "../../components/icons.ts";
 import "../../components/modal-dialog.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
-import { formatDateMs, formatDateTimeMs, formatDurationCompact } from "../../lib/format.ts";
+import {
+  clampText,
+  formatDateMs,
+  formatDateTimeMs,
+  formatDurationCompact,
+} from "../../lib/format.ts";
 import "../../styles/workboard.css";
 import {
   addWorkboardCardComment,
@@ -24,6 +28,7 @@ import {
   getWorkboardState,
   moveWorkboardCard,
   refreshWorkboard,
+  resetDraftState,
   saveWorkboardCardDraft,
   startWorkboardCard,
   stopWorkboardCard,
@@ -193,13 +198,6 @@ function formatAge(value: number | undefined): string {
   return formatDurationCompact(elapsedMs, { spaced: true }) ?? "0ms";
 }
 
-function truncateBadgeText(value: string, maxLength = 64): string {
-  const trimmed = value.trim();
-  return trimmed.length <= maxLength
-    ? trimmed
-    : `${truncateUtf16Safe(trimmed, Math.max(0, maxLength - 1))}…`;
-}
-
 function canMutate(props: WorkboardProps): boolean {
   return props.canWrite !== false && workboardMutationsReady(getWorkboardState(props.host));
 }
@@ -341,14 +339,14 @@ function renderCompactBadges(card: WorkboardCard, task?: WorkboardTaskSummary) {
   if (latestDiagnostic) {
     badges.push(
       html`<span class="workboard-card__badge--warning" title=${latestDiagnostic.detail}>
-        ${icons.alertTriangle}${truncateBadgeText(latestDiagnostic.title)}
+        ${icons.alertTriangle}${clampText(latestDiagnostic.title.trim(), 64)}
       </span>`,
     );
   }
   if (blockedReason) {
     badges.push(
       html`<span class="workboard-card__badge--warning" title=${blockedReason}>
-        ${icons.alertTriangle}${truncateBadgeText(blockedReason)}
+        ${icons.alertTriangle}${clampText(blockedReason.trim(), 64)}
       </span>`,
     );
   }
@@ -771,26 +769,8 @@ function getVisibleDetailCard(state: WorkboardUiState): WorkboardCard | null {
   return card;
 }
 
-function resetDraft(state: WorkboardUiState) {
-  const resolveStaleEdit = state.loaded && state.mutationReadiness === "stale_edit_draft";
-  state.draftOpen = false;
-  state.editingCardId = null;
-  state.draftTitle = "";
-  state.draftNotes = "";
-  state.draftStatus = "todo";
-  state.draftPriority = "normal";
-  state.draftLabels = "";
-  state.draftAgentId = "";
-  state.draftSessionKey = "";
-  state.draftTemplateId = "";
-  state.draftCommentBody = "";
-  if (resolveStaleEdit) {
-    state.mutationReadiness = "ready";
-  }
-}
-
 function openCreateModal(state: WorkboardUiState) {
-  resetDraft(state);
+  resetDraftState(state);
   state.draftOpen = true;
 }
 
@@ -870,7 +850,7 @@ function renderCardModal(props: WorkboardProps) {
     if (draftDismissalBusy) {
       return false;
     }
-    resetDraft(state);
+    resetDraftState(state);
     return true;
   };
   return html`


### PR DESCRIPTION
## What Problem This Solves

The control UI had seven small clusters of duplicate contracts, storage logic, keyboard handling, hashing, layout helpers, and dead styling that increased maintenance cost and invited subtle divergence.

## Why This Change Was Made

This mechanical cleanup centralizes sidebar contracts, segmented controls, slash-menu keys, persisted sets, UTF-16 FNV-1a hashing, and workboard helpers, while removing dead terminal CSS. The follow-up callback type correction is included in the same reviewed stack.

## User Impact

There is no intended user-visible behavior change. The UI keeps the same interactions and persisted storage keys with 214 fewer net lines.

## Evidence

- Focused suites passed with 166, 102, 226, 331, 217, 249, and 32 tests respectively.
- Control UI production build passed on Testbox `tbx_01kyc6f5ntsjqcm0bezt7ckra5`.
- Corrected core-test/UI typechecks and full lint passed with zero errors or warnings on Testbox `tbx_01kyc8b21b7d0nzf7g22qf936h`.
- Final branch autoreview reported no accepted or actionable findings.
- `git diff --check` is clean at `3c1eec7e73e23dcc600ce80c17016e5dc1328aad`.

