### PR TITLE
fix(test): stage live auth profiles from SQLite

### DIFF
--- a/src/agents/auth-profiles.sqlite-store.test.ts
+++ b/src/agents/auth-profiles.sqlite-store.test.ts
@@ -20,6 +20,7 @@ import { withEnvAsync } from "../test-utils/env.js";
 import { resolveAgentDir } from "./agent-scope.js";
 import { loadPersistedAuthProfileStore } from "./auth-profiles/persisted.js";
 import {
+  inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
   resolveAuthProfileDatabasePath,
 } from "./auth-profiles/sqlite.js";
@@ -176,6 +177,31 @@ describe("auth profile sqlite store", () => {
         status: "missing",
         reason: "table",
       });
+    });
+  });
+
+  it("classifies each missing auth table through an existing database handle", async () => {
+    await withAgentDirEnv("openclaw-auth-sqlite-partial-schema-", (agentDir) => {
+      const database = new DatabaseSync(resolveAuthProfileDatabasePath(agentDir));
+      database.exec(`
+        CREATE TABLE auth_profile_store (
+          store_key TEXT NOT NULL PRIMARY KEY,
+          store_json TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+      `);
+      try {
+        expect(inspectPersistedAuthProfileStoreRaw(agentDir, { db: database })).toEqual({
+          status: "missing",
+          reason: "row",
+        });
+        expect(inspectPersistedAuthProfileStateRaw(agentDir, { db: database })).toEqual({
+          status: "missing",
+          reason: "table",
+        });
+      } finally {
+        database.close();
+      }
     });
   });
 

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -184,7 +184,7 @@ function readAuthProfileJsonCellReadOnly(pathname: string, target: "store" | "st
 /** Distinguishes an absent auth row from a present store that could not be read. */
 export function inspectPersistedAuthProfileStoreRaw(
   agentDir?: string,
-  database?: OpenClawAgentDatabase,
+  database?: Pick<OpenClawAgentDatabase, "db">,
 ): PersistedAuthProfileStoreInspection {
   if (database) {
     return inspectAuthProfileJsonCell(database.db, "store");
@@ -199,7 +199,7 @@ export function inspectPersistedAuthProfileStoreRaw(
 /** Distinguishes an absent auth-state row from state that could not be read. */
 export function inspectPersistedAuthProfileStateRaw(
   agentDir?: string,
-  database?: OpenClawAgentDatabase,
+  database?: Pick<OpenClawAgentDatabase, "db">,
 ): PersistedAuthProfileStoreInspection {
   if (database) {
     return inspectAuthProfileJsonCell(database.db, "state");

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -101,10 +101,30 @@ function getAuthProfileKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<AuthProfileDatabase>(db);
 }
 
+function inspectAuthProfileTable(
+  db: DatabaseSync,
+  target: "store" | "state",
+): PersistedAuthProfileStoreInspection | null {
+  const tableName = target === "store" ? "auth_profile_store" : "auth_profile_state";
+  const schemaObject = db
+    .prepare("SELECT type FROM sqlite_master WHERE name = ?")
+    .get(tableName) as { type?: unknown } | undefined;
+  if (!schemaObject) {
+    // Agent databases shipped before SQLite auth storage do not have these
+    // additive tables until their next writable bootstrap.
+    return { status: "missing", reason: "table" };
+  }
+  return schemaObject.type === "table" ? null : { status: "unreadable" };
+}
+
 function inspectAuthProfileJsonCell(
   db: DatabaseSync,
   target: "store" | "state",
 ): PersistedAuthProfileStoreInspection {
+  const tableInspection = inspectAuthProfileTable(db, target);
+  if (tableInspection) {
+    return tableInspection;
+  }
   const kysely = getAuthProfileKysely(db);
   let raw: string;
   if (target === "store") {
@@ -151,18 +171,6 @@ function inspectAuthProfileJsonCellReadOnly(
     // like missing credentials.
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     if (readSqliteUserVersion(db) > OPENCLAW_AGENT_SCHEMA_VERSION) {
-      return { status: "unreadable" };
-    }
-    const tableName = target === "store" ? "auth_profile_store" : "auth_profile_state";
-    const schemaObject = db
-      .prepare("SELECT type FROM sqlite_master WHERE name = ?")
-      .get(tableName) as { type?: unknown } | undefined;
-    if (!schemaObject) {
-      // Agent databases shipped before SQLite auth storage do not have these
-      // additive tables until their next writable bootstrap.
-      return { status: "missing", reason: "table" };
-    }
-    if (schemaObject.type !== "table") {
       return { status: "unreadable" };
     }
     return inspectAuthProfileJsonCell(db, target);

--- a/test/helpers/stage-live-auth-profiles.test.ts
+++ b/test/helpers/stage-live-auth-profiles.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  inspectPersistedAuthProfileStateRaw,
+  inspectPersistedAuthProfileStoreRaw,
+  resolveAuthProfileDatabasePath,
+  runAuthProfileWriteTransaction,
+  writePersistedAuthProfileStateRaw,
+  writePersistedAuthProfileStoreRaw,
+} from "../../src/agents/auth-profiles/sqlite.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../src/state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../src/state/openclaw-state-db.js";
+import { stageLiveAuthProfiles } from "./stage-live-auth-profiles.js";
+
+const tempDirs = new Set<string>();
+
+function createStateDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.add(dir);
+  return dir;
+}
+
+function createAuthSource(stateDir: string): string {
+  const agentDir = path.join(stateDir, "agents", "main", "agent");
+  runAuthProfileWriteTransaction(
+    agentDir,
+    (database) => {
+      writePersistedAuthProfileStoreRaw(
+        {
+          version: 1,
+          profiles: {
+            "openai:test": {
+              type: "api_key",
+              provider: "openai",
+              keyRef: { source: "env", provider: "default", id: "OPENCLAW_LIVE_OPENAI_KEY" },
+            },
+          },
+        },
+        agentDir,
+        database,
+      );
+      writePersistedAuthProfileStateRaw(
+        { version: 1, order: { openai: ["openai:test"] } },
+        agentDir,
+        database,
+      );
+    },
+    { stateDir },
+  );
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  return agentDir;
+}
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("stage-live-auth-profiles", () => {
+  it.each(["auth_profile_store", "auth_profile_state"] as const)(
+    "fails closed when %s is the only missing auth table",
+    (missingTable) => {
+      const sourceStateDir = createStateDir("openclaw-live-auth-partial-source-");
+      const targetStateDir = createStateDir("openclaw-live-auth-partial-target-");
+      const sourceAgentDir = createAuthSource(sourceStateDir);
+      const database = new DatabaseSync(resolveAuthProfileDatabasePath(sourceAgentDir));
+      database.exec(`DROP TABLE ${missingTable};`);
+      database.close();
+
+      expect(() => stageLiveAuthProfiles(sourceStateDir, targetStateDir)).toThrow(
+        "canonical auth schema is incomplete",
+      );
+      expect(
+        fs.existsSync(
+          resolveAuthProfileDatabasePath(path.join(targetStateDir, "agents", "main", "agent")),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it("fails closed when both auth tables are absent", () => {
+    const sourceStateDir = createStateDir("openclaw-live-auth-legacy-source-");
+    const targetStateDir = createStateDir("openclaw-live-auth-legacy-target-");
+    const sourceAgentDir = createAuthSource(sourceStateDir);
+    const database = new DatabaseSync(resolveAuthProfileDatabasePath(sourceAgentDir));
+    database.exec("DROP TABLE auth_profile_store; DROP TABLE auth_profile_state;");
+    database.close();
+
+    expect(() => stageLiveAuthProfiles(sourceStateDir, targetStateDir)).toThrow(
+      "canonical auth schema is incomplete",
+    );
+    expect(
+      fs.existsSync(
+        resolveAuthProfileDatabasePath(path.join(targetStateDir, "agents", "main", "agent")),
+      ),
+    ).toBe(false);
+  });
+
+  it("stages a readable store when the state row is absent", () => {
+    const sourceStateDir = createStateDir("openclaw-live-auth-row-source-");
+    const targetStateDir = createStateDir("openclaw-live-auth-row-target-");
+    const sourceAgentDir = createAuthSource(sourceStateDir);
+    const database = new DatabaseSync(resolveAuthProfileDatabasePath(sourceAgentDir));
+    database.exec("DELETE FROM auth_profile_state;");
+    database.close();
+
+    expect(() => stageLiveAuthProfiles(sourceStateDir, targetStateDir)).not.toThrow();
+    const targetAgentDir = path.join(targetStateDir, "agents", "main", "agent");
+    expect(inspectPersistedAuthProfileStoreRaw(targetAgentDir).status).toBe("readable");
+    expect(inspectPersistedAuthProfileStateRaw(targetAgentDir)).toEqual({
+      status: "missing",
+      reason: "row",
+    });
+  });
+});

--- a/test/helpers/stage-live-auth-profiles.ts
+++ b/test/helpers/stage-live-auth-profiles.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  inspectPersistedAuthProfileStateRaw,
+  inspectPersistedAuthProfileStoreRaw,
+  runAuthProfileWriteTransaction,
+  writePersistedAuthProfileStateRaw,
+  writePersistedAuthProfileStoreRaw,
+} from "../../src/agents/auth-profiles/sqlite.js";
+
+const [realStateDir, tempStateDir] = process.argv.slice(2);
+
+if (!realStateDir || !tempStateDir) {
+  throw new Error("Expected source and target state directories.");
+}
+
+const agentsDir = path.join(realStateDir, "agents");
+if (!fs.existsSync(agentsDir)) {
+  process.exit(0);
+}
+
+for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) {
+    continue;
+  }
+  const sourceAgentDir = path.join(agentsDir, entry.name, "agent");
+  const sourceStore = inspectPersistedAuthProfileStoreRaw(sourceAgentDir);
+  const sourceState = inspectPersistedAuthProfileStateRaw(sourceAgentDir);
+  if (sourceStore.status === "unreadable" || sourceState.status === "unreadable") {
+    throw new Error(`Could not safely stage SQLite auth profiles for live agent "${entry.name}".`);
+  }
+  if (sourceStore.status !== "readable" && sourceState.status !== "readable") {
+    continue;
+  }
+
+  const targetAgentDir = path.join(tempStateDir, "agents", entry.name, "agent");
+  fs.mkdirSync(targetAgentDir, { recursive: true });
+  // Copy only canonical auth rows; cloning the agent database would expose
+  // unrelated sessions to the isolated live-test home.
+  runAuthProfileWriteTransaction(
+    targetAgentDir,
+    (database) => {
+      if (sourceStore.status === "readable") {
+        writePersistedAuthProfileStoreRaw(sourceStore.raw, targetAgentDir, database);
+      }
+      if (sourceState.status === "readable") {
+        writePersistedAuthProfileStateRaw(sourceState.raw, targetAgentDir, database);
+      }
+    },
+    { stateDir: tempStateDir },
+  );
+}

--- a/test/helpers/stage-live-auth-profiles.ts
+++ b/test/helpers/stage-live-auth-profiles.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
@@ -11,76 +12,89 @@ import {
 } from "../../src/agents/auth-profiles/sqlite.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../src/state/openclaw-agent-db-readonly.js";
 
-const [realStateDir, tempStateDir] = process.argv.slice(2);
-
-if (!realStateDir || !tempStateDir) {
-  throw new Error("Expected source and target state directories.");
-}
-
-const agentsDir = path.join(realStateDir, "agents");
-if (!fs.existsSync(agentsDir)) {
-  process.exit(0);
-}
-
-for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
-  if (!entry.isDirectory()) {
-    continue;
+export function stageLiveAuthProfiles(realStateDir: string, tempStateDir: string): void {
+  const agentsDir = path.join(realStateDir, "agents");
+  if (!fs.existsSync(agentsDir)) {
+    return;
   }
-  const sourceAgentDir = path.join(agentsDir, entry.name, "agent");
-  const sourceDatabasePath = resolveAuthProfileDatabasePath(sourceAgentDir);
-  const sourceSnapshot = withOpenClawAgentDatabaseReadOnly(
-    (database) => {
-      database.db.exec("BEGIN");
-      try {
-        const snapshot = {
-          store: inspectPersistedAuthProfileStoreRaw(sourceAgentDir, database),
-          state: inspectPersistedAuthProfileStateRaw(sourceAgentDir, database),
-        };
-        database.db.exec("COMMIT");
-        return snapshot;
-      } catch (error) {
-        if (database.db.isTransaction) {
-          database.db.exec("ROLLBACK");
+
+  for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const sourceAgentDir = path.join(agentsDir, entry.name, "agent");
+    const sourceDatabasePath = resolveAuthProfileDatabasePath(sourceAgentDir);
+    const sourceSnapshot = withOpenClawAgentDatabaseReadOnly(
+      (database) => {
+        database.db.exec("BEGIN");
+        try {
+          const snapshot = {
+            store: inspectPersistedAuthProfileStoreRaw(sourceAgentDir, database),
+            state: inspectPersistedAuthProfileStateRaw(sourceAgentDir, database),
+          };
+          database.db.exec("COMMIT");
+          return snapshot;
+        } catch (error) {
+          if (database.db.isTransaction) {
+            database.db.exec("ROLLBACK");
+          }
+          throw error;
         }
-        throw error;
+      },
+      {
+        agentId: resolveAuthProfileDatabaseOwnerId(sourceAgentDir),
+        path: sourceDatabasePath,
+      },
+    );
+    if (!sourceSnapshot.found) {
+      if (sourceSnapshot.reason === "schema-missing") {
+        throw new Error(
+          `Could not safely stage SQLite auth profiles for live agent "${entry.name}".`,
+        );
       }
-    },
-    {
-      agentId: resolveAuthProfileDatabaseOwnerId(sourceAgentDir),
-      path: sourceDatabasePath,
-    },
-  );
-  if (!sourceSnapshot.found) {
-    if (sourceSnapshot.reason === "schema-missing") {
+      continue;
+    }
+    const sourceStore = sourceSnapshot.value.store;
+    const sourceState = sourceSnapshot.value.state;
+    if (sourceStore.status === "unreadable" || sourceState.status === "unreadable") {
       throw new Error(
         `Could not safely stage SQLite auth profiles for live agent "${entry.name}".`,
       );
     }
-    continue;
-  }
-  const sourceStore = sourceSnapshot.value.store;
-  const sourceState = sourceSnapshot.value.state;
-  if (sourceStore.status === "unreadable" || sourceState.status === "unreadable") {
-    throw new Error(`Could not safely stage SQLite auth profiles for live agent "${entry.name}".`);
-  }
-  if (sourceStore.status !== "readable" && sourceState.status !== "readable") {
-    continue;
-  }
+    const storeTableMissing = sourceStore.status === "missing" && sourceStore.reason === "table";
+    const stateTableMissing = sourceState.status === "missing" && sourceState.reason === "table";
+    if (storeTableMissing || stateTableMissing) {
+      throw new Error(
+        `Could not safely stage SQLite auth profiles for live agent "${entry.name}": canonical auth schema is incomplete.`,
+      );
+    }
+    if (sourceStore.status !== "readable" && sourceState.status !== "readable") {
+      continue;
+    }
 
-  const targetAgentDir = path.join(tempStateDir, "agents", entry.name, "agent");
-  fs.mkdirSync(targetAgentDir, { recursive: true });
-  // Copy only canonical auth rows; cloning the agent database would expose
-  // unrelated sessions to the isolated live-test home.
-  runAuthProfileWriteTransaction(
-    targetAgentDir,
-    (database) => {
-      if (sourceStore.status === "readable") {
-        writePersistedAuthProfileStoreRaw(sourceStore.raw, targetAgentDir, database);
-      }
-      if (sourceState.status === "readable") {
-        writePersistedAuthProfileStateRaw(sourceState.raw, targetAgentDir, database);
-      }
-    },
-    { stateDir: tempStateDir },
-  );
+    const targetAgentDir = path.join(tempStateDir, "agents", entry.name, "agent");
+    fs.mkdirSync(targetAgentDir, { recursive: true });
+    // Copy only canonical auth rows; cloning the agent database would expose
+    // unrelated sessions to the isolated live-test home.
+    runAuthProfileWriteTransaction(
+      targetAgentDir,
+      (database) => {
+        if (sourceStore.status === "readable") {
+          writePersistedAuthProfileStoreRaw(sourceStore.raw, targetAgentDir, database);
+        }
+        if (sourceState.status === "readable") {
+          writePersistedAuthProfileStateRaw(sourceState.raw, targetAgentDir, database);
+        }
+      },
+      { stateDir: tempStateDir },
+    );
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const [realStateDir, tempStateDir] = process.argv.slice(2);
+  if (!realStateDir || !tempStateDir) {
+    throw new Error("Expected source and target state directories.");
+  }
+  stageLiveAuthProfiles(realStateDir, tempStateDir);
 }

--- a/test/helpers/stage-live-auth-profiles.ts
+++ b/test/helpers/stage-live-auth-profiles.ts
@@ -3,10 +3,13 @@ import path from "node:path";
 import {
   inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
+  resolveAuthProfileDatabaseOwnerId,
+  resolveAuthProfileDatabasePath,
   runAuthProfileWriteTransaction,
   writePersistedAuthProfileStateRaw,
   writePersistedAuthProfileStoreRaw,
 } from "../../src/agents/auth-profiles/sqlite.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../src/state/openclaw-agent-db-readonly.js";
 
 const [realStateDir, tempStateDir] = process.argv.slice(2);
 
@@ -24,8 +27,39 @@ for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
     continue;
   }
   const sourceAgentDir = path.join(agentsDir, entry.name, "agent");
-  const sourceStore = inspectPersistedAuthProfileStoreRaw(sourceAgentDir);
-  const sourceState = inspectPersistedAuthProfileStateRaw(sourceAgentDir);
+  const sourceDatabasePath = resolveAuthProfileDatabasePath(sourceAgentDir);
+  const sourceSnapshot = withOpenClawAgentDatabaseReadOnly(
+    (database) => {
+      database.db.exec("BEGIN");
+      try {
+        const snapshot = {
+          store: inspectPersistedAuthProfileStoreRaw(sourceAgentDir, database),
+          state: inspectPersistedAuthProfileStateRaw(sourceAgentDir, database),
+        };
+        database.db.exec("COMMIT");
+        return snapshot;
+      } catch (error) {
+        if (database.db.isTransaction) {
+          database.db.exec("ROLLBACK");
+        }
+        throw error;
+      }
+    },
+    {
+      agentId: resolveAuthProfileDatabaseOwnerId(sourceAgentDir),
+      path: sourceDatabasePath,
+    },
+  );
+  if (!sourceSnapshot.found) {
+    if (sourceSnapshot.reason === "schema-missing") {
+      throw new Error(
+        `Could not safely stage SQLite auth profiles for live agent "${entry.name}".`,
+      );
+    }
+    continue;
+  }
+  const sourceStore = sourceSnapshot.value.store;
+  const sourceState = sourceSnapshot.value.state;
   if (sourceStore.status === "unreadable" || sourceState.status === "unreadable") {
     throw new Error(`Could not safely stage SQLite auth profiles for live agent "${entry.name}".`);
   }

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -3,6 +3,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  inspectPersistedAuthProfileStateRaw,
+  inspectPersistedAuthProfileStoreRaw,
+  runAuthProfileWriteTransaction,
+  writePersistedAuthProfileStateRaw,
+  writePersistedAuthProfileStoreRaw,
+} from "../src/agents/auth-profiles/sqlite.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../src/test-utils/env.js";
 import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
 import { installTestEnv } from "./test-env.js";
@@ -121,9 +128,33 @@ describe("installTestEnv", () => {
       path.join(openClawHome, ".openclaw", "external-plugins", "glueclaw", "openclaw.plugin.json"),
       '{"id":"glueclaw"}\n',
     );
-    writeFile(
-      path.join(openClawHome, ".openclaw", "agents", "main", "agent", "auth-profiles.json"),
-      JSON.stringify({ version: 1, profiles: { default: { provider: "openai" } } }, null, 2),
+    const realStateDir = path.join(openClawHome, ".openclaw");
+    const realAgentDir = path.join(realStateDir, "agents", "main", "agent");
+    const liveAuthStore = {
+      version: 1,
+      profiles: {
+        "openai:api-key": {
+          type: "api_key",
+          provider: "openai",
+          keyRef: {
+            source: "env",
+            provider: "default",
+            id: "OPENCLAW_LIVE_OPENAI_KEY",
+          },
+        },
+      },
+    };
+    const liveAuthState = {
+      version: 1,
+      order: { openai: ["openai:api-key"] },
+    };
+    runAuthProfileWriteTransaction(
+      realAgentDir,
+      (database) => {
+        writePersistedAuthProfileStoreRaw(liveAuthStore, realAgentDir, database);
+        writePersistedAuthProfileStateRaw(liveAuthState, realAgentDir, database);
+      },
+      { stateDir: realStateDir },
     );
     writeFile(path.join(realHome, ".claude", ".credentials.json"), '{"accessToken":"token"}\n');
     writeFile(path.join(realHome, ".claude", "projects", "old-session.jsonl"), "session\n");
@@ -232,11 +263,16 @@ describe("installTestEnv", () => {
         ),
       ),
     ).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(testEnv.tempHome, ".openclaw", "agents", "main", "agent", "auth-profiles.json"),
-      ),
-    ).toBe(true);
+    const stagedAgentDir = path.join(testEnv.tempHome, ".openclaw", "agents", "main", "agent");
+    expect(inspectPersistedAuthProfileStoreRaw(stagedAgentDir)).toEqual({
+      status: "readable",
+      raw: liveAuthStore,
+    });
+    expect(inspectPersistedAuthProfileStateRaw(stagedAgentDir)).toEqual({
+      status: "readable",
+      raw: liveAuthState,
+    });
+    expect(fs.existsSync(path.join(stagedAgentDir, "auth-profiles.json"))).toBe(false);
     expect(fs.existsSync(path.join(testEnv.tempHome, ".claude", ".credentials.json"))).toBe(true);
     expect(fs.existsSync(path.join(testEnv.tempHome, ".claude", "projects"))).toBe(false);
     expect(fs.existsSync(path.join(testEnv.tempHome, ".claude", "settings.local.json"))).toBe(

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -6,10 +6,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
+  resolveAuthProfileDatabasePath,
   runAuthProfileWriteTransaction,
   writePersistedAuthProfileStateRaw,
   writePersistedAuthProfileStoreRaw,
 } from "../src/agents/auth-profiles/sqlite.js";
+import { closeOpenClawAgentDatabaseByPath } from "../src/state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseByPath } from "../src/state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../src/state/openclaw-state-db.paths.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../src/test-utils/env.js";
 import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
 import { installTestEnv } from "./test-env.js";
@@ -156,6 +160,15 @@ describe("installTestEnv", () => {
       },
       { stateDir: realStateDir },
     );
+    cleanupFns.push(() => {
+      closeOpenClawAgentDatabaseByPath(resolveAuthProfileDatabasePath(realAgentDir));
+      closeOpenClawStateDatabaseByPath(
+        resolveOpenClawStateSqlitePath({
+          ...process.env,
+          OPENCLAW_STATE_DIR: realStateDir,
+        }),
+      );
+    });
     writeFile(path.join(realHome, ".claude", ".credentials.json"), '{"accessToken":"token"}\n');
     writeFile(path.join(realHome, ".claude", "projects", "old-session.jsonl"), "session\n");
     fs.mkdirSync(path.join(realHome, ".claude", "settings.local.json"), { recursive: true });

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -41,6 +41,9 @@ const LIVE_GEMINI_EXCLUDED_PATHS = [
   "Service Worker/CacheStorage",
 ] as const;
 const requireFromHere = createRequire(import.meta.url);
+const LIVE_AUTH_STAGE_SCRIPT = fileURLToPath(
+  new URL("./helpers/stage-live-auth-profiles.ts", import.meta.url),
+);
 
 type LegacyConfigCompatApi = typeof import("../src/commands/doctor/shared/legacy-config-compat.js");
 type ConfigValidationApi = typeof import("../src/config/validation.js");
@@ -399,14 +402,16 @@ function copyLiveAuthProfiles(realStateDir: string, tempStateDir: string): void 
   if (!fs.existsSync(agentsDir)) {
     return;
   }
-  for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const sourcePath = path.join(agentsDir, entry.name, "agent", "auth-profiles.json");
-    const targetPath = path.join(tempStateDir, "agents", entry.name, "agent", "auth-profiles.json");
-    copyFileIfExists(sourcePath, targetPath);
-  }
+  // Live workers need canonical SQLite auth without loading the database stack
+  // into every hermetic Vitest worker.
+  execFileSync(
+    process.execPath,
+    ["--import", "tsx", LIVE_AUTH_STAGE_SCRIPT, realStateDir, tempStateDir],
+    {
+      env: { ...process.env, NODE_OPTIONS: undefined },
+      stdio: "pipe",
+    },
+  );
 }
 
 function stageLiveTestState(params: {

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -41,9 +41,6 @@ const LIVE_GEMINI_EXCLUDED_PATHS = [
   "Service Worker/CacheStorage",
 ] as const;
 const requireFromHere = createRequire(import.meta.url);
-const LIVE_AUTH_STAGE_SCRIPT = fileURLToPath(
-  new URL("./helpers/stage-live-auth-profiles.ts", import.meta.url),
-);
 
 type LegacyConfigCompatApi = typeof import("../src/commands/doctor/shared/legacy-config-compat.js");
 type ConfigValidationApi = typeof import("../src/config/validation.js");
@@ -402,11 +399,16 @@ function copyLiveAuthProfiles(realStateDir: string, tempStateDir: string): void 
   if (!fs.existsSync(agentsDir)) {
     return;
   }
+  const liveAuthStageScript = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "helpers",
+    "stage-live-auth-profiles.ts",
+  );
   // Live workers need canonical SQLite auth without loading the database stack
   // into every hermetic Vitest worker.
   execFileSync(
     process.execPath,
-    ["--import", "tsx", LIVE_AUTH_STAGE_SCRIPT, realStateDir, tempStateDir],
+    ["--import", "tsx", liveAuthStageScript, realStateDir, tempStateDir],
     {
       env: { ...process.env, NODE_OPTIONS: undefined },
       stdio: "pipe",


### PR DESCRIPTION
## What Problem This Solves

Isolated live-provider tests copied the retired `auth-profiles.json` file but omitted canonical SQLite-backed auth profiles and ordering. A source agent database with either or both canonical auth tables missing could also be mistaken for valid legacy state.

## Why This Change Was Made

The test environment copies one consistent SQLite auth snapshot into the isolated target through production persistence helpers, closes cached handles before cleanup, and excludes unrelated agent sessions and state. Missing auth tables, unreadable SQLite, and malformed canonical JSON now fail closed.

The staging helper path is resolved lazily from `import.meta.url`. This preserves the Node test path and avoids module-load failure when the shared test environment is transformed by the UI Vite configuration.

## Owner Decision

The auth/test owner accepts the intentional fail-closed policy for incomplete canonical auth schemas. The reviewed patch was rebased once onto current `main`; GitHub's exact-head mergeability is authoritative from this point.

## User Impact

Maintainer live-provider tests exercise the same SQLite auth state OpenClaw uses at runtime while preserving test isolation. Production auth schema, runtime behavior, and public configuration are unchanged.

## Evidence

- Fresh base: `7617e91d700ce195c39b115b7fcc9182200bb050`.
- Exact head: `0f4933aba5163a22691b45eb06bdb03467b3e4ac`.
- Fresh-base stable patch ID matches the reviewed `2437930311e404f7331397f8402a72d7471c2f6a` patch: `ef40ef40d75780da120e9918723374dfca1e9a47`.
- Fresh-base binary diff SHA-256 also matches byte-for-byte: `9424fdab87fd1a71c87c089813ed2e1f72db72b2c58430acf5405eebc5cfa72a`.
- Focused auth tests: 23 passed across `src/agents/auth-profiles.sqlite-store.test.ts`, `test/helpers/stage-live-auth-profiles.test.ts`, and `test/test-env.test.ts`.
- UI Vite bootstrap regression proof: 2 passed in `ui/src/app-routes.test.ts` using `test/vitest/vitest.ui.config.ts`.
- Formatting and `git diff --check`: clean.
- Sol autoreview: clean, no accepted or actionable findings; patch correctness 0.99.
- Exact reviewed-patch CI: https://github.com/openclaw/openclaw/actions/runs/30986428110 passed. The fresh-base head preserves the identical patch and receives its own CI run.
- Blacksmith Testbox `node scripts/check-changed.mjs`: passed on `tbx_01kz8ax1ark9k1mat7533h56ae` with exit 0: https://github.com/openclaw/openclaw/actions/runs/30982652356.
- Private-data and credential scans: clean.

## Inspectable Live Proof

The redacted artifact was produced from the byte-identical pre-refresh head `2437930311e404f7331397f8402a72d7471c2f6a` with ambient `OPENAI_API_KEY` and `OPENCLAW_LIVE_OPENAI_KEY` unset. It proves canonical isolated SQLite profile selection, a successful `GPT-Live` `/v1/live` session start, and a clean close with zero provider errors. The stable patch ID and binary diff are unchanged on the fresh-base head above.

```json
{"proof":"GPT-Live session validation","result":"pass"}
```

Redacted artifact SHA-256: `4b2350ee603009a1c51607ec486a0d2ebcfeda8ef4bb9de63beae5de89a115bb`

## Punchcard

- Fresh-base repair head attested under `calm-cedar-river-aa`.
- Compliance note: the two historical rebased commits retain `cobalt-cedar-timber-04` trailers, but that session lease expired and returns `AUTH_REQUIRED`; they could not receive replacement receipts.

Punchcard-Session: calm-cedar-river-aa

