### PR TITLE
test(qa): restore session turn ordering coverage

### DIFF
--- a/extensions/qa-lab/src/coverage-report.test.ts
+++ b/extensions/qa-lab/src/coverage-report.test.ts
@@ -258,6 +258,86 @@ describe("qa coverage report", () => {
     ).toContain("session-memory.memory-recall");
   });
 
+  it("inventories runnable multi-actor turn ordering as primary runtime evidence", () => {
+    const coverageId = "agent-runtime.session-turn-ordering";
+    const sourcePath = "qa/scenarios/channels/channel-multi-actor-ordering.yaml";
+    const scenarios = readQaScenarioPack().scenarios;
+    const scenario = expectDefined(
+      scenarios.find((candidate) => candidate.id === "channel-multi-actor-ordering"),
+      "multi-actor turn ordering scenario",
+    );
+
+    expect(scenario.execution.kind).toBe("flow");
+    expect(scenario.coverage?.primary).toEqual(["channels.room-allowlist", coverageId]);
+
+    const orderingActions = (
+      scenario.execution.flow?.steps.flatMap((step) => step.actions) ?? []
+    ).filter(
+      (action): action is Record<string, unknown> =>
+        typeof action === "object" &&
+        action !== null &&
+        ("sendInbound" in action ||
+          "waitForNoOutbound" in action ||
+          "waitForOutbound" in action ||
+          "assert" in action),
+    );
+    expect(orderingActions).toMatchObject([
+      {
+        sendInbound: {
+          conversation: { id: { ref: "config.conversationId" } },
+          senderId: "observer",
+        },
+      },
+      { waitForNoOutbound: { sinceIndex: { ref: "outboundStartIndex" } } },
+      {
+        sendInbound: {
+          conversation: { id: { ref: "config.conversationId" } },
+          senderId: "driver",
+        },
+      },
+      {
+        waitForOutbound: {
+          conversation: { id: { ref: "config.conversationId" } },
+          textIncludes: { ref: "config.expectedMarker" },
+        },
+      },
+      { assert: { expr: expect.stringContaining("config.blockedMarker") } },
+    ]);
+
+    const inventory = buildQaCoverageInventory(scenarios);
+    const coverage = expectDefined(
+      inventory.coverageIds.find((candidate) => candidate.id === coverageId),
+      "session turn ordering coverage inventory",
+    );
+    expect(coverage.scenarios).toContainEqual(
+      expect.objectContaining({
+        id: scenario.id,
+        sourcePath,
+        intent: "primary",
+      }),
+    );
+
+    const category = expectDefined(
+      inventory.scorecardTaxonomy.categories.find(
+        (candidate) => candidate.id === TEST_EXECUTABLE_CATEGORY_ID,
+      ),
+      "agent turn execution scorecard category",
+    );
+    expect(category.inventoryRefs).toContainEqual({
+      coverageId,
+      kind: "qa-scenario",
+      path: null,
+      role: "primary",
+      scenarioRefs: [sourcePath],
+    });
+    expect(inventory.scorecardTaxonomy.validationIssues).not.toContainEqual(
+      expect.objectContaining({
+        code: "coverage-id-missing-primary-inventory",
+        ref: coverageId,
+      }),
+    );
+  });
+
   it("rejects duplicate ownership across YAML and non-YAML catalogs", () => {
     const scenario = scenarioWithCoverage({
       primary: [TEST_EXECUTABLE_COVERAGE_ID],

--- a/qa/scenarios/channels/channel-multi-actor-ordering.yaml
+++ b/qa/scenarios/channels/channel-multi-actor-ordering.yaml
@@ -6,6 +6,7 @@ scenario:
   coverage:
     primary:
       - channels.room-allowlist
+      - agent-runtime.session-turn-ordering
   objective: Verify blocked secondary-actor traffic does not poison a later allowlisted driver turn.
   successCriteria:
     - The observer turn remains unanswered.


### PR DESCRIPTION
## What Problem This Solves

The QA coverage inventory no longer credits any scenario to the `agent-runtime.session-turn-ordering` primary surface even though the canonical channel multi-actor flow exercises exactly that session ordering behavior. This makes the actual shipped scenario invisible to session-turn-ordering coverage, matching, and release audits.

## Why This Change Was Made

Restore the truthful existing primary surface on the canonical multi-actor ordering scenario and add a focused coverage-report regression that proves the scenario is discoverable under the actual session-turn-ordering inventory. Keep the existing channel ordering behavior, ownership, and fixture intact.

## User Impact

QA coverage reports and targeted checks once again find the real multi-actor session turn-ordering scenario; no gateway, provider, channel, runtime, or public configuration behavior changes.

## Evidence

- Trusted remote `pnpm test extensions/qa-lab/src/coverage-report.test.ts`: 21 of 21 tests passed, including the actual coverage inventory regression.
- Trusted remote changed-file `pnpm format:check -- extensions/qa-lab/src/coverage-report.test.ts qa/scenarios/channels/channel-multi-actor-ordering.yaml`: passed.
- Trusted remote `node scripts/run-oxlint.mjs --tsconfig tsconfig.core.json extensions/qa-lab/src/coverage-report.test.ts`: passed; serialized remote timing recorded exit code 0.
- Fresh independent structured autoreview: no accepted findings.
- AI-assisted investigation, implementation, and review.
