### PR TITLE
fix: show provider 503 failures in group and channel chats

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -167,6 +167,7 @@ export const QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE = /final-only marker strea
 export const QA_BLOCK_STREAMING_PROMPT_RE = /block streaming qa check/i;
 export const QA_TOOL_PROGRESS_ERROR_PROMPT_RE = /tool progress error qa check/i;
 export const QA_TOOL_PROGRESS_PROMPT_RE = /tool progress qa check/i;
+export const QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE = /provider http 503 after tool qa check/i;
 export const QA_GROUP_VISIBLE_REPLY_TOOL_PROMPT_RE = /qa group visible reply tool check/i;
 export const QA_A2A_MESSAGE_TOOL_MIRROR_PROMPT_RE = /qa a2a message-tool mirror check/i;
 export const QA_GROUP_MESSAGE_UNAVAILABLE_FALLBACK_PROMPT_RE =

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -266,6 +266,42 @@ function explicitSessionsSpawnPrompt(token: string) {
 }
 
 describe("qa mock openai server", () => {
+  it("returns HTTP 503 only after the provider failure fixture receives tool output", async () => {
+    const server = await startMockServer();
+    const prompt = "Provider HTTP 503 after tool QA check: read QA_KICKOFF_TASK.md, then reply.";
+
+    const toolPlan = await postResponses(server, {
+      stream: false,
+      model: "gpt-5.6-luna",
+      tools: [READ_TOOL],
+      input: [makeUserInput(prompt)],
+    });
+    expect(toolPlan.status).toBe(200);
+    expect(outputItem(await toolPlan.json()).name).toBe("read");
+
+    const failure = await postResponses(server, {
+      stream: false,
+      model: "gpt-5.6-luna",
+      tools: [READ_TOOL],
+      input: [
+        makeUserInput(prompt),
+        {
+          type: "function_call_output",
+          call_id: "call_mock_provider_503",
+          output: "QA mission loaded",
+        },
+      ],
+    });
+
+    expect(failure.status).toBe(503);
+    expect(await failure.json()).toEqual({
+      error: {
+        type: "server_error",
+        message: "Service Unavailable",
+      },
+    });
+  });
+
   it("keeps cursor reads correct when retained debug requests rotate", async () => {
     const server = await startMockServer();
     const debugRequestLimit = 2_000;

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -27,6 +27,7 @@ import {
   QA_BLOCK_STREAMING_PROMPT_RE,
   QA_TOOL_PROGRESS_ERROR_PROMPT_RE,
   QA_TOOL_PROGRESS_PROMPT_RE,
+  QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE,
   QA_GROUP_VISIBLE_REPLY_TOOL_PROMPT_RE,
   QA_A2A_MESSAGE_TOOL_MIRROR_PROMPT_RE,
   QA_GROUP_MESSAGE_UNAVAILABLE_FALLBACK_PROMPT_RE,
@@ -1491,6 +1492,18 @@ export async function startQaMockOpenAiServer(params?: {
           toolOutputCallId: extractToolOutputCallId(input) || undefined,
           ...(extractToolOutputStructuredError(input) ? { toolOutputStructuredError: true } : {}),
         });
+        if (
+          QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE.test(allInputText) &&
+          extractToolOutput(input)
+        ) {
+          writeJson(res, 503, {
+            error: {
+              type: "server_error",
+              message: "Service Unavailable",
+            },
+          });
+          return;
+        }
         if (body.stream === false) {
           const completion = events.at(-1);
           if (!completion || completion.type !== "response.completed") {

--- a/qa/scenarios/channels/provider-http-503-visible-failure.yaml
+++ b/qa/scenarios/channels/provider-http-503-visible-failure.yaml
@@ -1,0 +1,111 @@
+title: Provider HTTP 503 remains visible after tool execution
+
+scenario:
+  id: provider-http-503-visible-failure
+  surface: channel
+  coverage:
+    primary:
+      - agent-runtime.structured-provider-diagnostics
+      - channels.group-final-reply
+    secondary:
+      - agent-runtime.failure-recovery-retry-policy
+      - channels.qa-channel-final-reply
+  objective: Verify a provider HTTP 503 after tool execution produces one safe visible channel reply without replaying the tool.
+  gatewayConfigPatch:
+    # Isolate this scenario from model-fallback replay policy. The regression
+    # target is the outer channel failure mapping after a post-tool 503.
+    agents:
+      defaults:
+        model:
+          fallbacks: []
+      entries:
+        qa:
+          model:
+            fallbacks: []
+  successCriteria:
+    - The mock provider plans one read before returning HTTP 503 on the post-tool request.
+    - The channel receives the existing sanitized temporary-provider-error reply exactly once.
+    - OpenClaw does not replay the tool-backed turn after the HTTP 503.
+    - Raw provider diagnostics are not delivered to the channel.
+  docsRefs:
+    - docs/channels/qa-channel.md
+  codeRefs:
+    - src/auto-reply/reply/provider-request-error-classifier.ts
+    - src/auto-reply/reply/agent-runner-error-handler.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+  execution:
+    kind: flow
+    channel: qa-channel
+    summary: Run one channel turn whose mock provider returns HTTP 503 after a tool result, then verify one sanitized reply and no tool replay.
+    config:
+      requiredProviderMode: mock-openai
+      conversationId: qa-provider-http-503
+      promptSnippet: Provider HTTP 503 after tool QA check
+      prompt: "@openclaw Provider HTTP 503 after tool QA check: read QA_KICKOFF_TASK.md, then reply."
+      expectedReply: "⚠️ The model provider returned a temporary internal error before replying. Try again in a moment, or switch to another model if it keeps happening."
+
+flow:
+  steps:
+    - name: surfaces one sanitized failure without replaying the tool
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: this seeded scenario is mock-openai only
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - set: requestCursorBefore
+          value:
+            expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
+        - sendInbound:
+            conversation:
+              id:
+                expr: config.conversationId
+              kind: channel
+              title: QA Provider Failure
+            senderId: alice
+            senderName: Alice
+            text:
+              expr: config.prompt
+        - call: waitForOutboundMessage
+          saveAs: outbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.conversation.id === config.conversationId && candidate.conversation.kind === 'channel' && String(candidate.text ?? '') === config.expectedReply"
+            - expr: liveTurnTimeoutMs(env, 180000)
+        - set: matchingOutbound
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && String(message.text ?? '') === config.expectedReply)"
+        - set: scenarioRequests
+          value:
+            expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet)) : []"
+        - set: plannedReads
+          value:
+            expr: "scenarioRequests.filter((request) => request.plannedToolName === 'read')"
+        - set: postToolRequests
+          value:
+            expr: "scenarioRequests.filter((request) => String(request.toolOutput ?? '').trim().length > 0)"
+        - assert:
+            expr: matchingOutbound.length === 1
+            message:
+              expr: "`expected one sanitized provider failure reply, saw ${matchingOutbound.length}`"
+        - assert:
+            expr: "!env.mock || plannedReads.length === 1"
+            message:
+              expr: "`provider failure turn must plan the read exactly once, saw ${plannedReads.length}`"
+        - assert:
+            expr: "!env.mock || postToolRequests.length >= 1"
+            message: expected at least one post-tool HTTP 503 request
+        - assert:
+            expr: "!String(outbound.text ?? '').includes('Service Unavailable') && !String(outbound.text ?? '').includes('biscuit_baker')"
+            message:
+              expr: "`raw provider diagnostics leaked into channel reply: ${String(outbound.text ?? '')}`"
+      detailsExpr: "`reply=${matchingOutbound.length}; plannedReads=${plannedReads.length}; postTool503=${postToolRequests.length}`"

--- a/qa/scenarios/channels/provider-http-503-visible-failure.yaml
+++ b/qa/scenarios/channels/provider-http-503-visible-failure.yaml
@@ -81,9 +81,12 @@ flow:
                 params: [candidate]
                 expr: "candidate.conversation.id === config.conversationId && candidate.conversation.kind === 'channel' && String(candidate.text ?? '') === config.expectedReply"
             - expr: liveTurnTimeoutMs(env, 180000)
-        - set: matchingOutbound
+        - call: sleep
+          args:
+            - expr: liveTurnTimeoutMs(env, 8000)
+        - set: conversationOutbound
           value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && String(message.text ?? '') === config.expectedReply)"
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && message.conversation.kind === 'channel')"
         - set: scenarioRequests
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet)) : []"
@@ -94,9 +97,13 @@ flow:
           value:
             expr: "scenarioRequests.filter((request) => String(request.toolOutput ?? '').trim().length > 0)"
         - assert:
-            expr: matchingOutbound.length === 1
+            expr: conversationOutbound.length === 1
             message:
-              expr: "`expected one sanitized provider failure reply, saw ${matchingOutbound.length}`"
+              expr: "`expected exactly one channel reply after settling, saw ${conversationOutbound.length}: ${JSON.stringify(conversationOutbound.map((message) => String(message.text ?? '')))}`"
+        - assert:
+            expr: "String(conversationOutbound[0]?.text ?? '') === config.expectedReply"
+            message:
+              expr: "`expected the sanitized provider failure reply, saw ${String(conversationOutbound[0]?.text ?? '')}`"
         - assert:
             expr: "!env.mock || plannedReads.length === 1"
             message:
@@ -105,7 +112,7 @@ flow:
             expr: "!env.mock || postToolRequests.length >= 1"
             message: expected at least one post-tool HTTP 503 request
         - assert:
-            expr: "!String(outbound.text ?? '').includes('Service Unavailable') && !String(outbound.text ?? '').includes('biscuit_baker')"
+            expr: "conversationOutbound.every((message) => !String(message.text ?? '').includes('Service Unavailable') && !String(message.text ?? '').includes('biscuit_baker'))"
             message:
-              expr: "`raw provider diagnostics leaked into channel reply: ${String(outbound.text ?? '')}`"
-      detailsExpr: "`reply=${matchingOutbound.length}; plannedReads=${plannedReads.length}; postTool503=${postToolRequests.length}`"
+              expr: "`raw provider diagnostics leaked into channel replies: ${JSON.stringify(conversationOutbound.map((message) => String(message.text ?? '')))}`"
+      detailsExpr: "`reply=${conversationOutbound.length}; plannedReads=${plannedReads.length}; postTool503=${postToolRequests.length}`"

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -401,17 +401,9 @@ export async function handleAgentExecutionError(params: {
     turn.replyOperation?.recordActivity();
     return { kind: "retry" };
   }
-  if (providerRequestError) {
-    takePendingLifecycleTerminal()?.emit("error", err);
-    turn.replyOperation?.fail("run_failed", err);
-    await params.modelPatch.fail(err);
-    return {
-      kind: "final",
-      payload: markAgentRunFailureReplyPayload({ text: providerRequestError.userMessage }),
-    };
-  }
   if (
     isTransientHttp &&
+    (!providerRequestError || providerRequestError.allowTransientHttpRetry) &&
     !params.overloadRetryState.unsafeToReplay &&
     params.consumeTransientHttpRetry()
   ) {
@@ -425,6 +417,15 @@ export async function handleAgentExecutionError(params: {
       return abortAction;
     }
     return { kind: "retry" };
+  }
+  if (providerRequestError) {
+    takePendingLifecycleTerminal()?.emit("error", err);
+    turn.replyOperation?.fail("run_failed", err);
+    await params.modelPatch.fail(err);
+    return {
+      kind: "final",
+      payload: markAgentRunFailureReplyPayload({ text: providerRequestError.userMessage }),
+    };
   }
   defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
   const isPureTransientSummary = isFallbackSummary ? isPureTransientRateLimitSummary(err) : false;

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -42,6 +42,16 @@ function createOverloadSummaryError() {
 const OPENAI_SERVICE_UNAVAILABLE_MESSAGE =
   "unexpected status 503 Service Unavailable: Service Unavailable, url: https://chatgpt.com/backend-api/codex/responses, cf-ray: qa-test-AMS, auth error: 503, auth error code: biscuit_baker_service_me_circuit_open";
 
+function createOpenAiServiceUnavailableError() {
+  return new FailoverError("LLM request timed out.", {
+    reason: "timeout",
+    provider: "openai",
+    model: "gpt-5.6",
+    status: 408,
+    rawError: OPENAI_SERVICE_UNAVAILABLE_MESSAGE,
+  });
+}
+
 describe("runAgentTurnWithFallback: provider failures", () => {
   it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
     "keeps raw runner failure boilerplate out of $label chats",
@@ -195,13 +205,7 @@ describe("runAgentTurnWithFallback: provider failures", () => {
     async (chatType) => {
       state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
         params.onExecutionPhase?.({ phase: "tool_execution_started", tool: "exec" });
-        throw new FailoverError("LLM request timed out.", {
-          reason: "timeout",
-          provider: "openai",
-          model: "gpt-5.6",
-          status: 408,
-          rawError: OPENAI_SERVICE_UNAVAILABLE_MESSAGE,
-        });
+        throw createOpenAiServiceUnavailableError();
       });
 
       const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
@@ -231,6 +235,53 @@ describe("runAgentTurnWithFallback: provider failures", () => {
       }
     },
   );
+
+  it("retries a provider HTTP 503 before output and delivers the recovered response", async () => {
+    vi.useFakeTimers();
+    state.runEmbeddedAgentMock
+      .mockRejectedValueOnce(createOpenAiServiceUnavailableError())
+      .mockResolvedValueOnce({
+        payloads: [{ text: "Recovered response" }],
+        meta: {},
+      });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const resultPromise = runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: createNonDirectFailureSessionCtx(NON_DIRECT_FAILURE_SURFACE_CASES[0]),
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await resultPromise;
+
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([{ text: "Recovered response" }]);
+    }
+  });
+
+  it("surfaces a sanitized provider HTTP 503 notice after the safe retry is exhausted", async () => {
+    vi.useFakeTimers();
+    state.runEmbeddedAgentMock.mockRejectedValue(createOpenAiServiceUnavailableError());
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const resultPromise = runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: createNonDirectFailureSessionCtx(NON_DIRECT_FAILURE_SURFACE_CASES[1]),
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await resultPromise;
+
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.isError).toBe(true);
+      expect(result.payload.text).toBe(PROVIDER_INTERNAL_ERROR_USER_MESSAGE);
+      expect(result.payload.text).not.toContain(OPENAI_SERVICE_UNAVAILABLE_MESSAGE);
+    }
+  });
 
   it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
     "surfaces provider authentication failures in $label chats",

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -39,6 +39,9 @@ function createOverloadSummaryError() {
   });
 }
 
+const OPENAI_SERVICE_UNAVAILABLE_MESSAGE =
+  "unexpected status 503 Service Unavailable: Service Unavailable, url: https://chatgpt.com/backend-api/codex/responses, cf-ray: qa-test-AMS, auth error: 503, auth error code: biscuit_baker_service_me_circuit_open";
+
 describe("runAgentTurnWithFallback: provider failures", () => {
   it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
     "keeps raw runner failure boilerplate out of $label chats",
@@ -183,6 +186,48 @@ describe("runAgentTurnWithFallback: provider failures", () => {
       if (result.kind === "final") {
         expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
         expect(result.payload.text).toContain('Missing API key for provider "openai"');
+      }
+    },
+  );
+
+  it.each(["group", "channel"] as const)(
+    "surfaces provider HTTP 503 failures in Discord %s chats without replaying after tool execution",
+    async (chatType) => {
+      state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+        params.onExecutionPhase?.({ phase: "tool_execution_started", tool: "exec" });
+        throw new FailoverError("LLM request timed out.", {
+          reason: "timeout",
+          provider: "openai",
+          model: "gpt-5.6",
+          status: 408,
+          rawError: OPENAI_SERVICE_UNAVAILABLE_MESSAGE,
+        });
+      });
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback(
+        createMinimalRunAgentTurnParams({
+          sessionCtx: {
+            Provider: "discord",
+            Surface: "discord",
+            ChatType: chatType,
+            GroupSubject: "agent group",
+            GroupChannel: "#general",
+            MessageSid: "msg",
+          } as unknown as TemplateContext,
+        }),
+      );
+
+      expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.isError).toBe(true);
+        expect(result.payload.text).toBe(PROVIDER_INTERNAL_ERROR_USER_MESSAGE);
+        expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
+        expect(result.payload.text).not.toContain(OPENAI_SERVICE_UNAVAILABLE_MESSAGE);
+        expect(getReplyPayloadMetadata(result.payload)).toMatchObject({
+          deliverDespiteSourceReplySuppression: true,
+        });
       }
     },
   );

--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -209,6 +209,7 @@ describe("provider request error classifier", () => {
       code: "provider_internal_error",
       userMessage: PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
       technicalMessage: "LLM request timed out.",
+      allowTransientHttpRetry: true,
     });
   });
 

--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -14,6 +14,8 @@ const PROVIDER_INTERNAL_ERROR_USER_MESSAGE =
   "⚠️ The model provider returned a temporary internal error before replying. Try again in a moment, or switch to another model if it keeps happening.";
 const PROVIDER_MODEL_UNAVAILABLE_USER_MESSAGE =
   "⚠️ The configured model is unavailable from the provider — it may have been renamed, retired, or is not offered on this account. This needs a config update (agents.defaults.model); retrying or starting a new session won't fix it.";
+const OPENAI_SERVICE_UNAVAILABLE_MESSAGE =
+  "unexpected status 503 Service Unavailable: Service Unavailable, url: https://chatgpt.com/backend-api/codex/responses, cf-ray: qa-test-AMS, auth error: 503, auth error code: biscuit_baker_service_me_circuit_open";
 
 describe("provider request error classifier", () => {
   it("classifies provider HTTP 401 authentication failures", () => {
@@ -192,5 +194,30 @@ describe("provider request error classifier", () => {
       userMessage: PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
       technicalMessage: message,
     });
+  });
+
+  it("classifies an explicit provider HTTP 503 after failover normalizes its status", () => {
+    const error = new FailoverError("LLM request timed out.", {
+      reason: "timeout",
+      provider: "openai",
+      model: "gpt-5.6",
+      status: 408,
+      rawError: OPENAI_SERVICE_UNAVAILABLE_MESSAGE,
+    });
+
+    expect(classifyProviderRequestError(error)).toEqual({
+      code: "provider_internal_error",
+      userMessage: PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
+      technicalMessage: "LLM request timed out.",
+    });
+  });
+
+  it.each([
+    "request timed out after 503ms",
+    "unexpected status 403 Forbidden",
+    "HTTP 429 Too Many Requests",
+    "HTTP 529 Provider Overloaded",
+  ])("does not classify unrelated status text as an internal error: %s", (message) => {
+    expect(classifyProviderRequestError(new Error(message))).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -20,6 +20,7 @@ type ProviderRequestErrorClassification = {
   code: ProviderRequestErrorCode;
   userMessage: string;
   technicalMessage: string;
+  allowTransientHttpRetry?: true;
 };
 
 /** User-facing copy for provider-side broken conversation state. */
@@ -86,10 +87,15 @@ export function classifyProviderRequestError(
       technicalMessage,
     };
   }
-  if (
-    hasHttp503Evidence(err, technicalMessage) ||
-    isProviderInternalErrorMessage(technicalMessage)
-  ) {
+  if (hasHttp503Evidence(err, technicalMessage)) {
+    return {
+      code: "provider_internal_error",
+      userMessage: PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
+      technicalMessage,
+      allowTransientHttpRetry: true,
+    };
+  }
+  if (isProviderInternalErrorMessage(technicalMessage)) {
     return {
       code: "provider_internal_error",
       userMessage: PROVIDER_INTERNAL_ERROR_USER_MESSAGE,

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -86,7 +86,10 @@ export function classifyProviderRequestError(
       technicalMessage,
     };
   }
-  if (isProviderInternalErrorMessage(technicalMessage)) {
+  if (
+    hasHttp503Evidence(err, technicalMessage) ||
+    isProviderInternalErrorMessage(technicalMessage)
+  ) {
     return {
       code: "provider_internal_error",
       userMessage: PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
@@ -136,12 +139,27 @@ function isProviderInternalErrorMessage(message: string): boolean {
 
 function hasHttp429Evidence(err: unknown, message: string): boolean {
   return (
-    readHttp429Status(err) ||
+    readHttpStatus(err, 429) ||
     /\b(?:http\s*)?429\b|["'](?:status|code)["']\s*:\s*429\b/iu.test(message)
   );
 }
 
-function readHttp429Status(err: unknown, seen = new Set<unknown>()): boolean {
+function hasHttp503Evidence(err: unknown, message: string): boolean {
+  const rawError = isFailoverError(err) ? err.rawError : undefined;
+  return (
+    readHttpStatus(err, 503) ||
+    hasHttp503TextEvidence(message) ||
+    (rawError ? hasHttp503TextEvidence(rawError) : false)
+  );
+}
+
+function hasHttp503TextEvidence(message: string): boolean {
+  return /\b(?:(?:unexpected\s+status|http)\s*503|503\s+service unavailable)\b|["'](?:status|code)["']\s*:\s*503\b/iu.test(
+    message,
+  );
+}
+
+function readHttpStatus(err: unknown, expectedStatus: number, seen = new Set<unknown>()): boolean {
   if (!err || typeof err !== "object" || seen.has(err)) {
     return false;
   }
@@ -150,16 +168,16 @@ function readHttp429Status(err: unknown, seen = new Set<unknown>()): boolean {
     (err as { status?: unknown; statusCode?: unknown }).status ??
     (err as { statusCode?: unknown }).statusCode;
   if (typeof candidate === "number" && Number.isFinite(candidate)) {
-    if (candidate === 429) {
+    if (candidate === expectedStatus) {
       return true;
     }
-  } else if (typeof candidate === "string" && Number(candidate.trim()) === 429) {
+  } else if (typeof candidate === "string" && Number(candidate.trim()) === expectedStatus) {
     return true;
   }
   const nested = err as { cause?: unknown; error?: unknown; response?: unknown };
   return (
-    readHttp429Status(nested.response, seen) ||
-    readHttp429Status(nested.error, seen) ||
-    readHttp429Status(nested.cause, seen)
+    readHttpStatus(nested.response, expectedStatus, seen) ||
+    readHttpStatus(nested.error, expectedStatus, seen) ||
+    readHttpStatus(nested.cause, expectedStatus, seen)
   );
 }


### PR DESCRIPTION
Related: #112259

## What Problem This Solves

Fixes an issue where users in visible group or channel chats could receive no reply when the model provider returned HTTP 503 after tool execution. The provider failure could be normalized to a generic timeout, then treated as an intentional silent group response.

## Why This Change Was Made

Recognize explicit HTTP 503 evidence from structured status fields, provider error text, and a `FailoverError`'s preserved raw error, then reuse the existing sanitized temporary-provider-error reply. This does not broaden retry or replay behavior: post-tool turns remain protected from unsafe replay, and unrelated timeout/status text remains unclassified.

The QA mock provider now has a deterministic post-tool HTTP 503 fixture and a channel scenario that verifies one tool plan, one sanitized visible reply, and no raw provider detail leakage.

## User Impact

Group and channel users now get a short actionable provider-error notice instead of apparent silence when a provider request ends in an explicit HTTP 503.

## Evidence

- Before the fix, the new classifier plus Discord group/channel regression tests failed 3 cases on main at `001319f1ad`: the normalized `FailoverError` was unclassified and the group/channel result was not an error payload. The affected classifier and runner test paths were unchanged between that base and the final rebase base.
- On exact PR head `dc4ad16931`, the focused suite passes: 4 files, 268 tests.

  ```text
  pnpm exec vitest run \
    extensions/qa-lab/src/providers/mock-openai/server.test.ts \
    extensions/qa-lab/src/scenario-catalog.test.ts \
    src/auto-reply/reply/provider-request-error-classifier.test.ts \
    src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
  ```

- The exact-head gateway QA scenario passes against the real channel/runtime boundary and mock OpenAI transport:

  ```text
  pnpm openclaw qa suite \
    --provider-mode mock-openai \
    --scenario provider-http-503-visible-failure

  Passed: 1
  Failed: 0
  Details: reply=1; plannedReads=1; postTool503=3
  ```

- `pnpm check` passes on the exact PR head, including preflight guards, TypeScript checks, full lint/formatting, and policy guards.
- Local `codex review --base upstream/main` found no actionable regressions.
- `pnpm check:changed` could not start locally because the installed Blacksmith `crabbox` binary failed its own `--version`/`--help` sanity check; the repository-wide `pnpm check` above completed successfully.

## AI Assistance

Developed with OpenAI Codex. I reviewed the complete diff, reproduced the pre-fix failure, ran the exact-head focused and repository-wide checks, exercised the real QA gateway scenario, and ran a separate read-only Codex review.
