### PR TITLE
fix(searxng): avoid duplicating configured search endpoint

### DIFF
--- a/extensions/searxng/src/searxng-client.test.ts
+++ b/extensions/searxng/src/searxng-client.test.ts
@@ -64,6 +64,21 @@ describe("searxng client", () => {
     );
   });
 
+  it("does not duplicate a configured search endpoint", () => {
+    expect(
+      testing.buildSearxngSearchUrl({
+        baseUrl: "https://search.example.com/search",
+        query: "openclaw",
+      }),
+    ).toBe("https://search.example.com/search?q=openclaw&format=json");
+    expect(
+      testing.buildSearxngSearchUrl({
+        baseUrl: "https://search.example.com/search/",
+        query: "openclaw",
+      }),
+    ).toBe("https://search.example.com/search?q=openclaw&format=json");
+  });
+
   it("parses SearXNG JSON results and applies the requested count cap", () => {
     expect(
       testing.parseSearxngResponseText(

--- a/extensions/searxng/src/searxng-client.ts
+++ b/extensions/searxng/src/searxng-client.ts
@@ -78,7 +78,8 @@ function buildSearxngSearchUrl(params: {
   language?: string;
 }): string {
   const url = new URL(params.baseUrl);
-  const pathname = url.pathname.endsWith("/") ? `${url.pathname}search` : `${url.pathname}/search`;
+  const basePathname = url.pathname.replace(/\/+$/u, "");
+  const pathname = basePathname.endsWith("/search") ? basePathname : `${basePathname}/search`;
   url.pathname = pathname;
   url.search = "";
   url.searchParams.set("q", params.query);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users configuring a self-hosted SearXNG instance with a base URL that already points at the `/search` endpoint would have OpenClaw send requests to `/search/search` instead.

This affects the SearXNG web-search path because `runSearxngSearch()` resolves the configured base URL and then `buildSearxngSearchUrl()` appends the search endpoint before the guarded provider request is made. A normal endpoint-style configuration such as `http://127.0.0.1:<port>/search` therefore targets the wrong route.

## Why This Change Was Made

The URL builder now trims trailing slashes from the configured path and reuses it when it already ends in `/search`; otherwise it keeps the existing behavior of appending `/search` to base-path prefixes.

This keeps the fix local to the SearXNG client endpoint construction. It does not change SSRF validation, trusted/self-hosted routing, query parameter handling, category retry behavior, response parsing, or cache keys.

## User Impact

Users can configure either a SearXNG host root or an explicit SearXNG search endpoint without OpenClaw duplicating the path segment.

For example, `https://search.example.com/searxng` still builds `https://search.example.com/searxng/search?...`, while `https://search.example.com/search` now builds `https://search.example.com/search?...` rather than `https://search.example.com/search/search?...`.

## Evidence

User-realistic local path capture using `runSearxngSearch()` against a local HTTP server:

```json
Before: {baseUrl:http://127.0.0.1:<port>/search,requests:[/search/search?q=q&format=json]}
After:  {baseUrl:http://127.0.0.1:<port>/search,requests:[/search?q=q&format=json]}
```

Focused validation:

```text
node scripts/run-vitest.mjs run extensions/searxng/src/searxng-client.test.ts

Test Files  1 passed (1)
Tests       15 passed (15)
```

Additional check:

```text
git diff --check -- extensions/searxng/src/searxng-client.ts extensions/searxng/src/searxng-client.test.ts
passed
```

Sibling surface checked: the existing base-path-prefix test still verifies that a configured prefix such as `/searxng` continues to append `/search` instead of being treated as a complete endpoint.