### PR TITLE
fix: inherit parent agent for dashboard-created sessions

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -430,6 +430,27 @@ test("createGatewaySession rechecks admin scope after incognito inheritance reso
   }
 });
 
+test("sessions.create preserves explicit and parent-derived agent routing", async () => {
+  const parent = await directSessionReq<{ key?: string }>("sessions.create", {
+    agentId: "work",
+  });
+  expect(parent.ok, JSON.stringify(parent.error)).toBe(true);
+  const parentSessionKey = requireNonEmptyString(parent.payload?.key, "work parent key");
+
+  const inherited = await directSessionReq<{ key?: string }>("sessions.create", {
+    parentSessionKey,
+  });
+  expect(inherited.ok, JSON.stringify(inherited.error)).toBe(true);
+  expect(inherited.payload?.key).toMatch(/^agent:work:dashboard:/u);
+
+  const explicit = await directSessionReq<{ key?: string }>("sessions.create", {
+    agentId: "main",
+    parentSessionKey,
+  });
+  expect(explicit.ok, JSON.stringify(explicit.error)).toBe(true);
+  expect(explicit.payload?.key).toMatch(/^agent:main:dashboard:/u);
+});
+
 test("incognito operator RPCs treat identityless connections as owner-equivalent", async () => {
   const { dir } = await createSessionStoreDir();
   const admin = await openClient({
@@ -2856,7 +2877,6 @@ test("sessions.create rejects fork while the parent session is active", async ()
 test("sessions.create resolves an agent-qualified fork from the parent store", async () => {
   const { dir } = await createSessionStoreDir();
   const storeTemplate = path.join(dir, "{agentId}", "sessions.json");
-  const mainStorePath = storeTemplate.replace("{agentId}", "main");
   const workStorePath = storeTemplate.replace("{agentId}", "work");
   const workDir = path.dirname(workStorePath);
   testState.sessionStorePath = storeTemplate;
@@ -2898,7 +2918,7 @@ test("sessions.create resolves an agent-qualified fork from the parent store", a
     });
 
     expect(created.ok, JSON.stringify(created.error)).toBe(true);
-    expect(created.payload?.key).toMatch(/^agent:main:dashboard:/);
+    expect(created.payload?.key).toMatch(/^agent:work:dashboard:/);
     expect(created.payload?.entry?.parentSessionKey).toBe("agent:work:main");
     expect(created.payload?.entry?.forkSource).toEqual({
       sessionKey: "agent:work:main",
@@ -2917,7 +2937,7 @@ test("sessions.create resolves an agent-qualified fork from the parent store", a
           "agent-qualified forked session id",
         ),
         sessionKey: created.payload?.key ?? "",
-        storePath: mainStorePath,
+        storePath: workStorePath,
       }),
     ).resolves.toEqual(
       expect.arrayContaining([

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -323,7 +323,9 @@ export async function createGatewaySession(params: {
   const requestedKey = normalizeOptionalString(params.key);
   const parentSessionKey = normalizeOptionalString(params.parentSessionKey);
   const agentId = normalizeAgentId(
-    normalizeOptionalString(params.agentId) ?? resolveDefaultAgentId(params.cfg),
+    normalizeOptionalString(params.agentId) ??
+      parseAgentSessionKey(parentSessionKey)?.agentId ??
+      resolveDefaultAgentId(params.cfg),
   );
   const catalogModel = normalizeOptionalString(params.catalogTarget?.model);
   const catalogAgentRuntime = normalizeOptionalAgentRuntimeId(params.catalogTarget?.agentRuntime);

--- a/ui/src/lib/sessions/create.test.ts
+++ b/ui/src/lib/sessions/create.test.ts
@@ -10,6 +10,25 @@ describe("resolveSessionCreateParams", () => {
       succeedsParent: false,
     });
   });
+
+  it("carries the parent agent when the dashboard omits an explicit agent", () => {
+    expect(resolveSessionCreateParams(" agent:research:dashboard:child ")).toEqual({
+      agentId: "research",
+      parentSessionKey: "agent:research:dashboard:child",
+      emitCommandHooks: true,
+      succeedsParent: false,
+    });
+  });
+
+  it("keeps no-context and legacy sentinel creates on the gateway default", () => {
+    expect(resolveSessionCreateParams()).toEqual({});
+    expect(resolveSessionCreateParams("unknown")).toEqual({});
+    expect(resolveSessionCreateParams("global")).toEqual({
+      parentSessionKey: "global",
+      emitCommandHooks: true,
+      succeedsParent: false,
+    });
+  });
 });
 
 describe("requestSessionCreate", () => {

--- a/ui/src/lib/sessions/create.ts
+++ b/ui/src/lib/sessions/create.ts
@@ -1,5 +1,6 @@
 import type { SessionsCreateResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { parseAgentSessionKey } from "./session-key.ts";
 
 export type SessionCreateOutcome = {
   key: string;
@@ -43,8 +44,12 @@ export function resolveSessionCreateParams(sessionKey = "", agentId?: string) {
     normalizedSessionKey && normalizedSessionKey.toLowerCase() !== "unknown"
       ? normalizedSessionKey
       : undefined;
+  const explicitAgentId = agentId?.trim();
+  const parentAgentId = parentSessionKey
+    ? parseAgentSessionKey(parentSessionKey)?.agentId
+    : undefined;
   return {
-    ...(agentId?.trim() ? { agentId: agentId.trim() } : {}),
+    ...(explicitAgentId || parentAgentId ? { agentId: explicitAgentId ?? parentAgentId } : {}),
     ...(parentSessionKey
       ? { parentSessionKey, emitCommandHooks: true, succeedsParent: false }
       : {}),


### PR DESCRIPTION
## What Problem This Solves

Dashboard-created child sessions can fall back to the configured default agent before considering the agent encoded in their parent session key. In a multi-agent dashboard, that can place newly created session state in the wrong agent-owned store. This change preserves explicit selections while deriving the parent agent when the dashboard omits one.

## Summary

- Derive the agent ID from `parentSessionKey` when the dashboard omits an explicit agent.
- Preserve explicit-agent precedence and the configured default for no-context and legacy sentinel creates.
- Add Gateway and Control UI regression coverage, including agent-qualified forks.

## Evidence

- Gateway session-create tests: 68 passed.
- UI test typecheck: passed.
- Commit diff check: passed.
- Public-artifact red-list scan: clean; the commit contains only approved GitHub noreply author metadata and the Mergeguez co-author trailer.
- The standard UI Vitest shard remains environment-blocked by the existing `No such built-in module: node:` browser externalization failure; no source failure was observed.

### Real behavior proof

Validated at exact PR head `5b153943f89c4f0938d6a22cd07a627576227937` using the Gateway WebSocket test harness with the `openclaw-control-ui` client identity, web/UI mode, and a loopback browser origin. The run exercised the real Gateway session-create path with configured `main` (default) and `work` agents; no session-create handler was mocked.

Observed results:

- A `work` parent created an `agent:work:dashboard:*` session.
- A dashboard-style create request carrying only that parent key created an `agent:work:dashboard:*` child.
- An explicit `agentId: "main"` override created an `agent:main:dashboard:*` session.
- A create request with no context used the configured default and created an `agent:main:dashboard:*` session.
- Targeted Gateway run: 1 real Gateway WebSocket test passed with 4 routing assertions; the focused Gateway session-create suite also passed 68 tests.

The evidence was redacted to retain only routing prefixes and assertion results; no credentials, private paths, session identifiers, or personal data are included.

## Coordination

Related to #113146. This PR is a focused follow-up for dashboard session agent routing and should be reviewed alongside #113146. If the behavior is already covered by that PR when it lands, this PR can be closed as superseded.