### PR TITLE
fix(telegram): scope dispatch dedupe by bot identity

### DIFF
--- a/extensions/telegram/src/bot-handlers.message-events.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-events.runtime.ts
@@ -174,16 +174,13 @@ export function registerTelegramMessageHandlers(
         storePath: sessionState.storePath,
       });
 
-      const dispatchDedupe = await claimMessageDispatchDedupe(event.msg);
+      const botUserId = event.ctx.me?.id ?? opts.botInfo?.id;
+      const dispatchDedupe = await claimMessageDispatchDedupe(event.msg, botUserId);
       if (!dispatchDedupe.process) {
         return;
       }
       dispatchDedupeClaims = dispatchDedupe.claims;
-      await recordMessageForReplyChain(
-        event.msg,
-        resolvedThreadId ?? dmThreadId,
-        event.ctx.me?.id ?? opts.botInfo?.id,
-      );
+      await recordMessageForReplyChain(event.msg, resolvedThreadId ?? dmThreadId, botUserId);
       await processInboundMessage({
         authorizationCfg: gate.context.cfg,
         ctx: event.ctx,

--- a/extensions/telegram/src/bot-handlers.message-events.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-events.runtime.ts
@@ -22,7 +22,7 @@ import type { TelegramContext, TelegramGetChat } from "./bot/types.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
 
 export function registerTelegramMessageHandlers(
-  { bot, opts, runtime, shouldSkipUpdate }: RegisterTelegramHandlerParams,
+  { bot, runtime, shouldSkipUpdate }: RegisterTelegramHandlerParams,
   messageRuntime: TelegramHandlerMessageRuntime,
   authorizationRuntime: TelegramHandlerAuthorizationRuntime,
   inboundRuntime: TelegramHandlerInboundRuntime,
@@ -43,6 +43,7 @@ export function registerTelegramMessageHandlers(
   type InboundTelegramEvent = {
     ctxForDedupe: TelegramUpdateKeyContext;
     ctx: TelegramContext;
+    botUserId: number;
     msg: Message;
     chatId: number;
     isGroup: boolean;
@@ -84,7 +85,7 @@ export function registerTelegramMessageHandlers(
     ctxForDedupe: TelegramUpdateKeyContext;
     msg: Message;
     requireConfiguredGroup: boolean;
-    botUserId?: number;
+    botUserId: number;
   }) => {
     if (shouldSkipUpdate(params.ctxForDedupe)) {
       return;
@@ -174,13 +175,12 @@ export function registerTelegramMessageHandlers(
         storePath: sessionState.storePath,
       });
 
-      const botUserId = event.ctx.me?.id ?? opts.botInfo?.id;
-      const dispatchDedupe = await claimMessageDispatchDedupe(event.msg, botUserId);
+      const dispatchDedupe = await claimMessageDispatchDedupe(event.msg, event.botUserId);
       if (!dispatchDedupe.process) {
         return;
       }
       dispatchDedupeClaims = dispatchDedupe.claims;
-      await recordMessageForReplyChain(event.msg, resolvedThreadId ?? dmThreadId, botUserId);
+      await recordMessageForReplyChain(event.msg, resolvedThreadId ?? dmThreadId, event.botUserId);
       await processInboundMessage({
         authorizationCfg: gate.context.cfg,
         ctx: event.ctx,
@@ -255,6 +255,7 @@ export function registerTelegramMessageHandlers(
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, normalizedMsg),
+      botUserId: ctx.me.id,
       msg: normalizedMsg,
       chatId: normalizedMsg.chat.id,
       isGroup,
@@ -278,7 +279,7 @@ export function registerTelegramMessageHandlers(
       ctxForDedupe: ctx,
       msg,
       requireConfiguredGroup: false,
-      botUserId: ctx.me?.id ?? opts.botInfo?.id,
+      botUserId: ctx.me.id,
     });
   });
 
@@ -297,6 +298,7 @@ export function registerTelegramMessageHandlers(
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, syntheticMsg),
+      botUserId: ctx.me.id,
       msg: syntheticMsg,
       chatId,
       isGroup: true,
@@ -324,7 +326,7 @@ export function registerTelegramMessageHandlers(
       ctxForDedupe: ctx,
       msg: normalizeChannelPostMessage(post),
       requireConfiguredGroup: true,
-      botUserId: ctx.me?.id ?? opts.botInfo?.id,
+      botUserId: ctx.me.id,
     });
   });
 }

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
@@ -1,7 +1,7 @@
 // Telegram dispatch dedupe, replay settlement, and synthetic-message helpers.
 import type { Message } from "grammy/types";
 import { formatMediaPlaceholderText } from "openclaw/plugin-sdk/channel-inbound";
-import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
+import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type {
   TelegramAmbientTranscriptWatermark,
   TelegramMessageContextOptions,
@@ -36,7 +36,6 @@ export function createTelegramMessageLifecycleRuntime({
       runtime.error?.(danger(`[telegram] message dispatch dedupe store failed: ${String(error)}`));
     },
   });
-  let invalidDedupeIdentityWarningEmitted = false;
   const normalizePromptContextMinTimestampMs = (timestampMs?: number) =>
     typeof timestampMs === "number" && Number.isFinite(timestampMs) ? timestampMs : undefined;
   const promptContextBoundaryOptions = (
@@ -130,7 +129,7 @@ export function createTelegramMessageLifecycleRuntime({
     participants.length > 0 ? { spooledReplay: true } : {};
   const claimMessageDispatchDedupe = async (
     msg: Message,
-    botUserId?: number,
+    botUserId: number,
   ): Promise<
     { process: true; claims: TelegramMessageDispatchReplayClaim[] } | { process: false }
   > => {
@@ -143,17 +142,6 @@ export function createTelegramMessageLifecycleRuntime({
     if (claim.kind === "duplicate") {
       logVerbose(`telegram dispatch dedupe: skipped message ${msg.chat.id}:${msg.message_id}`);
       return { process: false };
-    }
-    if (claim.kind === "invalid") {
-      const diagnostic =
-        `[telegram][diag] message dispatch dedupe bypassed ` +
-        `claim_kind=invalid_identity account=${accountId} ` +
-        `chat=${msg.chat.id} message=${msg.message_id}`;
-      logVerbose(diagnostic);
-      if (!invalidDedupeIdentityWarningEmitted) {
-        invalidDedupeIdentityWarningEmitted = true;
-        runtime.log?.(warn(diagnostic));
-      }
     }
     return { process: true, claims: claim.kind === "claimed" ? [claim.handle] : [] };
   };

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
@@ -1,7 +1,7 @@
 // Telegram dispatch dedupe, replay settlement, and synthetic-message helpers.
 import type { Message } from "grammy/types";
 import { formatMediaPlaceholderText } from "openclaw/plugin-sdk/channel-inbound";
-import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import type {
   TelegramAmbientTranscriptWatermark,
   TelegramMessageContextOptions,
@@ -36,6 +36,7 @@ export function createTelegramMessageLifecycleRuntime({
       runtime.error?.(danger(`[telegram] message dispatch dedupe store failed: ${String(error)}`));
     },
   });
+  let invalidDedupeIdentityWarningEmitted = false;
   const normalizePromptContextMinTimestampMs = (timestampMs?: number) =>
     typeof timestampMs === "number" && Number.isFinite(timestampMs) ? timestampMs : undefined;
   const promptContextBoundaryOptions = (
@@ -129,13 +130,30 @@ export function createTelegramMessageLifecycleRuntime({
     participants.length > 0 ? { spooledReplay: true } : {};
   const claimMessageDispatchDedupe = async (
     msg: Message,
+    botUserId?: number,
   ): Promise<
     { process: true; claims: TelegramMessageDispatchReplayClaim[] } | { process: false }
   > => {
-    const claim = await claimTelegramMessageDispatchReplay({ guard: replayGuard, accountId, msg });
+    const claim = await claimTelegramMessageDispatchReplay({
+      guard: replayGuard,
+      accountId,
+      botUserId,
+      msg,
+    });
     if (claim.kind === "duplicate") {
       logVerbose(`telegram dispatch dedupe: skipped message ${msg.chat.id}:${msg.message_id}`);
       return { process: false };
+    }
+    if (claim.kind === "invalid") {
+      const diagnostic =
+        `[telegram][diag] message dispatch dedupe bypassed ` +
+        `claim_kind=invalid_identity account=${accountId} ` +
+        `chat=${msg.chat.id} message=${msg.message_id}`;
+      logVerbose(diagnostic);
+      if (!invalidDedupeIdentityWarningEmitted) {
+        invalidDedupeIdentityWarningEmitted = true;
+        runtime.log?.(warn(diagnostic));
+      }
     }
     return { process: true, claims: claim.kind === "claimed" ? [claim.handle] : [] };
   };

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import type { Message } from "grammy/types";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createTelegramMessageLifecycleRuntime } from "./bot-handlers.message-lifecycle.runtime.js";
 
 function message(fields: Record<string, unknown>): Message {
@@ -41,25 +41,5 @@ describe("Telegram ambient transcript media text", () => {
     const body = runtime.formatTelegramAmbientTranscriptBody([message({ message_id: 9 })]);
 
     expect(body).toBe("#9 Ada: <media:attachment>");
-  });
-});
-
-describe("Telegram dispatch dedupe observability", () => {
-  it("warns once when missing bot identity makes dedupe fail open", async () => {
-    const log = vi.fn();
-    const lifecycle = createTelegramMessageLifecycleRuntime({
-      accountId: "default",
-      runtime: { log, error: () => {}, exit: () => {} } as never,
-    });
-
-    await expect(
-      lifecycle.claimMessageDispatchDedupe(message({ message_id: 10 })),
-    ).resolves.toEqual({ process: true, claims: [] });
-    await expect(
-      lifecycle.claimMessageDispatchDedupe(message({ message_id: 11 })),
-    ).resolves.toEqual({ process: true, claims: [] });
-
-    expect(log).toHaveBeenCalledTimes(1);
-    expect(log).toHaveBeenCalledWith(expect.stringContaining("claim_kind=invalid_identity"));
   });
 });

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import type { Message } from "grammy/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createTelegramMessageLifecycleRuntime } from "./bot-handlers.message-lifecycle.runtime.js";
 
 function message(fields: Record<string, unknown>): Message {
@@ -41,5 +41,25 @@ describe("Telegram ambient transcript media text", () => {
     const body = runtime.formatTelegramAmbientTranscriptBody([message({ message_id: 9 })]);
 
     expect(body).toBe("#9 Ada: <media:attachment>");
+  });
+});
+
+describe("Telegram dispatch dedupe observability", () => {
+  it("warns once when missing bot identity makes dedupe fail open", async () => {
+    const log = vi.fn();
+    const lifecycle = createTelegramMessageLifecycleRuntime({
+      accountId: "default",
+      runtime: { log, error: () => {}, exit: () => {} } as never,
+    });
+
+    await expect(
+      lifecycle.claimMessageDispatchDedupe(message({ message_id: 10 })),
+    ).resolves.toEqual({ process: true, claims: [] });
+    await expect(
+      lifecycle.claimMessageDispatchDedupe(message({ message_id: 11 })),
+    ).resolves.toEqual({ process: true, claims: [] });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("claim_kind=invalid_identity"));
   });
 });

--- a/extensions/telegram/src/message-dispatch-dedupe.test.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.test.ts
@@ -200,7 +200,7 @@ describe("Telegram message dispatch replay guard", () => {
     }
   });
 
-  it("does not let a legacy unscoped row suppress a bot-scoped message", async () => {
+  it("starts a fresh dedupe window when legacy rows lack bot identity", async () => {
     const legacy = createLegacyReplayGuard();
     const legacyClaim = await legacy.claim({ accountId: "default", msg: message() });
     if (legacyClaim.kind !== "claimed") {

--- a/extensions/telegram/src/message-dispatch-dedupe.test.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.test.ts
@@ -3,16 +3,17 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Message } from "grammy/types";
-import type { ChannelReplayClaimHandle } from "openclaw/plugin-sdk/persistent-dedupe";
+import {
+  createChannelReplayGuard,
+  type ChannelReplayClaimHandle,
+} from "openclaw/plugin-sdk/persistent-dedupe";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  buildTelegramMessageDispatchAccountReplayKey,
   claimTelegramMessageDispatchReplay,
   commitTelegramMessageDispatchReplay,
   createTelegramMessageDispatchReplayGuard,
   releaseTelegramMessageDispatchReplay,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE,
 } from "./message-dispatch-dedupe.js";
 
 type TelegramMessageDispatchReplayGuard = Parameters<
@@ -20,6 +21,13 @@ type TelegramMessageDispatchReplayGuard = Parameters<
 >[0]["guard"];
 
 const tempDirs: string[] = [];
+const DEFAULT_BOT_USER_ID = 99;
+const CURRENT_NAMESPACE = "v2";
+const LEGACY_NAMESPACE = "global";
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX = "telegram.message-dispatch-dedupe";
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID = "telegram-message-dispatch-dedupe";
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES = 50_000;
 let previousStateDir: string | undefined;
 
 function createStateDir(): string {
@@ -36,9 +44,28 @@ function message(params?: { chatId?: number; messageId?: number }): Message {
   } as Message;
 }
 
-function storedReplayKey(accountId: string, msg: Message): string {
+function storedReplayKey(accountId: string, botUserId: number, msg: Message): string {
   const key = JSON.stringify(["message", String(msg.chat.id), msg.message_id]);
-  return buildTelegramMessageDispatchAccountReplayKey({ accountId, key });
+  return JSON.stringify(["account", accountId, "bot", String(botUserId), key]);
+}
+
+function legacyStoredReplayKey(accountId: string, msg: Message): string {
+  const key = JSON.stringify(["message", String(msg.chat.id), msg.message_id]);
+  return JSON.stringify(["account", accountId, key]);
+}
+
+function createLegacyReplayGuard() {
+  return createChannelReplayGuard<{ accountId: string; msg: Message }>({
+    dedupe: {
+      ttlMs: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
+      memoryMaxSize: 50_000,
+      pluginId: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
+      namespacePrefix: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX,
+      stateMaxEntries: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES,
+    },
+    buildReplayKey: (event) => legacyStoredReplayKey(event.accountId, event.msg),
+    namespace: () => LEGACY_NAMESPACE,
+  });
 }
 
 function createTestReplayGuard(
@@ -106,13 +133,14 @@ describe("Telegram message dispatch replay guard", () => {
     const first = await claimTelegramMessageDispatchReplay({
       guard: writer,
       accountId: "default",
+      botUserId: DEFAULT_BOT_USER_ID,
       msg: message(),
     });
 
     if (first.kind !== "claimed") {
       throw new Error("expected initial claim");
     }
-    expect(first.handle.keys).toEqual([storedReplayKey("default", message())]);
+    expect(first.handle.keys).toEqual([storedReplayKey("default", DEFAULT_BOT_USER_ID, message())]);
     await commitTelegramMessageDispatchReplay({
       guard: writer,
       claims: [first.handle],
@@ -123,9 +151,81 @@ describe("Telegram message dispatch replay guard", () => {
       claimTelegramMessageDispatchReplay({
         guard: reader,
         accountId: "default",
+        botUserId: DEFAULT_BOT_USER_ID,
         msg: message(),
       }),
     ).resolves.toEqual({ kind: "duplicate" });
+  });
+
+  it("isolates identical message coordinates across bot identities", async () => {
+    const writer = createTelegramMessageDispatchReplayGuard();
+    const first = await claimTelegramMessageDispatchReplay({
+      guard: writer,
+      accountId: "default",
+      botUserId: 101,
+      msg: message(),
+    });
+    if (first.kind !== "claimed") {
+      throw new Error("expected first bot claim");
+    }
+    await first.handle.commit();
+
+    const second = await claimTelegramMessageDispatchReplay({
+      guard: writer,
+      accountId: "default",
+      botUserId: 202,
+      msg: message(),
+    });
+    expect(second.kind).toBe("claimed");
+    if (second.kind === "claimed") {
+      await second.handle.commit();
+    }
+
+    const reader = createTelegramMessageDispatchReplayGuard();
+    for (const botUserId of [101, 202]) {
+      await expect(
+        claimTelegramMessageDispatchReplay({
+          guard: reader,
+          accountId: "default",
+          botUserId,
+          msg: message(),
+        }),
+      ).resolves.toEqual({ kind: "duplicate" });
+    }
+  });
+
+  it("does not let a legacy V1 row suppress a bot-scoped V2 message", async () => {
+    const legacy = createLegacyReplayGuard();
+    const legacyClaim = await legacy.claim({ accountId: "default", msg: message() });
+    if (legacyClaim.kind !== "claimed") {
+      throw new Error("expected legacy claim");
+    }
+    await legacyClaim.handle.commit();
+
+    const current = createTelegramMessageDispatchReplayGuard();
+    const currentClaim = await claimTelegramMessageDispatchReplay({
+      guard: current,
+      accountId: "default",
+      botUserId: DEFAULT_BOT_USER_ID,
+      msg: message(),
+    });
+    expect(currentClaim.kind).toBe("claimed");
+    if (currentClaim.kind === "claimed") {
+      currentClaim.handle.release();
+    }
+  });
+
+  it("fails open when bot identity is unavailable", async () => {
+    const guard = createTelegramMessageDispatchReplayGuard();
+    await expect(
+      claimTelegramMessageDispatchReplay({
+        guard,
+        accountId: "default",
+        msg: message(),
+      }),
+    ).resolves.toEqual({ kind: "invalid" });
+    await expect(guard.warmup(CURRENT_NAMESPACE)).resolves.toBe(0);
+    await expect(guard.warmup(LEGACY_NAMESPACE)).resolves.toBe(0);
   });
 
   it("preserves concurrent commits", async () => {
@@ -135,6 +235,7 @@ describe("Telegram message dispatch replay guard", () => {
         const claim = await claimTelegramMessageDispatchReplay({
           guard: writer,
           accountId: "default",
+          botUserId: DEFAULT_BOT_USER_ID,
           msg: message({ messageId: index + 1 }),
         });
         if (claim.kind !== "claimed") {
@@ -150,9 +251,7 @@ describe("Telegram message dispatch replay guard", () => {
     });
 
     const reader = createTelegramMessageDispatchReplayGuard();
-    await expect(reader.warmup(TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE)).resolves.toBe(
-      claims.length,
-    );
+    await expect(reader.warmup(CURRENT_NAMESPACE)).resolves.toBe(claims.length);
   });
 
   it("commits replay keys serially before starting the next write", async () => {
@@ -292,11 +391,13 @@ describe("Telegram message dispatch replay guard", () => {
     const first = await claimTelegramMessageDispatchReplay({
       guard: writer,
       accountId: "default",
+      botUserId: DEFAULT_BOT_USER_ID,
       msg: message(),
     });
     const second = await claimTelegramMessageDispatchReplay({
       guard: writer,
       accountId: "work",
+      botUserId: DEFAULT_BOT_USER_ID,
       msg: message(),
     });
     if (first.kind !== "claimed" || second.kind !== "claimed") {
@@ -309,7 +410,7 @@ describe("Telegram message dispatch replay guard", () => {
     });
 
     const reader = createTelegramMessageDispatchReplayGuard();
-    await expect(reader.warmup(TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE)).resolves.toBe(2);
+    await expect(reader.warmup(CURRENT_NAMESPACE)).resolves.toBe(2);
     await expect(reader.warmup("default")).resolves.toBe(0);
   });
 
@@ -318,6 +419,7 @@ describe("Telegram message dispatch replay guard", () => {
     const first = await claimTelegramMessageDispatchReplay({
       guard,
       accountId: "default",
+      botUserId: DEFAULT_BOT_USER_ID,
       msg: message(),
     });
     if (first.kind !== "claimed") {
@@ -327,11 +429,12 @@ describe("Telegram message dispatch replay guard", () => {
     const work = await claimTelegramMessageDispatchReplay({
       guard,
       accountId: "work",
+      botUserId: DEFAULT_BOT_USER_ID,
       msg: message(),
     });
     expect(work.kind).toBe("claimed");
     if (work.kind === "claimed") {
-      expect(work.handle.keys).toEqual([storedReplayKey("work", message())]);
+      expect(work.handle.keys).toEqual([storedReplayKey("work", DEFAULT_BOT_USER_ID, message())]);
     }
 
     releaseTelegramMessageDispatchReplay({
@@ -340,6 +443,7 @@ describe("Telegram message dispatch replay guard", () => {
     const retry = await claimTelegramMessageDispatchReplay({
       guard,
       accountId: "default",
+      botUserId: DEFAULT_BOT_USER_ID,
       msg: message(),
     });
     expect(retry.kind).toBe("claimed");
@@ -353,6 +457,7 @@ describe("Telegram message dispatch replay guard", () => {
     const first = await claimTelegramMessageDispatchReplay({
       guard,
       accountId: "default",
+      botUserId: DEFAULT_BOT_USER_ID,
       msg: message(),
     });
     if (first.kind !== "claimed") {
@@ -362,6 +467,7 @@ describe("Telegram message dispatch replay guard", () => {
     const duplicate = claimTelegramMessageDispatchReplay({
       guard,
       accountId: "default",
+      botUserId: DEFAULT_BOT_USER_ID,
       msg: message(),
     });
     releaseTelegramMessageDispatchReplay({

--- a/extensions/telegram/src/message-dispatch-dedupe.test.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.test.ts
@@ -22,8 +22,7 @@ type TelegramMessageDispatchReplayGuard = Parameters<
 
 const tempDirs: string[] = [];
 const DEFAULT_BOT_USER_ID = 99;
-const CURRENT_NAMESPACE = "v2";
-const LEGACY_NAMESPACE = "global";
+const CURRENT_NAMESPACE = "global";
 const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX = "telegram.message-dispatch-dedupe";
 const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID = "telegram-message-dispatch-dedupe";
@@ -45,8 +44,15 @@ function message(params?: { chatId?: number; messageId?: number }): Message {
 }
 
 function storedReplayKey(accountId: string, botUserId: number, msg: Message): string {
-  const key = JSON.stringify(["message", String(msg.chat.id), msg.message_id]);
-  return JSON.stringify(["account", accountId, "bot", String(botUserId), key]);
+  return JSON.stringify([
+    "account",
+    accountId,
+    "bot",
+    String(botUserId),
+    "message",
+    String(msg.chat.id),
+    msg.message_id,
+  ]);
 }
 
 function legacyStoredReplayKey(accountId: string, msg: Message): string {
@@ -64,7 +70,7 @@ function createLegacyReplayGuard() {
       stateMaxEntries: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES,
     },
     buildReplayKey: (event) => legacyStoredReplayKey(event.accountId, event.msg),
-    namespace: () => LEGACY_NAMESPACE,
+    namespace: () => CURRENT_NAMESPACE,
   });
 }
 
@@ -194,7 +200,7 @@ describe("Telegram message dispatch replay guard", () => {
     }
   });
 
-  it("does not let a legacy V1 row suppress a bot-scoped V2 message", async () => {
+  it("does not let a legacy unscoped row suppress a bot-scoped message", async () => {
     const legacy = createLegacyReplayGuard();
     const legacyClaim = await legacy.claim({ accountId: "default", msg: message() });
     if (legacyClaim.kind !== "claimed") {
@@ -213,19 +219,6 @@ describe("Telegram message dispatch replay guard", () => {
     if (currentClaim.kind === "claimed") {
       currentClaim.handle.release();
     }
-  });
-
-  it("fails open when bot identity is unavailable", async () => {
-    const guard = createTelegramMessageDispatchReplayGuard();
-    await expect(
-      claimTelegramMessageDispatchReplay({
-        guard,
-        accountId: "default",
-        msg: message(),
-      }),
-    ).resolves.toEqual({ kind: "invalid" });
-    await expect(guard.warmup(CURRENT_NAMESPACE)).resolves.toBe(0);
-    await expect(guard.warmup(LEGACY_NAMESPACE)).resolves.toBe(0);
   });
 
   it("preserves concurrent commits", async () => {

--- a/extensions/telegram/src/message-dispatch-dedupe.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.ts
@@ -3,8 +3,8 @@
 // update_ids; debounce/media-group flushes merge N update_ids into one
 // dispatched turn, so a constituent message re-arriving under a *fresh*
 // update_id is invisible to the update_id tombstone. This guard keys the
-// logical (chat_id, message_id) — the only identity that catches that replay.
-import path from "node:path";
+// logical (bot_id, chat_id, message_id) — the only identity that catches that replay
+// without colliding when state is reused after rotating to a different bot.
 import type { Message } from "grammy/types";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -13,12 +13,14 @@ import {
   type ChannelReplayClaimHandle,
 } from "openclaw/plugin-sdk/persistent-dedupe";
 
-export const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-export const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE = "global";
-export const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX = "telegram.message-dispatch-dedupe";
-export const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID = "telegram-message-dispatch-dedupe";
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+// Safety invariant: no row with unknown bot identity may suppress a message.
+// Runtime claims therefore use only v2; older unscoped rows are intentionally ignored.
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE = "v2";
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX = "telegram.message-dispatch-dedupe";
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID = "telegram-message-dispatch-dedupe";
 const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_MEMORY_MAX_ENTRIES = 50_000;
-export const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES = 50_000;
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES = 50_000;
 
 type TelegramMessageDispatchClaim =
   | { kind: "claimed"; handle: ChannelReplayClaimHandle }
@@ -53,26 +55,6 @@ export function isTelegramMessageDispatchReplayForgetError(
   return error instanceof TelegramMessageDispatchReplayForgetError;
 }
 
-function sanitizeFileSegment(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return "default";
-  }
-  return trimmed.replace(/[^a-zA-Z0-9_-]/g, "_");
-}
-
-export function resolveTelegramMessageDispatchLegacyPath(params: {
-  storePath: string;
-  namespace: string;
-}): string {
-  return path.join(
-    path.dirname(params.storePath),
-    `${path.basename(params.storePath)}.telegram-message-dispatch-${sanitizeFileSegment(
-      params.namespace,
-    )}.json`,
-  );
-}
-
 function buildTelegramMessageDispatchReplayKey(msg: Message): string | null {
   const chatId = msg.chat?.id;
   const messageId = msg.message_id;
@@ -82,25 +64,26 @@ function buildTelegramMessageDispatchReplayKey(msg: Message): string | null {
   return JSON.stringify(["message", String(chatId), messageId]);
 }
 
-export function buildTelegramMessageDispatchAccountReplayKey(params: {
-  accountId: string;
-  key: string;
-}): string {
-  return JSON.stringify(["account", params.accountId, params.key]);
-}
-
 function buildTelegramMessageDispatchStoredReplayKey(params: {
   accountId: string;
+  botUserId?: number;
   msg: Message;
 }): string | null {
+  if (
+    typeof params.botUserId !== "number" ||
+    !Number.isSafeInteger(params.botUserId) ||
+    params.botUserId <= 0
+  ) {
+    return null;
+  }
   const key = buildTelegramMessageDispatchReplayKey(params.msg);
   return key
-    ? buildTelegramMessageDispatchAccountReplayKey({ accountId: params.accountId, key })
+    ? JSON.stringify(["account", params.accountId, "bot", String(params.botUserId), key])
     : null;
 }
 
 type TelegramMessageDispatchReplayEvent =
-  | { accountId: string; msg: Message }
+  | { accountId: string; botUserId?: number; msg: Message }
   | { keys?: readonly string[] };
 
 export function createTelegramMessageDispatchReplayGuard(
@@ -131,12 +114,14 @@ type TelegramMessageDispatchReplayGuard = Pick<
 export async function claimTelegramMessageDispatchReplay(params: {
   guard: TelegramMessageDispatchReplayGuard;
   accountId: string;
+  botUserId?: number;
   msg: Message;
 }): Promise<TelegramMessageDispatchClaim> {
   return await runClaimableDedupeClaimLoop(
     () =>
       params.guard.claim({
         accountId: params.accountId,
+        botUserId: params.botUserId,
         msg: params.msg,
       }),
     (_error, rejectionCount) => rejectionCount <= 1,

--- a/extensions/telegram/src/message-dispatch-dedupe.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.ts
@@ -14,9 +14,7 @@ import {
 } from "openclaw/plugin-sdk/persistent-dedupe";
 
 const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-// Safety invariant: no row with unknown bot identity may suppress a message.
-// Runtime claims therefore use only v2; older unscoped rows are intentionally ignored.
-const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE = "v2";
+const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE = "global";
 const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX = "telegram.message-dispatch-dedupe";
 const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID = "telegram-message-dispatch-dedupe";
 const TELEGRAM_MESSAGE_DISPATCH_DEDUPE_MEMORY_MAX_ENTRIES = 50_000;
@@ -55,35 +53,29 @@ export function isTelegramMessageDispatchReplayForgetError(
   return error instanceof TelegramMessageDispatchReplayForgetError;
 }
 
-function buildTelegramMessageDispatchReplayKey(msg: Message): string | null {
-  const chatId = msg.chat?.id;
-  const messageId = msg.message_id;
+function buildTelegramMessageDispatchStoredReplayKey(params: {
+  accountId: string;
+  botUserId: number;
+  msg: Message;
+}): string | null {
+  const chatId = params.msg.chat?.id;
+  const messageId = params.msg.message_id;
   if (chatId == null || typeof messageId !== "number" || messageId <= 0) {
     return null;
   }
-  return JSON.stringify(["message", String(chatId), messageId]);
-}
-
-function buildTelegramMessageDispatchStoredReplayKey(params: {
-  accountId: string;
-  botUserId?: number;
-  msg: Message;
-}): string | null {
-  if (
-    typeof params.botUserId !== "number" ||
-    !Number.isSafeInteger(params.botUserId) ||
-    params.botUserId <= 0
-  ) {
-    return null;
-  }
-  const key = buildTelegramMessageDispatchReplayKey(params.msg);
-  return key
-    ? JSON.stringify(["account", params.accountId, "bot", String(params.botUserId), key])
-    : null;
+  return JSON.stringify([
+    "account",
+    params.accountId,
+    "bot",
+    String(params.botUserId),
+    "message",
+    String(chatId),
+    messageId,
+  ]);
 }
 
 type TelegramMessageDispatchReplayEvent =
-  | { accountId: string; botUserId?: number; msg: Message }
+  | { accountId: string; botUserId: number; msg: Message }
   | { keys?: readonly string[] };
 
 export function createTelegramMessageDispatchReplayGuard(
@@ -114,7 +106,7 @@ type TelegramMessageDispatchReplayGuard = Pick<
 export async function claimTelegramMessageDispatchReplay(params: {
   guard: TelegramMessageDispatchReplayGuard;
   accountId: string;
-  botUserId?: number;
+  botUserId: number;
   msg: Message;
 }): Promise<TelegramMessageDispatchClaim> {
   return await runClaimableDedupeClaimLoop(

--- a/extensions/telegram/src/message-dispatch-dedupe.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.ts
@@ -63,6 +63,8 @@ function buildTelegramMessageDispatchStoredReplayKey(params: {
   if (chatId == null || typeof messageId !== "number" || messageId <= 0) {
     return null;
   }
+  // Legacy keys omitted bot identity, so they cannot be attributed safely after
+  // state is reused for another bot. This shape intentionally starts a fresh TTL window.
   return JSON.stringify([
     "account",
     params.accountId,

--- a/extensions/telegram/src/state-migrations.test.ts
+++ b/extensions/telegram/src/state-migrations.test.ts
@@ -5,24 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resolvePersistentDedupePluginStateNamespace } from "openclaw/plugin-sdk/persistent-dedupe";
-import {
-  createPluginStateSyncKeyedStoreForTests,
-  resetPluginStateStoreForTests,
-} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveTelegramBotInfoCachePath } from "./bot-info-cache.js";
 import { resolveTelegramMessageCachePath } from "./message-cache.js";
-import {
-  buildTelegramMessageDispatchAccountReplayKey,
-  resolveTelegramMessageDispatchLegacyPath,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
-} from "./message-dispatch-dedupe.js";
 import { detectTelegramLegacyStateMigrations } from "./state-migrations.js";
 import {
   resolveTopicNameCacheNamespace,
@@ -346,10 +333,6 @@ describe("telegram state migrations", () => {
     const stickerCachePath = path.join(dir, "telegram", "sticker-cache.json");
     const sentMessagePath = `${storePath}.telegram-sent-messages.json`;
     const threadBindingsPath = path.join(dir, "telegram", "thread-bindings-ops.json");
-    const dispatchPath = resolveTelegramMessageDispatchLegacyPath({
-      storePath,
-      namespace: "ops",
-    });
     try {
       await mkdir(path.dirname(updateOffsetPath), { recursive: true });
       await mkdir(path.dirname(sentMessagePath), { recursive: true });
@@ -393,11 +376,6 @@ describe("telegram state migrations", () => {
           ],
         }),
       );
-      await writeFile(
-        dispatchPath,
-        JSON.stringify({ [JSON.stringify(["message", "7", 42])]: now }),
-      );
-
       const cfg = {
         channels: {
           telegram: {
@@ -410,10 +388,6 @@ describe("telegram state migrations", () => {
         },
       } as OpenClawConfig;
       const plans = await detectTelegramLegacyStateMigrations({ cfg, env });
-      const dispatchNamespace = resolvePersistentDedupePluginStateNamespace({
-        namespace: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE,
-        namespacePrefix: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX,
-      });
 
       const byLabel = new Map(plans.map((plan) => [plan.label, plan]));
       expect(byLabel.get("Telegram update offset")).toMatchObject({
@@ -437,36 +411,12 @@ describe("telegram state migrations", () => {
         sourcePath: threadBindingsPath,
         namespace: "telegram.thread-bindings",
       });
-      expect(byLabel.get("Telegram message dispatch dedupe")).toMatchObject({
-        kind: "plugin-state-import",
-        pluginId: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
-        sourcePath: dispatchPath,
-        namespace: dispatchNamespace,
-        cleanupWhenEmpty: true,
-      });
-      const dispatchPlan = byLabel.get("Telegram message dispatch dedupe");
-      if (!dispatchPlan || dispatchPlan.kind !== "plugin-state-import") {
-        throw new Error("expected Telegram message dispatch dedupe import plan");
-      }
-      await expect(dispatchPlan.readEntries()).resolves.toMatchObject([
-        {
-          key: expect.stringMatching(/^k\.[a-f0-9]{32}$/),
-          value: {
-            key: buildTelegramMessageDispatchAccountReplayKey({
-              accountId: "ops",
-              key: JSON.stringify(["message", "7", 42]),
-            }),
-            seenAt: now,
-          },
-        },
-      ]);
 
       for (const label of [
         "Telegram update offset",
         "Telegram sticker cache",
         "Telegram sent-message cache",
         "Telegram thread bindings",
-        "Telegram message dispatch dedupe",
       ]) {
         const plan = byLabel.get(label);
         if (!plan || plan.kind !== "plugin-state-import") {
@@ -479,26 +429,18 @@ describe("telegram state migrations", () => {
     }
   });
 
-  it("cleans up expired and boundary Telegram TTL cache sidecars", async () => {
+  it("cleans up expired and boundary Telegram sent-message cache sidecars", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-15T12:00:00.000Z"));
     const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-state-migration-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
     const storePath = resolveStorePath(undefined, { env, agentId: "main" });
     const sentMessagePath = `${storePath}.telegram-sent-messages.json`;
-    const dispatchPath = resolveTelegramMessageDispatchLegacyPath({
-      storePath,
-      namespace: "ops",
-    });
     const expiredAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
     const boundaryAt = Date.now() - 24 * 60 * 60 * 1000;
     try {
       await mkdir(path.dirname(sentMessagePath), { recursive: true });
       await writeFile(sentMessagePath, JSON.stringify({ 7: { 42: expiredAt, 43: boundaryAt } }));
-      await writeFile(
-        dispatchPath,
-        JSON.stringify({ [JSON.stringify(["message", "7", 42])]: expiredAt }),
-      );
 
       const cfg = {
         channels: {
@@ -513,12 +455,10 @@ describe("telegram state migrations", () => {
       } as OpenClawConfig;
       const plans = await detectTelegramLegacyStateMigrations({ cfg, env });
       const expiredPlans = plans.filter(
-        (plan) =>
-          plan.kind === "plugin-state-import" &&
-          (plan.sourcePath === sentMessagePath || plan.sourcePath === dispatchPath),
+        (plan) => plan.kind === "plugin-state-import" && plan.sourcePath === sentMessagePath,
       );
 
-      expect(expiredPlans).toHaveLength(2);
+      expect(expiredPlans).toHaveLength(1);
       for (const plan of expiredPlans) {
         expect(plan).toMatchObject({ cleanupSource: "rename", cleanupWhenEmpty: true });
         if (plan.kind !== "plugin-state-import") {
@@ -528,122 +468,6 @@ describe("telegram state migrations", () => {
       }
     } finally {
       vi.useRealTimers();
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("migrates shipped Telegram message dispatch plugin-state buckets", async () => {
-    const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-state-migration-"));
-    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
-    const now = Date.now();
-    const replayKey = JSON.stringify(["message", "7", 42]);
-    const dispatchNamespace = resolvePersistentDedupePluginStateNamespace({
-      namespace: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE,
-      namespacePrefix: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX,
-    });
-    try {
-      const legacyStore = createPluginStateSyncKeyedStoreForTests("telegram", {
-        namespace: "telegram.message-dispatch-dedupe",
-        maxEntries: 4_096,
-        env,
-      });
-      legacyStore.register("legacy-bucket", {
-        scopeKey: "old-session-store",
-        namespace: "ops",
-        bucketId: "00",
-        entries: {
-          [replayKey]: now,
-        },
-      });
-      legacyStore.register("legacy-bucket-lock", {
-        scopeKey: "old-session-store",
-        namespace: "ops:lock",
-        bucketId: "00",
-        entries: {},
-      });
-
-      const cfg = {
-        channels: {
-          telegram: {
-            accounts: {
-              ops: {
-                botToken: "123456:secret",
-              },
-            },
-          },
-        },
-      } as OpenClawConfig;
-      const plans = await detectTelegramLegacyStateMigrations({ cfg, env });
-      const plan = plans.find(
-        (candidate) =>
-          candidate.kind === "plugin-state-import" &&
-          candidate.label === "Telegram message dispatch dedupe" &&
-          candidate.sourcePath === "plugin state:telegram.message-dispatch-dedupe:ops",
-      );
-
-      expect(plan).toMatchObject({
-        kind: "plugin-state-import",
-        pluginId: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
-        namespace: dispatchNamespace,
-        cleanupWhenEmpty: true,
-      });
-      if (!plan || plan.kind !== "plugin-state-import") {
-        throw new Error("expected Telegram message dispatch plugin-state import plan");
-      }
-      const entries = await plan.readEntries();
-      expect(entries).toMatchObject([
-        {
-          key: expect.stringMatching(/^k\.[a-f0-9]{32}$/),
-          value: {
-            key: buildTelegramMessageDispatchAccountReplayKey({
-              accountId: "ops",
-              key: replayKey,
-            }),
-            seenAt: now,
-          },
-        },
-      ]);
-
-      const targetStore = createPluginStateSyncKeyedStoreForTests(
-        TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
-        {
-          namespace: dispatchNamespace,
-          maxEntries: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES,
-          defaultTtlMs: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
-          env,
-        },
-      );
-      for (const entry of entries) {
-        targetStore.register(
-          entry.key,
-          entry.value,
-          entry.ttlMs ? { ttlMs: entry.ttlMs } : undefined,
-        );
-      }
-
-      // The plan stays detectable while legacy bucket rows remain so doctor --fix
-      // can finish by deleting the retired source namespace.
-      const plansAfterImport = await detectTelegramLegacyStateMigrations({ cfg, env });
-      expect(
-        plansAfterImport.some(
-          (candidate) =>
-            candidate.kind === "plugin-state-import" &&
-            candidate.sourcePath === "plugin state:telegram.message-dispatch-dedupe:ops",
-        ),
-      ).toBe(true);
-
-      await plan.removeSource?.();
-      expect(legacyStore.entries()).toHaveLength(0);
-
-      const plansAfterCleanup = await detectTelegramLegacyStateMigrations({ cfg, env });
-      expect(
-        plansAfterCleanup.some(
-          (candidate) =>
-            candidate.kind === "plugin-state-import" &&
-            candidate.sourcePath === "plugin state:telegram.message-dispatch-dedupe:ops",
-        ),
-      ).toBe(false);
-    } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
@@ -709,31 +533,20 @@ describe("telegram state migrations", () => {
     }
   });
 
-  it("imports legacy session-store sidecars into the current runtime scope", async () => {
+  it("imports legacy sent-message sidecars into the current runtime scope", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-state-migration-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
     const storePath = resolveStorePath(undefined, { env, agentId: "main" });
     const legacyStorePath = path.join(dir, "sessions", "sessions.json");
     const currentSentPath = `${storePath}.telegram-sent-messages.json`;
     const legacySentPath = `${legacyStorePath}.telegram-sent-messages.json`;
-    const currentDispatchPath = resolveTelegramMessageDispatchLegacyPath({
-      storePath,
-      namespace: "ops",
-    });
-    const legacyDispatchPath = resolveTelegramMessageDispatchLegacyPath({
-      storePath: legacyStorePath,
-      namespace: "ops",
-    });
     const now = Date.now();
     try {
       await mkdir(path.dirname(currentSentPath), { recursive: true });
       await mkdir(path.dirname(legacySentPath), { recursive: true });
       const sentPayload = JSON.stringify({ 7: { 42: now } });
-      const dispatchPayload = JSON.stringify({ [JSON.stringify(["message", "7", 42])]: now });
       await writeFile(currentSentPath, sentPayload);
       await writeFile(legacySentPath, sentPayload);
-      await writeFile(currentDispatchPath, dispatchPayload);
-      await writeFile(legacyDispatchPath, dispatchPayload);
 
       const cfg = {
         channels: {
@@ -756,17 +569,7 @@ describe("telegram state migrations", () => {
         (plan) =>
           plan.label === "Telegram sent-message cache" && plan.sourcePath === legacySentPath,
       );
-      const currentDispatchPlan = importPlans.find(
-        (plan) =>
-          plan.label === "Telegram message dispatch dedupe" &&
-          plan.sourcePath === currentDispatchPath,
-      );
-      const legacyDispatchPlan = importPlans.find(
-        (plan) =>
-          plan.label === "Telegram message dispatch dedupe" &&
-          plan.sourcePath === legacyDispatchPath,
-      );
-      if (!currentSentPlan || !legacySentPlan || !currentDispatchPlan || !legacyDispatchPlan) {
+      if (!currentSentPlan || !legacySentPlan) {
         throw new Error("expected current and legacy session-store import plans");
       }
 
@@ -777,12 +580,6 @@ describe("telegram state migrations", () => {
       expect(currentSentEntries[0]?.value).toMatchObject({
         scopeKey: createHash("sha256").update(storePath, "utf8").digest("hex").slice(0, 24),
       });
-      const stripDispatchSourceKey = (
-        entries: Awaited<ReturnType<typeof currentDispatchPlan.readEntries>>,
-      ) => entries.map(({ key: _key, ttlMs: _ttlMs, ...entry }) => entry);
-      expect(stripDispatchSourceKey(await legacyDispatchPlan.readEntries())).toStrictEqual(
-        stripDispatchSourceKey(await currentDispatchPlan.readEntries()),
-      );
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/extensions/telegram/src/state-migrations.ts
+++ b/extensions/telegram/src/state-migrations.ts
@@ -4,14 +4,6 @@ import path from "node:path";
 import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { ChannelLegacyStateMigrationPlan } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import {
-  type PersistentDedupeLegacyJsonImportEntry,
-  createPersistentDedupeImportEntry,
-  listPersistentDedupeLegacyJsonFileEntries,
-  resolvePersistentDedupePluginStateNamespace,
-  shouldReplacePersistentDedupeEntry,
-} from "openclaw/plugin-sdk/persistent-dedupe";
-import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/runtime-doctor";
 import { fileExists } from "openclaw/plugin-sdk/security-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { isRecord, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -31,15 +23,6 @@ import {
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
   TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION,
 } from "./message-cache.js";
-import {
-  buildTelegramMessageDispatchAccountReplayKey,
-  resolveTelegramMessageDispatchLegacyPath,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES,
-  TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
-} from "./message-dispatch-dedupe.js";
 import { parseTelegramMessageThreadId } from "./outbound-params.js";
 import {
   listTelegramLegacySentMessageCacheEntries,
@@ -72,14 +55,6 @@ import {
   TELEGRAM_UPDATE_OFFSET_MAX_ENTRIES,
   TELEGRAM_UPDATE_OFFSET_NAMESPACE,
 } from "./update-offset-store.js";
-
-const TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_NAMESPACE = "telegram.message-dispatch-dedupe";
-const TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_MAX_ENTRIES = 4_096;
-
-type TelegramLegacyMessageDispatchDedupeRecord = {
-  namespace: string;
-  entries: Record<string, number>;
-};
 
 function resolveLegacySessionStorePath(params: {
   env: NodeJS.ProcessEnv;
@@ -190,110 +165,6 @@ function listTelegramLegacyMessageCacheEntries(persistedPath: string) {
     }
   }
   return Array.from(entries, ([key, value]) => ({ key, value }));
-}
-
-function readLegacyMessageDispatchDedupeRecord(
-  value: unknown,
-): TelegramLegacyMessageDispatchDedupeRecord | undefined {
-  if (!isRecord(value) || typeof value.namespace !== "string") {
-    return undefined;
-  }
-  if (!isRecord(value.entries)) {
-    return undefined;
-  }
-  const entries: Record<string, number> = {};
-  for (const [key, seenAt] of Object.entries(value.entries)) {
-    if (typeof seenAt === "number" && Number.isFinite(seenAt) && seenAt > 0) {
-      entries[key] = seenAt;
-    }
-  }
-  return { namespace: value.namespace, entries };
-}
-
-function remainingMessageDispatchDedupeTtlMs(seenAt: number, now: number): number | undefined {
-  const ttlMs = TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS - Math.max(0, now - seenAt);
-  return ttlMs > 0 ? ttlMs : undefined;
-}
-
-function openTelegramLegacyMessageDispatchBucketStore(env: NodeJS.ProcessEnv) {
-  return createPluginStateSyncKeyedStore<unknown>("telegram", {
-    namespace: TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_NAMESPACE,
-    maxEntries: TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_MAX_ENTRIES,
-    env,
-  });
-}
-
-function readTelegramLegacyMessageDispatchBuckets(params: {
-  accountId: string;
-  env: NodeJS.ProcessEnv;
-  now?: number;
-}): { importEntries: PersistentDedupeLegacyJsonImportEntry[]; recordKeys: string[] } {
-  const store = openTelegramLegacyMessageDispatchBucketStore(params.env);
-  const latestSeenAtByKey = new Map<string, number>();
-  const recordKeys: string[] = [];
-  for (const entry of store.entries()) {
-    const record = readLegacyMessageDispatchDedupeRecord(entry.value);
-    if (!record) {
-      continue;
-    }
-    // Lock rows persist as `<accountId>:lock` buckets without dedupe entries;
-    // track them as removable so cleanup empties the retired namespace.
-    const ownsRecord =
-      record.namespace === params.accountId || record.namespace.startsWith(`${params.accountId}:`);
-    if (!ownsRecord) {
-      continue;
-    }
-    recordKeys.push(entry.key);
-    if (record.namespace !== params.accountId) {
-      continue;
-    }
-    for (const [key, seenAt] of Object.entries(record.entries)) {
-      latestSeenAtByKey.set(key, Math.max(latestSeenAtByKey.get(key) ?? 0, seenAt));
-    }
-  }
-  const now = params.now ?? Date.now();
-  const importEntries = [...latestSeenAtByKey.entries()].flatMap(([key, seenAt]) => {
-    const ttlMs = remainingMessageDispatchDedupeTtlMs(seenAt, now);
-    return ttlMs == null
-      ? []
-      : [
-          createPersistentDedupeImportEntry({
-            key: buildTelegramMessageDispatchAccountReplayKey({
-              accountId: params.accountId,
-              key,
-            }),
-            seenAt,
-            ttlMs,
-          }),
-        ];
-  });
-  return { importEntries, recordKeys };
-}
-
-function removeTelegramLegacyMessageDispatchBuckets(params: {
-  accountId: string;
-  env: NodeJS.ProcessEnv;
-}): void {
-  const store = openTelegramLegacyMessageDispatchBucketStore(params.env);
-  for (const key of readTelegramLegacyMessageDispatchBuckets(params).recordKeys) {
-    store.delete(key);
-  }
-}
-
-function mapTelegramMessageDispatchDedupeImportEntries(params: {
-  accountId: string;
-  entries: PersistentDedupeLegacyJsonImportEntry[];
-}): PersistentDedupeLegacyJsonImportEntry[] {
-  return params.entries.map((entry) =>
-    createPersistentDedupeImportEntry({
-      key: buildTelegramMessageDispatchAccountReplayKey({
-        accountId: params.accountId,
-        key: entry.value.key,
-      }),
-      seenAt: entry.value.seenAt,
-      ...(entry.ttlMs != null ? { ttlMs: entry.ttlMs } : {}),
-    }),
-  );
 }
 
 function listTelegramLegacySidecarAccountIds(params: {
@@ -537,93 +408,6 @@ function detectTelegramThreadBindingLegacyStateMigration(params: {
   });
 }
 
-function detectTelegramMessageDispatchLegacyStateMigration(params: {
-  cfg: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  stateDir?: string;
-}): ChannelLegacyStateMigrationPlan[] {
-  const storePath = resolveAgentSessionStorePath({
-    ...params,
-    agentId: resolveDefaultAgentId(params.cfg),
-  });
-  const legacyMainStorePath = resolveAgentSessionStorePath({ ...params, agentId: "main" });
-  const legacyStorePath = resolveLegacySessionStorePath(params);
-  const env = params.stateDir ? { ...params.env, OPENCLAW_STATE_DIR: params.stateDir } : params.env;
-  const namespace = resolvePersistentDedupePluginStateNamespace({
-    namespace: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE,
-    namespacePrefix: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_NAMESPACE_PREFIX,
-  });
-  return listTelegramAccountIds(params.cfg).flatMap((accountId) => {
-    const sources = uniqueStrings([storePath, legacyMainStorePath, legacyStorePath]).map(
-      (sourceStorePath) => ({
-        sourcePath: resolveTelegramMessageDispatchLegacyPath({
-          storePath: sourceStorePath,
-          namespace: accountId,
-        }),
-      }),
-    );
-    const jsonPlans: ChannelLegacyStateMigrationPlan[] = sources.flatMap((source) => {
-      const sourcePath = source.sourcePath;
-      if (!fileExists(sourcePath)) {
-        return [];
-      }
-      return {
-        kind: "plugin-state-import",
-        label: "Telegram message dispatch dedupe",
-        sourcePath,
-        targetPath: `plugin state:${namespace}`,
-        pluginId: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
-        namespace,
-        maxEntries: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES,
-        defaultTtlMs: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
-        scopeKey: "",
-        cleanupSource: "rename",
-        cleanupWhenEmpty: true,
-        preview: `- Telegram message dispatch dedupe: ${sourcePath} → plugin state (${namespace})`,
-        shouldReplaceExistingEntry: ({ existingValue, incomingValue }) =>
-          shouldReplacePersistentDedupeEntry({ existingValue, incomingValue }),
-        readEntries: async () =>
-          mapTelegramMessageDispatchDedupeImportEntries({
-            accountId,
-            entries: await listPersistentDedupeLegacyJsonFileEntries({
-              filePath: source.sourcePath,
-              ttlMs: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
-            }),
-          }),
-      };
-    });
-    let legacyRecordKeys: string[];
-    try {
-      legacyRecordKeys = readTelegramLegacyMessageDispatchBuckets({ accountId, env }).recordKeys;
-    } catch {
-      legacyRecordKeys = [];
-    }
-    // Emit the plan while any retired bucket rows remain (even TTL-expired ones)
-    // so doctor --fix imports live entries and then deletes the legacy source.
-    if (legacyRecordKeys.length === 0) {
-      return jsonPlans;
-    }
-    const pluginStatePlan: ChannelLegacyStateMigrationPlan = {
-      kind: "plugin-state-import",
-      label: "Telegram message dispatch dedupe",
-      sourcePath: `plugin state:${TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_NAMESPACE}:${accountId}`,
-      targetPath: `plugin state:${namespace}`,
-      pluginId: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
-      namespace,
-      maxEntries: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_MAX_ENTRIES,
-      defaultTtlMs: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
-      scopeKey: "",
-      cleanupWhenEmpty: true,
-      preview: `- Telegram message dispatch dedupe: plugin state (${TELEGRAM_MESSAGE_DISPATCH_LEGACY_BUCKET_NAMESPACE}) → plugin state (${namespace})`,
-      shouldReplaceExistingEntry: ({ existingValue, incomingValue }) =>
-        shouldReplacePersistentDedupeEntry({ existingValue, incomingValue }),
-      readEntries: () => readTelegramLegacyMessageDispatchBuckets({ accountId, env }).importEntries,
-      removeSource: () => removeTelegramLegacyMessageDispatchBuckets({ accountId, env }),
-    };
-    return jsonPlans.concat(pluginStatePlan);
-  });
-}
-
 function topicNameCacheImportSource(params: {
   sourceStorePath: string;
   targetStorePath?: string;
@@ -707,6 +491,5 @@ export async function detectTelegramLegacyStateMigrations(params: {
   plans.push(...detectTelegramSentMessageCacheLegacyStateMigration(params));
   plans.push(...detectTelegramTopicNameCacheLegacyStateMigration(params));
   plans.push(...detectTelegramThreadBindingLegacyStateMigration(params));
-  plans.push(...detectTelegramMessageDispatchLegacyStateMigration(params));
   return plans;
 }


### PR DESCRIPTION
## Summary

- scope persistent Telegram dispatch deduplication by numeric bot identity
- move runtime claims to a new `v2` namespace and deliberately ignore obsolete unscoped V1 rows
- fail open when bot identity is missing or invalid, with a bounded warning and per-event diagnostic trace
- preserve account isolation and existing replay settlement behavior
- remove the unreachable V1 replay-cache migration and its internal-only coverage

## What Problem This Solves

Telegram message IDs are scoped to a chat and bot, while private-chat IDs can be shared across different bots. Reusing persisted state after a bot-token rotation or state copy could therefore make a fresh message collide with a historical `(account, chat_id, message_id)` key and be silently treated as a duplicate.

The stored identity is now `(account, numeric_bot_id, chat_id, message_id)`. Claim returns a handle that freezes the exact namespace and keys; commit consumes that handle and does not reconstruct the identity.

Safety invariant: **no row whose bot identity is unknown may suppress a message**. Legacy V1 rows are neither imported nor consulted by runtime V2 claims. Missing identity processes the message without creating a claim or writing to either namespace.

The deliberate upgrade trade-off is that a genuine redelivery crossing the V1/V2 boundary can be processed once more; this is preferred over silent message loss.

## Evidence

### Controlled persisted-state runtime proof

A temporary TypeScript harness imported the actual `createTelegramMessageLifecycleRuntime` and persistent plugin-state implementation from this branch (no mocked guard). It used synthetic IDs and a fresh temporary state directory. Each first delivery was committed with `requirePersistent: true`; each replay used a newly created lifecycle runtime backed by that same on-disk state.

Redacted transcript:

```text
bot-a-first-delivery:
  bot=900001 coordinates=(chat=700001,message=42)
  process=true claimCount=1
  key=["account","proof-account","bot","900001",["message","700001",42]]

bot-a-replay-after-guard-recreation:
  bot=900001 coordinates=(chat=700001,message=42)
  process=false claimCount=0

bot-b-same-coordinates:
  bot=900002 coordinates=(chat=700001,message=42)
  process=true claimCount=1
  key=["account","proof-account","bot","900002",["message","700001",42]]

bot-b-replay-after-guard-recreation:
  bot=900002 coordinates=(chat=700001,message=42)
  process=false claimCount=0

missing-identity-fails-open:
  diagnostic claim_kind=invalid_identity
  process=true claimCount=0
```

Observed result: persisted same-bot replays remain suppressed after guard recreation, while another bot sharing the same account/chat/message coordinates receives an independent claim and is processed. Missing bot identity creates no claim and does not suppress the message. The temporary harness was removed after the run; it is not part of the PR.

### Native Telegram Desktop proof

[Mantis captured a before/after Telegram Desktop run](https://github.com/openclaw/openclaw/pull/113667#issuecomment-5080163083): main leaves the seeded message unanswered, while the candidate replies. The proof was recorded on precursor runtime SHA `3abc405958dd`; the current follow-up removes only the unreachable V1 migration/import path and associated helpers/tests.

### Automated validation

```text
Test Files  2 passed (2)
Tests       20 passed (20)
```

Coverage and checks include:

- cross-bot isolation for identical account/chat/message coordinates
- persistence and same-bot dedupe across guard recreation
- legacy V1 row does not suppress V2
- invalid identity fails open and writes to neither V2 nor legacy
- once-per-runtime warning for `claim_kind=invalid_identity`
- obsolete V1 replay-cache import and migration coverage removed
- Oxlint, formatter, and `git diff --check` clean
- TruffleHog clean
- fresh autoreview on the final adjustment: no accepted/actionable findings; patch assessed correct at 0.98 confidence

Exact-head CI for `73bdd08855c3d6cc832c86772b008a91d10de0d0`: 74 checks passed, including `openclaw/ci-gate`; no failures.
- ClawSweeper exact-head review: no actionable findings; real-behavior proof sufficient; maintainer approval requested only for the intentional V1-to-V2 cutover policy.

## Scope

Related to #113315. This addresses completed-without-dispatch losses caused by dedupe collisions when state is reused across bot identities. It does not claim to explain captures where no ingress/spool row was created; those manifestations remain open for separate investigation.

TTL and pruning policy are intentionally deferred to a follow-up because they are independent of the bot-identity invariant.