### PR TITLE
fix: retry chat avatar auth candidates

### DIFF
--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -2,7 +2,10 @@
 import { html } from "lit";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
 import { normalizeBasePath } from "../../app-route-paths.ts";
-import { resolveControlUiAuthHeader } from "../../app/control-ui-auth.ts";
+import {
+  resolveControlUiAuthCandidates,
+  resolveControlUiAuthHeader,
+} from "../../app/control-ui-auth.ts";
 import {
   resolveLocalUserAvatarText,
   resolveLocalUserAvatarUrl,
@@ -384,11 +387,32 @@ export async function refreshChatAvatar(host: ChatAvatarHost) {
   const avatarController = new AbortController();
   const avatarTimeout = scheduleChatAvatarFetchTimeout(avatarController, "chat avatar image fetch");
   try {
-    const avatarRes = await fetch(avatarUrl, {
+    let avatarRes = await fetch(avatarUrl, {
       method: "GET",
       ...(headers ? { headers } : {}),
       signal: avatarController.signal,
     });
+    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
+      return;
+    }
+    if (!avatarRes.ok && (avatarRes.status === 401 || avatarRes.status === 403)) {
+      const retryAuthHeaders = resolveControlUiAuthCandidates(host)
+        .map((candidate) => `Bearer ${candidate}`)
+        .filter((candidate) => candidate !== authHeader);
+      for (const retryAuthHeader of retryAuthHeaders) {
+        avatarRes = await fetch(avatarUrl, {
+          method: "GET",
+          headers: { Authorization: retryAuthHeader },
+          signal: avatarController.signal,
+        });
+        if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
+          return;
+        }
+        if (avatarRes.ok || (avatarRes.status !== 401 && avatarRes.status !== 403)) {
+          break;
+        }
+      }
+    }
     if (!avatarRes.ok) {
       if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
         clearChatAvatarUrl(host);

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -795,6 +795,54 @@ describe("refreshChatAvatar", () => {
     expect(host.chatAvatarUrl).toBe("blob:local-avatar");
   });
 
+  it("retries local avatar bytes with a device token that appears after a 401", async () => {
+    const createObjectURL = vi.fn(() => "blob:device-avatar");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal(
+      "URL",
+      class extends URL {
+        static override createObjectURL = createObjectURL;
+        static override revokeObjectURL = revokeObjectURL;
+      },
+    );
+    const host = makeHost({ basePath: "", sessionKey: "agent:main" });
+    let avatarFetchCount = 0;
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = requestUrl(input);
+      if (url === "/avatar/main?meta=1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ avatarUrl: "/avatar/main" }),
+        });
+      }
+      if (url === "/avatar/main") {
+        avatarFetchCount += 1;
+        if (avatarFetchCount === 1) {
+          host.hello = { auth: { deviceToken: "device-token" } } as ChatHost["hello"];
+          return Promise.resolve({ ok: false, status: 401 });
+        }
+        return Promise.resolve({
+          ok: true,
+          blob: async () => new Blob(["avatar"]),
+        });
+      }
+      throw new Error(`Unexpected avatar URL: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    await refreshChatAvatar(host);
+
+    expect(fetchUrl(fetchMock as unknown as MockCallSource, 0)).toBe("/avatar/main?meta=1");
+    expect(fetchUrl(fetchMock as unknown as MockCallSource, 1)).toBe("/avatar/main");
+    expect(fetchInit(fetchMock as unknown as MockCallSource, 1)).not.toHaveProperty("headers");
+    expect(fetchUrl(fetchMock as unknown as MockCallSource, 2)).toBe("/avatar/main");
+    expect(fetchInit(fetchMock as unknown as MockCallSource, 2).headers).toEqual({
+      Authorization: "Bearer device-token",
+    });
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    expect(host.chatAvatarUrl).toBe("blob:device-avatar");
+  });
+
   it("prefers the paired device token for avatar metadata and local avatar URLs", async () => {
     const createObjectURL = vi.fn(() => "blob:device-avatar");
     const revokeObjectURL = vi.fn();


### PR DESCRIPTION
Related: #112643

## What Problem This Solves

Fixes an issue where users opening the Control UI through Tailscale Serve / loopback-style access could lose a configured local assistant avatar when the `/avatar/<agent>` bytes request returned an auth failure before the live device token was available.

The metadata request can already resolve the configured local avatar and return an `avatarUrl`, but the local image fetch selected one Authorization header at request start and never retried another valid Control UI credential. When that first attempt returned 401/403, the chat UI cleared the avatar URL and kept the default assistant fallback.

## Why This Change Was Made

The chat avatar fetch now keeps its existing metadata behavior, then retries only local avatar byte requests that fail with 401/403 using the current `resolveControlUiAuthCandidates(host)` list. That reuses the existing Control UI credential ordering and lets a device token that appears while the first byte request is in flight recover the avatar fetch.

This deliberately does not change gateway authentication, tokenized URLs, remote/data avatars, object URL lifetime, metadata handling, timeout handling, or stale-session guards. It also avoids persisting blob URLs to localStorage; blob URLs are page-lifetime objects and are not a durable reload cache.

## User Impact

Users accessing Control UI through Tailscale Serve or similar protected same-origin routes can see configured local assistant avatars after the live session credential becomes available, instead of falling back permanently to the default assistant logo for that refresh.

No behavior changes for unauthenticated public avatar routes, remote avatars, data avatars, or successful first-attempt local avatar fetches.

## Evidence

The focused regression models the reported race in the client path:

1. `/avatar/main?meta=1` returns `{ "avatarUrl": "/avatar/main" }`.
2. The first `/avatar/main` bytes request is sent without an Authorization header and returns `401`.
3. The test then makes `host.hello.auth.deviceToken` available, matching a live session credential arriving after the first request started.
4. The retry calls `/avatar/main` again with `Authorization: Bearer device-token` and stores the returned blob URL.

A real-runtime proof also imports the production `refreshChatAvatar()` source and serves `/avatar/main` from a local protected same-origin loopback route. This is not a live Tailscale tenant; it covers the same protected-route credential timing boundary with the port and token redacted:

```text
$ node --import tsx <real-runtime proof script>
Real-runtime proof for PR #113679
protected same-origin route: http://127.0.0.1:<redacted-port>/avatar/main
{"route":"metadata","status":200,"authorization":"<none>"}
{"route":"image","attempt":1,"status":401,"authorization":"<none>"}
{"route":"image","attempt":2,"status":200,"authorization":"Bearer redacted-device-token"}
final chatAvatarUrl kind: blob-url
```

Validation run on the final rebased head (`97fd0c0c61b0e212e71e4bed7173449ce00a8960`):

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/chat/chat-avatar.test.ts ui/src/pages/chat/chat-send.test.ts
Test Files  2 passed (2)
Tests       245 passed (245)
```

```text
$ git diff --check -- ui/src/pages/chat/chat-avatar.ts ui/src/pages/chat/chat-send.test.ts
# clean
```

Local limitations: full `pnpm tsgo:ui` timed out after 180s without diagnostics in this Windows workspace, and the local formatter invocation also timed out before producing a result. The focused UI regression, real-runtime proof, and diff whitespace check are the validation available from this environment; broader type/format lanes are left to CI.

## Possible call chain / impact

```text
Control UI chat render
  -> refreshChatAvatar(host)
  -> GET /avatar/<agent>?meta=1
  -> metadata returns local avatarUrl
  -> GET /avatar/<agent> with the initially selected auth header
  -> 401/403 while the live session credential is now available
  -> retry with resolveControlUiAuthCandidates(host)
  -> create object URL and render the local avatar
```

Sibling surfaces checked: Control UI bootstrap config and plugin icon loading already use auth-candidate retry loops for same-origin requests. Agent selector avatars use an explicit `authToken` property and refetch on token rotation, so this host-based session credential race is specific to the chat avatar refresh path.

Adjacent scope: #102302 is a broader gateway-side Tailscale HTTP read-route auth PR that touches server authentication boundaries. This PR is intentionally independent and frontend-only: it only retries the chat avatar local image request with existing Control UI credential candidates.