### PR TITLE
chore(models): curate all provider model catalogs to current-generation lineups

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8552,7 +8552,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Privacy modes
   - H2: Getting started
   - H2: Model selection
-  - H2: Built-in catalog (30 models)
+  - H2: Built-in catalog (16 visible models)
   - H2: Model discovery
   - H2: DeepSeek V4 replay behavior
   - H2: Streaming and tool support

--- a/docs/providers/baseten.md
+++ b/docs/providers/baseten.md
@@ -88,7 +88,8 @@ The authenticated live catalog is authoritative. These rows keep setup and model
 | `baseten/zai-org/GLM-4.7`                          | text        |    200k |       200k |
 | `baseten/zai-org/GLM-5`                            | text        |    202k |       202k |
 | `baseten/zai-org/GLM-5.1`                          | text        |    202k |       202k |
-| `baseten/zai-org/GLM-5.2`                          | text        |    202k |       202k |
+| `baseten/zai-org/GLM-5.2`                          | text        |    524k |       262k |
+| `baseten/zai-org/GLM-5.2-Fast`                     | text        |    524k |       262k |
 | `baseten/thinkingmachines/inkling`                 | text, image |  1.048M |        32k |
 | `baseten/moonshotai/Kimi-K2.5`                     | text, image |    262k |       262k |
 | `baseten/moonshotai/Kimi-K2.6`                     | text, image |    262k |       262k |

--- a/docs/providers/cerebras.md
+++ b/docs/providers/cerebras.md
@@ -6,7 +6,7 @@ read_when:
   - You need the Cerebras API key env var or CLI auth choice
 ---
 
-[Cerebras](https://www.cerebras.ai) provides high-speed OpenAI-compatible inference on custom inference hardware. The plugin ships a static two-model catalog (no live discovery).
+[Cerebras](https://www.cerebras.ai) provides high-speed OpenAI-compatible inference on custom inference hardware. The plugin ships a static three-model catalog (no live discovery).
 
 | Property        | Value                                                     |
 | --------------- | --------------------------------------------------------- |
@@ -57,7 +57,7 @@ export CEREBRAS_API_KEY=csk-...
     openclaw models list --provider cerebras
     ```
 
-    Lists both static models. If `CEREBRAS_API_KEY` is unresolved, `openclaw models status --json` reports the missing credential under `auth.unusableProfiles`.
+    Lists all three static models. If `CEREBRAS_API_KEY` is unresolved, `openclaw models status --json` reports the missing credential under `auth.unusableProfiles`.
 
   </Step>
 </Steps>
@@ -73,12 +73,13 @@ openclaw onboard --non-interactive \
 
 ## Built-in catalog
 
-Both models share a 128k context window and 8,192 max output tokens.
+All three models have a 131,072-token context window and a 40,960-token max output.
 
-| Model ref               | Name         | Reasoning | Notes                                  |
-| ----------------------- | ------------ | --------- | -------------------------------------- |
-| `cerebras/zai-glm-4.7`  | Z.ai GLM 4.7 | yes       | Default model; preview reasoning model |
-| `cerebras/gpt-oss-120b` | GPT OSS 120B | yes       | Production reasoning model             |
+| Model ref               | Name         | Reasoning | Notes                                    |
+| ----------------------- | ------------ | --------- | ---------------------------------------- |
+| `cerebras/zai-glm-4.7`  | Z.ai GLM 4.7 | yes       | Default model; scheduled for deprecation |
+| `cerebras/gpt-oss-120b` | GPT OSS 120B | yes       | Production reasoning model               |
+| `cerebras/gemma-4-31b`  | Gemma 4 31B  | yes       | Text-and-image input; text output        |
 
 ## Manual config
 
@@ -102,6 +103,7 @@ Most setups only need the API key. Use explicit `models.providers.cerebras` conf
         models: [
           { id: "zai-glm-4.7", name: "Z.ai GLM 4.7" },
           { id: "gpt-oss-120b", name: "GPT OSS 120B" },
+          { id: "gemma-4-31b", name: "Gemma 4 31B" },
         ],
       },
     },
@@ -120,7 +122,7 @@ If the Gateway runs as a daemon (launchd, systemd, Docker), make sure `CEREBRAS_
     Choosing providers, model refs, and failover behavior.
   </Card>
   <Card title="Thinking modes" href="/tools/thinking" icon="brain">
-    Reasoning effort levels for the two reasoning-capable Cerebras models.
+    Reasoning effort levels for the Cerebras models.
   </Card>
   <Card title="Configuration reference" href="/gateway/config-agents#agent-defaults" icon="gear">
     Agent defaults and model configuration.

--- a/docs/providers/chutes.md
+++ b/docs/providers/chutes.md
@@ -31,7 +31,7 @@ openclaw gateway restart
 
 ## Getting started
 
-Both paths set the default model to `chutes/zai-org/GLM-5-TEE` and register
+Both paths set the default model to `chutes/zai-org/GLM-5.2-TEE` and register
 the Chutes catalog.
 
 <Tabs>
@@ -79,19 +79,23 @@ OpenClaw registers two convenience aliases for the Chutes catalog:
 | Alias           | Target model                           |
 | --------------- | -------------------------------------- |
 | `chutes-pro`    | `chutes/deepseek-ai/DeepSeek-V3.2-TEE` |
-| `chutes-vision` | `chutes/moonshotai/Kimi-K2.5-TEE`      |
+| `chutes-vision` | `chutes/moonshotai/Kimi-K2.6-TEE`      |
 
 ## Built-in starter catalog
 
-The bundled fallback catalog contains these five currently served models:
+The bundled fallback catalog contains these current starter models plus two
+compatible prior-generation refs that remain selectable but are hidden from
+pickers:
 
-| Model ref                              |
-| -------------------------------------- |
-| `chutes/zai-org/GLM-5-TEE`             |
-| `chutes/deepseek-ai/DeepSeek-V3.2-TEE` |
-| `chutes/moonshotai/Kimi-K2.5-TEE`      |
-| `chutes/MiniMaxAI/MiniMax-M2.5-TEE`    |
-| `chutes/Qwen/Qwen3.5-397B-A17B-TEE`    |
+| Model ref                              | Picker status |
+| -------------------------------------- | ------------- |
+| `chutes/zai-org/GLM-5.2-TEE`           | Visible       |
+| `chutes/deepseek-ai/DeepSeek-V3.2-TEE` | Visible       |
+| `chutes/moonshotai/Kimi-K2.6-TEE`      | Visible       |
+| `chutes/MiniMaxAI/MiniMax-M2.5-TEE`    | Visible       |
+| `chutes/Qwen/Qwen3.6-27B-TEE`          | Visible       |
+| `chutes/moonshotai/Kimi-K2.5-TEE`      | Hidden        |
+| `chutes/Qwen/Qwen3.5-397B-A17B-TEE`    | Hidden        |
 
 Run `openclaw models list --all --provider chutes` for the full list.
 
@@ -101,9 +105,9 @@ Run `openclaw models list --all --provider chutes` for the full list.
 {
   agents: {
     defaults: {
-      model: { primary: "chutes/zai-org/GLM-5-TEE" },
+      model: { primary: "chutes/zai-org/GLM-5.2-TEE" },
       models: {
-        "chutes/zai-org/GLM-5-TEE": { alias: "Chutes GLM 5" },
+        "chutes/zai-org/GLM-5.2-TEE": { alias: "Chutes GLM 5.2" },
         "chutes/deepseek-ai/DeepSeek-V3.2-TEE": { alias: "Chutes DeepSeek V3.2" },
       },
     },

--- a/docs/providers/cohere.md
+++ b/docs/providers/cohere.md
@@ -22,13 +22,13 @@ read_when:
 
 ## Built-in catalog
 
-| Model ref                            | Input       | Context | Max output | Notes                                         |
-| ------------------------------------ | ----------- | ------- | ---------- | --------------------------------------------- |
-| `cohere/command-a-plus-05-2026`      | text, image | 128,000 | 64,000     | Default; flagship agentic and reasoning model |
-| `cohere/command-a-03-2025`           | text        | 256,000 | 8,000      | Previous Command A model                      |
-| `cohere/command-a-reasoning-08-2025` | text        | 256,000 | 32,000     | Agentic reasoning and tool use                |
-| `cohere/command-a-vision-07-2025`    | text, image | 128,000 | 8,000      | Vision and document analysis; no tool use     |
-| `cohere/north-mini-code-1-0`         | text, image | 256,000 | 64,000     | Agentic coding; reasoning; free limits        |
+| Model ref                            | Visibility | Input       | Context | Max output | Notes                                         |
+| ------------------------------------ | ---------- | ----------- | ------- | ---------- | --------------------------------------------- |
+| `cohere/command-a-plus-05-2026`      | visible    | text, image | 128,000 | 64,000     | Default; flagship agentic and reasoning model |
+| `cohere/command-a-03-2025`           | hidden     | text        | 256,000 | 8,000      | Previous generation; replaced by Command A+   |
+| `cohere/command-a-reasoning-08-2025` | hidden     | text        | 256,000 | 32,000     | Previous generation; replaced by Command A+   |
+| `cohere/command-a-vision-07-2025`    | hidden     | text, image | 128,000 | 8,000      | Previous generation; replaced by Command A+   |
+| `cohere/north-mini-code-1-0`         | visible    | text, image | 256,000 | 64,000     | Agentic coding; reasoning; free limits        |
 
 Reasoning-capable Cohere models support two Compatibility API reasoning modes. OpenClaw maps **off** to `none` and every enabled thinking level to `high`. Command A Vision does not support tool use, so OpenClaw keeps agent tools disabled for that model.
 

--- a/docs/providers/deepinfra.md
+++ b/docs/providers/deepinfra.md
@@ -81,11 +81,13 @@ Any model on [deepinfra.com](https://deepinfra.com/) works with the
 
 ```text
 deepinfra/deepseek-ai/DeepSeek-V4-Flash
-deepinfra/deepseek-ai/DeepSeek-V3.2
-deepinfra/MiniMaxAI/MiniMax-M2.5
-deepinfra/moonshotai/Kimi-K2.5
+deepinfra/deepseek-ai/DeepSeek-V4-Pro
+deepinfra/zai-org/GLM-5.2
+deepinfra/stepfun-ai/Step-3.7-Flash
+deepinfra/moonshotai/Kimi-K2.7-Code
+deepinfra/moonshotai/Kimi-K2.6
+deepinfra/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B
 deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B
-deepinfra/zai-org/GLM-5.1
 ...and many more
 ```
 

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -76,18 +76,15 @@ available to that process (for example, in `~/.openclaw/.env` or via
 
 ## Built-in catalog
 
-| Model ref                    | Name              | Input | Context   | Max output | Notes                                         |
-| ---------------------------- | ----------------- | ----- | --------- | ---------- | --------------------------------------------- |
-| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | text  | 1,000,000 | 384,000    | Default model; V4 thinking-capable surface    |
-| `deepseek/deepseek-v4-pro`   | DeepSeek V4 Pro   | text  | 1,000,000 | 384,000    | V4 thinking-capable surface                   |
-| `deepseek/deepseek-chat`     | DeepSeek Chat     | text  | 1,000,000 | 384,000    | Hidden deprecated V4 Flash compatibility name |
-| `deepseek/deepseek-reasoner` | DeepSeek Reasoner | text  | 1,000,000 | 384,000    | Hidden deprecated V4 Flash thinking name      |
+| Model ref                    | Name              | Input | Context   | Max output | Notes                                      |
+| ---------------------------- | ----------------- | ----- | --------- | ---------- | ------------------------------------------ |
+| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | text  | 1,000,000 | 384,000    | Default model; V4 thinking-capable surface |
+| `deepseek/deepseek-v4-pro`   | DeepSeek V4 Pro   | text  | 1,000,000 | 384,000    | V4 thinking-capable surface                |
 
 <Warning>
 DeepSeek retired `deepseek-chat` and `deepseek-reasoner` on July 24, 2026 at
-15:59 UTC. They route to DeepSeek V4 Flash in non-thinking and
-thinking mode, respectively. Move configured model refs to
-`deepseek/deepseek-v4-flash` or `deepseek/deepseek-v4-pro` before the cutoff.
+15:59 UTC. Those model IDs are no longer accessible. Move configured model refs
+to `deepseek/deepseek-v4-flash` or `deepseek/deepseek-v4-pro`.
 </Warning>
 
 OpenClaw's local cost estimates follow DeepSeek's published cache-hit,

--- a/docs/providers/featherless.md
+++ b/docs/providers/featherless.md
@@ -65,9 +65,11 @@ documents native tool calling for the Qwen 3 family. OpenClaw configures its
 32,768-token context window, a conservative 4,096-token output limit, and
 Qwen chat-template thinking controls.
 
-The catalog cost fields are zero because Featherless supports multiple billing
-modes and OpenClaw does not embed account-specific plan or request-pricing
-rates.
+The catalog cost fields use Featherless's published request-pricing rates of
+$0.102 per million input tokens and $0.493 per million output tokens. Fixed
+subscription plans remain flat-rate; the cache cost fields stay zero because
+Featherless does not publish separate cache-read or cache-write rates for this
+model.
 
 ## Other Featherless models
 

--- a/docs/providers/fireworks.md
+++ b/docs/providers/fireworks.md
@@ -76,10 +76,10 @@ openclaw onboard --non-interactive \
 
 ## Built-in catalog
 
-| Model ref                                              | Name                        | Input        | Context | Max output | Thinking             |
-| ------------------------------------------------------ | --------------------------- | ------------ | ------- | ---------- | -------------------- |
-| `fireworks/accounts/fireworks/models/kimi-k2p6`        | Kimi K2.6                   | text + image | 262,144 | 262,144    | Forced off           |
-| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Turbo (Fire Pass) | text + image | 256,000 | 256,000    | Forced off (default) |
+| Model ref                                              | Name           | Input        | Context | Max output | Thinking             |
+| ------------------------------------------------------ | -------------- | ------------ | ------- | ---------- | -------------------- |
+| `fireworks/accounts/fireworks/models/kimi-k2p6`        | Kimi K2.6      | text + image | 262,144 | 262,144    | Forced off           |
+| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Fast | text + image | 262,144 | 256,000    | Forced off (default) |
 
 <Note>
   OpenClaw pins all Fireworks Kimi models to `thinking: off` because Kimi on Fireworks can leak chain-of-thought into the visible reply unless the request explicitly disables thinking. Routing the same model through [Moonshot](/providers/moonshot) directly preserves Kimi reasoning output. See [thinking modes](/tools/thinking) for switching between providers.

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -30,7 +30,7 @@ provider or agent runtime in three different ways.
       </Step>
       <Step title="Set a default model">
         ```bash
-        openclaw models set github-copilot/claude-opus-4.7
+        openclaw models set github-copilot/claude-opus-5
         ```
 
         Or in config:
@@ -38,7 +38,7 @@ provider or agent runtime in three different ways.
         ```json5
         {
           agents: {
-            defaults: { model: { primary: "github-copilot/claude-opus-4.7" } },
+            defaults: { model: { primary: "github-copilot/claude-opus-5" } },
           },
         }
         ```
@@ -62,9 +62,9 @@ provider or agent runtime in three different ways.
     {
       agents: {
         defaults: {
-          model: "github-copilot/gpt-5.5",
+          model: "github-copilot/gpt-5.6-sol",
           models: {
-            "github-copilot/gpt-5.5": {
+            "github-copilot/gpt-5.6-sol": {
               agentRuntime: { id: "copilot" },
             },
           },
@@ -211,7 +211,7 @@ back to `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, then `GITHUB_TOKEN`. Use
 
   <Accordion title="Model availability depends on your plan">
     Copilot model availability depends on your GitHub plan. If a model is
-    rejected, try another ID (for example `github-copilot/gpt-5.5`). See
+    rejected, try another ID (for example `github-copilot/gpt-5.6-sol`). See
     GitHub's [supported models per Copilot plan](https://docs.github.com/en/copilot/reference/ai-models/supported-models#supported-ai-models-per-copilot-plan)
     for the current model list.
   </Accordion>

--- a/docs/providers/gmi.md
+++ b/docs/providers/gmi.md
@@ -9,7 +9,7 @@ title: "GMI Cloud"
 GMI Cloud is a hosted inference platform for frontier and open-weight models
 behind an OpenAI-compatible API. In OpenClaw it is an official external provider
 plugin: install it once, store credentials through normal model auth, and use
-model refs like `gmi/google/gemini-3.1-flash-lite`.
+model refs like `gmi/openai/gpt-5.6-sol`.
 
 Use GMI when you want one API key for several hosted model families, including
 Anthropic, DeepSeek, Google, Moonshot, OpenAI, and Z.AI routes exposed by GMI's
@@ -26,7 +26,7 @@ rate limits, and any provider-side routing policy.
 | Auth env var  | `GMI_API_KEY`                            |
 | API           | OpenAI-compatible (`openai-completions`) |
 | Base URL      | `https://api.gmi-serving.com/v1`         |
-| Default model | `gmi/google/gemini-3.1-flash-lite`       |
+| Default model | `gmi/openai/gpt-5.6-sol`                 |
 
 ## Setup
 
@@ -70,12 +70,11 @@ The plugin catalog seeds commonly available GMI Cloud route ids:
 
 | Model ref                          | Input        | Context   | Max output |
 | ---------------------------------- | ------------ | --------- | ---------- |
-| `gmi/anthropic/claude-sonnet-4.6`  | text + image | 200,000   | 64,000     |
-| `gmi/deepseek-ai/DeepSeek-V3.2`    | text         | 163,840   | 65,536     |
-| `gmi/google/gemini-3.1-flash-lite` | text + image | 1,048,576 | 65,536     |
-| `gmi/moonshotai/Kimi-K2.5`         | text + image | 262,144   | 65,536     |
-| `gmi/openai/gpt-5.4`               | text + image | 400,000   | 128,000    |
-| `gmi/zai-org/GLM-5.1-FP8`          | text         | 202,752   | 65,536     |
+| `gmi/anthropic/claude-sonnet-5`    | text + image | 409,600   | 128,000    |
+| `gmi/deepseek-ai/DeepSeek-V4-Pro`  | text         | 1,048,576 | 384,000    |
+| `gmi/google/gemini-3.5-flash-lite` | text + image | 1,048,576 | 65,536     |
+| `gmi/openai/gpt-5.6-sol`           | text + image | 1,050,000 | 128,000    |
+| `gmi/zai-org/GLM-5.2-FP8`          | text         | 1,048,576 | 128,000    |
 
 The catalog is a seed, not a promise that every account can call every model at
 all times. List what the configured provider reports in your environment:

--- a/docs/providers/groq.md
+++ b/docs/providers/groq.md
@@ -17,7 +17,7 @@ read_when:
 | API                    | OpenAI-compatible (`openai-completions`) |
 | Base URL               | `https://api.groq.com/openai/v1`         |
 | Audio transcription    | `whisper-large-v3-turbo` (default)       |
-| Suggested chat default | `groq/llama-3.3-70b-versatile`           |
+| Suggested chat default | `groq/openai/gpt-oss-120b`               |
 
 ## Install plugin
 
@@ -44,7 +44,7 @@ export GROQ_API_KEY=gsk_...
     {
       agents: {
         defaults: {
-          model: { primary: "groq/llama-3.3-70b-versatile" },
+          model: { primary: "groq/openai/gpt-oss-120b" },
         },
       },
     }
@@ -64,7 +64,7 @@ export GROQ_API_KEY=gsk_...
   env: { GROQ_API_KEY: "gsk_..." },
   agents: {
     defaults: {
-      model: { primary: "groq/llama-3.3-70b-versatile" },
+      model: { primary: "groq/openai/gpt-oss-120b" },
     },
   },
 }
@@ -74,17 +74,16 @@ export GROQ_API_KEY=gsk_...
 
 OpenClaw ships a manifest-backed Groq catalog with both reasoning and non-reasoning entries. Run `openclaw models list --provider groq` to see the static rows for your installed version, or check [console.groq.com/docs/models](https://console.groq.com/docs/models) for Groq's authoritative list.
 
-| Model ref                                        | Name                    | Reasoning | Input        | Context |
-| ------------------------------------------------ | ----------------------- | --------- | ------------ | ------- |
-| `groq/llama-3.3-70b-versatile`                   | Llama 3.3 70B Versatile | no        | text         | 131,072 |
-| `groq/llama-3.1-8b-instant`                      | Llama 3.1 8B Instant    | no        | text         | 131,072 |
-| `groq/meta-llama/llama-4-scout-17b-16e-instruct` | Llama 4 Scout 17B       | no        | text + image | 131,072 |
-| `groq/openai/gpt-oss-120b`                       | GPT OSS 120B            | yes       | text         | 131,072 |
-| `groq/openai/gpt-oss-20b`                        | GPT OSS 20B             | yes       | text         | 131,072 |
-| `groq/openai/gpt-oss-safeguard-20b`              | Safety GPT OSS 20B      | yes       | text         | 131,072 |
-| `groq/qwen/qwen3-32b`                            | Qwen3 32B               | yes       | text         | 131,072 |
-| `groq/groq/compound`                             | Compound                | yes       | text         | 131,072 |
-| `groq/groq/compound-mini`                        | Compound Mini           | yes       | text         | 131,072 |
+| Model ref                           | Name               | Reasoning | Input        | Context |
+| ----------------------------------- | ------------------ | --------- | ------------ | ------- |
+| `groq/openai/gpt-oss-120b`          | GPT OSS 120B       | yes       | text         | 131,072 |
+| `groq/openai/gpt-oss-20b`           | GPT OSS 20B        | yes       | text         | 131,072 |
+| `groq/openai/gpt-oss-safeguard-20b` | Safety GPT OSS 20B | yes       | text         | 131,072 |
+| `groq/qwen/qwen3.6-27b`             | Qwen 3.6 27B       | yes       | text + image | 131,072 |
+| `groq/groq/compound`                | Compound           | no        | text         | 131,072 |
+| `groq/groq/compound-mini`           | Compound Mini      | no        | text         | 131,072 |
+
+The manifest also retains `groq/llama-3.1-8b-instant` and `groq/llama-3.3-70b-versatile` as hidden deprecated compatibility rows until Groq's August 16, 2026 shutdown. Use `groq/openai/gpt-oss-20b` and `groq/openai/gpt-oss-120b`, respectively, for new configurations.
 
 <Tip>
   The catalog evolves with each OpenClaw release. `openclaw models list --provider groq` shows the rows known to your installed version; cross-check with [console.groq.com/docs/models](https://console.groq.com/docs/models) for newly-added or deprecated models.

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -68,13 +68,13 @@ openclaw onboard --non-interactive --accept-risk \
 
 ## Built-in catalog
 
-| Model ref             | Name           | Reasoning | Context window | Max output |
-| --------------------- | -------------- | --------- | -------------- | ---------- |
-| `meta/muse-spark-1.1` | Muse Spark 1.1 | yes       | 1,048,576      | 131,072    |
+| Model ref             | Name           | Input                          | Reasoning | Context window | Max output | Input / cached input / output per 1M tokens |
+| --------------------- | -------------- | ------------------------------ | --------- | -------------- | ---------- | ------------------------------------------- |
+| `meta/muse-spark-1.1` | Muse Spark 1.1 | text, image, video, audio, PDF | yes       | 1,048,576      | 131,072    | $1.25 / $0.15 / $4.25                       |
 
 Capabilities:
 
-- Text + image input
+- Text, image, video, audio, and PDF input
 - Tool calling and streaming
 - Reasoning effort: `minimal`, `low`, `medium`, `high`, `xhigh` (default: `high`)
 - Stateless encrypted reasoning replay (`store: false`, `include: ["reasoning.encrypted_content"]`)

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -61,14 +61,12 @@ The bundled `mistral` plugin registers four contracts: chat completions, media u
 | Model ref                        | Input       | Context | Max output | Notes                                                 |
 | -------------------------------- | ----------- | ------- | ---------- | ----------------------------------------------------- |
 | `mistral/mistral-large-latest`   | text, image | 262,144 | 16,384     | Default model                                         |
-| `mistral/mistral-medium-2508`    | text, image | 262,144 | 8,192      | Mistral Medium 3.1                                    |
 | `mistral/mistral-medium-3-5`     | text, image | 262,144 | 8,192      | Mistral Medium 3.5; adjustable reasoning              |
 | `mistral/mistral-small-latest`   | text, image | 262,144 | 16,384     | Mistral Small 4 latest; adjustable `reasoning_effort` |
 | `mistral/mistral-small-2603`     | text, image | 262,144 | 16,384     | Mistral Small 4 pinned; adjustable `reasoning_effort` |
-| `mistral/pixtral-large-latest`   | text, image | 128,000 | 32,768     | Pixtral                                               |
-| `mistral/codestral-latest`       | text        | 256,000 | 4,096      | Coding                                                |
-| `mistral/devstral-medium-latest` | text        | 262,144 | 32,768     | Devstral 2                                            |
-| `mistral/magistral-small`        | text        | 128,000 | 40,000     | Reasoning-enabled                                     |
+| `mistral/codestral-latest`       | text        | 128,000 | 4,096      | Coding                                                |
+| `mistral/mistral-medium-2508`    | text, image | 128,000 | 8,192      | Deprecated; hidden; use Mistral Medium 3.5            |
+| `mistral/devstral-medium-latest` | text        | 262,144 | 32,768     | Deprecated; hidden; use Mistral Medium 3.5            |
 
 Browse the bundled catalog row before changing config:
 
@@ -180,7 +178,7 @@ OpenClaw defaults Mistral realtime STT to `pcm_mulaw` at 8 kHz so Voice Call can
     ```
 
     <Note>
-    Other bundled Mistral catalog models do not use this parameter. Keep using `magistral-*` models when you want Mistral's native reasoning-first behavior.
+    Other bundled Mistral catalog models do not use this parameter. Mistral's native Magistral models are deprecated; use adjustable reasoning on Mistral Small 4 or Mistral Medium 3.5 for current API models.
     </Note>
 
   </Accordion>

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -19,11 +19,11 @@ Moonshot and Kimi Coding are **separate providers**, each shipped as a separate 
 
 [//]: # "moonshot-kimi-k2-ids:start"
 
-| Model ref                           | Name                     | Reasoning  | Input       | Context   | Max output |
-| ----------------------------------- | ------------------------ | ---------- | ----------- | --------- | ---------- |
-| `moonshot/kimi-k3`                  | Kimi K3                  | Always max | text, image | 1,048,576 | 1,048,576  |
-| `moonshot/kimi-k2.7-code`           | Kimi K2.7 Code           | Always on  | text, image | 262,144   | 262,144    |
-| `moonshot/kimi-k2.7-code-highspeed` | Kimi K2.7 Code HighSpeed | Always on  | text, image | 262,144   | 262,144    |
+| Model ref                           | Name                     | Reasoning        | Input              | Context   | Max output |
+| ----------------------------------- | ------------------------ | ---------------- | ------------------ | --------- | ---------- |
+| `moonshot/kimi-k3`                  | Kimi K3                  | low / high / max | text, image, video | 1,048,576 | 1,048,576  |
+| `moonshot/kimi-k2.7-code`           | Kimi K2.7 Code           | Always on        | text, image, video | 262,144   | 262,144    |
+| `moonshot/kimi-k2.7-code-highspeed` | Kimi K2.7 Code HighSpeed | Always on        | text, image, video | 262,144   | 262,144    |
 
 [//]: # "moonshot-kimi-k2-ids:end"
 
@@ -32,8 +32,9 @@ live vendor pages for [Kimi K3](https://platform.kimi.ai/docs/pricing/chat-k3)
 and [Kimi K2.7 Code](https://platform.kimi.ai/docs/pricing/chat-k27-code)
 before making cost decisions.
 
-Kimi K3 always reasons at `reasoning_effort: "max"`. OpenClaw exposes only
-`/think max`, omits the K2-only `thinking` field, and removes sampling
+Kimi K3 always reasons and accepts `reasoning_effort` values `low`, `high`,
+and `max` (the default). OpenClaw exposes those exact levels and maps `/think
+xhigh` to `max`; it omits the K2-only `thinking` field and removes sampling
 overrides (`temperature`, `top_p`, `n`, `presence_penalty`, and
 `frequency_penalty`) that K3 fixes to provider defaults. Kimi K2.7 Code also
 always uses native thinking but requires both `thinking` and
@@ -141,13 +142,13 @@ onboarding.
                 thinkingLevelMap: {
                   off: null,
                   minimal: null,
-                  low: null,
+                  low: "low",
                   medium: null,
-                  high: null,
+                  high: "high",
                   xhigh: "max",
                   max: "max",
                 },
-                input: ["text", "image"],
+                input: ["text", "image", "video"],
                 cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
                 contextWindow: 1048576,
                 maxTokens: 1048576,
@@ -156,7 +157,7 @@ onboarding.
                 id: "kimi-k2.7-code",
                 name: "Kimi K2.7 Code",
                 reasoning: true,
-                input: ["text", "image"],
+                input: ["text", "image", "video"],
                 cost: { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 },
                 contextWindow: 262144,
                 maxTokens: 262144,
@@ -165,7 +166,7 @@ onboarding.
                 id: "kimi-k2.7-code-highspeed",
                 name: "Kimi K2.7 Code HighSpeed",
                 reasoning: true,
-                input: ["text", "image"],
+                input: ["text", "image", "video"],
                 cost: { input: 1.9, output: 8, cacheRead: 0.38, cacheWrite: 0 },
                 contextWindow: 262144,
                 maxTokens: 262144,

--- a/docs/providers/novita.md
+++ b/docs/providers/novita.md
@@ -9,7 +9,7 @@ title: "NovitaAI"
 NovitaAI is a hosted AI infrastructure provider with an OpenAI-compatible API.
 It ships as a bundled OpenClaw provider (no separate plugin install), so
 credentials go through the normal model auth flow and model refs look like
-`novita/deepseek/deepseek-v3-0324`.
+`novita/deepseek/deepseek-v4-pro`.
 
 ## Setup
 
@@ -27,22 +27,26 @@ export NOVITA_API_KEY="<your-novita-api-key>" # pragma: allowlist secret
 
 ## Defaults
 
-| Setting       | Value                              |
-| ------------- | ---------------------------------- |
-| Provider id   | `novita`                           |
-| Aliases       | `novita-ai`, `novitaai`            |
-| Base URL      | `https://api.novita.ai/openai/v1`  |
-| Env var       | `NOVITA_API_KEY`                   |
-| Default model | `novita/deepseek/deepseek-v3-0324` |
+| Setting       | Value                             |
+| ------------- | --------------------------------- |
+| Provider id   | `novita`                          |
+| Aliases       | `novita-ai`, `novitaai`           |
+| Base URL      | `https://api.novita.ai/openai/v1` |
+| Env var       | `NOVITA_API_KEY`                  |
+| Default model | `novita/deepseek/deepseek-v4-pro` |
 
 ## Bundled model catalog
 
-- `novita/moonshotai/kimi-k2.5`
-- `novita/minimax/minimax-m2.7`
-- `novita/zai-org/glm-5`
-- `novita/deepseek/deepseek-v3-0324`
-- `novita/deepseek/deepseek-r1-0528`
-- `novita/qwen/qwen3-235b-a22b-fp8`
+- `novita/moonshotai/kimi-k3`
+- `novita/moonshotai/kimi-k2.7-code`
+- `novita/minimax/minimax-m3`
+- `novita/zai-org/glm-5.2`
+- `novita/deepseek/deepseek-v4-pro`
+- `novita/deepseek/deepseek-v4-flash`
+- `novita/qwen/qwen3.7-max`
+
+`novita/minimax/minimax-m2.7` remains selectable as a deprecated compatibility
+entry but is hidden from model pickers.
 
 This is a starting point, not a live catalog. Your account, region, or
 Novita's current offering may add, remove, or restrict routes. Check before

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -105,16 +105,15 @@ pickers.
 | `nvidia/nvidia/nemotron-3-ultra-550b-a55b` | Nemotron 3 Ultra 550B | 1,048,576 | 8,192      |
 | `nvidia/nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super 120B | 1,000,000 | 8,192      |
 | `nvidia/z-ai/glm-5.2`                      | GLM 5.2               | 202,752   | 8,192      |
-| `nvidia/moonshotai/kimi-k2.6`              | Kimi K2.6             | 262,144   | 8,192      |
+| `nvidia/moonshotai/kimi-k2.6`              | Kimi K2.6             | 262,144   | 65,536     |
 | `nvidia/minimaxai/minimax-m3`              | Minimax M3            | 196,608   | 8,192      |
 | `nvidia/deepseek-ai/deepseek-v4-pro`       | DeepSeek V4 Pro       | 262,144   | 16,384     |
-| `nvidia/qwen/qwen3.5-397b-a17b`            | Qwen3.5 397B A17B     | 262,144   | 16,384     |
+| `nvidia/qwen/qwen3.5-397b-a17b`            | Qwen3.5 397B A17B     | 262,144   | 32,768     |
 
 The full compatibility catalog also retains these shipped refs for existing
 configurations: `nvidia/moonshotai/kimi-k2.5`, `nvidia/z-ai/glm-5.1`,
-`nvidia/minimaxai/minimax-m2.5`, `nvidia/z-ai/glm5`, and
-`nvidia/minimaxai/minimax-m2.7`. They remain available by exact reference but
-never appear in onboarding or model pickers.
+`nvidia/z-ai/glm5`, and `nvidia/minimaxai/minimax-m2.7`. They remain available
+by exact reference but never appear in onboarding or model pickers.
 
 ## Advanced configuration
 

--- a/docs/providers/ollama-cloud.md
+++ b/docs/providers/ollama-cloud.md
@@ -36,7 +36,7 @@ Non-interactive onboarding accepts the key directly:
 openclaw onboard --auth-choice ollama-cloud --ollama-cloud-api-key "<key>"
 ```
 
-Onboarding sets the default model to `ollama-cloud/kimi-k2.5:cloud`.
+Onboarding sets the default model to `ollama-cloud/minimax-m2.7`.
 
 ## Defaults
 
@@ -44,7 +44,7 @@ Onboarding sets the default model to `ollama-cloud/kimi-k2.5:cloud`.
 - Base URL: `https://ollama.com`
 - Env var: `OLLAMA_API_KEY`
 - API style: Ollama native `/api/chat`
-- Onboarding default model: `ollama-cloud/kimi-k2.5:cloud`
+- Onboarding default model: `ollama-cloud/minimax-m2.7`
 
 ## When to choose Ollama Cloud
 
@@ -70,10 +70,11 @@ openclaw models list --provider ollama-cloud
 openclaw models set ollama-cloud/kimi-k2.6
 ```
 
-Hosted ids in the live catalog include `deepseek-v4-flash`, `glm-5`,
+Hosted ids in the live catalog include `deepseek-v4-flash`, `glm-5.2`,
 `gpt-oss:20b`, `kimi-k2.6`, and `minimax-m2.7`. When live discovery returns
-nothing, OpenClaw falls back to the bundled rows `kimi-k2.5:cloud`,
-`minimax-m2.7:cloud`, `glm-5.1:cloud`, and `glm-5.2:cloud`.
+nothing, OpenClaw falls back to the bundled rows `minimax-m2.7`, `glm-5.1`,
+and `glm-5.2`. The retiring `kimi-k2.5` model is hidden from model pickers but
+remains selectable by exact reference until Ollama retires it on July 31, 2026.
 
 Model ids are cloud catalog ids, not local pull names. If a model name works in
 a local Ollama host but is absent from the hosted catalog, use the `ollama`

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -39,7 +39,7 @@ one OpenCode setup.
       </Step>
       <Step title="Set a Zen model as the default">
         ```bash
-        openclaw config set agents.defaults.model.primary "opencode/claude-opus-4-6"
+        openclaw config set agents.defaults.model.primary "opencode/gpt-5.6-sol"
         ```
       </Step>
       <Step title="Verify models are available">
@@ -86,7 +86,7 @@ one OpenCode setup.
 ```json5
 {
   env: { OPENCODE_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "opencode/claude-opus-4-6" } } },
+  agents: { defaults: { model: { primary: "opencode/gpt-5.6-sol" } } },
 }
 ```
 
@@ -94,14 +94,16 @@ one OpenCode setup.
 
 ### Zen
 
-| Property         | Value                                                                                         |
-| ---------------- | --------------------------------------------------------------------------------------------- |
-| Runtime provider | `opencode`                                                                                    |
-| Example models   | `opencode/claude-opus-4-6`, `opencode/gpt-5.5`, `opencode/gemini-3.1-pro`, `opencode/glm-5.2` |
+| Property         | Value                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------- |
+| Runtime provider | `opencode`                                                                                        |
+| Example models   | `opencode/gpt-5.6-sol`, `opencode/gemini-3.6-flash`, `opencode/minimax-m3`, `opencode/big-pickle` |
 
 Run `openclaw models list --provider opencode` for the full current list, which
-also includes free-tier rows such as `opencode/big-pickle` and
-`opencode/deepseek-v4-flash-free`.
+also includes the currently promoted free-tier rows `opencode/big-pickle`,
+`opencode/deepseek-v4-flash-free`, `opencode/laguna-s-2.1-free`,
+`opencode/ling-3.0-flash-free`, `opencode/mimo-v2.5-free`,
+`opencode/nemotron-3-ultra-free`, and `opencode/north-mini-code-free`.
 
 ### Go
 

--- a/docs/providers/qianfan.md
+++ b/docs/providers/qianfan.md
@@ -54,10 +54,13 @@ openclaw gateway restart
 
 ## Built-in catalog
 
-| Model ref                            | Input       | Context | Max output | Reasoning | Notes         |
-| ------------------------------------ | ----------- | ------- | ---------- | --------- | ------------- |
-| `qianfan/deepseek-v3.2`              | text        | 98,304  | 32,768     | Yes       | Default model |
-| `qianfan/ernie-5.0-thinking-preview` | text, image | 119,000 | 64,000     | Yes       | Multimodal    |
+| Model ref                            | Input       | Context   | Max output | Reasoning | Notes                                                                      |
+| ------------------------------------ | ----------- | --------- | ---------- | --------- | -------------------------------------------------------------------------- |
+| `qianfan/deepseek-v4-pro`            | text        | 1,000,000 | 393,216    | Yes       | Current DeepSeek flagship                                                  |
+| `qianfan/ernie-5.1`                  | text        | 128,000   | 65,536     | No        | Latest ERNIE text flagship                                                 |
+| `qianfan/ernie-5.0`                  | text, image | 128,000   | 65,536     | Yes       | Current multimodal and thinking model                                      |
+| `qianfan/deepseek-v3.2`              | text        | 128,000   | 32,768     | No        | Deprecated onboarding compatibility default; replaced by `deepseek-v4-pro` |
+| `qianfan/ernie-5.0-thinking-preview` | text, image | 128,000   | 65,536     | Yes       | Deprecated alias; replaced by `ernie-5.0`                                  |
 
 The catalog is static; there is no live model discovery.
 
@@ -67,14 +70,16 @@ You only need to override `models.providers.qianfan` when you need a custom base
 
 ## Config example
 
+This example explicitly selects the current DeepSeek flagship instead of the onboarding compatibility default.
+
 ```json5
 {
   env: { QIANFAN_API_KEY: "bce-v3/ALTAK-..." },
   agents: {
     defaults: {
-      model: { primary: "qianfan/deepseek-v3.2" },
+      model: { primary: "qianfan/deepseek-v4-pro" },
       models: {
-        "qianfan/deepseek-v3.2": { alias: "QIANFAN" },
+        "qianfan/deepseek-v4-pro": { alias: "QIANFAN" },
       },
     },
   },
@@ -85,22 +90,18 @@ You only need to override `models.providers.qianfan` when you need a custom base
         api: "openai-completions",
         models: [
           {
-            id: "deepseek-v3.2",
-            name: "DEEPSEEK V3.2",
+            id: "deepseek-v4-pro",
+            name: "DeepSeek V4 Pro",
             reasoning: true,
             input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 98304,
-            maxTokens: 32768,
-          },
-          {
-            id: "ernie-5.0-thinking-preview",
-            name: "ERNIE-5.0-Thinking-Preview",
-            reasoning: true,
-            input: ["text", "image"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 119000,
-            maxTokens: 64000,
+            cost: {
+              input: 1.771957,
+              output: 3.543915,
+              cacheRead: 0.147663,
+              cacheWrite: 0,
+            },
+            contextWindow: 1000000,
+            maxTokens: 393216,
           },
         ],
       },
@@ -110,7 +111,7 @@ You only need to override `models.providers.qianfan` when you need a custom base
 ```
 
 <Note>
-Model refs use the `qianfan/` prefix (for example `qianfan/deepseek-v3.2`).
+Model refs use the `qianfan/` prefix (for example `qianfan/deepseek-v4-pro`).
 </Note>
 
 <AccordionGroup>

--- a/docs/providers/qwen.md
+++ b/docs/providers/qwen.md
@@ -227,25 +227,20 @@ present in the static catalog.
 
 ### Token Plan catalog
 
-Token Plan uses a separate exact-string allowlist. Image-generation-only plan
-models are not included here because they use different APIs.
+Token Plan uses a separate exact-string allowlist. The built-in catalog shows
+Alibaba's currently recommended plan models and keeps the newer Qwen3-Coder
+compatibility tier selectable but hidden. Other allowlisted model IDs remain
+available as custom model refs. Image-generation-only plan models are not
+included here because they use different APIs.
 
-| Model ref                           | Input       | Context   |
-| ----------------------------------- | ----------- | --------- |
-| `qwen-token-plan/qwen3.7-max`       | text        | 1,000,000 |
-| `qwen-token-plan/qwen3.7-plus`      | text, image | 1,000,000 |
-| `qwen-token-plan/qwen3.6-plus`      | text, image | 1,000,000 |
-| `qwen-token-plan/qwen3.6-flash`     | text, image | 1,000,000 |
-| `qwen-token-plan/deepseek-v4-pro`   | text        | 1,000,000 |
-| `qwen-token-plan/deepseek-v4-flash` | text        | 1,000,000 |
-| `qwen-token-plan/deepseek-v3.2`     | text        | 131,072   |
-| `qwen-token-plan/kimi-k2.7-code`    | text, image | 262,144   |
-| `qwen-token-plan/kimi-k2.6`         | text, image | 262,144   |
-| `qwen-token-plan/kimi-k2.5`         | text, image | 262,144   |
-| `qwen-token-plan/glm-5.2`           | text        | 1,000,000 |
-| `qwen-token-plan/glm-5.1`           | text        | 202,752   |
-| `qwen-token-plan/glm-5`             | text        | 202,752   |
-| `qwen-token-plan/MiniMax-M2.5`      | text        | 196,608   |
+| Model ref                          | Input       | Context   | Picker status |
+| ---------------------------------- | ----------- | --------- | ------------- |
+| `qwen-token-plan/qwen3.7-plus`     | text, image | 1,000,000 | visible       |
+| `qwen-token-plan/qwen3.6-plus`     | text, image | 1,000,000 | visible       |
+| `qwen-token-plan/qwen3-coder-next` | text        | 262,144   | hidden        |
+| `qwen-token-plan/kimi-k2.5`        | text, image | 262,144   | visible       |
+| `qwen-token-plan/glm-5`            | text        | 202,752   | visible       |
+| `qwen-token-plan/MiniMax-M2.5`     | text        | 196,608   | visible       |
 
 ## Thinking controls
 

--- a/docs/providers/stepfun.md
+++ b/docs/providers/stepfun.md
@@ -163,7 +163,7 @@ A single auth flow writes region-matched profiles for both `stepfun` and `stepfu
                 name: "Step 3.5 Flash",
                 reasoning: true,
                 input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                cost: { input: 0.1, output: 0.3, cacheRead: 0.02, cacheWrite: 0 },
                 contextWindow: 262144,
                 maxTokens: 65536,
               },

--- a/docs/providers/tencent.md
+++ b/docs/providers/tencent.md
@@ -95,11 +95,11 @@ openclaw onboard --non-interactive \
 
 ## Built-in catalog
 
-| Model ref                      | Name                   | Input | Context | Max output | Notes             |
-| ------------------------------ | ---------------------- | ----- | ------- | ---------- | ----------------- |
-| `tencent-tokenhub/hy3-preview` | hy3 preview (TokenHub) | text  | 256,000 | 64,000     | reasoning-enabled |
-| `tencent-tokenhub/hy3`         | hy3 (TokenHub)         | text  | 256,000 | 64,000     | reasoning-enabled |
-| `tencent-tokenplan/hy3`        | hy3 (TokenPlan)        | text  | 256,000 | 64,000     | reasoning-enabled |
+| Model ref                      | Name                   | Input | Context | Max output | Notes                      |
+| ------------------------------ | ---------------------- | ----- | ------- | ---------- | -------------------------- |
+| `tencent-tokenhub/hy3-preview` | hy3 preview (TokenHub) | text  | 256,000 | 128,000    | deprecated; use `hy3`      |
+| `tencent-tokenhub/hy3`         | hy3 (TokenHub)         | text  | 256,000 | 128,000    | reasoning-enabled; current |
+| `tencent-tokenplan/hy3`        | hy3 (TokenPlan)        | text  | 256,000 | 128,000    | reasoning-enabled; current |
 
 hy3 is Tencent Hunyuan's large MoE language model for reasoning, long-context instruction following, code, and agent workflows. Tencent's OpenAI-compatible examples use `hy3` as the model id and support standard chat-completions tool calling plus `reasoning_effort`.
 

--- a/docs/providers/together.md
+++ b/docs/providers/together.md
@@ -62,13 +62,12 @@ default model.
 
 Cost is USD per million tokens.
 
-| Model ref                                          | Name                         | Input       | Context | Max output | Cost (in/out) | Notes               |
-| -------------------------------------------------- | ---------------------------- | ----------- | ------- | ---------- | ------------- | ------------------- |
-| `together/meta-llama/Llama-3.3-70B-Instruct-Turbo` | Llama 3.3 70B Instruct Turbo | text        | 131,072 | 8,192      | 0.88 / 0.88   | Default model       |
-| `together/moonshotai/Kimi-K2.6`                    | Kimi K2.6 FP4                | text, image | 262,144 | 32,768     | 1.20 / 4.50   | Reasoning model     |
-| `together/deepseek-ai/DeepSeek-V4-Pro`             | DeepSeek V4 Pro              | text        | 512,000 | 8,192      | 2.10 / 4.40   | Reasoning model     |
-| `together/Qwen/Qwen2.5-7B-Instruct-Turbo`          | Qwen2.5 7B Instruct Turbo    | text        | 32,768  | 8,192      | 0.30 / 0.30   | Fast, non-reasoning |
-| `together/zai-org/GLM-5.1`                         | GLM 5.1 FP4                  | text        | 202,752 | 8,192      | 1.40 / 4.40   | Reasoning model     |
+| Model ref                                          | Name                         | Input       | Context | Max output | Cost (in/out) | Notes           |
+| -------------------------------------------------- | ---------------------------- | ----------- | ------- | ---------- | ------------- | --------------- |
+| `together/meta-llama/Llama-3.3-70B-Instruct-Turbo` | Llama 3.3 70B Instruct Turbo | text        | 131,072 | 8,192      | 1.04 / 1.04   | Default model   |
+| `together/moonshotai/Kimi-K2.6`                    | Kimi K2.6 FP4                | text, image | 262,144 | 32,768     | 1.20 / 4.50   | Reasoning model |
+| `together/deepseek-ai/DeepSeek-V4-Pro`             | DeepSeek V4 Pro              | text        | 512,000 | 384,000    | 1.74 / 3.48   | Reasoning model |
+| `together/zai-org/GLM-5.2`                         | GLM 5.2 FP4                  | text        | 262,144 | 131,072    | 1.40 / 4.40   | Reasoning model |
 
 ## Video generation
 

--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -12,10 +12,10 @@ All endpoints are OpenAI-compatible (`/v1`).
 
 ## Privacy modes
 
-| Mode           | Behavior                                                         | Models                                                        |
-| -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Private**    | Prompts/responses are never stored or logged. Ephemeral.         | Llama, Qwen, DeepSeek, Kimi, MiniMax, Venice Uncensored, etc. |
-| **Anonymized** | Proxied through Venice with metadata stripped before forwarding. | Claude, GPT, Gemini, Grok                                     |
+| Mode           | Behavior                                                         | Models                                                          |
+| -------------- | ---------------------------------------------------------------- | --------------------------------------------------------------- |
+| **Private**    | Prompts/responses are never stored or logged. Ephemeral.         | GLM, Gemma, Grok, Qwen, DeepSeek, Kimi, Venice Uncensored, etc. |
+| **Anonymized** | Proxied through Venice with metadata stripped before forwarding. | Claude, GPT, and selected Qwen models                           |
 
 <Warning>
 Anonymized models are not fully private. Venice strips metadata before forwarding, but the underlying provider (OpenAI, Anthropic, Google, xAI) still processes the request. Use Private models when full privacy is required.
@@ -60,18 +60,18 @@ Anonymized models are not fully private. Venice strips metadata before forwardin
   </Step>
   <Step title="Verify setup">
     ```bash
-    openclaw agent --model venice/kimi-k2-5 --message "Hello, are you working?"
+    openclaw agent --model venice/kimi-k2-6 --message "Hello, are you working?"
     ```
   </Step>
 </Steps>
 
 ## Model selection
 
-- **Default**: `venice/kimi-k2-5` (private, reasoning, vision).
-- **Strongest anonymized option**: `venice/claude-opus-4-6`.
+- **Default**: `venice/kimi-k2-6` (private, reasoning, vision).
+- **Strongest anonymized option**: `venice/claude-opus-5`.
 
 ```bash
-openclaw models set venice/kimi-k2-5
+openclaw models set venice/kimi-k2-6
 openclaw models list --all --provider venice
 ```
 
@@ -80,55 +80,49 @@ You can also run `openclaw configure` and pick **Model/auth provider > Venice AI
 <Tip>
 | Use case              | Model                                        | Why                                    |
 | --------------------- | -------------------------------------------- | -------------------------------------- |
-| General chat (default) | `kimi-k2-5`                                  | Strong private reasoning plus vision   |
-| Best overall quality   | `claude-opus-4-6`                            | Strongest anonymized Venice option     |
+| General chat (default) | `kimi-k2-6`                                  | Current promoted private Kimi model    |
+| Best overall quality   | `claude-opus-5`                              | Current promoted anonymized Opus model |
 | Privacy + coding       | `qwen3-coder-480b-a35b-instruct-turbo`       | Private coding model with large context |
-| Fast + cheap           | `llama-3.2-3b`                               | Compact private model                  |
-| Complex private tasks  | `deepseek-v3.2`                              | Strong reasoning; tool calling disabled |
+| Fast + cheap           | `google-gemma-4-31b-it`                      | Low-cost promoted private vision model |
+| Complex private tasks  | `deepseek-v3.2`                              | Promoted private reasoning model       |
 | Uncensored             | `venice-uncensored-1-2`                      | Current uncensored Venice model        |
 </Tip>
 
-## Built-in catalog (30 models)
+## Built-in catalog (16 visible models)
 
 <AccordionGroup>
-  <Accordion title="Private models (20) — fully private, no logging">
-    | Model ID                               | Name                                 | Context | Notes                      |
-    | -------------------------------------- | ------------------------------------- | ------- | --------------------------- |
-    | `kimi-k2-5`                            | Kimi K2.5                             | 256k    | Default, reasoning, vision  |
-    | `llama-3.3-70b`                        | Llama 3.3 70B                         | 128k    | General                     |
-    | `llama-3.2-3b`                         | Llama 3.2 3B                          | 128k    | General                     |
-    | `hermes-3-llama-3.1-405b`              | Hermes 3 Llama 3.1 405B               | 128k    | General, tools disabled     |
-    | `qwen3-235b-a22b-thinking-2507`        | Qwen3 235B Thinking                   | 128k    | Reasoning                   |
-    | `qwen3-235b-a22b-instruct-2507`        | Qwen3 235B Instruct                   | 128k    | General                     |
-    | `qwen3-coder-480b-a35b-instruct-turbo` | Qwen3 Coder 480B Turbo                | 256k    | Coding                      |
-    | `qwen3-5-35b-a3b`                      | Qwen3.5 35B A3B                       | 256k    | Reasoning, vision           |
-    | `qwen3-next-80b`                       | Qwen3 Next 80B                        | 256k    | General                     |
-    | `qwen3-vl-235b-a22b`                   | Qwen3 VL 235B (Vision)                | 256k    | Vision                      |
-    | `deepseek-v3.2`                        | DeepSeek V3.2                         | 160k    | Reasoning, tools disabled    |
-    | `google-gemma-3-27b-it`                | Google Gemma 3 27B Instruct           | 198k    | Vision                       |
-    | `openai-gpt-oss-120b`                  | OpenAI GPT OSS 120B                   | 128k    | General                      |
-    | `nvidia-nemotron-3-nano-30b-a3b`       | NVIDIA Nemotron 3 Nano 30B            | 128k    | General                      |
-    | `olafangensan-glm-4.7-flash-heretic`   | GLM 4.7 Flash Heretic                 | 128k    | Reasoning                    |
-    | `zai-org-glm-4.6`                      | GLM 4.6                               | 198k    | General                      |
-    | `zai-org-glm-4.7`                      | GLM 4.7                               | 198k    | Reasoning                    |
-    | `zai-org-glm-4.7-flash`                | GLM 4.7 Flash                         | 128k    | Reasoning                    |
-    | `zai-org-glm-5`                        | GLM 5                                 | 198k    | Reasoning                    |
-    | `minimax-m25`                          | MiniMax M2.5                          | 198k    | Reasoning                    |
+  <Accordion title="Private models (10) — fully private, no logging">
+    | Model ID                               | Name                        | Context | Notes                       |
+    | -------------------------------------- | --------------------------- | ------- | --------------------------- |
+    | `zai-org-glm-5-2`                      | GLM 5.2                     | 1M      | Recommended, coding         |
+    | `zai-org-glm-4.7`                      | GLM 4.7                     | 198k    | Venice default              |
+    | `venice-uncensored-1-2`                | Venice Uncensored 1.2       | 128k    | Most uncensored, vision     |
+    | `google-gemma-4-31b-it`                | Google Gemma 4 31B Instruct | 256k    | Recommended, vision         |
+    | `kimi-k2-6`                            | Kimi K2.6                   | 256k    | Recommended, coding, vision |
+    | `deepseek-v3.2`                        | DeepSeek V3.2               | 160k    | Recommended, reasoning      |
+    | `qwen3-235b-a22b-thinking-2507`        | Qwen3 235B Thinking         | 128k    | Default reasoning           |
+    | `qwen3-coder-480b-a35b-instruct-turbo` | Qwen3 Coder 480B Turbo      | 256k    | Default coding              |
+    | `qwen3-vl-235b-a22b`                   | Qwen3 VL 235B               | 128k    | Default vision              |
+    | `grok-4-5`                             | Grok 4.5                    | 500k    | Recommended, coding, vision |
   </Accordion>
 
-  <Accordion title="Anonymized models (10) — via Venice proxy">
-    | Model ID                        | Name                           | Context | Notes                      |
-    | -------------------------------- | -------------------------------- | ------- | ---------------------------- |
-    | `claude-opus-4-6`               | Claude Opus 4.6 (via Venice)    | 1M      | Reasoning, vision            |
-    | `claude-sonnet-4-6`             | Claude Sonnet 4.6 (via Venice)  | 1M      | Reasoning, vision            |
-    | `openai-gpt-54`                 | GPT-5.4 (via Venice)            | 1M      | Reasoning, vision            |
-    | `openai-gpt-53-codex`           | GPT-5.3 Codex (via Venice)      | 400k    | Reasoning, vision, coding     |
-    | `openai-gpt-52`                 | GPT-5.2 (via Venice)            | 256k    | Reasoning                    |
-    | `openai-gpt-52-codex`           | GPT-5.2 Codex (via Venice)      | 256k    | Reasoning, vision, coding     |
-    | `openai-gpt-4o-2024-11-20`      | GPT-4o (via Venice)             | 128k    | Vision                        |
-    | `openai-gpt-4o-mini-2024-07-18` | GPT-4o Mini (via Venice)        | 128k    | Vision                        |
-    | `gemini-3-1-pro-preview`        | Gemini 3.1 Pro (via Venice)     | 1M      | Reasoning, vision             |
-    | `gemini-3-flash-preview`        | Gemini 3 Flash (via Venice)     | 256k    | Reasoning, vision             |
+  <Accordion title="Anonymized models (6) — via Venice proxy">
+    | Model ID            | Name                             | Context | Notes                       |
+    | ------------------- | -------------------------------- | ------- | --------------------------- |
+    | `qwen-3-7-max`      | Qwen 3.7 Max (via Venice)        | 1M      | Recommended, coding, vision |
+    | `qwen-3-7-plus`     | Qwen 3.7 Plus (via Venice)       | 1M      | Recommended, coding, vision |
+    | `claude-fable-5`    | Claude Fable 5 (via Venice)      | 1M      | Recommended, coding, vision |
+    | `claude-opus-5`     | Claude Opus 5 (via Venice)       | 1M      | Recommended, coding, vision |
+    | `claude-sonnet-4-6` | Claude Sonnet 4.6 (via Venice)   | 1M      | Recommended, coding, vision |
+    | `openai-gpt-56-sol` | GPT-5.6 Sol (via Venice)         | 1M      | Recommended, vision         |
+  </Accordion>
+
+  <Accordion title="Deprecated compatibility rows (3) — hidden from pickers">
+    | Model ID                | Replacement                 |
+    | ----------------------- | --------------------------- |
+    | `zai-org-glm-4.6`       | `zai-org-glm-4.7`           |
+    | `google-gemma-3-27b-it` | `google-gemma-4-31b-it`     |
+    | `kimi-k2-5`             | `kimi-k2-6`                 |
   </Accordion>
 </AccordionGroup>
 
@@ -157,12 +151,12 @@ separate from the native DeepSeek provider's own thinking controls.
 
 ## Streaming and tool support
 
-| Feature          | Support                                           |
-| ---------------- | ------------------------------------------------- |
-| Streaming        | All models                                        |
-| Function calling | Most models; disabled per-model where noted above |
-| Vision/Images    | Models marked "Vision" above                      |
-| JSON mode        | Via `response_format`                             |
+| Feature          | Support                                                |
+| ---------------- | ------------------------------------------------------ |
+| Streaming        | All models                                             |
+| Function calling | All visible seed models; live rows follow API metadata |
+| Vision/Images    | Models marked "Vision" above                           |
+| JSON mode        | Via `response_format`                                  |
 
 ## Pricing
 
@@ -174,10 +168,10 @@ direct API pricing plus a small Venice fee. See
 
 ```bash
 # Default private model
-openclaw agent --model venice/kimi-k2-5 --message "Quick health check"
+openclaw agent --model venice/kimi-k2-6 --message "Quick health check"
 
 # Claude Opus via Venice (anonymized)
-openclaw agent --model venice/claude-opus-4-6 --message "Summarize this task"
+openclaw agent --model venice/claude-opus-5 --message "Summarize this task"
 
 # Uncensored model
 openclaw agent --model venice/venice-uncensored-1-2 --message "Draft options"
@@ -223,7 +217,7 @@ More help: [Troubleshooting](/help/troubleshooting) and [FAQ](/help/faq).
     ```json5
     {
       env: { VENICE_API_KEY: "vapi_..." },
-      agents: { defaults: { model: { primary: "venice/kimi-k2-5" } } },
+      agents: { defaults: { model: { primary: "venice/kimi-k2-6" } } },
       models: {
         mode: "merge",
         providers: {
@@ -233,11 +227,11 @@ More help: [Troubleshooting](/help/troubleshooting) and [FAQ](/help/faq).
             api: "openai-completions",
             models: [
               {
-                id: "kimi-k2-5",
-                name: "Kimi K2.5",
+                id: "kimi-k2-6",
+                name: "Kimi K2.6",
                 reasoning: true,
                 input: ["text", "image"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                cost: { input: 0.75, output: 3.5, cacheRead: 0.16, cacheWrite: 0 },
                 contextWindow: 256000,
                 maxTokens: 65536,
               },

--- a/docs/providers/volcengine.md
+++ b/docs/providers/volcengine.md
@@ -75,19 +75,23 @@ Both providers are configured from a single API key. Setup registers both automa
 
 <Tabs>
   <Tab title="General (volcengine)">
-    | Model ref                                    | Name                            | Input       | Context |
-    | -------------------------------------------- | ------------------------------- | ----------- | ------- |
-    | `volcengine/deepseek-v3-2-251201`            | DeepSeek V3.2                   | text, image | 128,000 |
-    | `volcengine/doubao-seed-1-8-251228`          | Doubao Seed 1.8                 | text, image | 256,000 |
-    | `volcengine/doubao-seed-code-preview-251028` | doubao-seed-code-preview-251028 | text, image | 256,000 |
-    | `volcengine/glm-4-7-251222`                  | GLM 4.7                         | text, image | 200,000 |
-    | `volcengine/kimi-k2-5-260127`                | Kimi K2.5                       | text, image | 256,000 |
+    | Model ref                                      | Name                    | Input              | Context   |
+    | ---------------------------------------------- | ----------------------- | ------------------ | --------- |
+    | `volcengine/doubao-seed-evolving`              | Doubao Seed Evolving    | text, image, video | 1,024,000 |
+    | `volcengine/doubao-seed-2-1-pro-260628`        | Doubao Seed 2.1 Pro     | text, image, video | 256,000   |
+    | `volcengine/doubao-seed-2-1-turbo-260628`      | Doubao Seed 2.1 Turbo   | text, image, video | 256,000   |
+    | `volcengine/glm-5-2-260617`                    | GLM 5.2                 | text               | 1,024,000 |
+    | `volcengine/deepseek-v4-pro-260425`            | DeepSeek V4 Pro         | text               | 1,024,000 |
+    | `volcengine/deepseek-v4-flash-260425`          | DeepSeek V4 Flash       | text               | 1,024,000 |
   </Tab>
   <Tab title="Coding (volcengine-plan)">
-    | Model ref                                         | Name                     | Input | Context |
-    | ------------------------------------------------- | ------------------------ | ----- | ------- |
-    | `volcengine-plan/ark-code-latest`                 | Ark Coding Plan          | text  | 256,000 |
-    | `volcengine-plan/doubao-seed-code`                | Doubao Seed Code         | text  | 256,000 |
+    | Model ref                                  | Name                  | Input              | Context   |
+    | ------------------------------------------ | --------------------- | ------------------ | --------- |
+    | `volcengine-plan/ark-code-latest`          | Ark Coding Plan       | text               | 256,000   |
+    | `volcengine-plan/doubao-seed-2.1-turbo`    | Doubao Seed 2.1 Turbo | text, image, video | 256,000   |
+    | `volcengine-plan/glm-5.2`                  | GLM 5.2               | text               | 1,024,000 |
+    | `volcengine-plan/deepseek-v4-pro`          | DeepSeek V4 Pro       | text               | 1,024,000 |
+    | `volcengine-plan/deepseek-v4-flash`        | DeepSeek V4 Flash     | text               | 1,024,000 |
   </Tab>
 </Tabs>
 

--- a/docs/providers/xiaomi.md
+++ b/docs/providers/xiaomi.md
@@ -236,7 +236,7 @@ Token Plan:
 }
 ```
 
-Pricing comes from the bundled manifest (Token Plan models include tiered cache-read pricing), so the config example omits `cost`.
+Token Plan charges against a fixed subscription's Credits rather than per-token USD pricing, so its bundled catalog rows use zero USD cost and the config example omits `cost`.
 
 <AccordionGroup>
   <Accordion title="Auto-injection behavior">

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -165,10 +165,12 @@ openclaw models list --all --provider zai
 
 The manifest-backed catalog currently includes:
 
-| Model ref     | Notes                                             |
-| ------------- | ------------------------------------------------- |
-| `zai/glm-5.2` | Coding Plan default; 1M context                   |
-| `zai/glm-5.1` | Deprecated; hidden unless configured; use GLM-5.2 |
+| Model ref          | Notes                                             |
+| ------------------ | ------------------------------------------------- |
+| `zai/glm-5.2`      | Coding Plan default; 1M context                   |
+| `zai/glm-5-turbo`  | OpenClaw-optimized text model; 200K context       |
+| `zai/glm-5v-turbo` | Multimodal coding model; 200K context             |
+| `zai/glm-5.1`      | Deprecated; hidden unless configured; use GLM-5.2 |
 
 Catalog token-cost metadata follows Z.AI's current
 [pay-as-you-go pricing](https://docs.z.ai/guides/overview/pricing). Coding Plan

--- a/extensions/baseten/index.test.ts
+++ b/extensions/baseten/index.test.ts
@@ -142,7 +142,7 @@ describe("Baseten provider registration", () => {
       baseUrl: "https://inference.baseten.co/v1",
       api: "openai-completions",
     });
-    expect(catalog.models).toHaveLength(12);
+    expect(catalog.models).toHaveLength(9);
     expect(provider.staticCatalog).toBeDefined();
     expect(
       provider.buildReplayPolicy?.({
@@ -153,13 +153,15 @@ describe("Baseten provider registration", () => {
   });
 
   it("sets and clears chat-template thinking while preserving caller arguments", () => {
-    expect(captureThinkingPayload("zai-org/GLM-5", "high")).toMatchObject({
+    expect(captureThinkingPayload("zai-org/GLM-5.2-Fast", "high")).toMatchObject({
       chat_template_args: { preserve_me: true, enable_thinking: true },
     });
     expect(captureThinkingPayload("moonshotai/Kimi-K2.6", "off")).toMatchObject({
       chat_template_args: { preserve_me: true, enable_thinking: false },
     });
-    expect(captureThinkingPayload("NVIDIA/Nemotron-120B-A12B", undefined)).toMatchObject({
+    expect(
+      captureThinkingPayload("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B", undefined),
+    ).toMatchObject({
       chat_template_args: { preserve_me: true, enable_thinking: false },
     });
   });
@@ -181,6 +183,16 @@ describe("Baseten provider registration", () => {
       provider.resolveThinkingProfile?.({
         provider: "baseten",
         modelId: "zai-org/GLM-5.2",
+        reasoning: true,
+      } as never),
+    ).toEqual({
+      levels: [{ id: "off" }, { id: "high" }, { id: "max" }],
+      defaultLevel: "off",
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "baseten",
+        modelId: "zai-org/GLM-5.2-Fast",
         reasoning: true,
       } as never),
     ).toEqual({

--- a/extensions/baseten/models.test.ts
+++ b/extensions/baseten/models.test.ts
@@ -23,8 +23,20 @@ describe("Baseten model catalog", () => {
     const models = buildStaticBasetenModels();
 
     expect(BASETEN_DEFAULT_MODEL_REF).toBe("baseten/thinkingmachines/inkling");
-    expect(models).toHaveLength(12);
+    expect(models).toHaveLength(9);
     expect(models.map((model) => model.id)).toEqual(BASETEN_MODEL_CATALOG.map((model) => model.id));
+    expect(models.find((model) => model.id === "zai-org/GLM-5.2")).toMatchObject({
+      contextWindow: 524_000,
+      maxTokens: 262_000,
+      cost: { input: 1.4, output: 4.4, cacheRead: 0.14, cacheWrite: 0 },
+    });
+    expect(models.find((model) => model.id === "zai-org/GLM-5.2-Fast")).toMatchObject({
+      reasoning: true,
+      input: ["text"],
+      contextWindow: 524_000,
+      maxTokens: 262_000,
+      cost: { input: 2.1, output: 6.6, cacheRead: 0.21, cacheWrite: 0 },
+    });
     expect(models.find((model) => model.id === "thinkingmachines/inkling")).toMatchObject({
       reasoning: true,
       input: ["text", "image"],
@@ -122,7 +134,7 @@ describe("Baseten model catalog", () => {
   });
 
   it("keeps discovery offline without resolved auth", async () => {
-    await expect(discoverBasetenModels()).resolves.toHaveLength(12);
+    await expect(discoverBasetenModels()).resolves.toHaveLength(9);
   });
 
   it("authenticates live discovery and does not cache unusable rows", async () => {
@@ -156,7 +168,7 @@ describe("Baseten model catalog", () => {
         forceLive: true,
         fetchGuard,
       }),
-    ).resolves.toHaveLength(12);
+    ).resolves.toHaveLength(9);
     await expect(
       discoverBasetenModels({
         discoveryApiKey: TEST_VALUE,

--- a/extensions/baseten/models.ts
+++ b/extensions/baseten/models.ts
@@ -22,13 +22,10 @@ const DEFAULT_MAX_TOKENS = 8_192;
 
 const CHAT_TEMPLATE_THINKING_MODEL_IDS = new Set([
   "zai-org/glm-4.7",
-  "zai-org/glm-5",
-  "zai-org/glm-5.1",
   "zai-org/glm-5.2",
-  "moonshotai/kimi-k2.5",
+  "zai-org/glm-5.2-fast",
   "moonshotai/kimi-k2.6",
   "moonshotai/kimi-k2.7-code",
-  "nvidia/nemotron-120b-a12b",
   "nvidia/nvidia-nemotron-3-ultra-550b-a55b",
 ]);
 
@@ -87,7 +84,7 @@ function buildBasetenReasoningCompat(modelId: string): ModelCompatConfig {
       },
     };
   }
-  if (modelId === "zai-org/GLM-5.2") {
+  if (modelId === "zai-org/GLM-5.2" || modelId === "zai-org/GLM-5.2-Fast") {
     return {
       supportsReasoningEffort: true,
       supportedReasoningEfforts: ["none", "high", "max"],

--- a/extensions/baseten/openclaw.plugin.json
+++ b/extensions/baseten/openclaw.plugin.json
@@ -6,7 +6,9 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["baseten"],
+  "providers": [
+    "baseten"
+  ],
   "providerRequest": {
     "providers": {
       "baseten": {
@@ -27,7 +29,9 @@
             "id": "deepseek-ai/DeepSeek-V4-Pro",
             "name": "DeepSeek V4 Pro",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 262000,
             "maxTokens": 262000,
             "cost": {
@@ -41,7 +45,9 @@
             "id": "zai-org/GLM-4.7",
             "name": "GLM 4.7",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 200000,
             "maxTokens": 200000,
             "cost": {
@@ -52,44 +58,34 @@
             }
           },
           {
-            "id": "zai-org/GLM-5",
-            "name": "GLM 5",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 202000,
-            "maxTokens": 202000,
-            "cost": {
-              "input": 0.95,
-              "output": 3.15,
-              "cacheRead": 0.2,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "zai-org/GLM-5.1",
-            "name": "GLM 5.1",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 202000,
-            "maxTokens": 202000,
-            "cost": {
-              "input": 1.3,
-              "output": 4.3,
-              "cacheRead": 0.26,
-              "cacheWrite": 0
-            }
-          },
-          {
             "id": "zai-org/GLM-5.2",
             "name": "GLM 5.2",
             "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 202000,
-            "maxTokens": 202000,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 524000,
+            "maxTokens": 262000,
             "cost": {
               "input": 1.4,
               "output": 4.4,
-              "cacheRead": 0.26,
+              "cacheRead": 0.14,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai-org/GLM-5.2-Fast",
+            "name": "GLM 5.2 Fast",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 524000,
+            "maxTokens": 262000,
+            "cost": {
+              "input": 2.1,
+              "output": 6.6,
+              "cacheRead": 0.21,
               "cacheWrite": 0
             }
           },
@@ -97,7 +93,10 @@
             "id": "thinkingmachines/inkling",
             "name": "Inkling",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "contextWindow": 1048000,
             "maxTokens": 32000,
             "cost": {
@@ -108,24 +107,13 @@
             }
           },
           {
-            "id": "moonshotai/Kimi-K2.5",
-            "name": "Kimi K2.5",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 262000,
-            "maxTokens": 262000,
-            "cost": {
-              "input": 0.6,
-              "output": 3,
-              "cacheRead": 0.12,
-              "cacheWrite": 0
-            }
-          },
-          {
             "id": "moonshotai/Kimi-K2.6",
             "name": "Kimi K2.6",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "contextWindow": 262000,
             "maxTokens": 262000,
             "cost": {
@@ -139,7 +127,10 @@
             "id": "moonshotai/Kimi-K2.7-Code",
             "name": "Kimi K2.7 Code",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "contextWindow": 262000,
             "maxTokens": 262000,
             "cost": {
@@ -150,24 +141,12 @@
             }
           },
           {
-            "id": "nvidia/Nemotron-120B-A12B",
-            "name": "Nemotron Super",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 202000,
-            "maxTokens": 202000,
-            "cost": {
-              "input": 0.3,
-              "output": 0.75,
-              "cacheRead": 0.06,
-              "cacheWrite": 0
-            }
-          },
-          {
             "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
             "name": "Nemotron Ultra",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 202000,
             "maxTokens": 202000,
             "cost": {
@@ -181,7 +160,9 @@
             "id": "openai/gpt-oss-120b",
             "name": "GPT OSS 120B",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 128000,
             "maxTokens": 128000,
             "cost": {
@@ -202,7 +183,9 @@
     "providers": [
       {
         "id": "baseten",
-        "envVars": ["BASETEN_API_KEY"]
+        "envVars": [
+          "BASETEN_API_KEY"
+        ]
       }
     ]
   },

--- a/extensions/baseten/thinking.ts
+++ b/extensions/baseten/thinking.ts
@@ -17,7 +17,7 @@ export function resolveBasetenThinkingProfile(
   modelId: string,
 ): ProviderThinkingProfile | undefined {
   const normalized = modelId.trim().toLowerCase();
-  if (normalized === "zai-org/glm-5.2") {
+  if (normalized === "zai-org/glm-5.2" || normalized === "zai-org/glm-5.2-fast") {
     return BASETEN_GLM_52_THINKING_PROFILE;
   }
   return usesBasetenChatTemplateThinking(normalized) ? BASETEN_BINARY_THINKING_PROFILE : undefined;

--- a/extensions/byteplus/index.test.ts
+++ b/extensions/byteplus/index.test.ts
@@ -34,7 +34,6 @@ describe("byteplus plugin", () => {
     expect(planEntry?.contextWindow).toBe(codingModel.contextWindow);
     expect(BYTEPLUS_CODING_MODEL_CATALOG.map((entry) => entry.id)).toEqual([
       "ark-code-latest",
-      "glm-4.7",
       "kimi-k2.5",
     ]);
   });
@@ -50,16 +49,11 @@ describe("byteplus plugin", () => {
   });
 
   it("keeps Kimi catalog metadata aligned with provider capabilities", () => {
-    const standardKimi = BYTEPLUS_MODEL_CATALOG.find((entry) => entry.id === "kimi-k2-5-260127");
     const planKimi = BYTEPLUS_CODING_MODEL_CATALOG.find((entry) => entry.id === "kimi-k2.5");
 
-    for (const entry of [standardKimi, planKimi]) {
-      expect(entry?.reasoning).toBe(true);
-      expect(entry?.maxTokens).toBe(32768);
-      expect(entry?.cost?.input).toBe(0.6);
-      expect(entry?.cost?.output).toBe(2.5);
-      expect(entry?.cost?.cacheRead).toBe(0.12);
-      expect(entry?.cost?.cacheWrite).toBe(0);
-    }
+    expect(planKimi?.reasoning).toBe(true);
+    expect(planKimi?.input).toEqual(["text", "image"]);
+    expect(planKimi?.maxTokens).toBe(32768);
+    expect(planKimi?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
   });
 });

--- a/extensions/byteplus/openclaw.plugin.json
+++ b/extensions/byteplus/openclaw.plugin.json
@@ -24,42 +24,88 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "seed-1-8-251228",
-            "name": "Seed 1.8",
+            "id": "dola-seed-2-1-turbo-260628",
+            "name": "Dola Seed 2.1 Turbo",
+            "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 256000,
-            "maxTokens": 4096,
+            "maxTokens": 256000,
             "cost": {
-              "input": 0.0001,
-              "output": 0.0002,
-              "cacheRead": 0,
+              "input": 0.5,
+              "output": 2.5,
+              "cacheRead": 0.1,
               "cacheWrite": 0
             }
           },
           {
-            "id": "kimi-k2-5-260127",
-            "name": "Kimi K2.5",
+            "id": "seed-2-0-code-preview-260328",
+            "name": "Seed 2.0 Code Preview",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 256000,
-            "maxTokens": 32768,
+            "maxTokens": 128000,
             "cost": {
-              "input": 0.6,
-              "output": 2.5,
-              "cacheRead": 0.12,
+              "input": 0.5,
+              "output": 3,
+              "cacheRead": 0.1,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "glm-5-2-260617",
+            "name": "GLM 5.2",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1024000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 1.4,
+              "output": 4.4,
+              "cacheRead": 0.26,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-v4-pro-260425",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1024000,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 1.74,
+              "output": 3.48,
+              "cacheRead": 0.145,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-v4-flash-260425",
+            "name": "DeepSeek V4 Flash",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1024000,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 0.14,
+              "output": 0.28,
+              "cacheRead": 0.028,
               "cacheWrite": 0
             }
           },
           {
             "id": "glm-4-7-251222",
             "name": "GLM 4.7",
-            "input": ["text", "image"],
-            "contextWindow": 200000,
-            "maxTokens": 4096,
+            "status": "deprecated",
+            "replacedBy": "glm-5-2-260617",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 256000,
+            "maxTokens": 128000,
             "cost": {
-              "input": 0.0001,
-              "output": 0.0002,
-              "cacheRead": 0,
+              "input": 0.6,
+              "output": 2.2,
+              "cacheRead": 0.11,
               "cacheWrite": 0
             }
           }
@@ -76,21 +122,8 @@
             "contextWindow": 256000,
             "maxTokens": 4096,
             "cost": {
-              "input": 0.0001,
-              "output": 0.0002,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "glm-4.7",
-            "name": "GLM 4.7 Coding",
-            "input": ["text"],
-            "contextWindow": 200000,
-            "maxTokens": 4096,
-            "cost": {
-              "input": 0.0001,
-              "output": 0.0002,
+              "input": 0,
+              "output": 0,
               "cacheRead": 0,
               "cacheWrite": 0
             }
@@ -99,13 +132,13 @@
             "id": "kimi-k2.5",
             "name": "Kimi K2.5 Coding",
             "reasoning": true,
-            "input": ["text"],
+            "input": ["text", "image"],
             "contextWindow": 256000,
             "maxTokens": 32768,
             "cost": {
-              "input": 0.6,
-              "output": 2.5,
-              "cacheRead": 0.12,
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
               "cacheWrite": 0
             }
           }

--- a/extensions/cerebras/openclaw.plugin.json
+++ b/extensions/cerebras/openclaw.plugin.json
@@ -29,8 +29,8 @@
             "name": "Z.ai GLM 4.7",
             "input": ["text"],
             "reasoning": true,
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 131072,
+            "maxTokens": 40960,
             "cost": {
               "input": 2.25,
               "output": 2.75,
@@ -43,13 +43,27 @@
             "name": "GPT OSS 120B",
             "input": ["text"],
             "reasoning": true,
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 131072,
+            "maxTokens": 40960,
             "cost": {
               "input": 0.35,
               "output": 0.75,
               "cacheRead": 0.35,
               "cacheWrite": 0.75
+            }
+          },
+          {
+            "id": "gemma-4-31b",
+            "name": "Gemma 4 31B",
+            "input": ["text", "image"],
+            "reasoning": true,
+            "contextWindow": 131072,
+            "maxTokens": 40960,
+            "cost": {
+              "input": 0.99,
+              "output": 1.49,
+              "cacheRead": 0.99,
+              "cacheWrite": 1.49
             }
           }
         ]

--- a/extensions/chutes/models.test.ts
+++ b/extensions/chutes/models.test.ts
@@ -4,6 +4,7 @@ import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-cata
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildChutesModelDefinition,
+  CHUTES_DEFAULT_MODEL_ID,
   CHUTES_DEFAULT_MODEL_REF,
   CHUTES_MODEL_CATALOG,
   discoverChutesModels,
@@ -13,9 +14,11 @@ import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const EXPECTED_STATIC_MODEL_IDS = [
   "deepseek-ai/DeepSeek-V3.2-TEE",
+  "moonshotai/Kimi-K2.6-TEE",
   "moonshotai/Kimi-K2.5-TEE",
-  "zai-org/GLM-5-TEE",
+  "zai-org/GLM-5.2-TEE",
   "MiniMaxAI/MiniMax-M2.5-TEE",
+  "Qwen/Qwen3.6-27B-TEE",
   "Qwen/Qwen3.5-397B-A17B-TEE",
 ];
 
@@ -117,7 +120,7 @@ describe("chutes-models", () => {
   });
 
   it("keeps image-capable fallback models in the runtime catalog", () => {
-    const visionModelIds = ["moonshotai/Kimi-K2.5-TEE", "Qwen/Qwen3.5-397B-A17B-TEE"];
+    const visionModelIds = ["moonshotai/Kimi-K2.6-TEE", "Qwen/Qwen3.6-27B-TEE"];
     for (const id of visionModelIds) {
       const model = CHUTES_MODEL_CATALOG.find((candidate) => candidate.id === id);
       expect(model).toBeDefined();
@@ -133,6 +136,21 @@ describe("chutes-models", () => {
     const runtimeIds = CHUTES_MODEL_CATALOG.map((model) => model.id);
     expect(manifestIds).toEqual(EXPECTED_STATIC_MODEL_IDS);
     expect(runtimeIds).toEqual(EXPECTED_STATIC_MODEL_IDS);
+    expect(CHUTES_DEFAULT_MODEL_ID).toBe("zai-org/GLM-5.2-TEE");
+    expect(
+      manifest.modelCatalog.providers.chutes.models
+        .filter((model) => "status" in model && model.status === "deprecated")
+        .map((model) => ({ id: model.id, replacedBy: model.replacedBy })),
+    ).toEqual([
+      {
+        id: "moonshotai/Kimi-K2.5-TEE",
+        replacedBy: "moonshotai/Kimi-K2.6-TEE",
+      },
+      {
+        id: "Qwen/Qwen3.5-397B-A17B-TEE",
+        replacedBy: "Qwen/Qwen3.6-27B-TEE",
+      },
+    ]);
 
     const cfg = applyChutesConfig({});
     expect(cfg.models?.providers?.chutes?.models.map((model) => model.id)).toEqual(
@@ -140,27 +158,29 @@ describe("chutes-models", () => {
     );
     expect(cfg.agents?.defaults?.model).toEqual({
       primary: CHUTES_DEFAULT_MODEL_REF,
-      fallbacks: ["chutes/deepseek-ai/DeepSeek-V3.2-TEE", "chutes/moonshotai/Kimi-K2.5-TEE"],
+      fallbacks: ["chutes/deepseek-ai/DeepSeek-V3.2-TEE", "chutes/moonshotai/Kimi-K2.6-TEE"],
     });
     expect(cfg.agents?.defaults?.imageModel).toEqual({
-      primary: "chutes/moonshotai/Kimi-K2.5-TEE",
-      fallbacks: ["chutes/Qwen/Qwen3.5-397B-A17B-TEE"],
+      primary: "chutes/moonshotai/Kimi-K2.6-TEE",
+      fallbacks: ["chutes/Qwen/Qwen3.6-27B-TEE"],
     });
     expect(cfg.agents?.defaults?.models?.["chutes-fast"]).toBeUndefined();
     expect(cfg.agents?.defaults?.models?.["chutes-pro"]?.alias).toBe(
       "chutes/deepseek-ai/DeepSeek-V3.2-TEE",
     );
     expect(cfg.agents?.defaults?.models?.["chutes-vision"]?.alias).toBe(
-      "chutes/moonshotai/Kimi-K2.5-TEE",
+      "chutes/moonshotai/Kimi-K2.6-TEE",
     );
-    const configuredTargets = [
+    const catalogBackedTargets = [
       CHUTES_DEFAULT_MODEL_REF,
       "chutes/deepseek-ai/DeepSeek-V3.2-TEE",
-      "chutes/moonshotai/Kimi-K2.5-TEE",
-      "chutes/Qwen/Qwen3.5-397B-A17B-TEE",
+      "chutes/moonshotai/Kimi-K2.6-TEE",
+      "chutes/Qwen/Qwen3.6-27B-TEE",
     ];
     expect(
-      configuredTargets.every((modelRef) => runtimeIds.includes(modelRef.slice("chutes/".length))),
+      catalogBackedTargets.every((modelRef) =>
+        runtimeIds.includes(modelRef.slice("chutes/".length)),
+      ),
     ).toBe(true);
   });
 
@@ -180,7 +200,7 @@ describe("chutes-models", () => {
     const mockFetch = vi.fn().mockResolvedValue(
       jsonResponse({
         data: [
-          { id: "zai-org/GLM-5-TEE" },
+          { id: "zai-org/GLM-5.2-TEE" },
           {
             id: "new-provider/new-model-r1",
             supported_features: ["reasoning"],
@@ -199,7 +219,7 @@ describe("chutes-models", () => {
       if (models.length === 3) {
         const firstModel = requireChutesModel(models, 0);
         const secondModel = requireChutesModel(models, 1);
-        expect(firstModel.id).toBe("zai-org/GLM-5-TEE");
+        expect(firstModel.id).toBe("zai-org/GLM-5.2-TEE");
         expect(secondModel.reasoning).toBe(true);
         expect(secondModel.cost).toEqual({
           input: 0.1,

--- a/extensions/chutes/models.ts
+++ b/extensions/chutes/models.ts
@@ -31,7 +31,7 @@ const CHUTES_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
 /** Base URL for Chutes OpenAI-compatible inference. */
 export const CHUTES_BASE_URL = CHUTES_MANIFEST_PROVIDER.baseUrl;
 /** Default Chutes model id used for onboarding. */
-export const CHUTES_DEFAULT_MODEL_ID = "zai-org/GLM-5-TEE";
+export const CHUTES_DEFAULT_MODEL_ID = "zai-org/GLM-5.2-TEE";
 /** Default Chutes model ref used for onboarding. */
 export const CHUTES_DEFAULT_MODEL_REF = `chutes/${CHUTES_DEFAULT_MODEL_ID}`;
 

--- a/extensions/chutes/onboard.ts
+++ b/extensions/chutes/onboard.ts
@@ -29,7 +29,7 @@ export function applyChutesProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
       ...CHUTES_MODEL_CATALOG.map((model) => `chutes/${model.id}`),
       {
         modelRef: "chutes-vision",
-        alias: "chutes/moonshotai/Kimi-K2.5-TEE",
+        alias: "chutes/moonshotai/Kimi-K2.6-TEE",
       },
       { modelRef: "chutes-pro", alias: "chutes/deepseek-ai/DeepSeek-V3.2-TEE" },
     ],
@@ -49,11 +49,11 @@ export function applyChutesConfig(cfg: OpenClawConfig): OpenClawConfig {
         ...next.agents?.defaults,
         model: {
           primary: CHUTES_DEFAULT_MODEL_REF,
-          fallbacks: ["chutes/deepseek-ai/DeepSeek-V3.2-TEE", "chutes/moonshotai/Kimi-K2.5-TEE"],
+          fallbacks: ["chutes/deepseek-ai/DeepSeek-V3.2-TEE", "chutes/moonshotai/Kimi-K2.6-TEE"],
         },
         imageModel: {
-          primary: "chutes/moonshotai/Kimi-K2.5-TEE",
-          fallbacks: ["chutes/Qwen/Qwen3.5-397B-A17B-TEE"],
+          primary: "chutes/moonshotai/Kimi-K2.6-TEE",
+          fallbacks: ["chutes/Qwen/Qwen3.6-27B-TEE"],
         },
       },
     },

--- a/extensions/chutes/openclaw.plugin.json
+++ b/extensions/chutes/openclaw.plugin.json
@@ -80,6 +80,20 @@
             }
           },
           {
+            "id": "moonshotai/Kimi-K2.6-TEE",
+            "name": "moonshotai/Kimi-K2.6-TEE",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 65535,
+            "cost": {
+              "input": 0.66,
+              "output": 3.5,
+              "cacheRead": 0.33,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "moonshotai/Kimi-K2.5-TEE",
             "name": "moonshotai/Kimi-K2.5-TEE",
             "reasoning": true,
@@ -91,19 +105,21 @@
               "output": 2,
               "cacheRead": 0.22,
               "cacheWrite": 0
-            }
+            },
+            "status": "deprecated",
+            "replacedBy": "moonshotai/Kimi-K2.6-TEE"
           },
           {
-            "id": "zai-org/GLM-5-TEE",
-            "name": "zai-org/GLM-5-TEE",
+            "id": "zai-org/GLM-5.2-TEE",
+            "name": "zai-org/GLM-5.2-TEE",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 202752,
+            "contextWindow": 1048576,
             "maxTokens": 65535,
             "cost": {
-              "input": 0.95,
-              "output": 2.55,
-              "cacheRead": 0.475,
+              "input": 1.25,
+              "output": 3.95,
+              "cacheRead": 0.625,
               "cacheWrite": 0
             }
           },
@@ -122,6 +138,20 @@
             }
           },
           {
+            "id": "Qwen/Qwen3.6-27B-TEE",
+            "name": "Qwen/Qwen3.6-27B-TEE",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.3,
+              "output": 2,
+              "cacheRead": 0.15,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "Qwen/Qwen3.5-397B-A17B-TEE",
             "name": "Qwen/Qwen3.5-397B-A17B-TEE",
             "reasoning": true,
@@ -133,7 +163,9 @@
               "output": 3,
               "cacheRead": 0.225,
               "cacheWrite": 0
-            }
+            },
+            "status": "deprecated",
+            "replacedBy": "Qwen/Qwen3.6-27B-TEE"
           }
         ]
       }

--- a/extensions/cohere/index.test.ts
+++ b/extensions/cohere/index.test.ts
@@ -108,6 +108,8 @@ describe("Cohere provider plugin", () => {
         }),
         expect.objectContaining({
           id: "command-a-03-2025",
+          status: "deprecated",
+          replacedBy: COHERE_COMMAND_A_PLUS_MODEL_ID,
           compat: {
             supportsStore: false,
             supportsUsageInStreaming: false,
@@ -116,6 +118,8 @@ describe("Cohere provider plugin", () => {
         }),
         expect.objectContaining({
           id: COHERE_COMMAND_A_REASONING_MODEL_ID,
+          status: "deprecated",
+          replacedBy: COHERE_COMMAND_A_PLUS_MODEL_ID,
           reasoning: true,
           input: ["text"],
           contextWindow: 256000,
@@ -123,6 +127,8 @@ describe("Cohere provider plugin", () => {
         }),
         expect.objectContaining({
           id: COHERE_COMMAND_A_VISION_MODEL_ID,
+          status: "deprecated",
+          replacedBy: COHERE_COMMAND_A_PLUS_MODEL_ID,
           reasoning: false,
           input: ["text", "image"],
           contextWindow: 128000,

--- a/extensions/cohere/openclaw.plugin.json
+++ b/extensions/cohere/openclaw.plugin.json
@@ -48,6 +48,8 @@
           {
             "id": "command-a-03-2025",
             "name": "Command A",
+            "status": "deprecated",
+            "replacedBy": "command-a-plus-05-2026",
             "input": ["text"],
             "contextWindow": 256000,
             "maxTokens": 8000,
@@ -66,6 +68,8 @@
           {
             "id": "command-a-reasoning-08-2025",
             "name": "Command A Reasoning",
+            "status": "deprecated",
+            "replacedBy": "command-a-plus-05-2026",
             "reasoning": true,
             "input": ["text"],
             "contextWindow": 256000,
@@ -98,6 +102,8 @@
           {
             "id": "command-a-vision-07-2025",
             "name": "Command A Vision",
+            "status": "deprecated",
+            "replacedBy": "command-a-plus-05-2026",
             "reasoning": false,
             "input": ["text", "image"],
             "contextWindow": 128000,

--- a/extensions/deepinfra/openclaw.plugin.json
+++ b/extensions/deepinfra/openclaw.plugin.json
@@ -42,9 +42,128 @@
             "contextWindow": 1048576,
             "maxTokens": 1048576,
             "cost": {
-              "input": 0.1,
-              "output": 0.2,
-              "cacheRead": 0.02,
+              "input": 0.09,
+              "output": 0.18,
+              "cacheRead": 0.018,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "deepseek-ai/DeepSeek-V4-Pro",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 1048576,
+            "cost": {
+              "input": 1.3,
+              "output": 2.6,
+              "cacheRead": 0.1,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "zai-org/GLM-5.2",
+            "name": "GLM-5.2",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 1048576,
+            "cost": {
+              "input": 0.93,
+              "output": 3,
+              "cacheRead": 0.18,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "stepfun-ai/Step-3.7-Flash",
+            "name": "Step 3.7 Flash",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.2,
+              "output": 1.15,
+              "cacheRead": 0.04,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "moonshotai/Kimi-K2.7-Code",
+            "name": "Kimi K2.7 Code",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.74,
+              "output": 3.5,
+              "cacheRead": 0.15,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "moonshotai/Kimi-K2.6",
+            "name": "Kimi K2.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.75,
+              "output": 3.5,
+              "cacheRead": 0.15,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+            "name": "NVIDIA Nemotron 3 Ultra 550B A55B",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.5,
+              "output": 2.2,
+              "cacheRead": 0.1,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B",
+            "name": "NVIDIA Nemotron 3 Super 120B A12B",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.085,
+              "output": 0.4,
+              "cacheRead": 0,
               "cacheWrite": 0
             },
             "compat": {
@@ -54,6 +173,8 @@
           {
             "id": "deepseek-ai/DeepSeek-V3.2",
             "name": "DeepSeek V3.2",
+            "status": "deprecated",
+            "replacedBy": "deepseek-ai/DeepSeek-V4-Pro",
             "reasoning": false,
             "input": ["text"],
             "contextWindow": 163840,
@@ -71,6 +192,8 @@
           {
             "id": "zai-org/GLM-5.1",
             "name": "GLM-5.1",
+            "status": "deprecated",
+            "replacedBy": "zai-org/GLM-5.2",
             "reasoning": true,
             "input": ["text"],
             "contextWindow": 202752,
@@ -88,7 +211,9 @@
           {
             "id": "stepfun-ai/Step-3.5-Flash",
             "name": "Step 3.5 Flash",
-            "reasoning": false,
+            "status": "deprecated",
+            "replacedBy": "stepfun-ai/Step-3.7-Flash",
+            "reasoning": true,
             "input": ["text"],
             "contextWindow": 262144,
             "maxTokens": 262144,
@@ -103,25 +228,10 @@
             }
           },
           {
-            "id": "MiniMaxAI/MiniMax-M2.5",
-            "name": "MiniMax M2.5",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 196608,
-            "maxTokens": 196608,
-            "cost": {
-              "input": 0.15,
-              "output": 1.15,
-              "cacheRead": 0.03,
-              "cacheWrite": 0
-            },
-            "compat": {
-              "supportsUsageInStreaming": true
-            }
-          },
-          {
             "id": "moonshotai/Kimi-K2.5",
             "name": "Kimi K2.5",
+            "status": "deprecated",
+            "replacedBy": "moonshotai/Kimi-K2.6",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 262144,
@@ -130,40 +240,6 @@
               "input": 0.45,
               "output": 2.25,
               "cacheRead": 0.070000002,
-              "cacheWrite": 0
-            },
-            "compat": {
-              "supportsUsageInStreaming": true
-            }
-          },
-          {
-            "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B",
-            "name": "NVIDIA Nemotron 3 Super 120B A12B",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 262144,
-            "maxTokens": 262144,
-            "cost": {
-              "input": 0.1,
-              "output": 0.5,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "compat": {
-              "supportsUsageInStreaming": true
-            }
-          },
-          {
-            "id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
-            "name": "Llama 3.3 70B Instruct Turbo",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 131072,
-            "maxTokens": 131072,
-            "cost": {
-              "input": 0.1,
-              "output": 0.32,
-              "cacheRead": 0,
               "cacheWrite": 0
             },
             "compat": {

--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -200,8 +200,6 @@ describe("deepseek provider plugin", () => {
     expect(catalogProvider.models?.map((model) => model.id)).toEqual([
       "deepseek-v4-flash",
       "deepseek-v4-pro",
-      "deepseek-chat",
-      "deepseek-reasoner",
     ]);
     const flashModel = catalogProvider.models?.find((model) => model.id === "deepseek-v4-flash");
     expect(flashModel?.reasoning).toBe(true);
@@ -209,9 +207,6 @@ describe("deepseek provider plugin", () => {
     expect(flashModel?.maxTokens).toBe(384_000);
     expect(flashModel?.compat?.supportsReasoningEffort).toBe(true);
     expect(flashModel?.compat?.maxTokensField).toBe("max_tokens");
-    expect(
-      catalogProvider.models?.find((model) => model.id === "deepseek-reasoner")?.reasoning,
-    ).toBe(true);
     expect(
       Object.fromEntries(
         (catalogProvider.models ?? []).map((model) => [
@@ -233,16 +228,6 @@ describe("deepseek provider plugin", () => {
         contextWindow: 1_000_000,
         maxTokens: 384_000,
         cost: { input: 0.435, output: 0.87, cacheRead: 0.003625, cacheWrite: 0 },
-      },
-      "deepseek-chat": {
-        contextWindow: 1_000_000,
-        maxTokens: 384_000,
-        cost: { input: 0.14, output: 0.28, cacheRead: 0.0028, cacheWrite: 0 },
-      },
-      "deepseek-reasoner": {
-        contextWindow: 1_000_000,
-        maxTokens: 384_000,
-        cost: { input: 0.14, output: 0.28, cacheRead: 0.0028, cacheWrite: 0 },
       },
     });
   });

--- a/extensions/deepseek/openclaw.plugin.json
+++ b/extensions/deepseek/openclaw.plugin.json
@@ -66,46 +66,6 @@
               "supportsReasoningEffort": true,
               "maxTokensField": "max_tokens"
             }
-          },
-          {
-            "id": "deepseek-chat",
-            "name": "DeepSeek Chat",
-            "status": "deprecated",
-            "replacedBy": "deepseek-v4-flash",
-            "input": ["text"],
-            "contextWindow": 1000000,
-            "maxTokens": 384000,
-            "cost": {
-              "input": 0.14,
-              "output": 0.28,
-              "cacheRead": 0.0028,
-              "cacheWrite": 0
-            },
-            "compat": {
-              "supportsUsageInStreaming": true,
-              "maxTokensField": "max_tokens"
-            }
-          },
-          {
-            "id": "deepseek-reasoner",
-            "name": "DeepSeek Reasoner",
-            "status": "deprecated",
-            "replacedBy": "deepseek-v4-flash",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 1000000,
-            "maxTokens": 384000,
-            "cost": {
-              "input": 0.14,
-              "output": 0.28,
-              "cacheRead": 0.0028,
-              "cacheWrite": 0
-            },
-            "compat": {
-              "supportsUsageInStreaming": true,
-              "supportsReasoningEffort": false,
-              "maxTokensField": "max_tokens"
-            }
           }
         ]
       }

--- a/extensions/deepseek/provider-policy-api.test.ts
+++ b/extensions/deepseek/provider-policy-api.test.ts
@@ -92,7 +92,7 @@ describe("deepseek provider-policy-api", () => {
     });
   });
 
-  it("hydrates the legacy chat alias with current V4 Flash metadata", () => {
+  it("leaves an uncataloged retired alias unchanged", () => {
     const providerConfig: ModelProviderConfig = {
       baseUrl: "https://api.deepseek.com",
       api: "openai-completions",
@@ -107,18 +107,10 @@ describe("deepseek provider-policy-api", () => {
     };
 
     const result = normalizeConfig({ provider: "deepseek", providerConfig });
-    const model = requireModel(result, 0);
-    expect(model.contextWindow).toBe(1_000_000);
-    expect(model.maxTokens).toBe(384_000);
-    expect(model.cost).toEqual({
-      input: 0.14,
-      output: 0.28,
-      cacheRead: 0.0028,
-      cacheWrite: 0,
-    });
+    expect(result).toBe(providerConfig);
   });
 
-  it("refreshes exact catalog metadata snapshots written by prior releases", () => {
+  it("refreshes exact current-model catalog metadata snapshots written by prior releases", () => {
     const providerConfig: ModelProviderConfig = {
       baseUrl: "https://api.deepseek.com",
       api: "openai-completions",
@@ -140,24 +132,6 @@ describe("deepseek provider-policy-api", () => {
           contextWindow: 1_000_000,
           maxTokens: 384_000,
           cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
-        },
-        {
-          id: "deepseek-chat",
-          name: "DeepSeek Chat",
-          reasoning: false,
-          input: ["text"],
-          contextWindow: 131_072,
-          maxTokens: 8_192,
-          cost: { input: 0.28, output: 0.42, cacheRead: 0.028, cacheWrite: 0 },
-        },
-        {
-          id: "deepseek-reasoner",
-          name: "DeepSeek Reasoner",
-          reasoning: true,
-          input: ["text"],
-          contextWindow: 131_072,
-          maxTokens: 65_536,
-          cost: { input: 0.28, output: 0.42, cacheRead: 0.028, cacheWrite: 0 },
         },
       ],
     };
@@ -184,22 +158,10 @@ describe("deepseek provider-policy-api", () => {
         maxTokens: 384_000,
         cost: { input: 0.435, output: 0.87, cacheRead: 0.003625, cacheWrite: 0 },
       },
-      {
-        id: "deepseek-chat",
-        contextWindow: 1_000_000,
-        maxTokens: 384_000,
-        cost: { input: 0.14, output: 0.28, cacheRead: 0.0028, cacheWrite: 0 },
-      },
-      {
-        id: "deepseek-reasoner",
-        contextWindow: 1_000_000,
-        maxTokens: 384_000,
-        cost: { input: 0.14, output: 0.28, cacheRead: 0.0028, cacheWrite: 0 },
-      },
     ]);
   });
 
-  it("refreshes exact zero-cost legacy alias rows written by tagged releases", () => {
+  it("leaves zero-cost retired alias snapshots unchanged when uncataloged", () => {
     const providerConfig: ModelProviderConfig = {
       baseUrl: "https://api.deepseek.com",
       api: "openai-completions",
@@ -226,17 +188,7 @@ describe("deepseek provider-policy-api", () => {
     };
 
     const result = normalizeConfig({ provider: "deepseek", providerConfig });
-
-    for (const model of result.models) {
-      expect(model.contextWindow).toBe(1_000_000);
-      expect(model.maxTokens).toBe(384_000);
-      expect(model.cost).toEqual({
-        input: 0.14,
-        output: 0.28,
-        cacheRead: 0.0028,
-        cacheWrite: 0,
-      });
-    }
+    expect(result).toBe(providerConfig);
   });
 
   it("preserves legacy alias metadata when any catalog-owned field is customized", () => {

--- a/extensions/featherless/index.test.ts
+++ b/extensions/featherless/index.test.ts
@@ -29,7 +29,7 @@ function createDefaultRuntimeModel(): ProviderRuntimeModel {
     baseUrl: FEATHERLESS_BASE_URL,
     reasoning: true,
     input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    cost: { input: 0.102, output: 0.493, cacheRead: 0, cacheWrite: 0 },
     contextWindow: FEATHERLESS_DEFAULT_CONTEXT_WINDOW,
     maxTokens: FEATHERLESS_DEFAULT_MAX_TOKENS,
     compat: { thinkingFormat: "qwen-chat-template" },
@@ -84,6 +84,7 @@ describe("featherless provider plugin", () => {
         input: ["text"],
         contextWindow: FEATHERLESS_DEFAULT_CONTEXT_WINDOW,
         maxTokens: FEATHERLESS_DEFAULT_MAX_TOKENS,
+        cost: { input: 0.102, output: 0.493, cacheRead: 0, cacheWrite: 0 },
         compat: expect.objectContaining({
           maxTokensField: "max_tokens",
           thinkingFormat: "qwen-chat-template",

--- a/extensions/featherless/openclaw.plugin.json
+++ b/extensions/featherless/openclaw.plugin.json
@@ -53,8 +53,8 @@
             "contextWindow": 32768,
             "maxTokens": 4096,
             "cost": {
-              "input": 0,
-              "output": 0,
+              "input": 0.102,
+              "output": 0.493,
               "cacheRead": 0,
               "cacheWrite": 0
             },

--- a/extensions/fireworks/index.test.ts
+++ b/extensions/fireworks/index.test.ts
@@ -73,10 +73,23 @@ describe("fireworks provider plugin", () => {
     expect(models[0]?.input).toEqual(["text", "image"]);
     expect(models[0]?.contextWindow).toBe(262144);
     expect(models[0]?.maxTokens).toBe(262144);
+    expect(models[0]?.cost).toEqual({
+      input: 0.95,
+      output: 4,
+      cacheRead: 0.16,
+      cacheWrite: 0,
+    });
+    expect(models[1]?.name).toBe("Kimi K2.6 Fast");
     expect(models[1]?.reasoning).toBe(false);
     expect(models[1]?.input).toEqual(["text", "image"]);
-    expect(models[1]?.contextWindow).toBe(FIREWORKS_DEFAULT_CONTEXT_WINDOW);
+    expect(models[1]?.contextWindow).toBe(262144);
     expect(models[1]?.maxTokens).toBe(FIREWORKS_DEFAULT_MAX_TOKENS);
+    expect(models[1]?.cost).toEqual({
+      input: 2,
+      output: 8,
+      cacheRead: 0.3,
+      cacheWrite: 0,
+    });
   });
 
   it("resolves forward-compat Fireworks model ids from the default template", async () => {

--- a/extensions/fireworks/openclaw.plugin.json
+++ b/extensions/fireworks/openclaw.plugin.json
@@ -45,24 +45,24 @@
             "cost": {
               "input": 0.95,
               "output": 4,
-              "cacheRead": 0,
+              "cacheRead": 0.16,
               "cacheWrite": 0
             }
           },
           {
             "id": "accounts/fireworks/routers/kimi-k2p6-turbo",
-            "name": "Kimi K2.6 Turbo (Fire Pass)",
+            "name": "Kimi K2.6 Fast",
             "reasoning": false,
             "input": ["text", "image"],
-            "contextWindow": 256000,
+            "contextWindow": 262144,
             "maxTokens": 256000,
             "compat": {
               "unsupportedToolSchemaKeywords": ["not"]
             },
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 2,
+              "output": 8,
+              "cacheRead": 0.3,
               "cacheWrite": 0
             }
           }

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -474,7 +474,7 @@ describe("github-copilot plugin", () => {
           },
         },
       ],
-      defaultModel: "github-copilot/claude-opus-4.7",
+      defaultModel: "github-copilot/claude-opus-5",
     });
   });
 
@@ -1228,9 +1228,9 @@ describe("github-copilot plugin", () => {
       mode: "token",
     });
     expect(result?.agents?.defaults?.model).toEqual({
-      primary: "github-copilot/claude-opus-4.7",
+      primary: "github-copilot/claude-opus-5",
     });
-    expect(result?.agents?.defaults?.models?.["github-copilot/claude-opus-4.7"]).toStrictEqual({});
+    expect(result?.agents?.defaults?.models?.["github-copilot/claude-opus-5"]).toStrictEqual({});
 
     const profile = ensureAuthProfileStore(agentDir).profiles["github-copilot:github"];
     expect(profile).toEqual({
@@ -1329,7 +1329,7 @@ describe("github-copilot plugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
     expect(result?.agents?.defaults?.model).toEqual({
       fallbacks: ["openai/gpt-5.4"],
-      primary: "github-copilot/claude-opus-4.7",
+      primary: "github-copilot/claude-opus-5",
     });
 
     const profile = ensureAuthProfileStore(agentDir).profiles["github-copilot:github"];

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -42,7 +42,7 @@ const COPILOT_ENV_VARS: [string, string, string] = [
   "GH_TOKEN",
   "GITHUB_TOKEN",
 ];
-const DEFAULT_COPILOT_MODEL = "github-copilot/claude-opus-4.7";
+const DEFAULT_COPILOT_MODEL = "github-copilot/claude-opus-5";
 const DEFAULT_COPILOT_PROFILE_ID = "github-copilot:github";
 
 type GithubCopilotPluginConfig = {

--- a/extensions/github-copilot/model-metadata.ts
+++ b/extensions/github-copilot/model-metadata.ts
@@ -14,9 +14,18 @@ const COPILOT_CHAT_COMPLETIONS_COMPAT: ModelDefinitionConfig["compat"] = {
   supportsUsageInStreaming: false,
   maxTokensField: "max_tokens",
 };
-const COPILOT_XHIGH_MODEL_IDS = new Set(["gpt-5.4", "gpt-5.3-codex"]);
+const COPILOT_XHIGH_MODEL_IDS = new Set([
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+  "gpt-5.4",
+  "gpt-5.3-codex",
+]);
 
 const STATIC_MODEL_OVERRIDES = new Map<string, Partial<ModelDefinitionConfig>>([
+  // These two non-catalog ids preserve metadata for legacy configured refs and
+  // account discovery responses. They are intentionally not picker entries.
   [
     "claude-opus-4.6-1m",
     {
@@ -42,11 +51,39 @@ const STATIC_MODEL_OVERRIDES = new Map<string, Partial<ModelDefinitionConfig>>([
     },
   ],
   [
+    "gpt-5.3-codex",
+    {
+      name: "GPT-5.3-Codex",
+      api: "openai-responses",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 400_000,
+      contextTokens: 272_000,
+      maxTokens: 128_000,
+    },
+  ],
+  [
+    "gpt-5.4",
+    {
+      name: "GPT-5.4",
+      api: "openai-responses",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+    },
+  ],
+  [
     "gpt-5.5",
     {
       name: "GPT-5.5",
+      api: "openai-responses",
       reasoning: true,
-      contextWindow: 400_000,
+      input: ["text", "image"],
+      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+      contextWindow: 1_050_000,
       contextTokens: 272_000,
       maxTokens: 128_000,
     },

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -76,53 +76,35 @@ describe("resolveCopilotForwardCompatModel", () => {
     expect(resolveCopilotForwardCompatModel(ctx)).toBeUndefined();
   });
 
-  it("clones gpt-5.3-codex template for gpt-5.4", () => {
-    const template = {
-      id: "gpt-5.3-codex",
-      name: "gpt-5.3-codex",
-      provider: "github-copilot",
-      api: "openai-responses",
-      reasoning: true,
-      contextWindow: 200_000,
-    };
-    const ctx = createMockCtx("gpt-5.4", {
-      "github-copilot/gpt-5.3-codex": template,
-    });
-    const result = requireResolvedModel(ctx);
-    expect(result.id).toBe("gpt-5.4");
-    expect(result.name).toBe("gpt-5.4");
-    expect((result as unknown as Record<string, unknown>).reasoning).toBe(true);
-  });
-
   it("uses static metadata for gpt-5.3-codex when not in registry", () => {
-    const ctx = createMockCtx("gpt-5.3-codex");
-    const result = requireResolvedModel(ctx);
-    expect(result.id).toBe("gpt-5.3-codex");
-    expect(result.name).toBe("gpt-5.3-codex");
-    expect((result as unknown as Record<string, unknown>).reasoning).toBe(true);
-  });
-
-  it("uses gpt-5.3-codex as the template source for gpt-5.4", () => {
-    const template53 = {
+    const result = requireResolvedModel(createMockCtx("gpt-5.3-codex"));
+    expect(result).toEqual({
       id: "gpt-5.3-codex",
-      name: "gpt-5.3-codex",
+      name: "GPT-5.3-Codex",
       provider: "github-copilot",
       api: "openai-responses",
       reasoning: true,
-      contextWindow: 300_000,
-    };
-    const ctx = createMockCtx("gpt-5.4", {
-      "github-copilot/gpt-5.3-codex": template53,
+      input: ["text", "image"],
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 400_000,
+      contextTokens: 272_000,
+      maxTokens: 128_000,
     });
-    const result = requireResolvedModel(ctx);
-    expect(result.id).toBe("gpt-5.4");
-    expect((result as unknown as Record<string, unknown>).contextWindow).toBe(300_000);
   });
 
-  it("falls through to synthetic catch-all when codex template is missing", () => {
-    const ctx = createMockCtx("gpt-5.4");
-    const result = requireResolvedModel(ctx);
-    expect(result.id).toBe("gpt-5.4");
+  it("uses curated static metadata for gpt-5.4 when not in registry", () => {
+    const result = requireResolvedModel(createMockCtx("gpt-5.4"));
+    expect(result).toEqual({
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      provider: "github-copilot",
+      api: "openai-responses",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+    });
   });
 
   it("uses static metadata for gpt-5.5 when live discovery rows are unavailable", () => {
@@ -134,14 +116,14 @@ describe("resolveCopilotForwardCompatModel", () => {
       api: "openai-responses",
       reasoning: true,
       input: ["text", "image"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 400_000,
+      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+      contextWindow: 1_050_000,
       contextTokens: 272_000,
       maxTokens: 128_000,
     });
   });
 
-  it("preserves static Anthropic thinking maps for Claude Opus 1M fallback rows", () => {
+  it("preserves static Anthropic thinking maps for legacy Claude Opus configured ids", () => {
     const opus46 = requireResolvedModel(createMockCtx("claude-opus-4.6-1m"));
     expect(opus46.thinkingLevelMap).toEqual({ xhigh: null, max: null });
 

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -21,10 +21,6 @@ import {
 } from "./model-metadata.js";
 
 export const PROVIDER_ID = "github-copilot";
-const CODEX_FORWARD_COMPAT_TARGET_IDS = new Set(["gpt-5.4", "gpt-5.3-codex"]);
-// gpt-5.3-codex is only a useful template when gpt-5.4 is the target; it is
-// always a registry miss (and therefore skipped) when it is the target itself.
-const CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex"] as const;
 
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 8192;
@@ -46,26 +42,6 @@ export function resolveCopilotForwardCompatModel(
   const existing = ctx.modelRegistry.find(PROVIDER_ID, lowerModelId);
   if (existing) {
     return undefined;
-  }
-
-  // For gpt-5.4 and gpt-5.3-codex, clone from a registered codex template
-  // to inherit the correct reasoning and capability flags.
-  if (CODEX_FORWARD_COMPAT_TARGET_IDS.has(lowerModelId)) {
-    for (const templateId of CODEX_TEMPLATE_MODEL_IDS) {
-      const template = ctx.modelRegistry.find(
-        PROVIDER_ID,
-        templateId,
-      ) as ProviderRuntimeModel | null;
-      if (!template) {
-        continue;
-      }
-      return normalizeModelCompat({
-        ...template,
-        id: trimmedModelId,
-        name: trimmedModelId,
-      } as ProviderRuntimeModel);
-    }
-    // Template not found — fall through to synthetic catch-all below.
   }
 
   const staticOverride = resolveStaticCopilotModelOverride(lowerModelId);

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -25,101 +25,178 @@
         "api": "openai-responses",
         "models": [
           {
-            "id": "claude-opus-4.6",
-            "name": "Claude Opus 4.6",
+            "id": "claude-fable-5",
+            "name": "Claude Fable 5",
             "api": "anthropic-messages",
+            "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": { "input": 10, "output": 50, "cacheRead": 1, "cacheWrite": 12.5 }
           },
           {
-            "id": "claude-opus-4.7",
-            "name": "Claude Opus 4.7",
+            "id": "claude-opus-5",
+            "name": "Claude Opus 5",
+            "api": "anthropic-messages",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": { "input": 5, "output": 25, "cacheRead": 0.5, "cacheWrite": 6.25 }
+          },
+          {
+            "id": "claude-sonnet-5",
+            "name": "Claude Sonnet 5",
+            "api": "anthropic-messages",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": { "input": 2, "output": 10, "cacheRead": 0.2, "cacheWrite": 2.5 }
+          },
+          {
+            "id": "claude-haiku-4.5",
+            "name": "Claude Haiku 4.5",
             "api": "anthropic-messages",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "contextWindow": 200000,
+            "maxTokens": 64000,
+            "cost": { "input": 1, "output": 5, "cacheRead": 0.1, "cacheWrite": 1.25 }
           },
           {
             "id": "claude-opus-4.8",
             "name": "Claude Opus 4.8",
             "api": "anthropic-messages",
+            "status": "deprecated",
+            "replacedBy": "claude-opus-5",
+            "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": { "input": 5, "output": 25, "cacheRead": 0.5, "cacheWrite": 6.25 }
           },
           {
             "id": "claude-sonnet-4.6",
             "name": "Claude Sonnet 4.6",
             "api": "anthropic-messages",
+            "status": "deprecated",
+            "replacedBy": "claude-sonnet-5",
+            "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": { "input": 3, "output": 15, "cacheRead": 0.3, "cacheWrite": 3.75 }
+          },
+          {
+            "id": "gemini-3.6-flash",
+            "name": "Gemini 3.6 Flash",
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": { "input": 1.5, "output": 7.5, "cacheRead": 0.15, "cacheWrite": 0 }
+          },
+          {
+            "id": "gemini-3.1-pro-preview",
+            "name": "Gemini 3.1 Pro Preview",
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": { "input": 2, "output": 12, "cacheRead": 0.2, "cacheWrite": 0 }
+          },
+          {
+            "id": "gemini-3.5-flash",
+            "name": "Gemini 3.5 Flash",
+            "status": "deprecated",
+            "replacedBy": "gemini-3.6-flash",
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": { "input": 1.5, "output": 9, "cacheRead": 0.15, "cacheWrite": 0 }
           },
           {
             "id": "gemini-2.5-pro",
             "name": "Gemini 2.5 Pro",
+            "status": "deprecated",
+            "replacedBy": "gemini-3.1-pro-preview",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": { "input": 1.25, "output": 10, "cacheRead": 0.125, "cacheWrite": 0 }
           },
           {
-            "id": "gemini-3-flash",
-            "name": "Gemini 3 Flash",
+            "id": "gpt-5.6-sol",
+            "name": "GPT-5.6 Sol",
+            "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "contextWindow": 1050000,
+            "contextTokens": 922000,
+            "maxTokens": 128000,
+            "cost": { "input": 5, "output": 30, "cacheRead": 0.5, "cacheWrite": 0 }
           },
           {
-            "id": "gemini-3.1-pro",
-            "name": "Gemini 3.1 Pro",
+            "id": "gpt-5.6-terra",
+            "name": "GPT-5.6 Terra",
+            "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "contextWindow": 1050000,
+            "contextTokens": 922000,
+            "maxTokens": 128000,
+            "cost": { "input": 2.5, "output": 15, "cacheRead": 0.25, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-5.6-luna",
+            "name": "GPT-5.6 Luna",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1050000,
+            "contextTokens": 922000,
+            "maxTokens": 128000,
+            "cost": { "input": 1, "output": 6, "cacheRead": 0.1, "cacheWrite": 0 }
           },
           {
             "id": "gpt-5.3-codex",
             "name": "GPT-5.3-Codex",
             "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "input": ["text", "image"],
+            "contextWindow": 400000,
+            "contextTokens": 272000,
+            "maxTokens": 128000,
+            "cost": { "input": 1.75, "output": 14, "cacheRead": 0.175, "cacheWrite": 0 }
           },
           {
             "id": "gpt-5.4",
             "name": "GPT-5.4",
+            "status": "deprecated",
+            "replacedBy": "gpt-5.6-terra",
             "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "contextWindow": 1050000,
+            "maxTokens": 128000,
+            "cost": { "input": 2.5, "output": 15, "cacheRead": 0.25, "cacheWrite": 0 }
           },
           {
             "id": "gpt-5.5",
             "name": "GPT-5.5",
+            "status": "deprecated",
+            "replacedBy": "gpt-5.6-sol",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1050000,
+            "contextTokens": 272000,
+            "maxTokens": 128000,
+            "cost": { "input": 5, "output": 30, "cacheRead": 0.5, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-5.4-mini",
+            "name": "GPT-5.4 mini",
+            "status": "deprecated",
+            "replacedBy": "gpt-5.6-luna",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 400000,
             "contextTokens": 272000,
             "maxTokens": 128000,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
-          },
-          {
-            "id": "gpt-5.4-mini",
-            "name": "GPT-5.4 mini",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "cost": { "input": 0.75, "output": 4.5, "cacheRead": 0.075, "cacheWrite": 0 }
           },
           {
             "id": "raptor-mini",
@@ -127,15 +204,7 @@
             "input": ["text"],
             "contextWindow": 128000,
             "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
-          },
-          {
-            "id": "goldeneye",
-            "name": "Goldeneye",
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "cost": { "input": 0.25, "output": 2, "cacheRead": 0.025, "cacheWrite": 0 }
           }
         ]
       }

--- a/extensions/github-copilot/provider-policy-api.test.ts
+++ b/extensions/github-copilot/provider-policy-api.test.ts
@@ -7,13 +7,20 @@ describe("github-copilot provider-policy-api", () => {
     expect(
       resolveThinkingProfile({
         provider: "github-copilot",
-        modelId: "claude-opus-4.6",
+        modelId: "claude-haiku-4.5",
       })?.levels.map((level) => level.id),
     ).toEqual(["off", "minimal", "low", "medium", "high"]);
   });
 
   it("appends xhigh for current static GPT Copilot xhigh ids", () => {
-    for (const modelId of ["gpt-5.4", "gpt-5.3-codex"]) {
+    for (const modelId of [
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.3-codex",
+    ]) {
       expect(
         resolveThinkingProfile({
           provider: "github-copilot",

--- a/extensions/gmi/README.md
+++ b/extensions/gmi/README.md
@@ -11,4 +11,4 @@ openclaw gateway restart
 ```
 
 Configure a GMI Cloud API key, then select models with refs such as
-`gmi/google/gemini-3.1-flash-lite`.
+`gmi/openai/gpt-5.6-sol`.

--- a/extensions/gmi/index.test.ts
+++ b/extensions/gmi/index.test.ts
@@ -24,6 +24,7 @@ describe("gmi provider plugin", () => {
     expect(provider.aliases).toEqual(["gmi-cloud", "gmicloud"]);
     expect(provider.envVars).toEqual(["GMI_API_KEY"]);
     expect(provider.auth?.map((method) => method.id)).toEqual(["api-key"]);
+    expect(provider.auth?.[0]?.defaultModel).toBe("gmi/openai/gpt-5.6-sol");
 
     const result = await provider.staticCatalog?.run({
       config: {},
@@ -32,8 +33,6 @@ describe("gmi provider plugin", () => {
     } as never);
     const catalogProvider = requireCatalogProvider(result);
     expect(catalogProvider.baseUrl).toBe("https://api.gmi-serving.com/v1");
-    expect(catalogProvider.models?.map((model) => model.id)).toContain(
-      "google/gemini-3.1-flash-lite",
-    );
+    expect(catalogProvider.models?.map((model) => model.id)).toContain("openai/gpt-5.6-sol");
   });
 });

--- a/extensions/gmi/index.test.ts
+++ b/extensions/gmi/index.test.ts
@@ -24,7 +24,7 @@ describe("gmi provider plugin", () => {
     expect(provider.aliases).toEqual(["gmi-cloud", "gmicloud"]);
     expect(provider.envVars).toEqual(["GMI_API_KEY"]);
     expect(provider.auth?.map((method) => method.id)).toEqual(["api-key"]);
-    expect(provider.auth?.[0]?.defaultModel).toBe("gmi/openai/gpt-5.6-sol");
+    expect(provider.auth?.[0]?.starterModel).toBe("gmi/openai/gpt-5.6-sol");
 
     const result = await provider.staticCatalog?.run({
       config: {},

--- a/extensions/gmi/models.ts
+++ b/extensions/gmi/models.ts
@@ -10,7 +10,7 @@ const GMI_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
 
 export const GMI_BASE_URL = GMI_MANIFEST_PROVIDER.baseUrl;
 export const GMI_MODEL_CATALOG: ModelDefinitionConfig[] = GMI_MANIFEST_PROVIDER.models;
-export const GMI_DEFAULT_MODEL_REF = "gmi/google/gemini-3.1-flash-lite";
+export const GMI_DEFAULT_MODEL_REF = "gmi/openai/gpt-5.6-sol";
 
 export function buildGmiModelDefinition(model: ModelDefinitionConfig): ModelDefinitionConfig {
   return {

--- a/extensions/gmi/openclaw.plugin.json
+++ b/extensions/gmi/openclaw.plugin.json
@@ -75,87 +75,121 @@
         "api": "openai-completions",
         "models": [
           {
+            "id": "zai-org/GLM-5.2-FP8",
+            "name": "GLM-5.2 FP8",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.923,
+              "output": 2.903,
+              "cacheRead": 0.171,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "zai-org/GLM-5.1-FP8",
             "name": "GLM-5.1 FP8",
+            "status": "deprecated",
+            "replacedBy": "zai-org/GLM-5.2-FP8",
             "reasoning": true,
             "input": ["text"],
             "contextWindow": 202752,
             "maxTokens": 65536,
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 0.979,
+              "output": 3.08,
+              "cacheRead": 0.182,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-ai/DeepSeek-V4-Pro",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 0.678,
+              "output": 1.357,
+              "cacheRead": 0.056,
               "cacheWrite": 0
             }
           },
           {
             "id": "deepseek-ai/DeepSeek-V3.2",
             "name": "DeepSeek V3.2",
+            "status": "deprecated",
+            "replacedBy": "deepseek-ai/DeepSeek-V4-Pro",
             "reasoning": false,
             "input": ["text"],
             "contextWindow": 163840,
             "maxTokens": 65536,
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 0.29,
+              "output": 0.43,
+              "cacheRead": 0.03,
               "cacheWrite": 0
             }
           },
           {
-            "id": "moonshotai/Kimi-K2.5",
-            "name": "Kimi K2.5",
+            "id": "google/gemini-3.5-flash-lite",
+            "name": "Gemini 3.5 Flash Lite",
             "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 262144,
-            "maxTokens": 65536,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "google/gemini-3.1-flash-lite",
-            "name": "Gemini 3.1 Flash Lite",
-            "reasoning": false,
             "input": ["text", "image"],
             "contextWindow": 1048576,
             "maxTokens": 65536,
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 0.3,
+              "output": 2.5,
+              "cacheRead": 0.03,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "anthropic/claude-sonnet-5",
+            "name": "Claude Sonnet 5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 409600,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 2,
+              "output": 10,
+              "cacheRead": 0.2,
               "cacheWrite": 0
             }
           },
           {
             "id": "anthropic/claude-sonnet-4.6",
             "name": "Claude Sonnet 4.6",
-            "reasoning": false,
+            "status": "deprecated",
+            "replacedBy": "anthropic/claude-sonnet-5",
+            "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 200000,
+            "contextWindow": 409600,
             "maxTokens": 64000,
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 3,
+              "output": 15,
+              "cacheRead": 0.3,
               "cacheWrite": 0
             }
           },
           {
-            "id": "openai/gpt-5.4",
-            "name": "GPT-5.4",
+            "id": "openai/gpt-5.6-sol",
+            "name": "GPT-5.6 Sol",
             "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 400000,
+            "contextWindow": 1050000,
             "maxTokens": 128000,
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
+              "input": 5,
+              "output": 30,
+              "cacheRead": 0.5,
+              "cacheWrite": 6.25
             }
           }
         ]

--- a/extensions/groq/api.ts
+++ b/extensions/groq/api.ts
@@ -1,7 +1,7 @@
 // Groq API module exposes the plugin public contract.
 import type { ModelCompatConfig } from "openclaw/plugin-sdk/provider-model-shared";
 
-const GROQ_QWEN3_32B_ID = "qwen/qwen3-32b";
+const GROQ_QWEN3_6_27B_ID = "qwen/qwen3.6-27b";
 const GROQ_GPT_OSS_REASONING_IDS = new Set([
   "openai/gpt-oss-20b",
   "openai/gpt-oss-120b",
@@ -34,7 +34,7 @@ export function resolveGroqReasoningCompatPatch(
   "supportsReasoningEffort" | "supportedReasoningEfforts" | "reasoningEffortMap"
 > | null {
   const normalized = normalizeGroqModelId(modelId);
-  if (normalized === GROQ_QWEN3_32B_ID) {
+  if (normalized === GROQ_QWEN3_6_27B_ID) {
     return {
       supportsReasoningEffort: true,
       supportedReasoningEfforts: [...GROQ_QWEN_REASONING_EFFORTS],

--- a/extensions/groq/index.test.ts
+++ b/extensions/groq/index.test.ts
@@ -305,7 +305,7 @@ describe("groq provider compat", () => {
   });
 
   it("maps Groq Qwen 3 reasoning to provider-native none/default values", () => {
-    expect(resolveGroqReasoningCompatPatch("qwen/qwen3-32b")).toEqual({
+    expect(resolveGroqReasoningCompatPatch("qwen/qwen3.6-27b")).toEqual({
       supportsReasoningEffort: true,
       supportedReasoningEfforts: ["none", "default"],
       reasoningEffortMap: {
@@ -343,6 +343,7 @@ describe("groq provider compat", () => {
     });
     expect(provider.auth).toHaveLength(1);
     expect(provider.auth[0]).toMatchObject({
+      defaultModel: "groq/openai/gpt-oss-120b",
       id: "api-key",
       kind: "api_key",
       label: "Groq API key",

--- a/extensions/groq/index.ts
+++ b/extensions/groq/index.ts
@@ -12,8 +12,8 @@ import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-c
 import { groqMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
-const GROQ_DEFAULT_MODEL_REF = "groq/llama-3.3-70b-versatile";
-const GROQ_DEFAULT_MODEL_ID = "llama-3.3-70b-versatile";
+const GROQ_DEFAULT_MODEL_REF = "groq/openai/gpt-oss-120b";
+const GROQ_OVERSIZED_RECOVERY_MODEL_ID = "llama-3.3-70b-versatile";
 const GROQ_FALLBACK_MAX_TOKENS = 1_024;
 
 function buildGroqCatalogProvider() {
@@ -194,7 +194,7 @@ export default definePluginEntry({
           ctx.streamFn,
           // Older compatible hosts omit this provenance. Only a known discovered default
           // is safe to replace; an unknown value could be a user-configured cap.
-          ctx.modelId === GROQ_DEFAULT_MODEL_ID &&
+          ctx.modelId === GROQ_OVERSIZED_RECOVERY_MODEL_ID &&
             !hasExplicitMaxTokens(ctx.extraParams) &&
             !hasExplicitMaxTokens(ctx.model?.params) &&
             ctx.model?.maxTokensSource === "discovered",

--- a/extensions/groq/openclaw.plugin.json
+++ b/extensions/groq/openclaw.plugin.json
@@ -52,7 +52,7 @@
           {
             "id": "groq/compound",
             "name": "Compound",
-            "reasoning": true,
+            "reasoning": false,
             "input": ["text"],
             "contextWindow": 131072,
             "maxTokens": 8192,
@@ -66,7 +66,7 @@
           {
             "id": "groq/compound-mini",
             "name": "Compound Mini",
-            "reasoning": true,
+            "reasoning": false,
             "input": ["text"],
             "contextWindow": 131072,
             "maxTokens": 8192,
@@ -80,6 +80,8 @@
           {
             "id": "llama-3.1-8b-instant",
             "name": "Llama 3.1 8B Instant",
+            "status": "deprecated",
+            "replacedBy": "openai/gpt-oss-20b",
             "reasoning": false,
             "input": ["text"],
             "contextWindow": 131072,
@@ -94,6 +96,8 @@
           {
             "id": "llama-3.3-70b-versatile",
             "name": "Llama 3.3 70B Versatile",
+            "status": "deprecated",
+            "replacedBy": "openai/gpt-oss-120b",
             "reasoning": false,
             "input": ["text"],
             "contextWindow": 131072,
@@ -101,23 +105,6 @@
             "cost": {
               "input": 0.59,
               "output": 0.79,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "meta-llama/llama-4-scout-17b-16e-instruct",
-            "name": "Llama 4 Scout 17B",
-            "reasoning": false,
-            "input": ["text", "image"],
-            "mediaInput": {
-              "image": { "maxPixels": 33177600, "preferredSidePx": 2048, "tokenMode": "provider" }
-            },
-            "contextWindow": 131072,
-            "maxTokens": 8192,
-            "cost": {
-              "input": 0.11,
-              "output": 0.34,
               "cacheRead": 0,
               "cacheWrite": 0
             }
@@ -132,7 +119,7 @@
             "cost": {
               "input": 0.15,
               "output": 0.6,
-              "cacheRead": 0,
+              "cacheRead": 0.075,
               "cacheWrite": 0
             }
           },
@@ -146,7 +133,7 @@
             "cost": {
               "input": 0.075,
               "output": 0.3,
-              "cacheRead": 0,
+              "cacheRead": 0.0375,
               "cacheWrite": 0
             }
           },
@@ -165,15 +152,15 @@
             }
           },
           {
-            "id": "qwen/qwen3-32b",
-            "name": "Qwen3 32B",
+            "id": "qwen/qwen3.6-27b",
+            "name": "Qwen 3.6 27B",
             "reasoning": true,
-            "input": ["text"],
+            "input": ["text", "image"],
             "contextWindow": 131072,
-            "maxTokens": 40960,
+            "maxTokens": 16384,
             "cost": {
-              "input": 0.29,
-              "output": 0.59,
+              "input": 0.6,
+              "output": 3,
               "cacheRead": 0,
               "cacheWrite": 0
             }

--- a/extensions/meta/index.test.ts
+++ b/extensions/meta/index.test.ts
@@ -44,7 +44,13 @@ describe("meta provider", () => {
     expect(model.contextWindow).toBe(1048576);
     expect(model.maxTokens).toBe(131072);
     expect(model.reasoning).toBe(true);
-    expect(model.input).toContain("image");
+    expect(model.input).toEqual(["text", "image", "video", "audio", "document"]);
+    expect(model.cost).toEqual({
+      input: 1.25,
+      output: 4.25,
+      cacheRead: 0.15,
+      cacheWrite: 0,
+    });
   });
 
   it("advertises a high default thinking profile for muse-spark-1.1", () => {

--- a/extensions/meta/openclaw.plugin.json
+++ b/extensions/meta/openclaw.plugin.json
@@ -4,11 +4,15 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["meta"],
+  "providers": [
+    "meta"
+  ],
   "providerEndpoints": [
     {
       "endpointClass": "meta-native",
-      "hosts": ["api.meta.ai"]
+      "hosts": [
+        "api.meta.ai"
+      ]
     }
   ],
   "providerRequest": {
@@ -28,7 +32,11 @@
             "id": "muse-spark-1.1",
             "name": "Muse Spark 1.1",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image",
+              "document"
+            ],
             "contextWindow": 1048576,
             "maxTokens": 131072,
             "thinkingLevelMap": {
@@ -51,9 +59,9 @@
               ]
             },
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 1.25,
+              "output": 4.25,
+              "cacheRead": 0.15,
               "cacheWrite": 0
             }
           }
@@ -68,8 +76,12 @@
     "providers": [
       {
         "id": "meta",
-        "authMethods": ["api-key"],
-        "envVars": ["MODEL_API_KEY"]
+        "authMethods": [
+          "api-key"
+        ],
+        "envVars": [
+          "MODEL_API_KEY"
+        ]
       }
     ]
   },

--- a/extensions/mistral/model-definitions.test.ts
+++ b/extensions/mistral/model-definitions.test.ts
@@ -51,14 +51,17 @@ describe("mistral model definitions", () => {
     const models = buildCatalogModels();
     const codestral = catalogModelById(models, "codestral-latest");
     expect(codestral.input).toEqual(["text"]);
-    expect(codestral.contextWindow).toBe(256000);
+    expect(codestral.contextWindow).toBe(128000);
     expect(codestral.maxTokens).toBe(4096);
 
-    const magistralSmall = catalogModelById(models, "magistral-small");
-    expect(magistralSmall.reasoning).toBe(true);
-    expect(magistralSmall.input).toEqual(["text"]);
-    expect(magistralSmall.contextWindow).toBe(128000);
-    expect(magistralSmall.maxTokens).toBe(40000);
+    const devstral = catalogModelById(models, "devstral-medium-latest");
+    expect(devstral.status).toBe("deprecated");
+    expect(devstral.replacedBy).toBe("mistral-medium-3-5");
+
+    const medium31 = catalogModelById(models, "mistral-medium-2508");
+    expect(medium31.status).toBe("deprecated");
+    expect(medium31.replacedBy).toBe("mistral-medium-3-5");
+    expect(medium31.contextWindow).toBe(128000);
 
     const medium = catalogModelById(models, "mistral-medium-3-5");
     expect(medium.reasoning).toBe(true);
@@ -85,9 +88,7 @@ describe("mistral model definitions", () => {
     expect(small4.maxTokens).toBe(16384);
     expect(small4.cost).toEqual(smallLatest.cost);
 
-    const pixtralLarge = catalogModelById(models, "pixtral-large-latest");
-    expect(pixtralLarge.input).toEqual(["text", "image"]);
-    expect(pixtralLarge.contextWindow).toBe(128000);
-    expect(pixtralLarge.maxTokens).toBe(32768);
+    expect(models.map((model) => model.id)).not.toContain("magistral-small");
+    expect(models.map((model) => model.id)).not.toContain("pixtral-large-latest");
   });
 });

--- a/extensions/mistral/model-definitions.test.ts
+++ b/extensions/mistral/model-definitions.test.ts
@@ -1,6 +1,7 @@
 // Mistral tests cover model definitions plugin behavior.
 import { describe, expect, it } from "vitest";
 import { buildMistralModelDefinition, MISTRAL_DEFAULT_MODEL_ID } from "./model-definitions.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { buildMistralProvider } from "./provider-catalog.js";
 
 function buildCatalogModels() {
@@ -55,13 +56,21 @@ describe("mistral model definitions", () => {
     expect(codestral.maxTokens).toBe(4096);
 
     const devstral = catalogModelById(models, "devstral-medium-latest");
-    expect(devstral.status).toBe("deprecated");
-    expect(devstral.replacedBy).toBe("mistral-medium-3-5");
+    expect(devstral.contextWindow).toBe(262144);
+    expect(devstral.maxTokens).toBe(32768);
 
     const medium31 = catalogModelById(models, "mistral-medium-2508");
-    expect(medium31.status).toBe("deprecated");
-    expect(medium31.replacedBy).toBe("mistral-medium-3-5");
     expect(medium31.contextWindow).toBe(128000);
+
+    const manifestRows = manifest.modelCatalog.providers.mistral.models as Array<
+      Record<string, unknown>
+    >;
+    for (const id of ["devstral-medium-latest", "mistral-medium-2508"]) {
+      expect(manifestRows.find((model) => model.id === id)).toMatchObject({
+        status: "deprecated",
+        replacedBy: "mistral-medium-3-5",
+      });
+    }
 
     const medium = catalogModelById(models, "mistral-medium-3-5");
     expect(medium.reasoning).toBe(true);

--- a/extensions/mistral/openclaw.plugin.json
+++ b/extensions/mistral/openclaw.plugin.json
@@ -29,7 +29,7 @@
             "id": "codestral-latest",
             "name": "Codestral (latest)",
             "input": ["text"],
-            "contextWindow": 256000,
+            "contextWindow": 128000,
             "maxTokens": 4096,
             "cost": {
               "input": 0.3,
@@ -41,6 +41,8 @@
           {
             "id": "devstral-medium-latest",
             "name": "Devstral 2 (latest)",
+            "status": "deprecated",
+            "replacedBy": "mistral-medium-3-5",
             "input": ["text"],
             "contextWindow": 262144,
             "maxTokens": 32768,
@@ -52,22 +54,8 @@
             }
           },
           {
-            "id": "magistral-small",
-            "name": "Magistral Small",
-            "input": ["text"],
-            "reasoning": true,
-            "contextWindow": 128000,
-            "maxTokens": 40000,
-            "cost": {
-              "input": 0.5,
-              "output": 1.5,
-              "cacheRead": 0.05,
-              "cacheWrite": 0
-            }
-          },
-          {
             "id": "mistral-large-latest",
-            "name": "Mistral Large (latest)",
+            "name": "Mistral Large 3 (latest)",
             "input": ["text", "image"],
             "contextWindow": 262144,
             "maxTokens": 16384,
@@ -81,8 +69,10 @@
           {
             "id": "mistral-medium-2508",
             "name": "Mistral Medium 3.1",
+            "status": "deprecated",
+            "replacedBy": "mistral-medium-3-5",
             "input": ["text", "image"],
-            "contextWindow": 262144,
+            "contextWindow": 128000,
             "maxTokens": 8192,
             "cost": {
               "input": 0.4,
@@ -130,19 +120,6 @@
               "input": 0.15,
               "output": 0.6,
               "cacheRead": 0.015,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "pixtral-large-latest",
-            "name": "Pixtral Large (latest)",
-            "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 32768,
-            "cost": {
-              "input": 2,
-              "output": 6,
-              "cacheRead": 0.2,
               "cacheWrite": 0
             }
           }

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -5,7 +5,9 @@
   },
   "enabledByDefault": true,
   "providerCatalogEntry": "./provider-discovery.ts",
-  "providers": ["moonshot"],
+  "providers": [
+    "moonshot"
+  ],
   "providerAuthAliases": {
     "moonshotai": "moonshot",
     "moonshot-ai": "moonshot"
@@ -13,7 +15,10 @@
   "providerEndpoints": [
     {
       "endpointClass": "moonshot-native",
-      "baseUrls": ["https://api.moonshot.ai/v1", "https://api.moonshot.cn/v1"]
+      "baseUrls": [
+        "https://api.moonshot.ai/v1",
+        "https://api.moonshot.cn/v1"
+      ]
     }
   ],
   "providerRequest": {
@@ -57,13 +62,16 @@
             "thinkingLevelMap": {
               "off": null,
               "minimal": null,
-              "low": null,
+              "low": "low",
               "medium": null,
-              "high": null,
+              "high": "high",
               "xhigh": "max",
               "max": "max"
             },
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "contextWindow": 1048576,
             "maxTokens": 1048576,
             "cost": {
@@ -74,14 +82,21 @@
             },
             "compat": {
               "supportsReasoningEffort": true,
-              "supportedReasoningEfforts": ["max"]
+              "supportedReasoningEfforts": [
+                "low",
+                "high",
+                "max"
+              ]
             }
           },
           {
             "id": "kimi-k2.7-code",
             "name": "Kimi K2.7 Code",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "contextWindow": 262144,
             "maxTokens": 262144,
             "cost": {
@@ -95,7 +110,10 @@
             "id": "kimi-k2.7-code-highspeed",
             "name": "Kimi K2.7 Code HighSpeed",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "contextWindow": 262144,
             "maxTokens": 262144,
             "cost": {
@@ -116,7 +134,10 @@
     "providers": [
       {
         "id": "moonshot",
-        "envVars": ["MOONSHOT_API_KEY", "KIMI_API_KEY"]
+        "envVars": [
+          "MOONSHOT_API_KEY",
+          "KIMI_API_KEY"
+        ]
       }
     ]
   },
@@ -129,7 +150,7 @@
       "choiceLabel": "Moonshot API key (.ai)",
       "groupId": "moonshot",
       "groupLabel": "Moonshot AI (Kimi)",
-      "groupHint": "Kimi API models · https://platform.kimi.ai/docs/pricing/chat",
+      "groupHint": "Kimi API models \u00b7 https://platform.kimi.ai/docs/pricing/chat",
       "optionKey": "moonshotApiKey",
       "cliFlag": "--moonshot-api-key",
       "cliOption": "--moonshot-api-key <key>",
@@ -143,7 +164,7 @@
       "choiceLabel": "Moonshot API key (.cn)",
       "groupId": "moonshot",
       "groupLabel": "Moonshot AI (Kimi)",
-      "groupHint": "Kimi API models · https://platform.kimi.ai/docs/pricing/chat",
+      "groupHint": "Kimi API models \u00b7 https://platform.kimi.ai/docs/pricing/chat",
       "optionKey": "moonshotApiKey",
       "cliFlag": "--moonshot-api-key",
       "cliOption": "--moonshot-api-key <key>",
@@ -166,12 +187,19 @@
     }
   },
   "contracts": {
-    "mediaUnderstandingProviders": ["moonshot"],
-    "webSearchProviders": ["kimi"]
+    "mediaUnderstandingProviders": [
+      "moonshot"
+    ],
+    "webSearchProviders": [
+      "kimi"
+    ]
   },
   "mediaUnderstandingProviderMetadata": {
     "moonshot": {
-      "capabilities": ["image", "video"],
+      "capabilities": [
+        "image",
+        "video"
+      ],
       "defaultModels": {
         "image": "kimi-k2.6",
         "video": "kimi-k2.6"
@@ -190,7 +218,10 @@
         "additionalProperties": false,
         "properties": {
           "apiKey": {
-            "type": ["string", "object"]
+            "type": [
+              "string",
+              "object"
+            ]
           },
           "baseUrl": {
             "type": "string"

--- a/extensions/moonshot/provider-catalog.test.ts
+++ b/extensions/moonshot/provider-catalog.test.ts
@@ -49,13 +49,13 @@ describe("moonshot provider catalog", () => {
       thinkingLevelMap: {
         off: null,
         minimal: null,
-        low: null,
+        low: "low",
         medium: null,
-        high: null,
+        high: "high",
         xhigh: "max",
         max: "max",
       },
-      input: ["text", "image"],
+      input: ["text", "image", "video"],
       contextWindow: 1_048_576,
       maxTokens: 1_048_576,
       cost: {
@@ -66,12 +66,12 @@ describe("moonshot provider catalog", () => {
       },
       compat: {
         supportsReasoningEffort: true,
-        supportedReasoningEfforts: ["max"],
+        supportedReasoningEfforts: ["low", "high", "max"],
       },
     });
     expect(requireMoonshotModel(provider, "kimi-k2.7-code")).toMatchObject({
       reasoning: true,
-      input: ["text", "image"],
+      input: ["text", "image", "video"],
       contextWindow: 262144,
       maxTokens: 262144,
       cost: {
@@ -83,7 +83,7 @@ describe("moonshot provider catalog", () => {
     });
     expect(requireMoonshotModel(provider, "kimi-k2.7-code-highspeed")).toMatchObject({
       reasoning: true,
-      input: ["text", "image"],
+      input: ["text", "image", "video"],
       contextWindow: 262144,
       maxTokens: 262144,
       cost: {

--- a/extensions/novita/index.test.ts
+++ b/extensions/novita/index.test.ts
@@ -24,7 +24,7 @@ describe("novita provider plugin", () => {
     expect(provider.aliases).toEqual(["novita-ai", "novitaai"]);
     expect(provider.envVars).toEqual(["NOVITA_API_KEY"]);
     expect(provider.auth?.map((method) => method.id)).toEqual(["api-key"]);
-    expect(provider.auth?.[0]?.defaultModel).toBe("novita/deepseek/deepseek-v4-pro");
+    expect(provider.auth?.[0]?.starterModel).toBe("novita/deepseek/deepseek-v4-pro");
 
     const result = await provider.staticCatalog?.run({
       config: {},

--- a/extensions/novita/index.test.ts
+++ b/extensions/novita/index.test.ts
@@ -24,6 +24,7 @@ describe("novita provider plugin", () => {
     expect(provider.aliases).toEqual(["novita-ai", "novitaai"]);
     expect(provider.envVars).toEqual(["NOVITA_API_KEY"]);
     expect(provider.auth?.map((method) => method.id)).toEqual(["api-key"]);
+    expect(provider.auth?.[0]?.defaultModel).toBe("novita/deepseek/deepseek-v4-pro");
 
     const result = await provider.staticCatalog?.run({
       config: {},
@@ -32,6 +33,6 @@ describe("novita provider plugin", () => {
     } as never);
     const catalogProvider = requireCatalogProvider(result);
     expect(catalogProvider.baseUrl).toBe("https://api.novita.ai/openai/v1");
-    expect(catalogProvider.models?.map((model) => model.id)).toContain("deepseek/deepseek-v3-0324");
+    expect(catalogProvider.models?.map((model) => model.id)).toContain("deepseek/deepseek-v4-pro");
   });
 });

--- a/extensions/novita/models.ts
+++ b/extensions/novita/models.ts
@@ -10,7 +10,7 @@ const NOVITA_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
 
 export const NOVITA_BASE_URL = NOVITA_MANIFEST_PROVIDER.baseUrl;
 export const NOVITA_MODEL_CATALOG: ModelDefinitionConfig[] = NOVITA_MANIFEST_PROVIDER.models;
-export const NOVITA_DEFAULT_MODEL_REF = "novita/deepseek/deepseek-v3-0324";
+export const NOVITA_DEFAULT_MODEL_REF = "novita/deepseek/deepseek-v4-pro";
 
 export function buildNovitaModelDefinition(model: ModelDefinitionConfig): ModelDefinitionConfig {
   return {

--- a/extensions/novita/openclaw.plugin.json
+++ b/extensions/novita/openclaw.plugin.json
@@ -73,86 +73,116 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "moonshotai/kimi-k2.5",
-            "name": "Kimi K2.5",
+            "id": "moonshotai/kimi-k3",
+            "name": "Kimi K3",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 1048576,
+            "cost": {
+              "input": 3,
+              "output": 15,
+              "cacheRead": 0.3,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "moonshotai/kimi-k2.7-code",
+            "name": "Kimi K2.7 Code",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.95,
+              "output": 4,
+              "cacheRead": 0.19,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "minimax/minimax-m3",
+            "name": "MiniMax M3",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.3,
+              "output": 1.2,
+              "cacheRead": 0.06,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai-org/glm-5.2",
+            "name": "GLM-5.2",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 1.4,
+              "output": 4.4,
+              "cacheRead": 0.26,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek/deepseek-v4-pro",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 393216,
+            "cost": {
+              "input": 1.6,
+              "output": 3.2,
+              "cacheRead": 0.135,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek/deepseek-v4-flash",
+            "name": "DeepSeek V4 Flash",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 393216,
+            "cost": {
+              "input": 0.14,
+              "output": 0.28,
+              "cacheRead": 0.028,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "qwen/qwen3.7-max",
+            "name": "Qwen3.7-Max",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1000000,
             "maxTokens": 65536,
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 1.25,
+              "output": 3.75,
+              "cacheRead": 0.25,
               "cacheWrite": 0
             }
           },
           {
             "id": "minimax/minimax-m2.7",
             "name": "MiniMax M2.7",
+            "status": "deprecated",
+            "replacedBy": "minimax/minimax-m3",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 1000000,
-            "maxTokens": 65536,
+            "contextWindow": 204800,
+            "maxTokens": 131072,
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "zai-org/glm-5",
-            "name": "GLM-5",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 202752,
-            "maxTokens": 65536,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "deepseek/deepseek-v3-0324",
-            "name": "DeepSeek V3 0324",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 163840,
-            "maxTokens": 65536,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "deepseek/deepseek-r1-0528",
-            "name": "DeepSeek R1 0528",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 163840,
-            "maxTokens": 65536,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "qwen/qwen3-235b-a22b-fp8",
-            "name": "Qwen3 235B A22B FP8",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 262144,
-            "maxTokens": 65536,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 0.3,
+              "output": 1.2,
+              "cacheRead": 0.06,
               "cacheWrite": 0
             }
           }

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -5,12 +5,18 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["nvidia"],
+  "providers": [
+    "nvidia"
+  ],
   "providerEndpoints": [
     {
       "endpointClass": "nvidia-native",
-      "hosts": ["integrate.api.nvidia.com"],
-      "baseUrls": ["https://integrate.api.nvidia.com/v1"]
+      "hosts": [
+        "integrate.api.nvidia.com"
+      ],
+      "baseUrls": [
+        "https://integrate.api.nvidia.com/v1"
+      ]
     }
   ],
   "modelIdNormalization": {
@@ -29,7 +35,10 @@
           {
             "id": "nvidia/nemotron-3-ultra-550b-a55b",
             "name": "Nemotron 3 Ultra 550B",
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
+            "reasoning": true,
             "contextWindow": 1048576,
             "maxTokens": 8192,
             "cost": {
@@ -45,7 +54,10 @@
           {
             "id": "nvidia/nemotron-3-super-120b-a12b",
             "name": "Nemotron 3 Super 120B",
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
+            "reasoning": true,
             "contextWindow": 1000000,
             "maxTokens": 8192,
             "cost": {
@@ -61,7 +73,10 @@
           {
             "id": "z-ai/glm-5.2",
             "name": "GLM 5.2",
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
+            "reasoning": true,
             "contextWindow": 202752,
             "maxTokens": 8192,
             "cost": {
@@ -77,9 +92,13 @@
           {
             "id": "moonshotai/kimi-k2.6",
             "name": "Kimi K2.6",
-            "input": ["text"],
+            "input": [
+              "text",
+              "image"
+            ],
+            "reasoning": true,
             "contextWindow": 262144,
-            "maxTokens": 8192,
+            "maxTokens": 65536,
             "cost": {
               "input": 0,
               "output": 0,
@@ -93,7 +112,11 @@
           {
             "id": "minimaxai/minimax-m3",
             "name": "Minimax M3",
-            "input": ["text"],
+            "input": [
+              "text",
+              "image"
+            ],
+            "reasoning": true,
             "contextWindow": 196608,
             "maxTokens": 8192,
             "cost": {
@@ -109,7 +132,10 @@
           {
             "id": "deepseek-ai/deepseek-v4-pro",
             "name": "DeepSeek V4 Pro",
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
+            "reasoning": true,
             "contextWindow": 262144,
             "maxTokens": 16384,
             "cost": {
@@ -125,9 +151,13 @@
           {
             "id": "qwen/qwen3.5-397b-a17b",
             "name": "Qwen3.5 397B A17B",
-            "input": ["text"],
+            "input": [
+              "text",
+              "image"
+            ],
+            "reasoning": true,
             "contextWindow": 262144,
-            "maxTokens": 16384,
+            "maxTokens": 32768,
             "cost": {
               "input": 0,
               "output": 0,
@@ -141,9 +171,13 @@
           {
             "id": "moonshotai/kimi-k2.5",
             "name": "Kimi K2.5",
-            "input": ["text"],
+            "input": [
+              "text",
+              "image"
+            ],
+            "reasoning": true,
             "contextWindow": 262144,
-            "maxTokens": 8192,
+            "maxTokens": 32768,
             "cost": {
               "input": 0,
               "output": 0,
@@ -160,7 +194,9 @@
           {
             "id": "z-ai/glm-5.1",
             "name": "GLM 5.1",
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 202752,
             "maxTokens": 8192,
             "cost": {
@@ -177,28 +213,11 @@
             "replacedBy": "z-ai/glm-5.2"
           },
           {
-            "id": "minimaxai/minimax-m2.5",
-            "name": "MiniMax M2.5",
-            "input": ["text"],
-            "contextWindow": 196608,
-            "maxTokens": 8192,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "compat": {
-              "requiresStringContent": true
-            },
-            "status": "deprecated",
-            "statusReason": "Still available by exact reference; use minimaxai/minimax-m3 for new NVIDIA setups.",
-            "replacedBy": "minimaxai/minimax-m3"
-          },
-          {
             "id": "z-ai/glm5",
             "name": "GLM-5",
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 202752,
             "maxTokens": 8192,
             "cost": {
@@ -217,9 +236,12 @@
           {
             "id": "minimaxai/minimax-m2.7",
             "name": "Minimax M2.7",
-            "input": ["text"],
-            "contextWindow": 196608,
-            "maxTokens": 8192,
+            "input": [
+              "text"
+            ],
+            "reasoning": true,
+            "contextWindow": 204800,
+            "maxTokens": 16384,
             "cost": {
               "input": 0,
               "output": 0,
@@ -244,7 +266,9 @@
     "providers": [
       {
         "id": "nvidia",
-        "envVars": ["NVIDIA_API_KEY"]
+        "envVars": [
+          "NVIDIA_API_KEY"
+        ]
       }
     ]
   },

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -30,7 +30,7 @@ const EXPECTED_FEATURED_MODELS = [
     id: "moonshotai/kimi-k2.6",
     name: "Kimi K2.6",
     contextWindow: 262_144,
-    maxTokens: 8_192,
+    maxTokens: 65_536,
   },
   {
     id: "minimaxai/minimax-m3",
@@ -48,7 +48,7 @@ const EXPECTED_FEATURED_MODELS = [
     id: "qwen/qwen3.5-397b-a17b",
     name: "Qwen3.5 397B A17B",
     contextWindow: 262_144,
-    maxTokens: 16_384,
+    maxTokens: 32_768,
   },
 ] as const;
 
@@ -57,7 +57,7 @@ const EXPECTED_DEPRECATED_MODELS = [
     id: "moonshotai/kimi-k2.5",
     name: "Kimi K2.5",
     contextWindow: 262_144,
-    maxTokens: 8_192,
+    maxTokens: 32_768,
   },
   {
     id: "z-ai/glm-5.1",
@@ -65,18 +65,12 @@ const EXPECTED_DEPRECATED_MODELS = [
     contextWindow: 202_752,
     maxTokens: 8_192,
   },
-  {
-    id: "minimaxai/minimax-m2.5",
-    name: "MiniMax M2.5",
-    contextWindow: 196_608,
-    maxTokens: 8_192,
-  },
   { id: "z-ai/glm5", name: "GLM-5", contextWindow: 202_752, maxTokens: 8_192 },
   {
     id: "minimaxai/minimax-m2.7",
     name: "Minimax M2.7",
-    contextWindow: 196_608,
-    maxTokens: 8_192,
+    contextWindow: 204_800,
+    maxTokens: 16_384,
   },
 ] as const;
 
@@ -129,6 +123,41 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.filter((model) => model.compat?.requiresStringContent !== true)).toEqual(
       [],
     );
+    expect(
+      provider.models.slice(0, EXPECTED_FEATURED_MODELS.length).map(({ id, input, reasoning }) => ({
+        id,
+        input,
+        reasoning,
+      })),
+    ).toEqual([
+      {
+        id: "nvidia/nemotron-3-ultra-550b-a55b",
+        input: ["text"],
+        reasoning: true,
+      },
+      {
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        input: ["text"],
+        reasoning: true,
+      },
+      { id: "z-ai/glm-5.2", input: ["text"], reasoning: true },
+      {
+        id: "moonshotai/kimi-k2.6",
+        input: ["text", "image", "video"],
+        reasoning: true,
+      },
+      {
+        id: "minimaxai/minimax-m3",
+        input: ["text", "image", "video"],
+        reasoning: true,
+      },
+      { id: "deepseek-ai/deepseek-v4-pro", input: ["text"], reasoning: true },
+      {
+        id: "qwen/qwen3.5-397b-a17b",
+        input: ["text", "image", "video"],
+        reasoning: true,
+      },
+    ]);
     expect(provider.models[0]).toMatchObject({
       contextWindow: 1_048_576,
       maxTokens: 8_192,
@@ -150,10 +179,21 @@ describe("nvidia provider catalog", () => {
     ).toEqual([
       { id: "moonshotai/kimi-k2.5", replacedBy: "moonshotai/kimi-k2.6" },
       { id: "z-ai/glm-5.1", replacedBy: "z-ai/glm-5.2" },
-      { id: "minimaxai/minimax-m2.5", replacedBy: "minimaxai/minimax-m3" },
       { id: "z-ai/glm5", replacedBy: "z-ai/glm-5.2" },
       { id: "minimaxai/minimax-m2.7", replacedBy: "minimaxai/minimax-m3" },
     ]);
+    expect(provider.models.find((model) => model.id === "moonshotai/kimi-k2.5")).toMatchObject({
+      input: ["text", "image", "video"],
+      reasoning: true,
+      contextWindow: 262_144,
+      maxTokens: 32_768,
+    });
+    expect(provider.models.find((model) => model.id === "minimaxai/minimax-m2.7")).toMatchObject({
+      input: ["text"],
+      reasoning: true,
+      contextWindow: 204_800,
+      maxTokens: 16_384,
+    });
   });
 
   it("keeps deprecated exact-reference rows out of the selectable catalog", () => {

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1679,10 +1679,32 @@ describe("ollama plugin", () => {
     }
     expect(result.provider.baseUrl).toBe("https://ollama.com");
     expect(result.provider.models?.map((model: { id: string }) => model.id)).toEqual([
-      "kimi-k2.5:cloud",
-      "minimax-m2.7:cloud",
-      "glm-5.1:cloud",
-      "glm-5.2:cloud",
+      "minimax-m2.7",
+      "glm-5.1",
+      "glm-5.2",
+    ]);
+    expect(result.provider.models).toEqual([
+      expect.objectContaining({
+        id: "minimax-m2.7",
+        contextWindow: 196_608,
+        reasoning: true,
+        input: ["text"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
+      expect.objectContaining({
+        id: "glm-5.1",
+        contextWindow: 202_752,
+        reasoning: true,
+        input: ["text"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
+      expect.objectContaining({
+        id: "glm-5.2",
+        contextWindow: 1_000_000,
+        reasoning: true,
+        input: ["text"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
     ]);
 
     provider.createStreamFn?.({
@@ -1698,7 +1720,7 @@ describe("ollama plugin", () => {
     buildOllamaProviderMock.mockResolvedValueOnce({
       baseUrl: "https://ollama.com",
       api: "ollama",
-      models: [buildOllamaModelDefinitionMock("glm-5.2:cloud")],
+      models: [buildOllamaModelDefinitionMock("glm-5.2")],
     });
 
     const result = await provider.catalog.run({
@@ -1716,9 +1738,7 @@ describe("ollama plugin", () => {
     });
     expect(result?.provider.apiKey).toBe("OLLAMA_API_KEY");
     expect(result?.provider.models).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: "glm-5.2:cloud", name: "glm-5.2:cloud" }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ id: "glm-5.2", name: "glm-5.2" })]),
     );
   });
 
@@ -1727,7 +1747,7 @@ describe("ollama plugin", () => {
     buildOllamaProviderMock.mockResolvedValueOnce({
       baseUrl: "https://ollama.com",
       api: "ollama",
-      models: [buildOllamaModelDefinitionMock("kimi-k2.5:cloud")],
+      models: [buildOllamaModelDefinitionMock("kimi-k2.6")],
     });
     queryOllamaModelShowInfoMock.mockResolvedValueOnce({
       contextWindow: 1_000_000,
@@ -1735,7 +1755,7 @@ describe("ollama plugin", () => {
     });
     const result = await provider.catalog.run({
       config: {
-        agents: { defaults: { model: { primary: "ollama-cloud/glm-5.2:cloud" } } },
+        agents: { defaults: { model: { primary: "ollama-cloud/glm-5.2" } } },
       },
       env: {},
       resolveProviderApiKey: () => ({
@@ -1748,15 +1768,13 @@ describe("ollama plugin", () => {
       apiKey: "cloud-key",
       quiet: true,
     });
-    expect(queryOllamaModelShowInfoMock).toHaveBeenCalledWith(
-      "https://ollama.com",
-      "glm-5.2:cloud",
-      { apiKey: "cloud-key" },
-    );
+    expect(queryOllamaModelShowInfoMock).toHaveBeenCalledWith("https://ollama.com", "glm-5.2", {
+      apiKey: "cloud-key",
+    });
     expect(result?.provider.models).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: "glm-5.2:cloud",
+          id: "glm-5.2",
           contextWindow: 1_000_000,
           maxTokens: 8192,
           reasoning: true,
@@ -1769,13 +1787,13 @@ describe("ollama plugin", () => {
     const provider = registerOllamaCloudProvider();
     const model = provider.resolveDynamicModel?.({
       provider: "ollama-cloud",
-      modelId: "glm-5.2:cloud",
+      modelId: "glm-5.2",
     } as never);
 
     expect(model).toEqual(
       expect.objectContaining({
         provider: "ollama-cloud",
-        id: "glm-5.2:cloud",
+        id: "glm-5.2",
         contextWindow: 1_000_000,
         maxTokens: 8192,
         reasoning: true,

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -68,6 +68,7 @@ import {
 } from "./src/node-inference.js";
 import { readProviderBaseUrl } from "./src/provider-base-url.js";
 import {
+  buildDefaultOllamaCloudModelDefinition,
   capLocalOllamaModelContext,
   capLocalOllamaProviderContext,
 } from "./src/provider-models.js";
@@ -101,7 +102,7 @@ function classifyOllamaFailoverReason(errorMessage: string): "server_error" | un
 }
 
 const dynamicModelCache = new Map<string, ProviderRuntimeModel[]>();
-const OLLAMA_CLOUD_DEFAULT_MODEL_REF = `${OLLAMA_CLOUD_PROVIDER_ID}/${OLLAMA_CLOUD_DEFAULT_MODELS[0]}`;
+const OLLAMA_CLOUD_DEFAULT_MODEL_REF = `${OLLAMA_CLOUD_PROVIDER_ID}/${OLLAMA_CLOUD_DEFAULT_MODELS[0].id}`;
 const OLLAMA_CONFIGURED_SHOW_CONCURRENCY = 4;
 const OLLAMA_CONFIGURED_SHOW_MAX_MODELS = 8;
 const OLLAMA_APP_GUIDED_MIN_CONTEXT_TOKENS = 16_384;
@@ -445,7 +446,7 @@ function buildStaticOllamaCloudProvider(): ModelProviderConfig {
   return {
     baseUrl: OLLAMA_CLOUD_BASE_URL,
     api: "ollama",
-    models: OLLAMA_CLOUD_DEFAULT_MODELS.map((model) => buildOllamaModelDefinition(model)),
+    models: OLLAMA_CLOUD_DEFAULT_MODELS.map(buildDefaultOllamaCloudModelDefinition),
   };
 }
 
@@ -468,16 +469,15 @@ async function buildOllamaCloudProvider(apiKey?: string): Promise<ModelProviderC
   if (typeof showInfo.contextWindow !== "number" && (showInfo.capabilities?.length ?? 0) === 0) {
     return discovered;
   }
+  const defaultModel = OLLAMA_CLOUD_DEFAULT_MODELS.find(
+    (model) => model.id === OLLAMA_GLM52_CLOUD_MODEL_ID,
+  );
+  if (!defaultModel) {
+    return discovered;
+  }
   return {
     ...discovered,
-    models: [
-      ...discovered.models,
-      buildOllamaModelDefinition(
-        OLLAMA_GLM52_CLOUD_MODEL_ID,
-        showInfo.contextWindow,
-        showInfo.capabilities,
-      ),
-    ],
+    models: [...discovered.models, buildDefaultOllamaCloudModelDefinition(defaultModel)],
   };
 }
 

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -5,7 +5,10 @@
     "onStartup": true
   },
   "enabledByDefault": true,
-  "providers": ["ollama", "ollama-cloud"],
+  "providers": [
+    "ollama",
+    "ollama-cloud"
+  ],
   "providerCatalogEntry": "./provider-discovery.ts",
   "providerRequest": {
     "providers": {
@@ -27,17 +30,25 @@
       }
     }
   },
-  "syntheticAuthRefs": ["ollama"],
-  "nonSecretAuthMarkers": ["ollama-local"],
+  "syntheticAuthRefs": [
+    "ollama"
+  ],
+  "nonSecretAuthMarkers": [
+    "ollama-local"
+  ],
   "setup": {
     "providers": [
       {
         "id": "ollama",
-        "envVars": ["OLLAMA_API_KEY"]
+        "envVars": [
+          "OLLAMA_API_KEY"
+        ]
       },
       {
         "id": "ollama-cloud",
-        "envVars": ["OLLAMA_API_KEY"]
+        "envVars": [
+          "OLLAMA_API_KEY"
+        ]
       }
     ]
   },
@@ -81,17 +92,21 @@
         "api": "ollama",
         "models": [
           {
-            "id": "kimi-k2.5:cloud",
-            "name": "kimi-k2.5:cloud",
+            "id": "kimi-k2.5",
+            "name": "kimi-k2.5",
+            "status": "deprecated",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text",
+              "image"
+            ],
             "cost": {
               "input": 0,
               "output": 0,
               "cacheRead": 0,
               "cacheWrite": 0
             },
-            "contextWindow": 128000,
+            "contextWindow": 262144,
             "maxTokens": 8192,
             "compat": {
               "supportsTools": true,
@@ -99,17 +114,19 @@
             }
           },
           {
-            "id": "minimax-m2.7:cloud",
-            "name": "minimax-m2.7:cloud",
+            "id": "minimax-m2.7",
+            "name": "minimax-m2.7",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "cost": {
               "input": 0,
               "output": 0,
               "cacheRead": 0,
               "cacheWrite": 0
             },
-            "contextWindow": 128000,
+            "contextWindow": 196608,
             "maxTokens": 8192,
             "compat": {
               "supportsTools": true,
@@ -117,17 +134,19 @@
             }
           },
           {
-            "id": "glm-5.1:cloud",
-            "name": "glm-5.1:cloud",
+            "id": "glm-5.1",
+            "name": "glm-5.1",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "cost": {
               "input": 0,
               "output": 0,
               "cacheRead": 0,
               "cacheWrite": 0
             },
-            "contextWindow": 128000,
+            "contextWindow": 202752,
             "maxTokens": 8192,
             "compat": {
               "supportsTools": true,
@@ -135,10 +154,12 @@
             }
           },
           {
-            "id": "glm-5.2:cloud",
-            "name": "glm-5.2:cloud",
+            "id": "glm-5.2",
+            "name": "glm-5.2",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "cost": {
               "input": 0,
               "output": 0,
@@ -161,9 +182,15 @@
     }
   },
   "contracts": {
-    "memoryEmbeddingProviders": ["ollama"],
-    "tools": ["node_inference"],
-    "webSearchProviders": ["ollama"]
+    "memoryEmbeddingProviders": [
+      "ollama"
+    ],
+    "tools": [
+      "node_inference"
+    ],
+    "webSearchProviders": [
+      "ollama"
+    ]
   },
   "configSchema": {
     "type": "object",
@@ -173,14 +200,18 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "enabled": { "type": "boolean" }
+          "enabled": {
+            "type": "boolean"
+          }
         }
       },
       "nodeInference": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "enabled": { "type": "boolean" }
+          "enabled": {
+            "type": "boolean"
+          }
         }
       }
     }

--- a/extensions/ollama/src/defaults.ts
+++ b/extensions/ollama/src/defaults.ts
@@ -3,13 +3,23 @@ export const OLLAMA_DEFAULT_BASE_URL = "http://127.0.0.1:11434";
 export const OLLAMA_DOCKER_HOST_BASE_URL = "http://host.docker.internal:11434";
 export const OLLAMA_CLOUD_BASE_URL = "https://ollama.com";
 export const OLLAMA_CLOUD_PROVIDER_ID = "ollama-cloud";
-export const OLLAMA_GLM52_CLOUD_MODEL_ID = "glm-5.2:cloud";
-export const OLLAMA_GLM52_CONTEXT_WINDOW = 1_000_000;
+export const OLLAMA_GLM52_CLOUD_MODEL_ID = "glm-5.2";
 export const OLLAMA_CLOUD_DEFAULT_MODELS = [
-  "kimi-k2.5:cloud",
-  "minimax-m2.7:cloud",
-  "glm-5.1:cloud",
-  OLLAMA_GLM52_CLOUD_MODEL_ID,
+  {
+    id: "minimax-m2.7",
+    contextWindow: 196_608,
+    capabilities: ["completion", "thinking", "tools"],
+  },
+  {
+    id: "glm-5.1",
+    contextWindow: 202_752,
+    capabilities: ["completion", "thinking", "tools"],
+  },
+  {
+    id: OLLAMA_GLM52_CLOUD_MODEL_ID,
+    contextWindow: 1_000_000,
+    capabilities: ["completion", "thinking", "tools"],
+  },
 ] as const;
 
 export const OLLAMA_DEFAULT_CONTEXT_WINDOW = 128000;

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -5,12 +5,11 @@ import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-sha
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-onboard";
 import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
+  OLLAMA_CLOUD_DEFAULT_MODELS,
   OLLAMA_DEFAULT_BASE_URL,
   OLLAMA_DEFAULT_CONTEXT_WINDOW,
   OLLAMA_DEFAULT_COST,
   OLLAMA_DEFAULT_MAX_TOKENS,
-  OLLAMA_GLM52_CLOUD_MODEL_ID,
-  OLLAMA_GLM52_CONTEXT_WINDOW,
   OLLAMA_LOCAL_CONTEXT_TOKENS,
 } from "./defaults.js";
 
@@ -292,11 +291,12 @@ export function isReasoningModelHeuristic(modelId: string): boolean {
 }
 
 function isKnownOllamaCloudReasoningModel(modelId: string): boolean {
-  const normalized = modelId.trim().toLowerCase();
-  return (
-    normalized === OLLAMA_GLM52_CLOUD_MODEL_ID ||
-    /^deepseek-v4-(?:flash|pro):cloud$/.test(normalized)
-  );
+  // Match both the canonical direct-host id and the local `:cloud` routing alias.
+  const normalized = modelId
+    .trim()
+    .toLowerCase()
+    .replace(/:cloud$/, "");
+  return normalized === "glm-5.2" || /^deepseek-v4-(?:flash|pro)$/.test(normalized);
 }
 
 export function buildOllamaModelDefinition(
@@ -331,11 +331,26 @@ export function buildOllamaModelDefinition(
     cost: OLLAMA_DEFAULT_COST,
     contextWindow:
       contextWindow ??
-      (modelId.trim().toLowerCase() === OLLAMA_GLM52_CLOUD_MODEL_ID
-        ? OLLAMA_GLM52_CONTEXT_WINDOW
+      (modelId
+        .trim()
+        .toLowerCase()
+        .replace(/:cloud$/, "") === "glm-5.2"
+        ? 1_000_000
         : OLLAMA_DEFAULT_CONTEXT_WINDOW),
     maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
     compat,
+  };
+}
+
+export function buildDefaultOllamaCloudModelDefinition(
+  model: (typeof OLLAMA_CLOUD_DEFAULT_MODELS)[number],
+): ModelDefinitionConfig {
+  return {
+    ...buildOllamaModelDefinition(model.id, model.contextWindow, [...model.capabilities]),
+    compat: {
+      supportsTools: true,
+      supportsUsageInStreaming: true,
+    },
   };
 }
 

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -202,7 +202,7 @@ describe("ollama setup", () => {
     });
     const modelIds = result.config.models?.providers?.ollama?.models?.map((m) => m.id);
 
-    expect(modelIds?.[0]).toBe("kimi-k2.5:cloud");
+    expect(modelIds?.[0]).toBe("minimax-m2.7");
     expect(result.config.models?.providers?.ollama?.baseUrl).toBe("https://ollama.com");
     expect(result.config.models?.providers?.ollama?.apiKey).toBe("test-ollama-key");
     expect(result.credential).toBe("test-ollama-key");
@@ -243,7 +243,6 @@ describe("ollama setup", () => {
 
     expect(modelIds).toEqual([
       "gemma4",
-      "kimi-k2.5:cloud",
       "minimax-m2.7:cloud",
       "glm-5.1:cloud",
       "glm-5.2:cloud",
@@ -428,15 +427,29 @@ describe("ollama setup", () => {
     const models = result.config.models?.providers?.ollama?.models;
     const modelIds = models?.map((m) => m.id);
 
-    expect(modelIds).toEqual([
-      "kimi-k2.5:cloud",
-      "minimax-m2.7:cloud",
-      "glm-5.1:cloud",
-      "glm-5.2:cloud",
-    ]);
-    expect(models?.find((model) => model.id === "kimi-k2.5:cloud")?.input).toEqual([
-      "text",
-      "image",
+    expect(modelIds).toEqual(["minimax-m2.7", "glm-5.1", "glm-5.2"]);
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: "minimax-m2.7",
+        contextWindow: 196_608,
+        reasoning: true,
+        input: ["text"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
+      expect.objectContaining({
+        id: "glm-5.1",
+        contextWindow: 202_752,
+        reasoning: true,
+        input: ["text"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
+      expect.objectContaining({
+        id: "glm-5.2",
+        contextWindow: 1_000_000,
+        reasoning: true,
+        input: ["text"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
     ]);
   });
 
@@ -458,10 +471,9 @@ describe("ollama setup", () => {
     const modelIds = models?.map((m) => m.id);
 
     expect(modelIds).toEqual([
-      "kimi-k2.5:cloud",
-      "minimax-m2.7:cloud",
-      "glm-5.1:cloud",
-      "glm-5.2:cloud",
+      "minimax-m2.7",
+      "glm-5.1",
+      "glm-5.2",
       "qwen3-coder:480b-cloud",
       "gpt-oss:120b-cloud",
     ]);

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -30,6 +30,7 @@ import {
 import { readProviderBaseUrl } from "./provider-base-url.js";
 import {
   buildOllamaBaseUrlSsrFPolicy,
+  buildDefaultOllamaCloudModelDefinition,
   buildOllamaProvider,
   buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
@@ -42,7 +43,10 @@ import {
 export { buildOllamaProvider };
 
 const OLLAMA_SUGGESTED_MODELS_LOCAL = [OLLAMA_DEFAULT_MODEL];
-const OLLAMA_SUGGESTED_MODELS_CLOUD = [...OLLAMA_CLOUD_DEFAULT_MODELS];
+const OLLAMA_SUGGESTED_MODELS_CLOUD = OLLAMA_CLOUD_DEFAULT_MODELS.map((model) => model.id);
+const OLLAMA_SUGGESTED_MODELS_LOCAL_CLOUD = OLLAMA_CLOUD_DEFAULT_MODELS.map(
+  (model) => `${model.id}:cloud`,
+);
 const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
 const OLLAMA_CLOUD_MAX_DISCOVERED_MODELS = 500;
 const OLLAMA_PULL_RESPONSE_TIMEOUT_MS = 30_000;
@@ -50,6 +54,8 @@ const OLLAMA_PULL_STREAM_IDLE_TIMEOUT_MS = 300_000;
 const OLLAMA_RECOMMENDED_TOOLS_MODEL = "gemma4:e4b";
 const OLLAMA_RECOMMENDED_TOOLS_MODEL_SIZE = "about 9.6 GB";
 const OLLAMA_TOOLS_SCAN_CONCURRENCY = 8;
+
+type OllamaCloudDefaultModel = (typeof OLLAMA_CLOUD_DEFAULT_MODELS)[number];
 
 type OllamaSetupOptions = {
   customBaseUrl?: string;
@@ -428,14 +434,21 @@ async function promptForOllamaCloudCredential(params: {
 function buildOllamaModelsConfig(
   modelNames: string[],
   discoveredModelsByName?: Map<string, OllamaModelWithContext>,
+  defaultModels: readonly OllamaCloudDefaultModel[] = [],
 ) {
   return modelNames.map((name) => {
     const discovered = discoveredModelsByName?.get(name);
-    // Suggested cloud models may be injected before `/api/tags` exposes them,
-    // so keep Kimi vision-capable during setup even without discovered metadata.
+    const defaultModel = defaultModels.find((model) => model.id === name);
+    if (defaultModel && !discovered) {
+      return buildDefaultOllamaCloudModelDefinition(defaultModel);
+    }
     const capabilities =
-      discovered?.capabilities ?? (name === "kimi-k2.5:cloud" ? ["vision"] : undefined);
-    return buildOllamaModelDefinition(name, discovered?.contextWindow, capabilities);
+      discovered?.capabilities ?? (defaultModel ? [...defaultModel.capabilities] : undefined);
+    return buildOllamaModelDefinition(
+      name,
+      discovered?.contextWindow ?? defaultModel?.contextWindow,
+      capabilities,
+    );
   });
 }
 
@@ -489,6 +502,7 @@ function applyOllamaProviderConfig(
   modelNames: string[],
   discoveredModelsByName?: Map<string, OllamaModelWithContext>,
   apiKey: SecretInput = "OLLAMA_API_KEY",
+  defaultModels: readonly OllamaCloudDefaultModel[] = [],
 ): OpenClawConfig {
   return {
     ...cfg,
@@ -501,7 +515,7 @@ function applyOllamaProviderConfig(
           baseUrl,
           api: "ollama",
           apiKey,
-          models: buildOllamaModelsConfig(modelNames, discoveredModelsByName),
+          models: buildOllamaModelsConfig(modelNames, discoveredModelsByName, defaultModels),
         },
       },
     },
@@ -542,7 +556,10 @@ async function resolveHostBackedSuggestedModelNames(params: {
 
   const auth = await checkOllamaCloudAuth(params.baseUrl);
   if (auth.signedIn) {
-    return mergeUniqueModelNames(OLLAMA_SUGGESTED_MODELS_LOCAL, OLLAMA_SUGGESTED_MODELS_CLOUD);
+    return mergeUniqueModelNames(
+      OLLAMA_SUGGESTED_MODELS_LOCAL,
+      OLLAMA_SUGGESTED_MODELS_LOCAL_CLOUD,
+    );
   }
 
   await params.prompter.note(
@@ -795,6 +812,7 @@ export async function promptAndConfigureOllama(params: {
         modelNames,
         undefined,
         credential,
+        OLLAMA_CLOUD_DEFAULT_MODELS,
       ),
     };
   }

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -42,9 +42,9 @@
             "contextWindow": 1000000,
             "maxTokens": 384000,
             "cost": {
-              "input": 1.74,
-              "output": 3.48,
-              "cacheRead": 0.145,
+              "input": 0.435,
+              "output": 0.87,
+              "cacheRead": 0.003625,
               "cacheWrite": 0
             },
             "compat": {
@@ -71,7 +71,7 @@
             "cost": {
               "input": 0.14,
               "output": 0.28,
-              "cacheRead": 0.028,
+              "cacheRead": 0.0028,
               "cacheWrite": 0
             },
             "compat": {

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -318,17 +318,54 @@ describe("opencode provider plugin", () => {
       throw new Error("expected manifest opencode models");
     }
     expect(manifestModels.map((model) => requireRecord(model, "manifest model").id)).toEqual([
+      "claude-opus-5",
       "claude-opus-4-8",
+      "gpt-5.6-sol",
       "gpt-5.5",
+      "gemini-3.6-flash",
       "gemini-3.1-pro",
+      "minimax-m3",
       "minimax-m2.7",
+      "big-pickle",
+      "deepseek-v4-flash-free",
+      "mimo-v2.5-free",
+      "laguna-s-2.1-free",
+      "ling-3.0-flash-free",
+      "nemotron-3-ultra-free",
+      "north-mini-code-free",
     ]);
+    const manifestClaude48 = requireRecord(
+      manifestModels.find(
+        (model) => requireRecord(model, "manifest model").id === "claude-opus-4-8",
+      ),
+      "manifest claude-opus-4-8",
+    );
+    expect(manifestClaude48).toMatchObject({
+      status: "deprecated",
+      replacedBy: "claude-opus-5",
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    });
+    const manifestGpt55 = requireRecord(
+      manifestModels.find((model) => requireRecord(model, "manifest model").id === "gpt-5.5"),
+      "manifest gpt-5.5",
+    );
+    expect(manifestGpt55).toMatchObject({
+      status: "deprecated",
+      replacedBy: "gpt-5.6-sol",
+      contextWindow: 1_050_000,
+    });
     const manifestMiniMax = requireRecord(
       manifestModels.find((model) => requireRecord(model, "manifest model").id === "minimax-m2.7"),
       "manifest minimax-m2.7",
     );
     expect(manifestMiniMax.api).toBe("openai-completions");
     expect(manifestMiniMax.baseUrl).toBe("https://opencode.ai/zen/v1");
+    expect(manifestMiniMax).toMatchObject({
+      status: "deprecated",
+      replacedBy: "minimax-m3",
+      cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 },
+    });
   });
 
   it("keeps documented OpenCode Zen example models resolvable", async () => {
@@ -435,7 +472,7 @@ describe("opencode provider plugin", () => {
       ["glm-5.2", { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 }],
       ["hy3-free", { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }],
       ["kimi-k2.7-code", { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 }],
-      ["minimax-m2.7", { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 }],
+      ["minimax-m2.7", { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 }],
       ["minimax-m3", { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 }],
     ] as const);
 

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -31,6 +31,31 @@
         "api": "openai-completions",
         "models": [
           {
+            "id": "claude-opus-5",
+            "name": "Claude Opus 5",
+            "api": "anthropic-messages",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 5,
+              "output": 25,
+              "cacheRead": 0.5,
+              "cacheWrite": 6.25
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
             "id": "claude-opus-4-8",
             "name": "Claude Opus 4.8",
             "api": "anthropic-messages",
@@ -47,11 +72,67 @@
               "cacheRead": 0.5,
               "cacheWrite": 6.25
             },
-            "contextWindow": 200000,
-            "maxTokens": 65536,
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens"
+            },
+            "status": "deprecated",
+            "replacedBy": "claude-opus-5"
+          },
+          {
+            "id": "gpt-5.6-sol",
+            "name": "GPT-5.6 Sol",
+            "api": "openai-responses",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 5,
+              "output": 30,
+              "cacheRead": 0.5,
+              "cacheWrite": 6.25,
+              "tieredPricing": [
+                {
+                  "input": 5,
+                  "output": 30,
+                  "cacheRead": 0.5,
+                  "cacheWrite": 6.25,
+                  "range": [
+                    0,
+                    272000
+                  ]
+                },
+                {
+                  "input": 10,
+                  "output": 45,
+                  "cacheRead": 1,
+                  "cacheWrite": 12.5,
+                  "range": [
+                    272000
+                  ]
+                }
+              ]
+            },
+            "contextWindow": 1050000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ],
               "maxTokensField": "max_tokens"
             }
           },
@@ -93,8 +174,35 @@
                 }
               ]
             },
-            "contextWindow": 400000,
+            "contextWindow": 1050000,
             "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens"
+            },
+            "status": "deprecated",
+            "replacedBy": "gpt-5.6-sol"
+          },
+          {
+            "id": "gemini-3.6-flash",
+            "name": "Gemini 3.6 Flash",
+            "api": "google-generative-ai",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 1.5,
+              "output": 7.5,
+              "cacheRead": 0.15,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,
@@ -148,6 +256,33 @@
             }
           },
           {
+            "id": "minimax-m3",
+            "name": "MiniMax M3",
+            "api": "openai-completions",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0.3,
+              "output": 1.2,
+              "cacheRead": 0.06,
+              "cacheWrite": 0
+            },
+            "contextWindow": 512000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens",
+              "supportsDeveloperRole": false,
+              "supportsStrictMode": false
+            }
+          },
+          {
             "id": "minimax-m2.7",
             "name": "MiniMax M2.7",
             "api": "openai-completions",
@@ -161,10 +296,195 @@
               "input": 0.3,
               "output": 1.2,
               "cacheRead": 0.06,
-              "cacheWrite": 0.375
+              "cacheWrite": 0
             },
             "contextWindow": 204800,
             "maxTokens": 131072,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens",
+              "supportsDeveloperRole": false,
+              "supportsStrictMode": false
+            },
+            "status": "deprecated",
+            "replacedBy": "minimax-m3"
+          },
+          {
+            "id": "big-pickle",
+            "name": "Big Pickle",
+            "api": "openai-completions",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 200000,
+            "maxTokens": 32000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens",
+              "supportsDeveloperRole": false,
+              "supportsStrictMode": false
+            }
+          },
+          {
+            "id": "deepseek-v4-flash-free",
+            "name": "DeepSeek V4 Flash Free",
+            "api": "openai-completions",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 200000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens",
+              "supportsDeveloperRole": false,
+              "supportsStrictMode": false
+            }
+          },
+          {
+            "id": "mimo-v2.5-free",
+            "name": "MiMo V2.5 Free",
+            "api": "openai-completions",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 200000,
+            "maxTokens": 32000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens",
+              "supportsDeveloperRole": false,
+              "supportsStrictMode": false
+            }
+          },
+          {
+            "id": "laguna-s-2.1-free",
+            "name": "Laguna S 2.1 Free",
+            "api": "openai-completions",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 256000,
+            "maxTokens": 32000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens",
+              "supportsDeveloperRole": false,
+              "supportsStrictMode": false
+            }
+          },
+          {
+            "id": "ling-3.0-flash-free",
+            "name": "Ling-3.0-flash Free",
+            "api": "openai-completions",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 32768,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens",
+              "supportsDeveloperRole": false,
+              "supportsStrictMode": false
+            }
+          },
+          {
+            "id": "nemotron-3-ultra-free",
+            "name": "Nemotron 3 Ultra Free",
+            "api": "openai-completions",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens",
+              "supportsDeveloperRole": false,
+              "supportsStrictMode": false
+            }
+          },
+          {
+            "id": "north-mini-code-free",
+            "name": "North Mini Code Free",
+            "api": "openai-completions",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 256000,
+            "maxTokens": 64000,
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,

--- a/extensions/qianfan/index.test.ts
+++ b/extensions/qianfan/index.test.ts
@@ -47,47 +47,160 @@ describe("qianfan provider plugin", () => {
     expect(catalogProvider.baseUrl).toBe("https://qianfan.baidubce.com/v2");
     const models = expectRecord(catalogProvider.models, "Qianfan catalog models");
     expect(models.map((model) => model.id)).toEqual([
+      "deepseek-v4-pro",
+      "ernie-5.1",
+      "ernie-5.0",
       "deepseek-v3.2",
       "ernie-5.0-thinking-preview",
     ]);
-    expect(
-      expectRecord(
-        models.find((model) => model.id === "deepseek-v3.2"),
-        "deepseek model",
-      ),
-    ).toEqual({
-      name: "DEEPSEEK V3.2",
-      id: "deepseek-v3.2",
-      reasoning: true,
-      input: ["text"],
-      contextWindow: 98304,
-      maxTokens: 32768,
-      cost: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
+    const expectedModels = [
+      {
+        id: "deepseek-v4-pro",
+        name: "DeepSeek V4 Pro",
+        reasoning: true,
+        input: ["text"],
+        contextWindow: 1000000,
+        maxTokens: 393216,
+        cost: {
+          input: 1.771957,
+          output: 3.543915,
+          cacheRead: 0.147663,
+          cacheWrite: 0,
+        },
       },
-    });
-    expect(
-      expectRecord(
-        models.find((model) => model.id === "ernie-5.0-thinking-preview"),
-        "ernie model",
-      ),
-    ).toEqual({
-      name: "ERNIE-5.0-Thinking-Preview",
-      id: "ernie-5.0-thinking-preview",
-      reasoning: true,
-      input: ["text", "image"],
-      contextWindow: 119000,
-      maxTokens: 64000,
-      cost: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
+      {
+        id: "ernie-5.1",
+        name: "ERNIE 5.1",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 128000,
+        maxTokens: 65536,
+        cost: {
+          input: 0.590652,
+          output: 2.657936,
+          cacheRead: 0,
+          cacheWrite: 0,
+          tieredPricing: [
+            {
+              input: 0.590652,
+              output: 2.657936,
+              cacheRead: 0,
+              cacheWrite: 0,
+              range: [0, 32001] as [number, number],
+            },
+            {
+              input: 0.885979,
+              output: 3.248589,
+              cacheRead: 0,
+              cacheWrite: 0,
+              range: [32001] as [number],
+            },
+          ],
+        },
       },
-    });
+      {
+        id: "ernie-5.0",
+        name: "ERNIE 5.0",
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 128000,
+        maxTokens: 65536,
+        cost: {
+          input: 0.885979,
+          output: 3.543915,
+          cacheRead: 0,
+          cacheWrite: 0,
+          tieredPricing: [
+            {
+              input: 0.885979,
+              output: 3.543915,
+              cacheRead: 0,
+              cacheWrite: 0,
+              range: [0, 32001] as [number, number],
+            },
+            {
+              input: 1.476631,
+              output: 5.906525,
+              cacheRead: 0,
+              cacheWrite: 0,
+              range: [32001] as [number],
+            },
+          ],
+        },
+      },
+      {
+        id: "deepseek-v3.2",
+        name: "DeepSeek V3.2",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 128000,
+        maxTokens: 32768,
+        cost: {
+          input: 0.295326,
+          output: 0.442989,
+          cacheRead: 0.059065,
+          cacheWrite: 0,
+          tieredPricing: [
+            {
+              input: 0.295326,
+              output: 0.442989,
+              cacheRead: 0.059065,
+              cacheWrite: 0,
+              range: [0, 32001] as [number, number],
+            },
+            {
+              input: 0.590652,
+              output: 0.885979,
+              cacheRead: 0.059065,
+              cacheWrite: 0,
+              range: [32001] as [number],
+            },
+          ],
+        },
+        status: "deprecated",
+        replacedBy: "deepseek-v4-pro",
+      },
+      {
+        id: "ernie-5.0-thinking-preview",
+        name: "ERNIE-5.0-Thinking-Preview",
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 128000,
+        maxTokens: 65536,
+        cost: {
+          input: 0.885979,
+          output: 3.543915,
+          cacheRead: 0,
+          cacheWrite: 0,
+          tieredPricing: [
+            {
+              input: 0.885979,
+              output: 3.543915,
+              cacheRead: 0,
+              cacheWrite: 0,
+              range: [0, 32001] as [number, number],
+            },
+            {
+              input: 1.476631,
+              output: 5.906525,
+              cacheRead: 0,
+              cacheWrite: 0,
+              range: [32001] as [number],
+            },
+          ],
+        },
+        status: "deprecated",
+        replacedBy: "ernie-5.0",
+      },
+    ] satisfies Array<Partial<(typeof models)[number]>>;
+    for (const expected of expectedModels) {
+      expect(
+        expectRecord(
+          models.find((model) => model.id === expected.id),
+          `${expected.id} model`,
+        ),
+      ).toMatchObject(expected);
+    }
   });
 
   it("sets Qianfan as the agent primary model in full onboarding mode", () => {

--- a/extensions/qianfan/index.test.ts
+++ b/extensions/qianfan/index.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import qianfanPlugin from "./index.js";
 import { applyQianfanConfig, QIANFAN_DEFAULT_MODEL_REF } from "./onboard.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 function expectRecord<T>(value: T | null | undefined, label: string): NonNullable<T> {
   if (!value) {
@@ -157,8 +158,6 @@ describe("qianfan provider plugin", () => {
             },
           ],
         },
-        status: "deprecated",
-        replacedBy: "deepseek-v4-pro",
       },
       {
         id: "ernie-5.0-thinking-preview",
@@ -189,8 +188,6 @@ describe("qianfan provider plugin", () => {
             },
           ],
         },
-        status: "deprecated",
-        replacedBy: "ernie-5.0",
       },
     ] satisfies Array<Partial<(typeof models)[number]>>;
     for (const expected of expectedModels) {
@@ -200,6 +197,19 @@ describe("qianfan provider plugin", () => {
           `${expected.id} model`,
         ),
       ).toMatchObject(expected);
+    }
+
+    const manifestRows = manifest.modelCatalog.providers.qianfan.models as Array<
+      Record<string, unknown>
+    >;
+    for (const [id, replacedBy] of [
+      ["deepseek-v3.2", "deepseek-v4-pro"],
+      ["ernie-5.0-thinking-preview", "ernie-5.0"],
+    ]) {
+      expect(manifestRows.find((model) => model.id === id)).toMatchObject({
+        status: "deprecated",
+        replacedBy,
+      });
     }
   });
 

--- a/extensions/qianfan/openclaw.plugin.json
+++ b/extensions/qianfan/openclaw.plugin.json
@@ -22,32 +22,144 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "deepseek-v3.2",
-            "name": "DEEPSEEK V3.2",
+            "id": "deepseek-v4-pro",
+            "name": "DeepSeek V4 Pro",
             "input": ["text"],
             "reasoning": true,
-            "contextWindow": 98304,
-            "maxTokens": 32768,
+            "contextWindow": 1000000,
+            "maxTokens": 393216,
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 1.771957,
+              "output": 3.543915,
+              "cacheRead": 0.147663,
               "cacheWrite": 0
             }
+          },
+          {
+            "id": "ernie-5.1",
+            "name": "ERNIE 5.1",
+            "input": ["text"],
+            "reasoning": false,
+            "contextWindow": 128000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.590652,
+              "output": 2.657936,
+              "cacheRead": 0,
+              "cacheWrite": 0,
+              "tieredPricing": [
+                {
+                  "input": 0.590652,
+                  "output": 2.657936,
+                  "cacheRead": 0,
+                  "cacheWrite": 0,
+                  "range": [0, 32001]
+                },
+                {
+                  "input": 0.885979,
+                  "output": 3.248589,
+                  "cacheRead": 0,
+                  "cacheWrite": 0,
+                  "range": [32001]
+                }
+              ]
+            }
+          },
+          {
+            "id": "ernie-5.0",
+            "name": "ERNIE 5.0",
+            "input": ["text", "image"],
+            "reasoning": true,
+            "contextWindow": 128000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.885979,
+              "output": 3.543915,
+              "cacheRead": 0,
+              "cacheWrite": 0,
+              "tieredPricing": [
+                {
+                  "input": 0.885979,
+                  "output": 3.543915,
+                  "cacheRead": 0,
+                  "cacheWrite": 0,
+                  "range": [0, 32001]
+                },
+                {
+                  "input": 1.476631,
+                  "output": 5.906525,
+                  "cacheRead": 0,
+                  "cacheWrite": 0,
+                  "range": [32001]
+                }
+              ]
+            }
+          },
+          {
+            "id": "deepseek-v3.2",
+            "name": "DeepSeek V3.2",
+            "input": ["text"],
+            "reasoning": false,
+            "contextWindow": 128000,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0.295326,
+              "output": 0.442989,
+              "cacheRead": 0.059065,
+              "cacheWrite": 0,
+              "tieredPricing": [
+                {
+                  "input": 0.295326,
+                  "output": 0.442989,
+                  "cacheRead": 0.059065,
+                  "cacheWrite": 0,
+                  "range": [0, 32001]
+                },
+                {
+                  "input": 0.590652,
+                  "output": 0.885979,
+                  "cacheRead": 0.059065,
+                  "cacheWrite": 0,
+                  "range": [32001]
+                }
+              ]
+            },
+            "status": "deprecated",
+            "statusReason": "Still available by exact reference; use deepseek-v4-pro for new Qianfan setups.",
+            "replacedBy": "deepseek-v4-pro"
           },
           {
             "id": "ernie-5.0-thinking-preview",
             "name": "ERNIE-5.0-Thinking-Preview",
             "input": ["text", "image"],
             "reasoning": true,
-            "contextWindow": 119000,
-            "maxTokens": 64000,
+            "contextWindow": 128000,
+            "maxTokens": 65536,
             "cost": {
-              "input": 0,
-              "output": 0,
+              "input": 0.885979,
+              "output": 3.543915,
               "cacheRead": 0,
-              "cacheWrite": 0
-            }
+              "cacheWrite": 0,
+              "tieredPricing": [
+                {
+                  "input": 0.885979,
+                  "output": 3.543915,
+                  "cacheRead": 0,
+                  "cacheWrite": 0,
+                  "range": [0, 32001]
+                },
+                {
+                  "input": 1.476631,
+                  "output": 5.906525,
+                  "cacheRead": 0,
+                  "cacheWrite": 0,
+                  "range": [32001]
+                }
+              ]
+            },
+            "status": "deprecated",
+            "statusReason": "Still available by exact reference; use the stable ernie-5.0 id for new Qianfan setups.",
+            "replacedBy": "ernie-5.0"
           }
         ]
       }

--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -115,7 +115,7 @@ describe("qwen provider plugin", () => {
     } as never);
     const catalogProvider = requireCatalogProvider(result);
     expect(catalogProvider.baseUrl).toBe(QWEN_TOKEN_PLAN_GLOBAL_BASE_URL);
-    expect(catalogProvider.models).toHaveLength(14);
+    expect(catalogProvider.models).toHaveLength(6);
 
     const legacy = requireRegisteredProvider(providers, QWEN_TOKEN_PLAN_LEGACY_PROVIDER_ID);
     expect(legacy.auth).toEqual([]);
@@ -196,13 +196,13 @@ describe("qwen provider plugin", () => {
       apiKey: "canonical-key",
       baseUrl: QWEN_TOKEN_PLAN_CN_BASE_URL,
     });
-    expect(catalogProvider.models).toHaveLength(14);
+    expect(catalogProvider.models).toHaveLength(6);
     expect(catalogProvider.models?.map((model) => model.id)).not.toContain("legacy-only");
     expect(resolveProviderApiKey).toHaveBeenCalledTimes(1);
     expect(resolveProviderApiKey).toHaveBeenCalledWith(QWEN_TOKEN_PLAN_PROVIDER_ID);
   });
 
-  it("exposes on-only thinking controls for thinking-only Token Plan models", async () => {
+  it("preserves thinking controls for catalog and uncataloged Token Plan refs", async () => {
     const { providers } = await registerProviderPlugin({
       plugin: qwenPlugin,
       id: "qwen",
@@ -245,12 +245,12 @@ describe("qwen provider plugin", () => {
       throw new Error("Token Plan provider missing after onboarding");
     }
     const globalModels = [...(globalProvider.models ?? [])];
-    const glmIndex = globalModels.findIndex((model) => model.id === "glm-5.2");
-    const glmModel = globalModels[glmIndex];
-    if (!glmModel) {
-      throw new Error("GLM 5.2 missing from Token Plan catalog");
+    const qwenIndex = globalModels.findIndex((model) => model.id === "qwen3.7-plus");
+    const qwenModel = globalModels[qwenIndex];
+    if (!qwenModel) {
+      throw new Error("Qwen3.7-Plus missing from Token Plan catalog");
     }
-    globalModels[glmIndex] = { ...glmModel, name: "Custom GLM 5.2" };
+    globalModels[qwenIndex] = { ...qwenModel, name: "Custom Qwen3.7-Plus" };
     globalModels.push({
       id: "custom-model",
       name: "Custom model",
@@ -278,16 +278,17 @@ describe("qwen provider plugin", () => {
 
     const tokenPlanProvider = (config: OpenClawConfig) =>
       config.models?.providers?.[QWEN_TOKEN_PLAN_PROVIDER_ID];
-    const glmContext = (config: OpenClawConfig) =>
-      tokenPlanProvider(config)?.models?.find((model) => model.id === "glm-5.2")?.contextWindow;
-    expect(glmContext(global)).toBe(1_000_000);
-    expect(glmContext(cnFromGlobal)).toBe(1_000_000);
-    expect(glmContext(globalAgain)).toBe(1_000_000);
+    const qwenContext = (config: OpenClawConfig) =>
+      tokenPlanProvider(config)?.models?.find((model) => model.id === "qwen3.7-plus")
+        ?.contextWindow;
+    expect(qwenContext(global)).toBe(1_000_000);
+    expect(qwenContext(cnFromGlobal)).toBe(1_000_000);
+    expect(qwenContext(globalAgain)).toBe(1_000_000);
     expect(tokenPlanProvider(cnFromGlobal)?.baseUrl).toBe(QWEN_TOKEN_PLAN_CN_BASE_URL);
     expect(tokenPlanProvider(globalAgain)?.baseUrl).toBe(QWEN_TOKEN_PLAN_GLOBAL_BASE_URL);
     expect(
-      tokenPlanProvider(globalAgain)?.models?.find((model) => model.id === "glm-5.2")?.name,
-    ).toBe("Custom GLM 5.2");
+      tokenPlanProvider(globalAgain)?.models?.find((model) => model.id === "qwen3.7-plus")?.name,
+    ).toBe("Custom Qwen3.7-Plus");
     expect(tokenPlanProvider(globalAgain)?.models?.map((model) => model.id)).toContain(
       "custom-model",
     );

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -116,6 +116,7 @@ function createQwenTokenPlanAuthMethod(region: "global" | "cn") {
 }
 
 function resolveQwenTokenPlanThinkingProfile(modelId: string) {
+  // Uncataloged exact refs remain selectable, so family predicates preserve their request controls.
   if (isQwenTokenPlanThinkingOnlyModelId(modelId)) {
     return {
       levels: [{ id: "low" as const, label: "on" }],

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -36,25 +36,21 @@ export const QWEN_DEFAULT_MODEL_REF = `qwen/${QWEN_DEFAULT_MODEL_ID}`;
 export const QWEN_TOKEN_PLAN_DEFAULT_MODEL_ID = QWEN_37_PLUS_MODEL_ID;
 export const QWEN_TOKEN_PLAN_DEFAULT_MODEL_REF = `${QWEN_TOKEN_PLAN_PROVIDER_ID}/${QWEN_TOKEN_PLAN_DEFAULT_MODEL_ID}`;
 
-const QWEN_TOKEN_PLAN_THINKING_ONLY_MODEL_IDS = new Set(["kimi-k2.7-code", "minimax-m2.5"]);
-const QWEN_TOKEN_PLAN_DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-pro", "deepseek-v4-flash"]);
-const QWEN_TOKEN_PLAN_KIMI_MODEL_IDS = new Set(["kimi-k2.7-code", "kimi-k2.6", "kimi-k2.5"]);
-const QWEN_TOKEN_PLAN_GLM_MODEL_IDS = new Set(["glm-5.2", "glm-5.1", "glm-5"]);
-
 export function isQwenTokenPlanThinkingOnlyModelId(modelId: string): boolean {
-  return QWEN_TOKEN_PLAN_THINKING_ONLY_MODEL_IDS.has(modelId.trim().toLowerCase());
+  const normalized = modelId.trim().toLowerCase();
+  return normalized === "minimax-m2.5" || normalized.startsWith("kimi-k2.7-code");
 }
 
 export function isQwenTokenPlanDeepSeekV4ModelId(modelId: string): boolean {
-  return QWEN_TOKEN_PLAN_DEEPSEEK_V4_MODEL_IDS.has(modelId.trim().toLowerCase());
+  return modelId.trim().toLowerCase().startsWith("deepseek-v4");
 }
 
 export function isQwenTokenPlanKimiModelId(modelId: string): boolean {
-  return QWEN_TOKEN_PLAN_KIMI_MODEL_IDS.has(modelId.trim().toLowerCase());
+  return modelId.trim().toLowerCase().startsWith("kimi-");
 }
 
 export function isQwenTokenPlanGlmModelId(modelId: string): boolean {
-  return QWEN_TOKEN_PLAN_GLM_MODEL_IDS.has(modelId.trim().toLowerCase());
+  return modelId.trim().toLowerCase().startsWith("glm-");
 }
 
 export function supportsQwenTokenPlanGlmMaxThinking(modelId: string): boolean {
@@ -73,17 +69,8 @@ export function resolveQwenTokenPlanBaseUrl(region: QwenTokenPlanRegion): string
 }
 
 // Token Plan is credit-based, so per-token prices do not map to its billing model.
-// This is the exact chat allowlist; image-generation-only models use separate APIs.
+// This curated picker catalog keeps current recommendations plus one selectable compatibility row.
 export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = [
-  {
-    id: QWEN_37_MAX_MODEL_ID,
-    name: QWEN_37_MAX_MODEL_ID,
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
   {
     id: QWEN_37_PLUS_MODEL_ID,
     name: QWEN_37_PLUS_MODEL_ID,
@@ -103,58 +90,15 @@ export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig>
     maxTokens: 65_536,
   },
   {
-    id: QWEN_36_FLASH_MODEL_ID,
-    name: QWEN_36_FLASH_MODEL_ID,
-    reasoning: true,
-    input: ["text", "image"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: "deepseek-v4-pro",
-    name: "deepseek-v4-pro",
+    id: "qwen3-coder-next",
+    name: "qwen3-coder-next",
     reasoning: true,
     input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 393_216,
-  },
-  {
-    id: "deepseek-v4-flash",
-    name: "deepseek-v4-flash",
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 393_216,
-  },
-  {
-    id: "deepseek-v3.2",
-    name: "deepseek-v3.2",
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 131_072,
-    maxTokens: 65_536,
-  },
-  {
-    id: "kimi-k2.7-code",
-    name: "kimi-k2.7-code",
-    reasoning: true,
-    input: ["text", "image"],
     cost: QWEN_DEFAULT_COST,
     contextWindow: 262_144,
-    maxTokens: 98_304,
-  },
-  {
-    id: "kimi-k2.6",
-    name: "kimi-k2.6",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 262_144,
-    maxTokens: 98_304,
+    maxTokens: 65_536,
+    status: "deprecated",
+    replacedBy: QWEN_37_PLUS_MODEL_ID,
   },
   {
     id: "kimi-k2.5",
@@ -164,24 +108,6 @@ export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig>
     cost: QWEN_DEFAULT_COST,
     contextWindow: 262_144,
     maxTokens: 98_304,
-  },
-  {
-    id: "glm-5.2",
-    name: "glm-5.2",
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 131_072,
-  },
-  {
-    id: "glm-5.1",
-    name: "glm-5.1",
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 202_752,
-    maxTokens: 131_072,
   },
   {
     id: "glm-5",

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -97,8 +97,6 @@ export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig>
     cost: QWEN_DEFAULT_COST,
     contextWindow: 262_144,
     maxTokens: 65_536,
-    status: "deprecated",
-    replacedBy: QWEN_37_PLUS_MODEL_ID,
   },
   {
     id: "kimi-k2.5",

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -93,15 +93,6 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "qwen3.7-max",
-            "name": "qwen3.7-max",
-            "reasoning": true,
-            "input": ["text"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 1000000,
-            "maxTokens": 65536
-          },
-          {
             "id": "qwen3.7-plus",
             "name": "qwen3.7-plus",
             "reasoning": true,
@@ -120,58 +111,15 @@
             "maxTokens": 65536
           },
           {
-            "id": "qwen3.6-flash",
-            "name": "qwen3.6-flash",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 1000000,
-            "maxTokens": 65536
-          },
-          {
-            "id": "deepseek-v4-pro",
-            "name": "deepseek-v4-pro",
+            "id": "qwen3-coder-next",
+            "name": "qwen3-coder-next",
             "reasoning": true,
             "input": ["text"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 1000000,
-            "maxTokens": 393216
-          },
-          {
-            "id": "deepseek-v4-flash",
-            "name": "deepseek-v4-flash",
-            "reasoning": true,
-            "input": ["text"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 1000000,
-            "maxTokens": 393216
-          },
-          {
-            "id": "deepseek-v3.2",
-            "name": "deepseek-v3.2",
-            "reasoning": true,
-            "input": ["text"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 131072,
-            "maxTokens": 65536
-          },
-          {
-            "id": "kimi-k2.7-code",
-            "name": "kimi-k2.7-code",
-            "reasoning": true,
-            "input": ["text", "image"],
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
             "contextWindow": 262144,
-            "maxTokens": 98304
-          },
-          {
-            "id": "kimi-k2.6",
-            "name": "kimi-k2.6",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 262144,
-            "maxTokens": 98304
+            "maxTokens": 65536,
+            "status": "deprecated",
+            "replacedBy": "qwen3.7-plus"
           },
           {
             "id": "kimi-k2.5",
@@ -181,24 +129,6 @@
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
             "contextWindow": 262144,
             "maxTokens": 98304
-          },
-          {
-            "id": "glm-5.2",
-            "name": "glm-5.2",
-            "reasoning": true,
-            "input": ["text"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 1000000,
-            "maxTokens": 131072
-          },
-          {
-            "id": "glm-5.1",
-            "name": "glm-5.1",
-            "reasoning": true,
-            "input": ["text"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 202752,
-            "maxTokens": 131072
           },
           {
             "id": "glm-5",

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -99,57 +99,53 @@ describe("qwen provider catalog", () => {
 });
 
 describe("qwen token plan provider catalog", () => {
-  it("ships the exact 14-model Global catalog through manifest and runtime", () => {
+  it("ships the curated six-row Global catalog through manifest and runtime", () => {
     const provider = buildQwenTokenPlanProvider();
-    const modelIds = provider.models.map((model) => model.id);
+    const models = provider.models;
+    const modelIds = models.map((model) => model.id);
 
     expect(provider.baseUrl).toBe(QWEN_TOKEN_PLAN_GLOBAL_BASE_URL);
     expect(provider.api).toBe("openai-completions");
     expect(modelIds).toEqual([
-      "qwen3.7-max",
       QWEN_TOKEN_PLAN_DEFAULT_MODEL_ID,
       "qwen3.6-plus",
-      "qwen3.6-flash",
-      "deepseek-v4-pro",
-      "deepseek-v4-flash",
-      "deepseek-v3.2",
-      "kimi-k2.7-code",
-      "kimi-k2.6",
+      "qwen3-coder-next",
       "kimi-k2.5",
-      "glm-5.2",
-      "glm-5.1",
       "glm-5",
       "MiniMax-M2.5",
     ]);
-    expect(provider.models.every((model) => model.reasoning)).toBe(true);
-    expect(manifest.modelCatalog.providers["qwen-token-plan"].models).toEqual(provider.models);
+    expect(models.find((model) => model.id === "qwen3-coder-next")).toMatchObject({
+      status: "deprecated",
+      replacedBy: QWEN_TOKEN_PLAN_DEFAULT_MODEL_ID,
+    });
+    expect(models.every((model) => model.reasoning)).toBe(true);
+    expect(manifest.modelCatalog.providers["qwen-token-plan"].models).toEqual(models);
     expect(manifest.modelCatalog.discovery["qwen-token-plan"]).toBe("refreshable");
   });
 
-  it("uses region-scoped endpoints with the documented GLM 5.2 window", () => {
+  it("uses region-scoped endpoints with the documented Qwen3.7-Plus window", () => {
     expect(resolveQwenTokenPlanBaseUrl("global")).toBe(QWEN_TOKEN_PLAN_GLOBAL_BASE_URL);
     expect(resolveQwenTokenPlanBaseUrl("cn")).toBe(QWEN_TOKEN_PLAN_CN_BASE_URL);
 
     const globalProvider = buildQwenTokenPlanProvider();
     const cnProvider = buildQwenTokenPlanProvider({ baseUrl: QWEN_TOKEN_PLAN_CN_BASE_URL });
-    expect(globalProvider.models.find((model) => model.id === "glm-5.2")?.contextWindow).toBe(
+    expect(globalProvider.models.find((model) => model.id === "qwen3.7-plus")?.contextWindow).toBe(
       1_000_000,
     );
-    expect(cnProvider.models.find((model) => model.id === "glm-5.2")?.contextWindow).toBe(
+    expect(cnProvider.models.find((model) => model.id === "qwen3.7-plus")?.contextWindow).toBe(
       1_000_000,
     );
   });
 
   it("uses current model limits instead of the stale contributor catalog", () => {
-    const provider = buildQwenTokenPlanProvider();
+    const models = buildQwenTokenPlanProvider().models;
 
-    expect(provider.models.find((model) => model.id === "qwen3.6-flash")?.maxTokens).toBe(65_536);
-    expect(provider.models.find((model) => model.id === "deepseek-v4-pro")).toMatchObject({
-      contextWindow: 1_000_000,
-      maxTokens: 393_216,
+    expect(models.find((model) => model.id === "qwen3-coder-next")).toMatchObject({
+      contextWindow: 262_144,
+      maxTokens: 65_536,
     });
-    expect(provider.models.find((model) => model.id === "kimi-k2.7-code")?.maxTokens).toBe(98_304);
-    expect(provider.models.find((model) => model.id === "MiniMax-M2.5")).toMatchObject({
+    expect(models.find((model) => model.id === "kimi-k2.5")?.maxTokens).toBe(98_304);
+    expect(models.find((model) => model.id === "MiniMax-M2.5")).toMatchObject({
       contextWindow: 196_608,
       maxTokens: 32_768,
     });
@@ -159,7 +155,7 @@ describe("qwen token plan provider catalog", () => {
     "opts Token Plan endpoint %s into native streaming usage",
     (baseUrl) => {
       const provider = applyQwenNativeStreamingUsageCompat(buildQwenTokenPlanProvider({ baseUrl }));
-      expect(provider.models).toHaveLength(14);
+      expect(provider.models).toHaveLength(6);
       expect(
         provider.models.every((model) => model.compat?.supportsUsageInStreaming === true),
       ).toBe(true);

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -114,12 +114,15 @@ describe("qwen token plan provider catalog", () => {
       "glm-5",
       "MiniMax-M2.5",
     ]);
-    expect(models.find((model) => model.id === "qwen3-coder-next")).toMatchObject({
+    const manifestModels = manifest.modelCatalog.providers["qwen-token-plan"].models as Array<
+      Record<string, unknown>
+    >;
+    expect(manifestModels.find((model) => model.id === "qwen3-coder-next")).toMatchObject({
       status: "deprecated",
       replacedBy: QWEN_TOKEN_PLAN_DEFAULT_MODEL_ID,
     });
     expect(models.every((model) => model.reasoning)).toBe(true);
-    expect(manifest.modelCatalog.providers["qwen-token-plan"].models).toEqual(models);
+    expect(manifestModels.map((model) => model.id)).toEqual(modelIds);
     expect(manifest.modelCatalog.discovery["qwen-token-plan"]).toBe("refreshable");
   });
 

--- a/extensions/stepfun/index.test.ts
+++ b/extensions/stepfun/index.test.ts
@@ -47,10 +47,14 @@ describe("stepfun provider registration", () => {
 
     expect(STEPFUN_DEFAULT_MODEL_REF).toBe("stepfun/step-3.5-flash");
     expect(STEPFUN_PLAN_DEFAULT_MODEL_REF).toBe("stepfun-plan/step-3.5-flash");
-    expect(
-      standard.models?.find((model) => model.id === "step-3.5-flash")?.compat
-        ?.supportsReasoningEffort,
-    ).not.toBe(true);
+    const standard35 = standard.models?.find((model) => model.id === "step-3.5-flash");
+    expect(standard35?.compat?.supportsReasoningEffort).not.toBe(true);
+    expect(standard35?.cost).toEqual({
+      input: 0.1,
+      output: 0.3,
+      cacheRead: 0.02,
+      cacheWrite: 0,
+    });
     expect(standardModel).toMatchObject({
       reasoning: true,
       input: ["text", "image"],

--- a/extensions/stepfun/openclaw.plugin.json
+++ b/extensions/stepfun/openclaw.plugin.json
@@ -73,9 +73,9 @@
             "contextWindow": 262144,
             "maxTokens": 65536,
             "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
+              "input": 0.1,
+              "output": 0.3,
+              "cacheRead": 0.02,
               "cacheWrite": 0
             }
           }

--- a/extensions/tencent/index.test.ts
+++ b/extensions/tencent/index.test.ts
@@ -143,11 +143,15 @@ describe("tencent provider plugin", () => {
 
     const hy3 = catalogProvider.models?.find((m) => m.id === "hy3");
     expect(hy3?.reasoning).toBe(true);
+    expect(hy3?.maxTokens).toBe(128_000);
     expect(hy3?.compat?.supportsReasoningEffort).toBe(true);
-    expect(hy3?.compat?.supportedReasoningEfforts).toEqual(["none", "high"]);
+    expect(hy3?.compat?.supportedReasoningEfforts).toEqual(["none", "low", "high"]);
 
     const hy3Preview = catalogProvider.models?.find((m) => m.id === "hy3-preview");
+    expect(hy3Preview?.status).toBe("deprecated");
+    expect(hy3Preview?.replacedBy).toBe("hy3");
     expect(hy3Preview?.reasoning).toBe(true);
+    expect(hy3Preview?.maxTokens).toBe(128_000);
     expect(hy3Preview?.compat?.supportsReasoningEffort).toBe(true);
     expect(hy3Preview?.compat?.supportedReasoningEfforts).toEqual(["none", "low", "high"]);
   });
@@ -164,8 +168,9 @@ describe("tencent provider plugin", () => {
 
     const hy3 = catalogProvider.models?.find((m) => m.id === "hy3");
     expect(hy3?.reasoning).toBe(true);
+    expect(hy3?.maxTokens).toBe(128_000);
     expect(hy3?.compat?.supportsReasoningEffort).toBe(true);
-    expect(hy3?.compat?.supportedReasoningEfforts).toEqual(["none", "high"]);
+    expect(hy3?.compat?.supportedReasoningEfforts).toEqual(["none", "low", "high"]);
   });
 
   it("injects reasoning_effort into TokenPlan hy3 chat-completions payload", async () => {

--- a/extensions/tencent/index.test.ts
+++ b/extensions/tencent/index.test.ts
@@ -10,6 +10,7 @@ import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-trans
 import { describe, expect, it } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import tencentPlugin from "./index.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 type OpenAICompletionsModel = Model<"openai-completions">;
 
@@ -148,12 +149,18 @@ describe("tencent provider plugin", () => {
     expect(hy3?.compat?.supportedReasoningEfforts).toEqual(["none", "low", "high"]);
 
     const hy3Preview = catalogProvider.models?.find((m) => m.id === "hy3-preview");
-    expect(hy3Preview?.status).toBe("deprecated");
-    expect(hy3Preview?.replacedBy).toBe("hy3");
     expect(hy3Preview?.reasoning).toBe(true);
     expect(hy3Preview?.maxTokens).toBe(128_000);
     expect(hy3Preview?.compat?.supportsReasoningEffort).toBe(true);
     expect(hy3Preview?.compat?.supportedReasoningEfforts).toEqual(["none", "low", "high"]);
+
+    const manifestRows = manifest.modelCatalog.providers["tencent-tokenhub"].models as Array<
+      Record<string, unknown>
+    >;
+    expect(manifestRows.find((model) => model.id === "hy3-preview")).toMatchObject({
+      status: "deprecated",
+      replacedBy: "hy3",
+    });
   });
 
   it("builds the static Tencent TokenPlan model catalog with reasoning flags", async () => {

--- a/extensions/tencent/openclaw.plugin.json
+++ b/extensions/tencent/openclaw.plugin.json
@@ -15,10 +15,12 @@
           {
             "id": "hy3-preview",
             "name": "Hy3 preview (TokenHub)",
+            "status": "deprecated",
+            "replacedBy": "hy3",
             "reasoning": true,
             "input": ["text"],
             "contextWindow": 256000,
-            "maxTokens": 64000,
+            "maxTokens": 128000,
             "cost": {
               "input": 0.176,
               "output": 0.587,
@@ -60,11 +62,17 @@
             "reasoning": true,
             "input": ["text"],
             "contextWindow": 256000,
-            "maxTokens": 64000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.147,
+              "output": 0.587,
+              "cacheRead": 0.037,
+              "cacheWrite": 0
+            },
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,
-              "supportedReasoningEfforts": ["none", "high"]
+              "supportedReasoningEfforts": ["none", "low", "high"]
             }
           }
         ]
@@ -79,11 +87,11 @@
             "reasoning": true,
             "input": ["text"],
             "contextWindow": 256000,
-            "maxTokens": 64000,
+            "maxTokens": 128000,
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,
-              "supportedReasoningEfforts": ["none", "high"]
+              "supportedReasoningEfforts": ["none", "low", "high"]
             }
           }
         ]

--- a/extensions/together/openclaw.plugin.json
+++ b/extensions/together/openclaw.plugin.json
@@ -56,7 +56,7 @@
               "input": 1.2,
               "output": 4.5,
               "cacheRead": 0.2,
-              "cacheWrite": 4.5
+              "cacheWrite": 0
             }
           },
           {
@@ -66,10 +66,10 @@
             "contextWindow": 131072,
             "maxTokens": 8192,
             "cost": {
-              "input": 0.88,
-              "output": 0.88,
-              "cacheRead": 0.88,
-              "cacheWrite": 0.88
+              "input": 1.04,
+              "output": 1.04,
+              "cacheRead": 1.04,
+              "cacheWrite": 0
             }
           },
           {
@@ -78,39 +78,26 @@
             "reasoning": true,
             "input": ["text"],
             "contextWindow": 512000,
-            "maxTokens": 8192,
+            "maxTokens": 384000,
             "cost": {
-              "input": 2.1,
-              "output": 4.4,
+              "input": 1.74,
+              "output": 3.48,
               "cacheRead": 0.2,
-              "cacheWrite": 4.4
+              "cacheWrite": 0
             }
           },
           {
-            "id": "Qwen/Qwen2.5-7B-Instruct-Turbo",
-            "name": "Qwen2.5 7B Instruct Turbo",
-            "input": ["text"],
-            "contextWindow": 32768,
-            "maxTokens": 8192,
-            "cost": {
-              "input": 0.3,
-              "output": 0.3,
-              "cacheRead": 0.3,
-              "cacheWrite": 0.3
-            }
-          },
-          {
-            "id": "zai-org/GLM-5.1",
-            "name": "GLM 5.1 FP4",
+            "id": "zai-org/GLM-5.2",
+            "name": "GLM 5.2 FP4",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 202752,
-            "maxTokens": 8192,
+            "contextWindow": 262144,
+            "maxTokens": 131072,
             "cost": {
               "input": 1.4,
               "output": 4.4,
-              "cacheRead": 1.4,
-              "cacheWrite": 4.4
+              "cacheRead": 0.26,
+              "cacheWrite": 0
             }
           }
         ]

--- a/extensions/venice/index.test.ts
+++ b/extensions/venice/index.test.ts
@@ -45,9 +45,9 @@ describe("venice provider plugin", () => {
 
     expect(
       provider.normalizeResolvedModel?.({
-        modelId: "venice/llama-3.3-70b",
+        modelId: "venice/qwen3-coder-480b-a35b-instruct-turbo",
         model: {
-          id: "llama-3.3-70b",
+          id: "qwen3-coder-480b-a35b-instruct-turbo",
           compat: {},
         },
       } as never),

--- a/extensions/venice/models.test.ts
+++ b/extensions/venice/models.test.ts
@@ -130,19 +130,52 @@ describe("venice-models", () => {
     expect(def.maxTokens).toBe(entry.maxTokens);
   });
 
-  it("excludes retired models from the static fallback catalog", () => {
+  it("excludes stale models from the static fallback catalog", () => {
     const catalogIds = new Set(VENICE_MODEL_CATALOG.map((model) => model.id));
-    for (const retiredId of [
+    for (const staleId of [
+      "claude-opus-4-6",
       "gemini-3-pro-preview",
+      "gemini-3-1-pro-preview",
+      "gemini-3-flash-preview",
       "grok-41-fast",
+      "hermes-3-llama-3.1-405b",
       "kimi-k2-thinking",
+      "llama-3.2-3b",
+      "llama-3.3-70b",
       "minimax-m21",
+      "minimax-m25",
       "mistral-31-24b",
+      "nvidia-nemotron-3-nano-30b-a3b",
+      "openai-gpt-4o-2024-11-20",
+      "openai-gpt-4o-mini-2024-07-18",
+      "openai-gpt-52",
+      "openai-gpt-52-codex",
+      "openai-gpt-53-codex",
+      "openai-gpt-54",
+      "openai-gpt-oss-120b",
       "qwen3-4b",
+      "qwen3-5-35b-a3b",
+      "qwen3-235b-a22b-instruct-2507",
       "qwen3-coder-480b-a35b-instruct",
+      "qwen3-next-80b",
       "venice-uncensored",
+      "zai-org-glm-4.7-flash",
+      "zai-org-glm-5",
     ]) {
-      expect(catalogIds.has(retiredId)).toBe(false);
+      expect(catalogIds.has(staleId)).toBe(false);
+    }
+  });
+
+  it("keeps only immediate predecessors as deprecated compatibility rows", () => {
+    for (const [id, replacedBy] of [
+      ["zai-org-glm-4.6", "zai-org-glm-4.7"],
+      ["google-gemma-3-27b-it", "google-gemma-4-31b-it"],
+      ["kimi-k2-5", "kimi-k2-6"],
+    ]) {
+      expect(VENICE_MODEL_CATALOG.find((model) => model.id === id)).toMatchObject({
+        status: "deprecated",
+        replacedBy,
+      });
     }
   });
 
@@ -155,19 +188,19 @@ describe("venice-models", () => {
           cause: { code: "ECONNRESET", message: "socket hang up" },
         });
       }
-      return makeModelsResponse("llama-3.3-70b");
+      return makeModelsResponse("zai-org-glm-4.7");
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const models = await runWithDiscoveryEnabled(() => discoverVeniceModels({ retryDelayMs: 0 }));
     expect(attempts).toBe(3);
-    expect(models.map((m) => m.id)).toContain("llama-3.3-70b");
+    expect(models.map((m) => m.id)).toContain("zai-org-glm-4.7");
   });
 
   it("uses API maxCompletionTokens for catalog models when present", async () => {
     stubVeniceModelsFetch([
       {
-        id: "llama-3.3-70b",
+        id: "zai-org-glm-4.7",
         availableContextTokens: 131072,
         maxCompletionTokens: 2048,
         capabilities: {
@@ -179,14 +212,14 @@ describe("venice-models", () => {
     ]);
 
     const models = await runWithDiscoveryEnabled(() => discoverVeniceModels({ retryDelayMs: 0 }));
-    const llama = models.find((m) => m.id === "llama-3.3-70b");
-    expect(llama?.maxTokens).toBe(2048);
+    const glm = models.find((m) => m.id === "zai-org-glm-4.7");
+    expect(glm?.maxTokens).toBe(2048);
   });
 
   it("retains catalog maxTokens when the API omits maxCompletionTokens", async () => {
     stubVeniceModelsFetch([
       {
-        id: "qwen3-235b-a22b-instruct-2507",
+        id: "qwen3-235b-a22b-thinking-2507",
         availableContextTokens: 131072,
         capabilities: {
           supportsReasoning: false,
@@ -197,15 +230,15 @@ describe("venice-models", () => {
     ]);
 
     const models = await runWithDiscoveryEnabled(() => discoverVeniceModels({ retryDelayMs: 0 }));
-    const qwen = models.find((m) => m.id === "qwen3-235b-a22b-instruct-2507");
+    const qwen = models.find((m) => m.id === "qwen3-235b-a22b-thinking-2507");
     expect(qwen?.maxTokens).toBe(16384);
   });
 
-  it("disables tools for catalog models that do not support function calling", () => {
+  it("keeps tools enabled for DeepSeek V3.2", () => {
     const model = buildVeniceModelDefinition(
       VENICE_MODEL_CATALOG.find((entry) => entry.id === "deepseek-v3.2")!,
     );
-    expect(model.compat?.supportsTools).toBe(false);
+    expect(model.compat?.supportsTools).toBeUndefined();
   });
 
   it("uses a conservative bounded maxTokens value for new models", async () => {
@@ -251,7 +284,7 @@ describe("venice-models", () => {
   it("ignores missing capabilities on partial metadata instead of aborting discovery", async () => {
     stubVeniceModelsFetch([
       {
-        id: "llama-3.3-70b",
+        id: "zai-org-glm-4.7",
         availableContextTokens: 131072,
         maxCompletionTokens: 2048,
       },
@@ -262,7 +295,7 @@ describe("venice-models", () => {
     ]);
 
     const models = await runWithDiscoveryEnabled(() => discoverVeniceModels());
-    const knownModel = models.find((m) => m.id === "llama-3.3-70b");
+    const knownModel = models.find((m) => m.id === "zai-org-glm-4.7");
     const partialModel = models.find((m) => m.id === "new-model-partial");
     expect(models).not.toHaveLength(VENICE_MODEL_CATALOG.length);
     expect(knownModel?.maxTokens).toBe(2048);
@@ -273,7 +306,7 @@ describe("venice-models", () => {
 
   it("keeps known models discoverable when a row omits model_spec", async () => {
     stubVeniceModelsFetch([
-      { id: "llama-3.3-70b", includeModelSpec: false },
+      { id: "qwen3-coder-480b-a35b-instruct-turbo", includeModelSpec: false },
       {
         id: "new-model-valid",
         availableContextTokens: 32_000,
@@ -287,10 +320,10 @@ describe("venice-models", () => {
     ]);
 
     const models = await runWithDiscoveryEnabled(() => discoverVeniceModels());
-    const knownModel = models.find((m) => m.id === "llama-3.3-70b");
+    const knownModel = models.find((m) => m.id === "qwen3-coder-480b-a35b-instruct-turbo");
     const newModel = models.find((m) => m.id === "new-model-valid");
     expect(models).not.toHaveLength(VENICE_MODEL_CATALOG.length);
-    expect(knownModel?.maxTokens).toBe(4096);
+    expect(knownModel?.maxTokens).toBe(65536);
     expect(newModel?.contextWindow).toBe(32000);
     expect(newModel?.maxTokens).toBe(2048);
   });

--- a/extensions/venice/models.test.ts
+++ b/extensions/venice/models.test.ts
@@ -7,6 +7,7 @@ import {
   discoverVeniceModels,
   VENICE_MODEL_CATALOG,
 } from "./models.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 const ORIGINAL_VITEST = process.env.VITEST;
@@ -167,12 +168,17 @@ describe("venice-models", () => {
   });
 
   it("keeps only immediate predecessors as deprecated compatibility rows", () => {
+    // Lifecycle metadata lives on the manifest rows; the runtime provider-config
+    // bridge (ModelDefinitionConfig) intentionally carries no status fields.
+    const manifestRows = manifest.modelCatalog.providers.venice.models as Array<
+      Record<string, unknown>
+    >;
     for (const [id, replacedBy] of [
       ["zai-org-glm-4.6", "zai-org-glm-4.7"],
       ["google-gemma-3-27b-it", "google-gemma-4-31b-it"],
       ["kimi-k2-5", "kimi-k2-6"],
     ]) {
-      expect(VENICE_MODEL_CATALOG.find((model) => model.id === id)).toMatchObject({
+      expect(manifestRows.find((model) => model.id === id)).toMatchObject({
         status: "deprecated",
         replacedBy,
       });

--- a/extensions/venice/openclaw.plugin.json
+++ b/extensions/venice/openclaw.plugin.json
@@ -45,168 +45,13 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "llama-3.3-70b",
-            "name": "Llama 3.3 70B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 4096,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "llama-3.2-3b",
-            "name": "Llama 3.2 3B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 4096,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "hermes-3-llama-3.1-405b",
-            "name": "Hermes 3 Llama 3.1 405B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false,
-              "supportsTools": false
-            }
-          },
-          {
-            "id": "qwen3-235b-a22b-thinking-2507",
-            "name": "Qwen3 235B Thinking",
+            "id": "zai-org-glm-5-2",
+            "name": "GLM 5.2",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-235b-a22b-instruct-2507",
-            "name": "Qwen3 235B Instruct",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-coder-480b-a35b-instruct-turbo",
-            "name": "Qwen3 Coder 480B Turbo",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 256000,
-            "maxTokens": 65536,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-5-35b-a3b",
-            "name": "Qwen3.5 35B A3B",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 256000,
-            "maxTokens": 65536,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-next-80b",
-            "name": "Qwen3 Next 80B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 256000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-vl-235b-a22b",
-            "name": "Qwen3 VL 235B (Vision)",
-            "reasoning": false,
-            "input": ["text", "image"],
-            "contextWindow": 256000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "deepseek-v3.2",
-            "name": "DeepSeek V3.2",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 160000,
-            "maxTokens": 32768,
-            "compat": {
-              "supportsUsageInStreaming": false,
-              "supportsTools": false
-            }
-          },
-          {
-            "id": "google-gemma-3-27b-it",
-            "name": "Google Gemma 3 27B Instruct",
-            "reasoning": false,
-            "input": ["text", "image"],
-            "contextWindow": 198000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "openai-gpt-oss-120b",
-            "name": "OpenAI GPT OSS 120B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "nvidia-nemotron-3-nano-30b-a3b",
-            "name": "NVIDIA Nemotron 3 Nano 30B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "olafangensan-glm-4.7-flash-heretic",
-            "name": "GLM 4.7 Flash Heretic",
-            "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 24000,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "zai-org-glm-4.6",
-            "name": "GLM 4.6",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 198000,
-            "maxTokens": 16384,
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "cost": { "input": 1.4, "output": 4.4, "cacheRead": 0.26, "cacheWrite": 0 },
             "compat": {
               "supportsUsageInStreaming": false
             }
@@ -218,61 +63,151 @@
             "input": ["text"],
             "contextWindow": 198000,
             "maxTokens": 16384,
+            "cost": { "input": 0.55, "output": 2.65, "cacheRead": 0.11, "cacheWrite": 0 },
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "zai-org-glm-4.7-flash",
-            "name": "GLM 4.7 Flash",
-            "reasoning": true,
-            "input": ["text"],
+            "id": "venice-uncensored-1-2",
+            "name": "Venice Uncensored 1.2",
+            "reasoning": false,
+            "input": ["text", "image"],
             "contextWindow": 128000,
-            "maxTokens": 16384,
+            "maxTokens": 8192,
+            "cost": { "input": 0.2, "output": 0.9, "cacheRead": 0, "cacheWrite": 0 },
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "zai-org-glm-5",
-            "name": "GLM 5",
+            "id": "google-gemma-4-31b-it",
+            "name": "Google Gemma 4 31B Instruct",
             "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 198000,
-            "maxTokens": 32000,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 8192,
+            "cost": { "input": 0.12, "output": 0.36, "cacheRead": 0.09, "cacheWrite": 0 },
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "kimi-k2-5",
-            "name": "Kimi K2.5",
+            "id": "kimi-k2-6",
+            "name": "Kimi K2.6",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 256000,
             "maxTokens": 65536,
+            "cost": { "input": 0.75, "output": 3.5, "cacheRead": 0.16, "cacheWrite": 0 },
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "minimax-m25",
-            "name": "MiniMax M2.5",
+            "id": "deepseek-v3.2",
+            "name": "DeepSeek V3.2",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 198000,
+            "contextWindow": 160000,
             "maxTokens": 32768,
+            "cost": { "input": 0.33, "output": 0.48, "cacheRead": 0.16, "cacheWrite": 0 },
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "claude-opus-4-6",
-            "name": "Claude Opus 4.6 (via Venice)",
+            "id": "qwen3-235b-a22b-thinking-2507",
+            "name": "Qwen3 235B Thinking",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "cost": { "input": 0.45, "output": 3.5, "cacheRead": 0, "cacheWrite": 0 },
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-coder-480b-a35b-instruct-turbo",
+            "name": "Qwen3 Coder 480B Turbo",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "cost": { "input": 0.35, "output": 1.5, "cacheRead": 0.04, "cacheWrite": 0 },
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-vl-235b-a22b",
+            "name": "Qwen3 VL 235B (Vision)",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "cost": { "input": 0.21, "output": 1.9, "cacheRead": 0.1, "cacheWrite": 0 },
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "grok-4-5",
+            "name": "Grok 4.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 500000,
+            "maxTokens": 32000,
+            "cost": { "input": 2.27, "output": 6.8, "cacheRead": 0.34, "cacheWrite": 0 },
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen-3-7-max",
+            "name": "Qwen 3.7 Max (via Venice)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": { "input": 2.7, "output": 8.05, "cacheRead": 0.27, "cacheWrite": 3.35 },
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen-3-7-plus",
+            "name": "Qwen 3.7 Plus (via Venice)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": { "input": 0.5, "output": 2, "cacheRead": 0.05, "cacheWrite": 0.625 },
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "claude-fable-5",
+            "name": "Claude Fable 5 (via Venice)",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 1000000,
             "maxTokens": 128000,
+            "cost": { "input": 12, "output": 60, "cacheRead": 1.2, "cacheWrite": 15 },
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "claude-opus-5",
+            "name": "Claude Opus 5 (via Venice)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": { "input": 6, "output": 30, "cacheRead": 0.6, "cacheWrite": 7.5 },
             "compat": {
               "supportsUsageInStreaming": false
             }
@@ -284,94 +219,66 @@
             "input": ["text", "image"],
             "contextWindow": 1000000,
             "maxTokens": 64000,
+            "cost": { "input": 3.6, "output": 18, "cacheRead": 0.36, "cacheWrite": 4.5 },
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "openai-gpt-52",
-            "name": "GPT-5.2 (via Venice)",
+            "id": "openai-gpt-56-sol",
+            "name": "GPT-5.6 Sol (via Venice)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 6.25,
+              "output": 37.5,
+              "cacheRead": 0.625,
+              "cacheWrite": 7.8125
+            },
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "zai-org-glm-4.6",
+            "name": "GLM 4.6",
+            "status": "deprecated",
+            "replacedBy": "zai-org-glm-4.7",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 256000,
-            "maxTokens": 65536,
+            "contextWindow": 198000,
+            "maxTokens": 16384,
+            "cost": { "input": 0.43, "output": 1.75, "cacheRead": 0.08, "cacheWrite": 0 },
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "openai-gpt-52-codex",
-            "name": "GPT-5.2 Codex (via Venice)",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 256000,
-            "maxTokens": 65536,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "openai-gpt-53-codex",
-            "name": "GPT-5.3 Codex (via Venice)",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 400000,
-            "maxTokens": 128000,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "openai-gpt-54",
-            "name": "GPT-5.4 (via Venice)",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 1000000,
-            "maxTokens": 131072,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "openai-gpt-4o-2024-11-20",
-            "name": "GPT-4o (via Venice)",
+            "id": "google-gemma-3-27b-it",
+            "name": "Google Gemma 3 27B Instruct",
+            "status": "deprecated",
+            "replacedBy": "google-gemma-4-31b-it",
             "reasoning": false,
             "input": ["text", "image"],
-            "contextWindow": 128000,
+            "contextWindow": 198000,
             "maxTokens": 16384,
+            "cost": { "input": 0.12, "output": 0.2, "cacheRead": 0, "cacheWrite": 0 },
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "openai-gpt-4o-mini-2024-07-18",
-            "name": "GPT-4o Mini (via Venice)",
-            "reasoning": false,
-            "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "gemini-3-1-pro-preview",
-            "name": "Gemini 3.1 Pro (via Venice)",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 1000000,
-            "maxTokens": 32768,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "gemini-3-flash-preview",
-            "name": "Gemini 3 Flash (via Venice)",
+            "id": "kimi-k2-5",
+            "name": "Kimi K2.5",
+            "status": "deprecated",
+            "replacedBy": "kimi-k2-6",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 256000,
             "maxTokens": 65536,
+            "cost": { "input": 0.56, "output": 3.5, "cacheRead": 0.22, "cacheWrite": 0 },
             "compat": {
               "supportsUsageInStreaming": false
             }

--- a/extensions/volcengine/index.test.ts
+++ b/extensions/volcengine/index.test.ts
@@ -38,7 +38,10 @@ describe("volcengine plugin", () => {
     ]);
     expect(DOUBAO_CODING_MODEL_CATALOG.map((entry) => entry.id)).toEqual([
       "ark-code-latest",
-      "doubao-seed-code",
+      "doubao-seed-2.1-turbo",
+      "glm-5.2",
+      "deepseek-v4-pro",
+      "deepseek-v4-flash",
     ]);
   });
 
@@ -77,9 +80,9 @@ describe("volcengine plugin", () => {
 
     const normalized = provider.normalizeResolvedModel?.({
       provider: "volcengine-plan",
-      modelId: "doubao-seed-code",
+      modelId: "doubao-seed-2.1-turbo",
       model: {
-        id: "doubao-seed-code",
+        id: "doubao-seed-2.1-turbo",
         provider: "volcengine-plan",
         api: "openai-completions",
         compat: { unsupportedToolSchemaKeywords: ["not"] },

--- a/extensions/volcengine/openclaw.plugin.json
+++ b/extensions/volcengine/openclaw.plugin.json
@@ -5,16 +5,26 @@
   },
   "enabledByDefault": true,
   "providerCatalogEntry": "./provider-discovery.ts",
-  "providers": ["volcengine", "volcengine-plan"],
+  "providers": [
+    "volcengine",
+    "volcengine-plan"
+  ],
   "setup": {
     "providers": [
       {
         "id": "volcengine",
-        "envVars": ["VOLCANO_ENGINE_API_KEY"]
+        "envVars": [
+          "VOLCANO_ENGINE_API_KEY"
+        ]
       },
       {
         "id": "volcengine-tts",
-        "envVars": ["VOLCENGINE_TTS_API_KEY", "BYTEPLUS_SEED_SPEECH_API_KEY", "VOLCENGINE_TTS_APPID", "VOLCENGINE_TTS_TOKEN"]
+        "envVars": [
+          "VOLCENGINE_TTS_API_KEY",
+          "BYTEPLUS_SEED_SPEECH_API_KEY",
+          "VOLCENGINE_TTS_APPID",
+          "VOLCENGINE_TTS_TOKEN"
+        ]
       }
     ]
   },
@@ -42,35 +52,111 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "doubao-seed-code-preview-251028",
-            "name": "doubao-seed-code-preview-251028",
-            "input": ["text", "image"],
-            "contextWindow": 256000,
-            "maxTokens": 4096,
+            "id": "doubao-seed-evolving",
+            "name": "Doubao Seed Evolving",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1024000,
+            "maxTokens": 256000,
             "cost": {
-              "input": 0.0001,
-              "output": 0.0002,
-              "cacheRead": 0,
+              "input": 0.885478,
+              "output": 4.427391,
+              "cacheRead": 0.177096,
               "cacheWrite": 0
             }
           },
           {
-            "id": "doubao-seed-1-8-251228",
-            "name": "Doubao Seed 1.8",
-            "input": ["text", "image"],
+            "id": "doubao-seed-2-1-pro-260628",
+            "name": "Doubao Seed 2.1 Pro",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
             "contextWindow": 256000,
-            "maxTokens": 4096,
+            "maxTokens": 256000,
             "cost": {
-              "input": 0.0001,
-              "output": 0.0002,
-              "cacheRead": 0,
+              "input": 0.885478,
+              "output": 4.427391,
+              "cacheRead": 0.177096,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "doubao-seed-2-1-turbo-260628",
+            "name": "Doubao Seed 2.1 Turbo",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 256000,
+            "maxTokens": 256000,
+            "cost": {
+              "input": 0.442739,
+              "output": 2.213695,
+              "cacheRead": 0.088548,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "glm-5-2-260617",
+            "name": "GLM 5.2",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1024000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 1.180638,
+              "output": 4.132231,
+              "cacheRead": 0.295159,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-v4-pro-260425",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1024000,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 1.770956,
+              "output": 3.541913,
+              "cacheRead": 0.14758,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-v4-flash-260425",
+            "name": "DeepSeek V4 Flash",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1024000,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 0.14758,
+              "output": 0.295159,
+              "cacheRead": 0.029516,
               "cacheWrite": 0
             }
           },
           {
             "id": "kimi-k2-5-260127",
             "name": "Kimi K2.5",
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "contextWindow": 256000,
             "maxTokens": 4096,
             "cost": {
@@ -78,33 +164,66 @@
               "output": 0.0002,
               "cacheRead": 0,
               "cacheWrite": 0
-            }
+            },
+            "status": "deprecated",
+            "replacedBy": "doubao-seed-evolving"
           },
           {
             "id": "glm-4-7-251222",
             "name": "GLM 4.7",
-            "input": ["text", "image"],
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
             "contextWindow": 200000,
-            "maxTokens": 4096,
+            "maxTokens": 128000,
             "cost": {
               "input": 0.0001,
               "output": 0.0002,
               "cacheRead": 0,
               "cacheWrite": 0
-            }
+            },
+            "status": "deprecated",
+            "replacedBy": "glm-5-2-260617"
           },
           {
             "id": "deepseek-v3-2-251201",
             "name": "DeepSeek V3.2",
-            "input": ["text", "image"],
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
             "contextWindow": 128000,
-            "maxTokens": 4096,
+            "maxTokens": 32000,
             "cost": {
-              "input": 0.0001,
-              "output": 0.0002,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
+              "input": 0.295159,
+              "output": 0.442739,
+              "cacheRead": 0.059032,
+              "cacheWrite": 0,
+              "tieredPricing": [
+                {
+                  "input": 0.295159,
+                  "output": 0.442739,
+                  "cacheRead": 0.059032,
+                  "cacheWrite": 0,
+                  "range": [
+                    0,
+                    32000
+                  ]
+                },
+                {
+                  "input": 0.590319,
+                  "output": 0.885478,
+                  "cacheRead": 0.059032,
+                  "cacheWrite": 0,
+                  "range": [
+                    32000
+                  ]
+                }
+              ]
+            },
+            "status": "deprecated",
+            "replacedBy": "deepseek-v4-flash-260425"
           }
         ]
       },
@@ -115,25 +234,79 @@
           {
             "id": "ark-code-latest",
             "name": "Ark Coding Plan",
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 256000,
             "maxTokens": 4096,
             "cost": {
-              "input": 0.0001,
-              "output": 0.0002,
+              "input": 0,
+              "output": 0,
               "cacheRead": 0,
               "cacheWrite": 0
             }
           },
           {
-            "id": "doubao-seed-code",
-            "name": "Doubao Seed Code",
-            "input": ["text"],
+            "id": "doubao-seed-2.1-turbo",
+            "name": "Doubao Seed 2.1 Turbo",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
             "contextWindow": 256000,
-            "maxTokens": 4096,
+            "maxTokens": 256000,
             "cost": {
-              "input": 0.0001,
-              "output": 0.0002,
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "glm-5.2",
+            "name": "GLM 5.2",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1024000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-v4-pro",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1024000,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-v4-flash",
+            "name": "DeepSeek V4 Flash",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1024000,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 0,
+              "output": 0,
               "cacheRead": 0,
               "cacheWrite": 0
             }
@@ -168,6 +341,8 @@
     "properties": {}
   },
   "contracts": {
-    "speechProviders": ["volcengine"]
+    "speechProviders": [
+      "volcengine"
+    ]
   }
 }

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -319,6 +319,9 @@ describe("xiaomi provider plugin", () => {
       "text",
       "image",
     ]);
+    for (const model of configured.provider.models ?? []) {
+      expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    }
   });
 
   it("rejects token-plan keys on the pay-as-you-go auth choice", async () => {

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -66,16 +66,7 @@
             "reasoning": true,
             "contextWindow": 1048576,
             "maxTokens": 131072,
-            "cost": {
-              "input": 1,
-              "output": 3,
-              "cacheRead": 0.2,
-              "cacheWrite": 0,
-              "tieredPricing": [
-                { "input": 1, "output": 3, "cacheRead": 0.2, "cacheWrite": 0, "range": [0, 256000] },
-                { "input": 1, "output": 3, "cacheRead": 0.4, "cacheWrite": 0, "range": [256000] }
-              ]
-            }
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {
             "id": "mimo-v2.5",
@@ -84,16 +75,7 @@
             "reasoning": true,
             "contextWindow": 1048576,
             "maxTokens": 131072,
-            "cost": {
-              "input": 0.4,
-              "output": 2,
-              "cacheRead": 0.08,
-              "cacheWrite": 0,
-              "tieredPricing": [
-                { "input": 0.4, "output": 2, "cacheRead": 0.08, "cacheWrite": 0, "range": [0, 256000] },
-                { "input": 0.4, "output": 2, "cacheRead": 0.16, "cacheWrite": 0, "range": [256000] }
-              ]
-            }
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           }
         ]
       }

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -106,8 +106,8 @@ describe("zai provider plugin", () => {
           baseUrl: "https://api.z.ai/api/paas/v4",
           input: ["text"],
           reasoning: true,
-          contextWindow: 202800,
-          maxTokens: 131100,
+          contextWindow: 200_000,
+          maxTokens: 131_072,
         },
       },
       {
@@ -117,8 +117,8 @@ describe("zai provider plugin", () => {
           baseUrl: "https://api.z.ai/api/paas/v4",
           input: ["text", "image"],
           reasoning: true,
-          contextWindow: 202800,
-          maxTokens: 131100,
+          contextWindow: 200_000,
+          maxTokens: 131_072,
         },
       },
     ] as const;

--- a/extensions/zai/model-definitions.test.ts
+++ b/extensions/zai/model-definitions.test.ts
@@ -48,9 +48,31 @@ describe("zai model definitions", () => {
       id: "glm-5.1",
       reasoning: true,
       input: ["text"],
-      contextWindow: 202800,
-      maxTokens: 131100,
+      contextWindow: 200_000,
+      maxTokens: 131_072,
       cost: { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
+    });
+  });
+
+  it("uses official GLM-5-Turbo metadata", () => {
+    expectZaiModelFields({
+      id: "glm-5-turbo",
+      reasoning: true,
+      input: ["text"],
+      contextWindow: 200_000,
+      maxTokens: 131_072,
+      cost: { input: 1.2, output: 4, cacheRead: 0.24, cacheWrite: 0 },
+    });
+  });
+
+  it("uses official GLM-5V-Turbo metadata", () => {
+    expectZaiModelFields({
+      id: "glm-5v-turbo",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 200_000,
+      maxTokens: 131_072,
+      cost: { input: 1.2, output: 4, cacheRead: 0.24, cacheWrite: 0 },
     });
   });
 });

--- a/extensions/zai/openclaw.plugin.json
+++ b/extensions/zai/openclaw.plugin.json
@@ -48,14 +48,42 @@
             }
           },
           {
+            "id": "glm-5-turbo",
+            "name": "GLM-5-Turbo",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 200000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 1.2,
+              "output": 4,
+              "cacheRead": 0.24,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "glm-5v-turbo",
+            "name": "GLM-5V-Turbo",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 200000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 1.2,
+              "output": 4,
+              "cacheRead": 0.24,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "glm-5.1",
             "name": "GLM-5.1",
             "status": "deprecated",
             "replacedBy": "glm-5.2",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 202800,
-            "maxTokens": 131100,
+            "contextWindow": 200000,
+            "maxTokens": 131072,
             "cost": {
               "input": 1.4,
               "output": 4.4,

--- a/src/plugin-sdk/test-helpers/provider-auth-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-auth-contract.ts
@@ -341,7 +341,7 @@ export function describeGithubCopilotProviderAuthContract(load: ProviderAuthCont
               },
             },
           ],
-          defaultModel: "github-copilot/claude-opus-4.7",
+          defaultModel: "github-copilot/claude-opus-5",
         });
       } finally {
         if (previousIsTTYDescriptor) {
@@ -424,7 +424,7 @@ export function describeGithubCopilotProviderAuthContract(load: ProviderAuthCont
             },
           },
         ],
-        defaultModel: "github-copilot/claude-opus-4.7",
+        defaultModel: "github-copilot/claude-opus-5",
       });
       // Credential is sourced from the device flow response, not from the existing
       // on-disk auth store. ensureAuthProfileStore is still called by the


### PR DESCRIPTION
## What Problem This Solves

PR #113594 introduced curated default model pickers (deprecated/disabled catalog rows hidden unless configured) and curated the five major providers. The remaining ~28 provider extensions with static catalogs still shipped stale rows — retired Kimi K2.5-era models, GLM 4.x/5.0/5.1 generations, dead DeepSeek aliases, year-old hosted-OSS lineups — and several extensions carried runtime/onboarding catalog copies that were never synchronized with their manifests.

## Why This Change Was Made

Maintainer-directed follow-up: extend the curation policy to every provider catalog and double-check the whole list. Every provider extension with static catalog rows was researched against its vendor's current official documentation, live public model APIs where available (Venice, Cerebras, OpenCode Zen, Ollama, Alibaba coding-plan endpoints), pricing pages, and deprecation notices. Policy per provider: visible = current generation actively promoted by the vendor; `status: "deprecated"` + `replacedBy` = immediately-previous frontier or still-resolving retired aliases (picker-hidden, selectable); deleted = anything older or vendor-retired.

## User Impact

- 39 provider catalogs across 33 extensions are now current: e.g. GitHub Copilot 13→18 rows reflecting Copilot's current lineup (11 visible), Venice 30→19 (16 visible, verified against its live models API), Mistral/Groq/NVIDIA/DeepInfra/Novita/Together/Baseten refreshed to current hosted lineups, Chinese providers (BytePlus, Volcengine, Qianfan, Tencent, Xiaomi, StepFun, Qwen coding plan) refreshed against their current official catalogs.
- Metadata corrections where vendors' official docs disagreed with shipped values (context windows, max output, pricing, modalities) — each cited in the audit reports.
- Ollama Cloud ids canonicalized to the direct-host ids published by `ollama.com/api/tags` (the `:cloud` suffix is the local-daemon routing alias); runtime helpers accept both forms.
- Runtime/onboarding catalog copies (`models.ts`, `defaults.ts`, onboarding hints) synchronized with the curated manifests in baseten, chutes, github-copilot, gmi, groq, novita, ollama, and qwen.
- Hidden and deleted rows remain selectable by exact ref (core escape hatch shipped in #113594); no config surface or migration changes.

Release-note context: `chore(models): all provider model catalogs curated to current-generation lineups; stale models hidden or removed from pickers`.

## Evidence

- Method: one research worker per provider extension with live web verification (official model lists, pricing, deprecation pages, live public APIs), followed by coordinator schema validation (status/modality vocabulary, `replacedBy` integrity), a repo-wide stale-reference sweep, and runtime-sync follow-ups. Per-provider audit reports with source URLs for every keep/hide/delete/add decision are archived in the session workspace; decision tables are reproduced in the reports.
- Central validation: all 33 manifests parse; schema vocabulary clean; no dangling `replacedBy`; no prod-code references to deleted ids (remaining matches verified as legacy-repair tables or separate provider surfaces).
- Tests: full `extensions` suite run locally — all touched extensions green; core catalog suites green (manifest planner, provider-index planner, model-catalog-visibility 10/10, model-visibility-policy 18/18, model-selection 124/124). Six pre-existing failures in untouched extensions (active-memory, browser, codex) are local-environment failures on the dev machine (browser executable discovery, machine Codex CLI session binding) and are green on `main` CI.
- Notable verifications: BytePlus `dola-seed-2-1-turbo-260628` confirmed as a text-generation LLM via verbatim quote from the official ModelArk text-generation table (an external search snippet had conflated it with the Dola Seed image series); Moonshot manifest ids confirmed correct for the Moonshot endpoint (`k3`/`kimi-for-coding` belong to Kimi's separate Code endpoint); DeepSeek legacy aliases deleted based on the official retirement notice (fully inaccessible after 2026-07-24) while the legacy-config metadata repair table is intentionally retained.
- Autoreview (Codex, gpt-5.6-sol): clean.
