### PR TITLE
test(macos): stabilize prepare wizard progress assertion

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -694,6 +694,9 @@ struct OnboardingAISetupTests {
         ])
         #expect(requests.authChoices == ["llama-cpp"])
         #expect(model.isPreparingModel)
+        for _ in 0..<200 where model.authStep.map(wizardStepType) != "progress" {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
         #expect(model.authStep.map(wizardStepType) == "progress")
     }
 


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Resolves a problem where the macOS onboarding Swift suite could fail after observing the `wizard.next` request but before the mocked response updated the model's progress step. The race failed all three retries in an otherwise unrelated SQLite reliability PR.

## Why This Change Was Made

The test now waits, with the suite's existing bounded polling pattern, for the exact `authStep` state it asserts. Production onboarding behavior is unchanged.

## User Impact

No user-visible behavior changes. Pull requests are less likely to be blocked by a timing-dependent macOS onboarding assertion.

## Evidence

- Before: `macos-swift` failed all three retries at `OnboardingAISetupTests.swift:697` in https://github.com/openclaw/openclaw/actions/runs/30158324456/job/89679375918
- Latest `main` CI remained green, confirming a timing-dependent PR failure: https://github.com/openclaw/openclaw/actions/runs/30159046200
- `git diff --check`
- Fresh `autoreview --mode branch --base origin/main`: clean, confidence 0.98
- Exact-head CI passed, including `macos-swift`: https://github.com/openclaw/openclaw/actions/runs/30159353226/job/89682066596
