### PR TITLE
fix: route skill verification through the managed proxy

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -462,4 +462,5 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["skills", "list"], exact: true, policy: { networkProxy: "bypass" } },
   { commandPath: ["skills", "search"], exact: true },
   { commandPath: ["skills", "update"], exact: true },
+  { commandPath: ["skills", "verify"], exact: true },
 ];

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -322,6 +322,12 @@ describe("command-path-policy", () => {
     );
   });
 
+  it("routes ClawHub skill verification through the network proxy", () => {
+    expect(
+      resolveCliNetworkProxyPolicy(["node", "openclaw", "skills", "verify", "@demo-owner/weather"]),
+    ).toBe("default");
+  });
+
   it("uses the longest catalog command path for deep network proxy overrides", async () => {
     const catalog: readonly CliCommandCatalogEntry[] = [
       { commandPath: ["nodes"], policy: { networkProxy: "bypass" } },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users verifying a ClawHub skill behind a managed network proxy would bypass that proxy and fail to reach the verification service.

## Why This Change Was Made

Register `skills verify` in the existing CLI command catalog alongside the other network-capable skill operations. The existing longest-prefix resolver can then select normal managed proxy routing instead of inheriting the bare `skills` proxy-bypass rule. No credentials, new configuration, dependency, protocol, or plugin ownership is changed.

## User Impact

`openclaw skills verify @owner/skill` uses the same managed-network behavior as other remote skill operations; local, informational skill commands keep their existing proxy bypass.

## Evidence

- Independently reproduced source/control-flow on immutable main `d56a270ffcac06935440bb1d9c851202810f7f7c`.
- Added the focused policy regression covering actual `skills verify` argument routing.
- Repository formatter: both changed TypeScript files pass.
- `git diff --check`: passed.
- Fresh independent `$autoreview`: `patch is correct`, confidence `0.96`, no actionable findings.
- Exact reviewed head: `c8be4ab33917b8223fae746065d8720d921b36d7`.
- Remote focused-test and hosted exact-head CI: pending. This draft must not be merged or added to the verified bug ledger before those checks pass.

AI-assisted; the change is limited to the existing CLI catalog and one regression test.