### PR TITLE
fix: preserve child process signal exit codes

### DIFF
--- a/src/cli/container-target.test.ts
+++ b/src/cli/container-target.test.ts
@@ -125,6 +125,27 @@ describe("maybeRunCliInContainer", () => {
     });
   });
 
+  it.each([
+    { signal: "SIGINT" as const, exitCode: 130 },
+    { signal: "SIGTERM" as const, exitCode: 143 },
+  ])("preserves exit code $exitCode when the container child exits from $signal", (testCase) => {
+    const spawnSync = vi
+      .fn()
+      .mockReturnValueOnce({ status: 0, stdout: "true\n" })
+      .mockReturnValueOnce({ status: 1, stdout: "" })
+      .mockReturnValueOnce({ status: null, signal: testCase.signal });
+
+    expect(
+      maybeRunCliInContainer(["node", "openclaw", "status"], {
+        env: { OPENCLAW_CONTAINER: "demo" } as NodeJS.ProcessEnv,
+        spawnSync,
+      }),
+    ).toEqual({
+      handled: true,
+      exitCode: testCase.exitCode,
+    });
+  });
+
   it("uses OPENCLAW_CONTAINER when the flag is absent", () => {
     const spawnSync = vi
       .fn()

--- a/src/cli/container-target.ts
+++ b/src/cli/container-target.ts
@@ -7,6 +7,7 @@ import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-optio
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import { scanCliRootOptions } from "./root-option-scan.js";
 import { takeCliRootOptionValue } from "./root-option-value.js";
+import { resolveSubprocessExitCode } from "./subprocess-exit-code.js";
 
 type CliContainerParseResult =
   | { ok: true; container: string | null; argv: string[] }
@@ -321,6 +322,6 @@ export function maybeRunCliInContainer(
   );
   return {
     handled: true,
-    exitCode: typeof result.status === "number" ? result.status : 1,
+    exitCode: resolveSubprocessExitCode(result.status, result.signal),
   };
 }

--- a/src/cli/proxy-cli.runtime.test.ts
+++ b/src/cli/proxy-cli.runtime.test.ts
@@ -482,6 +482,29 @@ describe("proxy cli runtime", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it.each([
+    { signal: "SIGINT" as const, exitCode: 130 },
+    { signal: "SIGTERM" as const, exitCode: 143 },
+  ])(
+    "preserves exit code $exitCode when the proxied child exits from $signal",
+    async (testCase) => {
+      spawnMock.mockImplementation(() => {
+        const child = new EventEmitter();
+        queueMicrotask(() => {
+          child.emit("exit", null, testCase.signal);
+        });
+        return child;
+      });
+
+      const { runDebugProxyRunCommand } = await import("./proxy-cli.runtime.js");
+
+      await runDebugProxyRunCommand({ commandArgs: ["example-command"] });
+
+      expect(process.exitCode).toBe(testCase.exitCode);
+      expect(serverStopSpy).toHaveBeenCalledOnce();
+    },
+  );
+
   it("stops the proxy server and ends the session when child spawn fails", async () => {
     spawnMock.mockImplementation(() => {
       const child = new EventEmitter();

--- a/src/cli/proxy-cli.runtime.ts
+++ b/src/cli/proxy-cli.runtime.ts
@@ -22,6 +22,7 @@ import {
   getDebugProxyCaptureStore,
 } from "../proxy-capture/store.sqlite.js";
 import type { CaptureQueryPreset } from "../proxy-capture/types.js";
+import { resolveSubprocessExitCode } from "./subprocess-exit-code.js";
 
 export async function runDebugProxyStartCommand(opts: { host?: string; port?: number }) {
   const settings = resolveDebugProxySettings();
@@ -108,7 +109,7 @@ export async function runDebugProxyRunCommand(opts: {
       });
       child.once("error", reject);
       child.once("exit", (code, signal) => {
-        process.exitCode = signal ? 1 : (code ?? 1);
+        process.exitCode = resolveSubprocessExitCode(code, signal);
         resolve();
       });
     });

--- a/src/cli/subprocess-exit-code.ts
+++ b/src/cli/subprocess-exit-code.ts
@@ -1,0 +1,12 @@
+import { constants as osConstants } from "node:os";
+
+export function resolveSubprocessExitCode(
+  exitCode: number | null | undefined,
+  signal: NodeJS.Signals | null | undefined,
+): number {
+  if (typeof exitCode === "number") {
+    return exitCode;
+  }
+  const signalNumber = signal ? (osConstants.signals as Record<string, number>)[signal] : undefined;
+  return typeof signalNumber === "number" ? 128 + signalNumber : 1;
+}


### PR DESCRIPTION
## What Problem This Solves

CLI commands wrapping a terminated child process incorrectly returned exit code `1`, preventing calling scripts and supervisors from recognizing interruption (`130`) or termination (`143`).

## Why This Change Was Made

Normalize child-process results through one narrow CLI helper. Preserve ordinary numeric process exits; translate known termination signals to their standard `128 + signal` result and retain the existing fallback for unknown results. Apply the same canonical behavior to proxy-wrapped and container-targeted commands.

## User Impact

`openclaw proxy run` and container-targeted operations propagate real `SIGINT` and `SIGTERM` child exit codes without changing process cleanup, configuration, authentication, or network policy.

## Evidence

Exact reviewed head: `7cc312b36c4967a8ee30d40ca2beae2758512571`.

The actual CLI was run on an isolated, fresh-state Blacksmith Testbox; the invoked child process sent the signal to **itself**. The five changed files were verified against the exact Git blob hashes before the commands ran. No mocked subprocess, user-owned process, production configuration, or external service was involved.

```text
pnpm openclaw proxy run -- node -e 'process.kill(process.pid, "SIGINT")'
OPENCLAW_REAL_PROXY_SIGNAL case=SIGINT expected=130 actual=130

pnpm openclaw proxy run -- node -e 'process.kill(process.pid, "SIGTERM")'
OPENCLAW_REAL_PROXY_SIGNAL case=SIGTERM expected=143 actual=143

pnpm openclaw proxy run -- node -e 'process.exit(7)'
OPENCLAW_REAL_PROXY_SIGNAL case=NUMERIC expected=7 actual=7
```

- `pnpm test src/cli/container-target.test.ts src/cli/proxy-cli.runtime.test.ts`: **49/49 passed** on the exact-source remote checkout.
- `pnpm exec oxfmt --check src/cli/container-target.test.ts src/cli/container-target.ts src/cli/proxy-cli.runtime.test.ts src/cli/proxy-cli.runtime.ts src/cli/subprocess-exit-code.ts`: passed.
- Independent structured review: **0.97**, no actionable findings.
- Remote provider: Blacksmith Testbox; complete real-CLI, test, formatting, and cleanup command returned **exit 0** in **25.774 seconds**.
- Exact-head required GitHub `openclaw/ci-gate`: **SUCCESS**, workflow run `30159653020`, job `89683430370`.

AI-assisted; changes remain restricted to two existing subprocess wrappers, their focused regression tests, and one shared CLI-local helper.
