### PR TITLE
refactor(agents): validate workspace attestation rows structurally, not by filename allowlist

### DIFF
--- a/src/agents/workspace-state-store.test.ts
+++ b/src/agents/workspace-state-store.test.ts
@@ -103,7 +103,7 @@ describe("workspace state store", () => {
     },
   );
 
-  it.each(["../AGENTS.md", "nested\\AGENTS.md", "C:outside.md"])(
+  it.each(["../AGENTS.md", "nested\\AGENTS.md", "C:outside.md", "NUL.md", "com1.md", "CON.md"])(
     "rejects an unsafe persisted attestation filename: %s",
     (filename) => {
       insertPersistedAttestationHash(filename, "a".repeat(64));

--- a/src/agents/workspace-state-store.test.ts
+++ b/src/agents/workspace-state-store.test.ts
@@ -103,16 +103,24 @@ describe("workspace state store", () => {
     },
   );
 
-  it.each(["../AGENTS.md", "nested\\AGENTS.md", "C:outside.md", "NUL.md", "com1.md", "CON.md"])(
-    "rejects an unsafe persisted attestation filename: %s",
-    (filename) => {
-      insertPersistedAttestationHash(filename, "a".repeat(64));
+  it.each([
+    "../AGENTS.md",
+    "nested\\AGENTS.md",
+    "C:outside.md",
+    "NUL.md",
+    "com1.md",
+    "CON.md",
+    "COM¹.md",
+    "CONIN$.md",
+    "CONOUT$.md",
+    ".hidden.md",
+  ])("rejects an unsafe persisted attestation filename: %s", (filename) => {
+    insertPersistedAttestationHash(filename, "a".repeat(64));
 
-      expect(() => readWorkspaceStateSnapshot(workspaceDir())).toThrow(
-        "workspace attestation hash row is invalid",
-      );
-    },
-  );
+    expect(() => readWorkspaceStateSnapshot(workspaceDir())).toThrow(
+      "workspace attestation hash row is invalid",
+    );
+  });
 
   it("rejects a malformed persisted attestation hash", () => {
     insertPersistedAttestationHash("AGENTS.md", "a".repeat(63));

--- a/src/agents/workspace-state-store.test.ts
+++ b/src/agents/workspace-state-store.test.ts
@@ -49,6 +49,17 @@ function deleteState(targetDir: string): void {
   deleteWorkspaceState(prepareWorkspaceStateDeletion(targetDir));
 }
 
+function insertPersistedAttestationHash(filename: string, sha256: string): void {
+  const identity = resolveWorkspaceStateIdentity(workspaceDir());
+  const db = openOpenClawStateDatabase().db;
+  db.prepare(
+    "INSERT INTO workspace_attestations (workspace_key, attested_at_ms, updated_at_ms) VALUES (?, 1, 1)",
+  ).run(identity.workspaceKey);
+  db.prepare(
+    "INSERT INTO workspace_generated_bootstrap_hashes (workspace_key, filename, sha256) VALUES (?, ?, ?)",
+  ).run(identity.workspaceKey, filename, sha256);
+}
+
 describe("workspace state store", () => {
   it("round-trips setup and attestation state after a database restart", () => {
     const dir = workspaceDir();
@@ -79,6 +90,36 @@ describe("workspace state store", () => {
       ["AGENTS.md", "a".repeat(64)],
       ["TOOLS.md", "b".repeat(64)],
     ]);
+  });
+
+  it.each(["HEARTBEAT.md", "RETIRED.md"])(
+    "reads a persisted hash for a retired or unknown bootstrap filename: %s",
+    (filename) => {
+      insertPersistedAttestationHash(filename, "a".repeat(64));
+
+      expect([
+        ...readWorkspaceStateSnapshot(workspaceDir()).attestation!.generatedHashes.entries(),
+      ]).toStrictEqual([[filename, "a".repeat(64)]]);
+    },
+  );
+
+  it.each(["../AGENTS.md", "nested\\AGENTS.md", "C:outside.md"])(
+    "rejects an unsafe persisted attestation filename: %s",
+    (filename) => {
+      insertPersistedAttestationHash(filename, "a".repeat(64));
+
+      expect(() => readWorkspaceStateSnapshot(workspaceDir())).toThrow(
+        "workspace attestation hash row is invalid",
+      );
+    },
+  );
+
+  it("rejects a malformed persisted attestation hash", () => {
+    insertPersistedAttestationHash("AGENTS.md", "a".repeat(63));
+
+    expect(() => readWorkspaceStateSnapshot(workspaceDir())).toThrow(
+      "workspace attestation hash row is invalid",
+    );
   });
 
   it("never regresses persisted setup milestones", () => {

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -20,23 +20,21 @@ export const WORKSPACE_ATTESTATION_RECENT_MS = 24 * 60 * 60 * 1000;
 export const WORKSPACE_LEGACY_STATE_MIGRATION_KIND = "legacy-workspace-setup-files";
 const MAX_WORKSPACE_ATTESTATION_FILENAME_LENGTH = 255;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/u;
+// Attested names are joined onto the workspace dir and read back, so keep the
+// accepted set closed rather than denying unsafe forms one at a time: a plain
+// ASCII markdown basename excludes separators, traversal, colons, NUL, and the
+// Win32 superscript/`CONIN$` device aliases in one rule.
+const SAFE_ATTESTATION_BASENAME = /^[A-Za-z0-9._-]+\.md$/u;
 // Win32 keeps these stems special even with an extension, so `NUL.md` names a
-// device rather than a workspace file. Attested names are later joined onto the
-// workspace dir and read back, so reject them alongside separators/traversal.
+// device rather than a workspace file; the charset above cannot catch them.
 const WINDOWS_RESERVED_DEVICE_STEMS = /^(?:con|prn|aux|nul|com[0-9]|lpt[0-9])$/iu;
 
 export function isSafeWorkspaceAttestationFilename(filename: string): boolean {
   return (
-    filename.length > 0 &&
     filename.length <= MAX_WORKSPACE_ATTESTATION_FILENAME_LENGTH &&
-    filename !== "." &&
-    filename !== ".." &&
-    !filename.includes("/") &&
-    !filename.includes("\\") &&
-    !filename.includes(":") &&
-    !filename.includes("\0") &&
-    !WINDOWS_RESERVED_DEVICE_STEMS.test(filename.split(".")[0] ?? "") &&
-    filename.endsWith(".md")
+    SAFE_ATTESTATION_BASENAME.test(filename) &&
+    !filename.startsWith(".") &&
+    !WINDOWS_RESERVED_DEVICE_STEMS.test(filename.split(".")[0] ?? "")
   );
 }
 

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -18,15 +18,22 @@ import { resolveUserPath } from "../utils.js";
 export const WORKSPACE_SETUP_STATE_VERSION = 1 as const;
 export const WORKSPACE_ATTESTATION_RECENT_MS = 24 * 60 * 60 * 1000;
 export const WORKSPACE_LEGACY_STATE_MIGRATION_KIND = "legacy-workspace-setup-files";
-export const WORKSPACE_ATTESTED_BOOTSTRAP_FILENAMES: ReadonlySet<string> = new Set([
-  "AGENTS.md",
-  "SOUL.md",
-  "TOOLS.md",
-  "IDENTITY.md",
-  "USER.md",
-  "HEARTBEAT.md",
-]);
+const MAX_WORKSPACE_ATTESTATION_FILENAME_LENGTH = 255;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/u;
+
+export function isSafeWorkspaceAttestationFilename(filename: string): boolean {
+  return (
+    filename.length > 0 &&
+    filename.length <= MAX_WORKSPACE_ATTESTATION_FILENAME_LENGTH &&
+    filename !== "." &&
+    filename !== ".." &&
+    !filename.includes("/") &&
+    !filename.includes("\\") &&
+    !filename.includes(":") &&
+    !filename.includes("\0") &&
+    filename.endsWith(".md")
+  );
+}
 
 function isCanonicalIsoTimestamp(value: string): boolean {
   const timestamp = new Date(value);
@@ -322,8 +329,10 @@ function readSnapshotFromDatabase(params: {
         .orderBy("filename", "asc"),
     ).rows;
     for (const row of hashRows) {
+      // Validate names structurally rather than against today's bootstrap set:
+      // retiring a seeded file must not make an existing attestation unreadable.
       if (
-        !WORKSPACE_ATTESTED_BOOTSTRAP_FILENAMES.has(row.filename) ||
+        !isSafeWorkspaceAttestationFilename(row.filename) ||
         !SHA256_HEX_PATTERN.test(row.sha256)
       ) {
         throw new Error("workspace attestation hash row is invalid");
@@ -466,7 +475,7 @@ export function replaceWorkspaceAttestation(params: {
     assertCanonicalIntegerTimestamp(params.nowMs, "attestation update");
   }
   for (const [filename, sha256] of params.generatedHashes) {
-    if (!WORKSPACE_ATTESTED_BOOTSTRAP_FILENAMES.has(filename) || !SHA256_HEX_PATTERN.test(sha256)) {
+    if (!isSafeWorkspaceAttestationFilename(filename) || !SHA256_HEX_PATTERN.test(sha256)) {
       throw new Error("workspace attestation hash is invalid");
     }
   }

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -20,6 +20,10 @@ export const WORKSPACE_ATTESTATION_RECENT_MS = 24 * 60 * 60 * 1000;
 export const WORKSPACE_LEGACY_STATE_MIGRATION_KIND = "legacy-workspace-setup-files";
 const MAX_WORKSPACE_ATTESTATION_FILENAME_LENGTH = 255;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/u;
+// Win32 keeps these stems special even with an extension, so `NUL.md` names a
+// device rather than a workspace file. Attested names are later joined onto the
+// workspace dir and read back, so reject them alongside separators/traversal.
+const WINDOWS_RESERVED_DEVICE_STEMS = /^(?:con|prn|aux|nul|com[0-9]|lpt[0-9])$/iu;
 
 export function isSafeWorkspaceAttestationFilename(filename: string): boolean {
   return (
@@ -31,6 +35,7 @@ export function isSafeWorkspaceAttestationFilename(filename: string): boolean {
     !filename.includes("\\") &&
     !filename.includes(":") &&
     !filename.includes("\0") &&
+    !WINDOWS_RESERVED_DEVICE_STEMS.test(filename.split(".")[0] ?? "") &&
     filename.endsWith(".md")
   );
 }

--- a/src/infra/state-migrations.workspace-setup-store.ts
+++ b/src/infra/state-migrations.workspace-setup-store.ts
@@ -2,9 +2,9 @@
 import { createHash } from "node:crypto";
 import { LEGACY_WORKSPACE_ATTESTATION_HEADER } from "../agents/workspace-legacy-state.js";
 import {
-  WORKSPACE_ATTESTED_BOOTSTRAP_FILENAMES,
   WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
   WORKSPACE_SETUP_STATE_VERSION,
+  isSafeWorkspaceAttestationFilename,
   registerWorkspaceStateAliasesInTransaction,
 } from "../agents/workspace-state-store.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -129,7 +129,7 @@ function parseAttestation(snapshot: SourceSnapshot): ParsedSource {
   const generatedHashes = new Map<string, string>();
   for (const line of lines.slice(2)) {
     const match = /^generated:([^:]+):([a-f0-9]{64})$/.exec(line);
-    if (!match?.[1] || !match[2] || !WORKSPACE_ATTESTED_BOOTSTRAP_FILENAMES.has(match[1])) {
+    if (!match?.[1] || !match[2] || !isSafeWorkspaceAttestationFilename(match[1])) {
       throw new Error("legacy workspace attestation has an invalid generated hash");
     }
     if (generatedHashes.has(match[1])) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where retiring any workspace bootstrap file permanently pins its filename into persisted state, because a hardcoded filename allowlist is used as a semantic gate inside a persistence **read** path.

`readWorkspaceStateSnapshot` throws `workspace attestation hash row is invalid` for any persisted hash row whose filename is not in `WORKSPACE_ATTESTED_BOOTSTRAP_FILENAMES`. That set therefore has to keep every filename OpenClaw has ever seeded, forever — and dropping one becomes a state-migration problem rather than a deletion.

This is not hypothetical. It blocked the cleanup in #113621: the attestation writer included `HEARTBEAT.md` from `1b10739d609` (2026-05-31) until the heartbeat retirement, so installs that attested in that window carry a persisted `HEARTBEAT.md` row. Removing the name from the set today would make every workspace-state snapshot read throw on those installs, so the retired filename had to stay behind.

## Why This Change Was Made

At this call site the allowlist's real job is **input sanitation** — reject corrupt or unsafe rows — not **semantics** — decide which bootstrap files currently exist. Conflating the two put a product decision inside the storage layer.

Validation is now structural, and the accepted set is closed by construction rather than by denying unsafe forms one at a time: a filename must match `^[A-Za-z0-9._-]+\.md$`, be at most 255 characters, not start with `.`, and not use a Win32 reserved device stem (`CON`, `PRN`, `AUX`, `NUL`, `COM0-9`, `LPT0-9`). The ASCII charset alone excludes path separators, traversal, colons, NUL bytes, and the Windows superscript (`COM¹.md`) and console (`CONIN$.md`) device aliases; the reserved-stem check exists only for plain-ASCII names like `NUL.md`, which no charset can distinguish from an ordinary file. SHA-256 validation is unchanged.

A denylist was the first attempt and was deliberately abandoned: extending it per newly-named device alias is just a slower allowlist, which is the thing this PR is removing. The positive charset is both stricter and shorter — it replaced four `includes()` checks with one regex.

Corrupt or unsafe rows still throw; a well-formed row naming a file OpenClaw no longer seeds is retained as inert data and is cleaned up naturally on the next attestation write, since `replaceWorkspaceAttestation` already deletes and reinserts the row set wholesale.

The same predicate replaces the allowlist in all three call sites that used it — the snapshot read path, the write-side validation in `replaceWorkspaceAttestation`, and the legacy JSON→SQLite attestation parser in `state-migrations.workspace-setup-store.ts` — so read and write stay symmetric and the set could be deleted outright.

Deliberately unchanged: wipe-detection semantics. `WorkspaceVanishedError` throw sites, the survival-evidence chain, and `collectGeneratedBootstrapHashes`'s writer list are untouched. This PR changes what a *read* rejects, not what is written or how a vanished workspace is decided. `workspaceAttestedGeneratedFilesIntact` and `workspaceRequiredBootstrapLooksCustomized` still hard-require `AGENTS.md` + `TOOLS.md`; that coupling is real but entangled with an open product question about `TOOLS.md`, so it is left for a follow-up rather than guessed at here.

**No SQLite schema change and no schema-version bump.** This is read-validation only.

## User Impact

- No behavior change for any current install. The only writer emits `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, all of which pass both the old and new checks.
- Installs carrying a legacy `HEARTBEAT.md` attestation row keep reading their workspace state normally, and that row is now inert instead of load-bearing.
- Future bootstrap-file retirements become a plain deletion instead of a persisted-state migration.

## Evidence

New regression coverage inserts rows directly into `workspace_generated_bootstrap_hashes` via SQL, so it exercises genuinely pre-existing persisted state rather than only the predicate:

- a retired or unknown but well-formed filename (`HEARTBEAT.md`, `RETIRED.md`) reads back cleanly;
- unsafe filenames still throw, covering traversal (`../AGENTS.md`), separators (`nested\AGENTS.md`), drive-relative paths (`C:outside.md`), hidden names (`.hidden.md`), and Windows device aliases (`NUL.md`, `com1.md`, `CON.md`, `COM¹.md`, `CONIN$.md`, `CONOUT$.md`);
- a malformed sha256 still throws.

```text
src/agents/workspace-state-store    1 file   31 tests passed
src/agents/workspace               4 files   75 tests passed
src/infra/state-migrations        29 files  402 passed | 2 skipped
```

`node scripts/check-changed.mjs` green on Blacksmith Testbox (run 30159212929, exit 0): typecheck core + core tests, lint 0 warnings/0 errors, format clean, import cycles 0, native state schema version guard passed (v6), database-first legacy-store guard passed, dependency pin guard, plugin boundary report, and the env-var and max-lines ratchets all passed.



### Live upgrade-path proof

Real SQLite state database, seeded with raw writes matching the persisted workspace
setup/alias/attestation/hash tables, then read through the production
`readWorkspaceStateSnapshot` in a fresh process. Both runs used the **same database file**
(identity `16777234:1377733745`) — `origin/main` from a detached clone, this branch from its
worktree. Isolated `OPENCLAW_STATE_DIR`, paths redacted.

**Before (`origin/main`, cb628df1993) — 3/3 scenarios as expected:**

```text
SEEDED ["HEARTBEAT.md"]                  → READ_OK
SEEDED ["HEARTBEAT.md","MEMORY.md"]      → Error: workspace attestation hash row is invalid
                                             at readSnapshotFromDatabase (workspace-state-store.ts:329)
SEEDED ["HEARTBEAT.md","RETIRED.md"]     → Error: workspace attestation hash row is invalid
```

`MEMORY.md` is a real current bootstrap file that was never in the attested allowlist, so a
persisted row naming it makes the snapshot read throw and the workspace state unreadable. That is
the defect this PR removes — not a hypothetical.

**After (this branch, 6249956427e) — 9/9 scenarios as expected:**

```text
SEEDED ["HEARTBEAT.md","MEMORY.md","RETIRED.md"] → READ_OK filenames=[all three]
```

Safety preserved — each of these still throws `workspace attestation hash row is invalid`:
`../AGENTS.md`, `nested\AGENTS.md`, `C:outside.md`, `.hidden.md`, `NUL.md`, `COM¹.md`,
`CONIN$.md`, and a malformed sha256.

So the legacy `HEARTBEAT.md` row keeps loading (no regression for installs that attested before the
heartbeat retirement), names outside the old allowlist load instead of bricking state reads (the
fix), and every unsafe form is still rejected.
