### PR TITLE
fix(ui): give run state its own color instead of brand red

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -99,6 +99,11 @@
   --danger-subtle: rgba(248, 113, 113, 0.08);
   --info: #60a5fa;
   --info-subtle: rgba(96, 165, 250, 0.08);
+  /* Run state needs its own token: --accent is red in every shipped theme and
+     sits on top of --danger, so a spinning ring reads as a failed session.
+     Graphical indicator, judged against WCAG 1.4.11 (3:1), not the label audit
+     above: #14b8a6 is 7.7:1 on --bg. */
+  --run: #14b8a6;
 
   /* Focus */
   --focus: rgba(255, 92, 92, 0.2);
@@ -264,6 +269,9 @@
   --danger-subtle: rgba(185, 28, 28, 0.08);
   --info: #1d4ed8;
   --info-subtle: rgba(29, 78, 216, 0.08);
+  /* See the dark-theme note: run state stays off --accent. #0d9488 is 3.6:1 on
+     --bg, above the 3:1 WCAG 1.4.11 bar for a non-text indicator. */
+  --run: #0d9488;
 
   --focus: rgba(189, 69, 49, 0.15);
   --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 70%, transparent);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -79,8 +79,8 @@ openclaw-session-owner-chip {
   position: absolute;
   inset: -2px;
   box-sizing: border-box;
-  border: 1.5px solid color-mix(in srgb, var(--accent) 28%, transparent);
-  border-top-color: var(--accent);
+  border: 1.5px solid color-mix(in srgb, var(--run) 28%, transparent);
+  border-top-color: var(--run);
   border-radius: var(--radius-full);
   pointer-events: none;
 }
@@ -5714,8 +5714,8 @@ td.data-table-key-col {
   width: 12px;
   height: 12px;
   flex: 0 0 auto;
-  border: 1.5px solid color-mix(in srgb, var(--accent) 28%, transparent);
-  border-top-color: var(--accent);
+  border: 1.5px solid color-mix(in srgb, var(--run) 28%, transparent);
+  border-top-color: var(--run);
   border-radius: var(--radius-full);
 }
 
@@ -5734,7 +5734,7 @@ td.data-table-key-col {
   .session-run-spinner,
   .session-glyph__ring {
     animation: none;
-    border-color: var(--accent);
+    border-color: var(--run);
   }
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1849,7 +1849,7 @@ html.openclaw-native-macos
 }
 
 .sidebar-child-session-toggle--running {
-  color: var(--accent);
+  color: var(--run);
 }
 
 .sidebar-child-session-toggle--failed {


### PR DESCRIPTION
Closes #113677

## What Problem This Solves

Fixes an issue where running sessions read as failed sessions at a glance. The run spinner and ring used `--accent`, which in the dark theme is `#ff5c5c` — effectively the same red as `--danger` `#f87171`, the color the sidebar uses for the error attention icon and failed/timeout statuses. Working and broken shared a color.

This surfaced after #113645 consolidated the sidebar's run indicators into a single leading column. That PR was color-neutral, but it stacked the indicators, and a column of red rings reads as a list of errors. The first feedback on it was exactly that.

## Why This Change Was Made

Run state now has its own semantic token, `--run`, defined alongside `--ok` / `--warn` / `--danger` / `--info` in `base.css` — teal `#14b8a6` dark, `#0d9488` light. The indicators consume it in three rules: `.session-glyph__ring`, `.session-run-spinner`, and their shared reduced-motion fallback. `.sidebar-child-session-toggle--running` moves too, since it sat directly above `--failed { color: var(--danger) }` and had the identical collision inside one widget.

A dedicated token rather than an alias of `--accent-2` is deliberate. `--accent-2` is teal only in the default themes; it is `#8b1a2b` and `#7a1420` (dark reds) under `openknot`, and `#a88050` / `#6a4e30` (golds) under `dash`, so aliasing would have reintroduced the exact collision in the openknot themes and produced a muddy gold indicator in dash. `--run` is defined once per light/dark base and inherited by the four derived themes, matching how `--danger` is handled.

Non-goal: the chat streaming bubble border still pulses `--accent`. It is a large surface with its own keyframe, and recoloring it changes the feel of the chat view rather than fixing an ambiguous indicator, so it deserves its own look rather than a drive-by. `--run` is not added to the `widget-theme.ts` MCP guest token contract, which is a published surface that this change does not need to extend.

## User Impact

Running sessions no longer look like broken sessions. The sidebar now separates three states cleanly: teal running, amber waiting on you, red failed. Contrast is `7.7:1` on `--bg` in dark and `3.6:1` in light, both above the WCAG 1.4.11 `3:1` bar for a non-text indicator.

## Evidence

Rendered the real sidebar DOM through the existing test harness with the shipped stylesheets, in all six shipped themes, with running rows next to genuinely failed rows. Confirmed the token resolves correctly rather than trusting the cascade:

| theme | `--run` | `--accent` | `--danger` |
|---|---|---|---|
| dark | `#14b8a6` | `#ff5c5c` | `#f87171` |
| light | `#0d9488` | `#bd4531` | `#b91c1c` |
| openknot | `#14b8a6` | `#e5243b` | `#f87171` |
| openknot-light | `#0d9488` | `#c41e30` | `#b91c1c` |
| dash | `#14b8a6` | `#b47840` | `#f87171` |
| dash-light | `#0d9488` | `#6e4828` | `#b91c1c` |

In every theme the running rows read as clearly not-red while the failed rows keep their red triangle and label.

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 168/168 pass.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/widget-theme.test.ts` — 3/3 pass (token contract unchanged).
- Codex autoreview (`gpt-5.6-sol`, xhigh) — clean, no findings.

Known limitation, not addressed here: emoji page icons sit about 1.9px left of the ring center at 15px. Pixel measurement across five glyphs shows the ink is not centered inside its advance width, so it is a font-metric property rather than a layout bug, and every static fix is a per-font constant that would go wrong on Windows and Linux. Tracked separately.
