### PR TITLE
fix: reconnect after browser gateway handshake errors

### DIFF
--- a/ui/src/api/gateway-browser-socket.test.ts
+++ b/ui/src/api/gateway-browser-socket.test.ts
@@ -10,7 +10,11 @@ const sockets: MockWebSocket[] = [];
 
 class MockWebSocket {
   static readonly OPEN = 1;
-  readonly close = vi.fn();
+  readonly close = vi.fn((code?: number, _reason?: string) => {
+    if (code !== undefined && code !== 1000 && (code < 3000 || code > 4999)) {
+      throw new DOMException("invalid code", "InvalidAccessError");
+    }
+  });
   readonly handlers = new Map<string, MockSocketHandler[]>();
   readyState = 0;
 
@@ -116,5 +120,39 @@ describe("createBrowserGatewaySocket", () => {
 
     expect(socket?.close).toHaveBeenCalledWith(1000, "stopped");
     expect(handlers.error).not.toHaveBeenCalled();
+  });
+
+  it("maps protocol policy-violation closes to the browser-safe connect failure code", () => {
+    const handlers = createHandlers();
+    const socketAdapter = createBrowserGatewaySocket("wss://gateway.example", handlers);
+
+    expect(() => socketAdapter.close(1008, "connect failed")).not.toThrow();
+    expect(sockets[0]?.close).toHaveBeenCalledWith(4008, "connect failed");
+  });
+
+  it.each([1000, 3000, 4000, 4008, 4013, 4999])("preserves browser-valid close code %i", (code) => {
+    const handlers = createHandlers();
+    const socketAdapter = createBrowserGatewaySocket("wss://gateway.example", handlers);
+
+    expect(() => socketAdapter.close(code, "valid close")).not.toThrow();
+    expect(sockets[0]?.close).toHaveBeenCalledWith(code, "valid close");
+  });
+
+  it("does not normalize other invalid browser close codes", () => {
+    const handlers = createHandlers();
+    const socketAdapter = createBrowserGatewaySocket("wss://gateway.example", handlers);
+
+    expect(() => socketAdapter.close(1009, "invalid client close")).toThrow(
+      expect.objectContaining({ name: "InvalidAccessError" }),
+    );
+  });
+
+  it("preserves policy-violation closes received from the gateway", () => {
+    const handlers = createHandlers();
+    createBrowserGatewaySocket("wss://gateway.example", handlers);
+
+    sockets[0]?.emit("close", { code: 1008, reason: "pairing required" });
+
+    expect(handlers.close).toHaveBeenCalledWith(1008, "pairing required");
   });
 });

--- a/ui/src/api/gateway-browser-socket.ts
+++ b/ui/src/api/gateway-browser-socket.ts
@@ -61,7 +61,8 @@ export function createBrowserGatewaySocket(
     send: (data) => socket.send(data),
     close: (code, reason) => {
       finishOpening();
-      socket.close(code, reason);
+      // Browser-initiated closes reject the shared protocol's 1008 policy code.
+      socket.close(code === 1008 ? 4008 : code, reason);
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The browser Gateway transport forwards the shared protocol close code `1008` into native `WebSocket.close()`. Browser APIs permit an explicit close code only when it is `1000` or in `3000`–`4999`, so the call throws rather than closing and reconnecting correctly.

## Why This Change Was Made

Translate locally initiated protocol-policy close `1008` to the valid application close `4008` at the existing browser-specific transport boundary. Leave inbound server close codes and every already-valid code unchanged. The browser contract is independently documented by [MDN WebSocket.close()](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close).

## User Impact

Control UI browser clients correctly close and recover from Gateway handshake and policy errors instead of throwing `InvalidAccessError`. No Gateway protocol, authentication, provider, or configuration contract changes.

## Evidence

- Exact reviewed head: `a67525f9c8a609ab40a71a58e90270695b08931b`.
- Both changed files were independently checked against their exact Git blob hashes on a fresh remote Blacksmith Testbox.
- `pnpm test ui/src/api/gateway-browser-socket.test.ts`: **13/13 focused browser-contract regressions passed**.
- `pnpm exec oxfmt --check ui/src/api/gateway-browser-socket.ts ui/src/api/gateway-browser-socket.test.ts`: passed.
- Full remote source verification, focused tests, formatting, and whitespace: **exit 0**, **21.300 seconds**.
- Fresh independent full-branch structured review: **0.98**, zero actionable findings.
- Both changed owner files were checked against current `main`; no intervening owner-path drift.

AI-assisted; scope is limited to the existing browser adapter and its owner tests.
