### PR TITLE
fix: preserve repeated messages while chat history reloads

### DIFF
--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -3072,6 +3072,630 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatMessages).toEqual([persistedUser, optimisticUser]);
   });
 
+  it("preserves a distinct pending turn after an earlier repeated-history anchor", async () => {
+    const firstRepeatedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { seq: 1 },
+    };
+    const secondRepeatedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { seq: 2 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "a distinct pending turn" }],
+      __openclaw: { idempotencyKey: "third-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [firstRepeatedUser, secondRepeatedUser],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [firstRepeatedUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([firstRepeatedUser, secondRepeatedUser, optimisticUser]);
+  });
+
+  it("does not revive an unmatched pending turn beyond unrelated history", async () => {
+    const sharedUser = {
+      role: "user",
+      content: [{ type: "text", text: "shared earlier turn" }],
+      __openclaw: { id: "shared-user", seq: 1 },
+    };
+    const laterUser = {
+      role: "user",
+      content: [{ type: "text", text: "different authoritative turn" }],
+      __openclaw: { id: "later-user", seq: 2 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [sharedUser, laterUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [sharedUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([sharedUser, laterUser]);
+  });
+
+  it("does not adopt an imported message through a colliding native transcript id", async () => {
+    const nativeUser = {
+      role: "user",
+      content: [{ type: "text", text: "native transcript" }],
+      __openclaw: { id: "source-local-id" },
+    };
+    const importedUser = {
+      role: "user",
+      content: [{ type: "text", text: "imported transcript" }],
+      __openclaw: {
+        id: "source-local-id",
+        externalId: "source-local-id",
+        importedFrom: "claude-cli",
+        cliSessionId: "imported-session",
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [nativeUser, importedUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [nativeUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([nativeUser, importedUser]);
+  });
+
+  it("does not guess an imported source identity when its session is missing", async () => {
+    const firstImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: {
+        id: "source-local-id",
+        externalId: "source-local-id",
+        importedFrom: "claude-cli",
+      },
+    };
+    const secondImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: {
+        id: "source-local-id",
+        externalId: "source-local-id",
+        importedFrom: "claude-cli",
+      },
+    };
+    const previousImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: {
+        id: "source-local-id",
+        externalId: "source-local-id",
+        importedFrom: "claude-cli",
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [firstImportedUser, secondImportedUser],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [previousImportedUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([firstImportedUser, secondImportedUser]);
+  });
+
+  it("does not anchor a missing canonical id to another same-sequence projection", async () => {
+    const unrelatedProjection = {
+      role: "user",
+      content: [{ type: "text", text: "different sequence projection" }],
+      __openclaw: { seq: 7 },
+    };
+    const previousProjection = {
+      role: "user",
+      content: [{ type: "text", text: "original sequence projection" }],
+      __openclaw: { id: "missing-canonical-id", seq: 7 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [unrelatedProjection] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [previousProjection, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([unrelatedProjection]);
+  });
+
+  it("does not adopt import provenance lacking an external id as a native row", async () => {
+    const nativeUser = {
+      role: "user",
+      content: [{ type: "text", text: "native transcript" }],
+      __openclaw: { id: "source-local-id" },
+    };
+    const importedUser = {
+      role: "user",
+      content: [{ type: "text", text: "imported transcript" }],
+      __openclaw: {
+        id: "source-local-id",
+        importedFrom: "claude-cli",
+        cliSessionId: "imported-session",
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [nativeUser, importedUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [nativeUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([nativeUser, importedUser]);
+  });
+
+  it("does not use matching display text to adopt an incomplete imported source", async () => {
+    const previousImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: { externalId: "first-import", importedFrom: "claude-cli" },
+    };
+    const otherImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: { externalId: "different-import", importedFrom: "claude-cli" },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [otherImportedUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [previousImportedUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([otherImportedUser]);
+  });
+
+  it("does not drop a canonical id for a same-text sequence projection", async () => {
+    const unrelatedProjection = {
+      role: "user",
+      content: [{ type: "text", text: "repeated projection" }],
+      __openclaw: { seq: 7 },
+    };
+    const previousProjection = {
+      role: "user",
+      content: [{ type: "text", text: "repeated projection" }],
+      __openclaw: { id: "missing-canonical-id", seq: 7 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [unrelatedProjection] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [previousProjection, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([unrelatedProjection]);
+  });
+
+  it("does not revive an identity-free tail after a distinct repeated history turn", async () => {
+    const firstUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "first-user", seq: 1 },
+    };
+    const secondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "second-user", seq: 2 },
+    };
+    const identityFreeTail = {
+      role: "user",
+      content: [{ type: "text", text: "identity-free pending turn" }],
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [firstUser, secondUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [firstUser, identityFreeTail],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([firstUser, secondUser]);
+  });
+
+  it("does not reconcile native legacy history with an imported display match", async () => {
+    const previousNativeUser = {
+      role: "user",
+      content: [{ type: "text", text: "same visible turn" }],
+      __openclaw: { senderId: "native-user" },
+    };
+    const importedUser = {
+      role: "user",
+      content: [{ type: "text", text: "same visible turn" }],
+      __openclaw: {
+        externalId: "external-user",
+        importedFrom: "claude-cli",
+        cliSessionId: "external-session",
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [importedUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [previousNativeUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([importedUser]);
+  });
+
+  it("does not replay an optimistic send already persisted before the history anchor", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "already persisted prompt" }],
+      __openclaw: { id: "persisted-user", seq: 1, idempotencyKey: "persisted-run:user" },
+    };
+    const persistedAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "already persisted answer" }],
+      __openclaw: { id: "persisted-assistant", seq: 2 },
+    };
+    const staleOptimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "already persisted prompt" }],
+      __openclaw: { idempotencyKey: "persisted-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, persistedAssistant],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser, persistedAssistant, staleOptimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, persistedAssistant]);
+  });
+
+  it("does not cross unrelated signature-free history markers", async () => {
+    const firstMarker = {
+      content: [{ type: "status", value: "first marker" }],
+      __openclaw: { id: "first-marker", seq: 1 },
+    };
+    const laterMarker = {
+      content: [{ type: "status", value: "different marker" }],
+      __openclaw: { id: "later-marker", seq: 2 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [firstMarker, laterMarker] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [firstMarker, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([firstMarker, laterMarker]);
+  });
+
+  it("does not duplicate repeated history without an echoed send identity", async () => {
+    const firstUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "first-user", seq: 1 },
+    };
+    const persistedRepeatedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "persisted-repeated-user", seq: 2 },
+    };
+    const optimisticRepeatedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { idempotencyKey: "repeated-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [firstUser, persistedRepeatedUser],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [firstUser, optimisticRepeatedUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([firstUser, persistedRepeatedUser]);
+  });
+
+  it("does not revive an assistant after its user was persisted before the anchor", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "already persisted prompt" }],
+      __openclaw: { id: "persisted-user", seq: 1, idempotencyKey: "persisted-run:user" },
+    };
+    const persistedAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "already persisted answer" }],
+      __openclaw: { id: "persisted-assistant", seq: 2 },
+    };
+    const staleOptimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "already persisted prompt" }],
+      __openclaw: { idempotencyKey: "persisted-run:user" },
+    };
+    const staleOptimisticAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "stale streamed assistant" }],
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, persistedAssistant],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [
+        persistedUser,
+        persistedAssistant,
+        staleOptimisticUser,
+        staleOptimisticAssistant,
+      ],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, persistedAssistant]);
+  });
+
+  it("preserves a distinct repeated send when the earlier anchor has different text", async () => {
+    const setupUser = {
+      role: "user",
+      content: [{ type: "text", text: "setup" }],
+      __openclaw: { id: "setup-user", seq: 1, idempotencyKey: "setup-run:user" },
+    };
+    const secondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "second-user", seq: 2, idempotencyKey: "second-run:user" },
+    };
+    const thirdUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { idempotencyKey: "third-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [setupUser, secondUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [setupUser, thirdUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([setupUser, secondUser, thirdUser]);
+  });
+
+  it("keeps a new repeated prompt after a different same-text turn reaches history", async () => {
+    const firstUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "first-user", idempotencyKey: "first-run:user", seq: 1 },
+    };
+    const secondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "second-user", idempotencyKey: "second-run:user", seq: 2 },
+    };
+    const optimisticThirdUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { idempotencyKey: "third-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [firstUser, secondUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [firstUser, optimisticThirdUser],
+      chatRunId: "third-run",
+      chatStream: "Still working on the third turn.",
+      chatStreamStartedAt: 100,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([firstUser, secondUser, optimisticThirdUser]);
+    expect(state.chatRunId).toBe("third-run");
+    expect(state.chatStream).toBe("Still working on the third turn.");
+    expect(state.chatStreamStartedAt).toBe(100);
+  });
+
+  it("reconciles repeated imported messages using the complete external source identity", async () => {
+    const firstImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: {
+        id: "shared-external-id",
+        externalId: "shared-external-id",
+        importedFrom: "claude-cli",
+        cliSessionId: "first-session",
+      },
+    };
+    const secondImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: {
+        id: "shared-external-id",
+        externalId: "shared-external-id",
+        importedFrom: "claude-cli",
+        cliSessionId: "second-session",
+      },
+    };
+    const optimisticSecondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [firstImportedUser, secondImportedUser],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [firstImportedUser, optimisticSecondUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([firstImportedUser, secondImportedUser]);
+  });
+
+  it("does not invent an anchor for ambiguous identity-free repeated history", async () => {
+    const firstLegacyUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { senderId: "alice" },
+    };
+    const secondLegacyUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { senderId: "alice" },
+    };
+    const previousLegacyUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { senderId: "alice" },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unproven pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [firstLegacyUser, secondLegacyUser],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [previousLegacyUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([firstLegacyUser, secondLegacyUser]);
+  });
+
+  it("does not attach a current optimistic turn to an unrelated older snapshot", async () => {
+    const olderHistoryUser = {
+      role: "user",
+      content: [{ type: "text", text: "older snapshot" }],
+      __openclaw: { id: "older-user", seq: 1 },
+    };
+    const currentHistoryUser = {
+      role: "user",
+      content: [{ type: "text", text: "current snapshot" }],
+      __openclaw: { id: "current-user", seq: 2 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "pending on the current snapshot" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [olderHistoryUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [currentHistoryUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([olderHistoryUser]);
+  });
+
+  it("never restores a hidden optimistic assistant during history reconciliation", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "visible prompt" }],
+      __openclaw: { id: "visible-user", seq: 1 },
+    };
+    const hiddenAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "NO_REPLY" }],
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [persistedUser] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser, hiddenAssistant],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser]);
+  });
+
   it("keeps active streamed assistant text when history reload returns a stale snapshot", async () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -3041,6 +3041,37 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatStream).toBeNull();
   });
 
+  it("keeps a newly sent repeated user message when history reload is still stale", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      timestamp: 10,
+      __openclaw: {
+        id: "first-user-message",
+        idempotencyKey: "first-run:user",
+        seq: 1,
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      timestamp: 20,
+      __openclaw: { idempotencyKey: "second-run:user" },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser, optimisticUser],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, optimisticUser]);
+  });
+
   it("keeps active streamed assistant text when history reload returns a stale snapshot", async () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/pages/chat/history-merge.test.ts
+++ b/ui/src/pages/chat/history-merge.test.ts
@@ -29,6 +29,94 @@ describe("preserveOptimisticTailMessages", () => {
     ).toEqual([persistedUser, optimisticUser, optimisticAssistant]);
   });
 
+  it("keeps a new same-text user turn while history still ends at the earlier turn", () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      timestamp: 10,
+      __openclaw: {
+        id: "first-user-message",
+        idempotencyKey: "first-run:user",
+        seq: 1,
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      timestamp: 20,
+      __openclaw: { idempotencyKey: "second-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([persistedUser], [persistedUser, optimisticUser]),
+    ).toEqual([persistedUser, optimisticUser]);
+  });
+
+  it("keeps a repeated user turn after the previous persisted assistant reply", () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: {
+        id: "first-user-message",
+        idempotencyKey: "first-run:user",
+        seq: 1,
+      },
+    };
+    const persistedAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "first answer" }],
+      __openclaw: { id: "first-assistant-message", seq: 2 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      timestamp: 20,
+      __openclaw: { idempotencyKey: "second-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [persistedUser, persistedAssistant],
+        [persistedUser, persistedAssistant, optimisticUser],
+      ),
+    ).toEqual([persistedUser, persistedAssistant, optimisticUser]);
+  });
+
+  it("does not duplicate a repeated user turn after its own history entry arrives", () => {
+    const persistedFirstUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: {
+        id: "first-user-message",
+        idempotencyKey: "first-run:user",
+        seq: 1,
+      },
+    };
+    const optimisticSecondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      timestamp: 20,
+      __openclaw: { idempotencyKey: "second-run:user" },
+    };
+    const persistedSecondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      timestamp: 20,
+      __openclaw: {
+        id: "second-user-message",
+        idempotencyKey: "second-run:user",
+        seq: 2,
+      },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [persistedFirstUser, persistedSecondUser],
+        [persistedFirstUser, optimisticSecondUser],
+      ),
+    ).toEqual([persistedFirstUser, persistedSecondUser]);
+  });
+
   it("drops streamed assistant tail when final history has caught up past the shared user", () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/pages/chat/history-merge.test.ts
+++ b/ui/src/pages/chat/history-merge.test.ts
@@ -52,6 +52,641 @@ describe("preserveOptimisticTailMessages", () => {
     ).toEqual([persistedUser, optimisticUser]);
   });
 
+  it("finds an earlier authoritative duplicate before preserving a distinct pending turn", () => {
+    const firstRepeatedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { seq: 1 },
+    };
+    const secondRepeatedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { seq: 2 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "a distinct pending turn" }],
+      __openclaw: { idempotencyKey: "third-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [firstRepeatedUser, secondRepeatedUser],
+        [firstRepeatedUser, optimisticUser],
+      ),
+    ).toEqual([firstRepeatedUser, secondRepeatedUser, optimisticUser]);
+  });
+
+  it("does not revive an unmatched pending turn beyond unrelated authoritative history", () => {
+    const sharedUser = {
+      role: "user",
+      content: [{ type: "text", text: "shared earlier turn" }],
+      __openclaw: { id: "shared-user", seq: 1 },
+    };
+    const laterUser = {
+      role: "user",
+      content: [{ type: "text", text: "different authoritative turn" }],
+      __openclaw: { id: "later-user", seq: 2 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([sharedUser, laterUser], [sharedUser, optimisticUser]),
+    ).toEqual([sharedUser, laterUser]);
+  });
+
+  it("does not anchor a native transcript to a colliding imported source-local id", () => {
+    const nativeUser = {
+      role: "user",
+      content: [{ type: "text", text: "native transcript" }],
+      __openclaw: { id: "source-local-id" },
+    };
+    const importedUser = {
+      role: "user",
+      content: [{ type: "text", text: "imported transcript" }],
+      __openclaw: {
+        id: "source-local-id",
+        externalId: "source-local-id",
+        importedFrom: "claude-cli",
+        cliSessionId: "imported-session",
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([nativeUser, importedUser], [nativeUser, optimisticUser]),
+    ).toEqual([nativeUser, importedUser]);
+  });
+
+  it("does not invent an imported source identity from an incomplete source tuple", () => {
+    const firstImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: {
+        id: "source-local-id",
+        externalId: "source-local-id",
+        importedFrom: "claude-cli",
+      },
+    };
+    const secondImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: {
+        id: "source-local-id",
+        externalId: "source-local-id",
+        importedFrom: "claude-cli",
+      },
+    };
+    const previousImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: {
+        id: "source-local-id",
+        externalId: "source-local-id",
+        importedFrom: "claude-cli",
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [firstImportedUser, secondImportedUser],
+        [previousImportedUser, optimisticUser],
+      ),
+    ).toEqual([firstImportedUser, secondImportedUser]);
+  });
+
+  it("does not substitute a different same-sequence projection for a missing canonical id", () => {
+    const unrelatedProjection = {
+      role: "user",
+      content: [{ type: "text", text: "different sequence projection" }],
+      __openclaw: { seq: 7 },
+    };
+    const previousProjection = {
+      role: "user",
+      content: [{ type: "text", text: "original sequence projection" }],
+      __openclaw: { id: "missing-canonical-id", seq: 7 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([unrelatedProjection], [previousProjection, optimisticUser]),
+    ).toEqual([unrelatedProjection]);
+  });
+
+  it("keeps import provenance without an external id out of native identity", () => {
+    const nativeUser = {
+      role: "user",
+      content: [{ type: "text", text: "native transcript" }],
+      __openclaw: { id: "source-local-id" },
+    };
+    const importedUser = {
+      role: "user",
+      content: [{ type: "text", text: "imported transcript" }],
+      __openclaw: {
+        id: "source-local-id",
+        importedFrom: "claude-cli",
+        cliSessionId: "imported-session",
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([nativeUser, importedUser], [nativeUser, optimisticUser]),
+    ).toEqual([nativeUser, importedUser]);
+  });
+
+  it("does not use display text as authority for an incomplete imported identity", () => {
+    const previousImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: { externalId: "first-import", importedFrom: "claude-cli" },
+    };
+    const otherImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "repeated imported turn" }],
+      __openclaw: { externalId: "different-import", importedFrom: "claude-cli" },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([otherImportedUser], [previousImportedUser, optimisticUser]),
+    ).toEqual([otherImportedUser]);
+  });
+
+  it("does not discard a canonical id when a sequence has the same visible text", () => {
+    const unrelatedProjection = {
+      role: "user",
+      content: [{ type: "text", text: "repeated projection" }],
+      __openclaw: { seq: 7 },
+    };
+    const previousProjection = {
+      role: "user",
+      content: [{ type: "text", text: "repeated projection" }],
+      __openclaw: { id: "missing-canonical-id", seq: 7 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([unrelatedProjection], [previousProjection, optimisticUser]),
+    ).toEqual([unrelatedProjection]);
+  });
+
+  it("does not revive an identity-free tail past a distinct same-text history turn", () => {
+    const firstUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "first-user", seq: 1 },
+    };
+    const secondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "second-user", seq: 2 },
+    };
+    const identityFreeTail = {
+      role: "user",
+      content: [{ type: "text", text: "identity-free pending turn" }],
+    };
+
+    expect(
+      preserveOptimisticTailMessages([firstUser, secondUser], [firstUser, identityFreeTail]),
+    ).toEqual([firstUser, secondUser]);
+  });
+
+  it("does not display-match a native legacy row to an imported transcript", () => {
+    const previousNativeUser = {
+      role: "user",
+      content: [{ type: "text", text: "same visible turn" }],
+      __openclaw: { senderId: "native-user" },
+    };
+    const importedUser = {
+      role: "user",
+      content: [{ type: "text", text: "same visible turn" }],
+      __openclaw: {
+        externalId: "external-user",
+        importedFrom: "claude-cli",
+        cliSessionId: "external-session",
+      },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([importedUser], [previousNativeUser, optimisticUser]),
+    ).toEqual([importedUser]);
+  });
+
+  it("does not replay a send that history already persisted before its current anchor", () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "already persisted prompt" }],
+      __openclaw: { id: "persisted-user", seq: 1, idempotencyKey: "persisted-run:user" },
+    };
+    const persistedAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "already persisted answer" }],
+      __openclaw: { id: "persisted-assistant", seq: 2 },
+    };
+    const staleOptimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "already persisted prompt" }],
+      __openclaw: { idempotencyKey: "persisted-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [persistedUser, persistedAssistant],
+        [persistedUser, persistedAssistant, staleOptimisticUser],
+      ),
+    ).toEqual([persistedUser, persistedAssistant]);
+  });
+
+  it("does not cross visible history markers with no display signature", () => {
+    const firstMarker = {
+      content: [{ type: "status", value: "first marker" }],
+      __openclaw: { id: "first-marker", seq: 1 },
+    };
+    const laterMarker = {
+      content: [{ type: "status", value: "different marker" }],
+      __openclaw: { id: "later-marker", seq: 2 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unmatched pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([firstMarker, laterMarker], [firstMarker, optimisticUser]),
+    ).toEqual([firstMarker, laterMarker]);
+  });
+
+  it("does not duplicate a repeated turn whose persisted row has no send identity", () => {
+    const firstUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "first-user", seq: 1 },
+    };
+    const persistedRepeatedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "persisted-repeated-user", seq: 2 },
+    };
+    const optimisticRepeatedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { idempotencyKey: "repeated-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [firstUser, persistedRepeatedUser],
+        [firstUser, optimisticRepeatedUser],
+      ),
+    ).toEqual([firstUser, persistedRepeatedUser]);
+  });
+
+  it("does not replay an assistant tail after consuming its already-persisted user", () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "already persisted prompt" }],
+      __openclaw: { id: "persisted-user", seq: 1, idempotencyKey: "persisted-run:user" },
+    };
+    const persistedAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "already persisted answer" }],
+      __openclaw: { id: "persisted-assistant", seq: 2 },
+    };
+    const staleOptimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "already persisted prompt" }],
+      __openclaw: { idempotencyKey: "persisted-run:user" },
+    };
+    const staleOptimisticAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "stale streamed assistant" }],
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [persistedUser, persistedAssistant],
+        [persistedUser, persistedAssistant, staleOptimisticUser, staleOptimisticAssistant],
+      ),
+    ).toEqual([persistedUser, persistedAssistant]);
+  });
+
+  it("preserves a distinct keyed repeated turn after an anchor with different text", () => {
+    const setupUser = {
+      role: "user",
+      content: [{ type: "text", text: "setup" }],
+      __openclaw: { id: "setup-user", seq: 1, idempotencyKey: "setup-run:user" },
+    };
+    const secondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "second-user", seq: 2, idempotencyKey: "second-run:user" },
+    };
+    const thirdUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { idempotencyKey: "third-run:user" },
+    };
+
+    expect(preserveOptimisticTailMessages([setupUser, secondUser], [setupUser, thirdUser])).toEqual(
+      [setupUser, secondUser, thirdUser],
+    );
+  });
+
+  it("anchors an updated display projection by its authoritative transcript id", () => {
+    const previousUser = {
+      role: "user",
+      content: [{ type: "text", text: "original projection" }],
+      __openclaw: { id: "persisted-user", seq: 3 },
+    };
+    const authoritativeUser = {
+      role: "user",
+      content: [{ type: "text", text: "updated projection" }],
+      __openclaw: { id: "persisted-user", seq: 3 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "still pending" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([authoritativeUser], [previousUser, optimisticUser]),
+    ).toEqual([authoritativeUser, optimisticUser]);
+  });
+
+  it("distinguishes same-sequence projections by their authoritative transcript ids", () => {
+    const firstProjection = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "first-projection", seq: 7 },
+    };
+    const persistedSecondProjection = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: {
+        id: "second-projection",
+        idempotencyKey: "second-run:user",
+        seq: 7,
+      },
+    };
+    const optimisticSecondProjection = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { idempotencyKey: "second-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [firstProjection, persistedSecondProjection],
+        [firstProjection, optimisticSecondProjection],
+      ),
+    ).toEqual([firstProjection, persistedSecondProjection]);
+  });
+
+  it("keeps transcript projections with the same entry identity in their own roles", () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "show the source reply" }],
+      __openclaw: { id: "shared-transcript-entry", seq: 7 },
+    };
+    const persistedAssistantMirror = {
+      role: "assistant",
+      content: [{ type: "text", text: "source reply" }],
+      __openclaw: { id: "shared-transcript-entry", seq: 7 },
+    };
+    const optimisticAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "source reply" }],
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [persistedUser, persistedAssistantMirror],
+        [persistedUser, optimisticAssistant],
+      ),
+    ).toEqual([persistedUser, persistedAssistantMirror]);
+  });
+
+  it("scopes imported external identities to their provider and CLI session", () => {
+    const firstImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: {
+        id: "shared-external-id",
+        externalId: "shared-external-id",
+        importedFrom: "claude-cli",
+        cliSessionId: "first-session",
+      },
+    };
+    const secondImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: {
+        id: "shared-external-id",
+        externalId: "shared-external-id",
+        importedFrom: "claude-cli",
+        cliSessionId: "second-session",
+      },
+    };
+    const optimisticSecondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [firstImportedUser, secondImportedUser],
+        [firstImportedUser, optimisticSecondUser],
+      ),
+    ).toEqual([firstImportedUser, secondImportedUser]);
+  });
+
+  it("anchors updated imported messages by their source-scoped external identity", () => {
+    const metadata = {
+      id: "external-user",
+      externalId: "external-user",
+      importedFrom: "claude-cli",
+      cliSessionId: "cli-session",
+    };
+    const previousImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "original imported text" }],
+      __openclaw: metadata,
+    };
+    const authoritativeImportedUser = {
+      role: "user",
+      content: [{ type: "text", text: "updated imported text" }],
+      __openclaw: { ...metadata },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "pending after import" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [authoritativeImportedUser],
+        [previousImportedUser, optimisticUser],
+      ),
+    ).toEqual([authoritativeImportedUser, optimisticUser]);
+  });
+
+  it("does not guess between repeated history rows without authoritative identity", () => {
+    const firstLegacyUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { senderId: "alice" },
+    };
+    const secondLegacyUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { senderId: "alice" },
+    };
+    const previousLegacyUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { senderId: "alice" },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "unproven pending turn" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [firstLegacyUser, secondLegacyUser],
+        [previousLegacyUser, optimisticUser],
+      ),
+    ).toEqual([firstLegacyUser, secondLegacyUser]);
+  });
+
+  it("uses an unambiguous display match when transcript identity is unavailable", () => {
+    const previousLegacyUser = {
+      role: "user",
+      content: [{ type: "text", text: "unique legacy message" }],
+      __openclaw: { senderId: "alice" },
+    };
+    const authoritativeLegacyUser = {
+      role: "user",
+      content: [{ type: "text", text: "unique legacy message" }],
+      __openclaw: { senderId: "alice" },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "pending after legacy history" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [authoritativeLegacyUser],
+        [previousLegacyUser, optimisticUser],
+      ),
+    ).toEqual([authoritativeLegacyUser, optimisticUser]);
+  });
+
+  it("preserves a repeated optimistic prompt distinguished by its send identity", () => {
+    const firstUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "first-user", idempotencyKey: "first-run:user", seq: 1 },
+    };
+    const secondUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { id: "second-user", idempotencyKey: "second-run:user", seq: 2 },
+    };
+    const optimisticThirdUser = {
+      role: "user",
+      content: [{ type: "text", text: "continue" }],
+      __openclaw: { idempotencyKey: "third-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([firstUser, secondUser], [firstUser, optimisticThirdUser]),
+    ).toEqual([firstUser, secondUser, optimisticThirdUser]);
+  });
+
+  it("does not revive a pending tail from an unrelated older history snapshot", () => {
+    const olderHistoryUser = {
+      role: "user",
+      content: [{ type: "text", text: "older snapshot" }],
+      __openclaw: { id: "older-user", seq: 1 },
+    };
+    const currentHistoryUser = {
+      role: "user",
+      content: [{ type: "text", text: "current snapshot" }],
+      __openclaw: { id: "current-user", seq: 2 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "pending on the current snapshot" }],
+      __openclaw: { idempotencyKey: "pending-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([olderHistoryUser], [currentHistoryUser, optimisticUser]),
+    ).toEqual([olderHistoryUser]);
+  });
+
+  it("never preserves a hidden optimistic tail", () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "visible prompt" }],
+      __openclaw: { id: "visible-user", seq: 1 },
+    };
+    const hiddenAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "NO_REPLY" }],
+    };
+
+    expect(
+      preserveOptimisticTailMessages(
+        [persistedUser],
+        [persistedUser, hiddenAssistant],
+        (message) => message === hiddenAssistant,
+      ),
+    ).toEqual([persistedUser]);
+  });
+
   it("keeps a repeated user turn after the previous persisted assistant reply", () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/pages/chat/history-merge.ts
+++ b/ui/src/pages/chat/history-merge.ts
@@ -80,9 +80,19 @@ export function preserveOptimisticTailMessages(
   let sharedPreviousIndex = -1;
   let sharedHistoryIndex = -1;
   for (let index = previousMessages.length - 1; index >= 0; index--) {
-    const signature = messageDisplaySignature(previousMessages[index]);
+    const message = previousMessages[index];
+    // Only transcript-backed rows can anchor history; a newer optimistic turn
+    // may intentionally repeat an earlier user's exact visible text.
+    if (isLocallyOptimisticHistoryMessage(message)) {
+      continue;
+    }
+    const signature = messageDisplaySignature(message);
     const historyIndex = signature ? historySignatureIndexes.get(signature) : undefined;
-    if (typeof historyIndex === "number") {
+    const sequence = readTranscriptSequence(message);
+    if (
+      typeof historyIndex === "number" &&
+      (sequence === null || readTranscriptSequence(historyMessages[historyIndex]) === sequence)
+    ) {
       sharedPreviousIndex = index;
       sharedHistoryIndex = historyIndex;
       break;
@@ -97,7 +107,7 @@ export function preserveOptimisticTailMessages(
       return historyMessages;
     }
     const signature = messageDisplaySignature(message);
-    if (!signature || historySignatureIndexes.has(signature)) {
+    if (!signature) {
       return historyMessages;
     }
     optimisticTail.push(message);

--- a/ui/src/pages/chat/history-merge.ts
+++ b/ui/src/pages/chat/history-merge.ts
@@ -1,28 +1,51 @@
 import { extractText } from "../../lib/chat/message-extract.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 
-function hasTranscriptMeta(message: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const metadata = (message as { __openclaw?: unknown })["__openclaw"];
-  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-    return false;
-  }
-  // An idempotency marker alone identifies a locally materialized queued turn;
-  // authoritative transcript metadata adds identity, sequence, or kind fields.
-  return Object.keys(metadata).some((key) => key !== "idempotencyKey");
-}
+type TranscriptMessageIdentity = {
+  role: string;
+  signature: string | null;
+  isImported: boolean;
+  externalSource: string | null;
+  id: string | null;
+  sequence: number | null;
+  idempotencyKey: string | null;
+};
 
-export function readTranscriptSequence(message: unknown): number | null {
+type IndexedHistoryMessage = {
+  index: number;
+  identity: TranscriptMessageIdentity;
+  message: unknown;
+};
+
+type HistoryMessageIndex = Map<string, IndexedHistoryMessage[]>;
+
+function readTranscriptMetadata(message: unknown): Record<string, unknown> | null {
   if (!message || typeof message !== "object" || Array.isArray(message)) {
     return null;
   }
   const metadata = (message as Record<string, unknown>)["__openclaw"];
-  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? (metadata as Record<string, unknown>)
+    : null;
+}
+
+function readMetadataString(value: unknown): string | null {
+  if (typeof value !== "string") {
     return null;
   }
-  const seq = (metadata as Record<string, unknown>).seq;
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function hasTranscriptMeta(message: unknown): boolean {
+  const metadata = readTranscriptMetadata(message);
+  // An idempotency marker alone identifies a locally materialized queued turn;
+  // authoritative transcript metadata adds identity, sequence, or kind fields.
+  return metadata !== null && Object.keys(metadata).some((key) => key !== "idempotencyKey");
+}
+
+export function readTranscriptSequence(message: unknown): number | null {
+  const seq = readTranscriptMetadata(message)?.seq;
   return typeof seq === "number" && Number.isSafeInteger(seq) && seq > 0 ? seq : null;
 }
 
@@ -54,6 +77,190 @@ export function messageDisplaySignature(message: unknown): string | null {
   }
 }
 
+function readTranscriptMessageIdentity(message: unknown): TranscriptMessageIdentity {
+  const metadata = readTranscriptMetadata(message);
+  const externalId = readMetadataString(metadata?.externalId);
+  const importedFrom = readMetadataString(metadata?.importedFrom);
+  const cliSessionId = readMetadataString(metadata?.cliSessionId);
+  const isImported = Boolean(externalId || importedFrom || cliSessionId);
+  // Imported ids are source-local. A partial source tuple cannot prove that
+  // two imports came from the same provider and CLI session.
+  const externalSource =
+    externalId && importedFrom && cliSessionId
+      ? JSON.stringify([importedFrom, cliSessionId, externalId])
+      : null;
+  return {
+    role:
+      message && typeof message === "object"
+        ? normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role)
+        : "",
+    signature: messageDisplaySignature(message),
+    isImported,
+    externalSource,
+    id: readMetadataString(metadata?.id),
+    sequence: readTranscriptSequence(message),
+    idempotencyKey: readMetadataString(metadata?.idempotencyKey),
+  };
+}
+
+function indexHistoryMessage(
+  historyIndex: HistoryMessageIndex,
+  key: string,
+  entry: IndexedHistoryMessage,
+): void {
+  const entries = historyIndex.get(key);
+  if (entries) {
+    entries.push(entry);
+    return;
+  }
+  historyIndex.set(key, [entry]);
+}
+
+function createHistoryMessageIndex(
+  messages: unknown[],
+  shouldHideMessage: (message: unknown) => boolean,
+): HistoryMessageIndex {
+  const historyIndex: HistoryMessageIndex = new Map();
+  messages.forEach((message, index) => {
+    if (shouldHideMessage(message)) {
+      return;
+    }
+    const identity = readTranscriptMessageIdentity(message);
+    const entry = { identity, index, message };
+    if (identity.externalSource) {
+      indexHistoryMessage(historyIndex, `external:${identity.externalSource}`, entry);
+    }
+    // Source-local import ids must never collide with canonical native ids.
+    if (identity.id && !identity.isImported) {
+      indexHistoryMessage(historyIndex, `id:${identity.id}`, entry);
+    }
+    if (identity.sequence !== null) {
+      indexHistoryMessage(historyIndex, `seq:${identity.sequence}`, entry);
+    }
+    if (identity.idempotencyKey) {
+      indexHistoryMessage(historyIndex, `send:${identity.idempotencyKey}`, entry);
+    }
+    if (identity.signature) {
+      indexHistoryMessage(historyIndex, `display:${identity.signature}`, entry);
+    }
+    if (identity.role) {
+      indexHistoryMessage(historyIndex, `role:${identity.role}`, entry);
+    }
+  });
+  return historyIndex;
+}
+
+function findTranscriptHistoryAnchor(
+  historyIndex: HistoryMessageIndex,
+  message: unknown,
+): IndexedHistoryMessage | null {
+  const identity = readTranscriptMessageIdentity(message);
+  // Imported identity is never display-only. Without the complete source
+  // tuple, no source-local id can prove ownership of a transcript row.
+  if (identity.isImported && !identity.externalSource) {
+    return null;
+  }
+  const authoritativeKeys: string[] = [];
+  if (identity.externalSource) {
+    authoritativeKeys.push(`external:${identity.externalSource}`);
+  }
+  if (identity.id && !identity.isImported) {
+    authoritativeKeys.push(`id:${identity.id}`);
+  }
+  if (identity.sequence !== null) {
+    authoritativeKeys.push(`seq:${identity.sequence}`);
+  }
+  for (const key of authoritativeKeys) {
+    const entries = historyIndex.get(key) ?? [];
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const entry = entries[index];
+      if (!entry) {
+        continue;
+      }
+      if (identity.role && entry.identity.role !== identity.role) {
+        continue;
+      }
+      if (identity.isImported !== entry.identity.isImported) {
+        continue;
+      }
+      if (identity.externalSource && entry.identity.externalSource !== identity.externalSource) {
+        continue;
+      }
+      if (
+        identity.id &&
+        (!identity.isImported || entry.identity.id) &&
+        entry.identity.id !== identity.id
+      ) {
+        continue;
+      }
+      if (
+        identity.sequence !== null &&
+        entry.identity.sequence !== null &&
+        entry.identity.sequence !== identity.sequence
+      ) {
+        continue;
+      }
+      // A missing canonical id cannot prove which same-sequence projection is
+      // being adopted. Preserve the projection check on every sequence fallback.
+      if (
+        key.startsWith("seq:") &&
+        !identity.externalSource &&
+        entry.identity.signature !== identity.signature
+      ) {
+        continue;
+      }
+      return entry;
+    }
+  }
+  if (authoritativeKeys.length > 0 || !identity.signature) {
+    return null;
+  }
+  const entries = (historyIndex.get(`display:${identity.signature}`) ?? []).filter(
+    (entry) => entry.identity.isImported === identity.isImported,
+  );
+  const sameInstance = entries.find((entry) => entry.message === message);
+  // Display text is not transcript identity. A copied legacy row is safe to
+  // anchor only when its visible signature has exactly one history candidate.
+  return sameInstance ?? (entries.length === 1 ? (entries[0] ?? null) : null);
+}
+
+function findOptimisticHistoryMatch(
+  historyIndex: HistoryMessageIndex,
+  identity: TranscriptMessageIdentity,
+  afterIndex: number,
+): IndexedHistoryMessage | "ambiguous" | null {
+  if (identity.idempotencyKey) {
+    const entries = historyIndex.get(`send:${identity.idempotencyKey}`) ?? [];
+    // A send already persisted before the active anchor is still consumed;
+    // only a later match is allowed to advance that anchor.
+    return entries.findLast((entry) => entry.index > afterIndex) ?? entries.at(-1) ?? null;
+  }
+  if (!identity.signature) {
+    return null;
+  }
+  const entries = (historyIndex.get(`display:${identity.signature}`) ?? []).filter(
+    (entry) => entry.index > afterIndex,
+  );
+  if (entries.length > 1) {
+    return "ambiguous";
+  }
+  if (entries[0]) {
+    return entries[0];
+  }
+  if (identity.role !== "assistant") {
+    return null;
+  }
+  const assistantEntries = (historyIndex.get("role:assistant") ?? []).filter(
+    (entry) => entry.index > afterIndex,
+  );
+  // A persisted assistant can complete a partial stream with different text;
+  // never replay that stream as an extra assistant answer.
+  if (assistantEntries.length > 1) {
+    return "ambiguous";
+  }
+  return assistantEntries[0] ?? null;
+}
+
 export function preserveOptimisticTailMessages(
   historyMessages: unknown[],
   previousMessages: unknown[],
@@ -70,45 +277,88 @@ export function preserveOptimisticTailMessages(
       ? previousMessages
       : historyMessages;
   }
-  const historySignatureIndexes = new Map<string, number>();
-  historyMessages.forEach((message, index) => {
-    const signature = messageDisplaySignature(message);
-    if (signature) {
-      historySignatureIndexes.set(signature, index);
-    }
-  });
+  const historyIndex = createHistoryMessageIndex(historyMessages, shouldHideMessage);
   let sharedPreviousIndex = -1;
   let sharedHistoryIndex = -1;
+  let sharedHistorySignature: string | null = null;
   for (let index = previousMessages.length - 1; index >= 0; index--) {
     const message = previousMessages[index];
     // Only transcript-backed rows can anchor history; a newer optimistic turn
     // may intentionally repeat an earlier user's exact visible text.
-    if (isLocallyOptimisticHistoryMessage(message)) {
+    if (isLocallyOptimisticHistoryMessage(message) || shouldHideMessage(message)) {
       continue;
     }
-    const signature = messageDisplaySignature(message);
-    const historyIndex = signature ? historySignatureIndexes.get(signature) : undefined;
-    const sequence = readTranscriptSequence(message);
-    if (
-      typeof historyIndex === "number" &&
-      (sequence === null || readTranscriptSequence(historyMessages[historyIndex]) === sequence)
-    ) {
+    const historyEntry = findTranscriptHistoryAnchor(historyIndex, message);
+    if (historyEntry) {
       sharedPreviousIndex = index;
-      sharedHistoryIndex = historyIndex;
+      sharedHistoryIndex = historyEntry.index;
+      sharedHistorySignature = historyEntry.identity.signature;
       break;
     }
   }
-  if (sharedPreviousIndex < 0 || sharedHistoryIndex < historyMessages.length - 1) {
+  if (sharedPreviousIndex < 0) {
     return historyMessages;
   }
   const optimisticTail: unknown[] = [];
+  let consumedPersistedTurn = false;
   for (const message of previousMessages.slice(sharedPreviousIndex + 1)) {
     if (!isLocallyOptimisticHistoryMessage(message) || shouldHideMessage(message)) {
       return historyMessages;
     }
-    const signature = messageDisplaySignature(message);
-    if (!signature) {
+    const identity = readTranscriptMessageIdentity(message);
+    if (!identity.signature) {
       return historyMessages;
+    }
+    // A consumed historical send owns its following optimistic assistant;
+    // retaining that stream would duplicate the already-persisted answer.
+    if (consumedPersistedTurn && identity.role === "assistant") {
+      continue;
+    }
+    if (optimisticTail.length === 0) {
+      const historyMatch = findOptimisticHistoryMatch(historyIndex, identity, sharedHistoryIndex);
+      if (historyMatch === "ambiguous") {
+        return historyMessages;
+      }
+      if (historyMatch) {
+        if (historyMatch.index > sharedHistoryIndex) {
+          sharedHistoryIndex = historyMatch.index;
+          sharedHistorySignature = historyMatch.identity.signature;
+          consumedPersistedTurn = false;
+        } else if (identity.role === "user") {
+          consumedPersistedTurn = true;
+        }
+        continue;
+      }
+      // Only a pending send with its own identity may cross a repeated
+      // projection; identity-free tails may belong to the replaced snapshot.
+      if (
+        sharedHistoryIndex < historyMessages.length - 1 &&
+        (!identity.idempotencyKey ||
+          historyMessages.slice(sharedHistoryIndex + 1).some((historyMessage) => {
+            if (shouldHideMessage(historyMessage)) {
+              return false;
+            }
+            const historyIdentity = readTranscriptMessageIdentity(historyMessage);
+            const historySignature = historyIdentity.signature;
+            // A persisted repeat may follow a differently worded anchor; a
+            // distinct send key proves that row cannot consume this turn.
+            const isDistinctPersistedSend =
+              historySignature === identity.signature &&
+              historyIdentity.idempotencyKey !== null &&
+              historyIdentity.idempotencyKey !== identity.idempotencyKey;
+            return (
+              sharedHistorySignature === null ||
+              historySignature === null ||
+              (historySignature !== sharedHistorySignature && !isDistinctPersistedSend) ||
+              (historySignature === identity.signature && historyIdentity.idempotencyKey === null)
+            );
+          }))
+      ) {
+        return historyMessages;
+      }
+    }
+    if (identity.role === "user") {
+      consumedPersistedTurn = false;
     }
     optimisticTail.push(message);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending repeated chat messages could lose their newest pending turn when Control UI history refreshed before the Gateway had finished persisting it. It also prevents stale pending turns from reappearing after unrelated history has arrived.

## Why This Change Was Made

Reconcile chat history using authoritative transcript identity instead of the last matching display string. Preserve every repeated-history candidate; keep native entry IDs, complete imported source identities, transcript sequences, and optimistic send identities in their correct namespaces. Only preserve a pending turn when its authoritative anchor and current send can actually be reconciled.

## User Impact

Repeated prompts remain visible during active sends and history refresh. Imported transcripts, same-sequence display projections, hidden messages, streaming replies, cached history, and initial-turn handoff do not restore, duplicate, or remove the wrong chat turn.

## Evidence

- Real end-to-end browser verification: **1/1 passing** against the exact reviewed head, using production Control UI, real Playwright Chromium, an actual authenticated Gateway WebSocket, and two real OpenAI `openai/gpt-5.4` turns. The scenario submits the same prompt twice through the production composer with Enter, verifies the expected assistant text does not occur anywhere in the user prompt, captures the first completed assistant turn and the second pending turn, performs a real hard browser reload, and verifies authoritative history contains exactly **2 user messages and 2 completed assistant replies**. The live scenario passed in **23.472 seconds**; the complete isolated browser run passed in **129.67 seconds**.
- Independently verified the live public OpenAI Responses API returned canonical model `gpt-5.4-2026-03-05` and the exact expected verification output. The recorded, redacted real browser-to-Gateway exchange contains **314 WebSocket frames**, exactly **2 `chat.send` requests**, **6 `chat.history` requests**, and real agent, chat, session, presence, and connection events. No provider credentials or Gateway tokens are present in the evidence.
- Personally inspected the real full-page browser screenshots for the first completed turn, second pending turn, and final reloaded transcript. Final screenshot SHA-256: `cba5fe1db1edd60c4a56784b8398992b79fbf759e938117393abc27f4943c746`; redacted WebSocket evidence SHA-256: `4111db4857157bc6b4c25ac52b62a1cacc2f923b49b7ad50d80b82a459c214f9`. The complete live interaction is also recorded as a **730,807-byte WebM video**. The isolated verification first restored and verified the exact head's tracked workspace templates and frozen lockfile so the real Gateway had the same canonical assets as the reviewed checkout.
- Five independent structured-review rounds uncovered fourteen distinct identity and stale-history edge cases. Every finding was first reproduced against the real UI test project twice: once directly in the history owner and once through actual Gateway history loading. The five isolated failing-before runs produced 8/8, 8/8, 6/6, 4/4, and 2/2 expected regression failures while the remaining existing tests continued passing.
- Final exact-source, remote Linux verification: **213/213 passing tests** across four actually executed suites: `history-merge.test.ts` (31), `chat-gateway.test.ts` (166), `initial-turn-handoff.test.ts` (4), and `session-message-cache.test.ts` (12).
- Regression coverage includes distinct same-text sends, earlier duplicate anchors, source-local imported ID collisions, all partial import provenance, incomplete source tuples, cross-provenance display matches, strong canonical IDs and sequence projections, sends persisted before the current history anchor, stale snapshots, identity-free pending tails, signature-free visible rows, repeated sends whose persisted records omit their send identity, consumed sends with stale assistant tails, differently worded anchors with proven distinct repeated sends, hidden rows, persisted streamed replies, and idempotent send recovery.
- The isolated Linux Testbox verified the exact Git blob of every changed file and ran `node scripts/run-oxlint.mjs`, the repository formatter check, and `git diff --check` successfully.
- The final isolated Linux run completed successfully with an authoritative timing record and exit code `0`.
- Fresh final independent structured review: **patch is correct**, confidence **0.94**, **zero actionable findings**. All five prior review rounds were used to produce the real failing-before regressions described above.
- Exact independently reviewed and Linux-tested head: `8a53a3338df345044b148a9c249027b5bc64ade0`; each changed source blob matches the remote test run.
- Current `main` was fetched once before the update. None of the three touched history-owner or Gateway-test files changed on `main` since this branch's merge base.
- Independently verified the required hosted `openclaw/ci-gate` is **SUCCESS** for the exact reviewed head; CI run `30161889127`, required gate job `89689131961`.

AI-assisted; limited to the Control UI history owner and its direct and Gateway-level regression tests.
