### PR TITLE
fix: recognize configured plugin dependencies by manifest id

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -557,6 +557,39 @@ describe("discoverOpenClawPlugins", () => {
     });
   });
 
+  it("recognizes the validated manifest id of an explicitly configured plugin file", async () => {
+    const stateDir = makeTempDir();
+    const coreDir = path.join(stateDir, "configured-plugins", "acme-core");
+    const coreEntry = path.join(coreDir, "index.ts");
+    mkdirSafe(coreDir);
+    writePluginManifest({ pluginDir: coreDir, id: "acme-core" });
+    writePluginEntry(coreEntry);
+
+    const dependentDir = path.join(stateDir, "extensions", "acme-addon");
+    createPackagePluginWithEntry({
+      packageDir: dependentDir,
+      packageName: "@acme/acme-addon",
+      pluginId: "acme-addon",
+    });
+    writePluginManifest({
+      pluginDir: dependentDir,
+      id: "acme-addon",
+      requiresPlugins: ["acme-core"],
+    });
+
+    const result = await discoverWithStateDir(stateDir, { extraPaths: [coreEntry] });
+
+    expectCandidatePresence(result, {
+      present: ["index", "acme-addon"],
+      absent: ["acme-core"],
+    });
+    expectNoDiagnostic({
+      diagnostics: result.diagnostics,
+      pluginId: "acme-addon",
+      messageIncludes: 'requires plugin "acme-core"',
+    });
+  });
+
   it.skipIf(!canCreateDirectorySymlinks)(
     "discovers symlinked plugin directories in global roots",
     async () => {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -402,12 +402,39 @@ function mergeDiscoveryResult(
   }
 }
 
-function addMissingRequiredPluginDiagnostics(result: PluginDiscoveryResult): void {
+function addMissingRequiredPluginDiagnostics(
+  result: PluginDiscoveryResult,
+  params: { env: NodeJS.ProcessEnv; realpathCache: Map<string, string> },
+): void {
   const candidateIds = new Set(result.candidates.map((candidate) => candidate.idHint));
   const seen = new Set<string>();
+  let configuredFileManifestIds: Set<string> | undefined;
   for (const candidate of result.candidates) {
     for (const requiredPluginId of candidate.requiredPluginIds ?? []) {
       if (candidateIds.has(requiredPluginId) || requiredPluginId === candidate.idHint) {
+        continue;
+      }
+      if (!configuredFileManifestIds) {
+        configuredFileManifestIds = new Set();
+        // Explicit files keep filename hints; only a validated root manifest
+        // can establish their canonical identity for a missing dependency.
+        for (const configuredCandidate of result.candidates) {
+          if (configuredCandidate.origin !== "config" || configuredCandidate.packageDir) {
+            continue;
+          }
+          const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
+            origin: configuredCandidate.origin,
+            rootDir: configuredCandidate.rootDir,
+            env: params.env,
+            realpathCache: params.realpathCache,
+          });
+          const manifest = resolveCandidateManifest(configuredCandidate.rootDir, rejectHardlinks);
+          if (manifest) {
+            configuredFileManifestIds.add(manifest.manifest.id);
+          }
+        }
+      }
+      if (configuredFileManifestIds.has(requiredPluginId)) {
         continue;
       }
       const key = `${candidate.idHint}\0${requiredPluginId}`;
@@ -1711,7 +1738,7 @@ export function discoverOpenClawPlugins(params: {
   const seenDiagnostics = new Set<string>();
   mergeDiscoveryResult(result, scopedResult, seenSources, seenDiagnostics);
   mergeDiscoveryResult(result, sharedResult, seenSources, seenDiagnostics);
-  addMissingRequiredPluginDiagnostics(result);
+  addMissingRequiredPluginDiagnostics(result, { env, realpathCache });
   return result;
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Discovery reports an installed plugin dependency as missing when the required plugin was explicitly configured by its entry-file path: the filename-derived candidate hint differs from the plugin's canonical, validated manifest ID.

## Why This Change Was Made

Preserve existing discovery candidate IDs and precedence. When an actual dependency is otherwise missing, lazily consult canonical manifest IDs only for explicitly configured file candidates, using the existing manifest validation and hardlink-safety owner contract.

## User Impact

Valid explicitly configured plugin dependencies no longer emit a false missing-dependency warning. No SDK, public plugin API, configuration format, plugin enablement, security policy, or dependency-install behavior changes.

## Evidence

- Exact reviewed head: `811cd6803da85cbef8390258eb4bcf2706b25133`.
- Both production/test files were independently verified against the exact reviewed Git blob hashes on a fresh remote Blacksmith Testbox.
- `pnpm test src/plugins/discovery.test.ts`: **75/75 canonical plugin-discovery tests passed**.
- `pnpm exec oxfmt --check src/plugins/discovery.ts src/plugins/discovery.test.ts`: passed.
- Full remote source verification, focused regression, formatting, and whitespace: **exit 0**, **5.380 seconds**.
- Fresh independent structured review over the complete current-main branch: **0.95**, zero actionable findings.
- Both owner files were checked against current `main`; no intervening owner-path drift.

AI-assisted; scope is restricted to manifest-first plugin discovery and its existing owner tests.
