### PR TITLE
fix: preserve agent session cancellation and timeout reasons

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
@@ -6,6 +6,7 @@ import {
   createEmbeddedAttemptRunAbort,
   type EmbeddedAttemptAbortStatePort,
 } from "./attempt-abort.js";
+import { createEmbeddedAttemptSessionSettleTracker } from "./attempt-session-settle.js";
 import { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
 import { createEmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
 import { SESSIONS_YIELD_ABORT_REASON } from "./attempt.sessions-yield.js";
@@ -54,17 +55,23 @@ function createAbortState() {
   };
 }
 
+function createTrackedSessionAbort() {
+  const abort = vi.fn(async (_reason?: unknown) => {});
+  const tracker = createEmbeddedAttemptSessionSettleTracker({ abort });
+  return { abort, tracker };
+}
+
 beforeEach(() => {
   mocks.countActiveToolExecutions.mockReset().mockReturnValue(0);
   mocks.markActiveEmbeddedRunAbandoned.mockReset();
 });
 
 describe("createEmbeddedAttemptExternalAbortController", () => {
-  it("aborts setup state before the live run handler is installed", () => {
+  it("preserves external cancellation through active session settlement", async () => {
     const source = new AbortController();
     const runAbortController = new AbortController();
     const state = createAbortState();
-    const abortActiveSession = vi.fn(async () => {});
+    const session = createTrackedSessionAbort();
     const controller = createEmbeddedAttemptExternalAbortController({
       abortSignal: source.signal,
       cleanupAfterEarlyAbort: vi.fn(async () => {}),
@@ -72,7 +79,7 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
       runId: "run-external",
       state: state.port,
     });
-    controller.setActiveSessionAbort(abortActiveSession);
+    controller.setActiveSessionAbort(session.tracker.abortActiveSession);
     controller.arm();
     const reason = new Error("cancelled");
 
@@ -82,7 +89,8 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
     expect(state.markAborted).toHaveBeenCalledTimes(1);
     expect(state.setPromptError).toHaveBeenCalledWith(reason);
     expect(runAbortController.signal.reason).toBe(reason);
-    expect(abortActiveSession).toHaveBeenCalledTimes(1);
+    expect(session.abort).toHaveBeenCalledExactlyOnceWith(reason);
+    await session.tracker.buildAbortSettlePromise();
     controller.dispose();
   });
 
@@ -143,7 +151,7 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
     const source = new AbortController();
     const runAbortController = new AbortController();
     const state = createAbortState();
-    const abortActiveSession = vi.fn(async () => {});
+    const session = createTrackedSessionAbort();
     const onAttemptTimeout = vi.fn();
     const releaseHeldLockForAbort = vi.fn(async () => {});
     const attempt = {
@@ -163,7 +171,7 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
       state: state.port,
     });
     const abortRun = createEmbeddedAttemptRunAbort({
-      abortActiveSession,
+      abortActiveSession: session.tracker.abortActiveSession,
       activeSession: { abortCompaction: vi.fn(), isCompacting: false },
       attempt,
       getQueueHandle: () => ({}) as EmbeddedAgentQueueHandle,
@@ -194,13 +202,13 @@ describe("createEmbeddedAttemptExternalAbortController", () => {
       const reason = new Error("upstream request timed out");
       reason.name = "TimeoutError";
       source.abort(reason);
-      await Promise.resolve();
+      await session.tracker.buildAbortSettlePromise();
 
       expect(state.markExternalAbort).toHaveBeenCalledOnce();
       expect(state.markAborted).toHaveBeenCalledOnce();
       expect(state.markTimedOut).toHaveBeenCalledOnce();
       expect(onAttemptTimeout).toHaveBeenCalledOnce();
-      expect(abortActiveSession).toHaveBeenCalledOnce();
+      expect(session.abort).toHaveBeenCalledExactlyOnceWith(reason);
       expect(mocks.markActiveEmbeddedRunAbandoned).toHaveBeenCalledOnce();
       expect(releaseHeldLockForAbort).toHaveBeenCalledOnce();
     } finally {

--- a/src/agents/embedded-agent-runner/run/attempt-abort.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.ts
@@ -105,7 +105,7 @@ export function createEmbeddedAttemptExternalAbortController(input: {
     if (!input.runAbortController.signal.aborted) {
       input.runAbortController.abort(isTimeout ? (reason ?? createTimeoutAbortReason()) : reason);
     }
-    void abortActiveSession?.();
+    void abortActiveSession?.(input.runAbortController.signal.reason);
   };
 
   return {
@@ -214,7 +214,7 @@ export function createEmbeddedAttemptRunAbort(input: {
       input.runAbortController.abort(reason);
     }
     abortCompaction();
-    void input.abortActiveSession();
+    void input.abortActiveSession(input.runAbortController.signal.reason);
     const queueHandle = input.getQueueHandle();
     if (isTimeout && queueHandle) {
       markActiveEmbeddedRunAbandoned({


### PR DESCRIPTION
## What Problem This Solves

Embedded agent cancellation and timeout owners record an authoritative reason on `runAbortController`, but two active-session handoffs discarded it by calling `abortActiveSession()` without an argument. The session-settle tracker already accepts and forwards a reason to `AgentSession.abort(reason)`, so transcripts and downstream session handling could lose the reason even though the producer had recorded it correctly.

## Why This Change Was Made

Both handoffs now pass `runAbortController.signal.reason`, the canonical value after the controller has accepted or normalized the abort. This repairs the producer-to-session owner boundary without rederiving cancellation-versus-timeout precedence; `src/agents/agent-run-terminal-outcome.ts` remains the sole terminal normalization owner.

Explicit `Error` values, including coded errors, retain their object identity and metadata. Explicit `TimeoutError` values likewise retain their name, message, code, and cause. When timeout arrives without an `Error`, the existing abort owner still synthesizes its canonical `TimeoutError` before forwarding it. Non-Error cancellation values remain the existing controller reason and continue through downstream transport normalization unchanged; this PR adds no new interpretation of uncoded reasons.

## User Impact

Cancelled and timed-out active sessions retain the reason already chosen by the attempt owner instead of receiving `undefined`. Cancellation policy, timeout precedence, session state, configuration, and public interfaces are unchanged.

## Evidence

- Before the production fix, `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-abort.test.ts` ran 9 tests with exactly 2 failures: the real session-settle handoff called `AgentSession.abort` with `undefined` instead of the original cancellation `Error` and original `TimeoutError`.
- After the fix and final formatting, the same focused command passed 9 of 9 tests in 4.62 seconds.
- The regression uses the production `createEmbeddedAttemptSessionSettleTracker`, then asserts the reason at the `AgentSession.abort` boundary for both external cancellation and timeout. This is deterministic provider-independent runtime proof of the exact active-session handoff; a live model call would not exercise additional logic at this synchronous seam.
- Direct max-lines ratchet: `max-lines ratchet OK: 980 grandfathered suppressions.`
- `git diff --check`: passed.
- Exact changed gate: Blacksmith Testbox `tbx_01kzk36jqpvaqaz42w2nwe39py`, Actions run https://github.com/openclaw/openclaw/actions/runs/31309949037, authoritative `exitCode=0`; production/test typechecks, 245-rule lint, formatting, dependency, boundary, database, cycle, and security guards passed.
- Exact-head pull-request CI: https://github.com/openclaw/openclaw/actions/runs/31310451499 completed green with zero pending or failed checks.
- Codex-backed autoreview: clean in one round, no accepted or actionable findings; TruffleHog clean; correctness 0.99.
- Production LOC: +2/-2 (net 0). Tests: +16/-8 (net +8).
- No changelog, authentication, configuration, schema, protocol, persistence, terminal-precedence, or public API changes.
