### PR TITLE
feat(sqlite): migrate persisted media to canonical facts and stop legacy writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "openclaw": {
     "schemaVersions": {
       "state": 6,
-      "agent": 15
+      "agent": 16
     }
   },
   "description": "Multi-channel AI gateway with extensible messaging integrations",

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -102,6 +102,7 @@ const rawSqliteAllowPathGroups = {
     "src/infra/state-migrations.meeting-transcripts-detection.ts",
     "src/infra/state-migrations.meeting-transcripts-files.ts",
     "src/infra/state-migrations.meeting-transcripts-verify.ts",
+    "src/infra/state-migrations.media-persistence.ts",
   ],
   "shared database stores with direct DatabaseSync access": ["src/proxy-capture/store.sqlite.ts"],
   "Kysely-backed stores that own a DatabaseSync boundary": [

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -3572,10 +3572,11 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(attempt.userTurnTranscriptRecorder?.message).toMatchObject({
       role: "user",
       content: "",
-      MediaPath: "/media/inbound/image-1.png",
-      MediaPaths: ["/media/inbound/image-1.png"],
-      MediaType: "image/png",
-      MediaTypes: ["image/png"],
+      __openclaw: {
+        media: [
+          expect.objectContaining({ path: "/media/inbound/image-1.png", contentType: "image/png" }),
+        ],
+      },
     });
   });
 

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -3618,8 +3618,9 @@ describe("runCliAgent reliability", () => {
         expect.objectContaining({
           role: "user",
           content: "recorder display prompt",
-          MediaPath: "/tmp/image.png",
-          MediaType: "image/png",
+          __openclaw: {
+            media: [expect.objectContaining({ path: "/tmp/image.png", contentType: "image/png" })],
+          },
           timestamp: 123,
           idempotencyKey: "cli-recorder:user",
         }),

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -1612,10 +1612,14 @@ describe("CLI attempt execution", () => {
       expect.objectContaining({
         role: "user",
         content: "",
-        MediaPath: "/media/inbound/image-1.png",
-        MediaPaths: ["/media/inbound/image-1.png"],
-        MediaType: "image/png",
-        MediaTypes: ["image/png"],
+        __openclaw: {
+          media: [
+            expect.objectContaining({
+              path: "/media/inbound/image-1.png",
+              contentType: "image/png",
+            }),
+          ],
+        },
       }),
     );
   });

--- a/src/agents/embedded-agent-runner/replay-history.test.ts
+++ b/src/agents/embedded-agent-runner/replay-history.test.ts
@@ -107,7 +107,7 @@ describe("normalizeAssistantReplayContent", () => {
       legacyOnly,
     ]);
 
-    expect(out).toEqual([blankString, { ...blankArray, content: "" }, urlOnly, legacyOnly]);
+    expect(out).toEqual([blankString, { ...blankArray, content: "" }, urlOnly]);
   });
 
   it("converts mid-turn assistant content: [] to a non-empty sentinel text block when stopReason is error", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-finalize.media.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-finalize.media.test.ts
@@ -3,7 +3,7 @@ import { finalizeEmbeddedAttempt } from "./attempt-finalize.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 describe("finalizeEmbeddedAttempt media trajectory capture", () => {
-  it("records facts-only message snapshots with canonical conflict precedence", () => {
+  it("records canonical message snapshots without reprojecting them", () => {
     const recordEvent = vi.fn();
     const result = {
       terminal: { kind: "ok" },
@@ -20,8 +20,6 @@ describe("finalizeEmbeddedAttempt media trajectory capture", () => {
         {
           role: "user",
           content: "inspect",
-          MediaPath: "/media/legacy.png",
-          MediaType: "image/png",
           __openclaw: {
             media: [{ path: "/media/canonical.png", contentType: "image/png" }],
           },

--- a/src/agents/embedded-agent-runner/run/attempt-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-finalize.ts
@@ -1,5 +1,4 @@
 import { formatErrorMessage } from "../../../infra/errors.js";
-import { projectPersistedMessageMediaFacts } from "../../../media/media-facts.js";
 import { buildTrajectoryArtifacts } from "../../../trajectory/metadata.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import {
@@ -71,9 +70,7 @@ export function finalizeEmbeddedAttempt(
     compactionCount: result.compactionCount,
     assistantTexts: result.assistantTexts,
     finalPromptText: result.finalPromptText,
-    messagesSnapshot: result.messagesSnapshot.map((message) =>
-      projectPersistedMessageMediaFacts(message),
-    ),
+    messagesSnapshot: result.messagesSnapshot,
   });
   trajectoryRecorder?.recordEvent(
     "trace.artifacts",

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.test.ts
@@ -184,11 +184,6 @@ describe("prepareEmbeddedAttemptPromptExecution", () => {
 
   it.each([
     {
-      name: "legacy-only",
-      message: { MediaPath: "/tmp/legacy.png", MediaType: "image/png" },
-      expectedPath: "/tmp/legacy.png",
-    },
-    {
       name: "facts-only",
       message: { __openclaw: { media: [{ path: "/tmp/fact.png", contentType: "image/png" }] } },
       expectedPath: "/tmp/fact.png",
@@ -231,7 +226,7 @@ describe("prepareEmbeddedAttemptPromptExecution", () => {
       },
       expectedPath: "/tmp/media-only.png",
     },
-  ])("hydrates $name persisted rows through facts-first media", async (testCase) => {
+  ])("hydrates $name persisted rows through canonical media", async (testCase) => {
     const base = createInput();
     const persistedMessage = {
       role: "user" as const,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.ts
@@ -1,7 +1,7 @@
 /** Prepares prompt-lock ownership and prompt-local images for submission. */
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import type { OwnedSessionTranscriptCacheSnapshot } from "../../../config/sessions/transcript-write-context.js";
-import { readPersistedMediaFactsWithLegacyFallback } from "../../../media/media-facts.js";
+import { readPersistedMediaFacts } from "../../../media/media-facts.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import type { SandboxContext } from "../../sandbox/types.js";
 import type { AgentSession } from "../../sessions/index.js";
@@ -71,9 +71,7 @@ export async function prepareEmbeddedAttemptPromptExecution(input: {
   const persistedMessage =
     attempt.userTurnTranscriptRecorder?.message ??
     (await attempt.userTurnTranscriptRecorder?.resolveMessage());
-  const persistedMedia = persistedMessage
-    ? (readPersistedMediaFactsWithLegacyFallback(persistedMessage) ?? [])
-    : [];
+  const persistedMedia = persistedMessage ? (readPersistedMediaFacts(persistedMessage) ?? []) : [];
 
   return await detectAndLoadPromptImages({
     prompt: input.prompt,

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
@@ -477,7 +477,11 @@ describe("append-only late media (issue #99495)", () => {
     const normalized = normalizeMessagesForLlmBoundary([merged], { timezone: TZ });
 
     expect(normalized).toHaveLength(1);
-    expect(merged).toMatchObject({ MediaPath: "media://inbound/image.jpg" });
+    expect(merged).toMatchObject({
+      __openclaw: {
+        media: [expect.objectContaining({ path: "media://inbound/image.jpg" })],
+      },
+    });
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -278,17 +278,17 @@ describe("normalizeMessagesForLlmBoundary", () => {
     expect(normalizedArray?.content).toEqual([{ type: "text", text: expectedText }, image]);
   });
 
-  it("synthesizes marked late-media path lines with legacy-identical string bytes", () => {
+  it("synthesizes marked late-media path lines with reference-identical string bytes", () => {
     const timestamp = 1717570800000;
     const mediaText = "[media attached: /tmp/a.png]\n[media attached: media://inbound/b.jpg]";
     const marked = {
       role: "user",
       content: "",
       timestamp,
-      MediaPath: "/tmp/a.png",
-      MediaPaths: ["/tmp/a.png", ""],
-      MediaUrls: ["", "media://inbound/b.jpg"],
-      __openclaw: { lateMedia: true },
+      __openclaw: {
+        lateMedia: true,
+        media: [{ path: "/tmp/a.png" }, { url: "media://inbound/b.jpg" }],
+      },
     };
     const legacy = { ...marked, content: mediaText, __openclaw: undefined };
     const [normalizedMarked] = normalizeMessagesForLlmBoundary(
@@ -311,8 +311,10 @@ describe("normalizeMessagesForLlmBoundary", () => {
           role: "user",
           content: "",
           timestamp,
-          MediaUrl: "https://example.test/late.png",
-          __openclaw: { lateMedia: true },
+          __openclaw: {
+            lateMedia: true,
+            media: [{ url: "https://example.test/late.png" }],
+          },
         },
       ] as unknown as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
       { timezone: "UTC" },
@@ -326,18 +328,13 @@ describe("normalizeMessagesForLlmBoundary", () => {
     const timestamp = 1717570800000;
     const mediaText = "[media attached: /tmp/input.png]";
     const image = { type: "image", data: "aGVsbG8=", mimeType: "image/png" };
-    const fields = {
-      role: "user",
-      timestamp,
-      MediaPath: "/tmp/input.png",
-      MediaPaths: ["/tmp/input.png"],
-    };
+    const fields = { role: "user", timestamp };
     const [normalizedMarked] = normalizeMessagesForLlmBoundary(
       [
         {
           ...fields,
           content: [image],
-          __openclaw: { lateMedia: true },
+          __openclaw: { lateMedia: true, media: [{ path: "/tmp/input.png" }] },
         },
       ] as unknown as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
       { timezone: "UTC" },

--- a/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
@@ -186,16 +186,15 @@ describe("pruneProcessedHistoryImages", () => {
     expect(user?.content).toBe(`please remember ${PRUNED_HISTORY_MEDIA_REFERENCE_MARKER}`);
   });
 
-  it("prunes fact-owned and factless legacy late-media projections", () => {
-    const fields = {
-      role: "user" as const,
-      MediaPath: "media://inbound/stale-image.png",
-      MediaPaths: ["media://inbound/stale-image.png"],
-    };
+  it("prunes fact-owned and factless late-media projections", () => {
+    const fields = { role: "user" as const };
     const markedString = castAgentMessage({
       ...fields,
       content: "",
-      __openclaw: { lateMedia: true },
+      __openclaw: {
+        lateMedia: true,
+        media: [{ path: "media://inbound/stale-image.png" }],
+      },
     });
     const legacyString = castAgentMessage({
       content: "[media attached: media://inbound/stale-image.png]",
@@ -204,7 +203,10 @@ describe("pruneProcessedHistoryImages", () => {
     const markedArray = castAgentMessage({
       ...fields,
       content: [{ ...image }],
-      __openclaw: { lateMedia: true },
+      __openclaw: {
+        lateMedia: true,
+        media: [{ path: "media://inbound/stale-image.png" }],
+      },
     });
     const legacyArray = castAgentMessage({
       role: "user",
@@ -239,15 +241,20 @@ describe("pruneProcessedHistoryImages", () => {
     const message = castAgentMessage({
       role: "user",
       content: "resolved subtitle",
-      MediaPath: "media://inbound/stale-image.png",
-      MediaPaths: ["media://inbound/stale-image.png"],
-      __openclaw: { lateMedia: true },
+      __openclaw: {
+        lateMedia: true,
+        media: [{ path: "media://inbound/stale-image.png" }],
+      },
     });
 
     const pruned = expectPrunedMessages([message, ...oldEnoughTail()]);
-    const output = pruned as unknown as Array<{ content?: unknown; MediaPath?: unknown }>;
+    const output = pruned as unknown as Array<{
+      content?: unknown;
+      __openclaw?: { media?: unknown; mediaImagePruned?: boolean };
+    }>;
     expect(output[0]?.content).toBe("resolved subtitle");
-    expect(output[0]?.MediaPath).toBeUndefined();
+    expect(output[0]?.["__openclaw"]?.media).toBeUndefined();
+    expect(output[0]?.["__openclaw"]?.mediaImagePruned).toBe(true);
   });
 
   it("drops runtime facts from captioned old turns without changing their text", () => {
@@ -383,15 +390,12 @@ describe("pruneProcessedHistoryImages", () => {
     ]);
   });
 
-  it("redacts a fact-backed legacy image-source projection", () => {
+  it("redacts a fact-backed image-source projection", () => {
     const imagePath = "/tmp/legacy-owned.jpg";
     const message = castAgentMessage({
       role: "user",
       content: `[Image: source: ${imagePath}]\ncaption stays`,
-      MediaPath: imagePath,
-      MediaPaths: [imagePath],
-      MediaType: "image/jpeg",
-      MediaTypes: ["image/jpeg"],
+      __openclaw: { media: [{ path: imagePath, contentType: "image/jpeg" }] },
     });
 
     const pruned = expectPrunedMessages([message, ...oldEnoughTail()]);
@@ -404,10 +408,7 @@ describe("pruneProcessedHistoryImages", () => {
     const message = castAgentMessage({
       role: "user",
       content: `caption mentions ${mediaRef} as text`,
-      MediaPath: mediaRef,
-      MediaPaths: [mediaRef],
-      MediaType: "image/png",
-      MediaTypes: ["image/png"],
+      __openclaw: { media: [{ path: mediaRef, contentType: "image/png" }] },
     });
 
     const pruned = expectPrunedMessages([message, ...oldEnoughTail()]);
@@ -647,7 +648,7 @@ describe("installHistoryImagePruneContextTransform", () => {
       castAgentMessage({
         role: "user",
         content: `caption mentions ${mediaRef} as text`,
-        media: [{ url: mediaRef, contentType: "image/png" }],
+        __openclaw: { media: [{ url: mediaRef, contentType: "image/png" }] },
       }),
       ...oldEnoughTail(),
     ];

--- a/src/agents/embedded-agent-runner/run/history-image-prune.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.ts
@@ -1,6 +1,6 @@
 import { buildInboundMediaNoteProjection } from "../../../auto-reply/media-note.js";
 import {
-  readPersistedMediaFactsWithLegacyFallback,
+  readPersistedMediaFacts,
   readRuntimePromptMediaFacts,
   stripLegacyMediaContextFields,
   type MediaFact,
@@ -80,7 +80,7 @@ function resolveMessageMediaFacts(message: AgentMessage): MediaFact[] {
   if (runtimeMedia) {
     return runtimeMedia;
   }
-  return readPersistedMediaFactsWithLegacyFallback(message) ?? [];
+  return readPersistedMediaFacts(message) ?? [];
 }
 
 function wasStructurallyMediaPruned(message: AgentMessage): boolean {

--- a/src/agents/embedded-agent-runner/run/images.replay.test.ts
+++ b/src/agents/embedded-agent-runner/run/images.replay.test.ts
@@ -105,10 +105,7 @@ describe("structured prompt media replay", () => {
     const message = {
       role: "user" as const,
       content: "missing attachment",
-      MediaPath: missingPath,
-      MediaPaths: [missingPath],
-      MediaType: "image/png",
-      MediaTypes: ["image/png"],
+      __openclaw: { media: [{ path: missingPath, contentType: "image/png" }] },
     } as unknown as AgentMessage;
 
     try {
@@ -118,7 +115,9 @@ describe("structured prompt media replay", () => {
         workspaceOnly: true,
       });
       const replayed = result[0] as unknown as Record<string, unknown>;
-      expect(replayed.MediaPaths).toEqual([missingPath]);
+      expect(replayed["__openclaw"]).toMatchObject({
+        media: [expect.objectContaining({ path: missingPath })],
+      });
       expect(replayed.content).toEqual([{ type: "text", text: "missing attachment" }]);
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
@@ -478,12 +477,12 @@ describe("structured prompt media replay", () => {
     expect(result.images).toEqual([]);
   });
 
-  it("pairs an identity-less legacy fact with its existing inline block", async () => {
+  it("pairs an identity-less persisted fact with its existing inline block", async () => {
     const inlineImage = { type: "image" as const, data: TINY_PNG_BASE64, mimeType: "image/png" };
     const message = {
       role: "user" as const,
       content: [{ type: "text" as const, text: "legacy identity-less" }, inlineImage],
-      media: [{ kind: "image" }],
+      __openclaw: { media: [{ kind: "image" }] },
     } as unknown as AgentMessage;
 
     const result = await hydratePromptMediaMessages([message], {
@@ -497,12 +496,14 @@ describe("structured prompt media replay", () => {
     ]);
   });
 
-  it("does not pair an unresolved remote legacy fact with an existing inline block", async () => {
+  it("does not pair an unresolved remote persisted fact with an existing inline block", async () => {
     const inlineImage = { type: "image" as const, data: TINY_PNG_BASE64, mimeType: "image/png" };
     const message = {
       role: "user" as const,
       content: [{ type: "text" as const, text: "remote identity" }, inlineImage],
-      media: [{ kind: "image", url: "https://example.test/remote.png" }],
+      __openclaw: {
+        media: [{ kind: "image", url: "https://example.test/remote.png" }],
+      },
     } as unknown as AgentMessage;
 
     const result = await hydratePromptMediaMessages([message], {
@@ -520,7 +521,7 @@ describe("structured prompt media replay", () => {
     ]);
   });
 
-  it("hydrates an identity-bearing legacy fact beside an unowned inline block", async () => {
+  it("hydrates an identity-bearing persisted fact beside an unowned inline block", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-inline-"));
     const imagePath = path.join(workspaceDir, "inline.png");
     await fs.writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
@@ -528,10 +529,7 @@ describe("structured prompt media replay", () => {
     const message = {
       role: "user" as const,
       content: [{ type: "text" as const, text: "legacy" }, inlineImage],
-      MediaPath: imagePath,
-      MediaPaths: [imagePath],
-      MediaType: "image/png",
-      MediaTypes: ["image/png"],
+      __openclaw: { media: [{ path: imagePath, contentType: "image/png" }] },
     } as unknown as AgentMessage;
 
     try {
@@ -550,7 +548,7 @@ describe("structured prompt media replay", () => {
     }
   });
 
-  it("keeps identity-bearing legacy facts ahead of an unowned inline block", async () => {
+  it("keeps identity-bearing persisted facts ahead of an unowned inline block", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-order-"));
     const existingPath = path.join(workspaceDir, "existing.png");
     const hydratedPath = path.join(workspaceDir, "hydrated.png");
@@ -565,10 +563,12 @@ describe("structured prompt media replay", () => {
     const message = {
       role: "user" as const,
       content: [{ type: "text" as const, text: "legacy order" }, existingImage],
-      MediaPath: existingPath,
-      MediaPaths: [existingPath, hydratedPath],
-      MediaType: "image/png",
-      MediaTypes: ["image/png", "image/png"],
+      __openclaw: {
+        media: [
+          { path: existingPath, contentType: "image/png" },
+          { path: hydratedPath, contentType: "image/png" },
+        ],
+      },
     } as unknown as AgentMessage;
 
     try {

--- a/src/agents/embedded-agent-runner/run/images.test.ts
+++ b/src/agents/embedded-agent-runner/run/images.test.ts
@@ -733,17 +733,14 @@ describe("hydratePromptMediaMessages", () => {
     }
   });
 
-  it("reconstructs recent facts from serialized transcript media fields", async () => {
+  it("reconstructs recent facts from canonical transcript media", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-replayed-image-"));
     const imagePath = path.join(workspaceDir, "photo.png");
     await fs.writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
     const message = {
       role: "user" as const,
       content: "describe the replayed image",
-      MediaPath: imagePath,
-      MediaPaths: [imagePath],
-      MediaType: "image/png",
-      MediaTypes: ["image/png"],
+      __openclaw: { media: [{ path: imagePath, contentType: "image/png" }] },
     } as unknown as AgentMessage;
 
     try {

--- a/src/agents/embedded-agent-runner/run/images.ts
+++ b/src/agents/embedded-agent-runner/run/images.ts
@@ -9,7 +9,7 @@ import {
   normalizeMediaFacts,
   readRuntimePromptImageOrder,
   readRuntimePromptMediaFacts,
-  readPersistedMediaFactsWithLegacyFallback,
+  readPersistedMediaFacts,
   type MediaFact,
 } from "../../../media/media-facts.js";
 import { resolveMediaReferenceLocalPath } from "../../../media/media-reference.js";
@@ -607,7 +607,7 @@ export async function hydratePromptMediaMessages(
     }
     const runtimeMedia = readRuntimePromptMediaFacts(message);
     const meta = (message as unknown as Record<string, unknown>)["__openclaw"];
-    const resolvedMedia = runtimeMedia ?? readPersistedMediaFactsWithLegacyFallback(message) ?? [];
+    const resolvedMedia = runtimeMedia ?? readPersistedMediaFacts(message) ?? [];
     const runtimeImageOrder = readRuntimePromptImageOrder(message);
     const mediaImageLayout = readPersistedMediaImageLayout(message);
     if (!resolvedMedia.length) {

--- a/src/agents/embedded-agent-runner/run/plugin-harness-prompt-images.ts
+++ b/src/agents/embedded-agent-runner/run/plugin-harness-prompt-images.ts
@@ -1,8 +1,5 @@
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
-import {
-  isImageMediaFact,
-  readPersistedMediaFactsWithLegacyFallback,
-} from "../../../media/media-facts.js";
+import { isImageMediaFact, readPersistedMediaFacts } from "../../../media/media-facts.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { resolveAttemptWorkspaceSandbox } from "./attempt-setup.js";
 import { detectAndLoadPromptImages } from "./images.js";
@@ -51,9 +48,7 @@ export async function preparePluginHarnessPromptImages(params: {
   const persistedMessage =
     runParams.userTurnTranscriptRecorder?.message ??
     (await runParams.userTurnTranscriptRecorder?.resolveMessage());
-  const persistedMedia = persistedMessage
-    ? (readPersistedMediaFactsWithLegacyFallback(persistedMessage) ?? [])
-    : [];
+  const persistedMedia = persistedMessage ? (readPersistedMediaFacts(persistedMessage) ?? []) : [];
   const hydrationMedia = persistedMedia.length > 0 ? persistedMedia : runParams.media;
   if (!hydrationMedia?.some(isImageMediaFact)) {
     return {

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
@@ -64,9 +64,8 @@ describe("plugin harness prompt media", () => {
           message: {
             role: "user",
             content: "inspect",
-            MediaPaths: [imagePath, documentFact.path],
-            MediaTypes: ["image/png", "application/pdf"],
             __openclaw: {
+              media: [{ path: imagePath, contentType: "image/png" }, documentFact],
               mediaImageLayout: { slots: [{ kind: "offloaded", factIndex: 0 }] },
             },
           },
@@ -260,9 +259,11 @@ describe("plugin harness prompt media", () => {
           message: {
             role: "user",
             content: "compare",
-            MediaPaths: ["/tmp/described.png", "/tmp/inline.png"],
-            MediaTypes: ["image/png", "image/png"],
             __openclaw: {
+              media: [
+                { path: "/tmp/described.png", contentType: "image/png" },
+                { path: "/tmp/inline.png", contentType: "image/png" },
+              ],
               mediaImageLayout: {
                 slots: [{ kind: "inline", factIndex: 1 }],
                 suppressedFactIndexes: [0],

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -769,7 +769,7 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
       role: "user",
       content: "",
-      MediaPath: "/tmp/input.png",
+      __openclaw: { media: [expect.objectContaining({ path: "/tmp/input.png" })] },
     });
   });
 
@@ -1227,10 +1227,9 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
       role: "user",
       content: "describe this",
-      MediaPath: imagePath,
-      MediaPaths: [imagePath],
-      MediaType: "image/png",
-      MediaTypes: ["image/png"],
+      __openclaw: {
+        media: [expect.objectContaining({ path: imagePath, contentType: "image/png" })],
+      },
     });
     expect(call.followupRun.images?.[0]?.data).toHaveLength(92);
     expect(call.followupRun.imageOrder).toEqual(["inline"]);

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -3904,10 +3904,11 @@ describe("followup queue collect routing", () => {
     const message = await calls[0]?.userTurnTranscriptRecorder?.resolveMessage();
     expect(message?.content).toContain("first transcript");
     expect(message?.content).toContain("second transcript");
-    expect((message as unknown as { MediaPaths?: string[] } | undefined)?.MediaPaths).toEqual([
-      "/tmp/first.png",
-      "/tmp/second.png",
-    ]);
+    expect(
+      (message as unknown as { __openclaw?: { media?: Array<{ path?: string }> } } | undefined)?.[
+        "__openclaw"
+      ]?.media?.map((fact) => fact.path),
+    ).toEqual(["/tmp/first.png", "/tmp/second.png"]);
     await vi.waitFor(() => expect(firstComplete).toHaveBeenCalledTimes(1));
     expect(secondComplete).toHaveBeenCalledTimes(1);
   });

--- a/src/boards/board-store.parity.test.ts
+++ b/src/boards/board-store.parity.test.ts
@@ -5,6 +5,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { replaceSessionEntrySync } from "../config/sessions/session-accessor.entry.js";
 import { deleteSessionEntryLifecycle } from "../config/sessions/session-accessor.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { migrateLegacyMediaPersistence } from "../infra/state-migrations.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -530,6 +531,8 @@ describe("SqliteBoardStore persistence", () => {
     `);
     existingV14.close();
 
+    expect(migrateLegacyMediaPersistence({ env }).warnings).toEqual([]);
+
     const reopened = openOpenClawAgentDatabase({ agentId: "main", env });
     expect(
       reopened.db
@@ -625,6 +628,8 @@ describe("SqliteBoardStore persistence", () => {
       UPDATE schema_meta SET schema_version = 14 WHERE meta_key = 'primary';
     `);
     closeOpenClawAgentDatabasesForTest();
+
+    expect(migrateLegacyMediaPersistence({ env }).warnings).toEqual([]);
 
     const upgradedStore = new SqliteBoardStore({
       resolveSession: () => ({ agentId: "main", sessionKey }),

--- a/src/channels/inbound-event/media.test.ts
+++ b/src/channels/inbound-event/media.test.ts
@@ -598,7 +598,6 @@ describe("channel inbound media facts", () => {
     expect(buildMediaPayload(media)).toEqual(compact);
 
     const aligned = { ...compact, MediaTypes: ["image/png", ""] };
-    expect(projectMediaFacts(media, "aligned")).toEqual(aligned);
     expect(buildMediaPayload(media, { preserveMediaTypeCardinality: true })).toEqual(aligned);
   });
 
@@ -621,10 +620,6 @@ describe("channel inbound media facts", () => {
     expect(projectMediaFacts(richerMedia, "compact")).toEqual(compact);
     expect(buildAgentMediaPayload(richerMedia)).toEqual(compact);
     expect(buildMediaPayload(richerMedia)).toEqual(compact);
-    expect(projectMediaFacts(richerMedia, "aligned")).toEqual({
-      ...compact,
-      MediaTypes: [""],
-    });
     expect(buildMediaPayload(richerMedia, { preserveMediaTypeCardinality: true })).toEqual({
       ...compact,
       MediaTypes: [""],

--- a/src/channels/plugins/media-payload.ts
+++ b/src/channels/plugins/media-payload.ts
@@ -23,5 +23,11 @@ export function buildMediaPayload(
   mediaList: MediaPayloadInput[],
   opts?: { preserveMediaTypeCardinality?: boolean },
 ): MediaPayload {
-  return projectMediaFacts(mediaList, opts?.preserveMediaTypeCardinality ? "aligned" : "compact");
+  const projected = projectMediaFacts(mediaList, "compact");
+  return opts?.preserveMediaTypeCardinality
+    ? {
+        ...projected,
+        MediaTypes: mediaList.map((entry) => entry.contentType ?? ""),
+      }
+    : projected;
 }

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1514,6 +1514,7 @@ vi.mock("./doctor-state-migrations.js", () => ({
   autoMigrateLegacyState: vi.fn(async () => ({ changes: [], warnings: [] })),
   autoMigrateLegacyStateDir: vi.fn(async () => ({ changes: [], warnings: [] })),
   autoMigrateLegacyTaskStateSidecars: vi.fn(async () => ({ changes: [], warnings: [] })),
+  migrateLegacyMediaPersistence: vi.fn(() => ({ changes: [], warnings: [] })),
 }));
 
 function resetTerminalNoteMock() {

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -77,6 +77,9 @@ const autoMigrateLegacyTaskStateSidecars = vi.hoisted(() =>
     }),
   ),
 );
+const migrateLegacyMediaPersistence = vi.hoisted(() =>
+  vi.fn(() => ({ changes: [], warnings: [] })),
+);
 const repairLegacyCronStoreWithoutPrompt = vi.hoisted(() =>
   vi.fn(
     async (): Promise<{
@@ -156,6 +159,7 @@ vi.mock("./doctor-state-migrations.js", () => ({
   autoMigrateLegacyStateDir,
   autoMigrateLegacyPluginDoctorState,
   autoMigrateLegacyTaskStateSidecars,
+  migrateLegacyMediaPersistence,
 }));
 
 vi.mock("./doctor/cron/legacy-repair.js", () => ({

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -425,6 +425,7 @@ export async function runDoctorConfigPreflight(
   let startupMigrationHeartbeatError: unknown;
   const startupMigrationWarnings: string[] = [];
   const cronCodexRuntimePolicyTargets: CronCodexRuntimePolicyTarget[] = [];
+  let doctorMediaPersistenceAttempted = false;
   const noteStartupStateMigrationResult = (result: {
     changes: string[];
     warnings: string[];
@@ -605,17 +606,17 @@ export async function runDoctorConfigPreflight(
             cronCodexRuntimePolicyTargets.push(...cronCodexPlan.targets);
             noteStartupStateMigrationResult({ changes: [], warnings: cronCodexPlan.warnings });
           }
-          noteStartupStateMigrationResult(
-            await autoMigrateLegacyState({
-              cfg: stateMigrationInput.cfg,
-              ...(stateMigrationInput.pluginDoctorConfig
-                ? { pluginDoctorConfig: stateMigrationInput.pluginDoctorConfig }
-                : {}),
-              env: process.env,
-              recoverCorruptTargetStore: options.recoverCorruptTargetStore,
-              doctorOnlyStateMigrations: options.doctorOnlyStateMigrations,
-            }),
-          );
+          const legacyStateResult = await autoMigrateLegacyState({
+            cfg: stateMigrationInput.cfg,
+            ...(stateMigrationInput.pluginDoctorConfig
+              ? { pluginDoctorConfig: stateMigrationInput.pluginDoctorConfig }
+              : {}),
+            env: process.env,
+            recoverCorruptTargetStore: options.recoverCorruptTargetStore,
+            doctorOnlyStateMigrations: options.doctorOnlyStateMigrations,
+          });
+          doctorMediaPersistenceAttempted = options.doctorOnlyStateMigrations === true;
+          noteStartupStateMigrationResult(legacyStateResult);
         } else if (stateMigrationInput.pluginDoctorConfig) {
           noteStartupStateMigrationResult(
             await autoMigrateLegacyPluginDoctorState({
@@ -637,7 +638,17 @@ export async function runDoctorConfigPreflight(
         );
       }
     }
-
+    if (
+      stateMigrations &&
+      stateMigrationsAllowed &&
+      freshConfigGuardAllowed &&
+      options.doctorOnlyStateMigrations === true &&
+      !doctorMediaPersistenceAttempted
+    ) {
+      noteStartupStateMigrationResult(
+        stateMigrations.migrateLegacyMediaPersistence({ env: process.env }),
+      );
+    }
     if (startupCheckpoint) {
       if (shouldRecordStartupCheckpoint) {
         if (startupMigrationHeartbeatError) {

--- a/src/commands/doctor-state-migrations.ts
+++ b/src/commands/doctor-state-migrations.ts
@@ -7,6 +7,7 @@ export {
   autoMigrateLegacyState,
   detectLegacyStateMigrations,
   migrateLegacyAgentDir,
+  migrateLegacyMediaPersistence,
   resetAutoMigrateLegacyStateDirForTest,
   resetAutoMigrateLegacyTaskStateSidecarsForTest,
   resetAutoMigrateLegacyStateForTest,

--- a/src/config/sessions/archive-compression.ts
+++ b/src/config/sessions/archive-compression.ts
@@ -70,6 +70,17 @@ export function readSessionArchiveContentSync(filePath: string): string {
   return zstdCodec.decompress(fs.readFileSync(filePath)).toString("utf8");
 }
 
+/** Decodes staged archive bytes using the source archive's codec. */
+export function decodeSessionArchiveBytes(bytes: Uint8Array, compressed: boolean): string {
+  if (!compressed) {
+    return Buffer.from(bytes).toString("utf8");
+  }
+  if (!zstdCodec) {
+    throw new Error("Cannot decode compressed transcript archive: this runtime lacks zstd support");
+  }
+  return zstdCodec.decompress(Buffer.from(bytes)).toString("utf8");
+}
+
 /**
  * Materializes a compressed archive as a plain JSONL cache file and returns
  * the readable path; plain archives pass through untouched. Archives are

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -5,6 +5,7 @@ import {
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
 import { redactSecrets } from "../../logging/redact.js";
+import { canonicalizePersistedUserMessageMedia } from "../../media/media-facts.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type {
   TranscriptEvent,
@@ -49,11 +50,12 @@ export function appendTranscriptEventInTransaction(
     touchMutation?: boolean;
   } = {},
 ): boolean {
+  const persistedEvent = canonicalizeTranscriptEventMedia(event);
   const db = getSessionKysely(database.db);
-  const createdAt = readEventTimestamp(event) ?? Date.now();
+  const createdAt = readEventTimestamp(persistedEvent) ?? Date.now();
   ensureTranscriptSessionRoot(database, scope, createdAt);
   ensureTranscriptGenerationInTransaction(database, scope.sessionId);
-  const identity = readTranscriptEventIdentity(event);
+  const identity = readTranscriptEventIdentity(persistedEvent);
   if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
     return false;
   }
@@ -74,7 +76,7 @@ export function appendTranscriptEventInTransaction(
     db.insertInto("transcript_events").values({
       session_id: scope.sessionId,
       seq,
-      event_json: JSON.stringify(event),
+      event_json: JSON.stringify(persistedEvent),
       created_at: createdAt,
     }),
   );
@@ -84,7 +86,7 @@ export function appendTranscriptEventInTransaction(
   const projectionNeedsRebuild = indexAppendedTranscriptEventInTransaction(database.db, {
     sessionId: scope.sessionId,
     seq,
-    event,
+    event: persistedEvent,
     eventId: identity?.eventId ?? null,
     createdAt,
   });
@@ -177,10 +179,12 @@ function appendTranscriptEventRowInTransaction(
   event: TranscriptEvent,
   seq: number,
   state: { seenEventIds: Set<string>; seenMessageIdempotencyKeys: Set<string> },
+  createdAtOverride?: number,
 ): boolean {
+  const persistedEvent = canonicalizeTranscriptEventMedia(event);
   const db = getSessionKysely(database.db);
-  const createdAt = readEventTimestamp(event) ?? Date.now();
-  const identity = readTranscriptEventIdentity(event);
+  const createdAt = createdAtOverride ?? readEventTimestamp(persistedEvent) ?? Date.now();
+  const identity = readTranscriptEventIdentity(persistedEvent);
   if (identity && state.seenEventIds.has(identity.eventId)) {
     return false;
   }
@@ -189,14 +193,14 @@ function appendTranscriptEventRowInTransaction(
     db.insertInto("transcript_events").values({
       session_id: scope.sessionId,
       seq,
-      event_json: JSON.stringify(event),
+      event_json: JSON.stringify(persistedEvent),
       created_at: createdAt,
     }),
   );
   indexAppendedTranscriptEventInTransaction(database.db, {
     sessionId: scope.sessionId,
     seq,
-    event,
+    event: persistedEvent,
     eventId: identity?.eventId ?? null,
     createdAt,
   });
@@ -313,6 +317,10 @@ export function replaceSqliteTranscriptEventsInTransaction(
   database: OpenClawAgentDatabase,
   resolved: ResolvedTranscriptScope,
   events: readonly TranscriptEvent[],
+  options: {
+    createdAtByIndex?: readonly number[];
+    preserveSessionWindowTimestamps?: boolean;
+  } = {},
 ): void {
   const previousGeneration = readTranscriptGenerationInTransaction(database, resolved.sessionId);
   const deleted = deleteSqliteTranscriptEventsInTransaction(database, resolved.sessionId);
@@ -323,7 +331,9 @@ export function replaceSqliteTranscriptEventsInTransaction(
     }
     return;
   }
-  ensureTranscriptSessionRoot(database, resolved, readEventTimestamp(events[0]) ?? Date.now());
+  if (!deleted || options.preserveSessionWindowTimestamps !== true) {
+    ensureTranscriptSessionRoot(database, resolved, readEventTimestamp(events[0]) ?? Date.now());
+  }
   if (deleted || previousGeneration) {
     rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
   } else {
@@ -332,12 +342,19 @@ export function replaceSqliteTranscriptEventsInTransaction(
   let seq = 0;
   const seenEventIds = new Set<string>();
   const seenMessageIdempotencyKeys = new Set<string>();
-  for (const event of events) {
+  for (const [eventIndex, event] of events.entries()) {
     if (
-      appendTranscriptEventRowInTransaction(database, resolved, event, seq, {
-        seenEventIds,
-        seenMessageIdempotencyKeys,
-      })
+      appendTranscriptEventRowInTransaction(
+        database,
+        resolved,
+        event,
+        seq,
+        {
+          seenEventIds,
+          seenMessageIdempotencyKeys,
+        },
+        options.createdAtByIndex?.[eventIndex],
+      )
     ) {
       seq += 1;
     }
@@ -346,6 +363,42 @@ export function replaceSqliteTranscriptEventsInTransaction(
     touchTranscriptMutationInTransaction(database, resolved.sessionId);
     reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
   }
+}
+
+/** Rewrite existing transcript rows exactly, without append-time deduplication. */
+export function rewriteSqliteTranscriptEventRowsInTransaction(
+  database: OpenClawAgentDatabase,
+  resolved: ResolvedTranscriptScope,
+  rows: readonly {
+    event: TranscriptEvent;
+    expectedEventJson: string;
+    seq: number;
+  }[],
+): void {
+  if (rows.length === 0) {
+    return;
+  }
+  const db = getSessionKysely(database.db);
+  for (const row of rows) {
+    const persistedEvent = canonicalizeTranscriptEventMedia(row.event);
+    const result = executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("transcript_events")
+        .set({ event_json: JSON.stringify(persistedEvent) })
+        .where("session_id", "=", resolved.sessionId)
+        .where("seq", "=", row.seq)
+        .where("event_json", "=", row.expectedEventJson),
+    );
+    if (result.numAffectedRows !== 1n) {
+      throw new Error(
+        `Transcript row ${resolved.sessionId}:${row.seq} changed before exact rewrite`,
+      );
+    }
+  }
+  rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
+  touchTranscriptMutationInTransaction(database, resolved.sessionId);
+  reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
 }
 
 export function readTranscriptIdentityByEventId(
@@ -470,6 +523,24 @@ function readTranscriptEventIdentity(event: unknown):
         messageIdempotencyKey: readMessageIdempotencyKey(record.message),
       }
     : undefined;
+}
+
+function canonicalizeTranscriptEventMedia(event: TranscriptEvent): TranscriptEvent {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return event;
+  }
+  const record = event as Record<string, unknown>;
+  const message = record.message;
+  if (
+    record.type !== "message" ||
+    !message ||
+    typeof message !== "object" ||
+    Array.isArray(message)
+  ) {
+    return event;
+  }
+  const canonical = canonicalizePersistedUserMessageMedia(message);
+  return canonical.changed ? { ...record, message: canonical.message } : event;
 }
 
 export function readMessageIdempotencyKey(message: unknown): string | null {

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -14,11 +14,7 @@ import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import { extractCanvasFromDetails, extractCanvasFromText } from "../chat/canvas-render.js";
-import {
-  isMeaningfulMediaFact,
-  projectPersistedMessageMediaFacts,
-  readPersistedMediaFactsWithLegacyFallback,
-} from "../media/media-facts.js";
+import { isMeaningfulMediaFact, readPersistedMediaFacts } from "../media/media-facts.js";
 import {
   INTER_SESSION_PROMPT_PREFIX_BASE,
   normalizeInputProvenance,
@@ -1507,7 +1503,7 @@ function isEmptyTextOnlyContent(content: unknown): boolean {
 }
 
 function hasTranscriptMediaFacts(message: Record<string, unknown>): boolean {
-  return (readPersistedMediaFactsWithLegacyFallback(message) ?? []).some(isMeaningfulMediaFact);
+  return (readPersistedMediaFacts(message) ?? []).some(isMeaningfulMediaFact);
 }
 
 function extractProjectedText(content: unknown): string {
@@ -2131,8 +2127,7 @@ export function projectChatDisplayMessagesWithState(
 ): ChatDisplayProjectionResult {
   const source = options?.stripEnvelope === false ? messages : stripEnvelopeFromMessages(messages);
   const mirrored = mirrorMessageToolVisibleReplies(source);
-  const projectedMedia = toProjectedMessages(mirrored).map(projectPersistedMessageMediaFacts);
-  const projectedErrors = projectEmptyAssistantErrorMessages(projectedMedia);
+  const projectedErrors = projectEmptyAssistantErrorMessages(toProjectedMessages(mirrored));
   const filtered = filterVisibleProjectedHistoryMessages(
     projectSessionsSendInterSessionMessages(
       toProjectedMessages(sanitizeChatHistoryMessages(projectedErrors, Number.MAX_SAFE_INTEGER)),

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -5362,9 +5362,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expect(typeof mockState.savedMediaCalls[1]?.size).toBe("number");
       const userTurnInput = mockState.lastDispatchUserTurnInput as
         | {
+            __openclaw?: { media?: Array<{ contentType?: string; path?: string }> };
             content?: unknown;
-            MediaPaths?: string[];
-            MediaTypes?: string[];
           }
         | undefined;
       if (!userTurnInput) {
@@ -5372,11 +5371,14 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       }
       expect(findUserUpdate()).toBeUndefined();
       expect(userTurnInput.content).toBe("edit these");
-      expect(userTurnInput.MediaPaths).toEqual([
+      expect(userTurnInput["__openclaw"]?.media?.map((fact) => fact.path)).toEqual([
         "/tmp/chat-send-image-a.png",
         "/tmp/chat-send-image-b.jpg",
       ]);
-      expect(userTurnInput.MediaTypes).toEqual(["image/png", "image/jpeg"]);
+      expect(userTurnInput["__openclaw"]?.media?.map((fact) => fact.contentType)).toEqual([
+        "image/png",
+        "image/jpeg",
+      ]);
       expect(mockState.lastDispatchCtx?.media).toBeUndefined();
       expect(mockState.lastDispatchImages).toHaveLength(2);
     });
@@ -5414,9 +5416,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await waitForAssertion(() => {
       const userTurnInput = mockState.lastDispatchUserTurnInput as
         | {
+            __openclaw?: { media?: Array<{ contentType?: string; path?: string }> };
             content?: unknown;
-            MediaPaths?: string[];
-            MediaTypes?: string[];
           }
         | undefined;
       expect(mockState.lastDispatchImages).toBeUndefined();
@@ -5429,8 +5430,12 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expect(typeof mockState.savedMediaCalls[0]?.size).toBe("number");
       expect(findUserUpdate()).toBeUndefined();
       expect(userTurnInput?.content).toBe("summarize this");
-      expect(userTurnInput?.MediaPaths).toEqual(["/tmp/chat-send-brief.pdf"]);
-      expect(userTurnInput?.MediaTypes).toEqual(["application/pdf"]);
+      expect(userTurnInput?.["__openclaw"]?.media).toEqual([
+        expect.objectContaining({
+          path: "/tmp/chat-send-brief.pdf",
+          contentType: "application/pdf",
+        }),
+      ]);
     });
   });
 
@@ -5486,13 +5491,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await waitForAssertion(() => {
       const userTurnInput = mockState.lastDispatchUserTurnInput as
         | {
+            __openclaw?: { media?: Array<{ path?: string }> };
             content?: unknown;
-            MediaPaths?: string[];
           }
         | undefined;
       expect(findUserUpdate()).toBeUndefined();
       expect(userTurnInput?.content).toBe("edit both");
-      expect(userTurnInput?.MediaPaths).toEqual([
+      expect(userTurnInput?.["__openclaw"]?.media?.map((fact) => fact.path)).toEqual([
         "/tmp/chat-send-inline.png",
         "/tmp/offloaded-big.png",
       ]);

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -2178,30 +2178,9 @@ describe("projectRecentChatDisplayMessages", () => {
 
   it.each([
     {
-      name: "legacy-only",
-      message: { MediaPath: "/tmp/openclaw/legacy.png", MediaType: "image/png" },
-      expectedPath: "/tmp/openclaw/legacy.png",
-    },
-    {
       name: "facts-only",
       message: { __openclaw: { media: [{ path: "/tmp/openclaw/fact.png" }] } },
       expectedPath: "/tmp/openclaw/fact.png",
-    },
-    {
-      name: "both-equal",
-      message: {
-        MediaPath: "/tmp/openclaw/equal.png",
-        __openclaw: { media: [{ path: "/tmp/openclaw/equal.png" }] },
-      },
-      expectedPath: "/tmp/openclaw/equal.png",
-    },
-    {
-      name: "both-conflict",
-      message: {
-        MediaPath: "/tmp/openclaw/legacy-conflict.png",
-        __openclaw: { media: [{ path: "/tmp/openclaw/canonical.png" }] },
-      },
-      expectedPath: "/tmp/openclaw/canonical.png",
     },
     {
       name: "sparse",
@@ -2219,7 +2198,7 @@ describe("projectRecentChatDisplayMessages", () => {
       message: { __openclaw: { media: [{ path: "/tmp/openclaw/media-only.png" }] } },
       expectedPath: "/tmp/openclaw/media-only.png",
     },
-  ])("keeps $name media-only users through facts-first display projection", (testCase) => {
+  ])("keeps $name media-only users through canonical display projection", (testCase) => {
     const result = projectRecentChatDisplayMessages([
       { role: "user", content: "", timestamp: 1, ...testCase.message },
       { role: "user", content: "", timestamp: 2 },

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -80,6 +80,7 @@ import {
   detectLegacyMcpOAuthStores,
   migrateLegacyMcpOAuthStores,
 } from "./state-migrations.mcp-oauth.js";
+import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 import {
   detectLegacyMeetingTranscripts,
   migrateLegacyMeetingTranscripts,
@@ -1288,6 +1289,22 @@ export async function autoMigrateLegacyState(params: {
       ...(stateDirResult.notices?.length ? { notices: stateDirResult.notices } : {}),
     };
   }
+  const mediaPersistence =
+    params.doctorOnlyStateMigrations === true
+      ? migrateLegacyMediaPersistence({ env: { ...env, OPENCLAW_STATE_DIR: stateDir } })
+      : { changes: [], warnings: [] };
+  if (mediaPersistence.warnings.length > 0) {
+    return {
+      migrated:
+        stateDirResult.migrated ||
+        stateSchema.changes.length > 0 ||
+        mediaPersistence.changes.length > 0,
+      skipped: false,
+      changes: [...stateDirResult.changes, ...stateSchema.changes, ...mediaPersistence.changes],
+      warnings: [...stateDirResult.warnings, ...stateSchema.warnings, ...mediaPersistence.warnings],
+      ...(stateDirResult.notices?.length ? { notices: stateDirResult.notices } : {}),
+    };
+  }
   const pluginDoctorConfig = params.pluginDoctorConfig ?? params.cfg;
   const configMachineState = migrateLegacyConfigMachineState({
     config: pluginDoctorConfig,
@@ -1425,6 +1442,7 @@ export async function autoMigrateLegacyState(params: {
     const changes = [
       ...stateDirResult.changes,
       ...stateSchema.changes,
+      ...mediaPersistence.changes,
       ...configMachineState.changes,
       ...orphanKeys.changes,
       ...acpSessionMetadata.changes,
@@ -1448,6 +1466,7 @@ export async function autoMigrateLegacyState(params: {
     const warnings = [
       ...stateDirResult.warnings,
       ...stateSchema.warnings,
+      ...mediaPersistence.warnings,
       ...configMachineState.warnings,
       ...detected.warnings,
       ...orphanKeys.warnings,
@@ -1486,6 +1505,7 @@ export async function autoMigrateLegacyState(params: {
       migrated:
         stateDirResult.migrated ||
         stateSchema.changes.length > 0 ||
+        mediaPersistence.changes.length > 0 ||
         configMachineState.changes.length > 0 ||
         orphanKeys.changes.length > 0 ||
         acpSessionMetadata.changes.length > 0 ||
@@ -1536,6 +1556,7 @@ export async function autoMigrateLegacyState(params: {
     const changes = [
       ...stateDirResult.changes,
       ...stateSchema.changes,
+      ...mediaPersistence.changes,
       ...configMachineState.changes,
       ...orphanKeys.changes,
       ...acpSessionMetadata.changes,
@@ -1546,6 +1567,7 @@ export async function autoMigrateLegacyState(params: {
     const warnings = [
       ...stateDirResult.warnings,
       ...stateSchema.warnings,
+      ...mediaPersistence.warnings,
       ...configMachineState.warnings,
       ...detected.warnings,
       ...orphanKeys.warnings,
@@ -1565,6 +1587,7 @@ export async function autoMigrateLegacyState(params: {
       migrated:
         stateDirResult.migrated ||
         stateSchema.changes.length > 0 ||
+        mediaPersistence.changes.length > 0 ||
         configMachineState.changes.length > 0 ||
         orphanKeys.changes.length > 0 ||
         acpSessionMetadata.changes.length > 0 ||
@@ -1648,6 +1671,7 @@ export async function autoMigrateLegacyState(params: {
   const changes = [
     ...stateDirResult.changes,
     ...stateSchema.changes,
+    ...mediaPersistence.changes,
     ...configMachineState.changes,
     ...orphanKeys.changes,
     ...acpSessionMetadata.changes,
@@ -1676,6 +1700,7 @@ export async function autoMigrateLegacyState(params: {
   const warnings = [
     ...stateDirResult.warnings,
     ...stateSchema.warnings,
+    ...mediaPersistence.warnings,
     ...configMachineState.warnings,
     ...detected.warnings,
     ...orphanKeys.warnings,

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -18,10 +18,7 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
-import {
-  mediaPersistenceMigrationTesting,
-  migrateLegacyMediaPersistence,
-} from "./state-migrations.media-persistence.js";
+import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 
 const tempDirs: string[] = [];
 const PREVIOUS_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
@@ -853,11 +850,13 @@ describe("legacy media persistence doctor migration", () => {
       env,
       eventsBySession: { drift: [event] },
     });
-    expect(() =>
-      mediaPersistenceMigrationTesting.migrateRegisteredDatabase({
-        agentId: "main",
-        pathname: databasePath,
-        beforeTransaction: () => {
+    const transcriptDrift = migrateLegacyMediaPersistence({
+      env,
+      hooks: {
+        beforeDatabaseTransaction: (pathname) => {
+          if (pathname !== databasePath) {
+            return;
+          }
           const writer = new DatabaseSync(databasePath);
           writer
             .prepare(
@@ -866,8 +865,9 @@ describe("legacy media persistence doctor migration", () => {
             .run("drift");
           writer.close();
         },
-      }),
-    ).toThrow("source changed");
+      },
+    });
+    expect(transcriptDrift.warnings.join("\n")).toContain("source changed");
     expect(readDatabaseSnapshot(databasePath).version.user_version).toBe(PREVIOUS_VERSION);
 
     const trajectoryWriter = new DatabaseSync(databasePath);
@@ -883,11 +883,13 @@ describe("legacy media persistence doctor migration", () => {
         2000,
       );
     trajectoryWriter.close();
-    expect(() =>
-      mediaPersistenceMigrationTesting.migrateRegisteredDatabase({
-        agentId: "main",
-        pathname: databasePath,
-        beforeTransaction: () => {
+    const trajectoryDrift = migrateLegacyMediaPersistence({
+      env,
+      hooks: {
+        beforeDatabaseTransaction: (pathname) => {
+          if (pathname !== databasePath) {
+            return;
+          }
           const writer = new DatabaseSync(databasePath);
           writer
             .prepare(
@@ -901,23 +903,39 @@ describe("legacy media persistence doctor migration", () => {
             );
           writer.close();
         },
-      }),
-    ).toThrow("trajectory source changed");
+      },
+    });
+    expect(trajectoryDrift.warnings.join("\n")).toContain("trajectory source changed");
     expect(readDatabaseSnapshot(databasePath).version.user_version).toBe(PREVIOUS_VERSION);
 
-    const archivePath = path.join(stateDir, "drift.jsonl.deleted.2026-07-24T01-02-03.000Z");
+    const archivePath = path.join(
+      stateDir,
+      "agents",
+      "main",
+      "sessions",
+      "drift.jsonl.deleted.2026-07-24T01-02-03.000Z",
+    );
     writeArchive(archivePath, [event], false);
-    expect(() =>
-      mediaPersistenceMigrationTesting.migrateTranscriptArchive(archivePath, {
-        beforeReplace: () => fs.writeFileSync(archivePath, "replacement\n"),
-      }),
-    ).toThrow("changed before atomic");
+    const archiveDrift = migrateLegacyMediaPersistence({
+      env,
+      hooks: {
+        beforeArchiveReplace: (candidate) => {
+          if (candidate === archivePath) {
+            fs.writeFileSync(archivePath, "replacement\n");
+          }
+        },
+      },
+    });
+    expect(archiveDrift.warnings.join("\n")).toContain("changed before atomic");
     expect(fs.readFileSync(archivePath, "utf8")).toBe("replacement\n");
   });
 
   it("rejects ambiguous sparse arrays and ignores stale interrupted temp files", () => {
     const stateDir = makeTempDir(tempDirs, "media-persistence-sparse-");
-    const archivePath = path.join(stateDir, "sparse.jsonl.bak.2026-07-24T01-02-03.000Z");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    createLegacyDatabaseFixture({ env, eventsBySession: {} });
+    const archiveDir = path.join(stateDir, "agents", "main", "sessions");
+    const archivePath = path.join(archiveDir, "sparse.jsonl.bak.2026-07-24T01-02-03.000Z");
     const event = createEvent({
       id: "event-1",
       parentId: null,
@@ -929,19 +947,21 @@ describe("legacy media persistence doctor migration", () => {
       },
     });
     writeArchive(archivePath, [event], false);
-    expect(() => mediaPersistenceMigrationTesting.migrateTranscriptArchive(archivePath)).toThrow(
+    expect(migrateLegacyMediaPersistence({ env }).warnings.join("\n")).toContain(
       "ambiguous sparse positional alignment",
     );
+    fs.unlinkSync(archivePath);
 
     const corruptArchivePath = path.join(
-      stateDir,
+      archiveDir,
       "corrupt.jsonl.deleted.2026-07-24T01-02-04.000Z",
     );
     fs.writeFileSync(corruptArchivePath, "{broken\n");
-    expect(() =>
-      mediaPersistenceMigrationTesting.migrateTranscriptArchive(corruptArchivePath),
-    ).toThrow("invalid transcript JSON");
+    expect(migrateLegacyMediaPersistence({ env }).warnings.join("\n")).toContain(
+      "invalid transcript JSON",
+    );
     expect(fs.readFileSync(corruptArchivePath, "utf8")).toBe("{broken\n");
+    fs.unlinkSync(corruptArchivePath);
 
     writeArchive(
       archivePath,
@@ -956,7 +976,9 @@ describe("legacy media persistence doctor migration", () => {
       false,
     );
     fs.writeFileSync(`${archivePath}.media-retirement.999.interrupted.tmp`, "partial");
-    expect(mediaPersistenceMigrationTesting.migrateTranscriptArchive(archivePath)).toBe(true);
+    expect(migrateLegacyMediaPersistence({ env }).changes.join("\n")).toContain(
+      "Migrated archived transcript media",
+    );
     expect(readSessionArchiveContentSync(archivePath)).toContain('"__openclaw"');
   });
 });

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -1,0 +1,962 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import {
+  encodeSessionArchiveContent,
+  readSessionArchiveContentSync,
+  SESSION_ARCHIVE_ZSTD_SUFFIX,
+} from "../config/sessions/archive-compression.js";
+import { appendTranscriptEventInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
+import { reconcileSessionTranscriptIndexInTransaction } from "../config/sessions/session-transcript-index.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import {
+  mediaPersistenceMigrationTesting,
+  migrateLegacyMediaPersistence,
+} from "./state-migrations.media-persistence.js";
+
+const tempDirs: string[] = [];
+const PREVIOUS_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+
+type FixtureEvent = Record<string, unknown>;
+
+function createEvent(params: {
+  id: string;
+  message: Record<string, unknown>;
+  parentId: string | null;
+  timestamp: number;
+}): FixtureEvent {
+  return {
+    type: "message",
+    id: params.id,
+    parentId: params.parentId,
+    timestamp: params.timestamp,
+    message: params.message,
+  };
+}
+
+function createLegacyDatabaseFixture(params: {
+  agentId?: string;
+  env: NodeJS.ProcessEnv;
+  eventsBySession: Record<string, FixtureEvent[]>;
+}): string {
+  const agentId = params.agentId ?? "main";
+  const opened = openOpenClawAgentDatabase({ agentId, env: params.env });
+  const databasePath = opened.path;
+  closeOpenClawAgentDatabasesForTest();
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec("PRAGMA foreign_keys = ON;");
+    database.exec(`PRAGMA user_version = ${PREVIOUS_VERSION};`);
+    database
+      .prepare(
+        "UPDATE schema_meta SET schema_version = ?, app_version = ? WHERE meta_key = 'primary'",
+      )
+      .run(PREVIOUS_VERSION, "legacy-test");
+    for (const [sessionId, events] of Object.entries(params.eventsBySession)) {
+      const sessionKey = `agent:${agentId}:${sessionId}`;
+      const firstTimestamp = Number(events[0]?.timestamp ?? 1);
+      database
+        .prepare(
+          "INSERT INTO session_nodes(session_key,current_session_id,entry_json,updated_at) VALUES(?,?,?,?)",
+        )
+        .run(sessionKey, sessionId, "{}", firstTimestamp);
+      database
+        .prepare(
+          "INSERT INTO session_windows(session_id,session_key,created_at,updated_at) VALUES(?,?,?,?)",
+        )
+        .run(sessionId, sessionKey, firstTimestamp, firstTimestamp);
+      database
+        .prepare(
+          "INSERT INTO transcript_rewrite_watermarks(session_id,generation,updated_at) VALUES(?,?,?)",
+        )
+        .run(sessionId, `generation-${sessionId}`, firstTimestamp);
+      events.forEach((event, seq) => {
+        const createdAt = Number(event.timestamp ?? firstTimestamp) + 100;
+        database
+          .prepare(
+            "INSERT INTO transcript_events(session_id,seq,event_json,created_at) VALUES(?,?,?,?)",
+          )
+          .run(sessionId, seq, JSON.stringify(event), createdAt);
+        database
+          .prepare(
+            "INSERT INTO transcript_event_identities(session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at) VALUES(?,?,?,?,?,?,?)",
+          )
+          .run(
+            sessionId,
+            String(event.id),
+            seq,
+            String(event.type),
+            typeof event.parentId === "string" ? event.parentId : null,
+            (event.message as { idempotencyKey?: string }).idempotencyKey ?? null,
+            createdAt,
+          );
+      });
+      reconcileSessionTranscriptIndexInTransaction(database, sessionId);
+    }
+  } finally {
+    database.close();
+  }
+  registerOpenClawAgentDatabase({ agentId, env: params.env, path: databasePath });
+  return databasePath;
+}
+
+function readDatabaseSnapshot(databasePath: string) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
+    const rows = database
+      .prepare(
+        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      event_json: string;
+      created_at: number;
+    }>;
+    const identities = database
+      .prepare(
+        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
+      )
+      .all();
+    const activeBranch = database
+      .prepare(
+        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
+      )
+      .all();
+    const windows = database
+      .prepare(
+        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
+      )
+      .all();
+    const generations = database
+      .prepare(
+        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
+      )
+      .all();
+    const trajectoryCount = database
+      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
+      .get() as { count: number };
+    const trajectoryRows = database
+      .prepare(
+        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      run_id: string | null;
+      event_json: string;
+      created_at: number;
+    }>;
+    return {
+      activeBranch,
+      generations,
+      identities,
+      rows,
+      trajectoryCount: trajectoryCount.count,
+      trajectoryRows,
+      version,
+      windows,
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function writeArchive(filePath: string, events: FixtureEvent[], compressed: boolean): void {
+  const content = `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  if (!compressed) {
+    fs.writeFileSync(filePath, content);
+    return;
+  }
+  const encoded = encodeSessionArchiveContent(content);
+  if (encoded.suffix !== SESSION_ARCHIVE_ZSTD_SUFFIX) {
+    throw new Error("test runtime does not support zstd");
+  }
+  fs.writeFileSync(filePath, encoded.bytes);
+}
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("legacy media persistence doctor migration", () => {
+  it("canonicalizes assistant media at the generic transcript append owner", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-append-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        expect(
+          appendTranscriptEventInTransaction(
+            database,
+            {
+              agentId: "main",
+              env,
+              sessionId: "append-session",
+              sessionKey: "agent:main:append-session",
+            },
+            createEvent({
+              id: "event-1",
+              parentId: null,
+              timestamp: 1000,
+              message: {
+                role: "assistant",
+                content: "append",
+                MediaPaths: ["/media/a.png"],
+                MediaTypes: ["image/png"],
+              },
+            }),
+          ),
+        ).toBe(true);
+      },
+      { agentId: "main", env },
+    );
+    const database = openOpenClawAgentDatabase({ agentId: "main", env });
+    const row = database.db
+      .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
+      .get("append-session") as { event_json: string };
+    const message = (JSON.parse(row.event_json) as { message: Record<string, unknown> }).message;
+    expect(message).toMatchObject({ role: "assistant", content: "append" });
+    expect(message).not.toHaveProperty("MediaPaths");
+    expect(message).not.toHaveProperty("MediaTypes");
+    expect(message["__openclaw"]).toMatchObject({
+      media: [expect.objectContaining({ path: "/media/a.png", contentType: "image/png" })],
+    });
+  });
+
+  it("rewrites every active shape and trajectory snapshot, migrates mixed archives, and reruns as a no-op", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-migration-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const legacy = createEvent({
+      id: "event-legacy",
+      parentId: null,
+      timestamp: 1000,
+      message: {
+        role: "user",
+        content: "legacy",
+        idempotencyKey: "idem-legacy",
+        MediaPaths: ["/media/a.ogg", "/media/b.png"],
+        MediaTypes: ["audio", "image/png"],
+        MediaTranscribedIndexes: [0],
+        MediaWorkspaceDir: "/workspace",
+      },
+    });
+    const conflict = createEvent({
+      id: "event-conflict",
+      parentId: "event-legacy",
+      timestamp: 2000,
+      message: {
+        role: "user",
+        content: "conflict",
+        MediaPath: "/legacy.png",
+        MediaType: "image/png",
+        __openclaw: {
+          traceId: "trace-1",
+          media: [{ path: "/canonical.jpg", contentType: "image/jpeg" }],
+        },
+      },
+    });
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        "session-a": [legacy, conflict],
+        "session-b": [
+          createEvent({
+            id: "event-sparse",
+            parentId: null,
+            timestamp: 3000,
+            message: {
+              role: "user",
+              content: "sparse",
+              MediaPaths: ["", "/media/c.pdf"],
+              MediaTypes: ["", "application/pdf"],
+            },
+          }),
+        ],
+      },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const trajectoryDatabase = new DatabaseSync(databasePath);
+    trajectoryDatabase
+      .prepare(
+        "INSERT INTO trajectory_runtime_events(session_id,seq,run_id,event_json,created_at) VALUES(?,?,?,?,?)",
+      )
+      .run(
+        "session-a",
+        0,
+        "run-1",
+        JSON.stringify({
+          type: "model.completed",
+          data: {
+            messagesSnapshot: [legacy.message],
+            modelOutput: "done",
+            timing: { totalMs: 125 },
+            toolTraces: [{ name: "read", durationMs: 5 }],
+          },
+        }),
+        4000,
+      );
+    trajectoryDatabase
+      .prepare(
+        "INSERT INTO trajectory_runtime_events(session_id,seq,run_id,event_json,created_at) VALUES(?,?,?,?,?)",
+      )
+      .run(
+        "session-a",
+        1,
+        "run-1",
+        JSON.stringify({ data: { toolArguments: { MediaPath: "/not-a-message-field" } } }),
+        4001,
+      );
+    trajectoryDatabase
+      .prepare(
+        "INSERT INTO trajectory_runtime_events(session_id,seq,run_id,event_json,created_at) VALUES(?,?,?,?,?)",
+      )
+      .run(
+        "session-a",
+        2,
+        "run-1",
+        JSON.stringify({
+          data: {
+            messagesSnapshot: [{ role: "user", media: [{ path: "/legacy-top-level.png" }] }],
+          },
+        }),
+        4002,
+      );
+    const emptyCarrierEventJson = JSON.stringify({
+      type: "model.completed",
+      data: {
+        messagesSnapshot: [
+          { role: "user", content: "empty", media: [], MediaPaths: [], MediaTypes: [] },
+        ],
+        modelOutput: "empty",
+      },
+    });
+    trajectoryDatabase
+      .prepare(
+        "INSERT INTO trajectory_runtime_events(session_id,seq,run_id,event_json,created_at) VALUES(?,?,?,?,?)",
+      )
+      .run("session-a", 3, "run-1", emptyCarrierEventJson, 4003);
+    trajectoryDatabase.close();
+
+    const archiveDir = path.join(stateDir, "agents", "main", "sessions");
+    const plainArchive = path.join(archiveDir, "cold-plain.jsonl.deleted.2026-07-24T01-02-03.000Z");
+    const compressedArchive = `${path.join(
+      archiveDir,
+      "cold-zstd.jsonl.reset.2026-07-24T01-02-04.000Z",
+    )}${SESSION_ARCHIVE_ZSTD_SUFFIX}`;
+    writeArchive(plainArchive, [legacy], false);
+    writeArchive(compressedArchive, [conflict], true);
+
+    const before = readDatabaseSnapshot(databasePath);
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(3);
+
+    const after = readDatabaseSnapshot(databasePath);
+    expect(after.version.user_version).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(after.trajectoryCount).toBe(4);
+    expect(after.trajectoryRows.map(({ event_json: _eventJson, ...row }) => row)).toEqual(
+      before.trajectoryRows.map(({ event_json: _eventJson, ...row }) => row),
+    );
+    const migratedTrajectory = JSON.parse(after.trajectoryRows[0]?.event_json ?? "null") as {
+      data?: Record<string, unknown>;
+    };
+    expect(migratedTrajectory.data).toMatchObject({
+      modelOutput: "done",
+      timing: { totalMs: 125 },
+      toolTraces: [{ name: "read", durationMs: 5 }],
+    });
+    const migratedMessagesSnapshot = migratedTrajectory.data?.messagesSnapshot;
+    expect(migratedMessagesSnapshot).toBeInstanceOf(Array);
+    const migratedTrajectoryMessage = (
+      migratedMessagesSnapshot as Array<Record<string, unknown>>
+    )[0];
+    expect(migratedTrajectoryMessage).not.toHaveProperty("MediaPaths");
+    expect(migratedTrajectoryMessage?.["__openclaw"]).toMatchObject({
+      media: [
+        expect.objectContaining({ path: "/media/a.ogg" }),
+        expect.objectContaining({ path: "/media/b.png" }),
+      ],
+    });
+    expect(after.trajectoryRows[1]?.event_json).toBe(before.trajectoryRows[1]?.event_json);
+    const topLevelMediaMessage = (
+      JSON.parse(after.trajectoryRows[2]?.event_json ?? "null") as {
+        data: { messagesSnapshot: Array<Record<string, unknown>> };
+      }
+    ).data.messagesSnapshot[0];
+    expect(topLevelMediaMessage).not.toHaveProperty("media");
+    expect(topLevelMediaMessage?.["__openclaw"]).toMatchObject({
+      media: [expect.objectContaining({ path: "/legacy-top-level.png" })],
+    });
+    expect(after.trajectoryRows[3]?.event_json).toBe(emptyCarrierEventJson);
+    expect(after.rows.map((row) => row.created_at)).toEqual(
+      before.rows.map((row) => row.created_at),
+    );
+    expect(after.identities).toEqual(before.identities);
+    expect(after.activeBranch).toEqual(before.activeBranch);
+    expect(after.windows).toEqual(before.windows);
+    expect(after.generations).not.toEqual(before.generations);
+    const messages = after.rows.map((row) => (JSON.parse(row.event_json) as FixtureEvent).message);
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: "legacy",
+        idempotencyKey: "idem-legacy",
+        __openclaw: {
+          media: [
+            expect.objectContaining({ kind: "audio", transcribed: true }),
+            expect.objectContaining({ contentType: "image/png" }),
+          ],
+        },
+      }),
+      expect.objectContaining({
+        __openclaw: {
+          traceId: "trace-1",
+          media: [expect.objectContaining({ path: "/canonical.jpg" })],
+        },
+      }),
+      expect.objectContaining({
+        __openclaw: {
+          media: [expect.any(Object), expect.objectContaining({ path: "/media/c.pdf" })],
+        },
+      }),
+    ]);
+    for (const message of messages) {
+      expect(JSON.stringify(message)).not.toMatch(/"Media(?:Path|Paths|Type|Types|Url|Urls)/u);
+    }
+    expect(readSessionArchiveContentSync(plainArchive)).toContain('"__openclaw"');
+    expect(readSessionArchiveContentSync(compressedArchive)).toContain('"__openclaw"');
+
+    expect(openOpenClawAgentDatabase({ agentId: "main", env }).db.isOpen).toBe(true);
+    closeOpenClawAgentDatabasesForTest();
+    expect(migrateLegacyMediaPersistence({ env })).toEqual({ changes: [], warnings: [] });
+  });
+
+  it("upgrades the existing v14 structural schema before the media cutover", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-v14-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        legacy: [
+          createEvent({
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: { role: "user", content: "legacy", MediaPath: "/media/a.png" },
+          }),
+        ],
+      },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      DROP TABLE session_suggestions;
+      PRAGMA user_version = 14;
+      UPDATE schema_meta SET schema_version = 14 WHERE meta_key = 'primary';
+    `);
+    database.close();
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const after = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(after.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        after
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'session_suggestions'",
+          )
+          .get(),
+      ).toEqual({ name: "session_suggestions" });
+      const row = after
+        .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
+        .get("legacy") as { event_json: string };
+      const message = (JSON.parse(row.event_json) as { message: Record<string, unknown> }).message;
+      expect(message).not.toHaveProperty("MediaPath");
+      expect(message["__openclaw"]).toMatchObject({
+        media: [expect.objectContaining({ path: "/media/a.png" })],
+      });
+    } finally {
+      after.close();
+    }
+  });
+
+  it("upgrades an owned v0 database through the media prerequisite schema", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-v0-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        legacy: [
+          createEvent({
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: { role: "user", content: "legacy", MediaPath: "/media/a.png" },
+          }),
+        ],
+      },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      PRAGMA user_version = 0;
+      UPDATE schema_meta SET schema_version = 0 WHERE meta_key = 'primary';
+    `);
+    database.close();
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const after = readDatabaseSnapshot(databasePath);
+    expect(after.version.user_version).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    const message = (JSON.parse(after.rows[0]?.event_json ?? "null") as FixtureEvent).message;
+    expect(message).not.toHaveProperty("MediaPath");
+  });
+
+  it("migrates complete PR-1 facts beside a compact legacy projection", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-dual-write-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        dual: [
+          createEvent({
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: {
+              role: "user",
+              content: "dual",
+              MediaPaths: ["/media/a.bin", "/media/b.pdf"],
+              MediaTypes: ["application/pdf"],
+              __openclaw: {
+                media: [
+                  { path: "/media/a.bin", contentType: "application/octet-stream" },
+                  { path: "/media/b.pdf", contentType: "application/pdf" },
+                ],
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const after = readDatabaseSnapshot(databasePath);
+    expect(after.version.user_version).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    const message = (
+      JSON.parse(after.rows[0]?.event_json ?? "null") as {
+        message: Record<string, unknown>;
+      }
+    ).message;
+    expect(message).not.toHaveProperty("MediaPaths");
+    expect(message).not.toHaveProperty("MediaTypes");
+    expect(message["__openclaw"]).toMatchObject({
+      media: [
+        expect.objectContaining({
+          path: "/media/a.bin",
+          contentType: "application/octet-stream",
+        }),
+        expect.objectContaining({ path: "/media/b.pdf", contentType: "application/pdf" }),
+      ],
+    });
+  });
+
+  it("repairs a missing canonical v15 index before the media cutover", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-v15-index-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        legacy: [
+          createEvent({
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: { role: "user", content: "legacy", MediaPath: "/media/a.png" },
+          }),
+        ],
+      },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec("DROP INDEX idx_agent_transcript_event_parent;");
+    database.close();
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const after = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(after.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        after
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'index' AND name = 'idx_agent_transcript_event_parent'",
+          )
+          .get(),
+      ).toEqual({ name: "idx_agent_transcript_event_parent" });
+    } finally {
+      after.close();
+    }
+  });
+
+  it("canonicalizes retired media carriers on every transcript message role", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-message-roles-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        roles: [
+          createEvent({
+            id: "event-assistant",
+            parentId: null,
+            timestamp: 1000,
+            message: { role: "assistant", content: "result", MediaPath: "/media/result.png" },
+          }),
+          createEvent({
+            id: "event-roleless",
+            parentId: "event-assistant",
+            timestamp: 2000,
+            message: { content: "imported", MediaPath: "/media/imported.png" },
+          }),
+        ],
+      },
+    });
+
+    expect(migrateLegacyMediaPersistence({ env }).warnings).toEqual([]);
+    const messages = readDatabaseSnapshot(databasePath).rows.map(
+      (row) => (JSON.parse(row.event_json) as FixtureEvent).message,
+    );
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        __openclaw: { media: [expect.objectContaining({ path: "/media/result.png" })] },
+      }),
+      expect.objectContaining({
+        __openclaw: { media: [expect.objectContaining({ path: "/media/imported.png" })] },
+      }),
+    ]);
+    for (const message of messages) {
+      expect(message).not.toHaveProperty("MediaPath");
+    }
+  });
+
+  it("canonicalizes legacy trajectory metadata onto existing facts", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-trajectory-metadata-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        metadata: [
+          createEvent({
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: {
+              role: "user",
+              content: "metadata",
+              __openclaw: {
+                media: [{ path: "/media/a.png", contentType: "image/png" }],
+              },
+            },
+          }),
+        ],
+      },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database
+      .prepare(
+        "INSERT INTO trajectory_runtime_events(session_id,seq,run_id,event_json,created_at) VALUES(?,?,?,?,?)",
+      )
+      .run(
+        "metadata",
+        0,
+        "run-1",
+        JSON.stringify({
+          data: {
+            messagesSnapshot: [
+              {
+                role: "user",
+                content: "metadata",
+                __openclaw: {
+                  media: [{ path: "/media/a.png", contentType: "image/png" }],
+                },
+                MediaTranscribedIndexes: [0],
+                MediaWorkspaceDir: "/workspace",
+                MediaStaged: true,
+              },
+            ],
+            timing: { totalMs: 10 },
+          },
+        }),
+        1100,
+      );
+    database.close();
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const after = readDatabaseSnapshot(databasePath);
+    expect(after.trajectoryRows).toHaveLength(1);
+    const event = JSON.parse(after.trajectoryRows[0]?.event_json ?? "null") as {
+      data: { messagesSnapshot: Array<Record<string, unknown>>; timing: { totalMs: number } };
+    };
+    expect(event.data.timing).toEqual({ totalMs: 10 });
+    const message = event.data.messagesSnapshot[0];
+    expect(message).not.toHaveProperty("MediaTranscribedIndexes");
+    expect(message).not.toHaveProperty("MediaWorkspaceDir");
+    expect(message).not.toHaveProperty("MediaStaged");
+    expect(message?.["__openclaw"]).toMatchObject({
+      media: [
+        expect.objectContaining({
+          path: "/media/a.png",
+          transcribed: true,
+          workspaceDir: "/workspace",
+          staged: true,
+        }),
+      ],
+    });
+  });
+
+  it("preserves duplicate physical transcript rows during canonicalization", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-duplicates-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const event = createEvent({
+      id: "duplicate-event",
+      parentId: null,
+      timestamp: 1000,
+      message: { role: "user", content: "duplicate", MediaPath: "/media/a.png" },
+    });
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: { duplicates: [event] },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database
+      .prepare(
+        "INSERT INTO transcript_events(session_id,seq,event_json,created_at) VALUES(?,?,?,?)",
+      )
+      .run("duplicates", 1, JSON.stringify(event), 1200);
+    database.close();
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const rows = readDatabaseSnapshot(databasePath).rows;
+    expect(rows).toHaveLength(2);
+    const migrated = rows.map((row) => JSON.parse(row.event_json) as FixtureEvent);
+    expect(migrated.map((entry) => entry.id)).toEqual(["duplicate-event", "duplicate-event"]);
+    for (const entry of migrated) {
+      expect(entry.message).not.toHaveProperty("MediaPath");
+      expect(entry.message).toMatchObject({
+        __openclaw: { media: [expect.objectContaining({ path: "/media/a.png" })] },
+      });
+    }
+  });
+
+  it("aborts one database on invalid JSON without advancing its version", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-corrupt-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        corrupt: [
+          createEvent({
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: { role: "user", MediaPath: "/media/a.png" },
+          }),
+        ],
+      },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database
+      .prepare("UPDATE transcript_events SET event_json = ? WHERE session_id = ? AND seq = 0")
+      .run("{broken", "corrupt");
+    database.close();
+
+    expect(() => openOpenClawAgentDatabase({ agentId: "main", env })).toThrow(
+      "run openclaw doctor --fix to migrate persisted media",
+    );
+    closeOpenClawAgentDatabasesForTest();
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toHaveLength(1);
+    expect(readDatabaseSnapshot(databasePath).version.user_version).toBe(PREVIOUS_VERSION);
+  });
+
+  it("aborts one database on invalid trajectory JSON without advancing its version", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-corrupt-trajectory-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        corrupt: [
+          createEvent({
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: { role: "user", MediaPath: "/media/a.png" },
+          }),
+        ],
+      },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database
+      .prepare(
+        "INSERT INTO trajectory_runtime_events(session_id,seq,run_id,event_json,created_at) VALUES(?,?,?,?,?)",
+      )
+      .run("corrupt", 0, "run-1", "{broken", 2000);
+    database.close();
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("invalid trajectory JSON");
+    const snapshot = readDatabaseSnapshot(databasePath);
+    expect(snapshot.version.user_version).toBe(PREVIOUS_VERSION);
+    expect(snapshot.trajectoryCount).toBe(1);
+  });
+
+  it("aborts on active-row drift and archive source replacement without partial deletion", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-drift-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const { DatabaseSync } = requireNodeSqlite();
+    const event = createEvent({
+      id: "event-1",
+      parentId: null,
+      timestamp: 1000,
+      message: { role: "user", content: "before", MediaPath: "/media/a.png" },
+    });
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: { drift: [event] },
+    });
+    expect(() =>
+      mediaPersistenceMigrationTesting.migrateRegisteredDatabase({
+        agentId: "main",
+        pathname: databasePath,
+        beforeTransaction: () => {
+          const writer = new DatabaseSync(databasePath);
+          writer
+            .prepare(
+              "UPDATE transcript_events SET created_at = created_at + 1 WHERE session_id = ?",
+            )
+            .run("drift");
+          writer.close();
+        },
+      }),
+    ).toThrow("source changed");
+    expect(readDatabaseSnapshot(databasePath).version.user_version).toBe(PREVIOUS_VERSION);
+
+    const trajectoryWriter = new DatabaseSync(databasePath);
+    trajectoryWriter
+      .prepare(
+        "INSERT INTO trajectory_runtime_events(session_id,seq,run_id,event_json,created_at) VALUES(?,?,?,?,?)",
+      )
+      .run(
+        "drift",
+        0,
+        "run-1",
+        JSON.stringify({ data: { messagesSnapshot: [{ role: "user", MediaPath: "/old.png" }] } }),
+        2000,
+      );
+    trajectoryWriter.close();
+    expect(() =>
+      mediaPersistenceMigrationTesting.migrateRegisteredDatabase({
+        agentId: "main",
+        pathname: databasePath,
+        beforeTransaction: () => {
+          const writer = new DatabaseSync(databasePath);
+          writer
+            .prepare(
+              "UPDATE trajectory_runtime_events SET event_json = ? WHERE session_id = ? AND seq = 0",
+            )
+            .run(
+              JSON.stringify({
+                data: { messagesSnapshot: [{ role: "user", MediaPath: "/changed.png" }] },
+              }),
+              "drift",
+            );
+          writer.close();
+        },
+      }),
+    ).toThrow("trajectory source changed");
+    expect(readDatabaseSnapshot(databasePath).version.user_version).toBe(PREVIOUS_VERSION);
+
+    const archivePath = path.join(stateDir, "drift.jsonl.deleted.2026-07-24T01-02-03.000Z");
+    writeArchive(archivePath, [event], false);
+    expect(() =>
+      mediaPersistenceMigrationTesting.migrateTranscriptArchive(archivePath, {
+        beforeReplace: () => fs.writeFileSync(archivePath, "replacement\n"),
+      }),
+    ).toThrow("changed before atomic");
+    expect(fs.readFileSync(archivePath, "utf8")).toBe("replacement\n");
+  });
+
+  it("rejects ambiguous sparse arrays and ignores stale interrupted temp files", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-sparse-");
+    const archivePath = path.join(stateDir, "sparse.jsonl.bak.2026-07-24T01-02-03.000Z");
+    const event = createEvent({
+      id: "event-1",
+      parentId: null,
+      timestamp: 1000,
+      message: {
+        role: "user",
+        MediaPaths: ["", "/media/b.png"],
+        MediaTypes: ["image/png"],
+      },
+    });
+    writeArchive(archivePath, [event], false);
+    expect(() => mediaPersistenceMigrationTesting.migrateTranscriptArchive(archivePath)).toThrow(
+      "ambiguous sparse positional alignment",
+    );
+
+    const corruptArchivePath = path.join(
+      stateDir,
+      "corrupt.jsonl.deleted.2026-07-24T01-02-04.000Z",
+    );
+    fs.writeFileSync(corruptArchivePath, "{broken\n");
+    expect(() =>
+      mediaPersistenceMigrationTesting.migrateTranscriptArchive(corruptArchivePath),
+    ).toThrow("invalid transcript JSON");
+    expect(fs.readFileSync(corruptArchivePath, "utf8")).toBe("{broken\n");
+
+    writeArchive(
+      archivePath,
+      [
+        createEvent({
+          id: "event-1",
+          parentId: null,
+          timestamp: 1000,
+          message: { role: "user", MediaPath: "/media/a.png", MediaType: "image/png" },
+        }),
+      ],
+      false,
+    );
+    fs.writeFileSync(`${archivePath}.media-retirement.999.interrupted.tmp`, "partial");
+    expect(mediaPersistenceMigrationTesting.migrateTranscriptArchive(archivePath)).toBe(true);
+    expect(readSessionArchiveContentSync(archivePath)).toContain('"__openclaw"');
+  });
+});

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -567,6 +567,10 @@ function listTranscriptArchives(directory: string): string[] {
 /** Doctor-only migration from top-level Media* transcript fields to canonical facts. */
 export function migrateLegacyMediaPersistence(
   params: {
+    hooks?: {
+      beforeArchiveReplace?: (archivePath: string) => void;
+      beforeDatabaseTransaction?: (databasePath: string) => void;
+    };
     env?: NodeJS.ProcessEnv;
   } = {},
 ): MigrationMessages {
@@ -602,6 +606,9 @@ export function migrateLegacyMediaPersistence(
     try {
       const result = migrateRegisteredDatabase({
         agentId: entry.agentId,
+        beforeTransaction: params.hooks?.beforeDatabaseTransaction
+          ? () => params.hooks?.beforeDatabaseTransaction?.(pathname)
+          : undefined,
         pathname,
       });
       if (result.versionAdvanced) {
@@ -631,7 +638,13 @@ export function migrateLegacyMediaPersistence(
     }
     for (const archive of archives) {
       try {
-        if (migrateTranscriptArchive(archive)) {
+        if (
+          migrateTranscriptArchive(archive, {
+            beforeReplace: params.hooks?.beforeArchiveReplace
+              ? () => params.hooks?.beforeArchiveReplace?.(archive)
+              : undefined,
+          })
+        ) {
           changes.push(`Migrated archived transcript media in ${archive}.`);
         }
       } catch (error) {
@@ -643,9 +656,3 @@ export function migrateLegacyMediaPersistence(
   }
   return { changes, warnings };
 }
-
-export const mediaPersistenceMigrationTesting = {
-  migrateRegisteredDatabase,
-  migrateTranscriptArchive,
-  transformTranscriptEvent,
-};

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -1,0 +1,651 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  decodeSessionArchiveBytes,
+  encodeSessionArchiveContent,
+  readSessionArchiveContentSync,
+  SESSION_ARCHIVE_ZSTD_SUFFIX,
+} from "../config/sessions/archive-compression.js";
+import { isSessionArchiveArtifactName } from "../config/sessions/artifacts.js";
+import type { TranscriptEvent } from "../config/sessions/session-accessor.sqlite-contract.js";
+import { resolveSqliteTranscriptArchiveDirectory } from "../config/sessions/session-accessor.sqlite-scope.js";
+import { rewriteSqliteTranscriptEventRowsInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
+import {
+  canonicalizePersistedUserMessageMedia,
+  hasMeaningfulRetiredMediaCarrier,
+} from "../media/media-facts.js";
+import { assertOpenClawAgentDatabaseOwner } from "../state/openclaw-agent-db-maintenance.js";
+import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db-registry.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import { assertOpenClawAgentSchemaContains } from "../state/openclaw-agent-db-schema-helpers.js";
+import { migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema } from "../state/openclaw-agent-db-schema.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
+import {
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+  type OpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.generated.js";
+import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../state/openclaw-state-db.js";
+import { VERSION } from "../version.js";
+import {
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+  clearNodeSqliteKyselyCacheForDatabase,
+} from "./kysely-sync.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { replaceFileAtomicSync } from "./replace-file.js";
+import { repairCanonicalSqliteIndexes } from "./sqlite-index-schema.js";
+import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
+import { readSqliteUserVersion } from "./sqlite-user-version.js";
+import type { MigrationMessages } from "./state-migrations.types.js";
+
+const PREVIOUS_MEDIA_SCHEMA_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+const ARCHIVE_TEMP_MARKER = ".media-retirement";
+
+type MediaMigrationDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "schema_meta" | "session_windows" | "trajectory_runtime_events" | "transcript_events"
+>;
+
+type TranscriptRowSnapshot = {
+  createdAt: number;
+  event: TranscriptEvent;
+  eventJson: string;
+  seq: number;
+  sessionId: string;
+};
+
+type SessionRewritePlan = {
+  changed: boolean;
+  events: TranscriptEvent[];
+  rows: TranscriptRowSnapshot[];
+  sessionId: string;
+  sessionKey: string;
+};
+
+type TrajectoryRowRewritePlan = {
+  eventJson: string;
+  rewrittenEventJson: string;
+  seq: number;
+  sessionId: string;
+};
+
+type ArchiveSourceSnapshot = {
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  sha256: string;
+  size: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function transformTranscriptEvent(event: TranscriptEvent): {
+  changed: boolean;
+  event: TranscriptEvent;
+} {
+  if (!isRecord(event) || event.type !== "message" || !isRecord(event.message)) {
+    return { changed: false, event };
+  }
+  const canonical = canonicalizePersistedUserMessageMedia(event.message);
+  return canonical.changed
+    ? { changed: true, event: { ...event, message: canonical.message } }
+    : { changed: false, event };
+}
+
+function parseTranscriptEvent(raw: string, owner: string): TranscriptEvent {
+  try {
+    return JSON.parse(raw) as TranscriptEvent;
+  } catch (error) {
+    throw new Error(`${owner} contains invalid transcript JSON: ${String(error)}`, {
+      cause: error,
+    });
+  }
+}
+
+function eventIdentity(event: TranscriptEvent): string {
+  if (!isRecord(event)) {
+    return JSON.stringify({ id: null, parentId: null, type: null });
+  }
+  return JSON.stringify({
+    id: typeof event.id === "string" ? event.id : null,
+    parentId: typeof event.parentId === "string" ? event.parentId : null,
+    type: typeof event.type === "string" ? event.type : null,
+  });
+}
+
+function assertEventIdentitiesUnchanged(
+  before: readonly TranscriptEvent[],
+  after: readonly TranscriptEvent[],
+  owner: string,
+): void {
+  if (before.length !== after.length) {
+    throw new Error(`${owner} event count changed during media migration`);
+  }
+  for (let index = 0; index < before.length; index += 1) {
+    if (eventIdentity(before[index]) !== eventIdentity(after[index])) {
+      throw new Error(`${owner} event identity changed at index ${index}`);
+    }
+  }
+}
+
+function planTranscriptRows(database: DatabaseSync, pathname: string): SessionRewritePlan[] {
+  const db = getNodeSqliteKysely<MediaMigrationDatabase>(database);
+  const sessionRows = executeSqliteQuerySync(
+    database,
+    db.selectFrom("session_windows").select(["session_id", "session_key"]),
+  ).rows;
+  const sessionKeys = new Map(sessionRows.map((row) => [row.session_id, row.session_key]));
+  const rows = executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("transcript_events")
+      .select(["session_id", "seq", "event_json", "created_at"])
+      .orderBy("session_id", "asc")
+      .orderBy("seq", "asc"),
+  ).rows;
+  const bySession = new Map<string, TranscriptRowSnapshot[]>();
+  for (const row of rows) {
+    const snapshots = bySession.get(row.session_id) ?? [];
+    snapshots.push({
+      createdAt: row.created_at,
+      event: parseTranscriptEvent(row.event_json, `${pathname}:${row.session_id}:${row.seq}`),
+      eventJson: row.event_json,
+      seq: row.seq,
+      sessionId: row.session_id,
+    });
+    bySession.set(row.session_id, snapshots);
+  }
+  return [...bySession].map(([sessionId, snapshots]) => {
+    const sessionKey = sessionKeys.get(sessionId);
+    if (!sessionKey) {
+      throw new Error(`${pathname}:${sessionId} has transcript rows without a session window`);
+    }
+    let changed = false;
+    const events = snapshots.map((row) => {
+      const transformed = transformTranscriptEvent(row.event);
+      changed ||= transformed.changed;
+      return transformed.event;
+    });
+    assertEventIdentitiesUnchanged(
+      snapshots.map((row) => row.event),
+      events,
+      `${pathname}:${sessionId}`,
+    );
+    return { changed, events, rows: snapshots, sessionId, sessionKey };
+  });
+}
+
+function assertTranscriptSourceUnchanged(
+  database: DatabaseSync,
+  pathname: string,
+  planned: readonly SessionRewritePlan[],
+): void {
+  const db = getNodeSqliteKysely<MediaMigrationDatabase>(database);
+  const current = executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("transcript_events")
+      .select(["session_id", "seq", "event_json", "created_at"])
+      .orderBy("session_id", "asc")
+      .orderBy("seq", "asc"),
+  ).rows;
+  const expected = planned.flatMap((session) => session.rows);
+  if (current.length !== expected.length) {
+    throw new Error(`${pathname} transcript source changed before migration commit`);
+  }
+  for (let index = 0; index < expected.length; index += 1) {
+    const left = current[index];
+    const right = expected[index];
+    if (
+      !left ||
+      !right ||
+      left.session_id !== right.sessionId ||
+      left.seq !== right.seq ||
+      left.event_json !== right.eventJson ||
+      left.created_at !== right.createdAt
+    ) {
+      throw new Error(`${pathname} transcript source changed before migration commit`);
+    }
+  }
+}
+
+function planTrajectoryRowRewrite(params: {
+  eventJson: string;
+  owner: string;
+  seq: number;
+  sessionId: string;
+}): TrajectoryRowRewritePlan {
+  let event: unknown;
+  try {
+    event = JSON.parse(params.eventJson) as unknown;
+  } catch (error) {
+    throw new Error(`${params.owner} contains invalid trajectory JSON: ${String(error)}`, {
+      cause: error,
+    });
+  }
+  if (!isRecord(event) || !isRecord(event.data) || !Array.isArray(event.data.messagesSnapshot)) {
+    return {
+      eventJson: params.eventJson,
+      rewrittenEventJson: params.eventJson,
+      seq: params.seq,
+      sessionId: params.sessionId,
+    };
+  }
+  let changed = false;
+  const messagesSnapshot = event.data.messagesSnapshot.map((message) => {
+    if (!isRecord(message) || !hasMeaningfulRetiredMediaCarrier(message)) {
+      return message;
+    }
+    const canonical = canonicalizePersistedUserMessageMedia(message);
+    changed ||= canonical.changed;
+    return canonical.message;
+  });
+  return {
+    eventJson: params.eventJson,
+    rewrittenEventJson: changed
+      ? JSON.stringify({
+          ...event,
+          data: { ...event.data, messagesSnapshot },
+        })
+      : params.eventJson,
+    seq: params.seq,
+    sessionId: params.sessionId,
+  };
+}
+
+function assertTrajectorySourceUnchanged(
+  database: DatabaseSync,
+  pathname: string,
+  planned: readonly TrajectoryRowRewritePlan[],
+): void {
+  const db = getNodeSqliteKysely<MediaMigrationDatabase>(database);
+  const current = executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("trajectory_runtime_events")
+      .select(["session_id", "seq", "event_json"])
+      .orderBy("session_id", "asc")
+      .orderBy("seq", "asc"),
+  ).rows;
+  if (current.length !== planned.length) {
+    throw new Error(`${pathname} trajectory source changed before migration commit`);
+  }
+  for (let index = 0; index < planned.length; index += 1) {
+    const left = current[index];
+    const right = planned[index];
+    if (
+      !left ||
+      !right ||
+      left.session_id !== right.sessionId ||
+      left.seq !== right.seq ||
+      left.event_json !== right.eventJson
+    ) {
+      throw new Error(`${pathname} trajectory source changed before migration commit`);
+    }
+  }
+}
+
+function createMigrationDatabaseHandle(
+  database: DatabaseSync,
+  agentId: string,
+  pathname: string,
+): OpenClawAgentDatabase {
+  return {
+    agentId,
+    db: database,
+    path: pathname,
+    walMaintenance: { checkpoint: () => false, close: () => false },
+  };
+}
+
+function migrateRegisteredDatabase(params: {
+  agentId: string;
+  beforeTransaction?: () => void;
+  pathname: string;
+}): { rewrittenSessions: number; rewrittenTrajectoryRows: number; versionAdvanced: boolean } {
+  const database = openNodeSqliteDatabase(params.pathname);
+  try {
+    database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+    let metadata = assertOpenClawAgentDatabaseOwner(database, {
+      agentId: params.agentId,
+      pathname: params.pathname,
+    });
+    let userVersion = readSqliteUserVersion(database);
+    if (userVersion < PREVIOUS_MEDIA_SCHEMA_VERSION) {
+      migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema(database, {
+        agentId: params.agentId,
+        path: params.pathname,
+      });
+      metadata = assertOpenClawAgentDatabaseOwner(database, {
+        agentId: params.agentId,
+        pathname: params.pathname,
+      });
+      userVersion = readSqliteUserVersion(database);
+    }
+    if (
+      userVersion !== PREVIOUS_MEDIA_SCHEMA_VERSION &&
+      userVersion !== OPENCLAW_AGENT_SCHEMA_VERSION
+    ) {
+      throw new Error(
+        `${params.pathname} uses schema version ${userVersion}; expected ${PREVIOUS_MEDIA_SCHEMA_VERSION} or ${OPENCLAW_AGENT_SCHEMA_VERSION}`,
+      );
+    }
+    if (metadata.schemaVersion !== userVersion) {
+      throw new Error(
+        `${params.pathname} metadata schema version ${metadata.schemaVersion ?? "invalid"} does not match ${userVersion}`,
+      );
+    }
+    if (userVersion === PREVIOUS_MEDIA_SCHEMA_VERSION) {
+      repairCanonicalSqliteIndexes(database, params.pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
+        validateAfterRepair: () =>
+          assertOpenClawAgentSchemaContains(database, params.pathname, OPENCLAW_AGENT_SCHEMA_SQL),
+      });
+    }
+    assertOpenClawAgentSchemaContains(database, params.pathname, OPENCLAW_AGENT_SCHEMA_SQL);
+    const planned = planTranscriptRows(database, params.pathname);
+    const db = getNodeSqliteKysely<MediaMigrationDatabase>(database);
+    const plannedTrajectoryRows = executeSqliteQuerySync(
+      database,
+      db
+        .selectFrom("trajectory_runtime_events")
+        .select(["session_id", "seq", "event_json"])
+        .orderBy("session_id", "asc")
+        .orderBy("seq", "asc"),
+    ).rows.map((row) =>
+      planTrajectoryRowRewrite({
+        eventJson: row.event_json,
+        owner: `${params.pathname}:${row.session_id}:${row.seq}`,
+        seq: row.seq,
+        sessionId: row.session_id,
+      }),
+    );
+    const changedTrajectoryRows = plannedTrajectoryRows.filter(
+      (row) => row.rewrittenEventJson !== row.eventJson,
+    );
+    const changedSessions = planned.filter((session) => session.changed);
+    const versionAdvanced = userVersion === PREVIOUS_MEDIA_SCHEMA_VERSION;
+    if (!versionAdvanced && changedSessions.length === 0 && changedTrajectoryRows.length === 0) {
+      return { rewrittenSessions: 0, rewrittenTrajectoryRows: 0, versionAdvanced: false };
+    }
+
+    params.beforeTransaction?.();
+    const owner = createMigrationDatabaseHandle(database, params.agentId, params.pathname);
+    runSqliteImmediateTransactionSync(
+      database,
+      () => {
+        assertTranscriptSourceUnchanged(database, params.pathname, planned);
+        assertTrajectorySourceUnchanged(database, params.pathname, plannedTrajectoryRows);
+        for (const session of changedSessions) {
+          const rows = session.events.flatMap((event, index) => {
+            const source = session.rows[index];
+            if (!source || JSON.stringify(event) === source.eventJson) {
+              return [];
+            }
+            return [{ event, expectedEventJson: source.eventJson, seq: source.seq }];
+          });
+          rewriteSqliteTranscriptEventRowsInTransaction(
+            owner,
+            {
+              agentId: params.agentId,
+              path: params.pathname,
+              sessionId: session.sessionId,
+              sessionKey: session.sessionKey,
+            },
+            rows,
+          );
+        }
+        for (const row of changedTrajectoryRows) {
+          executeSqliteQuerySync(
+            database,
+            db
+              .updateTable("trajectory_runtime_events")
+              .set({ event_json: row.rewrittenEventJson })
+              .where("session_id", "=", row.sessionId)
+              .where("seq", "=", row.seq),
+          );
+        }
+        if (versionAdvanced) {
+          database.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};`);
+          executeSqliteQuerySync(
+            database,
+            db
+              .updateTable("schema_meta")
+              .set({
+                app_version: VERSION,
+                schema_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+                updated_at: Date.now(),
+              })
+              .where("meta_key", "=", "primary"),
+          );
+        }
+      },
+      {
+        busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+        databaseLabel: params.pathname,
+        operationLabel: "media-persistence-retirement",
+      },
+    );
+    return {
+      rewrittenSessions: changedSessions.length,
+      rewrittenTrajectoryRows: changedTrajectoryRows.length,
+      versionAdvanced,
+    };
+  } finally {
+    clearNodeSqliteKyselyCacheForDatabase(database);
+    database.close();
+  }
+}
+
+function readArchiveSourceSnapshot(filePath: string): ArchiveSourceSnapshot {
+  const stat = fs.lstatSync(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`${filePath} is not a regular archive file`);
+  }
+  const bytes = fs.readFileSync(filePath);
+  return {
+    dev: stat.dev,
+    ino: stat.ino,
+    mtimeMs: stat.mtimeMs,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    size: stat.size,
+  };
+}
+
+function archiveSourceMatches(filePath: string, expected: ArchiveSourceSnapshot): boolean {
+  try {
+    const current = readArchiveSourceSnapshot(filePath);
+    return (
+      current.dev === expected.dev &&
+      current.ino === expected.ino &&
+      current.mtimeMs === expected.mtimeMs &&
+      current.sha256 === expected.sha256 &&
+      current.size === expected.size
+    );
+  } catch {
+    return false;
+  }
+}
+
+function parseArchiveContent(content: string, filePath: string): TranscriptEvent[] {
+  const lines = content.endsWith("\n") ? content.slice(0, -1).split("\n") : content.split("\n");
+  if (lines.length === 1 && lines[0] === "") {
+    return [];
+  }
+  return lines.map((line, index) => {
+    if (!line) {
+      throw new Error(`${filePath} contains a blank JSONL record at line ${index + 1}`);
+    }
+    return parseTranscriptEvent(line, `${filePath}:${index + 1}`);
+  });
+}
+
+function serializeArchiveEvents(
+  events: readonly TranscriptEvent[],
+  trailingNewline: boolean,
+): string {
+  if (events.length === 0) {
+    return "";
+  }
+  return `${events.map((event) => JSON.stringify(event)).join("\n")}${trailingNewline ? "\n" : ""}`;
+}
+
+function migrateTranscriptArchive(
+  filePath: string,
+  options: { beforeReplace?: () => void } = {},
+): boolean {
+  const source = readArchiveSourceSnapshot(filePath);
+  const content = readSessionArchiveContentSync(filePath);
+  const events = parseArchiveContent(content, filePath);
+  let changed = false;
+  const transformed = events.map((event) => {
+    const result = transformTranscriptEvent(event);
+    changed ||= result.changed;
+    return result.event;
+  });
+  if (!changed) {
+    return false;
+  }
+  assertEventIdentitiesUnchanged(events, transformed, filePath);
+  const rewritten = serializeArchiveEvents(transformed, content.endsWith("\n"));
+  const compressed = filePath.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX);
+  const encoded = compressed
+    ? encodeSessionArchiveContent(rewritten)
+    : { bytes: Buffer.from(rewritten, "utf8"), suffix: "" as const };
+  if (compressed && encoded.suffix !== SESSION_ARCHIVE_ZSTD_SUFFIX) {
+    throw new Error(`${filePath} could not be re-encoded with its zstd codec`);
+  }
+  options.beforeReplace?.();
+  replaceFileAtomicSync({
+    filePath,
+    content: encoded.bytes,
+    preserveExistingMode: true,
+    syncParentDir: true,
+    syncTempFile: true,
+    tempPrefix: `${path.basename(filePath)}${ARCHIVE_TEMP_MARKER}`,
+    beforeRename: ({ tempPath }) => {
+      if (!archiveSourceMatches(filePath, source)) {
+        throw new Error(`${filePath} changed before atomic media migration replacement`);
+      }
+      const staged = decodeSessionArchiveBytes(fs.readFileSync(tempPath), compressed);
+      if (staged !== rewritten) {
+        throw new Error(`${filePath} failed codec readback before replacement`);
+      }
+      assertEventIdentitiesUnchanged(events, parseArchiveContent(staged, tempPath), filePath);
+    },
+  });
+  if (readSessionArchiveContentSync(filePath) !== rewritten) {
+    throw new Error(`${filePath} failed codec readback after replacement`);
+  }
+  return true;
+}
+
+function listTranscriptArchives(directory: string): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+  return entries
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        entry.name.includes(".jsonl.") &&
+        isSessionArchiveArtifactName(entry.name),
+    )
+    .map((entry) => path.join(directory, entry.name));
+}
+
+/** Doctor-only migration from top-level Media* transcript fields to canonical facts. */
+export function migrateLegacyMediaPersistence(
+  params: {
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): MigrationMessages {
+  const env = params.env ?? process.env;
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  let registered: ReturnType<typeof listOpenClawRegisteredAgentDatabases>;
+  try {
+    registered = listOpenClawRegisteredAgentDatabases({ env });
+  } catch (error) {
+    return {
+      changes,
+      warnings: [
+        `Failed enumerating registered agent databases for media migration: ${String(error)}`,
+      ],
+    };
+  }
+
+  const seenPaths = new Set<string>();
+  const archiveDirectories = new Set<string>();
+  for (const entry of registered) {
+    const pathname = path.resolve(entry.path);
+    archiveDirectories.add(
+      resolveSqliteTranscriptArchiveDirectory({
+        agentId: entry.agentId,
+        path: pathname,
+      }),
+    );
+    if (seenPaths.has(pathname)) {
+      continue;
+    }
+    seenPaths.add(pathname);
+    try {
+      const result = migrateRegisteredDatabase({
+        agentId: entry.agentId,
+        pathname,
+      });
+      if (result.versionAdvanced) {
+        registerOpenClawAgentDatabase({ agentId: entry.agentId, env, path: pathname });
+      }
+      if (
+        result.versionAdvanced ||
+        result.rewrittenSessions > 0 ||
+        result.rewrittenTrajectoryRows > 0
+      ) {
+        changes.push(
+          `Migrated media persistence in ${pathname}: ${result.rewrittenSessions} transcript session(s), ${result.rewrittenTrajectoryRows} trajectory row(s), schema v${OPENCLAW_AGENT_SCHEMA_VERSION}.`,
+        );
+      }
+    } catch (error) {
+      warnings.push(`Skipped media persistence migration for ${pathname}: ${String(error)}`);
+    }
+  }
+
+  for (const directory of archiveDirectories) {
+    let archives: string[];
+    try {
+      archives = listTranscriptArchives(directory);
+    } catch (error) {
+      warnings.push(`Could not enumerate transcript archives in ${directory}: ${String(error)}`);
+      continue;
+    }
+    for (const archive of archives) {
+      try {
+        if (migrateTranscriptArchive(archive)) {
+          changes.push(`Migrated archived transcript media in ${archive}.`);
+        }
+      } catch (error) {
+        warnings.push(
+          `Skipped archived transcript media migration for ${archive}: ${String(error)}`,
+        );
+      }
+    }
+  }
+  return { changes, warnings };
+}
+
+export const mediaPersistenceMigrationTesting = {
+  migrateRegisteredDatabase,
+  migrateTranscriptArchive,
+  transformTranscriptEvent,
+};

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -8,6 +8,7 @@ export {
   runLegacyStateMigrations,
 } from "./state-migrations.doctor.js";
 export { migrateLegacyAgentDir } from "./state-migrations.legacy-sessions.js";
+export { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 export { migrateOrphanedSessionKeys } from "./state-migrations.session-store.js";
 export {
   autoMigrateLegacyStateDir,

--- a/src/media/media-facts.persisted.test.ts
+++ b/src/media/media-facts.persisted.test.ts
@@ -1,101 +1,174 @@
 import { describe, expect, it } from "vitest";
 import {
-  projectPersistedMessageMediaFacts,
-  readPersistedMediaFactsWithLegacyFallback,
+  canonicalizePersistedUserMessageMedia,
+  PERSISTED_LEGACY_MEDIA_KEYS,
+  readPersistedMediaFacts,
 } from "./media-facts.js";
 
 const canonicalFact = { path: "/media/canonical.png", contentType: "image/png" };
 
-const persistedConsumerCases = [
-  {
-    name: "legacy-only",
-    message: { MediaPath: "/media/legacy.png", MediaType: "image/png" },
-    expectedPath: "/media/legacy.png",
-  },
-  {
-    name: "facts-only",
-    message: { __openclaw: { media: [canonicalFact] } },
-    expectedPath: canonicalFact.path,
-  },
-  {
-    name: "both-equal",
-    message: {
-      MediaPath: canonicalFact.path,
-      MediaType: canonicalFact.contentType,
-      __openclaw: { media: [canonicalFact] },
+describe("canonical persisted media", () => {
+  it.each([
+    {
+      name: "legacy-only",
+      message: { MediaPath: "/media/legacy.png", MediaType: "image/png" },
+      expected: [{ path: "/media/legacy.png", contentType: "image/png", kind: "image" }],
     },
-    expectedPath: canonicalFact.path,
-  },
-  {
-    name: "both-conflict",
-    message: {
-      MediaPath: "/media/legacy-conflict.jpg",
-      MediaType: "image/jpeg",
-      __openclaw: { media: [canonicalFact] },
+    {
+      name: "facts-only",
+      message: { __openclaw: { media: [canonicalFact] } },
+      expected: [{ ...canonicalFact, kind: "image" }],
     },
-    expectedPath: canonicalFact.path,
-  },
-  {
-    name: "sparse",
-    message: { __openclaw: { media: [{}, canonicalFact] } },
-    expectedPath: canonicalFact.path,
-    expectedIndex: 1,
-  },
-  {
-    name: "type-only",
-    message: { __openclaw: { media: [{ contentType: "image/png" }] } },
-    expectedPath: undefined,
-  },
-  {
-    name: "media-only",
-    message: { role: "user", content: "", __openclaw: { media: [canonicalFact] } },
-    expectedPath: canonicalFact.path,
-  },
-] as const;
-
-describe("persisted media consumer compatibility", () => {
-  it.each(persistedConsumerCases)("reads $name rows facts first", (testCase) => {
-    const media = readPersistedMediaFactsWithLegacyFallback(testCase.message);
-    const index = "expectedIndex" in testCase ? (testCase.expectedIndex ?? 0) : 0;
-    expect(media?.[index]?.path).toBe(testCase.expectedPath);
-    if (testCase.name === "both-conflict") {
-      expect(media?.[0]?.path).not.toBe(testCase.message.MediaPath);
+    {
+      name: "top-level-media-only",
+      message: { media: [canonicalFact] },
+      expected: [{ ...canonicalFact, kind: "image" }],
+    },
+    {
+      name: "both-equal",
+      message: {
+        MediaPath: canonicalFact.path,
+        MediaType: canonicalFact.contentType,
+        __openclaw: { media: [canonicalFact] },
+      },
+      expected: [{ ...canonicalFact, kind: "image" }],
+    },
+    {
+      name: "both-conflict",
+      message: {
+        MediaPath: "/media/legacy-conflict.jpg",
+        MediaType: "image/jpeg",
+        __openclaw: { media: [canonicalFact] },
+      },
+      expected: [{ ...canonicalFact, kind: "image" }],
+    },
+    {
+      name: "sparse",
+      message: {
+        MediaPaths: ["", "/media/second.png"],
+        MediaTypes: ["", "image/png"],
+        __openclaw: { media: [{ url: "https://example.test/first" }] },
+      },
+      expected: [
+        { url: "https://example.test/first" },
+        { path: "/media/second.png", contentType: "image/png", kind: "image" },
+      ],
+    },
+    {
+      name: "type-only",
+      message: { MediaType: "image" },
+      expected: [{ kind: "image" }],
+    },
+    {
+      name: "media-only",
+      message: { role: "user", content: "", __openclaw: { media: [canonicalFact] } },
+      expected: [{ ...canonicalFact, kind: "image" }],
+    },
+  ])("canonicalizes $name rows", ({ message, expected }) => {
+    const result = canonicalizePersistedUserMessageMedia(message);
+    for (const key of PERSISTED_LEGACY_MEDIA_KEYS) {
+      expect(result.message).not.toHaveProperty(key);
     }
+    expect(readPersistedMediaFacts(result.message)).toEqual(
+      expected.map((fact) => expect.objectContaining(fact)),
+    );
   });
 
-  it.each(persistedConsumerCases)("projects $name rows to facts only", (testCase) => {
-    const projected = projectPersistedMessageMediaFacts(testCase.message) as Record<
-      string,
-      unknown
-    >;
-    expect(projected).not.toHaveProperty("MediaPath");
-    expect(projected).not.toHaveProperty("MediaType");
-    expect(projected["__openclaw"]).toMatchObject({ media: expect.any(Array) });
-  });
-
-  it("strips empty legacy projections without inventing canonical facts", () => {
-    const projected = projectPersistedMessageMediaFacts({
-      role: "user",
-      MediaPaths: [],
-      MediaTypes: [],
+  it("copies transcription and workspace metadata while preserving adjacent metadata", () => {
+    const result = canonicalizePersistedUserMessageMedia({
+      MediaPaths: ["/media/a.ogg", "/media/b.png"],
+      MediaTypes: ["audio", "image/png"],
+      MediaTranscribedIndexes: [0],
+      MediaStaged: true,
+      MediaWorkspaceDir: "/media/workspace",
+      __openclaw: { traceId: "trace-1", media: [{ messageId: "m1" }] },
     });
 
-    expect(projected).toEqual({ role: "user" });
+    expect(result.message).toEqual({
+      __openclaw: {
+        traceId: "trace-1",
+        media: [
+          expect.objectContaining({
+            path: "/media/a.ogg",
+            kind: "audio",
+            transcribed: true,
+            staged: true,
+            workspaceDir: "/media/workspace",
+            messageId: "m1",
+          }),
+          expect.objectContaining({
+            path: "/media/b.png",
+            contentType: "image/png",
+            staged: true,
+            workspaceDir: "/media/workspace",
+          }),
+        ],
+      },
+    });
+  });
+
+  it("rejects compact types after a sparse positional gap", () => {
+    expect(() =>
+      canonicalizePersistedUserMessageMedia({
+        MediaPaths: ["", "/media/b.png"],
+        MediaTypes: ["image/png"],
+      }),
+    ).toThrow("ambiguous sparse positional alignment");
+  });
+
+  it("rejects under-cardinal compact types after dense attachment paths", () => {
+    expect(() =>
+      canonicalizePersistedUserMessageMedia({
+        MediaPaths: ["/media/a.bin", "/media/b.pdf"],
+        MediaTypes: ["application/pdf"],
+      }),
+    ).toThrow("ambiguous sparse positional alignment");
+  });
+
+  it("accepts compact legacy types when complete canonical facts cover every slot", () => {
+    const result = canonicalizePersistedUserMessageMedia({
+      MediaPaths: ["/media/a.bin", "/media/b.pdf"],
+      MediaTypes: ["application/pdf"],
+      __openclaw: {
+        media: [
+          { path: "/media/a.bin", contentType: "application/octet-stream" },
+          { path: "/media/b.pdf", contentType: "application/pdf" },
+        ],
+      },
+    });
+
+    expect(readPersistedMediaFacts(result.message)).toEqual([
+      expect.objectContaining({
+        path: "/media/a.bin",
+        contentType: "application/octet-stream",
+      }),
+      expect.objectContaining({ path: "/media/b.pdf", contentType: "application/pdf" }),
+    ]);
+  });
+
+  it("does not materialize a compact legacy type into an empty canonical slot", () => {
+    const result = canonicalizePersistedUserMessageMedia({
+      MediaPaths: ["", "/media/b.png"],
+      MediaType: "image",
+      MediaTypes: ["image/png"],
+      __openclaw: {
+        media: [{}, { path: "/media/b.png", contentType: "image/png" }],
+      },
+    });
+
+    expect((result.message["__openclaw"] as { media: unknown[] }).media).toEqual([
+      {},
+      expect.objectContaining({ path: "/media/b.png", contentType: "image/png" }),
+    ]);
   });
 
   it("removes a conflicting top-level media copy", () => {
-    const projected = projectPersistedMessageMediaFacts({
+    const result = canonicalizePersistedUserMessageMedia({
       media: [{ path: "/media/runtime.png", contentType: "image/png" }],
       __openclaw: { media: [canonicalFact] },
     });
 
-    expect(projected).not.toHaveProperty("media");
-    expect(projected["__openclaw"].media).toMatchObject([canonicalFact]);
-  });
-
-  it("strips an empty top-level media carrier", () => {
-    expect(projectPersistedMessageMediaFacts({ role: "user", media: [] })).toEqual({
-      role: "user",
-    });
+    expect(result.message).not.toHaveProperty("media");
+    expect(readPersistedMediaFacts(result.message)?.[0]).toMatchObject(canonicalFact);
   });
 });

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -160,7 +160,7 @@ function hasUnderCardinalLegacyTypes(source: MediaFactSource): boolean {
   return types.length > 0 && types.length < slotCount;
 }
 
-export type CanonicalizedPersistedMediaMessage<T extends object> = {
+type CanonicalizedPersistedMediaMessage<T extends object> = {
   changed: boolean;
   hadLegacy: boolean;
   message: T;

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -50,24 +50,17 @@ export function readRuntimePromptMediaFacts(message: object): MediaFact[] | unde
 
 /** Reads the canonical persisted media envelope without consulting legacy top-level fields. */
 export function readPersistedMediaFacts(message: object): MediaFact[] | undefined {
+  const media = readPersistedMediaFactInputs(message);
+  return media ? normalizeMediaFacts(media) : undefined;
+}
+
+function readPersistedMediaFactInputs(message: object): MediaFactInput[] | undefined {
   const metadata = (message as Record<string, unknown>)["__openclaw"];
   const media =
     metadata && typeof metadata === "object" && !Array.isArray(metadata)
       ? (metadata as Record<string, unknown>).media
       : undefined;
-  return Array.isArray(media) ? normalizeMediaFacts(media as MediaFactInput[]) : undefined;
-}
-
-/** Reads canonical persisted facts, falling back only for rows written before facts were universal. */
-export function readPersistedMediaFactsWithLegacyFallback(
-  message: object,
-): MediaFact[] | undefined {
-  const canonical = readPersistedMediaFacts(message);
-  if (canonical) {
-    return canonical;
-  }
-  const legacy = resolveMediaFacts(message as MediaFactSource);
-  return legacy.length > 0 ? legacy : undefined;
+  return Array.isArray(media) ? (media as MediaFactInput[]) : undefined;
 }
 
 const LEGACY_MEDIA_CONTEXT_KEYS = [
@@ -84,31 +77,178 @@ const LEGACY_MEDIA_CONTEXT_KEYS = [
 ] as const;
 export type LegacyMediaContextKey = (typeof LEGACY_MEDIA_CONTEXT_KEYS)[number];
 
+export const PERSISTED_LEGACY_MEDIA_KEYS = [
+  "MediaPath",
+  "MediaPaths",
+  "MediaUrl",
+  "MediaUrls",
+  "MediaType",
+  "MediaTypes",
+  "MediaTranscribedIndexes",
+  "MediaStaged",
+  "MediaWorkspaceDir",
+] as const;
+
+/** Returns whether a top-level retired carrier contains an attachment fact worth migrating. */
+export function hasMeaningfulRetiredMediaCarrier(message: object): boolean {
+  const record = message as Record<string, unknown>;
+  const retired: Record<string, unknown> = {};
+  if (Array.isArray(record.media)) {
+    retired.media = record.media;
+  }
+  for (const key of PERSISTED_LEGACY_MEDIA_KEYS) {
+    if (Object.hasOwn(record, key)) {
+      retired[key] = record[key];
+    }
+  }
+  if (resolveMediaFacts(retired as MediaFactSource).some(isMeaningfulMediaFact)) {
+    return true;
+  }
+  const canonical = normalizeMediaFacts(readPersistedMediaFactInputs(message));
+  if (canonical.length === 0) {
+    return false;
+  }
+  const transcribedIndexes = Array.isArray(record.MediaTranscribedIndexes)
+    ? record.MediaTranscribedIndexes
+    : [];
+  return (
+    transcribedIndexes.some(
+      (index) => Number.isInteger(index) && index >= 0 && index < canonical.length,
+    ) ||
+    Boolean(normalizeOptionalString(record.MediaWorkspaceDir)) ||
+    record.MediaStaged === true
+  );
+}
+
+const LEGACY_MEDIA_KINDS = new Set<MediaKind>([
+  "image",
+  "audio",
+  "video",
+  "document",
+  "sticker",
+  "unknown",
+]);
+
+function hasAmbiguousSparseLegacyMediaAlignment(source: MediaFactSource): boolean {
+  const paths = Array.isArray(source.MediaPaths) ? source.MediaPaths : [];
+  const urls = Array.isArray(source.MediaUrls) ? source.MediaUrls : [];
+  const types = Array.isArray(source.MediaTypes) ? source.MediaTypes : [];
+  const canonical = normalizeMediaFacts(source.media);
+  const slotCount = Math.max(paths.length, urls.length);
+  if (types.length === 0 || types.length >= slotCount) {
+    return false;
+  }
+  return Array.from({ length: slotCount }, (_, index) =>
+    Boolean(normalizeOptionalString(paths[index]) ?? normalizeOptionalString(urls[index])),
+  ).some((meaningful, index) => {
+    if (!meaningful) {
+      return false;
+    }
+    const fact = canonical[index];
+    const canonicalIdentity =
+      normalizeOptionalString(fact?.path) ?? normalizeOptionalString(fact?.url);
+    const canonicalClassification = normalizeOptionalString(fact?.contentType) ?? fact?.kind;
+    return !canonicalIdentity || !canonicalClassification;
+  });
+}
+
+function hasUnderCardinalLegacyTypes(source: MediaFactSource): boolean {
+  const paths = Array.isArray(source.MediaPaths) ? source.MediaPaths : [];
+  const urls = Array.isArray(source.MediaUrls) ? source.MediaUrls : [];
+  const types = Array.isArray(source.MediaTypes) ? source.MediaTypes : [];
+  const slotCount = Math.max(paths.length, urls.length);
+  return types.length > 0 && types.length < slotCount;
+}
+
+export type CanonicalizedPersistedMediaMessage<T extends object> = {
+  changed: boolean;
+  hadLegacy: boolean;
+  message: T;
+};
+
+/** Canonicalizes persisted user-message media; ambiguous sparse legacy arrays are rejected. */
+export function canonicalizePersistedUserMessageMedia<T extends object>(
+  message: T,
+): CanonicalizedPersistedMediaMessage<T> {
+  const record = message as Record<string, unknown>;
+  const hadLegacy = PERSISTED_LEGACY_MEDIA_KEYS.some((key) => Object.hasOwn(record, key));
+  const hadTopLevelMedia = Object.hasOwn(record, "media");
+  const canonical = readPersistedMediaFactInputs(message);
+  if (!hadLegacy && !hadTopLevelMedia && canonical === undefined) {
+    return { changed: false, hadLegacy: false, message };
+  }
+
+  const topLevelMedia = Array.isArray(record.media)
+    ? (record.media as readonly MediaFactInput[])
+    : undefined;
+  const source: MediaFactSource = { ...record, media: canonical ?? topLevelMedia };
+  const hasAmbiguousLegacyAlignment = hasAmbiguousSparseLegacyMediaAlignment(source);
+  if (hadLegacy && hasAmbiguousLegacyAlignment) {
+    throw new Error("legacy media arrays have ambiguous sparse positional alignment");
+  }
+  const resolvedSource =
+    hasUnderCardinalLegacyTypes(source) && !hasAmbiguousLegacyAlignment
+      ? { ...source, MediaType: undefined, MediaTypes: [] }
+      : source;
+  const resolvedMedia = resolveMediaFacts(resolvedSource);
+  const stagedMedia =
+    resolvedSource.MediaStaged === true ? resolveStagedMediaFacts(resolvedSource) : undefined;
+  const legacyTypes = Array.isArray(resolvedSource.MediaTypes) ? resolvedSource.MediaTypes : [];
+  const canonicalInputs = Array.isArray(resolvedSource.media) ? resolvedSource.media : [];
+  const media: MediaFact[] = [];
+  for (const [index, fact] of resolvedMedia.entries()) {
+    const legacyType = normalizeOptionalString(
+      legacyTypes[index] ?? (index === 0 ? resolvedSource.MediaType : undefined),
+    );
+    const existing = canonicalInputs[index];
+    const bareLegacyKind =
+      legacyType &&
+      LEGACY_MEDIA_KINDS.has(legacyType as MediaKind) &&
+      !normalizeOptionalString(existing?.contentType) &&
+      existing?.kind === undefined;
+    const explicitKind = existing?.kind ?? (bareLegacyKind ? (legacyType as MediaKind) : undefined);
+    media.push({
+      ...(fact.path ? { path: fact.path } : {}),
+      ...(fact.url ? { url: fact.url } : {}),
+      ...(fact.contentType && !bareLegacyKind ? { contentType: fact.contentType } : {}),
+      ...(explicitKind ? { kind: explicitKind } : {}),
+      ...(fact.transcribed ? { transcribed: true } : {}),
+      ...(fact.messageId ? { messageId: fact.messageId } : {}),
+      ...(fact.workspaceDir ? { workspaceDir: fact.workspaceDir } : {}),
+      ...(fact.staged || stagedMedia?.[index]?.staged ? { staged: true } : {}),
+      ...(fact.hydrationSuppressed ? { hydrationSuppressed: true } : {}),
+    });
+  }
+
+  const next: Record<string, unknown> = { ...record };
+  delete next.media;
+  for (const key of PERSISTED_LEGACY_MEDIA_KEYS) {
+    delete next[key];
+  }
+  const metadata = record["__openclaw"];
+  const openclaw =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? { ...(metadata as Record<string, unknown>) }
+      : {};
+  if (media.length > 0 || canonical !== undefined || topLevelMedia !== undefined) {
+    openclaw.media = media;
+  }
+  if (Object.keys(openclaw).length > 0) {
+    next["__openclaw"] = openclaw;
+  } else {
+    delete next["__openclaw"];
+  }
+  return {
+    changed: JSON.stringify(next) !== JSON.stringify(record),
+    hadLegacy,
+    message: next as T,
+  };
+}
+
 export function stripLegacyMediaContextFields(ctx: Record<string, unknown>): void {
   for (const key of LEGACY_MEDIA_CONTEXT_KEYS) {
     delete ctx[key];
   }
-}
-
-export function projectPersistedMessageMediaFacts<T extends object>(message: T): T {
-  const media = readPersistedMediaFactsWithLegacyFallback(message);
-  const record = message as Record<string, unknown>;
-  const hasLegacyProjection = LEGACY_MEDIA_CONTEXT_KEYS.some((key) => Object.hasOwn(record, key));
-  if (media === undefined && !hasLegacyProjection && !Object.hasOwn(record, "media")) {
-    return message;
-  }
-  const next = { ...record };
-  delete next.media;
-  stripLegacyMediaContextFields(next);
-  if (media === undefined) {
-    return next as T;
-  }
-  const metadata = record["__openclaw"];
-  next["__openclaw"] = {
-    ...(metadata && typeof metadata === "object" && !Array.isArray(metadata) ? metadata : {}),
-    media,
-  };
-  return next as T;
 }
 
 export function readRuntimePromptImageOrder(message: object): PromptImageOrderEntry[] | undefined {
@@ -251,7 +391,7 @@ function resolveMediaFactsWithPrecedence(
     paths.length,
     urls.length,
     types.length,
-    source.MediaPath || source.MediaUrl ? 1 : 0,
+    source.MediaPath || source.MediaUrl || source.MediaType ? 1 : 0,
   );
   const transcribed = new Set(source.MediaTranscribedIndexes ?? []);
   const legacyHasPath =
@@ -323,7 +463,7 @@ function projectStrings(
 
 export function projectMediaFacts(
   media: readonly MediaFactInput[] | null | undefined,
-  mode: "channel" | "compact" | "aligned" = "channel",
+  mode: "channel" | "compact" = "channel",
 ): MediaFactLegacyProjection {
   const entries = Array.isArray(media) ? media : [];
   const preserveEmptyLists = mode !== "channel";

--- a/src/sessions/user-turn-media.test.ts
+++ b/src/sessions/user-turn-media.test.ts
@@ -3,7 +3,6 @@ import { hasPersistedMedia } from "./user-turn-media.js";
 
 describe("hasPersistedMedia", () => {
   it.each([
-    ["legacy-only", { MediaPath: "/media/legacy.png" }],
     ["facts-only", { __openclaw: { media: [{ path: "/media/fact.png" }] } }],
     [
       "both-equal",
@@ -24,6 +23,7 @@ describe("hasPersistedMedia", () => {
   });
 
   it("rejects empty and alignment-only rows", () => {
+    expect(hasPersistedMedia({ MediaPath: "/media/legacy.png" })).toBe(false);
     expect(hasPersistedMedia({ role: "user", content: "" })).toBe(false);
     expect(hasPersistedMedia({ __openclaw: { media: [{}] } })).toBe(false);
   });

--- a/src/sessions/user-turn-media.ts
+++ b/src/sessions/user-turn-media.ts
@@ -1,7 +1,4 @@
-import {
-  isMeaningfulMediaFact,
-  readPersistedMediaFactsWithLegacyFallback,
-} from "../media/media-facts.js";
+import { isMeaningfulMediaFact, readPersistedMediaFacts } from "../media/media-facts.js";
 
 // Model-facing marker for user turns that carry media but no caption. Never
 // persist it as transcript content — UIs render content verbatim; the LLM
@@ -12,5 +9,5 @@ export function hasPersistedMedia(message: unknown): boolean {
   if (!message || typeof message !== "object" || Array.isArray(message)) {
     return false;
   }
-  return (readPersistedMediaFactsWithLegacyFallback(message) ?? []).some(isMeaningfulMediaFact);
+  return (readPersistedMediaFacts(message) ?? []).some(isMeaningfulMediaFact);
 }

--- a/src/sessions/user-turn-transcript.media-normalize.ts
+++ b/src/sessions/user-turn-transcript.media-normalize.ts
@@ -19,15 +19,6 @@ function normalizeOptionalText(value: string | null | undefined): string | undef
   return normalized ? normalized : undefined;
 }
 
-function mediaTypeForTranscript(media: PersistedUserTurnMediaInput, mediaPath?: string): string {
-  return (
-    normalizeOptionalText(media.contentType) ??
-    normalizeOptionalText(media.kind) ??
-    mimeTypeFromFilePath(mediaPath) ??
-    "application/octet-stream"
-  );
-}
-
 function normalizeStructuredMediaKind(value: string | null | undefined): MediaFactInput["kind"] {
   const kind = normalizeOptionalText(value);
   return kind && STRUCTURED_MEDIA_KINDS.has(kind as NonNullable<MediaFactInput["kind"]>)
@@ -45,25 +36,6 @@ export function resolveTranscriptMediaPath(
     return pathValue;
   }
   return path.join(workspaceDir, pathValue);
-}
-
-export function normalizeMediaEntryForTranscript(
-  media: PersistedUserTurnMediaInput,
-): MediaFactInput {
-  const rawPath = normalizeOptionalText(media.path) ?? normalizeOptionalText(media.url);
-  if (!rawPath) {
-    return media.hydrationSuppressed === true
-      ? {
-          contentType: normalizeOptionalText(media.contentType),
-          hydrationSuppressed: true,
-        }
-      : {};
-  }
-  return {
-    path: resolveTranscriptMediaPath(rawPath, normalizeOptionalText(media.workspaceDir)),
-    contentType: mediaTypeForTranscript(media, rawPath),
-    ...(media.hydrationSuppressed === true ? { hydrationSuppressed: true } : {}),
-  };
 }
 
 export function normalizeStructuredMediaEntryForTranscript(
@@ -89,12 +61,4 @@ export function normalizeStructuredMediaEntryForTranscript(
     ...(workspaceDir ? { workspaceDir } : {}),
     ...(media.hydrationSuppressed === true ? { hydrationSuppressed: true } : {}),
   };
-}
-
-export function shouldPersistStructuredMediaEntries(
-  media: readonly PersistedUserTurnMediaInput[] | null | undefined,
-): boolean {
-  // PR 1 dual-writes canonical facts beside byte-stable legacy fields. PR 3
-  // removes this compatibility decision together with the legacy writer.
-  return Array.isArray(media) && media.length > 0;
 }

--- a/src/sessions/user-turn-transcript.media.test.ts
+++ b/src/sessions/user-turn-transcript.media.test.ts
@@ -1,4 +1,4 @@
-// User-turn media persistence tests cover fact normalization and legacy row projection.
+// User-turn media persistence tests cover canonical fact normalization.
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { readPersistedMediaFacts } from "../media/media-facts.js";
@@ -7,132 +7,47 @@ import {
   buildPersistedUserTurnMediaInputsFromFields,
   buildPersistedUserTurnMessage,
 } from "./user-turn-transcript.js";
-import { shouldPersistStructuredMediaEntries } from "./user-turn-transcript.media-normalize.js";
 
 describe("buildPersistedUserTurnMediaInputsFromFields", () => {
-  it("builds media facts from persisted parallel fields", () => {
+  it("builds media inputs from canonical persisted facts", () => {
     expect(
       buildPersistedUserTurnMediaInputsFromFields({
-        MediaPath: "/tmp/a.png",
-        MediaPaths: ["/tmp/a.png", "/tmp/b.jpg"],
-        MediaType: "image/png",
-        MediaTypes: ["image/png", "image/jpeg"],
-      }),
+        __openclaw: {
+          media: [
+            { path: "/tmp/a.png", contentType: "image/png" },
+            { url: "https://example.test/b.jpg", contentType: "image/jpeg" },
+          ],
+        },
+      } as never),
     ).toEqual([
       { path: "/tmp/a.png", contentType: "image/png" },
-      { path: "/tmp/b.jpg", contentType: "image/jpeg" },
+      { url: "https://example.test/b.jpg", contentType: "image/jpeg" },
     ]);
   });
 
-  it("uses url-backed media fields when no local path is present", () => {
-    expect(
-      buildPersistedUserTurnMediaInputsFromFields({
-        MediaUrl: "media://inbound/a.png",
-        MediaType: "image/png",
-      }),
-    ).toEqual([{ url: "media://inbound/a.png", contentType: "image/png" }]);
-  });
-
-  it("infers transcript media type from media path when explicit type is absent", () => {
-    expect(
-      buildPersistedUserTurnMediaInputsFromFields({
-        MediaPaths: ["/tmp/a.png", "https://example.test/report.pdf"],
-      }),
-    ).toEqual([
-      { path: "/tmp/a.png", contentType: "image/png" },
-      { path: "https://example.test/report.pdf", contentType: "application/pdf" },
-    ]);
-  });
-
-  it("does not reuse singular media type for later media paths", () => {
-    expect(
-      buildPersistedUserTurnMediaInputsFromFields({
-        MediaPath: "/tmp/a.png",
-        MediaPaths: ["/tmp/a.png", "/tmp/report.pdf"],
-        MediaType: "image/png",
-      }),
-    ).toEqual([
-      { path: "/tmp/a.png", contentType: "image/png" },
-      { path: "/tmp/report.pdf", contentType: "application/pdf" },
-    ]);
-  });
-
-  it("resolves staged legacy paths against the media workspace", () => {
+  it("resolves relative canonical paths against each fact workspace", () => {
     const workspaceDir = "/tmp/openclaw-user-turn-workspace";
     expect(
       buildPersistedUserTurnMediaInputsFromFields({
-        MediaPaths: ["media/inbound/a.png", "media/inbound/b.jpg"],
-        MediaTypes: ["image/png", "image/jpeg"],
-        MediaWorkspaceDir: workspaceDir,
-      }),
-    ).toEqual([
-      { path: path.join(workspaceDir, "media/inbound/a.png"), contentType: "image/png" },
-      { path: path.join(workspaceDir, "media/inbound/b.jpg"), contentType: "image/jpeg" },
-    ]);
+        __openclaw: {
+          media: [{ path: "media/inbound/a.png", contentType: "image/png", workspaceDir }],
+        },
+      } as never),
+    ).toEqual([{ path: path.join(workspaceDir, "media/inbound/a.png"), contentType: "image/png" }]);
   });
 
-  it("does not rewrite absolute or URL-like media paths", () => {
-    const workspaceDir = "/tmp/openclaw-user-turn-workspace";
-    const absolutePath = path.join(workspaceDir, "media/inbound/a.png");
-    expect(
-      buildPersistedUserTurnMediaInputsFromFields({
-        MediaPaths: [absolutePath, "media://inbound/b.jpg", "https://example.test/c.png"],
-        MediaTypes: ["image/png", "image/jpeg", "image/png"],
-        MediaWorkspaceDir: workspaceDir,
-      }),
-    ).toEqual([
-      { path: absolutePath, contentType: "image/png" },
-      { path: "media://inbound/b.jpg", contentType: "image/jpeg" },
-      { path: "https://example.test/c.png", contentType: "image/png" },
-    ]);
-  });
-
-  it("does not infer media from absent structured fields", () => {
+  it("does not consult legacy top-level fields after the versioned cutover", () => {
     expect(buildPersistedUserTurnMediaInputsFromFields(undefined)).toEqual([]);
-    expect(buildPersistedUserTurnMediaInputsFromFields({})).toEqual([]);
-    expect(buildPersistedUserTurnMediaInputsFromFields({ MediaTypes: ["image/png"] })).toEqual([]);
-  });
-
-  it("preserves aligned content-type holes while normalizing the row", () => {
-    const result = buildPersistedUserTurnMediaInputsFromFields({
-      MediaPaths: ["/media/a.bin", "/media/b.png"],
-      MediaTypes: ["", "image/png"],
-    });
-    expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ path: "/media/a.bin" });
-    expect(result[0]?.contentType).not.toBe("image/png");
-    expect(result[1]).toEqual({ path: "/media/b.png", contentType: "image/png" });
-  });
-
-  it("preserves aligned path and URL holes while normalizing the row", () => {
-    expect(
-      buildPersistedUserTurnMediaInputsFromFields({
-        MediaPaths: ["/media/local.bin", ""],
-        MediaUrls: ["", "https://example.test/remote.png"],
-        MediaTypes: ["application/octet-stream", "image/png"],
-      }),
-    ).toEqual([
-      { path: "/media/local.bin", contentType: "application/octet-stream" },
-      { url: "https://example.test/remote.png", contentType: "image/png" },
-    ]);
-  });
-
-  it("keeps empty attachment slots aligned for a later writer", () => {
-    expect(
-      buildPersistedUserTurnMediaInputsFromFields({
-        MediaPaths: ["", "/media/b.png"],
-        MediaTypes: ["", "image/png"],
-      }),
-    ).toEqual([{}, { path: "/media/b.png", contentType: "image/png" }]);
+    expect(buildPersistedUserTurnMediaInputsFromFields({} as never)).toEqual([]);
   });
 });
 
-describe("buildLateMediaAttachedProjection facts-first compatibility", () => {
+describe("buildLateMediaAttachedProjection canonical persistence", () => {
   it.each([
     {
       name: "legacy-only",
       message: { MediaPath: "/media/legacy.png", MediaType: "image/png" },
-      expectedPath: "/media/legacy.png",
+      expectedPath: undefined,
     },
     {
       name: "facts-only",
@@ -189,13 +104,6 @@ describe("buildLateMediaAttachedProjection facts-first compatibility", () => {
 });
 
 describe("buildPersistedUserTurnMessage media projection", () => {
-  const legacyProjection = (message: Record<string, unknown>) => ({
-    ...(message.MediaPath === undefined ? {} : { MediaPath: message.MediaPath }),
-    ...(message.MediaPaths === undefined ? {} : { MediaPaths: message.MediaPaths }),
-    ...(message.MediaType === undefined ? {} : { MediaType: message.MediaType }),
-    ...(message.MediaTypes === undefined ? {} : { MediaTypes: message.MediaTypes }),
-  });
-
   it.each([
     {
       name: "zero attachments",
@@ -381,23 +289,17 @@ describe("buildPersistedUserTurnMessage media projection", () => {
         },
       ],
     },
-  ])(
-    "keeps $name legacy bytes stable while persisting canonical facts",
-    ({ media, expectedLegacy, expectedMedia }) => {
-      const message = buildPersistedUserTurnMessage({ text: "inspect", timestamp: 123, media });
-      expect(message).toMatchObject({ role: "user", content: "inspect", timestamp: 123 });
-      expect(legacyProjection(message as unknown as Record<string, unknown>)).toEqual(
-        expectedLegacy,
-      );
-      expect(JSON.stringify(legacyProjection(message as unknown as Record<string, unknown>))).toBe(
-        JSON.stringify(expectedLegacy),
-      );
-      expect(
-        (message as unknown as { __openclaw?: { media?: unknown } })["__openclaw"]?.media,
-      ).toEqual(expectedMedia);
-      expect(shouldPersistStructuredMediaEntries(media)).toBe(Boolean(media?.length));
-    },
-  );
+  ])("persists $name as canonical facts without legacy fields", ({ media, expectedMedia }) => {
+    const message = buildPersistedUserTurnMessage({ text: "inspect", timestamp: 123, media });
+    expect(message).toMatchObject({ role: "user", content: "inspect", timestamp: 123 });
+    expect(message).not.toHaveProperty("MediaPath");
+    expect(message).not.toHaveProperty("MediaPaths");
+    expect(message).not.toHaveProperty("MediaType");
+    expect(message).not.toHaveProperty("MediaTypes");
+    expect(
+      (message as unknown as { __openclaw?: { media?: unknown } })["__openclaw"]?.media,
+    ).toEqual(expectedMedia);
+  });
 
   it("reads canonical persisted facts without merging disagreeing legacy fields", () => {
     const message = {

--- a/src/sessions/user-turn-transcript.persistence.test.ts
+++ b/src/sessions/user-turn-transcript.persistence.test.ts
@@ -100,10 +100,6 @@ describe("persistUserTurnTranscript", () => {
       role: "user",
       content: "What is in this image?",
       timestamp: 123,
-      MediaPath: "/tmp/image.png",
-      MediaPaths: ["/tmp/image.png"],
-      MediaType: "image/png",
-      MediaTypes: ["image/png"],
       __openclaw: {
         senderIsOwner: true,
         media: [{ path: "/tmp/image.png", contentType: "image/png" }],
@@ -124,10 +120,6 @@ describe("persistUserTurnTranscript", () => {
       role: "user",
       content: "Inspect both",
       timestamp: 456,
-      MediaPath: "/tmp/image.png",
-      MediaPaths: ["/tmp/image.png", "https://example.test/report.pdf"],
-      MediaType: "image/png",
-      MediaTypes: ["image/png", "application/pdf"],
       __openclaw: {
         media: [
           { path: "/tmp/image.png", contentType: "image/png" },

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -107,8 +107,9 @@ describe("user turn transcript persistence", () => {
         content: "display prompt",
         provenance: { sourceChannel: "telegram" },
         timestamp: 123,
-        MediaPath: "/tmp/image.png",
-        MediaType: "image/png",
+        __openclaw: {
+          media: [expect.objectContaining({ path: "/tmp/image.png", contentType: "image/png" })],
+        },
       });
     });
 
@@ -262,8 +263,14 @@ describe("user turn transcript persistence", () => {
       });
 
       expect(recorder.message).toMatchObject({
-        MediaPath: "/tmp/provider-media.bin",
-        MediaType: "provider/custom-media",
+        __openclaw: {
+          media: [
+            expect.objectContaining({
+              path: "/tmp/provider-media.bin",
+              contentType: "provider/custom-media",
+            }),
+          ],
+        },
       });
     });
 
@@ -377,15 +384,22 @@ describe("user turn transcript persistence", () => {
       expect(persisted?.message).toMatchObject({
         role: "user",
         content: "describe this",
-        MediaPath: path.join(dir, "image.png"),
-        MediaType: "image/png",
+        __openclaw: {
+          media: [
+            expect.objectContaining({
+              path: path.join(dir, "image.png"),
+              contentType: "image/png",
+            }),
+          ],
+        },
       });
       await expect(readTranscriptMessages(target)).resolves.toEqual([
         expect.objectContaining({
           role: "user",
           content: "describe this",
-          MediaPath: path.join(dir, "image.png"),
-          MediaType: "image/png",
+          __openclaw: {
+            media: [expect.objectContaining({ path: path.join(dir, "image.png") })],
+          },
         }),
       ]);
     });
@@ -445,11 +459,11 @@ describe("user turn transcript persistence", () => {
         expect.objectContaining({
           content: "",
           idempotencyKey: "chat-run-late:user:late-media",
-          MediaPath: path.join(dir, "image.png"),
-          MediaPaths: [path.join(dir, "image.png")],
-          MediaType: "image/png",
-          MediaTypes: ["image/png"],
-          __openclaw: { hookOwned: true, lateMedia: true },
+          __openclaw: {
+            hookOwned: true,
+            lateMedia: true,
+            media: [expect.objectContaining({ path: path.join(dir, "image.png") })],
+          },
         }),
       ]);
       const lateProjection = buildLateMediaAttachedProjection(castAgentMessage(messages[1]));
@@ -503,7 +517,6 @@ describe("user turn transcript persistence", () => {
         expect.objectContaining({ content: "describe this" }),
         expect.objectContaining({
           content: "resolved subtitle",
-          MediaPath: path.join(dir, "image.png"),
           __openclaw: {
             lateMedia: true,
             media: [{ path: path.join(dir, "image.png"), contentType: "image/png" }],
@@ -539,7 +552,9 @@ describe("user turn transcript persistence", () => {
         expect.objectContaining({
           content: "describe this",
           idempotencyKey: "chat-run-early:user",
-          MediaPath: path.join(dir, "image.png"),
+          __openclaw: {
+            media: [expect.objectContaining({ path: path.join(dir, "image.png") })],
+          },
         }),
       ]);
     });

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -5,17 +5,11 @@ import {
   persistSessionTranscriptTurn,
   type SessionTranscriptTurnPersistOptions,
 } from "../config/sessions/session-accessor.js";
-import {
-  projectMediaFacts,
-  readPersistedMediaFactsWithLegacyFallback,
-  type MediaFact,
-} from "../media/media-facts.js";
+import { readPersistedMediaFacts, type MediaFact } from "../media/media-facts.js";
 import { applyInputProvenanceToUserMessage, normalizeInputProvenance } from "./input-provenance.js";
 import {
-  normalizeMediaEntryForTranscript,
   normalizeStructuredMediaEntryForTranscript,
   resolveTranscriptMediaPath,
-  shouldPersistStructuredMediaEntries,
 } from "./user-turn-transcript.media-normalize.js";
 import type {
   CreateUserTurnTranscriptRecorderParams,
@@ -40,23 +34,6 @@ export type {
 export function buildRunUserTurnIdempotencyKey(runId: string): string {
   return `${runId}:user`;
 }
-
-type PersistedUserTurnMediaFields = {
-  MediaPath?: string;
-  MediaPaths?: string[];
-  MediaType?: string;
-  MediaTypes?: string[];
-};
-
-type PersistedUserTurnMediaFieldSource = {
-  MediaPath?: string | null;
-  MediaPaths?: readonly (string | null | undefined)[] | null;
-  MediaUrl?: string | null;
-  MediaUrls?: readonly (string | null | undefined)[] | null;
-  MediaType?: string | null;
-  MediaTypes?: readonly (string | null | undefined)[] | null;
-  MediaWorkspaceDir?: string | null;
-};
 
 function normalizeOptionalText(value: string | null | undefined): string | undefined {
   const normalized = value?.trim();
@@ -85,13 +62,13 @@ function resolveTranscriptMediaType(params: {
 }
 
 export function buildPersistedUserTurnMediaInputsFromFields(
-  fields: PersistedUserTurnMediaFieldSource | PersistedUserTurnMessage | null | undefined,
+  fields: PersistedUserTurnMessage | null | undefined,
 ): PersistedUserTurnMediaInput[] {
   if (!fields) {
     return [];
   }
 
-  const facts = readPersistedMediaFactsWithLegacyFallback(fields) ?? [];
+  const facts = readPersistedMediaFacts(fields) ?? [];
   const normalizedMedia = facts.map((fact) => {
     const rawPath = normalizeOptionalText(fact.path);
     const mediaPath = rawPath
@@ -126,7 +103,7 @@ export function buildLateMediaAttachedProjection(message: AgentMessage): {
   media: MediaFact[];
 } {
   const isLateMedia = readOpenClawMessageMeta(message)?.lateMedia === true;
-  const media = isLateMedia ? (readPersistedMediaFactsWithLegacyFallback(message) ?? []) : [];
+  const media = isLateMedia ? (readPersistedMediaFacts(message) ?? []) : [];
   const text = media
     .flatMap((fact) => {
       const mediaRef = fact.path ?? fact.url;
@@ -134,22 +111,6 @@ export function buildLateMediaAttachedProjection(message: AgentMessage): {
     })
     .join("\n");
   return { ...(text ? { text } : {}), media };
-}
-
-function buildPersistedUserTurnMediaFields(
-  media: readonly PersistedUserTurnMediaInput[] | null | undefined,
-): PersistedUserTurnMediaFields {
-  const normalized = (Array.isArray(media) ? media : []).map(normalizeMediaEntryForTranscript);
-  const projected = projectMediaFacts(normalized, "aligned");
-  if (!projected.MediaPaths?.some(Boolean)) {
-    return {};
-  }
-  return {
-    ...(projected.MediaPath ? { MediaPath: projected.MediaPath } : {}),
-    MediaPaths: projected.MediaPaths,
-    ...(projected.MediaType ? { MediaType: projected.MediaType } : {}),
-    MediaTypes: projected.MediaTypes ?? [],
-  };
 }
 
 function buildUserTurnSenderMeta(
@@ -176,7 +137,6 @@ function readOpenClawMessageMeta(message: AgentMessage): Record<string, unknown>
 }
 
 export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {
-  const mediaFields = buildPersistedUserTurnMediaFields(params.media);
   const normalizedMedia = (params.media ?? []).map(normalizeStructuredMediaEntryForTranscript);
   const text = normalizeTranscriptText(params.text);
   // Storage is BARE (no timestamp prefix). The per-message timestamp is added
@@ -190,7 +150,7 @@ export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedU
     ...(params.senderIsOwner === undefined ? {} : { senderIsOwner: params.senderIsOwner }),
     ...senderMeta,
     ...(params.transport ? { transport: params.transport } : {}),
-    ...(shouldPersistStructuredMediaEntries(params.media) ? { media: normalizedMedia } : {}),
+    ...(normalizedMedia.length > 0 ? { media: normalizedMedia } : {}),
     ...(params.mediaImageLayout
       ? {
           mediaImageLayout: {
@@ -209,7 +169,6 @@ export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedU
     content: text,
     timestamp: params.timestamp ?? Date.now(),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
-    ...mediaFields,
     ...(Object.keys(openClawMeta).length > 0 ? { __openclaw: openClawMeta } : {}),
   } as PersistedUserTurnMessage;
   return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
@@ -350,6 +309,11 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const senderIsOwner = readOpenClawMessageMeta(message)?.senderIsOwner;
   const originalTransport = readOpenClawMessageMeta(message)?.transport;
   const lateMedia = readOpenClawMessageMeta(message)?.lateMedia === true;
+  const originalMedia = readOpenClawMessageMeta(message)?.media;
+  const media = Array.isArray(originalMedia) ? structuredClone(originalMedia) : undefined;
+  const originalMediaImageLayout = readOpenClawMessageMeta(message)?.mediaImageLayout;
+  const mediaImageLayout =
+    originalMediaImageLayout === undefined ? undefined : structuredClone(originalMediaImageLayout);
   // Hooks receive the original message object and may mutate nested metadata in
   // place. Snapshot transport correlation before handing them that reference.
   const transport =
@@ -367,7 +331,14 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const nextUserMessage = provenance
     ? (applyInputProvenanceToUserMessage(nextMessage, provenance) as PersistedUserTurnMessage)
     : nextMessage;
-  if (!idempotencyKey && typeof senderIsOwner !== "boolean" && !transport && !lateMedia) {
+  if (
+    !idempotencyKey &&
+    typeof senderIsOwner !== "boolean" &&
+    !transport &&
+    !lateMedia &&
+    media === undefined &&
+    mediaImageLayout === undefined
+  ) {
     return nextUserMessage;
   }
   const protectedMeta = {
@@ -375,6 +346,8 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
     ...(typeof senderIsOwner === "boolean" ? { senderIsOwner } : {}),
     ...(transport ? { transport } : {}),
     ...(lateMedia ? { lateMedia: true } : {}),
+    ...(media === undefined ? {} : { media }),
+    ...(mediaImageLayout === undefined ? {} : { mediaImageLayout }),
   };
   return {
     ...(nextUserMessage as unknown as Record<string, unknown>),

--- a/src/state/openclaw-agent-db-contract.ts
+++ b/src/state/openclaw-agent-db-contract.ts
@@ -2,6 +2,8 @@ import type { DatabaseSync } from "node:sqlite";
 import type { SqliteWalMaintenance } from "../infra/sqlite-wal.js";
 import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db.js";
 
+// v16 retires legacy top-level Media* transcript fields. It is a downgrade
+// guard only; the physical schema is unchanged and Doctor owns the data rewrite.
 // v15 makes board and session-sharing tables part of the canonical agent schema.
 // v14 = logical session nodes, generation windows, and node-owned artifact FKs.
 // v13 = one durable rewrite watermark per raw session transcript.
@@ -16,7 +18,7 @@ import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db.js";
 // The v4 session/transcript flip and main's v2 memory-identity
 // change is folded in structure-gated migrations, so v2 main DBs and
 // pre-merge v4 flip DBs both converge on this schema.
-export const OPENCLAW_AGENT_SCHEMA_VERSION = 15;
+export const OPENCLAW_AGENT_SCHEMA_VERSION = 16;
 
 /** Open per-agent SQLite database handle plus lifecycle maintenance. */
 export type OpenClawAgentDatabase = {

--- a/src/state/openclaw-agent-db-readonly.ts
+++ b/src/state/openclaw-agent-db-readonly.ts
@@ -5,6 +5,7 @@ import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { OpenClawAgentDatabaseOptions } from "./openclaw-agent-db-contract.js";
 import {
+  assertCanonicalAgentMediaPersistenceVersion,
   assertExistingAgentSchemaOwner,
   assertSupportedAgentSchemaVersion,
   readExistingAgentSchemaMeta,
@@ -56,6 +57,7 @@ export function withOpenClawAgentDatabaseReadOnly<T>(
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     assertSupportedAgentSchemaVersion(db, pathname);
+    assertCanonicalAgentMediaPersistenceVersion(db, pathname);
     const schemaMeta = readExistingAgentSchemaMeta(db);
     if (!schemaMeta) {
       return { found: false, reason: "schema-missing" };

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -154,6 +154,24 @@ export function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: st
   }
 }
 
+/** Refuse steady-state reads until Doctor has completed the v16 media cutover. */
+export function assertCanonicalAgentMediaPersistenceVersion(
+  db: DatabaseSync,
+  pathname: string,
+): void {
+  const userVersion = readSqliteUserVersion(db);
+  const hasApplicationSchema = db
+    .prepare("SELECT 1 FROM sqlite_master WHERE substr(name, 1, 7) <> 'sqlite_' LIMIT 1")
+    .get();
+  const isNewUnownedDatabase =
+    userVersion === 0 && readExistingAgentSchemaMeta(db) === null && !hasApplicationSchema;
+  if (userVersion < OPENCLAW_AGENT_SCHEMA_VERSION && !isNewUnownedDatabase) {
+    throw new Error(
+      `OpenClaw agent database ${pathname} uses schema version ${userVersion}; run openclaw doctor --fix to migrate persisted media before using it.`,
+    );
+  }
+}
+
 export function readExistingAgentSchemaMeta(db: DatabaseSync): ExistingAgentSchemaMeta | null {
   const schemaMetaTable = db
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'schema_meta'")

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -19,6 +19,7 @@ import { ensureOpenClawAgentDatabasePermissions } from "./openclaw-agent-db-perm
 import { registerOpenClawAgentDatabase } from "./openclaw-agent-db-registry.js";
 import {
   assertExistingAgentSchemaOwner,
+  assertOpenClawAgentSchemaContains,
   assertOpenClawAgentCurrentRuntimeSchema,
   assertSupportedAgentSchemaVersion,
   readExistingAgentSchemaMeta,
@@ -486,7 +487,27 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
   }
 }
 
-function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string): void {
+function assertAgentSchemaVersion(
+  db: DatabaseSync,
+  options: { agentId: string; pathname: string; version: number },
+): void {
+  const metadata = readExistingAgentSchemaMeta(db);
+  assertExistingAgentSchemaOwner(metadata, options.agentId, options.pathname);
+  const userVersion = readSqliteUserVersion(db);
+  if (userVersion !== options.version || metadata?.schemaVersion !== options.version) {
+    throw new Error(
+      `OpenClaw agent database ${options.pathname} did not converge on schema version ${options.version}.`,
+    );
+  }
+  assertOpenClawAgentSchemaContains(db, options.pathname, OPENCLAW_AGENT_SCHEMA_SQL);
+}
+
+function ensureAgentSchema(
+  db: DatabaseSync,
+  agentId: string,
+  pathname: string,
+  targetVersion = OPENCLAW_AGENT_SCHEMA_VERSION,
+): void {
   // FK enforcement must be off before BEGIN: PRAGMA foreign_keys is a silent
   // no-op inside a transaction, and legacy owner-table rebuilds would otherwise
   // cascade-delete their children. Steady-state enforcement is restored below.
@@ -500,13 +521,19 @@ function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string):
       assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
       assertSupportedAgentSchemaVersion(db, pathname);
       const previousVersion = readSqliteUserVersion(db);
-      if (previousVersion === OPENCLAW_AGENT_SCHEMA_VERSION) {
+      if (previousVersion > targetVersion) {
+        throw new Error(
+          `OpenClaw agent database ${pathname} uses schema version ${previousVersion}; expected at most ${targetVersion} for this migration.`,
+        );
+      }
+      if (previousVersion === targetVersion) {
         // Repeat index repair before the transactional schema assertion so a
         // concurrent opener cannot turn repairable drift into a hard refusal.
         repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
           verifyPhysicalIntegrity: false,
         });
-        assertOpenClawAgentCurrentRuntimeSchema(db, { agentId, pathname });
+        assertAgentSchemaVersion(db, { agentId, pathname, version: targetVersion });
+        return;
       } else if (previousVersion === 14) {
         repairAndAssertOpenClawAgentV14SchemaForMigration(db, { agentId, pathname });
       }
@@ -527,7 +554,7 @@ function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string):
       backfillSessionEntryProvenance(db, previousVersion);
       migrateSessionNodesAndWindows(db, previousVersion);
       db.exec(OPENCLAW_AGENT_SCHEMA_SQL);
-      if (previousVersion < OPENCLAW_AGENT_SCHEMA_VERSION) {
+      if (previousVersion < targetVersion) {
         ensureOpenClawAgentBoardSchemaInTransaction(db);
       }
       migrateSessionTranscriptGenerations(db, previousVersion);
@@ -541,7 +568,7 @@ function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string):
         verifyPhysicalIntegrity: false,
       });
       const kysely = getNodeSqliteKysely<OpenClawAgentMetadataDatabase>(db);
-      db.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};`);
+      db.exec(`PRAGMA user_version = ${targetVersion};`);
       const now = Date.now();
       executeSqliteQuerySync(
         db,
@@ -550,7 +577,7 @@ function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string):
           .values({
             meta_key: "primary",
             role: "agent",
-            schema_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+            schema_version: targetVersion,
             agent_id: agentId,
             app_version: VERSION,
             created_at: now,
@@ -559,14 +586,14 @@ function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string):
           .onConflict((conflict) =>
             conflict.column("meta_key").doUpdateSet({
               role: "agent",
-              schema_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+              schema_version: targetVersion,
               agent_id: agentId,
               app_version: VERSION,
               updated_at: now,
             }),
           ),
       );
-      assertOpenClawAgentCurrentRuntimeSchema(db, { agentId, pathname });
+      assertAgentSchemaVersion(db, { agentId, pathname, version: targetVersion });
     });
   } finally {
     db.exec("PRAGMA foreign_keys = ON;");
@@ -594,6 +621,25 @@ export function ensureOpenClawAgentDatabaseSchema(
   if (options.register === true) {
     registerOpenClawAgentDatabase({ agentId, path: pathname, env: options.env });
   }
+}
+
+/** Upgrade older owned databases to the structural schema required by the media cutover. */
+export function migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema(
+  db: DatabaseSync,
+  options: OpenClawAgentDatabaseOptions,
+): void {
+  const targetVersion = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+  const userVersion = readSqliteUserVersion(db);
+  if (userVersion >= targetVersion) {
+    return;
+  }
+  const agentId = normalizeAgentId(options.agentId);
+  const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
+  assertAgentDatabaseIntegrityBeforeMutation(db, agentId, pathname);
+  configureSqlitePreSchemaPragmas(db, {
+    busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+  });
+  ensureAgentSchema(db, agentId, pathname, targetVersion);
 }
 
 export { ensureAgentSchema as ensureOpenClawAgentSchema };

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -74,6 +74,20 @@ function createTempStateDir(): string {
   return makeTempDir(agentDbTempDirs, "openclaw-agent-db-");
 }
 
+function migrateAndOpenLegacyAgentDatabaseForTest(
+  options: Parameters<typeof openOpenClawAgentDatabase>[0],
+) {
+  const pathname = resolveOpenClawAgentSqlitePath(options);
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(pathname);
+  try {
+    ensureOpenClawAgentDatabaseSchema(database, options);
+  } finally {
+    database.close();
+  }
+  return openOpenClawAgentDatabase(options);
+}
+
 const tempVolumeIsCaseInsensitive = (() => {
   const probeDir = fs.realpathSync(createTempStateDir());
   const probePath = path.join(probeDir, "CaseProbe");
@@ -960,7 +974,7 @@ describe("openclaw agent database", () => {
   });
 
   it("opens a v13 database that already contains additive board storage", () => {
-    expect(OPENCLAW_AGENT_SCHEMA_VERSION).toBe(15);
+    expect(OPENCLAW_AGENT_SCHEMA_VERSION).toBe(16);
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
@@ -976,7 +990,7 @@ describe("openclaw agent database", () => {
     `);
     existingV13.close();
 
-    const reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const reopened = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(
       reopened.db
         .prepare(
@@ -1070,7 +1084,7 @@ describe("openclaw agent database", () => {
     `);
     legacy.close();
 
-    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(
       migrated.db
         .prepare(
@@ -1192,7 +1206,7 @@ describe("openclaw agent database", () => {
   });
 
   it("keeps additive heartbeat repair while upgrading schema version 12", () => {
-    expect(OPENCLAW_AGENT_SCHEMA_VERSION).toBe(15);
+    expect(OPENCLAW_AGENT_SCHEMA_VERSION).toBe(16);
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
@@ -1209,7 +1223,7 @@ describe("openclaw agent database", () => {
     `);
     existingV12.close();
 
-    const reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const reopened = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(
       reopened.db
         .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
@@ -1247,7 +1261,7 @@ describe("openclaw agent database", () => {
     `);
     legacy.close();
 
-    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     const generations = migrated.db
       .prepare(
         "SELECT session_id, generation FROM transcript_rewrite_watermarks ORDER BY session_id",
@@ -1295,7 +1309,7 @@ describe("openclaw agent database", () => {
     `);
     legacy.close();
 
-    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(migrated.db.prepare("PRAGMA user_version").get()).toEqual({
       user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
     });
@@ -1345,7 +1359,7 @@ describe("openclaw agent database", () => {
     `);
     legacy.close();
 
-    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(migrated.db.prepare("PRAGMA user_version").get()).toEqual({
       user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
     });
@@ -1418,7 +1432,7 @@ describe("openclaw agent database", () => {
     `);
     legacy.close();
 
-    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(
       migrated.db
         .prepare("SELECT strict FROM pragma_table_list WHERE name = 'auth_profile_state'")
@@ -1499,7 +1513,7 @@ describe("openclaw agent database", () => {
     );
     seedVersion1MemoryAgentDatabase(databasePath);
 
-    const database = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const database = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
 
     expect(readSqliteNumberPragma(database.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
     expect(
@@ -2652,7 +2666,7 @@ describe("openclaw agent database", () => {
       legacy.close();
     }
 
-    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(
       migrated.db
         .prepare("SELECT status FROM session_nodes WHERE session_key = ?")
@@ -2688,7 +2702,7 @@ describe("openclaw agent database", () => {
       legacy.close();
     }
 
-    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     const indexNames = migrated.db
       .prepare(
         `SELECT name
@@ -2846,7 +2860,7 @@ describe("openclaw agent database", () => {
     drifted.exec("DROP TABLE auth_profile_store;");
     drifted.close();
 
-    expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(
+    expect(() => migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env })).toThrow(
       /missing table auth_profile_store/iu,
     );
     expect(() =>
@@ -2886,7 +2900,7 @@ describe("openclaw agent database", () => {
     `);
     damaged.close();
 
-    expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(
+    expect(() => migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env })).toThrow(
       /missing table auth_profile_store/iu,
     );
 
@@ -2920,7 +2934,7 @@ describe("openclaw agent database", () => {
     `);
     legacy.close();
 
-    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(
       migrated.db
         .prepare(
@@ -3136,7 +3150,7 @@ describe("openclaw agent database", () => {
     `);
     db.close();
 
-    const database = openOpenClawAgentDatabase({
+    const database = migrateAndOpenLegacyAgentDatabaseForTest({
       agentId: "worker-1",
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
@@ -3229,7 +3243,7 @@ describe("openclaw agent database", () => {
     `);
     db.close();
 
-    const database = openOpenClawAgentDatabase({
+    const database = migrateAndOpenLegacyAgentDatabaseForTest({
       agentId: "worker-1",
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
@@ -3296,7 +3310,7 @@ describe("openclaw agent database", () => {
     `);
     db.close();
 
-    const database = openOpenClawAgentDatabase({
+    const database = migrateAndOpenLegacyAgentDatabaseForTest({
       agentId: "worker-1",
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
@@ -3373,7 +3387,7 @@ describe("openclaw agent database", () => {
     `);
     db.close();
 
-    const database = openOpenClawAgentDatabase({
+    const database = migrateAndOpenLegacyAgentDatabaseForTest({
       agentId: "worker-1",
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
@@ -3495,7 +3509,7 @@ describe("openclaw agent database", () => {
     `);
     db.close();
 
-    const database = openOpenClawAgentDatabase({
+    const database = migrateAndOpenLegacyAgentDatabaseForTest({
       agentId: "worker-1",
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
@@ -3645,6 +3659,55 @@ describe("openclaw agent database", () => {
     expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(
       /integrity_check failed.*missing from index unsafe_index_records_value/iu,
     );
+  });
+
+  it.each([0, OPENCLAW_AGENT_SCHEMA_VERSION - 1])(
+    "rechecks the media version guard at v%d after a validated handle is physically reopened",
+    (version) => {
+      const stateDir = createTempStateDir();
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const databasePath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
+      expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
+
+      const { DatabaseSync } = requireNodeSqlite();
+      const downgraded = new DatabaseSync(databasePath);
+      try {
+        downgraded.exec(`
+          PRAGMA user_version = ${version};
+          UPDATE schema_meta SET schema_version = ${version} WHERE meta_key = 'primary';
+        `);
+      } finally {
+        downgraded.close();
+      }
+
+      expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(
+        "run openclaw doctor --fix to migrate persisted media",
+      );
+    },
+  );
+
+  it("does not hide a sqlitefoo-only metadata-less v0 database as internal", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(stateDir, "populated-v0.sqlite");
+    const { DatabaseSync } = requireNodeSqlite();
+    const populated = new DatabaseSync(databasePath);
+    try {
+      populated.exec("CREATE TABLE sqlitefoo (value TEXT);");
+    } finally {
+      populated.close();
+    }
+
+    expect(() =>
+      withOpenClawAgentDatabaseReadOnly(() => "unused", {
+        agentId: "worker-1",
+        env,
+        path: databasePath,
+      }),
+    ).toThrow("uses schema version 0; run openclaw doctor --fix");
+    expect(() =>
+      openOpenClawAgentDatabase({ agentId: "worker-1", env, path: databasePath }),
+    ).toThrow("uses schema version 0; run openclaw doctor --fix");
   });
 
   it("runs full integrity before a pending agent schema migration", () => {

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -38,6 +38,7 @@ import {
   unregisterOpenClawAgentDatabase,
 } from "./openclaw-agent-db-registry.js";
 import {
+  assertCanonicalAgentMediaPersistenceVersion,
   assertExistingAgentSchemaOwner,
   assertSupportedAgentSchemaVersion,
   readExistingAgentSchemaMeta,
@@ -312,6 +313,7 @@ export function openOpenClawAgentDatabase(
         // Integrity is not process-stable: the file can be damaged while evicted.
         // This guard is read-only (no busy waits), so every physical open pays it.
         assertAgentDatabaseIntegrityBeforeMutation(db, agentId, pathname);
+        assertCanonicalAgentMediaPersistenceVersion(db, pathname);
         configureSqlitePreSchemaPragmas(db, {
           busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
         });

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -315,11 +315,7 @@ describe("OpenClaw database integrity verifier", () => {
     const replacementPath = `${agent.path}.replacement`;
     const { DatabaseSync } = requireNodeSqlite();
     const replacement = new DatabaseSync(replacementPath);
-    try {
-      replacement.exec("CREATE TABLE replacement_marker (id INTEGER PRIMARY KEY) STRICT;");
-    } finally {
-      replacement.close();
-    }
+    replacement.close();
     expect(closeOpenClawAgentDatabaseByPath(agent.path)).toBe(true);
     fs.rmSync(agent.path);
     fs.renameSync(replacementPath, agent.path);

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -432,56 +432,6 @@ describe("exportTrajectoryBundle", () => {
     expect(artifacts.promptCache).toEqual(promptCache);
   });
 
-  it("projects legacy media in existing runtime message snapshots", async () => {
-    const tmpDir = makeTempDir();
-    const sessionFile = path.join(tmpDir, "session.jsonl");
-    const runtimeFile = path.join(tmpDir, "session.trajectory.jsonl");
-    const outputDir = path.join(tmpDir, "bundle");
-    writeSimpleSessionFile(sessionFile);
-    const runtimeEvent: TrajectoryEvent = {
-      traceSchema: "openclaw-trajectory",
-      schemaVersion: 1,
-      traceId: "session-1",
-      source: "runtime",
-      type: "model.completed",
-      ts: "2026-04-22T08:00:02.000Z",
-      seq: 1,
-      sessionId: "session-1",
-      data: {
-        messagesSnapshot: [
-          {
-            role: "user",
-            content: "",
-            MediaPath: "media/legacy.png",
-            MediaType: "image/png",
-          },
-        ],
-      },
-    };
-    fs.writeFileSync(runtimeFile, `${JSON.stringify(runtimeEvent)}\n`, "utf8");
-
-    await exportTrajectoryBundle({
-      outputDir,
-      sessionFile,
-      sessionId: "session-1",
-      workspaceDir: tmpDir,
-      runtimeFile,
-    });
-
-    const exportedEvents = fs
-      .readFileSync(path.join(outputDir, "events.jsonl"), "utf8")
-      .trim()
-      .split(/\r?\n/u)
-      .map((line) => JSON.parse(line) as TrajectoryEvent);
-    const snapshot = exportedEvents.find((event) => event.type === "model.completed")?.data
-      ?.messagesSnapshot as Array<Record<string, unknown>> | undefined;
-    expect(snapshot?.[0]).not.toHaveProperty("MediaPath");
-    expect(snapshot?.[0]).not.toHaveProperty("MediaType");
-    expect(snapshot?.[0]?.["__openclaw"]).toMatchObject({
-      media: [{ path: "media/legacy.png", contentType: "image/png" }],
-    });
-  });
-
   it("preserves numeric transcript timestamps", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");
@@ -507,32 +457,116 @@ describe("exportTrajectoryBundle", () => {
     );
   });
 
+  it("rejects retired media fields in versionless transcript inputs", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    writeSimpleSessionFile(sessionFile, {
+      userMessage: {
+        ...userMessage(""),
+        MediaPath: "media/legacy.png",
+        MediaType: "image/png",
+      } as unknown as Message,
+    });
+
+    await expect(
+      exportTrajectoryBundle({
+        outputDir: path.join(tmpDir, "bundle"),
+        sessionFile,
+        sessionId: "session-1",
+        workspaceDir: tmpDir,
+      }),
+    ).rejects.toThrow("retired top-level media fields");
+  });
+
+  it("rejects empty retired media fields in versionless transcript inputs", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    writeSimpleSessionFile(sessionFile, {
+      userMessage: {
+        ...userMessage("empty"),
+        media: null,
+      } as unknown as Message,
+    });
+
+    await expect(
+      exportTrajectoryBundle({
+        outputDir: path.join(tmpDir, "bundle"),
+        sessionFile,
+        sessionId: "session-1",
+        workspaceDir: tmpDir,
+      }),
+    ).rejects.toThrow("retired top-level media fields");
+  });
+
+  it("rejects retired media carriers in versionless runtime trajectories", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const runtimeFile = path.join(tmpDir, "session.trajectory.jsonl");
+    writeSimpleSessionFile(sessionFile);
+    const runtimeEvent: TrajectoryEvent = {
+      traceSchema: "openclaw-trajectory",
+      schemaVersion: 1,
+      traceId: "session-1",
+      source: "runtime",
+      type: "model.completed",
+      ts: "2026-04-22T08:00:02.000Z",
+      seq: 1,
+      sessionId: "session-1",
+      data: {
+        messagesSnapshot: [{ role: "user", content: "", media: [{ path: "media/legacy.png" }] }],
+      },
+    };
+    fs.writeFileSync(runtimeFile, `${JSON.stringify(runtimeEvent)}\n`, "utf8");
+
+    await expect(
+      exportTrajectoryBundle({
+        outputDir: path.join(tmpDir, "bundle"),
+        sessionFile,
+        sessionId: "session-1",
+        workspaceDir: tmpDir,
+        runtimeFile,
+      }),
+    ).rejects.toThrow("retired top-level media fields");
+  });
+
+  it("allows empty retired media carriers in versionless runtime trajectories", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const runtimeFile = path.join(tmpDir, "session.trajectory.jsonl");
+    writeSimpleSessionFile(sessionFile);
+    const runtimeEvent: TrajectoryEvent = {
+      traceSchema: "openclaw-trajectory",
+      schemaVersion: 1,
+      traceId: "session-1",
+      source: "runtime",
+      type: "model.completed",
+      ts: "2026-04-22T08:00:02.000Z",
+      seq: 1,
+      sessionId: "session-1",
+      data: {
+        messagesSnapshot: [
+          { role: "user", content: "empty", media: [], MediaPaths: [], MediaTypes: [] },
+        ],
+      },
+    };
+    fs.writeFileSync(runtimeFile, `${JSON.stringify(runtimeEvent)}\n`, "utf8");
+
+    await expect(
+      exportTrajectoryBundle({
+        outputDir: path.join(tmpDir, "bundle"),
+        sessionFile,
+        sessionId: "session-1",
+        workspaceDir: tmpDir,
+        runtimeFile,
+      }),
+    ).resolves.toBeDefined();
+  });
+
   it.each([
-    {
-      name: "legacy-only",
-      message: { MediaPath: "media/legacy.png", MediaType: "image/png" },
-      expectedPath: "media/legacy.png",
-    },
     {
       name: "facts-only",
       message: { __openclaw: { media: [{ path: "media/fact.png", contentType: "image/png" }] } },
       expectedPath: "media/fact.png",
-    },
-    {
-      name: "both-equal",
-      message: {
-        MediaPath: "media/equal.png",
-        __openclaw: { media: [{ path: "media/equal.png", contentType: "image/png" }] },
-      },
-      expectedPath: "media/equal.png",
-    },
-    {
-      name: "both-conflict",
-      message: {
-        MediaPath: "media/legacy-conflict.png",
-        __openclaw: { media: [{ path: "media/canonical.png", contentType: "image/png" }] },
-      },
-      expectedPath: "media/canonical.png",
     },
     {
       name: "sparse",

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -27,7 +27,10 @@ import {
   type SupportRedactionContext,
 } from "../logging/diagnostic-support-redaction.js";
 import { redactSecrets, redactToolPayloadText } from "../logging/redact.js";
-import { projectPersistedMessageMediaFacts } from "../media/media-facts.js";
+import {
+  hasMeaningfulRetiredMediaCarrier,
+  PERSISTED_LEGACY_MEDIA_KEYS,
+} from "../media/media-facts.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
 import { TRAJECTORY_RUNTIME_FILE_MAX_BYTES, safeTrajectorySessionFileName } from "./paths.js";
 import { isRegularNonSymlinkFile, resolveTrajectoryRuntimeFile } from "./runtime-file.js";
@@ -612,30 +615,29 @@ function buildTranscriptEvents(params: {
   return events;
 }
 
-function projectTrajectoryBranchMediaFacts(entries: SessionEntry[]): SessionEntry[] {
-  return entries.map((entry) =>
-    entry.type === "message"
-      ? { ...entry, message: projectPersistedMessageMediaFacts(entry.message) }
-      : entry,
+function assertCanonicalTrajectoryInputs(
+  entries: readonly SessionEntry[],
+  runtimeEvents: readonly TrajectoryEvent[],
+): void {
+  const branchHasLegacy = entries.some(
+    (entry) =>
+      entry.type === "message" &&
+      isRecord(entry.message) &&
+      (Object.hasOwn(entry.message, "media") ||
+        PERSISTED_LEGACY_MEDIA_KEYS.some((key) => Object.hasOwn(entry.message, key))),
   );
-}
-
-function projectRuntimeTrajectoryMediaFacts(event: TrajectoryEvent): TrajectoryEvent {
-  const messagesSnapshot = event.data?.messagesSnapshot;
-  if (!Array.isArray(messagesSnapshot)) {
-    return event;
-  }
-  return {
-    ...event,
-    data: {
-      ...event.data,
-      messagesSnapshot: messagesSnapshot.map((message) =>
-        message && typeof message === "object" && !Array.isArray(message)
-          ? projectPersistedMessageMediaFacts(message)
-          : message,
+  const runtimeHasLegacy = runtimeEvents.some(
+    (event) =>
+      Array.isArray(event.data?.messagesSnapshot) &&
+      event.data.messagesSnapshot.some(
+        (message) => isRecord(message) && hasMeaningfulRetiredMediaCarrier(message),
       ),
-    },
-  };
+  );
+  if (branchHasLegacy || runtimeHasLegacy) {
+    throw new Error(
+      "Trajectory export input contains retired top-level media fields; migrate the source transcript before exporting.",
+    );
+  }
 }
 
 function sortTrajectoryEvents(events: TrajectoryEvent[]): TrajectoryEvent[] {
@@ -1105,8 +1107,9 @@ export async function exportTrajectoryBundle(params: BuildTrajectoryBundleParams
     sessionId: params.sessionId,
   });
   const runtimeFile = runtimeParse.runtimeFile;
-  const runtimeEvents = runtimeParse.events.map(projectRuntimeTrajectoryMediaFacts);
-  const projectedBranchEntries = projectTrajectoryBranchMediaFacts(branchEntries);
+  const runtimeEvents = runtimeParse.events;
+  assertCanonicalTrajectoryInputs(branchEntries, runtimeEvents);
+  const projectedBranchEntries = branchEntries;
   const transcriptEvents = buildTranscriptEvents({
     entries: projectedBranchEntries,
     sessionId: params.sessionId,


### PR DESCRIPTION
## What Problem This Solves

PR 3 of the media legacy retirement program (#113355 shipped unconditional facts + replacement APIs; #113496 flipped all consumers facts-first). Persisted history still holds legacy-shaped rows, the writer still dual-writes the legacy projection, and runtime still carries a compatibility reader — the retirement cannot complete without one owned migration and a downgrade guard.

## Why This Change Was Made

- `openclaw doctor --fix` gains one idempotent migration: active `transcript_events` rows canonicalize to `__openclaw.media` (facts-first positional gap-fill, bare legacy kinds become `fact.kind`, transcribed indexes and workspace dirs move onto per-fact fields), written through the transcript replacement owner so watermarks and derived indexes stay coherent. Cold plain and `.zst` archives rewrite through temp-file + codec readback + event/id verification + atomic replace. Trajectory runtime snapshots canonicalize **in place** — telemetry, timings, and tool traces in the same event are never deleted. Invalid JSON, genuinely ambiguous legacy-only sparse alignment, or a changed source aborts that owner without partial work; reruns are no-ops. Registered databases are enumerated, not just open handles.
- The per-agent schema advances to **v16** as a pure downgrade guard: pre-cutover binaries only recognize top-level `Media*` and silently drop facts-only media turns from replay. The operator approved this cutover (phrased v14→v15 at audit time; main independently took v15 for board/session-sharing tables, so v16 is the audit's anticipated "next available version"). No columns, tables, or indexes change; the shared-state DB is untouched. v15 databases repair canonical indexes before the version assertion so repairable installations never strand.
- Legacy writes stop: the user-turn builder emits facts only, `shouldPersistStructuredMediaEntries` and the `"aligned"` projection mode are deleted, and the generic transcript append boundary canonicalizes every message role so SDK/mirror writers cannot recreate legacy rows post-cutover. Internal persisted-reader fallbacks are removed. The public SDK projection remains until PR 4's window (2026-10-01) expires.

## User Impact

Operators upgrade normally; doctor migrates history once and reruns are no-ops. Older binaries refuse to open migrated databases instead of silently misreading media turns. Prompt bytes and goldens are unchanged.

## Evidence

- Migration fixture matrix: every legacy shape, multiple sessions/generations, corrupt JSON, changed-source abort, interrupted-migration recovery, rerun idempotence, mixed plain/.zst archives; before/after equality of event ids, parents, idempotency keys, visible branch, timestamps, content, and fact ordering; old-version open refuses v16 while current opens; fresh trajectory capture/export contains no scoped legacy key.
- Three independent review rounds, all findings fixed with fixture regressions: trajectory rows canonicalize in place instead of being deleted (unrelated telemetry preserved; empty carriers untouched); v15 path repairs canonical indexes before asserting; append boundary canonicalizes all roles; exact row rewrites preserve physical duplicates; v0–v15 reopen guards; complete canonical facts bypass compact legacy projections so PR-1 dual-write rows migrate cleanly; SQLite `LIKE` underscore escaped so populated foreign databases are never claimed as new.
- Final autoreview clean (0.90); delegated `check:changed` fully green (wrapper exitCode 0 / runStatus succeeded); broad + focused Testbox suites green; exhaustive legacy-consumer sweep rerun.
- Prod LOC +~1,100: the audit's predicted one-time migration cost; the permanent runtime carriage it deletes (dual-write, aligned mode, compatibility reader) and PR 4's strongly negative deletion are the payoff.
