### PR TITLE
fix(qa): account for skipped scenarios in suite reports

### DIFF
--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -22,6 +22,7 @@ export type QaSuiteSummaryJson = {
     total: number;
     passed: number;
     failed: number;
+    skipped: number;
   };
   metrics?: {
     wallMs: number;

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -134,6 +134,25 @@ describe("buildQaSuiteSummaryJson", () => {
       total: 2,
       passed: 1,
       failed: 1,
+      skipped: 0,
+    });
+  });
+
+  it("includes skipped scenarios in the canonical summary counts", () => {
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      scenarios: [
+        ...baseParams.scenarios,
+        { name: "Scenario C", status: "skip" as const, steps: [] },
+        { name: "Scenario D", status: "skip" as const, steps: [] },
+      ],
+    });
+
+    expect(json.counts).toEqual({
+      total: 4,
+      passed: 1,
+      failed: 1,
+      skipped: 2,
     });
   });
 

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -723,6 +723,7 @@ export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): QaSui
       total: params.scenarios.length,
       passed: params.scenarios.filter((scenario) => scenario.status === "pass").length,
       failed: countQaSuiteFailedScenarios(params.scenarios),
+      skipped: params.scenarios.filter((scenario) => scenario.status === "skip").length,
     },
     ...(params.metrics ? { metrics: params.metrics } : {}),
     ...(params.evidence ? { evidence: params.evidence } : {}),


### PR DESCRIPTION
## What Problem This Solves

QA Lab suite reports omit skipped scenarios from their canonical counts. A default WhatsApp group scenario without a group ID correctly produces a real skip, but its JSON summary still reports only total, passed, and failed. Operators and confidence checks cannot account for what actually ran.

## Why This Change Was Made

Preserve the existing scenario and reporting contract by adding the actual skipped count at the single canonical summary builder and its exported JSON type. Do not change provider mode, credentials, scenario execution, or skip policy.

## User Impact

QA summaries report total, passed, failed, and skipped consistently, including zero skipped. Consumers can distinguish a successful scenario from unavailable coverage.

## Evidence

- Independently reproduced the actual scenario skip through the owning WhatsApp environment and QA flow.
- Added an executable regression proving two skipped scenarios produce total 4, passed 1, failed 1, skipped 2.
- Trusted Blacksmith Testbox tbx_01kychy5za146sm51dct901tnf: 50/50 QA summary, runtime-flow, and confidence-report tests pass.
- Full path-scoped changed gate, extension and extension-test typechecks, lint, package/plugin guards, database-first checks, and final remote timing all pass with exit 0.
- Fresh independent structured review: correct, 0.98 confidence, no actionable findings.
- Verified all touched product files are unchanged on refreshed main.
- AI-assisted and independently reviewed.
