### PR TITLE
fix: repair tool-call transcripts when plugins block results

### DIFF
--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -480,6 +480,44 @@ describe("installSessionToolResultGuard", () => {
     expect(blockedUserMessages[0]).toMatchObject({ role: "user", content: "hidden" });
   });
 
+  it("repairs a blocked real tool result before the next user message", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, {
+      beforeMessageWriteHook: ({ message }) =>
+        message.role === "toolResult" && message.isError === false ? { block: true } : undefined,
+    });
+
+    sm.appendMessage(toolCallMessage);
+    expect(
+      sm.appendMessage(
+        asAppendMessage({
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "read",
+          content: [{ type: "text", text: "blocked real result" }],
+          isError: false,
+        }),
+      ),
+    ).toBeUndefined();
+    expect(guard.getPendingIds()).toStrictEqual(["call_1"]);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "next user message",
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult", "user"]);
+    expect(messages[1]).toMatchObject({
+      toolCallId: "call_1",
+      toolName: "read",
+      isError: true,
+    });
+    expect(guard.getPendingIds()).toStrictEqual([]);
+  });
+
   it("applies before_message_write message mutations before persistence", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -484,7 +484,7 @@ describe("installSessionToolResultGuard", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {
       beforeMessageWriteHook: ({ message }) =>
-        message.role === "toolResult" && message.isError === false ? { block: true } : undefined,
+        message.role === "toolResult" && !message.isError ? { block: true } : undefined,
     });
 
     sm.appendMessage(toolCallMessage);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -792,9 +792,6 @@ export function installSessionToolResultGuard(
     if (nextRole === "toolResult") {
       const id = extractToolResultId(nextMessage as Extract<AgentMessage, { role: "toolResult" }>);
       const toolName = id ? pendingState.getToolName(id) : undefined;
-      if (id) {
-        pendingState.delete(id);
-      }
       const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
@@ -812,6 +809,10 @@ export function installSessionToolResultGuard(
       const persisted = applyBeforeWriteHook(transformed);
       if (!persisted) {
         return undefined;
+      }
+      // A blocked result must remain pending so the next message can repair its tool-call pair.
+      if (id) {
+        pendingState.delete(id);
       }
       return appendMessageAndCacheTranscriptSeq(
         capToolResultForPersistence(persisted.message, maxToolResultChars, redactionConfig),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an installed `before_message_write` hook could reject a real tool result and leave an assistant tool call permanently unpaired in the persisted session transcript. The next user message then bypassed the existing synthetic-result repair, exposing invalid tool-call ordering to providers and transcript consumers.

## Why This Change Was Made

Remove a pending tool-call identity only after the message-write hook has actually accepted its result. If the hook blocks the real result, the existing canonical repair mechanism remains responsible for inserting the paired synthetic result before the next user message. A focused regression exercises the actual blocked-hook and subsequent user-turn sequence.

## User Impact

Agent conversations preserve valid assistant/tool/user message ordering when a plugin blocks a tool result. This does not change hook permissions, configuration, plugin ownership, or the public provider protocol.

## Evidence

- Independent fresh repository-native `$autoreview`: **PASS**, zero actionable findings, confidence `0.97`.
- Trusted Blacksmith Testbox `tbx_01kycq008nsec7173ht4wztyhr`: **37/37** focused `session-tool-result-guard.test.ts` cases pass, including the new real hook-block regression.
- Remote touched-file formatter, `git diff --check`, and exact wrapper exit: **PASS**, exit `0`.
- Confirmed both owner and regression remain unchanged on fresh `origin/main` before committing.
- AI-assisted; no operator credentials, running Gateway state, or unrelated files are included.
