### PR TITLE
fix: recover outbound messages after the correct retry delay

### DIFF
--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -555,7 +555,7 @@ function isEntryEligibleForRecoveryRetry(
   entry: QueuedDelivery,
   now: number,
 ): { eligible: true } | { eligible: false; remainingBackoffMs: number } {
-  const backoff = computeBackoffMs(entry.retryCount + 1);
+  const backoff = computeBackoffMs(entry.retryCount);
   if (backoff <= 0) {
     return { eligible: true };
   }

--- a/src/infra/outbound/delivery-queue.recovery-backoff.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery-backoff.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadPendingDeliveries } from "./delivery-queue-storage.js";
+import { enqueueDelivery, recoverPendingDeliveries } from "./delivery-queue.js";
+import {
+  asDeliverFn,
+  createRecoveryLog,
+  installDeliveryQueueTmpDirHooks,
+  setQueuedEntryState,
+} from "./delivery-queue.test-helpers.js";
+
+describe("outbound delivery recovery retry backoff", () => {
+  const { tmpDir } = installDeliveryQueueTmpDirHooks();
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    { retryCount: 1, backoffMs: 5_000 },
+    { retryCount: 2, backoffMs: 25_000 },
+    { retryCount: 3, backoffMs: 120_000 },
+  ])("replays retry $retryCount after $backoffMs ms", async ({ retryCount, backoffMs }) => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-07-25T00:00:00.000Z");
+    vi.setSystemTime(startedAt);
+
+    const stateDir = tmpDir();
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "retry" }] },
+      stateDir,
+    );
+    setQueuedEntryState(stateDir, id, {
+      retryCount,
+      lastAttemptAt: startedAt.getTime(),
+    });
+
+    const deliver = vi.fn().mockResolvedValue([]);
+    const recover = () =>
+      recoverPendingDeliveries({
+        deliver: asDeliverFn(deliver),
+        log: createRecoveryLog(),
+        cfg: {},
+        stateDir,
+        maxRecoveryMs: 60_000,
+      });
+
+    vi.setSystemTime(startedAt.getTime() + backoffMs - 1);
+    await expect(recover()).resolves.toMatchObject({
+      recovered: 0,
+      deferredBackoff: 1,
+    });
+    expect(deliver).not.toHaveBeenCalled();
+
+    vi.setSystemTime(startedAt.getTime() + backoffMs);
+    await expect(recover()).resolves.toMatchObject({
+      recovered: 1,
+      deferredBackoff: 0,
+    });
+    expect(deliver).toHaveBeenCalledTimes(1);
+    await expect(loadPendingDeliveries(stateDir)).resolves.toEqual([]);
+  });
+});

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -2040,7 +2040,7 @@ describe("delivery-queue recovery", () => {
     });
     expect(firstDeliver).not.toHaveBeenCalled();
 
-    vi.setSystemTime(new Date(start.getTime() + 600_000 + 1));
+    vi.setSystemTime(new Date(start.getTime() + 120_000 + 1));
     const secondDeliver = vi.fn().mockResolvedValue([]);
     const secondRun = await runRecovery({ deliver: secondDeliver, maxRecoveryMs: 60_000 });
     expect(secondRun.result).toEqual({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where queued outbound messages would remain undelivered well beyond their expected retry window after a gateway restart or delivery failure. The first failed delivery waited 25 seconds instead of 5 seconds, and later retries also used the next delay in the schedule.

## Why This Change Was Made

Use the persisted completed retry count directly when computing eligibility, matching the shared retry package and sibling session-delivery recovery. Preserve existing storage, delivery ownership, retry ceilings, and configuration.

## User Impact

Queued outbound messages resume delivery at their documented 5-second, 25-second, and 120-second retry boundaries instead of being unnecessarily delayed.

## Evidence

- Independent regression proves before-and-at-boundary behavior for retries 1, 2, and 3 against the real outbound recovery owner.
- A dedicated Linux Testbox passed 87 actual tests across the outbound queue, session-delivery queue, and shared retry package.
- The complete path-scoped changed gate passed on the same Testbox, including formatting, both production and test typechecks, lint, boundaries, cycle, schema, and storage guards.
- Independent structured review reported no actionable findings.
