### PR TITLE
fix(sqlite): prevent snapshot starvation under writes

### DIFF
--- a/src/infra/sqlite-snapshot.test.ts
+++ b/src/infra/sqlite-snapshot.test.ts
@@ -408,6 +408,46 @@ describe("createVerifiedSqliteSnapshot", () => {
     }
   });
 
+  it("pins validation and backup to one WAL snapshot", async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, "source.sqlite");
+    const targetPath = path.join(tempDir, "snapshot.sqlite");
+    const sqlite = requireNodeSqlite();
+    const writer = new sqlite.DatabaseSync(sourcePath);
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      CREATE TABLE records (value TEXT NOT NULL);
+      INSERT INTO records VALUES ('before');
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+    const backup = sqlite.backup.bind(sqlite);
+    const backupSpy = vi.spyOn(sqlite, "backup").mockImplementationOnce(async (...args) => {
+      writer.prepare("INSERT INTO records VALUES (?)").run("during");
+      return await backup(...args);
+    });
+
+    try {
+      await createVerifiedSqliteSnapshot({ sourcePath, targetPath });
+
+      expect(writer.prepare("SELECT value FROM records ORDER BY rowid").all()).toEqual([
+        { value: "before" },
+        { value: "during" },
+      ]);
+      const snapshot = new sqlite.DatabaseSync(targetPath, { readOnly: true });
+      try {
+        expect(snapshot.prepare("SELECT value FROM records ORDER BY rowid").all()).toEqual([
+          { value: "before" },
+        ]);
+      } finally {
+        snapshot.close();
+      }
+    } finally {
+      backupSpy.mockRestore();
+      writer.close();
+    }
+  });
+
   it("rejects unsafe index drift and removes the failed target", async () => {
     const tempDir = await createTempDir();
     const sourcePath = path.join(tempDir, "source.sqlite");

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -663,15 +663,21 @@ export async function createVerifiedSqliteSnapshot(
         readOnly: true,
       });
       try {
-        source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF;");
-        await loadSqliteVecExtension({ db: source });
-        assertSqliteIntegrity(source, options.sourcePath);
-        options.validate?.(source, options.sourcePath);
-        // Copy in incremental steps so concurrent writers are blocked only while
-        // each batch is read. Compaction happens after releasing the live source.
-        await sqlite.backup(source, resolveSqliteFilesystemPath(stagedPath));
+        source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF; BEGIN;");
+        try {
+          // Pin validation and backup together; Node restarts stepped backups on concurrent writes.
+          source.prepare("PRAGMA schema_version;").get();
+          await loadSqliteVecExtension({ db: source });
+          assertSqliteIntegrity(source, options.sourcePath);
+          options.validate?.(source, options.sourcePath);
+          await sqlite.backup(source, resolveSqliteFilesystemPath(stagedPath));
+        } finally {
+          source.exec("ROLLBACK;");
+        }
       } finally {
-        source.close();
+        if (source.isOpen) {
+          source.close();
+        }
       }
     });
 


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Fixes an issue where SQLite snapshots could make no progress under sustained concurrent WAL writes. Node's stepped online backup restarts when another connection changes the source, so a busy OpenClaw state database could keep the snapshot process scanning the same early pages indefinitely.

## Why This Change Was Made

The source connection now opens and activates one explicit read transaction before integrity validation and online backup. Validation and copied bytes therefore come from the same SQLite snapshot, and the transaction is rolled back before the source connection closes.

This follows the existing pinned-read pattern in the read-only SQLite location helper instead of changing backup batch size or adding a retry budget.

## User Impact

Snapshot and backup operations remain consistent and complete under active WAL write load instead of starving. Concurrent WAL writers can continue while OpenClaw copies a stable read state, and the published snapshot still receives the existing integrity, index, foreign-key, compaction, and durability checks.

## Evidence

- ARM64 symptom: the default reliability profile spent more than 1 hour 45 minutes repeatedly reading the first approximately 2 MB of a 20.7 MB source while the writer continued.
- Dependency proof: Node v24.18.0's `BackupJob` repeatedly calls `sqlite3_backup_step`; SQLite documents that external source writes restart the backup.
- Live hypothesis proof: adding `BEGIN` plus `PRAGMA schema_version` copied the same 5,045-page, 20,664,320-byte source in 18 ms while the writer remained active.
- Regression: `src/infra/sqlite-snapshot.test.ts` injects a WAL commit immediately before backup and proves the snapshot contains only the transaction-pinned state.
- Focused Testbox: `tbx_01kycrts2k0qa02ctx1armvmz1`, 30 passed / 2 platform skips.
- Fresh exact-head `pnpm check:changed`: `tbx_01kycsj0z236xv1wsrp24s99sq`, passed in 4m52s.
- Autoreview: clean, no accepted/actionable findings, confidence 0.94.
- Linux ARM64 VM (`cbx_fb95c4edd52c`, Apple Virtualization, Node 24.15.0): full default profile passed in 51.4s with 25 concurrent restores, 57,312 writer rows, crash recovery, publication/restore/repository interruption, unsafe-index repair, VACUUM interruption, compaction, and post-compaction restore all verified.
- ARM64 peak WAL was 17,987,952 bytes against the 536,870,912-byte limit; final 4,096-row state hash was `784f055fe46aa3314615b5d5461425f787170b26e7b2fc7347d434a3252a5cb1`.
- Direct AWS ARM64 was attempted on two fresh `c7g.8xlarge` leases, but the broker withdrew SSH before code execution on both; no application result is inferred from those infrastructure failures.
