### PR TITLE
fix(qa): report live channel evidence from the actual driver

### DIFF
--- a/extensions/qa-lab/src/evidence-summary.test.ts
+++ b/extensions/qa-lab/src/evidence-summary.test.ts
@@ -123,6 +123,93 @@ describe("evidence summary", () => {
     });
   });
 
+  it.each([
+    ["live Discord transport", "discord", "live", undefined, "live", true],
+    ["live Matrix transport", "matrix", "live", undefined, "live", true],
+    ["live Slack transport", "slack", "live", undefined, "live", true],
+    ["live Telegram transport", "telegram", "live", undefined, "live", true],
+    ["live WhatsApp transport", "whatsapp", "live", undefined, "live", true],
+    [
+      "live transport without a bundled channel identity",
+      "custom-live-transport",
+      "live",
+      undefined,
+      "live",
+      true,
+    ],
+    [
+      "synthetic driver for a real channel identity",
+      "telegram",
+      "qa-channel",
+      undefined,
+      "qa-channel",
+      false,
+    ],
+    [
+      "Crabline driver for a real channel identity",
+      "telegram",
+      "crabline",
+      undefined,
+      "crabline",
+      false,
+    ],
+    [
+      "live driver selected through the QA environment",
+      "custom-live-transport",
+      undefined,
+      { OPENCLAW_QA_CHANNEL_DRIVER: "live" },
+      "live",
+      true,
+    ],
+    [
+      "live driver selected through the E2E environment",
+      "custom-live-transport",
+      undefined,
+      { OPENCLAW_E2E_CHANNEL_DRIVER: "live" },
+      "live",
+      true,
+    ],
+    [
+      "explicit synthetic driver overriding live environment",
+      "telegram",
+      "qa-channel",
+      { OPENCLAW_QA_CHANNEL_DRIVER: "live" },
+      "qa-channel",
+      false,
+    ],
+    [
+      "transport without a resolved driver",
+      "custom-live-transport",
+      undefined,
+      undefined,
+      undefined,
+      false,
+    ],
+  ] as const)(
+    "records actual channel liveness for %s independently of model liveness",
+    (_label, channelId, channelDriver, env, expectedDriver, expectedLive) => {
+      const evidence = buildQaSuiteEvidenceSummary({
+        artifactPaths: [],
+        channelId,
+        channelDriver,
+        env,
+        generatedAt: "2026-07-25T00:00:00.000Z",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        providerMode: "mock-openai",
+        scenarioDefinitions: [{ id: "channel-liveness", title: "Channel liveness" }],
+        scenarioResults: [{ name: "Channel liveness", status: "pass" }],
+      });
+
+      expect(validateQaEvidenceSummaryJson(evidence)).toEqual(evidence);
+      expect(evidence.entries[0]?.execution?.channel).toEqual({
+        id: channelId,
+        live: expectedLive,
+        driver: expectedDriver,
+      });
+      expect(evidence.entries[0]?.execution?.provider.live).toBe(false);
+    },
+  );
+
   it("prefers the checked-out ref over an inherited GitHub event SHA", () => {
     const repoRoot = process.cwd();
     const checkedOutRef = execFileSync("git", ["rev-parse", "--verify", "HEAD"], {

--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -539,7 +539,7 @@ export function buildQaSuiteEvidenceSummary(
         provider,
         channel: {
           id: params.channelId,
-          live: false,
+          live: channelDriver?.id === "live",
           driver: channelDriver?.id,
         },
         packageSource,

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1221,7 +1221,7 @@ describe("qa suite runtime launcher", () => {
     for (const scenarioId of ["whatsapp-status-command", "whatsapp-access-control-dm-open"]) {
       const blocked = evidence.entries?.find((entry) => entry.test?.id === scenarioId);
       expect(blocked).toMatchObject({
-        execution: { channel: { id: "whatsapp" } },
+        execution: { channel: { id: "whatsapp", driver: "live", live: true } },
         result: { status: "blocked" },
       });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where real Discord, Matrix, Slack, Telegram, WhatsApp, and external channel test runs were falsely recorded as non-live in QA evidence, including blocked transport evidence. Operators could not tell that an actual live channel driver had been selected, independently of whether the model provider was live.

## Why This Change Was Made

Derive channel liveness once from the existing resolved channel-driver owner. Preserve the current evidence schema, explicit-over-environment precedence, synthetic and Crabline driver semantics, independent provider liveness, and blocked scenario outcomes. Do not hard-code channel names or add configuration, provider, persistence, or protocol surfaces.

## User Impact

Actual live-channel QA runs and blocked-credential evidence now accurately report the chosen transport. Synthetic channels remain correctly marked non-live. All supported and future external channel IDs use the same canonical rule.

## Evidence

- Exact reviewed commit: 51b6ac504431d383e5c1cfb0ec7c3ed6a30f5737.
- Authentic current-main failing-before reproduction: 9 failures and 40 passing controls across all live transports, external IDs, both supported environment selections, and actual blocked aggregate evidence.
- Independent trusted remote Linux verification: 135/135 tests pass across nine QA, runtime, adapter, scorecard, and gallery suites.
- Full three-file changed gate: exit 0; both extension typecheck lanes, exact lint, formatter, plugin SDK, policy, storage, cycle, and boundary checks pass; authoritative remote command timing 235.983 s.
- Fresh independent full-source, secret-scanned structured autoreview: no findings, confidence 0.97.
- Fresh latest-main owner drift check on all three reviewed files: exit 0.
- AI-assisted; all changes were independently source-reviewed. Hosted exact-head CI must pass before native maintainer landing.