### PR TITLE
refactor(config): split validation responsibilities

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -703,7 +703,6 @@ src/config/sessions/session-accessor.conformance.test.ts
 src/config/sessions/session-accessor.test.ts
 src/config/sessions/transcript.test.ts
 src/config/sessions/transcript.ts
-src/config/validation.ts
 src/config/zod-schema.agent-runtime.ts
 src/config/zod-schema.core.ts
 src/context-engine/context-engine.test.ts

--- a/src/config/validation-channel-rules.ts
+++ b/src/config/validation-channel-rules.ts
@@ -1,0 +1,224 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  type ChannelDmAllowFromMode,
+  resolveChannelDmAllowFrom,
+  resolveChannelDmPolicy,
+} from "../channels/plugins/dm-access.js";
+import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
+import { isRecord } from "../utils.js";
+import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
+import {
+  type DmPolicyAllowFromViolation,
+  evaluateDmPolicyAllowFromDependency,
+} from "./zod-schema.core.js";
+
+export const bundledChannelSchemaById = new Map<string, unknown>(
+  GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.filter((entry) => entry.configurable !== false).map(
+    (entry) => [entry.channelId, entry.schema] as const,
+  ),
+);
+
+export const bundledChannelIds = Object.freeze(
+  GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.filter((entry) => entry.configurable !== false)
+    .map((entry) => normalizeLowercaseStringOrEmpty(entry.channelId))
+    .filter((channelId) => channelId.length > 0),
+);
+
+const bundledChannelIdSet = new Set(bundledChannelIds);
+const bundledChannelAliases = new Map<string, string>(
+  GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.filter((entry) => entry.configurable !== false).flatMap(
+    (entry) => {
+      const channelId = normalizeLowercaseStringOrEmpty(entry.channelId);
+      if (!channelId) {
+        return [];
+      }
+      return (entry.aliases ?? [])
+        .map((alias) => [normalizeLowercaseStringOrEmpty(alias), channelId] as const)
+        .filter(([alias]) => alias.length > 0);
+    },
+  ),
+);
+
+export function normalizeBundledChannelId(raw?: string | null): string | null {
+  const normalized = normalizeLowercaseStringOrEmpty(raw);
+  if (!normalized) {
+    return null;
+  }
+  const resolved = bundledChannelAliases.get(normalized) ?? normalized;
+  return bundledChannelIdSet.has(resolved) ? resolved : null;
+}
+
+export function formatRawChannelConfigIssueMessage(message: string): string {
+  return `invalid config: ${message}`;
+}
+
+function buildDmPolicyDependencyWarning(params: {
+  channelId: string;
+  accountId?: string;
+  allowFromSource?: "explicit" | "inherited";
+  violation: DmPolicyAllowFromViolation;
+}): ConfigValidationIssue {
+  const channelBase = `channels.${params.channelId}`;
+  const scope = params.accountId ? `${channelBase}.accounts.${params.accountId}` : channelBase;
+  const allowFromPath = `${scope}.allowFrom`;
+  const inherited = params.accountId && params.allowFromSource === "inherited";
+  const allowFromSubject = inherited
+    ? `${allowFromPath} is unset and ${channelBase}.allowFrom`
+    : allowFromPath;
+  const accountInheritedTarget = inherited ? ` or ${channelBase}.allowFrom` : "";
+  const accountOverrideFix =
+    params.accountId && !inherited
+      ? `, remove ${allowFromPath} to inherit ${channelBase}.allowFrom,`
+      : "";
+  const message =
+    params.violation === "open_requires_wildcard"
+      ? `${scope}.dmPolicy="open" but ${allowFromSubject} does not include "*"; all DMs will be dropped. Add "*" to ${allowFromPath}${accountInheritedTarget}${accountOverrideFix} or set ${scope}.dmPolicy to "pairing"/"allowlist".`
+      : `${scope}.dmPolicy="allowlist" but ${allowFromSubject} is empty; all DMs will be dropped. Add at least one sender ID to ${allowFromPath}${accountInheritedTarget}${accountOverrideFix} or change ${scope}.dmPolicy.`;
+  return { path: allowFromPath, message };
+}
+
+// Channel map keys that are not channels and must be skipped while scanning DM policy.
+const DM_POLICY_PSEUDO_CHANNEL_KEYS = new Set(["defaults", "modelByChannel", "tools"]);
+
+function hasDefinedConfigValue(record: Record<string, unknown>, key: string): boolean {
+  return Object.hasOwn(record, key) && record[key] !== undefined;
+}
+
+function hasConfiguredDmAllowFrom(
+  record: Record<string, unknown>,
+  mode: ChannelDmAllowFromMode,
+): boolean {
+  const dm = isRecord(record.dm) ? record.dm : null;
+  if (mode === "nestedOnly") {
+    return (
+      (dm !== null && hasDefinedConfigValue(dm, "allowFrom")) ||
+      hasDefinedConfigValue(record, "allowFrom")
+    );
+  }
+  return (
+    hasDefinedConfigValue(record, "allowFrom") ||
+    (dm !== null && hasDefinedConfigValue(dm, "allowFrom"))
+  );
+}
+
+function isConfigRecordEnabled(record: Record<string, unknown>): boolean {
+  return record.enabled !== false;
+}
+
+export function hasChannelDmPolicyDependencyWarningCandidates(config: OpenClawConfig): boolean {
+  if (!config.channels || !isRecord(config.channels)) {
+    return false;
+  }
+  return Object.entries(config.channels).some(
+    ([channelId, channelValue]) =>
+      !DM_POLICY_PSEUDO_CHANNEL_KEYS.has(channelId) &&
+      isRecord(channelValue) &&
+      isConfigRecordEnabled(channelValue),
+  );
+}
+
+/**
+ * Surface dmPolicy/allowFrom dependency problems generically for every channel that
+ * exposes DM policy via the canonical top-level `dmPolicy`/`allowFrom` fields. These
+ * configs parse fine but drop every DM at runtime, so we warn (rather than reject) to
+ * stay consistent with `security audit`/`doctor` and avoid breaking existing-but-usable
+ * configs on upgrade.
+ *
+ * Resolution goes through the shared DM-access helpers so the warning matches the
+ * effective policy/allowFrom the runtime sees, including the legacy `dm.*` aliases and
+ * account->channel inheritance. `nestedOnly` channels (canonical fields under `dm.*`)
+ * are skipped because their config shape does not match this warning's top-level paths.
+ */
+export function collectChannelDmPolicyDependencyWarnings(
+  config: OpenClawConfig,
+  options: { dmAllowFromModes?: ReadonlyMap<string, ChannelDmAllowFromMode> } = {},
+): ConfigValidationIssue[] {
+  if (!config.channels || !isRecord(config.channels)) {
+    return [];
+  }
+  const warnings: ConfigValidationIssue[] = [];
+  for (const [channelId, channelValue] of Object.entries(config.channels)) {
+    if (
+      DM_POLICY_PSEUDO_CHANNEL_KEYS.has(channelId) ||
+      !isRecord(channelValue) ||
+      !isConfigRecordEnabled(channelValue)
+    ) {
+      continue;
+    }
+    const mode = options.dmAllowFromModes?.get(channelId) ?? "topOnly";
+    if (mode === "nestedOnly") {
+      continue;
+    }
+    const channelViolation = evaluateDmPolicyAllowFromDependency({
+      policy: resolveChannelDmPolicy({ account: channelValue, mode }),
+      allowFrom: resolveChannelDmAllowFrom({ account: channelValue, mode }),
+    });
+    if (channelViolation) {
+      warnings.push(buildDmPolicyDependencyWarning({ channelId, violation: channelViolation }));
+    }
+    if (!isRecord(channelValue.accounts)) {
+      continue;
+    }
+    for (const [accountId, accountValue] of Object.entries(channelValue.accounts)) {
+      if (!isRecord(accountValue) || !isConfigRecordEnabled(accountValue)) {
+        continue;
+      }
+      const allowFromSource = hasConfiguredDmAllowFrom(accountValue, mode)
+        ? "explicit"
+        : "inherited";
+      const accountViolation = evaluateDmPolicyAllowFromDependency({
+        policy: resolveChannelDmPolicy({ account: accountValue, parent: channelValue, mode }),
+        allowFrom: resolveChannelDmAllowFrom({ account: accountValue, parent: channelValue, mode }),
+      });
+      if (accountViolation) {
+        warnings.push(
+          buildDmPolicyDependencyWarning({
+            channelId,
+            accountId,
+            allowFromSource,
+            violation: accountViolation,
+          }),
+        );
+      }
+    }
+  }
+  return warnings;
+}
+
+export function collectRawBundledChannelConfigIssues(
+  config: OpenClawConfig,
+): ConfigValidationIssue[] {
+  if (!config.channels || !isRecord(config.channels)) {
+    return [];
+  }
+  const issues: ConfigValidationIssue[] = [];
+  for (const [channelId, schema] of bundledChannelSchemaById) {
+    if (!Object.hasOwn(config.channels, channelId)) {
+      continue;
+    }
+    const result = validateJsonSchemaValue({
+      schema: schema as Record<string, unknown>,
+      cacheKey: `raw-channel:${channelId}`,
+      value: config.channels[channelId],
+      applyDefaults: false,
+    });
+    if (result.ok) {
+      continue;
+    }
+    for (const error of result.errors) {
+      const message = error.additionalProperty
+        ? `${error.message}: "${error.additionalProperty}"`
+        : error.message;
+      const path =
+        error.path === "<root>" ? `channels.${channelId}` : `channels.${channelId}.${error.path}`;
+      issues.push({
+        path,
+        message: formatRawChannelConfigIssueMessage(message),
+        allowedValues: error.allowedValues,
+        allowedValuesHiddenCount: error.allowedValuesHiddenCount,
+      });
+    }
+  }
+  return issues;
+}

--- a/src/config/validation-core.ts
+++ b/src/config/validation-core.ts
@@ -1,0 +1,347 @@
+import path from "node:path";
+import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
+import {
+  listAgentEntries,
+  listAgentEntriesWithSource,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  hasAvatarUriScheme,
+  isAvatarDataUrl,
+  isAvatarHttpUrl,
+  isPathWithinRoot,
+  isWindowsAbsolutePath,
+} from "../shared/avatar-policy.js";
+import {
+  formatUnsafeGatewayTailscaleNoAuthMessage,
+  isUnsafeGatewayTailscaleNoAuth,
+} from "../shared/gateway-tailscale-auth-policy.js";
+import { isRecord } from "../utils.js";
+import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
+import { migratePersistedImplicitMainRoster } from "./legacy.roster.js";
+import { materializeRuntimeConfig } from "./materialize.js";
+import {
+  isModelPolicyCompatSelector,
+  isValidExactModelPolicyRef,
+  parseModelPolicyWildcardRef,
+} from "./model-policy-ref.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
+import { collectRawBundledChannelConfigIssues } from "./validation-channel-rules.js";
+import {
+  collectUnsupportedSecretRefPolicyIssues,
+  mapZodIssueToConfigIssue,
+  mergeUnsupportedMutableSecretRefIssues,
+  withConfigIssuePath,
+} from "./validation-issues.js";
+import { isBuiltInModelProviderOverlayId } from "./zod-schema.core.js";
+import { OpenClawSchema } from "./zod-schema.js";
+
+function materializeBundledModelProviderOverlays(config: OpenClawConfig): OpenClawConfig {
+  const providers = config.models?.providers;
+  if (!providers) {
+    return config;
+  }
+  let nextProviders: typeof providers | undefined;
+  for (const [providerId, providerConfig] of Object.entries(providers)) {
+    if (
+      !isBuiltInModelProviderOverlayId(providerId) ||
+      (providerConfig.baseUrl && Array.isArray(providerConfig.models))
+    ) {
+      continue;
+    }
+    nextProviders ??= { ...providers };
+    nextProviders[providerId] = {
+      ...providerConfig,
+      baseUrl: providerConfig.baseUrl ?? "",
+      models: providerConfig.models ?? [],
+    };
+  }
+  return nextProviders
+    ? { ...config, models: { ...config.models, providers: nextProviders } }
+    : config;
+}
+
+function stripPreservedLegacyRootKeysForValidation(
+  raw: unknown,
+  keys?: readonly string[],
+): unknown {
+  if (!keys || keys.length === 0 || !isRecord(raw)) {
+    return raw;
+  }
+  const next = { ...raw };
+  for (const key of keys) {
+    delete next[key];
+  }
+  return next;
+}
+
+function isWorkspaceAvatarPath(value: string, workspaceDir: string): boolean {
+  const workspaceRoot = path.resolve(workspaceDir);
+  const resolved = path.resolve(workspaceRoot, value);
+  return isPathWithinRoot(workspaceRoot, resolved);
+}
+
+function createIdentityAvatarIssue(
+  source: ReturnType<typeof listAgentEntriesWithSource>[number]["source"],
+  message: string,
+): ConfigValidationIssue {
+  const pathSegments =
+    source.kind === "entries"
+      ? (["agents", "entries", source.key, "identity", "avatar"] as const)
+      : (["agents", "list", source.index, "identity", "avatar"] as const);
+  return withConfigIssuePath({ path: pathSegments.join("."), message }, pathSegments);
+}
+
+function validateIdentityAvatar(
+  config: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): ConfigValidationIssue[] {
+  const agents = listAgentEntriesWithSource(config);
+  if (agents.length === 0) {
+    return [];
+  }
+  const issues: ConfigValidationIssue[] = [];
+  for (const { entry, source } of agents) {
+    const avatarRaw = entry.identity?.avatar;
+    if (typeof avatarRaw !== "string") {
+      continue;
+    }
+    const avatar = avatarRaw.trim();
+    if (!avatar || isAvatarDataUrl(avatar) || isAvatarHttpUrl(avatar)) {
+      continue;
+    }
+    if (avatar.startsWith("~")) {
+      issues.push(
+        createIdentityAvatarIssue(
+          source,
+          "identity.avatar must be a workspace-relative path, http(s) URL, or data URI.",
+        ),
+      );
+      continue;
+    }
+    if (hasAvatarUriScheme(avatar) && !isWindowsAbsolutePath(avatar)) {
+      issues.push(
+        createIdentityAvatarIssue(
+          source,
+          "identity.avatar must be a workspace-relative path, http(s) URL, or data URI.",
+        ),
+      );
+      continue;
+    }
+    const workspaceDir = resolveAgentWorkspaceDir(
+      config,
+      entry.id ?? resolveDefaultAgentId(config),
+      env,
+    );
+    if (!isWorkspaceAvatarPath(avatar, workspaceDir)) {
+      issues.push(
+        createIdentityAvatarIssue(source, "identity.avatar must stay within the agent workspace."),
+      );
+    }
+  }
+  return issues;
+}
+
+function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationIssue[] {
+  const tailscaleMode = config.gateway?.tailscale?.mode ?? "off";
+  if (tailscaleMode !== "serve" && tailscaleMode !== "funnel") {
+    return [];
+  }
+  const bindMode = config.gateway?.bind ?? "loopback";
+  if (bindMode === "loopback") {
+    return [];
+  }
+  const customBindHost = config.gateway?.customBindHost;
+  if (
+    bindMode === "custom" &&
+    isCanonicalDottedDecimalIPv4(customBindHost) &&
+    isLoopbackIpAddress(customBindHost)
+  ) {
+    return [];
+  }
+  return [
+    {
+      path: "gateway.bind",
+      message:
+        `gateway.bind must resolve to loopback when gateway.tailscale.mode=${tailscaleMode} ` +
+        '(use gateway.bind="loopback" or gateway.bind="custom" with gateway.customBindHost="127.0.0.1")',
+    },
+  ];
+}
+
+function validateGatewayTailscaleAuth(config: OpenClawConfig): ConfigValidationIssue[] {
+  const tailscaleMode = config.gateway?.tailscale?.mode ?? "off";
+  if (!isUnsafeGatewayTailscaleNoAuth({ authMode: config.gateway?.auth?.mode, tailscaleMode })) {
+    return [];
+  }
+  return [
+    {
+      path: "gateway.auth.mode",
+      message: formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode),
+    },
+  ];
+}
+
+function collectModelPolicyAllowIssues(config: OpenClawConfig): ConfigValidationIssue[] {
+  const issues: ConfigValidationIssue[] = [];
+  const defaultModels = config.agents?.defaults?.models;
+  const collectAliases = (...modelMaps: Array<typeof defaultModels | undefined>): Set<string> => {
+    const aliases = new Set<string>();
+    for (const models of modelMaps) {
+      for (const entry of Object.values(models ?? {})) {
+        const alias = normalizeLowercaseStringOrEmpty(entry?.alias);
+        if (alias) {
+          aliases.add(alias);
+        }
+      }
+    }
+    return aliases;
+  };
+  const validateRefs = (
+    refs: readonly string[] | undefined,
+    configPath: string,
+    aliases: Set<string>,
+  ) => {
+    for (const [index, raw] of (refs ?? []).entries()) {
+      const trimmed = raw.trim();
+      if (
+        aliases.has(normalizeLowercaseStringOrEmpty(trimmed)) ||
+        isModelPolicyCompatSelector(trimmed) ||
+        isValidExactModelPolicyRef(trimmed) ||
+        parseModelPolicyWildcardRef(trimmed)
+      ) {
+        continue;
+      }
+      issues.push({
+        path: `${configPath}.${index}`,
+        message:
+          `invalid model policy ref: ${sanitizeForLog(JSON.stringify(raw))}. ` +
+          'Use a configured alias, an exact "provider/model" ref, or a trailing prefix wildcard such as "provider/*" or "provider/namespace/*".',
+      });
+    }
+  };
+
+  const defaultAliases = collectAliases(defaultModels);
+  validateRefs(
+    config.agents?.defaults?.modelPolicy?.allow,
+    "agents.defaults.modelPolicy.allow",
+    defaultAliases,
+  );
+  for (const { entry: agent, source } of listAgentEntriesWithSource(config)) {
+    const pathPrefix =
+      source.kind === "entries" ? `agents.entries.${source.key}` : `agents.list.${source.index}`;
+    validateRefs(
+      agent.modelPolicy?.allow,
+      `${pathPrefix}.modelPolicy.allow`,
+      collectAliases(defaultModels, agent.models),
+    );
+  }
+  return issues;
+}
+
+function attachAgentListProjection(config: OpenClawConfig): OpenClawConfig {
+  if (!config.agents) {
+    return config;
+  }
+  Object.defineProperty(config.agents, "list", {
+    configurable: true,
+    enumerable: false,
+    value: listAgentEntries(config),
+    writable: false,
+  });
+  return config;
+}
+
+/**
+ * Validates config without applying runtime defaults.
+ * Use this when you need the raw validated config (e.g., for writing back to file).
+ */
+export function validateConfigObjectRaw(
+  raw: unknown,
+  opts?: {
+    sourceRaw?: unknown;
+    touchedPaths?: ReadonlyArray<ReadonlyArray<string>>;
+    validateBundledChannels?: boolean;
+    preservedLegacyRootKeys?: readonly string[];
+    env?: NodeJS.ProcessEnv;
+  },
+): { ok: true; config: OpenClawConfig } | { ok: false; issues: ConfigValidationIssue[] } {
+  const normalizedRaw = stripPreservedLegacyRootKeysForValidation(
+    raw,
+    opts?.preservedLegacyRootKeys,
+  );
+  const policyIssues = collectUnsupportedSecretRefPolicyIssues(normalizedRaw);
+  const validated = OpenClawSchema.safeParse(normalizedRaw);
+  if (!validated.success) {
+    const schemaIssues = validated.error.issues.map(mapZodIssueToConfigIssue);
+    return {
+      ok: false,
+      issues: mergeUnsupportedMutableSecretRefIssues(policyIssues, schemaIssues),
+    };
+  }
+  const validatedConfig = attachAgentListProjection(
+    materializeBundledModelProviderOverlays(validated.data as OpenClawConfig),
+  );
+  const channelIssues =
+    policyIssues.length > 0 || opts?.validateBundledChannels
+      ? collectRawBundledChannelConfigIssues(validatedConfig)
+      : [];
+  if (channelIssues.length > 0) {
+    return {
+      ok: false,
+      issues: mergeUnsupportedMutableSecretRefIssues(policyIssues, channelIssues),
+    };
+  }
+  if (policyIssues.length > 0) {
+    return { ok: false, issues: policyIssues };
+  }
+  const duplicates = findDuplicateAgentDirs(validatedConfig);
+  if (duplicates.length > 0) {
+    return {
+      ok: false,
+      issues: [{ path: "agents.entries", message: formatDuplicateAgentDirError(duplicates) }],
+    };
+  }
+  const avatarIssues = validateIdentityAvatar(validatedConfig, opts?.env);
+  if (avatarIssues.length > 0) {
+    return { ok: false, issues: avatarIssues };
+  }
+  const gatewayTailscaleBindIssues = validateGatewayTailscaleBind(validatedConfig);
+  if (gatewayTailscaleBindIssues.length > 0) {
+    return { ok: false, issues: gatewayTailscaleBindIssues };
+  }
+  const gatewayTailscaleAuthIssues = validateGatewayTailscaleAuth(validatedConfig);
+  if (gatewayTailscaleAuthIssues.length > 0) {
+    return { ok: false, issues: gatewayTailscaleAuthIssues };
+  }
+  const modelPolicyAllowIssues = collectModelPolicyAllowIssues(validatedConfig);
+  if (modelPolicyAllowIssues.length > 0) {
+    return { ok: false, issues: modelPolicyAllowIssues };
+  }
+  return { ok: true, config: validatedConfig };
+}
+
+export function validateConfigObject(
+  raw: unknown,
+  opts?: {
+    manifestRegistry?: Pick<PluginMetadataSnapshot, "manifestRegistry">["manifestRegistry"];
+    sourceRaw?: unknown;
+  },
+): { ok: true; config: OpenClawConfig } | { ok: false; issues: ConfigValidationIssue[] } {
+  const result = validateConfigObjectRaw(migratePersistedImplicitMainRoster(raw).config, opts);
+  if (!result.ok) {
+    return result;
+  }
+  return {
+    ok: true,
+    config: attachAgentListProjection(
+      materializeRuntimeConfig(result.config, "snapshot", {
+        manifestRegistry: opts?.manifestRegistry,
+      }),
+    ),
+  };
+}

--- a/src/config/validation-issues.ts
+++ b/src/config/validation-issues.ts
@@ -1,0 +1,440 @@
+import { unsupportedSecretRefSurfacePolicy } from "../secrets/unsupported-surface-policy.js";
+import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
+import type { ConfigValidationIssue } from "./types.js";
+import { coerceSecretRef } from "./types.secrets.js";
+import { bundledChannelSchemaById } from "./validation-channel-rules.js";
+
+type UnknownIssueRecord = Record<string, unknown>;
+type ConfigPathSegment = string | number;
+type AllowedValuesCollection = {
+  values: unknown[];
+  incomplete: boolean;
+  hasValues: boolean;
+};
+type JsonSchemaLike = Record<string, unknown>;
+
+const CUSTOM_EXPECTED_ONE_OF_RE = /expected one of ((?:"[^"]+"(?:\|"?[^"]+"?)*)+)/i;
+const SECRETREF_POLICY_DOC_URL = "https://docs.openclaw.ai/reference/secretref-credential-surface";
+
+function toIssueRecord(value: unknown): UnknownIssueRecord | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  return value as UnknownIssueRecord;
+}
+
+function toConfigPathSegments(path: unknown): ConfigPathSegment[] {
+  if (!Array.isArray(path)) {
+    return [];
+  }
+  return path.filter((segment): segment is ConfigPathSegment => {
+    const segmentType = typeof segment;
+    return segmentType === "string" || segmentType === "number";
+  });
+}
+
+function formatConfigPath(segments: readonly ConfigPathSegment[]): string {
+  return segments.join(".");
+}
+
+export function withConfigIssuePath(
+  issue: ConfigValidationIssue,
+  pathSegments: readonly ConfigPathSegment[],
+): ConfigValidationIssue {
+  Object.defineProperty(issue, "pathSegments", {
+    value: [...pathSegments],
+    enumerable: false,
+  });
+  return issue;
+}
+
+function asJsonSchemaLike(value: unknown): JsonSchemaLike | null {
+  return value && typeof value === "object" ? (value as JsonSchemaLike) : null;
+}
+
+function lookupJsonSchemaNode(
+  schema: unknown,
+  pathSegments: readonly ConfigPathSegment[],
+): JsonSchemaLike | null {
+  let current = asJsonSchemaLike(schema);
+  for (const segment of pathSegments) {
+    if (!current) {
+      return null;
+    }
+    if (typeof segment === "number") {
+      const items = current.items;
+      if (Array.isArray(items)) {
+        current = asJsonSchemaLike(items[segment] ?? items[0]);
+        continue;
+      }
+      current = asJsonSchemaLike(items);
+      continue;
+    }
+    const properties = asJsonSchemaLike(current.properties);
+    const next =
+      (properties && asJsonSchemaLike(properties[segment])) ||
+      asJsonSchemaLike(current.additionalProperties);
+    current = next;
+  }
+  return current;
+}
+
+function collectAllowedValuesFromJsonSchemaNode(schema: unknown): AllowedValuesCollection {
+  const node = asJsonSchemaLike(schema);
+  if (!node) {
+    return { values: [], incomplete: false, hasValues: false };
+  }
+  if (Object.hasOwn(node, "const")) {
+    return { values: [node.const], incomplete: false, hasValues: true };
+  }
+  if (Array.isArray(node.enum)) {
+    return { values: node.enum, incomplete: false, hasValues: node.enum.length > 0 };
+  }
+  const type = node.type;
+  if (type === "boolean" || (Array.isArray(type) && type.includes("boolean"))) {
+    return { values: [true, false], incomplete: false, hasValues: true };
+  }
+  const unionBranches = Array.isArray(node.anyOf)
+    ? node.anyOf
+    : Array.isArray(node.oneOf)
+      ? node.oneOf
+      : null;
+  if (!unionBranches) {
+    return { values: [], incomplete: false, hasValues: false };
+  }
+  const collected: unknown[] = [];
+  for (const branch of unionBranches) {
+    const branchCollected = collectAllowedValuesFromJsonSchemaNode(branch);
+    if (branchCollected.incomplete || !branchCollected.hasValues) {
+      return { values: [], incomplete: true, hasValues: false };
+    }
+    collected.push(...branchCollected.values);
+  }
+  return { values: collected, incomplete: false, hasValues: collected.length > 0 };
+}
+
+function collectAllowedValuesFromBundledChannelSchemaPath(
+  pathSegments: readonly ConfigPathSegment[],
+): AllowedValuesCollection {
+  if (pathSegments[0] !== "channels" || typeof pathSegments[1] !== "string") {
+    return { values: [], incomplete: false, hasValues: false };
+  }
+  const channelSchema = bundledChannelSchemaById.get(pathSegments[1]);
+  if (!channelSchema) {
+    return { values: [], incomplete: false, hasValues: false };
+  }
+  const targetNode = lookupJsonSchemaNode(channelSchema, pathSegments.slice(2));
+  return targetNode
+    ? collectAllowedValuesFromJsonSchemaNode(targetNode)
+    : { values: [], incomplete: false, hasValues: false };
+}
+
+function collectAllowedValuesFromCustomIssue(record: UnknownIssueRecord): AllowedValuesCollection {
+  const message = typeof record.message === "string" ? record.message : "";
+  const expectedMatch = message.match(CUSTOM_EXPECTED_ONE_OF_RE);
+  if (expectedMatch?.[1]) {
+    const values = [...expectedMatch[1].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+    return { values, incomplete: false, hasValues: values.length > 0 };
+  }
+
+  // Custom Zod issues usually come from superRefine rules, but some normalized
+  // channel unions collapse to a generic custom issue. Use generated channel
+  // config metadata here so we can recover enum hints without touching runtime
+  // plugin registries during validation formatting.
+  return collectAllowedValuesFromBundledChannelSchemaPath(toConfigPathSegments(record.path));
+}
+
+function appendNumericBoundHint(message: string, record: UnknownIssueRecord): string {
+  // Numeric ceiling/floor hints (too_big / too_small with numeric origin).
+  // Append a parenthesized bound alongside Zod's native message,
+  // matching the clarity that enum/union rejections get via (allowed: …).
+  const origin = typeof record.origin === "string" ? record.origin : "";
+  if (origin !== "number") {
+    return message;
+  }
+  const inclusive = record.inclusive === true;
+  if (record.code === "too_big") {
+    const maximum = typeof record.maximum === "number" ? record.maximum : undefined;
+    if (maximum !== undefined) {
+      return inclusive
+        ? `${message} (maximum: ${maximum})`
+        : `${message} (must be less than ${maximum})`;
+    }
+  }
+  if (record.code === "too_small") {
+    const minimum = typeof record.minimum === "number" ? record.minimum : undefined;
+    if (minimum !== undefined) {
+      return inclusive
+        ? `${message} (minimum: ${minimum})`
+        : `${message} (must be greater than ${minimum})`;
+    }
+  }
+  return message;
+}
+
+function collectAllowedValuesFromIssue(issue: unknown): AllowedValuesCollection {
+  const record = toIssueRecord(issue);
+  if (!record) {
+    return { values: [], incomplete: false, hasValues: false };
+  }
+  const code = typeof record.code === "string" ? record.code : "";
+  if (code === "invalid_value") {
+    const values = record.values;
+    return Array.isArray(values)
+      ? { values, incomplete: false, hasValues: values.length > 0 }
+      : { values: [], incomplete: true, hasValues: false };
+  }
+  if (code === "invalid_type") {
+    return record.expected === "boolean"
+      ? { values: [true, false], incomplete: false, hasValues: true }
+      : { values: [], incomplete: true, hasValues: false };
+  }
+  if (code === "custom") {
+    return collectAllowedValuesFromCustomIssue(record);
+  }
+  if (code !== "invalid_union") {
+    return { values: [], incomplete: false, hasValues: false };
+  }
+  const nested = record.errors;
+  if (!Array.isArray(nested) || nested.length === 0) {
+    return { values: [], incomplete: true, hasValues: false };
+  }
+  const collected: unknown[] = [];
+  for (const branch of nested) {
+    if (!Array.isArray(branch) || branch.length === 0) {
+      return { values: [], incomplete: true, hasValues: false };
+    }
+    const branchCollected = collectAllowedValuesFromIssueList(branch);
+    if (branchCollected.incomplete || !branchCollected.hasValues) {
+      return { values: [], incomplete: true, hasValues: false };
+    }
+    collected.push(...branchCollected.values);
+  }
+  return { values: collected, incomplete: false, hasValues: collected.length > 0 };
+}
+
+function collectAllowedValuesFromIssueList(
+  issues: ReadonlyArray<unknown>,
+): AllowedValuesCollection {
+  const collected: unknown[] = [];
+  let hasValues = false;
+  for (const issue of issues) {
+    const branch = collectAllowedValuesFromIssue(issue);
+    if (branch.incomplete) {
+      return { values: [], incomplete: true, hasValues: false };
+    }
+    if (branch.hasValues) {
+      hasValues = true;
+      collected.push(...branch.values);
+    }
+  }
+  return { values: collected, incomplete: false, hasValues };
+}
+
+function collectAllowedValuesFromUnknownIssue(issue: unknown): unknown[] {
+  const collection = collectAllowedValuesFromIssue(issue);
+  return collection.incomplete || !collection.hasValues ? [] : collection.values;
+}
+
+function isBindingsIssuePath(pathSegments: readonly ConfigPathSegment[]): boolean {
+  return pathSegments[0] === "bindings" && typeof pathSegments[1] === "number";
+}
+
+function isRouteTypeMismatchIssue(issue: UnknownIssueRecord): boolean {
+  const issuePath = toConfigPathSegments(issue.path);
+  return (
+    issuePath.length === 1 &&
+    issuePath[0] === "type" &&
+    issue.code === "invalid_value" &&
+    Array.isArray(issue.values) &&
+    issue.values.includes("route")
+  );
+}
+
+function extractBindingsSpecificUnionIssue(
+  record: UnknownIssueRecord,
+  parentPathSegments: readonly ConfigPathSegment[],
+): ConfigValidationIssue | null {
+  if (!isBindingsIssuePath(toConfigPathSegments(record.path)) || !Array.isArray(record.errors)) {
+    return null;
+  }
+  let matchingBranchIssue: UnknownIssueRecord | null = null;
+  let matchingBranchIsUnrecognized = false;
+  let matchingBranchPathLen = -1;
+  let sawRouteTypeMismatch = false;
+  for (const errGroup of record.errors) {
+    if (!Array.isArray(errGroup)) {
+      continue;
+    }
+    const branch = errGroup.map(toIssueRecord).filter(Boolean) as UnknownIssueRecord[];
+    if (branch.length === 0) {
+      continue;
+    }
+    if (branch.some(isRouteTypeMismatchIssue)) {
+      sawRouteTypeMismatch = true;
+      continue;
+    }
+    let branchBestIssue: UnknownIssueRecord | null = null;
+    let branchBestIsUnrecognized = false;
+    let branchBestPathLen = -1;
+    for (const issue of branch) {
+      const issuePathLen = toConfigPathSegments(issue.path).length;
+      const issueIsUnrecognized = issue.code === "unrecognized_keys";
+      if (
+        issuePathLen > branchBestPathLen ||
+        (issuePathLen === branchBestPathLen && issueIsUnrecognized && !branchBestIsUnrecognized)
+      ) {
+        branchBestIssue = issue;
+        branchBestIsUnrecognized = issueIsUnrecognized;
+        branchBestPathLen = issuePathLen;
+      }
+    }
+    if (!branchBestIssue) {
+      continue;
+    }
+    if (matchingBranchIssue) {
+      return null;
+    }
+    matchingBranchIssue = branchBestIssue;
+    matchingBranchIsUnrecognized = branchBestIsUnrecognized;
+    matchingBranchPathLen = branchBestPathLen;
+  }
+  if (
+    !sawRouteTypeMismatch ||
+    !matchingBranchIssue ||
+    (matchingBranchPathLen === 0 && !matchingBranchIsUnrecognized)
+  ) {
+    return null;
+  }
+  const fullPathSegments = [
+    ...parentPathSegments,
+    ...toConfigPathSegments(matchingBranchIssue.path),
+  ];
+  const message =
+    typeof matchingBranchIssue.message === "string" ? matchingBranchIssue.message : "Invalid input";
+  return withConfigIssuePath(
+    { path: formatConfigPath(fullPathSegments), message },
+    fullPathSegments,
+  );
+}
+
+export function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
+  const record = toIssueRecord(issue);
+  const pathSegments = toConfigPathSegments(record?.path);
+  const path = formatConfigPath(pathSegments);
+  const message = typeof record?.message === "string" ? record.message : "Invalid input";
+  const enrichedMessage = record ? appendNumericBoundHint(message, record) : message;
+  const allowedValuesSummary = summarizeAllowedValues(collectAllowedValuesFromUnknownIssue(issue));
+
+  // Bindings use a plain union because legacy route bindings may omit `type`.
+  // When an explicit ACP binding fails strict-object checks, Zod collapses the
+  // useful ACP branch issue behind a generic union-level "Invalid input".
+  if (record?.code === "invalid_union" && !allowedValuesSummary) {
+    const betterIssue = extractBindingsSpecificUnionIssue(record, pathSegments);
+    if (betterIssue) {
+      return betterIssue;
+    }
+  }
+  if (!allowedValuesSummary) {
+    return withConfigIssuePath({ path, message: enrichedMessage }, pathSegments);
+  }
+  return withConfigIssuePath(
+    {
+      path,
+      message: appendAllowedValuesHint(enrichedMessage, allowedValuesSummary),
+      allowedValues: allowedValuesSummary.values,
+      allowedValuesHiddenCount: allowedValuesSummary.hiddenCount,
+    },
+    pathSegments,
+  );
+}
+
+function isObjectSecretRefCandidate(value: unknown): boolean {
+  return Boolean(
+    value && typeof value === "object" && !Array.isArray(value) && coerceSecretRef(value),
+  );
+}
+
+function formatUnsupportedMutableSecretRefMessage(path: string): string {
+  return [
+    `SecretRef objects are not supported at ${path}.`,
+    "This credential is runtime-mutable or runtime-managed and must stay a plain string value.",
+    'Use a plain string (env template strings like "${MY_VAR}" are allowed).',
+    `See ${SECRETREF_POLICY_DOC_URL}.`,
+  ].join(" ");
+}
+
+function collectUnsupportedMutableSecretRefIssues(raw: unknown): ConfigValidationIssue[] {
+  const issues: ConfigValidationIssue[] = [];
+  for (const candidate of unsupportedSecretRefSurfacePolicy.collectConfigCandidates(raw)) {
+    if (isObjectSecretRefCandidate(candidate.value)) {
+      issues.push({
+        path: candidate.path,
+        message: formatUnsupportedMutableSecretRefMessage(candidate.path),
+      });
+    }
+  }
+  return issues;
+}
+
+function formatFilteredUnrecognizedKeyMessage(message: string, keys: string[]): string {
+  const quotedKeys = keys.map((key) => `"${key}"`).join(", ");
+  if (/must not have additional properties/i.test(message)) {
+    return `must not have additional properties: ${quotedKeys}`;
+  }
+  return keys.length === 1 ? `Unrecognized key: ${quotedKeys}` : `Unrecognized keys: ${quotedKeys}`;
+}
+
+function filterUnsupportedMutableSecretRefSchemaIssue(params: {
+  issue: ConfigValidationIssue;
+  policyIssue: ConfigValidationIssue;
+}): ConfigValidationIssue | null {
+  const { issue, policyIssue } = params;
+  if (issue.path === policyIssue.path) {
+    return /expected string, received object/i.test(issue.message) ? null : issue;
+  }
+  if (!issue.path || !policyIssue.path || !policyIssue.path.startsWith(`${issue.path}.`)) {
+    return issue;
+  }
+  const childKey = policyIssue.path.slice(issue.path.length + 1).split(".")[0];
+  if (!childKey || !/Unrecognized key|must not have additional properties/i.test(issue.message)) {
+    return issue;
+  }
+  const unrecognizedKeys = [...issue.message.matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+  if (!unrecognizedKeys.includes(childKey)) {
+    return issue;
+  }
+  const remainingKeys = unrecognizedKeys.filter(
+    (key): key is string => key !== undefined && key !== childKey,
+  );
+  return remainingKeys.length === 0
+    ? null
+    : { ...issue, message: formatFilteredUnrecognizedKeyMessage(issue.message, remainingKeys) };
+}
+
+export function mergeUnsupportedMutableSecretRefIssues(
+  policyIssues: ConfigValidationIssue[],
+  schemaIssues: ConfigValidationIssue[],
+): ConfigValidationIssue[] {
+  if (policyIssues.length === 0) {
+    return schemaIssues;
+  }
+  const filteredSchemaIssues = schemaIssues.flatMap((issue) => {
+    let filteredIssue: ConfigValidationIssue | null = issue;
+    for (const policyIssue of policyIssues) {
+      if (!filteredIssue) {
+        return [];
+      }
+      filteredIssue = filterUnsupportedMutableSecretRefSchemaIssue({
+        issue: filteredIssue,
+        policyIssue,
+      });
+    }
+    return filteredIssue ? [filteredIssue] : [];
+  });
+  return [...policyIssues, ...filteredSchemaIssues];
+}
+
+export function collectUnsupportedSecretRefPolicyIssues(raw: unknown): ConfigValidationIssue[] {
+  return collectUnsupportedMutableSecretRefIssues(raw);
+}

--- a/src/config/validation-plugin-config.ts
+++ b/src/config/validation-plugin-config.ts
@@ -1,0 +1,429 @@
+import path from "node:path";
+import { isPathInside } from "../infra/path-guards.js";
+import {
+  normalizePluginsConfig,
+  normalizePluginId,
+  resolveEffectivePluginActivationState,
+  resolveMemorySlotDecision,
+} from "../plugins/config-state.js";
+import { resolveManifestCommandAliasOwnerInRegistry } from "../plugins/manifest-command-aliases.js";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import {
+  getOfficialExternalPluginCatalogEntry,
+  resolveOfficialExternalPluginInstall,
+} from "../plugins/official-external-plugin-catalog.js";
+import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
+import { hasKind } from "../plugins/slots.js";
+import { isRecord, resolveUserPath } from "../utils.js";
+import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
+
+const LEGACY_REMOVED_PLUGIN_IDS = new Set([
+  "google-antigravity-auth",
+  "google-gemini-cli-auth",
+  "skill-workshop",
+]);
+const BLOCKED_PLUGIN_CANDIDATE_PREFIX = "blocked plugin candidate:";
+
+export type ExplicitPluginReferences = {
+  entries: Set<string>;
+  allow: Set<string>;
+  deny: Set<string>;
+  slots: Map<string, string>;
+};
+
+export function collectExplicitPluginReferences(raw: unknown): ExplicitPluginReferences {
+  const references: ExplicitPluginReferences = {
+    entries: new Set(),
+    allow: new Set(),
+    deny: new Set(),
+    slots: new Map(),
+  };
+  if (!isRecord(raw) || !isRecord(raw.plugins)) {
+    return references;
+  }
+  const { plugins } = raw;
+  if (isRecord(plugins.entries)) {
+    for (const pluginId of Object.keys(plugins.entries)) {
+      const normalized = normalizePluginId(pluginId);
+      if (normalized) {
+        references.entries.add(normalized);
+      }
+    }
+  }
+  for (const [key, target] of [
+    ["allow", references.allow],
+    ["deny", references.deny],
+  ] as const) {
+    const value = plugins[key];
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    for (const entry of value) {
+      if (typeof entry === "string") {
+        const normalized = normalizePluginId(entry);
+        if (normalized) {
+          target.add(normalized);
+        }
+      }
+    }
+  }
+  if (isRecord(plugins.slots)) {
+    for (const [slotId, pluginId] of Object.entries(plugins.slots)) {
+      if (typeof pluginId !== "string") {
+        continue;
+      }
+      const normalized = normalizePluginId(pluginId);
+      if (normalized && normalized !== "none") {
+        references.slots.set(normalized, slotId);
+      }
+    }
+  }
+  return references;
+}
+
+export function resolveExplicitPluginReferencePath(
+  references: ExplicitPluginReferences,
+  pluginId: string,
+): string | undefined {
+  const normalized = normalizePluginId(pluginId);
+  if (!normalized) {
+    return undefined;
+  }
+  if (references.entries.has(normalized)) {
+    return `plugins.entries.${normalized}`;
+  }
+  if (references.allow.has(normalized)) {
+    return "plugins.allow";
+  }
+  if (references.deny.has(normalized)) {
+    return "plugins.deny";
+  }
+  const slotId = references.slots.get(normalized);
+  return slotId ? `plugins.slots.${slotId}` : undefined;
+}
+
+function formatRemovedPluginConfigWarning(pluginId: string): string {
+  if (pluginId === "skill-workshop") {
+    return "plugin removed: skill-workshop (stale plugin config ignored; Skill Workshop is built into OpenClaw skills now. Use skills.workshop settings and openclaw skills workshop commands, then remove this plugins config entry)";
+  }
+  return `plugin removed: ${pluginId} (stale config entry ignored; remove it from plugins config)`;
+}
+
+function formatMissingOfficialExternalPluginWarning(
+  pluginId: string,
+  opts?: { selectedMissingMemorySlot?: boolean },
+): string | null {
+  const catalogEntry = getOfficialExternalPluginCatalogEntry(pluginId);
+  if (!catalogEntry) {
+    return null;
+  }
+  const install = resolveOfficialExternalPluginInstall(catalogEntry);
+  const npmSpec = install?.npmSpec?.trim();
+  const clawhubSpec = install?.clawhubSpec?.trim();
+  const installSpec =
+    install?.defaultChoice === "clawhub" ? (clawhubSpec ?? npmSpec) : (npmSpec ?? clawhubSpec);
+  if (!installSpec) {
+    return null;
+  }
+  if (pluginId === "memory-lancedb" && opts?.selectedMissingMemorySlot) {
+    return `plugin not installed: ${pluginId} — gateway will run without persistent memory until installed; install the official external plugin with: openclaw plugins install ${installSpec}`;
+  }
+  return `plugin not installed: ${pluginId} — install the official external plugin with: openclaw plugins install ${installSpec}`;
+}
+
+export function validateExplicitPluginConfig(params: {
+  raw: unknown;
+  config: OpenClawConfig;
+  effectiveConfig: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  applyDefaults: boolean;
+  registry: PluginManifestRegistry;
+  knownIds: Set<string>;
+  normalizedPlugins: ReturnType<typeof normalizePluginsConfig>;
+  ensureCompatPluginIds: () => ReadonlySet<string>;
+  ensureOverriddenPluginIds: () => Set<string>;
+  replacePluginEntryConfig: (pluginId: string, nextValue: Record<string, unknown>) => void;
+  issues: ConfigValidationIssue[];
+  warnings: ConfigValidationIssue[];
+}): void {
+  const {
+    raw,
+    config,
+    effectiveConfig,
+    env,
+    applyDefaults,
+    registry,
+    knownIds,
+    normalizedPlugins,
+    ensureCompatPluginIds,
+    ensureOverriddenPluginIds,
+    issues,
+    warnings,
+  } = params;
+  const blockedPluginDiagnostics = new Map<string, { message: string; source?: string }>();
+  const blockedPluginDiagnosticsWithSource: Array<{ message: string; source: string }> = [];
+  const normalizeBlockedDiagnosticPath = (value: string | undefined): string => {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      return "";
+    }
+    try {
+      return path.resolve(resolveUserPath(trimmed, env ?? process.env));
+    } catch {
+      return path.resolve(trimmed);
+    }
+  };
+  for (const diag of registry.diagnostics) {
+    if (!diag.message.startsWith(BLOCKED_PLUGIN_CANDIDATE_PREFIX)) {
+      continue;
+    }
+    if (!diag.pluginId && diag.source) {
+      blockedPluginDiagnosticsWithSource.push({ message: diag.message, source: diag.source });
+    }
+    if (diag.pluginId) {
+      const normalizedPluginId = normalizePluginId(diag.pluginId);
+      for (const key of [diag.pluginId, normalizedPluginId]) {
+        if (key && !blockedPluginDiagnostics.has(key)) {
+          blockedPluginDiagnostics.set(key, {
+            message: diag.message,
+            ...(diag.source ? { source: diag.source } : {}),
+          });
+        }
+      }
+    }
+  }
+  const blockedDiagnosticSourceMatchesPluginId = (
+    diagnostic: { message: string; source: string },
+    pluginId: string,
+  ): boolean => {
+    const normalizedPluginId = normalizePluginId(pluginId);
+    if (!normalizedPluginId) {
+      return false;
+    }
+    const sourcePath = normalizeBlockedDiagnosticPath(diagnostic.source);
+    if (!sourcePath) {
+      return false;
+    }
+    if (
+      normalizePluginId(path.basename(sourcePath)) === normalizedPluginId ||
+      normalizePluginId(path.basename(path.dirname(sourcePath))) === normalizedPluginId
+    ) {
+      return true;
+    }
+    const loadPaths = config.plugins?.load?.paths;
+    if (!Array.isArray(loadPaths)) {
+      return false;
+    }
+    for (const loadPath of loadPaths) {
+      if (typeof loadPath !== "string") {
+        continue;
+      }
+      const resolvedLoadPath = normalizeBlockedDiagnosticPath(loadPath);
+      if (
+        resolvedLoadPath &&
+        normalizePluginId(path.basename(resolvedLoadPath)) === normalizedPluginId &&
+        (sourcePath === resolvedLoadPath ||
+          isPathInside(resolvedLoadPath, sourcePath) ||
+          isPathInside(sourcePath, resolvedLoadPath))
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+  const findBlockedPluginDiagnostic = (pluginId: string) =>
+    blockedPluginDiagnostics.get(pluginId) ??
+    blockedPluginDiagnostics.get(normalizePluginId(pluginId)) ??
+    blockedPluginDiagnosticsWithSource.find((diagnostic) =>
+      blockedDiagnosticSourceMatchesPluginId(diagnostic, pluginId),
+    );
+  const missingOfficialPluginWarningIds = new Set<string>();
+  const pushMissingPluginIssue = (
+    issuePath: string,
+    pluginId: string,
+    options?: {
+      warnOnly?: boolean;
+      officialInstallHint?: boolean;
+      missingMessage?: string | null;
+    },
+  ) => {
+    if (LEGACY_REMOVED_PLUGIN_IDS.has(pluginId)) {
+      warnings.push({ path: issuePath, message: formatRemovedPluginConfigWarning(pluginId) });
+      return;
+    }
+    const blockedDiagnostic = findBlockedPluginDiagnostic(pluginId);
+    if (blockedDiagnostic) {
+      const source = blockedDiagnostic.source ? `; source: ${blockedDiagnostic.source}` : "";
+      const message = `plugin present but blocked: ${pluginId} (see preceding plugin warning${source}; fix the blocked plugin path instead of removing config)`;
+      (options?.warnOnly ? warnings : issues).push({ path: issuePath, message });
+      return;
+    }
+    if (
+      normalizePluginId(pluginId) === "codex" &&
+      issuePath === "plugins.entries.codex" &&
+      shouldSuppressMissingCodexPluginDiagnostics(
+        config,
+        env ?? process.env,
+        isRecord(raw) ? (raw as OpenClawConfig) : undefined,
+      )
+    ) {
+      return;
+    }
+    if (options?.warnOnly && options.officialInstallHint !== false) {
+      const externalInstallWarning =
+        options.missingMessage ?? formatMissingOfficialExternalPluginWarning(pluginId);
+      if (externalInstallWarning) {
+        const normalizedPluginId = normalizePluginId(pluginId);
+        if (!options.missingMessage && normalizedPluginId) {
+          if (missingOfficialPluginWarningIds.has(normalizedPluginId)) {
+            return;
+          }
+          missingOfficialPluginWarningIds.add(normalizedPluginId);
+        }
+        warnings.push({ path: issuePath, message: externalInstallWarning });
+        return;
+      }
+    }
+    const message = options?.warnOnly
+      ? `plugin not found: ${pluginId} (stale config entry ignored; remove it from plugins config)`
+      : `plugin not found: ${pluginId}`;
+    (options?.warnOnly ? warnings : issues).push({ path: issuePath, message });
+  };
+
+  const pluginsConfig = config.plugins;
+  const entries = pluginsConfig?.entries;
+  if (entries && isRecord(entries)) {
+    for (const pluginId of Object.keys(entries)) {
+      if (!knownIds.has(pluginId)) {
+        // Keep gateway startup resilient when plugins are removed/renamed across upgrades.
+        pushMissingPluginIssue(`plugins.entries.${pluginId}`, pluginId, { warnOnly: true });
+      }
+    }
+  }
+  for (const pluginId of pluginsConfig?.allow ?? []) {
+    if (typeof pluginId !== "string" || !pluginId.trim() || knownIds.has(pluginId)) {
+      continue;
+    }
+    const commandAlias = resolveManifestCommandAliasOwnerInRegistry({
+      command: pluginId,
+      registry,
+    });
+    if (commandAlias?.pluginId && knownIds.has(commandAlias.pluginId)) {
+      warnings.push({
+        path: "plugins.allow",
+        message:
+          `"${pluginId}" is not a plugin — it is a command provided by the "${commandAlias.pluginId}" plugin. ` +
+          `Use "${commandAlias.pluginId}" in plugins.allow instead.`,
+      });
+    } else {
+      pushMissingPluginIssue("plugins.allow", pluginId, { warnOnly: true });
+    }
+  }
+  for (const pluginId of pluginsConfig?.deny ?? []) {
+    if (typeof pluginId === "string" && pluginId.trim() && !knownIds.has(pluginId)) {
+      pushMissingPluginIssue("plugins.deny", pluginId, {
+        warnOnly: true,
+        officialInstallHint: false,
+      });
+    }
+  }
+
+  // The default memory slot is inferred; only a user-configured slot should block startup.
+  const pluginSlots = pluginsConfig?.slots;
+  const hasExplicitMemorySlot = pluginSlots !== undefined && Object.hasOwn(pluginSlots, "memory");
+  const memorySlot = normalizedPlugins.slots.memory;
+  if (
+    hasExplicitMemorySlot &&
+    typeof memorySlot === "string" &&
+    memorySlot.trim() &&
+    !knownIds.has(memorySlot)
+  ) {
+    const missingMessage = formatMissingOfficialExternalPluginWarning(memorySlot, {
+      selectedMissingMemorySlot: true,
+    });
+    const isMissingOfficialExternalMemorySlot =
+      memorySlot === "memory-lancedb" && Boolean(missingMessage);
+    pushMissingPluginIssue("plugins.slots.memory", memorySlot, {
+      warnOnly: isMissingOfficialExternalMemorySlot && !findBlockedPluginDiagnostic(memorySlot),
+      missingMessage,
+    });
+  }
+
+  let selectedMemoryPluginId: string | null = null;
+  const seenPlugins = new Set<string>();
+  for (const record of registry.plugins) {
+    const pluginId = record.id;
+    if (seenPlugins.has(pluginId)) {
+      continue;
+    }
+    seenPlugins.add(pluginId);
+    const entry = normalizedPlugins.entries[pluginId];
+    const entryHasConfig = Boolean(entry?.config);
+    const activationState = resolveEffectivePluginActivationState({
+      id: pluginId,
+      origin: record.origin,
+      config: normalizedPlugins,
+      rootConfig: effectiveConfig,
+    });
+    let enabled = activationState.activated;
+    let reason = activationState.reason;
+    if (enabled) {
+      const memoryDecision = resolveMemorySlotDecision({
+        id: pluginId,
+        kind: record.kind,
+        slot: memorySlot,
+        selectedId: selectedMemoryPluginId,
+      });
+      if (!memoryDecision.enabled) {
+        enabled = false;
+        reason = memoryDecision.reason;
+      }
+      if (memoryDecision.selected && hasKind(record.kind, "memory")) {
+        selectedMemoryPluginId = pluginId;
+      }
+    }
+    const shouldReplacePluginConfig = entryHasConfig || (applyDefaults && enabled);
+    const shouldValidate = enabled || entryHasConfig;
+    if (shouldValidate) {
+      if (record.configSchema) {
+        const result = validateJsonSchemaValue({
+          schema: record.configSchema,
+          cacheKey: record.schemaCacheKey ?? record.manifestPath ?? pluginId,
+          value: entry?.config ?? {},
+          applyDefaults: true, // Always apply defaults for AJV schema validation;
+          // writeConfigFile persists persistCandidate, not validated.config (#61841)
+        });
+        if (!result.ok) {
+          for (const error of result.errors) {
+            const base = `plugins.entries.${pluginId}.config`;
+            issues.push({
+              path: !error.path || error.path === "<root>" ? base : `${base}.${error.path}`,
+              message: `invalid config: ${error.message}`,
+              allowedValues: error.allowedValues,
+              allowedValuesHiddenCount: error.allowedValuesHiddenCount,
+            });
+          }
+        } else if (shouldReplacePluginConfig) {
+          params.replacePluginEntryConfig(pluginId, result.value as Record<string, unknown>);
+        }
+      } else if (record.format === "bundle") {
+        // Compatible bundles currently expose no native OpenClaw config schema.
+        // Treat them as schema-less capability packs rather than failing validation.
+      } else {
+        issues.push({
+          path: `plugins.entries.${pluginId}`,
+          message: `plugin schema missing for ${pluginId}`,
+        });
+      }
+    }
+    const suppressDisabledConfigWarning =
+      ensureCompatPluginIds().has(pluginId) && !ensureOverriddenPluginIds().has(pluginId);
+    if (!enabled && entryHasConfig && !suppressDisabledConfigWarning) {
+      warnings.push({
+        path: `plugins.entries.${pluginId}`,
+        message: `plugin disabled (${reason ?? "disabled"}) but config is present`,
+      });
+    }
+  }
+}

--- a/src/config/validation-plugin-config.ts
+++ b/src/config/validation-plugin-config.ts
@@ -25,7 +25,7 @@ const LEGACY_REMOVED_PLUGIN_IDS = new Set([
 ]);
 const BLOCKED_PLUGIN_CANDIDATE_PREFIX = "blocked plugin candidate:";
 
-export type ExplicitPluginReferences = {
+type ExplicitPluginReferences = {
   entries: Set<string>;
   allow: Set<string>;
   deny: Set<string>;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,1249 +1,52 @@
 // Validates normalized OpenClaw config and reports user-facing errors.
-import path from "node:path";
 import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
-import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import {
-  listAgentEntries,
   listAgentEntriesWithSource,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import {
-  type ChannelDmAllowFromMode,
-  resolveChannelDmAllowFrom,
-  resolveChannelDmPolicy,
-} from "../channels/plugins/dm-access.js";
-import { isPathInside } from "../infra/path-guards.js";
+import type { ChannelDmAllowFromMode } from "../channels/plugins/dm-access.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
-import {
-  normalizePluginsConfig,
-  normalizePluginId,
-  resolveEffectivePluginActivationState,
-  resolveMemorySlotDecision,
-} from "../plugins/config-state.js";
+import { normalizePluginsConfig, normalizePluginId } from "../plugins/config-state.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "../plugins/installed-plugin-index-record-reader.js";
-import { resolveManifestCommandAliasOwnerInRegistry } from "../plugins/manifest-command-aliases.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
-import {
-  getOfficialExternalPluginCatalogEntry,
-  resolveOfficialExternalPluginInstall,
-} from "../plugins/official-external-plugin-catalog.js";
 import {
   resolvePluginMetadataSnapshot,
   type PluginMetadataSnapshot,
 } from "../plugins/plugin-metadata-snapshot.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
-import { hasKind } from "../plugins/slots.js";
 import { resolveWebSearchInstallCatalogEntries } from "../plugins/web-search-install-catalog.js";
-import { unsupportedSecretRefSurfacePolicy } from "../secrets/unsupported-surface-policy.js";
-import {
-  hasAvatarUriScheme,
-  isAvatarDataUrl,
-  isAvatarHttpUrl,
-  isPathWithinRoot,
-  isWindowsAbsolutePath,
-} from "../shared/avatar-policy.js";
-import {
-  formatUnsafeGatewayTailscaleNoAuthMessage,
-  isUnsafeGatewayTailscaleNoAuth,
-} from "../shared/gateway-tailscale-auth-policy.js";
-import { isRecord, resolveUserPath } from "../utils.js";
-import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
-import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
+import { isRecord } from "../utils.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
 import {
   collectChannelDmPolicyMetadata,
   collectChannelSchemaMetadataWithOwnership,
 } from "./channel-config-metadata.js";
-import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
 import { migratePersistedImplicitMainRoster } from "./legacy.roster.js";
 import { materializeRuntimeConfig } from "./materialize.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
 import {
-  isModelPolicyCompatSelector,
-  isValidExactModelPolicyRef,
-  parseModelPolicyWildcardRef,
-} from "./model-policy-ref.js";
-import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
-import { coerceSecretRef } from "./types.secrets.js";
+  bundledChannelIds,
+  collectChannelDmPolicyDependencyWarnings,
+  formatRawChannelConfigIssueMessage,
+  hasChannelDmPolicyDependencyWarningCandidates,
+  normalizeBundledChannelId,
+} from "./validation-channel-rules.js";
+import { validateConfigObjectRaw } from "./validation-core.js";
 import {
-  type DmPolicyAllowFromViolation,
-  evaluateDmPolicyAllowFromDependency,
-  isBuiltInModelProviderOverlayId,
-} from "./zod-schema.core.js";
-import { OpenClawSchema } from "./zod-schema.js";
-
-const LEGACY_REMOVED_PLUGIN_IDS = new Set([
-  "google-antigravity-auth",
-  "google-gemini-cli-auth",
-  "skill-workshop",
-]);
-const BLOCKED_PLUGIN_CANDIDATE_PREFIX = "blocked plugin candidate:";
-
-function formatRemovedPluginConfigWarning(pluginId: string): string {
-  if (pluginId === "skill-workshop") {
-    return "plugin removed: skill-workshop (stale plugin config ignored; Skill Workshop is built into OpenClaw skills now. Use skills.workshop settings and openclaw skills workshop commands, then remove this plugins config entry)";
-  }
-  return `plugin removed: ${pluginId} (stale config entry ignored; remove it from plugins config)`;
-}
-
-type UnknownIssueRecord = Record<string, unknown>;
-type ConfigPathSegment = string | number;
-type ExplicitPluginReferences = {
-  entries: Set<string>;
-  allow: Set<string>;
-  deny: Set<string>;
-  slots: Map<string, string>;
-};
-type AllowedValuesCollection = {
-  values: unknown[];
-  incomplete: boolean;
-  hasValues: boolean;
-};
-type JsonSchemaLike = Record<string, unknown>;
-
-function materializeBundledModelProviderOverlays(config: OpenClawConfig): OpenClawConfig {
-  const providers = config.models?.providers;
-  if (!providers) {
-    return config;
-  }
-  let nextProviders: typeof providers | undefined;
-  for (const [providerId, providerConfig] of Object.entries(providers)) {
-    if (
-      !isBuiltInModelProviderOverlayId(providerId) ||
-      (providerConfig.baseUrl && Array.isArray(providerConfig.models))
-    ) {
-      continue;
-    }
-    nextProviders ??= { ...providers };
-    nextProviders[providerId] = {
-      ...providerConfig,
-      baseUrl: providerConfig.baseUrl ?? "",
-      models: providerConfig.models ?? [],
-    };
-  }
-  if (!nextProviders) {
-    return config;
-  }
-  return {
-    ...config,
-    models: {
-      ...config.models,
-      providers: nextProviders,
-    },
-  };
-}
-
-function stripPreservedLegacyRootKeysForValidation(
-  raw: unknown,
-  keys?: readonly string[],
-): unknown {
-  if (!keys || keys.length === 0 || !isRecord(raw)) {
-    return raw;
-  }
-  const next = { ...raw };
-  for (const key of keys) {
-    delete next[key];
-  }
-  return next;
-}
-
-const CUSTOM_EXPECTED_ONE_OF_RE = /expected one of ((?:"[^"]+"(?:\|"?[^"]+"?)*)+)/i;
-const SECRETREF_POLICY_DOC_URL = "https://docs.openclaw.ai/reference/secretref-credential-surface";
-const bundledChannelSchemaById = new Map<string, unknown>(
-  GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.filter((entry) => entry.configurable !== false).map(
-    (entry) => [entry.channelId, entry.schema] as const,
-  ),
-);
-const bundledChannelIds = Object.freeze(
-  GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.filter((entry) => entry.configurable !== false)
-    .map((entry) => normalizeLowercaseStringOrEmpty(entry.channelId))
-    .filter((channelId) => channelId.length > 0),
-);
-const bundledChannelIdSet = new Set(bundledChannelIds);
-const bundledChannelAliases = new Map<string, string>(
-  GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.filter((entry) => entry.configurable !== false).flatMap(
-    (entry) => {
-      const channelId = normalizeLowercaseStringOrEmpty(entry.channelId);
-      if (!channelId) {
-        return [];
-      }
-      return (entry.aliases ?? [])
-        .map((alias) => [normalizeLowercaseStringOrEmpty(alias), channelId] as const)
-        .filter(([alias]) => alias.length > 0);
-    },
-  ),
-);
-
-function normalizeBundledChannelId(raw?: string | null): string | null {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return null;
-  }
-  const resolved = bundledChannelAliases.get(normalized) ?? normalized;
-  return bundledChannelIdSet.has(resolved) ? resolved : null;
-}
-
-function toIssueRecord(value: unknown): UnknownIssueRecord | null {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-  return value as UnknownIssueRecord;
-}
-
-function toConfigPathSegments(pathLocal3: unknown): ConfigPathSegment[] {
-  if (!Array.isArray(pathLocal3)) {
-    return [];
-  }
-  return pathLocal3.filter((segment): segment is ConfigPathSegment => {
-    const segmentType = typeof segment;
-    return segmentType === "string" || segmentType === "number";
-  });
-}
-
-function formatConfigPath(segments: readonly ConfigPathSegment[]): string {
-  return segments.join(".");
-}
-
-function withConfigIssuePath(
-  issue: ConfigValidationIssue,
-  pathSegments: readonly ConfigPathSegment[],
-): ConfigValidationIssue {
-  Object.defineProperty(issue, "pathSegments", {
-    value: [...pathSegments],
-    enumerable: false,
-  });
-  return issue;
-}
-
-function formatMissingOfficialExternalPluginWarning(
-  pluginId: string,
-  opts?: { selectedMissingMemorySlot?: boolean },
-): string | null {
-  const catalogEntry = getOfficialExternalPluginCatalogEntry(pluginId);
-  if (!catalogEntry) {
-    return null;
-  }
-  const install = resolveOfficialExternalPluginInstall(catalogEntry);
-  const npmSpec = install?.npmSpec?.trim();
-  const clawhubSpec = install?.clawhubSpec?.trim();
-  const installSpec =
-    install?.defaultChoice === "clawhub" ? (clawhubSpec ?? npmSpec) : (npmSpec ?? clawhubSpec);
-  if (!installSpec) {
-    return null;
-  }
-  if (pluginId === "memory-lancedb" && opts?.selectedMissingMemorySlot) {
-    return `plugin not installed: ${pluginId} — gateway will run without persistent memory until installed; install the official external plugin with: openclaw plugins install ${installSpec}`;
-  }
-  return `plugin not installed: ${pluginId} — install the official external plugin with: openclaw plugins install ${installSpec}`;
-}
-
-function asJsonSchemaLike(value: unknown): JsonSchemaLike | null {
-  return value && typeof value === "object" ? (value as JsonSchemaLike) : null;
-}
-
-function lookupJsonSchemaNode(
-  schema: unknown,
-  pathSegments: readonly ConfigPathSegment[],
-): JsonSchemaLike | null {
-  let current = asJsonSchemaLike(schema);
-  for (const segment of pathSegments) {
-    if (!current) {
-      return null;
-    }
-    if (typeof segment === "number") {
-      const items = current.items;
-      if (Array.isArray(items)) {
-        current = asJsonSchemaLike(items[segment] ?? items[0]);
-        continue;
-      }
-      current = asJsonSchemaLike(items);
-      continue;
-    }
-    const properties = asJsonSchemaLike(current.properties);
-    const next =
-      (properties && asJsonSchemaLike(properties[segment])) ||
-      asJsonSchemaLike(current.additionalProperties);
-    current = next;
-  }
-  return current;
-}
-
-function collectAllowedValuesFromJsonSchemaNode(schema: unknown): AllowedValuesCollection {
-  const node = asJsonSchemaLike(schema);
-  if (!node) {
-    return { values: [], incomplete: false, hasValues: false };
-  }
-
-  if (Object.hasOwn(node, "const")) {
-    return { values: [node.const], incomplete: false, hasValues: true };
-  }
-
-  if (Array.isArray(node.enum)) {
-    return { values: node.enum, incomplete: false, hasValues: node.enum.length > 0 };
-  }
-
-  const type = node.type;
-  if (type === "boolean") {
-    return { values: [true, false], incomplete: false, hasValues: true };
-  }
-  if (Array.isArray(type) && type.includes("boolean")) {
-    return { values: [true, false], incomplete: false, hasValues: true };
-  }
-
-  const unionBranches = Array.isArray(node.anyOf)
-    ? node.anyOf
-    : Array.isArray(node.oneOf)
-      ? node.oneOf
-      : null;
-  if (!unionBranches) {
-    return { values: [], incomplete: false, hasValues: false };
-  }
-
-  const collected: unknown[] = [];
-  for (const branch of unionBranches) {
-    const branchCollected = collectAllowedValuesFromJsonSchemaNode(branch);
-    if (branchCollected.incomplete || !branchCollected.hasValues) {
-      return { values: [], incomplete: true, hasValues: false };
-    }
-    collected.push(...branchCollected.values);
-  }
-
-  return { values: collected, incomplete: false, hasValues: collected.length > 0 };
-}
-
-function collectAllowedValuesFromBundledChannelSchemaPath(
-  pathSegments: readonly ConfigPathSegment[],
-): AllowedValuesCollection {
-  if (pathSegments[0] !== "channels" || typeof pathSegments[1] !== "string") {
-    return { values: [], incomplete: false, hasValues: false };
-  }
-  const channelSchema = bundledChannelSchemaById.get(pathSegments[1]);
-  if (!channelSchema) {
-    return { values: [], incomplete: false, hasValues: false };
-  }
-  const targetNode = lookupJsonSchemaNode(channelSchema, pathSegments.slice(2));
-  if (!targetNode) {
-    return { values: [], incomplete: false, hasValues: false };
-  }
-  return collectAllowedValuesFromJsonSchemaNode(targetNode);
-}
-
-function formatRawChannelConfigIssueMessage(message: string): string {
-  return `invalid config: ${message}`;
-}
-
-function buildDmPolicyDependencyWarning(params: {
-  channelId: string;
-  accountId?: string;
-  allowFromSource?: "explicit" | "inherited";
-  violation: DmPolicyAllowFromViolation;
-}): ConfigValidationIssue {
-  const channelBase = `channels.${params.channelId}`;
-  const scope = params.accountId ? `${channelBase}.accounts.${params.accountId}` : channelBase;
-  const allowFromPath = `${scope}.allowFrom`;
-  const inherited = params.accountId && params.allowFromSource === "inherited";
-  const allowFromSubject = inherited
-    ? `${allowFromPath} is unset and ${channelBase}.allowFrom`
-    : allowFromPath;
-  const accountInheritedTarget = inherited ? ` or ${channelBase}.allowFrom` : "";
-  const accountOverrideFix =
-    params.accountId && !inherited
-      ? `, remove ${allowFromPath} to inherit ${channelBase}.allowFrom,`
-      : "";
-  const message =
-    params.violation === "open_requires_wildcard"
-      ? `${scope}.dmPolicy="open" but ${allowFromSubject} does not include "*"; all DMs will be dropped. Add "*" to ${allowFromPath}${accountInheritedTarget}${accountOverrideFix} or set ${scope}.dmPolicy to "pairing"/"allowlist".`
-      : `${scope}.dmPolicy="allowlist" but ${allowFromSubject} is empty; all DMs will be dropped. Add at least one sender ID to ${allowFromPath}${accountInheritedTarget}${accountOverrideFix} or change ${scope}.dmPolicy.`;
-  return { path: allowFromPath, message };
-}
-
-// Channel map keys that are not channels and must be skipped while scanning DM policy.
-const DM_POLICY_PSEUDO_CHANNEL_KEYS = new Set(["defaults", "modelByChannel", "tools"]);
-
-function hasDefinedConfigValue(record: Record<string, unknown>, key: string): boolean {
-  return Object.hasOwn(record, key) && record[key] !== undefined;
-}
-
-function hasConfiguredDmAllowFrom(
-  record: Record<string, unknown>,
-  mode: ChannelDmAllowFromMode,
-): boolean {
-  const dm = isRecord(record.dm) ? record.dm : null;
-  if (mode === "nestedOnly") {
-    return (
-      (dm !== null && hasDefinedConfigValue(dm, "allowFrom")) ||
-      hasDefinedConfigValue(record, "allowFrom")
-    );
-  }
-  return (
-    hasDefinedConfigValue(record, "allowFrom") ||
-    (dm !== null && hasDefinedConfigValue(dm, "allowFrom"))
-  );
-}
-
-function isConfigRecordEnabled(record: Record<string, unknown>): boolean {
-  return record.enabled !== false;
-}
-
-type ChannelDmPolicyDependencyWarningOptions = {
-  dmAllowFromModes?: ReadonlyMap<string, ChannelDmAllowFromMode>;
-};
-
-function hasChannelDmPolicyDependencyWarningCandidates(config: OpenClawConfig): boolean {
-  if (!config.channels || !isRecord(config.channels)) {
-    return false;
-  }
-  return Object.entries(config.channels).some(
-    ([channelId, channelValue]) =>
-      !DM_POLICY_PSEUDO_CHANNEL_KEYS.has(channelId) &&
-      isRecord(channelValue) &&
-      isConfigRecordEnabled(channelValue),
-  );
-}
-
-/**
- * Surface dmPolicy/allowFrom dependency problems generically for every channel that
- * exposes DM policy via the canonical top-level `dmPolicy`/`allowFrom` fields. These
- * configs parse fine but drop every DM at runtime, so we warn (rather than reject) to
- * stay consistent with `security audit`/`doctor` and avoid breaking existing-but-usable
- * configs on upgrade.
- *
- * Resolution goes through the shared DM-access helpers so the warning matches the
- * effective policy/allowFrom the runtime sees, including the legacy `dm.*` aliases and
- * account->channel inheritance. `nestedOnly` channels (canonical fields under `dm.*`)
- * are skipped because their config shape does not match this warning's top-level paths.
- */
-function collectChannelDmPolicyDependencyWarnings(
-  config: OpenClawConfig,
-  options: ChannelDmPolicyDependencyWarningOptions = {},
-): ConfigValidationIssue[] {
-  if (!config.channels || !isRecord(config.channels)) {
-    return [];
-  }
-  const warnings: ConfigValidationIssue[] = [];
-  for (const [channelId, channelValue] of Object.entries(config.channels)) {
-    if (
-      DM_POLICY_PSEUDO_CHANNEL_KEYS.has(channelId) ||
-      !isRecord(channelValue) ||
-      !isConfigRecordEnabled(channelValue)
-    ) {
-      continue;
-    }
-    const mode = options.dmAllowFromModes?.get(channelId) ?? "topOnly";
-    if (mode === "nestedOnly") {
-      continue;
-    }
-    const channelViolation = evaluateDmPolicyAllowFromDependency({
-      policy: resolveChannelDmPolicy({ account: channelValue, mode }),
-      allowFrom: resolveChannelDmAllowFrom({ account: channelValue, mode }),
-    });
-    if (channelViolation) {
-      warnings.push(buildDmPolicyDependencyWarning({ channelId, violation: channelViolation }));
-    }
-    if (!isRecord(channelValue.accounts)) {
-      continue;
-    }
-    for (const [accountId, accountValue] of Object.entries(channelValue.accounts)) {
-      if (!isRecord(accountValue) || !isConfigRecordEnabled(accountValue)) {
-        continue;
-      }
-      const allowFromSource = hasConfiguredDmAllowFrom(accountValue, mode)
-        ? "explicit"
-        : "inherited";
-      const accountViolation = evaluateDmPolicyAllowFromDependency({
-        policy: resolveChannelDmPolicy({ account: accountValue, parent: channelValue, mode }),
-        allowFrom: resolveChannelDmAllowFrom({ account: accountValue, parent: channelValue, mode }),
-      });
-      if (accountViolation) {
-        warnings.push(
-          buildDmPolicyDependencyWarning({
-            channelId,
-            accountId,
-            allowFromSource,
-            violation: accountViolation,
-          }),
-        );
-      }
-    }
-  }
-  return warnings;
-}
-
-function collectRawBundledChannelConfigIssues(config: OpenClawConfig): ConfigValidationIssue[] {
-  if (!config.channels || !isRecord(config.channels)) {
-    return [];
-  }
-  const issues: ConfigValidationIssue[] = [];
-  for (const [channelId, schema] of bundledChannelSchemaById) {
-    if (!Object.hasOwn(config.channels, channelId)) {
-      continue;
-    }
-    const result = validateJsonSchemaValue({
-      schema: schema as Record<string, unknown>,
-      cacheKey: `raw-channel:${channelId}`,
-      value: config.channels[channelId],
-      applyDefaults: false,
-    });
-    if (result.ok) {
-      continue;
-    }
-    for (const error of result.errors) {
-      const message = error.additionalProperty
-        ? `${error.message}: "${error.additionalProperty}"`
-        : error.message;
-      const pathLocal2 =
-        error.path === "<root>" ? `channels.${channelId}` : `channels.${channelId}.${error.path}`;
-      issues.push({
-        path: pathLocal2,
-        message: formatRawChannelConfigIssueMessage(message),
-        allowedValues: error.allowedValues,
-        allowedValuesHiddenCount: error.allowedValuesHiddenCount,
-      });
-    }
-  }
-  return issues;
-}
-
-function collectAllowedValuesFromCustomIssue(record: UnknownIssueRecord): AllowedValuesCollection {
-  const message = typeof record.message === "string" ? record.message : "";
-  const expectedMatch = message.match(CUSTOM_EXPECTED_ONE_OF_RE);
-  if (expectedMatch?.[1]) {
-    const values = [...expectedMatch[1].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
-    return { values, incomplete: false, hasValues: values.length > 0 };
-  }
-
-  // Custom Zod issues usually come from superRefine rules, but some normalized
-  // channel unions collapse to a generic custom issue. Use generated channel
-  // config metadata here so we can recover enum hints without touching runtime
-  // plugin registries during validation formatting.
-  return collectAllowedValuesFromBundledChannelSchemaPath(toConfigPathSegments(record.path));
-}
-
-function appendNumericBoundHint(message: string, record: UnknownIssueRecord): string {
-  const origin = typeof record.origin === "string" ? record.origin : "";
-  if (origin !== "number") {
-    return message;
-  }
-  const inclusive = record.inclusive === true;
-  if (record.code === "too_big") {
-    const maximum = typeof record.maximum === "number" ? record.maximum : undefined;
-    if (maximum !== undefined) {
-      return inclusive
-        ? `${message} (maximum: ${maximum})`
-        : `${message} (must be less than ${maximum})`;
-    }
-  }
-  if (record.code === "too_small") {
-    const minimum = typeof record.minimum === "number" ? record.minimum : undefined;
-    if (minimum !== undefined) {
-      return inclusive
-        ? `${message} (minimum: ${minimum})`
-        : `${message} (must be greater than ${minimum})`;
-    }
-  }
-  return message;
-}
-
-function collectAllowedValuesFromIssue(issue: unknown): AllowedValuesCollection {
-  const record = toIssueRecord(issue);
-  if (!record) {
-    return { values: [], incomplete: false, hasValues: false };
-  }
-  const code = typeof record.code === "string" ? record.code : "";
-
-  if (code === "invalid_value") {
-    const values = record.values;
-    if (!Array.isArray(values)) {
-      return { values: [], incomplete: true, hasValues: false };
-    }
-    return { values, incomplete: false, hasValues: values.length > 0 };
-  }
-
-  if (code === "invalid_type") {
-    const expected = typeof record.expected === "string" ? record.expected : "";
-    if (expected === "boolean") {
-      return { values: [true, false], incomplete: false, hasValues: true };
-    }
-    return { values: [], incomplete: true, hasValues: false };
-  }
-
-  if (code === "custom") {
-    return collectAllowedValuesFromCustomIssue(record);
-  }
-
-  if (code !== "invalid_union") {
-    return { values: [], incomplete: false, hasValues: false };
-  }
-
-  const nested = record.errors;
-  if (!Array.isArray(nested) || nested.length === 0) {
-    return { values: [], incomplete: true, hasValues: false };
-  }
-
-  const collected: unknown[] = [];
-  for (const branch of nested) {
-    if (!Array.isArray(branch) || branch.length === 0) {
-      return { values: [], incomplete: true, hasValues: false };
-    }
-    const branchCollected = collectAllowedValuesFromIssueList(branch);
-    if (branchCollected.incomplete || !branchCollected.hasValues) {
-      return { values: [], incomplete: true, hasValues: false };
-    }
-    collected.push(...branchCollected.values);
-  }
-
-  return { values: collected, incomplete: false, hasValues: collected.length > 0 };
-}
-
-function collectAllowedValuesFromIssueList(
-  issues: ReadonlyArray<unknown>,
-): AllowedValuesCollection {
-  const collected: unknown[] = [];
-  let hasValues = false;
-  for (const issue of issues) {
-    const branch = collectAllowedValuesFromIssue(issue);
-    if (branch.incomplete) {
-      return { values: [], incomplete: true, hasValues: false };
-    }
-    if (!branch.hasValues) {
-      continue;
-    }
-    hasValues = true;
-    collected.push(...branch.values);
-  }
-  return { values: collected, incomplete: false, hasValues };
-}
-
-function collectAllowedValuesFromUnknownIssue(issue: unknown): unknown[] {
-  const collection = collectAllowedValuesFromIssue(issue);
-  if (collection.incomplete || !collection.hasValues) {
-    return [];
-  }
-  return collection.values;
-}
-
-function isBindingsIssuePath(pathSegments: readonly ConfigPathSegment[]): boolean {
-  return pathSegments[0] === "bindings" && typeof pathSegments[1] === "number";
-}
-
-function isRouteTypeMismatchIssue(issue: UnknownIssueRecord): boolean {
-  const issuePath = toConfigPathSegments(issue.path);
-  if (issuePath.length !== 1 || issuePath[0] !== "type") {
-    return false;
-  }
-  if (issue.code !== "invalid_value" || !Array.isArray(issue.values)) {
-    return false;
-  }
-  return issue.values.includes("route");
-}
-
-function extractBindingsSpecificUnionIssue(
-  record: UnknownIssueRecord,
-  parentPathSegments: readonly ConfigPathSegment[],
-): ConfigValidationIssue | null {
-  if (!isBindingsIssuePath(toConfigPathSegments(record.path)) || !Array.isArray(record.errors)) {
-    return null;
-  }
-
-  let matchingBranchIssue: UnknownIssueRecord | null = null;
-  let matchingBranchIsUnrecognized = false;
-  let matchingBranchPathLen = -1;
-  let sawRouteTypeMismatch = false;
-
-  for (const errGroup of record.errors) {
-    if (!Array.isArray(errGroup)) {
-      continue;
-    }
-
-    const branch = errGroup
-      .map((issue) => toIssueRecord(issue))
-      .filter(Boolean) as UnknownIssueRecord[];
-    if (branch.length === 0) {
-      continue;
-    }
-
-    if (branch.some((issue) => isRouteTypeMismatchIssue(issue))) {
-      sawRouteTypeMismatch = true;
-      continue;
-    }
-
-    let branchBestIssue: UnknownIssueRecord | null = null;
-    let branchBestIsUnrecognized = false;
-    let branchBestPathLen = -1;
-
-    for (const issue of branch) {
-      const issueCode = typeof issue.code === "string" ? issue.code : "";
-      const issuePathLen = toConfigPathSegments(issue.path).length;
-      const issueIsUnrecognized = issueCode === "unrecognized_keys";
-      const issueIsBetter =
-        issuePathLen > branchBestPathLen
-          ? true
-          : issuePathLen === branchBestPathLen && issueIsUnrecognized && !branchBestIsUnrecognized;
-
-      if (issueIsBetter) {
-        branchBestIssue = issue;
-        branchBestIsUnrecognized = issueIsUnrecognized;
-        branchBestPathLen = issuePathLen;
-      }
-    }
-
-    if (!branchBestIssue) {
-      continue;
-    }
-
-    if (matchingBranchIssue) {
-      return null;
-    }
-
-    matchingBranchIssue = branchBestIssue;
-    matchingBranchIsUnrecognized = branchBestIsUnrecognized;
-    matchingBranchPathLen = branchBestPathLen;
-  }
-
-  if (!sawRouteTypeMismatch || !matchingBranchIssue) {
-    return null;
-  }
-
-  if (matchingBranchPathLen === 0 && !matchingBranchIsUnrecognized) {
-    return null;
-  }
-
-  const fullPathSegments = [
-    ...parentPathSegments,
-    ...toConfigPathSegments(matchingBranchIssue.path),
-  ];
-  const subMessage =
-    typeof matchingBranchIssue.message === "string" ? matchingBranchIssue.message : "Invalid input";
-  return withConfigIssuePath(
-    { path: formatConfigPath(fullPathSegments), message: subMessage },
-    fullPathSegments,
-  );
-}
-
-function isObjectSecretRefCandidate(value: unknown): boolean {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  return coerceSecretRef(value) !== null;
-}
-
-function formatUnsupportedMutableSecretRefMessage(pathInner: string): string {
-  return [
-    `SecretRef objects are not supported at ${pathInner}.`,
-    "This credential is runtime-mutable or runtime-managed and must stay a plain string value.",
-    'Use a plain string (env template strings like "${MY_VAR}" are allowed).',
-    `See ${SECRETREF_POLICY_DOC_URL}.`,
-  ].join(" ");
-}
-
-function pushUnsupportedMutableSecretRefIssue(
-  issues: ConfigValidationIssue[],
-  pathScoped: string,
-  value: unknown,
-): void {
-  if (!isObjectSecretRefCandidate(value)) {
-    return;
-  }
-  issues.push({
-    path: pathScoped,
-    message: formatUnsupportedMutableSecretRefMessage(pathScoped),
-  });
-}
-
-function collectUnsupportedMutableSecretRefIssues(raw: unknown): ConfigValidationIssue[] {
-  const issues: ConfigValidationIssue[] = [];
-  for (const candidate of unsupportedSecretRefSurfacePolicy.collectConfigCandidates(raw)) {
-    pushUnsupportedMutableSecretRefIssue(issues, candidate.path, candidate.value);
-  }
-
-  return issues;
-}
-
-function formatFilteredUnrecognizedKeyMessage(message: string, keys: string[]): string {
-  const quotedKeys = keys.map((key) => `"${key}"`).join(", ");
-  if (/must not have additional properties/i.test(message)) {
-    return `must not have additional properties: ${quotedKeys}`;
-  }
-  return keys.length === 1 ? `Unrecognized key: ${quotedKeys}` : `Unrecognized keys: ${quotedKeys}`;
-}
-
-function filterUnsupportedMutableSecretRefSchemaIssue(params: {
-  issue: ConfigValidationIssue;
-  policyIssue: ConfigValidationIssue;
-}): ConfigValidationIssue | null {
-  const { issue, policyIssue } = params;
-  if (issue.path === policyIssue.path) {
-    return /expected string, received object/i.test(issue.message) ? null : issue;
-  }
-
-  if (!issue.path || !policyIssue.path || !policyIssue.path.startsWith(`${issue.path}.`)) {
-    return issue;
-  }
-
-  const remainder = policyIssue.path.slice(issue.path.length + 1);
-  const childKey = remainder.split(".")[0];
-  if (!childKey) {
-    return issue;
-  }
-
-  if (!/Unrecognized key|must not have additional properties/i.test(issue.message)) {
-    return issue;
-  }
-  const unrecognizedKeys = [...issue.message.matchAll(/"([^"]+)"/g)].map((match) => match[1]);
-  if (unrecognizedKeys.length === 0) {
-    return issue;
-  }
-  if (!unrecognizedKeys.includes(childKey)) {
-    return issue;
-  }
-  const remainingKeys = unrecognizedKeys.filter(
-    (key): key is string => key !== undefined && key !== childKey,
-  );
-  if (remainingKeys.length === 0) {
-    return null;
-  }
-  return {
-    ...issue,
-    message: formatFilteredUnrecognizedKeyMessage(issue.message, remainingKeys),
-  };
-}
-
-function mergeUnsupportedMutableSecretRefIssues(
-  policyIssues: ConfigValidationIssue[],
-  schemaIssues: ConfigValidationIssue[],
-): ConfigValidationIssue[] {
-  if (policyIssues.length === 0) {
-    return schemaIssues;
-  }
-  const filteredSchemaIssues = schemaIssues.flatMap((issue) => {
-    let filteredIssue: ConfigValidationIssue | null = issue;
-    for (const policyIssue of policyIssues) {
-      if (!filteredIssue) {
-        return [];
-      }
-      filteredIssue = filterUnsupportedMutableSecretRefSchemaIssue({
-        issue: filteredIssue,
-        policyIssue,
-      });
-    }
-    return filteredIssue ? [filteredIssue] : [];
-  });
-  return [...policyIssues, ...filteredSchemaIssues];
-}
-
-export function collectUnsupportedSecretRefPolicyIssues(raw: unknown): ConfigValidationIssue[] {
-  return collectUnsupportedMutableSecretRefIssues(raw);
-}
-
-function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
-  const record = toIssueRecord(issue);
-  const pathSegments = toConfigPathSegments(record?.path);
-  const pathItem = formatConfigPath(pathSegments);
-  const message = typeof record?.message === "string" ? record.message : "Invalid input";
-
-  // Numeric ceiling/floor hints (too_big / too_small with numeric origin).
-  // Append a parenthesized bound alongside Zod's native message,
-  // matching the clarity that enum/union rejections get via (allowed: …).
-  const enrichedMessage = record ? appendNumericBoundHint(message, record) : message;
-
-  const allowedValuesSummary = summarizeAllowedValues(collectAllowedValuesFromUnknownIssue(issue));
-
-  // Bindings use a plain union because legacy route bindings may omit `type`.
-  // When an explicit ACP binding fails strict-object checks, Zod collapses the
-  // useful ACP branch issue behind a generic union-level "Invalid input".
-  if (
-    record &&
-    typeof record.code === "string" &&
-    record.code === "invalid_union" &&
-    !allowedValuesSummary
-  ) {
-    const betterIssue = extractBindingsSpecificUnionIssue(record, pathSegments);
-    if (betterIssue) {
-      return betterIssue;
-    }
-  }
-
-  if (!allowedValuesSummary) {
-    return withConfigIssuePath({ path: pathItem, message: enrichedMessage }, pathSegments);
-  }
-
-  return withConfigIssuePath(
-    {
-      path: pathItem,
-      message: appendAllowedValuesHint(enrichedMessage, allowedValuesSummary),
-      allowedValues: allowedValuesSummary.values,
-      allowedValuesHiddenCount: allowedValuesSummary.hiddenCount,
-    },
-    pathSegments,
-  );
-}
-
-function collectExplicitPluginReferences(raw: unknown): ExplicitPluginReferences {
-  const references: ExplicitPluginReferences = {
-    entries: new Set(),
-    allow: new Set(),
-    deny: new Set(),
-    slots: new Map(),
-  };
-  if (!isRecord(raw) || !isRecord(raw.plugins)) {
-    return references;
-  }
-  const { plugins } = raw;
-  if (isRecord(plugins.entries)) {
-    for (const pluginId of Object.keys(plugins.entries)) {
-      const normalized = normalizePluginId(pluginId);
-      if (normalized) {
-        references.entries.add(normalized);
-      }
-    }
-  }
-  for (const [key, target] of [
-    ["allow", references.allow],
-    ["deny", references.deny],
-  ] as const) {
-    const value = plugins[key];
-    if (!Array.isArray(value)) {
-      continue;
-    }
-    for (const entry of value) {
-      if (typeof entry !== "string") {
-        continue;
-      }
-      const normalized = normalizePluginId(entry);
-      if (normalized) {
-        target.add(normalized);
-      }
-    }
-  }
-  if (isRecord(plugins.slots)) {
-    for (const [slotId, pluginId] of Object.entries(plugins.slots)) {
-      if (typeof pluginId !== "string") {
-        continue;
-      }
-      const normalized = normalizePluginId(pluginId);
-      if (normalized && normalized !== "none") {
-        references.slots.set(normalized, slotId);
-      }
-    }
-  }
-  return references;
-}
-
-function resolveExplicitPluginReferencePath(
-  references: ExplicitPluginReferences,
-  pluginId: string,
-): string | undefined {
-  const normalized = normalizePluginId(pluginId);
-  if (!normalized) {
-    return undefined;
-  }
-  if (references.entries.has(normalized)) {
-    return `plugins.entries.${normalized}`;
-  }
-  if (references.allow.has(normalized)) {
-    return "plugins.allow";
-  }
-  if (references.deny.has(normalized)) {
-    return "plugins.deny";
-  }
-  const slotId = references.slots.get(normalized);
-  if (slotId) {
-    return `plugins.slots.${slotId}`;
-  }
-  return undefined;
-}
-function isWorkspaceAvatarPath(value: string, workspaceDir: string): boolean {
-  const workspaceRoot = path.resolve(workspaceDir);
-  const resolved = path.resolve(workspaceRoot, value);
-  return isPathWithinRoot(workspaceRoot, resolved);
-}
-
-function createIdentityAvatarIssue(
-  source: ReturnType<typeof listAgentEntriesWithSource>[number]["source"],
-  message: string,
-): ConfigValidationIssue {
-  const pathSegments =
-    source.kind === "entries"
-      ? (["agents", "entries", source.key, "identity", "avatar"] as const)
-      : (["agents", "list", source.index, "identity", "avatar"] as const);
-  return withConfigIssuePath({ path: formatConfigPath(pathSegments), message }, pathSegments);
-}
-
-function validateIdentityAvatar(
-  config: OpenClawConfig,
-  env?: NodeJS.ProcessEnv,
-): ConfigValidationIssue[] {
-  const agents = listAgentEntriesWithSource(config);
-  if (agents.length === 0) {
-    return [];
-  }
-  const issues: ConfigValidationIssue[] = [];
-  for (const { entry, source } of agents) {
-    const avatarRaw = entry.identity?.avatar;
-    if (typeof avatarRaw !== "string") {
-      continue;
-    }
-    const avatar = avatarRaw.trim();
-    if (!avatar) {
-      continue;
-    }
-    if (isAvatarDataUrl(avatar) || isAvatarHttpUrl(avatar)) {
-      continue;
-    }
-    if (avatar.startsWith("~")) {
-      issues.push(
-        createIdentityAvatarIssue(
-          source,
-          "identity.avatar must be a workspace-relative path, http(s) URL, or data URI.",
-        ),
-      );
-      continue;
-    }
-    const hasScheme = hasAvatarUriScheme(avatar);
-    if (hasScheme && !isWindowsAbsolutePath(avatar)) {
-      issues.push(
-        createIdentityAvatarIssue(
-          source,
-          "identity.avatar must be a workspace-relative path, http(s) URL, or data URI.",
-        ),
-      );
-      continue;
-    }
-    const workspaceDir = resolveAgentWorkspaceDir(
-      config,
-      entry.id ?? resolveDefaultAgentId(config),
-      env,
-    );
-    if (!isWorkspaceAvatarPath(avatar, workspaceDir)) {
-      issues.push(
-        createIdentityAvatarIssue(source, "identity.avatar must stay within the agent workspace."),
-      );
-    }
-  }
-  return issues;
-}
-
-function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationIssue[] {
-  const tailscaleMode = config.gateway?.tailscale?.mode ?? "off";
-  if (tailscaleMode !== "serve" && tailscaleMode !== "funnel") {
-    return [];
-  }
-  const bindMode = config.gateway?.bind ?? "loopback";
-  if (bindMode === "loopback") {
-    return [];
-  }
-  const customBindHost = config.gateway?.customBindHost;
-  if (
-    bindMode === "custom" &&
-    isCanonicalDottedDecimalIPv4(customBindHost) &&
-    isLoopbackIpAddress(customBindHost)
-  ) {
-    return [];
-  }
-  return [
-    {
-      path: "gateway.bind",
-      message:
-        `gateway.bind must resolve to loopback when gateway.tailscale.mode=${tailscaleMode} ` +
-        '(use gateway.bind="loopback" or gateway.bind="custom" with gateway.customBindHost="127.0.0.1")',
-    },
-  ];
-}
-
-function validateGatewayTailscaleAuth(config: OpenClawConfig): ConfigValidationIssue[] {
-  const tailscaleMode = config.gateway?.tailscale?.mode ?? "off";
-  if (!isUnsafeGatewayTailscaleNoAuth({ authMode: config.gateway?.auth?.mode, tailscaleMode })) {
-    return [];
-  }
-  return [
-    {
-      path: "gateway.auth.mode",
-      message: formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode),
-    },
-  ];
-}
-
-function collectModelPolicyAllowIssues(config: OpenClawConfig): ConfigValidationIssue[] {
-  const issues: ConfigValidationIssue[] = [];
-  const defaultModels = config.agents?.defaults?.models;
-  const collectAliases = (...modelMaps: Array<typeof defaultModels | undefined>): Set<string> => {
-    const aliases = new Set<string>();
-    for (const models of modelMaps) {
-      for (const entry of Object.values(models ?? {})) {
-        const alias = normalizeLowercaseStringOrEmpty(entry?.alias);
-        if (alias) {
-          aliases.add(alias);
-        }
-      }
-    }
-    return aliases;
-  };
-  const validateRefs = (
-    refs: readonly string[] | undefined,
-    configPath: string,
-    aliases: Set<string>,
-  ) => {
-    for (const [index, raw] of (refs ?? []).entries()) {
-      const trimmed = raw.trim();
-      if (
-        aliases.has(normalizeLowercaseStringOrEmpty(trimmed)) ||
-        isModelPolicyCompatSelector(trimmed) ||
-        isValidExactModelPolicyRef(trimmed) ||
-        parseModelPolicyWildcardRef(trimmed)
-      ) {
-        continue;
-      }
-      issues.push({
-        path: `${configPath}.${index}`,
-        message:
-          `invalid model policy ref: ${sanitizeForLog(JSON.stringify(raw))}. ` +
-          'Use a configured alias, an exact "provider/model" ref, or a trailing prefix wildcard such as "provider/*" or "provider/namespace/*".',
-      });
-    }
-  };
-
-  const defaultAliases = collectAliases(defaultModels);
-  validateRefs(
-    config.agents?.defaults?.modelPolicy?.allow,
-    "agents.defaults.modelPolicy.allow",
-    defaultAliases,
-  );
-  for (const { entry: agent, source } of listAgentEntriesWithSource(config)) {
-    const pathPrefix =
-      source.kind === "entries" ? `agents.entries.${source.key}` : `agents.list.${source.index}`;
-    validateRefs(
-      agent.modelPolicy?.allow,
-      `${pathPrefix}.modelPolicy.allow`,
-      collectAliases(defaultModels, agent.models),
-    );
-  }
-  return issues;
-}
-
-/**
- * Validates config without applying runtime defaults.
- * Use this when you need the raw validated config (e.g., for writing back to file).
- */
-export function validateConfigObjectRaw(
-  raw: unknown,
-  opts?: {
-    sourceRaw?: unknown;
-    touchedPaths?: ReadonlyArray<ReadonlyArray<string>>;
-    validateBundledChannels?: boolean;
-    preservedLegacyRootKeys?: readonly string[];
-    env?: NodeJS.ProcessEnv;
-  },
-): { ok: true; config: OpenClawConfig } | { ok: false; issues: ConfigValidationIssue[] } {
-  const normalizedRaw = stripPreservedLegacyRootKeysForValidation(
-    raw,
-    opts?.preservedLegacyRootKeys,
-  );
-  const policyIssues = collectUnsupportedSecretRefPolicyIssues(normalizedRaw);
-  const validated = OpenClawSchema.safeParse(normalizedRaw);
-  if (!validated.success) {
-    const schemaIssues = validated.error.issues.map((issue) => mapZodIssueToConfigIssue(issue));
-    return {
-      ok: false,
-      issues: mergeUnsupportedMutableSecretRefIssues(policyIssues, schemaIssues),
-    };
-  }
-  const validatedConfig = attachAgentListProjection(
-    materializeBundledModelProviderOverlays(validated.data as OpenClawConfig),
-  );
-  const channelIssues =
-    policyIssues.length > 0 || opts?.validateBundledChannels
-      ? collectRawBundledChannelConfigIssues(validatedConfig)
-      : [];
-  if (channelIssues.length > 0) {
-    return {
-      ok: false,
-      issues: mergeUnsupportedMutableSecretRefIssues(policyIssues, channelIssues),
-    };
-  }
-  if (policyIssues.length > 0) {
-    return { ok: false, issues: policyIssues };
-  }
-  const duplicates = findDuplicateAgentDirs(validatedConfig);
-  if (duplicates.length > 0) {
-    return {
-      ok: false,
-      issues: [
-        {
-          path: "agents.entries",
-          message: formatDuplicateAgentDirError(duplicates),
-        },
-      ],
-    };
-  }
-  const avatarIssues = validateIdentityAvatar(validatedConfig, opts?.env);
-  if (avatarIssues.length > 0) {
-    return { ok: false, issues: avatarIssues };
-  }
-  const gatewayTailscaleBindIssues = validateGatewayTailscaleBind(validatedConfig);
-  if (gatewayTailscaleBindIssues.length > 0) {
-    return { ok: false, issues: gatewayTailscaleBindIssues };
-  }
-  const gatewayTailscaleAuthIssues = validateGatewayTailscaleAuth(validatedConfig);
-  if (gatewayTailscaleAuthIssues.length > 0) {
-    return { ok: false, issues: gatewayTailscaleAuthIssues };
-  }
-  const modelPolicyAllowIssues = collectModelPolicyAllowIssues(validatedConfig);
-  if (modelPolicyAllowIssues.length > 0) {
-    return { ok: false, issues: modelPolicyAllowIssues };
-  }
-  return {
-    ok: true,
-    config: validatedConfig,
-  };
-}
-
-export function validateConfigObject(
-  raw: unknown,
-  opts?: {
-    manifestRegistry?: Pick<PluginMetadataSnapshot, "manifestRegistry">["manifestRegistry"];
-    sourceRaw?: unknown;
-  },
-): { ok: true; config: OpenClawConfig } | { ok: false; issues: ConfigValidationIssue[] } {
-  const result = validateConfigObjectRaw(migratePersistedImplicitMainRoster(raw).config, opts);
-  if (!result.ok) {
-    return result;
-  }
-  return {
-    ok: true,
-    config: attachAgentListProjection(
-      materializeRuntimeConfig(result.config, "snapshot", {
-        manifestRegistry: opts?.manifestRegistry,
-      }),
-    ),
-  };
-}
-
-function attachAgentListProjection(config: OpenClawConfig): OpenClawConfig {
-  if (!config.agents) {
-    return config;
-  }
-  Object.defineProperty(config.agents, "list", {
-    configurable: true,
-    enumerable: false,
-    value: listAgentEntries(config),
-    writable: false,
-  });
-  return config;
-}
+  collectExplicitPluginReferences,
+  resolveExplicitPluginReferencePath,
+  validateExplicitPluginConfig,
+} from "./validation-plugin-config.js";
+
+export { validateConfigObject, validateConfigObjectRaw } from "./validation-core.js";
+export { collectUnsupportedSecretRefPolicyIssues } from "./validation-issues.js";
 
 type ValidateConfigWithPluginsResult =
-  | {
-      ok: true;
-      config: OpenClawConfig;
-      warnings: ConfigValidationIssue[];
-    }
-  | {
-      ok: false;
-      issues: ConfigValidationIssue[];
-      warnings: ConfigValidationIssue[];
-    };
+  | { ok: true; config: OpenClawConfig; warnings: ConfigValidationIssue[] }
+  | { ok: false; issues: ConfigValidationIssue[]; warnings: ConfigValidationIssue[] };
 
 type ValidateConfigWithPluginsParams = {
   env?: NodeJS.ProcessEnv;
@@ -1254,6 +57,15 @@ type ValidateConfigWithPluginsParams = {
   ) => Pick<PluginMetadataSnapshot, "manifestRegistry">;
   sourceRaw?: unknown;
   preservedLegacyRootKeys?: readonly string[];
+};
+
+type RegistryInfo = {
+  registry: PluginManifestRegistry;
+  knownIds?: Set<string>;
+  overriddenPluginIds?: Set<string>;
+  normalizedPlugins?: ReturnType<typeof normalizePluginsConfig>;
+  channelDmAllowFromModes?: Map<string, ChannelDmAllowFromMode>;
+  channelSchemas?: Map<string, { schema?: Record<string, unknown>; pluginId?: string }>;
 };
 
 export function validateConfigObjectWithPlugins(
@@ -1316,11 +128,7 @@ function validateConfigObjectWithPluginsBase(
       })
     : base.config;
   if (opts.pluginValidation === "skip") {
-    return {
-      ok: true,
-      config,
-      warnings: [],
-    };
+    return { ok: true, config, warnings: [] };
   }
 
   const issues: ConfigValidationIssue[] = [];
@@ -1328,35 +136,11 @@ function validateConfigObjectWithPluginsBase(
   const hasExplicitPluginsConfig = isRecord(raw) && Object.hasOwn(raw, "plugins");
   const explicitPluginReferences = collectExplicitPluginReferences(raw);
 
-  const resolvePluginConfigIssuePath = (pluginId: string, errorPath: string): string => {
-    const baseLocal = `plugins.entries.${pluginId}.config`;
-    if (!errorPath || errorPath === "<root>") {
-      return baseLocal;
-    }
-    return `${baseLocal}.${errorPath}`;
-  };
-
   const formatChannelConfigIssueMessage = (message: string, pluginId?: string): string => {
     const safePluginId = pluginId ? sanitizeForLog(pluginId).trim() : "";
-    if (safePluginId) {
-      return `invalid config for plugin ${safePluginId}: ${message}`;
-    }
-    return formatRawChannelConfigIssueMessage(message);
-  };
-
-  type RegistryInfo = {
-    registry: PluginManifestRegistry;
-    knownIds?: Set<string>;
-    overriddenPluginIds?: Set<string>;
-    normalizedPlugins?: ReturnType<typeof normalizePluginsConfig>;
-    channelDmAllowFromModes?: Map<string, ChannelDmAllowFromMode>;
-    channelSchemas?: Map<
-      string,
-      {
-        schema?: Record<string, unknown>;
-        pluginId?: string;
-      }
-    >;
+    return safePluginId
+      ? `invalid config for plugin ${safePluginId}: ${message}`
+      : formatRawChannelConfigIssueMessage(message);
   };
 
   let compatConfig: OpenClawConfig | null | undefined;
@@ -1373,16 +157,16 @@ function validateConfigObjectWithPluginsBase(
       const explicitPath = diag.pluginId
         ? resolveExplicitPluginReferencePath(explicitPluginReferences, diag.pluginId)
         : undefined;
-      let pathCandidate = explicitPath ?? (diag.pluginId ? "plugins" : "plugins");
+      let issuePath = explicitPath ?? "plugins";
       if (!diag.pluginId && diag.message.includes("plugin path not found")) {
-        pathCandidate = "plugins.load.paths";
+        issuePath = "plugins.load.paths";
       }
       const pluginLabel = diag.pluginId ? `plugin ${diag.pluginId}` : "plugin";
-      const message = `${pluginLabel}: ${diag.message}`;
+      const issue = { path: issuePath, message: `${pluginLabel}: ${diag.message}` };
       if (diag.level === "error" && (explicitPath || !diag.pluginId)) {
-        issues.push({ path: pathCandidate, message });
+        issues.push(issue);
       } else {
-        warnings.push({ path: pathCandidate, message });
+        warnings.push(issue);
       }
     }
   };
@@ -1440,7 +224,6 @@ function validateConfigObjectWithPluginsBase(
     if (compatConfig !== undefined) {
       return compatConfig ?? config;
     }
-
     compatConfig = config;
     return config;
   };
@@ -1454,41 +237,30 @@ function validateConfigObjectWithPluginsBase(
 
   const ensureKnownIds = (): Set<string> => {
     const info = ensureRegistry();
-    if (!info.knownIds) {
-      info.knownIds = new Set(info.registry.plugins.map((record) => record.id));
-    }
+    info.knownIds ??= new Set(info.registry.plugins.map((record) => record.id));
     return info.knownIds;
   };
 
   const ensureOverriddenPluginIds = (): Set<string> => {
     const info = ensureRegistry();
-    if (!info.overriddenPluginIds) {
-      info.overriddenPluginIds = new Set(
-        info.registry.diagnostics
-          .filter((diag) => diag.message.includes("duplicate plugin id detected"))
-          .map((diag) => diag.pluginId)
-          .filter(
-            (pluginId): pluginId is string => typeof pluginId === "string" && pluginId !== "",
-          ),
-      );
-    }
+    info.overriddenPluginIds ??= new Set(
+      info.registry.diagnostics
+        .filter((diag) => diag.message.includes("duplicate plugin id detected"))
+        .map((diag) => diag.pluginId)
+        .filter((pluginId): pluginId is string => typeof pluginId === "string" && pluginId !== ""),
+    );
     return info.overriddenPluginIds;
   };
 
   const ensureNormalizedPlugins = (): ReturnType<typeof normalizePluginsConfig> => {
     const info = ensureRegistry();
-    if (!info.normalizedPlugins) {
-      info.normalizedPlugins = normalizePluginsConfig(ensureCompatConfig().plugins);
-    }
+    info.normalizedPlugins ??= normalizePluginsConfig(ensureCompatConfig().plugins);
     return info.normalizedPlugins;
   };
 
   const ensureChannelSchemas = (): Map<
     string,
-    {
-      schema?: Record<string, unknown>;
-      pluginId?: string;
-    }
+    { schema?: Record<string, unknown>; pluginId?: string }
   > => {
     const info = ensureRegistry();
     if (!info.channelSchemas) {
@@ -1504,9 +276,7 @@ function validateConfigObjectWithPluginsBase(
             schema: entry.configSchema,
             pluginId: entry.schemaPluginOrigin === "bundled" ? undefined : entry.schemaPluginId,
           });
-          continue;
-        }
-        if (!current) {
+        } else if (!current) {
           info.channelSchemas.set(entry.id, {});
         }
       }
@@ -1516,13 +286,11 @@ function validateConfigObjectWithPluginsBase(
 
   const ensureChannelDmAllowFromModes = (): ReadonlyMap<string, ChannelDmAllowFromMode> => {
     const info = ensureLoadedRegistryInfo();
-    if (!info.channelDmAllowFromModes) {
-      info.channelDmAllowFromModes = new Map(
-        collectChannelDmPolicyMetadata(info.registry).flatMap((entry) =>
-          entry.dmAllowFromMode ? [[entry.id, entry.dmAllowFromMode] as const] : [],
-        ),
-      );
-    }
+    info.channelDmAllowFromModes ??= new Map(
+      collectChannelDmPolicyMetadata(info.registry).flatMap((entry) =>
+        entry.dmAllowFromMode ? [[entry.id, entry.dmAllowFromMode] as const] : [],
+      ),
+    );
     return info.channelDmAllowFromModes;
   };
 
@@ -1564,29 +332,13 @@ function validateConfigObjectWithPluginsBase(
       return false;
     }
     const pluginConfig = config.plugins;
-    if (
-      Array.isArray(pluginConfig?.allow) &&
-      pluginConfig.allow.some((pluginId) => normalizePluginId(pluginId) === normalizedChannelId)
-    ) {
-      return true;
-    }
-    if (
-      isRecord(pluginConfig?.entries) &&
-      Object.keys(pluginConfig.entries).some(
-        (pluginId) => normalizePluginId(pluginId) === normalizedChannelId,
-      )
-    ) {
-      return true;
-    }
-    if (
-      isRecord(pluginConfig?.installs) &&
-      Object.keys(pluginConfig.installs).some(
-        (pluginId) => normalizePluginId(pluginId) === normalizedChannelId,
-      )
-    ) {
-      return true;
-    }
-    return ensureInstalledPluginRecordIds().has(normalizedChannelId);
+    const matches = (pluginId: string) => normalizePluginId(pluginId) === normalizedChannelId;
+    return (
+      (Array.isArray(pluginConfig?.allow) && pluginConfig.allow.some(matches)) ||
+      (isRecord(pluginConfig?.entries) && Object.keys(pluginConfig.entries).some(matches)) ||
+      (isRecord(pluginConfig?.installs) && Object.keys(pluginConfig.installs).some(matches)) ||
+      ensureInstalledPluginRecordIds().has(normalizedChannelId)
+    );
   };
 
   const collectActiveWebSearchProviderIds = (): string[] => {
@@ -1616,47 +368,32 @@ function validateConfigObjectWithPluginsBase(
     ...pluginOrProviderIds: readonly string[]
   ): boolean => {
     const candidateIds = new Set(
-      pluginOrProviderIds.map((id) => normalizePluginId(id)).filter((id) => id.length > 0),
+      pluginOrProviderIds.map(normalizePluginId).filter((id) => id.length > 0),
     );
     if (candidateIds.size === 0) {
       return false;
     }
     const matches = (pluginId: string) => candidateIds.has(normalizePluginId(pluginId));
     const pluginConfig = config.plugins;
-    if (Array.isArray(pluginConfig?.allow) && pluginConfig.allow.some(matches)) {
+    if (
+      (Array.isArray(pluginConfig?.allow) && pluginConfig.allow.some(matches)) ||
+      (isRecord(pluginConfig?.entries) && Object.keys(pluginConfig.entries).some(matches)) ||
+      (isRecord(pluginConfig?.installs) && Object.keys(pluginConfig.installs).some(matches))
+    ) {
       return true;
     }
-    if (isRecord(pluginConfig?.entries) && Object.keys(pluginConfig.entries).some(matches)) {
-      return true;
-    }
-    if (isRecord(pluginConfig?.installs) && Object.keys(pluginConfig.installs).some(matches)) {
-      return true;
-    }
-    for (const pluginId of candidateIds) {
-      if (ensureInstalledPluginRecordIds().has(pluginId)) {
-        return true;
-      }
-    }
-    return false;
+    return [...candidateIds].some((pluginId) => ensureInstalledPluginRecordIds().has(pluginId));
   };
 
-  const hasStalePluginEvidenceForUnknownWebSearchProvider = (providerId: string): boolean => {
-    const normalizedProviderId = normalizePluginId(providerId);
-    if (!normalizedProviderId || ensureKnownIds().has(normalizedProviderId)) {
-      return false;
-    }
-    return hasPluginEvidenceForWebSearchProvider(providerId);
-  };
-
-  const validateWebSearchProvider = () => {
+  const validateWebSearchProvider = (): void => {
     const provider = config.tools?.web?.search?.provider;
     if (typeof provider !== "string") {
       return;
     }
     const trimmed = provider.trim();
-    const pathEntry = "tools.web.search.provider";
+    const issuePath = "tools.web.search.provider";
     if (!trimmed) {
-      issues.push({ path: pathEntry, message: "web_search provider must not be empty" });
+      issues.push({ path: issuePath, message: "web_search provider must not be empty" });
       return;
     }
     const activeProviderIds = collectActiveWebSearchProviderIds();
@@ -1668,7 +405,7 @@ function validateConfigObjectWithPluginsBase(
     );
     if (installCatalogEntry) {
       const issue = {
-        path: pathEntry,
+        path: issuePath,
         message: `web_search provider is not available: ${trimmed} (install or enable plugin "${installCatalogEntry.pluginId}", then run openclaw doctor --fix)`,
         allowedValues: collectKnownWebSearchProviderIds(),
       };
@@ -1677,9 +414,9 @@ function validateConfigObjectWithPluginsBase(
           ...issue,
           message: `web_search provider is not available: ${trimmed} (configured plugin "${installCatalogEntry.pluginId}" is unavailable; Gateway will ignore this optional provider until the plugin is installed/enabled or openclaw doctor --fix repairs the config)`,
         });
-        return;
+      } else {
+        issues.push(issue);
       }
-      issues.push(issue);
       return;
     }
     const allowedValues = collectKnownWebSearchProviderIds();
@@ -1687,31 +424,27 @@ function validateConfigObjectWithPluginsBase(
       return;
     }
     const issue = {
-      path: pathEntry,
+      path: issuePath,
       message: `unknown web_search provider: ${trimmed}`,
       allowedValues,
     };
-    if (hasStalePluginEvidenceForUnknownWebSearchProvider(trimmed)) {
+    const normalizedProviderId = normalizePluginId(trimmed);
+    const hasStaleEvidence = Boolean(
+      normalizedProviderId &&
+      !ensureKnownIds().has(normalizedProviderId) &&
+      hasPluginEvidenceForWebSearchProvider(trimmed),
+    );
+    if (hasStaleEvidence) {
       warnings.push({
         ...issue,
         message: `${issue.message} (stale web search plugin config ignored; run openclaw doctor --fix to remove stale config, or install the plugin)`,
       });
-      return;
+    } else {
+      issues.push(issue);
     }
-    issues.push(issue);
   };
 
-  const parseProviderModelRef = (value: string): { provider: string; model: string } | null => {
-    const slashIndex = value.indexOf("/");
-    if (slashIndex <= 0 || slashIndex >= value.length - 1) {
-      return null;
-    }
-    const provider = normalizeLowercaseStringOrEmpty(value.slice(0, slashIndex));
-    const model = normalizeLowercaseStringOrEmpty(value.slice(slashIndex + 1));
-    return provider && model ? { provider, model } : null;
-  };
-
-  const validateConfiguredModelRefs = () => {
+  const validateConfiguredModelRefs = (): void => {
     const configuredRefs = collectConfiguredModelRefs(config);
     if (configuredRefs.length === 0) {
       return;
@@ -1722,11 +455,8 @@ function validateConfigObjectWithPluginsBase(
       { provider: string; model: string; reason?: string }
     >();
     for (const suppression of planManifestModelCatalogSuppressions({ registry }).suppressions) {
-      if (suppression.when) {
-        continue;
-      }
       const key = `${suppression.provider}/${suppression.model}`;
-      if (!suppressedModels.has(key)) {
+      if (!suppression.when && !suppressedModels.has(key)) {
         suppressedModels.set(key, {
           provider: suppression.provider,
           model: suppression.model,
@@ -1734,21 +464,20 @@ function validateConfigObjectWithPluginsBase(
         });
       }
     }
-    if (suppressedModels.size === 0) {
-      return;
-    }
     const seen = new Set<string>();
     for (const ref of configuredRefs) {
-      const parsed = parseProviderModelRef(ref.value);
-      if (!parsed) {
+      const slashIndex = ref.value.indexOf("/");
+      if (slashIndex <= 0 || slashIndex >= ref.value.length - 1) {
         continue;
       }
-      const suppression = suppressedModels.get(`${parsed.provider}/${parsed.model}`);
-      if (!suppression) {
+      const provider = normalizeLowercaseStringOrEmpty(ref.value.slice(0, slashIndex));
+      const model = normalizeLowercaseStringOrEmpty(ref.value.slice(slashIndex + 1));
+      if (!provider || !model) {
         continue;
       }
-      const issueKey = `${ref.path}\0${parsed.provider}/${parsed.model}`;
-      if (seen.has(issueKey)) {
+      const suppression = suppressedModels.get(`${provider}/${model}`);
+      const issueKey = `${ref.path}\0${provider}/${model}`;
+      if (!suppression || seen.has(issueKey)) {
         continue;
       }
       seen.add(issueKey);
@@ -1762,47 +491,31 @@ function validateConfigObjectWithPluginsBase(
     }
   };
 
-  const replaceChannelConfig = (channelId: string, nextValue: unknown) => {
+  const replaceChannelConfig = (channelId: string, nextValue: unknown): void => {
     if (!channelsCloned) {
-      mutatedConfig = {
-        ...mutatedConfig,
-        channels: {
-          ...mutatedConfig.channels,
-        },
-      };
+      mutatedConfig = { ...mutatedConfig, channels: { ...mutatedConfig.channels } };
       channelsCloned = true;
     }
     (mutatedConfig.channels as Record<string, unknown>)[channelId] = nextValue;
   };
 
-  const replacePluginEntryConfig = (pluginId: string, nextValue: Record<string, unknown>) => {
+  const replacePluginEntryConfig = (pluginId: string, nextValue: Record<string, unknown>): void => {
     if (!pluginsCloned) {
-      mutatedConfig = {
-        ...mutatedConfig,
-        plugins: {
-          ...mutatedConfig.plugins,
-        },
-      };
+      mutatedConfig = { ...mutatedConfig, plugins: { ...mutatedConfig.plugins } };
       pluginsCloned = true;
     }
     if (!pluginEntriesCloned) {
       mutatedConfig.plugins = {
         ...mutatedConfig.plugins,
-        entries: {
-          ...mutatedConfig.plugins?.entries,
-        },
+        entries: { ...mutatedConfig.plugins?.entries },
       };
       pluginEntriesCloned = true;
     }
     const currentEntry = mutatedConfig.plugins?.entries?.[pluginId];
-    mutatedConfig.plugins!.entries![pluginId] = {
-      ...currentEntry,
-      config: nextValue,
-    };
+    mutatedConfig.plugins!.entries![pluginId] = { ...currentEntry, config: nextValue };
   };
 
   const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...bundledChannelIds]);
-
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {
       const trimmed = key.trim();
@@ -1810,18 +523,14 @@ function validateConfigObjectWithPluginsBase(
         continue;
       }
       if (!allowedChannels.has(trimmed)) {
-        const { registry } = ensureRegistry();
-        for (const record of registry.plugins) {
+        for (const record of ensureRegistry().registry.plugins) {
           for (const channelId of record.channels) {
             allowedChannels.add(channelId);
           }
         }
       }
       if (!allowedChannels.has(trimmed)) {
-        const issue = {
-          path: `channels.${trimmed}`,
-          message: `unknown channel id: ${trimmed}`,
-        };
+        const issue = { path: `channels.${trimmed}`, message: `unknown channel id: ${trimmed}` };
         if (hasStalePluginEvidenceForUnknownChannel(trimmed)) {
           warnings.push({
             ...issue,
@@ -1832,7 +541,6 @@ function validateConfigObjectWithPluginsBase(
         }
         continue;
       }
-
       const channelSchema = ensureChannelSchemas().get(trimmed);
       if (!channelSchema?.schema) {
         continue;
@@ -1846,45 +554,38 @@ function validateConfigObjectWithPluginsBase(
       });
       if (!result.ok) {
         for (const error of result.errors) {
-          const pathResult =
-            error.path === "<root>" ? `channels.${trimmed}` : `channels.${trimmed}.${error.path}`;
           issues.push({
-            path: pathResult,
+            path:
+              error.path === "<root>" ? `channels.${trimmed}` : `channels.${trimmed}.${error.path}`,
             message: formatChannelConfigIssueMessage(error.message, channelSchema.pluginId),
             allowedValues: error.allowedValues,
             allowedValuesHiddenCount: error.allowedValuesHiddenCount,
           });
         }
-        continue;
+      } else {
+        replaceChannelConfig(trimmed, result.value);
       }
-      replaceChannelConfig(trimmed, result.value);
     }
   }
 
-  const heartbeatChannelIds = new Set<string>();
-  for (const channelId of bundledChannelIds) {
-    heartbeatChannelIds.add(normalizeLowercaseStringOrEmpty(channelId));
-  }
-
-  const validateHeartbeatTarget = (target: string | undefined, pathValue: string) => {
+  const heartbeatChannelIds = new Set(
+    bundledChannelIds.map((channelId) => normalizeLowercaseStringOrEmpty(channelId)),
+  );
+  const validateHeartbeatTarget = (target: string | undefined, issuePath: string): void => {
     if (typeof target !== "string") {
       return;
     }
     const trimmed = target.trim();
     if (!trimmed) {
-      issues.push({ path: pathValue, message: "heartbeat target must not be empty" });
+      issues.push({ path: issuePath, message: "heartbeat target must not be empty" });
       return;
     }
     const normalized = normalizeLowercaseStringOrEmpty(trimmed);
-    if (normalized === "last" || normalized === "none") {
-      return;
-    }
-    if (normalizeBundledChannelId(trimmed)) {
+    if (normalized === "last" || normalized === "none" || normalizeBundledChannelId(trimmed)) {
       return;
     }
     if (!heartbeatChannelIds.has(normalized)) {
-      const { registry } = ensureRegistry();
-      for (const record of registry.plugins) {
+      for (const record of ensureRegistry().registry.plugins) {
         for (const channelId of record.channels) {
           const pluginChannel = channelId.trim();
           if (pluginChannel) {
@@ -1893,10 +594,9 @@ function validateConfigObjectWithPluginsBase(
         }
       }
     }
-    if (heartbeatChannelIds.has(normalized)) {
-      return;
+    if (!heartbeatChannelIds.has(normalized)) {
+      issues.push({ path: issuePath, message: `unknown heartbeat target: ${target}` });
     }
-    issues.push({ path: pathValue, message: `unknown heartbeat target: ${target}` });
   };
 
   validateHeartbeatTarget(
@@ -1908,338 +608,33 @@ function validateConfigObjectWithPluginsBase(
       source.kind === "entries" ? `agents.entries.${source.key}` : `agents.list.${source.index}`;
     validateHeartbeatTarget(entry?.heartbeat?.target, `${pathPrefix}.heartbeat.target`);
   }
-
   validateWebSearchProvider();
   validateConfiguredModelRefs();
 
   if (!hasExplicitPluginsConfig) {
-    if (issues.length > 0) {
-      return { ok: false, issues, warnings };
-    }
-    return { ok: true, config: mutatedConfig, warnings };
+    return issues.length > 0
+      ? { ok: false, issues, warnings }
+      : { ok: true, config: mutatedConfig, warnings };
   }
 
   const { registry } = ensureRegistry();
-  const knownIds = ensureKnownIds();
-  const normalizedPlugins = ensureNormalizedPlugins();
-  const effectiveConfig = ensureCompatConfig();
-  const blockedPluginDiagnostics = new Map<string, { message: string; source?: string }>();
-  const blockedPluginDiagnosticsWithSource: Array<{ message: string; source: string }> = [];
-  const normalizeBlockedDiagnosticPath = (value: string | undefined): string => {
-    const trimmed = value?.trim();
-    if (!trimmed) {
-      return "";
-    }
-    try {
-      return path.resolve(resolveUserPath(trimmed, opts.env ?? process.env));
-    } catch {
-      return path.resolve(trimmed);
-    }
-  };
-  for (const diag of registry.diagnostics) {
-    if (!diag.message.startsWith(BLOCKED_PLUGIN_CANDIDATE_PREFIX)) {
-      continue;
-    }
-    if (!diag.pluginId && diag.source) {
-      blockedPluginDiagnosticsWithSource.push({
-        message: diag.message,
-        source: diag.source,
-      });
-    }
-    if (diag.pluginId) {
-      const normalizedPluginId = normalizePluginId(diag.pluginId);
-      for (const key of [diag.pluginId, normalizedPluginId]) {
-        if (!key || blockedPluginDiagnostics.has(key)) {
-          continue;
-        }
-        blockedPluginDiagnostics.set(key, {
-          message: diag.message,
-          ...(diag.source ? { source: diag.source } : {}),
-        });
-      }
-    }
-  }
-  const blockedDiagnosticSourceMatchesPluginId = (
-    diagnostic: { message: string; source: string },
-    pluginId: string,
-  ): boolean => {
-    const normalizedPluginId = normalizePluginId(pluginId);
-    if (!normalizedPluginId) {
-      return false;
-    }
-    const sourcePath = normalizeBlockedDiagnosticPath(diagnostic.source);
-    if (!sourcePath) {
-      return false;
-    }
-    if (
-      normalizePluginId(path.basename(sourcePath)) === normalizedPluginId ||
-      normalizePluginId(path.basename(path.dirname(sourcePath))) === normalizedPluginId
-    ) {
-      return true;
-    }
-    const loadPaths = config.plugins?.load?.paths;
-    if (!Array.isArray(loadPaths)) {
-      return false;
-    }
-    for (const loadPath of loadPaths) {
-      if (typeof loadPath !== "string") {
-        continue;
-      }
-      const resolvedLoadPath = normalizeBlockedDiagnosticPath(loadPath);
-      if (!resolvedLoadPath) {
-        continue;
-      }
-      if (normalizePluginId(path.basename(resolvedLoadPath)) !== normalizedPluginId) {
-        continue;
-      }
-      if (
-        sourcePath === resolvedLoadPath ||
-        isPathInside(resolvedLoadPath, sourcePath) ||
-        isPathInside(sourcePath, resolvedLoadPath)
-      ) {
-        return true;
-      }
-    }
-    return false;
-  };
-  const findBlockedPluginDiagnostic = (pluginId: string) => {
-    const direct =
-      blockedPluginDiagnostics.get(pluginId) ??
-      blockedPluginDiagnostics.get(normalizePluginId(pluginId));
-    if (direct) {
-      return direct;
-    }
-    return blockedPluginDiagnosticsWithSource.find((diagnostic) =>
-      blockedDiagnosticSourceMatchesPluginId(diagnostic, pluginId),
-    );
-  };
-  const missingOfficialPluginWarningIds = new Set<string>();
-  const pushMissingPluginIssue = (
-    pathLocal: string,
-    pluginId: string,
-    optsLocal?: {
-      warnOnly?: boolean;
-      officialInstallHint?: boolean;
-      missingMessage?: string | null;
-    },
-  ) => {
-    if (LEGACY_REMOVED_PLUGIN_IDS.has(pluginId)) {
-      warnings.push({
-        path: pathLocal,
-        message: formatRemovedPluginConfigWarning(pluginId),
-      });
-      return;
-    }
-    const blockedDiagnostic = findBlockedPluginDiagnostic(pluginId);
-    if (blockedDiagnostic) {
-      const source = blockedDiagnostic.source ? `; source: ${blockedDiagnostic.source}` : "";
-      const message = `plugin present but blocked: ${pluginId} (see preceding plugin warning${source}; fix the blocked plugin path instead of removing config)`;
-      if (optsLocal?.warnOnly) {
-        warnings.push({ path: pathLocal, message });
-      } else {
-        issues.push({ path: pathLocal, message });
-      }
-      return;
-    }
-    if (
-      normalizePluginId(pluginId) === "codex" &&
-      pathLocal === "plugins.entries.codex" &&
-      shouldSuppressMissingCodexPluginDiagnostics(
-        config,
-        opts.env ?? process.env,
-        isRecord(raw) ? (raw as OpenClawConfig) : undefined,
-      )
-    ) {
-      return;
-    }
-    if (optsLocal?.warnOnly && optsLocal.officialInstallHint !== false) {
-      const externalInstallWarning =
-        optsLocal.missingMessage ?? formatMissingOfficialExternalPluginWarning(pluginId);
-      if (externalInstallWarning) {
-        const normalizedPluginId = normalizePluginId(pluginId);
-        if (!optsLocal.missingMessage && normalizedPluginId) {
-          if (missingOfficialPluginWarningIds.has(normalizedPluginId)) {
-            return;
-          }
-          missingOfficialPluginWarningIds.add(normalizedPluginId);
-        }
-        warnings.push({
-          path: pathLocal,
-          message: externalInstallWarning,
-        });
-        return;
-      }
-    }
-    if (optsLocal?.warnOnly) {
-      warnings.push({
-        path: pathLocal,
-        message: `plugin not found: ${pluginId} (stale config entry ignored; remove it from plugins config)`,
-      });
-      return;
-    }
-    issues.push({
-      path: pathLocal,
-      message: `plugin not found: ${pluginId}`,
-    });
-  };
+  validateExplicitPluginConfig({
+    raw,
+    config,
+    effectiveConfig: ensureCompatConfig(),
+    env: opts.env,
+    applyDefaults: opts.applyDefaults,
+    registry,
+    knownIds: ensureKnownIds(),
+    normalizedPlugins: ensureNormalizedPlugins(),
+    ensureCompatPluginIds,
+    ensureOverriddenPluginIds,
+    replacePluginEntryConfig,
+    issues,
+    warnings,
+  });
 
-  const pluginsConfig = config.plugins;
-
-  const entries = pluginsConfig?.entries;
-  if (entries && isRecord(entries)) {
-    for (const pluginId of Object.keys(entries)) {
-      if (!knownIds.has(pluginId)) {
-        // Keep gateway startup resilient when plugins are removed/renamed across upgrades.
-        pushMissingPluginIssue(`plugins.entries.${pluginId}`, pluginId, { warnOnly: true });
-      }
-    }
-  }
-
-  const allow = pluginsConfig?.allow ?? [];
-  for (const pluginId of allow) {
-    if (typeof pluginId !== "string" || !pluginId.trim()) {
-      continue;
-    }
-    if (!knownIds.has(pluginId)) {
-      const commandAlias = resolveManifestCommandAliasOwnerInRegistry({
-        command: pluginId,
-        registry,
-      });
-      if (commandAlias?.pluginId && knownIds.has(commandAlias.pluginId)) {
-        warnings.push({
-          path: "plugins.allow",
-          message:
-            `"${pluginId}" is not a plugin — it is a command provided by the "${commandAlias.pluginId}" plugin. ` +
-            `Use "${commandAlias.pluginId}" in plugins.allow instead.`,
-        });
-      } else {
-        pushMissingPluginIssue("plugins.allow", pluginId, { warnOnly: true });
-      }
-    }
-  }
-
-  const deny = pluginsConfig?.deny ?? [];
-  for (const pluginId of deny) {
-    if (typeof pluginId !== "string" || !pluginId.trim()) {
-      continue;
-    }
-    if (!knownIds.has(pluginId)) {
-      pushMissingPluginIssue("plugins.deny", pluginId, {
-        warnOnly: true,
-        officialInstallHint: false,
-      });
-    }
-  }
-
-  // The default memory slot is inferred; only a user-configured slot should block startup.
-  const pluginSlots = pluginsConfig?.slots;
-  const hasExplicitMemorySlot = pluginSlots !== undefined && Object.hasOwn(pluginSlots, "memory");
-  const memorySlot = normalizedPlugins.slots.memory;
-  if (
-    hasExplicitMemorySlot &&
-    typeof memorySlot === "string" &&
-    memorySlot.trim() &&
-    !knownIds.has(memorySlot)
-  ) {
-    const isMissingOfficialExternalMemorySlot =
-      memorySlot === "memory-lancedb" &&
-      Boolean(
-        formatMissingOfficialExternalPluginWarning(memorySlot, {
-          selectedMissingMemorySlot: true,
-        }),
-      );
-    pushMissingPluginIssue("plugins.slots.memory", memorySlot, {
-      warnOnly: isMissingOfficialExternalMemorySlot && !findBlockedPluginDiagnostic(memorySlot),
-      missingMessage: formatMissingOfficialExternalPluginWarning(memorySlot, {
-        selectedMissingMemorySlot: true,
-      }),
-    });
-  }
-
-  let selectedMemoryPluginId: string | null = null;
-  const seenPlugins = new Set<string>();
-  for (const record of registry.plugins) {
-    const pluginId = record.id;
-    if (seenPlugins.has(pluginId)) {
-      continue;
-    }
-    seenPlugins.add(pluginId);
-    const entry = normalizedPlugins.entries[pluginId];
-    const entryHasConfig = Boolean(entry?.config);
-
-    const activationState = resolveEffectivePluginActivationState({
-      id: pluginId,
-      origin: record.origin,
-      config: normalizedPlugins,
-      rootConfig: effectiveConfig,
-    });
-    let enabled = activationState.activated;
-    let reason = activationState.reason;
-
-    if (enabled) {
-      const memoryDecision = resolveMemorySlotDecision({
-        id: pluginId,
-        kind: record.kind,
-        slot: memorySlot,
-        selectedId: selectedMemoryPluginId,
-      });
-      if (!memoryDecision.enabled) {
-        enabled = false;
-        reason = memoryDecision.reason;
-      }
-      if (memoryDecision.selected && hasKind(record.kind, "memory")) {
-        selectedMemoryPluginId = pluginId;
-      }
-    }
-
-    const shouldReplacePluginConfig = entryHasConfig || (opts.applyDefaults && enabled);
-    const shouldValidate = enabled || entryHasConfig;
-    if (shouldValidate) {
-      if (record.configSchema) {
-        const res = validateJsonSchemaValue({
-          schema: record.configSchema,
-          cacheKey: record.schemaCacheKey ?? record.manifestPath ?? pluginId,
-          value: entry?.config ?? {},
-          applyDefaults: true, // Always apply defaults for AJV schema validation;
-          // writeConfigFile persists persistCandidate, not validated.config (#61841)
-        });
-        if (!res.ok) {
-          for (const error of res.errors) {
-            issues.push({
-              path: resolvePluginConfigIssuePath(pluginId, error.path),
-              message: `invalid config: ${error.message}`,
-              allowedValues: error.allowedValues,
-              allowedValuesHiddenCount: error.allowedValuesHiddenCount,
-            });
-          }
-        } else if (shouldReplacePluginConfig) {
-          replacePluginEntryConfig(pluginId, res.value as Record<string, unknown>);
-        }
-      } else if (record.format === "bundle") {
-        // Compatible bundles currently expose no native OpenClaw config schema.
-        // Treat them as schema-less capability packs rather than failing validation.
-      } else {
-        issues.push({
-          path: `plugins.entries.${pluginId}`,
-          message: `plugin schema missing for ${pluginId}`,
-        });
-      }
-    }
-
-    const suppressDisabledConfigWarning =
-      ensureCompatPluginIds().has(pluginId) && !ensureOverriddenPluginIds().has(pluginId);
-    if (!enabled && entryHasConfig && !suppressDisabledConfigWarning) {
-      warnings.push({
-        path: `plugins.entries.${pluginId}`,
-        message: `plugin disabled (${reason ?? "disabled"}) but config is present`,
-      });
-    }
-  }
-
-  if (issues.length > 0) {
-    return { ok: false, issues, warnings };
-  }
-
-  return { ok: true, config: mutatedConfig, warnings };
+  return issues.length > 0
+    ? { ok: false, issues, warnings }
+    : { ok: true, config: mutatedConfig, warnings };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

`src/config/validation.ts` had grown to 2,245 lines and mixed five distinct responsibilities: core schema validation, issue normalization, bundled-channel policy, plugin-aware validation, and explicit plugin config diagnostics. That made compatibility-sensitive validation changes harder to review and kept the file on the max-lines baseline.

This is a maintainer-commissioned LOC-reduction refactor. It is AI-assisted.

## Why This Change Was Made

The validator is split by existing ownership boundaries while `src/config/validation.ts` remains the stable public facade for plugin-aware validation and existing exports. Core schema/policy validation, issue formatting, bundled-channel rules, and explicit plugin config checks now live in focused modules under the 700-line production budget.

Validation ordering, lazy plugin-registry loading, warnings, errors, defaults, and accepted/rejected config shapes are intentionally unchanged. There are no config, environment, schema, protocol, or user-visible behavior changes.

### Beyond the split

- Hoisted the registry-state type out of the plugin-validation function so its cached fields and ownership are visible before the orchestration code that uses them.
- Collapsed equivalent conditional branches in local helper code where the same decision and output were preserved, reducing duplicate control flow without changing validation acceptance.
- Kept copy-on-write config mutation in the orchestrator while moving explicit plugin diagnostics and schema checks together, making the gather/validate/mutate boundary explicit.

## User Impact

No user-visible impact. Existing valid configs remain valid, retired keys remain rejected, and validation messages/default application remain unchanged. Maintainers get smaller modules with clearer ownership and the max-lines ratchet moves down by one entry.

## Evidence

- LOC: production TypeScript +1,592/-1,757 (net -165); tests +0/-0; baseline +0/-1; total +1,592/-1,758 (net -166).
- `node scripts/run-vitest.mjs src/config/dead-config-keys.test.ts src/config/config.schema-regressions.test.ts src/config/schema.test.ts src/config/validation.allowed-values.test.ts src/config/validation.policy.test.ts src/config/validation.channel-metadata.test.ts src/config/config.plugin-validation.test.ts src/config/validation.cold-imports.test.ts src/config/validation.legacy-rules-fast-path.test.ts src/config/config.model-ref-validation.test.ts src/config/config.gateway-tailscale-bind.test.ts src/config/config.secrets-schema.test.ts` — 12 files, 451 tests passed.
- `node scripts/check-changed.mjs -- config/max-lines-baseline.txt src/config/validation.ts src/config/validation-channel-rules.ts src/config/validation-core.ts src/config/validation-issues.ts src/config/validation-plugin-config.ts` — passed on Blacksmith Testbox `tbx_01kycrvzghqqvsp26jsga2pbd8`; production/test typechecks, formatting, all core lint shards, max-lines ratchet, import cycles, and architecture guards clean. Run: https://github.com/openclaw/openclaw/actions/runs/30160607521
- `pnpm deadcode:dependencies && pnpm deadcode:exports` — passed on Blacksmith Testbox `tbx_01kyctpkz6cbwwpptkvvxsgvw6`; production/full-tree/script Knip scans reported zero unused exports. Run: https://github.com/openclaw/openclaw/actions/runs/30161626890
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings, correctness confidence 0.96.
- The CI-triggered private-type correction received a second clean autoreview with no accepted/actionable findings (confidence 0.93).
- Rebased onto current `main`, then reran the focused validation suite: 12 files, 451 tests passed.
- `OPENCLAW_CONFIG_PATH=<synthetic-fixture> node --import tsx src/entry.ts config validate --json` — representative valid config returned `valid: true`; invalid config exited 1 and preserved the retired `gateway.handshakeTimeoutMs` rejection plus exact update-channel allowed values. Full sanitized transcript: https://github.com/openclaw/openclaw/pull/113713#issuecomment-5079127103

## Bugs Found

None.

## Placement Findings

None. The extracted modules remain within the config owner boundary.

## Baseline

Removed `src/config/validation.ts` from `config/max-lines-baseline.txt`; every resulting production file is below 700 effective lines.
