### PR TITLE
fix(ui): drop the sidebar agent menu below its card

### DIFF
--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -53,7 +53,7 @@ type AgentMenuAgent = {
 };
 
 type SidebarAgentMenuParams = {
-  position: { x: number; bottom: number } | null;
+  position: { x: number; top: number } | null;
   activeId: string;
   activeName: string;
   agents: readonly AgentMenuAgent[];
@@ -234,7 +234,7 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
       <wa-dropdown
         class="sidebar-customize-menu sidebar-agent-menu"
         .open=${true}
-        placement="top-start"
+        placement="bottom-start"
         .distance=${0}
         aria-label=${t("agentChip.menuLabel")}
         @wa-select=${(event: CustomEvent<{ item: HTMLElement & { value?: string } }>) => {
@@ -283,7 +283,7 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
           tabindex="-1"
           aria-hidden="true"
           aria-label=${t("agentChip.menuLabel")}
-          style="position: fixed; left: ${position.x}px; bottom: ${position.bottom}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+          style="position: fixed; left: ${position.x}px; top: ${position.top}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
         ></button>
         ${agents.length > 1
           ? html`

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -41,7 +41,7 @@ interface SidebarMenusControllerState {
   sessionMenuWork: SessionMenuWork | null;
   sessionGroupMenu: SidebarSessionGroupMenuState | null;
   sessionSortMenuPosition: { x: number; y: number } | null;
-  agentMenuPosition: { x: number; bottom: number } | null;
+  agentMenuPosition: { x: number; top: number } | null;
   agentMenuFilter: string;
   identityMenuPosition: { x: number; bottom: number; width: number } | null;
 }
@@ -118,7 +118,7 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
   sessionMenuWork: SessionMenuWork | null = null;
   sessionGroupMenu: SidebarSessionGroupMenuState | null = null;
   sessionSortMenuPosition: { x: number; y: number } | null = null;
-  agentMenuPosition: { x: number; bottom: number } | null = null;
+  agentMenuPosition: { x: number; top: number } | null = null;
   agentMenuFilter = "";
   // Anchored by its bottom edge so the footer menu grows upward regardless of height.
   identityMenuPosition: { x: number; bottom: number; width: number } | null = null;
@@ -415,9 +415,11 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     this.closeIdentityMenu();
     this.agentMenuTrigger = trigger;
     this.updateState("agentMenuFilter", "");
+    // The agent card sits at the top of the sidebar, so the menu drops below it
+    // and shares its left edge; anchoring above would cover the card you clicked.
     this.updateState("agentMenuPosition", {
-      x: Math.max(8, Math.min(rect.right - menuWidth, window.innerWidth - menuWidth - 8)),
-      bottom: Math.max(8, window.innerHeight - rect.top + 4),
+      x: Math.max(8, Math.min(rect.left, window.innerWidth - menuWidth - 8)),
+      top: Math.min(rect.bottom + 4, window.innerHeight - 8),
     });
   }
 

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -115,10 +115,22 @@ describeControlUiE2e("Control UI agent page scope", () => {
       await gateway.waitForRequest("agents.list");
       const sidebar = page.locator("openclaw-app-sidebar");
       await sidebar.getByRole("button", { name: /Switch agent/ }).click();
-      await sidebar
-        .locator("wa-dropdown.sidebar-agent-menu")
-        .locator('wa-dropdown-item[value="agent:writer"]')
-        .click();
+      const agentMenu = sidebar.locator("wa-dropdown.sidebar-agent-menu");
+      // The card sits at the top of the sidebar: the menu drops below it so the
+      // agent you clicked (and its checkmark row) stays visible.
+      await expect
+        .poll(async () => {
+          const [card, menu] = await Promise.all([
+            sidebar.locator(".sidebar-agent-card__main").boundingBox(),
+            agentMenu.locator('[part~="menu"], .wa-dropdown__menu').first().boundingBox(),
+          ]);
+          if (!card || !menu) {
+            return null;
+          }
+          return { belowCard: menu.y >= card.y + card.height, leftAligned: menu.x <= card.x + 4 };
+        })
+        .toEqual({ belowCard: true, leftAligned: true });
+      await agentMenu.locator('wa-dropdown-item[value="agent:writer"]').click();
       await waitForRequest(gateway, "sessions.list", (params) => params.agentId === "writer");
       await expect
         .poll(async () =>

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -84,6 +84,33 @@ describe("AppSidebar agent chip", () => {
     expect(sidebar.querySelector(".sidebar-agent-menu")).toBeNull();
   });
 
+  it("drops the menu below the agent card instead of covering it", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(
+      gateway,
+      createSessions("main", ["agent:main:main"]),
+      "panel",
+      TWO_AGENTS,
+    );
+    sidebar.connected = true;
+    await sidebar.updateComplete;
+
+    const card = sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-card__main");
+    if (!card) {
+      throw new Error("Expected the sidebar agent card");
+    }
+    card.getBoundingClientRect = () => ({ bottom: 88, left: 12, right: 252, top: 40 }) as DOMRect;
+    card.click();
+    await sidebar.updateComplete;
+
+    const menus = (sidebar as unknown as { sidebarMenus: { agentMenuPosition: unknown } })
+      .sidebarMenus;
+    expect(menus.agentMenuPosition).toEqual({ x: 12, top: 92 });
+    const menu = sidebar.querySelector(".sidebar-agent-menu");
+    expect(menu?.getAttribute("placement")).toBe("bottom-start");
+    expect(menu?.querySelector('[slot="trigger"]')?.getAttribute("style")).toContain("top: 92px");
+  });
+
   it("collapses a single-agent roster to the three agent actions", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(


### PR DESCRIPTION
## What Problem This Solves

Clicking the sidebar agent card opened its menu **above** the card. The card lives at the top of the sidebar, so the menu was pinned against the top of the viewport and drew straight over the thing you just clicked — hiding the active agent, its avatar, and the checkmark row that tells you which agent is selected.

The roster itself (up to 10 agents, checkmark on the active one, filter past that) already works; it was simply covered up.

## Why This Change Was Made

`toggleAgentMenu` anchored the popup by its bottom edge at `rect.top` with `placement="top-start"`, which is correct for the footer identity card but wrong since the agent card moved to the sidebar header. The menu now anchors below the card (`top: rect.bottom + 4`) and shares its left edge, with `placement="bottom-start"`.

## User Impact

Opening the agent switcher keeps the agent card visible; the roster reads top-down from the card you clicked instead of covering it. The footer identity menu is unchanged and still grows upward.

## Evidence

- `node ../scripts/run-vitest.mjs run --config vitest.config.ts --configLoader runner components/app-sidebar` — 201 passed, incl. new `drops the menu below the agent card instead of covering it`.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner agent-page-scope` — passes; verified it **fails** with the fix stashed (real-browser bounding-box guard: menu top >= card bottom, left-aligned).
- `node scripts/check-changed.mjs` — delegated Blacksmith Testbox `tbx_01kyct35bnxj20caf2vyy04dwz`, exit 0 (UI typecheck + lint + tests).
- `autoreview --mode uncommitted` (codex/gpt-5.6-sol) — clean, no actionable findings.
- Before/after screenshots posted in a follow-up comment.
